### PR TITLE
perf(watchlists): move URL monitor CPU work off event loop

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-watchlists-url-monitor-off-loop.md
+++ b/Docs/superpowers/plans/2026-08-14-watchlists-url-monitor-off-loop.md
@@ -1,0 +1,347 @@
+# Watchlists URLMonitor Off-Event-Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the remaining CPU-heavy HTML extraction and text comparison stages in local Watchlists URL monitoring off the asyncio event-loop thread without changing results, persistence, or per-URL ordering.
+
+**Architecture:** Keep the existing async fetch, threshold decision, circuit breaker, database offload, and sequential `url_list`/`sitemap` orchestration intact. Use the standard library's `asyncio.to_thread` at two narrow boundaries: HTML extraction and comparison; group the significant-change calculations in one private synchronous helper so each changed page incurs one worker hop and one pair of segment lists.
+
+**Tech Stack:** Python 3.11+, asyncio, `asyncio.to_thread`, BeautifulSoup, difflib, pytest, pytest-asyncio, SQLite-backed `SubscriptionsDB`.
+
+---
+
+## File map
+
+- Modify `tldw_chatbook/Subscriptions/monitoring_engine.py`: add one private significant-change helper and await CPU work through `asyncio.to_thread`.
+- Modify `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`: add thread-identity, threshold short-circuit, cancellation, and real changed-item coverage.
+- Modify `Tests/Subscriptions/test_local_watchlists_service.py`: prove every URL in a real `url_list` run takes the off-loop path while order and result accounting remain unchanged.
+- Modify `backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md`: align acceptance criteria with the approved `SequenceMatcher` percentage offload and record final evidence.
+
+ADR required: no.
+
+ADR path: N/A.
+
+Reason: TASK-15764 is the direct residual performance fix deferred by TASK-15463. It preserves storage, runtime, service, and public contracts and adds no new dependency or long-lived boundary.
+
+### Task 1: Pin HTML extraction to a worker thread
+
+**Files:**
+- Modify: `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`
+- Modify: `tldw_chatbook/Subscriptions/monitoring_engine.py:1448-1525`
+
+- [ ] **Step 1: Write the failing extraction thread-identity test**
+
+Add a real `_fetch_url_content` test that patches only the guarded HTTP response and wraps the real extractor:
+
+```python
+@pytest.mark.asyncio
+async def test_url_html_extraction_runs_off_the_event_loop(monkeypatch):
+    loop_thread = threading.get_ident()
+    extraction_threads: list[int] = []
+    real_extract = ContentExtractor.extract_text_from_html
+
+    def recording_extract(html, ignore_selectors=None):
+        extraction_threads.append(threading.get_ident())
+        return real_extract(html, ignore_selectors)
+
+    _serve(monkeypatch, "<html><body><p>Hello</p></body></html>", content_type="text/html")
+    monkeypatch.setattr(ContentExtractor, "extract_text_from_html", recording_extract)
+
+    result = await URLMonitor(SimpleNamespace())._fetch_url_content(
+        {"source": "https://example.com/page", "extraction_method": "auto"}
+    )
+
+    assert result["text"] == "Hello"
+    assert extraction_threads and all(t != loop_thread for t in extraction_threads)
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py::test_url_html_extraction_runs_off_the_event_loop
+```
+
+Expected: FAIL because the extractor records the event-loop thread.
+
+- [ ] **Step 3: Implement the minimal extraction offload**
+
+Replace only the `full`/`auto` extraction call:
+
+```python
+text = await asyncio.to_thread(
+    ContentExtractor.extract_text_from_html,
+    response.text,
+    ignore_selectors,
+)
+```
+
+Leave the raw-content branch, HTTP client, rate limiting, and response shaping unchanged.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: PASS; extracted text remains `Hello` and the recorded thread differs from the loop thread.
+
+- [ ] **Step 5: Commit the extraction slice**
+
+```bash
+git add Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py tldw_chatbook/Subscriptions/monitoring_engine.py
+git commit -m "perf(watchlists): offload URL HTML extraction"
+```
+
+### Task 2: Offload percentage and significant-change calculations
+
+**Files:**
+- Modify: `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`
+- Modify: `tldw_chatbook/Subscriptions/monitoring_engine.py:351-565,1156-1410`
+
+- [ ] **Step 1: Write failing changed-item thread and semantics tests**
+
+Add `test_changed_item_cpu_work_runs_off_the_event_loop_without_changing_semantics`. Use a file-backed `SubscriptionsDB`, run one real `check_url` to store a baseline, then a second with changed HTML. Wrap `ContentExtractor.calculate_change_percentage`, `_segment_for_diff`, `build_change_diff`, `added_and_removed_text`, and `classify_change_type` so each records `threading.get_ident()` before delegating to the real callable.
+
+Assert:
+
+```python
+assert disposition["kind"] == "changed"
+assert item is not None
+assert item["content_kind"] == "change"
+assert item["content_format"] == "diff"
+assert "Opus 4.5" in item["content"]
+assert percentage_threads and all(t != loop_thread for t in percentage_threads)
+assert operation_counts == {
+    "segment": 2,
+    "build": 1,
+    "added_removed": 1,
+    "classify": 1,
+}
+assert all(t != loop_thread for t in significant_change_threads)
+```
+
+Also capture the existing change percentage, diff summary, added/removed rule text, stored snapshot, and disposition so the test proves the worker boundary did not alter values or write order.
+
+- [ ] **Step 2: Write the failing below-threshold short-circuit test**
+
+Add `test_below_threshold_cpu_work_stops_before_significant_change_details`. Seed a baseline, set `change_threshold` above the real changed-page ratio, wrap `calculate_change_percentage` to record its thread, and replace the new helper seam with a function that raises if called.
+
+Assert the result is `None`, disposition is `withheld`, percentage ran off-loop, the significant-change helper was not called, and no new snapshot was written.
+
+- [ ] **Step 3: Run both tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py -k "changed_item_cpu_work or below_threshold_cpu_work"
+```
+
+Expected: FAIL because percentage and significant diff work still execute on the loop and the helper does not exist.
+
+- [ ] **Step 4: Add one private synchronous significant-change helper**
+
+Place the helper beside the existing diff helpers:
+
+```python
+def _build_significant_change_details(
+    previous_text: str,
+    current_text: str,
+) -> tuple[str, str, str, str, str]:
+    old_segments = _segment_for_diff(previous_text)
+    new_segments = _segment_for_diff(current_text)
+    diff_body, diff_summary = build_change_diff(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    added_text, removed_text = added_and_removed_text(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    return (
+        diff_body,
+        diff_summary,
+        added_text,
+        removed_text,
+        classify_change_type(previous_text, current_text),
+    )
+```
+
+Do not add a class, executor parameter, public export, or configuration switch.
+
+- [ ] **Step 5: Await percentage and significant-change work from `check_url`**
+
+Replace the inline calls with:
+
+```python
+change_percentage = await asyncio.to_thread(
+    ContentExtractor.calculate_change_percentage,
+    previous_text,
+    current_content["text"],
+)
+```
+
+Keep the threshold branch immediately after this await. Only after it passes, run:
+
+```python
+(
+    diff_body,
+    diff_summary,
+    added_text,
+    removed_text,
+    change_type,
+) = await asyncio.to_thread(
+    _build_significant_change_details,
+    previous_text,
+    current_content["text"],
+)
+```
+
+Use `change_type` in `change_info`; leave snapshot persistence and circuit-breaker success after result assembly exactly where they are.
+
+- [ ] **Step 6: Run the focused tests and verify GREEN**
+
+Run the Step 3 command.
+
+Expected: PASS with percentage in a worker, exactly two segment calls in the single significant-change worker, unchanged disposition and evidence, and no helper call below threshold.
+
+- [ ] **Step 7: Commit the comparison slice**
+
+```bash
+git add Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py tldw_chatbook/Subscriptions/monitoring_engine.py
+git commit -m "perf(watchlists): offload URL change comparison"
+```
+
+### Task 3: Pin cancellation behavior
+
+**Files:**
+- Modify: `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`
+
+- [ ] **Step 1: Write the cancellation regression**
+
+Wrap the real extractor with `threading.Event` gates. Start `check_url`, wait until the worker enters extraction without blocking the event loop, cancel the task, assert `CancelledError`, release the worker, and wait for its completion from another worker hop.
+
+Assert after completion:
+
+```python
+assert db.conn.execute(
+    "SELECT COUNT(*) FROM url_snapshots WHERE subscription_id = ?",
+    (source_id,),
+).fetchone()[0] == 0
+assert monitor.circuit_breakers[source_id].failure_count == 0
+```
+
+This pins the truthful contract: the thread may finish, but the cancelled coroutine does not resume to persist or report success/failure.
+
+- [ ] **Step 2: Run the cancellation test**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py::test_cancelled_url_check_does_not_resume_after_extraction_worker_finishes
+```
+
+Expected: PASS with the Task 1 implementation. If it fails, fix only the worker-await boundary; do not add shielding, process management, or custom cancellation machinery.
+
+- [ ] **Step 3: Commit the regression**
+
+```bash
+git add Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+git commit -m "test(watchlists): pin URL worker cancellation"
+```
+
+### Task 4: Prove every URL in a list follows the worker path
+
+**Files:**
+- Modify: `Tests/Subscriptions/test_local_watchlists_service.py`
+
+- [ ] **Step 1: Write the real multi-URL regression**
+
+Extend the existing real default-monitor `url_list` coverage rather than introducing a fake monitor. Create a two-URL source, serve baseline bodies for the first run and changed bodies for the second, and wrap the real extractor, percentage function, and significant-change helper to record `(url, thread_id)` through per-request body markers.
+
+Assert:
+
+```python
+assert fetched_urls == [url_a, url_b, url_a, url_b]
+assert changed_item_urls == [url_a, url_b]
+assert extraction_urls == [url_a, url_b, url_a, url_b]
+assert percentage_urls == [url_a, url_b]
+assert detail_urls == [url_a, url_b]
+assert all(thread_id != loop_thread for _, thread_id in cpu_calls)
+```
+
+Also assert the second run's disposition counts report two changed URLs and persisted items preserve URL order.
+
+- [ ] **Step 2: Run the new test and verify it passes with the implementation**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/Subscriptions/test_local_watchlists_service.py::test_url_list_offloads_cpu_work_for_every_url_in_order
+```
+
+Expected: PASS. Temporarily restoring either production offload call to an inline call must make the thread assertion fail; returning after the first URL must make the call-count/order assertions fail.
+
+- [ ] **Step 3: Commit the list regression**
+
+```bash
+git add Tests/Subscriptions/test_local_watchlists_service.py
+git commit -m "test(watchlists): cover URL-list CPU offload"
+```
+
+### Task 5: Run impacted verification and close TASK-15764
+
+**Files:**
+- Modify: `backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md`
+
+- [ ] **Step 1: Run the exact impacted test set**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py \
+  Tests/Subscriptions/test_watchlist_content_kind_producer.py \
+  Tests/Subscriptions/test_local_watchlists_service.py
+```
+
+Expected: all tests pass. Do not run the full repository suite; the user explicitly limited verification to touched/modified/impacted functionality.
+
+- [ ] **Step 2: Run scoped static checks**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/Subscriptions/monitoring_engine.py \
+  Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py \
+  Tests/Subscriptions/test_local_watchlists_service.py
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Subscriptions/monitoring_engine.py \
+  Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py \
+  Tests/Subscriptions/test_local_watchlists_service.py
+git diff --check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 3: Self-review the final diff**
+
+Confirm there is no custom executor, fan-out, database call inside the new plain `to_thread` boundaries, ordering change, threshold move, schema change, or unrelated edit. Confirm the helper segments each side exactly once and every public result field is unchanged.
+
+- [ ] **Step 4: Update task hygiene**
+
+Use Backlog CLI to check all acceptance criteria, add concise Implementation Notes with the impacted test evidence and ADR decision, and set TASK-15764 to Done only after all gates pass:
+
+```bash
+backlog task edit 15764 \
+  --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 \
+  --notes "Implemented standard-library worker offloads for URL HTML extraction, change percentage, and grouped significant-change details. Preserved sequential URL processing, thresholds, DB offload, persistence, and public results. ADR required: no. Verification: <insert exact impacted pytest and Ruff results>." \
+  -s Done
+```
+
+- [ ] **Step 5: Commit closeout metadata**
+
+```bash
+git add 'backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md'
+git commit -m "chore(watchlists): complete URL monitor offload task"
+```

--- a/Docs/superpowers/specs/2026-08-14-watchlists-url-monitor-off-loop-design.md
+++ b/Docs/superpowers/specs/2026-08-14-watchlists-url-monitor-off-loop-design.md
@@ -1,0 +1,92 @@
+# Watchlists URLMonitor Off-Event-Loop Design
+
+Date: 2026-08-14
+Task: [TASK-15764](../../../backlog/tasks/task-15764%20-%20Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md)
+Predecessor: TASK-15463
+
+## Goal
+
+Keep scheduled and manual `url`, `url_list`, and `sitemap` Watchlists checks responsive by moving `URLMonitor`'s remaining CPU-heavy HTML extraction and text comparison work off the caller's asyncio event-loop thread without changing fetched content, change classification, run accounting, persistence, or per-URL ordering.
+
+## Context
+
+TASK-15463 moved Watchlists database operations and feed parsing off the event loop. It deliberately left two pure-CPU URL-monitoring stages behind:
+
+- `ContentExtractor.extract_text_from_html`, which parses and cleans an HTML page admitted up to `MAX_FETCH_BYTES_PAGE`;
+- change comparison in `URLMonitor.check_url`, including `calculate_change_percentage`, `_segment_for_diff`, `build_change_diff`, `added_and_removed_text`, and `classify_change_type`.
+
+`calculate_change_percentage` is included because it constructs a `difflib.SequenceMatcher`; leaving it inline would retain a substantial event-loop CPU path even if the later diff renderer moved.
+
+## Design
+
+### HTML extraction
+
+`URLMonitor._fetch_url_content` keeps its rate limiting, guarded async HTTP fetch, response validation, headers, and raw-content branch unchanged. For `full` and `auto` extraction only, it awaits `asyncio.to_thread(ContentExtractor.extract_text_from_html, response.text, ignore_selectors)`.
+
+This is one worker hop per fetched URL. The inputs are immutable strings plus a per-call selector list, and the helper has no database or event-loop affinity.
+
+### Change percentage
+
+After the existing content-hash mismatch, `check_url` awaits `ContentExtractor.calculate_change_percentage` through `asyncio.to_thread`. The existing threshold comparison remains on the event loop after the worker returns.
+
+This preserves the important short circuit: a below-threshold change does not pay to segment or build a full diff.
+
+### Significant-change details
+
+A small synchronous module helper owns the existing significant-change calculation:
+
+1. segment the prior and current text once each;
+2. pass those shared segments to `build_change_diff`;
+3. pass the same segments to `added_and_removed_text`;
+4. compute `classify_change_type`;
+5. return the five existing output values.
+
+`check_url` invokes that helper through one `asyncio.to_thread` call. It continues to assemble `change_info`, update the snapshot, record the circuit-breaker result, and return the disposition on the event-loop thread.
+
+The helper is an implementation seam, not a new public abstraction or configuration point.
+
+### Ordering and concurrency
+
+`url_list` and `sitemap` execution remains sequential. Each URL finishes its fetch, extraction, comparison, snapshot write, and disposition before the next URL begins. No fan-out, custom executor, queue, semaphore, or new dependency is introduced.
+
+The standard library's default executor is sufficient because this change removes event-loop blocking; it does not claim CPU parallel speedup.
+
+## Error and cancellation behavior
+
+Worker exceptions propagate through the existing `check_url` `try`/`except`, so the circuit breaker records one failure and current per-URL isolation remains authoritative. Invalid ignore selectors retain the current skip-and-log behavior inside `extract_text_from_html`.
+
+Cancelling the awaiting coroutine raises cancellation at the `to_thread` await without waiting for already-started CPU work to stop. That worker may finish in the default executor, but `check_url` does not resume afterward to persist a snapshot, record success, or assemble a result. This is accepted because input remains capped by `MAX_FETCH_BYTES_PAGE`; adding process management or a custom cancellation protocol would exceed the task's latency goal and change failure semantics.
+
+No database operation moves into these plain `to_thread` calls. TASK-15463's `run_db_off_loop` and its in-memory SQLite guard remain unchanged.
+
+## Compatibility constraints
+
+- Extracted text, hashes, change percentage, threshold behavior, diff body and summary, added and removed text, change classification, timestamps, rule-matching fields, snapshots, and dispositions remain byte-for-byte or value-for-value identical.
+- First-check, rebaseline, unchanged, and below-threshold paths preserve their current writes and return shapes.
+- `url_list` and `sitemap` continue isolating one URL's failure without discarding successful siblings.
+- No UI, schema, migration, runtime-policy, or server-backend behavior changes.
+
+## Testing
+
+Tests use thread identity rather than timing:
+
+- a real `_fetch_url_content` path records that HTML extraction runs and that its thread differs from the event-loop thread;
+- a real changed-item path records that change percentage and every significant-change operation run off-loop, asserts each operation occurred, and compares the resulting item/disposition to the established semantics;
+- a real `url_list` execution with multiple URLs proves every URL—not only the first—takes the extraction and significant-diff worker paths while preserving sequential result order;
+- a below-threshold regression proves percentage calculation is off-loop and the expensive significant-change helper is not called;
+- a cancellation regression proves a cancelled `check_url` does not resume after a worker finishes to persist a snapshot or report success;
+- existing TASK-15463, content-kind/diff, and local Watchlists service modules remain green.
+
+Timing-based ticker assertions may remain as supporting evidence, but thread identity and call counts are the non-vacuous contract.
+
+## Scope
+
+In scope: `URLMonitor` HTML extraction and pure CPU comparison work for `url`, `url_list`, and `sitemap` sources.
+
+Out of scope: HTTP concurrency, source scheduling, database offload, executor tuning, process pools, diff algorithm changes, page-size changes, semantic comparison, UI work, and server Watchlists search parity.
+
+## ADR check
+
+ADR required: no.
+
+Reason: this is the direct residual performance fix explicitly deferred by TASK-15463. It preserves storage, runtime, service, and public contracts and introduces no new long-lived architectural boundary.

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -249,9 +249,7 @@ async def test_local_watchlists_service_persists_source_execution_settings(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_url_list_offloads_cpu_work_for_every_url_in_order(
-    tmp_path, monkeypatch
-):
+async def test_url_list_offloads_cpu_work_for_every_url_in_order(tmp_path, monkeypatch):
     urls = ["https://example.com/a", "https://example.com/b"]
     bodies = {
         "a:baseline": "<html><body><p>URL A baseline body.</p></body></html>",
@@ -390,8 +388,7 @@ async def test_url_list_offloads_cpu_work_for_every_url_in_order(
         (urls[1], "URL B changed body."),
     ]
     stored_items = db.conn.execute(
-        "SELECT url FROM subscription_items "
-        "WHERE subscription_id = ? ORDER BY id ASC",
+        "SELECT url FROM subscription_items WHERE subscription_id = ? ORDER BY id ASC",
         (source["source_id"],),
     ).fetchall()
     assert [row["url"] for row in stored_items] == urls

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 from inspect import isawaitable
 from types import SimpleNamespace
 
@@ -11,6 +12,8 @@ from tldw_chatbook.Notifications import (
     NotificationDispatchService,
 )
 from tldw_chatbook.Subscriptions import LocalWatchlistsService
+from tldw_chatbook.Subscriptions import monitoring_engine
+from tldw_chatbook.Subscriptions.monitoring_engine import ContentExtractor
 from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
 
 
@@ -243,6 +246,155 @@ async def test_local_watchlists_service_persists_source_execution_settings(tmp_p
     assert updated["settings"]["extraction_rules"] == {
         "urls": ["https://example.com/c"]
     }
+
+
+@pytest.mark.asyncio
+async def test_url_list_offloads_cpu_work_for_every_url_in_order(
+    tmp_path, monkeypatch
+):
+    urls = ["https://example.com/a", "https://example.com/b"]
+    bodies = {
+        "a:baseline": "<html><body><p>URL A baseline body.</p></body></html>",
+        "b:baseline": "<html><body><p>URL B baseline body.</p></body></html>",
+        "a:changed": "<html><body><p>URL A changed body.</p></body></html>",
+        "b:changed": "<html><body><p>URL B changed body.</p></body></html>",
+    }
+    text_markers = {
+        "URL A baseline body.": "a:baseline",
+        "URL B baseline body.": "b:baseline",
+        "URL A changed body.": "a:changed",
+        "URL B changed body.": "b:changed",
+    }
+    phase = "baseline"
+    calls: list[tuple[str, str, int]] = []
+
+    async def serve(url, **_kwargs):
+        marker = f"{url.rsplit('/', 1)[-1]}:{phase}"
+        calls.append(("fetch", marker, threading.get_ident()))
+        return SimpleNamespace(
+            status_code=200,
+            headers={"content-type": "text/html"},
+            text=bodies[marker],
+            final_url=url,
+            raise_for_status=lambda: None,
+        )
+
+    real_extract = ContentExtractor.extract_text_from_html
+    real_percentage = ContentExtractor.calculate_change_percentage
+    real_details = monitoring_engine._build_significant_change_details
+
+    def recording_extract(html, ignore_selectors=None):
+        marker = next(key for key, body in bodies.items() if body == html)
+        calls.append(("extract", marker, threading.get_ident()))
+        return real_extract(html, ignore_selectors)
+
+    def recording_percentage(old_content, new_content):
+        marker = f"{text_markers[old_content]}->{text_markers[new_content]}"
+        calls.append(("percentage", marker, threading.get_ident()))
+        return real_percentage(old_content, new_content)
+
+    def recording_details(previous_text, current_text):
+        marker = f"{text_markers[previous_text]}->{text_markers[current_text]}"
+        calls.append(("details", marker, threading.get_ident()))
+        return real_details(previous_text, current_text)
+
+    monkeypatch.setattr(monitoring_engine, "guarded_fetch_httpx_async", serve)
+    monkeypatch.setattr(
+        ContentExtractor,
+        "extract_text_from_html",
+        staticmethod(recording_extract),
+    )
+    monkeypatch.setattr(
+        ContentExtractor,
+        "calculate_change_percentage",
+        staticmethod(recording_percentage),
+    )
+    monkeypatch.setattr(
+        monitoring_engine,
+        "_build_significant_change_details",
+        recording_details,
+    )
+
+    db = SubscriptionsDB(tmp_path / "subscriptions.db", "test")
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    output_orders: list[list[str]] = []
+    real_apply_filters = service._apply_filters_and_alerts
+
+    def recording_apply_filters(items, filters, content_alert_rules, run_id):
+        output_orders.append([item["url"] for item in items])
+        return real_apply_filters(items, filters, content_alert_rules, run_id)
+
+    monkeypatch.setattr(service, "_apply_filters_and_alerts", recording_apply_filters)
+    source = await service.create_source(
+        {
+            "name": "Docs",
+            "source_type": "url_list",
+            "extraction_rules": {"urls": urls},
+            "change_threshold": 0.0,
+        }
+    )
+    loop_thread = threading.get_ident()
+
+    baseline_run = await service.launch_run(source_id=source["source_id"])
+    baseline = await service.execute_run(baseline_run["run_id"])
+    phase = "changed"
+    changed_run = await service.launch_run(source_id=source["source_id"])
+    changed = await service.execute_run(changed_run["run_id"])
+
+    expected_call_order = [
+        ("fetch", "a:baseline"),
+        ("extract", "a:baseline"),
+        ("fetch", "b:baseline"),
+        ("extract", "b:baseline"),
+        ("fetch", "a:changed"),
+        ("extract", "a:changed"),
+        ("percentage", "a:baseline->a:changed"),
+        ("details", "a:baseline->a:changed"),
+        ("fetch", "b:changed"),
+        ("extract", "b:changed"),
+        ("percentage", "b:baseline->b:changed"),
+        ("details", "b:baseline->b:changed"),
+    ]
+    assert [(kind, marker) for kind, marker, _thread in calls] == expected_call_order
+    assert all(
+        thread == loop_thread for kind, _marker, thread in calls if kind == "fetch"
+    )
+    assert all(
+        thread != loop_thread for kind, _marker, thread in calls if kind != "fetch"
+    )
+
+    assert baseline["stats"]["items_found"] == 0
+    assert baseline["stats"]["dispositions"]["baseline"] == 2
+    assert changed["status"] == "completed"
+    assert changed["stats"]["items_found"] == 2
+    assert changed["stats"]["items_ingested"] == 2
+    assert changed["stats"]["dispositions"] == {
+        "changed": 2,
+        "unchanged": 0,
+        "withheld": 0,
+        "baseline": 0,
+        "rebaselined": 0,
+        "error": 0,
+    }
+    assert output_orders == [[], urls]
+
+    snapshots = db.conn.execute(
+        "SELECT url, extracted_content FROM url_snapshots "
+        "WHERE subscription_id = ? ORDER BY id ASC",
+        (source["source_id"],),
+    ).fetchall()
+    assert [(row["url"], row["extracted_content"]) for row in snapshots] == [
+        (urls[0], "URL A baseline body."),
+        (urls[1], "URL B baseline body."),
+        (urls[0], "URL A changed body."),
+        (urls[1], "URL B changed body."),
+    ]
+    stored_items = db.conn.execute(
+        "SELECT url FROM subscription_items "
+        "WHERE subscription_id = ? ORDER BY id ASC",
+        (source["source_id"],),
+    ).fetchall()
+    assert [row["url"] for row in stored_items] == urls
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
@@ -30,6 +30,7 @@ the_calling_thread` pins.
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import threading
 import time
@@ -601,6 +602,144 @@ async def test_below_threshold_cpu_work_stops_before_significant_change_details(
         (source_id,),
     ).fetchall()
     assert [row["extracted_content"] for row in snapshots] == [previous_text]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_change_worker_does_not_resume_check_or_mutate_state(
+    tmp_path, monkeypatch
+):
+    """Cancelling the await abandons a late worker result without failure."""
+    before_html = """<html><body>
+<p>Alpha sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    after_html = """<html><body>
+<p>Beta sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="Cancelled page",
+        type="url",
+        source="https://example.com/page",
+        change_threshold=0.0,
+    )
+    subscription = db.get_subscription(source_id)
+    _serve_in_order(monkeypatch, [before_html, after_html])
+    monitor = URLMonitor(db)
+
+    first_item, first_disposition = await monitor.check_url(subscription)
+    assert first_item is None
+    assert first_disposition["kind"] == "baseline_stored"
+
+    breaker = monitor.circuit_breakers[source_id]
+    success_calls: list[int] = []
+    real_record_success = breaker.record_success
+
+    def recording_success() -> None:
+        success_calls.append(threading.get_ident())
+        real_record_success()
+
+    monkeypatch.setattr(breaker, "record_success", recording_success)
+    real_details = monitoring_engine._build_significant_change_details
+    worker_entered = threading.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    worker_threads: list[int] = []
+
+    def blocked_details(previous_text, current_text):
+        worker_threads.append(threading.get_ident())
+        worker_entered.set()
+        try:
+            release_worker.wait()
+            return real_details(previous_text, current_text)
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(
+        monitoring_engine, "_build_significant_change_details", blocked_details
+    )
+    loop_thread = threading.get_ident()
+    check_task = asyncio.create_task(monitor.check_url(subscription))
+
+    try:
+        assert await asyncio.to_thread(worker_entered.wait, 5.0)
+        check_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await check_task
+    finally:
+        release_worker.set()
+        assert await asyncio.to_thread(worker_finished.wait, 5.0)
+
+    snapshots = db.conn.execute(
+        "SELECT extracted_content FROM url_snapshots "
+        "WHERE subscription_id = ? ORDER BY id",
+        (source_id,),
+    ).fetchall()
+    assert len(snapshots) == 1
+    assert snapshots[0]["extracted_content"] == "Alpha sentence. Shared context."
+    assert breaker.failure_count == 0
+    assert success_calls == []
+    assert check_task.cancelled()
+    assert len(worker_threads) == 1
+    assert worker_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_failing_change_worker_propagates_and_records_breaker_failure(
+    tmp_path, monkeypatch
+):
+    """A grouped-worker exception propagates through the existing failure path."""
+    before_html = """<html><body>
+<p>Alpha sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    after_html = """<html><body>
+<p>Beta sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="Failing page",
+        type="url",
+        source="https://example.com/page",
+        change_threshold=0.0,
+    )
+    subscription = db.get_subscription(source_id)
+    _serve_in_order(monkeypatch, [before_html, after_html])
+    monitor = URLMonitor(db)
+
+    first_item, first_disposition = await monitor.check_url(subscription)
+    assert first_item is None
+    assert first_disposition["kind"] == "baseline_stored"
+
+    class SignificantDetailsError(RuntimeError):
+        pass
+
+    worker_threads: list[int] = []
+
+    def failing_details(_previous_text, _current_text):
+        worker_threads.append(threading.get_ident())
+        raise SignificantDetailsError("significant details failed")
+
+    monkeypatch.setattr(
+        monitoring_engine, "_build_significant_change_details", failing_details
+    )
+    loop_thread = threading.get_ident()
+
+    with pytest.raises(SignificantDetailsError, match="significant details failed"):
+        await monitor.check_url(subscription)
+
+    snapshots = db.conn.execute(
+        "SELECT extracted_content FROM url_snapshots "
+        "WHERE subscription_id = ? ORDER BY id",
+        (source_id,),
+    ).fetchall()
+    assert len(snapshots) == 1
+    assert snapshots[0]["extracted_content"] == "Alpha sentence. Shared context."
+    assert monitor.circuit_breakers[source_id].failure_count == 1
+    assert len(worker_threads) == 1
+    assert worker_threads[0] != loop_thread
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
@@ -42,6 +42,7 @@ from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
 from tldw_chatbook.Scheduling.scheduler.handlers.watchlist_check_handler import (
     WatchlistCheckHandler,
 )
+from tldw_chatbook.Subscriptions import monitoring_engine
 from tldw_chatbook.Subscriptions.db_offload import run_db_off_loop
 from tldw_chatbook.Subscriptions.local_watchlists_service import (
     LocalWatchlistsService,
@@ -92,6 +93,16 @@ def _serve(monkeypatch, body: str, *, content_type: str) -> list[str]:
         fake_guarded,
     )
     return fetched
+
+
+def _serve_in_order(monkeypatch, bodies: list[str]) -> None:
+    """Serve one HTML body per request from the real fetch seam."""
+    remaining = list(bodies)
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        return _response(remaining.pop(0), url, content_type="text/html")
+
+    monkeypatch.setattr(monitoring_engine, "guarded_fetch_httpx_async", fake_guarded)
 
 
 def _add_due_source(db: SubscriptionsDB, **kwargs) -> int:
@@ -388,6 +399,208 @@ async def test_url_html_extraction_runs_off_the_event_loop(monkeypatch):
         "URL HTML extraction must run under asyncio.to_thread, not inline on "
         "the event loop"
     )
+
+
+@pytest.mark.asyncio
+async def test_changed_item_cpu_work_runs_off_the_event_loop_without_changing_semantics(
+    tmp_path, monkeypatch
+):
+    """Percentage and significant-change details are worker-thread CPU work."""
+    before_html = """<html><body>
+<p>Alpha sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    after_html = """<html><body>
+<p>Beta sentence.</p>
+<p>Shared context.</p>
+<p>Extra details.</p>
+</body></html>"""
+    previous_text = "Alpha sentence. Shared context."
+    current_text = "Beta sentence. Shared context. Extra details."
+
+    real_percentage = ContentExtractor.calculate_change_percentage
+    real_segment = monitoring_engine._segment_for_diff
+    real_build = monitoring_engine.build_change_diff
+    real_added_removed = monitoring_engine.added_and_removed_text
+    real_classify = monitoring_engine.classify_change_type
+    expected_percentage = real_percentage(previous_text, current_text)
+    old_segments = real_segment(previous_text)
+    new_segments = real_segment(current_text)
+    expected_diff, expected_summary = real_build(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    expected_added, expected_removed = real_added_removed(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    expected_type = real_classify(previous_text, current_text)
+
+    calls: dict[str, list[int]] = {
+        "percentage": [],
+        "segment": [],
+        "build": [],
+        "added_removed": [],
+        "classify": [],
+    }
+
+    def record(name, function):
+        def wrapper(*args, **kwargs):
+            calls[name].append(threading.get_ident())
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    monkeypatch.setattr(
+        ContentExtractor,
+        "calculate_change_percentage",
+        staticmethod(record("percentage", real_percentage)),
+    )
+    monkeypatch.setattr(
+        monitoring_engine, "_segment_for_diff", record("segment", real_segment)
+    )
+    monkeypatch.setattr(
+        monitoring_engine, "build_change_diff", record("build", real_build)
+    )
+    monkeypatch.setattr(
+        monitoring_engine,
+        "added_and_removed_text",
+        record("added_removed", real_added_removed),
+    )
+    monkeypatch.setattr(
+        monitoring_engine, "classify_change_type", record("classify", real_classify)
+    )
+
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="Changed page",
+        type="url",
+        source="https://example.com/page",
+        change_threshold=0.0,
+    )
+    subscription = db.get_subscription(source_id)
+    _serve_in_order(monkeypatch, [before_html, after_html])
+    monitor = URLMonitor(db)
+    loop_thread = threading.get_ident()
+
+    first_item, first_disposition = await monitor.check_url(subscription)
+    item, disposition = await monitor.check_url(subscription)
+
+    assert first_item is None
+    assert first_disposition["kind"] == "baseline_stored"
+    assert item is not None, "the changed page must produce a real item"
+    assert disposition["kind"] == "changed"
+    assert item["type"] == "url_change"
+    assert item["content_kind"] == "change"
+    assert item["content_format"] == "diff"
+    assert item["change_type"] == expected_type == "content"
+    assert item["change_percentage"] == pytest.approx(expected_percentage * 100.0)
+    assert item["content"] == expected_diff
+    assert item["diff_summary"] == expected_summary
+    assert item[monitoring_engine.RULE_MATCH_TEXT_KEY] == current_text
+    assert item[monitoring_engine.RULE_MATCH_ADDED_TEXT_KEY] == expected_added
+    assert item[monitoring_engine.RULE_MATCH_REMOVED_TEXT_KEY] == expected_removed
+
+    snapshots = db.conn.execute(
+        "SELECT content_hash, extracted_content FROM url_snapshots "
+        "WHERE subscription_id = ? ORDER BY id",
+        (source_id,),
+    ).fetchall()
+    assert [(row["extracted_content"], row["content_hash"]) for row in snapshots] == [
+        (previous_text, ContentExtractor.calculate_content_hash(previous_text)),
+        (current_text, ContentExtractor.calculate_content_hash(current_text)),
+    ]
+
+    assert len(calls["percentage"]) == 1
+    assert calls["percentage"][0] != loop_thread
+    assert len(calls["segment"]) == 2
+    assert len(calls["build"]) == 1
+    assert len(calls["added_removed"]) == 1
+    assert len(calls["classify"]) == 1
+    for name in ("segment", "build", "added_removed", "classify"):
+        assert all(thread_id != loop_thread for thread_id in calls[name]), (
+            f"{name} must run inside the grouped worker-thread comparison"
+        )
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_cpu_work_stops_before_significant_change_details(
+    tmp_path, monkeypatch
+):
+    """A withheld change offloads its ratio but never builds diff evidence."""
+    before_html = """<html><body>
+<p>Alpha sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    after_html = """<html><body>
+<p>Beta sentence.</p>
+<p>Shared context.</p>
+</body></html>"""
+    previous_text = "Alpha sentence. Shared context."
+    current_text = "Beta sentence. Shared context."
+    real_percentage = ContentExtractor.calculate_change_percentage
+    actual_ratio = real_percentage(previous_text, current_text)
+    threshold = actual_ratio + 0.1
+    assert threshold < 1.0
+
+    percentage_threads: list[int] = []
+
+    def recording_percentage(old_content, new_content):
+        percentage_threads.append(threading.get_ident())
+        return real_percentage(old_content, new_content)
+
+    grouped_calls: list[int] = []
+
+    def significant_details_must_not_run(*args, **kwargs):
+        grouped_calls.append(threading.get_ident())
+        pytest.fail("below-threshold changes must not build significant details")
+
+    monkeypatch.setattr(
+        ContentExtractor,
+        "calculate_change_percentage",
+        staticmethod(recording_percentage),
+    )
+    monkeypatch.setattr(
+        monitoring_engine,
+        "_build_significant_change_details",
+        significant_details_must_not_run,
+        raising=False,
+    )
+
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="Withheld page",
+        type="url",
+        source="https://example.com/page",
+        change_threshold=threshold,
+    )
+    subscription = db.get_subscription(source_id)
+    _serve_in_order(monkeypatch, [before_html, after_html])
+    monitor = URLMonitor(db)
+    loop_thread = threading.get_ident()
+
+    first_item, first_disposition = await monitor.check_url(subscription)
+    item, disposition = await monitor.check_url(subscription)
+
+    assert first_item is None
+    assert first_disposition["kind"] == "baseline_stored"
+    assert item is None
+    assert disposition["kind"] == "withheld_below_threshold"
+    assert disposition["reason"] == "below_change_threshold"
+    assert disposition["withheld_percentage"] == pytest.approx(actual_ratio * 100.0)
+    assert len(percentage_threads) == 1
+    assert percentage_threads[0] != loop_thread
+    assert grouped_calls == []
+    snapshots = db.conn.execute(
+        "SELECT extracted_content FROM url_snapshots "
+        "WHERE subscription_id = ? ORDER BY id",
+        (source_id,),
+    ).fetchall()
+    assert [row["extracted_content"] for row in snapshots] == [previous_text]
 
 
 @pytest.mark.asyncio

--- a/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
@@ -46,7 +46,11 @@ from tldw_chatbook.Subscriptions.db_offload import run_db_off_loop
 from tldw_chatbook.Subscriptions.local_watchlists_service import (
     LocalWatchlistsService,
 )
-from tldw_chatbook.Subscriptions.monitoring_engine import FeedMonitor
+from tldw_chatbook.Subscriptions.monitoring_engine import (
+    ContentExtractor,
+    FeedMonitor,
+    URLMonitor,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -352,6 +356,36 @@ async def test_the_feed_parse_runs_off_the_event_loop_thread(
     assert parse_threads, "the parser must have been called at all"
     assert parse_threads[0] != threading.get_ident(), (
         "the feed body parse must run under asyncio.to_thread, not inline on "
+        "the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_url_html_extraction_runs_off_the_event_loop(monkeypatch):
+    """URL HTML parsing must not block the event-loop thread."""
+    body = "<html><body><article>Hello <b>watchlist</b></article></body></html>"
+    _serve(monkeypatch, body, content_type="text/html")
+    real_extract = ContentExtractor.extract_text_from_html
+    extraction_threads: list[int] = []
+
+    def recording_extract(html, ignore_selectors=None):
+        extraction_threads.append(threading.get_ident())
+        return real_extract(html, ignore_selectors)
+
+    monkeypatch.setattr(ContentExtractor, "extract_text_from_html", recording_extract)
+    loop_thread = threading.get_ident()
+
+    content = await URLMonitor(SubscriptionsDB(":memory:", "test"))._fetch_url_content(
+        {
+            "source": "https://example.com/article",
+            "extraction_method": "auto",
+        }
+    )
+
+    assert content["text"] == "Hello watchlist"
+    assert extraction_threads, "the real HTML extractor must have run"
+    assert all(thread_id != loop_thread for thread_id in extraction_threads), (
+        "URL HTML extraction must run under asyncio.to_thread, not inline on "
         "the event loop"
     )
 

--- a/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
+++ b/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
@@ -4,7 +4,7 @@ title: 'Watchlists: URLMonitor extraction and diff work off the event loop'
 status: Done
 assignee: []
 created_date: '2026-08-13 12:31'
-updated_date: '2026-08-15 00:09'
+updated_date: '2026-08-15 00:20'
 labels:
   - perf
   - watchlists
@@ -41,9 +41,12 @@ synchronously on the loop once per check, per URL.
       `added_and_removed_text`, `classify_change_type`) runs off the event loop
 - [x] #3 A `url_list` source with multiple URLs shows the same off-loop behavior
       for each URL, not just the first
-- [x] #4 Existing Watchlists/Subscriptions suites (including task-15463's
-      `test_watchlists_db_instance_and_off_loop.py`) stay green; due-detection,
-      run records, and change-classification semantics are unchanged
+- [x] #4 The impacted Watchlists/Subscriptions modules
+      `test_watchlists_db_instance_and_off_loop.py`,
+      `test_watchlist_content_kind_producer.py`, and
+      `test_local_watchlists_service.py` stay green in the approved impacted-only
+      verification scope; due-detection, run records, and change-classification
+      semantics are unchanged
 - [x] #5 `ContentExtractor.calculate_change_percentage` runs off the event loop
       while the existing below-threshold short circuit remains authoritative
 <!-- AC:END -->
@@ -66,5 +69,53 @@ synchronously on the loop once per check, per URL.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented standard-library asyncio.to_thread offloads for ContentExtractor.extract_text_from_html, calculate_change_percentage, and one private grouped significant-change helper; preserved sequential url_list processing, thresholds, persistence, circuit-breaker behavior, and public item/disposition shapes. Changed files: tldw_chatbook/Subscriptions/monitoring_engine.py, Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py, and Tests/Subscriptions/test_local_watchlists_service.py. Verification used the user-mandated impacted-only scope; no full suite was run. Exact three-module pytest command: 72 passed, 1 warning in 22.48s. Scoped Ruff check: all checks passed. git diff --check d63e3dbf29c516dc8bb4fea5fcdc73786a9e6cfd..HEAD: clean. Ruff format --check truthfully reports all three legacy files; base-vs-HEAD formatter-delta hashes are identical per file (monitoring_engine ce293878499d3e1b90ee8b11f614a825bb595e725792e187db35ffd759f1a467; DB/off-loop test ba7ec063a6b46ed3adc13fe048fa6812b99296377f040226a0b6f1dfb91a9c23; local service test ebd027dc98279634c68dcfc58de308f67c382c80e5bce655e9a49c7386f47e0a), proving pre-existing whole-file formatter debt outside introduced hunks; no mass-format was applied. ADR required: no; ADR path: N/A. Reason: direct residual performance fix with no storage, runtime, service, public-contract, dependency, or long-lived-boundary change. Plan deviation: cancellation coverage gates the later grouped significant-change worker rather than initial extraction because this directly pins that cancellation cannot resume into snapshot persistence or breaker success; extraction retains separate thread-identity coverage. Self-review: no custom executor, fan-out, schema, public-result, ordering, or threshold change; no DB call in the new plain helper; each text side is segmented exactly once.
+Implemented standard-library `asyncio.to_thread` offloads for
+`ContentExtractor.extract_text_from_html`, `calculate_change_percentage`, and
+one private grouped significant-change helper. Sequential `url_list` processing,
+thresholds, persistence, circuit-breaker behavior, and public item/disposition
+shapes remain unchanged.
+
+- Implementation/test files: `tldw_chatbook/Subscriptions/monitoring_engine.py`,
+  `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`, and
+  `Tests/Subscriptions/test_local_watchlists_service.py`.
+- Closeout record:
+  `backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md`.
+- Verification used the user-mandated impacted-only scope; no full suite was run.
+  Exact command:
+
+  ```bash
+  ../../.venv/bin/python -m pytest -q \
+    Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py \
+    Tests/Subscriptions/test_watchlist_content_kind_producer.py \
+    Tests/Subscriptions/test_local_watchlists_service.py
+  ```
+
+  Result: `72 passed, 1 warning in 22.48s`; the warning was the existing
+  `RequestsDependencyWarning` about the installed
+  urllib3/chardet/charset_normalizer versions.
+- Scoped Ruff lint passed.
+  `git diff --check d63e3dbf29c516dc8bb4fea5fcdc73786a9e6cfd..HEAD`
+  passed.
+- Scoped `ruff format --check` truthfully reported all three legacy files. To
+  classify it, the three files were archived from base
+  `d63e3dbf29c516dc8bb4fea5fcdc73786a9e6cfd` and from `HEAD`, each copy was
+  formatted with the same Ruff command, and each raw-to-formatted patch was
+  compared with `diff -U0` after removing only the path and `@@` line-number
+  headers. Base and HEAD had identical remaining formatter-diff bodies (one
+  hunk in `monitoring_engine.py`, two in the DB/off-loop test, and seventeen in
+  the local-service test); only their line offsets changed. The remaining Ruff
+  deltas therefore predate this task and are outside the introduced hunks. No
+  mass-format was applied.
+- ADR required: no. ADR path: N/A. This is a direct residual performance fix
+  with no storage, runtime, service, public-contract, dependency, or long-lived
+  boundary change.
+- Plan deviation: cancellation coverage gates the later grouped
+  significant-change worker rather than initial extraction because this
+  directly pins that cancellation cannot resume into snapshot persistence or
+  breaker success; extraction retains separate thread-identity coverage.
+- Self-review found no custom executor, fan-out, schema, public-result,
+  ordering, or threshold change; no DB call exists in the new plain helper;
+  each text side is segmented exactly once.
+- Lessons hygiene: no reusable lesson was added because the work surfaced no
+  new generalizable repository trap.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
+++ b/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-15764
 title: 'Watchlists: URLMonitor extraction and diff work off the event loop'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-13 12:31'
-updated_date: '2026-08-14 23:25'
+updated_date: '2026-08-15 00:09'
 labels:
   - perf
   - watchlists
@@ -35,16 +35,16 @@ synchronously on the loop once per check, per URL.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `ContentExtractor.extract_text_from_html` runs off the event loop for
+- [x] #1 `ContentExtractor.extract_text_from_html` runs off the event loop for
       `url`/`url_list`/`sitemap` checks (evidence: thread-identity test)
-- [ ] #2 `check_url`'s difflib work (`_segment_for_diff` ×2, `build_change_diff`,
+- [x] #2 `check_url`'s difflib work (`_segment_for_diff` ×2, `build_change_diff`,
       `added_and_removed_text`, `classify_change_type`) runs off the event loop
-- [ ] #3 A `url_list` source with multiple URLs shows the same off-loop behavior
+- [x] #3 A `url_list` source with multiple URLs shows the same off-loop behavior
       for each URL, not just the first
-- [ ] #4 Existing Watchlists/Subscriptions suites (including task-15463's
+- [x] #4 Existing Watchlists/Subscriptions suites (including task-15463's
       `test_watchlists_db_instance_and_off_loop.py`) stay green; due-detection,
       run records, and change-classification semantics are unchanged
-- [ ] #5 `ContentExtractor.calculate_change_percentage` runs off the event loop
+- [x] #5 `ContentExtractor.calculate_change_percentage` runs off the event loop
       while the existing below-threshold short circuit remains authoritative
 <!-- AC:END -->
 
@@ -62,3 +62,9 @@ synchronously on the loop once per check, per URL.
 5. Self-review, record ADR=no and verification evidence, complete acceptance
    criteria, and close the task.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented standard-library asyncio.to_thread offloads for ContentExtractor.extract_text_from_html, calculate_change_percentage, and one private grouped significant-change helper; preserved sequential url_list processing, thresholds, persistence, circuit-breaker behavior, and public item/disposition shapes. Changed files: tldw_chatbook/Subscriptions/monitoring_engine.py, Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py, and Tests/Subscriptions/test_local_watchlists_service.py. Verification used the user-mandated impacted-only scope; no full suite was run. Exact three-module pytest command: 72 passed, 1 warning in 22.48s. Scoped Ruff check: all checks passed. git diff --check d63e3dbf29c516dc8bb4fea5fcdc73786a9e6cfd..HEAD: clean. Ruff format --check truthfully reports all three legacy files; base-vs-HEAD formatter-delta hashes are identical per file (monitoring_engine ce293878499d3e1b90ee8b11f614a825bb595e725792e187db35ffd759f1a467; DB/off-loop test ba7ec063a6b46ed3adc13fe048fa6812b99296377f040226a0b6f1dfb91a9c23; local service test ebd027dc98279634c68dcfc58de308f67c382c80e5bce655e9a49c7386f47e0a), proving pre-existing whole-file formatter debt outside introduced hunks; no mass-format was applied. ADR required: no; ADR path: N/A. Reason: direct residual performance fix with no storage, runtime, service, public-contract, dependency, or long-lived-boundary change. Plan deviation: cancellation coverage gates the later grouped significant-change worker rather than initial extraction because this directly pins that cancellation cannot resume into snapshot persistence or breaker success; extraction retains separate thread-identity coverage. Self-review: no custom executor, fan-out, schema, public-result, ordering, or threshold change; no DB call in the new plain helper; each text side is segmented exactly once.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
+++ b/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
@@ -1,17 +1,20 @@
 ---
 id: TASK-15764
 title: 'Watchlists: URLMonitor extraction and diff work off the event loop'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-13 12:31'
+updated_date: '2026-08-14 23:25'
 labels:
   - perf
   - watchlists
+dependencies: []
 priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Follow-up named explicitly in task-15463's "Scope" section (input-latency
 burn-down, `Docs/Design/2026-08-11-input-latency-audit.md`): task-15463 moved
 the watchlist scheduler's sqlite work and feed-body parsing off the event
@@ -28,15 +31,34 @@ without task-15463's in-memory-connection hazard (no `:memory:` guard is
 needed here — this is not a DB call). A `url_list` source multiplies both
 costs by its URL count, so a source that watches several URLs pays this
 synchronously on the loop once per check, per URL.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] `ContentExtractor.extract_text_from_html` runs off the event loop for
+<!-- AC:BEGIN -->
+- [ ] #1 `ContentExtractor.extract_text_from_html` runs off the event loop for
       `url`/`url_list`/`sitemap` checks (evidence: thread-identity test)
-- [ ] `check_url`'s difflib work (`_segment_for_diff` ×2, `build_change_diff`,
+- [ ] #2 `check_url`'s difflib work (`_segment_for_diff` ×2, `build_change_diff`,
       `added_and_removed_text`, `classify_change_type`) runs off the event loop
-- [ ] A `url_list` source with multiple URLs shows the same off-loop behavior
+- [ ] #3 A `url_list` source with multiple URLs shows the same off-loop behavior
       for each URL, not just the first
-- [ ] Existing Watchlists/Subscriptions suites (including task-15463's
+- [ ] #4 Existing Watchlists/Subscriptions suites (including task-15463's
       `test_watchlists_db_instance_and_off_loop.py`) stay green; due-detection,
       run records, and change-classification semantics are unchanged
+- [ ] #5 `ContentExtractor.calculate_change_percentage` runs off the event loop
+      while the existing below-threshold short circuit remains authoritative
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add thread-identity RED coverage for HTML extraction and offload the existing
+   extractor with `asyncio.to_thread`.
+2. Add RED coverage for percentage, significant-diff, threshold, and
+   cancellation semantics; introduce one private grouped comparison helper and
+   offload it.
+3. Prove a real multi-URL source uses the worker path for every URL while
+   retaining sequential order and accounting.
+4. Run only impacted Watchlists tests plus scoped Ruff/format/diff checks.
+5. Self-review, record ADR=no and verification evidence, complete acceptance
+   criteria, and close the task.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -569,6 +569,28 @@ def classify_change_type(previous_text: str, current_text: str) -> str:
     return "content"
 
 
+def _build_significant_change_details(
+    previous_text: str, current_text: str
+) -> tuple[str, str, str, str, str]:
+    """Build all significant-change diff details from one segmentation pass."""
+    old_segments = _segment_for_diff(previous_text)
+    new_segments = _segment_for_diff(current_text)
+    diff_body, diff_summary = build_change_diff(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    added_text, removed_text = added_and_removed_text(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    change_type = classify_change_type(previous_text, current_text)
+    return diff_body, diff_summary, added_text, removed_text, change_type
+
+
 ########################################################################################################################
 #
 # Check dispositions (TASK-1362, spec §4)
@@ -1309,8 +1331,10 @@ class URLMonitor:
 
             # Calculate change details
             previous_text = previous["extracted_content"] or ""
-            change_percentage = ContentExtractor.calculate_change_percentage(
-                previous_text, current_content["text"]
+            change_percentage = await asyncio.to_thread(
+                ContentExtractor.calculate_change_percentage,
+                previous_text,
+                current_content["text"],
             )
 
             # Check if change exceeds threshold. Both sides of this comparison
@@ -1348,23 +1372,16 @@ class URLMonitor:
             # reader's `[full page]` / `[previous snapshot]` affordances read
             # from; storing it a second time here bought nothing and left the
             # reader unable to see what had actually changed.
-            # Segment each side ONCE and share it with both consumers: the
-            # reader's diff body and the "appeared"/"disappeared" added/removed
-            # text (TASK-1363) are different outputs of the same segmentation,
-            # and a page can be up to 10 MB (Qodo -- do not segment it twice).
-            _old_segments = _segment_for_diff(previous_text)
-            _new_segments = _segment_for_diff(current_content["text"])
-            diff_body, diff_summary = build_change_diff(
+            (
+                diff_body,
+                diff_summary,
+                added_text,
+                removed_text,
+                change_type,
+            ) = await asyncio.to_thread(
+                _build_significant_change_details,
                 previous_text,
                 current_content["text"],
-                old_segments=_old_segments,
-                new_segments=_new_segments,
-            )
-            added_text, removed_text = added_and_removed_text(
-                previous_text,
-                current_content["text"],
-                old_segments=_old_segments,
-                new_segments=_new_segments,
             )
             change_info = {
                 "type": "url_change",
@@ -1386,9 +1403,7 @@ class URLMonitor:
                 # reachable at all, a real 35% change would have displayed as
                 # "0% changed" and a total rewrite as "1% changed".
                 "change_percentage": change_percentage * 100.0,
-                "change_type": classify_change_type(
-                    previous_text, current_content["text"]
-                ),
+                "change_type": change_type,
                 "diff_summary": diff_summary,
                 "published_date": datetime.now(timezone.utc).isoformat(),
                 # Filters and content-alert rules are evaluated on the raw

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -1515,8 +1515,10 @@ class URLMonitor:
 
         if extraction_method == "full" or extraction_method == "auto":
             # Extract text from HTML
-            text = ContentExtractor.extract_text_from_html(
-                response.text, ignore_selectors
+            text = await asyncio.to_thread(
+                ContentExtractor.extract_text_from_html,
+                response.text,
+                ignore_selectors,
             )
         else:
             # Raw content


### PR DESCRIPTION
## Summary

- move Watchlists URL HTML extraction and change-percentage calculation off the asyncio event loop
- group significant-change segmentation, diff, added/removed evidence, and classification into one pure worker call
- add deterministic cancellation, failure, and real multi-URL ordering coverage
- complete TASK-15764 with the approved impacted-only verification scope

## Behavior preserved

- threshold short-circuit and change semantics
- sequential URL, URL-list, and sitemap processing
- snapshot persistence, circuit-breaker accounting, dispositions, and public evidence
- existing database offload and schema contracts

## Test plan

- [x] `72 passed, 1 existing RequestsDependencyWarning`
  - `Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py`
  - `Tests/Subscriptions/test_watchlist_content_kind_producer.py`
  - `Tests/Subscriptions/test_local_watchlists_service.py`
- [x] scoped Ruff lint
- [x] cumulative `git diff --check`
- [x] final spec and code-quality review: no findings

## Notes

- No full repository suite was run; verification was intentionally limited to touched and impacted Watchlists functionality.
- Remaining Ruff-format deltas in the three legacy files are identical to the pre-task baseline and outside introduced hunks.
- ADR required: no; this completes the CPU-offload boundary explicitly deferred by TASK-15463.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves CPU-heavy URL HTML extraction and change comparison in Watchlists off the asyncio event loop to improve responsiveness without changing results or per-URL ordering. Previously, extraction and difflib ran inline; now they run via `asyncio.to_thread` with one grouped helper for significant-change details. Completes TASK-15764’s acceptance criteria.

- Core changes:
  - In `check_url`, await `ContentExtractor.calculate_change_percentage` via `asyncio.to_thread`, preserve the threshold short-circuit, then await a new private `_build_significant_change_details` via `asyncio.to_thread`.
  - In `_fetch_url_content`, offload `ContentExtractor.extract_text_from_html` via `asyncio.to_thread` for `full`/`auto` extraction.
  - Adds design/plan docs; updates TASK-15764 closeout.

- Behavior and risk notes:
  - Preserves thresholds, sequential processing for `url`/`url_list`/`sitemap`, snapshot persistence, circuit-breaker semantics, and item/disposition fields.
  - Cancellation: a cancelled `check_url` does not resume after worker completion; no snapshot or success is recorded. Worker exceptions propagate and record a breaker failure.
  - No schema or API changes; no new dependencies; default executor only.
  - Tests added to pin off-loop execution, below-threshold short-circuit, cancellation, multi-URL ordering, and unchanged semantics in `Tests/Subscriptions/*`.

<sup>Written for commit 336d37a1746389b00cd153a6d4a72f7e402906ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

