### PR TITLE
fix(llm): accept Moonshot live stream metadata

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+++ b/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint` and terminal choice-usage SSE shapes so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
+**Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint`, terminal choice usage, and identical trailing usage SSE shapes so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
 
-**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlists, validate the optional fingerprint under the existing metadata cap, accept mapping-valued usage only on a terminal choice with no top-level usage, and prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before the final paid UAT.
+**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlists, validate the optional fingerprint under the existing metadata cap, accept mapping-valued usage only on a terminal choice with no same-event top-level usage, and accept a later top-level duplicate only when it is identical. Prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before the final paid UAT.
 
 **Tech Stack:** Python 3.12, pytest, requests/SSE, Textual Console agent bridge, Loguru redaction tests, Backlog.md, GitHub CLI
 
@@ -14,7 +14,7 @@
 
 - Modify `tldw_chatbook/LLM_Calls/hosted_chat.py`: admit and bound the standard
   optional streaming `system_fingerprint` field and Moonshot's terminal
-  choice-level usage mapping.
+  choice-level usage mapping and identical trailing duplicate.
 - Modify `Tests/LLM_Calls/test_hosted_chat.py`: pin accepted, null, malformed,
   oversized, ambiguous, misplaced, and unknown strict-parser behavior.
 - Modify `Tests/Chat/test_kimi_zai_native_tools.py`: mirror Moonshot's live
@@ -234,16 +234,18 @@ git commit -m "fix(llm): accept Moonshot stream fingerprints"
 - [ ] **Step 1: Pin accepted and fail-closed choice usage RED cases**
 
 Add a terminal stream choice containing a mapping-valued `usage` field. Add
-controls proving non-mapping usage, usage before a finish reason, and simultaneous
-top-level plus choice usage all raise `HostedChatProtocolError`. Update only the
-Moonshot joined fixture to reproduce choice-level terminal usage; preserve Z.ai's
-existing trailing top-level usage event.
+controls proving non-mapping usage, usage before a finish reason, simultaneous
+top-level plus choice usage, and a later conflicting duplicate all raise
+`HostedChatProtocolError`. Update only the Moonshot joined fixture to reproduce
+terminal choice usage followed by the identical trailing top-level event;
+preserve Z.ai's existing single trailing top-level usage event.
 
 - [ ] **Step 2: Apply the minimal choice allowlist correction**
 
 Admit `usage` in the strict choice allowlist, require it to be a mapping, reject
-dual placement, and reuse the existing terminal-placement check. Do not coerce,
-merge, log, or persist provider usage data.
+same-event dual placement, reuse the existing terminal-placement check, and
+accept a later top-level mapping only when it equals the recorded usage. Do not
+coerce, merge, log, or persist provider usage data.
 
 - [ ] **Step 3: Verify GREEN and commit**
 

--- a/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+++ b/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint` SSE metadata so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
+**Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint` and terminal choice-usage SSE shapes so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
 
-**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlist to match its existing non-streaming contract, validate the optional fingerprint under the existing metadata cap, and prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before one paid UAT.
+**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlists, validate the optional fingerprint under the existing metadata cap, accept mapping-valued usage only on a terminal choice with no top-level usage, and prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before the final paid UAT.
 
 **Tech Stack:** Python 3.12, pytest, requests/SSE, Textual Console agent bridge, Loguru redaction tests, Backlog.md, GitHub CLI
 
@@ -13,11 +13,13 @@
 ## Scope And File Map
 
 - Modify `tldw_chatbook/LLM_Calls/hosted_chat.py`: admit and bound the standard
-  optional streaming `system_fingerprint` field.
+  optional streaming `system_fingerprint` field and Moonshot's terminal
+  choice-level usage mapping.
 - Modify `Tests/LLM_Calls/test_hosted_chat.py`: pin accepted, null, malformed,
-  oversized, and unknown top-level metadata behavior at the strict parser.
+  oversized, ambiguous, misplaced, and unknown strict-parser behavior.
 - Modify `Tests/Chat/test_kimi_zai_native_tools.py`: mirror Moonshot's live
-  fingerprint in the existing joined Console HTTP/tool-continuation fixture.
+  fingerprint and terminal choice usage in the existing joined Console
+  HTTP/tool-continuation fixture while preserving Z.ai's wire shape.
 - Test `Tests/Chat/test_live_moonshot_zai_api.py` without modifying or weakening
   its exact tool/result/final marker contract.
 - Modify `backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md`:
@@ -221,6 +223,33 @@ git add -- \
   Tests/Chat/test_kimi_zai_native_tools.py
 git commit -m "fix(llm): accept Moonshot stream fingerprints"
 ```
+
+### Task 2A: Accept The UAT-Observed Terminal Choice Usage
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/hosted_chat.py`
+- Modify: `Tests/LLM_Calls/test_hosted_chat.py`
+- Modify: `Tests/Chat/test_kimi_zai_native_tools.py`
+
+- [ ] **Step 1: Pin accepted and fail-closed choice usage RED cases**
+
+Add a terminal stream choice containing a mapping-valued `usage` field. Add
+controls proving non-mapping usage, usage before a finish reason, and simultaneous
+top-level plus choice usage all raise `HostedChatProtocolError`. Update only the
+Moonshot joined fixture to reproduce choice-level terminal usage; preserve Z.ai's
+existing trailing top-level usage event.
+
+- [ ] **Step 2: Apply the minimal choice allowlist correction**
+
+Admit `usage` in the strict choice allowlist, require it to be a mapping, reject
+dual placement, and reuse the existing terminal-placement check. Do not coerce,
+merge, log, or persist provider usage data.
+
+- [ ] **Step 3: Verify GREEN and commit**
+
+Run the exact choice-usage parser cases and Moonshot joined node, then both
+touched test files and Task 3's related matrix. Ruff, formatting, compilation,
+and diff checks must pass before committing the correction.
 
 ### Task 3: Run Focused Related Verification
 

--- a/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+++ b/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
@@ -4,7 +4,7 @@
 
 **Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint`, terminal choice usage, and identical trailing usage SSE shapes so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
 
-**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlists, validate the optional fingerprint under the existing metadata cap, accept mapping-valued usage only on a terminal choice with no same-event top-level usage, and accept a later top-level duplicate only when it is identical. Prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before the final paid UAT.
+**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlists, validate the optional fingerprint under the existing metadata cap, accept mapping-valued usage only on a terminal choice with no same-event top-level usage, and accept exactly one later top-level duplicate only when it is identical under type-strict canonical JSON equality. Prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before the final paid UAT.
 
 **Tech Stack:** Python 3.12, pytest, requests/SSE, Textual Console agent bridge, Loguru redaction tests, Backlog.md, GitHub CLI
 
@@ -244,8 +244,10 @@ preserve Z.ai's existing single trailing top-level usage event.
 
 Admit `usage` in the strict choice allowlist, require it to be a mapping, reject
 same-event dual placement, reuse the existing terminal-placement check, and
-accept a later top-level mapping only when it equals the recorded usage. Do not
-coerce, merge, log, or persist provider usage data.
+accept exactly one later top-level mapping only when it canonically equals the
+recorded usage with JSON types preserved. Reject further duplicates and
+top-level-only repeats. Do not coerce, merge, log, or persist provider usage
+data.
 
 - [ ] **Step 3: Verify GREEN and commit**
 

--- a/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+++ b/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
@@ -1,0 +1,495 @@
+# Moonshot Live Native-Tool UAT Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept Moonshot Kimi K3's bounded `system_fingerprint` SSE metadata so the real Console native-tool continuation UAT completes instead of surfacing a synthetic 502.
+
+**Architecture:** Keep request construction, provider policy, AgentService, and Console unchanged. Correct the provider-neutral hosted streaming response allowlist to match its existing non-streaming contract, validate the optional fingerprint under the existing metadata cap, and prove the fix at both the pure parser and real Console-to-scripted-HTTP boundaries before one paid UAT.
+
+**Tech Stack:** Python 3.12, pytest, requests/SSE, Textual Console agent bridge, Loguru redaction tests, Backlog.md, GitHub CLI
+
+---
+
+## Scope And File Map
+
+- Modify `tldw_chatbook/LLM_Calls/hosted_chat.py`: admit and bound the standard
+  optional streaming `system_fingerprint` field.
+- Modify `Tests/LLM_Calls/test_hosted_chat.py`: pin accepted, null, malformed,
+  oversized, and unknown top-level metadata behavior at the strict parser.
+- Modify `Tests/Chat/test_kimi_zai_native_tools.py`: mirror Moonshot's live
+  fingerprint in the existing joined Console HTTP/tool-continuation fixture.
+- Test `Tests/Chat/test_live_moonshot_zai_api.py` without modifying or weakening
+  its exact tool/result/final marker contract.
+- Modify `backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md`:
+  record evidence, completed ACs, and Implementation Notes.
+- Modify the TASK-16074 spec and this plan only for review corrections or final
+  evidence links.
+
+No new production module, dependency, configuration field, provider branch,
+or persistent payload-capture hook is planned.
+
+ADR required: no
+
+ADR path: `backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md`
+
+Reason: this is a response-compatibility correction inside ADR-063's accepted
+neutral hosted wire boundary.
+
+### Task 0: Commit The Reviewed Design And Plan
+
+**Files:**
+- Modify: `backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md`
+- Modify: `Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md`
+- Create: `Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md`
+
+- [ ] **Step 1: Stage only the reviewed documentation**
+
+```bash
+git add -- \
+  'backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md' \
+  Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md \
+  Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+git diff --cached --check
+```
+
+Expected: only the task/spec/plan root-cause and review updates are staged.
+
+- [ ] **Step 2: Commit the planning checkpoint**
+
+```bash
+git commit -m "docs(chat): plan Moonshot stream fingerprint fix"
+git status --short
+```
+
+Expected: commit succeeds and the worktree is clean before TDD/rebase work.
+
+### Task 1: Pin The Complete Fingerprint Contract RED
+
+**Files:**
+- Modify: `Tests/LLM_Calls/test_hosted_chat.py:520-660`
+- Modify: `Tests/Chat/test_kimi_zai_native_tools.py:62-108`
+- Test: `Tests/LLM_Calls/test_hosted_chat.py`
+- Test: `Tests/Chat/test_kimi_zai_native_tools.py`
+
+- [ ] **Step 1: Add accepted bounded and null stream regressions**
+
+Add a complete synthetic stream whose first event includes the exact live
+top-level shape and a bounded fingerprint:
+
+```python
+@pytest.mark.parametrize("fingerprint", ["fp_kimi_live", None])
+def test_hosted_chat_stream_accepts_system_fingerprint(
+    fingerprint: str | None,
+) -> None:
+    event = {
+        "id": "chatcmpl_test",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "kimi-k3",
+        "system_fingerprint": fingerprint,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"total_tokens": 3},
+    }
+    stream = HostedChatStream(
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
+        finish_policy=_POLICY,
+    )
+
+    assert list(stream) == [event]
+    assert stream.terminal_turn.text == "done"
+```
+
+- [ ] **Step 2: Add malformed, oversized, and unknown-key RED cases**
+
+Before production changes, add a parameterized event test for:
+
+```python
+[True, 1, "", "x" * (hosted_chat._MAX_METADATA_CHARS + 1)]
+```
+
+Each `system_fingerprint` must raise `HostedChatProtocolError`. Add a separate
+event with `"unexpected_live_metadata": "value"` that must also raise. The
+malformed/unknown tests are expected to pass on the old code because the old
+allowlist rejects the field wholesale; their purpose is to constrain the
+minimal GREEN implementation before it is written.
+
+- [ ] **Step 3: Make the existing joined fixture reproduce the live field**
+
+In `_tool_turn(provider)`, add
+`"system_fingerprint": "fp_kimi_live"` to the first event only when
+`provider == "moonshot"`. Preserve the existing tool deltas, reasoning,
+terminal usage, continuation assertions, and Z.ai bytes.
+
+- [ ] **Step 4: Run the accepted and joined tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/LLM_Calls/test_hosted_chat.py::test_hosted_chat_stream_accepts_system_fingerprint \
+  'Tests/Chat/test_kimi_zai_native_tools.py::test_console_runs_two_native_calls_with_private_continuation[moonshot]'
+```
+
+Expected: both accepted parser cases fail with `HostedChatProtocolError: Hosted
+Chat stream event is malformed`. The joined test reaches an error outcome with
+no calculator tool/checkpoint and normally stops at its earlier
+`assert checkpoint is not None` assertion; it need not expose the parser
+exception directly because Console intentionally maps it to safe provider-error
+state.
+
+- [ ] **Step 5: Run the fail-closed cases on the old code**
+
+Run the new malformed/oversized/unknown tests by exact node or `-k
+'system_fingerprint or unexpected_live_metadata'`.
+
+Expected: all pass before production changes, proving the new GREEN cannot
+simply broaden the event to arbitrary metadata.
+
+- [ ] **Step 6: Confirm the accepted/joined RED is discriminating**
+
+Temporarily remove only `system_fingerprint` from each test event and rerun.
+Expected: both pass. Restore the field and confirm both are RED again. Do not
+commit this temporary mutation.
+
+### Task 2: Apply The Minimal Bounded Parser Fix
+
+**Files:**
+- Modify: `tldw_chatbook/LLM_Calls/hosted_chat.py:186-200`
+- Modify: `Tests/LLM_Calls/test_hosted_chat.py:520-760`
+- Test: `Tests/LLM_Calls/test_hosted_chat.py`
+- Test: `Tests/Chat/test_kimi_zai_native_tools.py`
+
+- [ ] **Step 1: Admit and validate the optional field**
+
+Change only the streaming top-level allowlist and optional metadata check:
+
+```python
+if set(event) - {
+    "id",
+    "object",
+    "created",
+    "model",
+    "system_fingerprint",
+    "choices",
+    "usage",
+}:
+    raise HostedChatProtocolError("Hosted Chat stream event is malformed.")
+fingerprint = event.get("system_fingerprint")
+if fingerprint is not None:
+    _required_metadata(fingerprint, "system fingerprint")
+```
+
+Do not allow arbitrary extra keys, coerce non-strings, change provider builders,
+or log/retain any new private state.
+
+- [ ] **Step 2: Run every new contract case and verify GREEN**
+
+Run the Task 1 accepted/joined command plus the malformed, oversized, and
+unknown-key nodes.
+
+Expected: every new case passes. The joined test completes its tool call and
+continuation rather than merely suppressing the parser error.
+
+- [ ] **Step 3: Run the complete neutral hosted parser file**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/LLM_Calls/test_hosted_chat.py
+```
+
+Expected: all tests pass; malformed, oversized, post-terminal, and resource
+limit cases remain green.
+
+- [ ] **Step 4: Commit the parser correction**
+
+```bash
+git add -- \
+  tldw_chatbook/LLM_Calls/hosted_chat.py \
+  Tests/LLM_Calls/test_hosted_chat.py \
+  Tests/Chat/test_kimi_zai_native_tools.py
+git commit -m "fix(llm): accept Moonshot stream fingerprints"
+```
+
+### Task 3: Run Focused Related Verification
+
+**Files:**
+- Test: `Tests/LLM_Calls/test_hosted_chat.py`
+- Test: `Tests/LLM_Calls/test_moonshot.py`
+- Test: `Tests/Chat/test_kimi_zai_provider_contract.py`
+- Test: `Tests/Chat/test_kimi_zai_native_tools.py`
+- Test: `Tests/Chat/test_console_provider_gateway.py`
+- Test: `Tests/Agents/test_provider_continuation_runtime.py`
+- Test: `Tests/Chat/test_sensitive_llm_logging.py`
+- Test: `Tests/Chat/test_live_moonshot_zai_api.py`
+
+- [ ] **Step 1: Run the provider and joined continuation matrix**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/LLM_Calls/test_hosted_chat.py \
+  Tests/LLM_Calls/test_moonshot.py \
+  Tests/Chat/test_kimi_zai_provider_contract.py \
+  Tests/Chat/test_kimi_zai_native_tools.py \
+  Tests/Chat/test_live_moonshot_zai_api.py \
+  Tests/Chat/test_console_provider_gateway.py \
+  -k 'moonshot or hosted or live_gate or live_subprocess'
+```
+
+Expected: all selected tests pass; paid cases skip because the live opt-in/key
+are absent. If loopback binding is sandbox-blocked, rerun only the affected
+`allow_network` nodes with loopback permission.
+
+- [ ] **Step 2: Run focused AgentService and privacy regressions**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Agents/test_provider_continuation_runtime.py \
+  Tests/Chat/test_sensitive_llm_logging.py \
+  -k 'moonshot or hosted or continuation'
+```
+
+Expected: all selected tests pass with no credential/payload canary in output.
+
+- [ ] **Step 3: Run targeted static checks**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/LLM_Calls/hosted_chat.py \
+  Tests/LLM_Calls/test_hosted_chat.py \
+  Tests/Chat/test_kimi_zai_native_tools.py
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/LLM_Calls/hosted_chat.py \
+  Tests/LLM_Calls/test_hosted_chat.py \
+  Tests/Chat/test_kimi_zai_native_tools.py
+../../.venv/bin/python -m compileall -q tldw_chatbook/LLM_Calls/hosted_chat.py
+git diff --check
+```
+
+Expected: all commands exit zero. Do not format unrelated legacy files.
+
+- [ ] **Step 4: Mutation-prove the regression**
+
+Temporarily remove `"system_fingerprint"` from the streaming allowlist.
+Run the two exact Task 1 nodes and expect both to fail. Restore the production
+line and rerun them GREEN. Confirm `git diff --check` afterward.
+
+### Task 4: Rebase And Review The Final Code Candidate
+
+**Files:**
+- Review: `origin/dev...HEAD`
+- Test: the Task 1 and Task 3 focused paths
+
+- [ ] **Step 1: Fetch and inspect upstream overlap**
+
+```bash
+git fetch origin dev
+git log --oneline HEAD..origin/dev -- \
+  tldw_chatbook/LLM_Calls/hosted_chat.py \
+  Tests/LLM_Calls/test_hosted_chat.py \
+  Tests/Chat/test_kimi_zai_native_tools.py
+```
+
+Expected: any upstream overlap is understood before rewriting the branch.
+
+- [ ] **Step 2: Rebase file-by-file**
+
+```bash
+git rebase origin/dev
+```
+
+Resolve conflicts one file at a time and stage only exact resolved paths—never
+`git add -A`. Confirm no upstream task filename or unrelated file was reverted.
+
+- [ ] **Step 3: Verify committed and working-tree whitespace**
+
+```bash
+git diff --check origin/dev...HEAD
+git diff --check
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 4: Rerun the focused candidate gates**
+
+Rerun the Task 1 exact regression nodes, both Task 3 pytest commands, Ruff,
+format check, compileall, and the mutation proof on the rebased HEAD.
+
+Expected: all focused checks are green and the mutation still fails for the
+intended reason.
+
+- [ ] **Step 5: Request correctness/privacy/YAGNI review**
+
+Use `superpowers:requesting-code-review` against `origin/dev...HEAD`. Reviewers
+must check the exact live evidence, bounded metadata type/size validation,
+unknown-key rejection, joined reachability, privacy, and whether one neutral
+allowlist entry is the smallest fix.
+
+- [ ] **Step 6: Resolve every actionable finding before UAT**
+
+For each finding, reproduce it with a focused failing test when behavior
+changes, implement the smallest correction, rerun affected tests plus Task 1,
+and commit the fix. Repeat Step 3 and the relevant Task 3 gates. Do not begin
+paid UAT while any actionable review finding remains.
+
+### Task 5: Run Paid UAT And Close Task Evidence
+
+**Files:**
+- Test: `Tests/Chat/test_live_moonshot_zai_api.py`
+- Read only: ignored main-checkout `moonshot-api-key.txt`
+- Modify: `backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md`
+- Modify: TASK-16074 spec and plan evidence only
+
+- [ ] **Step 1: Prove the credential file is ignored and untracked**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_chatbook check-ignore moonshot-api-key.txt
+git ls-files --error-unmatch moonshot-api-key.txt
+```
+
+Expected: the first command identifies the ignore rule; the second exits
+nonzero because the credential is not tracked.
+
+- [ ] **Step 2: Record the reviewed code SHA and run exactly the paid node**
+
+Record `git rev-parse HEAD`, then load the key into the child environment
+without printing it:
+
+```bash
+TLDW_LIVE_MOONSHOT=1 \
+MOONSHOT_API_KEY="$(</Users/macbook-dev/Documents/GitHub/tldw_chatbook/moonshot-api-key.txt)" \
+../../.venv/bin/python -m pytest -q \
+  'Tests/Chat/test_live_moonshot_zai_api.py::test_live_hosted_text_and_native_tool[moonshot]'
+```
+
+Expected: `1 passed`. The harness proves one calculator call, exact
+arguments/result, provider continuation, and the final marker on the reviewed,
+rebased production SHA.
+
+- [ ] **Step 3: Run a pre-closeout tracked-tree privacy search**
+
+```bash
+git grep -l -F \
+  -f /Users/macbook-dev/Documents/GitHub/tldw_chatbook/moonshot-api-key.txt \
+  -- .
+```
+
+Expected: exit 1 and no output. `-l` reports filenames only if a regression
+exists; it never prints the credential or matching line. This is an early
+guard; Step 7 repeats it after the evidence commit.
+
+- [ ] **Step 4: Audit the reviewed code candidate diff**
+
+```bash
+git status --short
+git diff --check origin/dev...HEAD
+git diff --stat origin/dev...HEAD
+```
+
+Inspect `git diff origin/dev...HEAD` and verify no key file, raw live body,
+complete request payload, diagnostic probe, or unrelated change is present.
+
+- [ ] **Step 5: Complete task hygiene after review and UAT**
+
+Check all four ACs and add concise Implementation Notes containing the root
+cause, RED/GREEN commands, paid UAT SHA/result, privacy audit, ADR-063 reuse,
+review result, and exact modified files. Set TASK-16074 to Done through Backlog
+CLI and re-read `backlog task 16074 --plain` to ensure notes/checklists survived.
+
+- [ ] **Step 6: Commit closeout documentation and verify committed whitespace**
+
+```bash
+git add -- \
+  'backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md' \
+  Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md \
+  Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+git diff --cached --check
+git commit -m "docs(chat): close Moonshot live tool UAT"
+git diff --check origin/dev...HEAD
+```
+
+Expected: task status/ACs/notes are committed and the full committed range is
+whitespace-clean. Documentation-only closeout does not invalidate the paid
+production SHA.
+
+- [ ] **Step 7: Repeat privacy and complete-diff audits after evidence commit**
+
+```bash
+git grep -l -F \
+  -f /Users/macbook-dev/Documents/GitHub/tldw_chatbook/moonshot-api-key.txt \
+  -- .
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: `git grep` exits 1 with no filenames, the committed range is clean,
+and the worktree is empty. Inspect the final `origin/dev...HEAD` diff so the
+Implementation Notes and task evidence are included in the privacy/scope audit.
+
+### Task 6: Open, Review, Merge, And Clean Up The Follow-Up PR
+
+**Files:**
+- Review: the pushed branch and GitHub PR against `dev`
+
+- [ ] **Step 1: Push the settled branch**
+
+```bash
+git push --set-upstream origin codex/moonshot-live-tool-uat-fix
+```
+
+Expected: the remote feature branch points at the verified local HEAD.
+
+- [ ] **Step 2: Open a ready PR to `dev`**
+
+Create a ready PR titled `fix(llm): accept Moonshot stream fingerprints`.
+Reference TASK-16074 and ADR-063; include focused RED/GREEN, static, review,
+privacy, and paid-UAT evidence without any credential, prompt, raw response, or
+payload content.
+
+- [ ] **Step 3: Inspect required checks and all review threads**
+
+Use `gh pr checks <number>` and `gh pr view <number> --comments` plus the GitHub
+API for unresolved inline review threads. Wait for required checks to complete;
+for external CI providers, report only their details URL.
+
+- [ ] **Step 4: Diagnose and fix each failure/comment separately**
+
+For every actionable failure or review comment: reproduce, add/adjust a focused
+test where behavior changes, implement the smallest fix, rerun only affected
+and Task 1 gates, run Ruff/diff checks, commit, and push. Then recheck CI and
+threads rather than assuming the push resolved them.
+
+- [ ] **Step 5: Re-run paid UAT and evidence gates after relevant changes**
+
+If any post-UAT commit changes `hosted_chat.py`, Moonshot transport, Console or
+AgentService behavior, or the live harness, rerun Task 5 Step 2 on the new HEAD
+and update task/PR evidence. Commit that evidence update, repeat Task 5 Step 7,
+push it, and wait for required CI/checks to rerun on the new SHA. Re-open the
+review-thread audit before proceeding. Documentation-only changes do not
+require another paid call, but still require the evidence commit, privacy/diff
+audit, push, and CI recheck when they alter tracked files.
+
+- [ ] **Step 6: Merge only after all gates are green**
+
+Confirm `git status --short` is empty, required checks pass, actionable review
+threads are resolved, the branch is mergeable with current `dev`, and the
+latest relevant-code SHA has a passing paid UAT. Merge the PR into `dev` and
+verify the resulting merge commit contains the parser fix and task closeout.
+
+- [ ] **Step 7: Clean up after the verified merge**
+
+Use `superpowers:finishing-a-development-branch` from the main checkout to
+remove this worktree and delete the merged local/remote feature branch.
+Preserve the ignored local key file unless the user explicitly asks to delete
+it.

--- a/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
+++ b/Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
@@ -470,6 +470,17 @@ Expected: `git grep` exits 1 with no filenames, the committed range is clean,
 and the worktree is empty. Inspect the final `origin/dev...HEAD` diff so the
 Implementation Notes and task evidence are included in the privacy/scope audit.
 
+## Execution Evidence
+
+- RED/GREEN covered all three live stream mismatches plus strict malformed,
+  conflicting, repeated, misplaced, and JSON-type-distinct controls.
+- Final focused gates: 109 touched-file tests, 77 provider/Console tests, and 60
+  AgentService/privacy tests passed; Ruff, formatting, focused mypy, compileall,
+  and diff checks passed.
+- Two independent final reviews approved code and spec.
+- Paid Moonshot UAT passed on reviewed/rebased code SHA `da2816853` (`1 passed`
+  in 16.82s).
+
 ### Task 6: Open, Review, Merge, And Clean Up The Follow-Up PR
 
 **Files:**

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -1,7 +1,7 @@
 # Moonshot Live Native-Tool UAT Fix Design
 
 Date: 2026-08-13
-Status: User-approved; root-cause evidence incorporated
+Status: Implemented and verified
 Backlog task: [TASK-16074](../../../backlog/tasks/task-16074%20-%20Make-Moonshot-live-native-tool-continuation-pass.md)
 Foundation task: [TASK-15676](../../../backlog/tasks/task-15676%20-%20Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md)
 Architecture decision: [ADR-063](../../../backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md)
@@ -165,6 +165,11 @@ The implementation must use strict RED-to-GREEN evidence:
 Per the user's test-scope instruction, verification is limited to touched files
 and directly related Moonshot/hosted/AgentService/Console continuation paths;
 no full-suite or broad-directory sweep is required.
+
+Final paid evidence: reviewed and rebased code SHA `da2816853` passed
+`test_live_hosted_text_and_native_tool[moonshot]` (`1 passed` in 16.82s),
+proving one calculator call, exact result continuation, and the required final
+marker through the real Console-to-AgentService-to-Moonshot path.
 
 ## ADR Check
 

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -1,7 +1,7 @@
 # Moonshot Live Native-Tool UAT Fix Design
 
 Date: 2026-08-13
-Status: Draft; awaiting written-spec review
+Status: Written-spec review approved; awaiting user approval for planning
 Backlog task: [TASK-16074](../../../backlog/tasks/task-16074%20-%20Make-Moonshot-live-native-tool-continuation-pass.md)
 Foundation task: [TASK-15676](../../../backlog/tasks/task-15676%20-%20Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md)
 Architecture decision: [ADR-063](../../../backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md)
@@ -35,7 +35,8 @@ committed.
 The exact offending field or interaction is not yet established. The remaining
 surface is the final first-turn request as composed by the joined product path,
 especially its messages and any request policy added above the already-proven
-tool-schema builder.
+tool-schema builder. This uncertainty is the investigation target, not an
+implementation placeholder. No production code has been changed at this stage.
 
 ## Goals
 

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -34,7 +34,8 @@ committed.
 | Exact joined first-turn messages with the original five and full captured eight-tool catalogs | HTTP 200 | The complete composed request and aggregate tool schemas |
 | Exact request fully consumed through Chatbook's strict Moonshot adapter | `HostedChatProtocolError` at `HostedChatStream._consume_event()` | The failure is response normalization, not request rejection |
 | Redacted event-key trace | `choices`, `created`, `id`, `model`, `object`, `system_fingerprint` | Streaming rejects Moonshot's standard `system_fingerprint` field |
-| Paid UAT after the fingerprint fix | Safe synthetic 502; keys-only failing terminal shape was `choices[0]` with `delta`, `finish_reason`, `index`, `usage` | Moonshot also places terminal usage inside the choice rather than in a trailing top-level usage event |
+| Paid UAT after the fingerprint fix | Safe synthetic 502; keys-only failing terminal shape was `choices[0]` with `delta`, `finish_reason`, `index`, `usage` | Moonshot also places terminal usage inside the choice |
+| Paid UAT after choice usage support | Safe synthetic 502; structural sequence showed the same usage again in a trailing top-level empty-choice event | Moonshot duplicates identical terminal usage across both accepted placements |
 | Real repository live harness through Console, AgentService, and Moonshot | Synthetic HTTP 502 before a recorded tool call | The parser defect is reachable through the product path |
 
 The exact defect is an asymmetric neutral-hosted response allowlist:
@@ -43,16 +44,19 @@ non-streaming response, while `HostedChatStream._consume_event()` rejects the
 same field on a streaming event. Moonshot currently emits it on the first Kimi
 K3 SSE event. After that mismatch was corrected, the paid joined UAT exposed a
 second strict-shape mismatch: Moonshot places its terminal usage mapping at
-`choices[0].usage`, while the neutral parser previously admitted usage only at
-the event top level. The parser raises before completing the provider turn in
-either case, and the Console gateway presents its default safe 502 error copy.
+`choices[0].usage`, then repeats the identical mapping in a trailing top-level
+empty-choice event. The neutral parser previously admitted only the latter and
+then rejected the duplicate once choice usage was supported. The parser raises
+before completing the provider turn in each case, and the Console gateway
+presents its default safe 502 error copy.
 
 ## Goals
 
 - Admit Moonshot's bounded `system_fingerprint` on hosted streaming events,
   matching the existing non-streaming contract.
 - Admit Moonshot's mapping-valued terminal `choices[0].usage` while rejecting
-  nonterminal, non-mapping, or dual top-level/choice placement.
+  nonterminal, non-mapping, or same-event dual placement; allow a later
+  top-level usage event only when it exactly matches the terminal mapping.
 - Pin both exact live event shapes in deterministic parser and joined Console
   native-tool regressions.
 - Correct the narrowest owner of the invalid value while preserving Moonshot,
@@ -96,8 +100,9 @@ The evidence proceeded from the smallest high-information boundary:
    `HostedChatProtocolError` at the stream event allowlist.
 4. A keys-only trace isolated `system_fingerprint` as the first unexpected
    top-level field. After that correction, a second keys/types-only trace of
-   the still-failing paid UAT isolated terminal `choices[0].usage`. No response
-   values or raw provider body were printed.
+   the still-failing paid UAT isolated terminal `choices[0].usage`, followed by
+   an identical trailing top-level usage event. No response values or raw
+   provider body were printed.
 
 The comparison was evidence collection, not a permanent generic
 payload-logging feature. Its temporary `/tmp` harness was deleted after the
@@ -109,10 +114,12 @@ The production change belongs only in
 `tldw_chatbook/LLM_Calls/hosted_chat.py`, whose neutral stream parser owns the
 top-level and choice-level OpenAI-shaped event allowlists. It accepts
 `system_fingerprint` only as optional bounded metadata and accepts choice-level
-usage only as a mapping on the terminal choice when no top-level usage is
-present. Unknown keys, malformed/oversized fingerprints, non-mapping usage,
-ambiguous dual placement, and nonterminal usage remain rejected. Tool,
-reasoning, finish, provider, and request construction behavior remain
+usage only as a mapping on the terminal choice when no same-event top-level
+usage is present. A subsequent empty-choice top-level usage event is accepted
+only when its mapping exactly matches the already recorded terminal usage.
+Unknown keys, malformed/oversized fingerprints, non-mapping usage, same-event
+dual placement, conflicting duplicates, and nonterminal usage remain rejected.
+Tool, reasoning, finish, provider, and request construction behavior remain
 unchanged.
 
 The outer regression adds both exact shapes to Moonshot's scripted SSE in the
@@ -139,8 +146,9 @@ requests.
 The implementation must use strict RED-to-GREEN evidence:
 
 1. Deterministic parser regressions first reproduce rejection of a bounded
-   `system_fingerprint` streaming event and terminal `choices[0].usage`
-   without network access, with fail-closed malformed/ambiguous controls.
+   `system_fingerprint` streaming event and terminal `choices[0].usage` plus
+   identical trailing usage without network access, with fail-closed
+   malformed/conflicting controls.
 2. A focused joined scripted-HTTP test proves Console/AgentService consumes
    that exact Moonshot event, executes the native calculator call, continues
    with its result, and completes.

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -56,7 +56,8 @@ presents its default safe 502 error copy.
   matching the existing non-streaming contract.
 - Admit Moonshot's mapping-valued terminal `choices[0].usage` while rejecting
   nonterminal, non-mapping, or same-event dual placement; allow a later
-  top-level usage event only when it exactly matches the terminal mapping.
+  top-level usage event only when it exactly matches the terminal mapping under
+  type-strict canonical JSON equality; reject any further duplicate.
 - Pin both exact live event shapes in deterministic parser and joined Console
   native-tool regressions.
 - Correct the narrowest owner of the invalid value while preserving Moonshot,
@@ -116,7 +117,8 @@ top-level and choice-level OpenAI-shaped event allowlists. It accepts
 `system_fingerprint` only as optional bounded metadata and accepts choice-level
 usage only as a mapping on the terminal choice when no same-event top-level
 usage is present. A subsequent empty-choice top-level usage event is accepted
-only when its mapping exactly matches the already recorded terminal usage.
+only once and only when its mapping exactly matches the already recorded
+terminal usage under type-strict canonical JSON equality.
 Unknown keys, malformed/oversized fingerprints, non-mapping usage, same-event
 dual placement, conflicting duplicates, and nonterminal usage remain rejected.
 Tool, reasoning, finish, provider, and request construction behavior remain

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -1,0 +1,149 @@
+# Moonshot Live Native-Tool UAT Fix Design
+
+Date: 2026-08-13
+Status: Draft; awaiting written-spec review
+Backlog task: [TASK-16074](../../../backlog/tasks/task-16074%20-%20Make-Moonshot-live-native-tool-continuation-pass.md)
+Foundation task: [TASK-15676](../../../backlog/tasks/task-15676%20-%20Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md)
+Architecture decision: [ADR-063](../../../backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md)
+
+## Purpose
+
+Correct the post-merge Moonshot Kimi K3 defect found by paid UAT: Chatbook's
+real Console-to-AgentService native-tool path receives a provider HTTP 502
+before the first tool call, even though smaller requests against the same
+credential, endpoint, model, streaming protocol, and tool schemas succeed.
+
+The fix must preserve the native-tool and durable-continuation contracts. It
+must not make the UAT pass by removing tools, bypassing the joined product path,
+or replacing the expected tool call with a text-only answer.
+
+## Verified Evidence
+
+The supplied credential was read only from the ignored local file
+`moonshot-api-key.txt`. It was not printed, logged, copied into a fixture, or
+committed.
+
+| Probe | Result | What it rules out |
+| --- | --- | --- |
+| `GET /v1/models` | HTTP 200; `kimi-k3` present | Invalid credential, base URL, or unavailable model |
+| Minimal Kimi K3 text request | HTTP 200 | General Kimi K3 request failure |
+| Minimal non-stream function-tool request | HTTP 200 with one tool call | Basic function-tool support |
+| Minimal streaming function-tool request with usage | HTTP 200 SSE with tool delta and `[DONE]` | Streaming tool calls and `stream_options.include_usage` |
+| Streaming request with Chatbook's initial calculator, datetime, and subagent schemas | HTTP 200 | The initial three tool schemas in isolation |
+| Real repository live harness through Console, AgentService, and Moonshot | HTTP 502 before a recorded tool call | The joined composed request remains defective |
+
+The exact offending field or interaction is not yet established. The remaining
+surface is the final first-turn request as composed by the joined product path,
+especially its messages and any request policy added above the already-proven
+tool-schema builder.
+
+## Goals
+
+- Identify the exact difference between Chatbook's failing first provider
+  request and the smallest equivalent passing request.
+- Pin that difference in a deterministic automated regression at the real
+  provider preparation/transport boundary.
+- Correct the narrowest owner of the invalid value while preserving Moonshot,
+  AgentService, Console, and durable continuation contracts.
+- Prove the joined paid path performs exactly one calculator call, sends its
+  result back to Kimi K3, and receives the required final marker.
+- Keep credentials and complete provider payloads out of persistent artifacts
+  and diagnostic output.
+
+## Non-Goals
+
+- No new provider, model, API mode, endpoint, SDK, or configuration surface.
+- No change to the durable checkpoint schema or Sync-v2 contract.
+- No weakening of native tool selection, approval, execution, or replay.
+- No provider-hosted tools and no expansion of the default Chatbook tool set.
+- No broad provider refactor or unrelated provider behavior change.
+- No paid network request in the default test suite.
+
+## Diagnostic Design
+
+The investigation will capture the final outbound Moonshot request object in
+memory at the existing provider preparation/transport seam. Capture occurs
+after all Console, AgentService, gateway, and Moonshot builder transformations,
+but before authorization headers are attached or network I/O begins.
+
+The captured object will be compared programmatically with a known-passing
+request assembled from the same user prompt and tool schemas. Diagnostics may
+emit only an allowlisted structural summary: request key names, value types,
+collection counts, bounded lengths, and non-reversible digests where equality
+must be checked. They must not print message content, tool arguments, the full
+payload, headers, the credential, or raw provider error bodies.
+
+The comparison proceeds from the smallest high-information boundary:
+
+1. Assert that model, streaming flags, usage options, tool choice, and tool
+   schema structure match the already-passing direct request.
+2. Compare message roles, counts, content shapes, and bounded sizes without
+   logging their values.
+3. If needed, remove or restore one captured request component at a time in a
+   local deterministic harness to identify the first discriminating field.
+4. Use another paid request only after the candidate is isolated locally, to
+   confirm that one difference changes the provider outcome.
+
+The comparison is evidence collection, not a permanent generic payload-logging
+feature. Any test seam introduced must remain narrow, injectable, and inert in
+normal execution.
+
+## Correction Boundary
+
+The regression will enter through the outermost practical product path that
+reproduces the composition defect and assert the final prepared Moonshot
+request. The production correction belongs to the earliest existing component
+that semantically owns the invalid value:
+
+- Moonshot-only policy stays in the Moonshot request builder.
+- Provider-neutral hosted Chat-Completions normalization stays in the neutral
+  hosted wire boundary.
+- Agent/runtime message or tool-catalog composition stays in its current
+  provider-neutral owner.
+
+No downstream layer will silently discard a valid upstream value merely to
+make Moonshot accept the request. Unrelated providers must retain their current
+prepared requests.
+
+## Error And Privacy Contract
+
+- Provider HTTP/network/malformed-response failures continue to use the
+  existing typed, redacted error path.
+- Authorization headers and API keys are never part of captured request data.
+- Complete outbound payloads, prompts, reasoning, tool arguments, and raw
+  provider bodies are never written to logs, tracebacks, fixtures, snapshots,
+  or committed files.
+- Automated assertions use synthetic canaries and structural comparisons so a
+  failure cannot reveal the paid UAT prompt or credential.
+- The paid test remains doubly gated by the explicit live-test opt-in and a
+  nonblank credential.
+
+## Verification
+
+The implementation must use strict RED-to-GREEN evidence:
+
+1. A deterministic regression first reproduces the exact invalid prepared
+   request property without network access.
+2. A focused joined test proves Console/AgentService reaches the Moonshot
+   preparation boundary with the corrected request and still exposes native
+   function tools.
+3. Existing focused Moonshot hosted transport, provider gateway, AgentService,
+   Console continuation, and privacy/redaction tests remain green.
+4. The paid Moonshot harness runs only after local evidence is green and proves
+   exactly one calculator execution, provider continuation with the tool
+   result, and the required final marker.
+5. A final repository search and diff audit prove the local key and full live
+   payload were not added to tracked files.
+
+Per the user's test-scope instruction, verification is limited to touched files
+and directly related Moonshot/hosted/AgentService/Console continuation paths;
+no full-suite or broad-directory sweep is required.
+
+## ADR Check
+
+ADR required: no.
+
+ADR-063 already assigns provider policy, neutral hosted wire mechanics,
+durable continuation ownership, redaction, and replay boundaries. This task is
+a compatibility bug fix inside those accepted boundaries and introduces no new
+architecture decision.

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -1,7 +1,7 @@
 # Moonshot Live Native-Tool UAT Fix Design
 
 Date: 2026-08-13
-Status: Written-spec review approved; awaiting user approval for planning
+Status: User-approved; root-cause evidence incorporated
 Backlog task: [TASK-16074](../../../backlog/tasks/task-16074%20-%20Make-Moonshot-live-native-tool-continuation-pass.md)
 Foundation task: [TASK-15676](../../../backlog/tasks/task-15676%20-%20Harden-Moonshot-Kimi-and-Z.ai-GLM-as-first-class-hosted-providers.md)
 Architecture decision: [ADR-063](../../../backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md)
@@ -9,9 +9,10 @@ Architecture decision: [ADR-063](../../../backlog/decisions/063-hosted-provider-
 ## Purpose
 
 Correct the post-merge Moonshot Kimi K3 defect found by paid UAT: Chatbook's
-real Console-to-AgentService native-tool path receives a provider HTTP 502
-before the first tool call, even though smaller requests against the same
-credential, endpoint, model, streaming protocol, and tool schemas succeed.
+real Console-to-AgentService native-tool path reports HTTP 502 before the first
+tool call, even though the provider accepts the request. The displayed status
+is Chatbook's generic mapping of an internal streaming protocol error, not an
+HTTP 502 response from Moonshot.
 
 The fix must preserve the native-tool and durable-continuation contracts. It
 must not make the UAT pass by removing tools, bypassing the joined product path,
@@ -30,20 +31,25 @@ committed.
 | Minimal non-stream function-tool request | HTTP 200 with one tool call | Basic function-tool support |
 | Minimal streaming function-tool request with usage | HTTP 200 SSE with tool delta and `[DONE]` | Streaming tool calls and `stream_options.include_usage` |
 | Streaming request with Chatbook's initial calculator, datetime, and subagent schemas | HTTP 200 | The initial three tool schemas in isolation |
-| Real repository live harness through Console, AgentService, and Moonshot | HTTP 502 before a recorded tool call | The joined composed request remains defective |
+| Exact joined first-turn messages with the original five and full captured eight-tool catalogs | HTTP 200 | The complete composed request and aggregate tool schemas |
+| Exact request fully consumed through Chatbook's strict Moonshot adapter | `HostedChatProtocolError` at `HostedChatStream._consume_event()` | The failure is response normalization, not request rejection |
+| Redacted event-key trace | `choices`, `created`, `id`, `model`, `object`, `system_fingerprint` | Streaming rejects Moonshot's standard `system_fingerprint` field |
+| Real repository live harness through Console, AgentService, and Moonshot | Synthetic HTTP 502 before a recorded tool call | The parser defect is reachable through the product path |
 
-The exact offending field or interaction is not yet established. The remaining
-surface is the final first-turn request as composed by the joined product path,
-especially its messages and any request policy added above the already-proven
-tool-schema builder. This uncertainty is the investigation target, not an
-implementation placeholder. No production code has been changed at this stage.
+The exact defect is an asymmetric neutral-hosted response allowlist:
+`normalize_hosted_chat_response()` already admits `system_fingerprint` on a
+non-streaming response, while `HostedChatStream._consume_event()` rejects the
+same field on a streaming event. Moonshot currently emits it on the first Kimi
+K3 SSE event. The strict parser raises before consuming the event's tool-call
+delta; the Console gateway then presents its default safe 502 error copy. No
+production code has been changed at this stage.
 
 ## Goals
 
-- Identify the exact difference between Chatbook's failing first provider
-  request and the smallest equivalent passing request.
-- Pin that difference in a deterministic automated regression at the real
-  provider preparation/transport boundary.
+- Admit Moonshot's bounded `system_fingerprint` on hosted streaming events,
+  matching the existing non-streaming contract.
+- Pin that exact live event shape in deterministic parser and joined Console
+  native-tool regressions.
 - Correct the narrowest owner of the invalid value while preserving Moonshot,
   AgentService, Console, and durable continuation contracts.
 - Prove the joined paid path performs exactly one calculator call, sends its
@@ -60,51 +66,50 @@ implementation placeholder. No production code has been changed at this stage.
 - No broad provider refactor or unrelated provider behavior change.
 - No paid network request in the default test suite.
 
-## Diagnostic Design
+## Root-Cause Method
 
-The investigation will capture the final outbound Moonshot request object in
-memory at the existing provider preparation/transport seam. Capture occurs
-after all Console, AgentService, gateway, and Moonshot builder transformations,
-but before authorization headers are attached or network I/O begins.
+The investigation captured the final outbound Moonshot request object in
+memory at the existing provider preparation/transport seam, after all Console,
+AgentService, gateway, and Moonshot builder transformations but before network
+I/O. It then compared only allowlisted structure and non-reversible content
+digests with passing direct requests.
 
-The captured object will be compared programmatically with a known-passing
-request assembled from the same user prompt and tool schemas. Diagnostics may
-emit only an allowlisted structural summary: request key names, value types,
-collection counts, bounded lengths, and non-reversible digests where equality
-must be checked. They must not print message content, tool arguments, the full
-payload, headers, the credential, or raw provider error bodies.
+The captured object was compared programmatically with a known-passing request
+assembled from the same user prompt and tool schemas. Diagnostics emitted only
+an allowlisted structural summary: request key names, value types, collection
+counts, bounded lengths, and non-reversible digests where equality had to be
+checked. They did not print message content, tool arguments, the full payload,
+headers, the credential, or raw provider error bodies.
 
-The comparison proceeds from the smallest high-information boundary:
+The evidence proceeded from the smallest high-information boundary:
 
-1. Assert that model, streaming flags, usage options, tool choice, and tool
-   schema structure match the already-passing direct request.
-2. Compare message roles, counts, content shapes, and bounded sizes without
-   logging their values.
-3. If needed, remove or restore one captured request component at a time in a
-   local deterministic harness to identify the first discriminating field.
-4. Use another paid request only after the candidate is isolated locally, to
-   confirm that one difference changes the provider outcome.
+1. Model, streaming flags, usage options, messages, and the initial tool schemas
+   matched already-passing direct requests.
+2. Each additional runtime tool schema, their combined five-tool catalog, and
+   the exact full captured catalog returned HTTP 200.
+3. Fully consuming the same request through Chatbook reproduced
+   `HostedChatProtocolError` at the stream event allowlist.
+4. A keys-only trace isolated `system_fingerprint` as the sole unexpected
+   top-level field. No response values or raw provider body were printed.
 
-The comparison is evidence collection, not a permanent generic payload-logging
-feature. Any test seam introduced must remain narrow, injectable, and inert in
-normal execution.
+The comparison was evidence collection, not a permanent generic
+payload-logging feature. Its temporary `/tmp` harness was deleted after the
+root cause was isolated; no repository seam was introduced.
 
 ## Correction Boundary
 
-The regression will enter through the outermost practical product path that
-reproduces the composition defect and assert the final prepared Moonshot
-request. The production correction belongs to the earliest existing component
-that semantically owns the invalid value:
+The production change belongs only in
+`tldw_chatbook/LLM_Calls/hosted_chat.py`, whose neutral stream parser owns the
+top-level OpenAI-shaped event allowlist. It will accept
+`system_fingerprint` only as optional bounded metadata, preserve strict
+rejection of unknown keys and malformed/oversized values, and leave tool,
+reasoning, usage, finish, provider, and request construction behavior
+unchanged.
 
-- Moonshot-only policy stays in the Moonshot request builder.
-- Provider-neutral hosted Chat-Completions normalization stays in the neutral
-  hosted wire boundary.
-- Agent/runtime message or tool-catalog composition stays in its current
-  provider-neutral owner.
-
-No downstream layer will silently discard a valid upstream value merely to
-make Moonshot accept the request. Unrelated providers must retain their current
-prepared requests.
+The outer regression will add the exact metadata field to Moonshot's scripted
+SSE in the existing real Console HTTP/native-tool test. No downstream layer
+will discard the field merely to bypass validation, and unrelated providers
+retain their current prepared requests.
 
 ## Error And Privacy Contract
 
@@ -123,11 +128,11 @@ prepared requests.
 
 The implementation must use strict RED-to-GREEN evidence:
 
-1. A deterministic regression first reproduces the exact invalid prepared
-   request property without network access.
-2. A focused joined test proves Console/AgentService reaches the Moonshot
-   preparation boundary with the corrected request and still exposes native
-   function tools.
+1. A deterministic parser regression first reproduces rejection of a bounded
+   `system_fingerprint` streaming event without network access.
+2. A focused joined scripted-HTTP test proves Console/AgentService consumes
+   that exact Moonshot event, executes the native calculator call, continues
+   with its result, and completes.
 3. Existing focused Moonshot hosted transport, provider gateway, AgentService,
    Console continuation, and privacy/redaction tests remain green.
 4. The paid Moonshot harness runs only after local evidence is green and proves

--- a/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+++ b/Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
@@ -34,21 +34,26 @@ committed.
 | Exact joined first-turn messages with the original five and full captured eight-tool catalogs | HTTP 200 | The complete composed request and aggregate tool schemas |
 | Exact request fully consumed through Chatbook's strict Moonshot adapter | `HostedChatProtocolError` at `HostedChatStream._consume_event()` | The failure is response normalization, not request rejection |
 | Redacted event-key trace | `choices`, `created`, `id`, `model`, `object`, `system_fingerprint` | Streaming rejects Moonshot's standard `system_fingerprint` field |
+| Paid UAT after the fingerprint fix | Safe synthetic 502; keys-only failing terminal shape was `choices[0]` with `delta`, `finish_reason`, `index`, `usage` | Moonshot also places terminal usage inside the choice rather than in a trailing top-level usage event |
 | Real repository live harness through Console, AgentService, and Moonshot | Synthetic HTTP 502 before a recorded tool call | The parser defect is reachable through the product path |
 
 The exact defect is an asymmetric neutral-hosted response allowlist:
 `normalize_hosted_chat_response()` already admits `system_fingerprint` on a
 non-streaming response, while `HostedChatStream._consume_event()` rejects the
 same field on a streaming event. Moonshot currently emits it on the first Kimi
-K3 SSE event. The strict parser raises before consuming the event's tool-call
-delta; the Console gateway then presents its default safe 502 error copy. No
-production code has been changed at this stage.
+K3 SSE event. After that mismatch was corrected, the paid joined UAT exposed a
+second strict-shape mismatch: Moonshot places its terminal usage mapping at
+`choices[0].usage`, while the neutral parser previously admitted usage only at
+the event top level. The parser raises before completing the provider turn in
+either case, and the Console gateway presents its default safe 502 error copy.
 
 ## Goals
 
 - Admit Moonshot's bounded `system_fingerprint` on hosted streaming events,
   matching the existing non-streaming contract.
-- Pin that exact live event shape in deterministic parser and joined Console
+- Admit Moonshot's mapping-valued terminal `choices[0].usage` while rejecting
+  nonterminal, non-mapping, or dual top-level/choice placement.
+- Pin both exact live event shapes in deterministic parser and joined Console
   native-tool regressions.
 - Correct the narrowest owner of the invalid value while preserving Moonshot,
   AgentService, Console, and durable continuation contracts.
@@ -89,8 +94,10 @@ The evidence proceeded from the smallest high-information boundary:
    the exact full captured catalog returned HTTP 200.
 3. Fully consuming the same request through Chatbook reproduced
    `HostedChatProtocolError` at the stream event allowlist.
-4. A keys-only trace isolated `system_fingerprint` as the sole unexpected
-   top-level field. No response values or raw provider body were printed.
+4. A keys-only trace isolated `system_fingerprint` as the first unexpected
+   top-level field. After that correction, a second keys/types-only trace of
+   the still-failing paid UAT isolated terminal `choices[0].usage`. No response
+   values or raw provider body were printed.
 
 The comparison was evidence collection, not a permanent generic
 payload-logging feature. Its temporary `/tmp` harness was deleted after the
@@ -100,16 +107,19 @@ root cause was isolated; no repository seam was introduced.
 
 The production change belongs only in
 `tldw_chatbook/LLM_Calls/hosted_chat.py`, whose neutral stream parser owns the
-top-level OpenAI-shaped event allowlist. It will accept
-`system_fingerprint` only as optional bounded metadata, preserve strict
-rejection of unknown keys and malformed/oversized values, and leave tool,
-reasoning, usage, finish, provider, and request construction behavior
+top-level and choice-level OpenAI-shaped event allowlists. It accepts
+`system_fingerprint` only as optional bounded metadata and accepts choice-level
+usage only as a mapping on the terminal choice when no top-level usage is
+present. Unknown keys, malformed/oversized fingerprints, non-mapping usage,
+ambiguous dual placement, and nonterminal usage remain rejected. Tool,
+reasoning, finish, provider, and request construction behavior remain
 unchanged.
 
-The outer regression will add the exact metadata field to Moonshot's scripted
-SSE in the existing real Console HTTP/native-tool test. No downstream layer
-will discard the field merely to bypass validation, and unrelated providers
-retain their current prepared requests.
+The outer regression adds both exact shapes to Moonshot's scripted SSE in the
+existing real Console HTTP/native-tool test. Z.ai retains its prior trailing
+top-level usage event. No downstream layer discards either field merely to
+bypass validation, and unrelated providers retain their current prepared
+requests.
 
 ## Error And Privacy Contract
 
@@ -128,8 +138,9 @@ retain their current prepared requests.
 
 The implementation must use strict RED-to-GREEN evidence:
 
-1. A deterministic parser regression first reproduces rejection of a bounded
-   `system_fingerprint` streaming event without network access.
+1. Deterministic parser regressions first reproduce rejection of a bounded
+   `system_fingerprint` streaming event and terminal `choices[0].usage`
+   without network access, with fail-closed malformed/ambiguous controls.
 2. A focused joined scripted-HTTP test proves Console/AgentService consumes
    that exact Moonshot event, executes the native calculator call, continues
    with its result, and completes.

--- a/Tests/Chat/test_kimi_zai_native_tools.py
+++ b/Tests/Chat/test_kimi_zai_native_tools.py
@@ -93,7 +93,12 @@ def _tool_turn(provider: str) -> bytes:
                         },
                         "finish_reason": None,
                     }
-                ]
+                ],
+                **(
+                    {"system_fingerprint": "fp_kimi_live"}
+                    if provider == "moonshot"
+                    else {}
+                ),
             },
             {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
             {

--- a/Tests/Chat/test_kimi_zai_native_tools.py
+++ b/Tests/Chat/test_kimi_zai_native_tools.py
@@ -61,7 +61,7 @@ def _sse(events: Sequence[dict[str, Any]], *, done: bool = True) -> bytes:
 
 def _stream_usage(provider: str, usage: dict[str, int]) -> tuple[dict, list[dict]]:
     if provider == "moonshot":
-        return {"usage": usage}, []
+        return {"usage": usage}, [{"choices": [], "usage": usage}]
     return {}, [{"choices": [], "usage": usage}]
 
 

--- a/Tests/Chat/test_kimi_zai_native_tools.py
+++ b/Tests/Chat/test_kimi_zai_native_tools.py
@@ -59,7 +59,17 @@ def _sse(events: Sequence[dict[str, Any]], *, done: bool = True) -> bytes:
     return wire + (b"data: [DONE]\n\n" if done else b"")
 
 
+def _stream_usage(provider: str, usage: dict[str, int]) -> tuple[dict, list[dict]]:
+    if provider == "moonshot":
+        return {"usage": usage}, []
+    return {}, [{"choices": [], "usage": usage}]
+
+
 def _tool_turn(provider: str) -> bytes:
+    choice_usage, trailing_usage = _stream_usage(
+        provider,
+        {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+    )
     return _sse(
         [
             {
@@ -100,15 +110,17 @@ def _tool_turn(provider: str) -> bytes:
                     else {}
                 ),
             },
-            {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
             {
-                "choices": [],
-                "usage": {
-                    "prompt_tokens": 20,
-                    "completion_tokens": 10,
-                    "total_tokens": 30,
-                },
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "tool_calls",
+                        **choice_usage,
+                    }
+                ]
             },
+            *trailing_usage,
         ]
     )
 
@@ -215,6 +227,10 @@ def _final_turn(
     reasoning: str | None = None,
 ) -> bytes:
     reasoning = reasoning or f"PRIVATE-{provider}-FINAL-REASONING"
+    choice_usage, trailing_usage = _stream_usage(
+        provider,
+        {"prompt_tokens": 30, "completion_tokens": 5, "total_tokens": 35},
+    )
     return _sse(
         [
             {
@@ -227,17 +243,11 @@ def _final_turn(
                             "reasoning_content": reasoning,
                         },
                         "finish_reason": "stop",
+                        **choice_usage,
                     }
                 ]
             },
-            {
-                "choices": [],
-                "usage": {
-                    "prompt_tokens": 30,
-                    "completion_tokens": 5,
-                    "total_tokens": 35,
-                },
-            },
+            *trailing_usage,
         ]
     )
 

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -739,11 +739,15 @@ def test_hosted_chat_stream_rejects_differing_trailing_usage_duplicate() -> None
                 event=None,
                 data=json.dumps({"choices": [], "usage": {"total_tokens": 4}}),
             ),
+            SSERecord(event=None, data="[DONE]"),
         ]
     )
     stream = HostedChatStream(records, finish_policy=_POLICY)
 
-    with pytest.raises(HostedChatProtocolError):
+    with pytest.raises(
+        HostedChatProtocolError,
+        match=r"^Hosted Chat stream usage is malformed\.$",
+    ):
         list(stream)
 
 
@@ -784,22 +788,36 @@ def test_hosted_chat_stream_rejects_unobserved_usage_duplicates(
     )
     stream = HostedChatStream(records, finish_policy=_POLICY)
 
-    with pytest.raises(HostedChatProtocolError):
+    with pytest.raises(
+        HostedChatProtocolError,
+        match=r"^Hosted Chat stream usage is malformed\.$",
+    ):
         list(stream)
 
 
 @pytest.mark.parametrize(
-    "choice_usage,top_level_usage,finish_reason",
+    "choice_usage,top_level_usage,finish_reason,error_match",
     [
-        (True, None, "stop"),
-        ({"total_tokens": 3}, {"total_tokens": 3}, "stop"),
-        ({"total_tokens": 3}, None, None),
+        (True, None, "stop", r"^Hosted Chat stream usage is malformed\.$"),
+        (
+            {"total_tokens": 3},
+            {"total_tokens": 3},
+            "stop",
+            r"^Hosted Chat stream usage is malformed\.$",
+        ),
+        (
+            {"total_tokens": 3},
+            None,
+            None,
+            r"^Hosted Chat stream usage preceded terminal state\.$",
+        ),
     ],
 )
 def test_hosted_chat_stream_rejects_malformed_or_misplaced_choice_usage(
     choice_usage: object,
     top_level_usage: object,
     finish_reason: str | None,
+    error_match: str,
 ) -> None:
     event = {
         "choices": [
@@ -814,11 +832,16 @@ def test_hosted_chat_stream_rejects_malformed_or_misplaced_choice_usage(
     if top_level_usage is not None:
         event["usage"] = top_level_usage
     stream = HostedChatStream(
-        iter([SSERecord(event=None, data=json.dumps(event))]),
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
         finish_policy=_POLICY,
     )
 
-    with pytest.raises(HostedChatProtocolError):
+    with pytest.raises(HostedChatProtocolError, match=error_match):
         list(stream)
 
 
@@ -870,11 +893,19 @@ def test_hosted_chat_stream_rejects_malformed_system_fingerprint(
         "usage": {"total_tokens": 3},
     }
     stream = HostedChatStream(
-        iter([SSERecord(event=None, data=json.dumps(event))]),
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
         finish_policy=_POLICY,
     )
 
-    with pytest.raises(HostedChatProtocolError):
+    with pytest.raises(
+        HostedChatProtocolError,
+        match=r"^Hosted Chat system fingerprint is malformed\.$",
+    ):
         list(stream)
 
 
@@ -891,11 +922,19 @@ def test_hosted_chat_stream_rejects_unknown_top_level_metadata() -> None:
         "usage": {"total_tokens": 3},
     }
     stream = HostedChatStream(
-        iter([SSERecord(event=None, data=json.dumps(event))]),
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
         finish_policy=_POLICY,
     )
 
-    with pytest.raises(HostedChatProtocolError):
+    with pytest.raises(
+        HostedChatProtocolError,
+        match=r"^Hosted Chat stream event is malformed\.$",
+    ):
         list(stream)
 
 

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -660,6 +660,65 @@ def test_hosted_chat_stream_accepts_usage_only_after_terminal_choice() -> None:
     assert stream.terminal_turn.usage == {"total_tokens": 3}
 
 
+def test_hosted_chat_stream_accepts_terminal_choice_usage() -> None:
+    event = {
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "done"},
+                "finish_reason": "stop",
+                "usage": {"total_tokens": 3},
+            }
+        ]
+    }
+    stream = HostedChatStream(
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
+        finish_policy=_POLICY,
+    )
+
+    assert list(stream) == [event]
+    assert stream.terminal_turn.usage == {"total_tokens": 3}
+
+
+@pytest.mark.parametrize(
+    "choice_usage,top_level_usage,finish_reason",
+    [
+        (True, None, "stop"),
+        ({"total_tokens": 3}, {"total_tokens": 3}, "stop"),
+        ({"total_tokens": 3}, None, None),
+    ],
+)
+def test_hosted_chat_stream_rejects_malformed_or_misplaced_choice_usage(
+    choice_usage: object,
+    top_level_usage: object,
+    finish_reason: str | None,
+) -> None:
+    event = {
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "done"},
+                "finish_reason": finish_reason,
+                "usage": choice_usage,
+            }
+        ]
+    }
+    if top_level_usage is not None:
+        event["usage"] = top_level_usage
+    stream = HostedChatStream(
+        iter([SSERecord(event=None, data=json.dumps(event))]),
+        finish_policy=_POLICY,
+    )
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+
+
 @pytest.mark.parametrize("fingerprint", ["fp_kimi_live", None])
 def test_hosted_chat_stream_accepts_system_fingerprint(
     fingerprint: str | None,

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -660,6 +660,83 @@ def test_hosted_chat_stream_accepts_usage_only_after_terminal_choice() -> None:
     assert stream.terminal_turn.usage == {"total_tokens": 3}
 
 
+@pytest.mark.parametrize("fingerprint", ["fp_kimi_live", None])
+def test_hosted_chat_stream_accepts_system_fingerprint(
+    fingerprint: str | None,
+) -> None:
+    event = {
+        "system_fingerprint": fingerprint,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "done"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"total_tokens": 3},
+    }
+    stream = HostedChatStream(
+        iter(
+            [
+                SSERecord(event=None, data=json.dumps(event)),
+                SSERecord(event=None, data="[DONE]"),
+            ]
+        ),
+        finish_policy=_POLICY,
+    )
+
+    assert list(stream) == [event]
+    assert stream.terminal_turn.text == "done"
+
+
+@pytest.mark.parametrize(
+    "fingerprint",
+    [True, 1, "", "x" * (hosted_chat._MAX_METADATA_CHARS + 1)],
+)
+def test_hosted_chat_stream_rejects_malformed_system_fingerprint(
+    fingerprint: object,
+) -> None:
+    event = {
+        "system_fingerprint": fingerprint,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "done"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"total_tokens": 3},
+    }
+    stream = HostedChatStream(
+        iter([SSERecord(event=None, data=json.dumps(event))]),
+        finish_policy=_POLICY,
+    )
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+
+
+def test_hosted_chat_stream_rejects_unknown_top_level_metadata() -> None:
+    event = {
+        "unexpected_live_metadata": "value",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "done"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"total_tokens": 3},
+    }
+    stream = HostedChatStream(
+        iter([SSERecord(event=None, data=json.dumps(event))]),
+        finish_policy=_POLICY,
+    )
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+
+
 @pytest.mark.parametrize(
     "records",
     [

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -748,6 +748,47 @@ def test_hosted_chat_stream_rejects_differing_trailing_usage_duplicate() -> None
 
 
 @pytest.mark.parametrize(
+    "choice_usage,trailing_usages",
+    [
+        ({"total_tokens": 3}, [{"total_tokens": 3}, {"total_tokens": 3}]),
+        (None, [{"total_tokens": 3}, {"total_tokens": 3}]),
+        ({"total_tokens": 1}, [{"total_tokens": True}]),
+    ],
+)
+def test_hosted_chat_stream_rejects_unobserved_usage_duplicates(
+    choice_usage: dict[str, object] | None,
+    trailing_usages: list[dict[str, object]],
+) -> None:
+    choice: dict[str, object] = {
+        "index": 0,
+        "delta": {"content": "done"},
+        "finish_reason": "stop",
+    }
+    if choice_usage is not None:
+        choice["usage"] = choice_usage
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps({"choices": [choice]}),
+            ),
+            *(
+                SSERecord(
+                    event=None,
+                    data=json.dumps({"choices": [], "usage": usage}),
+                )
+                for usage in trailing_usages
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    stream = HostedChatStream(records, finish_policy=_POLICY)
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+
+
+@pytest.mark.parametrize(
     "choice_usage,top_level_usage,finish_reason",
     [
         (True, None, "stop"),

--- a/Tests/LLM_Calls/test_hosted_chat.py
+++ b/Tests/LLM_Calls/test_hosted_chat.py
@@ -685,6 +685,68 @@ def test_hosted_chat_stream_accepts_terminal_choice_usage() -> None:
     assert stream.terminal_turn.usage == {"total_tokens": 3}
 
 
+def test_hosted_chat_stream_accepts_identical_trailing_usage_duplicate() -> None:
+    usage = {"total_tokens": 3}
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "done"},
+                                "finish_reason": "stop",
+                                "usage": usage,
+                            }
+                        ]
+                    }
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=json.dumps({"choices": [], "usage": usage}),
+            ),
+            SSERecord(event=None, data="[DONE]"),
+        ]
+    )
+    stream = HostedChatStream(records, finish_policy=_POLICY)
+
+    assert len(list(stream)) == 2
+    assert stream.terminal_turn.usage == usage
+
+
+def test_hosted_chat_stream_rejects_differing_trailing_usage_duplicate() -> None:
+    records = iter(
+        [
+            SSERecord(
+                event=None,
+                data=json.dumps(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "done"},
+                                "finish_reason": "stop",
+                                "usage": {"total_tokens": 3},
+                            }
+                        ]
+                    }
+                ),
+            ),
+            SSERecord(
+                event=None,
+                data=json.dumps({"choices": [], "usage": {"total_tokens": 4}}),
+            ),
+        ]
+    )
+    stream = HostedChatStream(records, finish_policy=_POLICY)
+
+    with pytest.raises(HostedChatProtocolError):
+        list(stream)
+
+
 @pytest.mark.parametrize(
     "choice_usage,top_level_usage,finish_reason",
     [

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -857,3 +857,24 @@ unavailable.
 one was in the server repo's own `Config_Files/.env` all along. Before
 recording a live check as blocked on credentials, look in the server repo -- the
 running process was started from it.
+
+---
+
+## Trace the whole stream sequence, not only the first failing event (TASK-16074, 2026-08-13)
+
+**Incident.** Moonshot's paid Kimi K3 native-tool UAT failed behind Console's
+safe synthetic 502. A keys-only trace of the first rejected SSE event isolated
+`system_fingerprint`; the parser fix passed every deterministic and joined
+fixture, but the paid UAT still failed. The next structural trace found terminal
+`choices[0].usage`; supporting that also passed the suite, but the paid UAT still
+failed because Moonshot repeated the identical usage mapping in the following
+top-level empty-choice event. The first probe was correct but incomplete: three
+valid shapes appeared at different points in one live stream.
+
+**What to do.** When a strict streaming parser rejects a real provider, trace
+the complete event sequence using only key names, container types/counts,
+bounded enums, and parser state transitions. Do not stop after the first
+unexpected field, and do not log raw values or bodies. Turn every newly observed
+sequence rule into RED/GREEN coverage, including negative controls for repeated,
+conflicting, misplaced, and JSON-type-distinct data. A first-event trace proves
+one incompatibility; only consuming the whole live stream proves the contract.

--- a/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
+++ b/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
@@ -1,0 +1,41 @@
+---
+id: TASK-16074
+title: Make Moonshot live native-tool continuation pass
+status: In Progress
+assignee: []
+created_date: '2026-08-14 02:20'
+labels: []
+dependencies:
+  - TASK-15676
+references:
+  - backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md
+  - Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so the real Console tool-call and continuation path completes successfully without weakening the provider contract or exposing credentials.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
+- [ ] #2 The exact outbound payload difference that caused Moonshot HTTP 502 is pinned by an automated regression at the real provider boundary.
+- [ ] #3 Moonshot credentials and provider payloads remain absent from logs, tracebacks, fixtures, and committed files.
+- [ ] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+Planning is intentionally deferred until the written design has completed its
+review gate.
+
+ADR required: no
+
+ADR path: backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md
+
+Reason: this is a compatibility correction within ADR-063's existing hosted
+provider wire and durable continuation boundaries; it does not introduce a new
+storage, sync, security, dependency, or cross-module ownership decision.

--- a/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
+++ b/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
@@ -23,17 +23,19 @@ Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
-- [ ] #2 The exact Moonshot SSE metadata field that triggered Chatbook's synthetic HTTP 502 error is accepted under a bounded allowlist and pinned by an automated regression at the real provider boundary.
+- [ ] #2 The exact Moonshot SSE fingerprint and terminal choice-usage shapes that triggered Chatbook's synthetic HTTP 502 errors are accepted under bounded, fail-closed validation and pinned by automated regressions at the real provider boundary.
 - [ ] #3 Moonshot credentials and captured live/raw provider payloads remain absent from logs, tracebacks, fixtures, and committed files; regressions use only minimal synthetic SSE data.
 - [ ] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
 
-1. Pin Moonshot's bounded `system_fingerprint` streaming event in the neutral
-   hosted parser and joined Console native-tool fixtures with strict RED tests.
-2. Apply the minimal provider-neutral streaming allowlist/metadata validation
-   correction and prove unknown or oversized metadata still fails closed.
+1. Pin Moonshot's bounded `system_fingerprint` and terminal
+   `choices[0].usage` streaming shapes in the neutral hosted parser and joined
+   Console native-tool fixtures with strict RED tests.
+2. Apply the minimal provider-neutral streaming validation corrections and
+   prove malformed, ambiguous, misplaced, unknown, or oversized data still
+   fails closed.
 3. Run only focused hosted/Moonshot/AgentService/Console/privacy regressions,
    then the doubly gated paid Moonshot UAT.
 4. Close task evidence, rebase on `dev`, open the follow-up PR, address its

--- a/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
+++ b/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
@@ -23,7 +23,7 @@ Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
-- [ ] #2 The exact Moonshot SSE fingerprint and terminal choice-usage shapes that triggered Chatbook's synthetic HTTP 502 errors are accepted under bounded, fail-closed validation and pinned by automated regressions at the real provider boundary.
+- [ ] #2 The exact Moonshot SSE fingerprint, terminal choice usage, and identical trailing usage duplicate that triggered Chatbook's synthetic HTTP 502 errors are accepted under bounded, fail-closed validation and pinned by automated regressions at the real provider boundary.
 - [ ] #3 Moonshot credentials and captured live/raw provider payloads remain absent from logs, tracebacks, fixtures, and committed files; regressions use only minimal synthetic SSE data.
 - [ ] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
 <!-- AC:END -->
@@ -31,10 +31,11 @@ Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so 
 ## Implementation Plan
 
 1. Pin Moonshot's bounded `system_fingerprint` and terminal
-   `choices[0].usage` streaming shapes in the neutral hosted parser and joined
-   Console native-tool fixtures with strict RED tests.
+   `choices[0].usage` plus identical trailing usage streaming shapes in the
+   neutral hosted parser and joined Console native-tool fixtures with strict
+   RED tests.
 2. Apply the minimal provider-neutral streaming validation corrections and
-   prove malformed, ambiguous, misplaced, unknown, or oversized data still
+   prove malformed, conflicting, misplaced, unknown, or oversized data still
    fails closed.
 3. Run only focused hosted/Moonshot/AgentService/Console/privacy regressions,
    then the doubly gated paid Moonshot UAT.

--- a/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
+++ b/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
@@ -10,6 +10,7 @@ dependencies:
 references:
   - backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md
   - Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+  - Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
 priority: high
 ---
 
@@ -22,15 +23,21 @@ Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
-- [ ] #2 The exact outbound payload difference that caused Moonshot HTTP 502 is pinned by an automated regression at the real provider boundary.
-- [ ] #3 Moonshot credentials and provider payloads remain absent from logs, tracebacks, fixtures, and committed files.
+- [ ] #2 The exact Moonshot SSE metadata field that triggered Chatbook's synthetic HTTP 502 error is accepted under a bounded allowlist and pinned by an automated regression at the real provider boundary.
+- [ ] #3 Moonshot credentials and captured live/raw provider payloads remain absent from logs, tracebacks, fixtures, and committed files; regressions use only minimal synthetic SSE data.
 - [ ] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
 
-Planning is intentionally deferred until the written design has completed its
-review gate.
+1. Pin Moonshot's bounded `system_fingerprint` streaming event in the neutral
+   hosted parser and joined Console native-tool fixtures with strict RED tests.
+2. Apply the minimal provider-neutral streaming allowlist/metadata validation
+   correction and prove unknown or oversized metadata still fails closed.
+3. Run only focused hosted/Moonshot/AgentService/Console/privacy regressions,
+   then the doubly gated paid Moonshot UAT.
+4. Close task evidence, rebase on `dev`, open the follow-up PR, address its
+   checks/review comments, merge it, and clean up the branch/worktree.
 
 ADR required: no
 

--- a/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
+++ b/backlog/tasks/task-16074 - Make-Moonshot-live-native-tool-continuation-pass.md
@@ -1,15 +1,17 @@
 ---
 id: TASK-16074
 title: Make Moonshot live native-tool continuation pass
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-14 02:20'
+updated_date: '2026-08-14 03:43'
 labels: []
 dependencies:
   - TASK-15676
 references:
   - backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuation.md
-  - Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-13-task-16074-moonshot-live-tool-uat-fix-design.md
   - Docs/superpowers/plans/2026-08-13-task-16074-moonshot-live-tool-uat-fix.md
 priority: high
 ---
@@ -22,14 +24,15 @@ Correct the post-merge Moonshot Kimi K3 integration defect found by paid UAT so 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
-- [ ] #2 The exact Moonshot SSE fingerprint, terminal choice usage, and identical trailing usage duplicate that triggered Chatbook's synthetic HTTP 502 errors are accepted under bounded, fail-closed validation and pinned by automated regressions at the real provider boundary.
-- [ ] #3 Moonshot credentials and captured live/raw provider payloads remain absent from logs, tracebacks, fixtures, and committed files; regressions use only minimal synthetic SSE data.
-- [ ] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
+- [x] #1 A doubly gated paid Moonshot Kimi K3 probe completes exactly one calculator call, continues with the tool result, and returns the required final marker.
+- [x] #2 The exact Moonshot SSE fingerprint, terminal choice usage, and identical trailing usage duplicate that triggered Chatbook's synthetic HTTP 502 errors are accepted under bounded, fail-closed validation and pinned by automated regressions at the real provider boundary.
+- [x] #3 Moonshot credentials and captured live/raw provider payloads remain absent from logs, tracebacks, fixtures, and committed files; regressions use only minimal synthetic SSE data.
+- [x] #4 Focused Moonshot, hosted Chat, AgentService, and Console continuation regressions remain green without changing unrelated provider behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Pin Moonshot's bounded `system_fingerprint` and terminal
    `choices[0].usage` plus identical trailing usage streaming shapes in the
    neutral hosted parser and joined Console native-tool fixtures with strict
@@ -49,3 +52,26 @@ ADR path: backlog/decisions/063-hosted-provider-wire-and-durable-tool-continuati
 Reason: this is a compatibility correction within ADR-063's existing hosted
 provider wire and durable continuation boundaries; it does not introduce a new
 storage, sync, security, dependency, or cross-module ownership decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Corrected the neutral hosted stream parser for Moonshot's live Kimi K3 event
+  sequence: bounded `system_fingerprint`, terminal choice-level usage, and one
+  type-strict identical trailing usage duplicate. Unknown, malformed,
+  misplaced, conflicting, repeated, and JSON-type-distinct data remain rejected.
+- Added pure parser RED/GREEN coverage and Moonshot-only joined
+  Console→AgentService→HTTP fixtures; Z.ai retains its prior wire shape.
+- Paid UAT passed on reviewed, rebased code SHA `da2816853`: the doubly gated
+  live node completed one calculator call, continued with its result, and
+  returned the required final marker (`1 passed` in 16.82s).
+- Focused verification: 109 touched-file tests passed; 77 provider/Console
+  related tests passed with two opt-in live skips; 60 AgentService/privacy tests
+  passed. Ruff, formatter, focused mypy, compileall, and diff checks passed.
+- Two independent final reviews approved the code/spec. A filenames-only
+  tracked-tree search found no credential match, and no raw live payload or
+  temporary diagnostic harness is committed.
+- Reused ADR-063; no new ADR was required. The plan expanded only after paid UAT
+  revealed later stream events that the first keys-only trace could not see.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -48,6 +48,22 @@ class HostedChatProtocolError(ValueError):
     """Raised when a hosted provider returns malformed Chat data."""
 
 
+def _same_json_value(left: object, right: object) -> bool:
+    return json.dumps(
+        left,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ) == json.dumps(
+        right,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
 class HostedChatFinishPolicy(Protocol):
     """Provider-owned finish and reasoning validation policy."""
 
@@ -110,6 +126,8 @@ class HostedChatStream(Iterator[dict[str, Any]]):
         self._call_ids: set[str] = set()
         self._finish_reason: str | None = None
         self._usage: dict[str, Any] | None = None
+        self._usage_from_choice = False
+        self._trailing_usage_seen = False
         self._terminal_turn: HostedChatTurn | None = None
         self._output_chars = 0
         self._closed = False
@@ -199,6 +217,7 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             _required_metadata(fingerprint, "system fingerprint")
         choices = event.get("choices")
         usage = event.get("usage")
+        usage_from_choice = False
         if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):
             raise HostedChatProtocolError("Hosted Chat stream choices are malformed.")
         if usage is not None and not isinstance(usage, Mapping):
@@ -207,9 +226,16 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             if self._finish_reason is None or usage is None:
                 raise HostedChatProtocolError("Hosted Chat stream usage is misplaced.")
             normalized_usage = deepcopy(dict(usage))
-            if self._usage is not None and self._usage != normalized_usage:
+            if self._usage is None:
+                self._usage = normalized_usage
+            elif not (
+                self._usage_from_choice
+                and not self._trailing_usage_seen
+                and _same_json_value(self._usage, normalized_usage)
+            ):
                 raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
-            self._usage = normalized_usage
+            else:
+                self._trailing_usage_seen = True
             return deepcopy(dict(event))
         if self._finish_reason is not None:
             raise HostedChatProtocolError(
@@ -232,6 +258,7 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             if "usage" in event or not isinstance(choice_usage, Mapping):
                 raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
             usage = choice_usage
+            usage_from_choice = True
         if type(choice.get("index")) is not int or choice.get("index") != 0:
             raise HostedChatProtocolError(
                 "Hosted Chat stream choice index is malformed."
@@ -273,6 +300,7 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             )
             if usage is not None:
                 self._usage = deepcopy(dict(usage))
+                self._usage_from_choice = usage_from_choice
         elif usage is not None:
             raise HostedChatProtocolError(
                 "Hosted Chat stream usage preceded terminal state."

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -204,9 +204,12 @@ class HostedChatStream(Iterator[dict[str, Any]]):
         if usage is not None and not isinstance(usage, Mapping):
             raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
         if not choices:
-            if self._finish_reason is None or usage is None or self._usage is not None:
+            if self._finish_reason is None or usage is None:
                 raise HostedChatProtocolError("Hosted Chat stream usage is misplaced.")
-            self._usage = deepcopy(dict(usage))
+            normalized_usage = deepcopy(dict(usage))
+            if self._usage is not None and self._usage != normalized_usage:
+                raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
+            self._usage = normalized_usage
             return deepcopy(dict(event))
         if self._finish_reason is not None:
             raise HostedChatProtocolError(

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -184,8 +184,19 @@ class HostedChatStream(Iterator[dict[str, Any]]):
                 pass
 
     def _consume_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
-        if set(event) - {"id", "object", "created", "model", "choices", "usage"}:
+        if set(event) - {
+            "id",
+            "object",
+            "created",
+            "model",
+            "system_fingerprint",
+            "choices",
+            "usage",
+        }:
             raise HostedChatProtocolError("Hosted Chat stream event is malformed.")
+        fingerprint = event.get("system_fingerprint")
+        if fingerprint is not None:
+            _required_metadata(fingerprint, "system fingerprint")
         choices = event.get("choices")
         usage = event.get("usage")
         if not isinstance(choices, Sequence) or isinstance(choices, (str, bytes)):

--- a/tldw_chatbook/LLM_Calls/hosted_chat.py
+++ b/tldw_chatbook/LLM_Calls/hosted_chat.py
@@ -221,8 +221,14 @@ class HostedChatStream(Iterator[dict[str, Any]]):
             "index",
             "delta",
             "finish_reason",
+            "usage",
         }:
             raise HostedChatProtocolError("Hosted Chat stream choice is malformed.")
+        if "usage" in choice:
+            choice_usage = choice.get("usage")
+            if "usage" in event or not isinstance(choice_usage, Mapping):
+                raise HostedChatProtocolError("Hosted Chat stream usage is malformed.")
+            usage = choice_usage
         if type(choice.get("index")) is not int or choice.get("index") != 0:
             raise HostedChatProtocolError(
                 "Hosted Chat stream choice index is malformed."


### PR DESCRIPTION
## Summary

- accept Moonshot Kimi K3 streaming `system_fingerprint`
- accept terminal choice-level usage plus exactly one type-strict identical trailing usage duplicate
- preserve strict rejection of malformed, misplaced, conflicting, repeated, unknown, and JSON-type-distinct data
- pin the exact live shapes in parser and joined Console/AgentService regressions

Closes TASK-16074. Reuses ADR-063; no new ADR required.

## Verification

- 109 touched-file tests passed
- 77 focused provider/Console tests passed; 2 opt-in live cases skipped in the non-live matrix
- 60 AgentService/privacy tests passed
- Ruff, formatter, focused mypy, compileall, and diff checks passed
- two independent final reviews approved
- paid Moonshot UAT passed on reviewed code SHA `da2816853`: exactly one calculator call, result continuation, and required final marker (`1 passed` in 16.82s)

## Privacy

The API key remained in the ignored local `moonshot-api-key.txt`; filenames-only tracked-tree searches found no match. No raw live payload, provider body, prompt, or diagnostic harness is committed.
