### PR TITLE
docs(watchlists): track server search parity

### DIFF
--- a/backlog/tasks/task-18904 - Add-server-mode-parity-for-Watchlists-Console-and-MCP-search-tools.md
+++ b/backlog/tasks/task-18904 - Add-server-mode-parity-for-Watchlists-Console-and-MCP-search-tools.md
@@ -1,0 +1,37 @@
+---
+id: TASK-18904
+title: Add server-mode parity for Watchlists Console and MCP search tools
+status: To Do
+assignee: []
+created_date: '2026-08-14 23:16'
+updated_date: '2026-08-18 00:00'
+labels:
+  - watchlists
+  - agent-tools
+  - mcp
+dependencies: []
+references:
+  - rmusser01/tldw_server TASK-13022
+  - TASK-16222
+  - Docs/superpowers/specs/2026-08-14-watchlists-agent-search-tools-design.md
+  - backlog/decisions/032-local-agent-tool-permission-boundary.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the current server-mode unsupported outcome for watchlists_search_items and watchlists_get_item with exact user-visible parity backed by tldw_server TASK-13022, while retaining the existing local behavior, permissions, privacy shaping, and byte bounds.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Server mode exposes the same two tool names, input schemas, status outcomes, evidence fields, ordering, and continuation semantics as local mode.
+- [ ] #2 Chatbook consumes tldw_server TASK-13022 through a transport safe for the synchronous agent worker and never blocks Textual's event loop.
+- [ ] #3 Server watchlists map to collection scope; human source and watchlist resolution retains exact-name precedence, bounded disambiguation, and explicit canonical IDs.
+- [ ] #4 Server statuses and dates map explicitly to the local public vocabulary, with no invented timestamps or aggregate last-updated field.
+- [ ] #5 Chatbook wraps server continuation with a backend and query fingerprint so local, server, and mismatched cursors fail closed.
+- [ ] #6 All server evidence passes through the existing strict less-than-30-KiB JSON packer, field allowlist, URL sanitization, terminal-control stripping, and untrusted-evidence labeling.
+- [ ] #7 The existing local:__local__ permission, kill-switch, approval, definition-hash, and external MCP exposure gates remain authoritative with no new principal or mutation capability.
+- [ ] #8 Tests cover Console and external MCP invocation, local/server switching, auth and transport failures, malformed cursors, scope ambiguity, parity fixtures, no event-loop blocking, and unchanged local-mode results.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

- file TASK-16309 for Watchlists Console and MCP server-mode search parity
- record the tldw_server TASK-13022 dependency and existing permission/privacy constraints
- define testable parity, cursor, transport, and evidence-bounding acceptance criteria

## Verification

- `backlog task 16309 --plain`
- `git diff --check origin/dev...HEAD`

This PR only files the backlog task; implementation is intentionally deferred for a coworker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks server-mode parity work for Watchlists Console and MCP search tools. Adds backlog task TASK-18904 with acceptance criteria and dependencies; no product behavior change.

- Links TASK-18904 to `rmusser01/tldw_server` TASK-13022 and TASK-16222; documents current permission and privacy constraints.
- Parity: server must expose the same tool names, input schemas, status outcomes, evidence fields, ordering, and continuation semantics as local.
- Transport: Chatbook uses event-loop-safe, non-blocking transport within the synchronous agent worker.
- Cursors: wrap continuation with backend and query fingerprints so mismatches fail closed.
- Mapping: server watchlists map to collection scope; human source and watchlist resolution keep exact-name precedence, bounded disambiguation, and canonical IDs; statuses/dates map to the public vocabulary with no synthetic timestamps.
- Evidence: enforce <30 KiB JSON packer, field allowlist, URL sanitization, control-code stripping, and untrusted-evidence labeling.
- Security: retain `local:__local__` permission, kill-switch, approvals, definition-hash, and external MCP exposure gates; add no new principals or mutation paths.
- Tests: cover Console and external MCP invocation, local/server switching, auth/transport failures, malformed cursors, scope ambiguity, parity fixtures, no event-loop blocking, and unchanged local-mode results.

<sup>Written for commit d5116e91faa03c125b50b0450489e5798bfc9eac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

