### PR TITLE
feat(console): app-owned Console runtime holder (task-15860, ownership move only)

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-headless-wake-task-1-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-task-1-report.md
@@ -1,0 +1,171 @@
+# Task 1 report — the pure ownership move (task-15860, headless wake)
+
+**Zero semantic change is the whole deliverable.** Only WHO constructs the
+Console runtime moved. Its lifetime, its teardown order, its hook binding
+and the `_shutdown_requested` gate that refuses a headless wake are all
+exactly as they were on `origin/dev` `97f643816`.
+
+- Branch: `feat/task-15860-console-runtime`, worktree
+  `.worktrees/headless-runtime`, base `origin/dev` `97f643816`.
+- Owner's staging condition (`DECISIONS.md`, answer (3)): Task 1 is a pure
+  ownership move, gated by the full battery, separately reviewable and
+  separately revertable from Tasks 2–3, with
+  `Tests/UI/test_screen_residency.py` green throughout. All four hold.
+
+## What shipped
+
+New: `tldw_chatbook/Chat/console_runtime.py` — `ConsoleRuntime`, an
+app-lifetime holder that lazily constructs and owns
+
+| Object | Was built in | Now built in |
+|---|---|---|
+| `ConsoleChatStore` (+ its `ChatPersistenceService`) | `ChatScreen._ensure_console_chat_store` | `ConsoleRuntime.ensure_chat_store` |
+| `ConsoleProviderGateway` (incl. the `console_provider_gateway_factory` seam) | `ChatScreen._ensure_console_provider_gateway` | `ConsoleRuntime.ensure_provider_gateway` |
+| `ConsoleAgentBridge` + its sibling `AgentRunsDB` + `register_fleet_attention` | `ConsoleAgentController._ensure_console_agent_bridge` | `ConsoleRuntime.ensure_agent_bridge` |
+| `ConsoleChatController` (and therefore `_register_fleet_wake`/`_register_fleet_usage_reattach`, which run inside its `__init__`) | `ChatScreen._ensure_console_chat_controller` | `ConsoleRuntime.ensure_chat_controller` |
+
+Constructed at `app.py` `TldwCli.__init__` Phase 1, immediately after
+`console_image_edit_operations` (the precedent this follows), and
+re-created lazily by `ensure_console_runtime(app, view=…)` for app objects
+that never had one — the shape `ChatScreen._h3_image_edit_registry`
+already uses.
+
+Disposed at `ChatScreen.on_unmount` via `dispose_console_runtime(app,
+view=self)`, **after** the unchanged teardown sequence
+(`fleet_teardown_split()` snapshot → `await controller.shutdown()` →
+`await gateway.aclose()`). `dispose()` is a reference drop and a
+generation bump; it shuts nothing down. That call is what Task 2 removes.
+
+The four `_ensure_*` seams keep their names, their laziness, their return
+types and their patchability. Three test files replace
+`_ensure_console_agent_bridge` by name on the screen instance
+(`Tests/Chat/test_change_turn_tracking.py` ×2,
+`Tests/Chat/test_console_agent_swap.py`) and ~65 sites reach
+`_ensure_console_chat_store`; nothing was renamed.
+
+`register_fleet_attention` moved with the bridge, unchanged, still passing
+the APP object and never a screen. The wake coordinator's registration
+travels inside `ConsoleChatController.__init__`, so it moved with the
+controller by construction.
+
+## Two ordering hazards found and closed, not discovered later
+
+1. **The no-agent-runtime probe must stay first.** The bridge's durable-DB
+   probe returns `None` before the store or the gateway is touched. Passing
+   them as values would have built both on an in-memory harness. Every
+   view-supplied dependency therefore crosses as a callable
+   (`store_factory`, `provider_gateway_factory`,
+   `native_tools_enabled_factory`).
+
+2. **Two `ChatScreen`s are briefly alive at once.**
+   `_complete_screen_navigation` (`app.py`) constructs the incoming screen
+   and calls `restore_state` **before** `switch_screen` unmounts the
+   outgoing one, and `_restore_native_console_state` reaches
+   `_ensure_console_chat_store`. A naive app-owned holder would have handed
+   the incoming screen the outgoing screen's controller, which
+   `on_unmount` then shuts down underneath it — a dead Console after a
+   same-target navigation. `ConsoleRuntime.view` closes it: a runtime
+   claimed by a different view is replaced with a fresh one, which is
+   exactly today's one-runtime-per-screen semantics, and `dispose` skips a
+   runtime claimed by someone else. This is Task 1 lifetime preservation,
+   **not** Task 2's attach/detach seam, and it is documented as such.
+
+## The two pins (`Tests/UI/test_console_runtime_ownership.py`)
+
+Both are labelled characterization pins in their docstrings. Task 1 has no
+user-visible behaviour change, so there is no defect red to reproduce;
+dressing these as defect reds would be a lie about what they measure.
+
+1. `test_console_runtime_is_the_single_construction_site` — greps the
+   shipped package: `ConsoleChatStore(` and `ConsoleChatController(` appear
+   only in `Chat/console_runtime.py`. (`ConsoleProviderGateway(` is
+   deliberately excluded: the Personas preview controller builds its own.)
+   **Mutation:** re-added a direct `ConsoleChatStore(...)` in
+   `_ensure_console_chat_store` → the pin failed, naming
+   `chat_screen.py:5118`. Restored by Edit; `grep MUTATION` clean.
+
+2. `test_second_console_visit_gets_a_new_runtime` — a real mount, a real
+   `handle_screen_navigation` away and back. Asserts the runtime owns what
+   the screen holds, that leaving still sets `_shutdown_requested`, that
+   `on_unmount` disposes (generation 0 → 1, app attribute cleared), and
+   that the second visit's runtime, controller, store and bridge are all
+   different objects. **Mutation:** made `dispose_console_runtime` a no-op
+   → the pin failed at `assert runtime_one.generation == 1`. Restored by
+   Edit.
+
+Pin 2 is the one that matters: it makes Task 2's change land as a visible
+diff to a test rather than a diff to nothing. When Task 2 gives the
+runtime cross-navigation lifetime this test must go red and be rewritten,
+and its docstring says so.
+
+## Gate — baseline (untouched branch) vs final, same commands, same order
+
+Runner: `.venv/bin/pytest <paths> -p no:randomly -q --no-header -rf`,
+cwd = the worktree.
+
+| Suite | Baseline | Final | Delta |
+|---|---|---|---|
+| `Tests/test_probe_import_provenance.py` | 1 passed | 1 passed | — |
+| `Tests/UI/test_screen_residency.py` | 7 passed | 7 passed | — |
+| wake (Chat: `test_console_fleet_wake*.py` + `test_fleet_*.py`) | 65 passed | 65 passed | — |
+| wake (UI: `test_console_fleet_wake*.py`) | 19 passed | 19 passed | — |
+| `Tests/Agents/` | 1409 passed | 1409 passed | — |
+| `Tests/Chat/` | 18 failed, 5445 passed, 66 skipped | 18 failed, 5445 passed, 66 skipped | — (failure sets byte-identical by `diff`) |
+| `Tests/UI/test_console*.py` | 32 failed, 3039 passed | 32 failed, 3041 passed | **+2 passed** = the two new pins; failure count identical, set swapped 2-for-2 |
+
+The `Tests/Chat/` 18 are pre-existing on this branch's base (measured
+before any edit) and include the known `test_console_visual_evaluation`
+and the 15663 marks-migration red.
+
+**The ui_console 2-for-2 swap is flake noise, established rather than
+assumed.** Went green: `test_console_agent_rail::test_drilldown_falls_back
+_to_overview_after_conversation_switch`, `test_console_rewind_restore::
+test_summarize_up_to_choice_blocked_while_a_run_is_streaming`. Went red:
+`test_console_control_bar_coalescing::test_requested_sync_still_executes`,
+`test_console_session_settings::test_console_settings_modal_refreshes_
+readiness_after_returning_to_model_list`. Evidence:
+
+- both newly-red tests pass in isolation AND with their whole module on
+  the changed branch (`238 passed` across all four modules, with a *third*
+  rewind test flipping red in that run instead — the cluster flips
+  independently of the change);
+- the settings-modal one drives a `ModalHarness` + `ConsoleSettingsModal`
+  and never constructs a `ChatScreen`, so no `ConsoleRuntime` exists in it
+  at all — it is structurally untouchable by this change;
+- the coalescing one asserts a debounce collapsed three requests into one
+  and observed three, i.e. timer timing, on a machine that was running six
+  other agents' pytest processes concurrently throughout;
+- the flip happened in both directions and left the count identical.
+
+Pre-existing red NOT caused here and not in the mandated battery:
+`Tests/Architecture/test_screen_size_ratchet.py` is already red on
+`origin/dev` (`chat_screen.py` measures 23,466 lines against a 17,727
+budget). This change leaves it at 23,470 (+4, docstrings) with the
+`ChatScreen` method count unchanged — no method was added or removed.
+
+## Deliberately not done in Task 1
+
+- The runtime does **not** join `_shutdown_app_owned_lifecycles`. That
+  hook runs before Textual closes screen state, and `dispose()` has no
+  durable work to settle, so joining it would only reorder Console's quit
+  path. Textual's exit unmount already disposes it. Add an exit-time
+  settle in Task 2, deliberately, with the quit ordering re-verified.
+- `ChatScreen` still holds `_console_chat_store` / `_console_provider_
+  gateway` / `_console_chat_controller` as its own handles, set from the
+  runtime by the `_ensure_*` seams. ~40 call sites read them directly as
+  "has this been built yet" probes, and 59 test sites assign them.
+  Repointing those to the runtime is Task 2's job, when the runtime starts
+  outliving the screen and the two can actually disagree.
+- Hooks are still bound to screen methods (`on_scope_flushed`, the
+  dictionary/world-info appliers, the wake probes). Task 0's P3 found all
+  five slots a viewless wake touches still pointing at a dead screen;
+  rebinding is Task 4.
+- `_attempt`'s `_shutdown_requested` gate — Task 0's P2 proved it is the
+  single line refusing a headless wake — is untouched.
+
+## Note on plan numbering
+
+The merged plan's "Task 1" is the teardown split. The coordinator
+re-sequenced per the owner's staging condition: this task is the pure
+ownership move, and the teardown split now follows it. The plan document
+was not edited here.

--- a/Docs/superpowers/plans/2026-08-14-headless-wake.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake.md
@@ -137,6 +137,40 @@ Both are recorded in `DECISIONS.md`. Neither blocks Tasks 1–2.
 
 ---
 
+## EXECUTION ORDER — reconciliation (coordinator, 2026-08-14)
+
+**The executed order differs from the numbering below. Read this before picking up work.**
+
+The owner approved design A on a staging condition: *the pure ownership move lands first,
+with ZERO semantic change, separately reviewable and separately revertable from any lifetime
+semantics.* That inverts the plan's Task 1/Task 2 order, so the coordinator dispatched the
+ownership move first.
+
+| Shipped | Commit | = plan task | State |
+|---|---|---|---|
+| Four execution probes | `25bc081b2` (PR #1641) | Task 0 | DONE |
+| App-owned `ConsoleRuntime` holder, **still disposed at unmount** (zero semantic change) | `f09bb991d` | Task 2's ownership half ONLY | DONE |
+| Teardown split (`leave_console` vs `dispose`) + the runtime SURVIVING unmount | — | Task 1 + Task 2's lifetime half | NEXT |
+| Tasks 3-8 | — | unchanged | pending |
+
+**Two hazards the seam map did not name, found while executing the ownership move — the next
+task must handle both:**
+
+1. **`_complete_screen_navigation` constructs the incoming screen and calls `restore_state`
+   BEFORE `switch_screen` unmounts the outgoing one**, and `_restore_native_console_state`
+   reaches `_ensure_console_chat_store`. A naive app-owned holder therefore hands the
+   incoming screen the OUTGOING screen's controller, which `on_unmount` then shuts down
+   underneath it — a dead Console after a same-target navigation (reachable via the
+   `coding → chat` alias). `ConsoleRuntime.view` currently closes this by replacing a runtime
+   claimed by a different view. **That is a lifetime-preservation device standing in for
+   today's semantics; the attach/detach seam must REPLACE it, not build on it.**
+2. **`ChatScreen` still holds its own `_console_chat_store` / `_console_provider_gateway` /
+   `_console_chat_controller` handles** — ~40 sites read them as "built yet?" probes and 59
+   test sites assign them. Identical lifetimes today, so they cannot diverge. The moment the
+   runtime outlives the screen, a fresh screen's `None` handle SHADOWS a live runtime object
+   until `_ensure_*` runs. **Repointing them is the next task's FIRST move, not an
+   afterthought.**
+
 ### Task 0 — the four execution probes (DONE)
 
 Delivered: `Docs/superpowers/plans/2026-08-14-headless-wake-task-0-report.md`,

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -1,0 +1,141 @@
+"""Characterization pins for the app-owned Console runtime (task-15860, Task 1).
+
+**Neither test here is a defect red.** Task 1 is a pure ownership move with
+zero observable behaviour change, so there is no user-visible defect to
+reproduce. These two pin what is true the moment the move lands, for two
+different reasons:
+
+1. `test_console_runtime_is_the_single_construction_site` pins the move
+   itself. If a later change re-adds a `ConsoleChatStore(...)` or
+   `ConsoleChatController(...)` anywhere but `Chat/console_runtime.py`, the
+   app stops being the owner and Design A quietly loses its premise.
+
+2. `test_second_console_visit_gets_a_new_runtime` pins TODAY's LIFETIME --
+   the thing Task 1 deliberately did NOT change. Leaving Console still
+   disposes the runtime, so the next visit builds a brand-new
+   store/gateway/bridge/controller, exactly as it did when `ChatScreen`
+   owned them. Task 2 makes the runtime survive a navigation; when it does,
+   this test must go red and be rewritten. That is the point: without it,
+   Task 2's central change would be a diff to nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _wait_for_selector
+from tldw_chatbook.Chat.console_runtime import (
+    CONSOLE_RUNTIME_ATTR,
+    ConsoleRuntime,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+#: Constructor calls that must exist in exactly one place: the runtime.
+#: `ConsoleProviderGateway(` is deliberately NOT here -- the Personas
+#: preview controller builds its own, unrelated to the Console runtime
+#: (`UI/Persona_Modules/personas_preview_controller.py`).
+_RUNTIME_OWNED_CONSTRUCTIONS = ("ConsoleChatStore(", "ConsoleChatController(")
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+_RUNTIME_MODULE = "tldw_chatbook/Chat/console_runtime.py"
+
+
+def _construction_sites(token: str) -> list[str]:
+    """Every `<path>:<line>` in the shipped package containing `token`."""
+    sites: list[str] = []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        if token not in source:
+            continue
+        rel = path.relative_to(_PACKAGE_ROOT.parent).as_posix()
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if token in line:
+                sites.append(f"{rel}:{lineno}: {line.strip()}")
+    return sites
+
+
+@pytest.mark.unit
+def test_console_runtime_is_the_single_construction_site():
+    """PIN (characterization): only the runtime builds the store/controller."""
+    for token in _RUNTIME_OWNED_CONSTRUCTIONS:
+        sites = _construction_sites(token)
+        assert sites, f"{token} vanished entirely -- the pin is stale."
+        foreign = [site for site in sites if not site.startswith(_RUNTIME_MODULE)]
+        assert not foreign, (
+            f"{token} is constructed outside {_RUNTIME_MODULE}; the app is no "
+            "longer the Console runtime's owner:\n  " + "\n  ".join(foreign)
+        )
+
+
+@pytest.mark.asyncio
+async def test_second_console_visit_gets_a_new_runtime(tmp_path):
+    """PIN (characterization) of TODAY's lifetime: leaving Console disposes
+    the runtime, so returning builds a brand-new one.
+
+    Task 2 deliberately breaks this. Rewrite it there; do not delete it.
+    """
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat = ChatScreen(app)
+        await app.push_screen(chat)
+        app._initial_screen_pushed = True
+        app.current_tab = "chat"
+        await pilot.pause()
+        await _wait_for_selector(chat, pilot, "#console-native-composer")
+
+        controller_one = chat._ensure_console_chat_controller()
+        runtime_one = getattr(app, CONSOLE_RUNTIME_ATTR, None)
+        assert isinstance(runtime_one, ConsoleRuntime), type(runtime_one).__name__
+        # The app -- not the screen -- is what built these.
+        assert runtime_one.chat_controller is controller_one
+        assert runtime_one.chat_store is chat._console_chat_store
+        assert runtime_one.provider_gateway is chat._console_provider_gateway
+        bridge_one = runtime_one.agent_bridge
+        assert bridge_one is not None, (
+            "the real-on-disk-DB rig must actually build an agent bridge, "
+            "or this test cannot say anything about bridge identity"
+        )
+        assert bridge_one is chat._console_agent_bridge
+        store_one = runtime_one.chat_store
+        assert runtime_one.generation == 0
+
+        # ---- leave Console through the real navigation API ---------------
+        await app.handle_screen_navigation(NavigateToScreen("library"))
+        await pilot.pause()
+        assert chat not in app.screen_stack, "Console must actually unmount"
+        # TODAY: teardown still shuts the controller down ...
+        assert controller_one._shutdown_requested.is_set(), (
+            "Task 1 must not change what leaving Console does to the "
+            "controller -- the shutdown is still on the unmount path"
+        )
+        # ... and still disposes the runtime with the view.
+        assert runtime_one.generation == 1, "on_unmount must dispose the runtime"
+        assert getattr(app, CONSOLE_RUNTIME_ATTR, None) is None
+
+        # ---- return to Console -------------------------------------------
+        await app.handle_screen_navigation(NavigateToScreen("chat"))
+        await pilot.pause()
+        chat_two = app.screen
+        assert isinstance(chat_two, ChatScreen), type(chat_two).__name__
+        assert chat_two is not chat, "screens are never cached"
+        await _wait_for_selector(chat_two, pilot, "#console-native-composer")
+
+        controller_two = chat_two._ensure_console_chat_controller()
+        runtime_two = getattr(app, CONSOLE_RUNTIME_ATTR, None)
+        assert isinstance(runtime_two, ConsoleRuntime), type(runtime_two).__name__
+        assert runtime_two is not runtime_one, "a second visit gets a NEW runtime"
+        assert controller_two is not controller_one
+        assert runtime_two.chat_store is not store_one
+        assert runtime_two.agent_bridge is not bridge_one

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1,0 +1,449 @@
+"""App-owned Console runtime holder (task-15860, headless wake — Task 1).
+
+**This module changes WHO constructs the Console runtime objects, and
+nothing else.** It is the "pure ownership move" the owner made a staging
+condition for design A (`.superpowers/sdd/2026-08-14-headless-wake/
+DECISIONS.md`, owner answer (3)): separately reviewable and separately
+revertable from the semantics work that follows it.
+
+## What it owns
+
+One `ConsoleRuntime` per app owns the four objects `ChatScreen` used to
+build for itself:
+
+- the `ConsoleChatStore` (with its `ChatPersistenceService`),
+- the `ConsoleProviderGateway`,
+- the `ConsoleAgentBridge` and the sibling `AgentRunsDB` file it is keyed
+  off, together with the `register_fleet_attention` fan-out registration
+  that `FleetDrainFanout.register`'s contract requires to sit next to
+  bridge construction (the wake coordinator's own registration travels
+  inside `ConsoleChatController.__init__`, so it moves with the
+  controller),
+- the `ConsoleChatController`.
+
+Each is built lazily, on first `ensure_*` call, from parameters the
+calling view supplies — the same parameters, in the same order, the
+screen's own `_ensure_*` methods passed before this module existed.
+
+## What it deliberately does NOT change (Task 1's whole discipline)
+
+- **Lifetime.** `ChatScreen.on_unmount` still records the fleet-teardown
+  notice and still `await`s `controller.shutdown()`, and then the runtime
+  is DISPOSED (`dispose_console_runtime`). A second Console visit
+  therefore still gets a brand-new store/gateway/bridge/controller —
+  exactly as today. Making the runtime *survive* teardown is Task 2, and
+  `Tests/Chat/test_console_runtime_ownership.py` pins today's behaviour so
+  that change lands as a visible diff to a test rather than a diff to
+  nothing.
+- **Hook binding.** The controller and store are still handed
+  screen-bound callables (`on_scope_flushed`, the dictionary/world-info
+  appliers, the wake probes, …). Task 0's P3 found all five slots a
+  viewless wake turn touches still pointing at a DEAD screen; rebinding
+  them is Task 4, not this task.
+- **The `_shutdown_requested` gate** in `ConsoleFleetWakeCoordinator.
+  _attempt` — Task 0's P2 proved it is the single line refusing a headless
+  wake — is untouched here.
+
+## Why an app attribute rather than a global
+
+`app.console_runtime` follows `app.console_image_edit_operations`
+(`app.py`, Phase 1 of `TldwCli.__init__`): constructed on the app, and
+re-created lazily by the screen when a test's app object never had one
+(`ChatScreen._h3_image_edit_registry` is the shape copied here). Screens
+are never cached (`app.py` `_create_navigation_screen`), so anything that
+must outlive a navigation cannot live on one.
+
+It deliberately does NOT join `_shutdown_app_owned_lifecycles`, unlike the
+image-edit registry: that hook runs *before* Textual closes screen state,
+and `dispose()` is a reference drop with no durable work to settle, so
+disposing there would only reorder Console's quit path for no gain. The
+unmount that Textual performs at exit already disposes it. When Task 2
+gives the runtime real cross-navigation lifetime, an exit-time settle
+becomes worth adding — and it should be added deliberately, with the quit
+ordering re-verified, not inherited from this task.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from loguru import logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+#: The app attribute this module's helpers read and write. Named once so a
+#: test can assert on the protocol rather than on a string literal.
+CONSOLE_RUNTIME_ATTR = "console_runtime"
+
+__all__ = [
+    "CONSOLE_RUNTIME_ATTR",
+    "ConsoleRuntime",
+    "dispose_console_runtime",
+    "ensure_console_runtime",
+]
+
+
+class ConsoleRuntime:
+    """The app-owned holder for one Console runtime.
+
+    Every `ensure_*` method is idempotent: it builds its object on the
+    first call and returns the cached instance afterwards, ignoring the
+    parameters on subsequent calls. That is the same laziness
+    `ChatScreen._ensure_*` had — the parameters were only ever read at
+    construction there too.
+
+    Attributes are exposed through non-constructing read-only properties
+    so a caller can ask "has this been built yet?" without building it,
+    which several `ChatScreen` call sites do (`store = self.
+    _console_chat_store` followed by an `is None` early return).
+    """
+
+    def __init__(self, app: Any) -> None:
+        """Bind the holder to one app object.
+
+        Args:
+            app: The `TldwCli` app (or, in tests, whatever object plays
+                that role for the screen under test). Read for
+                `chachanotes_db`, `citation_trace_repository`,
+                `workspace_registry_service` and the
+                `console_provider_gateway_factory` test seam — never
+                mutated.
+        """
+        self._app = app
+        self._chat_store: Any | None = None
+        self._provider_gateway: Any | None = None
+        self._agent_bridge: Any | None = None
+        self._chat_controller: Any | None = None
+        #: The view (a `ChatScreen`) that claimed this runtime, or `None`
+        #: while unclaimed. **Task 1's lifetime-preservation device, and
+        #: nothing more** -- it is NOT the attach/detach seam Task 2 builds.
+        #:
+        #: Two `ChatScreen`s are briefly alive at once whenever a navigation
+        #: lands back on Console: `_complete_screen_navigation` constructs
+        #: and `restore_state`s the incoming screen BEFORE `switch_screen`
+        #: unmounts the outgoing one (`app.py`), and `restore_state` reaches
+        #: `_ensure_console_chat_store`. Without a claim the incoming screen
+        #: would adopt the outgoing screen's controller and then watch
+        #: `on_unmount` shut it down underneath it. Today each screen builds
+        #: its own runtime, so a claim by a different view means "build a
+        #: fresh one" -- which is exactly what `ensure_console_runtime` does.
+        self.view: Any | None = None
+        #: Bumped by every `dispose()`. Task 1's new-runtime-per-visit pin
+        #: reads it; Task 2 will make it stop moving on a navigation.
+        self.generation: int = 0
+
+    # -- non-constructing accessors ---------------------------------------
+
+    @property
+    def app(self) -> Any:
+        """The app this runtime is bound to."""
+        return self._app
+
+    @property
+    def chat_store(self) -> "ConsoleChatStore | None":
+        """The built store, or `None` if nothing has asked for one yet."""
+        return self._chat_store
+
+    @property
+    def provider_gateway(self) -> Any | None:
+        """The built provider gateway, or `None`."""
+        return self._provider_gateway
+
+    @property
+    def agent_bridge(self) -> Any | None:
+        """The built agent bridge, or `None` (also `None` when resolved to
+        "no agent runtime" — see `ensure_agent_bridge`)."""
+        return self._agent_bridge
+
+    @property
+    def chat_controller(self) -> "ConsoleChatController | None":
+        """The built chat controller, or `None`."""
+        return self._chat_controller
+
+    # -- construction ------------------------------------------------------
+
+    def ensure_chat_store(
+        self,
+        *,
+        workspace_context: Any | None = None,
+        on_scope_flushed: Callable[..., Any] | None = None,
+    ) -> "ConsoleChatStore":
+        """Return the Console chat store, creating it lazily.
+
+        Moved verbatim from `ChatScreen._ensure_console_chat_store`: the
+        durable `ChatPersistenceService` is attached only when the app has
+        a ChaChaNotes DB, and the citation repository is dropped when it
+        belongs to a different DB than the one being persisted to.
+
+        Args:
+            workspace_context: The view's current
+                `ConsoleWorkspaceContext`. Read at construction only.
+            on_scope_flushed: The view's session-scope-flushed callback.
+                Read at construction only.
+
+        Returns:
+            ConsoleChatStore: The runtime's store.
+        """
+        if self._chat_store is not None:
+            return self._chat_store
+        from tldw_chatbook.Chat.chat_persistence_service import (
+            ChatPersistenceService,
+        )
+        from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+        persistence = None
+        db = getattr(self._app, "chachanotes_db", None)
+        if db is not None:
+            citation_repository = getattr(
+                self._app,
+                "citation_trace_repository",
+                None,
+            )
+            if (
+                citation_repository is not None
+                and getattr(citation_repository, "db", None) is not db
+            ):
+                citation_repository = None
+            persistence = ChatPersistenceService(
+                db,
+                workspace_registry=getattr(
+                    self._app,
+                    "workspace_registry_service",
+                    None,
+                ),
+                citation_repository=citation_repository,
+            )
+        self._chat_store = ConsoleChatStore(
+            persistence=persistence,
+            workspace_context=workspace_context,
+            on_scope_flushed=on_scope_flushed,
+        )
+        return self._chat_store
+
+    def ensure_provider_gateway(
+        self,
+        *,
+        config_provider: Callable[[], Any] | None = None,
+    ) -> Any:
+        """Return the Console provider gateway, creating it lazily.
+
+        Moved verbatim from `ChatScreen._ensure_console_provider_gateway`,
+        including the `console_provider_gateway_factory` test-injection
+        seam read off the app.
+
+        Args:
+            config_provider: Fresh-config source handed to a
+                real gateway; the gateway re-resolves readiness at send
+                time and must see Settings saves made after boot. Ignored
+                when the app supplies a factory.
+
+        Returns:
+            Any: The runtime's provider gateway.
+        """
+        if self._provider_gateway is not None:
+            return self._provider_gateway
+        factory = getattr(self._app, "console_provider_gateway_factory", None)
+        if callable(factory):
+            self._provider_gateway = factory()
+        else:
+            from tldw_chatbook.Chat.console_provider_gateway import (
+                ConsoleProviderGateway,
+            )
+
+            self._provider_gateway = ConsoleProviderGateway(
+                config_provider=config_provider,
+            )
+        return self._provider_gateway
+
+    def ensure_agent_bridge(
+        self,
+        *,
+        store_factory: Callable[[], Any],
+        provider_gateway_factory: Callable[[], Any],
+        skills_service: Any | None = None,
+        native_tools_enabled_factory: Callable[[], Any] | None = None,
+    ) -> Any:
+        """Return the Console agent bridge, creating it lazily.
+
+        Moved verbatim from
+        `ConsoleAgentController._ensure_console_agent_bridge`, ordering
+        included: the durable-DB probe runs FIRST and returns `None` (no
+        agent runtime) before the store or the gateway is touched, so an
+        in-memory harness still builds neither.
+
+        Every screen-supplied dependency arrives as a callable, precisely
+        to preserve that ordering — nothing on the view is read until the
+        probe has passed.
+
+        Args:
+            store_factory: Returns the chat store the bridge should use.
+                Called only past the durable-DB probe.
+            provider_gateway_factory: Returns the provider gateway. Same.
+            skills_service: The app's skills scope service, or `None`. A
+                plain value: it is a `getattr` on the APP, which the probe
+                has already touched.
+            native_tools_enabled_factory: Returns the callable the bridge
+                stores and calls later to read the `[console]
+                native_tool_calls` gate. A factory, not that callable, so
+                the view is not read on the no-agent-runtime path.
+
+        Returns:
+            Any: The `ConsoleAgentBridge`, or `None` when there is no
+            durable ChaChaNotes DB to key the sibling `AgentRunsDB` off.
+        """
+        if self._agent_bridge is not None:
+            return self._agent_bridge
+        db = getattr(self._app, "chachanotes_db", None)
+        db_path = getattr(db, "db_path", None) if db is not None else None
+        if not db_path or str(db_path) == ":memory:":
+            self._agent_bridge = None
+            return None
+        from pathlib import Path
+
+        from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+        runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
+        # TASK-1971 (Agent Change Review): the tracker is None when git is
+        # absent -- the bridge then skips tracking entirely, and runs behave
+        # exactly as before the feature existed (spec gating decision).
+        from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
+
+        change_tracker = ChangeTurnTracker()
+        self._agent_bridge = ConsoleAgentBridge(
+            agent_runs_db=runs_db,
+            store=store_factory(),
+            provider_gateway=provider_gateway_factory(),
+            skills_service=skills_service,
+            native_tools_enabled=(
+                native_tools_enabled_factory()
+                if native_tools_enabled_factory is not None
+                else None
+            ),
+            change_tracker=change_tracker if change_tracker.available else None,
+        )
+        # PR3a-2 Task 4: the survivor-completion attention consumer (durable
+        # unseen mark + app-wide toast + deep link), registered NEXT TO
+        # bridge construction per `FleetDrainFanout.register`'s contract.
+        # Captures the APP object only -- never a screen -- because the
+        # bridge (and its registered consumers) outlives the screen whenever
+        # a survivor is still running at teardown.
+        from tldw_chatbook.Chat.console_fleet_attention import (
+            register_fleet_attention,
+        )
+
+        register_fleet_attention(self._agent_bridge, self._app)
+        return self._agent_bridge
+
+    def ensure_chat_controller(self, **kwargs: Any) -> "ConsoleChatController":
+        """Return the Console chat controller, creating it lazily.
+
+        The keyword arguments are `ConsoleChatController.__init__`'s, passed
+        straight through from the view exactly as
+        `ChatScreen._ensure_console_chat_controller` passed them. They are
+        read at construction only; the screen keeps re-applying its
+        selection state and its UI hooks after this returns, as before.
+
+        Returns:
+            ConsoleChatController: The runtime's controller.
+        """
+        if self._chat_controller is not None:
+            return self._chat_controller
+        from tldw_chatbook.Chat.console_chat_controller import (
+            ConsoleChatController,
+        )
+
+        self._chat_controller = ConsoleChatController(**kwargs)
+        return self._chat_controller
+
+    # -- teardown ----------------------------------------------------------
+
+    def dispose(self) -> None:
+        """Drop every built object so the next `ensure_*` builds a fresh one.
+
+        Reference-drop ONLY. It does not shut the controller down and does
+        not close the gateway: `ChatScreen.on_unmount` still owns both of
+        those steps in Task 1, in the order it always ran them
+        (`fleet_teardown_split` snapshot -> `await controller.shutdown()`
+        -> `await gateway.aclose()`), and this is called after them.
+        """
+        self._chat_controller = None
+        self._agent_bridge = None
+        self._provider_gateway = None
+        self._chat_store = None
+        self.view = None
+        self.generation += 1
+
+
+def _attach(app: Any, runtime: ConsoleRuntime | None) -> None:
+    """Write `runtime` (or `None`) onto the app's runtime attribute."""
+    if app is None:
+        return
+    try:
+        setattr(app, CONSOLE_RUNTIME_ATTR, runtime)
+    except Exception:  # noqa: BLE001 - a read-only app double is not an error
+        logger.debug(
+            "Console runtime: could not write the app's %s attribute.",
+            CONSOLE_RUNTIME_ATTR,
+        )
+
+
+def ensure_console_runtime(app: Any, *, view: Any | None = None) -> ConsoleRuntime:
+    """Return `app`'s Console runtime, creating and attaching one if needed.
+
+    Mirrors `ChatScreen._h3_image_edit_registry`: the app normally builds
+    this in `__init__`, but a test app object (or one whose runtime was
+    disposed at the last unmount) has none, and the screen must still be
+    able to run.
+
+    Args:
+        app: The app object to read/attach the runtime on. `None` is
+            tolerated — a detached runtime is returned rather than raising,
+            because the screen's own accessors are reached from bare
+            `ChatScreen.__new__` fixtures.
+        view: The `ChatScreen` asking. A runtime already claimed by a
+            DIFFERENT view is replaced with a fresh one rather than shared,
+            which is what keeps Task 1's per-screen lifetime exact — see
+            `ConsoleRuntime.view`.
+
+    Returns:
+        ConsoleRuntime: The runtime `view` should use.
+    """
+    runtime = getattr(app, CONSOLE_RUNTIME_ATTR, None)
+    if isinstance(runtime, ConsoleRuntime) and (
+        view is None or runtime.view is None or runtime.view is view
+    ):
+        if view is not None:
+            runtime.view = view
+        return runtime
+    runtime = ConsoleRuntime(app)
+    runtime.view = view
+    _attach(app, runtime)
+    return runtime
+
+
+def dispose_console_runtime(app: Any, *, view: Any | None = None) -> None:
+    """Dispose `app`'s Console runtime and detach it.
+
+    Task 1 semantics: the next Console mount builds a brand-new runtime,
+    exactly as every navigation built a brand-new store/controller before
+    this module existed. **This call is what Task 2 removes.**
+
+    Args:
+        app: The app object holding the runtime. A missing or foreign
+            attribute is a no-op.
+        view: The `ChatScreen` unmounting. When the attached runtime was
+            claimed by a different, still-live view (the overlapping-screens
+            window described on `ConsoleRuntime.view`), this is a no-op:
+            a dying screen must not tear down the runtime its successor is
+            already using.
+    """
+    runtime = getattr(app, CONSOLE_RUNTIME_ATTR, None)
+    if not isinstance(runtime, ConsoleRuntime):
+        return
+    if view is not None and runtime.view is not None and runtime.view is not view:
+        return
+    runtime.dispose()
+    _attach(app, None)

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -488,45 +488,31 @@ class ConsoleAgentController:
         ChaChaNotes DB to key the sibling ``AgentRunsDB`` file off of (e.g. an
         in-memory test harness) -- callers use the provider-direct Console
         stream in that case regardless of the config gate.
+
+        task-15860 Task 1 (pure ownership move): the bridge, its
+        ``AgentRunsDB`` and the ``register_fleet_attention`` fan-out
+        registration that must sit next to construction are now built by
+        the app-owned ``ConsoleRuntime`` (``Chat/console_runtime.py``).
+        This method keeps its name -- three test files replace it on the
+        screen instance, see this module's docstring -- and its caching.
+        The store and gateway go over as CALLABLES so the runtime can keep
+        the original ordering: the durable-DB probe still runs before
+        either of them is touched.
         """
         if self._console_agent_bridge is not None:
             return self._console_agent_bridge
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        db_path = getattr(db, "db_path", None) if db is not None else None
-        if not db_path or str(db_path) == ":memory:":
-            self._console_agent_bridge = None
-            return None
-        from pathlib import Path
+        from tldw_chatbook.Chat.console_runtime import ensure_console_runtime
 
-        from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
-        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
-
-        runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
-        # TASK-1971 (Agent Change Review): the tracker is None when git is
-        # absent -- the bridge then skips tracking entirely, and runs behave
-        # exactly as before the feature existed (spec gating decision).
-        from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
-
-        change_tracker = ChangeTurnTracker()
-        self._console_agent_bridge = ConsoleAgentBridge(
-            agent_runs_db=runs_db,
-            store=self._ensure_console_chat_store(),
-            provider_gateway=self._ensure_console_provider_gateway(),
+        self._console_agent_bridge = ensure_console_runtime(
+            self.app_instance, view=self._screen
+        ).ensure_agent_bridge(
+            store_factory=self._ensure_console_chat_store,
+            provider_gateway_factory=self._ensure_console_provider_gateway,
             skills_service=getattr(self.app_instance, "skills_scope_service", None),
-            native_tools_enabled=self._console_native_tool_calls_enabled,
-            change_tracker=change_tracker if change_tracker.available else None,
+            native_tools_enabled_factory=(
+                lambda: self._console_native_tool_calls_enabled
+            ),
         )
-        # PR3a-2 Task 4: the survivor-completion attention consumer (durable
-        # unseen mark + app-wide toast + deep link), registered NEXT TO
-        # bridge construction per `FleetDrainFanout.register`'s contract.
-        # Captures the APP object only -- never this screen -- because the
-        # bridge (and its registered consumers) outlives the screen whenever
-        # a survivor is still running at teardown.
-        from tldw_chatbook.Chat.console_fleet_attention import (
-            register_fleet_attention,
-        )
-
-        register_fleet_attention(self._console_agent_bridge, self.app_instance)
         return self._console_agent_bridge
 
     def _console_agent_section_lines(self) -> tuple[str, str, str]:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -86,9 +86,9 @@ from ..Console_Modules.session import (
     _has_selected_text,
     _is_empty_select_value,
 )
-from ...Chat.chat_persistence_service import ChatPersistenceService
 from ...Chat.citation_trace_repository import ActiveCitationTraceState
 from ...Chat.console_chat_controller import ConsoleChatController
+from ...Chat.console_runtime import dispose_console_runtime, ensure_console_runtime
 from ...Chat.console_context_policy import (
     ConsoleContextPolicyOverrides,
 )
@@ -266,7 +266,6 @@ from ...Chat.console_chat_store import (
 )
 from ...Chat.console_provider_gateway import (
     DEFAULT_LLAMACPP_BASE_URL,
-    ConsoleProviderGateway,
     normalize_llamacpp_base_url,
 )
 from ...Chat.console_provider_endpoints import first_configured_endpoint
@@ -5105,32 +5104,19 @@ class ChatScreen(BaseAppScreen):
         return effective_settings, readiness
 
     def _ensure_console_chat_store(self) -> ConsoleChatStore:
-        """Return the native Console chat store, creating it lazily."""
+        """Return the native Console chat store, creating it lazily.
+
+        task-15860 Task 1 (pure ownership move): CONSTRUCTED by the
+        app-owned `ConsoleRuntime` (`Chat/console_runtime.py`, whose
+        docstring states what Task 1 deliberately does not change). Name,
+        laziness, return type and patchability are unchanged, and the
+        runtime is disposed at `on_unmount`, so a second Console visit
+        still gets a fresh store.
+        """
         if self._console_chat_store is None:
-            persistence = None
-            db = getattr(self.app_instance, "chachanotes_db", None)
-            if db is not None:
-                citation_repository = getattr(
-                    self.app_instance,
-                    "citation_trace_repository",
-                    None,
-                )
-                if (
-                    citation_repository is not None
-                    and getattr(citation_repository, "db", None) is not db
-                ):
-                    citation_repository = None
-                persistence = ChatPersistenceService(
-                    db,
-                    workspace_registry=getattr(
-                        self.app_instance,
-                        "workspace_registry_service",
-                        None,
-                    ),
-                    citation_repository=citation_repository,
-                )
-            self._console_chat_store = ConsoleChatStore(
-                persistence=persistence,
+            self._console_chat_store = ensure_console_runtime(
+                self.app_instance, view=self
+            ).ensure_chat_store(
                 workspace_context=self._workspace._current_console_workspace_context(),
                 on_scope_flushed=self._on_console_scope_flushed,
             )
@@ -5420,19 +5406,19 @@ class ChatScreen(BaseAppScreen):
         )
 
     def _ensure_console_provider_gateway(self) -> Any:
-        """Return the native Console provider gateway with a test injection seam."""
+        """Return the native Console provider gateway with a test injection seam.
+
+        task-15860 Task 1: constructed by the app-owned `ConsoleRuntime`,
+        which also reads the app's `console_provider_gateway_factory`
+        injection seam. Name, laziness and behaviour are unchanged.
+        """
         if self._console_provider_gateway is None:
-            factory = getattr(
-                self.app_instance, "console_provider_gateway_factory", None
-            )
-            self._console_provider_gateway = (
-                factory()
-                if callable(factory)
-                else ConsoleProviderGateway(
-                    # Fresh-config source: the gateway re-resolves readiness at
-                    # send time and must see Settings saves made after boot.
-                    config_provider=self._provider_readiness_app_config,
-                )
+            self._console_provider_gateway = ensure_console_runtime(
+                self.app_instance, view=self
+            ).ensure_provider_gateway(
+                # Fresh-config source: the gateway re-resolves readiness at
+                # send time and must see Settings saves made after boot.
+                config_provider=self._provider_readiness_app_config,
             )
         return self._console_provider_gateway
 
@@ -5490,10 +5476,19 @@ class ChatScreen(BaseAppScreen):
         return LibraryToolProvider(service)
 
     def _ensure_console_chat_controller(self) -> ConsoleChatController:
-        """Return the native Console chat controller with fresh selection state."""
+        """Return the native Console chat controller with fresh selection state.
+
+        task-15860 Task 1: CONSTRUCTED by the app-owned `ConsoleRuntime`,
+        same keyword arguments in the same order. Everything below the
+        construction block -- the UI hook wiring, the wake coordinator's
+        `wire(app=...)`, the core-state sync -- still runs here on every
+        call; rebinding those hooks for a viewless turn is Task 4.
+        """
         if self._console_chat_controller is None:
             selection = self._build_console_provider_selection()
-            self._console_chat_controller = ConsoleChatController(
+            self._console_chat_controller = ensure_console_runtime(
+                self.app_instance, view=self
+            ).ensure_chat_controller(
                 store=self._ensure_console_chat_store(),
                 provider_gateway=self._ensure_console_provider_gateway(),
                 provider=selection.provider,
@@ -15465,6 +15460,15 @@ class ChatScreen(BaseAppScreen):
                 await result
         self._console_provider_gateway = None
         self._console_chat_controller = None
+        # task-15860 Task 1: the runtime moved to the app, its LIFETIME did
+        # not. Disposing here -- AFTER the fleet-teardown notice, the
+        # `controller.shutdown()` and the gateway close above, in that same
+        # order -- is what keeps "a second Console visit gets a brand-new
+        # store/gateway/bridge/controller" true; Task 2 removes this call.
+        # `view=self` so an already-superseded screen (both are briefly
+        # alive when a navigation lands back on Console) cannot tear down
+        # the runtime its successor is using.
+        dispose_console_runtime(self.app_instance, view=self)
         super().on_unmount()
 
     async def _record_console_fleet_teardown(self, controller: Any) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -182,6 +182,7 @@ from tldw_chatbook.Chat.console_live_work import (
 from tldw_chatbook.Chat.console_image_edit_operations import (
     ImageEditOperationRegistry,
 )
+from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
 from tldw_chatbook.Chat.server_chat_conversation_service import (
     ServerChatConversationService,
 )
@@ -5407,6 +5408,15 @@ class TldwCli(
         self.app_config = load_settings()
         self.console_image_edit_operations = ImageEditOperationRegistry()
         self._console_image_edit_shutdown_task: asyncio.Task[None] | None = None
+        # task-15860 (headless wake, Task 1): the Console runtime -- chat
+        # store, provider gateway, agent bridge, chat controller -- is
+        # constructed by the APP, not by `ChatScreen`. Screens are never
+        # cached (`_create_navigation_screen`), so anything that must
+        # eventually outlive a navigation cannot be built on one. Task 1 is
+        # a PURE ownership move: `ChatScreen.on_unmount` still disposes this
+        # (`dispose_console_runtime`), so a second Console visit still gets
+        # a brand-new store/gateway/bridge/controller, exactly as before.
+        self.console_runtime: ConsoleRuntime | None = ConsoleRuntime(self)
         self.generated_video_store = _build_generated_video_store()
         # TASK-13157: snapshot any TOML parse failure `load_settings()` just
         # hit -- captured here (mirroring `_instance_lock_status` below, the


### PR DESCRIPTION
## Headless wake — the pure ownership move

First of the staged landings for task-15860. The Console runtime (`ConsoleChatStore` + persistence service, `ConsoleProviderGateway`, `ConsoleAgentBridge` + its `AgentRunsDB`, `ConsoleChatController`) is now constructed by one app-owned holder instead of four separate `_ensure_*` sites on `ChatScreen`.

**This PR ships zero semantic change, deliberately.** The runtime is still disposed at unmount, so a second Console visit still gets a brand-new controller, store and bridge — exactly as today. That is the owner's staging condition: the ownership move is reviewable and revertable on its own, before any lifetime semantics change.

**Verification is the point.** Baseline was measured on the untouched branch and compared suite by suite: provenance 1, screen-residency 7, wake (Chat) 65, wake (UI) 19, `Tests/Agents/` 1409, `Tests/Chat/` 18F/5445P/66S with the failure set **byte-identical by `diff`**. The only delta is **+2 passed** — exactly the two new pins. A 2-for-2 swap inside the `ui_console` failure set was investigated rather than assumed: both flip in isolation, one drives a `ModalHarness` that never constructs a `ChatScreen` at all, and the flip went both directions on a machine running six other sessions' pytest processes.

**Two characterization pins** (labelled as such — there is no defect red in a no-op ownership move): the runtime is the single construction site, and a second visit gets a *new* runtime. The second matters most: it makes the next task's lifetime change show up as a diff to a test rather than a diff to nothing. Both mutation-checked.

**Two hazards the plan's seam map did not name, found while executing** and recorded in the plan for the next task: `_complete_screen_navigation` calls `restore_state` on the *incoming* screen before the outgoing one unmounts (so a naive holder hands the new screen the old controller, which then gets shut down underneath it — a dead Console after same-target navigation); and `ChatScreen`'s own handles will shadow a surviving runtime the moment lifetimes diverge.

No test was renamed — `_ensure_console_agent_bridge` and `_ensure_console_chat_store` are patched by name from several suites, verified by grep before touching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates Console runtime construction into a single app-owned holder without changing behavior. Previously `ChatScreen` built the pieces across four `_ensure_*` methods; now `ConsoleRuntime` on the app lazily owns `ConsoleChatStore`, `ConsoleProviderGateway`, `ConsoleAgentBridge`/`AgentRunsDB`, and `ConsoleChatController`. The runtime is still disposed on unmount, so a second Console visit still creates a fresh runtime.

- Builds `tldw_chatbook/Chat/console_runtime.py` and attaches it at `app.console_runtime`; helpers `ensure_console_runtime(...)` and `dispose_console_runtime(...)` manage access and disposal.
- Keeps existing `_ensure_console_chat_store`, `_ensure_console_provider_gateway`, `_ensure_console_chat_controller`, and `_ensure_console_agent_bridge` names/patchability; they now delegate to the runtime with identical laziness and return types.
- Preserves provider factory seam (`app.console_provider_gateway_factory`) and all screen-bound hooks/gates; no lifetime or wake semantics change (task-15860 staging).
- Handles two ordering/lifecycle edges: runs the durable-DB probe before touching store/gateway, and uses `ConsoleRuntime.view` to avoid sharing a controller between two briefly-overlapping `ChatScreen`s during navigation.
- Unmount path unchanged in order; after shutdown and gateway close, calls `dispose_console_runtime(app, view=self)` to drop references only.
- Adds two small characterization tests to pin “single construction site” and “new runtime on second visit”; overall test counts stay at parity (+2 passed from the pins).

<sup>Written for commit 114d176ab0bedaf555fc57a594c9847829eb1364. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

