### PR TITLE
perf(library): compose once per visit

### DIFF
--- a/Docs/superpowers/plans/2026-08-13-library-compose-once.md
+++ b/Docs/superpowers/plans/2026-08-13-library-compose-once.md
@@ -1,0 +1,946 @@
+# Library Compose-Once-Per-Visit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the first Library composition authoritative and reconcile every automatically started entry result through retained rail/canvas owners with zero whole-screen recomposes.
+
+**Architecture:** `LibraryScreen` remains the entry-lifecycle and route authority. A focused snapshot-cache module validates and clones the app-scoped cache before composition, while a strict screen-owned reconciliation router tracks state generation, rendered generation, dirtiness, and route identity. Existing canvas `sync_state()` seams plus retained landing/handoff owners project changes below the screen boundary; route-specific entry workers use the same strict contract.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, Rich, pytest, pytest-asyncio, Ruff, Backlog.md.
+
+## Global Constraints
+
+- During the automatic entry lifecycle, `LibraryScreen.compose_content()` is called exactly once per visit.
+- Destination construction, mount, cache seed, source timeout, fresh reconciliation, retry, and automatically launched route workers must never call `LibraryScreen.refresh(recompose=True)` or `LibraryScreen.recompose()`.
+- Canvas-owned `sync_state()` may recompose only the retained canvas that owns the changed presentation.
+- User-initiated interactions remain out of scope, but they supersede stale entry-route ownership.
+- A valid cache is cloned and applied after constructor field initialization and before `restore_state()`/first composition.
+- Cache validation recognizes Notes/Media/Conversations record tuples, Prompts `(count, ())`, and Skills `(count, context_payload)`.
+- No mutable container reachable through the known snapshot schema may be shared between the app cache and a screen.
+- Equal fresh data performs zero DOM work only when rendered generation equals state generation and reconciliation is not dirty.
+- A failed strict update marks the generation dirty; an equal later result may retry it.
+- Targeted updates preserve semantic focus, selection, and scroll when the same enabled target remains.
+- Deferred work rechecks screen attachment, generation, and route identity before touching the DOM.
+- DOM remove/mount operations stay on the Textual message pump, not in an independent worker group.
+- Preserve current cache TTL, source queries, page sizes, service ownership, cancellation groups, copy, and screen-per-visit navigation.
+- Do not add dependencies, persistence, schema changes, or a new service boundary.
+- Render evidence must inspect the compositor/exported frame, not only widget state or geometry.
+- UAT uses a scratch `TLDW_CONFIG_PATH` whose `[paths].data_dir` is also scratch, plus before/after fingerprints of the real profile.
+- Use the parent `dev` worktree virtual environment for pytest commands.
+- ADR required: no.
+- ADR path: N/A.
+- ADR reason: this applies existing cache, screen/rail/canvas ownership, and targeted-update contracts without changing a durable or cross-module boundary.
+
+## File Structure
+
+- Create `tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py`: snapshot type aliases, schema validation, and copy-on-read/copy-on-write cloning.
+- Create `tldw_chatbook/Widgets/Library/library_entry_canvases.py`: retained Landing and Study handoff owners with in-place state synchronization.
+- Modify `tldw_chatbook/Widgets/Library/library_collections_panel.py`: add complete panel `sync_state()` for entry-result projection.
+- Modify `tldw_chatbook/UI/Screens/library_screen.py`: pre-compose cache seed, strict generation/router state, semantic focus capture, structural canvas replacement, and entry-worker routing.
+- Create `Tests/Library/test_library_snapshot_cache.py`: pure schema, malformed-input, and nested-alias tests.
+- Create `Tests/UI/test_library_entry_compose_once.py`: mounted lifecycle, entry-worker, identity, focus/scroll, race, retry, compositor, and latency evidence.
+- Modify `Tests/UI/test_library_shell.py`: retain existing cache/restored-route contracts while removing assertions that depend on a screen-level recompose.
+- Modify `Tests/UI/test_library_canvas_sync_defects.py`: extend portable focus/scroll coverage from Notes to snapshot-owned canvases.
+- Modify `backlog/tasks/task-15459 - Library---compose-once-per-visit.md`: implementation plan link, completed criteria, verification evidence, ADR disposition, and implementation notes.
+
+---
+
+### Task 1: Schema-Aware Cache and Pre-Compose Seed
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py`
+- Create: `Tests/Library/test_library_snapshot_cache.py`
+- Create: `Tests/UI/test_library_entry_compose_once.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_shell.py:6434-6680`
+
+**Interfaces:**
+
+- Produces: `LibrarySourceSnapshot`, the six-field snapshot alias consumed by `LibraryScreen`.
+- Produces: `clone_library_source_snapshot(snapshot: object) -> LibrarySourceSnapshot | None`.
+- Produces: `LibraryScreen._seed_local_source_snapshot_from_cache(*, now: float | None = None) -> bool`.
+- Consumes: `LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS`, app attributes `_library_source_snapshot_cache` and `_library_source_snapshot_cache_stamp`, and `_apply_local_source_snapshot(..., schedule_reconcile=False)` from Task 2's final signature. Until Task 2 lands, add the keyword with a default of `True` and keep existing mounted behavior.
+
+- [ ] **Step 1: Verify no parallel implementation has landed since the design checkpoint**
+
+Run from the isolated worktree:
+
+```powershell
+gh pr list --state all --search "15459" --json number,title,state,headRefName
+git fetch -q origin
+git log --oneline (git merge-base origin/dev HEAD)..origin/dev -- `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_shell.py `
+  backlog/tasks/'task-15459 - Library---compose-once-per-visit.md'
+```
+
+Expected: no independent TASK-15459 implementation or overlapping upstream change. If one exists, stop execution and reconcile it before editing.
+
+- [ ] **Step 2: Record the pre-change repeat-visit baseline**
+
+Add the harness below to `Tests/UI/test_library_entry_compose_once.py`. It records calls at the requirement boundary rather than inferring them from child mounts:
+
+```python
+from __future__ import annotations
+
+import statistics
+import time
+
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _build_test_app,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_library_shell,
+)
+
+
+@pytest.mark.asyncio
+async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatch):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    calls: list[LibraryScreen] = []
+    original = LibraryScreen.compose_content
+
+    def counted_compose(screen):
+        calls.append(screen)
+        yield from original(screen)
+
+    monkeypatch.setattr(LibraryScreen, "compose_content", counted_compose)
+    samples: list[float] = []
+    revisits: list[LibraryScreen] = []
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        first = _active_library_screen(host)
+        await _wait_for_library_shell(first, pilot)
+        await host.pop_screen()
+        await pilot.pause()
+        for _ in range(5):
+            revisit = LibraryScreen(app)
+            revisits.append(revisit)
+            started = time.perf_counter()
+            await host.push_screen(revisit)
+            await _wait_for_library_shell(revisit, pilot)
+            samples.append((time.perf_counter() - started) * 1000)
+            await host.pop_screen()
+            await pilot.pause()
+    print(
+        f"warm_visit_median_ms={statistics.median(samples):.3f} "
+        f"min_ms={min(samples):.3f} max_ms={max(samples):.3f} n={len(samples)}"
+    )
+    assert all(calls.count(revisit) == 1 for revisit in revisits)
+```
+
+Run:
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/UI/test_library_entry_compose_once.py::test_warm_repeat_visit_composes_once_before_fresh_reconcile `
+  -vv -s
+```
+
+Expected on the pre-change implementation: FAIL because the second screen composes more than once; preserve the printed timing and compose count in the task evidence.
+
+- [ ] **Step 3: Write failing pure cache-schema and deep-isolation tests**
+
+Add tests that cover both special entries and nested mutable records:
+
+```python
+from tldw_chatbook.UI.Library_Modules.library_snapshot_cache import (
+    clone_library_source_snapshot,
+)
+
+
+def _snapshot():
+    return (
+        {
+            "notes": ({"id": "n1", "meta": {"tags": ["a"]}},),
+            "media": ({"id": "m1"},),
+            "conversations": ({"id": "c1"},),
+            "prompts": (2, ()),
+            "skills": (
+                1,
+                {
+                    "available_skills": [{"name": "alpha", "tags": ["safe"]}],
+                    "blocked_skills": [],
+                },
+            ),
+        },
+        {"notes": 1, "media": 1, "conversations": 1},
+        {"notes": True, "media": True, "conversations": True},
+        None,
+        None,
+        {"study_decks": 1, "flashcards_due": 2, "quizzes": 3},
+    )
+
+
+def test_clone_accepts_real_prompt_and_skill_shapes_without_aliasing():
+    original = _snapshot()
+    cloned = clone_library_source_snapshot(original)
+    assert cloned == original
+    assert cloned is not original
+    assert cloned[0] is not original[0]
+    assert cloned[0]["notes"][0] is not original[0]["notes"][0]
+    assert cloned[0]["skills"][1] is not original[0]["skills"][1]
+    assert cloned[0]["skills"][1]["available_skills"] is not original[0]["skills"][1]["available_skills"]
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [None, (), ({},), ({"notes": []}, {}, {}, None, None, {})],
+)
+def test_clone_rejects_malformed_outer_or_source_shapes(malformed):
+    assert clone_library_source_snapshot(malformed) is None
+```
+
+Run:
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/Library/test_library_snapshot_cache.py -vv
+```
+
+Expected: FAIL at collection because `library_snapshot_cache` does not exist.
+
+- [ ] **Step 4: Implement the schema-aware clone helper**
+
+Create `library_snapshot_cache.py` with the exact public boundary below. Use `copy.deepcopy` only after validating the known outer/source shapes, so malformed arbitrary objects are never traversed as snapshots:
+
+```python
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+LibrarySourceSnapshot = tuple[
+    dict[str, tuple[Any, ...]],
+    dict[str, int],
+    dict[str, bool],
+    str | None,
+    Any,
+    dict[str, int | None],
+]
+
+_RECORD_SOURCES = ("notes", "media", "conversations")
+
+
+def clone_library_source_snapshot(snapshot: object) -> LibrarySourceSnapshot | None:
+    if not isinstance(snapshot, tuple) or len(snapshot) != 6:
+        return None
+    records, counts, total_known, lookup_error, recovery_state, study_counts = snapshot
+    if not all(isinstance(value, Mapping) for value in (records, counts, total_known, study_counts)):
+        return None
+    if any(not isinstance(records.get(source), tuple) for source in _RECORD_SOURCES):
+        return None
+    if any(not isinstance(record, Mapping) for source in _RECORD_SOURCES for record in records[source]):
+        return None
+    if any(not isinstance(counts.get(source), int) for source in _RECORD_SOURCES):
+        return None
+    if any(not isinstance(total_known.get(source), bool) for source in _RECORD_SOURCES):
+        return None
+    if any(
+        study_counts.get(key) is not None and not isinstance(study_counts.get(key), int)
+        for key in ("study_decks", "flashcards_due", "quizzes")
+    ):
+        return None
+    if lookup_error is not None and not isinstance(lookup_error, str):
+        return None
+    prompts = records.get("prompts")
+    skills = records.get("skills")
+    if not isinstance(prompts, tuple) or len(prompts) != 2 or not isinstance(prompts[1], tuple):
+        return None
+    if not isinstance(skills, tuple) or len(skills) != 2 or not isinstance(skills[1], Mapping):
+        return None
+    if prompts[0] is not None and not isinstance(prompts[0], int):
+        return None
+    if skills[0] is not None and not isinstance(skills[0], int):
+        return None
+    cloned = copy.deepcopy(snapshot)
+    return (
+        dict(cloned[0]),
+        dict(cloned[1]),
+        dict(cloned[2]),
+        cloned[3],
+        cloned[4],
+        dict(cloned[5]),
+    )
+```
+
+- [ ] **Step 5: Move cache application before composition**
+
+In `LibraryScreen.__init__`, initialize every snapshot/router field first, then call:
+
+```python
+self._seed_local_source_snapshot_from_cache()
+```
+
+Add:
+
+```python
+def _seed_local_source_snapshot_from_cache(self, *, now: float | None = None) -> bool:
+    stamp = getattr(self.app_instance, "_library_source_snapshot_cache_stamp", None)
+    if not isinstance(stamp, (int, float)):
+        return False
+    age = (time.monotonic() if now is None else now) - float(stamp)
+    if age < 0 or age >= LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS:
+        return False
+    snapshot = clone_library_source_snapshot(
+        getattr(self.app_instance, "_library_source_snapshot_cache", None)
+    )
+    if snapshot is None:
+        return False
+    self._apply_local_source_snapshot(*snapshot, schedule_reconcile=False)
+    return True
+```
+
+Delete the cache read/apply and explicit `self.refresh(recompose=True)` block from `on_mount()`. On successful fresh lookup, write `clone_library_source_snapshot(snapshot)` to the app cache and never store the screen's live containers.
+
+- [ ] **Step 6: Pin constructor/restore ordering and third-visit isolation**
+
+Extend `test_library_entry_compose_once.py` with a cache seeded before screen construction. Assert `_library_loaded` and cached counts before mounting, call `restore_state()`, and prove restored filter/selection wins. Extend the pure cache test by mutating nested Note and Skills lists in the second clone and asserting a third clone still equals the original.
+
+Run:
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/Library/test_library_snapshot_cache.py `
+  Tests/UI/test_library_shell.py -k "snapshot_cache or repeat_visit or restore_state" `
+  Tests/UI/test_library_entry_compose_once.py::test_warm_repeat_visit_composes_once_before_fresh_reconcile `
+  -vv -s
+```
+
+Expected: pure cache and ordering tests PASS; the compose-once test remains RED only for the fresh mounted reconcile, which Task 2 removes.
+
+- [ ] **Step 7: Run scoped Ruff and commit Task 1**
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py `
+  Tests/Library/test_library_snapshot_cache.py `
+  Tests/UI/test_library_entry_compose_once.py
+git diff --check
+git add -- `
+  tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/Library/test_library_snapshot_cache.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_shell.py
+git commit -m "perf(library): seed source cache before compose"
+```
+
+---
+
+### Task 2: Strict Generation-Gated Snapshot Reconciliation
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:1318-1504, 6229-6425`
+- Modify: `Tests/UI/test_library_entry_compose_once.py`
+- Modify: `Tests/UI/test_library_shell.py:23648-23735`
+
+**Interfaces:**
+
+- Produces: `LibraryEntryReconcileResult(Enum)` with `APPLIED`, `ALREADY_CURRENT`, `SUPERSEDED`, and `FAILED`.
+- Produces: `LibraryScreen._library_entry_route_key() -> tuple[object, ...]`.
+- Produces: `_sync_library_canvas(..., allow_screen_fallback: bool = True) -> bool`.
+- Produces: `LibraryScreen._schedule_library_entry_reconcile(generation: int, route_key: tuple[object, ...]) -> None`.
+- Produces: `async LibraryScreen._reconcile_library_entry_state(generation: int, route_key: tuple[object, ...]) -> LibraryEntryReconcileResult`.
+- Produces: `LibraryScreen._complete_library_entry_reconcile(generation: int, route_key: tuple[object, ...]) -> None`.
+- Changes: `_apply_local_source_snapshot(..., schedule_reconcile: bool = True) -> bool`, returning whether normalized presentation changed.
+
+- [ ] **Step 1: Write failing changed/equal/dirty generation tests**
+
+Use a mounted Conversations route and record the screen/rail/host/canvas identities. Patch both whole-screen APIs to append calls after first paint rather than raising inside broad exception handlers:
+
+```python
+refresh_calls: list[bool] = []
+recompose_calls: list[LibraryScreen] = []
+
+original_refresh = LibraryScreen.refresh
+original_recompose = LibraryScreen.recompose
+
+def recorded_refresh(screen, *regions, **kwargs):
+    refresh_calls.append(bool(kwargs.get("recompose")))
+    return original_refresh(screen, *regions, **kwargs)
+
+async def recorded_recompose(screen):
+    recompose_calls.append(screen)
+    return await original_recompose(screen)
+```
+
+Add three assertions:
+
+1. A changed snapshot updates rail and Conversations canvas while all four captured owners retain identity.
+2. An equal clean snapshot updates cache timestamp but calls neither canvas `sync_state()` nor either screen recompose API.
+3. Marking `_library_entry_reconcile_dirty = True` makes the same equal snapshot call targeted sync once and clear dirtiness.
+
+Run the three node IDs. Expected: FAIL because state/rendered generations and strict routing do not exist.
+
+- [ ] **Step 2: Make the shared canvas helper strict-capable**
+
+Change the helper boundary without changing legacy callers. Retain the current
+kind dispatch and state construction verbatim, initialize `canvas: Widget | None
+= None` before its `try`, return `True` immediately after the existing
+`canvas.sync_state(...)`, and replace the exception tail with:
+
+```python
+except Exception:
+    logger.opt(exception=True).debug(f"Library {kind} canvas sync failed.")
+    if allow_screen_fallback:
+        screen.refresh(recompose=True)
+        if then is not None:
+            screen.call_after_refresh(then)
+    elif then is not None and isinstance(canvas, PostRecomposeCallback):
+        canvas.queue_after_recompose(None)
+    return False
+```
+
+Keep `allow_screen_fallback=True` as the default so out-of-scope user-interaction callers retain current behavior. Every entry-lifecycle caller added by this plan passes `False` explicitly.
+
+- [ ] **Step 3: Add state/rendered generations and a route key**
+
+Initialize these class-safe fields in `__init__` before cache seeding:
+
+```python
+self._library_snapshot_state_generation = 0
+self._library_snapshot_rendered_generation = 0
+self._library_entry_reconcile_dirty = False
+self._library_entry_reconcile_pending: tuple[int, tuple[object, ...]] | None = None
+self._library_entry_reconcile_retry_generation: int | None = None
+```
+
+Implement a route key containing the fields that select the mounted owner:
+
+```python
+def _library_entry_route_key(self) -> tuple[object, ...]:
+    return (
+        self._library_selected_row_id,
+        self._library_notes_source,
+        self._library_notes_view,
+        self._library_media_view,
+        self._library_prompts_view,
+        self._library_skills_view,
+        self._selected_note_id,
+        self._selected_media_id,
+        self._selected_prompt_id,
+        self._selected_skill_name,
+    )
+```
+
+- [ ] **Step 4: Split state mutation from mounted projection**
+
+Normalize and compare all six snapshot fields before assignment. On changed presentation, increment state generation and set `_library_entry_reconcile_dirty = True` before scheduling projection. On a clean equal result, return `False` after cache freshness is written. On a dirty equal result, retain the generation and schedule repair. Constructor cache seeding passes `schedule_reconcile=False` and sets rendered generation equal to state generation because the first compose will project that state.
+
+Schedule DOM work on the screen pump:
+
+```python
+def _schedule_library_entry_reconcile(
+    self, generation: int, route_key: tuple[object, ...]
+) -> None:
+    pending = (generation, route_key)
+    if self._library_entry_reconcile_pending == pending:
+        return
+    self._library_entry_reconcile_pending = pending
+    self.call_later(self._reconcile_library_entry_state, generation, route_key)
+```
+
+Do not use `run_worker` for the remove/mount portion; Pilot's message-pump drain does not wait for independent worker DOM mutations.
+
+- [ ] **Step 5: Implement strict rail/header/list routing**
+
+The reconcile method must first reject detached, stale-generation, and stale-route work. Build shell state once, call `LibraryRail.sync_state()`, update `#library-header-line` only when text differs, and route snapshot-owned list surfaces through `_sync_library_canvas(..., allow_screen_fallback=False)`. Search/RAG keeps its current yield-free scope/run-gate synchronizer. Rail-only surfaces return `APPLIED` after rail/header sync.
+
+For direct in-place patches with no child recompose, complete immediately:
+
+```python
+def _complete_library_entry_reconcile(
+    self, generation: int, route_key: tuple[object, ...]
+) -> None:
+    if generation != self._library_snapshot_state_generation:
+        return
+    if route_key != self._library_entry_route_key():
+        return
+    self._library_snapshot_rendered_generation = generation
+    self._library_entry_reconcile_dirty = False
+    self._library_entry_reconcile_pending = None
+```
+
+For canvas-owned `sync_state()`, keep reconciliation dirty and queue
+`_complete_library_entry_reconcile(...)` through that canvas's
+`PostRecomposeCallback`. Returning from `sync_state()` means the recompose was
+requested, not that its children rendered. Structural remove/mount paths await
+mount and post-mount reseed before calling the completion method. This prevents an
+asynchronous canvas failure or teardown from falsely marking stale DOM clean.
+
+On a still-current missing target, schedule one `call_later` retry for the generation. On the second failure, set dirty, clear pending/retry markers, and return `FAILED`. Route changes return `SUPERSEDED` without logging an error.
+
+- [ ] **Step 6: Update the old Notes churn regression to assert the new contract**
+
+`test_library_note_recompose_and_fifty_route_cycles_return_to_baseline` currently applies the exact same snapshot five times and waits for a replaced `TextArea`. Replace that loop with:
+
+```python
+prior = screen.query_one("#library-note-body", TextArea)
+for _ in range(5):
+    screen._apply_local_source_snapshot(
+        dict(screen._local_source_records),
+        dict(screen._local_source_counts),
+        dict(screen._local_source_total_known),
+        screen._library_lookup_error,
+        screen._library_lookup_recovery_state,
+        dict(screen._library_study_counts),
+    )
+    await pilot.pause()
+    assert screen.query_one("#library-note-body", TextArea) is prior
+```
+
+Keep the rest of the ownership/timer assertions unchanged. This turns the test from pinning the removed bug into pinning the equal-clean no-op.
+
+- [ ] **Step 7: Run Task 2 tests and mutation-check both forbidden APIs**
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_shell.py -k "snapshot_cache or source_snapshot or recompose_and_fifty" `
+  Tests/UI/test_library_canvas_scoped_sync.py `
+  Tests/UI/test_library_canvas_sync_defects.py `
+  -vv -s
+```
+
+Expected: PASS. Mutation-check by temporarily restoring `self.refresh(recompose=True)` in the changed-snapshot path and then `await self.recompose()` in the deferred path; the whole-screen API spies must fail for each mutation. Restore product code and rerun the same nodes to PASS.
+
+- [ ] **Step 8: Run scoped Ruff and commit Task 2**
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_canvas_sync_defects.py
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_shell.py `
+  --ignore E721,F401
+git diff --check
+git add -- `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_shell.py
+git commit -m "perf(library): reconcile snapshots below screen"
+```
+
+---
+
+### Task 3: Retained Landing/Handoff Owners and Portable Focus
+
+**Files:**
+
+- Create: `tldw_chatbook/Widgets/Library/library_entry_canvases.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:7686-7754, 7895-8430`
+- Modify: `Tests/UI/test_library_entry_compose_once.py`
+- Modify: `Tests/UI/test_library_canvas_sync_defects.py`
+
+**Interfaces:**
+
+- Produces: frozen `LibraryLandingRecentItem`, `LibraryLandingCanvasState`, and `LibraryStudyHandoffCanvasState` dataclasses.
+- Produces: `LibraryLandingCanvas.sync_state(state: LibraryLandingCanvasState) -> None`.
+- Produces: `LibraryStudyHandoffCanvas.sync_state(state: LibraryStudyHandoffCanvasState) -> None`.
+- Produces: frozen `LibraryEntryFocusIdentity(widget_id: str = "", source_id: str = "", scroll_offset: tuple[int, int] | None = None)`.
+- Produces: `LibraryScreen._capture_library_entry_focus() -> LibraryEntryFocusIdentity | None` and `_restore_library_entry_focus(identity, *, generation, route_key) -> None`.
+- Produces: `LibraryScreen._finish_library_entry_canvas_sync(identity, *, generation, route_key) -> None`, the single post-recompose callback that restores focus/scroll and then marks the generation rendered.
+
+- [ ] **Step 1: Write failing retained-owner tests**
+
+Mount Landing with counts/recents, capture the three action Buttons, focus Search, apply a changed source snapshot, and assert:
+
+```python
+assert screen.query_one("#library-hub-action-import") is import_button
+assert screen.query_one("#library-hub-action-search") is search_button
+assert screen.query_one("#library-hub-action-new-note") is new_note_button
+assert screen.focused is search_button
+assert "Conversations (2)" in str(screen.query_one("#library-hub-counts").renderable)
+```
+
+Repeat on Study handoff, capturing its Open button while readiness/context changes. Assert the compositor paints the updated count/readiness copy and that the button remains the same object.
+
+Expected: FAIL because Landing and handoff content are currently composed inline by the screen and have no `sync_state()` owner.
+
+- [ ] **Step 2: Implement retained entry canvases**
+
+Create state dataclasses containing only display data and stable dispatch identities. `LibraryLandingCanvas.compose()` mounts the three static actions once, a counts `Static`, and a recents container. `sync_state()` updates counts and replaces only recent-row children. `LibraryStudyHandoffCanvas.compose()` always mounts purpose, context, owner, recovery, and Open action; absent context uses `display=False` instead of omitting the widget. Its `sync_state()` updates text, display, and recovery classes without replacing the Open button.
+
+The state synchronization boundaries are:
+
+```python
+def sync_state(self, state: LibraryLandingCanvasState) -> None:
+    self.state = state
+    self.query_one("#library-hub-counts", Static).update(state.counts_line)
+    self.call_later(self._replace_recent_rows)
+
+
+def sync_state(self, state: LibraryStudyHandoffCanvasState) -> None:
+    self.state = state
+    self.query_one("#library-study-handoff-purpose", Static).update(state.purpose)
+    context = self.query_one("#library-study-handoff-context", Static)
+    context.update(state.context)
+    context.display = bool(state.context)
+    self.query_one("#library-study-handoff-owner", Static).update(state.owner)
+    recovery = self.query_one("#library-study-handoff-recovery", Static)
+    recovery.update(state.recovery)
+    recovery.set_class(state.blocked, "ds-recovery-callout")
+    recovery.set_class(state.blocked, "is-blocked")
+```
+
+`_replace_recent_rows()` re-reads `self.state.recent_items` after its first await
+and once again after mounting. Multiple queued calls therefore converge on the
+latest state instead of mounting an older tuple captured before the yield.
+
+Build both state objects from existing `_hub_counts_line()`, `_hub_recent_items()`, and `_study_handoff_copy()` output so copy and source ordering remain unchanged.
+
+- [ ] **Step 3: Replace inline Landing/handoff composition with the retained widgets**
+
+`compose_content()` yields one `LibraryLandingCanvas` or `LibraryStudyHandoffCanvas` child. Extend the strict router to query that exact owner and call `sync_state()`. Do not add a nested card or extra visible wrapper; preserve current IDs/classes on the child controls so event handlers and CSS continue to resolve.
+
+- [ ] **Step 4: Extend semantic focus/scroll capture across list canvases**
+
+Capture the currently focused descendant before any strict canvas sync. Use a stable widget ID when present; for row buttons, store their existing record/source identity attribute. Capture the active canvas/scroll region's `(scroll_x, scroll_y)` when supported. Queue restoration with the canvas's `PostRecomposeCallback`, not `screen.call_after_refresh`.
+
+Restoration must verify:
+
+```python
+if generation != self._library_snapshot_state_generation:
+    return
+if route_key != self._library_entry_route_key():
+    return
+if self.focused is not outgoing_focus and self.focused is not None:
+    return
+```
+
+Then resolve the same enabled semantic target and restore scroll with `animate=False`. Notes continues to compose its richer existing identity with this portable outer contract.
+
+Queue exactly one callback on the canvas so `PostRecomposeCallback`'s replace-latest semantics cannot make focus restoration and rendered-generation completion displace each other:
+
+```python
+def _finish_library_entry_canvas_sync(
+    self,
+    identity: LibraryEntryFocusIdentity | None,
+    *,
+    generation: int,
+    route_key: tuple[object, ...],
+) -> None:
+    if identity is not None:
+        self._restore_library_entry_focus(
+            identity, generation=generation, route_key=route_key
+        )
+    self._complete_library_entry_reconcile(generation, route_key)
+```
+
+Pass this composed callback as `_sync_library_canvas(..., then=finish,
+allow_screen_fallback=False)`. The helper's existing Notes callback composition
+runs the richer Notes restore first and this completion second.
+
+- [ ] **Step 5: Add Conversations/Media/Prompts/Skills focus and scroll regressions**
+
+Parameterize one test over the four canvases. Focus a stable filter/action/row, set a nonzero scroll offset where the canvas owns scrolling, apply changed entry data, wait for the canvas's own post-recompose callback, and assert focus/scroll and screen/canvas identity. Add a missing-row arm proving focus is not yanked to an unrelated replacement.
+
+Run:
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/UI/test_library_entry_compose_once.py -k "landing or handoff or focus or scroll" `
+  Tests/UI/test_library_canvas_sync_defects.py `
+  Tests/UI/test_library_canvas_scoped_sync.py `
+  -vv
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Render-check compact and wide owner geometry**
+
+At `(60, 20)` and `(170, 48)`, export the SVG or inspect `screen._compositor.render_strips()`. Assert the three Landing actions or Study Open action are painted inside the viewport before and after synchronization. Widget existence alone is not the oracle.
+
+- [ ] **Step 7: Run Ruff and commit Task 3**
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/Widgets/Library/library_entry_canvases.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_canvas_sync_defects.py
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Screens/library_screen.py --ignore E721,F401
+git diff --check
+git add -- `
+  tldw_chatbook/Widgets/Library/library_entry_canvases.py `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_canvas_sync_defects.py
+git commit -m "perf(library): retain entry canvas controls"
+```
+
+---
+
+### Task 4: Route Every Automatic Entry Worker In Place
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_collections_panel.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:5256-5405, 9009-9370, 9655-9780, 25587-25602, 26519-26632`
+- Modify: `Tests/UI/test_library_entry_compose_once.py`
+- Modify: `Tests/UI/test_library_shell.py:16744-17218`
+
+**Interfaces:**
+
+- Produces: `LibraryCollectionsPanel.sync_state(state, *, name_value: str, description_value: str, delete_pending: bool) -> None`.
+- Produces: `async LibraryScreen._replace_library_canvas_child(widget: Widget, *, generation: int, route_key: tuple[object, ...]) -> LibraryEntryReconcileResult`.
+- Changes: `LibraryScreen._open_library_item_by_id(source_type: str, record_id: str, *, entry_origin: bool = False) -> None`.
+- Changes: `LibraryScreen._open_pending_library_source()` passes `entry_origin=True`.
+
+- [ ] **Step 1: Write a parameterized entry-worker compose-count matrix**
+
+Add mounted cases for restored/deep-linked Prompts list, Collections, Skills list, Notes editor, Media viewer, Export, and pending opens for media/notes/conversation/prompt. Each case must:
+
+1. arrange the initial route before mount;
+2. capture the first screen/rail/host/active-owner identities;
+3. wait on the worker's actual terminal state with a bounded condition, not only `pilot.pause()`;
+4. assert `calls.count(screen) == 1`;
+5. assert no recorded `refresh(recompose=True)` or `recompose()` call; and
+6. assert only the route-owned child changes when loading structurally transitions.
+
+Run the matrix. Expected: FAIL for Prompt browse, Collections, Skills trust posture, Media detail, and pending-open branches that still call whole-screen refresh/recompose.
+
+- [ ] **Step 2: Convert Prompt and Skills completion paths**
+
+Change `_sync_library_prompts_browse_result()` and `_load_library_skills_trust_posture()` to call `_sync_library_canvas(..., allow_screen_fallback=False)` only while their captured route identity is still current. Prompt loading and terminal results use the controller's existing request token as the stale-result authority; do not add a parallel token.
+
+- [ ] **Step 3: Add complete Collections panel synchronization**
+
+`LibraryCollectionsPanel.sync_state()` copies every compose input before `refresh(recompose=True)` on the panel itself:
+
+```python
+def sync_state(
+    self,
+    state: LibraryCollectionsPanelState,
+    *,
+    name_value: str,
+    description_value: str,
+    delete_pending: bool,
+) -> None:
+    self.state = state
+    self.name_value = name_value
+    self.description_value = description_value
+    self.delete_pending = delete_pending
+    self.refresh(recompose=True)
+```
+
+Change `_sync_collections_panel()` to query the retained panel and call this method. Entry lifecycle calls must not use `await self.recompose()` or `self.refresh(recompose=True)`.
+
+- [ ] **Step 4: Convert restored media/note detail and Export completion**
+
+Export already patches its always-mounted fields; add the route/generation guard and keep that path. Notes continues through `_sync_library_canvas("notes", allow_screen_fallback=False)`.
+
+For Media, extract the existing viewer-construction branch into `_build_library_media_active_child() -> Widget`, and use `_replace_library_canvas_child()` to replace only the loading child with `LibraryMediaViewer` or the list canvas. The helper hides/removes old children, mounts the new child, then re-reads current state and synchronizes once more after mount to close the state-read-before-await gap.
+
+- [ ] **Step 5: Make pending source opens strict without changing live actions**
+
+Pass `entry_origin=True` only from `_open_pending_library_source()`. For that branch, replace each `self.refresh(recompose=True)`/`await self.recompose()` with the strict active-child replacement. For Conversations, do not call `_select_library_rail_row()` because its general user-interaction fallback may recompose the screen; set the same route fields, build shell state, apply rail/header selection, and mount/sync the Conversations canvas through the strict helper.
+
+The ordinary Search/RAG Open action continues to call `_open_library_item_by_id(..., entry_origin=False)` and retains current user-interaction behavior in this task.
+
+- [ ] **Step 6: Prove stale entry results cannot overwrite a new route**
+
+Gate each representative service call, switch the screen route before releasing it, then assert the new route's owner and focus are unchanged. Cover at least Prompt token, Skills posture, Collections snapshot, Media detail, and one pending source open. The worker may settle state it owns, but its DOM result must return `SUPERSEDED`.
+
+- [ ] **Step 7: Run the full entry-worker and companion route suites**
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_shell.py -k "restored or deep_link or snapshot_cache or prompt or collections or skills or media_viewer or export" `
+  Tests/UI/test_library_prompt_browse_controller.py `
+  Tests/UI/test_library_prompt_collections.py `
+  Tests/UI/test_library_skills_canvas.py `
+  Tests/UI/test_library_media_side_by_side.py `
+  -vv
+```
+
+Expected: PASS with no whole-screen compose calls in the entry matrix.
+
+- [ ] **Step 8: Mutation-check each formerly broad worker and commit Task 4**
+
+For Prompt, Collections, Skills, Media detail, and pending-open, temporarily restore its former whole-screen call one at a time. The corresponding parameterized case must fail on the exact API spy. Restore and rerun to PASS.
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/Widgets/Library/library_collections_panel.py `
+  Tests/UI/test_library_entry_compose_once.py
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_shell.py `
+  --ignore E721,F401
+git diff --check
+git add -- `
+  tldw_chatbook/Widgets/Library/library_collections_panel.py `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_shell.py
+git commit -m "perf(library): update entry workers in place"
+```
+
+---
+
+### Task 5: Race Closure, Performance Evidence, UAT, and Task Closeout
+
+**Files:**
+
+- Modify: `Tests/UI/test_library_entry_compose_once.py`
+- Modify: `backlog/tasks/task-15459 - Library---compose-once-per-visit.md`
+- Modify if a generalizable incident occurs: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md`
+
+**Interfaces:**
+
+- Consumes all Task 1-4 interfaces.
+- Produces no new product API; this task proves, documents, and closes the agreed contract.
+
+- [ ] **Step 1: Add deterministic mount/race/failure coverage**
+
+Use `asyncio.Event` barriers, not sleeps, to cover:
+
+- worker completion while Mount dispatch is still active;
+- timeout state followed by fresh success;
+- two changed generations where only the newer generation renders;
+- route switch before a queued reconcile;
+- first targeted failure, one next-turn retry, then dirty stop;
+- equal data repairing a dirty generation; and
+- detached/unmounted completion as a no-op.
+
+Record reconcile results and target-sync calls after the fact. Do not raise sentinel assertions from inside broad `except Exception` paths.
+
+- [ ] **Step 2: Prove the retry and equality guards are non-vacuous**
+
+Mutation-check three guards independently:
+
+1. remove the generation comparison, expecting the two-generation race to fail;
+2. remove the dirty bypass, expecting equal-data repair to fail; and
+3. allow a second retry to schedule, expecting the bounded retry-count assertion to fail.
+
+Restore each mutation and rerun its node to PASS before continuing.
+
+- [ ] **Step 3: Run the complete focused product-path matrix**
+
+```powershell
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -p no:cacheprovider `
+  Tests/Library/test_library_snapshot_cache.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_canvas_scoped_sync.py `
+  Tests/UI/test_library_canvas_sync_defects.py `
+  Tests/UI/test_library_shell.py `
+  Tests/UI/test_library_prompt_browse_controller.py `
+  Tests/UI/test_library_prompt_collections.py `
+  Tests/UI/test_library_skills_canvas.py `
+  Tests/UI/test_library_media_side_by_side.py `
+  Tests/Widgets/Library/test_library_rail.py `
+  Tests/Widgets/Library/test_library_conversations_canvas.py `
+  Tests/Widgets/Library/test_library_notes_canvas.py `
+  -vv
+```
+
+Expected: PASS. If the literal command hits a baseline Windows-only collection issue, rerun the exact failing modules against `origin/dev` and document byte-identical attribution; do not change TTS/media-playback platform modules.
+
+- [ ] **Step 4: Record identical before/after warm-visit samples**
+
+Run the warm-repeat benchmark test with at least five iterations in one process, reporting median, minimum, maximum, sample count, compose count, and screen/rail/host/canvas identities. Use the same seeded records and `LIBRARY_TEST_SIZE` as the Task 1 baseline. The post-change result must show one `compose_content()` call and zero whole-screen recompose requests.
+
+- [ ] **Step 5: Run isolated rendered UAT at compact and wide sizes**
+
+Create a scratch directory outside the real profile, write a parse-validated config with both `TLDW_CONFIG_PATH` and `[paths].data_dir` pointing into it, set `TLDW_TEST_MODE=1`, disable model-catalog networking, and fingerprint the real config/data roots before launch.
+
+At `(60, 20)` and `(170, 48)`, drive:
+
+- warm Landing repeat visit with fresh reconciliation;
+- cold Conversations loading to rows;
+- restored Media viewer detail;
+- restored Prompts, Collections, Skills, Notes, and Export;
+- focus held on an action/filter while fresh data lands; and
+- one error/timeout-to-success transition.
+
+For each, inspect the compositor/exported SVG for visible updated copy and controls, and record object identities plus compose/recompose counters. Revalidate scratch TOML after shutdown and compare real-profile fingerprints before deleting the recovery snapshot. Restore on unexplained drift and do not claim causality without a controlled reproduction.
+
+- [ ] **Step 6: Run static checks and the full suite**
+
+```powershell
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py `
+  tldw_chatbook/Widgets/Library/library_entry_canvases.py `
+  tldw_chatbook/Widgets/Library/library_collections_panel.py `
+  Tests/Library/test_library_snapshot_cache.py `
+  Tests/UI/test_library_entry_compose_once.py `
+  Tests/UI/test_library_canvas_sync_defects.py
+& 'C:\Python312\Scripts\ruff.exe' check `
+  tldw_chatbook/UI/Screens/library_screen.py `
+  Tests/UI/test_library_shell.py `
+  --ignore E721,F401
+git diff --check origin/dev...HEAD
+& (Resolve-Path ..\..\.venv\Scripts\python.exe) -m pytest -q
+```
+
+Record unfiltered Ruff output for existing files before using the documented `E721,F401` baseline exclusions. Any new-line finding must be fixed. Attribute full-suite Windows collection failures only after reproducing the exact failures against unchanged `origin/dev` files.
+
+- [ ] **Step 7: Self-review the complete branch**
+
+Review `git diff origin/dev...HEAD` for:
+
+- any entry-lifecycle call to either whole-screen recompose API;
+- equality paths that can strand dirty rendered state;
+- DOM work scheduled in an independent worker;
+- state read before an awaited remove/mount without a post-mount reseed;
+- focus restoration that can override intervening user focus;
+- cache aliases in nested Note/Skills containers;
+- stale worker results lacking generation/route/token guards; and
+- tests that assert widget state without rendered-frame evidence where visibility is claimed.
+
+Fix findings with a red regression first and rerun the affected focused slice.
+
+- [ ] **Step 8: Close TASK-15459 manually and commit evidence**
+
+Because the Backlog CLI silently mishandles five-digit task IDs, edit the task file directly. Check all four acceptance criteria, add concise Implementation Notes, include exact test/Ruff/UAT/performance evidence, and retain:
+
+```text
+ADR required: no
+ADR path: N/A
+Reason: Applies existing Library cache and retained screen/rail/canvas ownership contracts.
+```
+
+Add a lessons entry only if implementation produced a new evidenced, reusable incident. Then:
+
+```powershell
+git diff --check
+git add -- `
+  Tests/UI/test_library_entry_compose_once.py `
+  backlog/tasks/'task-15459 - Library---compose-once-per-visit.md'
+git commit -m "docs(library): close task 15459"
+git status --short --branch
+```
+
+Expected: task status `Done`, four checked criteria, implementation notes and evidence present, and a clean worktree.
+
+---
+
+## Final Verification Checklist
+
+- [ ] Cache is valid before first compose on warm visits.
+- [ ] Every automatic entry route calls `compose_content()` exactly once.
+- [ ] Both whole-screen recompose APIs remain unused throughout entry lifecycle work.
+- [ ] Equal clean data performs zero DOM work.
+- [ ] Dirty equal data repairs the rendered generation.
+- [ ] Screen, rail, canvas host, and unaffected active owners retain identity.
+- [ ] Semantic focus/selection/scroll survive when their target remains.
+- [ ] Route/generation/token guards discard stale work.
+- [ ] Compact and wide compositor evidence shows updated controls/copy.
+- [ ] Warm-visit before/after measurements use identical data and dimensions.
+- [ ] Focused suites, scoped Ruff, diff-check, and attributable full-suite results are recorded.
+- [ ] Real profile fingerprints are unchanged after UAT.
+- [ ] TASK-15459 is `Done` with AC 4/4, ADR disposition, and Implementation Notes.

--- a/Docs/superpowers/specs/2026-08-13-library-compose-once-design.md
+++ b/Docs/superpowers/specs/2026-08-13-library-compose-once-design.md
@@ -2,7 +2,7 @@
 
 **Task:** TASK-15459
 **Date:** 2026-08-13
-**Status:** Written spec under review
+**Status:** Approved for implementation planning
 
 ## Context
 

--- a/Docs/superpowers/specs/2026-08-13-library-compose-once-design.md
+++ b/Docs/superpowers/specs/2026-08-13-library-compose-once-design.md
@@ -1,0 +1,359 @@
+# Library Compose-Once-Per-Visit Design
+
+**Task:** TASK-15459
+**Date:** 2026-08-13
+**Status:** Written spec under review
+
+## Context
+
+Every navigation to Library constructs a fresh `LibraryScreen`. On a warm visit,
+the first `compose_content()` currently runs before the app-scoped source snapshot
+cache is applied. `on_mount()` then applies the cache and explicitly requests a
+whole-screen recompose so the already-composed loading state becomes visible data.
+The fresh source reconciliation can request another whole-screen recompose.
+Route-specific work started automatically on mount can add more: Prompt browse,
+Collections, Skills trust posture, restored media detail, and pending-source
+opening still include whole-screen refresh paths. This turns one destination
+visit into a chain of complete compositions and can replace focusable widgets
+after the user has started interacting.
+
+TASK-15457 established rail and canvas-owned `sync_state()` seams. TASK-15458
+established persistent media-viewer children. TASK-15459 must use those ownership
+boundaries to make the first composition authoritative and keep later source
+reconciliation below the screen boundary.
+
+## Goals
+
+1. During the automatic entry lifecycle, each Library visit calls
+   `LibraryScreen.compose_content()` exactly once, including visits restored or
+   deep-linked to a non-default surface.
+2. A valid warm cache is present in screen state before the first composition.
+3. Cold, expired-cache, timeout, fresh-reconciliation, and automatically started
+   entry-worker paths perform zero whole-screen recomposes.
+4. Fresh data updates the rail and only the active surface that owns the changed
+   snapshot-derived presentation.
+5. Unchanged fresh snapshots update cache freshness without touching the DOM when
+   the current generation is already rendered cleanly.
+6. Targeted updates preserve active-canvas identity, keyboard focus, selection,
+   and scroll where the corresponding item or control still exists.
+7. Cached-then-fresh behavior, error states, and stale-result protection remain
+   intact.
+
+## Non-goals
+
+- Removing every remaining `refresh(recompose=True)` call from Library. TASK-15459
+  governs the complete destination-entry lifecycle, including work started
+  automatically because of restored or deep-linked entry state. User-initiated
+  interactions remain out of scope even if an entry worker is still settling;
+  those interactions supersede the old route owner, and every later entry result
+  remains subject to the strict targeted-update guard.
+- Changing source queries, page sizes, cache TTL, persistence, schemas, or service
+  boundaries.
+- Redesigning Library layout or copy.
+- Replacing the existing screen-per-visit navigation policy.
+
+## Decision
+
+Use **pre-compose cache seeding plus a strict entry-reconciliation router**.
+
+The cache is validated, cloned, and applied at the end of `LibraryScreen.__init__`,
+after every snapshot-dependent field has been initialized. The app subsequently
+calls `restore_state()` before mount, so saved navigation, selection, filter, and
+editor state overlay the cached source data before the first composition.
+
+`on_mount()` no longer reads or applies the cache and never asks the screen to
+recompose. It arms the existing timeout and starts the fresh snapshot worker and
+any route-specific entry work. When entry data arrives, state mutation and
+mounted presentation reconciliation are separate operations. Presentation is
+routed to the rail and the active owner. There is no whole-screen fallback on
+this lifecycle path.
+
+For this design, a whole-screen recompose request means either
+`LibraryScreen.refresh(recompose=True)` or `LibraryScreen.recompose()`. Neither
+API may be invoked by destination construction, mount, the source timeout,
+snapshot reconciliation, or work automatically launched because of the entry
+route. Canvas-owned `sync_state()` may recompose only that retained canvas.
+
+## Entry Lifecycle Boundary
+
+The entry lifecycle begins when a new `LibraryScreen` is constructed and ends
+when all work automatically required by its initial restored/navigation state has
+either settled or been superseded. It includes:
+
+- cached source seeding and the fresh source snapshot;
+- Prompt list browse loading and its terminal result;
+- Collections snapshot loading;
+- Skills snapshot and trust-posture loading;
+- restored or deep-linked note and media detail loading;
+- restored Export counts; and
+- a pending source-open request supplied by navigation context.
+
+These jobs keep their existing service and cancellation ownership. TASK-15459
+changes only how their landed state is projected into the mounted Library. A
+user action, including a rail switch, filter, edit, retry, mutation, or explicit
+refresh, is not part of this boundary. Such an action can supersede an entry
+owner, but cannot make a later entry-worker result eligible for a whole-screen
+recompose.
+
+## Cache Contract
+
+### Validation
+
+The cache seed helper accepts a snapshot only when:
+
+- the app exposes both a snapshot and a numeric monotonic timestamp;
+- the timestamp age is non-negative and below
+  `LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS`;
+- the snapshot has the expected six-field outer shape; and
+- its known source entries have the shapes consumed by the current builders:
+  record tuples for Notes, Media, and Conversations, `(count, ())` for Prompts,
+  and `(count, context_payload)` for Skills.
+
+A missing, expired, or malformed cache is ignored. Cache validation cannot prevent
+screen construction or navigation.
+
+### Copy-on-read and copy-on-write
+
+Cache reads and writes use one schema-aware clone helper. The new screen must
+never alias mutable state back into the app cache. The helper copies every known
+mutable container reachable through the snapshot schema: outer mappings, record
+mappings inside tuples, the Skills context mapping and its available/blocked
+lists and record mappings, counts, total-known flags, study counts, and mutable
+recovery payloads. Immutable scalar values may be reused.
+
+This closes the current gap without assuming that a tuple makes the mappings or
+lists nested inside it immutable. A repeat visit must not be able to corrupt the
+cache used by a third visit.
+
+### Ordering
+
+Cache seeding runs only after constructor initialization is complete. It does not
+run inside `compose_content()`, because composition must remain a read-only
+projection of settled state. `restore_state()` runs afterward and remains the
+owner of saved selection and view state.
+
+## State, Rendered Generation, and Dirtiness
+
+`_apply_local_source_snapshot()` remains the source-snapshot state-mutation seam.
+It:
+
+1. normalizes/copies the incoming snapshot;
+2. carries a selected out-of-page conversation forward as today;
+3. records whether snapshot-derived presentation actually changed;
+4. assigns the new records, counts, error/recovery state, study counts, and loaded
+   flag;
+5. invalidates workspace-depth derived state; and
+6. increments a monotonically increasing state generation only for a changed
+   presentation.
+
+Fresh successful results refresh the app cache and timestamp even when their
+presentation equals the current state. Equality is evaluated against normalized
+snapshot values before assignment.
+
+The screen separately tracks the generation last rendered successfully and a
+reconciliation-dirty flag. An equal result schedules no rail, canvas, or layout
+work only when the current generation is already rendered and not dirty. If a
+targeted update failed or was interrupted after state mutation, an equal later
+result retries reconciliation until the rendered generation catches the state
+generation. This makes the recovery promise compatible with the unchanged-data
+fast path.
+
+Every deferred mounted update captures the generation and entry-route identity it
+represents. Before touching the DOM it verifies both are still current. This
+prevents a timeout update, an immediate worker completion, a superseded entry
+worker, or an older retry from rendering over newer state.
+
+## Mount Timing
+
+An entry worker can finish while the Mount message is still being processed. If
+changed state arrives before the screen is attached, reconciliation is queued once
+for the next screen message-pump turn. The callback rechecks attachment,
+generation, and entry-route identity before routing the update. It does not depend
+on a whole-screen refresh being scheduled.
+
+Only one reconciliation is pending for a generation and owner. A newer
+generation or route supersedes it rather than adding another callback.
+
+## Strict Reconciliation Router
+
+The router first rebuilds normalized Library shell state, then synchronizes the
+mounted `LibraryRail`. Rail synchronization also refreshes snapshot-dependent
+workspace details. The destination header is patched only if its rendered line
+changed. The router returns a typed result: applied, already-current, superseded,
+or failed. It never calls either whole-screen recompose API.
+
+The active surface is then handled according to ownership:
+
+| Active surface | Snapshot reconciliation |
+| --- | --- |
+| Landing hub | Patch counts and reconcile recent-source rows inside a retained landing owner. Preserve the three action buttons. |
+| Conversations list | Call `LibraryConversationsCanvas.sync_state()` on the retained canvas. |
+| Media list | Call `LibraryMediaCanvas.sync_state()` on the retained canvas. |
+| Database Notes list | Call `LibraryNotesCanvas.sync_state()` on the retained canvas. |
+| Skills list | Call the existing Skills canvas sync with the fresh skills snapshot/trust state. |
+| Search/RAG | Use the existing narrow scope-count and Run-gate synchronizer. Do not rebuild query, results, history, or answer regions. |
+| Study/Flashcards/Quizzes handoff | Reconcile carried-source and readiness rows inside a retained handoff owner. Preserve its Open button. |
+| Media viewer, Media Trash, note editor, prompt editor/list, skill editor, File Notes, Collections, Ingest, Export | Update the rail only for source-snapshot changes. Route-specific entry results synchronize their own retained owner and do not remount unrelated fields or controls. |
+
+Prompts browse rows come from their browse controller, not the source snapshot.
+Collections, Ingest, Media Trash, and Export have separate data owners. A source
+snapshot must not overwrite their in-progress forms, selections, receipts, or
+workers.
+
+### Route-specific entry results
+
+- Prompt browse loading/results call the retained Prompts list canvas's
+  `sync_state()` and restore semantic focus through that canvas's
+  post-recompose callback.
+- Collections replaces or synchronizes only `#library-collections-panel` inside
+  the retained canvas host.
+- Skills trust posture calls the retained Skills canvas's `sync_state()`.
+- Note detail continues through the retained Notes canvas sync seam.
+- Media detail replaces only the active child inside `#library-canvas`; the
+  Library screen, rail, header, footer, host, and unrelated state retain identity.
+- Export counts continue to patch their always-mounted fields in place.
+- A pending source open uses the same narrow route/content replacement seam as a
+  settled entry rather than the legacy screen-level navigation fallback.
+
+### Loading and error transitions
+
+On a cold or expired-cache visit, the single initial composition can contain the
+existing loading or error placeholder for Conversations, Media, or Database Notes.
+When data changes that structural state, the router replaces children only inside
+`#library-canvas`. It constructs the appropriate active canvas/viewer/editor state
+through the same builders used by initial composition. The screen shell, rail,
+header, footer, and canvas host retain identity.
+
+The structural replacement helper must not duplicate conditional rendering logic.
+Initial composition and replacement share one focused builder for snapshot-owned
+canvas content.
+
+## Focus, Selection, and Scroll
+
+Before any canvas-owned recompose, the router records a shared semantic focus
+identity:
+
+- stable widget id for filters and action buttons;
+- source record id for row buttons; and
+- the active canvas's selection and scroll identity where available.
+
+After the scoped update settles, focus is restored only when:
+
+- the screen and generation are still current;
+- the user has not moved focus elsewhere during the update; and
+- the same semantic target remains present and enabled.
+
+Selection state continues to come from screen-owned row-selection and selected-id
+fields. The strict router uses the existing `PostRecomposeCallback` seam for
+Conversations, Media, Notes, Prompts, and Skills, extending TASK-15457's
+Notes-specific default into one shared entry-reconciliation contract. Canvas
+specializations may add richer selection/scroll details, but none may silently
+delegate entry focus preservation to a whole-screen recompose. A structural
+loading/error replacement has no outgoing interactive child to restore.
+
+## Failure Behavior
+
+The general `_sync_library_canvas()` helper currently falls back to
+`screen.refresh(recompose=True)` when a target is missing. That fallback remains
+available for unrelated legacy interaction callers, but the complete entry
+lifecycle invokes strict behavior that forbids it.
+
+A missing target caused by an ordinary route race is treated as superseded work.
+For a still-current route, the router performs one bounded next-turn targeted
+retry. If the target is still unavailable, it marks the current generation dirty,
+logs the surface, generation, and exception category, and stops. A later equal or
+changed result can repair the surface because dirty state bypasses the equality
+no-op gate. It never performs a whole-screen recompose and never loops within one
+reconciliation attempt.
+
+Malformed cache data is ignored. Fresh lookup errors continue to render the
+existing error copy through the same targeted route. The timeout and fresh worker
+share the generation guard, so a late timeout cannot replace a successful result.
+
+## Testing Strategy
+
+All behavior changes follow test-driven development. Each regression is observed
+red against the pre-change implementation before product code is written.
+
+### Lifecycle and cache tests
+
+- Warm repeat visit invokes `compose_content()` exactly once and its first rendered
+  frame contains cached counts/rows.
+- Cold and expired-cache visits invoke `compose_content()` exactly once; fresh data
+  replaces only the canvas placeholder.
+- Malformed cache data is ignored without blocking navigation.
+- Cache read containers do not alias live screen containers.
+- A third visit is unaffected by mutations performed on the second visit.
+- `restore_state()` selection/filter values overlay cached data before first paint.
+
+### Reconciliation tests
+
+- Equal fresh data updates cache freshness and performs zero DOM synchronization.
+- Equal fresh data retries targeted reconciliation when the rendered generation
+  is dirty, then returns to the zero-DOM fast path after success.
+- Changed fresh data preserves screen, rail, canvas-host, and active-canvas identity.
+- Landing counts/recents and handoff readiness update without replacing their
+  persistent action buttons.
+- Search/RAG preserves query, result, history, answer, focus, and scroll state.
+- Editors, viewers, File Notes, Collections, Ingest, Trash, and Export are not
+  remounted by source reconciliation.
+- A focused filter/action/row is restored after a required scoped canvas update
+  when its semantic target remains.
+
+### Route-entry worker tests
+
+- Restored/deep-linked Prompts, Collections, Skills, note editor, media viewer,
+  Export, and pending-source visits each call `compose_content()` once.
+- Prompt loading/result, Collections load, Skills trust posture, note/media
+  detail, Export counts, and pending-source completion update only their retained
+  owner.
+- Entry-worker completion after a route change is discarded.
+
+### Race and failure tests
+
+- Immediate worker completion during mount reconciles after mount rather than being
+  lost.
+- Fresh success supersedes a pending timeout update.
+- Two changed generations render only the newest generation.
+- Missing-widget and route-switch races perform at most one targeted retry per
+  attempt and zero whole-screen recomposes.
+- Spies on `LibraryScreen.refresh`, `LibraryScreen.recompose`, and
+  `compose_content` prove that no entry lifecycle path requests a whole-screen
+  recompose after the initial composition.
+
+### Verification and UAT
+
+- Run the focused Library lifecycle, canvas-sync, navigation, media-viewer, and
+  snapshot-cache suites using the parent `dev` virtual environment.
+- Run scoped Ruff and `git diff --check`.
+- Record warm-visit latency before and after with the same seeded snapshot and
+  terminal size, reporting median and sample count.
+- Render UAT at the supported compact and wide Library sizes. Confirm no loading
+  flash on a valid warm cache, no focus jump during fresh reconciliation, honest
+  loading/error behavior without a cache, and stable screen/rail/canvas identity.
+- Run rendered UAT with an isolated `TLDW_CONFIG_PATH` and data directory, and
+  fingerprint the real profile before and after, so verification cannot mutate
+  the user's Library.
+- Attribute unrelated Windows collection failures against `origin/dev` rather than
+  changing out-of-scope platform modules.
+
+## Acceptance Mapping
+
+- **AC1:** compose-count spies across default/restored/deep-linked entry routes,
+  retained identity assertions, strict no-screen-recompose failure tests, and
+  changed/unchanged reconciliation coverage.
+- **AC2:** cache validation, ordering, copy isolation, TTL, restored-state overlay,
+  and cached-then-fresh mounted tests.
+- **AC3:** identical before/after warm-visit benchmark plus rendered compact/wide
+  UAT.
+- **AC4:** both whole-screen recompose APIs are forbidden throughout cache,
+  timeout, fresh, retry, and route-entry worker paths; semantic focus/scroll
+  tests cover every snapshot-owned retained canvas.
+
+## ADR Check
+
+**ADR required:** no
+**ADR path:** N/A
+**Reason:** This design applies the existing Library screen/rail/canvas ownership,
+cache TTL, and targeted-update contracts. It changes no storage, schema, service,
+security, dependency, or cross-module runtime boundary.

--- a/Tests/Library/test_library_snapshot_cache.py
+++ b/Tests/Library/test_library_snapshot_cache.py
@@ -30,6 +30,11 @@ def _snapshot():
     )
 
 
+class _DeepcopyBomb:
+    def __deepcopy__(self, memo):
+        raise RuntimeError("deepcopy must degrade to a cache miss")
+
+
 def test_clone_accepts_real_prompt_and_skill_shapes_without_aliasing():
     original = _snapshot()
     cloned = clone_library_source_snapshot(original)
@@ -49,6 +54,28 @@ def test_clone_accepts_real_prompt_and_skill_shapes_without_aliasing():
     [None, (), ({},), ({"notes": []}, {}, {}, None, None, {})],
 )
 def test_clone_rejects_malformed_outer_or_source_shapes(malformed):
+    assert clone_library_source_snapshot(malformed) is None
+
+
+@pytest.mark.parametrize(
+    "skills_context",
+    [
+        {"available_skills": 7, "blocked_skills": []},
+        {"available_skills": [{"name": "alpha"}, "not-a-record"], "blocked_skills": []},
+        {"available_skills": [], "blocked_skills": [object()]},
+    ],
+)
+def test_clone_rejects_malformed_nested_skills_payloads(skills_context):
+    malformed = _snapshot()
+    malformed[0]["skills"] = (1, skills_context)
+
+    assert clone_library_source_snapshot(malformed) is None
+
+
+def test_clone_treats_deepcopy_failure_as_a_cache_miss():
+    malformed = _snapshot()
+    malformed[0]["skills"][1]["available_skills"][0]["opaque"] = _DeepcopyBomb()
+
     assert clone_library_source_snapshot(malformed) is None
 
 

--- a/Tests/Library/test_library_snapshot_cache.py
+++ b/Tests/Library/test_library_snapshot_cache.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.UI.Library_Modules.library_snapshot_cache import (
+    clone_library_source_snapshot,
+)
+
+
+def _snapshot():
+    return (
+        {
+            "notes": ({"id": "n1", "meta": {"tags": ["a"]}},),
+            "media": ({"id": "m1"},),
+            "conversations": ({"id": "c1"},),
+            "prompts": (2, ()),
+            "skills": (
+                1,
+                {
+                    "available_skills": [{"name": "alpha", "tags": ["safe"]}],
+                    "blocked_skills": [],
+                },
+            ),
+        },
+        {"notes": 1, "media": 1, "conversations": 1},
+        {"notes": True, "media": True, "conversations": True},
+        None,
+        None,
+        {"study_decks": 1, "flashcards_due": 2, "quizzes": 3},
+    )
+
+
+def test_clone_accepts_real_prompt_and_skill_shapes_without_aliasing():
+    original = _snapshot()
+    cloned = clone_library_source_snapshot(original)
+    assert cloned == original
+    assert cloned is not original
+    assert cloned[0] is not original[0]
+    assert cloned[0]["notes"][0] is not original[0]["notes"][0]
+    assert cloned[0]["skills"][1] is not original[0]["skills"][1]
+    assert (
+        cloned[0]["skills"][1]["available_skills"]
+        is not original[0]["skills"][1]["available_skills"]
+    )
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [None, (), ({},), ({"notes": []}, {}, {}, None, None, {})],
+)
+def test_clone_rejects_malformed_outer_or_source_shapes(malformed):
+    assert clone_library_source_snapshot(malformed) is None
+
+
+def test_clone_prevents_second_clone_mutation_from_reaching_third_clone():
+    original = _snapshot()
+    second_clone = clone_library_source_snapshot(original)
+    assert second_clone is not None
+    second_clone[0]["notes"][0]["meta"]["tags"].append("mutated")
+    second_clone[0]["skills"][1]["available_skills"][0]["tags"].append("unsafe")
+
+    third_clone = clone_library_source_snapshot(original)
+    assert third_clone == original

--- a/Tests/UI/test_library_canvas_sync_defects.py
+++ b/Tests/UI/test_library_canvas_sync_defects.py
@@ -442,9 +442,26 @@ async def test_entry_canvas_sync_restores_portable_focus_and_scroll(
         canvas = screen.query_one(canvas_selector)
         focused_before = screen.query_one(focus_selector)
         focused_before.focus()
-        canvas.scroll_to(y=4, animate=False, force=True, immediate=True)
+        scroll_before: tuple[int, int] | None = None
+        if kind == "skills":
+            canvas.styles.height = 6
+            canvas.refresh(layout=True)
         await pilot.pause()
-        scroll_before = (int(canvas.scroll_x), int(canvas.scroll_y))
+        if kind == "skills":
+            assert int(canvas.max_scroll_y) > 0, (
+                "Skills scroll preservation needs an overflowing canvas."
+            )
+            canvas.scroll_to(
+                y=canvas.max_scroll_y,
+                animate=False,
+                force=True,
+                immediate=True,
+            )
+            await pilot.pause()
+            scroll_before = (int(canvas.scroll_x), int(canvas.scroll_y))
+            assert scroll_before != (0, 0), (
+                "Skills scroll preservation needs a genuinely scrolled setup."
+            )
 
         if kind == "prompts":
             screen._library_prompts_browse_error = "Changed prompt entry data"
@@ -515,7 +532,7 @@ async def test_entry_canvas_sync_restores_portable_focus_and_scroll(
         assert screen.query_one(canvas_selector) is canvas
         assert screen.focused is not None
         assert screen.focused.id == focus_selector.lstrip("#")
-        if scroll_before != (0, 0):
+        if scroll_before is not None:
             assert (int(canvas.scroll_x), int(canvas.scroll_y)) == scroll_before
         assert screen._library_snapshot_rendered_generation == (
             screen._library_snapshot_state_generation

--- a/Tests/UI/test_library_canvas_sync_defects.py
+++ b/Tests/UI/test_library_canvas_sync_defects.py
@@ -19,12 +19,16 @@ evidence for dev's converted sites, not only for the ones this branch added.
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 from textual.widgets import Button, Static
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_library_selection_updates import _spy_screen_recomposes
 from Tests.UI.test_library_shell import (
+    _FakePromptScopeService,
+    _FakeSkillsScopeService,
     LIBRARY_TEST_SIZE,
     LibraryHarness,
     _active_library_screen,
@@ -32,6 +36,13 @@ from Tests.UI.test_library_shell import (
     _wait_for_library_shell,
     _wait_for_selector,
 )
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_CONVERSATIONS,
+    LIBRARY_ROW_BROWSE_MEDIA,
+    LIBRARY_ROW_BROWSE_PROMPTS,
+    LIBRARY_ROW_BROWSE_SKILLS,
+)
+from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas
 
 
 def _notes(count: int = 6):
@@ -363,3 +374,202 @@ async def test_notes_row_press_to_editor_keeps_focus_inside_the_canvas(monkeypat
         assert canvas in focused.ancestors_with_self, (
             f"focus escaped the notes canvas to {focused.id!r} on row -> editor"
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "row_id", "canvas_selector", "focus_selector"),
+    [
+        (
+            "conversations",
+            LIBRARY_ROW_BROWSE_CONVERSATIONS,
+            "#library-conversations-canvas",
+            "#library-conversations-filter",
+        ),
+        (
+            "media",
+            LIBRARY_ROW_BROWSE_MEDIA,
+            "#library-media-canvas",
+            "#library-media-type-filter",
+        ),
+        (
+            "prompts",
+            LIBRARY_ROW_BROWSE_PROMPTS,
+            "#library-prompts-canvas",
+            "#library-prompts-retry",
+        ),
+        (
+            "skills",
+            LIBRARY_ROW_BROWSE_SKILLS,
+            "#library-skills-canvas",
+            "#library-skills-filter",
+        ),
+    ],
+)
+async def test_entry_canvas_sync_restores_portable_focus_and_scroll(
+    kind,
+    row_id,
+    canvas_selector,
+    focus_selector,
+):
+    """Removing the shared finish callback loses focus or rendered completion."""
+    app = _build_test_app()
+    conversations = [
+        {
+            "title": f"Conversation {index}",
+            "conversation_id": f"chat-{index}",
+            "message_count": index,
+            "updated_at": f"2026-06-{(index % 28) + 1:02d}T10:00:00Z",
+        }
+        for index in range(24)
+    ]
+    media = _media(24)
+    _seed_conversations(app, conversations, media=media)
+    app.prompt_scope_service = _FakePromptScopeService(count=1)
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[{"name": f"skill-{index}"} for index in range(24)]
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_COMPACT_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(row_id)
+        await _wait_for_selector(screen, pilot, focus_selector)
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        canvas = screen.query_one(canvas_selector)
+        focused_before = screen.query_one(focus_selector)
+        focused_before.focus()
+        canvas.scroll_to(y=4, animate=False, force=True, immediate=True)
+        await pilot.pause()
+        scroll_before = (int(canvas.scroll_x), int(canvas.scroll_y))
+
+        if kind == "prompts":
+            screen._library_prompts_browse_error = "Changed prompt entry data"
+            screen._library_snapshot_state_generation += 1
+            screen._library_entry_reconcile_dirty = True
+            generation = screen._library_snapshot_state_generation
+            route_key = screen._library_entry_route_key()
+            identity = screen._capture_library_entry_focus()
+            finish = partial(
+                screen._finish_library_entry_canvas_sync,
+                identity,
+                generation=generation,
+                route_key=route_key,
+            )
+            assert _sync_library_canvas(
+                screen,
+                kind,
+                then=finish,
+                allow_screen_fallback=False,
+            )
+        else:
+            records = dict(screen._local_source_records)
+            counts = dict(screen._local_source_counts)
+            if kind == "conversations":
+                records["conversations"] = (
+                    *records["conversations"],
+                    {
+                        "title": "Changed conversation",
+                        "conversation_id": "chat-new",
+                        "message_count": 1,
+                        "updated_at": "2026-08-13T10:00:00Z",
+                    },
+                )
+                counts["conversations"] += 1
+            elif kind == "media":
+                records["media"] = (
+                    *records["media"],
+                    {
+                        "id": 99,
+                        "media_id": "99",
+                        "title": "Changed media",
+                        "type": "document",
+                        "content": "Changed",
+                        "ingestion_date": "2026-08-13T10:00:00Z",
+                    },
+                )
+                counts["media"] += 1
+            else:
+                skill_count, skill_context = records["skills"]
+                changed_context = dict(skill_context)
+                changed_context["available_skills"] = [
+                    *skill_context["available_skills"],
+                    {"name": "skill-new"},
+                ]
+                records["skills"] = (skill_count + 1, changed_context)
+            screen._apply_local_source_snapshot(
+                records,
+                counts,
+                dict(screen._local_source_total_known),
+                screen._library_lookup_error,
+                screen._library_lookup_recovery_state,
+                dict(screen._library_study_counts),
+            )
+
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.query_one(canvas_selector) is canvas
+        assert screen.focused is not None
+        assert screen.focused.id == focus_selector.lstrip("#")
+        if scroll_before != (0, 0):
+            assert (int(canvas.scroll_x), int(canvas.scroll_y)) == scroll_before
+        assert screen._library_snapshot_rendered_generation == (
+            screen._library_snapshot_state_generation
+        )
+
+
+@pytest.mark.asyncio
+async def test_entry_canvas_sync_does_not_focus_an_unrelated_replacement_row():
+    """Falling back from a missing semantic row to its reused index is wrong."""
+    app = _build_test_app()
+    conversations = [
+        {
+            "title": "Outgoing",
+            "conversation_id": "chat-outgoing",
+            "message_count": 1,
+            "updated_at": "2026-08-13T10:00:00Z",
+        },
+        {
+            "title": "Survivor",
+            "conversation_id": "chat-survivor",
+            "message_count": 1,
+            "updated_at": "2026-08-12T10:00:00Z",
+        },
+    ]
+    _seed_conversations(app, conversations)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        row = await _wait_for_selector(screen, pilot, "#library-conversation-row-0")
+        row.focus()
+        await pilot.pause()
+
+        records = dict(screen._local_source_records)
+        records["conversations"] = (
+            {
+                "title": "Replacement at row zero",
+                "conversation_id": "chat-replacement",
+                "message_count": 1,
+                "updated_at": "2026-08-14T10:00:00Z",
+            },
+            conversations[1],
+        )
+        screen._apply_local_source_snapshot(
+            records,
+            dict(screen._local_source_counts),
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert getattr(screen.focused, "conversation_id", None) != "chat-replacement"

--- a/Tests/UI/test_library_canvas_sync_defects.py
+++ b/Tests/UI/test_library_canvas_sync_defects.py
@@ -573,3 +573,125 @@ async def test_entry_canvas_sync_does_not_focus_an_unrelated_replacement_row():
         await pilot.pause()
 
         assert getattr(screen.focused, "conversation_id", None) != "chat-replacement"
+
+
+@pytest.mark.asyncio
+async def test_overlapping_reconciles_retain_original_semantic_focus():
+    """A replace-latest callback must not discard the first focus capture."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        focus_target = await _wait_for_selector(
+            screen, pilot, "#library-conversations-filter"
+        )
+        focus_target.focus()
+        await pilot.pause()
+        route_key = screen._library_entry_route_key()
+
+        first_generation = screen._library_snapshot_state_generation + 1
+        screen._library_snapshot_state_generation = first_generation
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (first_generation, route_key)
+        await screen._reconcile_library_entry_state(first_generation, route_key)
+
+        second_generation = first_generation + 1
+        screen._library_snapshot_state_generation = second_generation
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (second_generation, route_key)
+        await screen._reconcile_library_entry_state(second_generation, route_key)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.focused is not None
+        assert screen.focused.id == "library-conversations-filter"
+        assert screen._library_snapshot_rendered_generation == second_generation
+
+
+@pytest.mark.asyncio
+async def test_strict_failure_retry_retains_original_semantic_focus(monkeypatch):
+    """Clearing a failed strict callback must not clear its focus capture."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        focus_target = await _wait_for_selector(
+            screen, pilot, "#library-conversations-filter"
+        )
+        canvas = screen.query_one("#library-conversations-canvas")
+        original_sync = canvas.sync_state
+        attempts = 0
+
+        def fail_once(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("forced strict-sync failure")
+            return original_sync(*args, **kwargs)
+
+        monkeypatch.setattr(canvas, "sync_state", fail_once)
+        focus_target.focus()
+        await pilot.pause()
+        generation = screen._library_snapshot_state_generation + 1
+        route_key = screen._library_entry_route_key()
+        screen._library_snapshot_state_generation = generation
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+
+        await screen._reconcile_library_entry_state(generation, route_key)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert attempts == 2
+        assert screen.focused is not None
+        assert screen.focused.id == "library-conversations-filter"
+        assert screen._library_snapshot_rendered_generation == generation
+
+
+@pytest.mark.asyncio
+async def test_automatic_notes_reconcile_restores_richer_control_focus():
+    """Erasing focus before the Notes capture redirects it to a fallback."""
+    notes = _notes(4)
+    app = _build_test_app()
+    _seed_conversations(app, [], notes=notes)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = await _open_notes_canvas(host, pilot)
+        focus_target = screen.query_one("#library-notes-select-toggle", Button)
+        focus_target.focus()
+        await pilot.pause()
+        records = dict(screen._local_source_records)
+        records["notes"] = (
+            *records["notes"],
+            {
+                "id": "note-new",
+                "title": "New note",
+                "content": "New body",
+                "last_modified": "2026-08-13T10:00:00Z",
+            },
+        )
+        counts = dict(screen._local_source_counts)
+        counts["notes"] += 1
+
+        screen._apply_local_source_snapshot(
+            records,
+            counts,
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.focused is not None
+        assert screen.focused.id == "library-notes-select-toggle"

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import statistics
 import time
 
@@ -14,8 +15,15 @@ from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
     LIBRARY_ROW_BROWSE_SKILLS,
+    LIBRARY_ROW_CREATE_STUDY,
 )
-from tldw_chatbook.Widgets.Library import LibraryConversationsCanvas
+from tldw_chatbook.Widgets.Library import (
+    LibraryConversationsCanvas,
+    LibraryLandingCanvas,
+    LibraryLandingCanvasState,
+    LibraryLandingRecentItem,
+    LibraryStudyHandoffCanvas,
+)
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
     LibraryHarness,
@@ -26,6 +34,251 @@ from Tests.UI.test_library_shell import (
     _wait_for_library_shell,
     _wait_for_selector,
 )
+
+
+def _compositor_text(screen: LibraryScreen) -> str:
+    """Return only text actually painted in the current terminal frame."""
+    return "\n".join(
+        "".join(segment.text for segment in strip)
+        for strip in screen._compositor.render_strips()
+    )
+
+
+def _assert_widget_text_is_painted(
+    screen: LibraryScreen, selector: str, expected: str
+) -> None:
+    """Assert a widget and its literal label are inside the rendered viewport."""
+    widget = screen.query_one(selector)
+    viewport = screen.region
+    assert viewport.contains_region(widget.region)
+    lines = [
+        "".join(segment.text for segment in strip)
+        for strip in screen._compositor.render_strips()
+    ]
+    painted = "\n".join(
+        line[widget.region.x : widget.region.right]
+        for line in lines[widget.region.y : widget.region.bottom]
+    )
+    assert expected in painted, (
+        f"{selector} region={widget.region!r} display={widget.display!r} "
+        f"painted={painted!r} frame={_compositor_text(screen)!r}"
+    )
+
+
+def _apply_changed_snapshot(
+    screen: LibraryScreen,
+    *,
+    conversations: tuple[dict[str, object], ...] | None = None,
+    notes: tuple[dict[str, object], ...] | None = None,
+    study_decks: int | None = None,
+) -> bool:
+    """Apply one literal changed snapshot through the production boundary."""
+    records = dict(screen._local_source_records)
+    counts = dict(screen._local_source_counts)
+    if conversations is not None:
+        records["conversations"] = conversations
+        counts["conversations"] = len(conversations)
+    if notes is not None:
+        records["notes"] = notes
+        counts["notes"] = len(notes)
+    study_counts = dict(screen._library_study_counts)
+    if study_decks is not None:
+        study_counts["study_decks"] = study_decks
+    return screen._apply_local_source_snapshot(
+        records,
+        counts,
+        dict(screen._local_source_total_known),
+        screen._library_lookup_error,
+        screen._library_lookup_recovery_state,
+        study_counts,
+    )
+
+
+@pytest.mark.asyncio
+async def test_landing_snapshot_sync_retains_actions_focus_and_updates_recents():
+    """Recomposing the inline landing branch would replace all three actions."""
+    app = _build_test_app()
+    conversations = _two_conversations()
+    _seed_conversations(app, conversations[:1])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        landing = screen.query_one("#library-landing-canvas", LibraryLandingCanvas)
+        import_button = screen.query_one("#library-hub-action-import")
+        search_button = screen.query_one("#library-hub-action-search")
+        new_note_button = screen.query_one("#library-hub-action-new-note")
+        search_button.focus()
+        await pilot.pause()
+
+        changed = _apply_changed_snapshot(
+            screen,
+            conversations=(conversations[1], conversations[0]),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert changed is True
+        assert screen.query_one("#library-landing-canvas") is landing
+        assert screen.query_one("#library-hub-action-import") is import_button
+        assert screen.query_one("#library-hub-action-search") is search_button
+        assert screen.query_one("#library-hub-action-new-note") is new_note_button
+        assert screen.focused is search_button
+        assert "Conversations (2)" in str(
+            screen.query_one("#library-hub-counts").renderable
+        )
+        recent = screen.query_one("#library-hub-recent-conversations")
+        assert getattr(recent, "record_id", "") == "chat-2"
+
+
+@pytest.mark.asyncio
+async def test_landing_deferred_recents_converge_on_latest_state(monkeypatch):
+    """Capturing recents before the deferred await would mount stale rows."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        landing = screen.query_one("#library-landing-canvas", LibraryLandingCanvas)
+        first = LibraryLandingCanvasState(
+            purpose=landing.state.purpose,
+            counts_line="Conversations (1)",
+            recent_items=(
+                LibraryLandingRecentItem(
+                    "conversations", "stale", "Stale row", "Conversation"
+                ),
+            ),
+        )
+        latest = LibraryLandingCanvasState(
+            purpose=landing.state.purpose,
+            counts_line="Conversations (1)",
+            recent_items=(
+                LibraryLandingRecentItem(
+                    "conversations", "latest", "Latest row", "Conversation"
+                ),
+            ),
+        )
+
+        recents_owner = landing.query_one("#library-hub-recents")
+        original_remove = recents_owner.remove_children
+        removal_started = asyncio.Event()
+        release_removal = asyncio.Event()
+
+        async def delayed_remove():
+            removal_started.set()
+            await release_removal.wait()
+            await original_remove()
+
+        monkeypatch.setattr(recents_owner, "remove_children", delayed_remove)
+        landing.state = first
+        replacement = asyncio.create_task(landing._replace_recent_rows())
+        await removal_started.wait()
+        landing.state = latest
+        release_removal.set()
+        await replacement
+
+        recents = list(landing.query(".library-hub-recent"))
+        assert [getattr(recent, "record_id", "") for recent in recents] == ["latest"]
+
+
+@pytest.mark.asyncio
+async def test_study_handoff_snapshot_sync_retains_open_action_and_paints_readiness():
+    """A source/readiness change must patch the mounted handoff owner in place."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_CREATE_STUDY)
+        await _wait_for_selector(screen, pilot, "#library-study-handoff-canvas")
+        handoff = screen.query_one(
+            "#library-study-handoff-canvas", LibraryStudyHandoffCanvas
+        )
+        open_button = screen.query_one("#library-open-study")
+        assert "Import sources or create notes first" in _compositor_text(screen)
+
+        changed = _apply_changed_snapshot(
+            screen,
+            notes=(
+                {
+                    "id": "note-1",
+                    "title": "Retained source",
+                    "content": "Body",
+                    "last_modified": "2026-08-13T10:00:00Z",
+                },
+            ),
+            study_decks=2,
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        painted = _compositor_text(screen)
+        assert changed is True
+        assert screen.query_one("#library-study-handoff-canvas") is handoff
+        assert screen.query_one("#library-open-study") is open_button
+        assert "Source snapshot is ready." in painted
+        assert "Study decks (2)" in painted
+        assert "Retained source" in painted
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (170, 48)])
+@pytest.mark.parametrize("surface", ["landing", "handoff"])
+async def test_retained_entry_actions_paint_before_and_after_sync(size, surface):
+    """Existence is insufficient when compact geometry clips an entry action."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    screen = LibraryScreen(app)
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        if size[0] == 60 and surface == "landing":
+            # Compact Library is a one-pane presentation. Expose its mounted
+            # content stage so the render oracle measures the owner rather than
+            # correctly-hidden children behind the entry rail.
+            screen._library_notes_stage = "notes"
+            screen._set_library_rail_collapsed(True)
+            await pilot.pause()
+        if surface == "handoff":
+            await screen._select_library_rail_row(LIBRARY_ROW_CREATE_STUDY)
+            await _wait_for_selector(screen, pilot, "#library-open-study")
+            if size[0] == 60:
+                screen._set_library_rail_collapsed(True)
+                await pilot.pause()
+            checks = (("#library-open-study", "Continue in Study"),)
+        else:
+            checks = (
+                ("#library-hub-action-import", "Import…"),
+                ("#library-hub-action-search", "Search"),
+                ("#library-hub-action-new-note", "New note"),
+            )
+        for selector, expected in checks:
+            _assert_widget_text_is_painted(screen, selector, expected)
+
+        _apply_changed_snapshot(
+            screen,
+            notes=(
+                {
+                    "id": "note-geometry",
+                    "title": "Geometry source",
+                    "content": "Body",
+                    "last_modified": "2026-08-13T10:00:00Z",
+                },
+            ),
+            study_decks=2,
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        for selector, expected in checks:
+            _assert_widget_text_is_painted(screen, selector, expected)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -770,6 +770,82 @@ async def test_replace_canvas_child_repairs_current_route_after_remove_race(
 
 
 @pytest.mark.asyncio
+async def test_entry_reconcile_repairs_current_route_after_remove_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The entry reconciler itself must not strand an empty canvas host."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+        canvas_host = screen.query_one("#library-canvas")
+        original_remove = canvas_host.remove_children
+
+        def route_switching_remove(*children):
+            removal = original_remove(*children)
+            screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+            screen._library_snapshot_state_generation += 1
+            return removal
+
+        monkeypatch.setattr(canvas_host, "remove_children", route_switching_remove)
+        result = await screen._reconcile_library_entry_state(generation, route_key)
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert isinstance(screen._library_entry_canvas_owner(), LibraryMediaCanvas)
+
+
+@pytest.mark.asyncio
+async def test_entry_reconcile_repairs_current_route_after_mount_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale child mounted by entry reconcile must yield to the latest route."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+        canvas_host = screen.query_one("#library-canvas")
+        original_mount = canvas_host.mount
+        mounts = 0
+
+        def route_switching_mount(*widgets, **kwargs):
+            nonlocal mounts
+            mounted = original_mount(*widgets, **kwargs)
+            mounts += 1
+            if mounts == 1:
+                screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+                screen._library_snapshot_state_generation += 1
+            return mounted
+
+        monkeypatch.setattr(canvas_host, "mount", route_switching_mount)
+        result = await screen._reconcile_library_entry_state(generation, route_key)
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert isinstance(screen._library_entry_canvas_owner(), LibraryMediaCanvas)
+
+
+@pytest.mark.asyncio
 async def test_replace_canvas_child_repairs_owner_after_mount_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1037,10 +1113,10 @@ async def test_pending_conversation_open_cannot_overwrite_same_route_user_select
 
 
 @pytest.mark.asyncio
-async def test_pending_conversation_open_rejects_same_route_stale_generation(
+async def test_pending_conversation_open_retries_initial_snapshot_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Generation alone supersedes a pending fetch on the retained route."""
+    """An initial snapshot race must still open an out-of-page deep link."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
@@ -1051,10 +1127,14 @@ async def test_pending_conversation_open_rejects_same_route_stale_generation(
         focus = await _wait_for_selector(screen, pilot, "#library-conversations-filter")
         started = asyncio.Event()
         release = asyncio.Event()
+        fetch_calls = 0
 
         async def gated_fetch(_conversation_id: str):
-            started.set()
-            await release.wait()
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls == 1:
+                started.set()
+                await release.wait()
             return {
                 "conversation_id": "chat-pending",
                 "title": "Late pending conversation",
@@ -1075,14 +1155,40 @@ async def test_pending_conversation_open_rejects_same_route_stale_generation(
         task = asyncio.create_task(screen._open_pending_library_source())
         await started.wait()
 
-        screen._library_snapshot_state_generation += 1
+        snapshot_records = dict(screen._local_source_records)
+        snapshot_records["conversations"] = (
+            {
+                **_two_conversations()[0],
+                "title": "Initial snapshot landed while point fetch waited",
+            },
+        )
+        snapshot_counts = dict(screen._local_source_counts)
+        snapshot_counts["conversations"] = 1
+        changed = screen._apply_local_source_snapshot(
+            snapshot_records,
+            snapshot_counts,
+            dict(screen._local_source_total_known),
+        )
+        generation = screen._library_snapshot_state_generation
+        assert changed is True
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_snapshot_rendered_generation == generation,
+            message="Initial source snapshot did not finish reconciling.",
+        )
         release.set()
         result = await task
+        await pilot.pause()
 
-        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert result is LibraryEntryReconcileResult.APPLIED
+        assert fetch_calls == 2
         assert screen._selected_conversation_id == "chat-pending"
-        assert screen._library_entry_canvas_owner() is owner
-        assert screen.focused is focus
+        assert screen._conversation_record_id(
+            screen._local_source_records["conversations"][0], 0
+        ) == "chat-pending"
+        assert isinstance(
+            screen._library_entry_canvas_owner(), LibraryConversationsCanvas
+        )
 
 
 @pytest.mark.asyncio
@@ -1182,8 +1288,10 @@ async def test_export_counts_reject_same_route_stale_generation(tmp_path: Path) 
             message="Initial Export counts did not settle.",
         )
         rendered_before = str(scope_line.renderable)
+        counts_before = dict(active_screen._library_export_counts or {})
         generation = active_screen._library_snapshot_state_generation
         route_key = active_screen._library_entry_route_key()
+        request_id = active_screen._library_export_counts_request_id
         active_screen._library_snapshot_state_generation += 1
 
         result = active_screen._apply_library_export_counts(
@@ -1191,10 +1299,90 @@ async def test_export_counts_reject_same_route_stale_generation(tmp_path: Path) 
             {"media": 99, "conversations": 99, "notes": 99, "prompts": 99},
             generation=generation,
             route_key=route_key,
+            request_id=request_id,
         )
 
         assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert active_screen._library_export_counts == counts_before
         assert str(scope_line.renderable) == rendered_before
+
+
+@pytest.mark.asyncio
+async def test_export_counts_leave_return_same_scope_rejects_older_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A same-route/same-scope ABA visit keeps the newest landed counts."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    _wire_entry_export_databases(app, tmp_path)
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_snapshot_rendered_generation
+            == screen._library_snapshot_state_generation,
+            message="Export ABA setup did not settle its source snapshot.",
+        )
+        requests: list[tuple[Any, ...]] = []
+
+        def capture_counts_request(*args: Any) -> None:
+            requests.append(args)
+
+        monkeypatch.setattr(
+            screen, "_run_library_export_counts_worker", capture_counts_request
+        )
+
+        await screen._select_library_rail_row(LIBRARY_ROW_INGEST_EXPORT)
+        await _wait_for_selector(screen, pilot, "#library-export-canvas")
+        assert len(requests) == 1
+        old_request = requests[-1]
+
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await screen._select_library_rail_row(LIBRARY_ROW_INGEST_EXPORT)
+        await _wait_for_selector(screen, pilot, "#library-export-canvas")
+        assert len(requests) == 2
+        new_request = requests[-1]
+        assert len(old_request) == len(new_request) == 7
+        old_scope, *_, old_generation, old_route_key, old_request_id = old_request
+        new_scope, *_, new_generation, new_route_key, new_request_id = new_request
+        assert old_scope == new_scope
+        assert old_route_key == new_route_key
+        assert old_request_id < new_request_id
+
+        newest_counts = {
+            "media": 2,
+            "conversations": 3,
+            "notes": 5,
+            "prompts": 7,
+        }
+        newest_result = screen._apply_library_export_counts(
+            new_scope,
+            newest_counts,
+            generation=new_generation,
+            route_key=new_route_key,
+            request_id=new_request_id,
+        )
+        scope_line = screen.query_one("#library-export-scope-line")
+        rendered_newest = str(scope_line.renderable)
+        stale_result = screen._apply_library_export_counts(
+            old_scope,
+            {"media": 99, "conversations": 99, "notes": 99, "prompts": 99},
+            generation=old_generation,
+            route_key=old_route_key,
+            request_id=old_request_id,
+        )
+
+        assert newest_result is LibraryEntryReconcileResult.APPLIED
+        assert stale_result is LibraryEntryReconcileResult.SUPERSEDED
+        assert screen._library_export_counts == newest_counts
+        assert (
+            screen.query_one("#library-export-canvas").state.scope_line
+            == rendered_newest
+        )
+        assert str(scope_line.renderable) == rendered_newest
 
 
 def _compositor_text(screen: LibraryScreen) -> str:

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import math
 import statistics
 import threading
 import time
@@ -11,6 +12,8 @@ from typing import Any
 
 import pytest
 from textual.widget import Widget
+from textual.widgets import Input
+from textual.widgets._input import Selection
 
 from tldw_chatbook.Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
@@ -686,6 +689,77 @@ async def test_stale_skills_generation_cannot_project_on_the_same_route() -> Non
 
 
 @pytest.mark.asyncio
+async def test_skills_posture_sync_composes_focus_with_render_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A posture callback must not replace the pending generation completion."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[{"name": "code-review"}]
+    )
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_SKILLS})
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        focus = await _wait_for_selector(
+            active_screen, pilot, "#library-skills-filter"
+        )
+        await active_screen.workers.wait_for_complete()
+        canvas = active_screen.query_one(
+            "#library-skills-canvas", LibrarySkillsListCanvas
+        )
+        focus = active_screen.query_one("#library-skills-filter", Input)
+        focus.focus()
+        await pilot.pause()
+        restore_calls: list[str | None] = []
+        original_restore = active_screen._restore_library_entry_focus
+
+        def record_restore(identity, **kwargs) -> None:
+            restore_calls.append(identity.widget_id)
+            original_restore(identity, **kwargs)
+
+        monkeypatch.setattr(
+            active_screen,
+            "_restore_library_entry_focus",
+            record_restore,
+        )
+
+        # Hold both canvas refreshes before their shared replace-latest callback
+        # slot fires: source reconciliation queues completion first, then the
+        # automatic posture result queues its focus intent.
+        monkeypatch.setattr(canvas, "refresh", lambda *args, **kwargs: canvas)
+        generation = active_screen._library_snapshot_state_generation + 1
+        route_key = active_screen._library_entry_route_key()
+        active_screen._library_snapshot_state_generation = generation
+        active_screen._library_entry_reconcile_dirty = True
+        active_screen._library_entry_reconcile_pending = (generation, route_key)
+
+        result = await active_screen._reconcile_library_entry_state(
+            generation, route_key
+        )
+        await pilot.pause()
+        posture_result = await active_screen._load_library_skills_trust_posture(
+            lambda: "ready"
+        )
+        callback = canvas._post_recompose_callback
+        assert callback is not None
+        canvas._post_recompose_callback = None
+        callback()
+
+        assert (result, posture_result) == (
+            LibraryEntryReconcileResult.APPLIED,
+            LibraryEntryReconcileResult.APPLIED,
+        )
+        assert "library-skills-filter" in restore_calls
+        assert active_screen._library_snapshot_rendered_generation == generation
+        assert active_screen._library_entry_reconcile_dirty is False
+        assert active_screen._library_entry_reconcile_pending is None
+
+
+@pytest.mark.asyncio
 async def test_stale_collections_snapshot_cannot_project_after_route_switch() -> None:
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
@@ -767,6 +841,310 @@ async def test_stale_collections_generation_cannot_project_on_the_same_route() -
         assert result is LibraryEntryReconcileResult.SUPERSEDED
         assert active_screen._library_entry_canvas_owner() is owner
         assert active_screen.focused is focus
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("intervening_focus", [False, True], ids=["restore", "veto"])
+async def test_automatic_collections_result_preserves_input_semantics_unless_focus_moves(
+    monkeypatch: pytest.MonkeyPatch,
+    intervening_focus: bool,
+) -> None:
+    """Collections refresh restores one live Input but never overrides a later focus."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.library_collections_service = StaticLibraryCollectionsService([])
+    screen = LibraryScreen(app)
+    screen.apply_navigation_context({"mode": "collections"})
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_selector(
+            active_screen, pilot, "#library-collection-name-input"
+        )
+        await active_screen.workers.wait_for_complete()
+        await pilot.pause()
+        panel = active_screen.query_one(
+            "#library-collections-panel", LibraryCollectionsPanel
+        )
+        name_input = active_screen.query_one(
+            "#library-collection-name-input", Input
+        )
+        name_input.value = "Launch Evidence"
+        await pilot.pause()
+        name_input = active_screen.query_one(
+            "#library-collection-name-input", Input
+        )
+        name_input.focus()
+        await pilot.pause()
+        expected_selection = Selection(2, 9)
+        name_input.selection = expected_selection
+        await pilot.pause()
+
+        recompose_started = asyncio.Event()
+        release_recompose = asyncio.Event()
+        original_recompose = panel.recompose
+
+        async def gated_recompose() -> None:
+            recompose_started.set()
+            await release_recompose.wait()
+            await original_recompose()
+
+        monkeypatch.setattr(panel, "recompose", gated_recompose)
+        app.library_collections_service = StaticLibraryCollectionsService(
+            [
+                {
+                    "collection_id": "collection-1",
+                    "name": "Release Sources",
+                    "description": "Fresh automatic result.",
+                    "item_count": 1,
+                    "source_authority": "local",
+                    "sync_status": "local-only",
+                    "updated_at": "2026-08-13T10:00:00Z",
+                }
+            ]
+        )
+
+        if intervening_focus:
+            monkeypatch.setattr(panel, "refresh", lambda *args, **kwargs: panel)
+            result = await active_screen._sync_collections_panel(
+                refresh_snapshot=True
+            )
+            callback = panel._post_recompose_callback
+            assert callback is not None
+            intervening_target = active_screen.query_one(
+                "#console-rail-section-toggle-library-details"
+            )
+            active_screen.set_focus(intervening_target)
+            panel._post_recompose_callback = None
+            callback()
+
+            assert result is LibraryEntryReconcileResult.APPLIED
+            assert active_screen.focused is intervening_target
+            return
+
+        sync_task = asyncio.create_task(
+            active_screen._sync_collections_panel(refresh_snapshot=True)
+        )
+        await asyncio.wait_for(
+            recompose_started.wait(),
+            timeout=10,
+        )
+        release_recompose.set()
+        result = await sync_task
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(active_screen.query("#library-collection-select-0")),
+            message="Collections automatic result never rendered its row.",
+        )
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.APPLIED
+        restored = active_screen.query_one(
+            "#library-collection-name-input", Input
+        )
+        assert restored.value == "Launch Evidence"
+        assert restored.disabled is False
+        assert active_screen.focused is restored
+        assert restored.selection == expected_selection
+        assert restored.cursor_position == expected_selection.end
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("intervening_focus", [False, True], ids=["restore", "veto"])
+async def test_coalesced_collections_sync_preserves_pending_input_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    intervening_focus: bool,
+) -> None:
+    """A capture-less second sync must retain the first sync's focus intent."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.library_collections_service = StaticLibraryCollectionsService([])
+    screen = LibraryScreen(app)
+    screen.apply_navigation_context({"mode": "collections"})
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_selector(
+            active_screen, pilot, "#library-collection-name-input"
+        )
+        await active_screen.workers.wait_for_complete()
+        await pilot.pause()
+        panel = active_screen.query_one(
+            "#library-collections-panel", LibraryCollectionsPanel
+        )
+        name_input = active_screen.query_one(
+            "#library-collection-name-input", Input
+        )
+        name_input.value = "Coalesced Evidence"
+        name_input.focus()
+        await pilot.pause()
+        expected_selection = Selection(3, 11)
+        name_input.selection = expected_selection
+        await pilot.pause()
+
+        monkeypatch.setattr(panel, "refresh", lambda *args, **kwargs: panel)
+        sync_kwargs = {
+            "name_value": "stale worker value",
+            "description_value": panel.description_value,
+            "delete_pending": panel.delete_pending,
+            "deferred_guard": lambda: True,
+        }
+        panel.sync_state(panel.state, **sync_kwargs)
+        assert active_screen.focused is None
+        panel.sync_state(panel.state, **sync_kwargs)
+
+        callback = panel._post_recompose_callback
+        assert callback is not None
+        if intervening_focus:
+            intervening_target = active_screen.query_one(
+                "#console-rail-section-toggle-library-details"
+            )
+            active_screen.set_focus(intervening_target)
+        panel._post_recompose_callback = None
+        callback()
+
+        if intervening_focus:
+            assert active_screen.focused is intervening_target
+        else:
+            assert active_screen.focused is name_input
+            assert name_input.value == "Coalesced Evidence"
+            assert name_input.selection == expected_selection
+            assert name_input.cursor_position == expected_selection.end
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["media", "export", "collections"])
+async def test_superseded_entry_result_converges_on_current_dirty_generation(
+    surface: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A same-route dirty generation must admit automatic-result repair."""
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        media=_two_media_items(),
+    )
+    started = threading.Event()
+    release = threading.Event()
+
+    if surface == "media":
+
+        def gated_media(**kwargs):
+            started.set()
+            assert release.wait(timeout=10), "Media detail gate was not released."
+            return _two_media_items()[0]
+
+        app.media_reading_scope_service = SimpleNamespace(
+            get_media_item=gated_media,
+        )
+        screen = LibraryScreen(app)
+        screen.restore_state(
+            {
+                "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+                "selected_media_id": "media-1",
+                "library_media_view": "viewer",
+            }
+        )
+    elif surface == "collections":
+
+        def gated_collections():
+            started.set()
+            assert release.wait(timeout=10), "Collections gate was not released."
+            return (
+                {
+                    "collection_id": "collection-1",
+                    "name": "Dirty-generation sources",
+                    "description": "Must replace Loading.",
+                    "item_count": 1,
+                    "source_authority": "local",
+                    "sync_status": "local-only",
+                    "updated_at": "2026-08-13T10:00:00Z",
+                },
+            )
+
+        app.library_collections_service = SimpleNamespace(
+            list_collections=gated_collections
+        )
+        screen = LibraryScreen(app)
+        screen.apply_navigation_context({"mode": "collections"})
+    else:
+        _wire_entry_export_databases(app, tmp_path)
+        original_compute = LibraryScreen._compute_library_export_counts
+        compute_calls = 0
+
+        def gated_export(*args, **kwargs):
+            nonlocal compute_calls
+            compute_calls += 1
+            if compute_calls == 1:
+                started.set()
+                assert release.wait(timeout=10), "Export counts gate was not released."
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_compute_library_export_counts",
+            staticmethod(gated_export),
+        )
+        screen = LibraryScreen(app)
+        screen.restore_state({"library_selected_row_id": LIBRARY_ROW_INGEST_EXPORT})
+
+    host = LibraryHarness(app, screen=screen)
+    try:
+        async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+            active_screen = _active_library_screen(host)
+            await _wait_for_condition(
+                pilot,
+                started.is_set,
+                message=f"{surface} automatic worker did not reach its gate.",
+            )
+            await _wait_for_library_shell(active_screen, pilot)
+            current_generation = (
+                active_screen._library_snapshot_state_generation + 1
+            )
+            active_screen._library_snapshot_state_generation = current_generation
+            active_screen._library_snapshot_rendered_generation = (
+                current_generation - 1
+            )
+            active_screen._library_entry_reconcile_dirty = True
+            active_screen._library_entry_reconcile_pending = None
+            active_screen._library_entry_reconcile_retry_generation = None
+            release.set()
+
+            def rendered_result() -> bool:
+                if surface == "media":
+                    titles = list(active_screen.query("#library-media-viewer-title"))
+                    return bool(
+                        titles
+                        and "Interview Recording"
+                        in str(titles[0].renderable)
+                    )
+                if surface == "collections":
+                    titles = list(active_screen.query("#library-collections-title"))
+                    return bool(
+                        titles and "Collections (1)" in str(titles[0].renderable)
+                    )
+                scope_lines = list(active_screen.query("#library-export-scope-line"))
+                return bool(
+                    scope_lines
+                    and not str(scope_lines[0].renderable).startswith("Counting")
+                )
+
+            await _wait_for_condition(
+                pilot,
+                rendered_result,
+                timeout=4.0,
+                message=(
+                    f"{surface} automatic result did not converge on the "
+                    "current dirty generation."
+                ),
+            )
+            await active_screen.workers.wait_for_complete()
+    finally:
+        release.set()
 
 
 @pytest.mark.asyncio
@@ -2659,7 +3037,7 @@ async def test_library_source_snapshot_stale_route_clears_retry_markers():
         stale_route = screen._library_entry_route_key()
         screen._library_entry_reconcile_dirty = True
         screen._library_entry_reconcile_pending = (generation, stale_route)
-        screen._library_entry_reconcile_retry_generation = generation
+        screen._library_entry_reconcile_retry_generation = (generation, stale_route)
         screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
 
         result = await screen._reconcile_library_entry_state(
@@ -2669,6 +3047,50 @@ async def test_library_source_snapshot_stale_route_clears_retry_markers():
         assert result is LibraryEntryReconcileResult.SUPERSEDED
         assert screen._library_entry_reconcile_pending is None
         assert screen._library_entry_reconcile_retry_generation is None
+
+
+@pytest.mark.asyncio
+async def test_same_generation_new_route_receives_its_own_first_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A route-A retry marker must not consume route B's first retry."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        generation = screen._library_snapshot_state_generation
+        route_a = screen._library_entry_route_key()
+        queued: list[tuple[object, tuple[object, ...]]] = []
+
+        def capture_call_later(callback, *args):
+            queued.append((callback, args))
+
+        monkeypatch.setattr(screen, "call_later", capture_call_later)
+        first = screen._retry_or_fail_library_entry_reconcile(generation, route_a)
+        assert first is LibraryEntryReconcileResult.FAILED
+        assert screen._library_entry_reconcile_retry_generation == (
+            generation,
+            route_a,
+        )
+        assert len(queued) == 1
+
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+        route_b = screen._library_entry_route_key()
+        second = screen._retry_or_fail_library_entry_reconcile(generation, route_b)
+
+        assert second is LibraryEntryReconcileResult.FAILED
+        assert screen._library_entry_reconcile_pending == (generation, route_b)
+        assert screen._library_entry_reconcile_retry_generation == (
+            generation,
+            route_b,
+        )
+        assert len(queued) == 2
 
 
 @pytest.mark.asyncio
@@ -2706,7 +3128,10 @@ async def test_library_source_snapshot_missing_skills_retries_then_equal_can_ret
         assert reconcile_results == [LibraryEntryReconcileResult.FAILED]
         assert screen._library_entry_reconcile_dirty is True
         assert screen._library_entry_reconcile_pending == (generation, route_key)
-        assert screen._library_entry_reconcile_retry_generation == generation
+        assert screen._library_entry_reconcile_retry_generation == (
+            generation,
+            route_key,
+        )
         assert len(queued) == 1
 
         callback, args = queued.pop()
@@ -2756,7 +3181,7 @@ async def test_library_source_snapshot_shell_exception_releases_retry_markers(
         route_key = screen._library_entry_route_key()
         screen._library_entry_reconcile_dirty = True
         screen._library_entry_reconcile_pending = (generation, route_key)
-        screen._library_entry_reconcile_retry_generation = generation
+        screen._library_entry_reconcile_retry_generation = (generation, route_key)
         queued: list[tuple[object, tuple[object, ...]]] = []
 
         def capture_call_later(callback, *args):
@@ -2877,3 +3302,28 @@ def test_cache_seed_rejects_future_and_ttl_boundary_stamps():
         is True
     )
     assert screen._library_loaded is True
+
+
+def test_cache_seed_rejects_non_finite_timestamp():
+    """A NaN stamp must not bypass both cache-age comparisons."""
+    app = _build_test_app()
+    app._library_source_snapshot_cache = (
+        {
+            "notes": (),
+            "media": (),
+            "conversations": (),
+            "prompts": (None, ()),
+            "skills": (None, {"available_skills": [], "blocked_skills": []}),
+        },
+        {"notes": 0, "media": 0, "conversations": 0},
+        {"notes": True, "media": True, "conversations": True},
+        None,
+        None,
+        {"study_decks": None, "flashcards_due": None, "quizzes": None},
+    )
+    app._library_source_snapshot_cache_stamp = math.nan
+
+    screen = LibraryScreen(app)
+
+    assert screen._library_loaded is False
+    assert screen._library_snapshot_state_generation == 0

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import statistics
+import time
+
+import pytest
+
+from tldw_chatbook.UI.Screens.library_screen import (
+    LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS,
+    LibraryScreen,
+)
+from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _build_test_app,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_library_shell,
+)
+
+
+@pytest.mark.asyncio
+async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatch):
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    calls: list[LibraryScreen] = []
+    original = LibraryScreen.compose_content
+
+    def counted_compose(screen):
+        calls.append(screen)
+        yield from original(screen)
+
+    monkeypatch.setattr(LibraryScreen, "compose_content", counted_compose)
+    samples: list[float] = []
+    revisits: list[LibraryScreen] = []
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        first = _active_library_screen(host)
+        await _wait_for_library_shell(first, pilot)
+        await host.pop_screen()
+        await pilot.pause()
+        for _ in range(5):
+            revisit = LibraryScreen(app)
+            revisits.append(revisit)
+            started = time.perf_counter()
+            await host.push_screen(revisit)
+            await _wait_for_library_shell(revisit, pilot)
+            samples.append((time.perf_counter() - started) * 1000)
+            await host.pop_screen()
+            await pilot.pause()
+    print(
+        f"warm_visit_median_ms={statistics.median(samples):.3f} "
+        f"min_ms={min(samples):.3f} max_ms={max(samples):.3f} n={len(samples)}"
+    )
+    print(f"warm_visit_compose_counts={[calls.count(revisit) for revisit in revisits]}")
+    assert all(calls.count(revisit) == 1 for revisit in revisits)
+
+
+def test_constructor_seeds_cached_snapshot_before_restore_state_wins_selection():
+    """Changing pre-compose cache seeding to mount-time seeding would leave
+    this fresh screen unloaded before its first composition.
+    """
+    app = _build_test_app()
+    app._library_source_snapshot_cache = (
+        {
+            "notes": ({"id": "n1"},),
+            "media": ({"id": "m1"},),
+            "conversations": ({"id": "c1"},),
+            "prompts": (None, ()),
+            "skills": (None, {"available_skills": [], "blocked_skills": []}),
+        },
+        {"notes": 1, "media": 1, "conversations": 1},
+        {"notes": True, "media": True, "conversations": True},
+        None,
+        None,
+        {"study_decks": None, "flashcards_due": None, "quizzes": None},
+    )
+    app._library_source_snapshot_cache_stamp = time.monotonic()
+
+    screen = LibraryScreen(app)
+
+    assert screen._library_loaded is True
+    assert screen._local_source_counts == {
+        "notes": 1,
+        "media": 1,
+        "conversations": 1,
+    }
+
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+            "selected_media_id": "m1",
+            "library_media_view": "viewer",
+        }
+    )
+
+    assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+    assert screen._selected_media_id == "m1"
+    assert screen._library_media_view == "viewer"
+
+
+def test_cache_seed_rejects_future_and_ttl_boundary_stamps():
+    """Changing either cache-age guard would accept a future or expired seed."""
+    app = _build_test_app()
+    app._library_source_snapshot_cache = (
+        {
+            "notes": (),
+            "media": (),
+            "conversations": (),
+            "prompts": (None, ()),
+            "skills": (None, {"available_skills": [], "blocked_skills": []}),
+        },
+        {"notes": 0, "media": 0, "conversations": 0},
+        {"notes": True, "media": True, "conversations": True},
+        None,
+        None,
+        {"study_decks": None, "flashcards_due": None, "quizzes": None},
+    )
+    stamp = 100.0
+    app._library_source_snapshot_cache_stamp = stamp
+    screen = LibraryScreen(app)
+
+    assert screen._seed_local_source_snapshot_from_cache(now=stamp - 0.1) is False
+    assert (
+        screen._seed_local_source_snapshot_from_cache(
+            now=stamp + LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS
+        )
+        is False
+    )
+    assert screen._library_loaded is False
+
+    assert (
+        screen._seed_local_source_snapshot_from_cache(
+            now=stamp + LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS - 0.1
+        )
+        is True
+    )
+    assert screen._library_loaded is True

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -1,39 +1,1200 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import statistics
+import threading
 import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from textual.widget import Widget
 
+from tldw_chatbook.Constants import (
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
+from tldw_chatbook.Prompt_Management.prompt_scope_service import (
+    LocalPromptService,
+    PromptScopeService,
+)
+from tldw_chatbook.UI.Library_Modules.library_prompt_browse_controller import (
+    LibraryPromptBrowseController,
+)
 from tldw_chatbook.UI.Screens.library_screen import (
     LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS,
     LibraryEntryReconcileResult,
     LibraryScreen,
 )
 from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_COLLECTIONS,
     LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
+    LIBRARY_ROW_BROWSE_NOTES,
+    LIBRARY_ROW_BROWSE_PROMPTS,
     LIBRARY_ROW_BROWSE_SKILLS,
     LIBRARY_ROW_CREATE_STUDY,
+    LIBRARY_ROW_INGEST_EXPORT,
 )
 from tldw_chatbook.Widgets.Library import (
+    LibraryCollectionsPanel,
     LibraryConversationsCanvas,
+    LibraryExportCanvas,
     LibraryLandingCanvas,
     LibraryLandingCanvasState,
     LibraryLandingRecentItem,
+    LibraryMediaCanvas,
+    LibraryMediaTrashCanvas,
+    LibraryMediaViewer,
+    LibraryNotesCanvas,
+    LibraryPromptsListCanvas,
+    LibrarySkillsListCanvas,
     LibraryStudyHandoffCanvas,
 )
+from Tests.UI.test_library_content_hub import StaticLibraryCollectionsService
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
     LibraryHarness,
+    _FakeSkillsScopeService,
     _active_library_screen,
     _build_test_app,
     _seed_conversations,
     _two_conversations,
+    _two_media_items,
+    _two_notes,
+    _wait_for_condition,
     _wait_for_library_shell,
     _wait_for_selector,
 )
+
+
+@dataclasses.dataclass(frozen=True)
+class _EntryWorkerCase:
+    name: str
+    terminal_selector: str
+    owner_type: type[Widget]
+    owner_replaced: bool = False
+
+
+_ENTRY_WORKER_CASES = (
+    _EntryWorkerCase("prompts", "#library-prompt-row-1", LibraryPromptsListCanvas),
+    _EntryWorkerCase(
+        "collections", "#library-collection-select-0", LibraryCollectionsPanel
+    ),
+    _EntryWorkerCase("skills", "#library-skill-row-code-review", LibrarySkillsListCanvas),
+    _EntryWorkerCase(
+        "notes", "#library-note-body", LibraryNotesCanvas, owner_replaced=True
+    ),
+    _EntryWorkerCase(
+        "media", "#library-media-viewer", LibraryMediaViewer, owner_replaced=True
+    ),
+    _EntryWorkerCase("export", "#library-export-header", LibraryExportCanvas),
+    _EntryWorkerCase(
+        "pending-media",
+        "#library-media-viewer",
+        LibraryMediaViewer,
+        owner_replaced=True,
+    ),
+    _EntryWorkerCase(
+        "pending-notes",
+        "#library-note-body",
+        LibraryNotesCanvas,
+        owner_replaced=True,
+    ),
+    _EntryWorkerCase(
+        "pending-conversations",
+        "#library-conversations-canvas",
+        LibraryConversationsCanvas,
+        owner_replaced=True,
+    ),
+    _EntryWorkerCase(
+        "pending-prompt",
+        "#library-prompts-canvas",
+        LibraryPromptsListCanvas,
+        owner_replaced=True,
+    ),
+)
+
+
+def _wire_entry_prompt_service(app: Any, db_path: Path) -> int:
+    """Wire one real Prompt record through the production scope service."""
+    prompts_db = PromptsDatabase(db_path, client_id=f"entry-{db_path.stem}")
+    prompt_id, _prompt_uuid, _message = prompts_db.add_prompt(
+        name="Entry prompt",
+        author="Codex",
+        details="Entry worker fixture",
+        system_prompt="Be exact.",
+        user_prompt="Summarize {text}.",
+    )
+    app.prompts_db = prompts_db
+    app.prompt_scope_service = PromptScopeService(
+        local_service=LocalPromptService(prompts_db),
+        server_service=None,
+    )
+    return prompt_id
+
+
+def _wire_entry_export_databases(app: Any, root: Path) -> None:
+    """Use file-backed databases so Export counts run on its real worker."""
+    media_db = MediaDatabase(root / "entry-export-media.db", client_id="entry-export")
+    media_db.add_media_with_keywords(title="M1", content="c1", media_type="video")
+    app.media_db = media_db
+    app.media_reading_scope_service = MediaReadingScopeService(
+        LocalMediaReadingService(media_db),
+        None,
+    )
+    chachanotes_db = CharactersRAGDB(
+        root / "entry-export-notes.db", client_id="entry-export"
+    )
+    chachanotes_db.add_conversation({"title": "Conversation"})
+    chachanotes_db.add_note("Note", "Body")
+    app.chachanotes_db = chachanotes_db
+
+
+def _arrange_entry_worker_case(
+    case: _EntryWorkerCase,
+    *,
+    app: Any,
+    screen: LibraryScreen,
+    prompt_id: int,
+) -> None:
+    """Arrange the initial route before mount, matching production ordering."""
+    if case.name == "prompts":
+        screen.restore_state(
+            {
+                "library_selected_row_id": LIBRARY_ROW_BROWSE_PROMPTS,
+                "library_prompts_view": "list",
+            }
+        )
+    elif case.name == "collections":
+        screen.apply_navigation_context({"mode": "collections"})
+    elif case.name == "skills":
+        screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_SKILLS})
+    elif case.name == "notes":
+        screen.restore_state(
+            {
+                "library_selected_row_id": LIBRARY_ROW_BROWSE_NOTES,
+                "selected_note_id": "n-1",
+                "library_notes_view": "editor",
+            }
+        )
+    elif case.name == "media":
+        screen.restore_state(
+            {
+                "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+                "selected_media_id": "media-1",
+                "library_media_view": "viewer",
+            }
+        )
+    elif case.name == "export":
+        screen.restore_state({"library_selected_row_id": LIBRARY_ROW_INGEST_EXPORT})
+    elif case.name.startswith("pending-"):
+        source_type = case.name.removeprefix("pending-")
+        source_id = {
+            "media": "media-1",
+            "notes": "n-1",
+            "conversations": "chat-2",
+            "prompt": str(prompt_id),
+        }[source_type]
+        screen.apply_navigation_context(
+            {
+                LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: source_type,
+                LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: source_id,
+            }
+        )
+
+
+def _entry_worker_terminal(case: _EntryWorkerCase, screen: LibraryScreen) -> bool:
+    """Return the real worker terminal state paired with its mounted selector."""
+    selector_ready = bool(screen.query(case.terminal_selector))
+    if case.name == "prompts":
+        return (
+            screen._library_prompt_browse_controller.result.status == "ready"
+            and selector_ready
+        )
+    if case.name == "collections":
+        return screen._library_collections_loaded and selector_ready
+    if case.name == "skills":
+        return screen._library_skills_trust_posture == "ready" and selector_ready
+    if case.name in {"notes", "pending-notes"}:
+        return screen._library_note_load_state == "loaded" and selector_ready
+    if case.name in {"media", "pending-media"}:
+        return screen._library_media_detail is not None and selector_ready
+    if case.name == "export":
+        return screen._library_export_counts is not None and selector_ready
+    if case.name == "pending-conversations":
+        return screen._selected_conversation_id == "chat-2" and selector_ready
+    if case.name == "pending-prompt":
+        return screen._library_prompt_detail is not None and selector_ready
+    return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _ENTRY_WORKER_CASES, ids=lambda case: case.name)
+async def test_automatic_entry_worker_composes_screen_once_and_routes_in_place(
+    case: _EntryWorkerCase,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Restoring a former broad completion call must fail its exact API spy."""
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=_two_notes(),
+        media=_two_media_items(),
+    )
+    prompt_id = _wire_entry_prompt_service(app, tmp_path / f"{case.name}-prompts.db")
+    app.library_collections_service = StaticLibraryCollectionsService(
+        [
+            {
+                "collection_id": "collection-1",
+                "name": "Launch Evidence",
+                "description": "Sources for release review.",
+                "item_count": 3,
+                "source_authority": "local",
+                "sync_status": "local-only",
+                "updated_at": "2026-08-13T10:00:00Z",
+            }
+        ]
+    )
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[{"name": "code-review"}],
+    )
+    app.local_skill_trust_service = SimpleNamespace(trust_posture=lambda: "ready")
+    if case.name == "export":
+        _wire_entry_export_databases(app, tmp_path)
+
+    screen = LibraryScreen(app)
+    _arrange_entry_worker_case(
+        case,
+        app=app,
+        screen=screen,
+        prompt_id=prompt_id,
+    )
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    thread_started = threading.Event()
+    thread_release = threading.Event()
+    if case.name == "prompts":
+        original_load = LibraryPromptBrowseController._load
+
+        async def gated_prompt_load(controller, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(controller, *args, **kwargs)
+
+        monkeypatch.setattr(LibraryPromptBrowseController, "_load", gated_prompt_load)
+    elif case.name == "collections":
+        original_load = LibraryScreen._refresh_library_collections_snapshot
+
+        async def gated_collections_load(active_screen, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(active_screen, *args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_refresh_library_collections_snapshot",
+            gated_collections_load,
+        )
+    elif case.name == "skills":
+        original_load = LibraryScreen._load_library_skills_trust_posture
+
+        async def gated_skills_load(active_screen, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(active_screen, *args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_load_library_skills_trust_posture",
+            gated_skills_load,
+        )
+    elif case.name == "notes":
+        original_load = LibraryScreen._refresh_library_note_detail
+
+        async def gated_note_load(active_screen, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(active_screen, *args, **kwargs)
+
+        monkeypatch.setattr(LibraryScreen, "_refresh_library_note_detail", gated_note_load)
+    elif case.name == "media":
+        original_load = LibraryScreen._refresh_library_media_detail
+
+        async def gated_media_load(active_screen, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(active_screen, *args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_refresh_library_media_detail",
+            gated_media_load,
+        )
+    elif case.name == "export":
+        original_compute = LibraryScreen._compute_library_export_counts
+
+        def gated_export_counts(*args, **kwargs):
+            thread_started.set()
+            assert thread_release.wait(timeout=10), "Export counts gate was not released."
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_compute_library_export_counts",
+            staticmethod(gated_export_counts),
+        )
+    else:
+        original_load = LibraryScreen._open_pending_library_source
+
+        async def gated_pending_open(active_screen, *args, **kwargs):
+            started.set()
+            await release.wait()
+            return await original_load(active_screen, *args, **kwargs)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_open_pending_library_source",
+            gated_pending_open,
+        )
+
+    compose_calls: list[LibraryScreen] = []
+    refresh_recompose_calls: list[LibraryScreen] = []
+    recompose_calls: list[LibraryScreen] = []
+    original_compose = LibraryScreen.compose_content
+    original_refresh = LibraryScreen.refresh
+    original_recompose = LibraryScreen.recompose
+
+    def counted_compose(active_screen):
+        compose_calls.append(active_screen)
+        yield from original_compose(active_screen)
+
+    def recorded_refresh(active_screen, *regions, **kwargs):
+        if kwargs.get("recompose"):
+            refresh_recompose_calls.append(active_screen)
+        return original_refresh(active_screen, *regions, **kwargs)
+
+    async def recorded_recompose(active_screen):
+        recompose_calls.append(active_screen)
+        return await original_recompose(active_screen)
+
+    monkeypatch.setattr(LibraryScreen, "compose_content", counted_compose)
+    monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+    monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
+
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_library_shell(active_screen, pilot)
+        if case.name == "export":
+            await _wait_for_condition(
+                pilot,
+                thread_started.is_set,
+                message="Export entry worker did not reach its counts gate.",
+            )
+        else:
+            await _wait_for_condition(
+                pilot,
+                started.is_set,
+                message=f"{case.name} entry worker did not reach its gate.",
+            )
+        await _wait_for_condition(
+            pilot,
+            lambda: active_screen._library_entry_canvas_owner() is not None,
+            message=lambda: (
+                f"{case.name} initial route owner did not mount: "
+                f"{[(type(child).__name__, child.id, child.display, child.is_mounted) for child in active_screen.query_one('#library-canvas').children]}"
+            ),
+        )
+
+        first_screen = active_screen
+        first_rail = active_screen.query_one("#library-rail")
+        first_host = active_screen.query_one("#library-canvas")
+        first_owner = active_screen._library_entry_canvas_owner()
+        assert first_owner is not None
+
+        if case.name == "export":
+            thread_release.set()
+        else:
+            release.set()
+        await _wait_for_condition(
+            pilot,
+            lambda: _entry_worker_terminal(case, active_screen),
+            message=lambda: (
+                f"{case.name} did not reach its terminal state; "
+                f"route={active_screen._library_entry_route_key()!r}."
+            ),
+        )
+        await pilot.pause()
+
+        final_owner = active_screen._library_entry_canvas_owner()
+        assert _active_library_screen(host) is first_screen
+        assert active_screen.query_one("#library-rail") is first_rail
+        assert active_screen.query_one("#library-canvas") is first_host
+        assert isinstance(final_owner, case.owner_type)
+        if case.owner_replaced:
+            assert final_owner is not first_owner
+        else:
+            assert final_owner is first_owner
+        assert compose_calls.count(active_screen) == 1
+        assert refresh_recompose_calls == []
+        assert recompose_calls == []
+
+
+async def _capture_new_conversations_route(screen: LibraryScreen, pilot):
+    """Switch through the live interaction path and capture its owner/focus."""
+    await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+    focus = await _wait_for_selector(screen, pilot, "#library-conversations-filter")
+    owner = screen._library_entry_canvas_owner()
+    focus.focus()
+    await pilot.pause()
+    assert owner is not None
+    assert screen.focused is focus
+    return owner, focus
+
+
+def _assert_new_route_unchanged(
+    screen: LibraryScreen, *, owner: Widget, focus: Widget
+) -> None:
+    """Assert stale entry completion did not mutate the successor route."""
+    assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+    assert screen._library_entry_canvas_owner() is owner
+    assert screen.focused is focus
+
+
+@pytest.mark.asyncio
+async def test_stale_prompt_token_cannot_project_after_route_switch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    _wire_entry_prompt_service(app, tmp_path / "stale-prompt.db")
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_PROMPTS})
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    original_load = LibraryPromptBrowseController._load
+
+    async def gated_load(controller, *args, **kwargs):
+        started.set()
+        await release.wait()
+        try:
+            return await original_load(controller, *args, **kwargs)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(LibraryPromptBrowseController, "_load", gated_load)
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Prompt browse did not reach its service gate.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                active_screen._library_loaded
+                and active_screen._library_snapshot_rendered_generation
+                == active_screen._library_snapshot_state_generation
+            ),
+            message="Prompt stale-race setup did not settle its source snapshot.",
+        )
+        stale_result = active_screen._library_prompt_browse_controller.result
+        owner, focus = await _capture_new_conversations_route(active_screen, pilot)
+
+        release.set()
+        await _wait_for_condition(
+            pilot,
+            finished.is_set,
+            message="Stale Prompt browse did not settle after release.",
+        )
+
+        result = active_screen._sync_library_prompts_browse_result(
+            stale_result, "library-prompts-sort"
+        )
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        _assert_new_route_unchanged(active_screen, owner=owner, focus=focus)
+
+
+@pytest.mark.asyncio
+async def test_stale_prompt_token_is_rejected_on_the_same_route(
+    tmp_path: Path,
+) -> None:
+    """The controller token, not an incidental route change, owns Prompt results."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    _wire_entry_prompt_service(app, tmp_path / "same-route-stale-prompt.db")
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_PROMPTS})
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        row = await _wait_for_selector(active_screen, pilot, "#library-prompt-row-1")
+        stale_result = active_screen._library_prompt_browse_controller.result
+        active_screen._library_prompt_browse_controller.begin(stale_result.scope)
+        owner = active_screen._library_entry_canvas_owner()
+        row.focus()
+        await pilot.pause()
+
+        result = active_screen._sync_library_prompts_browse_result(
+            stale_result, row.id
+        )
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert active_screen._library_entry_canvas_owner() is owner
+        assert active_screen.focused is row
+
+
+@pytest.mark.asyncio
+async def test_stale_skills_posture_cannot_project_after_route_switch() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[{"name": "code-review"}]
+    )
+    app.local_skill_trust_service = SimpleNamespace(trust_posture=lambda: "ready")
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_SKILLS)
+        await _wait_for_selector(screen, pilot, "#library-skills-canvas")
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_posture() -> str:
+            started.set()
+            assert release.wait(timeout=10), "Skills posture gate was not released."
+            return "ready"
+
+        task = asyncio.create_task(screen._load_library_skills_trust_posture(gated_posture))
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Skills posture did not reach its service gate.",
+        )
+        owner, focus = await _capture_new_conversations_route(screen, pilot)
+
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        _assert_new_route_unchanged(screen, owner=owner, focus=focus)
+
+
+@pytest.mark.asyncio
+async def test_stale_skills_generation_cannot_project_on_the_same_route() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[{"name": "code-review"}]
+    )
+    app.local_skill_trust_service = SimpleNamespace(trust_posture=lambda: "ready")
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_SKILLS})
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        focus = await _wait_for_selector(
+            active_screen, pilot, "#library-skill-row-code-review"
+        )
+        await active_screen.workers.wait_for_complete()
+        await pilot.pause()
+        focus = active_screen.query_one("#library-skill-row-code-review")
+        owner = active_screen._library_entry_canvas_owner()
+        focus.focus()
+        await pilot.pause()
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_posture() -> str:
+            started.set()
+            assert release.wait(timeout=10), "Skills generation gate was not released."
+            return "updated"
+
+        task = asyncio.create_task(
+            active_screen._load_library_skills_trust_posture(gated_posture)
+        )
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Skills generation test did not reach its gate.",
+        )
+        active_screen._library_snapshot_state_generation += 1
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert active_screen._library_entry_canvas_owner() is owner
+        assert active_screen.focused is focus
+
+
+@pytest.mark.asyncio
+async def test_stale_collections_snapshot_cannot_project_after_route_switch() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.library_collections_service = StaticLibraryCollectionsService([])
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_COLLECTIONS)
+        await _wait_for_selector(screen, pilot, "#library-collections-panel")
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_collections():
+            started.set()
+            assert release.wait(timeout=10), "Collections snapshot gate was not released."
+            return []
+
+        app.library_collections_service = SimpleNamespace(
+            list_collections=gated_collections
+        )
+        task = asyncio.create_task(screen._sync_collections_panel(refresh_snapshot=True))
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Collections snapshot did not reach its service gate.",
+        )
+        owner, focus = await _capture_new_conversations_route(screen, pilot)
+
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        _assert_new_route_unchanged(screen, owner=owner, focus=focus)
+
+
+@pytest.mark.asyncio
+async def test_stale_collections_generation_cannot_project_on_the_same_route() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    app.library_collections_service = StaticLibraryCollectionsService([])
+    screen = LibraryScreen(app)
+    screen.apply_navigation_context({"mode": "collections"})
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        focus = await _wait_for_selector(
+            active_screen, pilot, "#library-collection-name-input"
+        )
+        await active_screen.workers.wait_for_complete()
+        await pilot.pause()
+        focus = active_screen.query_one("#library-collection-name-input")
+        owner = active_screen._library_entry_canvas_owner()
+        focus.focus()
+        await pilot.pause()
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_collections():
+            started.set()
+            assert release.wait(timeout=10), "Collections generation gate not released."
+            return []
+
+        app.library_collections_service = SimpleNamespace(
+            list_collections=gated_collections
+        )
+        task = asyncio.create_task(
+            active_screen._sync_collections_panel(refresh_snapshot=True)
+        )
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Collections generation test did not reach its gate.",
+        )
+        active_screen._library_snapshot_state_generation += 1
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert active_screen._library_entry_canvas_owner() is owner
+        assert active_screen.focused is focus
+
+
+@pytest.mark.asyncio
+async def test_replace_canvas_child_repairs_current_route_after_remove_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A route switch inside remove_children must not strand an empty host."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_library_shell(active_screen, pilot)
+        await active_screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(active_screen, pilot, "#library-media-canvas")
+        active_screen._selected_media_id = "media-1"
+        active_screen._library_media_view = "viewer"
+        active_screen._library_media_detail = _two_media_items()[0]
+        generation = active_screen._library_snapshot_state_generation
+        route_key = active_screen._library_entry_route_key()
+        canvas_host = active_screen.query_one("#library-canvas")
+        original_remove = canvas_host.remove_children
+
+        def route_switching_remove(*children):
+            removal = original_remove(*children)
+            active_screen._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+            active_screen._library_media_view = "list"
+            return removal
+
+        monkeypatch.setattr(canvas_host, "remove_children", route_switching_remove)
+        result = await active_screen._replace_library_canvas_child(
+            active_screen._build_library_media_active_child(),
+            generation=generation,
+            route_key=route_key,
+        )
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert isinstance(
+            active_screen._library_entry_canvas_owner(),
+            LibraryConversationsCanvas,
+        )
+
+
+@pytest.mark.asyncio
+async def test_replace_canvas_child_repairs_owner_after_mount_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One failed mount must reconstruct the current route below the shell."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_library_shell(active_screen, pilot)
+        await active_screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(active_screen, pilot, "#library-media-canvas")
+        active_screen._selected_media_id = "media-1"
+        active_screen._library_media_view = "viewer"
+        active_screen._library_media_detail = _two_media_items()[0]
+        generation = active_screen._library_snapshot_state_generation
+        route_key = active_screen._library_entry_route_key()
+        canvas_host = active_screen.query_one("#library-canvas")
+        original_mount = canvas_host.mount
+        attempts = 0
+
+        def fail_once_mount(*widgets, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("injected mount failure")
+            return original_mount(*widgets, **kwargs)
+
+        monkeypatch.setattr(canvas_host, "mount", fail_once_mount)
+        result = await active_screen._replace_library_canvas_child(
+            active_screen._build_library_media_active_child(),
+            generation=generation,
+            route_key=route_key,
+        )
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.FAILED
+        assert isinstance(active_screen._library_entry_canvas_owner(), LibraryMediaViewer)
+
+
+@pytest.mark.asyncio
+async def test_media_replacement_rereads_state_after_mount_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_library_shell(active_screen, pilot)
+        await active_screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(active_screen, pilot, "#library-media-canvas")
+        active_screen._selected_media_id = "media-1"
+        active_screen._library_media_view = "viewer"
+        active_screen._library_media_detail = _two_media_items()[0]
+        generation = active_screen._library_snapshot_state_generation
+        route_key = active_screen._library_entry_route_key()
+        canvas_host = active_screen.query_one("#library-canvas")
+        original_mount = canvas_host.mount
+
+        def state_changing_mount(*widgets, **kwargs):
+            mounted = original_mount(*widgets, **kwargs)
+            active_screen._library_media_editing = True
+            return mounted
+
+        monkeypatch.setattr(canvas_host, "mount", state_changing_mount)
+        result = await active_screen._replace_library_canvas_child(
+            active_screen._build_library_media_active_child(),
+            generation=generation,
+            route_key=route_key,
+        )
+        await pilot.pause()
+        viewer = active_screen.query_one("#library-media-viewer", LibraryMediaViewer)
+
+        assert result is LibraryEntryReconcileResult.APPLIED
+        assert viewer.editing is True
+        assert active_screen.query("#library-media-edit-title")
+
+
+@pytest.mark.asyncio
+async def test_stale_media_detail_cannot_project_after_route_switch() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+        screen._selected_media_id = "media-1"
+        screen._library_media_view = "viewer"
+        route_key = screen._library_entry_route_key()
+        replaced = await screen._replace_library_canvas_child(
+            screen._build_library_media_active_child(),
+            generation=screen._library_snapshot_state_generation,
+            route_key=route_key,
+        )
+        assert replaced is LibraryEntryReconcileResult.APPLIED
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_media(**_kwargs):
+            started.set()
+            assert release.wait(timeout=10), "Media detail gate was not released."
+            return _two_media_items()[0]
+
+        app.media_reading_scope_service = SimpleNamespace(get_media_item=gated_media)
+        task = asyncio.create_task(
+            screen._refresh_library_media_detail("media-1", entry_origin=True)
+        )
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Media detail did not reach its service gate.",
+        )
+        owner, focus = await _capture_new_conversations_route(screen, pilot)
+
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        _assert_new_route_unchanged(screen, owner=owner, focus=focus)
+
+
+@pytest.mark.asyncio
+async def test_stale_media_generation_cannot_project_on_the_same_route() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {
+            "library_selected_row_id": LIBRARY_ROW_BROWSE_MEDIA,
+            "selected_media_id": "media-1",
+            "library_media_view": "viewer",
+        }
+    )
+    started = threading.Event()
+    release = threading.Event()
+
+    def gated_media(**_kwargs):
+        started.set()
+        assert release.wait(timeout=10), "Media generation gate was not released."
+        return _two_media_items()[0]
+
+    app.media_reading_scope_service = SimpleNamespace(get_media_item=gated_media)
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Media generation test did not reach its gate.",
+        )
+        owner = active_screen._library_entry_canvas_owner()
+        assert owner is not None
+        active_screen._library_snapshot_state_generation += 1
+        release.set()
+        await _wait_for_condition(
+            pilot,
+            lambda: active_screen._library_media_detail is not None,
+            message="Stale Media worker did not settle its owned state.",
+        )
+        await pilot.pause()
+
+        assert active_screen._library_entry_canvas_owner() is owner
+        assert not active_screen.query("#library-media-viewer")
+
+
+@pytest.mark.asyncio
+async def test_stale_pending_conversation_open_cannot_project_after_route_switch() -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        started = threading.Event()
+        release = threading.Event()
+
+        def gated_conversation(_conversation_id, *, include_deleted=False):
+            assert include_deleted is False
+            started.set()
+            assert release.wait(timeout=10), "Pending-open gate was not released."
+            return {
+                "conversation_id": "chat-pending",
+                "title": "Late pending conversation",
+                "message_count": 1,
+            }
+
+        app.chachanotes_db = SimpleNamespace(
+            is_memory_db=False,
+            get_conversation_by_id=gated_conversation,
+        )
+        screen._pending_library_source_open = ("conversations", "chat-pending")
+        task = asyncio.create_task(screen._open_pending_library_source())
+        await _wait_for_condition(
+            pilot,
+            started.is_set,
+            message="Pending conversation open did not reach its service gate.",
+        )
+        owner, focus = await _capture_new_conversations_route(screen, pilot)
+
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        _assert_new_route_unchanged(screen, owner=owner, focus=focus)
+
+
+@pytest.mark.asyncio
+async def test_pending_conversation_open_cannot_overwrite_same_route_user_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The selected conversation is part of an entry worker's ownership."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def gated_fetch(_conversation_id: str):
+            started.set()
+            await release.wait()
+            return {
+                "conversation_id": "chat-pending",
+                "title": "Late pending conversation",
+                "message_count": 1,
+            }
+
+        monkeypatch.setattr(
+            screen,
+            "_fetch_library_conversation_by_id",
+            gated_fetch,
+        )
+        screen._selected_conversation_id = "chat-pending"
+        screen._pending_library_source_open = ("conversations", "chat-pending")
+        task = asyncio.create_task(screen._open_pending_library_source())
+        await started.wait()
+
+        screen._selected_conversation_id = "chat-1"
+        owner = screen._library_entry_canvas_owner()
+        assert isinstance(owner, LibraryConversationsCanvas)
+        owner.sync_state(screen._build_library_conversations_state())
+        await pilot.pause()
+        focus = next(
+            row
+            for row in screen.query(".library-conversation-row")
+            if getattr(row, "conversation_id", "") == "chat-1"
+        )
+        focus.focus()
+        await pilot.pause()
+
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert screen._selected_conversation_id == "chat-1"
+        assert screen._library_entry_canvas_owner() is owner
+        assert screen.focused is focus
+
+
+@pytest.mark.asyncio
+async def test_pending_conversation_open_rejects_same_route_stale_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generation alone supersedes a pending fetch on the retained route."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        focus = await _wait_for_selector(screen, pilot, "#library-conversations-filter")
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def gated_fetch(_conversation_id: str):
+            started.set()
+            await release.wait()
+            return {
+                "conversation_id": "chat-pending",
+                "title": "Late pending conversation",
+                "message_count": 1,
+            }
+
+        monkeypatch.setattr(
+            screen,
+            "_fetch_library_conversation_by_id",
+            gated_fetch,
+        )
+        screen._selected_conversation_id = "chat-pending"
+        screen._pending_library_source_open = ("conversations", "chat-pending")
+        owner = screen._library_entry_canvas_owner()
+        assert isinstance(owner, LibraryConversationsCanvas)
+        focus.focus()
+        await pilot.pause()
+        task = asyncio.create_task(screen._open_pending_library_source())
+        await started.wait()
+
+        screen._library_snapshot_state_generation += 1
+        release.set()
+        result = await task
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert screen._selected_conversation_id == "chat-pending"
+        assert screen._library_entry_canvas_owner() is owner
+        assert screen.focused is focus
+
+
+@pytest.mark.asyncio
+async def test_replace_canvas_child_repairs_media_trash_successor_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A swap superseded by Media Trash must reconstruct the Trash owner."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+        screen._selected_media_id = "media-1"
+        screen._library_media_view = "viewer"
+        screen._library_media_detail = _two_media_items()[0]
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        canvas_host = screen.query_one("#library-canvas")
+        original_remove = canvas_host.remove_children
+
+        def trash_switching_remove(*children):
+            removal = original_remove(*children)
+            screen._library_media_view = "trash"
+            return removal
+
+        monkeypatch.setattr(canvas_host, "remove_children", trash_switching_remove)
+        result = await screen._replace_library_canvas_child(
+            screen._build_library_media_active_child(),
+            generation=generation,
+            route_key=route_key,
+        )
+        await pilot.pause()
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert isinstance(screen._library_entry_canvas_owner(), LibraryMediaTrashCanvas)
+
+
+@pytest.mark.asyncio
+async def test_canvas_owner_repair_converges_after_repeated_supersession(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two route changes during mounts must not exhaust owner repair."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_MEDIA)
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+        screen._selected_media_id = "media-1"
+        screen._library_media_view = "viewer"
+        screen._library_media_detail = _two_media_items()[0]
+        canvas_host = screen.query_one("#library-canvas")
+        original_mount = canvas_host.mount
+        mounts = 0
+
+        def repeatedly_superseded_mount(*widgets, **kwargs):
+            nonlocal mounts
+            mounted = original_mount(*widgets, **kwargs)
+            mounts += 1
+            if mounts == 1:
+                screen._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+                screen._library_media_view = "list"
+            elif mounts == 2:
+                screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+            return mounted
+
+        monkeypatch.setattr(canvas_host, "mount", repeatedly_superseded_mount)
+        repaired = await screen._repair_library_entry_canvas_owner()
+        await pilot.pause()
+
+        assert repaired is True
+        assert mounts == 3
+        assert isinstance(screen._library_entry_canvas_owner(), LibraryMediaCanvas)
+
+
+@pytest.mark.asyncio
+async def test_export_counts_reject_same_route_stale_generation(tmp_path: Path) -> None:
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    _wire_entry_export_databases(app, tmp_path)
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_INGEST_EXPORT})
+    host = LibraryHarness(app, screen=screen)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        active_screen = _active_library_screen(host)
+        scope_line = await _wait_for_selector(
+            active_screen, pilot, "#library-export-scope-line"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: active_screen._library_export_counts is not None,
+            message="Initial Export counts did not settle.",
+        )
+        rendered_before = str(scope_line.renderable)
+        generation = active_screen._library_snapshot_state_generation
+        route_key = active_screen._library_entry_route_key()
+        active_screen._library_snapshot_state_generation += 1
+
+        result = active_screen._apply_library_export_counts(
+            active_screen._library_export_scope,
+            {"media": 99, "conversations": 99, "notes": 99, "prompts": 99},
+            generation=generation,
+            route_key=route_key,
+        )
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert str(scope_line.renderable) == rendered_before
 
 
 def _compositor_text(screen: LibraryScreen) -> str:

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -81,7 +81,7 @@ class _EntryWorkerCase:
     name: str
     terminal_selector: str
     owner_type: type[Widget]
-    owner_replaced: bool = False
+    owner_replaced: bool | None = False
 
 
 _ENTRY_WORKER_CASES = (
@@ -113,7 +113,9 @@ _ENTRY_WORKER_CASES = (
         "pending-conversations",
         "#library-conversations-canvas",
         LibraryConversationsCanvas,
-        owner_replaced=True,
+        # The initial paged snapshot may either patch the pre-mounted route
+        # owner or replace it before the pending point lookup settles.
+        owner_replaced=None,
     ),
     _EntryWorkerCase(
         "pending-prompt",
@@ -238,9 +240,11 @@ def _entry_worker_terminal(case: _EntryWorkerCase, screen: LibraryScreen) -> boo
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (170, 48)])
 @pytest.mark.parametrize("case", _ENTRY_WORKER_CASES, ids=lambda case: case.name)
 async def test_automatic_entry_worker_composes_screen_once_and_routes_in_place(
     case: _EntryWorkerCase,
+    size: tuple[int, int],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -394,7 +398,7 @@ async def test_automatic_entry_worker_composes_screen_once_and_routes_in_place(
     monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
 
     host = LibraryHarness(app, screen=screen)
-    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+    async with host.run_test(size=size) as pilot:
         active_screen = _active_library_screen(host)
         await _wait_for_library_shell(active_screen, pilot)
         if case.name == "export":
@@ -423,11 +427,28 @@ async def test_automatic_entry_worker_composes_screen_once_and_routes_in_place(
         first_host = active_screen.query_one("#library-canvas")
         first_owner = active_screen._library_entry_canvas_owner()
         assert first_owner is not None
+        if size == (60, 20):
+            active_screen._library_notes_stage = "notes"
+            active_screen._set_library_rail_collapsed(True)
+            await pilot.pause()
+            await pilot.pause()
 
         if case.name == "export":
             thread_release.set()
         else:
             release.set()
+        painted_copy = {
+            "prompts": "Entry prompt",
+            "collections": "Launch Evidence",
+            "skills": "code-review",
+            "notes": "Q3 retro",
+            "media": "Interview Recording",
+            "export": "Export bundle (.zip)",
+            "pending-media": "Interview Recording",
+            "pending-notes": "Q3 retro",
+            "pending-conversations": "Design review notes",
+            "pending-prompt": "Entry prompt",
+        }[case.name]
         await _wait_for_condition(
             pilot,
             lambda: _entry_worker_terminal(case, active_screen),
@@ -436,20 +457,40 @@ async def test_automatic_entry_worker_composes_screen_once_and_routes_in_place(
                 f"route={active_screen._library_entry_route_key()!r}."
             ),
         )
-        await pilot.pause()
+        await _wait_for_condition(
+            pilot,
+            lambda: painted_copy in _compositor_text(active_screen),
+            message=lambda: (
+                f"{case.name} terminal copy was not painted: "
+                f"{_compositor_text(active_screen)!r}"
+            ),
+        )
 
         final_owner = active_screen._library_entry_canvas_owner()
         assert _active_library_screen(host) is first_screen
         assert active_screen.query_one("#library-rail") is first_rail
         assert active_screen.query_one("#library-canvas") is first_host
         assert isinstance(final_owner, case.owner_type)
-        if case.owner_replaced:
+        if case.owner_replaced is True:
             assert final_owner is not first_owner
-        else:
+        elif case.owner_replaced is False:
             assert final_owner is first_owner
         assert compose_calls.count(active_screen) == 1
         assert refresh_recompose_calls == []
         assert recompose_calls == []
+        compositor = _compositor_text(active_screen)
+        exported_svg = _exported_svg_text(host)
+        assert painted_copy in compositor
+        assert painted_copy in exported_svg
+        print(
+            "task5_uat_entry "
+            f"size={size} route={case.name} copy={painted_copy!r} "
+            f"screen={id(active_screen)} rail={id(first_rail)} host={id(first_host)} "
+            f"owner_before={id(first_owner)} owner_after={id(final_owner)} "
+            f"compose={compose_calls.count(active_screen)} "
+            f"refresh_recompose={len(refresh_recompose_calls)} "
+            f"recompose={len(recompose_calls)}"
+        )
 
 
 async def _capture_new_conversations_route(screen: LibraryScreen, pilot):
@@ -1394,6 +1435,56 @@ def _compositor_text(screen: LibraryScreen) -> str:
     )
 
 
+def _exported_svg_text(host: LibraryHarness) -> str:
+    """Return text nodes from an exported compositor frame as plain text."""
+    import re
+    from html import unescape
+
+    svg = host.export_screenshot(simplify=True)
+    joined = "".join(re.findall(r"<text[^>]*>([^<]*)</text>", svg))
+    return unescape(joined).replace("\xa0", " ")
+
+
+def _install_screen_lifecycle_spies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SimpleNamespace:
+    """Record compose plus both whole-screen recompose APIs for UAT."""
+    evidence = SimpleNamespace(compose=[], refresh_recompose=[], recompose=[])
+    original_compose = LibraryScreen.compose_content
+    original_refresh = LibraryScreen.refresh
+    original_recompose = LibraryScreen.recompose
+
+    def counted_compose(screen):
+        evidence.compose.append(screen)
+        yield from original_compose(screen)
+
+    def recorded_refresh(screen, *regions, **kwargs):
+        if kwargs.get("recompose"):
+            evidence.refresh_recompose.append(screen)
+        return original_refresh(screen, *regions, **kwargs)
+
+    async def recorded_recompose(screen):
+        evidence.recompose.append(screen)
+        return await original_recompose(screen)
+
+    monkeypatch.setattr(LibraryScreen, "compose_content", counted_compose)
+    monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+    monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
+    return evidence
+
+
+def _screen_identity_tuple(screen: LibraryScreen) -> tuple[int, int, int, int]:
+    """Return screen/rail/host/active-owner identities for evidence output."""
+    owner = screen._library_entry_canvas_owner()
+    assert owner is not None
+    return (
+        id(screen),
+        id(screen.query_one("#library-rail")),
+        id(screen.query_one("#library-canvas")),
+        id(owner),
+    )
+
+
 def _assert_widget_text_is_painted(
     screen: LibraryScreen, selector: str, expected: str
 ) -> None:
@@ -1442,6 +1533,157 @@ def _apply_changed_snapshot(
         screen._library_lookup_recovery_state,
         study_counts,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (170, 48)])
+async def test_uat_warm_landing_fresh_reconcile_retains_frame_and_focus(
+    size: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A warm Landing frame must paint cached data before fresh data lands."""
+    app = _build_test_app()
+    conversations = _two_conversations()
+    _seed_conversations(app, conversations[:1])
+    evidence = _install_screen_lifecycle_spies(monkeypatch)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=size) as pilot:
+        first = _active_library_screen(host)
+        await _wait_for_library_shell(first, pilot)
+        await first.workers.wait_for_complete()
+        await host.pop_screen()
+        await pilot.pause()
+
+        _seed_conversations(app, conversations)
+        fresh_started = asyncio.Event()
+        release_fresh = asyncio.Event()
+        original_list = LibraryScreen._list_local_source_snapshot
+
+        async def gated_fresh(screen: LibraryScreen):
+            fresh_started.set()
+            await release_fresh.wait()
+            return await original_list(screen)
+
+        monkeypatch.setattr(
+            LibraryScreen,
+            "_list_local_source_snapshot",
+            gated_fresh,
+        )
+        revisit = LibraryScreen(app)
+        await host.push_screen(revisit)
+        await _wait_for_library_shell(revisit, pilot)
+        await fresh_started.wait()
+        if size == (60, 20):
+            revisit._library_notes_stage = "notes"
+            revisit._set_library_rail_collapsed(True)
+            await pilot.pause()
+            await pilot.pause()
+
+        identity_before = _screen_identity_tuple(revisit)
+        search = revisit.query_one("#library-hub-action-search")
+        search.focus()
+        await pilot.pause()
+        assert "Conversations (1)" in _compositor_text(revisit)
+        assert "Conversations (1)" in _exported_svg_text(host)
+
+        release_fresh.set()
+        await revisit.workers.wait_for_complete()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                revisit._local_source_counts["conversations"] == 2
+                and revisit._library_snapshot_rendered_generation
+                == revisit._library_snapshot_state_generation
+            ),
+            message="Warm Landing fresh reconciliation did not settle.",
+        )
+        await pilot.pause()
+        identity_after = _screen_identity_tuple(revisit)
+        compositor = _compositor_text(revisit)
+        exported_svg = _exported_svg_text(host)
+
+        assert identity_after == identity_before
+        assert revisit.focused is search
+        assert "Conversations (2)" in compositor
+        assert "Conversations (2)" in exported_svg
+        assert "Search" in compositor
+        assert "Search" in exported_svg
+        assert evidence.compose.count(revisit) == 1
+        assert revisit not in evidence.refresh_recompose
+        assert revisit not in evidence.recompose
+        print(
+            "task5_uat_warm_landing "
+            f"size={size} identity_before={identity_before} "
+            f"identity_after={identity_after} compose={evidence.compose.count(revisit)} "
+            f"refresh_recompose={evidence.refresh_recompose.count(revisit)} "
+            f"recompose={evidence.recompose.count(revisit)} focus={search.id}"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (170, 48)])
+async def test_uat_cold_conversations_loading_to_rows_is_compositor_visible(
+    size: tuple[int, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cold Conversations must paint loading and then rows without a screen recompose."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    evidence = _install_screen_lifecycle_spies(monkeypatch)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    original_list = LibraryScreen._list_local_source_snapshot
+
+    async def gated_list(screen: LibraryScreen):
+        started.set()
+        await release.wait()
+        return await original_list(screen)
+
+    monkeypatch.setattr(LibraryScreen, "_list_local_source_snapshot", gated_list)
+    screen = LibraryScreen(app)
+    screen.restore_state(
+        {"library_selected_row_id": LIBRARY_ROW_BROWSE_CONVERSATIONS}
+    )
+    host = LibraryHarness(app, screen=screen)
+
+    async with host.run_test(size=size) as pilot:
+        active = _active_library_screen(host)
+        await started.wait()
+        await _wait_for_selector(active, pilot, "#library-canvas-loading")
+        if size == (60, 20):
+            active._library_notes_stage = "notes"
+            active._set_library_rail_collapsed(True)
+            await pilot.pause()
+            await pilot.pause()
+        loading_identity = _screen_identity_tuple(active)
+        assert "Loading local Library sources" in _compositor_text(active)
+        assert "Loading local Library sources" in _exported_svg_text(host)
+
+        release.set()
+        await _wait_for_selector(active, pilot, "#library-conversation-row-0")
+        await active.workers.wait_for_complete()
+        await pilot.pause()
+        rows_identity = _screen_identity_tuple(active)
+        compositor = _compositor_text(active)
+        exported_svg = _exported_svg_text(host)
+
+        assert rows_identity[:3] == loading_identity[:3]
+        assert rows_identity[3] != loading_identity[3]
+        assert "Conversations (2)" in compositor
+        assert "Conversations (2)" in exported_svg
+        assert "Design review notes" in compositor
+        assert "Design review notes" in exported_svg
+        assert evidence.compose.count(active) == 1
+        assert active not in evidence.refresh_recompose
+        assert active not in evidence.recompose
+        print(
+            "task5_uat_cold_conversations "
+            f"size={size} loading_identity={loading_identity} "
+            f"rows_identity={rows_identity} compose={evidence.compose.count(active)} "
+            f"refresh_recompose={evidence.refresh_recompose.count(active)} "
+            f"recompose={evidence.recompose.count(active)}"
+        )
 
 
 @pytest.mark.asyncio
@@ -1760,7 +2002,9 @@ async def test_source_worker_completion_during_mount_dispatch_reconciles_once(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (170, 48)])
 async def test_snapshot_timeout_is_repaired_by_blocked_fresh_success(
+    size: tuple[int, int],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A timeout generation must not prevent the in-flight fetch from repairing it."""
@@ -1772,6 +2016,7 @@ async def test_snapshot_timeout_is_repaired_by_blocked_fresh_success(
     target_sync_calls: list[int] = []
     original_apply = LibraryScreen._apply_local_source_snapshot
     original_sync = library_screen_module._sync_library_canvas
+    evidence = _install_screen_lifecycle_spies(monkeypatch)
 
     async def gated_snapshot(_screen: LibraryScreen):
         fetch_started.set()
@@ -1809,12 +2054,22 @@ async def test_snapshot_timeout_is_repaired_by_blocked_fresh_success(
     monkeypatch.setattr(library_screen_module, "_sync_library_canvas", recorded_sync)
 
     host = LibraryHarness(app)
-    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+    async with host.run_test(size=size) as pilot:
         screen = _active_library_screen(host)
         await fetch_started.wait()
         screen._apply_source_snapshot_timeout()
         await pilot.pause()
+        if size == (60, 20):
+            screen._library_notes_stage = "notes"
+            screen._set_library_rail_collapsed(True)
+            await pilot.pause()
+            await pilot.pause()
+        identity_before = _screen_identity_tuple(screen)
         assert screen._library_lookup_error == library_screen_module.LIBRARY_SERVICE_ERROR_COPY
+        assert library_screen_module.LIBRARY_SERVICE_ERROR_COPY in _compositor_text(screen)
+        assert library_screen_module.LIBRARY_SERVICE_ERROR_COPY in _exported_svg_text(
+            host
+        )
 
         release_fetch.set()
         async with asyncio.timeout(10):
@@ -1827,9 +2082,22 @@ async def test_snapshot_timeout_is_repaired_by_blocked_fresh_success(
         assert screen._local_source_counts["conversations"] == 2
         assert screen._library_entry_reconcile_dirty is False
         assert target_sync_calls[-1] == screen._library_snapshot_state_generation
+        identity_after = _screen_identity_tuple(screen)
+        assert identity_after == identity_before
         assert "Conversations (2)" in _compositor_text(screen)
+        assert "Conversations (2)" in _exported_svg_text(host)
         assert library_screen_module.LIBRARY_SERVICE_ERROR_COPY not in _compositor_text(
             screen
+        )
+        assert evidence.compose.count(screen) == 1
+        assert screen not in evidence.refresh_recompose
+        assert screen not in evidence.recompose
+        print(
+            "task5_uat_timeout_success "
+            f"size={size} identity_before={identity_before} "
+            f"identity_after={identity_after} compose={evidence.compose.count(screen)} "
+            f"refresh_recompose={evidence.refresh_recompose.count(screen)} "
+            f"recompose={evidence.recompose.count(screen)}"
         )
 
 

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -7,9 +7,14 @@ import pytest
 
 from tldw_chatbook.UI.Screens.library_screen import (
     LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS,
+    LibraryEntryReconcileResult,
     LibraryScreen,
 )
-from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_ROW_BROWSE_CONVERSATIONS,
+    LIBRARY_ROW_BROWSE_MEDIA,
+)
+from tldw_chatbook.Widgets.Library import LibraryConversationsCanvas
 from Tests.UI.test_library_shell import (
     LIBRARY_TEST_SIZE,
     LibraryHarness,
@@ -18,6 +23,7 @@ from Tests.UI.test_library_shell import (
     _seed_conversations,
     _two_conversations,
     _wait_for_library_shell,
+    _wait_for_selector,
 )
 
 
@@ -56,6 +62,251 @@ async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatc
     )
     print(f"warm_visit_compose_counts={[calls.count(revisit) for revisit in revisits]}")
     assert all(calls.count(revisit) == 1 for revisit in revisits)
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_changed_reconciles_conversations_below_screen(
+    monkeypatch,
+):
+    """Restoring either whole-screen refresh would replace captured owners."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        rail = screen.query_one("#library-rail")
+        canvas_host = screen.query_one("#library-canvas")
+        canvas = screen.query_one(
+            "#library-conversations-canvas", LibraryConversationsCanvas
+        )
+        refresh_calls: list[bool] = []
+        recompose_calls: list[LibraryScreen] = []
+        original_refresh = LibraryScreen.refresh
+        original_recompose = LibraryScreen.recompose
+
+        def recorded_refresh(active_screen, *regions, **kwargs):
+            refresh_calls.append(bool(kwargs.get("recompose")))
+            return original_refresh(active_screen, *regions, **kwargs)
+
+        async def recorded_recompose(active_screen):
+            recompose_calls.append(active_screen)
+            return await original_recompose(active_screen)
+
+        monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+        monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
+        records = dict(screen._local_source_records)
+        records["conversations"] = (
+            *records["conversations"],
+            {
+                "title": "Incident review",
+                "conversation_id": "chat-3",
+                "message_count": 5,
+                "updated_at": "2026-06-03T12:00:00Z",
+            },
+        )
+        counts = dict(screen._local_source_counts)
+        counts["conversations"] = 3
+
+        changed = screen._apply_local_source_snapshot(
+            records,
+            counts,
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert changed is True
+        assert _active_library_screen(host) is screen
+        assert screen.query_one("#library-rail") is rail
+        assert screen.query_one("#library-canvas") is canvas_host
+        assert (
+            screen.query_one(
+                "#library-conversations-canvas", LibraryConversationsCanvas
+            )
+            is canvas
+        )
+        assert "Conversations (3)" in str(
+            screen.query_one("#library-conversations-title").renderable
+        )
+        assert "(3)" in str(screen.query_one("#library-row-browse-conversations").label)
+        assert True not in refresh_calls
+        assert recompose_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_equal_clean_refreshes_cache_without_dom_work(
+    monkeypatch,
+):
+    """Removing the equality gate would call canvas or screen recomposition."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        canvas = screen.query_one(
+            "#library-conversations-canvas", LibraryConversationsCanvas
+        )
+        sync_calls: list[None] = []
+        refresh_calls: list[bool] = []
+        recompose_calls: list[LibraryScreen] = []
+        original_sync_state = canvas.sync_state
+        original_refresh = LibraryScreen.refresh
+        original_recompose = LibraryScreen.recompose
+
+        def recorded_sync_state(*args, **kwargs):
+            sync_calls.append(None)
+            return original_sync_state(*args, **kwargs)
+
+        def recorded_refresh(active_screen, *regions, **kwargs):
+            refresh_calls.append(bool(kwargs.get("recompose")))
+            return original_refresh(active_screen, *regions, **kwargs)
+
+        async def recorded_recompose(active_screen):
+            recompose_calls.append(active_screen)
+            return await original_recompose(active_screen)
+
+        async def equal_snapshot():
+            return (
+                dict(screen._local_source_records),
+                dict(screen._local_source_counts),
+                dict(screen._local_source_total_known),
+                screen._library_lookup_error,
+                screen._library_lookup_recovery_state,
+                dict(screen._library_study_counts),
+            )
+
+        monkeypatch.setattr(canvas, "sync_state", recorded_sync_state)
+        monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+        monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
+        monkeypatch.setattr(screen, "_list_local_source_snapshot", equal_snapshot)
+        previous_stamp = time.monotonic() - 1.0
+        app._library_source_snapshot_cache_stamp = previous_stamp
+
+        screen._refresh_local_source_snapshot()
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert app._library_source_snapshot_cache_stamp > previous_stamp
+        assert screen._library_snapshot_rendered_generation == (
+            screen._library_snapshot_state_generation
+        )
+        assert screen._library_entry_reconcile_dirty is False
+        assert sync_calls == []
+        assert True not in refresh_calls
+        assert recompose_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_equal_dirty_repairs_with_targeted_sync(
+    monkeypatch,
+):
+    """Skipping dirty equal state would leave the mounted canvas stale."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        canvas = screen.query_one(
+            "#library-conversations-canvas", LibraryConversationsCanvas
+        )
+        sync_calls: list[None] = []
+        refresh_calls: list[bool] = []
+        recompose_calls: list[LibraryScreen] = []
+        original_sync_state = canvas.sync_state
+        original_refresh = LibraryScreen.refresh
+        original_recompose = LibraryScreen.recompose
+
+        def recorded_sync_state(*args, **kwargs):
+            sync_calls.append(None)
+            return original_sync_state(*args, **kwargs)
+
+        def recorded_refresh(active_screen, *regions, **kwargs):
+            refresh_calls.append(bool(kwargs.get("recompose")))
+            return original_refresh(active_screen, *regions, **kwargs)
+
+        async def recorded_recompose(active_screen):
+            recompose_calls.append(active_screen)
+            return await original_recompose(active_screen)
+
+        monkeypatch.setattr(canvas, "sync_state", recorded_sync_state)
+        monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+        monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
+        generation = screen._library_snapshot_state_generation
+        screen._library_entry_reconcile_dirty = True
+
+        changed = screen._apply_local_source_snapshot(
+            dict(screen._local_source_records),
+            dict(screen._local_source_counts),
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert changed is False
+        assert sync_calls == [None]
+        assert screen._library_snapshot_state_generation == generation
+        assert screen._library_snapshot_rendered_generation == generation
+        assert screen._library_entry_reconcile_dirty is False
+        assert True not in refresh_calls
+        assert recompose_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_stale_route_clears_retry_markers():
+    """Leaving the retry generation armed would skip the new route's retry."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        generation = screen._library_snapshot_state_generation
+        stale_route = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, stale_route)
+        screen._library_entry_reconcile_retry_generation = generation
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+
+        result = await screen._reconcile_library_entry_state(
+            generation, stale_route
+        )
+
+        assert result is LibraryEntryReconcileResult.SUPERSEDED
+        assert screen._library_entry_reconcile_pending is None
+        assert screen._library_entry_reconcile_retry_generation is None
 
 
 def test_constructor_seeds_cached_snapshot_before_restore_state_wins_selection():

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -28,6 +28,7 @@ from tldw_chatbook.Prompt_Management.prompt_scope_service import (
 from tldw_chatbook.UI.Library_Modules.library_prompt_browse_controller import (
     LibraryPromptBrowseController,
 )
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens.library_screen import (
     LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS,
     LibraryEntryReconcileResult,
@@ -1671,20 +1672,401 @@ async def test_retained_entry_actions_paint_before_and_after_sync(size, surface)
 
 
 @pytest.mark.asyncio
+async def test_source_worker_completion_during_mount_dispatch_reconciles_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing mount-safe scheduling would lose a fetch that completes in Mount."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+    fresh_applied = asyncio.Event()
+    mount_dispatch_active = False
+    apply_during_mount: list[bool] = []
+    mounted_at_apply: list[bool] = []
+    attached_at_apply: list[bool] = []
+    target_sync_calls: list[int] = []
+    original_on_mount = LibraryScreen.on_mount
+    original_apply = LibraryScreen._apply_local_source_snapshot
+    original_sync = library_screen_module._sync_library_canvas
+
+    async def gated_snapshot(_screen: LibraryScreen):
+        fetch_started.set()
+        await release_fetch.wait()
+        return (
+            {
+                "notes": (),
+                "media": (),
+                "conversations": tuple(_two_conversations()),
+                "prompts": (0, ()),
+                "skills": (
+                    0,
+                    {"available_skills": [], "blocked_skills": []},
+                ),
+            },
+            {"notes": 0, "media": 0, "conversations": 2},
+            {"notes": True, "media": True, "conversations": True},
+            None,
+            None,
+            {"study_decks": 0, "flashcards_due": 0, "quizzes": 0},
+        )
+
+    def recorded_apply(screen: LibraryScreen, records, *args, **kwargs):
+        result = original_apply(screen, records, *args, **kwargs)
+        if len(records.get("conversations", ())) == 2:
+            apply_during_mount.append(mount_dispatch_active)
+            mounted_at_apply.append(screen.is_mounted)
+            attached_at_apply.append(screen.is_attached)
+            fresh_applied.set()
+        return result
+
+    def recorded_sync(screen: LibraryScreen, kind: str, **kwargs):
+        target_sync_calls.append(screen._library_snapshot_state_generation)
+        return original_sync(screen, kind, **kwargs)
+
+    async def gated_on_mount(screen: LibraryScreen) -> None:
+        nonlocal mount_dispatch_active
+        mount_dispatch_active = True
+        try:
+            original_on_mount(screen)
+            await fetch_started.wait()
+            release_fetch.set()
+            async with asyncio.timeout(10):
+                await fresh_applied.wait()
+        finally:
+            mount_dispatch_active = False
+
+    monkeypatch.setattr(LibraryScreen, "_list_local_source_snapshot", gated_snapshot)
+    monkeypatch.setattr(LibraryScreen, "_apply_local_source_snapshot", recorded_apply)
+    monkeypatch.setattr(library_screen_module, "_sync_library_canvas", recorded_sync)
+    monkeypatch.setattr(LibraryScreen, "on_mount", gated_on_mount)
+
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert apply_during_mount == [True]
+        assert mounted_at_apply == [False]
+        assert attached_at_apply == [True]
+        assert screen._local_source_counts["conversations"] == 2
+        assert screen._library_snapshot_rendered_generation == (
+            screen._library_snapshot_state_generation
+        )
+        assert target_sync_calls == [screen._library_snapshot_state_generation]
+        assert "Conversations (2)" in _compositor_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_timeout_is_repaired_by_blocked_fresh_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout generation must not prevent the in-flight fetch from repairing it."""
+    app = _build_test_app()
+    _seed_conversations(app, [])
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+    success_applied = asyncio.Event()
+    target_sync_calls: list[int] = []
+    original_apply = LibraryScreen._apply_local_source_snapshot
+    original_sync = library_screen_module._sync_library_canvas
+
+    async def gated_snapshot(_screen: LibraryScreen):
+        fetch_started.set()
+        await release_fetch.wait()
+        return (
+            {
+                "notes": (),
+                "media": (),
+                "conversations": tuple(_two_conversations()),
+                "prompts": (0, ()),
+                "skills": (
+                    0,
+                    {"available_skills": [], "blocked_skills": []},
+                ),
+            },
+            {"notes": 0, "media": 0, "conversations": 2},
+            {"notes": True, "media": True, "conversations": True},
+            None,
+            None,
+            {"study_decks": 0, "flashcards_due": 0, "quizzes": 0},
+        )
+
+    def recorded_apply(screen: LibraryScreen, records, *args, **kwargs):
+        result = original_apply(screen, records, *args, **kwargs)
+        if len(records.get("conversations", ())) == 2:
+            success_applied.set()
+        return result
+
+    def recorded_sync(screen: LibraryScreen, kind: str, **kwargs):
+        target_sync_calls.append(screen._library_snapshot_state_generation)
+        return original_sync(screen, kind, **kwargs)
+
+    monkeypatch.setattr(LibraryScreen, "_list_local_source_snapshot", gated_snapshot)
+    monkeypatch.setattr(LibraryScreen, "_apply_local_source_snapshot", recorded_apply)
+    monkeypatch.setattr(library_screen_module, "_sync_library_canvas", recorded_sync)
+
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await fetch_started.wait()
+        screen._apply_source_snapshot_timeout()
+        await pilot.pause()
+        assert screen._library_lookup_error == library_screen_module.LIBRARY_SERVICE_ERROR_COPY
+
+        release_fetch.set()
+        async with asyncio.timeout(10):
+            await success_applied.wait()
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._library_lookup_error is None
+        assert screen._local_source_counts["conversations"] == 2
+        assert screen._library_entry_reconcile_dirty is False
+        assert target_sync_calls[-1] == screen._library_snapshot_state_generation
+        assert "Conversations (2)" in _compositor_text(screen)
+        assert library_screen_module.LIBRARY_SERVICE_ERROR_COPY not in _compositor_text(
+            screen
+        )
+
+
+@pytest.mark.asyncio
+async def test_two_changed_generations_render_only_the_newer_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing the generation guard would project both queued generations."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        canvas = screen.query_one(
+            "#library-conversations-canvas", LibraryConversationsCanvas
+        )
+        sync_generations: list[int] = []
+        original_sync_state = canvas.sync_state
+
+        def recorded_sync_state(*args, **kwargs):
+            sync_generations.append(screen._library_snapshot_state_generation)
+            return original_sync_state(*args, **kwargs)
+
+        monkeypatch.setattr(canvas, "sync_state", recorded_sync_state)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        original_reconcile = screen._reconcile_library_entry_state
+        route_key = screen._library_entry_route_key()
+
+        first_records = dict(screen._local_source_records)
+        first_records["conversations"] = (
+            *first_records["conversations"],
+            {
+                "title": "Superseded generation",
+                "conversation_id": "chat-old",
+                "message_count": 1,
+                "updated_at": "2026-08-13T10:00:00Z",
+            },
+        )
+        assert screen._apply_local_source_snapshot(
+            first_records,
+            {**screen._local_source_counts, "conversations": 3},
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+            schedule_reconcile=False,
+        )
+        first_generation = screen._library_snapshot_state_generation
+
+        async def gated_reconcile(generation, queued_route):
+            if generation == first_generation:
+                first_started.set()
+                await release_first.wait()
+            return await original_reconcile(generation, queued_route)
+
+        monkeypatch.setattr(screen, "_reconcile_library_entry_state", gated_reconcile)
+        first_task = asyncio.create_task(
+            screen._reconcile_library_entry_state(first_generation, route_key)
+        )
+        await first_started.wait()
+
+        newer_records = dict(first_records)
+        newer_records["conversations"] = (
+            *tuple(
+                record
+                for record in first_records["conversations"]
+                if record.get("conversation_id") != "chat-old"
+            ),
+            {
+                "title": "Newest generation",
+                "conversation_id": "chat-new",
+                "message_count": 2,
+                "updated_at": "2026-08-13T10:01:00Z",
+            },
+        )
+        assert screen._apply_local_source_snapshot(
+            newer_records,
+            {**screen._local_source_counts, "conversations": 3},
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+            schedule_reconcile=False,
+        )
+        newer_generation = screen._library_snapshot_state_generation
+        newer_result = await original_reconcile(newer_generation, route_key)
+        await pilot.pause()
+        await pilot.pause()
+
+        release_first.set()
+        first_result = await first_task
+
+        assert (first_result, newer_result) == (
+            LibraryEntryReconcileResult.SUPERSEDED,
+            LibraryEntryReconcileResult.APPLIED,
+        )
+        assert sync_generations == [newer_generation]
+        assert screen._library_snapshot_rendered_generation == newer_generation
+        assert "Newest generation" in _compositor_text(screen)
+        assert "Superseded generation" not in _compositor_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_queued_reconcile_supersedes_after_route_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing the queued route guard would mutate the successor route."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        generation = screen._library_snapshot_state_generation
+        stale_route = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        queued: list[tuple[object, tuple[object, ...]]] = []
+        results: list[LibraryEntryReconcileResult] = []
+        target_sync_calls: list[str] = []
+        original_sync = library_screen_module._sync_library_canvas
+
+        def capture_call_later(callback, *args):
+            queued.append((callback, args))
+
+        def recorded_sync(active_screen: LibraryScreen, kind: str, **kwargs):
+            target_sync_calls.append(kind)
+            return original_sync(active_screen, kind, **kwargs)
+
+        monkeypatch.setattr(screen, "call_later", capture_call_later)
+        monkeypatch.setattr(library_screen_module, "_sync_library_canvas", recorded_sync)
+        screen._schedule_library_entry_reconcile(generation, stale_route)
+        assert len(queued) == 1
+
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+        callback, args = queued.pop()
+        results.append(await callback(*args))
+
+        assert results == [LibraryEntryReconcileResult.SUPERSEDED]
+        assert target_sync_calls == []
+        assert screen._library_entry_reconcile_pending is None
+
+
+@pytest.mark.asyncio
+async def test_detached_queued_reconcile_completion_is_a_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing the attachment guard would let detached completion touch the DOM."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    completion_started = asyncio.Event()
+    release_completion = asyncio.Event()
+    target_sync_calls: list[str] = []
+    result: LibraryEntryReconcileResult | None = None
+    task: asyncio.Task[LibraryEntryReconcileResult] | None = None
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        await screen.workers.wait_for_complete()
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+        original_reconcile = screen._reconcile_library_entry_state
+        original_sync = library_screen_module._sync_library_canvas
+
+        def recorded_sync(active_screen: LibraryScreen, kind: str, **kwargs):
+            target_sync_calls.append(kind)
+            return original_sync(active_screen, kind, **kwargs)
+
+        async def delayed_completion() -> LibraryEntryReconcileResult:
+            completion_started.set()
+            await release_completion.wait()
+            return await original_reconcile(generation, route_key)
+
+        monkeypatch.setattr(library_screen_module, "_sync_library_canvas", recorded_sync)
+        task = asyncio.create_task(delayed_completion())
+        await completion_started.wait()
+
+    assert task is not None
+    assert screen.is_attached is False
+    release_completion.set()
+    result = await task
+
+    assert result is LibraryEntryReconcileResult.SUPERSEDED
+    assert target_sync_calls == []
+    assert screen._library_entry_reconcile_pending is None
+
+
+@pytest.mark.asyncio
 async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatch):
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
     host = LibraryHarness(app)
     calls: list[LibraryScreen] = []
+    refresh_recompose_calls: list[LibraryScreen] = []
+    recompose_calls: list[LibraryScreen] = []
     original = LibraryScreen.compose_content
+    original_refresh = LibraryScreen.refresh
+    original_recompose = LibraryScreen.recompose
 
     def counted_compose(screen):
         calls.append(screen)
         yield from original(screen)
 
+    def recorded_refresh(screen, *regions, **kwargs):
+        if kwargs.get("recompose"):
+            refresh_recompose_calls.append(screen)
+        return original_refresh(screen, *regions, **kwargs)
+
+    async def recorded_recompose(screen):
+        recompose_calls.append(screen)
+        return await original_recompose(screen)
+
     monkeypatch.setattr(LibraryScreen, "compose_content", counted_compose)
+    monkeypatch.setattr(LibraryScreen, "refresh", recorded_refresh)
+    monkeypatch.setattr(LibraryScreen, "recompose", recorded_recompose)
     samples: list[float] = []
     revisits: list[LibraryScreen] = []
+    identity_samples: list[tuple[int, int, int, int]] = []
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         first = _active_library_screen(host)
         await _wait_for_library_shell(first, pilot)
@@ -1697,6 +2079,16 @@ async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatc
             await host.push_screen(revisit)
             await _wait_for_library_shell(revisit, pilot)
             samples.append((time.perf_counter() - started) * 1000)
+            await revisit.workers.wait_for_complete()
+            await pilot.pause()
+            identity_samples.append(
+                (
+                    id(revisit),
+                    id(revisit.query_one("#library-rail")),
+                    id(revisit.query_one("#library-canvas")),
+                    id(revisit._library_entry_canvas_owner()),
+                )
+            )
             await host.pop_screen()
             await pilot.pause()
     print(
@@ -1704,7 +2096,16 @@ async def test_warm_repeat_visit_composes_once_before_fresh_reconcile(monkeypatc
         f"min_ms={min(samples):.3f} max_ms={max(samples):.3f} n={len(samples)}"
     )
     print(f"warm_visit_compose_counts={[calls.count(revisit) for revisit in revisits]}")
+    print(f"warm_visit_identity_samples={identity_samples}")
+    print(
+        "warm_visit_screen_recompose_counts="
+        f"refresh={len(refresh_recompose_calls)} recompose={len(recompose_calls)}"
+    )
     assert all(calls.count(revisit) == 1 for revisit in revisits)
+    assert len(identity_samples) == 5
+    assert all(all(identity > 0 for identity in sample) for sample in identity_samples)
+    assert refresh_recompose_calls == []
+    assert recompose_calls == []
 
 
 @pytest.mark.asyncio
@@ -2021,27 +2422,37 @@ async def test_library_source_snapshot_missing_skills_retries_then_equal_can_ret
         screen._library_entry_reconcile_dirty = True
         screen._library_entry_reconcile_pending = (generation, route_key)
         queued: list[tuple[object, tuple[object, ...]]] = []
+        scheduled_attempts: list[tuple[object, ...]] = []
+        reconcile_results: list[LibraryEntryReconcileResult] = []
 
         def capture_call_later(callback, *args):
             queued.append((callback, args))
+            scheduled_attempts.append(args)
 
         monkeypatch.setattr(screen, "call_later", capture_call_later)
 
-        first = await screen._reconcile_library_entry_state(generation, route_key)
+        reconcile_results.append(
+            await screen._reconcile_library_entry_state(generation, route_key)
+        )
 
-        assert first is LibraryEntryReconcileResult.FAILED
+        assert reconcile_results == [LibraryEntryReconcileResult.FAILED]
         assert screen._library_entry_reconcile_dirty is True
         assert screen._library_entry_reconcile_pending == (generation, route_key)
         assert screen._library_entry_reconcile_retry_generation == generation
         assert len(queued) == 1
 
         callback, args = queued.pop()
-        second = await callback(*args)
+        reconcile_results.append(await callback(*args))
 
-        assert second is LibraryEntryReconcileResult.FAILED
+        assert reconcile_results == [
+            LibraryEntryReconcileResult.FAILED,
+            LibraryEntryReconcileResult.FAILED,
+        ]
         assert screen._library_entry_reconcile_dirty is True
         assert screen._library_entry_reconcile_pending is None
         assert screen._library_entry_reconcile_retry_generation is None
+        assert queued == []
+        assert len(scheduled_attempts) == 1
 
         changed = screen._apply_local_source_snapshot(
             dict(screen._local_source_records),
@@ -2055,6 +2466,7 @@ async def test_library_source_snapshot_missing_skills_retries_then_equal_can_ret
         assert changed is False
         assert screen._library_entry_reconcile_pending == (generation, route_key)
         assert len(queued) == 1
+        assert len(scheduled_attempts) == 2
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -185,6 +185,46 @@ async def test_landing_deferred_recents_converge_on_latest_state(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stale_landing_deferred_sync_performs_zero_dom_mutation():
+    """A route-stale deferred replacement must leave mounted rows untouched."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations()[:1])
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        landing = screen.query_one("#library-landing-canvas", LibraryLandingCanvas)
+        recents_owner = landing.query_one("#library-hub-recents")
+        children_before = tuple(recents_owner.children)
+        assert len(children_before) == 1
+
+        records = dict(screen._local_source_records)
+        records["conversations"] = (
+            {
+                "title": "Newer conversation",
+                "conversation_id": "chat-new",
+                "message_count": 1,
+                "updated_at": "2026-08-13T10:00:00Z",
+            },
+        )
+        screen._local_source_records = records
+        generation = screen._library_snapshot_state_generation + 1
+        route_key = screen._library_entry_route_key()
+        screen._library_snapshot_state_generation = generation
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+
+        await screen._reconcile_library_entry_state(generation, route_key)
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+        await pilot.pause()
+        await pilot.pause()
+
+        assert tuple(recents_owner.children) == children_before
+        assert children_before[0].parent is recents_owner
+
+
+@pytest.mark.asyncio
 async def test_study_handoff_snapshot_sync_retains_open_action_and_paints_readiness():
     """A source/readiness change must patch the mounted handoff owner in place."""
     app = _build_test_app()

--- a/Tests/UI/test_library_entry_compose_once.py
+++ b/Tests/UI/test_library_entry_compose_once.py
@@ -13,6 +13,7 @@ from tldw_chatbook.UI.Screens.library_screen import (
 from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
+    LIBRARY_ROW_BROWSE_SKILLS,
 )
 from tldw_chatbook.Widgets.Library import LibraryConversationsCanvas
 from Tests.UI.test_library_shell import (
@@ -141,6 +142,56 @@ async def test_library_source_snapshot_changed_reconciles_conversations_below_sc
         assert "(3)" in str(screen.query_one("#library-row-browse-conversations").label)
         assert True not in refresh_calls
         assert recompose_calls == []
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_changed_retains_conversation_row_focus():
+    """Dropping the Conversations follow-up moves focus outside its canvas."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversation-row-0")
+        await screen.workers.wait_for_complete()
+        row = screen.query_one("#library-conversation-row-0")
+        row.focus()
+        await pilot.pause()
+        assert getattr(screen.focused, "conversation_id", None) == "chat-2"
+
+        records = dict(screen._local_source_records)
+        records["conversations"] = (
+            *records["conversations"],
+            {
+                "title": "Incident review",
+                "conversation_id": "chat-3",
+                "message_count": 5,
+                "updated_at": "2026-06-03T12:00:00Z",
+            },
+        )
+        counts = dict(screen._local_source_counts)
+        counts["conversations"] = 3
+
+        screen._apply_local_source_snapshot(
+            records,
+            counts,
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        focused = screen.focused
+        assert getattr(focused, "conversation_id", None) == "chat-2"
+        assert focused is not None and focused.disabled is False
+        assert screen.query_one("#library-conversations-canvas") in (
+            focused.ancestors_with_self
+        )
 
 
 @pytest.mark.asyncio
@@ -307,6 +358,121 @@ async def test_library_source_snapshot_stale_route_clears_retry_markers():
         assert result is LibraryEntryReconcileResult.SUPERSEDED
         assert screen._library_entry_reconcile_pending is None
         assert screen._library_entry_reconcile_retry_generation is None
+
+
+@pytest.mark.asyncio
+async def test_library_source_snapshot_missing_skills_retries_then_equal_can_retry(
+    monkeypatch,
+):
+    """Falling through a missing Skills selector would falsely mark it rendered."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen._library_selected_row_id = LIBRARY_ROW_BROWSE_SKILLS
+        screen._library_skills_view = "list"
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+        queued: list[tuple[object, tuple[object, ...]]] = []
+
+        def capture_call_later(callback, *args):
+            queued.append((callback, args))
+
+        monkeypatch.setattr(screen, "call_later", capture_call_later)
+
+        first = await screen._reconcile_library_entry_state(generation, route_key)
+
+        assert first is LibraryEntryReconcileResult.FAILED
+        assert screen._library_entry_reconcile_dirty is True
+        assert screen._library_entry_reconcile_pending == (generation, route_key)
+        assert screen._library_entry_reconcile_retry_generation == generation
+        assert len(queued) == 1
+
+        callback, args = queued.pop()
+        second = await callback(*args)
+
+        assert second is LibraryEntryReconcileResult.FAILED
+        assert screen._library_entry_reconcile_dirty is True
+        assert screen._library_entry_reconcile_pending is None
+        assert screen._library_entry_reconcile_retry_generation is None
+
+        changed = screen._apply_local_source_snapshot(
+            dict(screen._local_source_records),
+            dict(screen._local_source_counts),
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+
+        assert changed is False
+        assert screen._library_entry_reconcile_pending == (generation, route_key)
+        assert len(queued) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_site", ["rail", "header"])
+async def test_library_source_snapshot_shell_exception_releases_retry_markers(
+    monkeypatch, failure_site
+):
+    """An owned shell failure must not deduplicate the next equal repair."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        await _wait_for_selector(screen, pilot, "#library-conversations-canvas")
+        generation = screen._library_snapshot_state_generation
+        route_key = screen._library_entry_route_key()
+        screen._library_entry_reconcile_dirty = True
+        screen._library_entry_reconcile_pending = (generation, route_key)
+        screen._library_entry_reconcile_retry_generation = generation
+        queued: list[tuple[object, tuple[object, ...]]] = []
+
+        def capture_call_later(callback, *args):
+            queued.append((callback, args))
+
+        def fail_shell_sync(*args, **kwargs):
+            raise RuntimeError(f"forced {failure_site} sync failure")
+
+        monkeypatch.setattr(screen, "call_later", capture_call_later)
+        if failure_site == "rail":
+            rail = screen.query_one("#library-rail")
+            monkeypatch.setattr(rail, "sync_state", fail_shell_sync)
+        else:
+            header = screen.query_one("#library-header-line")
+            header.update("stale header")
+            monkeypatch.setattr(header, "update", fail_shell_sync)
+
+        result = await screen._reconcile_library_entry_state(
+            generation, route_key
+        )
+
+        assert result is LibraryEntryReconcileResult.FAILED
+        assert screen._library_entry_reconcile_dirty is True
+        assert screen._library_entry_reconcile_pending is None
+        assert screen._library_entry_reconcile_retry_generation is None
+
+        changed = screen._apply_local_source_snapshot(
+            dict(screen._local_source_records),
+            dict(screen._local_source_counts),
+            dict(screen._local_source_total_known),
+            screen._library_lookup_error,
+            screen._library_lookup_recovery_state,
+            dict(screen._library_study_counts),
+        )
+
+        assert changed is False
+        assert screen._library_entry_reconcile_pending == (generation, route_key)
+        assert len(queued) == 1
 
 
 def test_constructor_seeds_cached_snapshot_before_restore_state_wins_selection():

--- a/Tests/UI/test_library_export_receipt.py
+++ b/Tests/UI/test_library_export_receipt.py
@@ -207,6 +207,9 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
             _library_selected_row_id=LIBRARY_ROW_INGEST_EXPORT,
             _library_export_scope=scope,
             _library_export_counts=None,
+            _library_export_counts_request_id=1,
+            _library_snapshot_state_generation=0,
+            _library_export_quality_choices_visible=False,
             _library_export_form={
                 "name": "x",
                 "description": "",
@@ -224,12 +227,17 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
             _library_export_last_at=None,
             query_one=pilot.app.query_one,
         )
+        fake._library_entry_route_key = lambda: (LIBRARY_ROW_INGEST_EXPORT,)
+        fake._library_entry_reconcile_is_current = lambda *_args: True
         fake._build_library_export_state = (
             lambda: LibraryScreen._build_library_export_state(fake)
         )
 
         LibraryScreen._apply_library_export_counts(
-            fake, scope, {"media": 1, "conversations": 0, "notes": 0}
+            fake,
+            scope,
+            {"media": 1, "conversations": 0, "notes": 0},
+            request_id=1,
         )
 
         assert button.disabled is True  # still blocked: no destination now
@@ -265,6 +273,7 @@ async def test_update_library_export_canvas_after_run_patches_receipt_and_toolti
             _library_selected_row_id=LIBRARY_ROW_INGEST_EXPORT,
             _library_export_scope=scope,
             _library_export_counts={"media": 1, "conversations": 0, "notes": 0},
+            _library_export_quality_choices_visible=False,
             _library_export_form={
                 "name": "x",
                 "description": "",

--- a/Tests/UI/test_library_export_receipt.py
+++ b/Tests/UI/test_library_export_receipt.py
@@ -209,7 +209,6 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
             _library_export_counts=None,
             _library_export_counts_request_id=1,
             _library_snapshot_state_generation=0,
-            _library_export_quality_choices_visible=False,
             _library_export_form={
                 "name": "x",
                 "description": "",
@@ -273,7 +272,6 @@ async def test_update_library_export_canvas_after_run_patches_receipt_and_toolti
             _library_selected_row_id=LIBRARY_ROW_INGEST_EXPORT,
             _library_export_scope=scope,
             _library_export_counts={"media": 1, "conversations": 0, "notes": 0},
-            _library_export_quality_choices_visible=False,
             _library_export_form={
                 "name": "x",
                 "description": "",

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -16567,8 +16567,16 @@ async def test_library_shell_ingest_canvas_happy_path_open_in_library(tmp_path):
 
         # Path clears immediately on submit (metadata fields would persist).
         # A registry-driven targeted canvas refresh may briefly detach the
-        # Input, so assert the screen-owned form state at this boundary.
-        assert screen._library_ingest_form.path == ""
+        # Input, so poll across that gap and assert the eventual rendered
+        # control rather than only the screen-owned mirror.
+        path_input = await _wait_for_widget_state(
+            screen,
+            pilot,
+            "#library-ingest-path",
+            lambda widget: isinstance(widget, Input) and widget.value == "",
+            what="the rendered ingest path Input never cleared after submit",
+        )
+        assert path_input.value == ""
 
         # Task 4 has no live-update listener yet (that's Task 5) -- the
         # canvas only re-renders on a user-triggered recompose, so poll the

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -24841,36 +24841,18 @@ async def test_library_note_recompose_and_fifty_route_cycles_return_to_baseline(
         dirty_body = screen._library_note_session.snapshot.body
         assert screen._library_note_session.snapshot.dirty is True
 
-        for cycle in range(5):
-            prior = screen.query_one("#library-note-body", TextArea)
-            # task-15459: `_apply_local_source_snapshot` now skips its
-            # recompose when the incoming snapshot is byte-for-byte
-            # identical to what is already rendered (the whole point of
-            # that task -- a warm revisit's reconcile fetch confirming the
-            # cache verbatim no longer pays for a redundant repaint). This
-            # loop's actual purpose is stress-testing recompose CHURN while
-            # a dirty note session is open, standing in for a real
-            # background refresh that found new source data -- so the
-            # counts must genuinely differ each iteration to keep forcing
-            # that recompose, the same way a real DB change would.
-            varied_counts = dict(screen._local_source_counts)
-            varied_counts["notes"] = varied_counts.get("notes", 0) + cycle + 1
+        prior = screen.query_one("#library-note-body", TextArea)
+        for _ in range(5):
             screen._apply_local_source_snapshot(
                 dict(screen._local_source_records),
-                varied_counts,
+                dict(screen._local_source_counts),
                 dict(screen._local_source_total_known),
                 screen._library_lookup_error,
                 screen._library_lookup_recovery_state,
                 dict(screen._library_study_counts),
             )
-            await _wait_for_condition(
-                pilot,
-                lambda: screen.query_one("#library-note-body", TextArea) is not prior,
-                message=(
-                    "Generic source-snapshot completion never recomposed the "
-                    "Notes workbench."
-                ),
-            )
+            await pilot.pause()
+            assert screen.query_one("#library-note-body", TextArea) is prior
             assert screen._library_note_session is coordinator
             assert screen._library_note_session.snapshot.body == dirty_body
             assert screen._library_note_session.snapshot.dirty is True

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -7736,7 +7736,9 @@ async def test_library_shell_collections_deeplink_loads_before_mount():
         assert "Launch Evidence" in str(select_button.label)
 
 
-@pytest.mark.parametrize("source_type", ["media", "notes", "conversations"])
+@pytest.mark.parametrize(
+    "source_type", ["media", "notes", "conversations", "prompt"]
+)
 def test_library_open_source_context_accepts_only_supported_exact_types(
     source_type: str,
 ) -> None:
@@ -7764,10 +7766,6 @@ def test_library_open_source_context_rejects_invalid_values_without_replacing_pe
         {},
         {LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media"},
         {LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: "source-exact"},
-        {
-            LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "prompt",
-            LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: "source-exact",
-        },
         {
             LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: 1,
             LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: "source-exact",
@@ -7846,7 +7844,7 @@ async def test_library_open_source_context_calls_existing_opener_once_when_mount
         )
         await pilot.pause()
 
-        opener.assert_awaited_once_with("media", "media-exact")
+        opener.assert_awaited_once_with("media", "media-exact", entry_origin=True)
 
 
 @pytest.mark.asyncio
@@ -7878,7 +7876,9 @@ async def test_library_open_source_context_defers_before_mount_and_opens_once(
         )
         await pilot.pause()
 
-        opener.assert_awaited_once_with("conversations", "c-2")
+        opener.assert_awaited_once_with(
+            "conversations", "c-2", entry_origin=True
+        )
         assert screen._pending_library_source_open is None
 
 
@@ -7943,6 +7943,7 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
         await _wait_for_library_shell(screen, pilot)
         opener = AsyncMock()
         flush = AsyncMock()
+        recompose = AsyncMock()
 
         async def flush_note() -> NoteFlushOutcome:
             await flush()
@@ -7952,6 +7953,7 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
 
         monkeypatch.setattr(screen, "_open_library_item_by_id", opener)
         monkeypatch.setattr(screen, "_flush_library_note_save", flush_note)
+        monkeypatch.setattr(screen, "recompose", recompose)
         monkeypatch.setattr(
             type(screen),
             "_library_note_dirty",
@@ -7972,6 +7974,7 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
         await pilot.pause()
 
         flush.assert_awaited_once_with()
+        recompose.assert_not_awaited()
         if veto:
             opener.assert_not_awaited()
             assert screen._pending_library_source_open is None
@@ -7981,7 +7984,9 @@ async def test_library_open_source_context_uses_dirty_note_flush_and_veto(
                 lambda: opener.await_count == 1,
                 message="Open-source context never resumed after a successful flush.",
             )
-            opener.assert_awaited_once_with("notes", "note-exact")
+            opener.assert_awaited_once_with(
+                "notes", "note-exact", entry_origin=True
+            )
 
 
 @pytest.mark.asyncio
@@ -18248,12 +18253,24 @@ async def test_library_shell_restored_export_canvas_rekicks_counts_worker_on_mou
                 "Restored export canvas never re-kicked its counts worker."
             )
 
-        screen.refresh(recompose=True)
-        await pilot.pause()
+        await _wait_for_condition(
+            pilot,
+            lambda: str(
+                screen.query_one("#library-export-scope-line").renderable
+            )
+            == screen._build_library_export_state().scope_line,
+            message=lambda: (
+                "Export counts landed without updating the retained scope line: "
+                f"{screen.query_one('#library-export-scope-line').renderable!r}; "
+                f"counts={screen._library_export_counts!r}."
+            ),
+        )
 
         scope_line = str(screen.query_one("#library-export-scope-line").renderable)
-        assert scope_line == (
-            "Everything: 1 media · 1 conversations · 1 notes · 0 prompts"
+        assert scope_line == screen._build_library_export_state().scope_line
+        assert all(
+            fragment in scope_line
+            for fragment in ("1 media", "1 conversations", "1 notes", "0 prompts")
         )
         # Non-empty scope + counts landed: Export is no longer stuck
         # disabled by a permanent "Counting…" (only the missing

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -7151,13 +7151,9 @@ def _error_source_snapshot():
 
 @pytest.mark.asyncio
 async def test_library_shell_snapshot_cache_is_isolated_from_live_record_mutation():
-    """The app-scoped snapshot cache must hold COPIES, not the live records
-    dict (Qodo review). ``_apply_local_source_snapshot`` aliases
-    ``self._local_source_records = records``, and later in-place key
-    reassignments (a media edit does ``self._local_source_records["media"]
-    = ...``) would otherwise mutate the cached dict too -- corrupting the
-    next visit's instant-apply. Mutating the live records after a snapshot is
-    cached must leave the cache untouched.
+    """The app-scoped snapshot cache must detach nested records from the
+    live source snapshot. A later in-place record edit must not corrupt the
+    next visit's seed.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
@@ -7170,14 +7166,16 @@ async def test_library_shell_snapshot_cache_is_isolated_from_live_record_mutatio
         cached = getattr(app, "_library_source_snapshot_cache", None)
         assert cached is not None, "a successful snapshot should have been cached"
         cached_records = cached[0]
-        # The cached dict must not be the same object the live view holds.
+        # Neither the records map nor its individual records may alias the
+        # live view, which is allowed to mutate records in place.
         assert cached_records is not screen._local_source_records
+        live_conversation = screen._local_source_records["conversations"][0]
+        cached_conversation = cached_records["conversations"][0]
+        assert cached_conversation is not live_conversation
 
-        sentinel = ({"id": "sentinel-mutation"},)
-        screen._local_source_records["media"] = sentinel
+        live_conversation["title"] = "sentinel mutation"
 
-        # The cache still holds the pre-mutation records.
-        assert app._library_source_snapshot_cache[0]["media"] is not sentinel
+        assert cached_conversation["title"] != "sentinel mutation"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -922,7 +922,9 @@ async def test_hub_recents_render_as_clickable_rows_that_open_the_item():
         assert "Reading list" in str(notes_row.label)
         assert "Quarterly report.pdf" in str(media_row.label)
         assert "Quarterly planning sync" in str(conv_row.label)
-        assert not screen.query("#library-hub-recents")
+        # The retained landing owner keeps one stable recents container and
+        # replaces only its rows when a fresh snapshot lands.
+        assert screen.query_one("#library-hub-recents")
 
         # The next-action triad stays on top of the recents.
         actions = screen.query_one("#library-hub-actions")
@@ -950,7 +952,7 @@ async def test_hub_recents_rows_absent_on_an_empty_library():
         await _wait_for_library_shell(screen, pilot)
 
         assert not screen.query(".library-hub-recent")
-        assert not screen.query("#library-hub-recents")
+        assert screen.query_one("#library-hub-recents")
 
 
 def test_hub_recents_one_line_helpers_are_removed():
@@ -1824,10 +1826,10 @@ async def test_library_shell_flashcards_row_renders_handoff_canvas():
         await _wait_for_library_shell(screen, pilot)
 
         screen.query_one("#library-row-create-flashcards").press()
-        await _wait_for_selector(screen, pilot, "#library-study-handoff-detail")
+        await _wait_for_selector(screen, pilot, "#library-study-handoff-canvas")
 
         canvas = screen.query_one("#library-canvas")
-        detail = screen.query_one("#library-study-handoff-detail")
+        detail = screen.query_one("#library-study-handoff-canvas")
         assert canvas in detail.ancestors
 
         # Header: the row's own title, not a second "X mode" restatement.
@@ -16564,7 +16566,9 @@ async def test_library_shell_ingest_canvas_happy_path_open_in_library(tmp_path):
         await pilot.pause()
 
         # Path clears immediately on submit (metadata fields would persist).
-        assert screen.query_one("#library-ingest-path", Input).value == ""
+        # A registry-driven targeted canvas refresh may briefly detach the
+        # Input, so assert the screen-owned form state at this boundary.
+        assert screen._library_ingest_form.path == ""
 
         # Task 4 has no live-update listener yet (that's Task 5) -- the
         # canvas only re-renders on a user-triggered recompose, so poll the
@@ -20484,20 +20488,21 @@ async def test_library_rag_scope_recovery_steady_state_snapshot_causes_no_churn(
         # Let the first-ever mirror worker (always reconciles once,
         # regardless of whether the value actually changed vs. compose)
         # finish before capturing the baseline identity.
-        for _ in range(75):
-            await pilot.pause(0.02)
-            if screen.query("#library-rag-scope-recovery"):
-                break
-        else:
-            raise AssertionError(
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-rag-scope-recovery")),
+            message=(
                 "the recovery banner never mounted for a genuinely empty "
                 "library on the first snapshot"
-            )
+            ),
+        )
 
-        recovery_line = screen.query_one("#library-rag-scope-recovery", Static)
-        recovery_button = screen.query_one("#library-rag-open-import-export", Button)
         scope_container = screen.query_one("#library-rag-source-scope")
         assert scope_container.has_class("has-recovery")
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+        recovery_line = screen.query_one("#library-rag-scope-recovery", Static)
+        recovery_button = screen.query_one("#library-rag-open-import-export", Button)
 
         # Spy (not replace) so a genuinely-scheduled mirror would still run
         # -- this proves the repeat call below schedules nothing, on top of

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -288,6 +288,28 @@ after the fact** over raising inside code that catches broadly.
 
 ---
 
+## Mount dispatch can be attached before it is mounted
+
+**TASK-15459, 2026-08-13.** A deterministic `asyncio.Event` barrier released
+the Library source worker while `LibraryScreen.on_mount()` was still awaiting.
+The fresh snapshot reached the screen and advanced its state generation, but
+the rendered generation stayed behind and the targeted-sync recorder remained
+empty. Instrumentation at the snapshot boundary showed the exact lifecycle
+state: `is_attached` was true while `is_mounted` was false. The reconciliation
+scheduler used `is_mounted`, so it silently discarded completion during the
+Mount dispatch window. Changing only that scheduler boundary to attachment
+authority made the RED race pass, while the detached-completion regression
+continued to return `SUPERSEDED` with zero DOM calls.
+
+**What to do.** When work may complete during a Textual Mount handler, do not
+infer that attachment and mounting flags change together. Gate message-pump
+scheduling on the lifecycle property the operation actually needs (attachment
+for queuing to the screen), then keep a second current/attached guard at DOM
+execution time. Prove both halves with Event barriers: completion during Mount
+must render, and completion after detach must do nothing.
+
+---
+
 ## Trigger cancellation from the state the test claims to cancel
 
 **TASK-3771, 2026-08-11.** A QwenCloud native-tool regression claimed to prove

--- a/tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py
+++ b/tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py
@@ -1,0 +1,74 @@
+"""Validated detached snapshots used to seed a new Library entry."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+LibrarySourceSnapshot = tuple[
+    dict[str, tuple[Any, ...]],
+    dict[str, int],
+    dict[str, bool],
+    str | None,
+    Any,
+    dict[str, int | None],
+]
+
+_RECORD_SOURCES = ("notes", "media", "conversations")
+
+
+def clone_library_source_snapshot(snapshot: object) -> LibrarySourceSnapshot | None:
+    if not isinstance(snapshot, tuple) or len(snapshot) != 6:
+        return None
+    records, counts, total_known, lookup_error, recovery_state, study_counts = snapshot
+    if not all(
+        isinstance(value, Mapping)
+        for value in (records, counts, total_known, study_counts)
+    ):
+        return None
+    if any(not isinstance(records.get(source), tuple) for source in _RECORD_SOURCES):
+        return None
+    if any(
+        not isinstance(record, Mapping)
+        for source in _RECORD_SOURCES
+        for record in records[source]
+    ):
+        return None
+    if any(not isinstance(counts.get(source), int) for source in _RECORD_SOURCES):
+        return None
+    if any(
+        not isinstance(total_known.get(source), bool) for source in _RECORD_SOURCES
+    ):
+        return None
+    if any(
+        study_counts.get(key) is not None
+        and not isinstance(study_counts.get(key), int)
+        for key in ("study_decks", "flashcards_due", "quizzes")
+    ):
+        return None
+    if lookup_error is not None and not isinstance(lookup_error, str):
+        return None
+    prompts = records.get("prompts")
+    skills = records.get("skills")
+    if not isinstance(prompts, tuple) or len(prompts) != 2 or not isinstance(
+        prompts[1], tuple
+    ):
+        return None
+    if not isinstance(skills, tuple) or len(skills) != 2 or not isinstance(
+        skills[1], Mapping
+    ):
+        return None
+    if prompts[0] is not None and not isinstance(prompts[0], int):
+        return None
+    if skills[0] is not None and not isinstance(skills[0], int):
+        return None
+    cloned = copy.deepcopy(snapshot)
+    return (
+        dict(cloned[0]),
+        dict(cloned[1]),
+        dict(cloned[2]),
+        cloned[3],
+        cloned[4],
+        dict(cloned[5]),
+    )

--- a/tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py
+++ b/tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py
@@ -16,54 +16,74 @@ LibrarySourceSnapshot = tuple[
 ]
 
 _RECORD_SOURCES = ("notes", "media", "conversations")
+_SKILL_RECORD_LISTS = ("available_skills", "blocked_skills")
 
 
-def clone_library_source_snapshot(snapshot: object) -> LibrarySourceSnapshot | None:
+def _is_valid_library_source_snapshot(snapshot: object) -> bool:
     if not isinstance(snapshot, tuple) or len(snapshot) != 6:
-        return None
-    records, counts, total_known, lookup_error, recovery_state, study_counts = snapshot
+        return False
+    records, counts, total_known, lookup_error, _recovery_state, study_counts = (
+        snapshot
+    )
     if not all(
         isinstance(value, Mapping)
         for value in (records, counts, total_known, study_counts)
     ):
-        return None
+        return False
     if any(not isinstance(records.get(source), tuple) for source in _RECORD_SOURCES):
-        return None
+        return False
     if any(
         not isinstance(record, Mapping)
         for source in _RECORD_SOURCES
         for record in records[source]
     ):
-        return None
+        return False
     if any(not isinstance(counts.get(source), int) for source in _RECORD_SOURCES):
-        return None
+        return False
     if any(
         not isinstance(total_known.get(source), bool) for source in _RECORD_SOURCES
     ):
-        return None
+        return False
     if any(
         study_counts.get(key) is not None
         and not isinstance(study_counts.get(key), int)
         for key in ("study_decks", "flashcards_due", "quizzes")
     ):
-        return None
+        return False
     if lookup_error is not None and not isinstance(lookup_error, str):
-        return None
+        return False
     prompts = records.get("prompts")
     skills = records.get("skills")
     if not isinstance(prompts, tuple) or len(prompts) != 2 or not isinstance(
         prompts[1], tuple
     ):
-        return None
+        return False
     if not isinstance(skills, tuple) or len(skills) != 2 or not isinstance(
         skills[1], Mapping
     ):
-        return None
+        return False
     if prompts[0] is not None and not isinstance(prompts[0], int):
-        return None
+        return False
     if skills[0] is not None and not isinstance(skills[0], int):
+        return False
+    for key in _SKILL_RECORD_LISTS:
+        skill_records = skills[1].get(key, ())
+        if not isinstance(skill_records, (list, tuple)):
+            return False
+        if any(not isinstance(record, Mapping) for record in skill_records):
+            return False
+    return True
+
+
+def clone_library_source_snapshot(snapshot: object) -> LibrarySourceSnapshot | None:
+    if not _is_valid_library_source_snapshot(snapshot):
         return None
-    cloned = copy.deepcopy(snapshot)
+    try:
+        cloned = copy.deepcopy(snapshot)
+    except Exception:
+        return None
+    if not _is_valid_library_source_snapshot(cloned):
+        return None
     return (
         dict(cloned[0]),
         dict(cloned[1]),

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6364,13 +6364,14 @@ class LibraryScreen(BaseAppScreen):
             if (
                 source_type == raw_source_type
                 and source_id == raw_source_id
-                and source_type in {"media", "notes", "conversations"}
+                and source_type in {"media", "notes", "conversations", "prompt"}
                 and source_id
             ):
                 target_row_id = {
                     "media": LIBRARY_ROW_BROWSE_MEDIA,
                     "notes": LIBRARY_ROW_BROWSE_NOTES,
                     "conversations": LIBRARY_ROW_BROWSE_CONVERSATIONS,
+                    "prompt": LIBRARY_ROW_BROWSE_PROMPTS,
                 }[source_type]
         return target_row_id
 
@@ -7688,8 +7689,11 @@ class LibraryScreen(BaseAppScreen):
         conversation_records = tuple(normalized_records.get("conversations", ()))
         if (
             lookup_error is None
-            and not self._library_conversation_page_loaded
             and not self._library_conversation_query
+            and (
+                not self._library_conversation_page_loaded
+                or self._library_conversation_page == 1
+            )
         ):
             self._library_conversation_page_records = conversation_records
             self._library_conversation_page = 1
@@ -30463,6 +30467,16 @@ class LibraryScreen(BaseAppScreen):
             self._library_conversation_page_records = (
                 target_record,
                 *self._conversation_records(),
+            )[:LIBRARY_CONVERSATION_PAGE_SIZE]
+            self._local_source_records["conversations"] = (
+                target_record,
+                *(
+                    record
+                    for index, record in enumerate(
+                        self._local_source_records.get("conversations", ())
+                    )
+                    if self._conversation_record_id(record, index) != record_id
+                ),
             )[:LIBRARY_CONVERSATION_PAGE_SIZE]
             self._library_conversation_page_loaded = True
             self._library_conversation_page = 1

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -7707,7 +7707,7 @@ class LibraryScreen(BaseAppScreen):
         if not presentation_changed:
             if (
                 schedule_reconcile
-                and self.is_mounted
+                and self.is_attached
                 and not self._file_notes_active()
                 and (
                     self._library_entry_reconcile_dirty
@@ -7732,7 +7732,7 @@ class LibraryScreen(BaseAppScreen):
         self._invalidate_library_workspace_depth_state()
         self._library_snapshot_state_generation += 1
         self._library_entry_reconcile_dirty = True
-        if schedule_reconcile and self.is_mounted and not self._file_notes_active():
+        if schedule_reconcile and self.is_attached and not self._file_notes_active():
             self._schedule_library_entry_reconcile(
                 self._library_snapshot_state_generation,
                 self._library_entry_route_key(),

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3525,6 +3525,11 @@ class LibraryScreen(BaseAppScreen):
         # plan's screen-attrs contract.
         self._library_export_scope: ExportScope = ExportScope(kind="everything")
         self._library_export_counts: dict[str, int] | None = None
+        # Monotonic ownership for the counts request, separate from the export
+        # execution token below.  Scope/route/generation can all repeat after a
+        # leave -> return ABA visit, so none of them can identify the newest
+        # counts worker on its own.
+        self._library_export_counts_request_id: int = 0
         self._library_export_form: dict[str, Any] = self._default_library_export_form()
         # task-14902: True while the export quality chooser's direct-pick
         # strip renders below its (still-visible) opener button.
@@ -6629,16 +6634,61 @@ class LibraryScreen(BaseAppScreen):
     async def _open_pending_library_source(
         self,
     ) -> LibraryEntryReconcileResult | None:
-        """Consume one validated navigation target through Library's opener."""
+        """Consume one validated navigation target through Library's opener.
+
+        A conversation point lookup may overlap the initial paged snapshot.
+        That snapshot advances entry generation, so the first lookup result is
+        correctly rejected; while the same pending target still owns the same
+        conversation selection, retry under the new generation instead of
+        permanently falling back to the first loaded row.
+        """
 
         if self._library_prompts_mutation_in_flight:
             return
 
         pending = self._pending_library_source_open
-        self._pending_library_source_open = None
         if pending is None:
             return
-        return await self._open_library_item_by_id(*pending, entry_origin=True)
+        while self._pending_library_source_open == pending:
+            result = await self._open_library_item_by_id(*pending, entry_origin=True)
+            if result is not LibraryEntryReconcileResult.SUPERSEDED:
+                if self._pending_library_source_open == pending:
+                    self._pending_library_source_open = None
+                return result
+            if not self._pending_library_conversation_open_is_current(pending):
+                if self._pending_library_source_open == pending:
+                    self._pending_library_source_open = None
+                return result
+            # Let a scheduled snapshot reconcile finish before recapturing the
+            # current generation in the next point-lookup attempt.
+            await asyncio.sleep(0)
+        return LibraryEntryReconcileResult.SUPERSEDED
+
+    def _pending_library_conversation_open_is_current(
+        self, pending: tuple[str, str]
+    ) -> bool:
+        """Return whether a generation-only retry still owns its deep link."""
+
+        source_type, record_id = pending
+        return (
+            source_type == "conversations"
+            and self._pending_library_source_open == pending
+            and self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+            and self._selected_conversation_id == record_id
+        )
+
+    def _adopt_library_conversation_state_selection(self, selected_id: str) -> None:
+        """Adopt list normalization unless it would consume a pending deep link."""
+
+        pending = self._pending_library_source_open
+        if (
+            pending is not None
+            and pending[0] == "conversations"
+            and self._selected_conversation_id == pending[1]
+            and selected_id != pending[1]
+        ):
+            return
+        self._selected_conversation_id = selected_id
 
     # Own group, deliberately separate from the "default" group the plain
     # `self.run_worker(self._sync_collections_panel(...))` calls above use
@@ -7079,7 +7129,7 @@ class LibraryScreen(BaseAppScreen):
         )
         if shell.canvas_kind == "conversations":
             state = self._build_library_conversations_state()
-            self._selected_conversation_id = state.selected_id
+            self._adopt_library_conversation_state_selection(state.selected_id)
             return LibraryConversationsCanvas(
                 state, id="library-conversations-canvas"
             )
@@ -7426,7 +7476,9 @@ class LibraryScreen(BaseAppScreen):
             expected_selector = "#library-conversations-canvas"
             if self._library_lookup_error is None:
                 conversations_state = self._build_library_conversations_state()
-                self._selected_conversation_id = conversations_state.selected_id
+                self._adopt_library_conversation_state_selection(
+                    conversations_state.selected_id
+                )
                 sync_kind = "conversations"
                 replacement = LibraryConversationsCanvas(
                     conversations_state,
@@ -7518,10 +7570,12 @@ class LibraryScreen(BaseAppScreen):
                 if outgoing:
                     await canvas_host.remove_children(outgoing)
                 if generation != self._library_snapshot_state_generation:
+                    await self._repair_library_entry_canvas_owner()
                     return self._supersede_library_entry_reconcile(
                         generation, route_key
                     )
                 if route_key != self._library_entry_route_key():
+                    await self._repair_library_entry_canvas_owner()
                     return self._supersede_library_entry_reconcile(
                         generation, route_key
                     )
@@ -7534,10 +7588,12 @@ class LibraryScreen(BaseAppScreen):
                     generation, route_key
                 )
             if generation != self._library_snapshot_state_generation:
+                await self._repair_library_entry_canvas_owner()
                 return self._supersede_library_entry_reconcile(
                     generation, route_key
                 )
             if route_key != self._library_entry_route_key():
+                await self._repair_library_entry_canvas_owner()
                 return self._supersede_library_entry_reconcile(
                     generation, route_key
                 )
@@ -9330,7 +9386,9 @@ class LibraryScreen(BaseAppScreen):
                     )
                 elif shell.canvas_kind == "conversations":
                     conversations_state = self._build_library_conversations_state()
-                    self._selected_conversation_id = conversations_state.selected_id
+                    self._adopt_library_conversation_state_selection(
+                        conversations_state.selected_id
+                    )
                     yield LibraryConversationsCanvas(
                         conversations_state,
                         id="library-conversations-canvas",
@@ -11760,6 +11818,8 @@ class LibraryScreen(BaseAppScreen):
         A real (file-backed) deployment always takes the
         ``group="library_export_counts"`` worker-thread path.
         """
+        self._library_export_counts_request_id += 1
+        request_id = self._library_export_counts_request_id
         scope = self._library_export_scope
         generation = self._library_snapshot_state_generation
         route_key = self._library_entry_route_key()
@@ -11779,6 +11839,7 @@ class LibraryScreen(BaseAppScreen):
                 counts,
                 generation=generation,
                 route_key=route_key,
+                request_id=request_id,
             )
             if (
                 result is not LibraryEntryReconcileResult.APPLIED
@@ -11795,6 +11856,7 @@ class LibraryScreen(BaseAppScreen):
                     counts,
                     generation=generation,
                     route_key=route_key,
+                    request_id=request_id,
                 )
             return
         self._run_library_export_counts_worker(
@@ -11804,6 +11866,7 @@ class LibraryScreen(BaseAppScreen):
             prompts_db,
             generation,
             route_key,
+            request_id,
         )
 
     @work(thread=True, exclusive=True, group="library_export_counts")
@@ -11815,6 +11878,7 @@ class LibraryScreen(BaseAppScreen):
         prompts_db: Any,
         generation: int,
         route_key: tuple[object, ...],
+        request_id: int,
     ) -> None:
         counts = self._compute_library_export_counts(
             scope, media_db, chachanotes_db, prompts_db
@@ -11832,6 +11896,7 @@ class LibraryScreen(BaseAppScreen):
                 counts,
                 generation=generation,
                 route_key=route_key,
+                request_id=request_id,
             )
         except Exception:
             # A shutdown/detach mid-marshal can raise RuntimeError OR
@@ -11846,6 +11911,7 @@ class LibraryScreen(BaseAppScreen):
         *,
         generation: int | None = None,
         route_key: tuple[object, ...] | None = None,
+        request_id: int,
     ) -> LibraryEntryReconcileResult:
         """Marshal a landed counts result onto the export form (UI thread).
 
@@ -11875,10 +11941,12 @@ class LibraryScreen(BaseAppScreen):
             scope: The scope the landed ``counts`` were computed for.
             counts: The landed counts (keys "media"/"conversations"/"notes"/
                 "prompts").
+            request_id: Monotonic identity of the Export visit/count request.
         """
+        if request_id != self._library_export_counts_request_id:
+            return LibraryEntryReconcileResult.SUPERSEDED
         if scope != self._library_export_scope:
             return LibraryEntryReconcileResult.SUPERSEDED
-        self._library_export_counts = counts
         if (
             generation is not None
             and generation != self._library_snapshot_state_generation
@@ -11907,6 +11975,7 @@ class LibraryScreen(BaseAppScreen):
         active_route_key = self._library_entry_route_key()
         if not self._library_entry_reconcile_is_current(generation, active_route_key):
             return LibraryEntryReconcileResult.SUPERSEDED
+        self._library_export_counts = counts
         state = self._build_library_export_state()
         try:
             canvas = self.query_one("#library-export-canvas", LibraryExportCanvas)
@@ -30378,7 +30447,9 @@ class LibraryScreen(BaseAppScreen):
         if entry_origin:
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
             conversations_state = self._build_library_conversations_state()
-            self._selected_conversation_id = conversations_state.selected_id
+            self._adopt_library_conversation_state_selection(
+                conversations_state.selected_id
+            )
             generation = self._library_snapshot_state_generation
             route_key = self._library_entry_route_key()
             return await self._replace_library_canvas_child(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -717,6 +717,16 @@ class LibraryEntryFocusIdentity:
 
 
 @dataclasses.dataclass(frozen=True)
+class _LibraryEntryFocusCapture:
+    """Focus intent carried across superseding strict entry syncs."""
+
+    identity: LibraryEntryFocusIdentity
+    outgoing_focus: Widget
+    route_key: tuple[object, ...]
+    notes_identity: LibraryNotesFocusIdentity | None = None
+
+
+@dataclasses.dataclass(frozen=True)
 class _LibraryNotesRecomposeCapture:
     """Portable identity needed to rehydrate a replaced Notes canvas."""
 
@@ -1455,6 +1465,8 @@ def _sync_library_canvas(
     *,
     then: Callable[[], None] | None = None,
     allow_screen_fallback: bool = True,
+    notes_focus_identity: LibraryNotesFocusIdentity | None = None,
+    deferred_guard: Callable[[], bool] | None = None,
 ) -> bool:
     """Canvas-scoped targeted update for a Library browse canvas (Tier 2).
 
@@ -1497,6 +1509,10 @@ def _sync_library_canvas(
 
         allow_screen_fallback: Whether a failed targeted update may request
             the legacy whole-screen recompose.
+        notes_focus_identity: Rich Notes identity captured before portable
+            entry focus is detached, when automatic reconciliation owns sync.
+        deferred_guard: Ownership predicate checked by deferred retained-owner
+            DOM work before and after each await.
 
     Returns:
         True when the mounted canvas accepted the state; otherwise False.
@@ -1614,7 +1630,11 @@ def _sync_library_canvas(
             # resolves to a fallback target (measured: the rail row), which is
             # worse than leaving focus to the transition's own arming path
             # (``_arm_library_note_editor`` + its explicit editor identity).
-            identity = screen._capture_library_notes_focus_identity()
+            identity = (
+                notes_focus_identity
+                if notes_focus_identity is not None
+                else screen._capture_library_notes_focus_identity()
+            )
 
             def _restore_then_explicit(
                 _identity: LibraryNotesFocusIdentity = identity,
@@ -1625,6 +1645,8 @@ def _sync_library_canvas(
                     _explicit()
 
             follow_up = _restore_then_explicit
+        if kind == "landing":
+            canvas.set_deferred_sync_guard(deferred_guard)
         if follow_up is not None:
             canvas.queue_after_recompose(follow_up)
         canvas.sync_state(*sync_args, **sync_kwargs)
@@ -3593,9 +3615,7 @@ class LibraryScreen(BaseAppScreen):
             tuple[int, tuple[object, ...]] | None
         ) = None
         self._library_entry_reconcile_retry_generation: int | None = None
-        self._library_entry_focus_capture: (
-            tuple[LibraryEntryFocusIdentity, Widget | None] | None
-        ) = None
+        self._library_entry_focus_capture: _LibraryEntryFocusCapture | None = None
         self._seed_local_source_snapshot_from_cache()
 
     def _library_footer_shortcuts_for_current_state(
@@ -4073,6 +4093,7 @@ class LibraryScreen(BaseAppScreen):
                 return f"file-notes:{widget_id}"
         direct_roles = {
             "library-notes-filter": "filter",
+            "library-notes-select-toggle": "select-toggle",
             "library-note-title": "title",
             "library-note-body": "body",
             "library-note-preview-region": "preview-body",
@@ -4227,6 +4248,7 @@ class LibraryScreen(BaseAppScreen):
         role = identity.semantic_role
         selector = {
             "filter": "#library-notes-filter",
+            "select-toggle": "#library-notes-select-toggle",
             "title": "#library-note-title",
             "body": "#library-note-body",
             "preview-body": "#library-note-preview-region",
@@ -6809,7 +6831,14 @@ class LibraryScreen(BaseAppScreen):
         """Capture a focused canvas descendant by stable control or row identity."""
         focused = self.focused
         owner = self._library_entry_canvas_owner()
-        if focused is None or owner is None or owner not in focused.ancestors_with_self:
+        route_key = self._library_entry_route_key()
+        capture = self._library_entry_focus_capture
+        if focused is None:
+            if capture is not None and capture.route_key == route_key:
+                return capture.identity
+            self._library_entry_focus_capture = None
+            return None
+        if owner is None or owner not in focused.ancestors_with_self:
             self._library_entry_focus_capture = None
             return None
 
@@ -6835,7 +6864,17 @@ class LibraryScreen(BaseAppScreen):
             source_id=source_id,
             scroll_offset=scroll_offset,
         )
-        self._library_entry_focus_capture = (identity, focused)
+        notes_identity = (
+            self._capture_library_notes_focus_identity()
+            if owner.id == "library-notes-canvas"
+            else None
+        )
+        self._library_entry_focus_capture = _LibraryEntryFocusCapture(
+            identity=identity,
+            outgoing_focus=focused,
+            route_key=route_key,
+            notes_identity=notes_identity,
+        )
         # Detach DOM focus before the owner removes its focused child. Textual
         # otherwise falls back to unrelated screen chrome during teardown,
         # which is indistinguishable from a user focus move at restore time.
@@ -6858,10 +6897,10 @@ class LibraryScreen(BaseAppScreen):
             return
         capture = self._library_entry_focus_capture
         outgoing_focus = (
-            capture[1] if capture is not None and capture[0] is identity else None
+            capture.outgoing_focus
+            if capture is not None and capture.identity is identity
+            else None
         )
-        if self.focused is not outgoing_focus and self.focused is not None:
-            return
 
         owner = self._library_entry_canvas_owner()
         if owner is None:
@@ -6889,6 +6928,14 @@ class LibraryScreen(BaseAppScreen):
                 target = owner.query_one(f"#{identity.widget_id}", Widget)
             except (NoMatches, QueryError):
                 target = None
+        if (
+            self.focused is not outgoing_focus
+            and self.focused is not None
+            and self.focused is not target
+        ):
+            if self._library_entry_focus_capture is capture:
+                self._library_entry_focus_capture = None
+            return
         if target is not None and not getattr(target, "disabled", False):
             target.focus()
         if identity.scroll_offset is not None and hasattr(owner, "scroll_to"):
@@ -6916,6 +6963,16 @@ class LibraryScreen(BaseAppScreen):
                 route_key=route_key,
             )
         self._complete_library_entry_reconcile(generation, route_key)
+
+    def _library_entry_reconcile_is_current(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> bool:
+        """Return whether deferred entry work still owns this screen route."""
+        return (
+            self.is_mounted
+            and generation == self._library_snapshot_state_generation
+            and route_key == self._library_entry_route_key()
+        )
 
     def _schedule_library_entry_reconcile(
         self, generation: int, route_key: tuple[object, ...]
@@ -7094,6 +7151,7 @@ class LibraryScreen(BaseAppScreen):
                 self._complete_library_entry_reconcile(generation, route_key)
                 return LibraryEntryReconcileResult.APPLIED
             identity = self._capture_library_entry_focus()
+            capture = self._library_entry_focus_capture
             finish = partial(
                 self._finish_library_entry_canvas_sync,
                 identity,
@@ -7105,6 +7163,16 @@ class LibraryScreen(BaseAppScreen):
                 sync_kind,
                 then=finish,
                 allow_screen_fallback=False,
+                notes_focus_identity=(
+                    capture.notes_identity
+                    if capture is not None and capture.identity is identity
+                    else None
+                ),
+                deferred_guard=partial(
+                    self._library_entry_reconcile_is_current,
+                    generation,
+                    route_key,
+                ),
             ):
                 self._library_entry_reconcile_retry_generation = None
                 return LibraryEntryReconcileResult.APPLIED
@@ -7146,6 +7214,7 @@ class LibraryScreen(BaseAppScreen):
                 )
             if sync_kind is not None:
                 identity = self._capture_library_entry_focus()
+                capture = self._library_entry_focus_capture
                 finish = partial(
                     self._finish_library_entry_canvas_sync,
                     identity,
@@ -7157,6 +7226,16 @@ class LibraryScreen(BaseAppScreen):
                     sync_kind,
                     then=finish,
                     allow_screen_fallback=False,
+                    notes_focus_identity=(
+                        capture.notes_identity
+                        if capture is not None and capture.identity is identity
+                        else None
+                    ),
+                    deferred_guard=partial(
+                        self._library_entry_reconcile_is_current,
+                        generation,
+                        route_key,
+                    ),
                 ):
                     return self._retry_or_fail_library_entry_reconcile(
                         generation, route_key

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timezone
+from enum import Enum
 from functools import partial
 import hashlib
 from pathlib import Path
@@ -416,6 +417,7 @@ from ...Widgets.Library.library_note_folder_dialog import (
     LibraryNoteFolderNameDialog,
     LibraryNoteFolderTargetDialog,
 )
+from ...Widgets.Library.library_canvas_sync import PostRecomposeCallback
 from ...Widgets.Library.library_notes_canvas import LibraryNotePresentationState
 from ...Widgets.ModelArtifacts import (
     InstallProgressed,
@@ -688,6 +690,15 @@ class _LibraryIngestStartConsent:
         return bool(
             self.active_job_ids and self.admission_scope.active_job_ids_complete
         )
+
+
+class LibraryEntryReconcileResult(Enum):
+    """Outcome of projecting a source snapshot into the mounted Library."""
+
+    APPLIED = "applied"
+    ALREADY_CURRENT = "already-current"
+    SUPERSEDED = "superseded"
+    FAILED = "failed"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1428,7 +1439,8 @@ def _sync_library_canvas(
     kind: str,
     *,
     then: Callable[[], None] | None = None,
-) -> None:
+    allow_screen_fallback: bool = True,
+) -> bool:
     """Canvas-scoped targeted update for a Library browse canvas (Tier 2).
 
     Rebuilds the given canvas's fresh display state and hands it to the
@@ -1468,9 +1480,13 @@ def _sync_library_canvas(
             for another kind raises into the whole-screen fallback rather
             than silently dropping the follow-up.
 
+        allow_screen_fallback: Whether a failed targeted update may request
+            the legacy whole-screen recompose.
+
     Returns:
-        None.
+        True when the mounted canvas accepted the state; otherwise False.
     """
+    canvas: Widget | None = None
     try:
         sync_args: tuple[Any, ...] = ()
         sync_kwargs: dict[str, Any] = {}
@@ -1583,6 +1599,7 @@ def _sync_library_canvas(
         if follow_up is not None:
             canvas.queue_after_recompose(follow_up)
         canvas.sync_state(*sync_args, **sync_kwargs)
+        return True
         # NOTE (task-15457 review): a footer re-derivation was added here and
         # then REMOVED after probing. Both footer tiers that a targeted sync
         # can flip -- the Notes tier (select mode / sort-strip visibility) and
@@ -1597,19 +1614,14 @@ def _sync_library_canvas(
         # gone; the coupling itself is recorded in the task file's residuals.
 
     except Exception:
-        logger.debug(
-            f"Library {kind} canvas sync failed; falling back to full recompose.",
-            exc_info=True,
-        )
-        screen.refresh(recompose=True)
-        if then is not None:
-            # The fallback tears the canvas down, taking any callback queued
-            # on it; re-schedule the follow-up the way a whole-screen
-            # recompose has always scheduled one, so a failed targeted sync
-            # costs a rebuild but never the user's focus. Only the EXPLICIT
-            # follow-up is re-scheduled: the default restore above is what
-            # the whole-screen path does for itself.
-            screen.call_after_refresh(then)
+        logger.opt(exception=True).debug(f"Library {kind} canvas sync failed.")
+        if allow_screen_fallback:
+            screen.refresh(recompose=True)
+            if then is not None:
+                screen.call_after_refresh(then)
+        elif then is not None and isinstance(canvas, PostRecomposeCallback):
+            canvas.queue_after_recompose(None)
+        return False
 
 
 def _canonical_shortcut_key(key: str) -> str:
@@ -3545,6 +3557,13 @@ class LibraryScreen(BaseAppScreen):
         # alone is not sufficient (``restore_state`` seeds again, below,
         # once the restored selection is known) and ``on_mount``'s for the
         # mount-time reconciliation that follows the initial render.
+        self._library_snapshot_state_generation = 0
+        self._library_snapshot_rendered_generation = 0
+        self._library_entry_reconcile_dirty = False
+        self._library_entry_reconcile_pending: (
+            tuple[int, tuple[object, ...]] | None
+        ) = None
+        self._library_entry_reconcile_retry_generation: int | None = None
         self._seed_local_source_snapshot_from_cache()
 
     def _library_footer_shortcuts_for_current_state(
@@ -6731,6 +6750,250 @@ class LibraryScreen(BaseAppScreen):
             else None
         )
         return (prompts_count, skills_count)
+    def _library_entry_route_key(self) -> tuple[object, ...]:
+        """Return the state fields that select the mounted Library owner."""
+        return (
+            self._library_selected_row_id,
+            self._library_notes_source,
+            self._library_notes_view,
+            self._library_media_view,
+            self._library_prompts_view,
+            self._library_skills_view,
+            self._selected_note_id,
+            self._selected_media_id,
+            self._selected_prompt_id,
+            self._selected_skill_name,
+        )
+
+    def _schedule_library_entry_reconcile(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> None:
+        """Queue one generation/route-specific DOM projection on this pump."""
+        pending = (generation, route_key)
+        if self._library_entry_reconcile_pending == pending:
+            return
+        self._library_entry_reconcile_pending = pending
+        self.call_later(self._reconcile_library_entry_state, generation, route_key)
+
+    def _complete_library_entry_reconcile(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> None:
+        """Mark a still-current snapshot generation as rendered."""
+        if generation != self._library_snapshot_state_generation:
+            return
+        if route_key != self._library_entry_route_key():
+            return
+        self._library_snapshot_rendered_generation = generation
+        self._library_entry_reconcile_dirty = False
+        self._library_entry_reconcile_pending = None
+        self._library_entry_reconcile_retry_generation = None
+
+    def _supersede_library_entry_reconcile(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> LibraryEntryReconcileResult:
+        """Release markers owned by one stale reconciliation callback."""
+        pending = (generation, route_key)
+        if self._library_entry_reconcile_pending == pending:
+            self._library_entry_reconcile_pending = None
+            if self._library_entry_reconcile_retry_generation == generation:
+                self._library_entry_reconcile_retry_generation = None
+        return LibraryEntryReconcileResult.SUPERSEDED
+
+    def _retry_or_fail_library_entry_reconcile(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> LibraryEntryReconcileResult:
+        """Retry one still-current missing target, then leave it dirty."""
+        if generation != self._library_snapshot_state_generation:
+            return self._supersede_library_entry_reconcile(generation, route_key)
+        if route_key != self._library_entry_route_key():
+            return self._supersede_library_entry_reconcile(generation, route_key)
+        self._library_entry_reconcile_dirty = True
+        if self._library_entry_reconcile_retry_generation != generation:
+            self._library_entry_reconcile_retry_generation = generation
+            self._library_entry_reconcile_pending = (generation, route_key)
+            self.call_later(
+                self._reconcile_library_entry_state, generation, route_key
+            )
+            return LibraryEntryReconcileResult.FAILED
+        self._library_entry_reconcile_pending = None
+        self._library_entry_reconcile_retry_generation = None
+        return LibraryEntryReconcileResult.FAILED
+
+    async def _reconcile_library_entry_state(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> LibraryEntryReconcileResult:
+        """Project one current snapshot into the mounted rail and canvas."""
+        pending = (generation, route_key)
+        if not self.is_attached:
+            return self._supersede_library_entry_reconcile(generation, route_key)
+        if generation != self._library_snapshot_state_generation:
+            return self._supersede_library_entry_reconcile(generation, route_key)
+        if route_key != self._library_entry_route_key():
+            return self._supersede_library_entry_reconcile(generation, route_key)
+        if (
+            not self._library_entry_reconcile_dirty
+            and self._library_snapshot_rendered_generation == generation
+        ):
+            if self._library_entry_reconcile_pending == pending:
+                self._library_entry_reconcile_pending = None
+            self._library_entry_reconcile_retry_generation = None
+            return LibraryEntryReconcileResult.ALREADY_CURRENT
+
+        shell = build_library_shell_state(
+            self._build_library_shell_input(),
+            selected_row_id=self._library_selected_row_id,
+        )
+        try:
+            rail = self.query_one("#library-rail", LibraryRail)
+            header = self.query_one("#library-header-line", Static)
+        except (NoMatches, QueryError):
+            return self._retry_or_fail_library_entry_reconcile(
+                generation, route_key
+            )
+
+        rail.sync_state(
+            shell,
+            self._library_rail_preferences(),
+            query=self._library_rag_query,
+        )
+        header_renderable = header.renderable
+        header_text = getattr(header_renderable, "plain", str(header_renderable))
+        if header_text != shell.header_line:
+            header.update(shell.header_line)
+
+        sync_kind: str | None = None
+        expected_selector = ""
+        replacement: Widget | None = None
+        local_list_surface = False
+        if shell.canvas_kind == "conversations":
+            local_list_surface = True
+            expected_selector = "#library-conversations-canvas"
+            if self._library_lookup_error is None:
+                conversations_state = self._build_library_conversations_state()
+                self._selected_conversation_id = conversations_state.selected_id
+                sync_kind = "conversations"
+                replacement = LibraryConversationsCanvas(
+                    conversations_state,
+                    id="library-conversations-canvas",
+                )
+        elif shell.canvas_kind == "media" and self._library_media_view == "list":
+            local_list_surface = True
+            expected_selector = "#library-media-canvas"
+            if self._library_lookup_error is None:
+                media_state = self._build_library_media_state()
+                self._selected_media_id = media_state.selected_id
+                sync_kind = "media"
+                replacement = LibraryMediaCanvas(
+                    media_state,
+                    id="library-media-canvas",
+                )
+        elif (
+            shell.canvas_kind == LIBRARY_CANVAS_KIND_NOTES
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+            and self._library_notes_view == "list"
+        ):
+            local_list_surface = True
+            expected_selector = "#library-notes-canvas"
+            if self._library_lookup_error is None:
+                sync_kind = "notes"
+                replacement = LibraryNotesCanvas(
+                    **self._library_notes_canvas_kwargs(),
+                    id="library-notes-canvas",
+                )
+        elif shell.canvas_kind == "skills" and self._library_skills_view == "list":
+            sync_kind = "skills"
+            expected_selector = "#library-skills-canvas"
+
+        if local_list_surface and self._library_lookup_error is not None:
+            expected_selector = "#library-canvas-error"
+            replacement = Static(
+                self._library_lookup_error,
+                id="library-canvas-error",
+                classes="destination-purpose",
+                markup=False,
+            )
+
+        if expected_selector and self.query(expected_selector):
+            if sync_kind is None:
+                self._complete_library_entry_reconcile(generation, route_key)
+                return LibraryEntryReconcileResult.APPLIED
+            completed = partial(
+                self._complete_library_entry_reconcile, generation, route_key
+            )
+            if _sync_library_canvas(
+                self,
+                sync_kind,
+                then=completed,
+                allow_screen_fallback=False,
+            ):
+                self._library_entry_reconcile_retry_generation = None
+                return LibraryEntryReconcileResult.APPLIED
+            return self._retry_or_fail_library_entry_reconcile(
+                generation, route_key
+            )
+
+        if local_list_surface and replacement is not None:
+            try:
+                canvas_host = self.query_one("#library-canvas", Vertical)
+                outgoing = tuple(canvas_host.children)
+                for child in outgoing:
+                    child.display = False
+                if outgoing:
+                    await canvas_host.remove_children(outgoing)
+                if generation != self._library_snapshot_state_generation:
+                    return self._supersede_library_entry_reconcile(
+                        generation, route_key
+                    )
+                if route_key != self._library_entry_route_key():
+                    return self._supersede_library_entry_reconcile(
+                        generation, route_key
+                    )
+                await canvas_host.mount(replacement)
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Library snapshot canvas replacement failed."
+                )
+                return self._retry_or_fail_library_entry_reconcile(
+                    generation, route_key
+                )
+            if generation != self._library_snapshot_state_generation:
+                return self._supersede_library_entry_reconcile(
+                    generation, route_key
+                )
+            if route_key != self._library_entry_route_key():
+                return self._supersede_library_entry_reconcile(
+                    generation, route_key
+                )
+            if sync_kind is not None:
+                completed = partial(
+                    self._complete_library_entry_reconcile, generation, route_key
+                )
+                if not _sync_library_canvas(
+                    self,
+                    sync_kind,
+                    then=completed,
+                    allow_screen_fallback=False,
+                ):
+                    return self._retry_or_fail_library_entry_reconcile(
+                        generation, route_key
+                    )
+            else:
+                self._complete_library_entry_reconcile(generation, route_key)
+            return LibraryEntryReconcileResult.APPLIED
+
+        if self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH:
+            try:
+                self._sync_library_rag_scope_toggle_and_run_gate_widgets()
+            except Exception:
+                logger.opt(exception=True).debug(
+                    "Library Search/RAG snapshot sync failed."
+                )
+                return self._retry_or_fail_library_entry_reconcile(
+                    generation, route_key
+                )
+
+        self._complete_library_entry_reconcile(generation, route_key)
+        return LibraryEntryReconcileResult.APPLIED
 
     def _apply_local_source_snapshot(
         self,
@@ -6742,9 +7005,18 @@ class LibraryScreen(BaseAppScreen):
         study_counts: dict[str, int | None] | None = None,
         *,
         schedule_reconcile: bool = True,
-    ) -> None:
-        records = self._carry_selected_conversation_into_snapshot(records)
-        conversation_records = tuple(records.get("conversations", ()))
+    ) -> bool:
+        normalized_records = self._carry_selected_conversation_into_snapshot(
+            dict(records)
+        )
+        normalized_counts = dict(counts)
+        normalized_total_known = dict(total_known)
+        normalized_study_counts = (
+            dict(study_counts)
+            if study_counts is not None
+            else {"study_decks": None, "flashcards_due": None, "quizzes": None}
+        )
+        conversation_records = tuple(normalized_records.get("conversations", ()))
         if (
             lookup_error is None
             and not self._library_conversation_page_loaded
@@ -6753,10 +7025,10 @@ class LibraryScreen(BaseAppScreen):
             self._library_conversation_page_records = conversation_records
             self._library_conversation_page = 1
             self._library_conversation_total = max(
-                0, int(counts.get("conversations", 0))
+                0, int(normalized_counts.get("conversations", 0))
             )
             self._library_conversation_total_known = bool(
-                total_known.get("conversations", True)
+                normalized_total_known.get("conversations", True)
             )
             self._library_conversation_has_more = (
                 len(conversation_records) < self._library_conversation_total
@@ -6771,153 +7043,48 @@ class LibraryScreen(BaseAppScreen):
             self._library_conversation_error = (
                 "Couldn't load conversations. Submit the filter to try again."
             )
-        study_counts = (
-            study_counts
-            if study_counts is not None
-            else {"study_decks": None, "flashcards_due": None, "quizzes": None}
+        presentation_changed = not self._library_loaded or (
+            normalized_records != self._local_source_records
+            or normalized_counts != self._local_source_counts
+            or normalized_total_known != self._local_source_total_known
+            or lookup_error != self._library_lookup_error
+            or recovery_state != self._library_lookup_recovery_state
+            or normalized_study_counts != self._library_study_counts
         )
-        # task-15459 (+ review fix): detect whether this snapshot actually
-        # differs from what is already rendered -- typically the pre-mount
-        # cache seed (``_seed_local_source_snapshot_from_cache``) being
-        # confirmed by this same visit's reconcile fetch -- so the
-        # recompose below can be skipped on that common warm-revisit case
-        # instead of repainting an identical screen. Split into TWO
-        # domains rather than one flat comparison:
-        #
-        # STRUCTURAL = notes/media/conversations rows+counts+total_known,
-        # the whole-snapshot lookup_error/recovery_state, and the Skills
-        # canvas's actual available/blocked payload -- everything a
-        # currently mounted canvas renders as content.
-        #
-        # DECORATIVE = the Create-rail badges (study_decks/flashcards_due/
-        # quizzes) plus the Prompts/Skills rail COUNTS. Every one of these
-        # is fetched by a ``..._or_none`` helper (``_study_count_or_none``,
-        # ``_prompts_count_or_none``, ``_skills_context_or_none``) that
-        # swallows ANY exception and degrades to ``None`` (see their
-        # docstrings) -- so under thread-pool contention the pre-mount
-        # cache seed and this visit's reconcile fetch can legitimately
-        # disagree on a decorative field even though nothing a user would
-        # call "the data" changed. Folding decorative fields into a single
-        # flat comparison made that disagreement force a full recompose
-        # for a badge flap -- reproduced deterministically by injecting a
-        # transient exception into one decorative fetch between the seed
-        # and the reconcile (see
-        # ``test_library_shell_decorative_count_flap_patches_rail_in_
-        # place_without_recompose``). Splitting the domains lets a
-        # decorative-only change patch the rail's counts in place
-        # (``rail.sync_state``, the exact mechanism the Ingest/Prompts/
-        # Search branch below already uses) instead of recomposing, while
-        # a STRUCTURAL change (the only kind covered by ``notes_true_
-        # count``'s optional override -- deliberately kept structural per
-        # review scope, not folded into the decorative bucket here) still
-        # gets the full picture. ``not self._library_loaded`` always
-        # counts as a structural change even if the incoming records
-        # happen to be all-empty: the screen is still showing the
-        # "Loading…" placeholder in that case, which DOES need a
-        # recompose to clear.
-        structural_unchanged = self._library_loaded and (
-            self._structural_records_for_comparison(records)
-            == self._structural_records_for_comparison(self._local_source_records)
-            and counts == self._local_source_counts
-            and total_known == self._local_source_total_known
-            and lookup_error == self._library_lookup_error
-            and recovery_state == self._library_lookup_recovery_state
-        )
-        decorative_changed = (
-            study_counts != self._library_study_counts
-            or self._decorative_rail_counts_for_comparison(records)
-            != self._decorative_rail_counts_for_comparison(self._local_source_records)
-        )
-        self._local_source_records = records
-        self._local_source_counts = counts
-        self._local_source_total_known = total_known
+        if not presentation_changed:
+            if (
+                schedule_reconcile
+                and self.is_mounted
+                and not self._file_notes_active()
+                and (
+                    self._library_entry_reconcile_dirty
+                    or self._library_snapshot_rendered_generation
+                    != self._library_snapshot_state_generation
+                )
+            ):
+                self._library_entry_reconcile_dirty = True
+                self._schedule_library_entry_reconcile(
+                    self._library_snapshot_state_generation,
+                    self._library_entry_route_key(),
+                )
+            return False
+
+        self._local_source_records = normalized_records
+        self._local_source_counts = normalized_counts
+        self._local_source_total_known = normalized_total_known
         self._library_lookup_error = lookup_error
         self._library_lookup_recovery_state = recovery_state
-        self._library_study_counts = study_counts
+        self._library_study_counts = normalized_study_counts
         self._library_loaded = True
         self._invalidate_library_workspace_depth_state()
+        self._library_snapshot_state_generation += 1
+        self._library_entry_reconcile_dirty = True
         if schedule_reconcile and self.is_mounted and not self._file_notes_active():
-            if (
-                self._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
-                or self._library_selected_row_id
-                in {LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT}
-                or self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH
-            ):
-                # A source refresh only updates the Prompts rail count. Exact
-                # list rows have their own browse result, while an open editor
-                # owns a dirty working copy. Recompose only the rail in either
-                # Prompt view so rows, cursor, selection, scroll position, and
-                # native undo history remain under their rightful owners.
-                # (task-2042) Same protection for the Ingest canvas: this
-                # snapshot lands right after every completed job, and a full
-                # recompose here remounted the form mid-click (the queue
-                # renders from the job registry, not this snapshot -- only
-                # the rail needs the fresh counts).
-                # (RAG-27) Same protection for the Search/RAG canvas: a
-                # background ingest completing while the user is mid-search
-                # must not eject them from the panel either -- the rail sync
-                # below covers the rail, and the extra call further down
-                # syncs the panel's own scope-toggle counts and Run-gate
-                # label/enabled state (NOT results/history/the query-status
-                # callout -- see
-                # `_sync_library_rag_scope_toggle_and_run_gate_widgets`'s
-                # docstring for why this path deliberately stays a plain,
-                # non-`await`ed attribute sync rather than the shared
-                # `_refresh_search_rag_panel_state_widgets` coroutine every
-                # other caller uses).
-                try:
-                    rail = self.query_one("#library-rail", LibraryRail)
-                except (NoMatches, QueryError):
-                    return
-                rail.sync_state(
-                    build_library_shell_state(
-                        self._build_library_shell_input(),
-                        selected_row_id=self._library_selected_row_id,
-                    ),
-                    self._library_rail_preferences(),
-                    query=self._library_rag_query,
-                )
-                if self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH:
-                    self._sync_library_rag_scope_toggle_and_run_gate_widgets()
-                return
-            # The pending-focus-wait carve-out applies to BOTH skip paths
-            # below: that flag's own release
-            # (``_release_library_notes_focus_after_snapshot``) is only
-            # ever armed from inside the recompose call further down (see
-            # ``action_library_note_editor_back``'s docstring), so skipping
-            # the recompose while the flag is armed -- for ANY reason --
-            # would strand it set forever, since nothing else clears it.
-            if not self._library_notes_pending_focus_waits_for_snapshot:
-                if structural_unchanged and not decorative_changed:
-                    # task-15459: the in-memory snapshot above is already
-                    # up to date and nothing on screen needs to change --
-                    # update-in-place, no recompose.
-                    return
-                if structural_unchanged:
-                    # task-15459 review fix: only a DECORATIVE rail badge
-                    # flapped (see the domain-split comment above) --
-                    # patch the rail's counts in place via the same
-                    # targeted sync the Ingest/Prompts/Search branch above
-                    # already uses, instead of paying for a whole-screen
-                    # recompose over a badge repaint.
-                    try:
-                        rail = self.query_one("#library-rail", LibraryRail)
-                    except (NoMatches, QueryError):
-                        return
-                    rail.sync_state(
-                        build_library_shell_state(
-                            self._build_library_shell_input(),
-                            selected_row_id=self._library_selected_row_id,
-                        ),
-                        self._library_rail_preferences(),
-                        query=self._library_rag_query,
-                    )
-                    return
-            self.refresh(recompose=True)
-            if self._library_notes_pending_focus_waits_for_snapshot:
-                self.call_after_refresh(
-                    self._release_library_notes_focus_after_snapshot
-                )
+            self._schedule_library_entry_reconcile(
+                self._library_snapshot_state_generation,
+                self._library_entry_route_key(),
+            )
+        return True
 
     def _seed_local_source_snapshot_from_cache(
         self, *, now: float | None = None
@@ -6935,6 +7102,10 @@ class LibraryScreen(BaseAppScreen):
         if snapshot is None:
             return False
         self._apply_local_source_snapshot(*snapshot, schedule_reconcile=False)
+        self._library_snapshot_rendered_generation = (
+            self._library_snapshot_state_generation
+        )
+        self._library_entry_reconcile_dirty = False
         return True
 
     def _apply_source_snapshot_timeout(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6,6 +6,7 @@ import asyncio
 import dataclasses
 import inspect
 import json
+import math
 import re
 import threading
 import time
@@ -3619,7 +3620,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_entry_reconcile_pending: (
             tuple[int, tuple[object, ...]] | None
         ) = None
-        self._library_entry_reconcile_retry_generation: int | None = None
+        self._library_entry_reconcile_retry_generation: (
+            tuple[int, tuple[object, ...]] | None
+        ) = None
         self._library_entry_focus_capture: _LibraryEntryFocusCapture | None = None
         self._seed_local_source_snapshot_from_cache()
 
@@ -7085,7 +7088,7 @@ class LibraryScreen(BaseAppScreen):
         pending = (generation, route_key)
         if self._library_entry_reconcile_pending == pending:
             self._library_entry_reconcile_pending = None
-            if self._library_entry_reconcile_retry_generation == generation:
+            if self._library_entry_reconcile_retry_generation == pending:
                 self._library_entry_reconcile_retry_generation = None
         return LibraryEntryReconcileResult.SUPERSEDED
 
@@ -7098,9 +7101,10 @@ class LibraryScreen(BaseAppScreen):
         if route_key != self._library_entry_route_key():
             return self._supersede_library_entry_reconcile(generation, route_key)
         self._library_entry_reconcile_dirty = True
-        if self._library_entry_reconcile_retry_generation != generation:
-            self._library_entry_reconcile_retry_generation = generation
-            self._library_entry_reconcile_pending = (generation, route_key)
+        pending = (generation, route_key)
+        if self._library_entry_reconcile_retry_generation != pending:
+            self._library_entry_reconcile_retry_generation = pending
+            self._library_entry_reconcile_pending = pending
             self.call_later(
                 self._reconcile_library_entry_state, generation, route_key
             )
@@ -7117,7 +7121,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_entry_reconcile_dirty = True
         if self._library_entry_reconcile_pending == pending:
             self._library_entry_reconcile_pending = None
-            if self._library_entry_reconcile_retry_generation == generation:
+            if self._library_entry_reconcile_retry_generation == pending:
                 self._library_entry_reconcile_retry_generation = None
         return LibraryEntryReconcileResult.FAILED
 
@@ -7228,11 +7232,18 @@ class LibraryScreen(BaseAppScreen):
         elif isinstance(owner, LibraryStudyHandoffCanvas):
             kind = "handoff"
         elif isinstance(owner, LibraryCollectionsPanel):
+            generation = self._library_snapshot_state_generation
+            route_key = self._library_entry_route_key()
             owner.sync_state(
                 self._library_collections_panel_state(),
                 name_value=self._library_collection_name_input,
                 description_value=self._library_collection_description_input,
                 delete_pending=bool(self._library_collection_pending_delete_id),
+                deferred_guard=partial(
+                    self._library_entry_reconcile_is_current,
+                    generation,
+                    route_key,
+                ),
             )
             return True
         if kind is None:
@@ -7395,6 +7406,11 @@ class LibraryScreen(BaseAppScreen):
                 name_value=self._library_collection_name_input,
                 description_value=self._library_collection_description_input,
                 delete_pending=bool(self._library_collection_pending_delete_id),
+                deferred_guard=partial(
+                    self._library_entry_reconcile_is_current,
+                    generation,
+                    route_key,
+                ),
             )
 
         if sync_kind is not None:
@@ -7744,7 +7760,7 @@ class LibraryScreen(BaseAppScreen):
     ) -> bool:
         """Apply a recent detached cache snapshot before first composition."""
         stamp = getattr(self.app_instance, "_library_source_snapshot_cache_stamp", None)
-        if not isinstance(stamp, (int, float)):
+        if not isinstance(stamp, (int, float)) or not math.isfinite(float(stamp)):
             return False
         age = (time.monotonic() if now is None else now) - float(stamp)
         if age < 0 or age >= LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS:
@@ -11174,14 +11190,34 @@ class LibraryScreen(BaseAppScreen):
         ):
             return LibraryEntryReconcileResult.SUPERSEDED
         identity = self._capture_library_entry_focus()
+        prior_callback: Callable[[], None] | None = None
+        pending = (generation, route_key)
+        if (
+            self._library_entry_reconcile_dirty
+            and self._library_entry_reconcile_pending == pending
+        ):
+            try:
+                canvas = self.query_one(
+                    "#library-skills-canvas", LibrarySkillsListCanvas
+                )
+            except (NoMatches, QueryError):
+                canvas = None
+            if canvas is not None:
+                prior_callback = canvas._post_recompose_callback
+
+        def finish_posture_sync() -> None:
+            if prior_callback is not None:
+                prior_callback()
+            if identity is not None:
+                self._restore_library_entry_focus(
+                    identity,
+                    generation=generation,
+                    route_key=route_key,
+                )
+
         follow_up = (
-            partial(
-                self._restore_library_entry_focus,
-                identity,
-                generation=generation,
-                route_key=route_key,
-            )
-            if identity is not None
+            finish_posture_sync
+            if prior_callback is not None or identity is not None
             else None
         )
         if _sync_library_canvas(
@@ -11322,6 +11358,7 @@ class LibraryScreen(BaseAppScreen):
                         entry_route_key == current_pending[1]
                         and (
                             self._library_entry_reconcile_pending == current_pending
+                            or self._library_entry_reconcile_dirty
                             or self._library_snapshot_rendered_generation
                             == current_pending[0]
                         )
@@ -11959,6 +11996,7 @@ class LibraryScreen(BaseAppScreen):
                 route_key == current_pending[1]
                 and (
                     self._library_entry_reconcile_pending == current_pending
+                    or self._library_entry_reconcile_dirty
                     or self._library_snapshot_rendered_generation == current_pending[0]
                 )
             ):
@@ -29231,6 +29269,7 @@ class LibraryScreen(BaseAppScreen):
                 route_key == current_pending[1]
                 and (
                     self._library_entry_reconcile_pending == current_pending
+                    or self._library_entry_reconcile_dirty
                     or self._library_snapshot_rendered_generation == current_pending[0]
                 )
             ):
@@ -29261,6 +29300,11 @@ class LibraryScreen(BaseAppScreen):
             name_value=name_value,
             description_value=description_value,
             delete_pending=delete_pending,
+            deferred_guard=partial(
+                self._library_entry_reconcile_is_current,
+                generation,
+                route_key,
+            ),
         )
         if wait_for_recompose:
             await asyncio.sleep(0)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -430,6 +430,9 @@ from ..Library_Modules import (
     LibraryPromptHistoryController,
     LibraryPromptHistoryRegion,
 )
+from ..Library_Modules.library_snapshot_cache import (
+    clone_library_source_snapshot,
+)
 from ..Navigation.base_app_screen import BaseAppScreen
 from ..Navigation.main_navigation import NavigateToScreen
 from ..Views.RAGSearch.search_handoff import build_library_rag_console_live_work_payload
@@ -3541,7 +3544,7 @@ class LibraryScreen(BaseAppScreen):
         # ``_seed_local_source_snapshot_from_cache``'s docstring for why this
         # alone is not sufficient (``restore_state`` seeds again, below,
         # once the restored selection is known) and ``on_mount``'s for the
-        # fallback this replaces for the common case.
+        # mount-time reconciliation that follows the initial render.
         self._seed_local_source_snapshot_from_cache()
 
     def _library_footer_shortcuts_for_current_state(
@@ -5429,22 +5432,12 @@ class LibraryScreen(BaseAppScreen):
     def on_mount(self) -> None:
         """Populate the Library on entry, rendering instantly from cache.
 
-        Arms the snapshot-timeout failsafe, then (166) -- unless
-        ``__init__``/``restore_state`` already seeded ``_local_source_
-        records`` from the app-scoped snapshot cache before this screen was
-        even mounted (task-15459; see
-        ``_seed_local_source_snapshot_from_cache``, which sets
-        ``_library_loaded`` True on a hit) -- re-checks that same cache and,
-        if it holds a recent result (within
-        ``LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS``), applies it synchronously so
-        a returning visit paints immediately instead of showing the loading
-        placeholder. Either way, unconditionally kicks
-        ``_refresh_local_source_snapshot`` to reconcile against the DB
-        (``_apply_local_source_snapshot`` only recomposes again there if
-        the reconciled data actually differs from what is already
-        rendered). Also seeds the ingest registry listener and runs any
-        deferred deep-link loads (collections / note editor / media viewer)
-        that ``apply_navigation_context`` could not run before mount.
+        The constructor has already seeded any valid, recent app-scoped
+        snapshot before first compose. Mount arms the snapshot-timeout
+        failsafe and unconditionally kicks ``_refresh_local_source_snapshot``
+        to reconcile against the DB. It also seeds the ingest registry listener
+        and runs deferred deep-link loads (collections / note editor / media
+        viewer) that ``apply_navigation_context`` could not run before mount.
         """
         self._register_footer_shortcuts()
         # No super().on_mount(): the dispatcher already invokes
@@ -5455,45 +5448,6 @@ class LibraryScreen(BaseAppScreen):
             LIBRARY_SOURCE_SNAPSHOT_TIMEOUT_SECONDS,
             self._apply_source_snapshot_timeout,
         )
-        if not self._library_loaded:
-            # task-15459: only reached when the pre-mount seed above found
-            # no fresh-enough cache to apply (cache miss, or the TTL
-            # expired in the window between construction and mount) --
-            # `_library_loaded` is set True by NOTHING else before this
-            # point (see its only other setter, `_apply_local_source_
-            # snapshot`), so this is a reliable "did the seed already
-            # apply" signal, not a proxy that could go stale.
-            cached_snapshot = getattr(
-                self.app_instance, "_library_source_snapshot_cache", None
-            )
-            cached_stamp = getattr(
-                self.app_instance, "_library_source_snapshot_cache_stamp", None
-            )
-            if (
-                cached_snapshot is not None
-                and cached_stamp is not None
-                and time.monotonic() - cached_stamp < LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS
-            ):
-                # Instant-then-reconcile: paint the previous visit's snapshot
-                # synchronously so a returning visit never shows the loading
-                # placeholder, then still kick the real refresh below -- its
-                # completion re-applies fresh data and refreshes the cache,
-                # so this can't drift more than one refresh cycle stale.
-                self._apply_local_source_snapshot(*cached_snapshot)
-                # `_apply_local_source_snapshot`'s own `self.is_mounted`-guarded
-                # `refresh(recompose=True)` is a no-op here: Textual only flips
-                # `_is_mounted` True in the `finally` clause AFTER the Mount
-                # event finishes dispatching (see
-                # `MessagePump._pre_process`) -- i.e. strictly after this very
-                # `on_mount` call returns -- so without an explicit recompose
-                # here the cached attrs above would be set correctly but the
-                # already-composed (stale, pre-cache) DOM would never actually
-                # repaint. `Widget.refresh(recompose=True)` itself has no such
-                # guard (it just schedules `_check_recompose` via
-                # `call_next`), so calling it directly is safe mid-mount and is
-                # what actually makes the cached snapshot visible at first
-                # paint.
-                self.refresh(recompose=True)
         self._refresh_local_source_snapshot()
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
@@ -6599,7 +6553,8 @@ class LibraryScreen(BaseAppScreen):
             recovery_state,
             study_counts,
         ) = await self._list_local_source_snapshot()
-        # Refresh the app-scoped instant-repeat-visit cache (see `on_mount`)
+        # Refresh the app-scoped instant-repeat-visit cache (seeded in
+        # `__init__` before first compose)
         # with this fresh snapshot before applying it, so any other
         # LibraryScreen instance mounted from here on -- including a
         # concurrent one, since screens are recomposed per visit -- reads
@@ -6614,24 +6569,19 @@ class LibraryScreen(BaseAppScreen):
         # snapshot (or nothing) in place, so the next visit does a normal
         # fresh fetch instead.
         if lookup_error is None:
-            # Cache SHALLOW COPIES of the mutable containers, not the live
-            # objects (Qodo review): ``_apply_local_source_snapshot`` below
-            # aliases ``self._local_source_records = records``, and later
-            # in-place key reassignments (e.g. ``self._local_source_records
-            # ["media"] = ...`` after a media edit) would otherwise mutate
-            # the cached dict too, so a return visit's instant-apply would
-            # render a snapshot whose records no longer match its cached
-            # counts/totals. The record tuples themselves are immutable, so a
-            # one-level dict copy is enough to isolate the cache.
-            self.app_instance._library_source_snapshot_cache = (
-                dict(records),
-                dict(counts) if isinstance(counts, dict) else counts,
-                dict(total_known) if isinstance(total_known, dict) else total_known,
-                lookup_error,
-                recovery_state,
-                dict(study_counts) if isinstance(study_counts, dict) else study_counts,
+            snapshot = clone_library_source_snapshot(
+                (
+                    records,
+                    counts,
+                    total_known,
+                    lookup_error,
+                    recovery_state,
+                    study_counts,
+                )
             )
-            self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
+            if snapshot is not None:
+                self.app_instance._library_source_snapshot_cache = snapshot
+                self.app_instance._library_source_snapshot_cache_stamp = time.monotonic()
         self._apply_local_source_snapshot(
             records, counts, total_known, lookup_error, recovery_state, study_counts
         )
@@ -6790,6 +6740,8 @@ class LibraryScreen(BaseAppScreen):
         lookup_error: str | None = None,
         recovery_state: DestinationRecoveryState | None = None,
         study_counts: dict[str, int | None] | None = None,
+        *,
+        schedule_reconcile: bool = True,
     ) -> None:
         records = self._carry_selected_conversation_into_snapshot(records)
         conversation_records = tuple(records.get("conversations", ()))
@@ -6884,7 +6836,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_study_counts = study_counts
         self._library_loaded = True
         self._invalidate_library_workspace_depth_state()
-        if self.is_mounted and not self._file_notes_active():
+        if schedule_reconcile and self.is_mounted and not self._file_notes_active():
             if (
                 self._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA
                 or self._library_selected_row_id
@@ -6966,6 +6918,24 @@ class LibraryScreen(BaseAppScreen):
                 self.call_after_refresh(
                     self._release_library_notes_focus_after_snapshot
                 )
+
+    def _seed_local_source_snapshot_from_cache(
+        self, *, now: float | None = None
+    ) -> bool:
+        """Apply a recent detached cache snapshot before first composition."""
+        stamp = getattr(self.app_instance, "_library_source_snapshot_cache_stamp", None)
+        if not isinstance(stamp, (int, float)):
+            return False
+        age = (time.monotonic() if now is None else now) - float(stamp)
+        if age < 0 or age >= LIBRARY_SNAPSHOT_CACHE_TTL_SECONDS:
+            return False
+        snapshot = clone_library_source_snapshot(
+            getattr(self.app_instance, "_library_source_snapshot_cache", None)
+        )
+        if snapshot is None:
+            return False
+        self._apply_local_source_snapshot(*snapshot, schedule_reconcile=False)
+        return True
 
     def _apply_source_snapshot_timeout(self) -> None:
         """Avoid leaving Library in an indefinite loading state."""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1571,6 +1571,41 @@ def _sync_library_canvas(
         # the restore runs first (portable focus + scroll), then the site's
         # own follow-up gets the last word on where focus lands.
         follow_up: Callable[[], None] | None = then
+        if kind == "conversations":
+            focused = screen.focused
+            if focused is not None and canvas in focused.ancestors_with_self:
+                focused_id = focused.id
+                conversation_id = getattr(focused, "conversation_id", None)
+
+                def _restore_conversations_then_explicit(
+                    _focused_id: str | None = focused_id,
+                    _conversation_id: str | None = conversation_id,
+                    _explicit: Callable[[], None] | None = then,
+                ) -> None:
+                    target: Widget | None = None
+                    if _conversation_id:
+                        target = next(
+                            (
+                                candidate
+                                for candidate in canvas.query(
+                                    ".library-conversation-row"
+                                )
+                                if getattr(candidate, "conversation_id", None)
+                                == _conversation_id
+                            ),
+                            None,
+                        )
+                    if target is None and _focused_id and not _conversation_id:
+                        try:
+                            target = canvas.query_one(f"#{_focused_id}", Widget)
+                        except (NoMatches, QueryError):
+                            target = None
+                    if target is not None and not target.disabled:
+                        target.focus()
+                    if _explicit is not None:
+                        _explicit()
+
+                follow_up = _restore_conversations_then_explicit
         # Gated on the KIND, not on the screen-level workflow predicate
         # (review m5): the identity is the notes canvas's, and
         # ``_library_notes_workflow_active()`` is also true while a
@@ -6819,6 +6854,18 @@ class LibraryScreen(BaseAppScreen):
         self._library_entry_reconcile_retry_generation = None
         return LibraryEntryReconcileResult.FAILED
 
+    def _fail_library_entry_reconcile(
+        self, generation: int, route_key: tuple[object, ...]
+    ) -> LibraryEntryReconcileResult:
+        """Leave a failed generation dirty and release its owned markers."""
+        pending = (generation, route_key)
+        self._library_entry_reconcile_dirty = True
+        if self._library_entry_reconcile_pending == pending:
+            self._library_entry_reconcile_pending = None
+            if self._library_entry_reconcile_retry_generation == generation:
+                self._library_entry_reconcile_retry_generation = None
+        return LibraryEntryReconcileResult.FAILED
+
     async def _reconcile_library_entry_state(
         self, generation: int, route_key: tuple[object, ...]
     ) -> LibraryEntryReconcileResult:
@@ -6851,15 +6898,21 @@ class LibraryScreen(BaseAppScreen):
                 generation, route_key
             )
 
-        rail.sync_state(
-            shell,
-            self._library_rail_preferences(),
-            query=self._library_rag_query,
-        )
-        header_renderable = header.renderable
-        header_text = getattr(header_renderable, "plain", str(header_renderable))
-        if header_text != shell.header_line:
-            header.update(shell.header_line)
+        try:
+            rail.sync_state(
+                shell,
+                self._library_rail_preferences(),
+                query=self._library_rag_query,
+            )
+            header_renderable = header.renderable
+            header_text = getattr(header_renderable, "plain", str(header_renderable))
+            if header_text != shell.header_line:
+                header.update(shell.header_line)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Library snapshot shell reconciliation failed."
+            )
+            return self._fail_library_entry_reconcile(generation, route_key)
 
         sync_kind: str | None = None
         expected_selector = ""
@@ -6980,6 +7033,11 @@ class LibraryScreen(BaseAppScreen):
             else:
                 self._complete_library_entry_reconcile(generation, route_key)
             return LibraryEntryReconcileResult.APPLIED
+
+        if expected_selector:
+            return self._retry_or_fail_library_entry_reconcile(
+                generation, route_key
+            )
 
         if self._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH:
             try:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -279,6 +279,7 @@ from ...Library.library_rail_state import (
     serialize_library_rail_preferences,
 )
 from ...Library.library_shell_state import (
+    LIBRARY_CANVAS_LANDING_COPY,
     LIBRARY_CANVAS_KIND_NOTES_CREATE,
     LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_DELETE_SELECTED_TOOLTIP,
@@ -370,6 +371,9 @@ from ...Widgets.Library import (
     LibraryIngestCanvas,
     LibraryIngestPreflightSummary,
     LibraryIngestQueuePanel,
+    LibraryLandingCanvas,
+    LibraryLandingCanvasState,
+    LibraryLandingRecentItem,
     LibraryMediaCanvas,
     LibraryMediaTrashCanvas,
     LibraryMediaViewer,
@@ -382,6 +386,8 @@ from ...Widgets.Library import (
     PROMPT_DISCARD_TOOLTIP_BUSY,
     PROMPT_DISCARD_TOOLTIP_CLEAN,
     PROMPT_DISCARD_TOOLTIP_DIRTY,
+    LibraryStudyHandoffCanvas,
+    LibraryStudyHandoffCanvasState,
     SKILL_DISCARD_TOOLTIP_CLEAN,
     SKILL_DISCARD_TOOLTIP_DIRTY,
     library_dim_label_text,
@@ -699,6 +705,15 @@ class LibraryEntryReconcileResult(Enum):
     ALREADY_CURRENT = "already-current"
     SUPERSEDED = "superseded"
     FAILED = "failed"
+
+
+@dataclasses.dataclass(frozen=True)
+class LibraryEntryFocusIdentity:
+    """Portable semantic focus and scroll identity for an entry canvas."""
+
+    widget_id: str = ""
+    source_id: str = ""
+    scroll_offset: tuple[int, int] | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1542,6 +1557,20 @@ def _sync_library_canvas(
         elif kind == "export":
             canvas = screen.query_one("#library-export-canvas", LibraryExportCanvas)
             sync_args = (screen._build_library_export_state(),)
+        elif kind == "landing":
+            canvas = screen.query_one(
+                "#library-landing-canvas", LibraryLandingCanvas
+            )
+            sync_args = (screen._library_landing_canvas_state(),)
+        elif kind == "handoff":
+            canvas = screen.query_one(
+                "#library-study-handoff-canvas", LibraryStudyHandoffCanvas
+            )
+            shell = build_library_shell_state(
+                screen._build_library_shell_input(),
+                selected_row_id=screen._library_selected_row_id,
+            )
+            sync_args = (screen._library_study_handoff_canvas_state(shell.canvas_target),)
         else:
             raise ValueError(
                 f"Unsupported Library canvas kind for targeted sync: {kind!r}"
@@ -1571,41 +1600,6 @@ def _sync_library_canvas(
         # the restore runs first (portable focus + scroll), then the site's
         # own follow-up gets the last word on where focus lands.
         follow_up: Callable[[], None] | None = then
-        if kind == "conversations":
-            focused = screen.focused
-            if focused is not None and canvas in focused.ancestors_with_self:
-                focused_id = focused.id
-                conversation_id = getattr(focused, "conversation_id", None)
-
-                def _restore_conversations_then_explicit(
-                    _focused_id: str | None = focused_id,
-                    _conversation_id: str | None = conversation_id,
-                    _explicit: Callable[[], None] | None = then,
-                ) -> None:
-                    target: Widget | None = None
-                    if _conversation_id:
-                        target = next(
-                            (
-                                candidate
-                                for candidate in canvas.query(
-                                    ".library-conversation-row"
-                                )
-                                if getattr(candidate, "conversation_id", None)
-                                == _conversation_id
-                            ),
-                            None,
-                        )
-                    if target is None and _focused_id and not _conversation_id:
-                        try:
-                            target = canvas.query_one(f"#{_focused_id}", Widget)
-                        except (NoMatches, QueryError):
-                            target = None
-                    if target is not None and not target.disabled:
-                        target.focus()
-                    if _explicit is not None:
-                        _explicit()
-
-                follow_up = _restore_conversations_then_explicit
         # Gated on the KIND, not on the screen-level workflow predicate
         # (review m5): the identity is the notes canvas's, and
         # ``_library_notes_workflow_active()`` is also true while a
@@ -3599,6 +3593,9 @@ class LibraryScreen(BaseAppScreen):
             tuple[int, tuple[object, ...]] | None
         ) = None
         self._library_entry_reconcile_retry_generation: int | None = None
+        self._library_entry_focus_capture: (
+            tuple[LibraryEntryFocusIdentity, Widget | None] | None
+        ) = None
         self._seed_local_source_snapshot_from_cache()
 
     def _library_footer_shortcuts_for_current_state(
@@ -6800,6 +6797,126 @@ class LibraryScreen(BaseAppScreen):
             self._selected_skill_name,
         )
 
+    def _library_entry_canvas_owner(self) -> Widget | None:
+        """Return the active direct child of the retained canvas host."""
+        try:
+            host = self.query_one("#library-canvas", Vertical)
+        except (NoMatches, QueryError):
+            return None
+        return next((child for child in host.children if child.display), None)
+
+    def _capture_library_entry_focus(self) -> LibraryEntryFocusIdentity | None:
+        """Capture a focused canvas descendant by stable control or row identity."""
+        focused = self.focused
+        owner = self._library_entry_canvas_owner()
+        if focused is None or owner is None or owner not in focused.ancestors_with_self:
+            self._library_entry_focus_capture = None
+            return None
+
+        source_id = ""
+        for attribute in (
+            "conversation_id",
+            "media_id",
+            "note_id",
+            "prompt_id",
+            "skill_name",
+            "record_id",
+            "source_id",
+        ):
+            value = getattr(focused, attribute, None)
+            if value is not None and str(value):
+                source_id = str(value)
+                break
+        scroll_offset: tuple[int, int] | None = None
+        if hasattr(owner, "scroll_x") and hasattr(owner, "scroll_y"):
+            scroll_offset = (int(owner.scroll_x), int(owner.scroll_y))
+        identity = LibraryEntryFocusIdentity(
+            widget_id=str(focused.id or ""),
+            source_id=source_id,
+            scroll_offset=scroll_offset,
+        )
+        self._library_entry_focus_capture = (identity, focused)
+        # Detach DOM focus before the owner removes its focused child. Textual
+        # otherwise falls back to unrelated screen chrome during teardown,
+        # which is indistinguishable from a user focus move at restore time.
+        # Any real focus move after this point lands on a non-None widget and
+        # is therefore protected by `_restore_library_entry_focus`'s guard.
+        self.set_focus(None)
+        return identity
+
+    def _restore_library_entry_focus(
+        self,
+        identity: LibraryEntryFocusIdentity,
+        *,
+        generation: int,
+        route_key: tuple[object, ...],
+    ) -> None:
+        """Restore one current semantic target without overriding user movement."""
+        if generation != self._library_snapshot_state_generation:
+            return
+        if route_key != self._library_entry_route_key():
+            return
+        capture = self._library_entry_focus_capture
+        outgoing_focus = (
+            capture[1] if capture is not None and capture[0] is identity else None
+        )
+        if self.focused is not outgoing_focus and self.focused is not None:
+            return
+
+        owner = self._library_entry_canvas_owner()
+        if owner is None:
+            return
+        target: Widget | None = None
+        if identity.source_id:
+            for candidate in owner.query(Widget):
+                if any(
+                    str(getattr(candidate, attribute, "") or "")
+                    == identity.source_id
+                    for attribute in (
+                        "conversation_id",
+                        "media_id",
+                        "note_id",
+                        "prompt_id",
+                        "skill_name",
+                        "record_id",
+                        "source_id",
+                    )
+                ):
+                    target = candidate
+                    break
+        elif identity.widget_id:
+            try:
+                target = owner.query_one(f"#{identity.widget_id}", Widget)
+            except (NoMatches, QueryError):
+                target = None
+        if target is not None and not getattr(target, "disabled", False):
+            target.focus()
+        if identity.scroll_offset is not None and hasattr(owner, "scroll_to"):
+            owner.scroll_to(
+                x=identity.scroll_offset[0],
+                y=identity.scroll_offset[1],
+                animate=False,
+                force=True,
+            )
+        if self._library_entry_focus_capture is capture:
+            self._library_entry_focus_capture = None
+
+    def _finish_library_entry_canvas_sync(
+        self,
+        identity: LibraryEntryFocusIdentity | None,
+        *,
+        generation: int,
+        route_key: tuple[object, ...],
+    ) -> None:
+        """Restore focus/scroll and complete one generation in one callback."""
+        if identity is not None:
+            self._restore_library_entry_focus(
+                identity,
+                generation=generation,
+                route_key=route_key,
+            )
+        self._complete_library_entry_reconcile(generation, route_key)
+
     def _schedule_library_entry_reconcile(
         self, generation: int, route_key: tuple[object, ...]
     ) -> None:
@@ -6956,6 +7073,12 @@ class LibraryScreen(BaseAppScreen):
         elif shell.canvas_kind == "skills" and self._library_skills_view == "list":
             sync_kind = "skills"
             expected_selector = "#library-skills-canvas"
+        elif shell.canvas_kind == "handoff":
+            sync_kind = "handoff"
+            expected_selector = "#library-study-handoff-canvas"
+        elif shell.canvas_kind == "empty":
+            sync_kind = "landing"
+            expected_selector = "#library-landing-canvas"
 
         if local_list_surface and self._library_lookup_error is not None:
             expected_selector = "#library-canvas-error"
@@ -6970,13 +7093,17 @@ class LibraryScreen(BaseAppScreen):
             if sync_kind is None:
                 self._complete_library_entry_reconcile(generation, route_key)
                 return LibraryEntryReconcileResult.APPLIED
-            completed = partial(
-                self._complete_library_entry_reconcile, generation, route_key
+            identity = self._capture_library_entry_focus()
+            finish = partial(
+                self._finish_library_entry_canvas_sync,
+                identity,
+                generation=generation,
+                route_key=route_key,
             )
             if _sync_library_canvas(
                 self,
                 sync_kind,
-                then=completed,
+                then=finish,
                 allow_screen_fallback=False,
             ):
                 self._library_entry_reconcile_retry_generation = None
@@ -7018,13 +7145,17 @@ class LibraryScreen(BaseAppScreen):
                     generation, route_key
                 )
             if sync_kind is not None:
-                completed = partial(
-                    self._complete_library_entry_reconcile, generation, route_key
+                identity = self._capture_library_entry_focus()
+                finish = partial(
+                    self._finish_library_entry_canvas_sync,
+                    identity,
+                    generation=generation,
+                    route_key=route_key,
                 )
                 if not _sync_library_canvas(
                     self,
                     sync_kind,
-                    then=completed,
+                    then=finish,
                     allow_screen_fallback=False,
                 ):
                     return self._retry_or_fail_library_entry_reconcile(
@@ -8057,8 +8188,45 @@ class LibraryScreen(BaseAppScreen):
             return self._hub_source_count_value(source_type)
 
         return (
-            f"Notes {value('notes')} · Media {value('media')} · "
-            f"Conversations {value('conversations')}"
+            f"Notes ({value('notes')}) · Media ({value('media')}) · "
+            f"Conversations ({value('conversations')})"
+        )
+
+    def _library_landing_canvas_state(self) -> LibraryLandingCanvasState:
+        """Build the landing owner's display-only snapshot."""
+        return LibraryLandingCanvasState(
+            purpose=LIBRARY_CANVAS_LANDING_COPY,
+            counts_line=self._hub_counts_line(),
+            recent_items=tuple(
+                LibraryLandingRecentItem(
+                    source_type=source_type,
+                    record_id=record_id,
+                    title=title,
+                    source_label=source_label,
+                )
+                for source_type, record_id, title, source_label in self._hub_recent_items()
+            ),
+        )
+
+    def _library_study_handoff_canvas_state(
+        self, kind: str
+    ) -> LibraryStudyHandoffCanvasState:
+        """Build one handoff owner's display-only snapshot."""
+        copy = self._study_handoff_copy(kind)
+        return LibraryStudyHandoffCanvasState(
+            header=copy["header"],
+            purpose=copy["purpose"],
+            context=copy["context"],
+            owner=copy["owner"],
+            recovery=copy["recovery"],
+            blocked=not self._has_local_sources(),
+            button_label=copy["button_label"],
+            button_id={
+                "study": "library-open-study",
+                "flashcards": "library-open-flashcards",
+                "quizzes": "library-open-quizzes",
+            }.get(kind, "library-open-study"),
+            action_label=copy["action_label"],
         )
 
     @classmethod
@@ -8443,76 +8611,6 @@ class LibraryScreen(BaseAppScreen):
                 id="library-workspaces-handoff",
                 classes="library-details-row",
             ),
-        )
-
-    def _study_handoff_detail_widget(self, kind: str) -> Vertical:
-        """Build the handoff canvas body: purpose, carried-forward sources,
-        ownership, snapshot readiness, and the Open action -- five elements,
-        down from the seven-line original (UX wave D1: no duplicated mode/
-        purpose lines, no "Primary action:" line, no WIP roadmap callout).
-        """
-        copy = self._study_handoff_copy(kind)
-        # D2: the ds-recovery-callout warning treatment is for the blocked
-        # (no local sources) state only; ready renders as a plain Static.
-        recovery_kwargs: dict[str, str] = (
-            {}
-            if self._has_local_sources()
-            else {"classes": "ds-recovery-callout is-blocked"}
-        )
-        action_button_id = {
-            "study": "library-open-study",
-            "flashcards": "library-open-flashcards",
-            "quizzes": "library-open-quizzes",
-        }.get(kind, "library-open-study")
-        handoff_toolbar = Horizontal(
-            Button(
-                copy["button_label"],
-                id=action_button_id,
-                # D3: the Open action is the canvas's primary control.
-                classes="library-canvas-action console-action-primary",
-                compact=True,
-                tooltip=(
-                    f"Open {copy['action_label']} with the current Library "
-                    "source snapshot, or globally when none is available."
-                ),
-            ),
-            id="library-study-handoff-actions",
-            classes="ds-toolbar",
-        )
-        handoff_toolbar.styles.height = "auto"
-        children: list[Static | Horizontal] = [
-            Static(
-                copy["purpose"],
-                id="library-study-handoff-purpose",
-            ),
-        ]
-        if copy["context"]:
-            # D1: omitted entirely (not "No ... will be carried forward.")
-            # when there is no Library source snapshot at all.
-            children.append(
-                Static(
-                    copy["context"],
-                    id="library-study-handoff-context",
-                )
-            )
-        children.append(
-            Static(
-                copy["owner"],
-                id="library-study-handoff-owner",
-            )
-        )
-        children.append(
-            Static(
-                copy["recovery"],
-                id="library-study-handoff-recovery",
-                **recovery_kwargs,
-            )
-        )
-        children.append(handoff_toolbar)
-        return Vertical(
-            *children,
-            id="library-study-handoff-detail",
-            classes="library-rag-region",
         )
 
     def _workspace_handoff_action_state(
@@ -9118,95 +9216,15 @@ class LibraryScreen(BaseAppScreen):
                     # restates the mode name a second, differently-worded way
                     # (formerly "Flashcards mode" + a duplicated description
                     # + next-action line).
-                    handoff_copy = LIBRARY_STUDY_HANDOFF_MODES.get(
-                        shell.canvas_target, LIBRARY_STUDY_HANDOFF_MODES["study"]
+                    yield LibraryStudyHandoffCanvas(
+                        self._library_study_handoff_canvas_state(shell.canvas_target),
+                        id="library-study-handoff-canvas",
                     )
-                    yield Static(
-                        handoff_copy["header"],
-                        id="library-active-mode-title",
-                        classes="destination-section",
-                    )
-                    yield self._study_handoff_detail_widget(shell.canvas_target)
                 else:
-                    yield Static(
-                        shell.canvas_empty_copy,
-                        id="library-canvas-landing",
-                        classes="destination-purpose",
-                        markup=False,
+                    yield LibraryLandingCanvas(
+                        self._library_landing_canvas_state(),
+                        id="library-landing-canvas",
                     )
-                    # F-010: the landing canvas is the wired hub, not a
-                    # one-line void -- per-source counts from the existing
-                    # helpers, quiet next-action rows that dispatch exactly
-                    # like their rail-row counterparts (same
-                    # `@on(.library-hub-action)` path, same dirty-edit
-                    # guards), and (task-2238) the recents as one clickable
-                    # row per source, jumping straight into the item via
-                    # the same route the Search/RAG "Open" action uses.
-                    yield Static(
-                        self._hub_counts_line(),
-                        id="library-hub-counts",
-                        classes="library-hub-meta",
-                        markup=False,
-                    )
-                    with Horizontal(id="library-hub-actions", classes="ds-toolbar"):
-                        for label, tooltip, row_id, target_id, button_id in (
-                            # task-2235 (R2): the canonical ingest CTA label
-                            # and tooltip match the rail-top primary button.
-                            # task-2857: relabeled "Import…" for consistency
-                            # with the canvas header/Start button/toast.
-                            (
-                                "Import…",
-                                "Add files, links, and transcripts to your Library.",
-                                LIBRARY_ROW_INGEST_MEDIA,
-                                "ingest-media",
-                                "library-hub-action-import",
-                            ),
-                            (
-                                "Search",
-                                "Search everything in the Library.",
-                                LIBRARY_ROW_BROWSE_SEARCH,
-                                "search",
-                                "library-hub-action-search",
-                            ),
-                            (
-                                "New note",
-                                "Create a new note.",
-                                LIBRARY_ROW_CREATE_NOTE,
-                                LIBRARY_CANVAS_KIND_NOTES_CREATE,
-                                "library-hub-action-new-note",
-                            ),
-                        ):
-                            action = Button(
-                                label,
-                                id=button_id,
-                                classes="library-hub-action console-action-subdued",
-                                compact=True,
-                                tooltip=tooltip,
-                            )
-                            # Same attributes the rail rows carry -- the
-                            # shared press handler reads them to dispatch.
-                            action.row_id = row_id
-                            action.target_kind = "canvas"
-                            action.target_id = target_id
-                            yield action
-                    # task-2238 (R2): the triad stays on top; the recents
-                    # follow as clickable rows, not one dim text line.
-                    for (
-                        source_type,
-                        record_id,
-                        title,
-                        source_label,
-                    ) in self._hub_recent_items():
-                        recent = Button(
-                            f"{source_label} · {escape_markup(title)}",
-                            id=f"library-hub-recent-{source_type}",
-                            classes="library-hub-recent console-action-subdued",
-                            compact=True,
-                            tooltip=f"Open {source_label.lower()}: {title}",
-                        )
-                        recent.source_type = source_type
-                        recent.record_id = record_id
-                        yield recent
 
     def _build_library_shell_input(self) -> LibraryShellInput:
         """Build the pure shell input from live counts and runtime state.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -5567,7 +5567,10 @@ class LibraryScreen(BaseAppScreen):
             # before mount cannot run_worker yet, so the detail fetch is
             # deferred to here once the canvas has actually been composed.
             self.run_worker(
-                self._refresh_library_note_detail(self._selected_note_id),
+                self._refresh_library_note_detail(
+                    self._selected_note_id,
+                    entry_origin=True,
+                ),
                 exclusive=True,
                 group="library_note_detail",
             )
@@ -5588,7 +5591,10 @@ class LibraryScreen(BaseAppScreen):
             # notifies and falls back to the list view when the id no
             # longer resolves.
             self.run_worker(
-                self._refresh_library_media_detail(self._selected_media_id),
+                self._refresh_library_media_detail(
+                    self._selected_media_id,
+                    entry_origin=True,
+                ),
                 exclusive=True,
                 group="library_media_detail",
             )
@@ -6430,7 +6436,7 @@ class LibraryScreen(BaseAppScreen):
         if target_row_id != LIBRARY_ROW_BROWSE_PROMPTS:
             self._clear_library_prompt_selection(announce=True)
         self._apply_navigation_context_state(context, recompose=False)
-        if self.is_mounted:
+        if self.is_mounted and self._pending_library_source_open is None:
             await self.recompose()
 
     def _apply_navigation_context_state(
@@ -6466,7 +6472,8 @@ class LibraryScreen(BaseAppScreen):
             if (
                 validated_source_type == raw_open_source_type
                 and validated_source_id == raw_open_source_id
-                and validated_source_type in ("media", "notes", "conversations")
+                and validated_source_type
+                in ("media", "notes", "conversations", "prompt")
                 and validated_source_id
             ):
                 open_source_type = validated_source_type
@@ -6571,6 +6578,28 @@ class LibraryScreen(BaseAppScreen):
             self._library_note_pending_blank_gc_id = None
             self._library_note_session_blank_id = None
             self._library_note_title_user_edited = False
+        if open_source_type:
+            self._library_selected_row_id = {
+                "media": LIBRARY_ROW_BROWSE_MEDIA,
+                "notes": LIBRARY_ROW_BROWSE_NOTES,
+                "conversations": LIBRARY_ROW_BROWSE_CONVERSATIONS,
+                "prompt": LIBRARY_ROW_BROWSE_PROMPTS,
+            }[open_source_type]
+            if open_source_type == "media":
+                self._selected_media_id = open_source_id
+                self._library_media_view = "list"
+            elif open_source_type == "notes":
+                self._selected_note_id = open_source_id
+                self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
+                self._library_notes_view = "list"
+            elif open_source_type == "conversations":
+                self._selected_conversation_id = open_source_id
+            elif open_source_type == "prompt":
+                try:
+                    self._selected_prompt_id = int(open_source_id)
+                except ValueError:
+                    self._selected_prompt_id = None
+                self._library_prompts_view = "list"
         if should_open_pending_source and self.is_mounted:
             self.run_worker(
                 self._open_pending_library_source(),
@@ -6594,10 +6623,12 @@ class LibraryScreen(BaseAppScreen):
                 # Deep-link into Collections must load the snapshot the retired
                 # chip flow ran; the panel shows the records once loaded.
                 self.run_worker(self._sync_collections_panel(refresh_snapshot=True))
-            elif recompose:
+            elif recompose and not open_source_type:
                 self.refresh(recompose=True)
 
-    async def _open_pending_library_source(self) -> None:
+    async def _open_pending_library_source(
+        self,
+    ) -> LibraryEntryReconcileResult | None:
         """Consume one validated navigation target through Library's opener."""
 
         if self._library_prompts_mutation_in_flight:
@@ -6607,7 +6638,7 @@ class LibraryScreen(BaseAppScreen):
         self._pending_library_source_open = None
         if pending is None:
             return
-        await self._open_library_item_by_id(*pending)
+        return await self._open_library_item_by_id(*pending, entry_origin=True)
 
     # Own group, deliberately separate from the "default" group the plain
     # `self.run_worker(self._sync_collections_panel(...))` calls above use
@@ -7039,6 +7070,304 @@ class LibraryScreen(BaseAppScreen):
             if self._library_entry_reconcile_retry_generation == generation:
                 self._library_entry_reconcile_retry_generation = None
         return LibraryEntryReconcileResult.FAILED
+
+    def _build_library_entry_active_child(self) -> Widget | None:
+        """Build the active entry-owned child from the latest screen state."""
+        shell = build_library_shell_state(
+            self._build_library_shell_input(),
+            selected_row_id=self._library_selected_row_id,
+        )
+        if shell.canvas_kind == "conversations":
+            state = self._build_library_conversations_state()
+            self._selected_conversation_id = state.selected_id
+            return LibraryConversationsCanvas(
+                state, id="library-conversations-canvas"
+            )
+        if shell.canvas_kind == "media":
+            if self._library_media_view == "trash":
+                trash_state = self._build_library_media_trash_state()
+                self._selected_media_trash_id = trash_state.selected_id
+                return LibraryMediaTrashCanvas(
+                    trash_state,
+                    id="library-media-trash-canvas",
+                )
+            return self._build_library_media_active_child()
+        if shell.canvas_kind in (
+            LIBRARY_CANVAS_KIND_NOTES,
+            LIBRARY_CANVAS_KIND_NOTES_CREATE,
+        ):
+            if self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES:
+                return self._library_file_notes_workspace or Static(
+                    "Opening File Notesâ€¦",
+                    id="library-file-notes-loading",
+                    classes="destination-purpose",
+                    markup=False,
+                )
+            return LibraryNotesCanvas(
+                **self._library_notes_canvas_kwargs(),
+                id="library-notes-canvas",
+            )
+        if shell.canvas_kind == "prompts":
+            return LibraryPromptsListCanvas(
+                **self._library_prompts_canvas_kwargs(),
+                id="library-prompts-canvas",
+            )
+        if shell.canvas_kind == "skills":
+            return LibrarySkillsListCanvas(
+                **self._library_skills_canvas_kwargs(),
+                id="library-skills-canvas",
+            )
+        if shell.canvas_kind == "collections":
+            return LibraryCollectionsPanel(
+                self._library_collections_panel_state(),
+                name_value=self._library_collection_name_input,
+                description_value=self._library_collection_description_input,
+                delete_pending=bool(self._library_collection_pending_delete_id),
+                id="library-collections-panel",
+            )
+        if shell.canvas_kind == "export":
+            return LibraryExportCanvas(
+                self._build_library_export_state(),
+                id="library-export-canvas",
+            )
+        if shell.canvas_kind == "search":
+            return LibrarySearchRagPanel(
+                self._library_rag_panel_state(),
+                id="library-search-rag-panel",
+            )
+        if shell.canvas_kind == "ingest-media":
+            return LibraryIngestCanvas(
+                self._build_library_ingest_state(),
+                external_busy=self._library_external_submit_busy,
+                external_status=self._library_external_submit_status,
+                id="library-ingest-canvas",
+            )
+        if shell.canvas_kind == "handoff":
+            return LibraryStudyHandoffCanvas(
+                self._library_study_handoff_canvas_state(shell.canvas_target),
+                id="library-study-handoff-canvas",
+            )
+        if shell.canvas_kind == "empty":
+            return LibraryLandingCanvas(
+                self._library_landing_canvas_state(),
+                id="library-landing-canvas",
+            )
+        return None
+
+    def _sync_library_entry_owner_from_current_state(self, owner: Widget) -> bool:
+        """Re-read state into a matching retained owner after an await."""
+        if isinstance(owner, LibraryMediaViewer):
+            return self._sync_library_media_viewer_state(owner)
+        kind = None
+        if isinstance(owner, LibraryConversationsCanvas):
+            kind = "conversations"
+        elif isinstance(owner, LibraryMediaCanvas):
+            kind = "media"
+        elif isinstance(owner, LibraryMediaTrashCanvas):
+            kind = "media-trash"
+        elif isinstance(owner, LibraryNotesCanvas):
+            kind = "notes"
+        elif isinstance(owner, LibraryPromptsListCanvas):
+            kind = "prompts"
+        elif isinstance(owner, LibrarySkillsListCanvas):
+            kind = "skills"
+        elif isinstance(owner, LibraryExportCanvas):
+            kind = "export"
+        elif isinstance(owner, LibraryLandingCanvas):
+            kind = "landing"
+        elif isinstance(owner, LibraryStudyHandoffCanvas):
+            kind = "handoff"
+        elif isinstance(owner, LibraryCollectionsPanel):
+            owner.sync_state(
+                self._library_collections_panel_state(),
+                name_value=self._library_collection_name_input,
+                description_value=self._library_collection_description_input,
+                delete_pending=bool(self._library_collection_pending_delete_id),
+            )
+            return True
+        if kind is None:
+            return False
+        return _sync_library_canvas(
+            self,
+            kind,
+            allow_screen_fallback=False,
+        )
+
+    async def _repair_library_entry_canvas_owner(self) -> bool:
+        """Converge an interrupted child swap on the latest route, in place."""
+        mount_failures = 0
+        while self.is_mounted:
+            generation = self._library_snapshot_state_generation
+            route_key = self._library_entry_route_key()
+            replacement = self._build_library_entry_active_child()
+            if replacement is None:
+                return False
+            try:
+                canvas_host = self.query_one("#library-canvas", Vertical)
+            except (NoMatches, QueryError):
+                return False
+            owner = self._library_entry_canvas_owner()
+            if (
+                owner is not None
+                and type(owner) is type(replacement)
+                and owner.id == replacement.id
+            ):
+                if self._library_entry_reconcile_is_current(generation, route_key):
+                    return self._sync_library_entry_owner_from_current_state(owner)
+                continue
+            try:
+                outgoing = tuple(canvas_host.children)
+                for child in outgoing:
+                    child.display = False
+                if outgoing:
+                    await canvas_host.remove_children(outgoing)
+                if not self._library_entry_reconcile_is_current(
+                    generation, route_key
+                ):
+                    continue
+                await canvas_host.mount(replacement)
+                if not self._library_entry_reconcile_is_current(
+                    generation, route_key
+                ):
+                    continue
+                return self._sync_library_entry_owner_from_current_state(replacement)
+            except Exception:
+                mount_failures += 1
+                logger.opt(exception=True).debug(
+                    "Library entry canvas repair attempt failed."
+                )
+                if mount_failures >= 2:
+                    return False
+        return False
+
+    def _schedule_library_entry_canvas_repair(self) -> None:
+        """Project already-settled state under fresh generation authority."""
+        if self.is_mounted:
+            self.call_later(self._repair_library_entry_canvas_owner)
+
+    async def _replace_library_canvas_child(
+        self,
+        widget: Widget,
+        *,
+        generation: int,
+        route_key: tuple[object, ...],
+    ) -> LibraryEntryReconcileResult:
+        """Replace only the active Library canvas child for one entry owner.
+
+        The generation/route pair is checked before every DOM mutation and
+        after each await.  Once mounted, stateful owners are synchronized from
+        the screen again so state changed while removal/mounting yielded to the
+        message pump cannot be stranded in the pre-await constructor snapshot.
+        """
+        if not self._library_entry_reconcile_is_current(generation, route_key):
+            return LibraryEntryReconcileResult.SUPERSEDED
+
+        shell = build_library_shell_state(
+            self._build_library_shell_input(),
+            selected_row_id=self._library_selected_row_id,
+        )
+        try:
+            rail = self.query_one("#library-rail", LibraryRail)
+            header = self.query_one("#library-header-line", Static)
+            canvas_host = self.query_one("#library-canvas", Vertical)
+        except (NoMatches, QueryError):
+            return LibraryEntryReconcileResult.FAILED
+
+        try:
+            rail.sync_state(
+                shell,
+                self._library_rail_preferences(),
+                query=self._library_rag_query,
+            )
+            header_renderable = header.renderable
+            header_text = getattr(header_renderable, "plain", str(header_renderable))
+            if header_text != shell.header_line:
+                header.update(shell.header_line)
+            if self.is_running:
+                self.app.capture_mouse(None)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Strict Library entry shell synchronization failed."
+            )
+            return LibraryEntryReconcileResult.FAILED
+
+        if not self._library_entry_reconcile_is_current(generation, route_key):
+            return LibraryEntryReconcileResult.SUPERSEDED
+
+        focus_identity = self._capture_library_entry_focus()
+        outgoing = tuple(canvas_host.children)
+        try:
+            for child in outgoing:
+                child.display = False
+            if outgoing:
+                await canvas_host.remove_children(outgoing)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Strict Library entry canvas removal failed."
+            )
+            await self._repair_library_entry_canvas_owner()
+            return LibraryEntryReconcileResult.FAILED
+
+        if not self._library_entry_reconcile_is_current(generation, route_key):
+            await self._repair_library_entry_canvas_owner()
+            return LibraryEntryReconcileResult.SUPERSEDED
+        try:
+            await canvas_host.mount(widget)
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Strict Library entry canvas mount failed."
+            )
+            await self._repair_library_entry_canvas_owner()
+            return LibraryEntryReconcileResult.FAILED
+        if not self._library_entry_reconcile_is_current(generation, route_key):
+            await self._repair_library_entry_canvas_owner()
+            return LibraryEntryReconcileResult.SUPERSEDED
+
+        sync_kind: str | None = None
+        if isinstance(widget, LibraryConversationsCanvas):
+            sync_kind = "conversations"
+        elif isinstance(widget, LibraryMediaCanvas):
+            sync_kind = "media"
+        elif isinstance(widget, LibraryNotesCanvas):
+            sync_kind = "notes"
+        elif isinstance(widget, LibraryPromptsListCanvas):
+            sync_kind = "prompts"
+        elif isinstance(widget, LibrarySkillsListCanvas):
+            sync_kind = "skills"
+        elif isinstance(widget, LibraryExportCanvas):
+            sync_kind = "export"
+        elif isinstance(widget, LibraryMediaViewer):
+            if not self._sync_library_media_viewer_state(widget):
+                return LibraryEntryReconcileResult.FAILED
+        elif isinstance(widget, LibraryCollectionsPanel):
+            widget.sync_state(
+                self._library_collections_panel_state(),
+                name_value=self._library_collection_name_input,
+                description_value=self._library_collection_description_input,
+                delete_pending=bool(self._library_collection_pending_delete_id),
+            )
+
+        if sync_kind is not None:
+            follow_up = (
+                partial(
+                    self._restore_library_entry_focus,
+                    focus_identity,
+                    generation=generation,
+                    route_key=route_key,
+                )
+                if focus_identity is not None
+                else None
+            )
+            if not _sync_library_canvas(
+                self,
+                sync_kind,
+                then=follow_up,
+                allow_screen_fallback=False,
+            ):
+                return LibraryEntryReconcileResult.FAILED
+        self._apply_library_notes_stage_visibility()
+        self._apply_library_notes_footer_context()
+        return LibraryEntryReconcileResult.APPLIED
 
     async def _reconcile_library_entry_state(
         self, generation: int, route_key: tuple[object, ...]
@@ -9010,39 +9339,7 @@ class LibraryScreen(BaseAppScreen):
                     shell.canvas_kind == "media"
                     and self._library_media_view == "viewer"
                 ):
-                    if self._library_media_detail is None:
-                        yield Static(
-                            "Loading media…",
-                            id="library-media-viewer-loading",
-                            classes="destination-purpose",
-                            markup=False,
-                        )
-                    else:
-                        # task-15458: record what this compose renders BEFORE
-                        # yielding it. Textual's ``recompose()`` awaits its
-                        # child teardown before it runs this generator, so a
-                        # detail worker can land mid-teardown and be picked up
-                        # right here; the arrival guard reads this to know its
-                        # own recompose would only re-parse the same document.
-                        self._library_media_composed_detail = (
-                            self._library_media_detail
-                        )
-                        yield LibraryMediaViewer(
-                            build_library_media_viewer_state(
-                                self._library_media_detail,
-                                arrival_note=(self._pop_library_media_arrival_note()),
-                            ),
-                            editing=self._library_media_editing,
-                            confirming_delete=self._library_media_confirming_delete,
-                            highlights=build_library_media_highlight_rows(
-                                self._library_media_highlights
-                            ),
-                            editing_analysis=self._library_media_editing_analysis,
-                            content_query=self._library_media_content_query,
-                            content_match_index=self._library_media_content_match_index,
-                            content_mode=self._library_media_content_mode,
-                            id="library-media-viewer",
-                        )
+                    yield self._build_library_media_active_child()
                 elif (
                     shell.canvas_kind == "media"
                     and self._library_media_view == "trash"
@@ -10625,35 +10922,54 @@ class LibraryScreen(BaseAppScreen):
         self,
         result: PromptBrowseResult,
         focus_identity: str | None,
-    ) -> None:
+    ) -> LibraryEntryReconcileResult:
         """Project controller state and restore stable Prompt-list focus."""
-        if self.is_mounted:
-            live_focus_identity = self._library_prompts_focus_identity()
-            live_focused = getattr(self, "focused", None)
-            cursor_context = self._library_prompts_filter_cursor_context
-            filter_cursor = (
-                live_focused.cursor_position
-                if live_focus_identity == "library-prompts-filter"
-                and isinstance(live_focused, Input)
-                else cursor_context[1]
-                if live_focus_identity is None
-                and cursor_context is not None
-                and cursor_context[0] == result.request_token
-                else None
-            )
-            restore_focus_identity = live_focus_identity or focus_identity
-            self.refresh(recompose=True)
-            if result.status == "loading" or restore_focus_identity is not None:
-                self.call_after_refresh(
-                    self._restore_library_prompts_focus,
-                    restore_focus_identity,
+        current = self._library_prompt_browse_controller.result
+        route_key = self._library_entry_route_key()
+        generation = self._library_snapshot_state_generation
+        if (
+            result.request_token != current.request_token
+            or not self._library_entry_reconcile_is_current(generation, route_key)
+            or self._library_selected_row_id
+            not in (LIBRARY_ROW_BROWSE_PROMPTS, LIBRARY_ROW_CREATE_PROMPT)
+            or self._library_prompts_view != "list"
+        ):
+            return LibraryEntryReconcileResult.SUPERSEDED
+
+        live_focus_identity = self._library_prompts_focus_identity()
+        live_focused = getattr(self, "focused", None)
+        cursor_context = self._library_prompts_filter_cursor_context
+        filter_cursor = (
+            live_focused.cursor_position
+            if live_focus_identity == "library-prompts-filter"
+            and isinstance(live_focused, Input)
+            else cursor_context[1]
+            if live_focus_identity is None
+            and cursor_context is not None
+            and cursor_context[0] == result.request_token
+            else None
+        )
+        restore_identity = live_focus_identity or focus_identity
+
+        def restore_focus() -> None:
+            if not self._library_entry_reconcile_is_current(generation, route_key):
+                return
+            if result.status == "loading" or restore_identity is not None:
+                self._restore_library_prompts_focus(
+                    restore_identity,
                     filter_cursor,
                 )
             elif not self._library_pending_list_entry_focus:
-                self.call_after_refresh(
-                    self._restore_library_prompts_focus,
-                    None,
-                )
+                self._restore_library_prompts_focus(None)
+
+        if _sync_library_canvas(
+            self,
+            "prompts",
+            then=restore_focus,
+            allow_screen_fallback=False,
+        ):
+            return LibraryEntryReconcileResult.APPLIED
+        return LibraryEntryReconcileResult.FAILED
 
     def _queue_library_prompts_search(self, query: str) -> None:
         """Debounce one normalized search without blocking the UI loop."""
@@ -10773,7 +11089,9 @@ class LibraryScreen(BaseAppScreen):
             exit_on_error=False,
         )
 
-    async def _load_library_skills_trust_posture(self, posture_fn) -> None:
+    async def _load_library_skills_trust_posture(
+        self, posture_fn
+    ) -> LibraryEntryReconcileResult:
         """Await the off-thread ``trust_posture()`` call and apply the result.
 
         Args:
@@ -10783,18 +11101,46 @@ class LibraryScreen(BaseAppScreen):
                 irrelevant here, but keeps this a pure "run this callable
                 off-thread" step).
         """
+        route_key = self._library_entry_route_key()
+        generation = self._library_snapshot_state_generation
         try:
             posture = await asyncio.to_thread(posture_fn)
         except Exception:
             posture = ""
         self._library_skills_trust_posture = posture if isinstance(posture, str) else ""
         if (
-            self.is_mounted
-            and self._library_selected_row_id == LIBRARY_ROW_BROWSE_SKILLS
+            route_key != self._library_entry_route_key()
+            or not self._library_entry_reconcile_is_current(generation, route_key)
+            or self._library_selected_row_id != LIBRARY_ROW_BROWSE_SKILLS
+            or self._library_skills_view != "list"
         ):
-            self.refresh(recompose=True)
+            return LibraryEntryReconcileResult.SUPERSEDED
+        identity = self._capture_library_entry_focus()
+        follow_up = (
+            partial(
+                self._restore_library_entry_focus,
+                identity,
+                generation=generation,
+                route_key=route_key,
+            )
+            if identity is not None
+            else None
+        )
+        if _sync_library_canvas(
+            self,
+            "skills",
+            then=follow_up,
+            allow_screen_fallback=False,
+        ):
+            return LibraryEntryReconcileResult.APPLIED
+        return LibraryEntryReconcileResult.FAILED
 
-    async def _refresh_library_media_detail(self, media_id: str) -> None:
+    async def _refresh_library_media_detail(
+        self,
+        media_id: str,
+        *,
+        entry_origin: bool = False,
+    ) -> LibraryEntryReconcileResult | None:
         """Fetch and store the full detail for a selected Library media item.
 
         Mirrors ``_refresh_library_collections_snapshot``: guards against an
@@ -10814,6 +11160,10 @@ class LibraryScreen(BaseAppScreen):
         Args:
             media_id: The Library media item id to fetch full detail for.
         """
+        entry_route_key = self._library_entry_route_key() if entry_origin else None
+        entry_generation = (
+            self._library_snapshot_state_generation if entry_origin else None
+        )
         service = getattr(self.app_instance, "media_reading_scope_service", None)
         get_media_item = getattr(service, "get_media_item", None)
         if not callable(get_media_item):
@@ -10821,8 +11171,18 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_composed_detail = None
             self._library_media_highlights = []
             if self.is_mounted:
+                if entry_origin:
+                    if not self._library_entry_reconcile_is_current(
+                        entry_generation, entry_route_key
+                    ):
+                        return LibraryEntryReconcileResult.SUPERSEDED
+                    return await self._replace_library_canvas_child(
+                        self._build_library_media_active_child(),
+                        generation=entry_generation,
+                        route_key=entry_route_key,
+                    )
                 self.refresh(recompose=True)
-            return
+            return None
         try:
             detail = await self._run_library_service_call(
                 get_media_item,
@@ -10845,11 +11205,25 @@ class LibraryScreen(BaseAppScreen):
         # for the previous selection must not overwrite the current one. The
         # highlights fetch is a second await point, so re-check after it too
         # and store detail + highlights together only when still current.
-        if media_id != self._selected_media_id or self._library_media_view != "viewer":
-            return
+        if (
+            media_id != self._selected_media_id
+            or self._library_media_view != "viewer"
+            or (
+                entry_route_key is not None
+                and entry_route_key != self._library_entry_route_key()
+            )
+        ):
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         highlights = await self._fetch_library_media_highlights(media_id)
-        if media_id != self._selected_media_id or self._library_media_view != "viewer":
-            return
+        if (
+            media_id != self._selected_media_id
+            or self._library_media_view != "viewer"
+            or (
+                entry_route_key is not None
+                and entry_route_key != self._library_entry_route_key()
+            )
+        ):
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         self._library_media_detail = detail if isinstance(detail, Mapping) else None
         self._library_media_highlights = highlights
         # LIB-13: default the content view per item, from the just-fetched
@@ -10880,28 +11254,36 @@ class LibraryScreen(BaseAppScreen):
                 notify("Media item is unavailable.", severity="warning")
             self._library_media_view = "list"
         if self.is_mounted:
-            # task-15458: deliberately NOT an immediate ``refresh(recompose=
-            # True)``. The open-time "Loading media…" recompose may still be
-            # awaiting its own child teardown right now -- Textual removes
-            # children BEFORE it calls ``compose()`` -- in which case that
-            # compose is about to render this very detail, and recomposing
-            # again would parse the whole document a second time (measured:
-            # 2 parses of a 49 KB / 2,000-line item per open, deterministic
-            # on macOS). The screen's message pump runs this callback after
-            # that in-flight compose finishes, which is the earliest point
-            # where the question can be answered instead of guessed.
+            if entry_origin:
+                if entry_generation != self._library_snapshot_state_generation:
+                    current_pending = (
+                        self._library_snapshot_state_generation,
+                        self._library_entry_route_key(),
+                    )
+                    if (
+                        entry_route_key == current_pending[1]
+                        and (
+                            self._library_entry_reconcile_pending == current_pending
+                            or self._library_snapshot_rendered_generation
+                            == current_pending[0]
+                        )
+                    ):
+                        self._schedule_library_entry_canvas_repair()
+                    return LibraryEntryReconcileResult.SUPERSEDED
+                route_key = self._library_entry_route_key()
+                return await self._replace_library_canvas_child(
+                    self._build_library_media_active_child(),
+                    generation=entry_generation,
+                    route_key=route_key,
+                )
+            # task-15458: deliberately defer the legacy non-entry refresh.
+            # The open-time compose may already be rendering this exact detail;
+            # the identity guard below avoids a duplicate large-document parse.
             self.call_next(self._recompose_library_media_detail_if_unrendered)
+        return None
 
     def _recompose_library_media_detail_if_unrendered(self) -> None:
-        """Recompose unless a compose already rendered the current media detail.
-
-        Deferred follow-up for ``_refresh_library_media_detail`` (task-15458).
-        Identity, not equality: the guard must only skip a recompose for the
-        exact Mapping a compose has already put on screen.
-
-        Returns:
-            None.
-        """
+        """Recompose unless a compose already rendered the current media detail."""
         if not self.is_mounted:
             return
         if (
@@ -10959,27 +11341,74 @@ class LibraryScreen(BaseAppScreen):
         if self.is_mounted:
             self.refresh(recompose=True)
 
-    async def _refresh_library_note_detail(self, note_id: str) -> None:
+    async def _project_library_note_entry_result(
+        self,
+        *,
+        entry_origin: bool,
+        then: Callable[[], None] | None = None,
+    ) -> LibraryEntryReconcileResult | None:
+        """Project one note-load result without a Library-screen fallback."""
+        if not self.is_mounted:
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
+        if entry_origin and not self.query("#library-notes-canvas"):
+            generation = self._library_snapshot_state_generation
+            route_key = self._library_entry_route_key()
+            result = await self._replace_library_canvas_child(
+                LibraryNotesCanvas(
+                    **self._library_notes_canvas_kwargs(),
+                    id="library-notes-canvas",
+                ),
+                generation=generation,
+                route_key=route_key,
+            )
+            if result is LibraryEntryReconcileResult.APPLIED and then is not None:
+                then()
+            return result
+        synced = _sync_library_canvas(
+            self,
+            "notes",
+            then=then,
+            allow_screen_fallback=not entry_origin,
+        )
+        if entry_origin:
+            return (
+                LibraryEntryReconcileResult.APPLIED
+                if synced
+                else LibraryEntryReconcileResult.FAILED
+            )
+        return None
+
+    async def _refresh_library_note_detail(
+        self,
+        note_id: str,
+        *,
+        entry_origin: bool = False,
+    ) -> LibraryEntryReconcileResult | None:
         """Open one normalized coordinator session and apply its typed outcome.
 
         Args:
             note_id: The Library note id to fetch full detail for.
         """
+        entry_route_key = self._library_entry_route_key() if entry_origin else None
         if (
             note_id != self._selected_note_id
             or self._library_notes_view != "editor"
             or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
         ):
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         outcome = await self._library_note_session.open_session(note_id)
         if outcome.kind is NoteLoadOutcomeKind.STALE:
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         if (
             note_id != self._selected_note_id
             or self._library_notes_view != "editor"
             or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
+            or (
+                entry_route_key is not None
+                and entry_route_key != self._library_entry_route_key()
+            )
         ):
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         if outcome.kind is NoteLoadOutcomeKind.MISSING:
             logger.info(
                 f"Library note {note_id!r} is no longer available; returning to list."
@@ -10987,17 +11416,17 @@ class LibraryScreen(BaseAppScreen):
             self._reset_library_note_editor_state()
             self._notify_library_note_missing_warning()
             self._refresh_local_source_snapshot()
-            if self.is_mounted:
-                _sync_library_canvas(self, "notes")
-            return
+            return await self._project_library_note_entry_result(
+                entry_origin=entry_origin
+            )
         if outcome.kind is NoteLoadOutcomeKind.FAILED:
             self._library_note_load_state = "failed"
             self._library_note_load_message = (
                 outcome.message or "Unable to load note. Press Retry."
             )
-            if self.is_mounted:
-                _sync_library_canvas(self, "notes")
-            return
+            return await self._project_library_note_entry_result(
+                entry_origin=entry_origin
+            )
 
         self._library_note_load_state = "loaded"
         self._library_note_load_message = ""
@@ -11024,9 +11453,15 @@ class LibraryScreen(BaseAppScreen):
                 self._arm_library_note_editor()
                 self._restore_library_notes_focus_identity(editor_identity)
 
-            _sync_library_canvas(self, "notes", then=arm_and_focus_editor)
+            return await self._project_library_note_entry_result(
+                entry_origin=entry_origin,
+                then=arm_and_focus_editor,
+            )
+        return None
 
-    def _begin_library_note_load(self, note_id: str) -> None:
+    def _begin_library_note_load(
+        self, note_id: str, *, entry_origin: bool = False
+    ) -> None:
         """Reset presentation, invalidate old work, and start one editor load."""
         self._supersede_library_notes_navigation()
         self._library_note_session.close_session()
@@ -11043,7 +11478,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_delete_origin_preview = False
         self._library_note_editor_armed = False
         self.run_worker(
-            self._refresh_library_note_detail(note_id),
+            self._refresh_library_note_detail(note_id, entry_origin=entry_origin),
             exclusive=True,
             group="library_note_detail",
         )
@@ -11326,6 +11761,8 @@ class LibraryScreen(BaseAppScreen):
         ``group="library_export_counts"`` worker-thread path.
         """
         scope = self._library_export_scope
+        generation = self._library_snapshot_state_generation
+        route_key = self._library_entry_route_key()
         media_db = getattr(self.app_instance, "media_db", None)
         chachanotes_db = self._resolve_library_export_chachanotes_db()
         prompts_db = getattr(self.app_instance, "prompts_db", None)
@@ -11337,10 +11774,36 @@ class LibraryScreen(BaseAppScreen):
             counts = self._compute_library_export_counts(
                 scope, media_db, chachanotes_db, prompts_db
             )
-            self._apply_library_export_counts(scope, counts)
+            result = self._apply_library_export_counts(
+                scope,
+                counts,
+                generation=generation,
+                route_key=route_key,
+            )
+            if (
+                result is not LibraryEntryReconcileResult.APPLIED
+                and self._library_selected_row_id == LIBRARY_ROW_INGEST_EXPORT
+                and route_key == self._library_entry_route_key()
+            ):
+                # During Screen.on_mount the screen is attached before its
+                # composed Export child is queryable. Retry the same strict,
+                # route-guarded field patch after that first refresh instead
+                # of requiring a whole-screen recompose to expose the counts.
+                self.call_after_refresh(
+                    self._apply_library_export_counts,
+                    scope,
+                    counts,
+                    generation=generation,
+                    route_key=route_key,
+                )
             return
         self._run_library_export_counts_worker(
-            scope, media_db, chachanotes_db, prompts_db
+            scope,
+            media_db,
+            chachanotes_db,
+            prompts_db,
+            generation,
+            route_key,
         )
 
     @work(thread=True, exclusive=True, group="library_export_counts")
@@ -11350,6 +11813,8 @@ class LibraryScreen(BaseAppScreen):
         media_db: Any,
         chachanotes_db: Any,
         prompts_db: Any,
+        generation: int,
+        route_key: tuple[object, ...],
     ) -> None:
         counts = self._compute_library_export_counts(
             scope, media_db, chachanotes_db, prompts_db
@@ -11361,7 +11826,13 @@ class LibraryScreen(BaseAppScreen):
         # reasoning). Guarded the same way: a shutdown mid-worker must
         # never surface as a crash.
         try:
-            self.app.call_from_thread(self._apply_library_export_counts, scope, counts)
+            self.app.call_from_thread(
+                self._apply_library_export_counts,
+                scope,
+                counts,
+                generation=generation,
+                route_key=route_key,
+            )
         except Exception:
             # A shutdown/detach mid-marshal can raise RuntimeError OR
             # Textual's NoApp (which subclasses Exception, not RuntimeError)
@@ -11369,8 +11840,13 @@ class LibraryScreen(BaseAppScreen):
             pass
 
     def _apply_library_export_counts(
-        self, scope: ExportScope, counts: dict[str, int]
-    ) -> None:
+        self,
+        scope: ExportScope,
+        counts: dict[str, int],
+        *,
+        generation: int | None = None,
+        route_key: tuple[object, ...] | None = None,
+    ) -> LibraryEntryReconcileResult:
         """Marshal a landed counts result onto the export form (UI thread).
 
         Guards against a stale result from a scope the user has since
@@ -11401,20 +11877,43 @@ class LibraryScreen(BaseAppScreen):
                 "prompts").
         """
         if scope != self._library_export_scope:
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED
         self._library_export_counts = counts
+        if (
+            generation is not None
+            and generation != self._library_snapshot_state_generation
+        ):
+            current_pending = (
+                self._library_snapshot_state_generation,
+                self._library_entry_route_key(),
+            )
+            if (
+                route_key == current_pending[1]
+                and (
+                    self._library_entry_reconcile_pending == current_pending
+                    or self._library_snapshot_rendered_generation == current_pending[0]
+                )
+            ):
+                self.call_after_refresh(self._start_library_export_counts_worker)
+            return LibraryEntryReconcileResult.SUPERSEDED
+        if route_key is not None and route_key != self._library_entry_route_key():
+            return LibraryEntryReconcileResult.SUPERSEDED
         if (
             not self.is_mounted
             or self._library_selected_row_id != LIBRARY_ROW_INGEST_EXPORT
         ):
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED
+        generation = self._library_snapshot_state_generation
+        active_route_key = self._library_entry_route_key()
+        if not self._library_entry_reconcile_is_current(generation, active_route_key):
+            return LibraryEntryReconcileResult.SUPERSEDED
         state = self._build_library_export_state()
         try:
             canvas = self.query_one("#library-export-canvas", LibraryExportCanvas)
         except (NoMatches, QueryError):
             # Canvas not mounted (yet) -- the state fields above are set,
             # so whatever composes it next renders the landed counts.
-            return
+            return LibraryEntryReconcileResult.FAILED
         # Keep the canvas's own state snapshot in step with what the
         # targeted updates below render, so any later widget-level
         # recompose can never resurrect the stale "Counting…" state.
@@ -11436,7 +11935,8 @@ class LibraryScreen(BaseAppScreen):
             submit_button = self.query_one("#library-export-submit", Button)
             apply_library_export_submit_gate(submit_button, state)
         except (NoMatches, QueryError):
-            pass
+            return LibraryEntryReconcileResult.FAILED
+        return LibraryEntryReconcileResult.APPLIED
 
     def _build_library_export_state(self) -> LibraryExportFormState:
         """Build the export canvas's full display state from screen fields."""
@@ -14519,11 +15019,14 @@ class LibraryScreen(BaseAppScreen):
         ):
             # First Collections entry must load the snapshot the retired chip
             # flow ran; _sync_collections_panel recomposes once records arrive.
-            await self._sync_collections_panel(
+            collections_result = await self._sync_collections_panel(
                 refresh_snapshot=True,
                 wait_for_recompose=True,
             )
-            return
+            if collections_result is LibraryEntryReconcileResult.APPLIED:
+                return
+            if collections_result is LibraryEntryReconcileResult.SUPERSEDED:
+                return
         shell = build_library_shell_state(
             self._build_library_shell_input(),
             selected_row_id=self._library_selected_row_id,
@@ -19215,7 +19718,8 @@ class LibraryScreen(BaseAppScreen):
         *,
         open_history: bool = False,
         expected_history_scope: tuple[str, int] | None = None,
-    ) -> None:
+        entry_origin: bool = False,
+    ) -> LibraryEntryReconcileResult | None:
         """Fetch and store the full detail for a selected Library prompt.
 
         Mirrors ``_refresh_library_note_detail``: offloads the (possibly
@@ -19236,21 +19740,32 @@ class LibraryScreen(BaseAppScreen):
             expected_history_scope: Optional exact restore/editor session identity.
                 Generic detail fetches omit this guard.
         """
+        entry_route_key = self._library_entry_route_key() if entry_origin else None
         if expected_history_scope is not None and not (
             self._library_prompt_history_controller.matches_scope(
                 prompt_uuid=expected_history_scope[0],
                 scope_token=expected_history_scope[1],
             )
         ):
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         service = getattr(self.app_instance, "prompt_scope_service", None)
         get_prompt = getattr(service, "get_prompt", None)
         if not callable(get_prompt):
             self._library_prompt_detail = None
             self._library_prompt_version = None
             if self.is_mounted:
-                _sync_library_canvas(self, "prompts")
-            return
+                synced = _sync_library_canvas(
+                    self,
+                    "prompts",
+                    allow_screen_fallback=not entry_origin,
+                )
+                if entry_origin:
+                    return (
+                        LibraryEntryReconcileResult.APPLIED
+                        if synced
+                        else LibraryEntryReconcileResult.FAILED
+                    )
+            return None
         try:
             detail = await self._run_library_service_call(
                 get_prompt,
@@ -19273,7 +19788,7 @@ class LibraryScreen(BaseAppScreen):
                     scope_token=expected_history_scope[1],
                 )
             ):
-                return
+                return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
             # The disclosure may have changed while the detail call was awaited.
             # Adopt the live, still-matching scope state rather than the caller's
             # pre-await Boolean.
@@ -19283,8 +19798,12 @@ class LibraryScreen(BaseAppScreen):
         if (
             prompt_id != self._selected_prompt_id
             or self._library_prompts_view != "editor"
+            or (
+                entry_route_key is not None
+                and entry_route_key != self._library_entry_route_key()
+            )
         ):
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED if entry_origin else None
         if not isinstance(detail, Mapping):
             logger.info(
                 f"Library prompt {prompt_id!r} is no longer available; returning to list."
@@ -19295,7 +19814,7 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity=None,
             )
             self._refresh_local_source_snapshot()
-            return
+            return LibraryEntryReconcileResult.APPLIED if entry_origin else None
         self._adopt_library_prompt_persisted_detail(
             detail,
             open_history=open_history,
@@ -19304,7 +19823,19 @@ class LibraryScreen(BaseAppScreen):
         if self.is_mounted:
             # See the skills twin: arming must not be lost to the
             # canvas-pump race (task-15457 review I4b).
-            _sync_library_canvas(self, "prompts", then=self._arm_library_prompt_editor)
+            synced = _sync_library_canvas(
+                self,
+                "prompts",
+                then=self._arm_library_prompt_editor,
+                allow_screen_fallback=not entry_origin,
+            )
+            if entry_origin:
+                return (
+                    LibraryEntryReconcileResult.APPLIED
+                    if synced
+                    else LibraryEntryReconcileResult.FAILED
+                )
+        return None
 
     def _adopt_library_prompt_persisted_detail(
         self,
@@ -28015,6 +28546,64 @@ class LibraryScreen(BaseAppScreen):
                 self._scroll_library_media_content_to_line, matches[0]
             )
 
+    def _build_library_media_active_child(self) -> Widget:
+        """Build the current Media viewer/loading child or its list fallback."""
+        if self._library_media_view != "viewer":
+            media_state = self._build_library_media_state()
+            self._selected_media_id = media_state.selected_id
+            return LibraryMediaCanvas(media_state, id="library-media-canvas")
+        if self._library_media_detail is None:
+            return Static(
+                "Loading media…",
+                id="library-media-viewer-loading",
+                classes="destination-purpose",
+                markup=False,
+            )
+        arrival_note = self._pop_library_media_arrival_note()
+        viewer = LibraryMediaViewer(
+            build_library_media_viewer_state(
+                self._library_media_detail,
+                arrival_note=arrival_note,
+            ),
+            editing=self._library_media_editing,
+            confirming_delete=self._library_media_confirming_delete,
+            highlights=build_library_media_highlight_rows(
+                self._library_media_highlights
+            ),
+            editing_analysis=self._library_media_editing_analysis,
+            content_query=self._library_media_content_query,
+            content_match_index=self._library_media_content_match_index,
+            content_mode=self._library_media_content_mode,
+            id="library-media-viewer",
+        )
+        viewer._library_entry_arrival_note = arrival_note
+        return viewer
+
+    def _sync_library_media_viewer_state(self, viewer: LibraryMediaViewer) -> bool:
+        """Re-read every viewer compose input after its mount await."""
+        if (
+            self._library_media_view != "viewer"
+            or not isinstance(self._library_media_detail, Mapping)
+        ):
+            return False
+        viewer.viewer = build_library_media_viewer_state(
+            self._library_media_detail,
+            arrival_note=str(
+                getattr(viewer, "_library_entry_arrival_note", "") or ""
+            ),
+        )
+        viewer.editing = self._library_media_editing
+        viewer.confirming_delete = self._library_media_confirming_delete
+        viewer.highlights = tuple(
+            build_library_media_highlight_rows(self._library_media_highlights)
+        )
+        viewer.editing_analysis = self._library_media_editing_analysis
+        viewer.content_query = self._library_media_content_query
+        viewer.content_match_index = self._library_media_content_match_index
+        viewer.content_mode = self._library_media_content_mode
+        viewer.refresh(recompose=True)
+        return True
+
     def _mounted_library_media_viewer(self) -> LibraryMediaViewer | None:
         """Return the mounted media viewer, or ``None`` during teardown."""
         try:
@@ -28553,16 +29142,60 @@ class LibraryScreen(BaseAppScreen):
         *,
         refresh_snapshot: bool = False,
         wait_for_recompose: bool = False,
-    ) -> None:
+    ) -> LibraryEntryReconcileResult:
+        route_key = self._library_entry_route_key()
+        generation = self._library_snapshot_state_generation
         if self._library_selected_row_id != LIBRARY_ROW_BROWSE_COLLECTIONS:
             self._library_collection_pending_delete_id = ""
-            return
+            return LibraryEntryReconcileResult.SUPERSEDED
         if refresh_snapshot:
             await self._refresh_library_collections_snapshot()
+        if (
+            route_key != self._library_entry_route_key()
+            or not self._library_entry_reconcile_is_current(generation, route_key)
+        ):
+            current_pending = (
+                self._library_snapshot_state_generation,
+                self._library_entry_route_key(),
+            )
+            if (
+                route_key == current_pending[1]
+                and (
+                    self._library_entry_reconcile_pending == current_pending
+                    or self._library_snapshot_rendered_generation == current_pending[0]
+                )
+            ):
+                self.call_later(
+                    self._sync_collections_panel,
+                    refresh_snapshot=False,
+                )
+            return LibraryEntryReconcileResult.SUPERSEDED
+        try:
+            panel = self.query_one(
+                "#library-collections-panel", LibraryCollectionsPanel
+            )
+        except (NoMatches, QueryError):
+            return LibraryEntryReconcileResult.FAILED
+        state = self._library_collections_panel_state()
+        name_value = self._library_collection_name_input
+        description_value = self._library_collection_description_input
+        delete_pending = bool(self._library_collection_pending_delete_id)
+        if (
+            panel.state == state
+            and panel.name_value == name_value
+            and panel.description_value == description_value
+            and panel.delete_pending == delete_pending
+        ):
+            return LibraryEntryReconcileResult.APPLIED
+        panel.sync_state(
+            state,
+            name_value=name_value,
+            description_value=description_value,
+            delete_pending=delete_pending,
+        )
         if wait_for_recompose:
-            await self.recompose()
-        else:
-            self.refresh(recompose=True)
+            await asyncio.sleep(0)
+        return LibraryEntryReconcileResult.APPLIED
 
     def _claim_library_collections_mutation(self) -> bool:
         """Admit one owner of Collection list/count/receipt mutations.
@@ -29478,7 +30111,13 @@ class LibraryScreen(BaseAppScreen):
             return
         await self._open_library_rag_result_by_index(index)
 
-    async def _open_library_item_by_id(self, source_type: str, record_id: str) -> None:
+    async def _open_library_item_by_id(
+        self,
+        source_type: str,
+        record_id: str,
+        *,
+        entry_origin: bool = False,
+    ) -> LibraryEntryReconcileResult | None:
         """Open a Library item straight to its detail surface by id.
 
         Shared route for per-result Search/RAG "Open" actions -- unlike
@@ -29496,6 +30135,9 @@ class LibraryScreen(BaseAppScreen):
                 only, since the Open action is only rendered for rows with
                 resolvable provenance (``LibraryRagResultRow.can_open``).
             record_id: The item's id within its source type.
+            entry_origin: Whether this open belongs to the automatic Library
+                entry lifecycle and therefore must use strict retained-owner
+                synchronization with no screen-level fallback.
         """
         if self._library_prompts_mutation_in_flight:
             return
@@ -29505,17 +30147,42 @@ class LibraryScreen(BaseAppScreen):
             "conversations",
             "prompt",
         ):
-            return
+            return None
+
+        entry_route_key = self._library_entry_route_key() if entry_origin else None
+        entry_generation = (
+            self._library_snapshot_state_generation if entry_origin else None
+        )
+        entry_conversation_id = (
+            self._selected_conversation_id
+            if entry_origin and source_type == "conversations"
+            else None
+        )
+
+        def entry_is_current() -> bool:
+            return (
+                not entry_origin
+                or (
+                    entry_generation == self._library_snapshot_state_generation
+                    and entry_route_key == self._library_entry_route_key()
+                    and (
+                        entry_conversation_id is None
+                        or entry_conversation_id == self._selected_conversation_id
+                    )
+                )
+            )
 
         if source_type == "prompt":
             if not await self._flush_library_prompt_save():
-                return
+                return None
+            if not entry_is_current():
+                return LibraryEntryReconcileResult.SUPERSEDED
             try:
                 parsed_prompt_id = int(record_id)
             except (TypeError, ValueError):
-                return
+                return None
             if parsed_prompt_id < 1:
-                return
+                return None
             self._clear_library_prompt_selection(announce=True)
             self._invalidate_library_prompts_browse()
             # Mirrors handle_library_prompt_row's full state-set exactly so
@@ -29525,18 +30192,38 @@ class LibraryScreen(BaseAppScreen):
             self._selected_prompt_id = parsed_prompt_id
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_PROMPTS
             self._library_prompts_view = "editor"
+            if entry_origin:
+                generation = self._library_snapshot_state_generation
+                route_key = self._library_entry_route_key()
+                result = await self._replace_library_canvas_child(
+                    LibraryPromptsListCanvas(
+                        **self._library_prompts_canvas_kwargs(),
+                        id="library-prompts-canvas",
+                    ),
+                    generation=generation,
+                    route_key=route_key,
+                )
+                if result is not LibraryEntryReconcileResult.APPLIED:
+                    return result
             self.run_worker(
-                self._refresh_library_prompt_detail(parsed_prompt_id),
+                self._refresh_library_prompt_detail(
+                    parsed_prompt_id,
+                    entry_origin=entry_origin,
+                ),
                 exclusive=True,
                 group="library_prompt_detail",
             )
+            if entry_origin:
+                return LibraryEntryReconcileResult.APPLIED
             self.refresh(recompose=True)
-            return
+            return None
 
         if source_type == "media":
             note_flush = await self._flush_library_note_save()
             if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
-                return
+                return None
+            if not entry_is_current():
+                return LibraryEntryReconcileResult.SUPERSEDED
             self._clear_library_prompt_selection(announce=True)
             # Mirrors handle_library_media_row's full state-set EXACTLY so
             # the recomposed canvas lands on a clean viewer, never a stale
@@ -29554,23 +30241,69 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_content_query = ""
             self._library_media_content_match_index = 0
             self._library_media_content_mode = "raw"
+            if entry_origin:
+                generation = self._library_snapshot_state_generation
+                route_key = self._library_entry_route_key()
+                result = await self._replace_library_canvas_child(
+                    self._build_library_media_active_child(),
+                    generation=generation,
+                    route_key=route_key,
+                )
+                if result is not LibraryEntryReconcileResult.APPLIED:
+                    return result
             self.run_worker(
-                self._refresh_library_media_detail(record_id),
+                self._refresh_library_media_detail(
+                    record_id,
+                    entry_origin=entry_origin,
+                ),
                 exclusive=True,
                 group="library_media_detail",
             )
+            if entry_origin:
+                return LibraryEntryReconcileResult.APPLIED
             self.refresh(recompose=True)
-            return
+            return None
 
         if source_type == "notes":
             note_flush = await self._flush_library_note_save()
             if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
-                return
+                return None
+            if not entry_is_current():
+                return LibraryEntryReconcileResult.SUPERSEDED
             self._clear_library_prompt_selection(announce=True)
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
-            self._begin_library_note_load(record_id)
+            if entry_origin:
+                self._supersede_library_notes_navigation()
+                self._library_note_session.close_session()
+                self._selected_note_id = record_id
+                self._library_notes_view = "editor"
+                self._library_note_load_state = "loading"
+                self._library_note_load_message = ""
+                self._library_note_autosave_state = "idle"
+                self._library_note_shortcut_status = ""
+                self._library_note_confirming_delete = False
+                self._library_note_preview = False
+                self._library_note_context = False
+                self._library_note_delete_origin_context = False
+                self._library_note_delete_origin_preview = False
+                self._library_note_editor_armed = False
+                generation = self._library_snapshot_state_generation
+                route_key = self._library_entry_route_key()
+                result = await self._replace_library_canvas_child(
+                    LibraryNotesCanvas(
+                        **self._library_notes_canvas_kwargs(),
+                        id="library-notes-canvas",
+                    ),
+                    generation=generation,
+                    route_key=route_key,
+                )
+                if result is not LibraryEntryReconcileResult.APPLIED:
+                    return result
+            self._begin_library_note_load(record_id, entry_origin=entry_origin)
+            if entry_origin:
+                return LibraryEntryReconcileResult.APPLIED
             self.refresh(recompose=True)
-            return
+            return None
 
         # conversations: jump straight to a specific conversation, fetching
         # it by id when it isn't already in the loaded snapshot. Closes the
@@ -29586,6 +30319,8 @@ class LibraryScreen(BaseAppScreen):
         )
         if target_record is None:
             target_record = await self._fetch_library_conversation_by_id(record_id)
+            if not entry_is_current():
+                return LibraryEntryReconcileResult.SUPERSEDED
             if target_record is None:
                 notify = getattr(self.app_instance, "notify", None)
                 if callable(notify):
@@ -29604,6 +30339,8 @@ class LibraryScreen(BaseAppScreen):
                 normalized_query,
                 generation,
             )
+            if not entry_is_current():
+                return LibraryEntryReconcileResult.SUPERSEDED
 
         record_ids = {
             self._conversation_record_id(record, index)
@@ -29638,7 +30375,22 @@ class LibraryScreen(BaseAppScreen):
         # entering Conversations via the rail; _select_library_rail_row
         # itself does not touch it.
         self._library_conversation_query = ""
+        if entry_origin:
+            self._library_selected_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+            conversations_state = self._build_library_conversations_state()
+            self._selected_conversation_id = conversations_state.selected_id
+            generation = self._library_snapshot_state_generation
+            route_key = self._library_entry_route_key()
+            return await self._replace_library_canvas_child(
+                LibraryConversationsCanvas(
+                    conversations_state,
+                    id="library-conversations-canvas",
+                ),
+                generation=generation,
+                route_key=route_key,
+            )
         await self._select_library_rail_row(LIBRARY_ROW_BROWSE_CONVERSATIONS)
+        return None
 
     async def _fetch_library_conversation_by_id(
         self, conversation_id: str

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -3,6 +3,13 @@
 from .library_collections_panel import LibraryCollectionsPanel
 from .library_conversations_canvas import LibraryConversationsCanvas
 from .library_export_canvas import LibraryExportCanvas
+from .library_entry_canvases import (
+    LibraryLandingCanvas,
+    LibraryLandingCanvasState,
+    LibraryLandingRecentItem,
+    LibraryStudyHandoffCanvas,
+    LibraryStudyHandoffCanvasState,
+)
 from .library_ingest_canvas import (
     LibraryIngestCanvas,
     LibraryIngestPreflightSummary,
@@ -73,6 +80,9 @@ __all__ = [
     "LibraryCollectionsPanel",
     "LibraryConversationsCanvas",
     "LibraryExportCanvas",
+    "LibraryLandingCanvas",
+    "LibraryLandingCanvasState",
+    "LibraryLandingRecentItem",
     "LibraryIngestCanvas",
     "LibraryIngestPreflightSummary",
     "LibraryIngestQueuePanel",
@@ -84,6 +94,8 @@ __all__ = [
     "LibraryPromptsListCanvas",
     "LibraryRail",
     "LibrarySearchRagPanel",
+    "LibraryStudyHandoffCanvas",
+    "LibraryStudyHandoffCanvasState",
     "LibrarySkillsListCanvas",
     "SKILL_MODEL_HINT_COPY",
     "next_skill_context",

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.css.query import NoMatches, QueryError
 from textual.widgets import Button, Collapsible, Input, Static
+from textual.widgets._input import Selection
 
 from ...Library.library_collections_state import LibraryCollectionsPanelState
 from ...Library.library_shell_state import library_disabled_action_label
+from .library_canvas_sync import PostRecomposeCallback
 
 
 LIBRARY_COLLECTIONS_STATUS_LINE = (
@@ -24,7 +30,18 @@ def _compact_receipt_name(value: str, limit: int = 42) -> str:
     return normalized[: limit - 1].rstrip() + "…"
 
 
-class LibraryCollectionsPanel(Vertical):
+@dataclass(frozen=True)
+class _CollectionsInputCapture:
+    """Portable state for one focused Input replaced by panel recompose."""
+
+    widget_id: str
+    value: str
+    selection: Selection
+    select_on_focus: bool
+    outgoing_focus: Input
+
+
+class LibraryCollectionsPanel(PostRecomposeCallback, Vertical):
     """Render-only Library Collections list, detail, and form controls."""
 
     def __init__(
@@ -41,6 +58,7 @@ class LibraryCollectionsPanel(Vertical):
         self.name_value = name_value
         self.description_value = description_value
         self.delete_pending = delete_pending
+        self._pending_input_capture: _CollectionsInputCapture | None = None
 
     def sync_state(
         self,
@@ -49,13 +67,107 @@ class LibraryCollectionsPanel(Vertical):
         name_value: str,
         description_value: str,
         delete_pending: bool,
+        deferred_guard: Callable[[], bool] | None = None,
     ) -> None:
         """Synchronize every compose input on the retained Collections owner."""
+        captured_now = self._capture_focused_input()
+        if captured_now is not None:
+            self._pending_input_capture = captured_now
+        capture = self._pending_input_capture
+        if capture is not None:
+            if capture.widget_id == "library-collection-name-input":
+                name_value = capture.value
+            elif capture.widget_id == "library-collection-description-input":
+                description_value = capture.value
         self.state = state
         self.name_value = name_value
         self.description_value = description_value
         self.delete_pending = delete_pending
+        self.queue_after_recompose(
+            None
+            if capture is None
+            else lambda: self._restore_pending_focused_input(
+                capture, deferred_guard
+            )
+        )
         self.refresh(recompose=True)
+
+    def _restore_pending_focused_input(
+        self,
+        capture: _CollectionsInputCapture,
+        deferred_guard: Callable[[], bool] | None,
+    ) -> None:
+        """Consume the latest focus capture after coalesced panel syncs."""
+        if self._pending_input_capture is not capture:
+            return
+        self._pending_input_capture = None
+        self._restore_focused_input(capture, deferred_guard)
+
+    def _capture_focused_input(self) -> _CollectionsInputCapture | None:
+        """Detach and capture the focused form Input before replacing it."""
+        if not self.is_attached:
+            return None
+        focused = self.screen.focused
+        if (
+            not isinstance(focused, Input)
+            or self not in focused.ancestors_with_self
+            or focused.disabled
+            or not focused.id
+        ):
+            return None
+        capture = _CollectionsInputCapture(
+            widget_id=str(focused.id),
+            value=focused.value,
+            selection=focused.selection,
+            select_on_focus=focused.select_on_focus,
+            outgoing_focus=focused,
+        )
+        self.screen.set_focus(None)
+        return capture
+
+    def _restore_focused_input(
+        self,
+        capture: _CollectionsInputCapture,
+        deferred_guard: Callable[[], bool] | None,
+    ) -> None:
+        """Restore one current, enabled Input without stealing later focus."""
+        if deferred_guard is not None and not deferred_guard():
+            return
+        if not self.is_attached or getattr(self, "_pruning", False):
+            return
+        try:
+            panels = list(self.screen.query("#library-collections-panel"))
+            target = self.query_one(f"#{capture.widget_id}", Input)
+        except (NoMatches, QueryError):
+            return
+        if len(panels) != 1 or panels[0] is not self or target.disabled:
+            return
+        if self.screen.focused not in (None, capture.outgoing_focus, target):
+            return
+        target.value = capture.value
+        target.select_on_focus = False
+        self.screen.set_focus(target)
+        target.selection = capture.selection
+        target.call_later(
+            self._restore_input_selection,
+            target,
+            capture,
+            deferred_guard,
+        )
+
+    def _restore_input_selection(
+        self,
+        target: Input,
+        capture: _CollectionsInputCapture,
+        deferred_guard: Callable[[], bool] | None,
+    ) -> None:
+        """Restore selection after Input's own focus handler has settled."""
+        target.select_on_focus = capture.select_on_focus
+        if deferred_guard is not None and not deferred_guard():
+            return
+        if not target.is_attached or self.screen.focused is not target:
+            return
+        target.selection = capture.selection
 
     def _compose_collection_form(self) -> ComposeResult:
         with Vertical(id="library-collection-form"):

--- a/tldw_chatbook/Widgets/Library/library_collections_panel.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_panel.py
@@ -42,6 +42,21 @@ class LibraryCollectionsPanel(Vertical):
         self.description_value = description_value
         self.delete_pending = delete_pending
 
+    def sync_state(
+        self,
+        state: LibraryCollectionsPanelState,
+        *,
+        name_value: str,
+        description_value: str,
+        delete_pending: bool,
+    ) -> None:
+        """Synchronize every compose input on the retained Collections owner."""
+        self.state = state
+        self.name_value = name_value
+        self.description_value = description_value
+        self.delete_pending = delete_pending
+        self.refresh(recompose=True)
+
     def _compose_collection_form(self) -> ComposeResult:
         with Vertical(id="library-collection-form"):
             yield Static("Create / Rename", classes="destination-section")

--- a/tldw_chatbook/Widgets/Library/library_entry_canvases.py
+++ b/tldw_chatbook/Widgets/Library/library_entry_canvases.py
@@ -1,0 +1,219 @@
+"""Retained owners for Library landing and Study handoff entry surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from rich.markup import escape as escape_markup
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_CANVAS_KIND_NOTES_CREATE,
+    LIBRARY_ROW_BROWSE_SEARCH,
+    LIBRARY_ROW_CREATE_NOTE,
+    LIBRARY_ROW_INGEST_MEDIA,
+)
+from tldw_chatbook.Widgets.Library.library_canvas_sync import PostRecomposeCallback
+
+
+@dataclass(frozen=True)
+class LibraryLandingRecentItem:
+    """Display data and stable dispatch identity for one landing recent row."""
+
+    source_type: str
+    record_id: str
+    title: str
+    source_label: str
+
+
+@dataclass(frozen=True)
+class LibraryLandingCanvasState:
+    """Complete display snapshot for the retained Library landing canvas."""
+
+    purpose: str
+    counts_line: str
+    recent_items: tuple[LibraryLandingRecentItem, ...] = ()
+
+
+@dataclass(frozen=True)
+class LibraryStudyHandoffCanvasState:
+    """Complete display snapshot for one retained Study handoff canvas."""
+
+    header: str
+    purpose: str
+    context: str
+    owner: str
+    recovery: str
+    blocked: bool
+    button_label: str
+    button_id: str
+    action_label: str
+
+
+class _RetainedSyncCallback(PostRecomposeCallback):
+    """Complete a targeted in-place sync through the mixin's single slot."""
+
+    def _complete_targeted_sync(self) -> None:
+        callback: Callable[[], None] | None = self._post_recompose_callback
+        self._post_recompose_callback = None
+        if callback is not None:
+            callback()
+
+
+class LibraryLandingCanvas(_RetainedSyncCallback, Vertical):
+    """Retain the landing actions while counts and recent rows change."""
+
+    def __init__(self, state: LibraryLandingCanvasState, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.state = state
+        self.styles.width = "1fr"
+        self.styles.min_width = 0
+
+    @staticmethod
+    def _action_button(
+        label: str,
+        tooltip: str,
+        row_id: str,
+        target_id: str,
+        button_id: str,
+    ) -> Button:
+        action = Button(
+            label,
+            id=button_id,
+            classes="library-hub-action console-action-subdued",
+            compact=True,
+            tooltip=tooltip,
+        )
+        action.row_id = row_id
+        action.target_kind = "canvas"
+        action.target_id = target_id
+        return action
+
+    @staticmethod
+    def _recent_button(item: LibraryLandingRecentItem) -> Button:
+        recent = Button(
+            f"{item.source_label} · {escape_markup(item.title)}",
+            id=f"library-hub-recent-{item.source_type}",
+            classes="library-hub-recent console-action-subdued",
+            compact=True,
+            tooltip=f"Open {item.source_label.lower()}: {item.title}",
+        )
+        recent.source_type = item.source_type
+        recent.record_id = item.record_id
+        return recent
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            self.state.purpose,
+            id="library-canvas-landing",
+            classes="destination-purpose",
+            markup=False,
+        )
+        yield Static(
+            self.state.counts_line,
+            id="library-hub-counts",
+            classes="library-hub-meta",
+            markup=False,
+        )
+        with Horizontal(id="library-hub-actions", classes="ds-toolbar"):
+            yield self._action_button(
+                "Import…",
+                "Add files, links, and transcripts to your Library.",
+                LIBRARY_ROW_INGEST_MEDIA,
+                "ingest-media",
+                "library-hub-action-import",
+            )
+            yield self._action_button(
+                "Search",
+                "Search everything in the Library.",
+                LIBRARY_ROW_BROWSE_SEARCH,
+                "search",
+                "library-hub-action-search",
+            )
+            yield self._action_button(
+                "New note",
+                "Create a new note.",
+                LIBRARY_ROW_CREATE_NOTE,
+                LIBRARY_CANVAS_KIND_NOTES_CREATE,
+                "library-hub-action-new-note",
+            )
+        recents = Vertical(id="library-hub-recents")
+        recents.styles.height = "auto"
+        with recents:
+            for item in self.state.recent_items:
+                yield self._recent_button(item)
+
+    def sync_state(self, state: LibraryLandingCanvasState) -> None:
+        """Patch counts and defer replacement of only the recent rows."""
+        self.state = state
+        self.query_one("#library-hub-counts", Static).update(state.counts_line)
+        self.call_later(self._replace_recent_rows)
+
+    async def _replace_recent_rows(self) -> None:
+        """Converge queued replacements on the latest state after each await."""
+        recents = self.query_one("#library-hub-recents", Vertical)
+        await recents.remove_children()
+        recent_items = self.state.recent_items
+        if recent_items:
+            await recents.mount(*(self._recent_button(item) for item in recent_items))
+        if recent_items != self.state.recent_items:
+            self.call_later(self._replace_recent_rows)
+            return
+        self._complete_targeted_sync()
+
+
+class LibraryStudyHandoffCanvas(_RetainedSyncCallback, Vertical):
+    """Retain a Study handoff action while source readiness changes."""
+
+    def __init__(self, state: LibraryStudyHandoffCanvasState, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.state = state
+        self.styles.width = "1fr"
+        self.styles.min_width = 0
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            self.state.header,
+            id="library-active-mode-title",
+            classes="destination-section",
+        )
+        yield Static(self.state.purpose, id="library-study-handoff-purpose")
+        context = Static(self.state.context, id="library-study-handoff-context")
+        context.display = bool(self.state.context)
+        yield context
+        yield Static(self.state.owner, id="library-study-handoff-owner")
+        recovery = Static(self.state.recovery, id="library-study-handoff-recovery")
+        recovery.set_class(self.state.blocked, "ds-recovery-callout")
+        recovery.set_class(self.state.blocked, "is-blocked")
+        yield recovery
+        toolbar = Horizontal(id="library-study-handoff-actions", classes="ds-toolbar")
+        toolbar.styles.height = "auto"
+        with toolbar:
+            yield Button(
+                self.state.button_label,
+                id=self.state.button_id,
+                classes="library-canvas-action console-action-primary",
+                compact=True,
+                tooltip=(
+                    f"Open {self.state.action_label} with the current Library "
+                    "source snapshot, or globally when none is available."
+                ),
+            )
+
+    def sync_state(self, state: LibraryStudyHandoffCanvasState) -> None:
+        """Patch handoff copy and blocked styling without replacing the action."""
+        self.state = state
+        self.query_one("#library-active-mode-title", Static).update(state.header)
+        self.query_one("#library-study-handoff-purpose", Static).update(state.purpose)
+        context = self.query_one("#library-study-handoff-context", Static)
+        context.update(state.context)
+        context.display = bool(state.context)
+        self.query_one("#library-study-handoff-owner", Static).update(state.owner)
+        recovery = self.query_one("#library-study-handoff-recovery", Static)
+        recovery.update(state.recovery)
+        recovery.set_class(state.blocked, "ds-recovery-callout")
+        recovery.set_class(state.blocked, "is-blocked")
+        self._complete_targeted_sync()

--- a/tldw_chatbook/Widgets/Library/library_entry_canvases.py
+++ b/tldw_chatbook/Widgets/Library/library_entry_canvases.py
@@ -69,8 +69,30 @@ class LibraryLandingCanvas(_RetainedSyncCallback, Vertical):
     def __init__(self, state: LibraryLandingCanvasState, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.state = state
+        self._deferred_sync_guard: Callable[[], bool] | None = None
+        self._deferred_sync_serial = 0
         self.styles.width = "1fr"
         self.styles.min_width = 0
+
+    def set_deferred_sync_guard(self, guard: Callable[[], bool] | None) -> None:
+        """Set the route/generation predicate for the next deferred row sync."""
+        self._deferred_sync_guard = guard
+
+    def _deferred_sync_is_current(self, serial: int) -> bool:
+        """Return whether deferred work still owns this attached canvas."""
+        return (
+            serial == self._deferred_sync_serial
+            and self.is_attached
+            and not getattr(self, "_pruning", False)
+            and (
+                self._deferred_sync_guard is None or self._deferred_sync_guard()
+            )
+        )
+
+    def _discard_stale_deferred_sync(self, serial: int) -> None:
+        """Clear only the callback owned by the latest now-stale sync."""
+        if serial == self._deferred_sync_serial:
+            self.queue_after_recompose(None)
 
     @staticmethod
     def _action_button(
@@ -150,17 +172,31 @@ class LibraryLandingCanvas(_RetainedSyncCallback, Vertical):
         """Patch counts and defer replacement of only the recent rows."""
         self.state = state
         self.query_one("#library-hub-counts", Static).update(state.counts_line)
-        self.call_later(self._replace_recent_rows)
+        self._deferred_sync_serial += 1
+        self.call_later(self._replace_recent_rows, self._deferred_sync_serial)
 
-    async def _replace_recent_rows(self) -> None:
+    async def _replace_recent_rows(self, serial: int | None = None) -> None:
         """Converge queued replacements on the latest state after each await."""
+        serial = self._deferred_sync_serial if serial is None else serial
+        if not self._deferred_sync_is_current(serial):
+            self._discard_stale_deferred_sync(serial)
+            return
         recents = self.query_one("#library-hub-recents", Vertical)
+        if not self._deferred_sync_is_current(serial):
+            self._discard_stale_deferred_sync(serial)
+            return
         await recents.remove_children()
+        if not self._deferred_sync_is_current(serial):
+            self._discard_stale_deferred_sync(serial)
+            return
         recent_items = self.state.recent_items
         if recent_items:
             await recents.mount(*(self._recent_button(item) for item in recent_items))
+        if not self._deferred_sync_is_current(serial):
+            self._discard_stale_deferred_sync(serial)
+            return
         if recent_items != self.state.recent_items:
-            self.call_later(self._replace_recent_rows)
+            self.call_later(self._replace_recent_rows, serial)
             return
         self._complete_targeted_sync()
 


### PR DESCRIPTION
## Summary
- seed the Library snapshot cache before first compose and retain the rail and active canvas owners
- reconcile source changes through targeted in-place updates with route, generation, and token ownership guards
- preserve focus, selection, and scroll while automatic entry workers update their canvases
- require zero whole-screen recomposes during automatic Library entry and refresh flows

## Verification
- 103 focused touched-code tests passed after the final rebase
- compact and wide UAT routes each reported compose=1, refresh_recompose=0, recompose=0
- scoped Ruff and git diff checks passed
- repository-wide tests were intentionally not run per request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes the Library once per visit by seeding the source snapshot before the first render and reconciling later changes in place. Previously, warm visits rendered loading UI, then triggered one or more whole-screen recomposes as the cache applied and entry workers ran; now the first compose uses the snapshot and all subsequent updates patch retained canvases, preserving focus and scroll.

- Refactors `LibraryScreen` to seed the cache pre-compose and route updates through a guarded reconciliation layer (generation, route key, token ownership); schedules on attachment to close the mount-window race.
- Adds `tldw_chatbook/UI/Library_Modules/library_snapshot_cache.py` with snapshot validation and `clone_library_source_snapshot`; degrades unsafe deep-copies to cache misses.
- Introduces retained entry canvases in `Widgets/Library/library_entry_canvases.py` (`LibraryLandingCanvas`, `LibraryStudyHandoffCanvas`) so row containers remain stable while rows update.
- Preserves input focus, selection, and scroll across targeted recomposes (notably in `library_collections_panel.py`).
- Updates tests to assert compose-once behavior and in-place canvas sync; shell tests now expect a stable recents container; adds an end-to-end compose-once suite.
- Satisfies TASK-15459: eliminate whole-screen recomposes during automatic Library entry and refresh flows.

<sup>Written for commit ed6c0d226ee7955caeb85ab5ce8f8a037a8468b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

