### PR TITLE
perf: move per-click I/O sundries off the event loop (TASK-15471)

### DIFF
--- a/Tests/Architecture/test_no_blocking_io_on_message_pump.py
+++ b/Tests/Architecture/test_no_blocking_io_on_message_pump.py
@@ -124,19 +124,9 @@ BASELINE: dict[tuple[str, str, str], str] = {
         "action_refresh",
         "zipfile.ZipFile",
     ): "dead file, no importers",
-    # `glob("*.zip")` plus one `stat` per entry -- no per-file archive open or
-    # parse, unlike the pre-TASK-1320 scan that measured 1030ms. A stat per
-    # chatbook is sub-millisecond for any realistic export directory.
-    (
-        "UI/ChatbookExportManagementWindow.py",
-        "on_mount",
-        "self.chatbooks_dir.glob",
-    ): "glob + one stat per entry, no archive read",
-    (
-        "UI/ChatbookExportManagementWindow.py",
-        "on_button_pressed",
-        "self.chatbooks_dir.glob",
-    ): "glob + one stat per entry, no archive read",
+    # The ChatbookExportManagementWindow glob+stat scan that was baselined
+    # here moved off the pump in task-15471 (`refresh_chatbook_list` now
+    # runs `_scan_chatbook_files` via `asyncio.to_thread`).
     # `glob("*.toml")` plus a `toml.load` per user-created theme, when the theme
     # editor is shown. Bounded by how many themes the user has authored by hand,
     # realistically single digits.

--- a/Tests/Chat/test_conversation_local_marks_service.py
+++ b/Tests/Chat/test_conversation_local_marks_service.py
@@ -328,9 +328,7 @@ def test_list_marked_ids_cache_never_serves_stale_results_across_writes(tmp_path
     ) == ("conv-c",)
     service.clear_mark("conv-c", ConversationLocalMarksService.FLEET_UNSEEN)
     assert (
-        service.list_marked_conversation_ids(
-            ConversationLocalMarksService.FLEET_UNSEEN
-        )
+        service.list_marked_conversation_ids(ConversationLocalMarksService.FLEET_UNSEEN)
         == ()
     )
 
@@ -338,3 +336,81 @@ def test_list_marked_ids_cache_never_serves_stale_results_across_writes(tmp_path
     assert service.list_marked_conversation_ids(limit=1) == ("conv-b",)
     service.star_conversation("conv-d")
     assert service.list_marked_conversation_ids(limit=1) == ("conv-d",)
+
+
+def test_list_cache_is_not_repopulated_with_a_pre_write_snapshot(tmp_path):
+    """A cache-missing reader must not store rows a concurrent write outdated.
+
+    task-15471 fix round (review M1): the reader holds its fetched rows
+    across the transaction COMMIT — a GIL-releasing sqlite call — before
+    storing them. A writer that commits AND invalidates inside that window
+    must win: without a generation check the reader re-populates the cache
+    with its pre-write snapshot, and the just-starred conversation shows
+    unstarred (or a FLEET_UNSEEN badge never appears) until the NEXT mark
+    write. Both halves are genuinely cross-thread in production: the star
+    toggle writes from a pool thread (workspace.py), the fleet drain from a
+    child thread (console_fleet_attention.py), while repaint reads run on
+    the loop.
+
+    Deterministic interleave (adapted from the review's probe): the reader
+    thread is paused exactly at its transaction exit — after fetch, before
+    store — while the writer stars a conversation and invalidates.
+    """
+    import threading
+
+    db = _db(tmp_path)
+    read_committed = threading.Event()
+    write_invalidated = threading.Event()
+    state: dict = {"reader_ident": None}
+
+    class _HookedTx:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            return self._inner.__enter__()
+
+        def __exit__(self, *exc):
+            result = self._inner.__exit__(*exc)
+            # Pause ONLY the reader, and only right after its COMMIT — the
+            # real scheduler-switch point between fetchall() and the store.
+            if threading.get_ident() == state["reader_ident"]:
+                read_committed.set()
+                write_invalidated.wait(5)
+            return result
+
+    class _DbProxy:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def transaction(self):
+            return _HookedTx(self._inner.transaction())
+
+    service = ConversationLocalMarksService(_DbProxy(db))
+    reader_seen: dict = {}
+
+    def _reader():
+        state["reader_ident"] = threading.get_ident()
+        reader_seen["value"] = service.list_marked_conversation_ids()
+
+    def _writer():
+        assert read_committed.wait(5), "reader never reached its commit"
+        service.star_conversation("conv-a")  # commits, then invalidates
+        write_invalidated.set()
+
+    reader = threading.Thread(target=_reader)
+    writer = threading.Thread(target=_writer)
+    reader.start()
+    writer.start()
+    reader.join(10)
+    writer.join(10)
+    assert not reader.is_alive() and not writer.is_alive()
+
+    # The reader legitimately saw the pre-write world...
+    assert reader_seen["value"] == ()
+    # ...but the SERVICE must now answer with post-write truth, not the
+    # reader's stale snapshot resurrected into the cache.
+    assert service.list_marked_conversation_ids() == ("conv-a",)

--- a/Tests/Chat/test_conversation_local_marks_service.py
+++ b/Tests/Chat/test_conversation_local_marks_service.py
@@ -293,3 +293,48 @@ def test_get_mark_returns_timestamps_with_created_at_stable_across_refreshes(
         service.get_mark("", ConversationLocalMarksService.FLEET_UNSEEN)
     with pytest.raises(ValueError):
         service.get_mark("conv-a", "not-a-mark")
+
+
+def test_list_marked_ids_cache_never_serves_stale_results_across_writes(tmp_path):
+    """`list_marked_conversation_ids` may cache, but writes must invalidate.
+
+    task-15471 made the list read cached (Console's browser refresh calls it
+    on the event loop from every repaint path). The cache is only sound if
+    every writer path -- star AND unstar, and the independent fleet mark
+    type -- drops it, so a toggle is never followed by a stale repaint.
+    """
+    service = ConversationLocalMarksService(_db(tmp_path))
+
+    assert service.list_marked_conversation_ids() == ()
+
+    service.star_conversation("conv-a")
+    assert service.list_marked_conversation_ids() == ("conv-a",)
+
+    # Repeat read (cache hit) must equal the first.
+    assert service.list_marked_conversation_ids() == ("conv-a",)
+
+    service.star_conversation("conv-b")
+    assert set(service.list_marked_conversation_ids()) == {"conv-a", "conv-b"}
+
+    service.unstar_conversation("conv-a")
+    assert service.list_marked_conversation_ids() == ("conv-b",)
+
+    # Mark types are cached independently: writing a fleet mark must not
+    # bleed into the starred list, and its own list must see the write.
+    service.set_mark("conv-c", ConversationLocalMarksService.FLEET_UNSEEN)
+    assert service.list_marked_conversation_ids() == ("conv-b",)
+    assert service.list_marked_conversation_ids(
+        ConversationLocalMarksService.FLEET_UNSEEN
+    ) == ("conv-c",)
+    service.clear_mark("conv-c", ConversationLocalMarksService.FLEET_UNSEEN)
+    assert (
+        service.list_marked_conversation_ids(
+            ConversationLocalMarksService.FLEET_UNSEEN
+        )
+        == ()
+    )
+
+    # Different limits are distinct cache keys and must both reflect writes.
+    assert service.list_marked_conversation_ids(limit=1) == ("conv-b",)
+    service.star_conversation("conv-d")
+    assert service.list_marked_conversation_ids(limit=1) == ("conv-d",)

--- a/Tests/Event_Handlers/test_collections_tag_events.py
+++ b/Tests/Event_Handlers/test_collections_tag_events.py
@@ -1,0 +1,107 @@
+"""Collections/Tags keyword handlers: off-loop DB calls and lookup dedupe.
+
+task-15471 coverage. Two properties are pinned here:
+
+1. **The handlers actually work.** Every handler in
+   `collections_tag_events.py` used to call ``app.run_in_thread`` -- a method
+   neither Textual 8.x's ``App`` nor ``TldwCli`` defines -- so rename/merge/
+   delete all raised ``AttributeError`` straight into their own error toast.
+   The success-path assertions below fail against that code.
+
+2. **Delete resolves each keyword name exactly once.** The old delete
+   handler ran the same ``SELECT`` twice per keyword id (once for the
+   notification, once again before the delete), synchronously on the event
+   loop. The batch lookup must issue one SELECT per id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.collections_tag_events import (
+    KeywordDeleteEvent,
+    KeywordRenameEvent,
+    handle_keyword_delete,
+    handle_keyword_rename,
+)
+
+
+class _FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeMediaDB:
+    # False on purpose: exercises the real asyncio.to_thread path.
+    is_memory_db = False
+
+    def __init__(self):
+        self.keywords = {1: "alpha", 2: "beta"}
+        self.select_calls = 0
+        self.deleted: list[str] = []
+        self.renames: list[tuple[int, str]] = []
+
+    def execute_query(self, query, params):
+        assert "SELECT keyword FROM Keywords" in query
+        self.select_calls += 1
+        keyword = self.keywords.get(params[0])
+        return _FakeCursor({"keyword": keyword} if keyword else None)
+
+    def soft_delete_keyword(self, keyword):
+        self.deleted.append(keyword)
+        return True
+
+    def rename_keyword(self, keyword_id, new_name):
+        self.renames.append((keyword_id, new_name))
+        return True
+
+
+class _FakeApp:
+    """Duck-typed TldwCli stand-in: media_db + notify recorder.
+
+    Deliberately has no ``query_one`` -- the handlers' window-refresh blocks
+    swallow that, and no ``run_in_thread`` -- the real app never had one
+    either, which is exactly what property 1 above pins.
+    """
+
+    def __init__(self, media_db):
+        self.media_db = media_db
+        self.notifications: list[tuple[str, str]] = []
+
+    def notify(self, message, severity="information"):
+        self.notifications.append((str(message), severity))
+
+
+@pytest.mark.asyncio
+async def test_keyword_delete_resolves_each_name_once_and_deletes_off_loop():
+    db = _FakeMediaDB()
+    app = _FakeApp(db)
+
+    await handle_keyword_delete(app, KeywordDeleteEvent([1, 2, 999]))
+
+    # One SELECT per requested id -- not two (the pre-task-15471 shape).
+    assert db.select_calls == 3
+    assert db.deleted == ["alpha", "beta"]
+
+    severities = {severity for _message, severity in app.notifications}
+    assert "error" not in severities
+    success = [m for m, s in app.notifications if s == "information"]
+    assert success and "alpha" in success[0] and "beta" in success[0]
+    # id 999 resolved to nothing, so one warning about the shortfall.
+    assert any(s == "warning" for _m, s in app.notifications)
+
+
+@pytest.mark.asyncio
+async def test_keyword_rename_succeeds_without_run_in_thread():
+    db = _FakeMediaDB()
+    app = _FakeApp(db)
+
+    await handle_keyword_rename(app, KeywordRenameEvent(1, "gamma"))
+
+    assert db.renames == [(1, "gamma")]
+    assert app.notifications, "rename must confirm"
+    message, severity = app.notifications[0]
+    assert severity == "information" and "gamma" in message

--- a/Tests/TTS/test_tts_improvements.py
+++ b/Tests/TTS/test_tts_improvements.py
@@ -614,6 +614,68 @@ class TestTTSEventHandler:
         assert not hasattr(handler, "_last_played_audio_files")
         assert handler._last_played == ("msg-4", last_audio)
 
+    @pytest.mark.asyncio
+    async def test_export_claim_keeps_cleanup_from_destroying_the_source_mid_copy(
+        self, handler, tmp_path, monkeypatch
+    ):
+        """A cleanup firing mid-export must wait, not zero the source.
+
+        task-15471 fix round (review M2): the export's `shutil.copy2` moved
+        to `asyncio.to_thread`, so it now yields -- and the 5s
+        `_cleanup_audio_file` task could resume mid-copy and secure-delete
+        the source, which OVERWRITES IT IN PLACE with zeros before the
+        unlink (`Utils/secure_temp_files.py`). The overlapping copy then
+        reads zeros for the uncopied tail while the handler still toasts
+        success. The export must claim the file first; a cleanup landing
+        inside the copy window waits for the claim to clear, then deletes.
+        """
+        import shutil as shutil_module
+        import threading
+
+        payload = b"real audio payload"
+        test_audio = tmp_path / "claimed.mp3"
+        test_audio.write_bytes(payload)
+        handler._audio_files["msg-claim"] = test_audio
+
+        copy_started = threading.Event()
+        release_copy = threading.Event()
+        real_copy2 = shutil_module.copy2
+
+        def gated_copy2(src, dst, **kwargs):
+            copy_started.set()
+            assert release_copy.wait(5), "test never released the gated copy"
+            return real_copy2(src, dst, **kwargs)
+
+        monkeypatch.setattr(shutil_module, "copy2", gated_copy2)
+
+        export_path = tmp_path / "exports" / "out.mp3"
+        export_task = asyncio.create_task(
+            handler.handle_tts_export(
+                TTSExportEvent("msg-claim", export_path, include_metadata=False)
+            )
+        )
+        # Wait (off-loop) until the pool thread is inside the gated copy.
+        assert await asyncio.to_thread(copy_started.wait, 5)
+
+        # Fire the deferred cleanup exactly mid-copy.
+        cleanup_task = asyncio.create_task(
+            handler._cleanup_audio_file("msg-claim", delay=0)
+        )
+        await asyncio.sleep(0.1)
+        # The claim holds the destroyer off: source present and NOT zeroed.
+        assert test_audio.exists(), "cleanup destroyed the source mid-copy"
+        assert test_audio.read_bytes() == payload
+        assert not cleanup_task.done()
+
+        release_copy.set()
+        await asyncio.wait_for(export_task, timeout=10)
+        assert export_path.read_bytes() == payload
+
+        # Once the export releases its claim, the pending cleanup completes.
+        await asyncio.wait_for(cleanup_task, timeout=10)
+        assert not test_audio.exists()
+        assert "msg-claim" not in handler._audio_files
+
 
 class TestAudioPlayer:
     """Test audio player improvements"""

--- a/Tests/UI/test_console_button_routing.py
+++ b/Tests/UI/test_console_button_routing.py
@@ -162,6 +162,9 @@ async def test_star_button_writes_a_durable_local_mark_and_toggles_it_back(tmp_p
 
         star.press()
         await pilot.pause()
+        # task-15471: the durable write runs on a worker now -- wait for it
+        # rather than racing the pool thread with the assertion.
+        await console.workers.wait_for_complete()
         assert marks.is_starred("conv-star-1") is True
 
         # A second press unstars: the branch reads current truth from the
@@ -169,6 +172,7 @@ async def test_star_button_writes_a_durable_local_mark_and_toggles_it_back(tmp_p
         await _sync_tray(console, pilot, _base_grouped_workspace_state(rows=rows))
         console.query_one("#console-conversation-star-0", Button).press()
         await pilot.pause()
+        await console.workers.wait_for_complete()
         assert marks.is_starred("conv-star-1") is False
 
 

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -1329,6 +1329,9 @@ async def test_console_conversation_star_press_confirms_the_toggle():
         console.app_instance.notify = lambda message, **kwargs: notes.append(message)
 
         await console.on_button_pressed(Button.Pressed(star))
+        # task-15471: the durable write + confirmation run on a worker now.
+        await console.workers.wait_for_complete()
+        await pilot.pause()
 
         assert any("Starred" in note for note in notes)
         # The markup is escaped (literal backslash-brackets), never interpreted.
@@ -1381,6 +1384,9 @@ async def test_console_conversation_star_confirms_an_untitled_conversation():
         console.app_instance.notify = lambda message, **kwargs: notes.append(message)
 
         await console.on_button_pressed(Button.Pressed(star))
+        # task-15471: the durable write + confirmation run on a worker now.
+        await console.workers.wait_for_complete()
+        await pilot.pause()
 
         # The durable write always landed; the confirmation is what was lost.
         assert starred, "the star write did not happen"

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -157,6 +157,12 @@ async def test_filter_hidden_count(tmp_path):
     """
     for name in ("a.json", "b.json", "c.txt", "d.txt", "e.txt"):
         (tmp_path / name).write_text("x")
+    # task-15471 fix round: a dotfile that ALSO fails the filter. With
+    # show_hidden off it is dotfile-hidden, so the filter-hidden count must
+    # NOT include it -- this pins the merged pass's "not already
+    # dotfile-hidden" guard, which the all-visible fixture above never
+    # exercised (review minor 7).
+    (tmp_path / ".hidden.txt").write_text("x")
 
     dialog = EnhancedFileOpen(
         location=str(tmp_path),
@@ -1389,7 +1395,6 @@ async def test_search_keystrokes_debounce_into_one_filtered_repopulation(tmp_pat
             await pilot.pause(0.05)
             if repopulates["count"]:
                 break
-        dir_nav._repopulate_display = real_repopulate
         assert repopulates["count"] == 1
 
         visible = {
@@ -1399,3 +1404,17 @@ async def test_search_keystrokes_debounce_into_one_filtered_repopulation(tmp_pat
         assert "beta.txt" in visible
         assert "alpha.txt" not in visible
         assert "gamma.txt" not in visible
+
+        # Clearing is a RESTORE, not a keystroke (task-15471 fix round,
+        # review minor 4): Esc / the Clear button empty the filter and the
+        # unfiltered list must be back IMMEDIATELY -- the watcher runs
+        # synchronously on assignment, so the rebuild has already happened
+        # by the next line, with no debounce interval in between.
+        dir_nav.search_filter = ""
+        assert repopulates["count"] == 2
+        dir_nav._repopulate_display = real_repopulate
+        restored = {
+            dir_nav.get_option_at_index(index).location.name
+            for index in range(dir_nav.option_count)
+        }
+        assert {"alpha.txt", "beta.txt", "gamma.txt"} <= restored

--- a/Tests/UI/test_enhanced_file_dialog_mount.py
+++ b/Tests/UI/test_enhanced_file_dialog_mount.py
@@ -1337,3 +1337,65 @@ def test_file_list_highlight_is_visible():
     assert "$surface" not in block, (
         "Highlighted row must not fall back to the near-invisible $surface color"
     )
+
+
+@pytest.mark.asyncio
+async def test_search_keystrokes_debounce_into_one_filtered_repopulation(tmp_path):
+    """A search-keystroke burst coalesces into ONE repopulation (task-15471).
+
+    Before task-15471 every ``search_filter`` assignment (one per
+    Input.Changed keystroke) rebuilt the whole option list synchronously on
+    the event loop -- measured at ~120 ms per keystroke on a 1000-file
+    directory. Now a burst only (re)arms the debounce timer; the single
+    deferred rebuild applies the final query, so the visible set is
+    unchanged from the pre-debounce behavior.
+    """
+    for name in ("alpha.txt", "beta.txt", "gamma.txt"):
+        (tmp_path / name).write_text("x")
+
+    dialog = EnhancedFileOpen(
+        location=str(tmp_path),
+        title="Test Debounced Search",
+        context="test_debounced_search",
+    )
+    app = _DialogHost(dialog)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        dir_nav = dialog.query_one(SearchableDirectoryNavigation)
+        await _wait_for_options(dir_nav, pilot)
+
+        repopulates = {"count": 0}
+        real_repopulate = dir_nav._repopulate_display
+
+        def counting_repopulate() -> None:
+            repopulates["count"] += 1
+            real_repopulate()
+
+        dir_nav._repopulate_display = counting_repopulate
+
+        # Three "keystrokes" -- exactly what the dialog's _on_search_changed
+        # does per Input.Changed. Watchers run synchronously on assignment,
+        # so a per-keystroke rebuild would already have counted here.
+        for fragment in ("b", "be", "bet"):
+            dir_nav.search_filter = fragment
+        assert repopulates["count"] == 0, (
+            "a keystroke must only arm the debounce timer, not rebuild inline"
+        )
+
+        # After the debounce interval: exactly one rebuild, final query applied.
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if repopulates["count"]:
+                break
+        dir_nav._repopulate_display = real_repopulate
+        assert repopulates["count"] == 1
+
+        visible = {
+            dir_nav.get_option_at_index(index).location.name
+            for index in range(dir_nav.option_count)
+        }
+        assert "beta.txt" in visible
+        assert "alpha.txt" not in visible
+        assert "gamma.txt" not in visible

--- a/backlog/tasks/task-15471 - Event-loop-I-O-sundries---per-click-writes-and-lookups-off-the-loop.md
+++ b/backlog/tasks/task-15471 - Event-loop-I-O-sundries---per-click-writes-and-lookups-off-the-loop.md
@@ -159,8 +159,10 @@ smallest per-site diff; every claim below names its measurement or command.
    main loop: `is_file` now runs at most once per entry, and not at all
    when no `file_filter` is set (it previously ran unconditionally, first
    in the `and` chain). Predicates are the vendored `hide()` unrolled;
-   the visible set and both posted counts are unchanged (pinned by the
-   pre-existing `test_filter_hidden_count` plus the new debounce test).
+   the visible set and both posted counts are unchanged (pinned by
+   `test_filter_hidden_count` — whose fixture the review fix round extended
+   with a dotfile, because without one the `not dot_hidden` guard was
+   unpinned (review minor 7) — plus the new debounce test).
 8. **CodeRepoCopyPaste — THREADED.** The per-click local-file preview read
    (`:716`) and the compile-selected read loop (`:901`) both moved into
    `asyncio.to_thread` closures; per-file error handling preserved.
@@ -207,13 +209,16 @@ service 10 passed + new
 (mutation-verified: removing `clear_mark`'s invalidation fails it); new
 `Tests/Event_Handlers/test_collections_tag_events.py` 2 passed (both red
 under a `run_in_thread` restoration AND the delete test red under a
-duplicated-lookup mutation); Console button routing 22 passed and full
-workspace-context-rail 96 passed — the three star tests now wait on
-`workers.wait_for_complete()` (the write moved to a worker; assertions were
-racing the pool thread), stable across 3 repeat runs; code-repo window +
-integration, chatbook management (9), TTS improvements + study
-product-maturity suites (45), chat-message widget + artifact actions +
-state ownership (155 with full rail), focus-contract + speak-autoplay (115).
+duplicated-lookup mutation); Console button routing **16 passed** and full
+workspace-context-rail **69 passed** (corrected in the review fix round —
+the earlier notes mis-tallied these from batch outputs as 22/96; the
+per-file counts above are re-run and read directly) — the three star tests
+now wait on `workers.wait_for_complete()` (the write moved to a worker;
+assertions were racing the pool thread), stable across 3 repeat runs;
+code-repo window + integration, chatbook management (9), TTS improvements
++ study product-maturity suites (45), chat-message widget + artifact
+actions + state ownership (155 with full rail), focus-contract +
+speak-autoplay (115).
 
 **Failures attributed to dev, not this change** (each reproduced byte-for-
 byte on a pristine `c3ed2854a` throwaway worktree, then the worktree
@@ -238,7 +243,91 @@ task-15766's list yet — candidates for that batch.
 `Tests/UI/test_console_button_routing.py`,
 `Tests/UI/test_console_workspace_context_rail.py`,
 `Tests/Event_Handlers/test_collections_tag_events.py` (new).
-Ruff: `check` clean on every touched file except 4 pre-existing findings in
-untouched regions (verified present at base); `format --check` clean on all
-files that were clean at base (workspace.py and enhanced_file_picker.py were
-format-dirty at base outside my hunks and were not reformatted).
+Ruff (corrected in the review fix round): `check` on the touched files
+reports exactly **1 production finding** — the pre-existing F811 duplicate
+`DEFAULT_WORKSPACE_ID` import in `workspace.py` (present at base
+`c3ed2854a`) — plus **3 F401s in `Tests/UI/test_console_workspace_context_
+rail.py`**, all three also present at base (verified by running
+`ruff check --isolated --select F401` on the base blob: they report at base
+lines 2610/2747/2768, shifted only by this branch's appended tests). The
+earlier "4 pre-existing findings" lumped these without the
+production-vs-test split. `format --check` clean on all files that were
+clean at base; base-format-dirty files were not reformatted, and the one
+new hunk the formatter flagged inside this branch's own additions (the
+marks cache test's wrapped assert) was conformed by hand.
+
+## Review fix round (independent concurrency review, verdict FIX-FIRST)
+
+Review report: session scratchpad `review15471/review.md` (all its findings
+reproduced by the reviewer; all reproduced again here before fixing).
+
+- **M1 (blocking) — populate-after-invalidate cache race, FIXED.**
+  `conversation_local_marks_service.py`: a cache-missing reader held its
+  fetched rows across the transaction COMMIT and stored them without
+  re-checking for a concurrent invalidation — a writer committing +
+  invalidating in that window (star toggle pool thread, fleet drain child
+  thread) left a pre-write snapshot cached until the NEXT mark write
+  (just-starred shows unstarred; a FLEET_UNSEEN badge never appears). Fix
+  is the reviewer's suggested shape: `_invalidate_list_cache` bumps a
+  generation counter under the lock; the reader captures it in the same
+  lock hold as its cache miss and stores only if unchanged — a lost race
+  costs one skipped store, never a stale cache. Kept the cache (vs
+  dropping it) because the guard is small and obviously correct: a global
+  counter, capture-before-SELECT, compare-before-store.
+  Evidence: new test `test_list_cache_is_not_repopulated_with_a_pre_write_
+  snapshot` (the reviewer's deterministic interleave adapted — reader
+  paused exactly at its commit-exit) was **born red against the committed
+  code** (`assert () == ('conv-a',)`, the exact staleness) and is green
+  after the fix; the reviewer's own probes re-run against the fix:
+  `probe_cache_race.py` → "no staleness observed",
+  `probe_cache_race_natural.py` → **stale rounds 0/300** (was 103/300).
+- **M2 — TTS export zeroed-file window, FIXED.** The threaded `copy2`
+  yields, so the 5 s `_cleanup_audio_file` task could secure-delete the
+  source mid-copy — and that delete overwrites the file IN PLACE with
+  zeros before unlinking (`Utils/secure_temp_files.py`), so the export
+  silently wrote zeros under a success toast. Boring durable option
+  chosen: the export **claims** the message id (refcounted dict guarded by
+  the existing `_audio_files_lock`, claimed in the same lock hold that
+  reads the source path, released in a `finally`), and
+  `_cleanup_audio_file` polls the claim (0.25 s interval, loop not
+  recursion) before deleting — copy and destroy are now mutually
+  exclusive, cleanup is deferred (never skipped, so no leak), and
+  refcounting keeps overlapping exports of one message safe. Evidence: new
+  test `test_export_claim_keeps_cleanup_from_destroying_the_source_mid_
+  copy` (gated `shutil.copy2`, cleanup fired mid-copy) — **born red
+  against the committed code** ("cleanup destroyed the source mid-copy"),
+  green after; it also pins that the deferred cleanup still deletes the
+  source once the export finishes.
+- **Minor 3 — star worker cancellation, FIXED.** `CancelledError` is a
+  `BaseException` and sailed past the `except Exception`, recreating the
+  TASK-357 silent-toggle shape (pool-thread write lands, no repaint). The
+  wrapper now catches `asyncio.CancelledError`, best-effort re-syncs the
+  workspace context, and re-raises.
+- **Minor 4 — debounce deferred clears, FIXED.** An emptied
+  `search_filter` (Esc / Clear button / programmatic reset) now
+  repopulates immediately; only non-empty typing debounces. Pinned by an
+  extension to the debounce test: after the debounced filter, `search_
+  filter = ""` must repopulate synchronously (count increments on the
+  assignment line) and restore the full listing.
+- **Minor 5 — emoji recents ordering, DOCUMENTED.** The unserialised
+  last-write-wins semantics (and why a lock is not worth it for a
+  cosmetic, error-swallowing recents file) are now stated in
+  `_save_recent_emoji_off_loop`'s docstring.
+- **Minor 6 — chatbook list cleared before the await, FIXED.**
+  `refresh_chatbook_list` now scans first and does clear+extend after the
+  await returns, so a failed scan leaves the previous state instead of an
+  empty list under a stale OptionList (the IndexError setup the review
+  described).
+- **Minor 7 — evidence honesty, CORRECTED IN PLACE.** The test-count and
+  ruff numbers above now carry the re-run values (routing 16, rail 69;
+  ruff 1 production + 3 test-file findings, all verified at base), and the
+  previously-unpinned `not dot_hidden` guard is now genuinely pinned: the
+  `test_filter_hidden_count` fixture gained a dotfile that also fails the
+  filter (count must stay 3), verified born-red by a drop-the-guard
+  mutation (count becomes 4) and restored.
+
+Fix-round test evidence: marks suite 18 passed (+ the known dev-red
+migration test, baselined on pristine base last round); TTS improvements
+25 passed; picker sweep + collections + arch guard + chatbook management
+64 passed; button routing 16 passed; workspace-context-rail 69 passed —
+all after the fixes, `PYTHONPATH` pinned to this worktree.

--- a/backlog/tasks/task-15471 - Event-loop-I-O-sundries---per-click-writes-and-lookups-off-the-loop.md
+++ b/backlog/tasks/task-15471 - Event-loop-I-O-sundries---per-click-writes-and-lookups-off-the-loop.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15471
 title: Event-loop I/O sundries: per-click writes and lookups off the loop
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-11 12:05'
 labels:
@@ -19,7 +19,226 @@ Fix direction: to_thread / debounce / dedupe per site, smallest-diff first; no b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each listed site is threaded, debounced, or deduped — or explicitly justified in the notes
-- [ ] #2 Behavior unchanged across the touched surfaces (targeted tests where they exist)
-- [ ] #3 Spot latency evidence recorded for the star toggle and file-picker typing
+- [x] #1 Each listed site is threaded, debounced, or deduped — or explicitly justified in the notes
+- [x] #2 Behavior unchanged across the touched surfaces (targeted tests where they exist)
+- [x] #3 Spot latency evidence recorded for the star toggle and file-picker typing
 <!-- AC:END -->
+
+## Implementation Plan
+
+All sites re-located and re-verified at HEAD `c3ed2854a` (dev has moved ~300 commits
+since the audit of `82b595049`; several cites shifted files/lines).
+
+1. Star toggle (`UI/Console_Modules/workspace.py:_toggle_console_conversation_star`,
+   now ~1970): keep the sync guards, move the marks-service `is_starred` +
+   `star/unstar_conversation` (a read + a write transaction with fsync on
+   chachanotes) into a `run_worker` async wrapper that calls
+   `asyncio.to_thread(...)` with the repo's `is_memory_db` guard (pattern copied
+   from `chat_screen.py` ~10550, task-15455's browser-search threading; the
+   controller exposes `run_worker` as a live property). Serialize toggles with an
+   `asyncio.Lock` so a rapid double-click still nets toggle-twice (deterministic,
+   matching sync semantics) instead of racing two threads.
+2. Browser starred-ids refresh (`chat_screen.py:_starred_console_conversation_ids`,
+   now ~10305, called from ~7 refresh paths): dedupe at the source — add a
+   result cache to `ConversationLocalMarksService.list_marked_conversation_ids`
+   keyed by (mark_type, limit), invalidated by `set_mark`/`clear_mark` under a
+   `threading.Lock` (service is now called from pool threads).
+3. Study (`Event_Handlers/Study_Events/study_events.py`): justify-no-change — the
+   audited handlers are dead code at HEAD (`STUDY_BUTTON_HANDLERS` /
+   `study_event_handler` referenced nowhere outside the module; flashcard actions
+   moved to `UI/Study_Modules/flashcards_handler.py` via the scope service).
+   Study dashboard fallback queries (`UI/Screens/study_screen.py:
+   _refresh_dashboard_snapshot` ~1088/1104/1123, direct sync `db.*` calls on
+   resume): wrap in `asyncio.to_thread` with the `is_memory_db` guard.
+4. Emoji picker (`Widgets/emoji_picker.py:1037/:1053`): hand `save_recent_emoji`
+   (load+rewrite of recents JSON per selection) to an app-owned thread worker
+   (`self.app.run_worker(..., thread=True, exit_on_error=False)`) — app-owned so
+   the immediately-following `dismiss()` cannot cancel it.
+5. TTS export (`Event_Handlers/TTS_Events/tts_events.py:handle_tts_export`
+   ~2531): move mkdir + `shutil.copy2` + metadata `json.dump` into one
+   `asyncio.to_thread` closure inside the existing try/except.
+6. Collections keyword delete (`Event_Handlers/collections_tag_events.py:
+   handle_keyword_delete`): dedupe 2×N SELECTs into one threaded batch lookup
+   reused for both the notification names and the delete loop. Discovered while
+   here: `app.run_in_thread` does not exist (Textual 8.2.8 App has no such
+   method; nothing in the repo defines it), so every "threaded" call in this
+   file raised AttributeError — rename/merge/delete were all broken. Replace all
+   `app.run_in_thread` uses in this file with `asyncio.to_thread` (behavior
+   repair, documented in notes).
+7. Save image (`Widgets/Chat_Widgets/chat_message_enhanced.py:handle_save_image`
+   ~635 — the audit's cite; `Widgets/chat_message_enhanced.py` is now an alias
+   shim): `await asyncio.to_thread(...)` for the multi-MB `write_bytes`, copying
+   the already-threaded Console pattern (`UI/Console_Modules/message.py:1645`).
+8. File picker search (`Widgets/enhanced_file_picker.py`): (a) debounce — add a
+   0.2 s debounced `_watch_search_filter` on `SearchableDirectoryNavigation`
+   (same interval as the rail-search debounce reference, task-15454);
+   (b) dedupe — merge `_repopulate_display`'s second full-directory
+   `is_file`/`is_hidden` pass (the `filter_hidden` count, ~724) into the main
+   entry loop so each entry is stat-ed once, not twice, per repopulate.
+9. CodeRepoCopyPaste (`UI/CodeRepoCopyPasteWindow.py:716/:901`): thread the
+   local-file preview read and the compile-selected read loop via
+   `asyncio.to_thread`.
+10. ChatbookExportManagement (`UI/ChatbookExportManagementWindow.py:
+    refresh_chatbook_list` ~489 glob+stat scan; `_load_chatbook_details` ~966
+    zip-manifest preview per selection): thread both via `asyncio.to_thread`;
+    remove the two now-stale BASELINE entries in
+    `Tests/Architecture/test_no_blocking_io_on_message_pump.py` (its
+    stale-entry test goes red on the fix and green on the baseline update —
+    born-red evidence).
+
+Evidence plan (AC3): direct timing harnesses under scratch HOME/XDG/
+TLDW_CONFIG_PATH with PYTHONPATH pinned to this worktree — (a) star toggle:
+time the on-loop portion before (service read+write, file-backed scratch DB)
+vs after (guards + worker spawn); (b) picker typing: 1000-file scratch dir,
+count `is_file` calls and time `_repopulate_display` per keystroke before vs
+after, plus debounce coalescing. Targeted tests for every touched surface;
+failures baselined against origin/dev before attribution.
+
+## Implementation Notes
+
+All nine audit sites re-located at HEAD `c3ed2854a` and handled with the
+smallest per-site diff; every claim below names its measurement or command.
+
+**Per-site outcome**
+
+1. **Star toggle — THREADED + DEDUPED.**
+   `workspace.py:_toggle_console_conversation_star` keeps its sync guards and
+   dispatches a `run_worker` async wrapper that runs the `is_starred` +
+   `star/unstar` pair via `asyncio.to_thread` (with the `is_memory_db` guard
+   copied from `chat_screen.py`'s task-15455 browser-search threading), then
+   toasts + re-syncs. A new controller-level `asyncio.Lock` serializes
+   presses so a rapid double-click still nets toggle-twice deterministically.
+   The browser-refresh read (`_starred_console_conversation_ids`, ~7 call
+   paths) is deduped at the source: `ConversationLocalMarksService.
+   list_marked_conversation_ids` now caches per (mark_type, limit) under a
+   `threading.Lock`, invalidated by `set_mark`/`clear_mark` — every star
+   writer in the process goes through this instance.
+2. **Study — JUSTIFIED (dead code) + fallbacks THREADED.** The audited
+   handlers in `Event_Handlers/Study_Events/study_events.py` are unreachable
+   at HEAD: `grep -rn "STUDY_BUTTON_HANDLERS\|study_event_handler"` finds no
+   reference outside the module; flashcard actions moved to
+   `UI/Study_Modules/flashcards_handler.py` via the scope service. (Aside:
+   the `#add-topic-btn` in `StructuredLearningWidget` currently has NO
+   handler at all — a pre-existing functional gap, out of this task's
+   scope.) The Study dashboard's three sync fallback queries in
+   `study_screen.py:_refresh_dashboard_snapshot` (`get_due_flashcards`,
+   `list_decks`, `list_quizzes` on resume) now run via `asyncio.to_thread`
+   with the `is_memory_db` guard.
+3. **Emoji picker — THREADED.** `save_recent_emoji` (read+rewrite of the
+   recents JSON per selection) is handed to an app-owned
+   `run_worker(thread=True, exit_on_error=False)` — app-owned because the
+   picker dismisses immediately and a screen-owned worker would be cancelled
+   before running.
+4. **TTS export — THREADED.** `handle_tts_export`'s mkdir + `shutil.copy2`
+   + metadata `json.dump` moved into one `asyncio.to_thread` closure inside
+   the existing try/except; toasts unchanged.
+5. **Collections keyword delete — DEDUPED + THREADED (+ behavior repair,
+   disclosed).** The 2×N per-id SELECTs collapsed to one threaded batch
+   lookup reused by both the notification and the delete loop. Discovered
+   while here: `app.run_in_thread` does not exist — Textual 8.2.8's `App`
+   has no such method (`hasattr(App, "run_in_thread") == False`) and nothing
+   in the repo defines it — so every "threaded" call in this file raised
+   `AttributeError` into its own error toast (rename/merge/delete were all
+   broken). All four call sites replaced with a small `_media_db_off_loop`
+   helper (`asyncio.to_thread` + `is_memory_db` guard;
+   `Client_Media_DB_v2` uses thread-local connections). This repairs the
+   handlers — a deliberate, disclosed behavior fix, pinned by the new tests.
+   **Follow-up flagged:** `Event_Handlers/multi_item_review_events.py` has
+   the same nonexistent `app.run_in_thread` at 4 sites — NOT fixed here
+   (uncited by the audit).
+6. **Save image — THREADED.** `Widgets/Chat_Widgets/chat_message_enhanced.py:
+   handle_save_image` (the audit's cite now lives here; the old path is an
+   alias shim) awaits `asyncio.to_thread(write_bytes)` with the bytes
+   snapshotted first — copying the already-threaded Console pattern
+   (`UI/Console_Modules/message.py:_save_console_message_image`).
+7. **File picker search — DEBOUNCED + DEDUPED.**
+   `SearchableDirectoryNavigation` gains a 0.2 s debounced
+   `_watch_search_filter` (same interval as the rail-search reference,
+   task-15454; widget-owned timer). `_repopulate_display`'s second
+   full-directory pass (the task-431 `filter_hidden` count) merged into the
+   main loop: `is_file` now runs at most once per entry, and not at all
+   when no `file_filter` is set (it previously ran unconditionally, first
+   in the `and` chain). Predicates are the vendored `hide()` unrolled;
+   the visible set and both posted counts are unchanged (pinned by the
+   pre-existing `test_filter_hidden_count` plus the new debounce test).
+8. **CodeRepoCopyPaste — THREADED.** The per-click local-file preview read
+   (`:716`) and the compile-selected read loop (`:901`) both moved into
+   `asyncio.to_thread` closures; per-file error handling preserved.
+9. **ChatbookExportManagement — THREADED.** `refresh_chatbook_list`'s
+   glob+stat scan extracted to `_scan_chatbook_files` run via
+   `asyncio.to_thread` (list identity kept via clear+extend), and
+   `_load_chatbook_details`' per-selection zip-manifest `preview_chatbook`
+   threaded the same way. The two now-stale BASELINE entries in
+   `Tests/Architecture/test_no_blocking_io_on_message_pump.py` were removed
+   — its stale-entry test went red on the code fix alone (born-red
+   evidence) and the suite is 6/6 green after the baseline update.
+
+**AC3 latency evidence** (direct timing harnesses, scratch
+HOME/XDG/TLDW_CONFIG_PATH, `tldw_chatbook.__file__` asserted to this
+worktree; scripts `probe_star_toggle.py` / `probe_star_after.py` /
+`probe_picker_search.py` in the session scratchpad):
+
+- *Star toggle*, file-backed scratch chachanotes DB, n=60: on-loop work
+  BEFORE (is_starred + star/unstar write) median **0.063 ms** (max 0.089);
+  AFTER the on-loop portion is the worker dispatch, median **0.0025 ms**,
+  with the durable write off-loop (end-to-end median 0.218 ms). The before
+  median is small on this dev box with an empty DB — the tail hazard the
+  threading removes is the sqlite `busy_timeout` block when another writer
+  holds the file, which a quiet-machine median cannot show. Browser-refresh
+  starred-ids read: **0.031 ms**/SELECT before → **0.0002 ms** cache hit
+  after.
+- *File-picker typing*, 1000-file scratch directory, mounted
+  `SearchableDirectoryNavigation` under a Pilot: BEFORE, every keystroke ran
+  one full repopulate at **121.1 ms median** on the loop (5-keystroke burst
+  = 5 repopulates ≈ 605 ms blocked); `is_file` stat calls per repopulate:
+  **1000**. AFTER, the same 5-keystroke burst = **1** repopulate (0.2 s
+  after typing pauses) and **0** `is_file` calls with no filter set (N, not
+  2N, with one). Single-repopulate wall time is unchanged (~134 ms,
+  dominated by the option-list rebuild itself — a separate lever, not this
+  task's).
+
+**Tests** (all via the repo venv with PYTHONPATH pinned to this worktree):
+Architecture no-blocking-io guard 6/6; picker suites
+(`Tests/test_enhanced_filepicker.py` + 4 UI files) 46 passed + new
+`test_search_keystrokes_debounce_into_one_filtered_repopulation`
+(mutation-verified born-red: inline-rebuild mutation fails it); marks
+service 10 passed + new
+`test_list_marked_ids_cache_never_serves_stale_results_across_writes`
+(mutation-verified: removing `clear_mark`'s invalidation fails it); new
+`Tests/Event_Handlers/test_collections_tag_events.py` 2 passed (both red
+under a `run_in_thread` restoration AND the delete test red under a
+duplicated-lookup mutation); Console button routing 22 passed and full
+workspace-context-rail 96 passed — the three star tests now wait on
+`workers.wait_for_complete()` (the write moved to a worker; assertions were
+racing the pool thread), stable across 3 repeat runs; code-repo window +
+integration, chatbook management (9), TTS improvements + study
+product-maturity suites (45), chat-message widget + artifact actions +
+state ownership (155 with full rail), focus-contract + speak-autoplay (115).
+
+**Failures attributed to dev, not this change** (each reproduced byte-for-
+byte on a pristine `c3ed2854a` throwaway worktree, then the worktree
+removed): `Tests/Chat/test_conversation_local_marks_service.py::
+test_local_marks_migrate_from_v16_to_v17_with_expected_schema`
+(v35→v36 migration: "table note_folders already exists") and
+`Tests/UI/test_product_maturity_phase3_knowledge_entry.py::
+test_study_screen_consumes_pending_initial_section` (network-egress
+teardown guard: `socket.connect -> 104.18.x.x:443`). Neither is on
+task-15766's list yet — candidates for that batch.
+
+**Modified files:** `tldw_chatbook/Chat/conversation_local_marks_service.py`,
+`UI/Console_Modules/workspace.py`, `UI/Screens/study_screen.py`,
+`Widgets/emoji_picker.py`, `Event_Handlers/TTS_Events/tts_events.py`,
+`Event_Handlers/collections_tag_events.py`,
+`Widgets/Chat_Widgets/chat_message_enhanced.py`,
+`Widgets/enhanced_file_picker.py`, `UI/CodeRepoCopyPasteWindow.py`,
+`UI/ChatbookExportManagementWindow.py`; tests:
+`Tests/Architecture/test_no_blocking_io_on_message_pump.py` (baseline),
+`Tests/Chat/test_conversation_local_marks_service.py`,
+`Tests/UI/test_enhanced_file_dialog_mount.py`,
+`Tests/UI/test_console_button_routing.py`,
+`Tests/UI/test_console_workspace_context_rail.py`,
+`Tests/Event_Handlers/test_collections_tag_events.py` (new).
+Ruff: `check` clean on every touched file except 4 pre-existing findings in
+untouched regions (verified present at base); `format --check` clean on all
+files that were clean at base (workspace.py and enhanced_file_picker.py were
+format-dirty at base outside my hunks and were not reformatted).

--- a/tldw_chatbook/Chat/conversation_local_marks_service.py
+++ b/tldw_chatbook/Chat/conversation_local_marks_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -51,6 +52,21 @@ class ConversationLocalMarksService:
                 context manager.
         """
         self.db = db
+        # task-15471: Console's conversation-browser refresh calls
+        # `list_marked_conversation_ids` on the event loop from every
+        # repaint path, so the answer is cached and only invalidated by
+        # this service's own writers (`set_mark`/`clear_mark` -- every star
+        # and fleet mark in the process goes through this instance). Guarded
+        # by a `threading.Lock`, not just loop discipline: the star toggle
+        # now writes from a pool thread via `asyncio.to_thread`.
+        self._list_cache: dict[tuple[str, int], tuple[str, ...]] = {}
+        self._list_cache_lock = threading.Lock()
+
+    def _invalidate_list_cache(self, mark_type: str) -> None:
+        """Drop cached id lists for one mark type after a write."""
+        with self._list_cache_lock:
+            for key in [k for k in self._list_cache if k[0] == mark_type]:
+                del self._list_cache[key]
 
     @staticmethod
     def _now() -> str:
@@ -134,6 +150,7 @@ class ConversationLocalMarksService:
                 """,
                 (conversation_id, mark_type, now, now),
             )
+        self._invalidate_list_cache(mark_type)
 
     def clear_mark(self, conversation_id: str, mark_type: str | None = None) -> None:
         """Remove a local conversation mark if present.
@@ -156,6 +173,7 @@ class ConversationLocalMarksService:
                 """,
                 (conversation_id, mark_type),
             )
+        self._invalidate_list_cache(mark_type)
 
     def has_mark(self, conversation_id: str, mark_type: str | None = None) -> bool:
         """Return whether a local mark exists for a conversation.
@@ -251,6 +269,11 @@ class ConversationLocalMarksService:
         safe_limit = int(limit)
         if safe_limit <= 0:
             raise ValueError("limit must be positive")
+        cache_key = (mark_type, safe_limit)
+        with self._list_cache_lock:
+            cached = self._list_cache.get(cache_key)
+        if cached is not None:
+            return cached
         with self.db.transaction() as conn:
             rows = conn.execute(
                 """
@@ -262,4 +285,7 @@ class ConversationLocalMarksService:
                 """,
                 (mark_type, safe_limit),
             ).fetchall()
-        return tuple(str(row["conversation_id"]) for row in rows)
+        result = tuple(str(row["conversation_id"]) for row in rows)
+        with self._list_cache_lock:
+            self._list_cache[cache_key] = result
+        return result

--- a/tldw_chatbook/Chat/conversation_local_marks_service.py
+++ b/tldw_chatbook/Chat/conversation_local_marks_service.py
@@ -59,12 +59,24 @@ class ConversationLocalMarksService:
         # and fleet mark in the process goes through this instance). Guarded
         # by a `threading.Lock`, not just loop discipline: the star toggle
         # now writes from a pool thread via `asyncio.to_thread`.
+        #
+        # The generation counter closes the populate-after-invalidate race
+        # (task-15471 review M1): a cache-missing reader holds its fetched
+        # rows across the transaction COMMIT -- a GIL-releasing sqlite call
+        # -- before storing them. A writer that commits and invalidates
+        # inside that window bumps the generation, so the reader detects
+        # its snapshot is outdated and skips the store instead of
+        # resurrecting pre-write rows into the cache. Global, not
+        # per-mark-type, on purpose: the cost of a false bump is one
+        # skipped store, and a single counter is obviously correct.
         self._list_cache: dict[tuple[str, int], tuple[str, ...]] = {}
         self._list_cache_lock = threading.Lock()
+        self._list_cache_generation = 0
 
     def _invalidate_list_cache(self, mark_type: str) -> None:
         """Drop cached id lists for one mark type after a write."""
         with self._list_cache_lock:
+            self._list_cache_generation += 1
             for key in [k for k in self._list_cache if k[0] == mark_type]:
                 del self._list_cache[key]
 
@@ -272,6 +284,7 @@ class ConversationLocalMarksService:
         cache_key = (mark_type, safe_limit)
         with self._list_cache_lock:
             cached = self._list_cache.get(cache_key)
+            generation = self._list_cache_generation
         if cached is not None:
             return cached
         with self.db.transaction() as conn:
@@ -287,5 +300,10 @@ class ConversationLocalMarksService:
             ).fetchall()
         result = tuple(str(row["conversation_id"]) for row in rows)
         with self._list_cache_lock:
-            self._list_cache[cache_key] = result
+            if self._list_cache_generation == generation:
+                # No writer invalidated while this read was in flight, so
+                # the snapshot is current and safe to cache. Otherwise the
+                # rows may predate a committed write -- return them (they
+                # were true when read) but never store them.
+                self._list_cache[cache_key] = result
         return result

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -65,6 +65,9 @@ _TTS_ARTIFACT_WRITE_BATCH_BYTES = 64 * 1024
 _TTS_IO_CANCELLATION_JOIN_TIMEOUT_SECONDS = 1.0
 _TTS_SECURE_DELETE_TIMEOUT_SECONDS = 1.0
 _TTS_RETAINED_WORK_DRAIN_TIMEOUT_SECONDS = 1.0
+# task-15471 fix round (review M2): how often a deferred cleanup re-checks
+# whether an in-flight export still holds its claim on the source file.
+_TTS_EXPORT_CLEANUP_RETRY_SECONDS = 0.25
 _GLOBAL_OVERRIDE_TOKEN_PATTERN = re.compile(r"[0-9a-f]{32}\Z")
 # F4 fix-round: hard cap, in bytes, on the in-memory WAV body the
 # opportunistic sink-upgrade attempt (see `wav_collect` in `_generate_tts`)
@@ -447,6 +450,15 @@ class TTSEventHandler:
         # are the whole point).
         self._legacy_handoff_stop_events: set[threading.Event] = set()
         self._audio_files_lock = asyncio.Lock()  # Lock for audio files dictionary
+        # task-15471 fix round (review M2): message_ids whose cached audio an
+        # export is currently copying, refcounted so overlapping exports of
+        # the same message keep the claim until the LAST one finishes.
+        # `_cleanup_audio_file` waits on this claim instead of secure-deleting
+        # -- the delete overwrites the source IN PLACE with zeros
+        # (`Utils/secure_temp_files.py`) before unlinking, so a delete
+        # overlapping the threaded copy would silently export zeros. Guarded
+        # by `_audio_files_lock` (same bookkeeping domain).
+        self._exporting_audio_refcounts: Dict[str, int] = {}
         self._active_tasks: set[asyncio.Task] = set()  # Track active async tasks
         self._active_tasks_lock = asyncio.Lock()  # Lock for active tasks set
         self._last_cooldown_cleanup = 0.0  # Track last cleanup time
@@ -2533,16 +2545,29 @@ class TTSEventHandler:
         import shutil
         import json
 
-        # Get audio file
+        # Get audio file, claiming it against cleanup in the same lock hold
+        # (task-15471 fix round, review M2): `_cleanup_audio_file`'s secure
+        # delete zeroes the source IN PLACE before unlinking, and the copy
+        # below now runs on a pool thread the loop no longer excludes -- an
+        # unclaimed overlap would export zeros under a success toast.
         async with self._audio_files_lock:
             source_file = self._audio_files.get(event.message_id)
+            if source_file is not None:
+                self._exporting_audio_refcounts[event.message_id] = (
+                    self._exporting_audio_refcounts.get(event.message_id, 0) + 1
+                )
 
-        if not source_file or not source_file.exists():
+        if not source_file:
             logger.error(f"No audio file found for message {event.message_id}")
             self.notify("No audio file found to export", severity="error")
             return
 
         try:
+            if not source_file.exists():
+                logger.error(f"No audio file found for message {event.message_id}")
+                self.notify("No audio file found to export", severity="error")
+                return
+
             # Validate output path
             output_path = event.output_path
             if not output_path.suffix:
@@ -2587,14 +2612,31 @@ class TTSEventHandler:
         except Exception as e:
             logger.error(f"Failed to export audio: {e}")
             self.notify(f"Failed to export audio: {str(e)}", severity="error")
+        finally:
+            # Release the claim; a cleanup that arrived mid-copy is polling
+            # for this and proceeds on its next check.
+            async with self._audio_files_lock:
+                remaining = self._exporting_audio_refcounts.get(event.message_id, 0) - 1
+                if remaining <= 0:
+                    self._exporting_audio_refcounts.pop(event.message_id, None)
+                else:
+                    self._exporting_audio_refcounts[event.message_id] = remaining
 
     async def _cleanup_audio_file(self, message_id: str, delay: float = 0) -> None:
         """Clean up audio file after playback"""
         if delay > 0:
             await asyncio.sleep(delay)
 
-        async with self._audio_files_lock:
-            audio_file = self._audio_files.get(message_id)
+        # task-15471 fix round (review M2): never destroy a source an export
+        # is still copying -- the secure delete zeroes it in place, and the
+        # overlapping copy would silently write zeros. Wait for the claim to
+        # clear (bounded in practice by one copy's duration), then delete.
+        while True:
+            async with self._audio_files_lock:
+                if message_id not in self._exporting_audio_refcounts:
+                    audio_file = self._audio_files.get(message_id)
+                    break
+            await asyncio.sleep(_TTS_EXPORT_CLEANUP_RETRY_SECONDS)
         if audio_file is None:
             return
 

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -2549,28 +2549,38 @@ class TTSEventHandler:
                 # Add extension from source file
                 output_path = output_path.with_suffix(source_file.suffix)
 
-            # Create parent directory if needed
-            output_path.parent.mkdir(parents=True, exist_ok=True)
+            def _write_export() -> None:
+                """Copy the audio + optional metadata sidecar to disk.
 
-            # Copy audio file
-            shutil.copy2(source_file, output_path)
-            logger.info(f"Exported audio to {output_path}")
+                task-15471: the `copy2` moves megabytes of audio and used
+                to run directly in this handler, on the event loop.
+                """
+                # Create parent directory if needed
+                output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Add metadata if requested
-            if event.include_metadata:
-                metadata = {
-                    "message_id": event.message_id,
-                    "export_time": datetime.now().isoformat(),
-                    "format": source_file.suffix[1:],  # Remove dot
-                    "source": "tldw_chatbook_tts",
-                }
+                # Copy audio file
+                shutil.copy2(source_file, output_path)
+                logger.info(f"Exported audio to {output_path}")
 
-                # Save metadata as JSON sidecar file
-                metadata_path = output_path.with_suffix(output_path.suffix + ".json")
-                with open(metadata_path, "w") as f:
-                    json.dump(metadata, f, indent=2)
+                # Add metadata if requested
+                if event.include_metadata:
+                    metadata = {
+                        "message_id": event.message_id,
+                        "export_time": datetime.now().isoformat(),
+                        "format": source_file.suffix[1:],  # Remove dot
+                        "source": "tldw_chatbook_tts",
+                    }
 
-                logger.info(f"Saved metadata to {metadata_path}")
+                    # Save metadata as JSON sidecar file
+                    metadata_path = output_path.with_suffix(
+                        output_path.suffix + ".json"
+                    )
+                    with open(metadata_path, "w") as f:
+                        json.dump(metadata, f, indent=2)
+
+                    logger.info(f"Saved metadata to {metadata_path}")
+
+            await asyncio.to_thread(_write_export)
 
             self.notify(f"Audio exported to {output_path.name}", severity="success")
 

--- a/tldw_chatbook/Event_Handlers/collections_tag_events.py
+++ b/tldw_chatbook/Event_Handlers/collections_tag_events.py
@@ -4,12 +4,30 @@ Event handlers for the Collections/Tag management functionality.
 Handles keyword operations like rename, merge, delete, and statistics.
 """
 
-from typing import TYPE_CHECKING, List, Dict, Any
+import asyncio
+from typing import TYPE_CHECKING, Callable, List, Dict, Any
 from textual.message import Message
 from loguru import logger
 
 if TYPE_CHECKING:
     from ..app import TldwCli
+
+
+async def _media_db_off_loop(app: "TldwCli", func: Callable, /, *args: Any) -> Any:
+    """Run one sync media-DB call off the event loop.
+
+    task-15471: this file's handlers called ``app.run_in_thread``, which
+    does not exist -- neither Textual 8.x's ``App`` nor ``TldwCli`` defines
+    it -- so every rename/merge/delete raised ``AttributeError`` into its
+    own error toast. Replaced with ``asyncio.to_thread`` (the DB uses
+    thread-local connections, so a pool thread opens its own), guarded the
+    same way as the Console browser-search threading: a per-connection
+    ``:memory:`` DB is only visible to the thread that migrated it and must
+    stay on the loop thread.
+    """
+    if bool(getattr(app.media_db, "is_memory_db", False)):
+        return func(*args)
+    return await asyncio.to_thread(func, *args)
 
 
 class KeywordRenameEvent(Message):
@@ -59,8 +77,8 @@ async def handle_keyword_rename(app: "TldwCli", event: KeywordRenameEvent) -> No
             raise RuntimeError("Media DB service not available")
 
         # Perform the rename operation
-        success = await app.run_in_thread(
-            app.media_db.rename_keyword, event.keyword_id, event.new_name
+        success = await _media_db_off_loop(
+            app, app.media_db.rename_keyword, event.keyword_id, event.new_name
         )
 
         if success:
@@ -105,7 +123,8 @@ async def handle_keyword_merge(app: "TldwCli", event: KeywordMergeEvent) -> None
             raise RuntimeError("Media DB service not available")
 
         # Perform the merge operation
-        success = await app.run_in_thread(
+        success = await _media_db_off_loop(
+            app,
             app.media_db.merge_keywords,
             event.source_keyword_ids,
             event.target_keyword,
@@ -154,37 +173,40 @@ async def handle_keyword_delete(app: "TldwCli", event: KeywordDeleteEvent) -> No
         if not app.media_db:
             raise RuntimeError("Media DB service not available")
 
-        # Get keywords info for notification
-        keywords_info = []
-        for keyword_id in event.keyword_ids:
-            try:
-                # Get keyword name before deletion
-                cursor = app.media_db.execute_query(
-                    "SELECT keyword FROM Keywords WHERE id = ? AND deleted = 0",
-                    (keyword_id,),
-                )
-                result = cursor.fetchone()
-                if result:
-                    keywords_info.append(result["keyword"])
-            except Exception:
-                pass
+        # Resolve keyword names ONCE, off the loop -- this lookup used to run
+        # twice per keyword (once for the notification, once again before the
+        # delete), synchronously on the event loop (task-15471). The single
+        # batch serves both the notification and the delete below.
+        def _fetch_keyword_names() -> Dict[int, str]:
+            names: Dict[int, str] = {}
+            for keyword_id in event.keyword_ids:
+                try:
+                    cursor = app.media_db.execute_query(
+                        "SELECT keyword FROM Keywords WHERE id = ? AND deleted = 0",
+                        (keyword_id,),
+                    )
+                    result = cursor.fetchone()
+                    if result:
+                        names[keyword_id] = result["keyword"]
+                except Exception:
+                    pass
+            return names
+
+        keyword_names = await _media_db_off_loop(app, _fetch_keyword_names)
+        keywords_info = list(keyword_names.values())
 
         # Perform the delete operations
         success_count = 0
         for keyword_id in event.keyword_ids:
+            keyword = keyword_names.get(keyword_id)
+            if keyword is None:
+                continue
             try:
-                # Get keyword name for soft_delete_keyword method
-                cursor = app.media_db.execute_query(
-                    "SELECT keyword FROM Keywords WHERE id = ? AND deleted = 0",
-                    (keyword_id,),
+                success = await _media_db_off_loop(
+                    app, app.media_db.soft_delete_keyword, keyword
                 )
-                result = cursor.fetchone()
-                if result:
-                    success = await app.run_in_thread(
-                        app.media_db.soft_delete_keyword, result["keyword"]
-                    )
-                    if success:
-                        success_count += 1
+                if success:
+                    success_count += 1
             except Exception as e:
                 logger.error(f"Error deleting keyword ID {keyword_id}: {e}")
 
@@ -235,7 +257,7 @@ async def load_keyword_statistics(app: "TldwCli") -> List[Dict[str, Any]]:
             return []
 
         # Get keyword statistics
-        stats = await app.run_in_thread(app.media_db.get_keyword_usage_stats)
+        stats = await _media_db_off_loop(app, app.media_db.get_keyword_usage_stats)
         logger.debug(f"Loaded statistics for {len(stats)} keywords")
         return stats
 

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -517,14 +517,16 @@ class ChatbookExportManagementWindow(ModalScreen):
 
     async def refresh_chatbook_list(self) -> None:
         """Refresh the list of chatbooks."""
-        self.chatbook_files.clear()
-
         try:
-            # Find all chatbook files, off the loop. `clear()` + `extend`
-            # (not reassignment) keeps the list identity other readers hold.
-            self.chatbook_files.extend(
-                await asyncio.to_thread(self._scan_chatbook_files)
-            )
+            # Find all chatbook files, off the loop. The clear happens
+            # AFTER the scan returns (review minor 6): clearing before the
+            # await left `chatbook_files` empty-but-listed if the scan
+            # raised, and a later selection would IndexError. `clear()` +
+            # `extend` (not reassignment) keeps the list identity other
+            # readers hold.
+            scanned = await asyncio.to_thread(self._scan_chatbook_files)
+            self.chatbook_files.clear()
+            self.chatbook_files.extend(scanned)
 
             # Update the list widget
             option_list = self.query_one("#chatbook-list", OptionList)

--- a/tldw_chatbook/UI/ChatbookExportManagementWindow.py
+++ b/tldw_chatbook/UI/ChatbookExportManagementWindow.py
@@ -12,6 +12,7 @@ Provides interface for:
 - Sharing chatbooks
 """
 
+import asyncio
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, List, Dict, Any, TYPE_CHECKING
@@ -486,30 +487,44 @@ class ChatbookExportManagementWindow(ModalScreen):
         await self.refresh_chatbook_list()
         await self.refresh_server_job_list()
 
+    def _scan_chatbook_files(self) -> List[Dict[str, Any]]:
+        """Glob + stat the export directory. Runs on a pool thread.
+
+        task-15471: the scan ran synchronously in `refresh_chatbook_list`
+        -- a directory walk on the event loop per refresh press (and after
+        every delete/export). Filesystem-only; no widget access.
+        """
+        scanned: List[Dict[str, Any]] = []
+        if self.chatbooks_dir.exists():
+            for file_path in self.chatbooks_dir.glob("*.zip"):
+                try:
+                    stat = file_path.stat()
+                    scanned.append(
+                        {
+                            "name": file_path.stem,
+                            "path": file_path,
+                            "size": stat.st_size,
+                            "modified": datetime.fromtimestamp(stat.st_mtime),
+                            "created": datetime.fromtimestamp(stat.st_ctime),
+                        }
+                    )
+                except Exception as e:
+                    logger.error(f"Error reading file {file_path}: {e}")
+
+        # Sort by modification time (newest first)
+        scanned.sort(key=lambda x: x["modified"], reverse=True)
+        return scanned
+
     async def refresh_chatbook_list(self) -> None:
         """Refresh the list of chatbooks."""
         self.chatbook_files.clear()
 
         try:
-            # Find all chatbook files
-            if self.chatbooks_dir.exists():
-                for file_path in self.chatbooks_dir.glob("*.zip"):
-                    try:
-                        stat = file_path.stat()
-                        self.chatbook_files.append(
-                            {
-                                "name": file_path.stem,
-                                "path": file_path,
-                                "size": stat.st_size,
-                                "modified": datetime.fromtimestamp(stat.st_mtime),
-                                "created": datetime.fromtimestamp(stat.st_ctime),
-                            }
-                        )
-                    except Exception as e:
-                        logger.error(f"Error reading file {file_path}: {e}")
-
-            # Sort by modification time (newest first)
-            self.chatbook_files.sort(key=lambda x: x["modified"], reverse=True)
+            # Find all chatbook files, off the loop. `clear()` + `extend`
+            # (not reassignment) keeps the list identity other readers hold.
+            self.chatbook_files.extend(
+                await asyncio.to_thread(self._scan_chatbook_files)
+            )
 
             # Update the list widget
             option_list = self.query_one("#chatbook-list", OptionList)
@@ -959,11 +974,19 @@ class ChatbookExportManagementWindow(ModalScreen):
 
         # Try to load manifest
         try:
-            # Create importer to preview
-            db_paths = get_chatbook_database_paths()
 
-            importer = ChatbookImporter(db_paths)
-            manifest, error = importer.preview_chatbook(chatbook["path"])
+            def _preview_manifest() -> tuple:
+                """Open the archive and parse its manifest, off the loop.
+
+                task-15471: this runs per list-selection click and reads
+                inside the zip -- the exact per-click archive-read shape
+                TASK-1320 measured at 1030ms on the mount path.
+                """
+                db_paths = get_chatbook_database_paths()
+                importer = ChatbookImporter(db_paths)
+                return importer.preview_chatbook(chatbook["path"])
+
+            manifest, error = await asyncio.to_thread(_preview_manifest)
 
             if manifest and not error:
                 self.current_manifest = manifest

--- a/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
+++ b/tldw_chatbook/UI/CodeRepoCopyPasteWindow.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 from typing import Optional, List, Dict, TYPE_CHECKING
+import asyncio
 import json
 import zipfile
 import os
@@ -711,10 +712,15 @@ class CodeRepoCopyPasteWindow(ModalScreen):
 
         try:
             if self.is_local_repo:
-                # Load from local file
+                # Load from local file, off the loop (task-15471): this runs
+                # per tree-node click and the file can be arbitrarily large.
                 full_path = Path(self.current_repo["path"]) / path
-                with open(full_path, "r", encoding="utf-8") as f:
-                    content = f.read()
+
+                def _read_local_file() -> str:
+                    with open(full_path, "r", encoding="utf-8") as f:
+                        return f.read()
+
+                content = await asyncio.to_thread(_read_local_file)
             else:
                 # Load from GitHub
                 branch = self.query_one("#branch-selector", Select).value
@@ -894,19 +900,29 @@ class CodeRepoCopyPasteWindow(ModalScreen):
             contents = []
 
             if self.is_local_repo:
-                # Load from local files
-                for file_path in selected_files:
-                    try:
-                        full_path = Path(self.current_repo["path"]) / file_path
-                        with open(full_path, "r", encoding="utf-8") as f:
-                            content = f.read()
-                        # Format with file markers
-                        contents.append(f"```{file_path}\n{content}\n```")
-                    except Exception as e:
-                        logger.error(f"Failed to read file {file_path}: {e}")
-                        contents.append(
-                            f"```{file_path}\n# Error reading file: {e}\n```"
-                        )
+                # Load from local files, all off the loop in one hop
+                # (task-15471): this used to read every selected file
+                # synchronously, per compile click. Per-file error handling
+                # is unchanged inside the closure.
+                repo_root = Path(self.current_repo["path"])
+
+                def _read_selected_files() -> List[str]:
+                    file_blocks: List[str] = []
+                    for file_path in selected_files:
+                        try:
+                            full_path = repo_root / file_path
+                            with open(full_path, "r", encoding="utf-8") as f:
+                                content = f.read()
+                            # Format with file markers
+                            file_blocks.append(f"```{file_path}\n{content}\n```")
+                        except Exception as e:
+                            logger.error(f"Failed to read file {file_path}: {e}")
+                            file_blocks.append(
+                                f"```{file_path}\n# Error reading file: {e}\n```"
+                            )
+                    return file_blocks
+
+                contents = await asyncio.to_thread(_read_selected_files)
             else:
                 # Load from GitHub
                 branch = self.query_one("#branch-selector", Select).value

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -348,6 +348,11 @@ class ConsoleWorkspaceController:
         self._console_workspace_conversation_search_total: int | None = None
         self._console_workspace_conversation_search_error = ""
         self._console_workspace_conversation_workspace_id: str | None = None
+        # task-15471: serializes star toggles now that the durable write
+        # runs off the loop -- two rapid presses must queue (each resolving
+        # current truth before toggling), never race two pool threads into
+        # a stale double-star.
+        self._console_star_toggle_lock = asyncio.Lock()
 
     # -- Framework services (kind 1: live-read via `@property`) ------------
 
@@ -2011,31 +2016,86 @@ class ConsoleWorkspaceController:
                 severity="warning",
             )
             return
-        star_action = "resolve"
-        try:
-            is_starred = getattr(marks_service, "is_starred", None)
-            currently_starred = (
-                bool(is_starred(conversation_id))
-                if callable(is_starred)
-                else bool(starred)
-            )
-            star_action = "unstar" if currently_starred else "star"
-            if currently_starred:
-                marks_service.unstar_conversation(conversation_id)
-            else:
-                marks_service.star_conversation(conversation_id)
-        except Exception:
-            logger.exception(
-                "Unable to update local conversation star "
-                "conversation_id={} action={}",
+        # task-15471: the resolve+toggle pair used to run right here, on the
+        # event loop -- a read transaction plus a durable write transaction
+        # per click, with the click frozen for the DB's whole busy_timeout
+        # if any other writer held the file. It now runs on a worker; the
+        # wrapper owns the failure/confirmation copy that followed it inline.
+        self.run_worker(
+            self._toggle_console_conversation_star_off_loop(
+                marks_service,
                 conversation_id,
-                star_action,
-            )
-            self.app_instance.notify(
-                "Unable to update local star.",
-                severity="warning",
-            )
-            return
+                starred=starred,
+                conversation_title=conversation_title,
+            ),
+            group="console-conversation-star",
+            exit_on_error=False,
+        )
+
+    async def _toggle_console_conversation_star_off_loop(
+        self,
+        marks_service: Any,
+        conversation_id: str,
+        *,
+        starred: bool,
+        conversation_title: str,
+    ) -> None:
+        """Resolve current star truth, toggle it off the loop, and confirm.
+
+        The deferred body of `_toggle_console_conversation_star`
+        (task-15471). `_console_star_toggle_lock` serializes concurrent
+        presses so each one resolves current truth from the service before
+        toggling -- a rapid double-press still nets toggle-twice, exactly
+        the pre-worker semantics, never two pool threads racing the same
+        pre-state into a stale double-star.
+
+        Args:
+            marks_service: The app's `conversation_local_marks_service`,
+                captured non-None by the dispatching guard.
+            conversation_id: See `_toggle_console_conversation_star`.
+            starred: Fallback only, as before -- used when the service
+                cannot answer `is_starred`.
+            conversation_title: For the confirmation toast.
+        """
+        progress = {"action": "resolve"}
+        async with self._console_star_toggle_lock:
+            try:
+
+                def _resolve_and_toggle() -> str:
+                    is_starred = getattr(marks_service, "is_starred", None)
+                    currently_starred = (
+                        bool(is_starred(conversation_id))
+                        if callable(is_starred)
+                        else bool(starred)
+                    )
+                    action = "unstar" if currently_starred else "star"
+                    progress["action"] = action
+                    if currently_starred:
+                        marks_service.unstar_conversation(conversation_id)
+                    else:
+                        marks_service.star_conversation(conversation_id)
+                    return action
+
+                db = getattr(marks_service, "db", None)
+                if bool(getattr(db, "is_memory_db", False)):
+                    # A per-connection :memory: DB is only visible to the
+                    # thread that migrated it -- same guard as the browser
+                    # search threading (`chat_screen.py`, task-15455).
+                    star_action = _resolve_and_toggle()
+                else:
+                    star_action = await asyncio.to_thread(_resolve_and_toggle)
+            except Exception:
+                logger.exception(
+                    "Unable to update local conversation star "
+                    "conversation_id={} action={}",
+                    conversation_id,
+                    progress["action"],
+                )
+                self.app_instance.notify(
+                    "Unable to update local star.",
+                    severity="warning",
+                )
+                return
         # TASK-357: confirm the toggle so a star/unstar is not a silent state
         # change (the review saw an accidental star go unnoticed).
         # `"".splitlines()` is `[]`, so indexing [0] raised IndexError on an

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -2084,6 +2084,21 @@ class ConsoleWorkspaceController:
                     star_action = _resolve_and_toggle()
                 else:
                     star_action = await asyncio.to_thread(_resolve_and_toggle)
+            except asyncio.CancelledError:
+                # Fix round (review minor 3): cancellation cannot stop the
+                # pool thread, so the durable write may still land -- and
+                # `CancelledError` is a `BaseException` that would sail past
+                # the `except Exception` below, recreating exactly the
+                # TASK-357 silent-toggle shape (write landed, no repaint).
+                # Best-effort re-sync so the rail repaints from truth, then
+                # let the cancellation propagate.
+                try:
+                    self._sync_console_workspace_context()
+                except Exception:
+                    logger.opt(exception=True).debug(
+                        "Star-toggle cancellation re-sync failed"
+                    )
+                raise
             except Exception:
                 logger.exception(
                     "Unable to update local conversation star "

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -1075,6 +1075,19 @@ class StudyScreen(BaseAppScreen):
         quiz_service = getattr(self.app_instance, "study_quiz_scope_service", None)
         db = getattr(self.app_instance, "chachanotes_db", None)
 
+        async def _db_off_loop(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+            """Run one sync fallback DB query off the event loop.
+
+            task-15471: these fallbacks ran synchronously in this async
+            method -- three chachanotes queries on the loop per screen
+            resume. Same `is_memory_db` guard as the Console browser-search
+            threading: a per-connection :memory: DB is only visible to the
+            thread that migrated it, so it must stay on the loop thread.
+            """
+            if bool(getattr(db, "is_memory_db", False)):
+                return func(*args, **kwargs)
+            return await asyncio.to_thread(func, *args, **kwargs)
+
         due_count = 0
         try:
             due_loader = getattr(study_service, "get_due_flashcards", None)
@@ -1086,7 +1099,9 @@ class StudyScreen(BaseAppScreen):
                     self._normalize_records(due_records) or list(due_records or [])
                 )
             elif db is not None and hasattr(db, "get_due_flashcards"):
-                due_count = len(list(db.get_due_flashcards(limit=25) or []))
+                due_count = len(
+                    list(await _db_off_loop(db.get_due_flashcards, limit=25) or [])
+                )
         except Exception:
             logger.opt(exception=True).debug("Failed to load Study due counts")
 
@@ -1104,7 +1119,9 @@ class StudyScreen(BaseAppScreen):
             elif db is not None and hasattr(db, "list_decks"):
                 recent_decks = [
                     str(deck.get("name") or "Untitled deck")
-                    for deck in list(db.list_decks(limit=3, offset=0) or [])[:3]
+                    for deck in list(
+                        await _db_off_loop(db.list_decks, limit=3, offset=0) or []
+                    )[:3]
                 ]
         except Exception:
             logger.opt(exception=True).debug("Failed to load Study deck recents")
@@ -1121,7 +1138,8 @@ class StudyScreen(BaseAppScreen):
                     for quiz in self._normalize_records(quizzes)[:3]
                 ]
             elif db is not None and hasattr(db, "list_quizzes"):
-                quizzes = db.list_quizzes(
+                quizzes = await _db_off_loop(
+                    db.list_quizzes,
                     q=None,
                     workspace_id=self.scope_state.workspace_id,
                     limit=3,

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_message_enhanced.py
@@ -4,6 +4,7 @@
 # Imports
 #
 # Standard Library
+import asyncio
 import base64
 import logging
 from datetime import datetime
@@ -645,9 +646,15 @@ Preview: {preview}...
             )
             filename = f"chat_image_{timestamp}.{extension}"
 
-            # Save to user's downloads directory
+            # Save to user's downloads directory. Written off the loop
+            # (task-15471): this can be a multi-MB payload, and the Console
+            # equivalent (`UI/Console_Modules/message.py`,
+            # `_save_console_message_image`) already threads its write the
+            # same way. Snapshot the bytes first so a mid-write reactive
+            # update cannot race the pool thread's read.
+            image_data = self.image_data
             downloads_path = Path.home() / "Downloads" / filename
-            downloads_path.write_bytes(self.image_data)
+            await asyncio.to_thread(downloads_path.write_bytes, image_data)
 
             self.app.notify(f"Image saved to: {downloads_path}")
         except Exception as e:

--- a/tldw_chatbook/Widgets/emoji_picker.py
+++ b/tldw_chatbook/Widgets/emoji_picker.py
@@ -1040,6 +1040,13 @@ class EmojiPickerScreen(ModalScreen[str]):
         press handler. The worker is app-owned deliberately -- the picker
         dismisses immediately after, and a screen-owned worker would be
         cancelled before the write ran.
+
+        Ordering is deliberately unserialised last-write-wins (review
+        minor 5): two saves in flight can lose one entry, and a picker
+        reopened inside the write window can read pre-write recents. Both
+        need a human to race a microsecond-scale JSON write, and the file
+        is a cosmetic recents list whose writer already swallows every
+        error -- not worth a lock.
         """
         self.app.run_worker(
             partial(save_recent_emoji, emoji_char),

--- a/tldw_chatbook/Widgets/emoji_picker.py
+++ b/tldw_chatbook/Widgets/emoji_picker.py
@@ -1,6 +1,7 @@
 # emoji_picker.py
 #
 # Imports
+from functools import partial
 from typing import List, Dict, Tuple, Optional, Set, Any
 from pathlib import Path
 
@@ -1031,10 +1032,26 @@ class EmojiPickerScreen(ModalScreen[str]):
             else:  # Should not be reached, fallback to search input
                 self.query_one("#search-input", Input).focus()
 
+    def _save_recent_emoji_off_loop(self, emoji_char: str) -> None:
+        """Persist a recently-used emoji without blocking the event loop.
+
+        task-15471: `save_recent_emoji` re-reads and rewrites the recents
+        JSON file per selection, and used to do it synchronously in the
+        press handler. The worker is app-owned deliberately -- the picker
+        dismisses immediately after, and a screen-owned worker would be
+        cancelled before the write ran.
+        """
+        self.app.run_worker(
+            partial(save_recent_emoji, emoji_char),
+            group="emoji-recents-save",
+            thread=True,
+            exit_on_error=False,
+        )
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if isinstance(event.button, EmojiButton):
             emoji_char = event.button.emoji_data["char"]
-            save_recent_emoji(emoji_char)  # Save to recently used
+            self._save_recent_emoji_off_loop(emoji_char)  # Save to recently used
             self.dismiss(emoji_char)
         elif event.button.id == "cancel-button":
             self.action_dismiss_picker()  # Corrected: call the action method
@@ -1050,7 +1067,7 @@ class EmojiPickerScreen(ModalScreen[str]):
             recent_emojis = self._categorized_emojis["Recently Used"]
             if index < len(recent_emojis):
                 emoji_char = recent_emojis[index]["char"]
-                save_recent_emoji(emoji_char)
+                self._save_recent_emoji_off_loop(emoji_char)
                 self.dismiss(emoji_char)
 
     def action_select_recent_1(self) -> None:

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -581,10 +581,37 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
                 continue
             yield cls, method
 
+    #: Debounce interval for search keystrokes -- matches the Console rail
+    #: conversation-search debounce (task-15454's 0.2 s reference).
+    SEARCH_DEBOUNCE_SECONDS = 0.2
+
     def __init__(self, location: Path | str = ".") -> None:
         super().__init__(location)
         self._type_ahead_buffer = ""
         self._type_ahead_timer: Optional[Timer] = None
+        self._search_debounce_timer: Optional[Timer] = None
+
+    def _watch_search_filter(self) -> None:
+        """Debounce repopulation while the user is typing a search query.
+
+        task-15471: the vendored base watcher repopulated synchronously per
+        keystroke -- a full rebuild (one stat per entry plus the option-list
+        rebuild, ~120 ms measured on a 1000-file directory) on the event
+        loop for every character typed. A keystroke now only (re)arms one
+        widget-owned timer; the rebuild runs once, after typing pauses.
+        `_repopulate_display` reads `self.search_filter` at fire time, so a
+        superseded fragment is never applied.
+        """
+        if self._search_debounce_timer is not None:
+            self._search_debounce_timer.stop()
+        self._search_debounce_timer = self.set_timer(
+            self.SEARCH_DEBOUNCE_SECONDS, self._apply_search_filter_after_debounce
+        )
+
+    def _apply_search_filter_after_debounce(self) -> None:
+        """Debounce timer callback: run the deferred repopulation."""
+        self._search_debounce_timer = None
+        self._repopulate_display()
 
     def _restart_type_ahead_timer(self) -> None:
         """Reset the inactivity timeout that clears the type-ahead buffer."""
@@ -684,6 +711,40 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
         multi_select = getattr(screen, "multi_select", False)
         selected = getattr(screen, "_selected_paths", set()) if multi_select else set()
 
+        # One pass over the entries computes both the visible options and the
+        # filter-hidden count (task-15471). Previously a second full loop
+        # below re-ran ``is_file`` on EVERY entry -- one extra stat per entry
+        # per repopulate, unconditionally, even with no ``file_filter`` set
+        # (``is_file`` was first in that ``and`` chain). The per-entry
+        # predicates here are the vendored ``DirectoryNavigation.hide()``
+        # unrolled: filter check first (files only), then the dotfile/
+        # show-hidden rule, so the visible set is unchanged.
+        #
+        # The filter-hidden count (task-431 AC#2) still counts a real file
+        # that passes the show-hidden/dotfile check but fails the filter,
+        # guarded by an explicit "not already dotfile-hidden" check so
+        # dotfiles aren't double-counted as filter-hidden.
+        file_filter = self.file_filter
+        filter_hidden = 0
+        display_entries: list[DirectoryEntry] = []
+        for entry in self._entries:
+            location = entry.location
+            dot_hidden = self.is_hidden(location) and not self.show_hidden
+            fails_filter = False
+            if file_filter is not None and is_file(location):
+                fails_filter = not file_filter(location)
+                if fails_filter and not dot_hidden:
+                    filter_hidden += 1
+            if fails_filter or dot_hidden:
+                continue
+            if query and query not in location.name.lower():
+                continue
+            display_entries.append(
+                MultiSelectDirectoryEntry(location, styles, location in selected)
+                if multi_select
+                else FormattedDirectoryEntry(location, styles)
+            )
+
         with self.app.batch_update():
             self.clear_options()
             if not self.is_root:
@@ -691,18 +752,7 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
                     self.add_option(MultiSelectDirectoryEntry(self._location / "..", styles, False))
                 else:
                     self.add_option(FormattedDirectoryEntry(self._location / "..", styles))
-            self.add_options(
-                self._sort(
-                    (
-                        MultiSelectDirectoryEntry(entry.location, styles, entry.location in selected)
-                        if multi_select
-                        else FormattedDirectoryEntry(entry.location, styles)
-                    )
-                    for entry in self._entries
-                    if not self.hide(entry.location)
-                    and (not query or query in entry.location.name.lower())
-                )
-            )
+            self.add_options(self._sort(display_entries))
         self._settle_highlight()
 
         # Restore the previous highlight if the entry still exists.
@@ -713,22 +763,6 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
                     break
 
         self.post_message(self.SearchCountChanged(self, self.option_count, query))
-
-        # Count entries excluded *specifically* by the active file_filter
-        # (task-431 AC#2) -- a real file that passes the show-hidden/dotfile
-        # check but fails the filter. Reuses the same filter-check condition
-        # as the vendored ``DirectoryNavigation.hide()`` (directory_navigation.py)
-        # rather than reinventing it, guarded by an explicit "not already
-        # dotfile-hidden" check so dotfiles aren't double-counted as
-        # filter-hidden.
-        filter_hidden = sum(
-            1
-            for entry in self._entries
-            if is_file(entry.location)
-            and not (self.is_hidden(entry.location) and not self.show_hidden)
-            and self.file_filter is not None
-            and not self.file_filter(entry.location)
-        )
         self.post_message(self.FilterHiddenCountChanged(self, filter_hidden))
 
     def _on_option_list_option_selected(

--- a/tldw_chatbook/Widgets/enhanced_file_picker.py
+++ b/tldw_chatbook/Widgets/enhanced_file_picker.py
@@ -604,6 +604,14 @@ class SearchableDirectoryNavigation(DirectoryNavigation):
         """
         if self._search_debounce_timer is not None:
             self._search_debounce_timer.stop()
+            self._search_debounce_timer = None
+        if not self.search_filter:
+            # Fix round (review minor 4): an emptied filter is a RESTORE --
+            # Esc / the Clear button / a programmatic reset -- and must
+            # repopulate immediately, not 200 ms later. Only live typing
+            # debounces.
+            self._repopulate_display()
+            return
         self._search_debounce_timer = self.set_timer(
             self.SEARCH_DEBOUNCE_SECONDS, self._apply_search_filter_after_debounce
         )


### PR DESCRIPTION
## Summary

The last task of the input-latency burn-down: nine small per-click event-loop blockers from the 2026-08-11 audit, each threaded, debounced, deduped, or explicitly justified — smallest-diff, no intended behavior changes, with one disclosed repair.

- **Console star toggle**: resolve+write off-loop via `asyncio.to_thread` with an `asyncio.Lock` serializing presses; starred-ids reads cached with write-path invalidation guarded by a generation counter (review found the populate-after-invalidate race — 103/300 naturally-stale rounds — fixed and pinned born-red; 0/300 after)
- **TTS export**: mkdir+copy+manifest in one thread call, with the export claiming the file from the 5s zeroing cleanup so copy-vs-destroy is mutually exclusive (review caught the interleave; deferral at the single delete choke point, born-red pinned)
- **Disclosed repair**: collections rename/merge/delete called `app.run_in_thread`, which does not exist in Textual 8.2.8 — all four sites were AttributeError-dead on dev; now `to_thread` with the redundant 2×N SELECTs batched (same residue in `multi_item_review_events.py` filed separately)
- **Also**: emoji-recents write per selection threaded (last-write-wins documented); chat save-image threaded copying the Console pattern; file-picker search debounced 0.2s with the double-stat pass merged (0 stats with no filter; clear/Esc repopulates immediately); CodeRepoCopyPaste reads and ChatbookExportManagement scans threaded; Study handler batch verified dead code at HEAD (justified, not touched)
- **Spot latency**: picker keystroke in a 1000-file dir 121ms×every-keystroke → 1 rebuild per 0.2s burst; star toggle dispatch 63µs→2.5µs (the real win is removing sqlite busy-timeout contention from the loop)

Review: independent opus concurrency review (two majors found and fixed, all born-red evidence reproduced by the reviewer, DB thread-affinity verified per site) + scoped delta re-review → MERGE. ~490 targeted tests green; the only reds are two dev-attributed failures reproduced byte-for-byte on pristine base (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves nine per-click I/O paths off the event loop to reduce input latency and avoid sqlite busy-timeout stalls (TASK-15471). Old behavior: sync reads/writes and per-keystroke rebuilds on the loop; new behavior: I/O runs in `asyncio.to_thread`, search input debounces, and repeated lookups cache/dedupe; functional behavior unchanged except the fixes below.

- Console star toggle: resolve+write runs off-loop and is serialized; starred-ids reads cache with generation-based invalidation; cancellation triggers a best‑effort re-sync; UI tests now wait on worker completion.
- TTS export: mkdir/copy/manifest moved off-loop; adds a claim so cleanup can’t zero the source mid-copy; cleanup waits and then deletes.
- Collections keywords: replaced nonexistent `app.run_in_thread` with `asyncio.to_thread` (fixes rename/merge/delete raising AttributeError); delete now resolves each keyword name once and reuses it for both notify and delete.
- File picker: 0.2s debounce for search keystrokes; merged double-stat pass into a single walk; clearing the filter repopulates immediately.
- Also threaded: emoji recents save, chat image save, ChatbookExportManagement glob+stat and zip preview, CodeRepoCopyPaste local reads, Study dashboard fallback queries. Architecture baseline updated to remove the two now-off-loop scans.

**Review focus**
- Concurrency patterns: `:memory:` DB guarded to stay on the loop thread; other DB/file work uses `asyncio.to_thread`. Star toggles are serialized; marks list cache uses a generation counter to avoid populate-after-invalidate races.
- Tests: new coverage for the marks cache race and TTS export claim; collections handler tests pin the behavior repair; UI tests now await worker groups.
- No config or schema changes. If other code called `app.run_in_thread`, replace it with the `asyncio.to_thread` pattern used here.

<sup>Written for commit 9a4c1d5e37fa882662b9cc0da1f489eee2c908c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

