### PR TITLE
docs: address PR 1642 Qodo review feedback

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-pr-1642-qodo-remediation.md
+++ b/Docs/superpowers/plans/2026-08-14-pr-1642-qodo-remediation.md
@@ -1,0 +1,148 @@
+# PR 1642 Qodo Review Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct Qodo's valid public-docstring finding while preserving and
+proving the approved retry-safe lease and dependency-free maintainer contracts.
+
+**Architecture:** This is a documentation-only runtime change. Existing tests
+remain the authority for lease retry and `python -S` execution; new focused tests
+pin the docstring sections and explicit `--output` behavior. No lease, path, or
+filesystem implementation changes are admitted.
+
+**Tech Stack:** Python 3.11+, pytest, standard-library subprocess execution,
+Ruff.
+
+**ADR required:** no
+
+**ADR path:**
+`backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`
+
+**Reason:** ADR-050 already governs exact lease ownership and retry. This plan
+changes documentation and tests only; it does not alter an architecture
+boundary.
+
+---
+
+### Task 1: Pin the review contracts
+
+**Files:**
+- Modify: `Tests/UI/test_model_curated_view.py`
+- Modify: `Tests/TTS/test_audio_cpp_artifact_catalog.py`
+
+- [ ] **Step 1: Write the failing Model Library docstring test**
+
+Add a parametrized test over the five public helpers in
+`model_curated_view.py`. Require `Args:` and `Returns:` in each docstring.
+
+- [ ] **Step 2: Write the failing maintainer-script docstring test**
+
+Add a parametrized test over `validate_commit`, `refresh_manifest_bytes`, and
+`main`. Require `Args:` and `Returns:` in each docstring and `Raises:` for all
+three functions, matching their exposed validation, parser, and I/O failures.
+
+- [ ] **Step 3: Write the explicit output-path regression**
+
+Extend the direct dependency-free command coverage with the complete invocation:
+
+```bash
+python -S scripts/refresh_audio_cpp_artifact_manifest.py \
+  --commit <exact 40-hex commit> \
+  --manifest <empty fixture manifest> \
+  --output <tmp destination>
+```
+
+Assert success, empty stdout, and
+`output_path.read_bytes() == expected_bytes`, including the trailing newline.
+
+- [ ] **Step 4: Verify RED**
+
+Run the three new tests. Expected: the two docstring tests fail on missing
+sections; the existing output behavior test passes.
+
+- [ ] **Step 5: Commit the tests**
+
+Commit the RED tests separately so the behavioral requirement is reviewable.
+
+### Task 2: Add the minimal documentation
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/model_curated_view.py`
+- Modify: `scripts/refresh_audio_cpp_artifact_manifest.py`
+
+- [ ] **Step 1: Expand the eight public docstrings**
+
+Document each argument and return value. Add `Raises:` to `validate_commit`,
+`refresh_manifest_bytes`, and `main`, matching their existing public failure
+contracts. The `main` docstring must state that `--manifest` and `--output` are
+explicit trusted-maintainer paths and that `--output` intentionally permits an
+arbitrary destination. Do not change executable statements.
+
+- [ ] **Step 2: Verify GREEN**
+
+Run the three new tests. Expected: all pass.
+
+- [ ] **Step 3: Re-run unchanged ownership boundaries**
+
+Run:
+
+```bash
+pytest -q \
+  Tests/Model_Artifacts/test_operation_leases.py::test_release_raises_stable_error_without_masking_unlock_failure \
+  Tests/Model_Artifacts/test_operation_leases.py::test_unlock_failure_retains_real_shared_lock_until_release_retry \
+  Tests/TTS/test_audio_cpp_artifact_catalog.py::test_refresh_command_runs_directly_without_network_for_empty_manifest
+```
+
+Expected: four parametrized cases pass. This proves the rejected lease/path
+recommendations did not alter their approved contracts.
+
+- [ ] **Step 4: Run focused suites and static checks**
+
+Run the two changed test files, Ruff check/format check on changed Python files,
+and `git diff --check`.
+
+- [ ] **Step 5: Run the repository test gate and self-review**
+
+Run `pytest -q`. If the environment produces existing failures, run the
+identical command on unmodified `origin/dev`, compare exact failing node IDs,
+and document only unchanged baseline outcomes. Review the complete branch diff
+for executable changes, privacy, dependency, and task-scope drift.
+
+- [ ] **Step 6: Commit the implementation**
+
+Commit the docstring-only runtime change.
+
+### Task 3: Close the task and publish the remediation
+
+**Files:**
+- Modify: `backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md`
+
+- [ ] **Step 1: Record evidence and close TASK-16301**
+
+Edit the five-digit task file directly: check all ACs, add concise
+implementation notes, retain the ADR-050 link, and set status to Done. Do not
+use `backlog task edit 16301`, which can create a ghost task file.
+
+- [ ] **Step 2: Verify branch hygiene**
+
+Run Backlog listing/parsing, `git status --short backlog/`, and confirm no
+`backlog/tasks/task-task- - .md` ghost exists. Run `git diff --check`.
+
+- [ ] **Step 3: Commit the task closeout**
+
+Commit the direct task-file update, then confirm the worktree is clean.
+
+- [ ] **Step 4: Push and open a separate PR against `dev`**
+
+Summarize the accepted docstring fix and the tested technical dispositions for
+the lease and explicit output-path recommendations.
+
+- [ ] **Step 5: Reply to Qodo on PR 1642**
+
+Post a concise top-level disposition linking the follow-up PR: accepted
+docstrings fixed; lease retry retained because closing would destroy exact
+authority; central path validator rejected because it breaks the approved
+dependency-free arbitrary-destination maintainer contract.

--- a/Docs/superpowers/specs/2026-08-14-pr-1642-qodo-remediation-design.md
+++ b/Docs/superpowers/specs/2026-08-14-pr-1642-qodo-remediation-design.md
@@ -1,0 +1,41 @@
+# PR 1642 Qodo Review Remediation Design
+
+## Goal
+
+Correct the valid documentation finding from Qodo's PR 1642 review while
+preserving the already-approved artifact lease and maintainer-script contracts.
+
+## Review dispositions
+
+1. Add Google-style `Args:` and `Returns:` sections to the affected public
+   Model Library projection/focus helpers and manifest-refresh entry points.
+2. Keep `ArtifactOperationLease.release()` retryable after an unlock failure.
+   ADR-050's removal and runtime ownership boundaries require the exact lease
+   object to retain its handle until unlock succeeds. Existing real-lock tests
+   prove that an exclusive contender stays blocked after the first failure and
+   that a later release succeeds.
+3. Keep the manifest refresh script dependency-free and runnable with
+   `python -S`. Its `--manifest` and `--output` arguments are explicit paths
+   selected by a trusted maintainer, and `--output` intentionally supports an
+   arbitrary destination. Importing the application path validator would add
+   Loguru/metrics dependencies and break that contract without adding a useful
+   confinement root. Document this trust boundary and retain the direct-run
+   regression.
+
+## Testing
+
+- Add a small documentation-contract test that fails on the current short
+  docstrings and passes only when the named public functions expose the required
+  sections.
+- Re-run the real unlock-failure retry test and the dependency-free direct
+  manifest command test unchanged.
+- Run Ruff, formatting, and `git diff --check` on the focused change.
+
+## Architecture decision
+
+ADR required: no
+
+ADR path: N/A; ADR-050 already governs exact lease ownership and retry.
+
+Reason: this is review remediation and documentation clarification. It does not
+change storage, ownership, runtime, security, dependency, or UI boundaries.

--- a/Docs/superpowers/specs/2026-08-14-pr-1642-qodo-remediation-design.md
+++ b/Docs/superpowers/specs/2026-08-14-pr-1642-qodo-remediation-design.md
@@ -7,8 +7,13 @@ preserving the already-approved artifact lease and maintainer-script contracts.
 
 ## Review dispositions
 
-1. Add Google-style `Args:` and `Returns:` sections to the affected public
-   Model Library projection/focus helpers and manifest-refresh entry points.
+1. Add Google-style `Args:` and `Returns:` sections to the five public Model
+   Library helpers (`model_library_focus_locator`,
+   `restore_model_library_focus`, `project_audio_cpp_observation`,
+   `clear_audio_cpp_observation`, and `audio_cpp_package_projection`) and the
+   three public manifest-refresh entry points (`validate_commit`,
+   `refresh_manifest_bytes`, and `main`). Add `Raises:` wherever the callable
+   exposes a failure contract.
 2. Keep `ArtifactOperationLease.release()` retryable after an unlock failure.
    ADR-050's removal and runtime ownership boundaries require the exact lease
    object to retain its handle until unlock succeeds. Existing real-lock tests
@@ -25,17 +30,20 @@ preserving the already-approved artifact lease and maintainer-script contracts.
 ## Testing
 
 - Add a small documentation-contract test that fails on the current short
-  docstrings and passes only when the named public functions expose the required
-  sections.
+  docstrings and passes only when all eight named public functions expose the
+  required sections.
 - Re-run the real unlock-failure retry test and the dependency-free direct
   manifest command test unchanged.
+- Add a direct `python -S` command regression with an explicit `--output`
+  destination and verify the expected manifest bytes are written there.
 - Run Ruff, formatting, and `git diff --check` on the focused change.
 
 ## Architecture decision
 
 ADR required: no
 
-ADR path: N/A; ADR-050 already governs exact lease ownership and retry.
+ADR path:
+[`backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md`](../../../backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md)
 
 Reason: this is review remediation and documentation clarification. It does not
 change storage, ownership, runtime, security, dependency, or UI boundaries.

--- a/Tests/TTS/test_audio_cpp_artifact_catalog.py
+++ b/Tests/TTS/test_audio_cpp_artifact_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import copy
 import hashlib
 import io
@@ -24,6 +25,19 @@ TREE_URL = (
     f"https://huggingface.co/api/models/{REPOSITORY}/tree/{COMMIT}"
     "?recursive=true&expand=true"
 )
+
+
+def _manifest_refresh_docstring(function_name: str) -> str:
+    script_path = (
+        Path(__file__).parents[2] / "scripts" / "refresh_audio_cpp_artifact_manifest.py"
+    )
+    module = ast.parse(script_path.read_text(encoding="utf-8"))
+    functions = {
+        node.name: node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    return ast.get_docstring(functions[function_name]) or ""
 
 
 def _valid_manifest() -> dict[str, Any]:
@@ -1155,14 +1169,23 @@ def test_public_manifest_refresh_functions_use_google_style_docstrings(
     function_name: str,
     requires_raises: bool,
 ) -> None:
-    import scripts.refresh_audio_cpp_artifact_manifest as module
-
-    docstring = getattr(module, function_name).__doc__ or ""
+    docstring = _manifest_refresh_docstring(function_name)
 
     assert "Args:" in docstring
     assert "Returns:" in docstring
     if requires_raises:
         assert "Raises:" in docstring
+
+
+def test_manifest_docstring_contract_does_not_mutate_import_state() -> None:
+    before_path = tuple(sys.path)
+    sentinel = object()
+    before_module = sys.modules.get("audio_cpp_artifact_catalog", sentinel)
+
+    _manifest_refresh_docstring("validate_commit")
+
+    assert tuple(sys.path) == before_path
+    assert sys.modules.get("audio_cpp_artifact_catalog", sentinel) is before_module
 
 
 def test_refresh_command_writes_exact_bytes_to_explicit_output_without_site_packages(

--- a/Tests/TTS/test_audio_cpp_artifact_catalog.py
+++ b/Tests/TTS/test_audio_cpp_artifact_catalog.py
@@ -1173,9 +1173,9 @@ def test_refresh_command_writes_exact_bytes_to_explicit_output_without_site_pack
     manifest_path = _write_manifest(tmp_path, payload)
     output_path = tmp_path / "nested" / "refreshed-manifest.json"
     output_path.parent.mkdir()
-    expected_bytes = (
-        json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    ).encode("utf-8")
+    expected_bytes = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
 
     result = subprocess.run(
         [

--- a/Tests/TTS/test_audio_cpp_artifact_catalog.py
+++ b/Tests/TTS/test_audio_cpp_artifact_catalog.py
@@ -1141,3 +1141,59 @@ def test_refresh_command_runs_directly_without_network_for_empty_manifest(
         "commit": COMMIT,
         "packages": [],
     }
+
+
+@pytest.mark.parametrize(
+    ("function_name", "requires_raises"),
+    [
+        ("validate_commit", True),
+        ("refresh_manifest_bytes", True),
+        ("main", True),
+    ],
+)
+def test_public_manifest_refresh_functions_use_google_style_docstrings(
+    function_name: str,
+    requires_raises: bool,
+) -> None:
+    import scripts.refresh_audio_cpp_artifact_manifest as module
+
+    docstring = getattr(module, function_name).__doc__ or ""
+
+    assert "Args:" in docstring
+    assert "Returns:" in docstring
+    if requires_raises:
+        assert "Raises:" in docstring
+
+
+def test_refresh_command_writes_exact_bytes_to_explicit_output_without_site_packages(
+    tmp_path: Path,
+) -> None:
+    repository_root = Path(__file__).parents[2]
+    payload = {"repository": REPOSITORY, "commit": COMMIT, "packages": []}
+    manifest_path = _write_manifest(tmp_path, payload)
+    output_path = tmp_path / "nested" / "refreshed-manifest.json"
+    output_path.parent.mkdir()
+    expected_bytes = (
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "scripts/refresh_audio_cpp_artifact_manifest.py",
+            "--commit",
+            COMMIT,
+            "--manifest",
+            str(manifest_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert result.stdout == b""
+    assert output_path.read_bytes() == expected_bytes

--- a/Tests/UI/test_model_curated_view.py
+++ b/Tests/UI/test_model_curated_view.py
@@ -62,6 +62,27 @@ from tldw_chatbook.Model_Artifacts.curated_registry import CuratedRegistry
 from tldw_chatbook.UI.Screens.model_curated_view import CuratedView
 
 
+@pytest.mark.parametrize(
+    "function_name",
+    [
+        "model_library_focus_locator",
+        "restore_model_library_focus",
+        "project_audio_cpp_observation",
+        "clear_audio_cpp_observation",
+        "audio_cpp_package_projection",
+    ],
+)
+def test_public_audio_cpp_projection_helpers_document_arguments_and_returns(
+    function_name: str,
+) -> None:
+    from tldw_chatbook.UI.Screens import model_curated_view as module
+
+    docstring = getattr(module, function_name).__doc__ or ""
+
+    assert "Args:" in docstring
+    assert "Returns:" in docstring
+
+
 class _ViewApp(ConsolidatedCSSApp):
     def __init__(self, view: CuratedView) -> None:
         self.view = view

--- a/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
+++ b/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
@@ -1,0 +1,35 @@
+---
+id: TASK-16301
+title: Address PR 1642 Qodo review feedback
+status: In Progress
+assignee: []
+created_date: '2026-08-14 20:42'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Correct the accepted maintainability findings from Qodo's review of PR 1642 and record tested technical dispositions for recommendations that conflict with the approved artifact lease and maintainer-script contracts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Affected public APIs use Google-style Args and Returns documentation.
+- [ ] #2 Artifact unlock failures retain exact retry authority and remain covered by deterministic tests.
+- [ ] #3 The maintainer script remains dependency-free and its explicit output-path trust boundary is documented and tested.
+- [ ] #4 Focused tests, Ruff, formatting, and diff checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm [ADR-050](../decisions/050-audio-cpp-generated-model-setup-ownership.md)
+   remains authoritative and no new ADR is required.
+2. Add failing documentation-contract tests.
+3. Add minimal Google-style docstrings without changing runtime behavior.
+4. Re-run lease and dependency-free script regressions.
+5. Publish a separate remediation PR and reply to Qodo with verified
+   dispositions.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
+++ b/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
@@ -25,8 +25,15 @@ Correct the accepted maintainability findings from Qodo's review of PR 1642 and 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Confirm [ADR-050](../decisions/050-audio-cpp-generated-model-setup-ownership.md)
-   remains authoritative and no new ADR is required.
+ADR required: no
+
+ADR path:
+[ADR-050](../decisions/050-audio-cpp-generated-model-setup-ownership.md)
+
+Reason: ADR-050 already governs exact lease ownership and retry. This task
+changes documentation and tests only.
+
+1. Confirm ADR-050 remains authoritative and no new ADR is required.
 2. Add failing documentation-contract tests.
 3. Add minimal Google-style docstrings without changing runtime behavior.
 4. Re-run lease and dependency-free script regressions.

--- a/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
+++ b/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
@@ -54,7 +54,12 @@ changes documentation and tests only.
 - Kept the maintainer refresh command dependency-free under ``python -S`` and
   documented ``--manifest``/``--output`` as explicit trusted-maintainer paths.
   Added coverage proving an explicit nested output receives the exact bytes.
-- Verification: the two affected test files passed 138 tests; the focused
+- A follow-up Qodo review found that importing the maintainer script to inspect
+  docstrings leaked its deliberate command-line ``sys.path`` setup into pytest.
+  The contract test now reads docstrings with stdlib ``ast`` instead, and an
+  isolation regression proves ``sys.path`` and the duplicate top-level module
+  slot remain unchanged.
+- Verification: the two affected test files passed 139 tests; the focused
   documentation/output contracts passed 9 tests; the unchanged lease/script
   boundary selection passed 4 tests; Ruff check, Ruff format check, and
   ``git diff --check`` passed. A repository-wide run was stopped after 1,564

--- a/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
+++ b/backlog/tasks/task-16301 - Address-PR-1642-Qodo-review-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16301
 title: Address PR 1642 Qodo review feedback
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-14 20:42'
 labels: []
@@ -16,10 +16,10 @@ Correct the accepted maintainability findings from Qodo's review of PR 1642 and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Affected public APIs use Google-style Args and Returns documentation.
-- [ ] #2 Artifact unlock failures retain exact retry authority and remain covered by deterministic tests.
-- [ ] #3 The maintainer script remains dependency-free and its explicit output-path trust boundary is documented and tested.
-- [ ] #4 Focused tests, Ruff, formatting, and diff checks pass.
+- [x] #1 Affected public APIs use Google-style Args and Returns documentation.
+- [x] #2 Artifact unlock failures retain exact retry authority and remain covered by deterministic tests.
+- [x] #3 The maintainer script remains dependency-free and its explicit output-path trust boundary is documented and tested.
+- [x] #4 Focused tests, Ruff, formatting, and diff checks pass.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,3 +40,27 @@ changes documentation and tests only.
 5. Publish a separate remediation PR and reply to Qodo with verified
    dispositions.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added Google-style ``Args`` and ``Returns`` documentation to the reviewed
+  Model Library projection helpers and manifest-refresh entry points; the
+  manifest helpers also document their bounded failure contracts.
+- Kept ADR-050's artifact unlock behavior unchanged. Deterministic tests prove
+  that an unlock failure retains the exact OS-lock authority until a later
+  release retry succeeds; closing the handle at the first failure would violate
+  that ownership contract.
+- Kept the maintainer refresh command dependency-free under ``python -S`` and
+  documented ``--manifest``/``--output`` as explicit trusted-maintainer paths.
+  Added coverage proving an explicit nested output receives the exact bytes.
+- Verification: the two affected test files passed 138 tests; the focused
+  documentation/output contracts passed 9 tests; the unchanged lease/script
+  boundary selection passed 4 tests; Ruff check, Ruff format check, and
+  ``git diff --check`` passed. A repository-wide run was stopped after 1,564
+  passes with 9 failures in untouched App ingestion and console architecture
+  tests; those unrelated failures are not represented as a green full-suite
+  result.
+- ADR required: no. ADR-050 remains the governing exact-lease ownership
+  decision; this remediation changes documentation and tests, not boundaries.
+<!-- SECTION:NOTES:END -->

--- a/scripts/refresh_audio_cpp_artifact_manifest.py
+++ b/scripts/refresh_audio_cpp_artifact_manifest.py
@@ -44,7 +44,17 @@ UrlOpen = Callable[[urllib.request.Request], BinaryIO]
 
 
 def validate_commit(commit: str) -> str:
-    """Require an explicit immutable Hugging Face commit."""
+    """Require an explicit immutable Hugging Face commit.
+
+    Args:
+        commit: Candidate Hugging Face Git revision.
+
+    Returns:
+        The validated lowercase 40-character commit.
+
+    Raises:
+        ValueError: The revision is not an exact lowercase Git commit.
+    """
 
     if _COMMIT_RE.fullmatch(commit) is None:
         raise ValueError("commit must be exactly 40 lowercase hexadecimal characters")
@@ -299,7 +309,21 @@ def refresh_manifest_bytes(
     *,
     urlopen: UrlOpen = urllib.request.urlopen,
 ) -> bytes:
-    """Refresh integrity facts while retaining reviewed mappings and licenses."""
+    """Refresh integrity facts while retaining reviewed mappings and licenses.
+
+    Args:
+        manifest_path: Existing reviewed manifest to refresh.
+        commit: Exact immutable Hugging Face commit to query.
+        urlopen: Bounded HTTP opener used for source evidence.
+
+    Returns:
+        Deterministic UTF-8 JSON bytes for the refreshed manifest.
+
+    Raises:
+        OSError: The manifest or remote source evidence cannot be read.
+        TypeError: Manifest or source facts have an invalid type.
+        ValueError: Manifest or source facts violate the bounded contract.
+    """
 
     commit = validate_commit(commit)
     current = load_audio_cpp_artifact_source_manifest(
@@ -360,7 +384,23 @@ def refresh_manifest_bytes(
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the explicit-revision maintainer refresh command."""
+    """Run the explicit-revision maintainer refresh command.
+
+    ``--manifest`` and ``--output`` are explicit trusted-maintainer paths.
+    The output path intentionally permits an arbitrary destination; this
+    dependency-free command does not impose an application confinement root.
+
+    Args:
+        argv: Optional command arguments; defaults to ``sys.argv``.
+
+    Returns:
+        Zero after writing the refreshed manifest successfully.
+
+    Raises:
+        OSError: Standard output or the explicit output destination cannot be
+            written.
+        SystemExit: Argument parsing or manifest refresh fails.
+    """
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--commit", required=True)

--- a/tldw_chatbook/UI/Screens/model_curated_view.py
+++ b/tldw_chatbook/UI/Screens/model_curated_view.py
@@ -74,7 +74,19 @@ def model_library_focus_locator(
     action_class: str,
     action_role: str,
 ) -> ModelLibraryFocusLocator | None:
-    """Identify one header or exact-ref model-library control."""
+    """Identify one header or exact-ref model-library control.
+
+    Args:
+        view: Model Library view containing the candidate control.
+        widget: Candidate focused widget.
+        row_selector: Selector for rows carrying exact artifact references.
+        action_class: Class identifying the row action to remember.
+        action_role: Semantic role assigned to that row action.
+
+    Returns:
+        A widget ID, an exact-reference role tuple, or ``None`` when the
+        widget has no restorable Model Library role.
+    """
 
     if widget.id:
         return widget.id
@@ -103,7 +115,18 @@ def restore_model_library_focus(
     action_role: str,
     action_selector: str,
 ) -> None:
-    """Restore one header or exact-ref control after a pane change."""
+    """Restore one header or exact-ref control after a pane change.
+
+    Args:
+        view: Model Library view containing the replacement controls.
+        locator: Previously captured widget ID or exact-reference role.
+        row_selector: Selector for rows carrying exact artifact references.
+        action_role: Semantic role identifying the row action.
+        action_selector: Selector for that row action.
+
+    Returns:
+        None.
+    """
 
     if isinstance(locator, str):
         try:
@@ -142,7 +165,17 @@ def project_audio_cpp_observation(
     reference: ArtifactRef,
     evidence: AudioCppArtifactRemovalEvidence,
 ) -> AudioCppPackageProjection:
-    """Apply only exact-reference Settings and live-supervisor evidence."""
+    """Apply only exact-reference Settings and live-supervisor evidence.
+
+    Args:
+        projection: Existing package projection to update.
+        reference: Exact artifact reference expected by the projection.
+        evidence: Settings and runtime observation to apply.
+
+    Returns:
+        The updated projection, or the original projection when the evidence
+        belongs to another artifact reference.
+    """
 
     if evidence.reference != reference:
         return projection
@@ -168,7 +201,14 @@ def project_audio_cpp_observation(
 def clear_audio_cpp_observation(
     projection: AudioCppPackageProjection,
 ) -> AudioCppPackageProjection:
-    """Discard prior-generation Settings/runtime claims while refreshing."""
+    """Discard prior-generation Settings/runtime claims while refreshing.
+
+    Args:
+        projection: Existing package projection.
+
+    Returns:
+        A projection with Configured and Running facts reset to unknown.
+    """
 
     return replace(
         projection,
@@ -180,7 +220,14 @@ def clear_audio_cpp_observation(
 def audio_cpp_package_projection(
     descriptor: ArtifactDescriptor,
 ) -> AudioCppPackageProjection | None:
-    """Join a reviewed audio.cpp descriptor to its frozen recipe facts."""
+    """Join a reviewed audio.cpp descriptor to its frozen recipe facts.
+
+    Args:
+        descriptor: Curated or installed artifact descriptor to project.
+
+    Returns:
+        Truthful audio.cpp package facts, or ``None`` for another consumer.
+    """
 
     if descriptor.consumer != "audio_cpp":
         return None


### PR DESCRIPTION
## Summary

- add Google-style API documentation for the reviewed Model Library and manifest-refresh helpers
- retain ADR-050 exact lease retry semantics and pin the behavior with deterministic real-lock coverage
- document and test the dependency-free maintainer command's explicit output-path trust boundary

## Qodo dispositions

- **Accepted:** missing public API documentation is fixed.
- **Rejected after verification:** closing an artifact lease handle when unlock fails would discard the exact retry authority. The existing real-lock regression proves the contender stays blocked until the retained handle releases successfully.
- **Rejected after verification:** importing application path validation into the maintainer command would break its deliberate `python -S` / stdlib-only contract. `--manifest` and `--output` remain explicit trusted-maintainer paths; a new regression proves exact nested-output bytes under `python -S`.

## Verification

- `pytest -q Tests/UI/test_model_curated_view.py Tests/TTS/test_audio_cpp_artifact_catalog.py` — 138 passed
- focused unchanged lease/script boundary — 4 passed
- Ruff check and format check — passed
- `git diff --check origin/dev...HEAD` — passed
- repository-wide run was stopped after 1,564 passed with 9 failures in untouched App ingestion and console architecture tests; this PR does not claim that broad baseline is green

Follow-up to #1642. TASK-16301 is closed with the same evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses Qodo feedback from PR #1642 by adding Google-style public API docs and pinning the maintainer-script trust boundary and lease semantics with focused tests. Behavior is unchanged; ADR-050 lease retry semantics and the dependency-free `python -S` maintainer command remain as designed.

- Adds `Args:`/`Returns:` to five UI helpers in `tldw_chatbook/UI/Screens/model_curated_view.py`; adds `Args:`/`Returns:`/`Raises:` to `validate_commit`, `refresh_manifest_bytes`, and `main` in `scripts/refresh_audio_cpp_artifact_manifest.py`.
- Enforces docstring contracts without importing the script under test: tests use stdlib `ast` to read docstrings and assert no `sys.path` or module-state mutation.
- Pins a direct `python -S` invocation that writes exact bytes to an explicit nested `--output` path; no lock, path, or filesystem logic changed.
- Documents why we reject changing lease release-on-unlock-failure and importing app path validation; existing real-lock tests and new docs cover the approved contracts. Closes TASK-16301.

**Verification**
- Focused docstring and `python -S` command tests pass; unchanged lease/script boundary tests pass.
- Ruff and format checks pass; `git diff --check` is clean.

<sup>Written for commit 8697aadd75354349c3e8ddceeb137a3932b65ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

