### PR TITLE
fix(fleet): wake integrity — typed-draft ties + off-view delivery ruling (15970/15971)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -401,13 +401,22 @@ first's genuinely-running rows.
   survivor billed after its turn — that remainder is recorded nowhere
   durable — and the plain-text conversation export contains no token
   figures at all.
-- The supervisor never acts while no Console screen is mounted. A
-  finished background sub-agent wakes its supervisor and notifies you
+- The supervisor can act while you are on another screen — deliberately.
+  A finished background sub-agent wakes its supervisor and notifies you
   from any screen (see
   [When a background sub-agent finishes — auto-wake](#when-a-background-sub-agent-finishes--auto-wake)),
-  but the wake turn itself only runs inside Console — a completion that
-  lands while you're elsewhere is recorded and delivered when Console
-  next mounts, never acted on invisibly in the background.
+  and if a live Console still exists — including one you navigated away
+  from — the wake turn fires immediately rather than waiting for you to
+  come back: acting on results without a human keystroke is what
+  auto-wake is for. You always learn of it: the toast fires the moment
+  the sub-agent finishes, and a wake that delivers while you're not
+  viewing that conversation leaves the `◈` marker set on it until you
+  view the delivered result. Only when no Console exists at all — before
+  the first Console open after a restart — is the completion staged
+  durably and delivered when Console next opens. *(This paragraph
+  previously promised the wake was "never acted on invisibly in the
+  background" while you were elsewhere; corrected 2026-08-14 — the wake
+  does act, and the `◈` marker is the guarantee you find out.)*
 
 **Turning it off.** Set `[agents] subagents_outlive_turn = false` in
 `config.toml`: sub-agents are then settled at the end of the turn that
@@ -431,8 +440,10 @@ What you see, wherever you are:
   "finished".
 - **The `◈` marker** on that conversation's tab and sidebar row (see
   [Background & parked runs](#background--parked-runs)). It is durable —
-  restart-proof — and clears when you view that conversation or once a
-  wake has delivered everything that was owed.
+  restart-proof — and clears when you view that conversation. A wake
+  that delivers while you're watching that conversation clears it too;
+  a wake that delivers while you're anywhere else leaves it set, so the
+  marker always points you at a result you haven't seen yet.
 - **In the transcript**, a System-class notice row — never a message
   from you. The notice is machine-origin and says so in its own text: it
   opens "[Background sub-agent completion — automated notice]" and

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -722,4 +722,21 @@ misleading "finish provider setup" composer state — the delivery itself
 was always correct and durable); one deferred wake's notice labeled a
 `done` child "running"; and after a restart the staged wake's `◈` badge
 did not render on the sidebar row, with delivery waiting on the next
-retry trigger rather than on opening the conversation.)*
+retry trigger rather than on opening the conversation.) The off-view
+delivery contract (the honest-limits correction above and the `◈`
+clear-semantics rewrite) verified @ 9144b235e — 2026-08-14
+(wake-integrity arc, tasks 15970/15971: driven live against a real
+Anthropic model on an isolated scratch profile. Confirmed by pane and by
+both databases: a draft typed with real keys DURING the spawning turn
+held a due wake back for the full ~90 seconds it existed (child `done`
+with a NULL `wake_delivered_at` stamp throughout) and clearing the draft
+delivered it within ~2 seconds; a completion landing while the
+conversation was not in view was DELIVERED immediately (stamped while a
+palette covered Console and another session tab was active) and left the
+`◈` marker set on the conversation's tab, which cleared — mark row gone —
+the moment the conversation was activated and viewed; and restart staging
+still held: SIGKILL with a wake owed left mark + NULL stamp in place, the
+relaunch rendered `◈` on the sidebar row before the conversation was
+opened, and one click on that row delivered the owed wake exactly once,
+stamped ~2s later. Every one of the five sub-agent runs in the session's
+ledger ended stamped exactly once.)*

--- a/Docs/superpowers/plans/2026-08-13-supervisor-fleet-pr3a2-autowake.md
+++ b/Docs/superpowers/plans/2026-08-13-supervisor-fleet-pr3a2-autowake.md
@@ -197,6 +197,16 @@ one missing guard.
   (2026-08-13: all five driven live against real Anthropic on an isolated
   scratch profile — see the sdd task-7 report for panes, DB stamps, and the
   three UI-layer findings filed as follow-ups.)
+  *(Scenario 2 corrected 2026-08-14, wake-integrity arc, per the
+  coordinator's design ruling for task-15971: on current dev a Chat screen
+  can stay RESIDENT on nav-away — a navigation issued while a pushed
+  screen sits above Chat pops the modal, not Chat — and the resident
+  screen's controller delivers the wake OFF-SCREEN immediately. That is
+  now the intended behavior: the user learns of it via the settle toast
+  plus the `FLEET_UNSEEN` `◈` mark, which an off-view delivery leaves SET
+  until the conversation is viewed. Staging-and-claim-at-next-mount, as
+  scenario 2 verified it, remains the contract only for a genuinely
+  unmounted Console: restart / first boot.)*
 - [x] Ledger + PR body: the headless limit stated plainly. (Ledger written;
   PR body is the coordinator's step — the headless limit text is staged in
   the task-7 report.)

--- a/Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-design.md
+++ b/Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-design.md
@@ -434,6 +434,28 @@ now fights the target, and nothing long-term sneaks into this program's ACs.
   ownership above the screen and is a filed follow-up (task-15860).
   Everything PR 3a-2 built is substrate that version needs; the only delta
   is where the wake runs.
+
+  *(Corrected 2026-08-14, wake-integrity arc — tasks 15970/15971, per the
+  coordinator's design ruling.)* "Whenever a Console screen is mounted"
+  includes a Console screen the user has NAVIGATED AWAY FROM: a Chat
+  screen can stay resident in the screen stack — mounted, pump running,
+  controller live — while another screen displays (observed live and
+  harness-reproduced: a navigation issued while a pushed screen sits
+  above Chat pops the modal off the stack, not Chat). **Off-screen
+  delivery from that resident screen is the intended behavior** — the
+  supervisor acts immediately; that IS the auto-wake invariant, and
+  staging ever existed only because the screen used to die on nav-away.
+  What the user is owed instead of staging is *knowledge*: the settle
+  toast fires at settle from any screen, and a wake turn that completes
+  while its conversation is not the displayed-and-active one **leaves the
+  `FLEET_UNSEEN` mark set** (delivery-commit visibility probe,
+  `wake_conversation_in_view`), so the `◈` badge points at the delivered
+  result until the user views it — view-clear applies normally then,
+  since a delivered wake has nothing pending. "Viewing" means DISPLAYED:
+  a mounted-but-hidden Console's sync tick never view-clears the mark.
+  Durable staging (mark + `wake_delivered_at` ledger + mount-claim +
+  session-open trigger) remains exactly for the genuinely-unmounted
+  case: restart / first boot, where no controller exists at all.
 - **Cost:** per-child token spend rolls into the existing Console cost
   ticker, attributed per agent in expanded rows; fleet aggregate visible on
   the summary line's expansion.

--- a/Tests/Chat/test_console_fleet_wake_view_mark.py
+++ b/Tests/Chat/test_console_fleet_wake_view_mark.py
@@ -1,0 +1,153 @@
+"""task-15971: a wake that completes off-view must leave the ◈ mark set.
+
+The coordinator's design ruling (wake-integrity arc, ledger progress.md):
+OFF-SCREEN DELIVERY IS THE INTENDED BEHAVIOR when the Chat screen is
+mounted-but-hidden -- the supervisor acts immediately; staging exists only
+for a genuinely-unmounted Console (restart / first boot). The requirement
+that replaces staging for the hidden case: the user must still LEARN of
+the delivery. Live (residue arc, run 3c0cdfaf): the wake delivered while
+Library was displayed and the FLEET_UNSEEN mark did not survive -- the
+delivery commit cleared it (and the hidden screen's sync tick, pinned
+UI-side in ``test_console_fleet_wake_hidden_screen.py``, consumed what
+was left). The user was told nothing beyond a transient toast.
+
+Pinned here, at the delivery commit (``_deliver``'s acceptance branch):
+
+- completing while the conversation is NOT in view (screen-wired
+  ``wake_conversation_in_view`` probe returns False) SETS the mark
+  through the named seam, so the ◈ badge points at the delivered result
+  until the user views it (view-clear then applies normally -- a
+  delivered wake has nothing pending);
+- completing IN view keeps the historical clear;
+- a raising probe keeps the mark (fail toward the badge: a stale badge
+  self-heals on the next viewed sync tick; a silently-cleared one is the
+  live bug);
+- an unwired probe (controller doubles, the pre-screen rig) keeps the
+  historical clear-on-delivery.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Tests.Chat.test_console_fleet_wake import (
+    _controller_rig,
+    _drain,
+    _settle,
+    _survivor,
+    _terminal_subagent_run,
+)
+from tldw_chatbook.Chat.console_fleet_attention import (
+    FLEET_UNSEEN_REVISION_ATTR,
+)
+from tldw_chatbook.Chat.conversation_local_marks_service import (
+    ConversationLocalMarksService,
+)
+
+
+def _marked(app, conversation_id) -> bool:
+    return app.conversation_local_marks_service.has_mark(
+        conversation_id, ConversationLocalMarksService.FLEET_UNSEEN
+    )
+
+
+async def _deliver_one(runs_db, app, session, gateway, controller):
+    """Drive one survivor settle through to an accepted, stamped delivery."""
+    _parent, run_id = _terminal_subagent_run(runs_db, session.id)
+    app.conversation_local_marks_service.set_mark(
+        session.id, ConversationLocalMarksService.FLEET_UNSEEN
+    )
+    wake = controller.fleet_wake
+    wake.on_fleet_drained(
+        _drain(session.id, _survivor(run_id, session_id=session.id))
+    )
+    assert await _settle(lambda: gateway.payloads), "the wake never delivered"
+    assert await _settle(lambda: not wake.has_pending(session.id))
+    assert runs_db.get_run(run_id).get("wake_delivered_at"), (
+        "harness precondition: the delivery must commit (stamped ledger)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_wake_completing_off_view_leaves_the_mark_set(tmp_path):
+    """The ruling's core requirement, RED against unmodified production:
+    the delivery commit cleared the mark regardless of visibility, so an
+    off-screen delivery left the user nothing."""
+    chacha, app, runs_db, store, session, gateway, bridge, controller = (
+        _controller_rig(tmp_path)
+    )
+    try:
+        controller.wake_conversation_in_view = (
+            lambda conversation_id, session_id: False
+        )
+        revision_before = int(getattr(app, FLEET_UNSEEN_REVISION_ATTR, 0))
+        await _deliver_one(runs_db, app, session, gateway, controller)
+        assert _marked(app, session.id), (
+            "a wake completing OFF-VIEW must leave the FLEET_UNSEEN mark "
+            "set -- the ◈ badge is how the user learns a supervisor turn "
+            "ran and delivered while they were elsewhere"
+        )
+        assert int(getattr(app, FLEET_UNSEEN_REVISION_ATTR, 0)) > revision_before, (
+            "the off-view mark must bump the badge revision so screen "
+            "caches repaint"
+        )
+    finally:
+        chacha.close()
+
+
+@pytest.mark.asyncio
+async def test_a_wake_completing_in_view_still_clears_the_mark(tmp_path):
+    """The preserved side: the user watched the wake land; nothing is
+    unseen; the historical clear stands."""
+    chacha, app, runs_db, store, session, gateway, bridge, controller = (
+        _controller_rig(tmp_path)
+    )
+    try:
+        controller.wake_conversation_in_view = (
+            lambda conversation_id, session_id: True
+        )
+        await _deliver_one(runs_db, app, session, gateway, controller)
+        assert not _marked(app, session.id), (
+            "a wake the user watched land is not unseen -- the delivery "
+            "commit must clear the mark as before"
+        )
+    finally:
+        chacha.close()
+
+
+@pytest.mark.asyncio
+async def test_a_raising_view_probe_keeps_the_mark(tmp_path):
+    """Uncertainty resolves toward the badge: a kept mark on a viewed
+    conversation self-heals on the next displayed sync tick; a cleared
+    mark on an unviewed delivery is the live silent-delivery bug."""
+    chacha, app, runs_db, store, session, gateway, bridge, controller = (
+        _controller_rig(tmp_path)
+    )
+    try:
+
+        def _broken_probe(conversation_id, session_id):
+            raise RuntimeError("view probe broke")
+
+        controller.wake_conversation_in_view = _broken_probe
+        await _deliver_one(runs_db, app, session, gateway, controller)
+        assert _marked(app, session.id), (
+            "a raising view probe must keep the mark (fail toward the "
+            "badge, never toward silence)"
+        )
+    finally:
+        chacha.close()
+
+
+@pytest.mark.asyncio
+async def test_an_unwired_view_probe_keeps_the_historical_clear(tmp_path):
+    """Controller doubles and the pre-screen rig have no view probe; they
+    keep the pre-15971 clear-on-delivery (the screen always wires the
+    probe in production)."""
+    chacha, app, runs_db, store, session, gateway, bridge, controller = (
+        _controller_rig(tmp_path)
+    )
+    try:
+        assert getattr(controller, "wake_conversation_in_view", None) is None
+        await _deliver_one(runs_db, app, session, gateway, controller)
+        assert not _marked(app, session.id)
+    finally:
+        chacha.close()

--- a/Tests/UI/test_console_fleet_wake_hidden_screen.py
+++ b/Tests/UI/test_console_fleet_wake_hidden_screen.py
@@ -120,6 +120,81 @@ async def test_probe_sees_a_draft_typed_with_real_keys(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_hidden_screens_probe_sees_the_displayed_screens_typed_draft(
+    tmp_path,
+):
+    """task-15970, the live shape: the resident hidden Chat screen's
+    coordinator consults the probe while the user types into the
+    DISPLAYED Chat screen's composer. RED before the fix: the hidden
+    probe read its own (empty) composer -- ``probe: composer=True
+    draft=''`` while the pane visibly held the text -- and the wake fired
+    through the held draft."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        hidden = await _leak_resident_chat(app, pilot)
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        displayed = app.screen
+        assert isinstance(displayed, ChatScreen) and displayed is not hidden
+        await _wait_for_composer(displayed, pilot)
+        assert hidden in app.screen_stack, "the leak must survive the return nav"
+
+        await pilot.press(*"drafting")
+        await pilot.pause()
+        displayed_composer = displayed._console_composer_or_none()
+        assert displayed_composer is not None
+        assert displayed_composer.draft_text() == "drafting", (
+            "harness precondition: the typed keys must land in the "
+            "displayed composer through the production key path"
+        )
+        hidden_session_id = (
+            hidden._ensure_console_chat_store().ensure_session().id
+        )
+        hidden_probe = (
+            hidden._console_chat_controller.wake_user_priority_probe
+        )
+        assert hidden_probe(hidden_session_id) is True, (
+            "the user-wins-ties probe must see the draft the user is "
+            "actually holding -- the hidden screen's coordinator firing "
+            "through the displayed composer's text is the live 15970 bug"
+        )
+
+
+@pytest.mark.asyncio
+async def test_typed_draft_defers_the_hidden_coordinators_due_wake(tmp_path):
+    """task-15970 AC#1, outcome level: a due wake on the hidden resident
+    screen's coordinator DEFERS (no delivery scheduled, pending intact)
+    while a real-keys draft is held in the displayed composer."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        hidden = await _leak_resident_chat(app, pilot)
+        hidden_controller = hidden._console_chat_controller
+        wake = hidden_controller.fleet_wake
+        hidden_session = hidden._ensure_console_chat_store().ensure_session()
+
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        displayed = app.screen
+        assert isinstance(displayed, ChatScreen) and displayed is not hidden
+        await _wait_for_composer(displayed, pilot)
+        await pilot.press(*"drafting my next thought".replace(" ", "_"))
+        await pilot.pause()
+
+        with wake._registry_lock:
+            wake._pending[hidden_session.id] = {"r-held": "done"}
+        wake._attempt(hidden_session.id)
+        assert wake.delivering_conversation_id() is None, (
+            "a wake must defer while the user holds a typed draft -- "
+            "delivering here is the live 'wake fired straight through a "
+            "held draft' failure"
+        )
+        assert not wake._delivery_tasks
+        assert wake.has_pending(hidden_session.id), (
+            "deferral must leave the pending bit untouched"
+        )
+
+
+@pytest.mark.asyncio
 async def test_hidden_screen_sync_never_view_clears_the_unseen_mark(tmp_path):
     """task-15971 AC#2: 'viewing IS the clear' requires VIEWING. The
     resident hidden screen's own sync tick kept running during Library

--- a/Tests/UI/test_console_fleet_wake_hidden_screen.py
+++ b/Tests/UI/test_console_fleet_wake_hidden_screen.py
@@ -1,0 +1,197 @@
+"""Wake-integrity arc (tasks 15970 + 15971): the mounted-but-hidden Console.
+
+The PR3a-2 residue arc's live pass found two failures with instrumented
+evidence (ledger ``residue-frames/dbg.log``): a wake fired straight
+through a draft the user was HOLDING in the visible composer (probe read
+``draft=''`` while the pane showed text, twice), and a wake DELIVERED
+while the Library screen was displayed, with no surviving unseen mark.
+
+This arc's diagnosis, reproduced here through the real production paths
+(no ``load_draft``, no hand-built screens): the app's navigation builds a
+FRESH screen per route and ``switch_screen`` pops the TOP of the screen
+stack -- so a navigation issued while any pushed screen (the nav overflow
+menu, a picker, a rename modal) sits above the Chat screen pops the MODAL
+and leaves the Chat screen alive in the stack: mounted, pump running,
+controller un-shut-down, wake coordinator armed. That resident hidden
+screen is what the residue arc's ``mounted=True`` instrumentation saw.
+Both live failures follow:
+
+- **task-15970**: the hidden screen's user-wins-ties probe read ITS OWN
+  (empty) composer while the user typed into the DISPLAYED screen's --
+  the "blindness" was a stale screen, not segment plumbing (the suspected
+  PR #1554-era composer path verified correct under real key input here).
+- **task-15971**: the hidden screen's controller never shuts down, so its
+  coordinator delivers off-screen -- ruled INTENDED by the coordinator's
+  design ruling (the supervisor acts immediately; that is the auto-wake
+  invariant) -- but the user must still LEARN of it: the hidden screen's
+  own 1s sync tick was "view"-clearing the FLEET_UNSEEN mark while the
+  user was on Library, which is how the live run ended with no badge.
+
+Pinned here: the probe reads the composer the user can actually type
+into; a mounted-but-undisplayed screen's sync never view-clears the mark;
+the displayed screen still clears it (Task 4 semantics preserved); and
+the screen wires the coordinator's conversation-in-view probe.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from tldw_chatbook.Chat.console_fleet_attention import (
+    bump_fleet_unseen_revision,
+)
+from tldw_chatbook.Chat.conversation_local_marks_service import (
+    ConversationLocalMarksService,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Navigation.nav_overflow_menu import NavOverflowMenu
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+async def _wait_for_composer(screen, pilot) -> None:
+    from Tests.UI.test_destination_shells import _wait_for_selector
+
+    await _wait_for_selector(screen, pilot, "#console-native-composer")
+
+
+async def _mount_chat(app, pilot) -> ChatScreen:
+    """Push the initial Chat screen the way startup does."""
+    await app.push_screen(ChatScreen(app))
+    app._initial_screen_pushed = True
+    await pilot.pause()
+    chat = app.screen
+    assert isinstance(chat, ChatScreen)
+    await _wait_for_composer(chat, pilot)
+    return chat
+
+
+async def _leak_resident_chat(app, pilot) -> ChatScreen:
+    """Drive the real navigation path that leaves Chat resident-but-hidden.
+
+    The nav overflow menu (a real pushed screen, reachable via its "More"
+    affordance) is above Chat when the navigation runs; ``switch_screen``
+    pops the MENU, and the Chat screen stays alive in the stack below the
+    incoming Library screen.
+    """
+    chat = await _mount_chat(app, pilot)
+    app.push_screen(NavOverflowMenu())
+    await pilot.pause()
+    await app.handle_screen_navigation(NavigateToScreen("library"))
+    await pilot.pause()
+    assert type(app.screen).__name__ == "LibraryScreen"
+    assert chat in app.screen_stack, (
+        "harness precondition: the nav-under-a-pushed-screen path must "
+        "leave the Chat screen resident in the stack (the residue arc's "
+        "live mounted=True state); if this stops holding, the hidden-"
+        "screen scenario below needs a new construction"
+    )
+    assert chat.is_running and chat._console_chat_controller is not None
+    assert not chat._console_chat_controller._shutdown_requested.is_set()
+    return chat
+
+
+def _build_app(tmp_path):
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_probe_sees_a_draft_typed_with_real_keys(tmp_path):
+    """task-15970 AC#2 groundwork: real key input through the production
+    ``on_key`` path (NOT ``load_draft`` -- the existing wiring test's
+    harness shortcut is exactly what let the live blindness pass) reaches
+    the probe on the DISPLAYED screen."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = await _mount_chat(app, pilot)
+        session_id = chat._ensure_console_chat_store().ensure_session().id
+        controller = chat._ensure_console_chat_controller()
+        probe = controller.wake_user_priority_probe
+        assert probe(session_id) is False, "an empty composer holds no claim"
+        await pilot.press(*"drafting")
+        await pilot.pause()
+        assert probe(session_id) is True, (
+            "a draft typed with real keys is the user's sending claim"
+        )
+
+
+@pytest.mark.asyncio
+async def test_hidden_screen_sync_never_view_clears_the_unseen_mark(tmp_path):
+    """task-15971 AC#2: 'viewing IS the clear' requires VIEWING. The
+    resident hidden screen's own sync tick kept running during Library
+    display (the dbg log's continuous sync-run beats) and consumed the
+    FLEET_UNSEEN mark -- which is why the live off-screen delivery left
+    the user nothing. A mounted-but-undisplayed Console must not count as
+    'in Console'."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        hidden = await _leak_resident_chat(app, pilot)
+        marks = app.conversation_local_marks_service
+        session = hidden._ensure_console_chat_store().ensure_session()
+        marks.set_mark(session.id, ConversationLocalMarksService.FLEET_UNSEEN)
+        bump_fleet_unseen_revision(app)
+
+        await hidden._sync_console_native_session_tabs()
+        await pilot.pause()
+        assert marks.has_mark(
+            session.id, ConversationLocalMarksService.FLEET_UNSEEN
+        ), (
+            "a hidden resident screen's sync tick must not view-clear the "
+            "unseen mark while the user is on another screen -- this is "
+            "how the live run ended with no badge after the off-screen "
+            "delivery"
+        )
+
+
+@pytest.mark.asyncio
+async def test_displayed_screen_sync_still_view_clears_the_mark(tmp_path):
+    """task-15971 AC#3, the preserved side: on the DISPLAYED Console the
+    active conversation's mark still clears on the sync tick (Task 4's
+    viewing-is-the-clear, unchanged for a delivered wake)."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = await _mount_chat(app, pilot)
+        marks = app.conversation_local_marks_service
+        session = chat._ensure_console_chat_store().ensure_session()
+        chat._ensure_console_chat_controller()
+        marks.set_mark(session.id, ConversationLocalMarksService.FLEET_UNSEEN)
+        bump_fleet_unseen_revision(app)
+
+        await chat._sync_console_native_session_tabs()
+        await pilot.pause()
+        assert not marks.has_mark(
+            session.id, ConversationLocalMarksService.FLEET_UNSEEN
+        ), "viewing the conversation on the displayed screen IS the clear"
+
+
+@pytest.mark.asyncio
+async def test_screen_wires_the_conversation_in_view_probe(tmp_path):
+    """task-15971 AC#1 wiring: the coordinator's delivery commit consults
+    a screen-wired conversation-in-view probe; True only when this screen
+    is the DISPLAYED one and the session is the active one."""
+    app = _build_app(tmp_path)
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = await _mount_chat(app, pilot)
+        controller = chat._ensure_console_chat_controller()
+        session = chat._ensure_console_chat_store().ensure_session()
+        probe = getattr(controller, "wake_conversation_in_view", None)
+        assert callable(probe), (
+            "the screen must wire the conversation-in-view probe the "
+            "delivery commit consults"
+        )
+        assert probe(session.id, session.id) is True
+        assert probe(session.id, "some-other-session") is False
+
+        # Hide the screen through the real leak path: not displayed any more.
+        app.push_screen(NavOverflowMenu())
+        await pilot.pause()
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+        assert chat in app.screen_stack
+        assert probe(session.id, session.id) is False, (
+            "a mounted-but-undisplayed screen's conversation is not in view"
+        )

--- a/backlog/tasks/task-15860 - Headless-wake-fire-the-supervisor-auto-wake-with-no-Console-screen-mounted.md
+++ b/backlog/tasks/task-15860 - Headless-wake-fire-the-supervisor-auto-wake-with-no-Console-screen-mounted.md
@@ -38,6 +38,28 @@ the hardened terminal signal + fan-out seam, the durable unseen-completion
 mark, the wake-delivery ledger, and the full wake machinery (kill switch,
 app-wide serialization, user-wins-ties, approval floor, AGENT_WAKE
 authorization). The only delta is WHERE the wake runs.
+
+**State update 2026-08-14 (wake-integrity arc, tasks 15970/15971):** the
+"no Console at all" case has NARROWED. On current dev a Chat screen can
+stay resident (mounted, controller live) after nav-away — observed live
+and harness-reproduced: a navigation issued while a pushed screen sits
+above Chat pops the modal off the stack, not Chat — and the coordinator's
+design ruling made off-screen delivery from such a resident screen the
+INTENDED behavior (the user learns of it via the settle toast + the
+FLEET_UNSEEN ◈ mark, which an off-view delivery now leaves SET until
+viewed; `ConsoleFleetWakeCoordinator._conversation_in_view` /
+`ChatScreen._console_wake_conversation_in_view`). The genuinely-headless
+gap this task owns is therefore restart / first boot — the window before
+the first Console open, where no controller has ever existed — plus any
+nav path that truly unmounts the Chat screen (the plain nav path still
+does: `on_unmount` → `controller.shutdown()`). The description above
+predates that ruling; scope accordingly. Also note: whether the
+resident-screen state itself (the modal-atop-Chat stack leak) is a nav
+bug to fix or the intended residency model is the coordinator's open
+call — see task-16210 (filed by the wake-integrity arc with the harness
+repro); if it is fixed toward always-unmount, the staged-wake path grows
+back to covering every nav-away and this task's ACs cover more ground
+again.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-15970 - User-wins-ties-probe-is-blind-to-a-live-typed-composer-draft.md
+++ b/backlog/tasks/task-15970 - User-wins-ties-probe-is-blind-to-a-live-typed-composer-draft.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15970
 title: User-wins-ties probe is blind to a live-typed composer draft
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:17'
+updated_date: '2026-08-14 02:53'
 labels:
   - fleet
   - console
@@ -22,3 +24,9 @@ PR3a-2 residue-arc live verification (2026-08-13, scratch profile, real Anthropi
 - [ ] #1 The user-wins-ties probe defers a due wake while a draft typed with real keys (not load_draft) is present
 - [ ] #2 A test drives the probe through real typed input and fails on the blindness before the fix
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce RED with real key input through the production on_key path (not load_draft)\n2. Diagnose where typed state lives vs where the probe reads\n3. Fix the probe to read the composer the user actually types into\n4. Mutation-test the fix\n5. Live re-verify the deferral with typed text
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-15970 - User-wins-ties-probe-is-blind-to-a-live-typed-composer-draft.md
+++ b/backlog/tasks/task-15970 - User-wins-ties-probe-is-blind-to-a-live-typed-composer-draft.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-15970
 title: User-wins-ties probe is blind to a live-typed composer draft
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-14 01:17'
-updated_date: '2026-08-14 02:53'
+updated_date: '2026-08-14 06:03'
 labels:
   - fleet
   - console
@@ -21,8 +21,8 @@ PR3a-2 residue-arc live verification (2026-08-13, scratch profile, real Anthropi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The user-wins-ties probe defers a due wake while a draft typed with real keys (not load_draft) is present
-- [ ] #2 A test drives the probe through real typed input and fails on the blindness before the fix
+- [x] #1 The user-wins-ties probe defers a due wake while a draft typed with real keys (not load_draft) is present
+- [x] #2 A test drives the probe through real typed input and fails on the blindness before the fix
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -30,3 +30,27 @@ PR3a-2 residue-arc live verification (2026-08-13, scratch profile, real Anthropi
 <!-- SECTION:PLAN:BEGIN -->
 1. Reproduce RED with real key input through the production on_key path (not load_draft)\n2. Diagnose where typed state lives vs where the probe reads\n3. Fix the probe to read the composer the user actually types into\n4. Mutation-test the fix\n5. Live re-verify the deferral with typed text
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+FIXED in commit 8d8b0c2be; the suspicion was WRONG and the fix landed elsewhere.
+The suspected PR #1554-era segment plumbing was verified CORRECT under real key
+input (a real-keys harness test passes against unmodified production). The real
+mechanism: a navigation issued while a pushed screen sits above the Chat screen
+pops the MODAL off the screen stack, leaving the Chat screen resident-but-hidden
+with a live controller — the live 'probe: composer=True draft=""' was the HIDDEN
+screen's probe reading its own empty composer while the user typed into the
+DISPLAYED screen's. Fix: _console_wake_user_priority resolves the composer via
+_console_wake_probe_composer — the displayed screen's composer whenever the
+displayed screen is a (different) Console screen, its own otherwise, with the
+task-15862 active_app-ContextVar lesson applied to self.app resolution. Tests
+(Tests/UI/test_console_fleet_wake_hidden_screen.py): real pilot.press keys, real
+nav construction of the two-screen state, RED pre-fix on the probe AND on the
+outcome (the hidden coordinator's _attempt delivered through the held draft);
+mutations M1/M2 killed. Live re-verified on a scratch profile vs real Anthropic:
+a draft typed with real keys during the spawning turn held the due wake ~90s
+(child done, stamp NULL throughout), clearing it delivered in ~2s. Evidence:
+.superpowers/sdd/2026-08-13-supervisor-fleet-pr3a2-autowake/wake-integrity-report.md
++ wake-integrity-frames/. The underlying stack leak is filed as task-16210.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15971 - Leaving-Console-no-longer-stages-a-wake-—-it-delivers-off-screen.md
+++ b/backlog/tasks/task-15971 - Leaving-Console-no-longer-stages-a-wake-—-it-delivers-off-screen.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-15971
 title: Leaving Console no longer stages a wake — it delivers off-screen
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-14 01:20'
-updated_date: '2026-08-14 02:53'
+updated_date: '2026-08-14 06:04'
 labels:
   - fleet
   - console
@@ -47,7 +47,7 @@ residue-frames/dbg.log (`delivery-hook fired: mounted=True` at
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
+<!-- AC:BEGIN -->
 **ACs rewritten 2026-08-14 to the coordinator's design ruling** (ledger
 `progress.md`, wake-integrity arc): OFF-SCREEN DELIVERY IS THE INTENDED
 BEHAVIOR when the Chat screen is mounted-but-hidden — the supervisor acts
@@ -56,11 +56,11 @@ the screen used to die on nav-away). The original ACs below pinned the
 superseded staging behaviour and are replaced.
 
 <!-- AC:BEGIN -->
-- [ ] #1 A wake turn that completes while its conversation is not the visible/active one leaves the FLEET_UNSEEN mark set (via the named seam), so the ◈ badge points at the delivered result
-- [ ] #2 A mounted-but-undisplayed Console screen's sync tick does not view-clear the mark (viewing means DISPLAYED; a resident hidden screen must not count as "in Console")
-- [ ] #3 View-clear semantics are otherwise unchanged: viewing the conversation on the displayed Console clears a delivered wake's mark normally
-- [ ] #4 Genuinely-unmounted staging (restart / first boot: durable mark + mount-claim + open-as-trigger, task-15864) still passes its suites untouched
-- [ ] #5 The spec's honesty line and the User Guide staging story are rewritten to match the ruling
+- [x] #1 A wake turn that completes while its conversation is not the visible/active one leaves the FLEET_UNSEEN mark set (via the named seam), so the ◈ badge points at the delivered result
+- [x] #2 A mounted-but-undisplayed Console screen's sync tick does not view-clear the mark (viewing means DISPLAYED; a resident hidden screen must not count as "in Console")
+- [x] #3 View-clear semantics are otherwise unchanged: viewing the conversation on the displayed Console clears a delivered wake's mark normally
+- [x] #4 Genuinely-unmounted staging (restart / first boot: durable mark + mount-claim + open-as-trigger, task-15864) still passes its suites untouched
+- [x] #5 The spec's honesty line and the User Guide staging story are rewritten to match the ruling
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -68,3 +68,35 @@ superseded staging behaviour and are replaced.
 <!-- SECTION:PLAN:BEGIN -->
 1. Reproduce the off-screen delivery + no-surviving-mark state RED against the ruling (real nav path)\n2. Implement: wake completing off-view sets FLEET_UNSEEN via the named seam; view-clear only when the screen is displayed\n3. Rewrite spec/User Guide honesty surfaces; update tests pinning superseded staging\n4. Keep genuinely-unmounted staging (15864) green untouched\n5. Update task-15860 with the narrowed headless case\n6. Live verify off-screen delivery -> badge -> view-clear; restart staging still delivers
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+IMPLEMENTED PER THE COORDINATOR'S DESIGN RULING (ACs rewritten to it, dated,
+before implementation — the original ACs pinned the superseded staging
+behaviour). Commits 243b19da7 (mechanism) + 9144b235e (honesty surfaces).
+Mechanism: the delivery COMMIT now consults a screen-wired
+wake_conversation_in_view probe — in-view keeps the historical clear; off-view
+SETS the mark via the new named seam set_fleet_unseen_completion (badge revision
+bumped); a raising probe keeps the mark (fail toward the badge); unwired doubles
+keep the historical clear. 'Viewing' now means DISPLAYED: the sync tick's
+view-clear is gated on _console_screen_displayed(), so a resident hidden
+screen's tick can no longer consume the mark while the user is elsewhere (the
+harness-diagnosed mechanism behind the live 'no mark ever' evidence — a
+modal-atop-Chat navigation pops the modal and leaves Chat resident; filed as
+task-16210). Genuinely-unmounted staging (restart/first-boot, task-15864)
+untouched — suites green unmodified; no pre-existing test pinned the superseded
+mounted-but-hidden staging, so none needed updating. Tests: Tests/Chat/
+test_console_fleet_wake_view_mark.py (4) + the 15971 half of Tests/UI/
+test_console_fleet_wake_hidden_screen.py (4), each RED pre-fix on its own
+assertion; mutations M3–M10 killed. Docs: spec §7 dated correction, User Guide
+honest-limits + ◈ semantics rewrite + live-verified stamp, plan scenario-2
+correction, task-15860 narrowed-scope update. Live: off-view completion
+delivered immediately (stamped while a palette covered Console and another tab
+was active), mark SURVIVED the commit, ◈ rendered on the tab, viewing cleared
+it; restart staging re-verified (SIGKILL with owed wake → ◈ on the sidebar row
+pre-open → one click → exactly-once delivery). Evidence: wake-integrity-report.md
++ wake-integrity-frames/ in the PR3a-2 ledger dir.
+<!-- SECTION:NOTES:END -->
+
+<!-- AC:END -->

--- a/backlog/tasks/task-15971 - Leaving-Console-no-longer-stages-a-wake-—-it-delivers-off-screen.md
+++ b/backlog/tasks/task-15971 - Leaving-Console-no-longer-stages-a-wake-—-it-delivers-off-screen.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-15971
 title: Leaving Console no longer stages a wake — it delivers off-screen
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:20'
+updated_date: '2026-08-14 02:53'
 labels:
   - fleet
   - console
@@ -13,6 +15,7 @@ priority: high
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 PR3a-2 residue-arc live verification (2026-08-13, scratch profile, real
 Anthropic, dev @cb89f3ff6 + the residue fixes): a survivor was spawned in
 Console, the user navigated to Library BEFORE settle, and the wake turn
@@ -41,9 +44,27 @@ repaint timer).
 Evidence: `.superpowers/sdd/2026-08-13-supervisor-fleet-pr3a2-autowake/`
 residue-frames/dbg.log (`delivery-hook fired: mounted=True` at
 1786669812/1786669814 during Library display) and the residue report.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 
-- [ ] #1 A survivor settling while Console is not the displayed screen stages its wake (durable mark + NULL stamp) instead of delivering
-- [ ] #2 The staged wake delivers exactly once when Console is next displayed
-- [ ] #3 A test pins the not-displayed staging path against the resident-screen nav lifecycle (a mounted-but-undisplayed Console must not count as "in Console")
+**ACs rewritten 2026-08-14 to the coordinator's design ruling** (ledger
+`progress.md`, wake-integrity arc): OFF-SCREEN DELIVERY IS THE INTENDED
+BEHAVIOR when the Chat screen is mounted-but-hidden — the supervisor acts
+immediately (that IS the auto-wake invariant; staging existed only because
+the screen used to die on nav-away). The original ACs below pinned the
+superseded staging behaviour and are replaced.
+
+<!-- AC:BEGIN -->
+- [ ] #1 A wake turn that completes while its conversation is not the visible/active one leaves the FLEET_UNSEEN mark set (via the named seam), so the ◈ badge points at the delivered result
+- [ ] #2 A mounted-but-undisplayed Console screen's sync tick does not view-clear the mark (viewing means DISPLAYED; a resident hidden screen must not count as "in Console")
+- [ ] #3 View-clear semantics are otherwise unchanged: viewing the conversation on the displayed Console clears a delivered wake's mark normally
+- [ ] #4 Genuinely-unmounted staging (restart / first boot: durable mark + mount-claim + open-as-trigger, task-15864) still passes its suites untouched
+- [ ] #5 The spec's honesty line and the User Guide staging story are rewritten to match the ruling
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the off-screen delivery + no-surviving-mark state RED against the ruling (real nav path)\n2. Implement: wake completing off-view sets FLEET_UNSEEN via the named seam; view-clear only when the screen is displayed\n3. Rewrite spec/User Guide honesty surfaces; update tests pinning superseded staging\n4. Keep genuinely-unmounted staging (15864) green untouched\n5. Update task-15860 with the narrowed headless case\n6. Live verify off-screen delivery -> badge -> view-clear; restart staging still delivers
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-16210 - Navigation-under-a-pushed-screen-leaks-a-resident-hidden-screen-in-the-stack.md
+++ b/backlog/tasks/task-16210 - Navigation-under-a-pushed-screen-leaks-a-resident-hidden-screen-in-the-stack.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16210
+title: Navigation under a pushed screen leaks a resident hidden screen in the stack
+status: To Do
+assignee: []
+created_date: '2026-08-14 03:27'
+labels:
+  - console
+  - navigation
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found by the wake-integrity arc (tasks 15970/15971) while diagnosing the
+residue arc's live evidence, and harness-reproduced deterministically
+(Tests/UI/test_console_fleet_wake_hidden_screen.py, `_leak_resident_chat`):
+`App.switch_screen` pops the TOP of the screen stack, so a navigation
+issued while any pushed screen (nav overflow menu, a picker, a rename
+modal, a confirmation dialog) sits above the current tab screen pops the
+MODAL and leaves the tab screen resident in the stack — mounted, message
+pump running, `on_unmount` never fired. For ChatScreen that means a live
+controller (no `shutdown()`), live sync/poll timers beating behind
+another screen (the residue dbg.log's continuous sync-run lines during
+Library display), and a second live ChatScreen once the user navigates
+back — the state behind BOTH live wake findings (the blind user-wins-ties
+probe and the off-screen delivery). The wake layer is now defensive
+against it (15970/15971), but the leak itself is generic: every leaked
+screen duplicates timers and workers indefinitely (perf), and any screen
+holding non-wake resources leaks them too.
+
+Coordinator note: the 15971 design ruling treats mounted-but-hidden
+off-screen delivery as INTENDED, so fixing this toward always-unmount is
+a product call, not an automatic bug-fix — if navigation is changed to
+always tear down the outgoing tab screen, the staged-wake path grows back
+to covering every nav-away (see task-15860's state update).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The navigation completion path removes the outgoing tab screen from the stack even when a pushed screen sat above it at switch time (or the residency model is explicitly ruled intended and documented)
+- [ ] #2 A test drives a real navigation with a pushed screen above the current tab screen and pins the ruled behavior
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1528,6 +1528,19 @@ class ConsoleChatController:
         #: and is retried on the next trigger. ``None`` = no probe wired
         #: (headless/tests): no user claim to lose to.
         self.wake_user_priority_probe: Callable[[str], bool] | None = None
+        #: task-15971: screen-wired ``(conversation_id, session_id) ->
+        #: bool`` probe the delivery COMMIT consults -- True only while
+        #: this conversation is actually being viewed (the screen is the
+        #: DISPLAYED one and the session is the active one). A wake that
+        #: completes off-view leaves the FLEET_UNSEEN mark set so the ◈
+        #: badge points at the delivered result (the coordinator's design
+        #: ruling: off-screen delivery is intended for a mounted-but-
+        #: hidden Console; the user must still LEARN of it). ``None`` =
+        #: unwired (controller doubles): the historical clear-on-delivery
+        #: stands.
+        self.wake_conversation_in_view: (
+            Callable[[str, str], bool] | None
+        ) = None
         self._register_fleet_wake(agent_bridge)
         #: task-2154.16 (FB-05): UI-thread callback invoked DIRECTLY (same
         #: main-loop guarantee as ``notify_run_outcome`` above) from

--- a/tldw_chatbook/Chat/console_fleet_attention.py
+++ b/tldw_chatbook/Chat/console_fleet_attention.py
@@ -114,6 +114,41 @@ def clear_fleet_unseen_completion(app: Any, conversation_id: str) -> bool:
     return True
 
 
+def set_fleet_unseen_completion(app: Any, conversation_id: str) -> bool:
+    """Set one conversation's unseen-completion mark (the named set seam).
+
+    task-15971: the set-side sibling of :func:`clear_fleet_unseen_completion`.
+    Its one production caller beyond the attention consumer's settle-time
+    write: Task 5's delivery commit, when a wake turn completes while its
+    conversation is NOT in view (the coordinator's design ruling -- a
+    mounted-but-hidden Console delivers immediately, and the ◈ badge is
+    how the user learns the result landed). Idempotent (the marks upsert),
+    and bumps the badge revision so screen caches repaint.
+
+    Args:
+        app: The application object holding the marks service.
+        conversation_id: The conversation to mark.
+
+    Returns:
+        True when the mark was written; False when the service is
+        unavailable or the write failed (a lost mark is a missing badge,
+        never a broken delivery).
+    """
+    service = getattr(app, "conversation_local_marks_service", None)
+    if service is None or not str(conversation_id or "").strip():
+        return False
+    try:
+        service.set_mark(conversation_id, service.FLEET_UNSEEN)
+    except Exception:  # noqa: BLE001 -- a lost mark is a missing badge, not a crash
+        logger.opt(exception=True).warning(
+            "fleet unseen mark set failed for conversation {conversation_id}",
+            conversation_id=conversation_id,
+        )
+        return False
+    bump_fleet_unseen_revision(app)
+    return True
+
+
 def fleet_completion_toast_copy(
     title: str, statuses: list[str]
 ) -> tuple[str, str]:

--- a/tldw_chatbook/Chat/console_fleet_wake.py
+++ b/tldw_chatbook/Chat/console_fleet_wake.py
@@ -106,6 +106,7 @@ from tldw_chatbook.Agents.agent_service import (
 from tldw_chatbook.Agents.run_log import _setting
 from tldw_chatbook.Chat.console_fleet_attention import (
     clear_fleet_unseen_completion,
+    set_fleet_unseen_completion,
 )
 
 if TYPE_CHECKING:  # pragma: no cover -- typing only
@@ -582,8 +583,53 @@ class ConsoleFleetWakeCoordinator:
                         self._pending.pop(conversation_id, None)
                 nothing_undelivered = conversation_id not in self._pending
             if nothing_undelivered and self._app is not None:
-                clear_fleet_unseen_completion(self._app, conversation_id)
+                # task-15971 (the coordinator's design ruling): the mark's
+                # fate at commit depends on whether the user WATCHED the
+                # delivery. In view -> the result is seen; clear through
+                # the named seam as always. Off view (a mounted-but-hidden
+                # Console delivering, or a non-active session tab) -> the
+                # delivery is real but unseen; the mark is SET so the ◈
+                # badge points at the delivered result until the user
+                # views it (view-clear then applies normally -- nothing
+                # is pending any more).
+                if self._conversation_in_view(conversation_id, session_id):
+                    clear_fleet_unseen_completion(self._app, conversation_id)
+                else:
+                    set_fleet_unseen_completion(self._app, conversation_id)
         self.retry_soon()
+
+    def _conversation_in_view(
+        self, conversation_id: str, session_id: str
+    ) -> bool:
+        """Whether the delivered conversation is actually being viewed.
+
+        Consults the screen-wired ``wake_conversation_in_view`` probe
+        (task-15971). Unwired (controller doubles, the pre-screen rig)
+        keeps the historical clear-on-delivery; a RAISING probe reports
+        not-in-view -- fail toward the badge: a kept mark on a viewed
+        conversation self-heals on the next displayed sync tick, while a
+        cleared mark on an unviewed delivery is the live silent-delivery
+        failure this exists to prevent.
+
+        Args:
+            conversation_id: The delivered conversation.
+            session_id: The session the wake turn ran in.
+
+        Returns:
+            True when the user watched the delivery (or no probe is
+            wired); False when it landed off-view or visibility is
+            uncertain.
+        """
+        probe = getattr(self._controller, "wake_conversation_in_view", None)
+        if not callable(probe):
+            return True
+        try:
+            return bool(probe(conversation_id, session_id))
+        except Exception:  # noqa: BLE001 -- uncertainty keeps the badge
+            logger.opt(exception=True).debug(
+                "wake view probe raised; keeping the unseen mark"
+            )
+            return False
 
     # -- mount claim ----------------------------------------------------------
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -14777,6 +14777,20 @@ class ChatScreen(BaseAppScreen):
         (``_on_console_composer_draft_changed``'s poke) and on every
         terminal run-state transition.
 
+        task-15970: "the Console composer" means the one the user can
+        actually TYPE into. This screen can outlive its display (a
+        navigation issued while a pushed screen sat above it pops the
+        MODAL off the stack and leaves this screen resident-but-hidden --
+        the residue arc's live ``mounted=True`` state), and the live bug
+        was exactly this probe reading the hidden screen's own empty
+        composer while the user held a typed draft in the DISPLAYED
+        screen's: the wake fired straight through it, twice. When the
+        displayed screen is a different Console screen, ITS composer is
+        the user's hands; this screen's own composer is the fallback
+        (nobody can type into any composer while e.g. Library is
+        displayed, and a stale non-empty draft deferring is the probe's
+        conservative direction).
+
         Args:
             session_id: The session the wake would fire into (unused by
                 the any-session rule; part of the probe contract).
@@ -14784,10 +14798,39 @@ class ChatScreen(BaseAppScreen):
         Returns:
             Whether the user currently holds a sending claim.
         """
-        composer = self._console_composer_or_none()
+        composer = self._console_wake_probe_composer()
         if composer is None:
             return False
         return bool(composer.draft_text().strip())
+
+    def _console_wake_probe_composer(self) -> ConsoleComposerBar | None:
+        """The composer the user's keystrokes actually reach (task-15970).
+
+        The displayed screen's composer when the displayed screen is a
+        (different) Console screen; this screen's own otherwise.
+        Duck-typed on ``_console_composer_or_none`` rather than an
+        ``isinstance`` so screen doubles keep working. ``self.app`` is
+        resolved defensively: the coordinator calls this probe from a
+        bare loop callback whose context may lack ``active_app`` (the
+        task-15862 ContextVar lesson) -- ``DOMNode.app`` then walks
+        ``_parent`` to the App, and a screen with no reachable App simply
+        falls back to its own composer.
+        """
+        displayed: Any | None
+        try:
+            displayed = self.app.screen
+        except Exception:  # noqa: BLE001 -- no reachable app: own composer
+            displayed = None
+        if displayed is not None and displayed is not self:
+            resolve = getattr(displayed, "_console_composer_or_none", None)
+            if callable(resolve):
+                try:
+                    composer = resolve()
+                except Exception:  # noqa: BLE001 -- a broken foreign screen
+                    composer = None
+                if composer is not None:
+                    return composer
+        return self._console_composer_or_none()
 
     def _console_screen_displayed(self) -> bool:
         """Whether THIS screen is the one the user is looking at.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5236,6 +5236,17 @@ class ChatScreen(BaseAppScreen):
         self._console_chat_controller.wake_user_priority_probe = (
             self._console_wake_user_priority
         )
+        # task-15971: the delivery COMMIT's visibility probe -- a wake
+        # completing while this conversation is not displayed-and-active
+        # leaves the FLEET_UNSEEN mark set (the ◈ badge is how the user
+        # learns an off-view delivery landed).
+        # task-15971: the delivery COMMIT's visibility probe -- a wake
+        # completing while this conversation is not displayed-and-active
+        # leaves the FLEET_UNSEEN mark set (the ◈ badge is how the user
+        # learns an off-view delivery landed).
+        self._console_chat_controller.wake_conversation_in_view = (
+            self._console_wake_conversation_in_view
+        )
         self._sync_console_chat_core_state()
         return self._console_chat_controller
 
@@ -14778,6 +14789,48 @@ class ChatScreen(BaseAppScreen):
             return False
         return bool(composer.draft_text().strip())
 
+    def _console_screen_displayed(self) -> bool:
+        """Whether THIS screen is the one the user is looking at.
+
+        task-15971: this screen can be mounted-but-hidden (resident in
+        the stack below the displayed screen), and "viewing" semantics --
+        the sync tick's view-clear, the delivery commit's in-view probe
+        -- must mean DISPLAYED, not merely mounted. A screen whose App is
+        unreachable (hand-built test fixtures that never mounted) reports
+        True, preserving those harnesses' historical behaviour; the
+        hidden-resident case this exists for always has a reachable App.
+        """
+        try:
+            return self.app.screen is self
+        except Exception:  # noqa: BLE001 -- no reachable app: fixtures
+            return True
+
+    def _console_wake_conversation_in_view(
+        self, conversation_id: str, session_id: str
+    ) -> bool:
+        """Delivery-commit visibility probe (task-15971).
+
+        True only when this screen is the DISPLAYED one and the wake's
+        session is the ACTIVE session -- i.e. the user actually watched
+        the result land. Anything else (Library displayed, a resident
+        hidden Console, a non-active session tab) is off-view: the
+        coordinator leaves the FLEET_UNSEEN mark set so the ◈ badge
+        points at the delivered result until the user views it.
+
+        Args:
+            conversation_id: The delivered conversation (unused: the
+                active-session comparison already scopes the view).
+            session_id: The session the wake turn ran in.
+
+        Returns:
+            Whether the delivery landed in the user's view.
+        """
+        if not self._console_screen_displayed():
+            return False
+        store = getattr(self, "_console_chat_store", None)
+        active = getattr(store, "active_session_id", None)
+        return active is not None and active == session_id
+
     def _poke_console_wake_retry(self) -> None:
         """Retry a staged auto-wake (task-15864 AC#2: session-open trigger).
 
@@ -16278,9 +16331,16 @@ class ChatScreen(BaseAppScreen):
                 wake_owed = callable(has_pending) and bool(
                     has_pending(active_conversation_id)
                 )
+                # task-15971: viewing means DISPLAYED. This screen can be
+                # resident-but-hidden (the stack-leak nav state the
+                # residue arc live-instrumented), and its sync tick kept
+                # running during Library display -- "view"-clearing a
+                # mark the user never saw. A hidden screen's tick must
+                # leave the mark for the screen the user is actually on.
                 if (
                     active_conversation_id in unseen_ids
                     and not wake_owed
+                    and self._console_screen_displayed()
                     and clear_fleet_unseen_completion(
                         self.app_instance, active_conversation_id
                     )


### PR DESCRIPTION
## Wake integrity: 15970 + 15971

Both high findings from the residue arc's live diagnosis, fixed — and both turned out to share **one mechanism nobody suspected**: `switch_screen` pops the TOP of the screen stack, so a navigation issued while any modal sits above Chat pops the modal and leaves the ChatScreen **resident** — running pump, live controller, armed wake coordinator — hidden behind the new screen. (The suspected composer segment plumbing was refuted by execution: real keys through the production `on_key` path reach the canonical segments correctly.)

- **15970 — user-wins-ties probe blind to a typed draft.** The hidden resident screen's probe read its own empty composer while the user typed into the displayed one. Fix: the probe reads the composer the user can actually type into. Reproduced red with real `pilot.press` keys through a real-navigation two-screen construction; live: a typed draft held the wake ~90s (stamp NULL throughout), clearing it delivered in 2s.
- **15971 — off-view wake delivery, ruling implemented.** Off-screen delivery is now by design (dev's nav model keeps Chat mounted; the supervisor acting immediately IS the auto-wake invariant). The guarantee that replaces staging: a wake completing off-view **leaves the ◈ FLEET_UNSEEN mark set** (new named seam), view-clear is gated on the screen being DISPLAYED (the hidden resident screen's sync tick was eating the mark), and the spec/User Guide honesty lines are rewritten with dated corrections. Restart/first-boot staging unchanged — all five 15864 suites pass unmodified.

Evidence: 10/10 mutations; new suites 10/10; Agents 1409; live panes archived (off-view delivery with surviving mark + badge; restart exactly-once re-verified). No pre-existing test pinned the superseded staging behavior — none needed updating.

**Filed, needs an owner decision: task-16210** — the screen-residency leak itself (fix toward always-unmount vs bless residency). **Also flagged: ~74 unowned dev reds at `7b122c702`** (62 bridge + 12 fleet-cluster; scripted runs land `error` while streaming correctly; absent at `cb89f3ff6`) — pre-existing for this branch, verified byte-identical on pristine dev; being triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wake integrity in Console: typed drafts now defer auto‑wake even when a hidden resident Chat screen exists, and off‑view wake delivery is intentional and leaves an unseen badge. Previously the hidden screen’s probe read its own empty composer and delivery cleared the `◈` mark; now the probe reads the displayed composer and off‑view commits set `FLEET_UNSEEN` until viewed, with staging reserved for genuinely unmounted Console (restart/first boot).

- Behavior
  - The user‑wins‑ties probe reads the displayed screen’s composer (`_console_wake_probe_composer`) so a real‑keys draft defers a due wake (15970).
  - Off‑view delivery commits set `FLEET_UNSEEN` (`set_fleet_unseen_completion`); in‑view clears as before. Raising/unwired probes fail toward keeping the mark. `_deliver` consults `wake_conversation_in_view` (wired by `ChatScreen`) (15971).
  - “Viewing” means displayed: the sync tick only view‑clears when the Chat screen is the displayed one (`_console_screen_displayed`). Staging remains only for restart/first‑boot.
  - Docs/User Guide/spec corrected to the new contract; tests added to pin off‑view mark semantics and hidden‑screen behavior.
- Review focus
  - `tldw_chatbook/Chat/console_fleet_wake.py`: commit‑time mark logic + view probe.
  - `tldw_chatbook/UI/Screens/chat_screen.py`: composer resolution for the probe, displayed gating, and `wake_conversation_in_view` wiring.
  - `tldw_chatbook/Chat/console_fleet_attention.py`: new `set_fleet_unseen_completion` seam and revision bump.
  - Navigation stack residency causing hidden screens is tracked separately (16210); no change here to unmount behavior.

<sup>Written for commit 44b7ed34e431c35a1814b16b49c89f033f0394b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

