### PR TITLE
docs: sync READMEs and guides with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ pytest --cov=tldw_chatbook  # With coverage
 
 ### Data Layer (`DB/`)
 
-- **`ChaChaNotes_DB.py`** - Main DB (conversations, messages, characters, notes), schema v7
+- **`ChaChaNotes_DB.py`** - Main DB (conversations, messages, characters, notes), schema v37
 - **`Client_Media_DB_v2.py`** - Media storage with chunking
 - **`RAG_Indexing_DB.py`** - Vector storage (when enabled)
 - Other DBs: Evals, Prompts, Subscriptions

--- a/Docs/Development/TTS/Higgs-Audio-TTS-Guide.md
+++ b/Docs/Development/TTS/Higgs-Audio-TTS-Guide.md
@@ -37,10 +37,10 @@ We provide installation scripts that automate the entire process:
 
 ```bash
 # Unix/Linux/macOS
-./scripts/install_higgs.sh
+./Helper_Scripts/Higgs-Install/install_higgs.sh
 
 # Windows
-scripts\install_higgs.bat
+Helper_Scripts\Higgs-Install\install_higgs.bat
 ```
 
 The script will:
@@ -81,7 +81,7 @@ pip install -e ".[higgs_tts]"
 
 ```bash
 # Run the verification script
-python scripts/verify_higgs_installation.py
+python Helper_Scripts/Higgs-Install/verify_higgs_installation.py
 
 # Or manually test imports
 python -c "import boson_multimodal; print('✅ Higgs Audio core installed successfully!')"

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -35,7 +35,7 @@ can sync with a tldw server you configure).
 | Ctrl+2 | [Console](console.md) | Live agent conversations, approvals, tools, RAG, and runs. |
 | Ctrl+3 | [Library](library.md) | Source material, imports, notes, media, conversations, prompts, skills, Search/RAG — plus hand-offs to Study for flashcards and quizzes. |
 | Ctrl+4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
-| Ctrl+5 | [Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md) | Characters, personas, chat dictionaries, and lore/world books. |
+| Ctrl+5 | [Roleplay](roleplay-chat-dictionaries.md) | Characters, personas, chat dictionaries, and lore/world books. |
 | Ctrl+6 | [Watchlists](watchlists.md) 🚧 | Monitored sources, runs, alerts, and recovery. |
 | Ctrl+7 | [Schedules](schedules.md) 🚧 | When jobs, watchlists, and workflows run. |
 | Ctrl+8 | [Workflows](workflows.md) 🚧 | Reusable procedures, recipes, dry-runs, and outputs. |
@@ -74,7 +74,7 @@ navigation shortcuts (typing `2` in the composer just types "2"). Clicking
 the nav label and **Ctrl+P** work everywhere too.
 
 One screen claims some of these digits for itself: on
-[Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md), **Ctrl+1 –
+[Roleplay](roleplay-chat-dictionaries.md), **Ctrl+1 –
 Ctrl+4 switch that screen's four modes** instead of changing screens.
 Ctrl+5 … Ctrl+0 still navigate from there, as do the nav bar and
 **Ctrl+P**.
@@ -86,10 +86,10 @@ Ctrl+5 … Ctrl+0 still navigate from there, as do the nav bar and
 | F1 | Open the current screen's keyboard-shortcuts list (content is screen-specific) |
 | Ctrl+P | Open the command palette — search and jump to any screen or command from anywhere |
 | Ctrl+Q | Quit the app |
-| Ctrl+1 … Ctrl+9, Ctrl+0 | Switch to the screen with that hotkey digit (see the nav map above). Exception: on [Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md), Ctrl+1 – Ctrl+4 switch that screen's modes instead |
+| Ctrl+1 … Ctrl+9, Ctrl+0 | Switch to the screen with that hotkey digit (see the nav map above). Exception: on [Roleplay](roleplay-chat-dictionaries.md), Ctrl+1 – Ctrl+4 switch that screen's modes instead |
 | F7 / F8 / F9 | Switch to Lab / Logs / Settings — the three destinations past the digit row; they work while a text field has focus, like the Ctrl+digit chords |
 | F6 | Cycle through the current screen's panes; on screens without a pane cycle it only shows a notice |
-| Shift+F6 | Cycle panes backward — bound only on [Console](console.md) and [Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md); elsewhere it does nothing |
+| Shift+F6 | Cycle panes backward — bound only on [Console](console.md) and [Roleplay](roleplay-chat-dictionaries.md); elsewhere it does nothing |
 
 Everything else (Enter/Ctrl+K/Ctrl+T in Console, and the single-letter
 mnemonics like `s`/`r`/`t` on Settings) is screen-specific — see that
@@ -140,13 +140,13 @@ Full detail on runs, approvals, and tools:
 | Subscriptions | [Watchlists](watchlists.md) 🚧 |
 | Coding | [Console](console.md) |
 | Conversations | [Library ▸ Media & conversations](library/media-and-conversations.md) |
-| CCP (Conversations, Characters & Prompts) | [Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md) for characters and personas; prompts moved to [Library ▸ Prompts](library/prompts.md) |
+| CCP (Conversations, Characters & Prompts) | [Roleplay](roleplay-chat-dictionaries.md) for characters and personas; prompts moved to [Library ▸ Prompts](library/prompts.md) |
 | LLM management | [Lab](lab.md) 🚧 |
 | Research | [Library](library.md) |
 | Ingest | [Library ▸ Import & export](library/import-and-export.md) |
 | Writing | [Library](library.md) |
 | Chatbooks | [Artifacts](artifacts.md) 🚧 |
-| Characters / Roleplay | [Roleplay & Chat Dictionaries](roleplay-chat-dictionaries.md) |
+| Characters / Roleplay | [Roleplay](roleplay-chat-dictionaries.md) |
 | Speech (STTS) / Evals | [Lab](lab.md) 🚧 |
 | Tools & Settings | [MCP](mcp.md) 🚧 |
 | Stats | [Settings](settings.md) (the palette's "Show Database Stats" opens the separate Statistics screen) |

--- a/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
+++ b/Docs/superpowers/plans/2026-07-19-console-screen-feedback-plan.md
@@ -24,6 +24,7 @@
 | `Tests/Chat/test_console_chat_controller.py` | Tests for agent finalization and context snapshot. |
 | `Tests/Chat/test_console_agent_bridge.py` | Bridge-level tests for `ConsoleAgentBridge.run_reply()`. |
 | `Tests/UI/test_console_context_modal.py` | Tests for the context viewer modal. |
+| `Tests/UI/test_chat_screen_context_modal.py` | Tests that `ChatScreen` keybinding and command palette open the modal. |
 
 ---
 
@@ -309,9 +310,16 @@ Expected: FAIL (`KeyError` or `_session_closed_result`).
 
 ### Step 2.5: Implement placeholder-missing fallback
 
-Refactor `_finalize_agent_reply` to delegate terminal handling to helpers. Replace the body after the stopped/cancelled guard with:
+Refactor `_finalize_agent_reply` to delegate terminal handling to helpers. Keep the existing stopped/cancelled guard intact, then delegate:
 
 ```python
+# Keep the existing task-227 guard unchanged:
+if current.status == "stopped" or (cancel_event is not None and cancel_event.is_set()):
+    self._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STOPPED, "Response stopped.")
+    )
+    return ConsoleSubmitResult(True, True, current.content)
+
 if outcome.status == RUN_CANCELLED:
     return self._finalize_agent_cancelled(assistant_message_id, session_id)
 
@@ -333,6 +341,33 @@ def _ensure_assistant_placeholder(self, assistant_message_id: str, session_id: s
         return None
 
 
+def _find_runtime_written_assistant(self, session_id: str) -> ConsoleChatMessage | None:
+    """Return the most recent assistant message if the runtime already wrote one."""
+    for message in reversed(list(self.store.messages_for_session(session_id))):
+        if message.role == ConsoleMessageRole.ASSISTANT:
+            return message
+    return None
+
+
+def _finalize_agent_cancelled(
+    self,
+    assistant_message_id: str,
+    session_id: str,
+) -> ConsoleSubmitResult:
+    visible_copy = "Response stopped/cancelled."
+    placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
+    if placeholder is None:
+        message = self.store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content=visible_copy,
+        )
+        failed = self.store.mark_message_failed(message.id)
+        return ConsoleSubmitResult(True, True, failed.content)
+    failed = self.store.mark_message_failed(assistant_message_id)
+    return ConsoleSubmitResult(True, True, failed.content)
+
+
 def _finalize_agent_success(
     self,
     assistant_message_id: str,
@@ -341,15 +376,26 @@ def _finalize_agent_success(
     *,
     variant_mode: bool,
 ) -> ConsoleSubmitResult:
+    from tldw_chatbook.Agents.agent_models import RUN_DONE
+
     placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
     if placeholder is None:
+        runtime_message = self._find_runtime_written_assistant(session_id)
+        if runtime_message is not None:
+            if not runtime_message.content:
+                runtime_message.content = outcome.final_text or "No response was generated."
+            runtime_message.status = "complete"
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
+            return ConsoleSubmitResult(True, True, runtime_message.content)
+        content = outcome.final_text or "No response was generated."
         message = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
-            content=outcome.final_text,
+            content=content,
         )
+        completed = self.store.mark_message_complete(message.id)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.COMPLETED, "Response complete."))
-        return ConsoleSubmitResult(True, True, message.content)
+        return ConsoleSubmitResult(True, True, completed.content)
 
     completed = self._complete_agent_message(
         assistant_message_id, variant_mode=variant_mode, outcome=outcome
@@ -367,15 +413,23 @@ def _finalize_agent_failure(
     visible_copy = self._agent_failure_visible_copy(outcome)
     placeholder = self._ensure_assistant_placeholder(assistant_message_id, session_id)
     if placeholder is None:
+        runtime_message = self._find_runtime_written_assistant(session_id)
+        if runtime_message is not None:
+            runtime_message.status = "failed"
+            if not runtime_message.content:
+                runtime_message.content = visible_copy
+            self._append_failure_system_row(session_id, visible_copy)
+            self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
+            return ConsoleSubmitResult(True, True, runtime_message.content)
         message = self.store.append_message(
             session_id,
             role=ConsoleMessageRole.ASSISTANT,
-            content="",
-            status="failed",
+            content=visible_copy,
         )
+        failed = self.store.mark_message_failed(message.id)
         self._append_failure_system_row(session_id, visible_copy)
         self._set_run_state(ConsoleRunState(ConsoleRunStatus.FAILED, visible_copy))
-        return ConsoleSubmitResult(True, True, message.content)
+        return ConsoleSubmitResult(True, True, failed.content)
 
     failed = self.store.mark_message_failed(assistant_message_id)
     self._append_failure_system_row(session_id, visible_copy)
@@ -391,7 +445,70 @@ pytest Tests/Chat/test_console_chat_controller.py::test_finalize_agent_reply_mis
 
 Expected: PASS.
 
-### Step 2.6: Add bridge-level tests
+### Step 2.6: Add tests for failure, cancel, and exception branches
+
+Append to `Tests/Chat/test_console_chat_controller.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_finalize_agent_reply_error_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+    from tldw_chatbook.Agents.agent_models import RUN_ERROR
+
+    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="partial")
+    outcome = RunOutcome(status=RUN_ERROR, steps=[], final_text="")
+    result = controller._finalize_agent_reply(assistant.id, session.id, outcome, variant_mode=False)
+
+    updated = store.get_message(assistant.id)
+    assert updated.status == "failed"
+    assert result.accepted is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_agent_reply_cancelled_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+    from tldw_chatbook.Agents.agent_models import RUN_CANCELLED
+
+    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="")
+    outcome = RunOutcome(status=RUN_CANCELLED, steps=[], final_text="")
+    result = controller._finalize_agent_reply(assistant.id, session.id, outcome, variant_mode=False)
+
+    updated = store.get_message(assistant.id)
+    assert updated.status == "failed"
+    assert "stopped" in updated.content.lower() or "cancelled" in updated.content.lower()
+    assert result.accepted is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_agent_reply_unknown_status_marks_failed():
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=StreamingGateway())
+    session = store.ensure_session(title="Chat 1")
+
+    assistant = store.append_message(session.id, role=ConsoleMessageRole.ASSISTANT, content="partial")
+    outcome = RunOutcome(status="RUN_SUPERSEDED", steps=[], final_text="")
+    result = controller._finalize_agent_reply(assistant.id, session.id, outcome, variant_mode=False)
+
+    updated = store.get_message(assistant.id)
+    assert updated.status == "failed"
+    assert "RUN_SUPERSEDED" in str(store.messages_for_session(session.id))
+```
+
+> Replace `StreamingGateway()` with the actual gateway class used by existing tests.
+
+Run:
+
+```bash
+pytest Tests/Chat/test_console_chat_controller.py::test_finalize_agent_reply_error_marks_failed Tests/Chat/test_console_chat_controller.py::test_finalize_agent_reply_cancelled_marks_stopped Tests/Chat/test_console_chat_controller.py::test_finalize_agent_reply_unknown_status_marks_failed -v
+```
+
+Expected: PASS.
+
+### Step 2.7: Add bridge-level tests
 
 Create `Tests/Chat/test_console_agent_bridge.py`:
 
@@ -454,7 +571,23 @@ pytest Tests/Chat/test_console_agent_bridge.py -v
 
 Expected: PASS.
 
-### Step 2.7: Add structured diagnostics logging
+### Step 2.8: Store MCP provider for context snapshot
+
+In `_run_agent_reply`, after composing the MCP provider, store it on the controller:
+
+```python
+self._mcp_provider = mcp_provider
+```
+
+Initialize it in `ConsoleChatController.__init__`:
+
+```python
+self._mcp_provider: Any | None = None
+```
+
+This allows `build_context_snapshot` to include the MCP-configured note in the next-send payload.
+
+### Step 2.9: Add structured diagnostics logging
 
 In `_run_agent_reply`, before and after the `asyncio.to_thread` call:
 
@@ -479,18 +612,52 @@ logger.info(
 )
 ```
 
-In `ConsoleAgentBridge.run_reply`, add at entry and exit:
+In `ConsoleAgentBridge.run_reply`, add at entry and exit, and wrap the tool-invocation closure so each tool call is logged:
 
 ```python
+from loguru import logger
+
 logger.info(
     "console_agent_bridge_run",
     conversation_id=conversation_id,
     model=model,
     allowed_tools_count=len(allowed_tools),
 )
+
+# If the bridge builds an invoke_tool closure for AgentService.run_turn,
+# wrap it to log each tool invocation:
+original_invoke_tool = invoke_tool
+
+def logged_invoke_tool(tool_call):
+    logger.info(
+        "console_agent_tool_call",
+        tool_name=getattr(tool_call, "name", "unknown"),
+        tool_id=getattr(tool_call, "id", "unknown"),
+    )
+    result = original_invoke_tool(tool_call)
+    logger.info(
+        "console_agent_tool_result",
+        tool_name=getattr(tool_call, "name", "unknown"),
+        success=getattr(result, "success", True),
+    )
+    return result
+
+# Pass logged_invoke_tool to AgentService.run_turn in place of invoke_tool.
 ```
 
-For per-turn/per-tool logging, add inside the bridge after `AgentService.run_turn` returns (or wrap the run in a lightweight callback if the runtime supports it). If the runtime does not expose hooks, document that per-turn logs are deferred to a future bridge refactor.
+After `AgentService.run_turn()` returns, log each step in the outcome:
+
+```python
+for i, step in enumerate(outcome.steps):
+    logger.info(
+        "console_agent_step",
+        step_index=i,
+        step_kind=getattr(step, "kind", "unknown"),
+        step_summary=getattr(step, "summary", "")[:200],
+    )
+```
+
+> The exact `AgentStep` shape is in `tldw_chatbook/Agents/agent_models.py`. Adjust attribute access (`step.kind`, `step.summary`, etc.) to match the actual fields.
 
 Run the existing controller tests:
 
@@ -500,7 +667,7 @@ pytest Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_
 
 Expected: all PASS.
 
-### Step 2.8: Commit
+### Step 2.9: Commit
 
 ```bash
 git add Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_agent_bridge.py
@@ -588,8 +755,12 @@ async def build_context_snapshot(
     # Redact secrets before returning.
     redacted_messages = self._redact_secrets(provider_messages)
 
+    # Deep-copy messages so the snapshot is independent of the store.
+    from dataclasses import replace
+    copied_messages = [replace(msg) for msg in current_messages]
+
     return ConsoleContextSnapshot(
-        current_messages=list(current_messages),
+        current_messages=copied_messages,
         next_send_payload={
             "model": self.model or self.configured_model,
             "messages": redacted_messages,
@@ -783,22 +954,38 @@ from __future__ import annotations
 
 from typing import Any
 
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
 from textual.screen import ModalScreen
-from textual.widgets import Button, Checkbox, Static, TabbedContent, TabPane, TextArea
+from textual.widgets import (
+    Button,
+    Checkbox,
+    Collapsible,
+    Label,
+    LoadingIndicator,
+    Static,
+    TabbedContent,
+    TabPane,
+    TextArea,
+)
 from textual.worker import Worker, WorkerState
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot
 
 
+SIZE_THRESHOLD_BYTES = 1 * 1024 * 1024
+
+
 class ConsoleContextModal(ModalScreen[None]):
     DEFAULT_CSS = """
     ConsoleContextModal { align: center middle; }
-    #console-context-modal { width: 95; height: 38; border: tall gray; }
+    #console-context-modal { width: 95; height: 40; border: tall gray; }
     #console-context-header { height: auto; }
     #console-context-warning { height: auto; color: yellow; }
+    #console-context-loading { display: none; }
+    #console-context-loading.loading { display: block; }
     #console-context-tabs { height: 1fr; }
     #console-context-actions { height: auto; }
     """
@@ -809,6 +996,7 @@ class ConsoleContextModal(ModalScreen[None]):
     raw_json = reactive(False)
     in_progress = reactive(False)
     token_estimate = reactive(None)
+    loading = reactive(False)
 
     def __init__(
         self,
@@ -826,27 +1014,36 @@ class ConsoleContextModal(ModalScreen[None]):
         with Vertical(id="console-context-modal"):
             yield Static("Chat Context", id="console-context-header")
             yield Static("", id="console-context-warning")
+            yield LoadingIndicator(id="console-context-loading")
 
             with TabbedContent(id="console-context-tabs"):
                 with TabPane("Current", id="console-context-current"):
-                    yield TextArea("", id="console-context-current-body", read_only=True)
+                    yield Vertical(id="console-context-current-body")
                 with TabPane("Next Send", id="console-context-next-send"):
-                    yield TextArea("", id="console-context-next-send-body", read_only=True)
+                    yield Vertical(id="console-context-next-send-body")
 
             with Horizontal(id="console-context-actions"):
                 yield Checkbox("Raw JSON", id="console-context-raw")
                 yield Button("Refresh", id="console-context-refresh", disabled=self.in_progress)
                 yield Button("Copy JSON", id="console-context-copy")
+                yield Button("Save to File", id="console-context-save")
                 yield Button("Close", id="console-context-close")
 
     def on_mount(self) -> None:
-        self._render()
+        self.run_worker(self._load_snapshot, exclusive=True)
 
     def watch_snapshot(self) -> None:
         self._render()
 
     def watch_raw_json(self) -> None:
         self._render()
+
+    def watch_loading(self) -> None:
+        loading = self.query_one("#console-context-loading", LoadingIndicator)
+        if self.loading:
+            loading.add_class("loading")
+        else:
+            loading.remove_class("loading")
 
     def _render(self) -> None:
         warning = self.query_one("#console-context-warning", Static)
@@ -861,53 +1058,77 @@ class ConsoleContextModal(ModalScreen[None]):
             header_text += f" (~{self.token_estimate} tokens)"
         header.update(header_text)
 
-        current_body = self.query_one("#console-context-current-body", TextArea)
-        next_body = self.query_one("#console-context-next-send-body", TextArea)
+        current_container = self.query_one("#console-context-current-body", Vertical)
+        current_container.remove_children()
+        current_container.mount(self._build_current_context_view())
 
-        current_body.text = self._format_current_context()
-        next_body.text = self._format_next_send()
+        next_container = self.query_one("#console-context-next-send-body", Vertical)
+        next_container.remove_children()
+        next_container.mount(self._build_next_send_view())
 
-    def _format_current_context(self) -> str:
-        lines: list[str] = []
+    def _build_current_context_view(self) -> Vertical:
+        container = Vertical()
+        if not self.snapshot.current_messages:
+            container.mount(Label("No conversation context."))
+            return container
         for msg in self.snapshot.current_messages:
-            lines.append(f"[{msg.role}] {msg.status}")
-            lines.append(msg.content)
-            lines.append("")
-        if not lines:
-            return "No conversation context."
-        return "\n".join(lines)
+            collapsible = Collapsible(title=f"[{msg.role}] {msg.status}", collapsed=True)
+            collapsible.mount(TextArea(msg.content, read_only=True))
+            container.mount(collapsible)
+        return container
 
-    def _format_next_send(self) -> str:
-        import json
+    def _build_next_send_view(self) -> Vertical:
+        container = Vertical()
+        payload = self.snapshot.next_send_payload
+        text = self._format_next_send_text()
+
+        if len(text.encode("utf-8")) > SIZE_THRESHOLD_BYTES:
+            container.mount(Label(
+                "Context exceeds 1 MiB. Use Save to File to view the full payload."
+            ))
+            return container
 
         if self.raw_json:
-            return json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
-        return self._format_payload_human_readable()
+            container.mount(TextArea(text, read_only=True))
+            return container
 
-    def _format_payload_human_readable(self) -> str:
-        import json
+        model_collapsible = Collapsible(title="Model", collapsed=False)
+        model_collapsible.mount(Label(str(payload.get("model", "unknown"))))
+        container.mount(model_collapsible)
 
-        payload = self.snapshot.next_send_payload
-        lines: list[str] = []
-        lines.append(f"Model: {payload.get('model', 'unknown')}")
-        lines.append("")
-        lines.append("System:")
-        lines.append(json.dumps(payload.get('system'), indent=2, default=str))
-        lines.append("")
-        lines.append("Messages:")
-        for msg in payload.get("messages", []):
-            lines.append(json.dumps(msg, indent=2, default=str))
-            lines.append("")
+        system_collapsible = Collapsible(title="System", collapsed=True)
+        system_collapsible.mount(TextArea(self._json_block(payload.get("system")), read_only=True))
+        container.mount(system_collapsible)
+
+        messages_collapsible = Collapsible(title="Messages", collapsed=False)
+        for i, msg in enumerate(payload.get("messages", [])):
+            msg_collapsible = Collapsible(title=f"Message {i}", collapsed=True)
+            msg_collapsible.mount(TextArea(self._json_block(msg), read_only=True))
+            messages_collapsible.mount(msg_collapsible)
+        container.mount(messages_collapsible)
+
         tools = payload.get("tools")
         if tools:
-            lines.append("Tools:")
-            lines.append(json.dumps(tools, indent=2, default=str))
-            lines.append("")
+            tools_collapsible = Collapsible(title="Tools", collapsed=True)
+            tools_collapsible.mount(TextArea(self._json_block(tools), read_only=True))
+            container.mount(tools_collapsible)
+
         staged = payload.get("staged_sources")
         if staged:
-            lines.append("Staged sources:")
-            lines.append(json.dumps(staged, indent=2, default=str))
-        return "\n".join(lines)
+            staged_collapsible = Collapsible(title="Staged Sources", collapsed=True)
+            staged_collapsible.mount(TextArea(self._json_block(staged), read_only=True))
+            container.mount(staged_collapsible)
+
+        return container
+
+    def _format_next_send_text(self) -> str:
+        import json
+        return json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+
+    @staticmethod
+    def _json_block(obj: Any) -> str:
+        import json
+        return json.dumps(obj, indent=2, default=str)
 
     @on(Button.Pressed, "#console-context-close")
     def _close(self, event: Button.Pressed) -> None:
@@ -920,10 +1141,15 @@ class ConsoleContextModal(ModalScreen[None]):
         self.run_worker(self._load_snapshot, exclusive=True)
 
     async def _load_snapshot(self) -> None:
-        self.snapshot = await self._snapshot_factory()
+        self.loading = True
+        try:
+            self.snapshot = await self._snapshot_factory()
+        finally:
+            self.loading = False
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.state == WorkerState.ERROR:
+            self.loading = False
             self.notify("Failed to refresh context.", severity="error")
 
     @on(Checkbox.Changed, "#console-context-raw")
@@ -937,7 +1163,6 @@ class ConsoleContextModal(ModalScreen[None]):
         import json
 
         text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
-        # Use existing clipboard utility if available; otherwise notify.
         try:
             import pyperclip
             pyperclip.copy(text)
@@ -945,11 +1170,24 @@ class ConsoleContextModal(ModalScreen[None]):
         except Exception:
             self.notify("Copy failed: pyperclip unavailable.", severity="warning")
 
+    @on(Button.Pressed, "#console-context-save")
+    def _save_json(self, event: Button.Pressed) -> None:
+        event.stop()
+        import json
+        from pathlib import Path
+        from datetime import datetime
+
+        text = json.dumps(self.snapshot.next_send_payload, indent=2, default=str)
+        filename = f"chatbook_context_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        path = Path.home() / "Downloads" / filename
+        path.write_text(text, encoding="utf-8")
+        self.notify(f"Saved to {path}")
+
     def action_refresh(self) -> None:
         self.run_worker(self._load_snapshot, exclusive=True)
 ```
 
-> Note: This is a v1 modal. The spec's "Save to file" >1 MiB fallback is deferred to a follow-up task; the Copy button is sufficient for the beta feedback.
+> Note: `LoadingIndicator` requires Textual ≥0.47. If the project uses an older version, replace it with a `Static("Loading…")` toggled via CSS.
 
 ### Step 4.2: Wire up keybinding and command palette
 
@@ -966,13 +1204,16 @@ from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextMo
 from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
 
 async def action_view_chat_context(self) -> None:
-    controller = self._controller
-    session = controller.store.session(controller.store.active_session_id)
+    controller = self._console_chat_controller
+    session_id = controller.store.active_session_id
+    if not session_id:
+        self.notify("No active conversation.", severity="warning")
+        return
 
     composer = self.query_one("#console-native-composer", ConsoleComposerBar)
     draft = composer.value if composer else ""
-    staged_sources = session.workspace_context.allowed_sources if session else []
-    attachments = controller.store.pending_attachments(session.id) if session else []
+    staged_sources = controller.store.workspace_context.allowed_sources
+    attachments = controller.store.pending_attachments(session_id)
 
     async def _factory() -> ConsoleContextSnapshot:
         return await controller.build_context_snapshot(
@@ -981,13 +1222,16 @@ async def action_view_chat_context(self) -> None:
             staged_sources=staged_sources,
         )
 
-    snapshot = await _factory()
-    token_estimate = self._estimate_tokens(snapshot.next_send_payload)
+    token_estimate = self._estimate_tokens({"draft": draft})
     in_progress = controller.run_state.status in (
         ConsoleRunStatus.STREAMING,
         ConsoleRunStatus.AGENT_RUNNING,
     )
-    self.push_screen(ConsoleContextModal(_factory, token_estimate=token_estimate, in_progress=in_progress))
+    self.push_screen(ConsoleContextModal(
+        _factory,
+        token_estimate=token_estimate,
+        in_progress=in_progress,
+    ))
 
 
 def _estimate_tokens(self, payload: dict[str, Any]) -> int | None:
@@ -1014,6 +1258,8 @@ Create `Tests/UI/test_console_context_modal.py`:
 ```python
 import pytest
 from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Collapsible, Label, Static, TextArea
 
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
@@ -1023,14 +1269,23 @@ from tldw_chatbook.Chat.console_chat_models import (
 from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextModal
 
 
+SNAPSHOT = ConsoleContextSnapshot(
+    current_messages=[
+        ConsoleChatMessage(role=ConsoleMessageRole.USER, content="Hello"),
+        ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="Hi"),
+    ],
+    next_send_payload={"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]},
+)
+
+EMPTY_SNAPSHOT = ConsoleContextSnapshot(current_messages=[], next_send_payload={})
+
+
 async def _snapshot_factory() -> ConsoleContextSnapshot:
-    return ConsoleContextSnapshot(
-        current_messages=[
-            ConsoleChatMessage(role=ConsoleMessageRole.USER, content="Hello"),
-            ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content="Hi"),
-        ],
-        next_send_payload={"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]},
-    )
+    return SNAPSHOT
+
+
+async def _empty_factory() -> ConsoleContextSnapshot:
+    return EMPTY_SNAPSHOT
 
 
 class ModalHarness(App):
@@ -1048,15 +1303,53 @@ async def test_context_modal_renders_tabs():
     async with app.run_test(size=(100, 40)) as pilot:
         modal = app.screen
         header = modal.query_one("#console-context-header", Static)
-        assert "Chat Context" in header.renderable
-        assert "42 tokens" in str(header.renderable)
+        header_text = str(header.renderable)
+        assert "Chat Context" in header_text
+        assert "42 tokens" in header_text
 
-        current_body = modal.query_one("#console-context-current-body", TextArea)
-        assert "Hello" in current_body.text
+        current_container = modal.query_one("#console-context-current-body", Vertical)
+        text_areas = current_container.query(TextArea)
+        assert any("Hello" in ta.text for ta in text_areas)
 
-        next_body = modal.query_one("#console-context-next-send-body", TextArea)
-        assert "gpt-4" in next_body.text
+        next_container = modal.query_one("#console-context-next-send-body", Vertical)
+        labels = list(next_container.query(Label))
+        assert any("gpt-4" in str(label.renderable) for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_empty_state():
+    app = ModalHarness()
+    app._push_empty = lambda: app.push_screen(
+        ConsoleContextModal(_empty_factory)
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app._push_empty()
+        await pilot.pause()
+        modal = app.screen
+        current_container = modal.query_one("#console-context-current-body", Vertical)
+        labels = list(current_container.query(Label))
+        assert any("No conversation context" in str(label.renderable) for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_context_modal_in_progress_warning():
+    app = ModalHarness()
+    app._push_in_progress = lambda: app.push_screen(
+        ConsoleContextModal(_snapshot_factory, in_progress=True)
+    )
+
+    async with app.run_test(size=(100, 40)) as pilot:
+        app._push_in_progress()
+        await pilot.pause()
+        modal = app.screen
+        warning = modal.query_one("#console-context-warning", Static)
+        assert "in progress" in str(warning.renderable)
+        refresh_button = modal.query_one("#console-context-refresh", Button)
+        assert refresh_button.disabled
 ```
+
+> The `query` method requires Textual 0.41+. If unavailable, use `query_one` with a descendant selector.
 
 Run:
 
@@ -1066,10 +1359,85 @@ pytest Tests/UI/test_console_context_modal.py -v
 
 Expected: PASS.
 
-### Step 4.4: Commit
+### Step 4.4: Add ChatScreen wiring tests
+
+Create `Tests/UI/test_chat_screen_context_modal.py`:
+
+```python
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage, ConsoleMessageRole
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console.console_context_modal import ConsoleContextModal
+
+
+class ChatScreenHarness(App):
+    def compose(self) -> ComposeResult:
+        yield ChatScreen()
+
+
+@pytest.mark.asyncio
+async def test_chat_screen_keybinding_opens_context_modal():
+    app = ChatScreenHarness()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Ensure an active session and a message exist.
+        screen = app.screen
+        controller = screen._console_chat_controller
+        session = controller.store.ensure_session(title="Test")
+        controller.store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Hello",
+        )
+        await pilot.pause()
+
+        await pilot.press("ctrl+shift+p")
+        await pilot.pause()
+
+        assert isinstance(app.screen, ConsoleContextModal)
+
+
+@pytest.mark.asyncio
+async def test_chat_screen_command_palette_opens_context_modal():
+    app = ChatScreenHarness()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        controller = screen._console_chat_controller
+        session = controller.store.ensure_session(title="Test")
+        controller.store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="Hello",
+        )
+        await pilot.pause()
+
+        # Open command palette and select the context command.
+        await pilot.press("ctrl+backslash")
+        await pilot.pause()
+        await pilot.press("Console: View chat context")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, ConsoleContextModal)
+```
+
+> Adjust the command palette key (`ctrl+backslash`) to the actual binding used by the project.
+
+Run:
 
 ```bash
-git add tldw_chatbook/Widgets/Console/console_context_modal.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/console_command_provider.py Tests/UI/test_console_context_modal.py
+pytest Tests/UI/test_chat_screen_context_modal.py -v
+```
+
+Expected: PASS.
+
+### Step 4.5: Commit
+
+```bash
+git add tldw_chatbook/Widgets/Console/console_context_modal.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/console_command_provider.py Tests/UI/test_console_context_modal.py Tests/UI/test_chat_screen_context_modal.py
 git commit -m "feat(console): add context viewer modal and keybinding"
 ```
 
@@ -1080,7 +1448,7 @@ git commit -m "feat(console): add context viewer modal and keybinding"
 ### Step 5.1: Run the full console test suites
 
 ```bash
-pytest Tests/UI/test_console_native_transcript.py Tests/UI/test_console_context_modal.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py -v
+pytest Tests/UI/test_console_native_transcript.py Tests/UI/test_console_context_modal.py Tests/UI/test_chat_screen_context_modal.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py -v
 ```
 
 Expected: all PASS.
@@ -1095,7 +1463,7 @@ Expected: all PASS.
 ### Step 5.3: Final commit
 
 ```bash
-git add Tests/UI/test_console_native_transcript.py Tests/UI/test_console_context_modal.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py
+git add Tests/UI/test_console_native_transcript.py Tests/UI/test_console_context_modal.py Tests/UI/test_chat_screen_context_modal.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_agent_bridge.py
 git commit -m "test(console): add integration tests and smoke checklist for console feedback"
 ```
 

--- a/Docs/superpowers/specs/2026-07-20-provider-instance-registry-design.md
+++ b/Docs/superpowers/specs/2026-07-20-provider-instance-registry-design.md
@@ -70,11 +70,11 @@ temperature = 0.7
 max_tokens = 4096
 
 [provider_instances.vllm-1.keys.production]
-value = "sk-..."
+value = "<API_KEY_HERE>"
 default = true
 
 [provider_instances.vllm-1.keys.staging]
-value = "sk-..."
+value = "<API_KEY_HERE>"
 ```
 
 ## Components

--- a/Docs/superpowers/specs/2026-07-20-provider-instance-registry-design.md
+++ b/Docs/superpowers/specs/2026-07-20-provider-instance-registry-design.md
@@ -1,0 +1,152 @@
+# Provider Instance Registry — Design Spec
+
+**Date:** 2026-07-20  
+**Status:** Approved  
+**Scope:** TUI API provider configuration and selection in `tldw_chatbook`.
+
+## Goal
+
+Enable users to configure multiple named API instances (endpoint + keys) for a single provider type, and improve the ergonomics of swapping between them during chat.
+
+## User Requests Addressed
+
+1. Support 9 local API instances (llama.cpp, vLLM, Triton) with quick swapping.
+2. Support 4 API keys per provider for testing across accounts.
+3. Allow switching keys mid-chat without losing conversation context.
+4. Provide a "duplicate current" workflow for quickly creating variants.
+
+## Approach
+
+Introduce a first-class `ProviderInstance` concept. Each instance is a named API endpoint with its own credentials and model defaults. Instances are grouped by `provider_type`, which determines the request/response adapter. The configuration migrates from flat `[api_settings.<provider>]` entries to `[provider_instances.<id>]` entries.
+
+## Architecture
+
+### Module Layout
+
+```
+Providers/
+├── __init__.py
+├── instances.py          # ProviderInstance dataclass + registry
+├── adapters/
+│   ├── __init__.py
+│   ├── base.py           # ProviderAdapter protocol
+│   ├── openai_compat.py  # Generic OpenAI-compatible adapter
+│   ├── llamacpp.py       # llama.cpp quirks
+│   ├── vllm.py           # vLLM quirks
+│   └── triton.py         # Triton quirks
+├── resolver.py           # Instance + key → call options
+└── readiness.py          # On-demand readiness checks with caching
+```
+
+### Data Model
+
+```python
+@dataclass(frozen=True)
+class ApiKey:
+    label: str                   # "production", "staging", "test"
+    value: str                   # The actual key
+    is_default: bool = False
+
+@dataclass(frozen=True)
+class ProviderInstance:
+    id: str                      # e.g., "vllm-1", "llamacpp-prod"
+    provider_type: str           # "vllm", "llamacpp", "triton", "custom"
+    name: str                    # User label, e.g., "vLLM Production"
+    endpoint: str                # "http://localhost:8000/v1"
+    api_keys: tuple[ApiKey, ...]
+    model_defaults: dict[str, Any]
+    extra_options: dict[str, Any]
+```
+
+### Config Schema
+
+```toml
+[provider_instances.vllm-1]
+provider_type = "vllm"
+name = "vLLM Production"
+endpoint = "http://localhost:8000/v1"
+model = "llama-3.1-70b"
+temperature = 0.7
+max_tokens = 4096
+
+[provider_instances.vllm-1.keys.production]
+value = "sk-..."
+default = true
+
+[provider_instances.vllm-1.keys.staging]
+value = "sk-..."
+```
+
+## Components
+
+| Component | Change |
+|-----------|--------|
+| `Providers/instances.py` | New. `ProviderInstance`, `ApiKey`, `InstanceRegistry`. |
+| `Providers/adapters/` | New. Adapter protocol + implementations for OpenAI-compatible, llama.cpp, vLLM, Triton. |
+| `Providers/resolver.py` | New. Resolve instance + key label to call options. |
+| `Providers/readiness.py` | New. On-demand readiness checks with TTL caching. |
+| `config.py` | Add `[provider_instances]` section; auto-migrate legacy `[api_settings]` on first run. |
+| `UI/Screens/settings_screen.py` | Add "Provider Instances" CRUD section. |
+| `UI/Chat_Window_Enhanced.py` | Two-level provider/instance/key selector; "Duplicate current" button. |
+
+## Chat UI
+
+- **Instance dropdown:** Primary selector, shows instance names grouped by provider type. Searchable. "Add new instance" at bottom.
+- **Key dropdown:** Secondary, only visible when instance has >1 key. Shows labels with default marker.
+- **Duplicate current:** Creates a new instance sharing the same endpoint, focuses settings on the new instance's keys.
+- **Keyboard shortcut:** `Ctrl+P` opens instance selector directly.
+
+## Settings UI
+
+- **List view:** All instances with provider type, name, endpoint, key count.
+- **Add instance:** Guided form (type → name → endpoint → first key → options).
+- **Edit instance:** Inline editing for name, endpoint, model defaults.
+- **Keys section:** Per-instance key management (add/remove/set default).
+- **Readiness test:** Button to test connectivity per instance.
+- **Duplicate:** Two modes — reference (share endpoint) or copy (full copy).
+
+## Error Handling
+
+- **Duplicate IDs:** Warn and reject on save; auto-rename only on migration.
+- **Key sanitization:** `sanitize_error_for_display()` strips keys from provider errors.
+- **Mid-chat failure:** Fail message with "Retry" and "Switch instance" options.
+- **Provider quirks:** Warn on fallback, no silent generic fallback.
+- **Model fallback:** Show system message when falling back to default model.
+- **Key switching:** One-time notice; offer "Fork conversation" option.
+- **Duplicate modes:** Reference (share endpoint) or copy (full copy).
+- **Readiness caching:** 5 min for success, 30 s for failure; manual bypass.
+- **Key storage:** Plaintext default; optional keyring with `[use_keyring = true]`.
+
+## Migration
+
+- On first run, legacy `[api_settings.<provider>]` entries migrate to `[provider_instances.<provider>-1]`, `<provider>-2`, etc.
+- Legacy config is preserved as fallback for 2 releases.
+- Corrupt or duplicate configs are skipped with warnings, never crash.
+
+## Testing Strategy
+
+- **Unit tests:** Dataclasses, registry, migration, resolver, readiness, sanitization.
+- **Integration tests:** Chat switching, settings CRUD, duplicate current, config watching, cross-adapter calls.
+- **Property tests (Hypothesis):** ID generation, key sanitization, migration validity, resolver validity, readiness TTL.
+- **Performance tests:** 36 instances dropdown (<100ms), 100 instances stress test, parallel readiness checks (<2s).
+- **Manual QA:** 9 real instances with 4 keys each, rapid switching, duplicate-and-edit workflow.
+
+## Acceptance Criteria
+
+- [ ] Users can add/edit/delete named provider instances in Settings.
+- [ ] Each instance supports multiple named API keys with a default.
+- [ ] Chat UI shows instances grouped by provider type.
+- [ ] Users can switch instances and keys mid-chat without losing conversation.
+- [ ] "Duplicate current" creates a variant sharing the endpoint.
+- [ ] Legacy `[api_settings]` configs migrate automatically on first run.
+- [ ] Readiness checks are on-demand and cached.
+- [ ] All new logic has unit, integration, and property tests.
+
+## Related Files
+
+- `tldw_chatbook/config.py`
+- `tldw_chatbook/Providers/` (new)
+- `tldw_chatbook/UI/Screens/settings_screen.py`
+- `tldw_chatbook/UI/Chat_Window_Enhanced.py`
+- `tldw_chatbook/Chat/provider_readiness.py`
+- `tldw_chatbook/Chat/provider_catalog.py`

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ pip install -e ".[embeddings_rag,chunker]"
 # Web search and scraping capabilities
 pip install -e ".[websearch]"
 
-# All optional features
-pip install -e ".[embeddings_rag,chunker,websearch,audio,video,pdf,ebook,nemo,mcp,chatterbox,local_tts,higgs_tts,ocr_docext,debugging,mlx_whisper,diarization,coding_map,local_vllm,local_mlx,local_transformers,web]"
+# Most optional features (full extras list lives in pyproject.toml's [project.optional-dependencies])
+pip install -e ".[embeddings_rag,chunker,websearch,audio,video,pdf,ebook,nemo,mcp,chatterbox,local_tts,higgs_tts,ocr_docext,debugging,mlx_whisper,diarization,coding_map,local_vllm,local_mlx,local_transformers,web,speech_recording,realtime]"
 
 # Common feature combinations
 pip install -e ".[audio,video]"  # Media transcription (includes faster-whisper)
@@ -116,7 +116,7 @@ Advanced optional capability groups:
 | `local_mlx`                    | Local inference | MLX inference (Apple Silicon) | mlx-lm |
 | `transcription_faster_whisper` | Media ingestion and transcription | CPU/CUDA optimized Whisper transcription | faster-whisper |
 | `transcription_lightning_whisper` | Media ingestion and transcription | Apple Silicon optimized Whisper | lightning-whisper-mlx |
-| `transcription_parakeet`       | Media ingestion and transcription | Real-time ASR for Apple Silicon | parakeet-mlx |
+| `transcription_parakeet`       | Media ingestion and transcription | Parakeet ONNX transcription (cross-platform) | onnx-asr |
 | `mlx_whisper`                  | Media ingestion and transcription | Legacy: Both Apple Silicon transcription providers | lightning-whisper-mlx, parakeet-mlx |
 | `audio`                        | Media ingestion and transcription | Audio processing with transcription | faster-whisper, soundfile, yt-dlp |
 | `video`                        | Media ingestion and transcription | Video processing with transcription | faster-whisper, soundfile, yt-dlp |
@@ -141,6 +141,7 @@ The application supports multiple transcription providers. By default, `audio`, 
 
 #### Available Providers:
 - **faster-whisper** (Default): CPU/CUDA optimized implementation, works everywhere
+- **parakeet-onnx**: Parakeet ONNX transcription, cross-platform (installed by the `transcription_parakeet` extra and by `audio`/`video`)
 - **lightning-whisper-mlx**: Apple Silicon optimized Whisper implementation
 - **parakeet-mlx**: Real-time ASR optimized for Apple Silicon
 
@@ -176,10 +177,10 @@ Higgs Audio V2 is a state-of-the-art TTS system with zero-shot voice cloning cap
 **Option 1: Automated Installation (Recommended)**
 ```bash
 # Unix/Linux/macOS
-./scripts/install_higgs.sh
+./Helper_Scripts/Higgs-Install/install_higgs.sh
 
 # Windows
-scripts\install_higgs.bat
+Helper_Scripts\Higgs-Install\install_higgs.bat
 ```
 
 **Option 2: Manual Installation**
@@ -200,7 +201,7 @@ pip install -e ".[higgs_tts]"
 
 3. **Verify installation:**
 ```bash
-python scripts/verify_higgs_installation.py
+python Helper_Scripts/Higgs-Install/verify_higgs_installation.py
 ```
 
 #### Troubleshooting
@@ -254,7 +255,7 @@ The screen shell is organized around a **master shell** of primary destinations 
 > **Migration note:** legacy tabs — `Chat` (now Console), `Notes`, `Media`, `Ingest`, `Search`, `Coding`, `Characters/Prompts` (now Personas), `Subscriptions` (now Watchlists), and `Chatbooks` (now under Artifacts) — still resolve as routes/aliases, but are no longer separate primary destinations. `Coding` in particular is now a thin compatibility stub; agentic programming happens in the Console.
 
 ### LLM Support
-- **Commercial LLM APIs**: OpenAI, Anthropic, Cohere, DeepSeek, Google, Groq, Mistral, OpenRouter, QwenCloud, HuggingFace
+- **Commercial LLM APIs**: OpenAI, Anthropic, Cohere, DeepSeek, Google, Groq, Mistral, OpenRouter, QwenCloud, HuggingFace, Moonshot (Kimi), Z.ai (GLM)
 - **Local LLM APIs**: Llama.cpp, Ollama, Kobold.cpp, vLLM, Aphrodite, MLX-LM, ONNX Runtime, Custom OpenAI-compatible endpoints
 - **Streaming responses** with real-time display
 - **Full conversation management**: Save, load, edit, fork conversations
@@ -263,7 +264,6 @@ The screen shell is organized around a **master shell** of primary destinations 
   explicit Resume or Discard recovery without re-running completed tools
 - **Model capability detection**: Vision support, tool calling, etc.
 - **Custom tokenizer support** for accurate token counting
-- **Chat Tabs**: Multiple concurrent chat sessions (enable with `enable_chat_tabs = true` in config)
 
 ### RAG (Basic - FTS5)
 Even without optional dependencies, you get:
@@ -279,7 +279,7 @@ Even without optional dependencies, you get:
 - **Safe execution**: Timeouts and concurrency control
 - **UI integration**: Dedicated widgets for tool calls and results
 - **Provider support**: Multiple LLM providers with tool calling capabilities
-- **Status**: Implementation complete, UI widgets functional, chat integration pending
+- **Chat integration**: Tool calls, results, and approvals render inline in the Console
 
 ## Enhanced Features (With Optional Dependencies)
 
@@ -293,26 +293,18 @@ Installing `pip install -e ".[embeddings_rag]"` adds:
 - **Advanced Caching**: Query and embedding result caching
 - **Memory Management**: Automatic cleanup at configurable thresholds
 
-#### Enabling the New Modular RAG System
-```bash
-# Set environment variable
-export USE_MODULAR_RAG=true
-# Or in config.toml: use_modular_service = true
-```
-
 #### Default Embedding Configuration
 The embeddings_rag module comes with sensible defaults that work out of the box:
-- **Default Model**: `mxbai-embed-large-v1` (1024 dimensions) - high-quality embeddings
+- **Default Model**: `e5-small-v2` (384 dimensions) - the shipped `[embedding_config] default_model_id`
 - **Auto-device Detection**: Automatically uses GPU (CUDA/MPS) if available
 - **Zero Configuration**: Works immediately after installation
-- **Flexible Dimensions**: Supports Matryoshka - can use 512 or 256 dimensions for speed/storage
 
 Common embedding models are pre-configured:
-- **High Quality (Default)**: `mxbai-embed-large-v1` (~335MB, 1024d, supports 512d/256d)
+- **High Quality**: `mxbai-embed-large-v1` (~335MB, 1024d, supports 512d/256d)
 - **State-of-the-Art**: 
   - `stella_en_1.5B_v5` (~1.5GB, 512-8192d, security-pinned)
   - `qwen3-embedding-4b` (~4GB, up to 4096d, 32k context)
-- **Small/Fast**: `e5-small-v2`, `all-MiniLM-L6-v2` (~100MB, 384d)
+- **Small/Fast (Default)**: `e5-small-v2`, `all-MiniLM-L6-v2` (~100MB, 384d)
 - **Balanced**: `e5-base-v2`, `all-mpnet-base-v2` (~400MB, 768d)
 - **Large Models**: `e5-large-v2`, `multilingual-e5-large-instruct` (~1.3GB, 1024d)
 - **API-based**: OpenAI embeddings (requires API key)
@@ -425,7 +417,7 @@ All chat features listed here work with the core installation:
 - **Browser automation**: Playwright for dynamic content
 - **Language detection**: For multi-lingual content
 - **Integration with RAG**: Web content as knowledge source
-- **Multiple search providers**: Google, Bing, DuckDuckGo, Brave, Kagi, Tavily, SearX, Baidu, Yandex
+- **Multiple search providers**: Google, Bing, DuckDuckGo, Brave, Kagi, Tavily, SearX, Serper, Exa, Baidu, Yandex
 
 ### Media Processing Features
 
@@ -505,6 +497,8 @@ Comprehensive TTS support with multiple backends:
 - **ElevenLabs**: Premium voice synthesis with custom voices
 - **Kokoro ONNX** (with `local_tts`): Local neural TTS with no internet required
 - **Chatterbox** (with `chatterbox`): Advanced local TTS model
+- **Higgs Audio V2** (with `higgs_tts`): Zero-shot voice cloning (see installation section above)
+- **AllTalk**: OpenAI-compatible local TTS server
 - **Unified Interface**: Single API for all backends
 - **Voice Selection**: Choose from available voices per backend
 - **Audio Output**: Direct playback or save to file
@@ -573,18 +567,17 @@ Edit `~/.config/tldw_cli/config.toml` to:
 Example embedding configuration:
 ```toml
 [embedding_config]
-default_model_id = "mxbai-embed-large-v1"  # High-quality default
+default_model_id = "e5-small-v2"  # Shipped default; mxbai-embed-large-v1 and others are documented options
 
-[rag.embedding]
-model = "mxbai-embed-large-v1"
-device = "auto"  # Auto-detects best device (cuda/mps/cpu)
+# RAG-side embedding overrides can also be set via environment variables:
+# RAG_EMBEDDING_MODEL, RAG_DEVICE
 ```
 
 Example audio transcription configuration:
 ```toml
 [transcription]
 # Use NVIDIA Parakeet for low-latency transcription
-default_provider = "parakeet"  # Options: faster-whisper, qwen2audio, parakeet
+default_provider = "parakeet"  # Options: faster-whisper, parakeet-onnx, qwen2audio, parakeet, canary, parakeet-mlx, lightning-whisper-mlx, remote-whisper
 default_model = "nvidia/parakeet-tdt-1.1b"  # TDT model for streaming
 device = "cuda"  # Use GPU for faster processing
 use_vad_by_default = true  # Voice Activity Detection
@@ -592,22 +585,21 @@ use_vad_by_default = true  # Voice Activity Detection
 
 Example TTS configuration:
 ```toml
-[tts]
-default_backend = "openai"  # Options: openai, elevenlabs, kokoro, chatterbox
+[app_tts]
+default_provider = "openai"  # Options: openai, elevenlabs, kokoro, chatterbox, alltalk
 default_voice = "alloy"  # Backend-specific voice ID
-auto_play = true  # Play audio automatically after generation
 
-[tts.kokoro]
-model_path = "models/kokoro-v0_19.onnx"  # Path to local model
-voice = "af_bella"  # Available voices vary by model
+# Kokoro ONNX model locations (used when default_provider = "kokoro")
+# KOKORO_ONNX_MODEL_PATH_DEFAULT = "models/kokoro-v0_19.onnx"
+# KOKORO_ONNX_VOICES_JSON_DEFAULT = "models/voices.json"
 ```
 
 Example MCP configuration:
 ```toml
 [mcp]
 enabled = true
-server_port = 3000
-allowed_tools = ["search", "rag", "media_ingest"]
+http_port = 3000
+allowed_clients = ["claude-desktop", "localhost"]
 ```
 
 Example splash screen configuration:
@@ -616,7 +608,9 @@ Example splash screen configuration:
 enabled = true
 duration = 3.0
 card_selection = "random"  # Options: random, sequential, or specific card name
-active_cards = ["default", "cyberpunk", "minimalist"]
+active_cards = ["default", "matrix", "minimal"]
+
+[splash_screen.effects]
 animation_speed = 1.0
 ```
 
@@ -692,13 +686,12 @@ exact controls, endpoints, recovery, and optional paid verification.
 
 ### Database Files
 Located at `~/.local/share/tldw_cli/`:
-- `ChaChaNotes.db`: Conversations, characters, and notes
-- `media_v2.db`: Ingested media files and metadata
-- `prompts.db`: Saved prompt templates
+- `tldw_chatbook_ChaChaNotes.db`: Conversations, characters, and notes
+- `tldw_chatbook_media_v2.db`: Ingested media files and metadata
+- `tldw_chatbook_prompts.db`: Saved prompt templates
 - `rag_indexing.db`: RAG indexing state (if using RAG features)
 - `evals.db`: Evaluation results and benchmarks
-- `subscriptions.db`: Content subscription tracking
-- `search_history.db`: Search query history
+- `tldw_chatbook_subscriptions.db`: Content subscription tracking
 
 ## Web Server Access
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -22,7 +22,7 @@ Tests/
 ├── ChaChaNotesDB/          # Character/Chat/Notes database tests
 ├── DB/                     # General database tests
 ├── Event_Handlers/         # Event handling tests
-├── Integration/            # Cross-module integration tests
+├── integration/            # Cross-module integration tests
 ├── LLM_Management/         # LLM provider management tests
 ├── Media_DB/               # Media database tests
 ├── Notes/                  # Notes functionality tests
@@ -76,8 +76,7 @@ pytest --cov=tldw_chatbook --cov-report=html
 # Run tests with timeout (default: 300s)
 pytest --timeout=60
 
-# Run tests in parallel (requires pytest-xdist — being added to the dev
-# extras in task-1453; not installed by default before that)
+# Run tests in parallel (requires pytest-xdist, included in the dev extras)
 pytest -n auto
 ```
 
@@ -358,16 +357,16 @@ response = get_mock_response("openai", streaming=False)
 
 The project uses GitHub Actions for continuous integration:
 
-1. **Simple Workflow** (`python-app.yml`):
-   - Basic single Python version testing
-   - Runs on main branch pushes/PRs
+1. **Test Workflow** (`test.yml`):
+   - Core job runs the full non-UI suite on Ubuntu and macOS (Python 3.12)
+   - Separate jobs for UI tests, workflow self-checks, and artifact-lease tests
+   - Nightly deep job (`nightly-deep`, scheduled) carries the OS/Python
+     breadth (Ubuntu 3.11/3.12/3.13, macOS 3.12, Windows 3.12) plus the
+     `--run-slow` tier and coverage
+   - Test result and coverage reporting
 
-2. **Comprehensive Workflow** (`test.yml`):
-   - Matrix testing (Python 3.11, 3.12, 3.13)
-   - Multi-platform (Ubuntu, macOS, Windows)
-   - Separate jobs for unit/integration/UI tests
-   - Test result reporting
-   - Coverage reporting
+2. **Guard Workflows** (`backlog-guard.yml`, `css-bundle-guard.yml`):
+   - Repo-hygiene and CSS bundle checks
 
 ### Running Tests Locally Like CI
 

--- a/tldw_chatbook/Config_Files/EMBEDDING_DEFAULTS_README.md
+++ b/tldw_chatbook/Config_Files/EMBEDDING_DEFAULTS_README.md
@@ -11,12 +11,10 @@ pip install tldw_chatbook[embeddings_rag]
 ```
 
 **Default Configuration:**
-- Model: `mxbai-embed-large-v1` (1024 dimensions)
+- Model: `e5-small-v2` (384 dimensions)
 - Provider: HuggingFace
 - Device: Auto-detected (CUDA > MPS > CPU)
 - Auto-download: Enabled
-- Model size: ~335MB
-- Special feature: Supports Matryoshka dimensions (512, 256)
 
 No additional configuration is required to start using embeddings!
 
@@ -25,20 +23,11 @@ No additional configuration is required to start using embeddings!
 Embedding settings can be configured in multiple places (in order of priority):
 
 1. **Environment Variables** (highest priority)
-   - `RAG_EMBEDDING_MODEL` - Override the embedding model
+   - `RAG_EMBEDDING_MODEL` - Override the embedding model used by RAG
    - `RAG_DEVICE` - Force specific device (cuda/mps/cpu)
    - `OPENAI_API_KEY` - For OpenAI embeddings
 
-2. **RAG Configuration** in `config.toml`:
-   ```toml
-   [rag.embedding]
-   model = "mxbai-embed-large-v1"
-   device = "auto"
-   cache_size = 2
-   batch_size = 16
-   ```
-
-3. **Embedding Configuration** in `config.toml`:
+2. **Embedding Configuration** in `config.toml`:
    ```toml
    [embedding_config]
    default_model_id = "mxbai-embed-large-v1"
@@ -49,20 +38,20 @@ Embedding settings can be configured in multiple places (in order of priority):
    dimension = 1024
    ```
 
-4. **Built-in Defaults** (lowest priority)
+3. **Built-in Defaults** (lowest priority)
 
 ## Available Default Models
 
 The system comes pre-configured with several embedding models:
 
-### High-Quality Models (Default)
-- **mxbai-embed-large-v1** (Default) - Best quality, supports Matryoshka dimensions
+### High-Quality Models
+- **mxbai-embed-large-v1** - Best quality, supports Matryoshka dimensions
   - Full: 1024 dimensions
   - Reduced: 512 dimensions (93% performance)
   - Fast: 256 dimensions (still good quality)
 
 ### Small Models (Fast, ~100MB)
-- **e5-small-v2** - Good balance of speed and quality
+- **e5-small-v2** (shipped default) - Good balance of speed and quality
 - **all-MiniLM-L6-v2** - Fastest, good for development
 - **bge-small-en-v1.5** - Good multilingual support
 
@@ -87,8 +76,8 @@ The system comes pre-configured with several embedding models:
 
 ### API Models (Requires API Key)
 - **openai-ada-002** - OpenAI's legacy model
-- **openai-3-small** - New generation, efficient
-- **openai-3-large** - Highest quality
+- **openai-text-embedding-3-small** - New generation, efficient
+- **openai-text-embedding-3-large** - Highest quality
 
 ## Basic Configuration Examples
 
@@ -125,12 +114,7 @@ batch_size = 16
 ### 4. Use OpenAI Embeddings
 ```toml
 [embedding_config]
-default_model_id = "openai-3-small"
-
-[embedding_config.models.openai-3-small]
-provider = "openai"
-model_name_or_path = "text-embedding-3-small"
-dimension = 1536
+default_model_id = "openai-text-embedding-3-small"
 # api_key set via OPENAI_API_KEY environment variable
 ```
 
@@ -148,15 +132,16 @@ dimension = 768
 
 ## RAG-Specific Configuration
 
-For RAG functionality, configure embeddings in the RAG section:
+RAG does not read a `[rag.embedding]` table from `config.toml`. The RAG
+embedding model defaults to the pipeline profile's `embedding.model`
+(`all-MiniLM-L6-v2` for the builtin profiles; see
+`tldw_chatbook/RAG_Search/config_profiles.py` and
+`tldw_chatbook/Config_Files/rag_pipelines.toml`), and can be overridden with
+the `RAG_EMBEDDING_MODEL` / `RAG_DEVICE` environment variables:
 
-```toml
-[rag.embedding]
-model = "e5-base-v2"     # Model ID from embedding_config
-device = "auto"          # Auto-detect best device
-cache_size = 2           # Models to keep in memory
-batch_size = 16          # Batch size for processing
-max_length = 512         # Max sequence length
+```bash
+export RAG_EMBEDDING_MODEL=e5-base-v2  # Model ID from embedding_config
+export RAG_DEVICE=auto                 # Auto-detect best device
 ```
 
 ## Advanced Usage
@@ -292,10 +277,10 @@ revision = "4bbc0f1e9df5b9563d418e9b5663e98070713eb8"  # Pinned for security
 
 If upgrading from an older version:
 
-1. The system now uses `mxbai-embed-large-v1` as default (was `e5-small-v2`)
-2. Device selection now supports `"auto"`
-3. RAG configuration moved to `[rag.embedding]` section
+1. The shipped `[embedding_config] default_model_id` is `e5-small-v2`
+2. Device selection supports `"auto"`
+3. RAG embedding overrides use the `RAG_EMBEDDING_MODEL` / `RAG_DEVICE` environment variables (there is no `[rag.embedding]` config table)
 4. Models are defined in `[embedding_config.models]` section
-5. New models support revision pinning for security
+5. Models support revision pinning for security
 
 Old configurations will continue to work via backward compatibility.

--- a/tldw_chatbook/Config_Files/EMBEDDING_DEFAULTS_README.md
+++ b/tldw_chatbook/Config_Files/EMBEDDING_DEFAULTS_README.md
@@ -27,10 +27,11 @@ Embedding settings can be configured in multiple places (in order of priority):
    - `RAG_DEVICE` - Force specific device (cuda/mps/cpu)
    - `OPENAI_API_KEY` - For OpenAI embeddings
 
-2. **Embedding Configuration** in `config.toml`:
+2. **Embedding Configuration** in `config.toml` (example: switching the
+   shipped `e5-small-v2` default to a higher-quality model):
    ```toml
    [embedding_config]
-   default_model_id = "mxbai-embed-large-v1"
+   default_model_id = "mxbai-embed-large-v1"  # overrides the shipped e5-small-v2 default
    
    [embedding_config.models.mxbai-embed-large-v1]
    provider = "huggingface"

--- a/tldw_chatbook/Local_Ingestion/README.md
+++ b/tldw_chatbook/Local_Ingestion/README.md
@@ -14,13 +14,9 @@ This module provides programmatic access to ingest local files into the tldw_cha
 
 ### Documents
 - PDF (`.pdf`)
-- Microsoft Word (`.docx`, `.doc`)
+- Microsoft Word (`.doc`, `.docx`)
 - OpenDocument Text (`.odt`)
 - Rich Text Format (`.rtf`)
-- PowerPoint (`.pptx`, `.ppt`)
-- Excel (`.xlsx`, `.xls`)
-- OpenDocument Spreadsheet (`.ods`)
-- OpenDocument Presentation (`.odp`)
 
 ### E-books
 - EPUB (`.epub`)
@@ -28,14 +24,20 @@ This module provides programmatic access to ingest local files into the tldw_cha
 - AZW (`.azw`, `.azw3`)
 - FictionBook (`.fb2`)
 
+### Web Pages
+- HTML (`.html`, `.htm`)
+
 ### Text Files
-- Plain Text (`.txt`, `.text`)
+- Plain Text (`.txt`)
 - Markdown (`.md`, `.markdown`)
 - reStructuredText (`.rst`)
+- Log files (`.log`)
+- CSV (`.csv`)
 
-### Structured Data
-- XML (`.xml`)
-- OPML (`.opml`)
+### Media
+- Images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.tiff`, `.tif`)
+- Audio (`.mp3`, `.m4a`, `.wav`, `.flac`, `.ogg`, `.aac`, `.wma`, `.opus`)
+- Video (`.mp4`, `.avi`, `.mkv`, `.mov`, `.webm`, `.flv`, `.wmv`, `.m4v`, `.mpg`, `.mpeg`)
 
 ## Quick Start
 
@@ -46,17 +48,14 @@ from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 # Initialize database
 media_db = MediaDatabase("/path/to/media_db.sqlite", client_id="my_script")
 
-# Ingest a single file
+# Ingest a single file (raises FileIngestionError / FileNotFoundError on failure)
 result = ingest_local_file(
     file_path="/path/to/document.pdf",
     media_db=media_db,
     keywords=["important", "document"]
 )
 
-if result['success']:
-    print(f"Successfully ingested with media_id: {result['media_id']}")
-else:
-    print(f"Failed: {result['message']}")
+print(f"Successfully ingested with media_id: {result['media_id']}")
 ```
 
 ## API Reference
@@ -71,29 +70,38 @@ Process and ingest a single local file.
 - `title` (str, optional): Override the document title
 - `author` (str, optional): Set the document author
 - `keywords` (list, optional): Keywords to associate with the content
-- `perform_chunking` (bool): Whether to chunk the content (default: True)
-- `chunk_options` (dict, optional): Chunking configuration
-  - `method`: Chunking method ('semantic', 'tokens', 'sentences', etc.)
-  - `chunk_size`: Size of each chunk
-  - `overlap`: Overlap between chunks
+- `custom_prompt` (str, optional): Custom analysis prompt
+- `system_prompt` (str, optional): System prompt for analysis
 - `perform_analysis` (bool): Whether to analyze/summarize (default: False)
 - `api_name` (str, optional): API provider for analysis
 - `api_key` (str, optional): API key if not using config default
-- `custom_prompt` (str, optional): Custom analysis prompt
-- `system_prompt` (str, optional): System prompt for analysis
-- `summarize_recursively` (bool): Recursive summarization (default: False)
-- `overwrite` (bool): Overwrite existing content (default: False)
+- `chunk_options` (dict, optional): Chunking configuration. Omitting the
+  argument means "chunk with defaults"; an explicit `None` disables
+  chunking for every type; `{}` or a populated dict chunks with
+  defaults/overrides. Keys:
+  - `method`: Chunking method ('semantic', 'tokens', 'sentences', 'paragraphs', 'words', 'ebook_chapters')
+  - `size` / `max_size`: Chunk size (default varies by method)
+  - `overlap`: Overlap between chunks (default varies by method)
+  - `adaptive`: Use adaptive chunking (bool)
+  - `multi_level`: Use multi-level chunking (bool)
+  - `language`: Language code for semantic chunking
+- `metadata` (dict, optional): Additional metadata to store with the media
 
 **Returns:**
 Dictionary with:
-- `success` (bool): Whether ingestion succeeded
 - `media_id` (int): Database ID of ingested content
-- `media_uuid` (str): UUID of ingested content
-- `message` (str): Success/error message
-- `file_path` (str): Path of processed file
-- `media_type` (str): Detected media type
 - `title` (str): Final title used
-- `processing_details` (dict): Raw processing results
+- `author` (str): Author used
+- `content_length` (int): Length of extracted content
+- `chunks_created` (int): Number of chunks created
+- `keywords` (list): Keywords associated with the media
+- `analysis`: Analysis results (if performed)
+- `file_type` (str): Detected media type
+- `file_path` (str): Path of processed file
+
+**Raises:**
+- `FileIngestionError`: If ingestion fails
+- `FileNotFoundError`: If file doesn't exist
 
 ### `batch_ingest_files()`
 
@@ -103,11 +111,19 @@ Process multiple files with common options.
 - `file_paths` (list): List of file paths to process
 - `media_db` (MediaDatabase): Database instance
 - `common_keywords` (list, optional): Keywords for all files
+- `perform_analysis` (bool): Whether to analyze all files (default: False)
+- `api_name` (str, optional): API provider for analysis
+- `api_key` (str, optional): API key for analysis
+- `chunk_options` (dict, optional): Chunking options for all files (same semantics as `ingest_local_file`)
 - `stop_on_error` (bool): Stop on first error (default: False)
-- `**common_options`: Options applied to all files
 
 **Returns:**
-List of result dictionaries for each file.
+List of result dictionaries for each file. Failed files get a
+`{"file_path", "error", "success": False}` entry instead of a result
+(when `stop_on_error` is False).
+
+**Raises:**
+- `FileIngestionError`: If `stop_on_error` is True and an error occurs
 
 ### `ingest_directory()`
 
@@ -117,8 +133,9 @@ Scan and ingest all supported files in a directory.
 - `directory_path` (str/Path): Directory to scan
 - `media_db` (MediaDatabase): Database instance
 - `recursive` (bool): Include subdirectories (default: False)
-- `file_extensions` (list, optional): Limit to specific extensions
-- `**common_options`: Options applied to all files
+- `file_types` (list, optional): Limit to specific media types (e.g. `['pdf', 'document']`); None processes all supported types
+- `exclude_patterns` (list, optional): Filename patterns to exclude (e.g. `['*.tmp', 'draft_*']`)
+- `**kwargs`: Additional arguments passed to `ingest_local_file`
 
 **Returns:**
 List of result dictionaries for each file found.
@@ -137,10 +154,9 @@ result = ingest_local_file(
     perform_analysis=True,
     api_name="openai",
     custom_prompt="Summarize the key findings and implications",
-    perform_chunking=True,
     chunk_options={
         "method": "semantic",
-        "chunk_size": 1000,
+        "size": 1000,
         "overlap": 200
     }
 )
@@ -152,38 +168,38 @@ result = ingest_local_file(
 files = [
     "/docs/report1.pdf",
     "/docs/report2.docx",
-    "/docs/data.xlsx"
+    "/docs/notes.txt"
 ]
 
 results = batch_ingest_files(
     file_paths=files,
     media_db=media_db,
     common_keywords=["2024", "quarterly"],
-    perform_chunking=True,
-    chunk_options={"method": "tokens", "chunk_size": 500}
+    chunk_options={"method": "tokens", "size": 500}
 )
 
-# Check results
+# Check results (failed files carry success=False and an error message)
 for r in results:
-    print(f"{r['file_path']}: {'✓' if r['success'] else '✗'} {r['message']}")
+    if r.get("success") is False:
+        print(f"{r['file_path']}: ✗ {r['error']}")
+    else:
+        print(f"{r['file_path']}: ✓ media_id {r['media_id']}")
 ```
 
 ### Directory Ingestion
 
 ```python
-# Ingest all PDFs and EPUBs in a directory tree
+# Ingest all PDFs and e-books in a directory tree
 results = ingest_directory(
     directory_path="/home/user/Documents",
     media_db=media_db,
     recursive=True,
-    file_extensions=['.pdf', '.epub'],
+    file_types=['pdf', 'ebook'],
     keywords=["archive", "2024"],
     perform_analysis=False  # Just store, don't analyze
 )
 
 print(f"Processed {len(results)} files")
-successful = sum(1 for r in results if r['success'])
-print(f"Success rate: {successful}/{len(results)}")
 ```
 
 ### Integration with Existing Code
@@ -196,40 +212,43 @@ class DocumentProcessor:
     
     def process_upload(self, file_path: str, user_tags: list):
         """Process a user-uploaded document."""
-        result = ingest_local_file(
-            file_path=file_path,
-            media_db=self.media_db,
-            keywords=user_tags,
-            perform_analysis=True,
-            api_name=self.config.get('analysis_api')
-        )
-        
-        if result['success']:
-            self.notify_user(f"Document processed: {result['title']}")
-            return result['media_id']
-        else:
-            self.handle_error(result['message'])
+        try:
+            result = ingest_local_file(
+                file_path=file_path,
+                media_db=self.media_db,
+                keywords=user_tags,
+                perform_analysis=True,
+                api_name=self.config.get('analysis_api')
+            )
+        except FileIngestionError as e:
+            self.handle_error(str(e))
             return None
+        
+        self.notify_user(f"Document processed: {result['title']}")
+        return result['media_id']
 ```
 
 ## Error Handling
 
-The functions provide detailed error information:
+`ingest_local_file()` reports failure by raising:
+
+- `FileNotFoundError`: the file doesn't exist
+- `FileIngestionError`: unsupported file type, processing failure, or database storage failure (the message names the failing stage)
 
 ```python
-result = ingest_local_file(file_path="/path/to/file.pdf", media_db=db)
+from tldw_chatbook.Local_Ingestion import FileIngestionError
 
-if not result['success']:
-    if "not found" in result['message']:
-        print("File doesn't exist")
-    elif "Unsupported" in result['message']:
-        print(f"File type not supported: {result['media_type']}")
-    elif "Processing failed" in result['message']:
-        # Check processing_details for more info
-        print(f"Processing error: {result['processing_details'].get('error')}")
-    elif "Database storage failed" in result['message']:
-        print("Failed to save to database")
+try:
+    result = ingest_local_file(file_path="/path/to/file.pdf", media_db=db)
+except FileNotFoundError:
+    print("File doesn't exist")
+except FileIngestionError as e:
+    print(f"Ingestion failed: {e}")
 ```
+
+`batch_ingest_files()` catches per-file errors (unless `stop_on_error=True`)
+and appends a `{"file_path", "error", "success": False}` entry to the
+results for each failed file.
 
 ## Performance Considerations
 
@@ -247,16 +266,17 @@ if not result['success']:
 
 ## Database Considerations
 
-- The functions use the existing `MediaDatabase.add_media_with_keywords()` method
+- The pipeline writes through `persist_parsed_media()`, whose single
+  `add_media_with_keywords()` call is the only database write in the ingest path
 - Content is deduplicated by URL and content hash
-- Use `overwrite=True` to update existing content — this governs **live** rows only.
+- Use `persist_parsed_media(payload, media_db, overwrite_existing=True)` to update existing content — this governs **live** rows only.
   A match that is sitting in Trash (`is_trash = 1`) is never modified by
-  `overwrite`; restoring it requires the explicit `restore_trashed=True` opt-in
+  `overwrite_existing`; restoring it requires the explicit
+  `restore_trashed=True` opt-in at the `add_media_with_keywords` level
   (task-4026; the Library ingest writer `persist_parsed_media` passes it)
 - All operations are transactional
 
 ## See Also
 
-- `examples/local_file_ingestion_example.py` - Complete working examples
 - Individual processor documentation in their respective modules
 - Media database documentation in `DB/Client_Media_DB_v2.py`

--- a/tldw_chatbook/Web_Scraping/README.md
+++ b/tldw_chatbook/Web_Scraping/README.md
@@ -100,7 +100,9 @@ asyncio.run(main())
 
 ```python
 import asyncio
-from tldw_chatbook.Web_Scraping.Article_Scraper import Scraper, ScraperConfig, ProcessorConfig, scrape_and_process_urls
+from tldw_chatbook.Web_Scraping.Article_Scraper.config import ProcessorConfig, ScraperConfig
+from tldw_chatbook.Web_Scraping.Article_Scraper.processors import scrape_and_process_urls
+from tldw_chatbook.Web_Scraping.Article_Scraper.scraper import Scraper
 
 async def main():
     urls = ["https://example.com/article1", "https://example.com/article2"]
@@ -173,7 +175,7 @@ cookies = get_cookies("example.com", browser="chrome")
 all_cookies = get_cookies("example.com", browser="all")
 
 # Use cookies with scraping
-from tldw_chatbook.Web_Scraping.Article_Scraper import Scraper
+from tldw_chatbook.Web_Scraping.Article_Scraper.scraper import Scraper
 
 async with Scraper(custom_cookies=cookies) as scraper:
     result = await scraper.scrape("https://example.com/protected-content")


### PR DESCRIPTION
## Summary

Audit of documentation vs. current implementation. Every change below is directly verifiable from code, the shipped config template, `pyproject.toml`, or the CI workflow files — nothing was inferred, and document structure/terminology/style were preserved.

## Files changed and evidence

### README.md
- **DB filenames**: `ChaChaNotes.db`/`media_v2.db`/`prompts.db`/`subscriptions.db` → `tldw_chatbook_ChaChaNotes.db`/`tldw_chatbook_media_v2.db`/`tldw_chatbook_prompts.db`/`tldw_chatbook_subscriptions.db`; dropped `search_history.db` (retired as dead code — `DB/DATABASE_PATH_STANDARDIZATION.md:50`). Evidence: `config.py:6175-6296` path getters.
- **Higgs installer paths**: `./scripts/install_higgs.sh` → `./Helper_Scripts/Higgs-Install/install_higgs.sh` (scripts live there; root `scripts/` contains only 3 unrelated files).
- **`[mcp]` example**: `server_port`/`allowed_tools` don't exist → `http_port`/`allowed_clients` (`config.py:4162-4172`; no reader for the old keys anywhere in `MCP/`).
- **`[tts]`/`[tts.kokoro]` example** → `[app_tts]` with real keys (`STTS_Window.py:451,1418`; `TTS/backends/kokoro.py:117-127`); added AllTalk/Higgs to the TTS backend list (`TTS/backends/alltalk.py`, `higgs.py`, `STTS_Window.py:1337-1343`).
- **`[transcription]` options**: expanded to the real eight providers (`config.py:4019-4023`); `transcription_parakeet` extra is cross-platform `onnx-asr`, not `parakeet-mlx` (`pyproject.toml:123-125`).
- **`[splash_screen]` example**: card names `cyberpunk`/`minimalist` don't exist (78-card catalog in `Splash_Screens/card_definitions.py`) → `matrix`/`minimal`; `animation_speed` moved under `[splash_screen.effects]` (`config.py:2832-2836`).
- **Embedding defaults**: default is `e5-small-v2` (384d) per the shipped template (`config.py:3658`); mxbai/stella/qwen3 are documented options, not the shipped default. Removed `[rag.embedding]` example — no code reads that table; only `RAG_EMBEDDING_MODEL`/`RAG_DEVICE` env vars (`RAG_Search/simplified/active_config.py:199-200`).
- **Removed stale sections**: "New Modular RAG" (`USE_MODULAR_RAG`/`use_modular_service` read by nothing) and Chat Tabs (`enable_chat_tabs` read by nothing; `_chat_tabs.tcss` removed per `css/build_css.py:90`).
- **Provider lists**: added Moonshot (Kimi) / Z.ai (GLM) (`config.py` `[api_settings.*]`) and Serper/Exa search (`WebSearch_APIs.py:3698,3770`); tool-calling "chat integration pending" → live (wired through `Chat/console_chat_controller.py`); extras list gains `speech_recording`/`realtime` referenced by the voice section.

### tldw_chatbook/Local_Ingestion/README.md
Fixed supported file types (dropped pptx/xlsx/ods/odp/xml/opml/.text; added html/image/audio/video — `local_file_ingestion.py:381-397,464-486`); real `ingest_local_file()` signature (no `perform_chunking`/`summarize_recursively`/`overwrite`; `chunk_options` keys `size`/`max_size` + omit-vs-`None` semantics per docstring); return shape (failures raise `FileIngestionError`, no `success` dict); `batch_ingest_files()` fixed params (no `**common_options`); `ingest_directory(file_types=…)` not `file_extensions`; error handling rewritten around exceptions; `overwrite_existing` on `persist_parsed_media`; dropped nonexistent `examples/` reference.

### tldw_chatbook/Config_Files/EMBEDDING_DEFAULTS_README.md
Default model corrected to `e5-small-v2` (doc self-contradicted line 14 vs 97; shipped template resolves it); removed unread `[rag.embedding]` location in favor of env vars/pipeline profiles; OpenAI model IDs fixed to shipped `openai-text-embedding-3-small/large` keys; migration notes corrected.

### Tests/README.md
CI section rewritten to the actual `test.yml` jobs (core non-UI Ubuntu/macOS on 3.12; UI tests; nightly-deep carrying OS/Python breadth incl. Windows; guard workflows) — `python-app.yml` doesn't exist; `Integration/` → `integration/`; pytest-xdist is in dev extras (`pyproject.toml:288`).

### Docs/User_Guide/index.md
"Roleplay & Chat Dictionaries" → "Roleplay" (6 occurrences; `UI/Navigation/shell_destinations.py:84-86` retires the long form; links unchanged).

### AGENTS.md
"schema v7" → "schema v37" (`DB/ChaChaNotes_DB.py:204`).

### tldw_chatbook/Web_Scraping/README.md
`from …Article_Scraper import …` raised ImportError (package `__init__.py` empty) → fixed to real submodules (`scraper.py:60`, `config.py:48,84`, `processors.py:116`).

### Docs/Development/TTS/Higgs-Audio-TTS-Guide.md
Same installer-path fixes as README.

## Verified correct (unchanged)

Version `v0.1.8.0`, entry points/CLI flags, QwenCloud/Moonshot/Z.ai sections, `[web_server]` example, splash "50+" (78 cards), `Ctrl+K`/`Alt+M`/`Ctrl+Shift+H` bindings, User-Guide anchors, `DB/DATABASE_PATH_STANDARDIZATION.md`.

## Notes

- README.md has mixed CRLF/LF line endings at HEAD; per-line endings were preserved so the diff contains only content changes.
- Docs-only change; no code paths touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs READMEs and guides to the current code to remove setup/config drift; adds a provider-instance registry design spec. Behavior is unchanged; the docs now match actual keys, defaults, filenames, and APIs.

- Corrects config examples and defaults: `[tts]` → `[app_tts]`; `[mcp]` uses `http_port`/`allowed_clients`; moves `animation_speed` under `[splash_screen.effects]`; ships embeddings default as `e5-small-v2` and drops the unread `[rag.embedding]` table in favor of `RAG_EMBEDDING_MODEL`/`RAG_DEVICE`; `transcription_parakeet` installs cross‑platform `onnx-asr`.
- Library API docs: local ingestion raises `FileIngestionError`/`FileNotFoundError` (no `success` dict); `chunk_options` keys are `size`/`max_size`; `batch_ingest_files()` drops `**common_options`; `ingest_directory()` takes `file_types` and supports `exclude_patterns`.
- Paths/imports: standardizes DB filenames (`tldw_chatbook_*.db`), moves Higgs installer scripts to `Helper_Scripts/Higgs-Install/`, and fixes web scraping imports to `Article_Scraper` submodules.
- Provider/search/Console: adds Moonshot (Kimi) and Z.ai (GLM); adds Serper and Exa search; tool-calling is documented as live in Console.
- Tests/CI docs: reflect the actual `test.yml` jobs, `integration/` dir, and `pytest-xdist` in dev extras.
- New docs: adds “Provider Instance Registry — Design Spec” (uses `<API_KEY_HERE>` placeholders); clarifies that `[embedding_config]` examples override the shipped `e5-small-v2` default.

**Migration actions**
- Update configs and scripts:
  - Rename `[tts]` to `[app_tts]`; update `[mcp]` keys (`server_port`/`allowed_tools` → `http_port`/`allowed_clients`); move splash `animation_speed` under `[splash_screen.effects]`.
  - Treat `e5-small-v2` as the default; remove `[rag.embedding]` and use `RAG_EMBEDDING_MODEL`/`RAG_DEVICE` for RAG overrides.
  - Use `Helper_Scripts/Higgs-Install/…` for Higgs installers.
- Rename/move data and imports:
  - Rename legacy DB files to `tldw_chatbook_ChaChaNotes.db`, `tldw_chatbook_media_v2.db`, `tldw_chatbook_prompts.db`, `tldw_chatbook_subscriptions.db`.
  - Import web scraping helpers from `Article_Scraper.{config,processors,scraper}`.
- Update ingestion call sites:
  - Catch `FileIngestionError`/`FileNotFoundError` instead of reading a `success` dict; pass `chunk_options` with `size`/`max_size`; use `file_types` with `ingest_directory()`.

<sup>Written for commit 769f2fa119c361d91bd6763101a9049a7ce88dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

