### PR TITLE
fix(console): usage-accounting failures never fail a streamed run; unstale the bridge fixture (task-16270)

### DIFF
--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -7,7 +7,6 @@ import json
 import threading
 import time
 from dataclasses import replace
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -355,6 +355,70 @@ def test_no_tool_message_streams_final_answer_like_today(tmp_path):
     assert ConsoleMessageRole.TOOL not in roles
 
 
+def test_usage_accounting_failure_never_flips_a_streamed_run_to_error(
+    tmp_path, monkeypatch
+):
+    """TASK-16270: usage accounting is pure observability. A run that
+    streamed its answer successfully and then fails INSIDE usage
+    extraction must complete ``done`` with the usage simply missing (plus
+    a logged warning naming the failure) — never flip to
+    ``status='error'``."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("usage extraction exploded")
+
+    monkeypatch.setattr(
+        console_agent_bridge, "_openai_usage_from_provider_call", _boom
+    )
+    warnings: list[str] = []
+    sink_id = logger.add(warnings.append, level="WARNING", format="{message}")
+    try:
+        bridge, _db, store, session, aid = _bridge(tmp_path, [["Tok", "yo."]])
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            aid,
+            resolution=ConsoleProviderResolution(
+                provider="TestProvider", base_url="", model=None, ready=True
+            ),
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert outcome.status == "done"
+    assert outcome.final_text == "Tokyo."
+    assert store.get_message(aid).content == "Tokyo."
+    # Usage is simply missing — never attached to the message.
+    assert store.get_message(aid).usage is None
+    assert any("usage accounting failed" in m for m in warnings)
+
+
+def test_a_genuine_provider_failure_still_classifies_as_error(tmp_path):
+    """The TASK-16270 wrap covers ONLY usage accounting: a failure in the
+    model call / stream itself must still land ``status='error'``."""
+
+    class _ExplodingGateway:
+        async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+            yield "Tok"
+            raise RuntimeError("provider connection dropped")
+
+    bridge, _db, store, session, aid = _bridge_with_gateway(
+        tmp_path, _ExplodingGateway()
+    )
+    outcome = _run(
+        bridge,
+        store,
+        session,
+        aid,
+        resolution=ConsoleProviderResolution(
+            provider="TestProvider", base_url="", model=None, ready=True
+        ),
+    )
+    assert outcome.status == "error"
+    assert any(step.kind == "error" for step in outcome.steps)
+
+
 def test_tool_turn_renders_a_tool_marker_not_prose(tmp_path):
     scripts = [
         [_fence("calculator", {"expression": "6*7"})],  # turn 1: leading fence

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -262,11 +262,26 @@ class _SignalChunkGateway(_ChunkGateway):
             yield chunk
 
 
-class _NativeResolution:
-    """A fake resolution whose execution_key resolves to a native-capable provider."""
+def _test_resolution(**over):
+    """Minimal REAL-shaped resolution for the shared harness.
 
-    provider = "Groq"
-    execution_key = "groq"
+    TASK-16270: PR #1612 widened ``_StreamingModelAdapter``'s implicit
+    ``resolution`` contract past an opaque token — ``.provider`` and
+    ``.model`` are now read unconditionally after every streamed turn
+    (usage accounting), so ``object()`` stand-ins no longer satisfy it.
+    Constructing the PRODUCTION ``ConsoleProviderResolution`` dataclass
+    here (instead of a hand-rolled stand-in) keeps this fixture from
+    silently drifting the next time the contract widens: a new required
+    field fails loudly in every suite that shares ``_run``.
+    """
+    fields = dict(provider="TestProvider", base_url="", model=None, ready=True)
+    fields.update(over)
+    return ConsoleProviderResolution(**fields)
+
+
+def _native_resolution():
+    """A real resolution whose execution_key resolves to a native-capable provider."""
+    return _test_resolution(provider="Groq", execution_key="groq")
 
 
 def _native_calls(name, args, call_id="c1"):
@@ -310,7 +325,7 @@ def _run(bridge, store, session, assistant_id, **over):
     kwargs = dict(
         conversation_id="conv-1",
         session_id=session.id,
-        resolution=object(),
+        resolution=_test_resolution(),
         assistant_message_id=assistant_id,
         model="test-model",
         session_system_prompt="",
@@ -489,23 +504,31 @@ def test_joined_continuation_never_logs_private_tool_arguments_or_results(
     )
     captured: list[str] = []
     sink = logger.add(lambda record: captured.append(str(record)), level="DEBUG")
+    target = ContinuationRestoreTarget(
+        provider="moonshot",
+        model="kimi-k2",
+        protocol="chat_completions",
+        api_base_url="https://api.moonshot.ai/v1",
+    )
     try:
         outcome = _run(
             bridge,
             store,
             session,
             assistant.id,
-            resolution=SimpleNamespace(
+            resolution=_test_resolution(
                 provider="Moonshot",
                 execution_key="moonshot",
+                model="kimi-k2",
+                base_url="https://api.moonshot.ai/v1",
             ),
             restore_provider_continuation=checkpoint,
-            restore_provider_target=ContinuationRestoreTarget(
-                provider="moonshot",
-                model="kimi-k2",
-                protocol="chat_completions",
-                api_base_url="https://api.moonshot.ai/v1",
-            ),
+            restore_provider_target=target,
+            # TASK-16270: PR #1612 widened the resume contract — an ACTIVE
+            # checkpoint now rides as a continuation group and requires an
+            # owner (production always passes assistant_message_id and
+            # derives the owner key from the continuation target).
+            continuation_target=target,
             expand_provider_continuation=lambda _checkpoint: [],
             resume_provider_continuation=True,
         )
@@ -732,7 +755,7 @@ def test_native_tool_call_round_trip_streams_final_answer(tmp_path):
     bridge, db, store, session, aid = _bridge(
         tmp_path, [[_native_calls("get_current_datetime", {})], ["It is ", "now."]]
     )
-    outcome = _run(bridge, store, session, aid, resolution=_NativeResolution())
+    outcome = _run(bridge, store, session, aid, resolution=_native_resolution())
     assert outcome.status == "done"
     assert store.get_message(aid).content == "It is now."
     gateway = bridge._gateway
@@ -757,7 +780,7 @@ def test_native_leaked_prose_is_reset_before_final_answer(tmp_path):
         tmp_path,
         [["Let me check. ", _native_calls("get_current_datetime", {})], ["Done."]],
     )
-    outcome = _run(bridge, store, session, aid, resolution=_NativeResolution())
+    outcome = _run(bridge, store, session, aid, resolution=_native_resolution())
     assert outcome.status == "done"
     assert store.get_message(aid).content == "Done."
 
@@ -768,7 +791,7 @@ def test_native_kill_switch_off_stays_on_fence_path(tmp_path):
         [[_fence("get_current_datetime", {})], ["Done."]],
         native_tools_enabled=lambda: False,
     )
-    outcome = _run(bridge, store, session, aid, resolution=_NativeResolution())
+    outcome = _run(bridge, store, session, aid, resolution=_native_resolution())
     assert outcome.status == "done"
     assert bridge._gateway.tools_seen[0] is None  # no tools= despite groq
 
@@ -787,7 +810,7 @@ def test_captured_native_tools_override_beats_later_callback_change(tmp_path):
         store,
         session,
         aid,
-        resolution=_NativeResolution(),
+        resolution=_native_resolution(),
         native_tools_enabled=True,
     )
 
@@ -4396,8 +4419,25 @@ def test_resumed_sidecars_reach_normal_prepared_gateway_once(tmp_path) -> None:
         ],
         restore_provider_continuation=active,
         restore_provider_target=target,
+        # TASK-16270: PR #1612 widened the resume contract — the ACTIVE
+        # checkpoint now rides as its own continuation group, attached to
+        # the canonical assistant row carrying the pending call's
+        # tool_calls, so the expanded transcript must include that row.
         expand_provider_continuation=lambda _checkpoint: [
-            {"role": "assistant", "content": "ACTIVE-CANONICAL-ONCE"}
+            {
+                "role": "assistant",
+                "content": "ACTIVE-CANONICAL-ONCE",
+                "tool_calls": [
+                    {
+                        "id": "active-call",
+                        "type": "function",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            }
         ],
         resume_provider_continuation=True,
         continuation_sidecar=(ProviderContinuationSidecar("prior", prior),),
@@ -4411,8 +4451,12 @@ def test_resumed_sidecars_reach_normal_prepared_gateway_once(tmp_path) -> None:
     assert len(gateway.dispatched) == 1
     prepared = gateway.dispatched[0]
     assert isinstance(prepared, PreparedProviderRequest)
+    # TASK-16270: since PR #1612 the ACTIVE checkpoint rides as its own
+    # continuation group, owned by the assistant message being resumed —
+    # alongside the prior sidecar group.
     assert [group.owner_message_id for group in prepared.continuation_groups] == [
-        "prior"
+        "prior",
+        aid,
     ]
     without_private = gateway.prepare_chat_request(
         resolution,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1711,19 +1711,39 @@ class _StreamingModelAdapter:
         if native_calls:
             message["tool_calls"] = native_calls
         response: dict[str, Any] = {"choices": [{"message": message}]}
-        usage_payload = (
-            terminal_metadata.usage if terminal_metadata is not None else None
-        )
-        usage = _openai_usage_from_provider_call(
-            usage_payload,
-            provider=self._resolution.provider,
-            model=self._resolution.model or model or "",
-        )
-        if usage is None and call_signals is not None:
+        # Design decision (TASK-16270): usage accounting is pure
+        # observability. By the time this block runs, the provider turn has
+        # already streamed and completed successfully — a failure HERE is
+        # bookkeeping failing, not the model call failing, so it must never
+        # convert the finished turn into an error outcome (PR #1612 hoisted
+        # this accounting out of the signals-only guard, which made an
+        # accounting crash fatal to an otherwise-successful run). A genuine
+        # provider failure still classifies as an error: it raises from the
+        # streaming/consume path above, OUTSIDE this wrap. On failure the
+        # turn completes with the usage simply missing, and the cause is
+        # logged.
+        usage: dict[str, Any] | None = None
+        try:
+            usage_payload = (
+                terminal_metadata.usage if terminal_metadata is not None else None
+            )
             usage = _openai_usage_from_provider_call(
-                call_signals.usage_snapshot(),
+                usage_payload,
                 provider=self._resolution.provider,
                 model=self._resolution.model or model or "",
+            )
+            if usage is None and call_signals is not None:
+                usage = _openai_usage_from_provider_call(
+                    call_signals.usage_snapshot(),
+                    provider=self._resolution.provider,
+                    model=self._resolution.model or model or "",
+                )
+        except Exception as exc:  # noqa: BLE001 — observability is never fatal
+            usage = None
+            logger.opt(exception=True).warning(
+                "usage accounting failed after a successful provider turn; "
+                "completing the turn without usage: {!r}",
+                exc,
             )
         if usage is not None:
             response["usage"] = usage


### PR DESCRIPTION
## task-16270 — 78 reds on dev: observability failures were fatal, and a fixture went stale

Bisect (this session) traced 78 reds — `Tests/Chat/test_console_agent_bridge.py` (62) plus nine fleet-cluster suites (16) — to **PR #1612** (`cc7bbf989`, Moonshot/Z.ai hardening), the first commit in the suspect window. It hoisted usage accounting out of its `if call_signals is not None:` guard, so `self._resolution.provider` is now read unconditionally after every streamed turn.

Two independent problems, fixed separately:

**1. A pure-observability failure must never fail a successful run.** The eager read raised `AttributeError`, the provider-failure classifier wrapped it as `"unexpected provider error"`, and a run that had *streamed its answer correctly* landed `status='error'`. Production was safe only by the luck of its callers always passing a real resolution. Usage accounting is now wrapped at the bookkeeping boundary alone: a failure there yields `done` with usage simply absent plus a logged warning, while a genuine provider failure still classifies as `error` (mutation-tested in both directions). The decision is recorded at the wrap site.

**2. The shared test fixture went stale against a widened contract.** The bridge/fleet harness passed `resolution=object()` — valid under the old opaque-token contract. It now builds a real-shaped resolution from the production dataclass (imported, not stubbed), so the fixture cannot silently drift from the contract again — one change covering all 78 call sites rather than 78 edits.

**Counts (READ):** bridge `195 passed / 0 failed` (was 62F/131P; +2 new tests) · fleet cluster `65 passed / 0 failed` (was 16F/49P) · `Tests/Agents/` 1409 · PR #1612's own provider suites `29 passed` — its feature does not regress. The one unrelated failure in the sweep (`test_settings_model_catalog_toggles`) was verified failing identically on a pristine `origin/dev` worktree — pre-existing, not this branch.

Closes task-16270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents usage-accounting failures from flipping a successfully streamed run to error and updates the bridge test fixture to the widened resolution/resume contract (task-16270). Previously, an exception during post-stream usage extraction turned a successful run into status=error; now the run completes done with usage omitted and a warning, while genuine provider failures still classify as error.

- Runtime: wraps only the usage-accounting block; on failure, logs “usage accounting failed …” and omits usage; streaming errors still raise and land status=error. No API or gateway behavior change.
- Tests/fixtures: shared harness now constructs a real-shaped `ConsoleProviderResolution`; resume tests pass `continuation_target` so the active checkpoint has an owner; helper renamed to `_native_resolution`; removed the stray `SimpleNamespace` import. Required for any remaining tests outside this suite: replace `resolution=object()` with a `ConsoleProviderResolution(...)`, and when resuming, pass `continuation_target` to set the active group owner.

<sup>Written for commit fe9e645aa04ff19eae002039355bdc7f465586b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

