### PR TITLE
fix(tests): console inventory batch 1 — staged-evidence copy cluster; grid blowout filed (task-15791)

### DIFF
--- a/Tests/UI/test_console_staged_evidence_strip.py
+++ b/Tests/UI/test_console_staged_evidence_strip.py
@@ -401,7 +401,11 @@ async def test_console_run_staging_fans_out_to_strip_and_truthful_chip() -> None
         assert "Source 1" in text
         assert "+1 more" in text
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 4 staged" in str(sources_chip.renderable)
+        # task-15791: 7dbbc401b (TASK-2154 UX remediation, owner-driven)
+        # shortened the chip to "Sources: N" -- the truthful COUNT is the
+        # contract; the " staged" suffix went with the same pass that
+        # renamed "RAG:" to "Library search:".
+        assert "Sources: 4" in str(sources_chip.renderable)
 
 
 @pytest.mark.asyncio
@@ -420,7 +424,7 @@ async def test_console_unstage_clears_context_strip_chip_and_tray() -> None:
         assert screen._pending_console_launch_context is None
         assert screen.query_one(STRIP_ID, ConsoleStagedEvidenceStrip).display is False
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 0 staged" in str(sources_chip.renderable)
+        assert "Sources: 0" in str(sources_chip.renderable)
         tray = screen.query_one(
             "#console-staged-context-tray", ConsoleStagedContextTray
         )
@@ -476,7 +480,7 @@ async def test_console_library_u_key_handoff_populates_the_strip() -> None:
         assert screen.query_one(STRIP_ID, ConsoleStagedEvidenceStrip).display is True
         assert "Source 1" in _strip_text(screen)
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 2 staged" in str(sources_chip.renderable)
+        assert "Sources: 2" in str(sources_chip.renderable)
 
 
 async def _submit(screen, draft: str):
@@ -517,7 +521,7 @@ async def test_console_send_consumes_staging_and_shows_the_sent_transient(
         assert screen._pending_console_launch_context is None
         assert "Evidence sent with this message · 2 sources" in _strip_text(screen)
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 0 staged" in str(sources_chip.renderable)
+        assert "Sources: 0" in str(sources_chip.renderable)
 
         # A SECOND send captures nothing: the evidence no longer rides along.
         await _submit(screen, "follow up")
@@ -552,7 +556,7 @@ async def test_console_sent_notice_counts_only_what_reached_the_model(
         screen._stage_console_library_rag_launch(launch)
         await pilot.pause()
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 4 staged" in str(sources_chip.renderable)
+        assert "Sources: 4" in str(sources_chip.renderable)
 
         await _submit(screen, "question")
         await pilot.pause()
@@ -700,7 +704,7 @@ async def test_console_rail_badge_and_chip_report_the_same_staged_count() -> Non
             "Source 4",
         ]
         sources_chip = screen.query_one("#console-sources-label", Static)
-        assert "Sources: 4 staged" in str(sources_chip.renderable)
+        assert "Sources: 4" in str(sources_chip.renderable)
 
 
 def test_workspace_context_falls_back_to_one_row_for_a_bundleless_launch() -> None:
@@ -900,6 +904,8 @@ async def test_console_send_blocked_reason_blocks_for_library_staged_zero_availa
 
         reason = screen._console_send_blocked_reason()
         assert (
-            "Console send blocked: Library Search/RAG has no available evidence"
+            # task-15791: same TASK-2154 rename as the chip ("RAG" -> "Library
+        # search") reached this blocked-reason copy.
+        "Console send blocked: Library search has no available evidence"
             in reason
         )

--- a/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
+++ b/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
@@ -39,8 +39,31 @@ if so, the same worker-lifetime + harness-seam remedy applies.
 
 ## Acceptance Criteria
 
-- [ ] The Sources-staged copy question is decided (product vs tests) with the 7dbbc401b context, then applied consistently
+- [x] The Sources-staged copy question is decided (product vs tests) with the 7dbbc401b context, then applied consistently
 - [ ] The settings endpoint-probe teardown pair is attributed, and fixed with the #1596 pattern if it is the same class
 - [ ] The maturity-phase1 timeouts are re-run without contention before being treated as failures
 - [ ] Each remaining cluster is attributed to its causing commit; genuine breaks fixed, not absorbed
 - [ ] The listed modules pass whole on dev
+
+## Implementation Notes (batch 1)
+
+Re-baselined every module on current dev first: 43 rows still live (24
+console + 19 destination/personas/snapshots).
+
+**Sources-staged copy: decided for the product.** 7dbbc401b (TASK-2154, the
+owner-driven 24-findings remediation) deliberately shortened the chip to
+"Sources: N" in the same pass that renamed "RAG:" to "Library search:"; the
+truthful COUNT is the contract and survives. All 6 pins updated with
+attribution, plus the blocked-reason copy that took the same rename.
+`test_console_staged_evidence_strip.py`: 30/30.
+
+**The size2 geometry cluster is a REAL layout regression, filed as
+TASK-16220 (high)** rather than absorbed: at 120x30 with the Inspector rail
+open, every workspace-grid fr resolves to fr x FULL-WIDTH (left 354, main
+1534, right 472 on a 120 screen) -- bisected to 7dbbc401b; a minimal Textual
+replica of the same structure lays out correctly, so the trigger is
+something production's children add. Full probe evidence in the task.
+
+Remaining clusters for batch 2: rail_width x3 + rail_sections/internals
+(likely the same 16220 geometry family), send-integration x4, snapshots x4
+(need a human eye), visual parity, personas x5, singletons.

--- a/backlog/tasks/task-16220 - Console-grid-blows-out-horizontally-at-120-columns-with-the-Inspector-rail-open.md
+++ b/backlog/tasks/task-16220 - Console-grid-blows-out-horizontally-at-120-columns-with-the-Inspector-rail-open.md
@@ -1,0 +1,52 @@
+---
+id: TASK-16220
+title: Console grid blows out horizontally at 120 columns with the Inspector rail open
+status: To Do
+assignee: []
+labels:
+  - bug
+  - console
+  - layout
+priority: high
+---
+
+## Description
+
+At 120x30 with the Inspector (right) rail open, the Console workspace grid's
+fr columns resolve to absurd widths -- measured live: left rail `3fr` -> 354,
+main `13fr` -> 1534, right rail `4fr` -> 472, i.e. **every fr unit resolved to
+118 (the full content width) instead of sharing it**. The shell is unusable at
+that size: the transcript starts ~400 columns off-screen. Four
+`test_console_shell_regions.py` size2 rows and the two
+`test_console_rail_width_budget.py` size rows pin exactly this and are red on
+dev.
+
+**Bisected**: green at `64bb15091` (the 120x30 baseline's own commit, 10/10),
+first bad commit `7dbbc401b` (TASK-2154 UX remediation) -- the same commit
+that raised the left rail's min-width 24 -> 30 (LY-07), added the
+force-collapse bands (left < 100, right < 150 unless explicitly opened), and
+the main min-width waiver (LY-11).
+
+**What is ruled out, measured**:
+- Not the config: `stack_collapsed_rail_labels` false everywhere.
+- Not stylesheet loss: the harness is `ConsolidatedCSSApp` (real CSS), and the
+  grid's computed styles read `overflow=(hidden,hidden)`, `layout=horizontal`.
+- Not raw Textual fr mechanics: a minimal repro of the exact structure
+  (Horizontal, overflow hidden, children 13 / 3fr min30 / 13fr min0 /
+  4fr min34 / 11, handles display-none, 120 wide) lays out CORRECTLY
+  (30/56/34). Something the production children add -- classes, frames, or
+  the rails' own content constraints -- flips the solver into per-child fr
+  resolution.
+- The grid's `min-height: 20` CSS is inline-overridden to 0 (a4c0d4f49) and
+  its height resolves 1fr -> 8 rows; the vertical squeeze is separate from
+  the horizontal blowout.
+
+Repro: `pytest Tests/UI/test_console_shell_regions.py -k size2` (4 fail);
+the exact-mins arithmetic and probe transcripts are in the task-15791 notes.
+
+## Acceptance Criteria
+
+- [ ] At 120x30 with the Inspector rail open, every workspace-grid child's region fits inside the 120-column viewport
+- [ ] The fr-blowout mechanism is identified and stated (what makes production's children resolve fr per-child when a minimal replica shares correctly)
+- [ ] The size2 rows of test_console_shell_regions.py and both size rows of test_console_rail_width_budget.py pass
+- [ ] Degradation at 100-149 columns with both rails open is a stated design rule (which rail yields), not an accident of the solver


### PR DESCRIPTION
## What

First batch of TASK-15791 (the sweep's console/destination inventory). Re-baselined on current dev first: 43 rows still live.

## Decided: the `Sources: N staged` copy question

`7dbbc401b` — TASK-2154, the owner-driven 24-findings UX remediation — deliberately shortened the chip to `Sources: N` in the same pass that renamed `RAG:` → `Library search:`. The truthful **count** is the contract and survives; the suffix went with the remediation. All 6 pins updated with attribution, plus the blocked-reason copy that took the same rename. `test_console_staged_evidence_strip.py`: **30/30**.

## Not absorbed: the size2 geometry cluster is a real regression — TASK-16220 (high)

At **120×30 with the Inspector rail open**, every workspace-grid `fr` resolves to fr × *full width* — measured live: left `3fr`→354, main `13fr`→1534, right `4fr`→472 on a 120-column screen. The shell is unusable at that size (the transcript starts ~400 columns off-screen).

Evidence in the task: **bisected** to `7dbbc401b` (green at the 120×30 baseline's own commit, 10/10); config and stylesheet ruled out (computed styles read `overflow=hidden, layout=horizontal`); and a minimal Textual replica of the exact structure lays out *correctly* — so the trigger is something production's children add, which is precisely the open question the task states. Six red rows (`shell_regions` size2 ×4, `rail_width_budget` ×2) pin this and stay red until it's fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns console staged-evidence tests with current product copy and documents an unrelated layout regression. Tests now expect “Sources: N” and “Library search …” instead of “Sources: N staged” and “Library Search/RAG …”; no runtime change.

- Advances TASK-15791 by deciding and applying the copy contract: the count is the contract; the chip is “Sources: N”; “RAG” is “Library search”.

**Review notes**
- Updates 6 assertions in `Tests/UI/test_console_staged_evidence_strip.py`; that module is green (30/30).
- Rationale: prior UX remediation (TASK-2154) shortened the chip and renamed RAG to Library search.
- No product code changed; this is test-only plus backlog notes.

**Follow-ups**
- A separate 120×30 layout regression with the Inspector rail open is tracked in TASK-16220; leave red rows in `test_console_shell_regions.py` (size2) and `test_console_rail_width_budget.py` for that fix.

<sup>Written for commit cc1ac3cfdc569942295b23d76a77bbbe46ac21af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

