### PR TITLE
docs(headless-wake): task-15860 plan + Task 0 execution probes

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md
@@ -1,0 +1,290 @@
+# Task 0 report — four execution probes (task-15860, headless wake)
+
+**No production code was written.** This is evidence only.
+
+- Branch/base: detached worktree at `origin/dev` `7a6e8f804`
+  (`.worktrees/headless-probe`).
+- Probes: `Tests/UI/test_probe_headless_wake_p1_continuity.py`,
+  `Tests/UI/test_probe_headless_wake_p2_p3_p4.py`,
+  `Tests/test_probe_import_provenance.py`.
+- Runner: `.venv/bin/pytest <files> -p no:randomly -q -s`, cwd = the
+  worktree. **Every probe was executed twice; every verdict below was
+  identical on both runs.** Run 1: `7 passed in 144.64s`. Run 2:
+  `7 passed in 141.31s`. The extended P3 (P3b) was executed after run 2:
+  `4 passed in 130.71s`.
+
+## Trap found before any probe ran
+
+The venv's editable install resolves `tldw_chatbook` to a **foreign
+worktree**:
+`.venv/lib/python3.12/site-packages/__editable___tldw_chatbook_0_1_8_0_finder.py`
+maps `tldw_chatbook` → `.worktrees/task-2512-mcp-unified/tldw_chatbook`.
+Every result in this report would have been about someone else's branch if
+that had won. It does not: setuptools' editable finder is *appended* to
+`sys.meta_path`, so the stdlib `PathFinder` (searching the rootdir pytest
+prepends, because `Tests/` is a package) resolves first.
+
+Proven, not assumed — `Tests/test_probe_import_provenance.py`:
+
+```
+PROBE imported tldw_chatbook from: .../.worktrees/headless-probe/tldw_chatbook/__init__.py
+PROBE worktree root:               .../.worktrees/headless-probe
+1 passed
+```
+
+---
+
+## P1 — the off-ramp. **VERDICT: the plan's reading is CONFIRMED. Design A survives.**
+
+**Question.** Console history continuity across a nav-away is claimed to be
+an in-memory `ScreenStateStore` snapshot, not the DB. If DB rows written
+while Console is down DO surface correctly at remount, designs B/C get far
+cheaper and A may be unjustified.
+
+**Method (all through production paths).** Real `TldwCli`
+(`Tests/UI/app_factory._build_test_app`), real on-disk `CharactersRAGDB`,
+real `ChatScreen` pushed and mounted, one real `submit_draft` to persist the
+conversation, then **the real navigation API**
+(`app.handle_screen_navigation(NavigateToScreen("library"))` — real
+`save_state`, real unmount, real `controller.shutdown()`), then a SYSTEM row
+and an ASSISTANT row appended through the production
+`ChatPersistenceService.create_message`, then `NavigateToScreen("chat")`
+back.
+
+**Executed output (run 2; run 1 identical modulo uuids):**
+
+```
+pre-nav DB rows: user:'first user message', assistant:'assistant one'
+pre-nav active_leaf=14292047-...
+after nav-away screen=LibraryScreen
+headless appends: system=302206ed-... assistant=b820dae3-...
+active_leaf after DB-only appends=14292047-... (unchanged=True)
+post-return in-memory transcript: [('user', 'first user message'), ('assistant', 'assistant one')]
+(a) headless rows in restored transcript:  system=False assistant=False
+(a-dom) headless rows in rendered widgets: system=False assistant=False
+post-return session persisted_conversation_id=0bce270a-...   <- same conversation
+(b) provider payload: [('system', 'You are a capable assistant with optiona'),
+                       ('user', 'first user message'),
+                       ('assistant', 'assistant one'),
+                       ('user', 'second user message')]
+(b) headless rows in provider payload: system=False assistant=False
+(c) final DB rows (id | sender | parent | content):
+      3bc60661 | user      | None     | 'first user message'
+      14292047 | assistant | 3bc60661 | 'assistant one'
+      302206ed | system    | 14292047 | 'HEADLESS-SYSTEM-ROW-P1'
+      b820dae3 | assistant | 302206ed | 'HEADLESS-ASSISTANT-ROW-P1'
+      22a62346 | user      | 14292047 | 'second user message'     <- FORK
+      76b0462f | assistant | 22a62346 | 'assistant one'
+(c) final active_leaf points at: assistant 'assistant one'   (the forked branch)
+(c) next persisted append -> FORKS away from the headless rows: True
+```
+
+**Answers.**
+
+- **(a) Do the rows render?** No. Absent from the restored in-memory
+  transcript and from the rendered widget tree. The restored screen is a
+  different `ChatScreen` instance (asserted) on the same persisted
+  conversation id (asserted), and it shows two rows where the DB has four.
+- **(b) Are they in the next send's provider payload?** No. The payload is
+  `system-prompt / user / assistant / user` — built entirely from the
+  restored in-memory store.
+- **(c) Active leaf and forking.** The DB-only append left
+  `conversations.active_leaf_message_id` untouched (still the pre-nav
+  assistant). The next persisted append parented itself to that pre-nav
+  assistant, **forking the tree**: the headless `system → assistant` chain
+  and the new `user → assistant` chain are siblings, and the leaf pointer
+  then moved onto the new branch. The headless rows are stranded on a dead
+  branch that no Console surface will ever show.
+
+**Two objections, closed by execution.**
+
+1. *"A real headless writer would also maintain the active-leaf pointer."*
+   Variant probe: same sequence plus
+   `db.set_conversation_active_leaf(conversation_id, headless_assistant_id)`.
+   Result unchanged — `system=False assistant=False` in both the transcript
+   and the payload, the next append still forked, and the pointer was then
+   overwritten (`final active_leaf still the headless assistant: False`).
+   The snapshot restore never consults the pointer.
+2. *"Maybe nothing reads DB appends, mounted or not."* Control probe: the
+   same out-of-band append **with Console still mounted** is also invisible
+   (`live store: False`, `next payload: False`). The in-memory store is the
+   source of truth for both the transcript and the payload in every case.
+   This makes the finding stronger, not weaker: a DB-only headless delivery
+   path is invisible unconditionally.
+
+**Consequence.** Designs B and C (throwaway headless controller / DB-only
+delivery) are rejected on evidence. The recommendation for design A stands,
+and the DECISIONS.md premise "(1) … DB-only headless writes are invisible +
+divergent at remount" is now executed rather than read.
+
+---
+
+## P2 — post-unmount fan-out on current dev
+
+**Question.** PR 3a-2 Task 1 proved the *attention* consumer fires
+post-teardown; the wake coordinator was added later. After `on_unmount`,
+does `ConsoleFleetWakeCoordinator.on_fleet_drained` still record, and is its
+captured loop still alive?
+
+**Method.** Real screen + real nav away (shutdown NOT suppressed), then the
+drain fired through **the bridge's own `FleetDrainFanout` from a plain
+thread** — the production path, not the coordinator method directly.
+
+```
+runs_db present pre-unmount: True
+captured loop pre-unmount is the app loop: True
+fan-out registrations pre-unmount:  ['fleet-attention', 'usage-reattach', 'fleet-wake']
+post-unmount _shutdown_requested set: True
+P2(loop) captured loop post-unmount: is_none=False is_closed=False is_app_loop=True is_running=True
+fan-out registrations post-unmount: ['fleet-attention', 'usage-reattach', 'fleet-wake']
+P2(registry) recorded post-unmount (via the bridge fan-out): has_pending=True pending_ids=('3b1edef9-...',)
+P2(delivery) wake turns reaching the provider after unmount: 0
+P2(delivery) delivering_conversation_id=None
+P2(ledger)   wake_delivered_at=None
+```
+
+**Answer: YES and YES.** The registration survives, the child-thread intake
+records into the pending registry, and the captured loop is the app loop —
+open and running. Delivery is refused, and the refusal is attributable to
+exactly one line: `_attempt`'s `_shutdown_requested` gate
+(`console_fleet_wake.py:460-462`). Nothing about the signal path dies with
+the screen.
+
+---
+
+## P3 — how much already works if the controller merely survives
+
+**Question.** Keep the controller alive artificially (skip `shutdown()`),
+unmount the screen, settle a survivor. Does the wake reach `submit_draft`,
+does the turn complete, and which screen-wired hook slots are touched with
+no view?
+
+**Method.** Identical rig; `ConsoleChatController.shutdown` monkeypatched to
+a no-op for the navigation only. The screen genuinely unmounts (asserted:
+`chat not in app.screen_stack`). Every controller attribute bound to a
+`ChatScreen` method was wrapped with a recorder *before* the navigation, so
+"touched" is measured, not inferred.
+
+```
+shutdown() was suppressed for this probe
+post-unmount _shutdown_requested set: False
+wake loop still the app loop: True
+P3(delivery) wake turns reaching the provider after unmount: 1
+P3(delivery) payload tail role='user' carries the child's result=True
+P3(turn) wake_delivered_at stamped (turn accepted+committed): True
+P3(transcript) rows in the (orphaned) store:
+    [('user','first user message'), ('assistant','wake reply'),
+     ('system','[Background sub-agent comple'), ('assistant','wake reply')]
+P3(hooks) screen-bound controller slots (15 incl. delivery_ui_hook):
+    _chat_dictionary_applier, _global_user_display_name, _library_provider_factory,
+    _rag_capture_provider, _world_info_applier, notify_run_failure, notify_run_outcome,
+    on_submission_accepted, park_pending_approval, set_pending_approval,
+    set_pending_skill_install, set_pending_skill_script, wake_conversation_in_view,
+    wake_user_priority_probe   (+ wake.delivery_ui_hook)
+P3(hooks) TOUCHED during the wake turn:
+    _chat_dictionary_applier, _world_info_applier, wake.delivery_ui_hook,
+    wake_conversation_in_view, wake_user_priority_probe
+P3(hooks) NOT touched:
+    _global_user_display_name, _library_provider_factory, _rag_capture_provider,
+    notify_run_failure, notify_run_outcome, on_submission_accepted,
+    park_pending_approval, set_pending_approval, set_pending_skill_install,
+    set_pending_skill_script
+```
+
+**Answer.** With the controller merely surviving, **the entire wake turn
+already works headlessly**: `submit_draft` was reached, the model payload's
+trailing `user` entry carried the child's `agent_runs.result`, the
+transcript gained a machine-origin SYSTEM row and no USER row, and the
+durable ledger stamped `wake_delivered_at` — which `_deliver` writes only
+after real acceptance. Five of fifteen hook slots are touched; three are
+the wake's own probes.
+
+**Sizing.** The work is not "build headless wake". It is: stop destroying
+the runtime, move continuity, and rebind five hooks.
+
+**Hazard found, not inferred.** All five touched slots were still bound to
+methods of a **dead** `ChatScreen`, and none raised. A silent wrong answer
+from `wake_conversation_in_view` decides whether the `◈` unseen mark
+survives (task-15971's entire mechanism), and one from
+`wake_user_priority_probe` decides whether the user wins a tie. Detach must
+rebind these, not leave them dangling.
+
+### P3b — the composition of P1 and P3 (the decision-relevant fact)
+
+Same run, extended: after the surviving-controller wake completed, the
+controller was really shut down and Console was re-entered through the real
+navigation API.
+
+```
+P3b(db) rows persisted by the surviving-controller wake:
+    [('user','first user message'), ('assistant','wake reply'),
+     ('system','[Background sub-agent comple'), ('assistant','wake reply')]
+P3b(remount) transcript the user sees on returning:
+    [('user','first user message'), ('assistant','wake reply')]
+P3b(remount) the wake notice survives the return: False
+```
+
+A wake turn that genuinely ran, spent money, and stamped the ledger is
+**invisible** to the user on return, because the `ScreenStateStore` snapshot
+was taken before it. This is the concrete cost of keeping continuity
+screen-owned, and it is why design A's structural half (plan Task 3) is
+required rather than cosmetic.
+
+---
+
+## P4 — headless approval cost
+
+**Question.** With no UI wired, a risk-tagged tool in a wake turn: actual
+wall time to denial, and the effective `[mcp] approval_timeout_seconds`.
+
+**Method.** A `ConsoleChatController` with **no `app`, no
+`set_pending_approval`, no `park_pending_approval`** (P3 established those
+slots are untouched by a viewless turn, so this is the real headless shape).
+The pending row is shaped as a risk-floored built-in — `server_key
+"agent:builtin"`, `reason "risk_floored"` — the shape
+`build_tool_review_hook` emits for a risk-tagged tool. A wake turn runs on
+the same controller and therefore through the same
+`request_mcp_approvals` gate.
+
+```
+controller.app wired: False
+set_pending_approval wired: False
+park_pending_approval wired: False
+P4(config)   effective [mcp] approval_timeout_seconds = 120.0  (shipped default constant 120.0)
+P4(measured) decisions={'builtin__write_file': 'timeout'}
+P4(measured) wall time to verdict = 120.43s      (run 1: 120.47s)
+control      injected 0.05s deadline -> elapsed 1.00s   (poll granularity is 1.0s)
+```
+
+**Answer.** **120.43 s** of real wall time, then the fail-closed `timeout`
+verdict, with nothing surfaced to the user at any point. The effective
+timeout is the shipped default `120.0`
+(`console_chat_controller.py:259`; resolved through
+`get_cli_setting("mcp", "approval_timeout_seconds", …)` at `:4325`, so a
+config override moves it). The control at a 0.05 s injected deadline
+returned in 1.00 s, confirming the cost IS the configured deadline plus the
+1.0 s poll granularity (`console_chat_controller.py:262`) and nothing else.
+
+Note on wording: the verdict word is `"timeout"`, not `"deny"`
+(`console_chat_controller.py:4051-4053`); the refusal and its audit record
+land downstream in the tool providers as `"denied-timeout"`. Fail-closed
+either way.
+
+---
+
+## Verdict
+
+**Design A survives P1.** The off-ramp was not taken: DB rows written while
+Console is unmounted do not surface, are not sent, and fork the conversation
+tree — and that holds even when the headless writer maintains the durable
+active-leaf pointer, and even when Console is still mounted. Designs B and C
+are rejected on evidence.
+
+P2 and P3 shrink the remaining work considerably: the signal path, the
+registry, the loop and the whole wake turn already survive teardown. What
+does not survive is the runtime object and the continuity mechanism. P3b
+shows those two are one problem, not two.
+
+P4 prices the one deliberately-deferred safety behaviour at 120 s of silence
+per risk-tagged call, which the User Guide must state rather than the user
+discover.

--- a/Docs/superpowers/plans/2026-08-14-headless-wake.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake.md
@@ -1,0 +1,303 @@
+# Headless Wake (task-15860) — app-owned Console runtime
+
+Task: `backlog/tasks/task-15860 - Headless-wake-fire-the-supervisor-auto-wake-with-no-Console-screen-mounted.md`
+(4 binding ACs, restated in "What done means" below).
+Spec: `Docs/superpowers/specs/2026-08-08-supervisor-agent-fleet-design.md`
+§3 invariant 5 (`:104`, auto-wake REQUIRED) and §7 (`:371`), whose
+"Where the wake itself runs — the honest architectural limit as built"
+paragraph (`:424-437`) names this task as the follow-up that removes the
+limit.
+Predecessor: `Docs/superpowers/plans/2026-08-13-supervisor-fleet-pr3a2-autowake.md`
+(PR 3a-2, merged) built every artifact headless wake needs; the only delta
+is WHERE the wake runs.
+Coordinator rulings and the two escalated owner calls:
+`.superpowers/sdd/2026-08-14-headless-wake/DECISIONS.md`.
+Task 0's executed evidence: `Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md`.
+
+## The design, and why it is A
+
+**Design A: the Console runtime (agent bridge + `ConsoleChatController` +
+the message store) is owned by the app, not by `ChatScreen`. The screen
+attaches to it as a VIEW at mount and detaches at unmount.**
+
+Three designs were on the table. B and C both keep per-screen ownership and
+make a headless wake write only to ChaChaNotes (B: a throwaway headless
+controller; C: a DB-only delivery path). Task 0 executed the premise both
+depend on, and it does not hold:
+
+- **P1.** With Console unmounted, SYSTEM + ASSISTANT rows written to the
+  conversation through the production `ChatPersistenceService` were, at the
+  next Console mount: absent from the transcript, absent from the rendered
+  widgets, absent from the next send's provider payload — and the next
+  persisted append **forked the tree**, parenting itself to the pre-nav
+  assistant and leaving the headless rows on a dead branch. Maintaining the
+  durable active-leaf pointer as well did not change any of it (the
+  snapshot restore does not consult the pointer, and the next send
+  overwrote it). Two runs, identical.
+- **P3b.** The composition that decides it: a wake turn that RAN headlessly
+  (surviving controller, real `submit_draft`, ledger stamped) persisted all
+  four rows to ChaChaNotes — and the user returning to Console saw only the
+  two that predated the snapshot. The wake notice and its reply were
+  invisible.
+
+So "DB-only headless writes are invisible and divergent at remount" is now
+executed, not read. B and C are rejected on evidence. The remaining question
+is not whether to move ownership but how little else has to move with it —
+and Task 0 answered that too:
+
+- **P2.** After a real `on_unmount` + `controller.shutdown()`, the bridge
+  fan-out is still registered (`['fleet-attention', 'usage-reattach',
+  'fleet-wake']`), `on_fleet_drained` still records into the pending
+  registry from a child thread, and the coordinator's captured loop is the
+  app loop, open and running. Nothing about the signal path dies with the
+  screen. The only thing that stops delivery is
+  `_attempt`'s `_shutdown_requested` gate.
+- **P3.** With `shutdown()` suppressed and the screen genuinely unmounted,
+  the wake reached `submit_draft`, the payload's trailing `user` entry
+  carried the child's result, and `agent_runs.wake_delivered_at` was
+  stamped — the full turn, with no view. Of 15 screen-wired hook slots only
+  5 were touched, and 3 of those are the wake's own probes.
+
+**The delta is therefore: (1) don't destroy the runtime when the view
+dies, (2) make the app-owned store the continuity owner instead of the
+screen snapshot, (3) rebind the five hook slots that a viewless turn
+touches.** Everything else already works.
+
+## Verified seam map — cite these, do not re-derive
+
+Every line number below was read in this worktree at `origin/dev`
+(`7a6e8f804`).
+
+| Seam | Where | Fact |
+|---|---|---|
+| Screens are never cached | `app.py:8128` `_create_navigation_screen` | Every navigation builds a fresh instance; `ScreenStateStore` is documented there as the continuity mechanism |
+| Navigation body | `app.py:8700` `_complete_screen_navigation` | `TAB_CHAT` snapshot is **discarded then re-saved** (`:8724-8736`); the incoming screen is restored BEFORE `switch_screen` (`:8791-8798`) |
+| Snapshot store | `app.py:5458` `self.screen_state_store = ScreenStateStore()` | App-owned already; only its CONTENT is screen-shaped |
+| Console snapshot write | `chat_screen.py:15781` `save_state` → `:15784` `_serialize_native_console_state` (`:15576`) | Writes `sessions` (`:15606`) + `messages_by_session` (`:15610`) |
+| Console snapshot read | `chat_screen.py:15800` `restore_state` → `:15646` `_restore_native_console_state`, `store.restore_state(...)` at `:15693` | Rebuilds the store from the payload; **never re-reads ChaChaNotes** (P1 confirms by execution) |
+| The DB resume path (not used by restore) | `console_chat_store.py:1136` `restore_persisted_session` | The only DB→store path; reached by opening a conversation, not by a tab switch |
+| Screen teardown | `chat_screen.py:15392` `on_unmount` → `:15470` `_record_console_fleet_teardown` → `:15486` `await controller.shutdown()`, then `:15467` drops the reference | The one line that has to change ownership |
+| What shutdown means today | `console_chat_controller.py:5621` `shutdown` | Sets `_shutdown_requested` unconditionally and first, then cancels EVERY session's stream task. Its own docstring records that `on_unmount` is the frequent caller, not process exit |
+| Teardown accounting | `console_chat_controller.py:2281` `fleet_teardown_split` | Already partitions killed-vs-surviving; AC#2's existing contract |
+| Fan-out | `console_agent_bridge.py:1112` `FleetDrainFanout`, registration `:3714` `on_fleet_drained` | Bridge-lifetime, child-thread, per-consumer isolation. P2: survives teardown intact |
+| Wake coordinator | `console_fleet_wake.py:275` | `on_fleet_drained` `:386`, `retry_soon` `:422`, `_attempt` `:446`, `_deliver` `:523`, `_conversation_in_view` `:601`, `seed_from_marks` `:636` |
+| The gate that stops a headless wake | `console_fleet_wake.py:460-462` | `_shutdown_requested.is_set()` → return. P2: this is the ONLY thing stopping delivery post-unmount |
+| Wake send authority | `console_chat_controller.py:2727` `submit_draft`, `AGENT_WAKE` branch `:2795`, no USER row `:2831` | `ConsoleSubmissionOrigin.AGENT_WAKE` = `console_chat_models.py:54` |
+| Wake send gate | `console_chat_controller.py:2422` `send_refusal_copy` | The same gate a manual send passes |
+| Screen→controller wake wiring | `chat_screen.py:5579-5601` | `wake.wire(app=...)`, `wake.delivery_ui_hook = _on_console_wake_delivery_started` (`:5587`, impl `:15304`), `wake_user_priority_probe` (`:5588`, impl `:15177`), `wake_conversation_in_view` (`:5599`, impl `:15262`) |
+| Mount claim | `chat_screen.py:15145` `_claim_console_fleet_wake_marks` (called synchronously in `on_mount`, `:15050`) → `seed_from_marks` | Ordering hazard: must precede the first tab sync |
+| Active leaf | `console_chat_store.py:696` `_active_leaf_by_session`, write-through `:6680` `_persist_active_leaf`; DB `ChaChaNotes_DB.py:8313` `set_conversation_active_leaf` / `:8330` `get_conversation_active_leaf` | Local-only column; P1: the snapshot restore ignores it entirely |
+| Out-of-band append | `chat_persistence_service.py:878` `create_message` (`sender=` is the role) | What a DB-only headless writer would use |
+| Approval clock | `console_chat_controller.py:4325` `_resolve_mcp_approval_timeout_seconds`, default `:259` `= 120.0`, deadline `:3955`, `timeout` verdict `:4051-4053`, poll granularity `:262` `= 1.0` | P4 measured 120.43s to verdict with no UI wired |
+| Honest-limits copy (AC#4) | `Docs/User_Guide/console/agent-runs-and-tools.md:494-501` | "**If Console isn't open, no wake fires**… follow-up work (task-15860)" |
+| Spec copy to correct | spec `:424-437` | Same limit, same follow-up id |
+
+## What done means (the task's 4 ACs, verbatim intent)
+
+1. A finished background sub-agent wakes its supervisor while no Console
+   screen is mounted, under the same `autowake_enabled` gate, caps, and
+   approval floor as the mounted case.
+2. The ownership move does not regress documented screen-scoped semantics
+   (leaving Console still cancels streaming turns and denies parked
+   approvals; survivors keep running).
+3. Every wake invariant holds headless: no USER transcript row, exactly-once
+   via the `wake_delivered_at` ledger, no phantom wake after restart.
+4. The User Guide's honest-limits paragraph is removed or rewritten.
+
+## Global constraints
+
+- Env rules as 3a-2: no `git stash`; Edit-based restores only; python ONLY
+  via pytest (a bare `python -c` importing `tldw_chatbook.config` rewrites
+  the live config); never touch `~/.config/tldw_cli`; no worktrees under
+  `/private/tmp`; regenerate the CSS bundle, never hand-edit.
+- **The venv's editable install resolves `tldw_chatbook` to a FOREIGN
+  worktree** (`.worktrees/task-2512-mcp-unified`). Run pytest with the
+  worktree as cwd and keep `Tests/test_probe_import_provenance.py` (or an
+  equivalent assertion) in the gate — it is the only thing that proves the
+  code under test is this branch.
+- **Reproduce red before fixing; mutation-test every new test.** Seven
+  confident readings have now been refuted by execution in this programme.
+- A wake notice is never user input and never approval, mounted or headless.
+- Nothing in this plan may add a second source of truth for conversation
+  history. Design A's whole justification is that it REMOVES one.
+
+## Escalated to the owner — blocking status
+
+Both are recorded in `DECISIONS.md`. Neither blocks Tasks 1–2.
+
+- **Owner call #2 — wake at app launch with no Console ever opened?**
+  Blocks Task 6 only. Recommendation stands: YES, gated by the existing
+  `autowake_enabled` AND triggered only by an existing `FLEET_UNSEEN` mark.
+- **Owner call #3 — does Console message state stop travelling through
+  `ScreenStateStore`?** Blocks Task 3, which is the structural half of
+  design A. Task 0's P3b is the argument FOR: with the runtime app-owned
+  but the snapshot still screen-owned, a wake that genuinely ran is
+  invisible on return. Task 3 is where the freeze-incident risk lives; do
+  not start it without the ruling.
+
+---
+
+### Task 0 — the four execution probes (DONE)
+
+Delivered: `Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md`,
+probes `Tests/UI/test_probe_headless_wake_p1_continuity.py`,
+`Tests/UI/test_probe_headless_wake_p2_p3_p4.py`,
+`Tests/test_probe_import_provenance.py`. No production code. Verdict:
+**design A survives P1**; the off-ramp was not taken.
+
+### Task 1 — split teardown: cancel the user's work vs destroy the runtime
+
+`shutdown()` currently does both (`console_chat_controller.py:5621`), and
+`_shutdown_requested` is the exact flag `_attempt` reads to refuse a wake
+(`console_fleet_wake.py:460-462`). AC#2 requires the first half to keep
+happening on nav-away; AC#1 requires the second half to stop.
+
+- [ ] Red: a test that navigates away from Console with (a) a streaming
+  user turn and (b) a parked approval round, and asserts both are still
+  cancelled/denied — while a survivor keeps running and the coordinator's
+  `_attempt` is NOT refused by a teardown flag. Fails today because one
+  flag governs both.
+- [ ] Introduce a view-detach path distinct from runtime shutdown:
+  detach cancels this view's in-flight USER turns and revokes parked
+  approval rounds (reusing `fleet_teardown_split`'s existing partition,
+  `:2281`); runtime shutdown keeps its current meaning and is called only
+  at app exit.
+- [ ] Mutation-test: flip the detach path to also set `_shutdown_requested`
+  and prove the AC#1 test goes red.
+- [ ] Gate + commit.
+
+### Task 2 — move bridge + controller ownership to the app
+
+- [ ] Red: after a real navigation away from Console (no `shutdown()`
+  suppression, no monkeypatching — the production path), a survivor's
+  settle delivers a wake turn that reaches the provider and stamps
+  `wake_delivered_at`. This is exactly P3's assertion with the artificial
+  survival removed; it fails on dev today.
+- [ ] The app constructs and owns the bridge + controller (+ store) lazily,
+  one per runtime identity (`app.py:8211` `_current_runtime_identity`);
+  `ChatScreen._ensure_console_chat_controller` returns the app-owned
+  instance instead of building one. `on_unmount` (`chat_screen.py:15392`)
+  detaches the view (Task 1's path) and no longer drops the runtime.
+- [ ] The coordinator's `wire(app=...)` and captured loop move to
+  construction time. P2 already proves the app loop is the right one and
+  that it outlives the screen — do not add a second loop.
+- [ ] Keep `seed_from_marks`'s mount-claim ordering intact
+  (`chat_screen.py:15050`): with an app-owned runtime the claim happens at
+  runtime construction, and the first tab sync's view-clear must still come
+  after it. Pin that ordering with its own test, as PR 3a-2 did.
+- [ ] Gate + commit.
+
+### Task 3 — the app-owned store becomes the continuity owner
+
+**Blocked on owner call #3.**
+
+- [ ] Red: P3b as a regression test — a wake turn that ran while Console
+  was unmounted is present in the transcript the user sees on returning.
+  Fails today (executed: the user sees 2 of 4 rows).
+- [ ] Console message state stops travelling through
+  `ScreenStateStore.native_console_state`; `_serialize_native_console_state`
+  /`_restore_native_console_state` (`chat_screen.py:15576`/`:15646`) are
+  retired or reduced to view-only state (draft text, image view modes,
+  focus), never `sessions`/`messages_by_session`.
+- [ ] The 2026-07-11 freeze incident hardened the mechanism being changed.
+  Add a rapid-switch soak (the shape `Tests/UI/run_workbench_soak.py`
+  already uses) to the gate for this task specifically.
+- [ ] Prove no second source of truth remains: a test that appends through
+  the runtime and asserts transcript, provider payload, DB rows and the
+  active-leaf pointer all agree — the four things P1 found disagreeing.
+- [ ] Gate + commit.
+
+### Task 4 — rebind the five hook slots a viewless wake turn touches
+
+P3 executed which slots a wake turn with no view actually touches:
+`wake.delivery_ui_hook`, `wake_conversation_in_view`,
+`wake_user_priority_probe`, `_chat_dictionary_applier`,
+`_world_info_applier`. In P3 all five were still bound to methods of a
+DEAD screen and none raised — which is worse than raising, because a
+silent wrong answer from `wake_conversation_in_view` decides whether the
+`◈` mark survives (task-15971's whole point) and a silent wrong answer
+from `wake_user_priority_probe` decides whether the user wins a tie.
+
+- [ ] Red: with no view attached, `wake_conversation_in_view` reports
+  not-in-view (so the mark is KEPT) and `wake_user_priority_probe` reports
+  no user claim — each proven by the observable consequence (mark set;
+  wake not deferred), not by asserting on the callable.
+- [ ] Attach/detach rebinds all five: a view sets them, detaching restores
+  viewless defaults. No slot may keep pointing at an unmounted screen.
+- [ ] `delivery_ui_hook` becomes a no-op when detached, and is re-armed by
+  the next attach if a wake is still delivering
+  (`delivering_conversation_id`, `console_fleet_wake.py:370`) — the
+  4-minute freeze PR 3a-2 Task 7 found is the cost of getting this wrong.
+- [ ] The 10 untouched slots (`set_pending_approval`,
+  `park_pending_approval`, `notify_run_outcome`, `notify_run_failure`,
+  `on_submission_accepted`, the two skill-confirm slots, and three
+  providers) get viewless defaults too, with a test per safety-relevant
+  one — "not touched in P3's turn" is a fact about one turn, not a proof
+  they cannot be reached.
+- [ ] Gate + commit.
+
+### Task 5 — headless approval: park, notify app-wide, keep the clock
+
+Coordinator decision 4. P4 measured the real cost with no UI wired: the
+round runs to the shipped `[mcp] approval_timeout_seconds` = 120.0
+(`console_chat_controller.py:259`) and verdicts `timeout` after **120.43s**,
+fail-closed. Nothing surfaced to the user during that window — P3 showed
+`set_pending_approval` and `park_pending_approval` are untouched by a
+viewless turn.
+
+- [ ] Red: a risk-tagged tool in a headless wake turn raises an app-wide
+  notification (toast + badge) at the moment the round arms, and the round
+  is resolvable by opening Console within the deadline.
+- [ ] Do NOT pause or extend the deadline while detached — that is a change
+  to a fail-closed safety gate and is deliberately deferred. Document the
+  120s cost in the User Guide instead of hiding it.
+- [ ] A round armed while detached and still armed at attach must mount its
+  card, not be silently re-parked (the payload-slot caveat at
+  `console_chat_controller.py:4103-4128` is a known limitation — assert
+  against it rather than around it).
+- [ ] Gate + commit.
+
+### Task 6 — wake at launch / first boot
+
+**Blocked on owner call #2.** This is the case the 2026-08-14 task-16300
+correction left as genuinely headless alongside ordinary navigation.
+
+- [ ] Red: with `FLEET_UNSEEN` marks and undelivered ledger rows present at
+  process start and Console never opened, the wake fires.
+- [ ] Gated by `autowake_enabled` AND an existing mark, per the
+  recommendation — never a bare "wake on launch".
+- [ ] AC#3's phantom-wake case: a run already stamped `wake_delivered_at`
+  must not be re-announced across a restart (`_rows_for`'s stale drop,
+  `console_fleet_wake.py:757-772`, already does this — pin it headless).
+- [ ] Unsaved (ephemeral) conversations wake headlessly while the process
+  lives and are gone after a restart — accepted (coordinator decision 5),
+  stated in the docs.
+- [ ] Gate + commit.
+
+### Task 7 — invariants under headless (AC#3) as one gate
+
+- [ ] No USER transcript row in a headless wake (the `AGENT_WAKE` branch,
+  `console_chat_controller.py:2831`) — asserted on the DB rows, not only
+  the in-memory store, because headless is exactly the case where the two
+  used to disagree.
+- [ ] Exactly-once across a restart mid-commit, via the ledger.
+- [ ] `autowake_enabled = false` silences the headless fire point too, and
+  loses nothing durable.
+- [ ] Deliveries stay serialized app-wide with the runtime app-owned (one
+  `_delivering` for one runtime, not one per screen).
+- [ ] Gate + commit.
+
+### Task 8 — documentation (AC#4)
+
+- [ ] `Docs/User_Guide/console/agent-runs-and-tools.md:494-501` — the
+  "**If Console isn't open, no wake fires**" paragraph is rewritten to what
+  now happens, including the 120s headless-approval cost from Task 5.
+- [ ] Spec `:424-437` — the "honest architectural limit as built" paragraph
+  gets its superseding note; §10's follow-up row for task-15860 closes.
+- [ ] Update the page's "Verified against" stamp.
+- [ ] `backlog/docs/lessons-*.md`: the import-provenance trap (the venv's
+  editable install pointing at a foreign worktree) and the P1 finding
+  (a DB append is invisible to a live Console *and* to the next mount —
+  the store, not the DB, is what the transcript and the payload are built
+  from) both generalise beyond this task.
+- [ ] Gate + commit.

--- a/Tests/UI/test_probe_headless_wake_p1_continuity.py
+++ b/Tests/UI/test_probe_headless_wake_p1_continuity.py
@@ -1,0 +1,380 @@
+"""PROBE P1 (task-15860 Task 0) -- Console history continuity across a
+nav-away, by EXECUTION.
+
+NOT a regression test. This file exists to answer one question the
+headless-wake plan's recommended design (A: app-owned Console runtime)
+rests on, and which was READ rather than RUN:
+
+    Are DB rows appended to a Console conversation while no Console screen
+    is mounted visible at the next Console mount, in the transcript AND in
+    the next send's provider payload?
+
+The claim under probe: `ChatScreen.save_state` ->
+`_serialize_native_console_state` snapshots `sessions`/`messages_by_session`
+into `ScreenStateStore`, and `_restore_native_console_state` rebuilds the
+store from THAT payload and never re-reads ChaChaNotes -- so a headless
+(DB-only) writer is invisible and divergent at remount.
+
+Everything here runs through the REAL navigation API
+(`app.handle_screen_navigation(NavigateToScreen(...))`), the real
+`ChatScreen`, a real on-disk ChaChaNotes DB, and the production
+`ChatPersistenceService` for the out-of-band appends.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _wait_for_selector
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+from Tests.Chat.test_console_fleet_wake import _RecordingWakeGateway
+
+HEADLESS_SYSTEM = "HEADLESS-SYSTEM-ROW-P1"
+HEADLESS_ASSISTANT = "HEADLESS-ASSISTANT-ROW-P1"
+
+
+def _report(title: str, lines: list[str]) -> None:
+    print(f"\n===== {title} =====")
+    for line in lines:
+        print(f"  {line}")
+
+
+@pytest.mark.asyncio
+async def test_probe_p1_db_rows_written_while_console_is_unmounted(tmp_path):
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    gateway = _RecordingWakeGateway(reply="assistant one")
+    app.console_provider_gateway_factory = lambda: gateway
+
+    findings: list[str] = []
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = ChatScreen(app)
+        await app.push_screen(chat)
+        app._initial_screen_pushed = True
+        app.current_tab = "chat"
+        await pilot.pause()
+        await _wait_for_selector(chat, pilot, "#console-native-composer")
+
+        controller = chat._ensure_console_chat_controller()
+        store = chat._console_chat_store
+        session = store.sessions()[0]
+        session_id = session.id
+
+        outcome = await controller.submit_draft(
+            "first user message", session_id=session_id
+        )
+        findings.append(f"pre-nav submit accepted={outcome.accepted}")
+        assert outcome.accepted, "the seeding send must be accepted"
+
+        conversation_id = store.sessions()[0].persisted_conversation_id
+        findings.append(f"persisted conversation_id={conversation_id}")
+        assert conversation_id, "the probe needs a PERSISTED conversation"
+
+        db = app.chachanotes_db
+        persistence = store.persistence
+        rows_before = db.get_messages_for_conversation(conversation_id, limit=100)
+        leaf_before = db.get_conversation_active_leaf(conversation_id)
+        findings.append(
+            "pre-nav DB rows: "
+            + ", ".join(f"{r['sender']}:{r['content'][:24]!r}" for r in rows_before)
+        )
+        findings.append(f"pre-nav active_leaf={leaf_before}")
+        in_memory_before = [
+            (m.role.value, m.content[:24])
+            for m in store.messages_for_session(session_id)
+        ]
+        findings.append(f"pre-nav in-memory: {in_memory_before}")
+
+        # ---- navigate away through the REAL navigation API -------------
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+        findings.append(f"after nav-away screen={type(app.screen).__name__}")
+        assert chat not in app.screen_stack, "Console must actually unmount"
+        assert controller._shutdown_requested.is_set(), (
+            "leaving Console must shut the controller down"
+        )
+
+        # ---- append rows to the conversation with NO Console mounted ----
+        last_id = rows_before[-1]["id"] if rows_before else None
+        system_id = persistence.create_message(
+            conversation_id=conversation_id,
+            sender="system",
+            content=HEADLESS_SYSTEM,
+            parent_message_id=last_id,
+        )
+        assistant_id = persistence.create_message(
+            conversation_id=conversation_id,
+            sender="assistant",
+            content=HEADLESS_ASSISTANT,
+            parent_message_id=system_id,
+        )
+        findings.append(
+            f"headless appends: system={system_id} assistant={assistant_id}"
+        )
+        leaf_after_append = db.get_conversation_active_leaf(conversation_id)
+        findings.append(
+            "active_leaf after DB-only appends="
+            f"{leaf_after_append} (unchanged={leaf_after_append == leaf_before})"
+        )
+
+        # ---- navigate BACK to Console -----------------------------------
+        gateway.payloads.clear()
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        chat2 = app.screen
+        assert isinstance(chat2, ChatScreen), type(chat2).__name__
+        assert chat2 is not chat, "screens are never cached"
+        await _wait_for_selector(chat2, pilot, "#console-native-composer")
+
+        store2 = chat2._console_chat_store
+        restored = store2.messages_for_session(session_id)
+        rendered = [(m.role.value, m.content[:40]) for m in restored]
+        findings.append(f"post-return in-memory transcript: {rendered}")
+
+        # (a) do the rows render?
+        transcript_text = "\n".join(m.content for m in restored)
+        system_visible = HEADLESS_SYSTEM in transcript_text
+        assistant_visible = HEADLESS_ASSISTANT in transcript_text
+        findings.append(
+            f"(a) headless rows in restored transcript: "
+            f"system={system_visible} assistant={assistant_visible}"
+        )
+
+        # ...and in the actual rendered DOM?
+        dom_text = " ".join(
+            str(getattr(node, "renderable", ""))
+            for node in chat2.query("*")
+        )
+        findings.append(
+            "(a-dom) headless rows in rendered widgets: "
+            f"system={HEADLESS_SYSTEM in dom_text} "
+            f"assistant={HEADLESS_ASSISTANT in dom_text}"
+        )
+
+        # (b) are they in the next send's provider payload?
+        controller2 = chat2._ensure_console_chat_controller()
+        session2 = next(
+            s for s in store2.sessions() if s.id == session_id
+        )
+        findings.append(
+            "post-return session persisted_conversation_id="
+            f"{session2.persisted_conversation_id}"
+        )
+        outcome2 = await controller2.submit_draft(
+            "second user message", session_id=session_id
+        )
+        findings.append(f"post-return submit accepted={outcome2.accepted}")
+        assert gateway.payloads, "the second send never reached the provider"
+        payload = gateway.payloads[-1]
+        payload_shape = [(m["role"], str(m["content"])[:40]) for m in payload]
+        findings.append(f"(b) provider payload: {payload_shape}")
+        payload_text = "\n".join(str(m["content"]) for m in payload)
+        findings.append(
+            "(b) headless rows in provider payload: "
+            f"system={HEADLESS_SYSTEM in payload_text} "
+            f"assistant={HEADLESS_ASSISTANT in payload_text}"
+        )
+
+        # (c) active leaf + does the next persisted append fork the tree?
+        leaf_final = db.get_conversation_active_leaf(conversation_id)
+        rows_after = db.get_messages_for_conversation(conversation_id, limit=100)
+        by_id = {r["id"]: r for r in rows_after}
+        findings.append("(c) final DB rows (id | sender | parent | content):")
+        for r in rows_after:
+            findings.append(
+                f"      {r['id'][:8]} | {r['sender']:9} | "
+                f"{str(r.get('parent_message_id'))[:8]:8} | {r['content'][:34]!r}"
+            )
+        findings.append(f"(c) final active_leaf={leaf_final}")
+        leaf_row = by_id.get(leaf_final) if leaf_final else None
+        findings.append(
+            "(c) active_leaf points at: "
+            + (
+                f"{leaf_row['sender']} {leaf_row['content'][:34]!r}"
+                if leaf_row
+                else repr(leaf_final)
+            )
+        )
+        new_user_rows = [
+            r
+            for r in rows_after
+            if r["sender"] == "user" and "second user message" in r["content"]
+        ]
+        if new_user_rows:
+            parent = new_user_rows[0].get("parent_message_id")
+            parent_row = by_id.get(parent)
+            forked = parent != assistant_id
+            findings.append(
+                "(c) next persisted append parent="
+                + (
+                    f"{parent_row['sender']} {parent_row['content'][:34]!r}"
+                    if parent_row
+                    else repr(parent)
+                )
+                + f" -> FORKS away from the headless rows: {forked}"
+            )
+        else:
+            findings.append("(c) the second send persisted NO user row")
+
+    _report("P1 -- DB rows written while Console is unmounted", findings)
+
+
+@pytest.mark.asyncio
+async def test_probe_p1_variant_headless_writer_also_moves_the_active_leaf(tmp_path):
+    """The obvious objection to the main probe, closed.
+
+    A real design-B/C headless writer would not stop at raw rows: it would
+    also write through the local-only active-leaf pointer the way
+    `ConsoleChatStore._persist_active_leaf` does. Does maintaining the
+    pointer make the headless rows survive the remount?
+    """
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    gateway = _RecordingWakeGateway(reply="assistant one")
+    app.console_provider_gateway_factory = lambda: gateway
+
+    findings: list[str] = []
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = ChatScreen(app)
+        await app.push_screen(chat)
+        app._initial_screen_pushed = True
+        app.current_tab = "chat"
+        await pilot.pause()
+        await _wait_for_selector(chat, pilot, "#console-native-composer")
+        controller = chat._ensure_console_chat_controller()
+        store = chat._console_chat_store
+        session_id = store.sessions()[0].id
+        await controller.submit_draft("first user message", session_id=session_id)
+        conversation_id = store.sessions()[0].persisted_conversation_id
+        db = app.chachanotes_db
+
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+
+        rows = db.get_messages_for_conversation(conversation_id, limit=100)
+        system_id = store.persistence.create_message(
+            conversation_id=conversation_id,
+            sender="system",
+            content=HEADLESS_SYSTEM,
+            parent_message_id=rows[-1]["id"],
+        )
+        assistant_id = store.persistence.create_message(
+            conversation_id=conversation_id,
+            sender="assistant",
+            content=HEADLESS_ASSISTANT,
+            parent_message_id=system_id,
+        )
+        # ...and write through the active-leaf pointer, as the store would.
+        db.set_conversation_active_leaf(conversation_id, assistant_id)
+        findings.append(
+            f"active_leaf written through to the headless assistant: "
+            f"{db.get_conversation_active_leaf(conversation_id) == assistant_id}"
+        )
+
+        gateway.payloads.clear()
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        chat2 = app.screen
+        await _wait_for_selector(chat2, pilot, "#console-native-composer")
+        store2 = chat2._console_chat_store
+        restored = "\n".join(
+            m.content for m in store2.messages_for_session(session_id)
+        )
+        findings.append(
+            "headless rows in the restored transcript (leaf maintained): "
+            f"system={HEADLESS_SYSTEM in restored} "
+            f"assistant={HEADLESS_ASSISTANT in restored}"
+        )
+        controller2 = chat2._ensure_console_chat_controller()
+        await controller2.submit_draft("second user message", session_id=session_id)
+        payload_text = "\n".join(str(m["content"]) for m in gateway.payloads[-1])
+        findings.append(
+            "headless rows in the next provider payload (leaf maintained): "
+            f"system={HEADLESS_SYSTEM in payload_text} "
+            f"assistant={HEADLESS_ASSISTANT in payload_text}"
+        )
+        rows_after = db.get_messages_for_conversation(conversation_id, limit=100)
+        by_id = {r["id"]: r for r in rows_after}
+        new_user = [
+            r
+            for r in rows_after
+            if r["sender"] == "user" and "second user message" in r["content"]
+        ]
+        if new_user:
+            parent = new_user[0].get("parent_message_id")
+            findings.append(
+                "next persisted append parent="
+                + repr(by_id.get(parent, {}).get("content", parent))
+                + f" -> FORKS away from the headless rows: {parent != assistant_id}"
+            )
+        findings.append(
+            "final active_leaf still the headless assistant: "
+            f"{db.get_conversation_active_leaf(conversation_id) == assistant_id}"
+        )
+
+    _report("P1 variant -- headless writer maintains the active leaf", findings)
+
+
+@pytest.mark.asyncio
+async def test_probe_p1_control_rows_written_while_console_is_mounted(tmp_path):
+    """Control: the SAME out-of-band DB append with Console still mounted.
+
+    Separates "the snapshot hides it" from "nothing ever reads DB appends".
+    """
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    gateway = _RecordingWakeGateway(reply="assistant one")
+    app.console_provider_gateway_factory = lambda: gateway
+
+    findings: list[str] = []
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = ChatScreen(app)
+        await app.push_screen(chat)
+        app._initial_screen_pushed = True
+        app.current_tab = "chat"
+        await pilot.pause()
+        await _wait_for_selector(chat, pilot, "#console-native-composer")
+
+        controller = chat._ensure_console_chat_controller()
+        store = chat._console_chat_store
+        session_id = store.sessions()[0].id
+        await controller.submit_draft("first user message", session_id=session_id)
+        conversation_id = store.sessions()[0].persisted_conversation_id
+        db = app.chachanotes_db
+        rows = db.get_messages_for_conversation(conversation_id, limit=100)
+        store.persistence.create_message(
+            conversation_id=conversation_id,
+            sender="assistant",
+            content=HEADLESS_ASSISTANT,
+            parent_message_id=rows[-1]["id"] if rows else None,
+        )
+        await pilot.pause()
+        for _ in range(10):
+            await pilot.pause()
+        live = "\n".join(m.content for m in store.messages_for_session(session_id))
+        findings.append(
+            "mounted-Console DB append visible in the live store: "
+            f"{HEADLESS_ASSISTANT in live}"
+        )
+        gateway.payloads.clear()
+        await controller.submit_draft("second user message", session_id=session_id)
+        payload_text = "\n".join(
+            str(m["content"]) for m in gateway.payloads[-1]
+        )
+        findings.append(
+            "mounted-Console DB append visible in the next payload: "
+            f"{HEADLESS_ASSISTANT in payload_text}"
+        )
+
+    _report("P1 control -- DB append with Console MOUNTED", findings)

--- a/Tests/UI/test_probe_headless_wake_p2_p3_p4.py
+++ b/Tests/UI/test_probe_headless_wake_p2_p3_p4.py
@@ -1,0 +1,419 @@
+"""PROBES P2/P3/P4 (task-15860 Task 0) -- what already works post-teardown.
+
+NOT regression tests. Three questions the headless-wake plan sizes its work
+from, answered by EXECUTION against current dev:
+
+P2  After `ChatScreen.on_unmount`, does `ConsoleFleetWakeCoordinator.
+    on_fleet_drained` still record into its pending registry, and is its
+    captured loop still alive? (PR 3a-2 Task 1 proved the *attention*
+    consumer fires post-teardown; the wake coordinator was added later.)
+
+P3  If the controller merely SURVIVES (shutdown skipped), does a wake
+    delivered after unmount reach `submit_draft` and complete the turn --
+    and which screen-wired hook slots are actually touched with no view?
+
+P4  With no UI wired, what is the wall time to a risk-tagged tool's denial
+    in a wake turn, and what is the effective `[mcp]
+    approval_timeout_seconds`?
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from Tests.Chat.test_console_fleet_wake import (
+    _RecordingWakeGateway,
+    _drain,
+    _survivor,
+)
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_mcp_approval import _pending
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _wait_for_selector
+from tldw_chatbook.Chat.console_chat_controller import (
+    _DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS,
+    ConsoleChatController,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+def _report(title: str, lines: list[str]) -> None:
+    print(f"\n===== {title} =====")
+    for line in lines:
+        print(f"  {line}")
+
+
+def _drain_from_child_thread(wake, drain) -> None:
+    """Deliver the drain the way production does: from a plain thread.
+
+    (`Tests/UI/test_console_fleet_wake_ui_freshness.py:66` -- an asyncio
+    task inherits the creating context, so a drain injected from the test
+    coroutine validates against a rig production never has.)
+    """
+    thread = threading.Thread(target=lambda: wake.on_fleet_drained(drain))
+    thread.start()
+    thread.join(5)
+
+
+def _hook_slots(controller, screen) -> dict[str, object]:
+    """Every controller attribute currently bound to a SCREEN method."""
+    slots: dict[str, object] = {}
+    for name in dir(controller):
+        if name.startswith("__"):
+            continue
+        try:
+            value = getattr(controller, name)
+        except Exception:  # noqa: BLE001 -- properties may raise off-loop
+            continue
+        if callable(value) and getattr(value, "__self__", None) is screen:
+            slots[name] = value
+    return slots
+
+
+async def _seed_console(app, pilot, gateway):
+    """Mount a real Console, send once, return (screen, controller, ids)."""
+    chat = ChatScreen(app)
+    await app.push_screen(chat)
+    app._initial_screen_pushed = True
+    app.current_tab = "chat"
+    await pilot.pause()
+    await _wait_for_selector(chat, pilot, "#console-native-composer")
+    controller = chat._ensure_console_chat_controller()
+    store = chat._console_chat_store
+    session_id = store.sessions()[0].id
+    await controller.submit_draft("first user message", session_id=session_id)
+    conversation_id = store.sessions()[0].persisted_conversation_id
+    return chat, controller, store, session_id, conversation_id
+
+
+def _terminal_survivor_run(runs_db, conversation_id, *, result="child answer"):
+    parent_id = runs_db.create_run(
+        conversation_id=conversation_id, agent_kind="primary"
+    )
+    runs_db.set_status(parent_id, "done", "turn final")
+    run_id = runs_db.create_run(
+        conversation_id=conversation_id,
+        agent_kind="subagent",
+        task="long job",
+        parent_run_id=parent_id,
+    )
+    runs_db.set_status(run_id, "done", result)
+    return run_id
+
+
+# ---------------------------------------------------------------------------
+# P2 -- post-unmount fan-out on current dev
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_p2_post_unmount_fanout(tmp_path):
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    gateway = _RecordingWakeGateway(reply="assistant one")
+    app.console_provider_gateway_factory = lambda: gateway
+
+    findings: list[str] = []
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        app_loop = asyncio.get_running_loop()
+        chat, controller, store, session_id, conversation_id = await _seed_console(
+            app, pilot, gateway
+        )
+        wake = controller.fleet_wake
+        bridge = controller._agent_bridge
+        runs_db = getattr(bridge, "runs_db", None)
+        findings.append(f"runs_db present pre-unmount: {runs_db is not None}")
+        loop_before = wake._loop
+        findings.append(
+            f"captured loop pre-unmount is the app loop: {loop_before is app_loop}"
+        )
+        fanout = getattr(bridge, "_fleet_drain_fanout", None)
+        findings.append(
+            "fan-out registrations pre-unmount: "
+            + str([name for name, _ in getattr(fanout, "_consumers", [])])
+        )
+        run_id = _terminal_survivor_run(runs_db, conversation_id)
+
+        # ---- real navigation away: on_unmount + controller.shutdown() ----
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+        assert chat not in app.screen_stack
+        findings.append(
+            f"post-unmount _shutdown_requested set: "
+            f"{controller._shutdown_requested.is_set()}"
+        )
+
+        loop_after = wake._loop
+        findings.append(
+            "P2(loop) captured loop post-unmount: "
+            f"is_none={loop_after is None} "
+            f"is_closed={None if loop_after is None else loop_after.is_closed()} "
+            f"is_app_loop={loop_after is app_loop} "
+            f"is_running={None if loop_after is None else loop_after.is_running()}"
+        )
+
+        # Fire through the BRIDGE's own fan-out from a plain thread -- the
+        # production path -- not just the coordinator method directly.
+        drain = _drain(conversation_id, _survivor(run_id, session_id=session_id))
+        fanout_after = getattr(bridge, "_fleet_drain_fanout", None)
+        findings.append(
+            "fan-out registrations post-unmount: "
+            + str([name for name, _ in getattr(fanout_after, "_consumers", [])])
+        )
+        thread = threading.Thread(target=lambda: fanout_after.fire(drain))
+        thread.start()
+        thread.join(5)
+        await pilot.pause()
+        findings.append(
+            "P2(registry) on_fleet_drained recorded post-unmount (via the "
+            "bridge fan-out): "
+            f"has_pending={wake.has_pending(conversation_id)} "
+            f"pending_ids={wake.pending_conversation_ids()}"
+        )
+
+        # Did the scheduled attempt do anything? (it must bail at the
+        # shutdown gate -- `_attempt`'s second check)
+        for _ in range(10):
+            await pilot.pause()
+        findings.append(
+            "P2(delivery) wake turns reaching the provider after unmount: "
+            f"{len(gateway.payloads) - 1}"  # minus the seeding send
+        )
+        findings.append(
+            f"P2(delivery) delivering_conversation_id={wake.delivering_conversation_id()}"
+        )
+        ledger = (runs_db.get_run(run_id) or {}).get("wake_delivered_at")
+        findings.append(f"P2(ledger) wake_delivered_at={ledger}")
+
+    _report("P2 -- post-unmount fan-out (real teardown, shutdown NOT skipped)", findings)
+
+
+# ---------------------------------------------------------------------------
+# P3 -- how much already works if the controller merely survives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_p3_controller_survives_unmount(tmp_path, monkeypatch):
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    gateway = _RecordingWakeGateway(reply="wake reply")
+    app.console_provider_gateway_factory = lambda: gateway
+    # The plain-provider path, so the wake turn streams through the double.
+    app.app_config.setdefault("console", {})["agent_runtime"] = False
+
+    findings: list[str] = []
+    touched: list[str] = []
+
+    # Keep the controller ALIVE artificially: skip shutdown() only.
+    real_shutdown = ConsoleChatController.shutdown
+
+    async def _no_shutdown(self):
+        findings.append("shutdown() was suppressed for this probe")
+        return None
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        app_loop = asyncio.get_running_loop()
+        chat, controller, store, session_id, conversation_id = await _seed_console(
+            app, pilot, gateway
+        )
+        wake = controller.fleet_wake
+        runs_db = controller._agent_bridge.runs_db
+        run_id = _terminal_survivor_run(runs_db, conversation_id)
+
+        # Instrument every screen-bound hook slot BEFORE the screen dies.
+        slots = _hook_slots(controller, chat)
+        slot_names = sorted(slots)
+        findings.append(f"P3(hooks) screen-bound controller slots: {slot_names}")
+        for name, fn in slots.items():
+            def _wrap(_name=name, _fn=fn):
+                def _recorder(*a, **kw):
+                    touched.append(_name)
+                    try:
+                        return _fn(*a, **kw)
+                    except Exception as exc:  # noqa: BLE001
+                        touched.append(f"{_name}!RAISED:{type(exc).__name__}")
+                        raise
+                return _recorder
+            setattr(controller, name, _wrap())
+        ui_hook = wake.delivery_ui_hook
+        findings.append(
+            f"P3(hooks) wake.delivery_ui_hook wired: {ui_hook is not None}"
+        )
+        if ui_hook is not None:
+            def _hook_recorder(session, _fn=ui_hook):
+                touched.append("wake.delivery_ui_hook")
+                try:
+                    return _fn(session)
+                except Exception as exc:  # noqa: BLE001
+                    touched.append(
+                        f"wake.delivery_ui_hook!RAISED:{type(exc).__name__}"
+                    )
+                    raise
+            wake.delivery_ui_hook = _hook_recorder
+
+        monkeypatch.setattr(ConsoleChatController, "shutdown", _no_shutdown)
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+        assert chat not in app.screen_stack, "the SCREEN must still unmount"
+        findings.append(
+            "post-unmount _shutdown_requested set: "
+            f"{controller._shutdown_requested.is_set()}"
+        )
+        findings.append(f"wake loop still the app loop: {wake._loop is app_loop}")
+        payloads_before = len(gateway.payloads)
+
+        _drain_from_child_thread(
+            wake, _drain(conversation_id, _survivor(run_id, session_id=session_id))
+        )
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if len(gateway.payloads) > payloads_before:
+                break
+            await asyncio.sleep(0.05)
+        delivered = len(gateway.payloads) - payloads_before
+        findings.append(
+            f"P3(delivery) wake turns reaching the provider after unmount: {delivered}"
+        )
+        if delivered:
+            tail = gateway.payloads[-1][-1]
+            findings.append(
+                f"P3(delivery) payload tail role={tail['role']!r} "
+                f"carries the child's result="
+                f"{'child answer' in str(tail['content'])}"
+            )
+        # Did the TURN complete (ledger stamped only after acceptance)?
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if (runs_db.get_run(run_id) or {}).get("wake_delivered_at"):
+                break
+            await asyncio.sleep(0.05)
+        findings.append(
+            "P3(turn) wake_delivered_at stamped (turn accepted+committed): "
+            f"{bool((runs_db.get_run(run_id) or {}).get('wake_delivered_at'))}"
+        )
+        findings.append(
+            "P3(transcript) rows now in the (orphaned) store: "
+            + str(
+                [
+                    (m.role.value, m.content[:28])
+                    for m in store.messages_for_session(session_id)
+                ]
+            )
+        )
+        findings.append(f"P3(hooks) slots TOUCHED during the wake turn: {sorted(set(touched))}")
+        findings.append(
+            "P3(hooks) slots NOT touched: "
+            + str(sorted(set(slot_names) - {t.split('!')[0] for t in touched}))
+        )
+
+        # P3b -- the composition of P1 and P3, the decision-relevant fact:
+        # the wake turn RAN and persisted, but the ScreenStateStore snapshot
+        # was taken BEFORE it. What does the user see on returning?
+        db = app.chachanotes_db
+        db_rows = db.get_messages_for_conversation(conversation_id, limit=100)
+        findings.append(
+            "P3b(db) rows persisted by the surviving-controller wake: "
+            + str([(r["sender"], r["content"][:28]) for r in db_rows])
+        )
+        monkeypatch.setattr(ConsoleChatController, "shutdown", real_shutdown)
+        await controller.shutdown()
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        chat2 = app.screen
+        await _wait_for_selector(chat2, pilot, "#console-native-composer")
+        restored = chat2._console_chat_store.messages_for_session(session_id)
+        findings.append(
+            "P3b(remount) transcript the user sees on returning: "
+            + str([(m.role.value, m.content[:28]) for m in restored])
+        )
+        restored_text = "\n".join(m.content for m in restored)
+        findings.append(
+            "P3b(remount) the wake notice survives the return: "
+            f"{'[Background sub-agent completion' in restored_text}"
+        )
+
+    _report("P3 -- controller survives unmount (shutdown skipped)", findings)
+
+
+# ---------------------------------------------------------------------------
+# P4 -- headless approval cost
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_probe_p4_headless_approval_cost():
+    """No UI wired at all: no `app`, no `set_pending_approval`.
+
+    Marked ``slow`` (needs ``--run-slow``): it deliberately runs to the
+    SHIPPED 120s deadline, because the measurement IS the finding. The
+    fast control below pins the same mechanism at 0.05s.
+
+    A wake turn runs on the SAME controller and therefore through the same
+    `request_mcp_approvals` gate, so this measures the wake case's cost.
+    The row is shaped as a risk-floored built-in (`server_key
+    "agent:builtin"`, `reason "risk_floored"`) -- the shape
+    `build_tool_review_hook` emits for a risk-tagged tool.
+    """
+    findings: list[str] = []
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+    session = store.ensure_session(title="Headless")
+    findings.append(f"controller.app wired: {controller.app is not None}")
+    findings.append(
+        f"set_pending_approval wired: {controller.set_pending_approval is not None}"
+    )
+    findings.append(
+        f"park_pending_approval wired: {controller.park_pending_approval is not None}"
+    )
+    effective = controller._resolve_mcp_approval_timeout_seconds()
+    findings.append(
+        f"P4(config) effective [mcp] approval_timeout_seconds = {effective} "
+        f"(shipped default constant {_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS})"
+    )
+
+    risk_row = _pending(
+        server_key="agent:builtin",
+        tool_name="write_file",
+        llm_name="builtin__write_file",
+        reason="risk_floored",
+    )
+    started = time.monotonic()
+    decisions = controller.request_mcp_approvals([risk_row], session_id=session.id)
+    elapsed = time.monotonic() - started
+    findings.append(f"P4(measured) decisions={decisions}")
+    findings.append(f"P4(measured) wall time to verdict = {elapsed:.2f}s")
+    findings.append(
+        "P4(measured) verdict is the fail-closed 'timeout' word (refusal is "
+        "recorded downstream as 'denied-timeout' in the tool providers)"
+    )
+    _report("P4 -- headless approval cost at the SHIPPED default", findings)
+
+
+def test_probe_p4_mechanism_at_a_short_injected_deadline():
+    """Control for P4: the same path at a 0.05s deadline, to show the cost
+    IS the configured deadline (plus <=1s poll slack) and not something
+    else that only looks like it at 120s."""
+    findings: list[str] = []
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+    session = store.ensure_session(title="Headless")
+    controller.mcp_approval_timeout_seconds = lambda: 0.05
+    started = time.monotonic()
+    decisions = controller.request_mcp_approvals(
+        [_pending(server_key="agent:builtin", reason="risk_floored")],
+        session_id=session.id,
+    )
+    elapsed = time.monotonic() - started
+    findings.append(f"decisions={decisions} elapsed={elapsed:.2f}s (deadline 0.05s)")
+    _report("P4 control -- injected 0.05s deadline", findings)

--- a/Tests/test_probe_import_provenance.py
+++ b/Tests/test_probe_import_provenance.py
@@ -1,0 +1,22 @@
+"""PROBE (task-15860 Task 0, throwaway): prove which checkout is imported.
+
+The venv's editable install resolves `tldw_chatbook` to a FOREIGN worktree
+(`.worktrees/task-2512-mcp-unified`). Every probe in this arc is worthless
+unless the code under test is THIS worktree's origin/dev checkout.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import tldw_chatbook
+
+
+def test_probe_imports_this_worktree():
+    here = Path(__file__).resolve().parents[1]
+    imported = Path(tldw_chatbook.__file__).resolve()
+    print(f"\nPROBE imported tldw_chatbook from: {imported}")
+    print(f"PROBE worktree root: {here}")
+    assert imported.is_relative_to(here), (
+        f"imported {imported} is NOT under {here} -- the editable install's "
+        "foreign-worktree finder won"
+    )


### PR DESCRIPTION
## Headless wake (task-15860) — plan, and the four probes that validated it

Auto-wake fires wherever a Console controller exists. Since task-16300 restored the always-unmount invariant, every navigation away from Console tears the controller down — so a child finishing while you are on Library leaves the supervisor waiting for you to come back. That is the deferral spec §3 invariant 5 exists to forbid.

**Task 0 executes the plan's premises rather than reading them** (six confident readings have been refuted by execution in this programme). All four probes ran twice with identical results.

**P1 — the off-ramp, not taken.** With Console unmounted through the real navigation API, SYSTEM + ASSISTANT rows written through the production persistence service were, at the next mount: not rendered (screen showed 2 rows where the DB had 4), not in the next send's provider payload, and the next persisted append **forked the tree**, stranding them on a dead branch. Two objections closed by execution: also writing the active-leaf pointer changed nothing, and a control proves the same DB append is invisible *even with Console mounted* — the in-memory store, not the DB, is what the transcript and payload are built from. **DB-only headless delivery (designs B and C) is rejected on evidence.**

**P3b — the decisive fact.** A headless wake persisted all four rows to ChaChaNotes; returning to Console showed two. **The wake notice itself was invisible.** The continuity half of the design is required, not cosmetic.

**P2 / P3 — the gap is smaller than it looked.** After real teardown the fan-out registrations are intact and the captured loop is the live app loop; delivery is refused by exactly one line (`_attempt`'s `_shutdown_requested` gate). With the controller artificially kept alive, a wake turn already completes end to end and stamps the ledger. Only 5 of 15 screen-wired hook slots are touched — **and all five were still bound to a dead screen and none raised**, so a silent wrong answer from the in-view probe decides whether the unseen mark survives.

**P4 — headless approval cost measured: 120.43 s** to the fail-closed `timeout` verdict with no UI wired, at the shipped `approval_timeout_seconds = 120.0` (a 0.05 s-deadline control returned in 1.00 s, confirming the cost is the deadline plus 1 s poll granularity).

The plan is design A (app-owned Console runtime; `ChatScreen` attaches as a view), scope narrowed by P2/P3, staged so the pure ownership move lands separately from any semantics change. Owner decisions are recorded: launch wake is mark-gated behind the existing kill switch, and design A proceeds.

Contains no production code — plan, report, and three probe tests. `Tests/test_probe_import_provenance.py` pins a real trap found on the way: the venv's editable install resolves `tldw_chatbook` to a foreign worktree and loses to pytest's rootdir prepend only by `sys.meta_path` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the headless wake plan for task-15860 and adds probe tests that execute the plan’s premises; no production code changes. The probes reject DB-only headless delivery and narrow the scope for implementing design A (app-owned Console runtime).

- Confirms the plan against task-15860’s ACs without changing runtime behavior.

**Key findings**
- P1: DB-only headless writes are invisible at remount, excluded from the next provider payload, and cause a fork even if the active-leaf pointer is maintained; designs B/C are rejected. Continuity today comes from `ScreenStateStore`, not the DB.
- P2: Post-unmount, fan-out and the captured app loop stay alive; delivery is stopped only by `_shutdown_requested` in `ConsoleFleetWakeCoordinator._attempt`.
- P3: If the `ConsoleChatController` survives unmount, a wake completes headlessly end-to-end and stamps the ledger. Five screen-wired hook slots are touched and remain bound to a dead screen; these must be rebound under design A.
- P3b: A real wake that persisted to ChaChaNotes is invisible on return because `ScreenStateStore` snapshotting predates it; continuity must move to the app-owned store.
- P4: Headless approval costs 120.43 s wall time to a `timeout` verdict at the shipped `[mcp] approval_timeout_seconds = 120.0`.

**Review notes**
- Scope: Adds plan and report docs plus three probe tests; no migration or config changes. Files to skim: `Docs/superpowers/plans/2026-08-14-headless-wake.md`, `Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md`, and `Tests/UI/test_probe_headless_wake_*.py`.
- Tests are probes, not gating; `P4` is marked slow. `Tests/test_probe_import_provenance.py` guards an editable-install trap; run `pytest` from the worktree root to ensure the right checkout is imported.

<sup>Written for commit 25bc081b2aab3991a3498b074f0d039e756637bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

