### PR TITLE
docs(models): close TASK-2062 phase 3

### DIFF
--- a/backlog/tasks/task-2062 - Model-browser-Phase-3-adopt-GGUF-models-and-retire-the-legacy-downloader.md
+++ b/backlog/tasks/task-2062 - Model-browser-Phase-3-adopt-GGUF-models-and-retire-the-legacy-downloader.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-2062
 title: 'Model browser Phase 3: adopt GGUF models and retire the legacy downloader'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-03 20:11'
-updated_date: '2026-08-13 01:32'
+updated_date: '2026-08-14 05:33'
 labels:
   - models
   - ui
@@ -23,11 +23,11 @@ Complete Model-browser Phase 3 without forcing managed-only model usage: add saf
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user can import an unmanaged GGUF as a path-private immutable managed copy with locally recorded integrity while Chatbook never writes renames or deletes the original
-- [ ] #2 llama.cpp supports mutually exclusive Managed and External GGUF sources; llamafile supports Embedded Managed and External sources; arbitrary external GGUF files outside the store remain first-class
-- [ ] #3 Managed runtime launches retain the exact artifact lease until the exact process is confirmed dead and external launches never mutate the managed store
-- [ ] #4 The legacy Widgets/HuggingFace and Transformers direct-write Models download paths are removed only after Import and External source flows are usable
-- [ ] #5 vLLM MLX the Hugging Face inference provider existing model IDs external directories and legacy unmanaged discovery remain unchanged
+- [x] #1 A user can import an unmanaged GGUF as a path-private immutable managed copy with locally recorded integrity while Chatbook never writes renames or deletes the original
+- [x] #2 llama.cpp supports mutually exclusive Managed and External GGUF sources; llamafile supports Embedded Managed and External sources; arbitrary external GGUF files outside the store remain first-class
+- [x] #3 Managed runtime launches retain the exact artifact lease until the exact process is confirmed dead and external launches never mutate the managed store
+- [x] #4 The legacy Widgets/HuggingFace and Transformers direct-write Models download paths are removed only after Import and External source flows are usable
+- [x] #5 vLLM MLX the Hugging Face inference provider existing model IDs external directories and legacy unmanaged discovery remain unchanged
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,3 +43,9 @@ Reason: TASK-2062 extends the shared artifact service into LLM GGUF ownership an
 4. Run focused TDD and mutation checks in each child; finish with affected regression, native file/process lifecycle, static, privacy, dead-reference, and mounted 80-column UI gates.
 5. Close the parent only after all child tasks satisfy their Definition of Done.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed Model-browser Phase 3 through TASK-2062.1, TASK-2062.2, and TASK-2062.3, merged in PRs #1578, #1610, and #1628. Added path-private content-addressed local GGUF import that never mutates the source; added exact managed-artifact and arbitrary external-GGUF runtime authority for llama.cpp and llamafile while preserving embedded llamafile; retained managed leases until proven process death; and removed the legacy Widgets/HuggingFace browser plus Transformers direct-write downloader only after the replacement flows were usable. Preserved vLLM, MLX, Hugging Face inference and provider caching, Remote acquisition, external directories, and legacy unmanaged discovery. Key implementation areas were Model_Artifacts admission/service, Installed and Models UI, GGUF source and server lifecycle ownership, and removal of obsolete downloader owners. Verification across the children included focused and mutation-tested suites, mounted 80-column production-CSS behavior, static/privacy/dead-reference checks, governed diagnostic inventory, and exact Linux/macOS/Windows evidence; all task-specific native lanes passed. Final reviews found no remaining correctness or minimality issues. ADR-025 remains the governing decision; no new ADR was required. Child-specific Windows stat, compositor timing, and generated-inventory incidents were handled in their task evidence and existing lessons. Parent closeout changes only this task metadata.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary\n- close parent TASK-2062 after TASK-2062.1, TASK-2062.2, and TASK-2062.3 merged in PRs #1578, #1610, and #1628\n- check all five parent acceptance criteria and add consolidated implementation notes\n- record ADR-025, preserved arbitrary external GGUF usage, and the completed native/static/privacy evidence\n\n## Scope\nMetadata-only parent closeout. No production code, tests, configuration, generated assets, or runtime behavior changed.\n\n## Verification\n- File: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-2062-parent-closeout/backlog/tasks/task-2062 - Model-browser-Phase-3-adopt-GGUF-models-and-retire-the-legacy-downloader.md

Task TASK-2062 - Model browser Phase 3: adopt GGUF models and retire the legacy downloader
==================================================

Status: ✔ Done
Priority: Medium
Created: 2026-08-03 20:11
Updated: 2026-08-14 05:33
Labels: models, ui
Subtasks (3):
- TASK-2062.1 - Import local GGUF files into the manag reports Done with all five criteria checked\n- all three child task files report Done with no unchecked acceptance criteria\n- all three child merge commits are ancestors of the branch base\n- Backlog duplicate-ID guard passes across 1,928 task files\n-  passes\n- diff contains exactly the TASK-2062 parent task file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-2062 by marking the parent task Done and consolidating Phase 3 implementation notes. This is a metadata-only closeout; no code, config, tests, or runtime behavior changed.

- Only change: update `backlog/tasks/task-2062 - Model-browser-Phase-3-adopt-GGUF-models-and-retire-the-legacy-downloader.md` (status In Progress → Done, date, AC #1–#5 checked, Implementation Notes added referencing ADR-025).
- Notes reflect met requirements: path-private GGUF import without mutating sources; managed vs external GGUF sources for llama.cpp and llamafile with lease-based runtime ownership; legacy Widgets/HuggingFace and Transformers downloaders removed after replacement flows were usable; vLLM/MLX/Hugging Face inference/provider behavior and external directories unchanged.

<sup>Written for commit 0a913f5baa353ff48401bc9604c949f59482f6c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

