### PR TITLE
feat(tts): add Windows audio.cpp lifecycle parity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,54 @@ jobs:
           exit 1
         fi
 
+  windows-audio-cpp:
+    name: Windows audio.cpp lifecycle - Python 3.12 - ${{ matrix.architecture }}
+    runs-on: windows-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [x86, x64]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12 (${{ matrix.architecture }})
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        architecture: ${{ matrix.architecture }}
+        cache: pip
+
+    - name: Install project and test dependencies
+      shell: pwsh
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -e .
+        pip install pytest pytest-asyncio pytest-timeout
+
+    - name: Verify Windows audio.cpp lifecycle
+      shell: pwsh
+      run: |
+        pytest `
+          Tests/TTS/test_windows_artifact_fs.py `
+          Tests/TTS/test_audio_cpp_package_scanner.py `
+          Tests/TTS/test_audio_cpp_guided_launch.py `
+          Tests/TTS/test_profile_reference_materialization_windows.py `
+          Tests/TTS/test_audio_cpp_supervisor.py `
+          Tests/TTS/test_audio_cpp_recipes.py `
+          Tests/TTS/test_audio_cpp_managed_config.py `
+          Tests/UI/test_settings_speech_tts_panel.py::test_windows_managed_ui_gate_uses_shared_platform_capability `
+          Tests/UI/test_settings_speech_tts_panel.py::test_supported_windows_offers_managed_mode_with_bounded_privacy_copy `
+          Tests/UI/test_speech_playground_pane_lifecycle.py::test_ready_clone_model_mounts_and_canonicalizes_path_free_setup `
+          Tests/UI/test_speech_playground_pane_lifecycle.py::test_audio_cpp_runtime_projection_reports_exact_artifact_privacy_posture `
+          Tests/UI/test_speech_playground_pane_lifecycle.py::test_server_shutdown_is_distinct_from_playback_stop_and_does_not_restart `
+          Tests/TTS/test_stts_audio_cpp_generation.py::test_audio_cpp_native_generation_consumes_and_closes_one_wav_response `
+          Tests/TTS/test_stts_audio_cpp_generation.py::test_audio_cpp_native_generation_propagates_cancellation_and_closes `
+          Tests/TTS/test_stts_audio_cpp_generation.py::test_native_local_failures_use_fixed_recovery_copy `
+          --timeout=180 `
+          -q
+
   ui-tests:
     name: UI Tests
     runs-on: ubuntu-latest
@@ -378,7 +426,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate]
+    needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate, windows-audio-cpp]
     if: always()
     
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,6 +189,18 @@ jobs:
         pip install -e .
         pip install pytest pytest-asyncio pytest-timeout
 
+    - name: Parse provisioned UAT wrapper
+      shell: pwsh
+      run: |
+        $tokens = $null
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+          (Resolve-Path "scripts/uat_audio_cpp_windows.ps1"),
+          [ref]$tokens,
+          [ref]$errors
+        ) | Out-Null
+        if ($errors.Count -ne 0) { throw "The Windows UAT wrapper is invalid." }
+
     - name: Verify Windows audio.cpp lifecycle
       shell: pwsh
       run: |
@@ -200,6 +212,7 @@ jobs:
           Tests/TTS/test_audio_cpp_supervisor.py `
           Tests/TTS/test_audio_cpp_recipes.py `
           Tests/TTS/test_audio_cpp_managed_config.py `
+          Tests/TTS/test_audio_cpp_windows_uat_harness.py `
           Tests/UI/test_settings_speech_tts_panel.py::test_windows_managed_ui_gate_uses_shared_platform_capability `
           Tests/UI/test_settings_speech_tts_panel.py::test_supported_windows_offers_managed_mode_with_bounded_privacy_copy `
           Tests/UI/test_speech_playground_pane_lifecycle.py::test_ready_clone_model_mounts_and_canonicalizes_path_free_setup `

--- a/Docs/superpowers/plans/2026-08-14-task-13208-audio-cpp-windows-lifecycle-parity.md
+++ b/Docs/superpowers/plans/2026-08-14-task-13208-audio-cpp-windows-lifecycle-parity.md
@@ -1,0 +1,679 @@
+# Windows audio.cpp Lifecycle and Clone Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Follow
+> strict RED/GREEN TDD and stop at every review checkpoint.
+
+**Goal:** Deliver truthful Guided audio.cpp and clone-reference parity on
+Windows 10+ x86/x64 with Python 3.12+, including native path/ACL safety, exact
+process-handle settlement, hosted Windows coverage, and a parameterized real
+UAT handoff.
+
+**Architecture:** Keep `AudioCppSupervisor`, the bounded package scanner,
+`AudioCppGeneratedLaunchArtifact`, and `TTSCloneReferenceMaterializer` as the
+only lifecycle owners. Add one TTS-scoped stdlib Win32 filesystem capability
+under them, retain all blocking/native work through existing async ownership
+patterns, and enable the existing Settings/Speech Lab UI only when the Windows
+capability baseline is satisfied.
+
+**Tech Stack:** Python 3.12+, `asyncio` Proactor subprocesses, stdlib `ctypes`
+and `msvcrt`, Textual 8.x, pytest, GitHub Actions `windows-latest`, Windows
+PowerShell 5.1+/PowerShell 7, Ruff, mypy
+
+## Global constraints
+
+- Supported Windows baseline: Windows 10+, x86 and x64, Python 3.12+.
+- ARM64 is out of scope and must remain labeled unsupported.
+- Do not add `pywin32`, another dependency, another process supervisor, a
+  process-tree registry, a background retry loop, or a second configuration
+  source.
+- Do not use Job Objects or claim ownership of descendants/daemonizing builds.
+- Do not weaken the existing POSIX descriptor-relative implementation.
+- Do not broaden ADR-029's Windows privacy claim beyond generated audio.cpp
+  launch artifacts and operation-scoped clone materializations.
+- Every native call must be hidden behind stable path-free outcomes; no Win32
+  error text, SID, username, executable/model/runtime path, transcript, WAV
+  bytes, child output, or environment value may enter public errors/logs.
+- All native work expected to exceed 100 ms runs off the Textual event loop.
+- Cleanup authority is retained until exact handles/locks/transports settle;
+  cancellation never abandons a thread or a returned owner.
+- Normal CI is hermetic. It never downloads audio.cpp or a model package.
+- The provisioned UAT takes parameters and contains no workstation-specific
+  paths, usernames, versions, or device assumptions.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/029-local-private-data-boundary.md` amendment
+
+Reason: TASK-13208 establishes a verified Windows DACL posture for two private
+plaintext artifact classes. ADR-023, ADR-050, and ADR-051 already govern the
+process, generated-configuration, and clone owners; no new lifecycle boundary
+is introduced.
+
+---
+
+### Task 1: Add the narrow native Windows artifact filesystem capability
+
+**Files:**
+
+- Create: `tldw_chatbook/TTS/windows_artifact_fs.py`
+- Create: `Tests/TTS/test_windows_artifact_fs.py`
+- Reference only: `tldw_chatbook/Notes/note_import_windows_fs.py`
+
+**Public/internal interfaces:**
+
+- `WindowsArtifactFilesystem` protocol for deterministic non-Windows tests.
+- `NativeWindowsArtifactFilesystem` stdlib implementation selected only on
+  native Windows.
+- Opaque `WindowsPinnedHandle` and frozen `WindowsFileIdentity` values; no raw
+  handle value appears in `repr`.
+- Narrow operations: normalize an admitted drive/UNC path, open/create without
+  following a reparse point, read/write through the retained handle, acquire or
+  release an exact `LockFileEx` lock, install/verify the approved DACL, enumerate
+  exact owned children, mark the exact handle for deletion, and close once.
+- `windows_audio_cpp_platform_supported()` for Windows version, Python version,
+  and process architecture gating.
+
+- [ ] **Step 1: Write RED path and capability tests**
+
+Cover absolute drive and UNC paths, Unicode, extended-length conversion,
+drive-relative paths, device namespaces, reserved names, x86/x64 pointer
+widths, Python <3.12, Windows <10, and ARM64. Assert unsupported tuples fail
+closed without importing or calling Win32 on POSIX.
+
+Run:
+
+```bash
+python -m pytest Tests/TTS/test_windows_artifact_fs.py -q
+```
+
+Expected RED: module/API missing.
+
+- [ ] **Step 2: Write RED native handle and DACL tests**
+
+Using an injectable fake kernel on every host and `pytest.mark.skipif` native
+probes on Windows, cover:
+
+- `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` and directory backup
+  semantics;
+- non-inheritable handles;
+- volume/file identity equality and substitution;
+- reparse, junction, mount-point, special-file, and case-collision rejection;
+- protected DACL installation and re-read verification for only current token
+  user SID, LocalSystem, and Builtin Administrators;
+- null/invalid DACL, unexpected allow trustee, and native failure;
+- exclusive nonblocking `LockFileEx` ownership;
+- exact handle-directed delete, idempotent close, retryable close failure, and
+  control-flow preservation; and
+- exception-graph/log canaries containing private paths, SIDs, and error text.
+
+- [ ] **Step 3: Implement the smallest stdlib capability**
+
+Use explicit `ctypes.WinDLL(..., use_last_error=True)` signatures with
+pointer-sized `wintypes.HANDLE`. Validate ordinary absolute paths before adding
+the `\\?\` or `\\?\UNC\` prefix. Keep all raw structures and codes private.
+Return stable errors such as `unavailable`, `changed`, `privacy_unavailable`,
+`busy`, and `cleanup_failed`.
+
+- [ ] **Step 4: Verify GREEN on the host-independent matrix**
+
+```bash
+python -m pytest Tests/TTS/test_windows_artifact_fs.py -q
+python -m ruff check tldw_chatbook/TTS/windows_artifact_fs.py Tests/TTS/test_windows_artifact_fs.py
+python -m ruff format --check tldw_chatbook/TTS/windows_artifact_fs.py Tests/TTS/test_windows_artifact_fs.py
+python -m mypy tldw_chatbook/TTS/windows_artifact_fs.py
+```
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add tldw_chatbook/TTS/windows_artifact_fs.py Tests/TTS/test_windows_artifact_fs.py
+git commit -m "feat(tts): add native Windows artifact handles"
+```
+
+---
+
+### Task 2: Pin Windows package scans without changing recipe matching
+
+**Files:**
+
+- Modify: `tldw_chatbook/TTS/audio_cpp_package_scanner.py`
+- Modify: `Tests/TTS/test_audio_cpp_package_scanner.py`
+- Use: `tldw_chatbook/TTS/windows_artifact_fs.py`
+
+**Interfaces:** Preserve `scan_audio_cpp_package_root()` and
+`scan_audio_cpp_package_root_async()` signatures for callers. Add only one
+optional internal filesystem seam for deterministic tests. Matching,
+budgets, result types, and managed-root equality remain shared.
+
+- [ ] **Step 1: Write RED Windows scanner regressions**
+
+Cover drive/UNC/Unicode/long roots, disclosed top-level link review, nested
+symlink/junction/reparse rejection, case-insensitive duplicate names,
+directory substitution between enumeration phases, file substitution before
+read, short reads, close failure, cancellation, and exact managed-root
+revalidation. Prove one selected root is scanned and no drive/profile search
+occurs.
+
+Run:
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_package_scanner.py -k windows -q
+```
+
+Expected RED: Windows falls into `NO_FOLLOW_UNAVAILABLE` or fails the new
+native pin assertions.
+
+- [ ] **Step 2: Add the Windows pin/read path**
+
+On native Windows, retain a no-reparse directory handle while each `scandir`
+iterator is live, compare pathname identity to the handle before and after
+enumeration, and read allowlisted metadata through a pinned no-reparse file
+handle. Keep the existing POSIX `O_NOFOLLOW` path byte-for-byte equivalent.
+
+- [ ] **Step 3: Mutation-check the two ownership guards**
+
+Temporarily remove (a) the directory identity recheck and (b) the file identity
+recheck. Each dedicated race test must fail. Restore both guards.
+
+- [ ] **Step 4: Verify scanner GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_package_scanner.py -q
+python -m ruff check tldw_chatbook/TTS/audio_cpp_package_scanner.py Tests/TTS/test_audio_cpp_package_scanner.py
+python -m mypy tldw_chatbook/TTS/audio_cpp_package_scanner.py
+```
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add tldw_chatbook/TTS/audio_cpp_package_scanner.py Tests/TTS/test_audio_cpp_package_scanner.py
+git commit -m "feat(tts): pin audio cpp scans on Windows"
+```
+
+---
+
+### Task 3: Create and clean generated launch artifacts with verified DACLs
+
+**Files:**
+
+- Modify: `tldw_chatbook/TTS/audio_cpp_guided_launch.py`
+- Modify: `Tests/TTS/test_audio_cpp_guided_launch.py`
+- Use: `tldw_chatbook/TTS/windows_artifact_fs.py`
+
+**Interfaces:** Keep `AudioCppGeneratedLaunchArtifact`,
+`materialize_audio_cpp_guided_launch()`, and cleanup-owner transfer unchanged
+for callers. The artifact privately retains either the current POSIX
+descriptor owner or one Windows handle owner. Add a bounded read-only
+`privacy_posture` projection that becomes Windows-account-protected only after
+the DACL is installed and reverified.
+
+- [ ] **Step 1: Write RED generated-artifact tests**
+
+Cover Windows creation, canonical JSON bytes, protected DACL verification,
+digest/size/identity validation, reparse and name substitution, unexpected
+entries, partial creation, cancellation during creation, cleanup fail/retry,
+managed-lease close failure, control flow, and no path/SID/native error leaks.
+
+- [ ] **Step 2: Add the Windows storage branch**
+
+Create `generation-<32 hex>/server.json` only beneath the app-owned generated
+root. Install and verify the DACL before publication, write and flush through
+the retained file handle, make the configuration read-only for the owning
+lifecycle, and keep the exact directory/file handles and identities until
+cleanup settles.
+
+- [ ] **Step 3: Preserve exact cleanup semantics**
+
+Delete only the recognized `server.json` and generation directory after exact
+identity/DACL/name/entry checks. Unknown or replaced contents must remain.
+Failed close/delete remains attached to the existing cleanup owner and is
+retryable by the adapter/supervisor lifecycle.
+
+- [ ] **Step 4: Verify both platform branches GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_guided_launch.py Tests/TTS/test_windows_artifact_fs.py -q
+python -m ruff check tldw_chatbook/TTS/audio_cpp_guided_launch.py Tests/TTS/test_audio_cpp_guided_launch.py
+python -m mypy tldw_chatbook/TTS/audio_cpp_guided_launch.py
+```
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add tldw_chatbook/TTS/audio_cpp_guided_launch.py Tests/TTS/test_audio_cpp_guided_launch.py
+git commit -m "feat(tts): protect Windows guided launch artifacts"
+```
+
+---
+
+### Task 4: Materialize clone references under the same native owner
+
+**Files:**
+
+- Modify: `tldw_chatbook/TTS/profile_reference_materialization.py`
+- Modify: `Tests/TTS/test_profile_reference_materialization.py`
+- Use: `tldw_chatbook/TTS/windows_artifact_fs.py`
+
+**Interfaces:** Preserve `TTSCloneReferenceMaterializer`,
+`TTSCloneReferenceMaterialization`, `voice_ref`, `validated_voice_ref()`, and
+`aclose()`. Internally admit a Windows materialization record alongside the
+existing POSIX record; do not create a second materializer.
+
+- [ ] **Step 1: Replace the Windows module skip with RED Windows contracts**
+
+Keep POSIX `fcntl` tests capability-gated, then add host-independent Windows
+record tests plus native Windows probes for protected root/owner/lock/asset
+DACLs, `LockFileEx`, exact identity validation, one active owner, orphan sweep,
+reparse/unknown-entry preservation, cancellation, shutdown, close retry, and
+WAV/transcript privacy.
+
+- [ ] **Step 2: Implement Windows create/validate/cleanup dispatch**
+
+Reuse the existing async retained-worker sets and locks. The synchronous
+Windows branch must create the recognized names, hold an exact nonblocking
+owner lock, flush the WAV, validate every retained handle and DACL, and delete
+only exact recognized entries. Do not use POSIX mode bits on Windows.
+
+- [ ] **Step 3: Mutation-check the live lock and identity guards**
+
+Removing the `LockFileEx` ownership check or accepting a replaced asset must
+fail its regression. Restore both guards before continuing.
+
+- [ ] **Step 4: Verify materialization GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_profile_reference_materialization.py -q
+python -m ruff check tldw_chatbook/TTS/profile_reference_materialization.py Tests/TTS/test_profile_reference_materialization.py
+python -m mypy tldw_chatbook/TTS/profile_reference_materialization.py
+```
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add tldw_chatbook/TTS/profile_reference_materialization.py Tests/TTS/test_profile_reference_materialization.py
+git commit -m "feat(tts): materialize clone references on Windows"
+```
+
+---
+
+### Task 5: Admit Windows binaries and select only evidenced backends
+
+**Files:**
+
+- Modify: `tldw_chatbook/TTS/audio_cpp_guided_launch.py`
+- Modify: `tldw_chatbook/TTS/audio_cpp_managed_config.py`
+- Modify: `tldw_chatbook/TTS/audio_cpp_recipes.py`
+- Modify: `tldw_chatbook/UI/Screens/settings_speech_tts.py`
+- Modify: `Tests/TTS/test_audio_cpp_guided_launch.py`
+- Modify: `Tests/TTS/test_audio_cpp_managed_config.py`
+- Modify: `Tests/TTS/test_audio_cpp_recipes.py`
+- Modify: `Tests/UI/test_settings_audio_cpp_experience_model.py`
+
+**Interfaces:** Keep manual selection and `detect_audio_cpp_server_binary()`.
+Detection adds Windows `PATHEXT` behavior for `audiocpp_server.exe`; it does
+not execute or recursively search. Normalize Windows process architectures to
+`x86` or `x86_64`. Add Expected CPU evidence for both exact Windows tuples;
+only provisioned evidence may become Verified.
+
+- [ ] **Step 1: Write RED binary/path tests**
+
+Cover PATH/PATHEXT discovery, manual `.exe`, drive/UNC/Unicode/long paths,
+relative and drive-relative rejection, directory/reparse/device-namespace
+rejection, non-PE files, x86/x64 PE machine evidence, and no execution or
+environment mutation during detection/Save.
+
+- [ ] **Step 2: Write RED backend tests**
+
+Cover Windows x86/x64 CPU Auto/explicit selection, unsupported ARM64, exact
+accelerated evidence, ambiguous device evidence, and no projection of x64
+evidence onto x86. Preserve macOS/Linux ordering.
+
+- [ ] **Step 3: Implement side-effect-free Windows admission**
+
+Use the native no-reparse handle for validation and a bounded PE header read
+for machine type. Add `windows` to the existing backend selector and retain
+the current recipe intersection semantics. Do not start the binary or probe a
+device during Save.
+
+- [ ] **Step 4: Verify admission/backend GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_guided_launch.py Tests/TTS/test_audio_cpp_managed_config.py Tests/TTS/test_audio_cpp_recipes.py Tests/UI/test_settings_audio_cpp_experience_model.py -q
+python -m ruff check tldw_chatbook/TTS/audio_cpp_guided_launch.py tldw_chatbook/TTS/audio_cpp_managed_config.py tldw_chatbook/TTS/audio_cpp_recipes.py tldw_chatbook/UI/Screens/settings_speech_tts.py
+python -m mypy tldw_chatbook/TTS/audio_cpp_guided_launch.py tldw_chatbook/TTS/audio_cpp_managed_config.py tldw_chatbook/TTS/audio_cpp_recipes.py
+```
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add tldw_chatbook/TTS/audio_cpp_guided_launch.py tldw_chatbook/TTS/audio_cpp_managed_config.py tldw_chatbook/TTS/audio_cpp_recipes.py tldw_chatbook/UI/Screens/settings_speech_tts.py Tests/TTS/test_audio_cpp_guided_launch.py Tests/TTS/test_audio_cpp_managed_config.py Tests/TTS/test_audio_cpp_recipes.py Tests/UI/test_settings_audio_cpp_experience_model.py
+git commit -m "feat(tts): admit evidenced Windows audio cpp runtimes"
+```
+
+---
+
+### Task 6: Settle the exact Windows process handle under the existing supervisor
+
+**Files:**
+
+- Modify: `tldw_chatbook/TTS/audio_cpp_supervisor.py`
+- Modify: `Tests/TTS/test_audio_cpp_supervisor.py`
+- Modify: `Tests/TTS/fixtures/fake_audiocpp_server.py`
+
+**Interfaces:** Extend private `_OwnedAudioCppProcess` with one idempotent
+`close_native_transport` callback. `AudioCppSupervisor` remains the sole
+owner. Extend `AudioCppProcessSnapshot` only with the bounded generated
+artifact privacy posture so Speech Lab can distinguish planned protection from
+an actually verified live artifact.
+
+- [ ] **Step 1: Write RED ownership/race tests**
+
+Cover cancellation and timeout while `create_subprocess_exec` is returning,
+start/stop, restart, crash, close-during-start, close-during-stop, repeated
+cancellation, inherited pipes, graceful timeout then force terminate, process
+wait failure, transport-close failure/retry, and one shared outer deadline.
+Assert no second waiter/reaper and no descendant/process-tree operation.
+
+- [ ] **Step 2: Retain spawn through ownership publication**
+
+Create one explicit launcher task and settle it through caller cancellation or
+timeout. If the process appears after the lifecycle epoch changed, immediately
+publish an internal generation owner, terminate/join it, close its pipes and
+transport, then re-raise the original cancellation. A returned process may
+never live only inside an abandoned future.
+
+- [ ] **Step 3: Close the exact transport last**
+
+After the exact child wait, output drains, hooks/client cleanup, generated
+artifact, clone materializations, and retained tasks settle, invoke the owned
+transport close exactly once. A failure keeps the generation and cleanup
+failure visible so `wait_closed()` cannot claim success and a later close may
+retry.
+
+- [ ] **Step 4: Add native Windows helper-process proof**
+
+On Windows 3.12, launch the existing short-lived fixture without a shell,
+inspect the exact native process handle in the test, terminate/wait when
+needed, close the owned transport, and prove the handle is invalid afterward.
+Prove an independently spawned descendant/sibling is never terminated or
+claimed.
+
+- [ ] **Step 5: Mutation-check spawn retention and close ordering**
+
+Removing spawn settlement must fail the cancellation race. Moving transport
+close before child wait/artifact cleanup must fail the ordering test. Restore
+both.
+
+- [ ] **Step 6: Verify supervisor GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_supervisor.py -q
+python -m ruff check tldw_chatbook/TTS/audio_cpp_supervisor.py Tests/TTS/test_audio_cpp_supervisor.py Tests/TTS/fixtures/fake_audiocpp_server.py
+python -m mypy tldw_chatbook/TTS/audio_cpp_supervisor.py
+```
+
+- [ ] **Step 7: Commit Task 6**
+
+```bash
+git add tldw_chatbook/TTS/audio_cpp_supervisor.py Tests/TTS/test_audio_cpp_supervisor.py Tests/TTS/fixtures/fake_audiocpp_server.py
+git commit -m "feat(tts): settle owned audio cpp processes on Windows"
+```
+
+---
+
+### Task 7: Enable truthful Windows Settings and Speech Lab parity
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py`
+- Modify: `tldw_chatbook/UI/Speech/speech_clone_setup.py`
+- Modify: `tldw_chatbook/UI/Speech/audio_cpp_runtime_card.py` only if the
+  existing projection lacks the required bounded posture row
+- Modify: `Tests/UI/test_settings_speech_tts_panel.py`
+- Modify: `Tests/UI/test_speech_playground_pane.py`
+- Modify: `Tests/UI/test_speech_playground_pane_lifecycle.py`
+- Modify: `Tests/TTS/test_stts_audio_cpp_generation.py`
+
+**Interfaces:** Replace `_AUDIO_CPP_MANAGED_UI_SUPPORTED = os.name != "nt"`
+with the shared capability predicate. Preserve all existing IDs, bindings,
+saved/applied/process projections, lifecycle actions, focus locators, and
+result ownership.
+
+- [ ] **Step 1: Write RED mounted Settings tests**
+
+On a supported Windows capability, Managed/Guided controls are available,
+PATH/manual selection works, Save remains side-effect free, invalid capability
+states explain why Managed is unavailable, and the privacy row says account
+protected / administrators and system retain access / plaintext / not
+encryption. Before launch it must say protection will be applied; only the
+verified live process snapshot may say it was applied. Test keyboard traversal
+and focus through scan/Save recompose.
+
+- [ ] **Step 2: Write RED mounted Speech Lab tests**
+
+Cover Start/Test/Restart/Shutdown, text WAV, clone WAV, last-valid-sample
+retention, profile Save, cancellation, crash, retry, app close, and focus at
+80x24. Assert saved/applied/process truth remains independent and every
+Windows failure uses bounded recovery copy.
+
+- [ ] **Step 3: Enable the existing surfaces**
+
+Use only the shared capability predicate and existing lifecycle events. Update
+clone privacy copy to distinguish POSIX mode posture from verified Windows
+DACL posture without promising exclusivity from administrators or encryption.
+Do not add controls, settings, bindings, or a Windows-only workflow.
+
+- [ ] **Step 4: Verify UI GREEN**
+
+```bash
+python -m pytest Tests/UI/test_settings_speech_tts_panel.py Tests/UI/test_speech_playground_pane.py Tests/UI/test_speech_playground_pane_lifecycle.py Tests/TTS/test_stts_audio_cpp_generation.py -q
+python -m ruff check tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py tldw_chatbook/UI/Speech/speech_clone_setup.py tldw_chatbook/UI/Speech/audio_cpp_runtime_card.py
+```
+
+- [ ] **Step 5: Commit Task 7**
+
+```bash
+git add tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py tldw_chatbook/UI/Speech/speech_clone_setup.py tldw_chatbook/UI/Speech/audio_cpp_runtime_card.py Tests/UI/test_settings_speech_tts_panel.py Tests/UI/test_speech_playground_pane.py Tests/UI/test_speech_playground_pane_lifecycle.py Tests/TTS/test_stts_audio_cpp_generation.py
+git commit -m "feat(ui): enable guided audio cpp on Windows"
+```
+
+---
+
+### Task 8: Add a hermetic Windows 3.12 CI gate
+
+**Files:**
+
+- Modify: `.github/workflows/test.yml`
+- Modify: `Tests/CI/test_github_actions_test_workflow.py`
+
+**Interfaces:** Add one PR-required `windows-latest` / Python 3.12 job matrix
+for `x86` and `x64`, running only the Windows capability, scanner, artifact,
+clone, supervisor, recipe, and focused mounted parity tests. Add its stable
+gate to `test-summary`.
+
+- [ ] **Step 1: Write RED workflow-shape assertions**
+
+Assert the job is on `windows-latest`, uses Python 3.12 with setup-python's
+`x86` and `x64` architectures, installs only project and test requirements,
+runs the exact owned test list with a timeout, does not download
+audio.cpp/models, and is required by the summary gate.
+
+- [ ] **Step 2: Add the focused Windows job**
+
+Use `shell: pwsh` where quoting differs. Keep fixtures local and use the Python
+helper process for subprocess tests. Do not place provisioned UAT secrets or
+paths in Actions.
+
+- [ ] **Step 3: Verify workflow GREEN**
+
+```bash
+python -m pytest Tests/CI/test_github_actions_test_workflow.py -q --confcutdir=Tests/CI
+python -m ruff check Tests/CI/test_github_actions_test_workflow.py
+```
+
+- [ ] **Step 4: Commit Task 8**
+
+```bash
+git add .github/workflows/test.yml Tests/CI/test_github_actions_test_workflow.py
+git commit -m "ci(tts): gate Windows audio cpp lifecycle"
+```
+
+---
+
+### Task 9: Provide the parameterized one-command Windows UAT
+
+**Files:**
+
+- Create: `scripts/uat_audio_cpp_windows.ps1`
+- Create: `scripts/uat_audio_cpp_windows.py`
+- Create: `Tests/TTS/test_audio_cpp_windows_uat_harness.py`
+- Create: `Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md`
+
+**Interfaces:** The PowerShell entry point accepts user-provisioned server,
+text package, clone package/reference, and exact expected identity parameters.
+It detects and records the exact x86/x64 tuple, creates disposable
+config/data/model/runtime roots, invokes the Python harness, and requires an
+explicit human audible confirmation. No parameter default identifies a
+particular machine.
+
+- [ ] **Step 1: Write RED harness tests**
+
+Cover required parameters, Windows/Python/architecture rejection, root
+isolation, environment restoration, no secret/path output, exact identity
+comparison, structural WAV validation, failed audible confirmation, cleanup
+failure, and stable JSON evidence. Use fixture binaries/packages only.
+
+- [ ] **Step 2: Implement the PowerShell wrapper**
+
+The wrapper remains compatible with Windows PowerShell 5.1 and PowerShell 7.
+It validates only parameter presence, creates one disposable root, sets
+process-local Chatbook environment variables, invokes the checked-in Python
+harness, asks the operator to confirm playback, and always runs cleanup. It
+emits a nonzero exit code for skipped, partial, failed, inaudible, or dirty
+teardown outcomes.
+
+- [ ] **Step 3: Implement the production-path Python journey**
+
+Exercise:
+
+1. explicit PATH/manual binary review without launch;
+2. one local package and one Model Library exact-root return;
+3. Guided Save with zero process creation;
+4. generated JSON, health, catalog, and exact model identities;
+5. one text WAV and one clone-reference WAV;
+6. restart, cancellation, forced crash, and recovery;
+7. exact runtime lease/removal blocking while live;
+8. final app shutdown; and
+9. no owned process/handle/task/client/endpoint/generated artifact/clone
+   materialization remaining.
+
+The Python harness returns sanitized structural evidence; the PowerShell layer
+records only `pass`, `fail`, `partial`, or `inaudible` plus bounded identities.
+
+- [ ] **Step 4: Verify the hermetic harness GREEN**
+
+```bash
+python -m pytest Tests/TTS/test_audio_cpp_windows_uat_harness.py -q
+python -m ruff check scripts/uat_audio_cpp_windows.py Tests/TTS/test_audio_cpp_windows_uat_harness.py
+python -m mypy scripts/uat_audio_cpp_windows.py
+```
+
+- [ ] **Step 5: Run the provisioned Windows UAT**
+
+From each claimed Windows architecture checkout, run the single parameterized
+command documented in the QA README. Do not copy machine-specific arguments
+into the repository. Require objective pass evidence plus the operator's
+explicit audible confirmation. If either x86 or x64 lacks a compatible server,
+or any journey step is unavailable, record that tuple as PARTIAL and keep
+TASK-13208 In Progress rather than projecting evidence across architectures.
+
+- [ ] **Step 6: Commit Task 9**
+
+```bash
+git add scripts/uat_audio_cpp_windows.ps1 scripts/uat_audio_cpp_windows.py Tests/TTS/test_audio_cpp_windows_uat_harness.py Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+git commit -m "test(tts): add provisioned Windows audio cpp UAT"
+```
+
+---
+
+### Task 10: Run the release matrix and close TASK-13208 truthfully
+
+**Files:**
+
+- Modify: `backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md`
+- Modify: `Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md`
+- Modify: `backlog/docs/lessons-live-verification.md` only if this task
+  reproduces a new generalizable incident not already documented
+
+- [ ] **Step 1: Run the focused cross-platform matrix**
+
+```bash
+python -m pytest \
+  Tests/TTS/test_windows_artifact_fs.py \
+  Tests/TTS/test_audio_cpp_package_scanner.py \
+  Tests/TTS/test_audio_cpp_guided_launch.py \
+  Tests/TTS/test_profile_reference_materialization.py \
+  Tests/TTS/test_audio_cpp_managed_config.py \
+  Tests/TTS/test_audio_cpp_recipes.py \
+  Tests/TTS/test_audio_cpp_supervisor.py \
+  Tests/TTS/test_audio_cpp_adapter.py \
+  Tests/TTS/test_stts_audio_cpp_generation.py \
+  Tests/UI/test_settings_speech_tts_panel.py \
+  Tests/UI/test_speech_playground_pane.py \
+  Tests/UI/test_speech_playground_pane_lifecycle.py \
+  Tests/CI/test_github_actions_test_workflow.py -q
+```
+
+- [ ] **Step 2: Run full static and formatting gates**
+
+```bash
+python -m ruff check <all changed Python files>
+python -m ruff format --check <all changed Python files>
+python -m mypy \
+  tldw_chatbook/TTS/windows_artifact_fs.py \
+  tldw_chatbook/TTS/audio_cpp_package_scanner.py \
+  tldw_chatbook/TTS/audio_cpp_guided_launch.py \
+  tldw_chatbook/TTS/profile_reference_materialization.py \
+  tldw_chatbook/TTS/audio_cpp_managed_config.py \
+  tldw_chatbook/TTS/audio_cpp_recipes.py \
+  tldw_chatbook/TTS/audio_cpp_supervisor.py
+git diff --check
+```
+
+- [ ] **Step 3: Verify hosted Windows and provisioned UAT evidence**
+
+Require both Windows 3.12 CI architectures to pass. Record the checked-out
+commit, each exact architecture tuple, objective UAT outcomes, clean-root
+proof, and human audible confirmation without storing private arguments or
+artifacts. Do not close the x86/x64 support claim with evidence from only one
+tuple.
+
+- [ ] **Step 4: Self-review ownership and privacy**
+
+Walk every native handle, lock, retained task, cleanup carrier, process
+transport, generated artifact, and materialization from acquisition through
+success, ordinary failure, control flow, cancellation, unmount, and app
+shutdown. Search the complete exception/log graph with private canaries.
+
+- [ ] **Step 5: Update Backlog truth**
+
+Only after every automated gate and the provisioned UAT pass:
+
+- check all seven acceptance criteria;
+- add concise Implementation Notes, including the ADR-029 amendment and any
+  plan deviations;
+- set TASK-13208 to Done; and
+- add a lesson only if a genuinely new recurring trap was reproduced.
+
+If UAT is partial, keep the task In Progress and document the exact bounded
+release gate instead of claiming support.
+
+- [ ] **Step 6: Commit closeout**
+
+```bash
+git add 'backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md' Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+git commit -m "docs(tts): close Windows audio cpp parity"
+```

--- a/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+++ b/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
@@ -1,0 +1,87 @@
+# Windows audio.cpp provisioned UAT
+
+Status: **NOT RUN — TASK-13208 remains In Progress**
+
+This handoff validates Windows 10+ on x86 or x64 with Python 3.12+. ARM is not
+claimed. The checked-in harness is generic and contains no workstation path,
+username, server build, model version, or device assumption.
+
+## What the harness consumes
+
+The operator provides:
+
+- an existing compatible audio.cpp server executable;
+- an existing local text package directory;
+- an existing clone-capable package directory;
+- a clone reference WAV and bounded transcript;
+- exact expected recipe/model identities; and
+- the exact curated managed-artifact identity for the clone package.
+
+The executable is reviewed and then launched **in place** by Chatbook's existing
+supervisor. It is not copied, imported, installed, downloaded, or bundled. The
+clone model package is copied into a disposable managed-model store through the
+normal `ModelArtifactService.install()` path so that the UAT exercises a real
+Model Library root and lease. Its source directory is unchanged. The local text
+package remains local and is scanned in place.
+
+## One-command run
+
+From the repository root in Windows PowerShell 5.1+ or PowerShell 7:
+
+```powershell
+./scripts/uat_audio_cpp_windows.ps1 `
+  -ServerBinary <server-executable> `
+  -TextPackageRoot <local-text-package-directory> `
+  -ClonePackageRoot <clone-package-directory> `
+  -CloneReferenceWav <reference-wav> `
+  -CloneReferenceText <reference-transcript> `
+  -TextRecipeId <text-recipe-id> `
+  -TextRecipeRevision <text-recipe-revision> `
+  -TextPackageVariant <text-package-variant> `
+  -TextModelId <text-model-id> `
+  -CloneRecipeId <clone-recipe-id> `
+  -CloneRecipeRevision <clone-recipe-revision> `
+  -ClonePackageVariant <clone-package-variant> `
+  -CloneModelId <clone-model-id> `
+  -CloneArtifactId <managed-artifact-id> `
+  -CloneArtifactRevision <managed-artifact-revision> `
+  -CloneArtifactVariant <managed-artifact-variant> `
+  -EvidenceOutput <sanitized-evidence-json>
+```
+
+Do not paste real parameter values into this file, an issue, a pull-request
+comment, or a chat transcript. The evidence JSON intentionally contains only
+the supported architecture, Python major/minor, fixed check names, structural
+WAV facts, the human audible result, cleanup state, and final status.
+
+## Objective journey
+
+The Python layer validates the host tuple and exact package identities, reviews
+the executable without launching it, installs the clone package into the
+disposable Model Library store, and constructs Guided settings without starting
+a process. Deliberate use then exercises generated configuration, health and
+catalog discovery, text WAV generation, operation-scoped clone-reference
+materialization and clone WAV generation, cancellation/restart recovery, forced
+owned-child crash recovery, live removal blocking, final shutdown, exact
+post-stop removal, and structural WAV validation.
+
+The PowerShell layer creates disposable home/config/data/runtime roots, restores
+the caller's process environment in `finally`, plays both generated WAVs with
+the Windows sound API, requires an explicit `yes`/`no` audible-and-intelligible
+answer, and removes the disposable root. Any unsupported, partial, failed,
+inaudible, or dirty-cleanup result exits nonzero.
+
+## Evidence required before closure
+
+Run the command independently on each architecture being claimed. Record only:
+
+- checked-out commit;
+- Windows major/minor and x86 or x64;
+- Python major/minor;
+- final fixed-schema evidence JSON; and
+- whether the hosted `windows-audio-cpp` CI job passed for that tuple.
+
+If either x86 or x64 lacks a compatible provisioned server/package combination,
+or any objective or audible step is unavailable, record that tuple as PARTIAL
+and leave TASK-13208 In Progress. Evidence from one architecture must not be
+projected onto the other.

--- a/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+++ b/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
@@ -2,6 +2,10 @@
 
 Status: **NOT RUN — TASK-13208 remains In Progress**
 
+Implementation checkpoint: branch `codex/task-13208-windows-audio-cpp`, UAT
+harness commit `5a3b2e22e`. Hosted Windows results and provisioned machine
+evidence are pending; this document does not claim either architecture yet.
+
 This handoff validates Windows 10+ on x86 or x64 with Python 3.12+. ARM is not
 claimed. The checked-in harness is generic and contains no workstation path,
 username, server build, model version, or device assumption.
@@ -85,3 +89,16 @@ If either x86 or x64 lacks a compatible provisioned server/package combination,
 or any objective or audible step is unavailable, record that tuple as PARTIAL
 and leave TASK-13208 In Progress. Evidence from one architecture must not be
 projected onto the other.
+
+## Host-side pre-handoff evidence
+
+- Focused lifecycle/UI/CI/harness matrix: 1,037 passed, two native-Windows
+  probes skipped on the non-Windows host.
+- Four real-child supervisor cases initially denied by the restricted loopback
+  sandbox: all four passed with loopback access.
+- Two unrelated mounted UI baseline tests remain failing and were previously
+  reproduced at the parent commit; neither failure intersects the Windows diff.
+- Changed Python files pass Ruff and Ruff format; the eight scoped production
+  modules pass mypy; CI shape, harness tests, and `git diff --check` pass.
+- No new reusable incident was found beyond the repository's existing testing
+  and live-verification lessons, so no lessons file was changed.

--- a/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+++ b/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
@@ -92,10 +92,12 @@ projected onto the other.
 
 ## Host-side pre-handoff evidence
 
-- Focused lifecycle/UI/CI/harness matrix: 1,037 passed, two native-Windows
+- Rebased lifecycle/UI/CI/harness matrix: 1,036 passed, two native-Windows
   probes skipped on the non-Windows host.
 - Four real-child supervisor cases initially denied by the restricted loopback
   sandbox: all four passed with loopback access.
+- One suite-load mount-readiness observation failed in the matrix and passed
+  immediately in isolation.
 - Two unrelated mounted UI baseline tests remain failing and were previously
   reproduced at the parent commit; neither failure intersects the Windows diff.
 - Changed Python files pass Ruff and Ruff format; the eight scoped production

--- a/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
+++ b/Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
@@ -3,7 +3,7 @@
 Status: **NOT RUN — TASK-13208 remains In Progress**
 
 Implementation checkpoint: branch `codex/task-13208-windows-audio-cpp`, UAT
-harness commit `5a3b2e22e`. Hosted Windows results and provisioned machine
+harness commit `9a32b1278`. Hosted Windows results and provisioned machine
 evidence are pending; this document does not claim either architecture yet.
 
 This handoff validates Windows 10+ on x86 or x64 with Python 3.12+. ARM is not

--- a/Docs/superpowers/specs/2026-08-14-audio-cpp-windows-lifecycle-parity-design.md
+++ b/Docs/superpowers/specs/2026-08-14-audio-cpp-windows-lifecycle-parity-design.md
@@ -1,0 +1,343 @@
+# audio.cpp Windows Lifecycle and Clone Parity — Design
+
+Status: Approved
+
+Date: 2026-08-14
+
+Task: [TASK-13208](../../../backlog/tasks/task-13208%20-%20Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md)
+
+Governing decisions:
+
+- [ADR-023: TTS adapter registry and audio.cpp runtime](../../../backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
+- [ADR-029: Local private data boundary](../../../backlog/decisions/029-local-private-data-boundary.md)
+- [ADR-050: Generated audio.cpp setup ownership](../../../backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md)
+- [ADR-051: Private TTS clone-reference assets](../../../backlog/decisions/051-private-tts-clone-reference-assets.md)
+
+Parent design:
+
+- [audio.cpp Guided Model Setup and Clone Profiles](2026-08-09-audio-cpp-guided-model-setup-design.md)
+
+## Purpose
+
+Complete Windows parity for the existing Guided audio.cpp lifecycle and clone
+reference flow without adding a second process manager, scanner, profile owner,
+or configuration source.
+
+The supported product baseline is Windows 10 or later on x86 or x64 with
+Python 3.12 or later. ARM64 is outside this task. Platform code must remain
+pointer-width neutral so ARM64 can be qualified later without a lifecycle
+rewrite, but no ARM64 support or compatibility label is implied here.
+
+## Scope
+
+This task covers:
+
+- Guided binary detection and manual path admission;
+- Windows drive, UNC, Unicode, and long-path handling;
+- no-follow package scanning with junction/reparse rejection;
+- owner-private generated launch artifacts and clone materializations;
+- exact native child-process ownership, shutdown, and handle closure;
+- Windows-aware CPU and evidenced accelerated backend selection;
+- Settings and Speech Lab truth, recovery, privacy, and focus parity;
+- hermetic Windows tests; and
+- a provisioned Windows CPU real-process and audible UAT handoff.
+
+It does not distribute or install `audiocpp_server`, claim ownership of process
+descendants, support daemonizing builds, add a general process-tree manager,
+or convert every existing Chatbook private path to native Windows ACLs.
+
+## Decision summary
+
+Chatbook will preserve the existing cross-platform lifecycle and add the
+smallest native Windows capabilities it lacks:
+
+1. a focused stdlib Windows filesystem capability for no-reparse handles,
+   stable identity, protected DACLs, ownership locks, and exact cleanup;
+2. an explicit close operation for the exact native subprocess transport
+   created by the existing supervisor;
+3. Windows-backed scanner file opens and directory pins rather than the current
+   fail-closed `O_NOFOLLOW` absence;
+4. Windows CPU/backend evidence in the existing recipe selection model; and
+5. a parameterized PowerShell UAT runner that consumes user-provisioned inputs.
+
+No new runtime dependency is added. Native calls use the Python standard
+library's `ctypes`, `msvcrt`, and existing `asyncio` Proactor subprocess support.
+
+## Architecture
+
+### One lifecycle owner
+
+`AudioCppSupervisor` remains the sole process owner. Guided launch continues to
+produce one `AudioCppManagedLaunchConfig` and one generated-artifact owner.
+Clone references continue to enter through the existing profile admission and
+materializer boundaries.
+
+Windows capabilities are injected below those owners. UI code does not call
+Win32 APIs, inspect handles, infer ACLs, or maintain cleanup registries.
+
+### Native Windows filesystem capability
+
+One internal capability provides:
+
+- conversion of an admitted absolute drive or UNC path to a wide Win32 path;
+- native opens with `FILE_FLAG_OPEN_REPARSE_POINT` and directory backup
+  semantics;
+- non-inheritable handles and explicit handle closure;
+- stable volume/file identity from the opened object;
+- reparse-attribute inspection before admission;
+- exclusive nonblocking ownership locks with `LockFileEx`;
+- protected DACL installation and verification; and
+- deletion disposition applied to the exact retained handle.
+
+Long-path support is explicit. Internally generated Win32 paths use the wide
+extended namespace only after ordinary absolute path validation. User-provided
+device namespaces and drive-relative paths such as `C:relative` are rejected.
+Unicode components are preserved. Public failures never echo the full path.
+
+The capability is native only on Windows. Injectable host-independent doubles
+cover failure and race matrices on other platforms; real Windows tests cover
+the actual calls.
+
+### ACL posture
+
+Generated launch directories/files and clone materialization
+directories/files receive a protected DACL with inheritance removed. Allowed
+trustees are limited to:
+
+- the current process token's user SID;
+- LocalSystem; and
+- Builtin Administrators.
+
+The owning user receives the access needed by the exact artifact lifecycle;
+system and administrators retain administrative access. Directory ACEs inherit
+only to owned children. Every installation is re-read and verified. A null or
+invalid DACL, an unexpected allow trustee, an unrecognized reparse point, or a
+native error fails the operation closed.
+
+The user-facing statement is truthful: the artifact is protected for the
+Windows account, local system/administrators retain access, the content is
+plaintext, and filesystem ACLs are not encryption or forensic erasure.
+
+This posture applies only to TASK-13208's generated audio.cpp launch artifacts
+and clone materializations. Other ADR-029 Windows paths remain unverified until
+separately implemented.
+
+### Exact cleanup
+
+Cleanup owns retained native handles and recognized random names. It deletes
+only the exact opened object through handle-directed deletion after verifying:
+
+- object type and stable identity;
+- expected protected ACL posture;
+- exact recognized owner/asset names;
+- no unexpected directory entries; and
+- no live ownership lock.
+
+Unknown directories, additional entries, reparse points, substituted names,
+identity changes, and ambiguous cleanup failures are preserved and reported as
+bounded cleanup failures. Age is never ownership evidence.
+
+### Package scanner
+
+The scanner keeps its existing bounded queue, recipe matching, cancellation,
+and partial-result vocabulary. On Windows it pins each directory with a native
+no-reparse handle that denies rename/delete while enumerating, and opens each
+allowlisted metadata file through the native capability before reading.
+
+The scanner rejects nested symlinks, junctions, mount-point reparses, other
+reparse points, special files, and identity changes. A disclosed top-level link
+may still resolve through the existing review flow, but its canonical target is
+reopened and pinned before becoming accepted identity.
+
+Drive roots, UNC roots, Unicode paths, paths beyond `MAX_PATH`, case-insensitive
+collisions, and reparse substitution receive real Windows coverage. The
+scanner never recursively searches a drive or user profile.
+
+### Binary admission
+
+Detection remains explicit and side-effect free:
+
+- retain the configured candidate;
+- use `shutil.which` with Windows `PATHEXT` behavior for
+  `audiocpp_server.exe`;
+- inspect only separately reviewed conventional candidates if the upstream
+  distribution documents them; and
+- keep manual file selection available.
+
+No recursive disk search, execution, version probe, PATH rewrite, or silent
+ambiguous selection occurs during detection or Save. Admission rejects
+relative, drive-relative, directory, reparse, and non-executable selections.
+
+### Process creation and ownership
+
+The supervisor keeps direct `asyncio.create_subprocess_exec` creation with the
+exact argument vector and `shell=False`. Windows uses the default Proactor
+subprocess implementation. No process group, shell, job object, process-tree
+kill, listener adoption, or descendant claim is introduced.
+
+The owned-process record gains one explicit native-transport close operation.
+The launch task is retained across cancellation so a process created while
+Start/Restart/App Close is racing cannot escape before ownership publication.
+After the exact child exits, the supervisor joins its one waiter, output drains,
+monitor, probes, clients, hooks, generated artifact, and clone materializations,
+then closes the exact process transport/handle once.
+
+Graceful termination and force termination apply only to that exact process.
+The same outer shutdown deadline governs startup, stop, and application close.
+A foreground budget expiry may report retained cleanup, but `wait_closed()`
+cannot claim completion while a process handle or generation resource remains.
+
+Native Windows tests inspect the handle before and after settlement and prove
+it becomes invalid only after exact exit/join. Builds that daemonize or break
+away from the owned process are unsupported and receive no clean-shutdown
+claim.
+
+### Backend evidence
+
+Backend selection accepts Windows plus normalized x86/x64 architecture names.
+CPU is the baseline candidate. Accelerated backends are selectable only when
+the exact recipe, host architecture, and binary evidence admit them.
+
+Static declarations begin as `Expected` or `Untested`. Only a provisioned real
+tuple may become `Verified`. Auto fallback remains limited to the existing
+allowlisted backend-unavailable failures and cannot start until the exact prior
+child and resources are fully cleaned.
+
+x86 lifecycle code is supported, but a recipe/backend tuple remains
+unverified until a compatible 32-bit server and package complete the same real
+gate. No x64 result is projected onto x86.
+
+### Settings and Speech Lab
+
+The existing saved/applied/process and package-evidence states remain
+authoritative. Windows adds no second preferences or runtime copy.
+
+The UI must:
+
+- display actual ACL posture rather than POSIX modes;
+- preserve keyboard/focus and immutable-action behavior;
+- retain last valid playable WAV on later failure;
+- keep sample, clone, profile-save, restart, and shutdown recovery unchanged;
+- expose stable phase-specific Windows failures without raw native messages;
+  and
+- avoid claiming Running, Verified, private, or cleaned before the matching
+  evidence settles.
+
+## Error and privacy contract
+
+Win32 error numbers, exception messages, SIDs, full executable/model/runtime
+paths, environment values, transcript, reference bytes, prompt text, and raw
+child output do not enter public errors, persistent logs, or exception graphs.
+
+Stable phases extend existing codes rather than introducing path-bearing
+Windows variants: binary unavailable, package changed, ACL unavailable,
+generated artifact unavailable, startup failed, cleanup failed, and clone
+materialization unavailable.
+
+Control-flow exceptions preserve their family after retained cleanup. Ordinary
+cleanup failure remains owned and retryable through the existing app lifecycle.
+
+## Verification
+
+### Hermetic tests
+
+The Windows CI matrix covers:
+
+- Win32 capability constants, pointer-width behavior, cleanup, and sanitization;
+- protected-DACL success, unexpected trustees, invalid/null DACL, and failures;
+- drive, UNC, Unicode, long-path, case, reserved-name, and device-namespace
+  validation;
+- top-level link review and nested junction/reparse rejection;
+- substitution during enumeration/open and exact handle identity;
+- generated JSON and clone materialization create/validate/cleanup matrices;
+- exact process wait/terminate/force/handle-close ordering;
+- start/restart/crash/cancel/app-close races under one deadline;
+- CPU/accelerated selection and allowlisted fallback; and
+- mounted Settings/Speech Lab truth, privacy, focus, and recovery.
+
+Normal CI uses local fixtures and a real short-lived helper process. It does not
+download audio.cpp or model packages.
+
+### Provisioned Windows UAT
+
+The repository provides one parameterized PowerShell entry point. The operator
+supplies the compatible server binary, local and/or Model Library package
+roots, clone reference inputs, and exact expected identities. The runner:
+
+1. creates disposable config, data, profile, model, and runtime roots;
+2. verifies Guided Save performs no launch;
+3. verifies generated JSON acceptance, health, catalog, and exact model IDs;
+4. synthesizes and structurally validates one text WAV;
+5. synthesizes and structurally validates one clone-reference WAV;
+6. exercises local and Model Library package paths;
+7. performs restart, cancellation, crash, and final app shutdown checks;
+8. proves no owned child, handle, task, client, endpoint, generated artifact,
+   or clone materialization remains; and
+9. requires a human audible-playback confirmation.
+
+The script emits only sanitized evidence. It does not bake in a specific
+machine version, username, path, or device. TASK-13208 remains In Progress
+until this provisioned gate passes.
+
+## Alternatives rejected
+
+### Add `pywin32`
+
+Rejected because the required primitives are narrow, stdlib `ctypes` is
+already used for no-reparse Windows reads in this repository, and a new
+platform dependency would widen packaging and installation risk.
+
+### Introduce Windows Job Objects
+
+Rejected because TASK-13208 explicitly owns only the exact created process and
+must not claim arbitrary descendants. A job object would establish a different
+process-tree ownership contract.
+
+### Rewrite POSIX and Windows behind a new general lifecycle framework
+
+Rejected because the existing POSIX lifecycle is heavily verified. The task
+needs a Windows capability seam, not a replacement supervisor, scanner, or
+private-storage architecture.
+
+### Keep Windows privacy `Unverified`
+
+Rejected because clone references and generated configuration are plaintext
+private artifacts and the task explicitly requires an implemented truthful ACL
+posture before enabling them.
+
+## Rollout and rollback
+
+- External and user-provided JSON sources remain unchanged.
+- POSIX behavior remains on its current implementation.
+- If native Windows capability initialization or verification fails, Guided
+  launch and clone materialization fail closed with bounded recovery.
+- Disabling Windows Guided/clone admission leaves saved configurations and
+  profile references visible; it does not delete them or silently retarget.
+- Rollback never deletes user-selected models, unknown runtime directories, or
+  unrecognized reparse objects.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/029-local-private-data-boundary.md` amendment
+
+Reason: TASK-13208 changes the Windows security posture for two classes of
+private plaintext artifacts. ADR-023, ADR-050, and ADR-051 already fix the
+process, generated-configuration, and clone owners; the narrow ADR-029
+amendment defines the newly verified Windows ACL boundary without implying
+that every other Windows private path is now protected.
+
+## ARM64 follow-up
+
+The native handle, ACL, path, scanner, and supervisor design is architecture
+neutral and uses pointer-sized Win32 types. A later ARM64 task should therefore
+need little lifecycle code. Its main work is:
+
+- admitting `windows/arm64` architecture normalization;
+- proving compatible audio.cpp binary and backend availability;
+- adding exact recipe/backend evidence; and
+- running the full provisioned ARM64 real-process and audible gate.
+
+Until that evidence exists, ARM64 remains unsupported rather than inheriting
+x64 or x86 labels.

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -9,6 +9,23 @@ ARTIFACT_LEASE_TEST_TARGETS = (
     "Tests/Model_Artifacts/test_operation_leases.py",
     "Tests/Model_Artifacts/test_operation_leases_process.py",
 )
+WINDOWS_AUDIO_CPP_TEST_TARGETS = (
+    "Tests/TTS/test_windows_artifact_fs.py",
+    "Tests/TTS/test_audio_cpp_package_scanner.py",
+    "Tests/TTS/test_audio_cpp_guided_launch.py",
+    "Tests/TTS/test_profile_reference_materialization_windows.py",
+    "Tests/TTS/test_audio_cpp_supervisor.py",
+    "Tests/TTS/test_audio_cpp_recipes.py",
+    "Tests/TTS/test_audio_cpp_managed_config.py",
+    "Tests/UI/test_settings_speech_tts_panel.py::test_windows_managed_ui_gate_uses_shared_platform_capability",
+    "Tests/UI/test_settings_speech_tts_panel.py::test_supported_windows_offers_managed_mode_with_bounded_privacy_copy",
+    "Tests/UI/test_speech_playground_pane_lifecycle.py::test_ready_clone_model_mounts_and_canonicalizes_path_free_setup",
+    "Tests/UI/test_speech_playground_pane_lifecycle.py::test_audio_cpp_runtime_projection_reports_exact_artifact_privacy_posture",
+    "Tests/UI/test_speech_playground_pane_lifecycle.py::test_server_shutdown_is_distinct_from_playback_stop_and_does_not_restart",
+    "Tests/TTS/test_stts_audio_cpp_generation.py::test_audio_cpp_native_generation_consumes_and_closes_one_wav_response",
+    "Tests/TTS/test_stts_audio_cpp_generation.py::test_audio_cpp_native_generation_propagates_cancellation_and_closes",
+    "Tests/TTS/test_stts_audio_cpp_generation.py::test_native_local_failures_use_fixed_recovery_copy",
+)
 
 
 def _workflow_text() -> str:
@@ -62,6 +79,13 @@ def _artifact_lease_shape_job_block() -> str:
     return workflow[start:end]
 
 
+def _windows_audio_cpp_job_block() -> str:
+    workflow = _workflow_text()
+    start = workflow.index("  windows-audio-cpp:")
+    end = workflow.index("  ui-tests:", start)
+    return workflow[start:end]
+
+
 def _artifact_lease_gate_job_block() -> str:
     workflow = _workflow_text()
     start = workflow.index("  artifact-lease-gate:")
@@ -84,7 +108,7 @@ def _pytest_invocations(block: str) -> list[list[str]]:
         if command != "pytest" and not command.startswith("pytest "):
             continue
 
-        while command.endswith("\\"):
+        while command.endswith(("\\", "`")):
             command = f"{command[:-1].rstrip()} {next(lines).strip()}"
         pytest_invocations.append(shlex.split(command))
 
@@ -160,8 +184,8 @@ def test_ci_exercises_mcp_against_minimum_textual() -> None:
     assert "Tests/UI/test_mcp_workbench.py" in textual_minimum
     assert "Tests/UI/test_mcp_tools_mode.py" in textual_minimum
     assert (
-        "needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate]"
-        in test_summary
+        "needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate, "
+        "windows-audio-cpp]" in test_summary
     )
 
 
@@ -235,6 +259,33 @@ def test_artifact_lease_gate_exposes_stable_required_context() -> None:
     )
     assert "exit 1" in gate
     assert "artifact-lease-gate" in test_summary
+
+
+def test_windows_audio_cpp_lifecycle_is_a_required_hermetic_x86_x64_gate() -> None:
+    block = _windows_audio_cpp_job_block()
+    summary = _test_summary_job_block()
+
+    assert "runs-on: windows-latest" in block
+    assert 'python-version: "3.12"' in block
+    assert "architecture: [x86, x64]" in block
+    assert "architecture: ${{ matrix.architecture }}" in block
+    assert "timeout-minutes:" in block
+    assert "shell: pwsh" in block
+    assert "pip install -e ." in block
+    assert "pip install pytest pytest-asyncio pytest-timeout" in block
+    assert "requirements-test.txt" not in block
+    assert "requirements.txt" not in block
+    assert "curl" not in block.casefold()
+    assert "invoke-webrequest" not in block.casefold()
+    assert "download" not in block.casefold()
+    invocations = _pytest_invocations(block)
+    assert len(invocations) == 1
+    assert (
+        tuple(token for token in invocations[0][1:] if token.startswith("Tests/"))
+        == WINDOWS_AUDIO_CPP_TEST_TARGETS
+    )
+    assert "--timeout=180" in invocations[0]
+    assert "windows-audio-cpp" in summary
 
 
 def test_pr_gate_shards_cover_the_whole_tree_in_parallel() -> None:

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -17,6 +17,7 @@ WINDOWS_AUDIO_CPP_TEST_TARGETS = (
     "Tests/TTS/test_audio_cpp_supervisor.py",
     "Tests/TTS/test_audio_cpp_recipes.py",
     "Tests/TTS/test_audio_cpp_managed_config.py",
+    "Tests/TTS/test_audio_cpp_windows_uat_harness.py",
     "Tests/UI/test_settings_speech_tts_panel.py::test_windows_managed_ui_gate_uses_shared_platform_capability",
     "Tests/UI/test_settings_speech_tts_panel.py::test_supported_windows_offers_managed_mode_with_bounded_privacy_copy",
     "Tests/UI/test_speech_playground_pane_lifecycle.py::test_ready_clone_model_mounts_and_canonicalizes_path_free_setup",
@@ -271,6 +272,7 @@ def test_windows_audio_cpp_lifecycle_is_a_required_hermetic_x86_x64_gate() -> No
     assert "architecture: ${{ matrix.architecture }}" in block
     assert "timeout-minutes:" in block
     assert "shell: pwsh" in block
+    assert "[System.Management.Automation.Language.Parser]::ParseFile" in block
     assert "pip install -e ." in block
     assert "pip install pytest pytest-asyncio pytest-timeout" in block
     assert "requirements-test.txt" not in block

--- a/Tests/TTS/test_audio_cpp_guided_launch.py
+++ b/Tests/TTS/test_audio_cpp_guided_launch.py
@@ -1169,3 +1169,183 @@ async def test_validation_rejects_size_change_without_reading_enlarged_file(
 
     assert caught.value.code == "artifact_changed"
     artifact.cleanup()
+
+
+class _FakeWindowsArtifactHandle:
+    def __init__(self, path: Path, *, kind: str) -> None:
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsFileIdentity
+
+        self.path = path
+        self.kind = kind
+        info = path.stat()
+        self.identity = WindowsFileIdentity(
+            volume_serial_number=info.st_dev,
+            file_id=info.st_ino.to_bytes(16, "little", signed=False),
+            kind=kind,  # type: ignore[arg-type]
+            reparse_tag=0,
+        )
+        self._data = path.read_bytes() if kind == "file" else b""
+        self.closed = False
+        self.deleted = False
+        self.close_failures = 0
+
+    @property
+    def privacy_posture(self) -> str:
+        return "windows_account_protected"
+
+    def verify_private_acl(self) -> bool:
+        return True
+
+    def read(self, count: int, *, offset: int = 0) -> bytes:
+        return self._data[offset : offset + count]
+
+    def delete_exact(self) -> None:
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsArtifactError
+
+        if not self.path.exists():
+            self.deleted = True
+            return
+        info = self.path.stat()
+        current = info.st_ino.to_bytes(16, "little", signed=False)
+        if current != self.identity.file_id:
+            raise WindowsArtifactError("changed")
+        self.deleted = True
+
+    def close(self) -> None:
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsArtifactError
+
+        if self.closed:
+            return
+        if self.close_failures:
+            self.close_failures -= 1
+            raise WindowsArtifactError("cleanup_failed", cleanup_owner=self)  # type: ignore[arg-type]
+        if self.deleted and self.path.exists():
+            if self.kind == "directory":
+                self.path.rmdir()
+            else:
+                self.path.unlink()
+        self.closed = True
+
+
+class _FakeWindowsArtifactFilesystem:
+    def __init__(self) -> None:
+        self.handles: list[_FakeWindowsArtifactHandle] = []
+        self.fail_file_creation = False
+        self.directory_close_failures = 0
+
+    def _handle(self, path: Path, kind: str) -> _FakeWindowsArtifactHandle:
+        handle = _FakeWindowsArtifactHandle(path, kind=kind)
+        self.handles.append(handle)
+        return handle
+
+    def protect_private_directory(self, path: Path) -> _FakeWindowsArtifactHandle:
+        return self._handle(Path(path), "directory")
+
+    def create_private_directory(self, path: Path) -> _FakeWindowsArtifactHandle:
+        selected = Path(path)
+        selected.mkdir()
+        handle = self._handle(selected, "directory")
+        handle.close_failures = self.directory_close_failures
+        return handle
+
+    def create_private_file(
+        self,
+        path: Path,
+        data: bytes,
+        *,
+        read_only: bool = False,
+    ) -> _FakeWindowsArtifactHandle:
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsArtifactError
+
+        assert read_only
+        if self.fail_file_creation:
+            raise WindowsArtifactError("unavailable")
+        selected = Path(path)
+        selected.write_bytes(data)
+        return self._handle(selected, "file")
+
+    def open_file_no_reparse(
+        self, path: Path, *, writable: bool = False
+    ) -> _FakeWindowsArtifactHandle:
+        assert not writable
+        return self._handle(Path(path), "file")
+
+
+def test_windows_generated_artifact_is_verified_and_cleanup_is_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    filesystem = _FakeWindowsArtifactFilesystem()
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+
+    artifact = launch_module._create_artifact(
+        runtime,
+        {"host": "127.0.0.1", "models": []},
+    )
+
+    assert artifact is not None
+    assert artifact.privacy_posture == "windows_account_protected"
+    assert json.loads(artifact.server_json_path.read_text()) == {
+        "host": "127.0.0.1",
+        "models": [],
+    }
+    artifact.validate()
+    generated = artifact.server_json_path.parent
+    artifact.cleanup()
+    artifact.cleanup()
+    assert not generated.exists()
+    assert runtime.exists()
+
+
+def test_windows_generated_artifact_rejects_path_substitution_and_foreign_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    filesystem = _FakeWindowsArtifactFilesystem()
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+    artifact = launch_module._create_artifact(runtime, {"models": []})
+    assert artifact is not None
+    artifact.server_json_path.unlink()
+    artifact.server_json_path.write_text("foreign", encoding="utf-8")
+    (artifact.server_json_path.parent / "unexpected.txt").write_text("foreign")
+
+    with pytest.raises(launch_module.AudioCppGuidedLaunchError) as validation:
+        artifact.validate()
+    with pytest.raises(launch_module.AudioCppGuidedLaunchError) as cleanup:
+        artifact.cleanup()
+
+    assert validation.value.code == "artifact_changed"
+    assert cleanup.value.code == "artifact_cleanup_failed"
+    assert artifact.server_json_path.read_text() == "foreign"
+
+
+def test_windows_partial_creation_cleanup_failure_returns_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    filesystem = _FakeWindowsArtifactFilesystem()
+    filesystem.fail_file_creation = True
+    filesystem.directory_close_failures = 1
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+
+    with pytest.raises(launch_module.AudioCppGuidedLaunchError) as raised:
+        launch_module._create_artifact(runtime, {"models": []})
+
+    assert raised.value.code == "artifact_cleanup_failed"
+    cleanup = raised.value.take_cleanup_owner()
+    assert cleanup is not None
+    assert raised.value.take_cleanup_owner() is None
+    cleanup.cleanup()
+    assert tuple(runtime.iterdir()) == ()

--- a/Tests/TTS/test_audio_cpp_guided_launch.py
+++ b/Tests/TTS/test_audio_cpp_guided_launch.py
@@ -1271,6 +1271,147 @@ class _FakeWindowsArtifactFilesystem:
         return self._handle(Path(path), "file")
 
 
+def _write_pe(path: Path, machine: int) -> None:
+    raw = bytearray(512)
+    raw[:2] = b"MZ"
+    raw[0x3C:0x40] = (0x80).to_bytes(4, "little")
+    raw[0x80:0x84] = b"PE\0\0"
+    raw[0x84:0x86] = machine.to_bytes(2, "little")
+    path.write_bytes(raw)
+
+
+@pytest.mark.parametrize(
+    ("architecture", "machine"),
+    (("x86", 0x014C), ("AMD64", 0x8664)),
+)
+def test_windows_binary_validation_requires_matching_bounded_pe_machine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    architecture: str,
+    machine: int,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    binary = tmp_path / "audiocpp_server.exe"
+    _write_pe(binary, machine)
+    filesystem = _FakeWindowsArtifactFilesystem()
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+
+    assert (
+        launch_module._validate_binary(
+            str(binary), system="windows", architecture=architecture
+        )
+        == binary
+    )
+    assert filesystem.handles[-1].closed
+
+
+def test_windows_binary_validation_rejects_wrong_machine_and_non_pe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    binary = tmp_path / "audiocpp_server.exe"
+    _write_pe(binary, 0x014C)
+    filesystem = _FakeWindowsArtifactFilesystem()
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+
+    assert (
+        launch_module._validate_binary(
+            str(binary), system="windows", architecture="AMD64"
+        )
+        is None
+    )
+    binary.write_bytes(b"not-a-pe")
+    assert (
+        launch_module._validate_binary(
+            str(binary), system="windows", architecture="x86"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("architecture", ("x86", "AMD64"))
+def test_windows_auto_and_explicit_cpu_backend_are_evidenced(
+    architecture: str,
+) -> None:
+    from tldw_chatbook.TTS.audio_cpp_guided_config import AudioCppBackendPreference
+    from tldw_chatbook.TTS.audio_cpp_guided_launch import (
+        select_audio_cpp_guided_backend,
+    )
+    from tldw_chatbook.TTS.audio_cpp_recipes import AUDIO_CPP_RECIPE_REGISTRY
+
+    recipe = AUDIO_CPP_RECIPE_REGISTRY.for_package("supertonic_3_orig")
+
+    assert (
+        select_audio_cpp_guided_backend(
+            AudioCppBackendPreference.AUTO,
+            (recipe,),
+            system="windows",
+            architecture=architecture,
+        )
+        is AudioCppBackendPreference.CPU
+    )
+    assert (
+        select_audio_cpp_guided_backend(
+            AudioCppBackendPreference.CPU,
+            (recipe,),
+            system="windows",
+            architecture=architecture,
+        )
+        is AudioCppBackendPreference.CPU
+    )
+
+
+def test_windows_arm64_backend_remains_unsupported() -> None:
+    from tldw_chatbook.TTS.audio_cpp_guided_config import AudioCppBackendPreference
+    from tldw_chatbook.TTS.audio_cpp_guided_launch import (
+        select_audio_cpp_guided_backend,
+    )
+    from tldw_chatbook.TTS.audio_cpp_recipes import AUDIO_CPP_RECIPE_REGISTRY
+
+    recipe = AUDIO_CPP_RECIPE_REGISTRY.for_package("supertonic_3_orig")
+
+    assert (
+        select_audio_cpp_guided_backend(
+            AudioCppBackendPreference.AUTO,
+            (recipe,),
+            system="windows",
+            architecture="ARM64",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_windows_guided_materialization_accepts_exact_pe_and_cpu_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as launch_module
+
+    binary = tmp_path / "audiocpp_server.exe"
+    _write_pe(binary, 0x8664)
+    package_root = tmp_path / "package"
+    _write_gguf(package_root, "supertonic-3-orig.gguf")
+    accepted = _accept(package_root, "supertonic_3_orig", "narrator")
+    filesystem = _FakeWindowsArtifactFilesystem()
+    monkeypatch.setattr(launch_module, "_windows_artifact_filesystem", filesystem)
+
+    launch = await launch_module.materialize_audio_cpp_guided_launch(
+        _settings(binary, [accepted]),
+        artifact_root=tmp_path / "generated",
+        port_selector=lambda: 50_131,
+        system="windows",
+        architecture="AMD64",
+    )
+
+    assert json.loads(launch.server_json_path.read_text())["backend"] == "cpu"
+    assert launch.generated_artifact is not None
+    launch.generated_artifact.cleanup()
+
+
 def test_windows_generated_artifact_is_verified_and_cleanup_is_exact(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/TTS/test_audio_cpp_managed_config.py
+++ b/Tests/TTS/test_audio_cpp_managed_config.py
@@ -299,6 +299,29 @@ def test_managed_binary_preserves_an_approved_symlink_path(tmp_path: Path) -> No
     assert launch.binary_path != binary_target
 
 
+def test_windows_managed_binary_uses_the_shared_pe_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_chatbook.TTS import audio_cpp_guided_launch as guided_launch
+
+    binary = tmp_path / "audiocpp_server.exe"
+    binary.write_bytes(b"bounded-pe-fixture")
+    server_json = _write_server_json(tmp_path / "server.json")
+    calls: list[str] = []
+    monkeypatch.setattr(managed_config_module.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        guided_launch,
+        "_validate_binary",
+        lambda value: calls.append(value) or binary,
+    )
+
+    launch = _validate_launch(_launch_config(binary, server_json))
+
+    assert launch.binary_path == binary
+    assert calls == [str(binary)]
+
+
 def test_server_json_requires_readable_regular_utf8_object(tmp_path: Path) -> None:
     binary = _write_executable(tmp_path / "audiocpp_server")
     server_json = tmp_path / "server.json"

--- a/Tests/TTS/test_audio_cpp_package_scanner.py
+++ b/Tests/TTS/test_audio_cpp_package_scanner.py
@@ -1610,3 +1610,255 @@ def test_guided_foundation_has_no_process_network_or_model_write_side_effects(
 
     assert recipe.recipe_id == accepted.recipe_id
     assert before == snapshot()
+
+
+class _FakeWindowsScanHandle:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        identity: object,
+        close_failures: int = 0,
+    ) -> None:
+        self.path = path
+        self.identity = identity
+        self.close_failures = close_failures
+        self.closed = False
+
+    def read(self, count: int, *, offset: int = 0) -> bytes:
+        return self.path.read_bytes()[offset : offset + count]
+
+    def close(self) -> None:
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsArtifactError
+
+        if self.close_failures:
+            self.close_failures -= 1
+            raise WindowsArtifactError("cleanup_failed", cleanup_owner=self)  # type: ignore[arg-type]
+        self.closed = True
+
+
+class _FakeWindowsScanFilesystem:
+    def __init__(self) -> None:
+        self.directory_opens: list[Path] = []
+        self.file_opens: list[Path] = []
+        self.handles: list[_FakeWindowsScanHandle] = []
+        self.before_file_open = None
+        self.directory_generation: dict[Path, int] = {}
+        self.close_failures = 0
+
+    @staticmethod
+    def _identity(path: Path, generation: int = 0):
+        from tldw_chatbook.TTS.windows_artifact_fs import WindowsFileIdentity
+
+        info = path.stat()
+        value = (info.st_ino + generation).to_bytes(16, "little", signed=False)
+        return WindowsFileIdentity(
+            volume_serial_number=info.st_dev,
+            file_id=value,
+            kind="directory" if path.is_dir() else "file",
+            reparse_tag=0,
+        )
+
+    def pin_directory_no_reparse(self, path: Path) -> _FakeWindowsScanHandle:
+        selected = Path(path)
+        self.directory_opens.append(selected)
+        identity = self._identity(
+            selected,
+            self.directory_generation.get(selected, 0),
+        )
+        handle = _FakeWindowsScanHandle(
+            selected,
+            identity=identity,
+            close_failures=self.close_failures,
+        )
+        self.close_failures = 0
+        self.handles.append(handle)
+        return handle
+
+    def open_file_no_reparse(
+        self, path: Path, *, writable: bool = False
+    ) -> _FakeWindowsScanHandle:
+        assert not writable
+        selected = Path(path)
+        if self.before_file_open is not None:
+            self.before_file_open(selected)
+        self.file_opens.append(selected)
+        handle = _FakeWindowsScanHandle(selected, identity=self._identity(selected))
+        self.handles.append(handle)
+        return handle
+
+
+def test_windows_scan_pins_selected_root_and_reads_exact_file_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "Voice 模型"
+    root.mkdir()
+    model = root / "supertonic-3-orig.gguf"
+    _write_gguf(model)
+    filesystem = _FakeWindowsScanFilesystem()
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is scanner.AudioCppScanOutcome.COMPLETE
+    assert result.discoveries[0].match.state.value == "exact"
+    assert filesystem.directory_opens.count(root.resolve()) >= 1
+    assert filesystem.file_opens == [model.resolve()]
+    assert all(handle.closed for handle in filesystem.handles)
+    assert scanner.AudioCppScanIssueCode.NO_FOLLOW_UNAVAILABLE not in {
+        issue.code for issue in result.issues
+    }
+
+
+def test_windows_scan_rejects_file_substitution_before_handle_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "selected"
+    root.mkdir()
+    model = root / "supertonic-3-orig.gguf"
+    _write_gguf(model)
+    filesystem = _FakeWindowsScanFilesystem()
+
+    def replace(path: Path) -> None:
+        replacement = path.with_suffix(".replacement")
+        _write_gguf(replacement)
+        path.unlink()
+        replacement.rename(path)
+        filesystem.before_file_open = None
+
+    filesystem.before_file_open = replace
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is scanner.AudioCppScanOutcome.PARTIAL
+    assert scanner.AudioCppScanIssueCode.SOURCE_CHANGED in {
+        issue.code for issue in result.issues
+    }
+    assert not result.discoveries or result.discoveries[0].match.state.value != "exact"
+
+
+def test_windows_scan_rejects_directory_identity_change_before_enumeration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "selected"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    _write_gguf(nested / "supertonic-3-orig.gguf")
+    filesystem = _FakeWindowsScanFilesystem()
+    original_pin = filesystem.pin_directory_no_reparse
+
+    def pin(path: Path) -> _FakeWindowsScanHandle:
+        selected = Path(path)
+        if selected == nested and selected in filesystem.directory_opens:
+            filesystem.directory_generation[selected] = 1
+        return original_pin(selected)
+
+    filesystem.pin_directory_no_reparse = pin  # type: ignore[method-assign]
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is scanner.AudioCppScanOutcome.PARTIAL
+    assert result.discoveries == ()
+    assert scanner.AudioCppScanIssueCode.SOURCE_CHANGED in {
+        issue.code for issue in result.issues
+    }
+
+
+def test_windows_scan_casefold_collision_is_never_exact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "selected"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    filesystem = _FakeWindowsScanFilesystem()
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+    real_entry = next(os.scandir(root))
+    duplicate = SimpleNamespace(name="SUPERTONIC-3-ORIG.GGUF")
+    monkeypatch.setattr(
+        scanner, "_scandir", lambda _path: iter((real_entry, duplicate))
+    )
+
+    result = scanner.scan_audio_cpp_package_root(root)
+
+    assert result.outcome is scanner.AudioCppScanOutcome.PARTIAL
+    assert not result.discoveries or result.discoveries[0].match.state.value != "exact"
+
+
+def test_windows_scan_close_failure_exposes_one_retry_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "selected"
+    root.mkdir()
+    _write_gguf(root / "supertonic-3-orig.gguf")
+    filesystem = _FakeWindowsScanFilesystem()
+    filesystem.close_failures = 2
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+
+    with pytest.raises(scanner.AudioCppPackageScanError) as raised:
+        scanner.scan_audio_cpp_package_root(root)
+
+    cleanup = raised.value.take_cleanup_owner()
+    assert cleanup is not None
+    assert raised.value.take_cleanup_owner() is None
+    cleanup.close()
+    assert cleanup.closed
+
+
+@pytest.mark.asyncio
+async def test_windows_scan_cancellation_waits_for_exact_handle_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_chatbook.TTS.audio_cpp_package_scanner as scanner
+
+    root = tmp_path / "selected"
+    root.mkdir()
+    model = root / "supertonic-3-orig.gguf"
+    _write_gguf(model)
+    started = threading.Event()
+    release = threading.Event()
+    filesystem = _FakeWindowsScanFilesystem()
+    original_open = filesystem.open_file_no_reparse
+
+    def open_blocking(path: Path, *, writable: bool = False) -> _FakeWindowsScanHandle:
+        handle = original_open(path, writable=writable)
+        original_read = handle.read
+
+        def read(count: int, *, offset: int = 0) -> bytes:
+            started.set()
+            assert release.wait(2.0)
+            return original_read(count, offset=offset)
+
+        handle.read = read  # type: ignore[method-assign]
+        return handle
+
+    filesystem.open_file_no_reparse = open_blocking  # type: ignore[method-assign]
+    monkeypatch.setattr(scanner, "_windows_artifact_filesystem", filesystem)
+    task = asyncio.create_task(scanner.scan_audio_cpp_package_root_async(root))
+    assert await asyncio.to_thread(started.wait, 1.0)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert all(handle.closed for handle in filesystem.handles)

--- a/Tests/TTS/test_audio_cpp_recipes.py
+++ b/Tests/TTS/test_audio_cpp_recipes.py
@@ -698,6 +698,21 @@ def test_recipe_has_exact_reviewed_layout_and_safe_projection(
         assert recipe.projection.model_relative_path is None
 
 
+def test_every_approved_recipe_has_expected_windows_x86_and_x64_cpu_evidence() -> None:
+    registry = _api()["AUDIO_CPP_RECIPE_REGISTRY"]
+
+    for recipe in registry.recipes:
+        windows_cpu = {
+            (evidence.architecture, evidence.backend.value, evidence.state.value)
+            for evidence in recipe.backend_evidence
+            if evidence.system == "windows"
+        }
+        assert windows_cpu == {
+            ("x86", "cpu", "expected"),
+            ("x86_64", "cpu", "expected"),
+        }
+
+
 def test_initial_tasks_and_pocket_language_options_follow_the_pinned_specs() -> None:
     registry = _api()["AUDIO_CPP_RECIPE_REGISTRY"]
     reference_requirement = _api()["AudioCppReferenceRequirement"]

--- a/Tests/TTS/test_audio_cpp_supervisor.py
+++ b/Tests/TTS/test_audio_cpp_supervisor.py
@@ -436,6 +436,7 @@ class _RealLauncher:
         return _OwnedAudioCppProcess(
             process=process,
             close_parent_pipes=owned.close_parent_pipes,
+            close_native_transport=owned.close_native_transport,
         )
 
 
@@ -831,6 +832,34 @@ async def test_generated_artifact_is_revalidated_and_cleaned_after_exact_stop(
     assert artifact.validate_calls == 2
     assert artifact.cleanup_calls == 1
     assert process.wait_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_snapshot_projects_only_bounded_generated_artifact_privacy_posture(
+    tmp_path: Path,
+) -> None:
+    artifact = _GeneratedArtifactSpy()
+    artifact.privacy_posture = "windows_account_protected"
+    process = _FakeProcess()
+    supervisor = AudioCppSupervisor(
+        source_environment={},
+        process_launcher=_FakeLauncher([process]),
+        port_preflight=_available_preflight,
+    )
+
+    await supervisor.ensure_running(
+        replace(_make_launch(tmp_path), generated_artifact=artifact),
+        generation_hooks_factory=_HooksFactory(),
+    )
+
+    assert (
+        supervisor.snapshot().generated_artifact_privacy_posture
+        == "windows_account_protected"
+    )
+    artifact.privacy_posture = "PRIVATE_UNKNOWN_POSTURE"
+    assert supervisor.snapshot().generated_artifact_privacy_posture == "unverified"
+    await supervisor.stop()
+    assert supervisor.snapshot().generated_artifact_privacy_posture == "not_applicable"
 
 
 @pytest.mark.asyncio
@@ -1328,6 +1357,14 @@ async def test_spawn_uses_exact_argv_cwd_stdin_and_environment(
 ) -> None:
     process = _FakeProcess()
     captured: dict[str, Any] = {}
+    transport_closes = 0
+
+    class Transport:
+        def close(self) -> None:
+            nonlocal transport_closes
+            transport_closes += 1
+
+    process._transport = Transport()
 
     async def create_subprocess_exec(*argv: str, **kwargs: Any) -> _FakeProcess:
         captured["argv"] = argv
@@ -1361,6 +1398,176 @@ async def test_spawn_uses_exact_argv_cwd_stdin_and_environment(
         "stderr": asyncio.subprocess.PIPE,
     }
     await supervisor.stop()
+    assert transport_closes == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_spawn_settles_late_process_and_native_transport(
+    tmp_path: Path,
+) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    process = _FakeProcess()
+    transport_closes = 0
+
+    def close_transport() -> None:
+        nonlocal transport_closes
+        transport_closes += 1
+
+    async def cancellation_resistant_launcher(
+        _launch: AudioCppManagedLaunchConfig,
+        _environment: dict[str, str],
+    ) -> _OwnedAudioCppProcess:
+        entered.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return _OwnedAudioCppProcess(
+            process=process,
+            close_parent_pipes=process.close_parent_pipes,
+            close_native_transport=close_transport,
+        )
+
+    supervisor = AudioCppSupervisor(
+        source_environment={},
+        process_launcher=cancellation_resistant_launcher,
+        port_preflight=_available_preflight,
+    )
+    start = asyncio.create_task(
+        supervisor.ensure_running(
+            _make_launch(tmp_path), generation_hooks_factory=_HooksFactory()
+        )
+    )
+    await entered.wait()
+    stopping = asyncio.create_task(supervisor.stop())
+    await asyncio.sleep(0)
+    assert not stopping.done()
+    release.set()
+
+    await stopping
+    await asyncio.gather(start, return_exceptions=True)
+
+    assert process.terminate_calls == 1
+    assert process.wait_calls == 1
+    assert transport_closes == 1
+    assert supervisor._generation is None
+    await supervisor.close()
+
+
+@pytest.mark.asyncio
+async def test_process_launcher_settlement_retains_late_owner_after_cancellation() -> (
+    None
+):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    owned = _OwnedAudioCppProcess(
+        process=_FakeProcess(),
+        close_parent_pipes=lambda: None,
+    )
+
+    async def cancellation_resistant_launcher() -> _OwnedAudioCppProcess:
+        entered.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return owned
+
+    settlement = asyncio.create_task(
+        supervisor_module._settle_process_launcher(
+            cancellation_resistant_launcher(),
+            timeout=10.0,
+        )
+    )
+    await entered.wait()
+    settlement.cancel()
+    await asyncio.sleep(0)
+    completed_before_owner = settlement.done()
+    release.set()
+
+    cancellation, timed_out, settled_owner, error = await settlement
+
+    assert completed_before_owner is False
+    assert cancellation is not None
+    assert timed_out is False
+    assert settled_owner is owned
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_native_transport_closes_after_wait_hooks_and_artifact_then_retries(
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    process = _FakeProcess()
+    real_wait = process.wait
+
+    async def ordered_wait() -> int:
+        result = await real_wait()
+        events.append("wait")
+        return result
+
+    process.wait = ordered_wait  # type: ignore[method-assign]
+    artifact = _GeneratedArtifactSpy()
+    real_artifact_cleanup = artifact.cleanup
+
+    def ordered_artifact_cleanup() -> None:
+        events.append("artifact")
+        real_artifact_cleanup()
+
+    artifact.cleanup = ordered_artifact_cleanup  # type: ignore[method-assign]
+    transport_attempts = 0
+
+    def close_transport() -> None:
+        nonlocal transport_attempts
+        transport_attempts += 1
+        events.append("transport")
+        if transport_attempts == 1:
+            raise RuntimeError("PRIVATE TRANSPORT DETAIL")
+
+    async def launcher(
+        _launch: AudioCppManagedLaunchConfig,
+        _environment: dict[str, str],
+    ) -> _OwnedAudioCppProcess:
+        return _OwnedAudioCppProcess(
+            process=process,
+            close_parent_pipes=process.close_parent_pipes,
+            close_native_transport=close_transport,
+        )
+
+    class OrderedHooks(_HooksFactory):
+        async def __call__(self, generation: int) -> AudioCppGenerationHooks:
+            hooks = await super().__call__(generation)
+
+            async def cleanup() -> None:
+                events.append("hooks")
+
+            return AudioCppGenerationHooks(
+                contract_probe=hooks.contract_probe,
+                health_probe=hooks.health_probe,
+                cleanup=cleanup,
+            )
+
+    launch = replace(_make_launch(tmp_path), generated_artifact=artifact)
+    supervisor = AudioCppSupervisor(
+        source_environment={},
+        process_launcher=launcher,
+        port_preflight=_available_preflight,
+    )
+    await supervisor.ensure_running(launch, generation_hooks_factory=OrderedHooks())
+
+    with pytest.raises(TTSOperationError) as first:
+        await supervisor.stop()
+
+    assert first.value.code == "cleanup_failed"
+    assert events.index("wait") < events.index("hooks")
+    assert events.index("hooks") < events.index("artifact")
+    assert events.index("artifact") < events.index("transport")
+    assert supervisor._generation is not None
+    await supervisor.stop()
+    assert transport_attempts == 2
+    assert supervisor._generation is None
 
 
 @pytest.mark.asyncio
@@ -1380,6 +1587,7 @@ async def test_default_launcher_suppresses_paths_in_asyncio_debug_logs(
         owned = await supervisor_module._default_process_launcher(launch, {})
         await asyncio.wait_for(owned.process.wait(), timeout=1)
         owned.close_parent_pipes()
+        owned.close_native_transport()
         asyncio_logger.debug("UNRELATED_ASYNCIO_AFTER")
     finally:
         loop.set_debug(prior_debug)
@@ -1388,6 +1596,47 @@ async def test_default_launcher_suppresses_paths_in_asyncio_debug_logs(
     assert str(launch.server_json_path) not in caplog.text
     assert "UNRELATED_ASYNCIO_BEFORE" in caplog.text
     assert "UNRELATED_ASYNCIO_AFTER" in caplog.text
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows subprocesses")
+@pytest.mark.asyncio
+async def test_native_windows_transport_close_invalidates_only_exact_child_handle() -> (
+    None
+):
+    import _winapi
+
+    child = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "raise SystemExit(0)",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    sibling = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(10)",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    transport = child._transport
+    native_process = transport.get_extra_info("subprocess")
+    native_handle = native_process._handle
+    close_transport = supervisor_module._process_native_transport_closer(child)
+    try:
+        assert await child.wait() == 0
+        _winapi.GetExitCodeProcess(native_handle)
+        close_transport()
+        close_transport()
+        with pytest.raises(OSError):
+            _winapi.GetExitCodeProcess(native_handle)
+        assert sibling.returncode is None
+    finally:
+        if sibling.returncode is None:
+            sibling.terminate()
+        await sibling.wait()
 
 
 @pytest.mark.asyncio

--- a/Tests/TTS/test_audio_cpp_windows_uat_harness.py
+++ b/Tests/TTS/test_audio_cpp_windows_uat_harness.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+import struct
+from pathlib import Path
+
+import pytest
+
+
+def _wav(*, frames: int = 160) -> bytes:
+    data = b"\x00\x00" * frames
+    fmt = struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, 16_000, 32_000, 2, 16)
+    body = b"WAVE" + fmt + struct.pack("<4sI", b"data", len(data)) + data
+    return b"RIFF" + struct.pack("<I", len(body)) + body
+
+
+def test_host_contract_accepts_only_supported_windows_tuple() -> None:
+    from scripts.uat_audio_cpp_windows import validate_host_contract
+
+    assert validate_host_contract("Windows", (10, 0), (3, 12), "AMD64") == "x64"
+    assert validate_host_contract("Windows", (10, 0), (3, 12), "x86") == "x86"
+    for values in (
+        ("Linux", (10, 0), (3, 12), "AMD64"),
+        ("Windows", (6, 3), (3, 12), "AMD64"),
+        ("Windows", (10, 0), (3, 11), "AMD64"),
+        ("Windows", (10, 0), (3, 12), "ARM64"),
+    ):
+        with pytest.raises(ValueError, match="unsupported"):
+            validate_host_contract(*values)
+
+
+def test_command_requires_every_provisioned_input() -> None:
+    from scripts.uat_audio_cpp_windows import _parser
+
+    with pytest.raises(SystemExit):
+        _parser().parse_args([])
+
+
+def test_structural_wav_validation_is_bounded() -> None:
+    from scripts.uat_audio_cpp_windows import validate_wav
+
+    evidence = validate_wav(_wav())
+    assert evidence == {
+        "channels": 1,
+        "frames": 160,
+        "sample_rate_hz": 16_000,
+    }
+    with pytest.raises(ValueError, match="invalid"):
+        validate_wav(b"PRIVATE_PATH_NOT_A_WAV")
+
+
+def test_identity_comparison_is_exact_and_path_free() -> None:
+    from scripts.uat_audio_cpp_windows import ExpectedPackage, compare_package
+
+    expected = ExpectedPackage(
+        recipe_id="recipe.one",
+        recipe_revision=2,
+        package_variant="variant_one",
+        model_id="model-one",
+    )
+    actual = expected.as_evidence()
+    assert compare_package(expected, actual) == actual
+    with pytest.raises(ValueError, match="identity") as caught:
+        compare_package(expected, {**actual, "recipe_revision": 3})
+    assert "PRIVATE" not in str(caught.value)
+
+
+def test_evidence_json_has_fixed_schema_and_no_private_inputs(tmp_path: Path) -> None:
+    from scripts.uat_audio_cpp_windows import UATEvidence, write_evidence
+
+    private = tmp_path / "PRIVATE_USER" / "server.exe"
+    evidence = UATEvidence(
+        status="partial",
+        objective="pass",
+        architecture="x64",
+        python="3.12",
+        checks=("host", "binary_review"),
+        text_package=None,
+        clone_package=None,
+        text_wav=None,
+        clone_wav=None,
+        audible=None,
+        cleanup="pass",
+    )
+    target = tmp_path / "evidence.json"
+    write_evidence(target, evidence)
+    payload = target.read_text(encoding="utf-8")
+    assert str(private) not in payload
+    assert json.loads(payload) == {
+        "architecture": "x64",
+        "audible": None,
+        "checks": ["host", "binary_review"],
+        "cleanup": "pass",
+        "clone_package": None,
+        "clone_wav": None,
+        "objective": "pass",
+        "python": "3.12",
+        "status": "partial",
+        "text_package": None,
+        "text_wav": None,
+    }
+
+
+def test_final_status_requires_audible_confirmation_and_clean_teardown() -> None:
+    from scripts.uat_audio_cpp_windows import final_status
+
+    assert final_status(journey="pass", audible=True, cleanup="pass") == "pass"
+    assert final_status(journey="pass", audible=False, cleanup="pass") == "inaudible"
+    assert final_status(journey="pass", audible=True, cleanup="fail") == "fail"
+    assert final_status(journey="partial", audible=True, cleanup="pass") == "partial"
+
+
+def test_objective_journey_reports_only_bounded_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import uat_audio_cpp_windows as harness
+
+    async def completed(_args: Namespace, *, architecture: str):
+        assert architecture == "x64"
+        return (
+            {"channels": 1, "frames": 100, "sample_rate_hz": 16_000},
+            {"channels": 1, "frames": 200, "sample_rate_hz": 16_000},
+            ("host", "shutdown_clean"),
+        )
+
+    monkeypatch.setattr(harness, "_production_journey", completed)
+    result = harness.run_journey(
+        Namespace(
+            text_recipe_id="text.recipe",
+            text_recipe_revision=1,
+            text_package_variant="text_variant",
+            text_model_id="text-model",
+            clone_recipe_id="clone.recipe",
+            clone_recipe_revision=2,
+            clone_package_variant="clone_variant",
+            clone_model_id="clone-model",
+            clone_artifact_id="clone-artifact",
+            clone_artifact_revision="a" * 40,
+            clone_artifact_variant="clone_variant",
+        ),
+        architecture="x64",
+    )
+    assert result.status == "partial"
+    assert result.objective == "pass"
+    assert result.cleanup == "pass"
+    assert result.checks == ("host", "shutdown_clean")
+
+
+def test_objective_journey_fails_closed_without_private_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts import uat_audio_cpp_windows as harness
+
+    async def failed(_args: Namespace, *, architecture: str):
+        del architecture
+        raise RuntimeError("PRIVATE_MACHINE_PATH")
+
+    monkeypatch.setattr(harness, "_production_journey", failed)
+    result = harness.run_journey(Namespace(), architecture="x86")
+    assert result.status == "fail"
+    assert result.objective == "fail"
+    assert result.cleanup == "fail"
+    assert "PRIVATE" not in repr(result)
+
+
+def test_powershell_wrapper_has_no_machine_defaults_and_restores_environment() -> None:
+    script = (
+        Path(__file__).parents[2] / "scripts" / "uat_audio_cpp_windows.ps1"
+    ).read_text(encoding="utf-8")
+    assert "[Parameter(Mandatory = $true)]" in script
+    assert "$env:TLDW_CONFIG_PATH" in script
+    assert "$env:XDG_CONFIG_HOME" in script
+    assert "$env:XDG_DATA_HOME" in script
+    assert "finally" in script
+    assert "Read-Host" in script
+    assert "System.Media.SoundPlayer" in script
+    for forbidden in ("C:\\Users\\", "Program Files", 'audiocpp_server.exe"'):
+        assert forbidden not in script
+
+
+def test_harness_never_copies_or_installs_the_server_executable() -> None:
+    script = (
+        Path(__file__).parents[2] / "scripts" / "uat_audio_cpp_windows.py"
+    ).read_text(encoding="utf-8")
+    assert "copy2(args.server_binary" not in script
+    assert "install(args.server_binary" not in script

--- a/Tests/TTS/test_profile_reference_materialization_windows.py
+++ b/Tests/TTS/test_profile_reference_materialization_windows.py
@@ -1,0 +1,483 @@
+"""Windows contracts for operation-scoped clone-reference materialization."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from tldw_chatbook.TTS import profile_reference_materialization as module
+from tldw_chatbook.TTS.profile_reference_materialization import (
+    TTSCloneMaterializationError,
+    TTSCloneReferenceMaterializer,
+)
+from tldw_chatbook.TTS.profile_reference_types import (
+    TTSCloneReference,
+    TTSCloneReferenceSummary,
+)
+from tldw_chatbook.TTS.windows_artifact_fs import (
+    WindowsArtifactError,
+    WindowsFileIdentity,
+)
+
+
+_NOW = datetime(2026, 8, 14, tzinfo=UTC)
+_PRIVATE_TEXT = "PRIVATE WINDOWS CLONE TRANSCRIPT"
+
+
+def _reference() -> TTSCloneReference:
+    wav_bytes = b"windows-clone-reference-wav"
+    return TTSCloneReference(
+        summary=TTSCloneReferenceSummary(
+            reference_id=UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            byte_length=len(wav_bytes),
+            duration_ms=250,
+            sample_rate_hz=24_000,
+            channels=1,
+            sample_encoding="pcm_s16le",
+            created_at=_NOW,
+            updated_at=_NOW,
+        ),
+        reference_text=_PRIVATE_TEXT,
+        sha256=hashlib.sha256(wav_bytes).hexdigest(),
+        wav_bytes=wav_bytes,
+    )
+
+
+class _FakeWindowsHandle:
+    def __init__(self, filesystem: _FakeWindowsFilesystem, path: Path, kind: str):
+        self.filesystem = filesystem
+        self.path = path
+        self.kind = kind
+        self.identity = self._current_identity()
+        self.closed = False
+        self.deleted = False
+        self.locked = False
+        self.close_failures = 0
+
+    def _current_identity(self) -> WindowsFileIdentity:
+        info = self.path.stat()
+        return WindowsFileIdentity(
+            volume_serial_number=info.st_dev,
+            file_id=info.st_ino.to_bytes(16, "little", signed=False),
+            kind=self.kind,  # type: ignore[arg-type]
+            reparse_tag=0,
+        )
+
+    @property
+    def privacy_posture(self) -> str:
+        return "windows_account_protected"
+
+    def verify_private_acl(self) -> bool:
+        return not self.closed
+
+    def read(self, count: int, *, offset: int = 0) -> bytes:
+        return self.path.read_bytes()[offset : offset + count]
+
+    def lock_exclusive_nonblocking(self) -> None:
+        key = self.identity.file_id
+        if key in self.filesystem.locks and not self.locked:
+            raise WindowsArtifactError("busy")
+        self.filesystem.locks.add(key)
+        self.locked = True
+
+    def unlock(self) -> None:
+        if self.locked:
+            self.filesystem.locks.discard(self.identity.file_id)
+            self.locked = False
+
+    def delete_exact(self) -> None:
+        if self.closed or self.deleted:
+            return
+        if not self.path.exists() or self._current_identity() != self.identity:
+            raise WindowsArtifactError("changed")
+        self.deleted = True
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        if self.close_failures:
+            self.close_failures -= 1
+            raise WindowsArtifactError("cleanup_failed", cleanup_owner=self)  # type: ignore[arg-type]
+        if self.deleted and self.path.exists():
+            if self.kind == "directory":
+                self.path.rmdir()
+            else:
+                self.path.unlink()
+        self.closed = True
+
+
+class _FakeWindowsFilesystem:
+    def __init__(self) -> None:
+        self.handles: list[_FakeWindowsHandle] = []
+        self.locks: set[bytes] = set()
+        self.fail_asset_creation = False
+        self.owner_close_failures = 0
+        self.root_close_failures = 0
+
+    def _handle(self, path: Path, kind: str) -> _FakeWindowsHandle:
+        handle = _FakeWindowsHandle(self, path, kind)
+        self.handles.append(handle)
+        return handle
+
+    def protect_private_directory(self, path: Path) -> _FakeWindowsHandle:
+        return self._handle(Path(path), "directory")
+
+    def pin_directory_no_reparse(self, path: Path) -> _FakeWindowsHandle:
+        return self._handle(Path(path), "directory")
+
+    def create_private_directory(self, path: Path) -> _FakeWindowsHandle:
+        selected = Path(path)
+        selected.mkdir()
+        handle = self._handle(selected, "directory")
+        if selected.name.startswith("clone-v1-"):
+            handle.close_failures = self.owner_close_failures
+        else:
+            handle.close_failures = self.root_close_failures
+        return handle
+
+    def create_private_file(
+        self,
+        path: Path,
+        data: bytes,
+        *,
+        read_only: bool = False,
+    ) -> _FakeWindowsHandle:
+        if data and self.fail_asset_creation:
+            raise WindowsArtifactError("unavailable")
+        selected = Path(path)
+        selected.write_bytes(data)
+        return self._handle(selected, "file")
+
+    def open_file_no_reparse(
+        self,
+        path: Path,
+        *,
+        writable: bool = False,
+    ) -> _FakeWindowsHandle:
+        del writable
+        return self._handle(Path(path), "file")
+
+
+@pytest.fixture
+def windows_filesystem(monkeypatch: pytest.MonkeyPatch) -> _FakeWindowsFilesystem:
+    filesystem = _FakeWindowsFilesystem()
+    monkeypatch.setattr(module, "_windows_artifact_filesystem", filesystem)
+    return filesystem
+
+
+@pytest.mark.asyncio
+async def test_windows_materialization_is_private_locked_and_exact(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+
+    handle = await materializer.materialize(_reference())
+
+    assert handle.voice_ref.read_bytes() == _reference().wav_bytes
+    assert handle.reference_text == _PRIVATE_TEXT
+    assert _PRIVATE_TEXT not in repr(handle)
+    assert not any(
+        _PRIVATE_TEXT in path.read_text(errors="ignore")
+        for path in tmp_path.rglob("*.*")
+    )
+    assert all(
+        owner.verify_private_acl()
+        for owner in windows_filesystem.handles
+        if not owner.closed
+    )
+    record = handle._record
+    assert record.lock_handle.locked
+    with pytest.raises(WindowsArtifactError) as busy:
+        contender = windows_filesystem.open_file_no_reparse(
+            handle.voice_ref.parent / "owner.lock"
+        )
+        contender.lock_exclusive_nonblocking()
+    assert busy.value.code == "busy"
+    assert await handle.validated_voice_ref() == handle.voice_ref
+
+    await handle.aclose()
+    assert not handle.voice_ref.parent.exists()
+    assert not materializer.owns(handle)
+    await materializer.close()
+
+
+@pytest.mark.asyncio
+async def test_windows_asset_substitution_is_preserved_and_rejected(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    handle = await materializer.materialize(_reference())
+    asset = handle.voice_ref
+    asset.unlink()
+    asset.write_bytes(_reference().wav_bytes)
+
+    with pytest.raises(TTSCloneMaterializationError) as validation:
+        await handle.validated_voice_ref()
+    with pytest.raises(TTSCloneMaterializationError) as cleanup:
+        await handle.aclose()
+
+    assert validation.value.code == "unavailable"
+    assert cleanup.value.code == "cleanup_failed"
+    assert asset.read_bytes() == _reference().wav_bytes
+    assert materializer.owns(handle)
+
+
+@pytest.mark.asyncio
+async def test_windows_root_substitution_is_preserved_and_rejected(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    root = tmp_path / "runtime"
+    moved = tmp_path / "moved-runtime"
+    materializer = TTSCloneReferenceMaterializer(root)
+    handle = await materializer.materialize(_reference())
+    owner_name = handle.voice_ref.parent.name
+    asset_name = handle.voice_ref.name
+    root.rename(moved)
+    replacement = root / owner_name
+    replacement.mkdir(parents=True)
+    (replacement / "owner.lock").write_bytes(b"")
+    replacement_asset = replacement / asset_name
+    replacement_asset.write_bytes(_reference().wav_bytes)
+
+    with pytest.raises(TTSCloneMaterializationError) as validation:
+        await handle.validated_voice_ref()
+    with pytest.raises(TTSCloneMaterializationError) as cleanup:
+        await handle.aclose()
+
+    assert validation.value.code == "unavailable"
+    assert cleanup.value.code == "cleanup_failed"
+    assert replacement_asset.read_bytes() == _reference().wav_bytes
+
+
+@pytest.mark.asyncio
+async def test_windows_cleanup_failure_retains_exact_owner_for_retry(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    handle = await materializer.materialize(_reference())
+    handle._record.owner_handle.close_failures = 1
+
+    with pytest.raises(TTSCloneMaterializationError) as first:
+        await handle.aclose()
+
+    assert first.value.code == "cleanup_failed"
+    assert materializer.owns(handle)
+    await handle.aclose()
+    assert not materializer.owns(handle)
+    assert not handle.voice_ref.parent.exists()
+    await materializer.close()
+
+
+@pytest.mark.asyncio
+async def test_windows_materializer_close_retries_retained_owner(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    handle = await materializer.materialize(_reference())
+    handle._record.owner_handle.close_failures = 1
+
+    with pytest.raises(TTSCloneMaterializationError) as first:
+        await materializer.close()
+
+    assert first.value.code == "cleanup_failed"
+    assert materializer.owns(handle)
+    await materializer.close()
+    assert not materializer.owns(handle)
+    assert not handle.voice_ref.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_windows_orphan_sweep_removes_only_unlocked_recognized_owner(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    root = tmp_path / "runtime"
+    root.mkdir()
+    orphan = root / ("clone-v1-" + "1" * 32)
+    orphan.mkdir()
+    (orphan / "owner.lock").write_bytes(b"")
+    (orphan / ("asset-" + "2" * 32 + ".wav")).write_bytes(b"orphan")
+    live = root / ("clone-v1-" + "3" * 32)
+    live.mkdir()
+    live_lock_path = live / "owner.lock"
+    live_lock_path.write_bytes(b"")
+    (live / ("asset-" + "4" * 32 + ".wav")).write_bytes(b"live")
+    live_lock = windows_filesystem.open_file_no_reparse(live_lock_path, writable=True)
+    live_lock.lock_exclusive_nonblocking()
+
+    materializer = TTSCloneReferenceMaterializer(root)
+    handle = await materializer.materialize(_reference())
+
+    assert not orphan.exists()
+    assert live.exists()
+    await handle.aclose()
+    await materializer.close()
+    live_lock.unlock()
+    live_lock.close()
+
+
+@pytest.mark.asyncio
+async def test_windows_unexpected_owner_entry_blocks_cleanup(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    handle = await materializer.materialize(_reference())
+    foreign = handle.voice_ref.parent / "foreign.txt"
+    foreign.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(TTSCloneMaterializationError) as raised:
+        await handle.aclose()
+
+    assert raised.value.code == "cleanup_failed"
+    assert foreign.read_text(encoding="utf-8") == "keep"
+    assert materializer.owns(handle)
+
+
+@pytest.mark.asyncio
+async def test_windows_cancellation_joins_creation_and_removes_publication(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    real_create = module._create_windows_materialization_sync
+
+    def blocked_create(*args: object, **kwargs: object):
+        entered.set()
+        assert release.wait(timeout=2.0)
+        return real_create(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_create_windows_materialization_sync", blocked_create)
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    operation = asyncio.create_task(materializer.materialize(_reference()))
+    assert await asyncio.to_thread(entered.wait, 2.0)
+    operation.cancel()
+    await asyncio.sleep(0)
+    assert not operation.done()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+
+    assert tuple((tmp_path / "runtime").iterdir()) == ()
+    await materializer.close()
+
+
+@pytest.mark.asyncio
+async def test_windows_cancelled_cleanup_failure_stays_materializer_owned(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    real_create = module._create_windows_materialization_sync
+    real_cleanup = module._cleanup_materialization_sync
+
+    def blocked_create(*args: object, **kwargs: object):
+        entered.set()
+        assert release.wait(timeout=2.0)
+        return real_create(*args, **kwargs)
+
+    def failed_cleanup(_record: object) -> None:
+        raise OSError("PRIVATE cleanup detail")
+
+    monkeypatch.setattr(module, "_create_windows_materialization_sync", blocked_create)
+    monkeypatch.setattr(module, "_cleanup_materialization_sync", failed_cleanup)
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+    operation = asyncio.create_task(materializer.materialize(_reference()))
+    assert await asyncio.to_thread(entered.wait, 2.0)
+    operation.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+
+    assert len(materializer._active) == 1
+    monkeypatch.setattr(module, "_cleanup_materialization_sync", real_cleanup)
+    await materializer.close()
+    assert tuple((tmp_path / "runtime").iterdir()) == ()
+
+
+@pytest.mark.asyncio
+async def test_windows_partial_creation_cleanup_failure_is_retained(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    windows_filesystem.fail_asset_creation = True
+    windows_filesystem.owner_close_failures = 1
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+
+    with pytest.raises(TTSCloneMaterializationError) as raised:
+        await materializer.materialize(_reference())
+
+    assert raised.value.code == "cleanup_failed"
+    assert len(materializer._pending_windows_cleanup) == 1
+    await materializer.close()
+    assert materializer._pending_windows_cleanup == []
+    assert tuple((tmp_path / "runtime").iterdir()) == ()
+
+
+@pytest.mark.asyncio
+async def test_windows_prepare_close_failure_is_retried_before_creation(
+    tmp_path: Path,
+    windows_filesystem: _FakeWindowsFilesystem,
+) -> None:
+    windows_filesystem.root_close_failures = 1
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+
+    with pytest.raises(TTSCloneMaterializationError) as first:
+        await materializer.materialize(_reference())
+
+    assert first.value.code == "cleanup_failed"
+    assert len(materializer._pending_windows_cleanup) == 1
+    windows_filesystem.root_close_failures = 0
+    handle = await materializer.materialize(_reference())
+    assert materializer._pending_windows_cleanup == []
+    await handle.aclose()
+    await materializer.close()
+
+
+@pytest.mark.asyncio
+async def test_platform_is_unsupported_only_when_neither_backend_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module, "_POSIX_SUPPORTED", False)
+    monkeypatch.setattr(module, "_windows_artifact_filesystem", None)
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+
+    with pytest.raises(TTSCloneMaterializationError) as raised:
+        await materializer.materialize(_reference())
+
+    assert raised.value.code == "unsupported"
+    await materializer.close()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows handles")
+@pytest.mark.asyncio
+async def test_native_windows_materialization_lifecycle(tmp_path: Path) -> None:
+    materializer = TTSCloneReferenceMaterializer(tmp_path / "runtime")
+
+    handle = await materializer.materialize(_reference())
+
+    assert await handle.validated_voice_ref() == handle.voice_ref
+    assert handle.voice_ref.read_bytes() == _reference().wav_bytes
+    assert _PRIVATE_TEXT not in repr(handle)
+    await handle.aclose()
+    assert not handle.voice_ref.parent.exists()
+    await materializer.close()

--- a/Tests/TTS/test_windows_artifact_fs.py
+++ b/Tests/TTS/test_windows_artifact_fs.py
@@ -1,0 +1,573 @@
+"""Contracts for the narrow native Windows audio.cpp artifact boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from tldw_chatbook.TTS import windows_artifact_fs
+
+
+class FakeWindowsKernel:
+    """Deterministic kernel boundary without host Win32 calls."""
+
+    def __init__(self) -> None:
+        self.next_handle = 40
+        self.identities: dict[int, windows_artifact_fs.WindowsFileIdentity] = {}
+        self.open_calls: list[tuple[str, Literal["directory", "file"], bool, bool]] = []
+        self.inheritable_calls: list[tuple[int, bool]] = []
+        self.closed: list[int] = []
+        self.close_failures = 0
+        self.set_acl_calls: list[tuple[int, bool]] = []
+        self.verify_acl_calls: list[tuple[int, bool]] = []
+        self.acl_matches = True
+        self.writes: list[tuple[int, bytes]] = []
+        self.flushes: list[int] = []
+        self.read_only: list[int] = []
+        self.locks: list[int] = []
+        self.unlocks: list[int] = []
+        self.deleted: list[int] = []
+
+    def open_handle(
+        self,
+        path: str,
+        *,
+        kind: Literal["directory", "file"],
+        create_new: bool,
+        writable: bool,
+    ) -> int:
+        self.open_calls.append((path, kind, create_new, writable))
+        handle = self.next_handle
+        self.next_handle += 1
+        self.identities[handle] = windows_artifact_fs.WindowsFileIdentity(
+            volume_serial_number=9,
+            file_id=handle.to_bytes(16, "little"),
+            kind=kind,
+            reparse_tag=0,
+        )
+        return handle
+
+    def set_inheritable(self, handle: int, inheritable: bool) -> None:
+        self.inheritable_calls.append((handle, inheritable))
+
+    def identity(self, handle: int) -> windows_artifact_fs.WindowsFileIdentity:
+        return self.identities[handle]
+
+    def current_user_sid(self) -> bytes:
+        return b"PRIVATE-TEST-SID"
+
+    def set_private_acl(self, handle: int, user_sid: bytes, directory: bool) -> None:
+        assert user_sid == b"PRIVATE-TEST-SID"
+        self.set_acl_calls.append((handle, directory))
+
+    def verify_private_acl(
+        self,
+        handle: int,
+        user_sid: bytes,
+        directory: bool,
+    ) -> bool:
+        assert user_sid == b"PRIVATE-TEST-SID"
+        self.verify_acl_calls.append((handle, directory))
+        return self.acl_matches
+
+    def write_all(self, handle: int, data: bytes) -> None:
+        self.writes.append((handle, data))
+
+    def read(self, handle: int, count: int, offset: int) -> bytes:
+        del handle, count, offset
+        return b"fixture"
+
+    def flush(self, handle: int) -> None:
+        self.flushes.append(handle)
+
+    def set_read_only(self, handle: int) -> None:
+        self.read_only.append(handle)
+
+    def lock_exclusive_nonblocking(self, handle: int) -> None:
+        self.locks.append(handle)
+
+    def unlock(self, handle: int) -> None:
+        self.unlocks.append(handle)
+
+    def delete_handle(self, handle: int) -> None:
+        self.deleted.append(handle)
+
+    def close_handle(self, handle: int) -> None:
+        if self.close_failures:
+            self.close_failures -= 1
+            raise OSError("PRIVATE CLOSE PATH")
+        self.closed.append(handle)
+
+
+def test_windows_artifact_filesystem_module_is_available() -> None:
+    assert find_spec("tldw_chatbook.TTS.windows_artifact_fs") is not None
+
+
+def test_process_default_filesystem_is_fail_closed_off_windows() -> None:
+    if os.name == "nt":
+        assert isinstance(
+            windows_artifact_fs.OS_WINDOWS_ARTIFACT_FILESYSTEM,
+            windows_artifact_fs.NativeWindowsArtifactFilesystem,
+        )
+    else:
+        assert isinstance(
+            windows_artifact_fs.OS_WINDOWS_ARTIFACT_FILESYSTEM,
+            windows_artifact_fs.UnavailableWindowsArtifactFilesystem,
+        )
+
+
+@pytest.mark.parametrize(
+    ("selected", "extended"),
+    [
+        (r"C:\Models\Voice 模型", r"\\?\C:\Models\Voice 模型"),
+        (
+            r"\\model-host\shared models\Voice",
+            r"\\?\UNC\model-host\shared models\Voice",
+        ),
+    ],
+)
+def test_normalize_windows_artifact_path_preserves_absolute_unicode_paths(
+    selected: str,
+    extended: str,
+) -> None:
+    assert windows_artifact_fs.normalize_windows_artifact_path(selected) == extended
+
+
+@pytest.mark.parametrize(
+    "selected",
+    [
+        "",
+        r"relative\model",
+        r"C:relative\model",
+        r"\\?\C:\private\model",
+        r"\\.\C:\private\model",
+        r"\Device\HarddiskVolume1\private\model",
+        r"C:\private\..\model",
+        r"C:\private\NUL\model",
+        "C:\\private\\trailing.\\model",
+        "C:\\private\\trailing \\model",
+        r"C:\private\asset:stream",
+    ],
+)
+def test_normalize_windows_artifact_path_rejects_ambiguous_namespaces(
+    selected: str,
+) -> None:
+    with pytest.raises(ValueError, match="Windows artifact path is unavailable"):
+        windows_artifact_fs.normalize_windows_artifact_path(selected)
+
+
+@pytest.mark.parametrize(
+    ("machine", "pointer_bits", "expected"),
+    [
+        ("AMD64", 64, "x86_64"),
+        ("x86_64", 64, "x86_64"),
+        ("AMD64", 32, "x86"),
+        ("x86", 32, "x86"),
+        ("i686", 32, "x86"),
+        ("ARM64", 64, None),
+        ("aarch64", 64, None),
+        ("x86", 64, None),
+        ("AMD64", 16, None),
+    ],
+)
+def test_normalize_windows_process_architecture_is_pointer_width_exact(
+    machine: str,
+    pointer_bits: int,
+    expected: str | None,
+) -> None:
+    assert (
+        windows_artifact_fs.normalize_windows_process_architecture(
+            machine, pointer_bits
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "system_name",
+        "windows_major",
+        "python_version",
+        "machine",
+        "pointer_bits",
+        "supported",
+    ),
+    [
+        ("Windows", 10, (3, 12), "AMD64", 64, True),
+        ("Windows", 11, (3, 13), "AMD64", 32, True),
+        ("Windows", 9, (3, 12), "AMD64", 64, False),
+        ("Windows", 10, (3, 11), "AMD64", 64, False),
+        ("Windows", 10, (3, 12), "ARM64", 64, False),
+        ("Darwin", 15, (3, 12), "AMD64", 64, False),
+    ],
+)
+def test_windows_audio_cpp_platform_support_is_explicit(
+    system_name: str,
+    windows_major: int,
+    python_version: tuple[int, int],
+    machine: str,
+    pointer_bits: int,
+    supported: bool,
+) -> None:
+    assert (
+        windows_artifact_fs.windows_audio_cpp_platform_supported(
+            system_name=system_name,
+            windows_major=windows_major,
+            python_version=python_version,
+            machine=machine,
+            pointer_bits=pointer_bits,
+        )
+        is supported
+    )
+
+
+def _filesystem(
+    kernel: FakeWindowsKernel,
+) -> windows_artifact_fs.NativeWindowsArtifactFilesystem:
+    return windows_artifact_fs.NativeWindowsArtifactFilesystem(kernel=kernel)
+
+
+def test_pinned_directory_is_non_inheritable_and_opaque() -> None:
+    kernel = FakeWindowsKernel()
+
+    pinned = _filesystem(kernel).pin_directory_no_reparse(r"C:\private\models")
+
+    assert kernel.open_calls == [(r"\\?\C:\private\models", "directory", False, False)]
+    assert kernel.inheritable_calls == [(40, False)]
+    assert pinned.identity == kernel.identities[40]
+    assert "40" not in repr(pinned)
+    assert "private" not in repr(pinned).casefold()
+    pinned.close()
+    pinned.close()
+    assert kernel.closed == [40]
+
+
+def test_reparse_directory_is_rejected_and_closed() -> None:
+    kernel = FakeWindowsKernel()
+    filesystem = _filesystem(kernel)
+    original_open = kernel.open_handle
+
+    def open_reparse(*args: object, **kwargs: object) -> int:
+        handle = original_open(*args, **kwargs)  # type: ignore[arg-type]
+        kernel.identities[handle] = windows_artifact_fs.WindowsFileIdentity(
+            volume_serial_number=9,
+            file_id=handle.to_bytes(16, "little"),
+            kind="directory",
+            reparse_tag=0xA0000003,
+        )
+        return handle
+
+    kernel.open_handle = open_reparse  # type: ignore[method-assign]
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        filesystem.pin_directory_no_reparse(r"C:\private\junction")
+
+    assert raised.value.code == "changed"
+    assert str(raised.value) == "Windows artifact identity changed"
+    assert kernel.closed == [40]
+
+
+def test_private_directory_installs_and_reverifies_protected_acl() -> None:
+    kernel = FakeWindowsKernel()
+
+    owner = _filesystem(kernel).create_private_directory(r"C:\private\owner")
+
+    assert kernel.open_calls == [(r"\\?\C:\private\owner", "directory", True, True)]
+    assert kernel.set_acl_calls == [(40, True)]
+    assert kernel.verify_acl_calls == [(40, True)]
+    assert owner.privacy_posture == "windows_account_protected"
+
+
+def test_private_file_is_flushed_hardened_and_verified_before_publication() -> None:
+    kernel = FakeWindowsKernel()
+
+    owner = _filesystem(kernel).create_private_file(
+        r"C:\private\owner\server.json",
+        b'{"host":"127.0.0.1"}\n',
+        read_only=True,
+    )
+
+    assert kernel.writes == [(40, b'{"host":"127.0.0.1"}\n')]
+    assert kernel.flushes == [40]
+    assert kernel.set_acl_calls == [(40, False)]
+    assert kernel.read_only == [40]
+    assert kernel.verify_acl_calls == [(40, False)]
+    assert owner.privacy_posture == "windows_account_protected"
+
+
+def test_failed_acl_verification_never_publishes_the_handle() -> None:
+    kernel = FakeWindowsKernel()
+    kernel.acl_matches = False
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        _filesystem(kernel).create_private_directory(r"C:\private\owner")
+
+    assert raised.value.code == "privacy_unavailable"
+    assert str(raised.value) == "Windows artifact privacy is unavailable"
+    assert kernel.closed == [40]
+
+
+def test_owner_lock_and_unlock_target_only_the_exact_handle() -> None:
+    kernel = FakeWindowsKernel()
+    owner = _filesystem(kernel).create_private_file(
+        r"C:\private\owner\owner.lock",
+        b"",
+    )
+
+    owner.lock_exclusive_nonblocking()
+    owner.unlock()
+
+    assert kernel.locks == [40]
+    assert kernel.unlocks == [40]
+
+
+def test_exact_delete_revalidates_identity_and_acl() -> None:
+    kernel = FakeWindowsKernel()
+    owner = _filesystem(kernel).create_private_directory(r"C:\private\owner")
+    initial_verifications = len(kernel.verify_acl_calls)
+
+    owner.delete_exact()
+
+    assert len(kernel.verify_acl_calls) == initial_verifications + 1
+    assert kernel.deleted == [40]
+
+
+def test_exact_delete_preserves_a_substituted_identity() -> None:
+    kernel = FakeWindowsKernel()
+    owner = _filesystem(kernel).create_private_directory(r"C:\private\owner")
+    kernel.identities[40] = windows_artifact_fs.WindowsFileIdentity(
+        volume_serial_number=10,
+        file_id=b"replacement".ljust(16, b"\0"),
+        kind="directory",
+        reparse_tag=0,
+    )
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        owner.delete_exact()
+
+    assert raised.value.code == "changed"
+    assert kernel.deleted == []
+
+
+def test_failed_close_retains_the_exact_handle_for_retry() -> None:
+    kernel = FakeWindowsKernel()
+    owner = _filesystem(kernel).create_private_directory(r"C:\private\owner")
+    kernel.close_failures = 1
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        owner.close()
+
+    assert raised.value.code == "cleanup_failed"
+    assert raised.value.take_cleanup_owner() is owner
+    assert raised.value.take_cleanup_owner() is None
+    owner.close()
+    assert kernel.closed == [40]
+
+
+def test_native_failures_are_bounded_and_path_free() -> None:
+    kernel = FakeWindowsKernel()
+
+    def fail_open(*args: object, **kwargs: object) -> int:
+        del args, kwargs
+        raise OSError("PRIVATE-TOKEN C:\\Users\\owner\\secret")
+
+    kernel.open_handle = fail_open  # type: ignore[method-assign]
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        _filesystem(kernel).pin_directory_no_reparse(r"C:\Users\owner\secret")
+
+    rendered = repr(raised.value) + str(raised.value)
+    assert raised.value.code == "unavailable"
+    assert "PRIVATE-TOKEN" not in rendered
+    assert "Users" not in rendered
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+
+
+def test_post_open_failure_and_close_failure_retains_cleanup_owner() -> None:
+    kernel = FakeWindowsKernel()
+    kernel.close_failures = 1
+
+    def fail_identity(handle: int) -> windows_artifact_fs.WindowsFileIdentity:
+        del handle
+        raise OSError("PRIVATE IDENTITY PATH")
+
+    kernel.identity = fail_identity  # type: ignore[method-assign]
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        _filesystem(kernel).pin_directory_no_reparse(r"C:\private\owner")
+
+    assert raised.value.code == "cleanup_failed"
+    cleanup = raised.value.take_cleanup_owner()
+    assert cleanup is not None
+    cleanup.close()
+    assert kernel.closed == [40]
+
+
+def test_rejected_reparse_and_close_failure_retains_cleanup_owner() -> None:
+    kernel = FakeWindowsKernel()
+    filesystem = _filesystem(kernel)
+    original_open = kernel.open_handle
+
+    def open_reparse(*args: object, **kwargs: object) -> int:
+        handle = original_open(*args, **kwargs)  # type: ignore[arg-type]
+        kernel.identities[handle] = windows_artifact_fs.WindowsFileIdentity(
+            volume_serial_number=9,
+            file_id=handle.to_bytes(16, "little"),
+            kind="directory",
+            reparse_tag=0xA0000003,
+        )
+        kernel.close_failures = 1
+        return handle
+
+    kernel.open_handle = open_reparse  # type: ignore[method-assign]
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        filesystem.pin_directory_no_reparse(r"C:\private\junction")
+
+    assert raised.value.code == "cleanup_failed"
+    cleanup = raised.value.take_cleanup_owner()
+    assert cleanup is not None
+    cleanup.close()
+    assert kernel.closed == [40]
+
+
+def test_failed_private_creation_retirement_is_retryable() -> None:
+    kernel = FakeWindowsKernel()
+
+    def fail_acl(handle: int, user_sid: bytes, directory: bool) -> None:
+        del handle, user_sid, directory
+        kernel.close_failures = 1
+        raise OSError("PRIVATE ACL PATH")
+
+    kernel.set_private_acl = fail_acl  # type: ignore[method-assign]
+
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as raised:
+        _filesystem(kernel).create_private_directory(r"C:\private\owner")
+
+    assert raised.value.code == "cleanup_failed"
+    cleanup = raised.value.take_cleanup_owner()
+    assert cleanup is not None
+    cleanup.close()
+    assert kernel.deleted == [40]
+    assert kernel.closed == [40]
+
+
+@pytest.mark.parametrize(
+    "signal",
+    [KeyboardInterrupt("PRIVATE INTERRUPT"), SystemExit(23), asyncio.CancelledError()],
+)
+def test_control_flow_preserves_family_and_retains_failed_cleanup(
+    signal: BaseException,
+) -> None:
+    kernel = FakeWindowsKernel()
+    kernel.close_failures = 1
+
+    def fail_write(handle: int, data: bytes) -> None:
+        del handle, data
+        raise signal
+
+    kernel.write_all = fail_write  # type: ignore[method-assign]
+
+    with pytest.raises(BaseException) as raised:
+        _filesystem(kernel).create_private_file(
+            r"C:\private\owner\server.json",
+            b"{}",
+        )
+
+    assert raised.value is signal
+    rendered = repr(raised.value) + str(raised.value)
+    assert "PRIVATE" not in rendered
+    if isinstance(signal, SystemExit):
+        assert signal.code == 23
+    cleanup = windows_artifact_fs.take_windows_artifact_cleanup_owner(signal)
+    assert cleanup is not None
+    assert windows_artifact_fs.take_windows_artifact_cleanup_owner(signal) is None
+    cleanup.close()
+    assert kernel.deleted == [40]
+    assert kernel.closed == [40]
+
+
+def test_close_control_flow_preserves_signal_and_exact_owner() -> None:
+    kernel = FakeWindowsKernel()
+    owner = _filesystem(kernel).create_private_directory(r"C:\private\owner")
+    signal = KeyboardInterrupt("PRIVATE CLOSE CONTROL")
+    original_close = kernel.close_handle
+
+    def fail_close(handle: int) -> None:
+        del handle
+        raise signal
+
+    kernel.close_handle = fail_close  # type: ignore[method-assign]
+
+    with pytest.raises(BaseException) as raised:
+        owner.close()
+
+    assert raised.value is signal
+    assert "PRIVATE" not in (repr(signal) + str(signal))
+    assert windows_artifact_fs.take_windows_artifact_cleanup_owner(signal) is owner
+    kernel.close_handle = original_close  # type: ignore[method-assign]
+    owner.close()
+    assert kernel.closed == [40]
+
+
+def test_control_group_is_recursively_bounded_and_retains_cleanup() -> None:
+    kernel = FakeWindowsKernel()
+    kernel.close_failures = 1
+    signal = BaseExceptionGroup(
+        "PRIVATE GROUP PATH",
+        [KeyboardInterrupt("PRIVATE CHILD"), SystemExit("PRIVATE EXIT")],
+    )
+
+    def fail_write(handle: int, data: bytes) -> None:
+        del handle, data
+        raise signal
+
+    kernel.write_all = fail_write  # type: ignore[method-assign]
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        _filesystem(kernel).create_private_file(
+            r"C:\private\owner\server.json",
+            b"{}",
+        )
+
+    rendered = repr(raised.value) + str(raised.value)
+    rendered += "".join(repr(child) + str(child) for child in raised.value.exceptions)
+    assert "PRIVATE" not in rendered
+    cleanup = windows_artifact_fs.take_windows_artifact_cleanup_owner(raised.value)
+    assert cleanup is not None
+    cleanup.close()
+    assert kernel.deleted == [40]
+    assert kernel.closed == [40]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows handles")
+def test_native_windows_private_handles_round_trip_and_lock(tmp_path: Path) -> None:
+    filesystem = windows_artifact_fs.NativeWindowsArtifactFilesystem()
+    owner_path = tmp_path / "owned artifacts"
+    file_path = owner_path / "server.json"
+
+    directory = filesystem.create_private_directory(owner_path)
+    first = filesystem.create_private_file(file_path, b'{"ok":true}', read_only=True)
+    second = filesystem.open_file_no_reparse(file_path, writable=True)
+
+    assert directory.privacy_posture == "windows_account_protected"
+    assert first.privacy_posture == "windows_account_protected"
+    assert first.read(64) == b'{"ok":true}'
+    first.lock_exclusive_nonblocking()
+    with pytest.raises(windows_artifact_fs.WindowsArtifactError) as busy:
+        second.lock_exclusive_nonblocking()
+    assert busy.value.code == "busy"
+    first.unlock()
+    second.close()
+    first.delete_exact()
+    first.close()
+    assert not file_path.exists()
+    directory.delete_exact()
+    directory.close()
+    assert not owner_path.exists()

--- a/Tests/TTS/test_windows_artifact_fs.py
+++ b/Tests/TTS/test_windows_artifact_fs.py
@@ -283,6 +283,17 @@ def test_private_directory_installs_and_reverifies_protected_acl() -> None:
     assert owner.privacy_posture == "windows_account_protected"
 
 
+def test_existing_directory_can_be_protected_without_recreation() -> None:
+    kernel = FakeWindowsKernel()
+
+    owner = _filesystem(kernel).protect_private_directory(r"C:\private\runtime")
+
+    assert kernel.open_calls == [(r"\\?\C:\private\runtime", "directory", False, True)]
+    assert kernel.set_acl_calls == [(40, True)]
+    assert kernel.verify_acl_calls == [(40, True)]
+    assert owner.privacy_posture == "windows_account_protected"
+
+
 def test_private_file_is_flushed_hardened_and_verified_before_publication() -> None:
     kernel = FakeWindowsKernel()
 

--- a/Tests/UI/test_settings_audio_cpp_experience_model.py
+++ b/Tests/UI/test_settings_audio_cpp_experience_model.py
@@ -389,6 +389,22 @@ def test_detect_audio_cpp_binary_returns_none_without_mutating_a_draft(
     assert settings_model.detect_audio_cpp_server_binary() is None
 
 
+def test_detect_audio_cpp_binary_uses_exact_windows_executable_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    detected = r"C:\Tools\audio.cpp\audiocpp_server.exe"
+    calls: list[str] = []
+    monkeypatch.setattr(settings_model.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        settings_model.shutil,
+        "which",
+        lambda command: calls.append(command) or detected,
+    )
+
+    assert settings_model.detect_audio_cpp_server_binary() == detected
+    assert calls == ["audiocpp_server.exe"]
+
+
 def _managed_values(binary_path: str, server_json_path: str) -> dict[str, object]:
     return {
         **AudioCppConfig(

--- a/Tests/UI/test_settings_speech_tts_panel.py
+++ b/Tests/UI/test_settings_speech_tts_panel.py
@@ -2110,7 +2110,68 @@ async def test_panel_does_not_offer_unqualified_managed_mode_on_windows(
             ).render()
         ).lower()
         assert "windows" in notice
+        assert "x86" in notice
+        assert "python 3.12" in notice
         assert "external" in notice
+
+
+def test_windows_managed_ui_gate_uses_shared_platform_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        speech_tts_settings_panel_module,
+        "windows_audio_cpp_platform_supported",
+        lambda: True,
+    )
+    assert (
+        speech_tts_settings_panel_module._audio_cpp_managed_ui_supported(
+            platform_name="nt"
+        )
+        is True
+    )
+    monkeypatch.setattr(
+        speech_tts_settings_panel_module,
+        "windows_audio_cpp_platform_supported",
+        lambda: False,
+    )
+    assert (
+        speech_tts_settings_panel_module._audio_cpp_managed_ui_supported(
+            platform_name="nt"
+        )
+        is False
+    )
+    assert (
+        speech_tts_settings_panel_module._audio_cpp_managed_ui_supported(
+            platform_name="posix"
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_supported_windows_offers_managed_mode_with_bounded_privacy_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        speech_tts_settings_panel_module,
+        "_AUDIO_CPP_MANAGED_UI_SUPPORTED",
+        True,
+    )
+    app = _PanelHarness(configure_provider="audio_cpp")
+
+    async with app.run_test(size=(150, 60)):
+        mode = app.query_one("#settings-speech-audio_cpp-mode", Select)
+        assert [value for _label, value in mode._options] == ["external", "managed"]
+        privacy = str(
+            app.query_one(
+                "#settings-speech-audio-cpp-managed-privacy",
+                Static,
+            ).render()
+        ).lower()
+        assert "will be applied" in privacy
+        assert "administrators and system retain access" in privacy
+        assert "plaintext" in privacy
+        assert "not encryption" in privacy
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_speech_playground_pane_lifecycle.py
+++ b/Tests/UI/test_speech_playground_pane_lifecycle.py
@@ -102,6 +102,7 @@ from tldw_chatbook.UI.stts_playground_catalog import (
 )
 from tldw_chatbook.UI.Speech.speech_playground_pane import SpeechPlaygroundPane
 from tldw_chatbook.UI.Speech import speech_playground_pane as playground_pane_module
+from tldw_chatbook.UI.Speech import speech_clone_setup as speech_clone_setup_module
 from tldw_chatbook.UI.Speech.speech_clone_setup import SpeechCloneSetup
 from tldw_chatbook.UI.Speech.audio_cpp_runtime_card import (
     AudioCppRuntimeCardObservation,
@@ -157,6 +158,7 @@ def _runtime_observation(
     saved_guided_text_ready: bool = False,
     applied_guided_text_ready: bool = False,
     clone_setup: AudioCppCloneSetupProjection | None = None,
+    artifact_privacy_posture: str = "not_applicable",
 ) -> AudioCppRuntimeObservation:
     return AudioCppRuntimeObservation(
         saved_mode=saved_mode,  # type: ignore[arg-type]
@@ -175,6 +177,7 @@ def _runtime_observation(
             last_failure=None,
             diagnostics=diagnostics,
             dropped_diagnostic_lines=dropped_diagnostics,
+            generated_artifact_privacy_posture=artifact_privacy_posture,  # type: ignore[arg-type]
         ),
         catalog_revision=catalog_revision,
         catalog_fresh=catalog_fresh,
@@ -241,9 +244,9 @@ def test_clone_transcript_boundary_runs_shared_input_validation(
         validate_text_input,
     )
 
-    assert playground_pane_module._validate_clone_transcript_input("  spoken words  ") == (
-        "spoken words"
-    )
+    assert playground_pane_module._validate_clone_transcript_input(
+        "  spoken words  "
+    ) == ("spoken words")
     assert calls == [("  spoken words  ", 4_096, True)]
 
 
@@ -294,6 +297,11 @@ async def test_ready_clone_model_mounts_and_canonicalizes_path_free_setup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(
+        speech_clone_setup_module,
+        "windows_audio_cpp_platform_supported",
+        lambda: True,
+    )
     model_id = "<opaque:model>"
     service = _RuntimeObservationService(
         _runtime_observation(
@@ -310,6 +318,7 @@ async def test_ready_clone_model_mounts_and_canonicalizes_path_free_setup(
             saved_guided_default_model_id=model_id,
             applied_guided_default_model_id=model_id,
             clone_setup=_clone_setup(model_id),
+            artifact_privacy_posture="windows_account_protected",
         )
     )
     monkeypatch.setattr(
@@ -335,9 +344,21 @@ async def test_ready_clone_model_mounts_and_canonicalizes_path_free_setup(
         )
         pane = app.query_one(SpeechPlaygroundPane)
         setup = app.query_one(SpeechCloneSetup)
-        assert "plaintext" in str(
-            setup.query_one("#speech-clone-privacy", Static).render()
-        ).lower()
+        assert (
+            "plaintext"
+            in str(setup.query_one("#speech-clone-privacy", Static).render()).lower()
+        )
+        privacy = str(setup.query_one("#speech-clone-privacy", Static).render()).lower()
+        assert "account protected" in privacy
+        assert "administrators and system retain access" in privacy
+        runtime_privacy = str(
+            app.query_one(
+                "#audio-cpp-runtime-artifact-privacy",
+                Static,
+            ).render()
+        )
+        assert "Account protected" in runtime_privacy
+        assert "administrators and SYSTEM retain access" in runtime_privacy
         app.query_one("#tts-text-input", TextArea).text = "Generate cloned speech."
         await pilot.pause()
         ordinary_generate = app.query_one("#tts-generate-btn", Button)
@@ -448,9 +469,9 @@ async def test_applied_clone_generation_change_clears_prior_private_draft(
     async with app.run_test(size=(100, 30)) as pilot:
         await _wait_until(pilot, lambda: len(app.query(SpeechCloneSetup)) == 1)
         pane = app.query_one(SpeechPlaygroundPane)
-        app.query_one("#speech-clone-reference-text", TextArea).text = (
-            "Exact words from the old applied generation."
-        )
+        app.query_one(
+            "#speech-clone-reference-text", TextArea
+        ).text = "Exact words from the old applied generation."
         pane._handle_clone_reference_selection(source)
         await _wait_until(pilot, lambda: pane._clone_setup_canonical is not None)
         prior_calls = service.runtime_observation_calls
@@ -696,13 +717,13 @@ async def test_clone_picker_cancel_and_field_errors_preserve_the_other_input(
         pane._handle_clone_reference_selection(tmp_path)
         await _wait_until(
             pilot,
-            lambda: pane._clone_setup_error
-            == "Choose a valid, bounded PCM WAV reference.",
+            lambda: (
+                pane._clone_setup_error == "Choose a valid, bounded PCM WAV reference."
+            ),
         )
         await _wait_until(
             pilot,
-            lambda: getattr(app.focused, "id", None)
-            == "speech-clone-reference-choose",
+            lambda: getattr(app.focused, "id", None) == "speech-clone-reference-choose",
         )
         assert transcript.text == "Exact words from the valid WAV."
         assert pane._clone_setup_source_path == tmp_path
@@ -1011,6 +1032,36 @@ def test_audio_cpp_runtime_projection_describes_generation_and_catalog_truth() -
     assert projection.catalog_copy == "Catalog: Stale · revision 11"
 
 
+@pytest.mark.parametrize(
+    ("posture", "expected"),
+    (
+        (
+            "windows_account_protected",
+            "Account protected · administrators and SYSTEM retain access · "
+            "plaintext, not encryption",
+        ),
+        (
+            "posix_owner_only",
+            "Owner-only filesystem mode · plaintext, not encryption",
+        ),
+        ("unverified", "Not verified — review required"),
+        (
+            "not_applicable",
+            "Not active · protection is applied only for a Guided start",
+        ),
+    ),
+)
+def test_audio_cpp_runtime_projection_reports_exact_artifact_privacy_posture(
+    posture: str,
+    expected: str,
+) -> None:
+    projection = project_audio_cpp_runtime_card(
+        _runtime_observation(artifact_privacy_posture=posture)
+    )
+
+    assert projection.artifact_privacy_copy == f"Generated launch privacy: {expected}"
+
+
 def test_staged_managed_projection_keeps_applied_external_truth() -> None:
     projection = project_audio_cpp_runtime_card(
         _runtime_observation(
@@ -1077,13 +1128,15 @@ async def test_runtime_diagnostics_are_collapsed_and_interactions_are_passive(
         diagnostics = app.query_one("#audio-cpp-runtime-diagnostics", Collapsible)
         await _wait_until(
             pilot,
-            lambda: "generation: 5"
-            in str(
-                app.query_one(
-                    "#audio-cpp-diagnostics-generation",
-                    Static,
-                ).render()
-            ).lower(),
+            lambda: (
+                "generation: 5"
+                in str(
+                    app.query_one(
+                        "#audio-cpp-diagnostics-generation",
+                        Static,
+                    ).render()
+                ).lower()
+            ),
         )
 
         assert diagnostics.collapsed is True
@@ -2761,9 +2814,9 @@ async def test_ready_clone_setup_preserves_editable_text_and_current_result_geom
         await _wait_until(pilot, lambda: len(screen.query(SpeechCloneSetup)) == 1)
         pane = screen.query_one(SpeechPlaygroundPane)
         screen.query_one("#tts-text-input", TextArea).text = "Generate speech."
-        screen.query_one("#speech-clone-reference-text", TextArea).text = (
-            "Exact words in the reference."
-        )
+        screen.query_one(
+            "#speech-clone-reference-text", TextArea
+        ).text = "Exact words in the reference."
         pane._handle_clone_reference_selection(source)
         await _wait_until(pilot, lambda: pane._clone_setup_canonical is not None)
         generated = _native_profile_artifact(tmp_path / "generated.wav")

--- a/backlog/decisions/029-local-private-data-boundary.md
+++ b/backlog/decisions/029-local-private-data-boundary.md
@@ -1,6 +1,6 @@
 # ADR-029: Local Private Data Boundary
 
-Status: Accepted (amended 2026-07-28 for operational metadata events — TASK-1240)
+Status: Accepted (amended 2026-07-28 for operational metadata events — TASK-1240; amended 2026-08-14 for scoped audio.cpp Windows artifacts — TASK-13208)
 Date: 2026-07-23
 Related Tasks: [TASK-943](../tasks/task-943%20-%20Establish-private-path-boundary-and-harden-config-bootstrap.md), [TASK-489](../tasks/task-489%20-%20Apply-private-storage-boundary-to-every-SQLite-owner-and-backup.md), [TASK-490](../tasks/task-490%20-%20Harden-persistent-log-and-tool-cache-file-lifecycles.md), [TASK-491](../tasks/task-491%20-%20Make-config-persistence-use-one-effective-path-and-live-runtime-boundary.md), [TASK-492](../tasks/task-492%20-%20Remove-private-payloads-from-persistent-diagnostics-and-tool-history.md), [TASK-493](../tasks/task-493%20-%20Contain-legacy-Notes-sync-paths-and-preserve-file-modes.md), [TASK-494](../tasks/task-494%20-%20Complete-metadata-only-boundary-across-remaining-production-diagnostics.md)
 Supersedes: N/A
@@ -22,6 +22,17 @@ file logging is disabled rather than writing to an unsafe target.
 Windows permission state is reported as unverified until a separately approved
 ACL implementation exists. Chatbook must not translate `chmod` success into a
 claim that a Windows discretionary ACL is private.
+
+For the two artifact classes admitted by TASK-13208 only—generated audio.cpp
+launch artifacts and operation-scoped clone-reference materializations—the
+separately approved native Windows boundary is now defined. Chatbook installs
+and re-verifies a protected DACL whose only allowed trustees are the current
+process-token user SID, LocalSystem, and Builtin Administrators. It rejects
+reparse points, null or invalid DACLs, unexpected allow trustees, and native
+verification failures. The product states that these artifacts are plaintext,
+that local system and administrators retain access, and that ACLs are not
+encryption or forensic erasure. Other Windows private paths retain the
+unverified posture until separately implemented and approved.
 
 The config module is the sole persistence owner for `config.toml`. Every
 create, save, delete, encryption, decryption, and password-change operation

--- a/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
+++ b/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
@@ -88,9 +88,10 @@ Detailed executable plan:
   place, copies only the clone model package into its disposable managed store,
   requires structural text/clone WAV evidence, and cannot report final pass
   without explicit audible-and-intelligible confirmation.
-- Host-side focused verification reached 1,037 passing tests plus two expected
+- Rebased host-side focused verification reached 1,036 passing tests plus two expected
   native-Windows skips. Four sandbox-denied loopback real-child tests passed
-  when granted loopback access. Two unrelated mounted UI baseline failures
+  when granted loopback access. One suite-load mount-readiness miss passed
+  immediately in isolation. Two unrelated mounted UI baseline failures
   reproduced outside this change; changed-file Ruff, format, scoped mypy, CI
   shape, harness, and diff gates pass.
 - Release gate: hosted Windows CI and provisioned objective/audible UAT evidence

--- a/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
+++ b/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
@@ -21,6 +21,7 @@ references:
 documentation:
   - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
   - Docs/superpowers/specs/2026-08-14-audio-cpp-windows-lifecycle-parity-design.md
+  - Docs/superpowers/plans/2026-08-14-task-13208-audio-cpp-windows-lifecycle-parity.md
 priority: high
 ---
 
@@ -40,3 +41,32 @@ Provide Windows process, path, ACL, scanner, backend-selection, clone-materializ
 - [ ] #6 Settings and Speech Lab preserve the same saved/applied/process truth, keyboard/focus behavior, sample/clone flows, stable errors, and privacy guarantees on Windows as on POSIX.
 - [ ] #7 Windows-specific unit/integration tests plus pinned Windows CPU real-process UAT prove generated JSON acceptance, health/catalog, text and clone WAV synthesis, Model Library/local package paths, exact shutdown, no orphaned child/handle, and audible playback in a disposable profile.
 <!-- AC:END -->
+
+## Implementation Plan
+
+ADR required: yes
+
+ADR path: `backlog/decisions/029-local-private-data-boundary.md` amendment
+
+Reason: Windows owner-private DACL verification changes the security posture
+for generated audio.cpp launch artifacts and clone-reference materializations;
+the existing runtime and ownership ADRs otherwise remain authoritative.
+
+Detailed executable plan:
+`Docs/superpowers/plans/2026-08-14-task-13208-audio-cpp-windows-lifecycle-parity.md`
+
+1. Add one TTS-scoped stdlib Win32 filesystem capability for absolute paths,
+   no-reparse handles, identity, protected DACLs, locks, and exact cleanup.
+2. Use that capability in the existing bounded package scanner without
+   changing recipe matching or result ownership.
+3. Add a Windows storage branch to the existing generated launch artifact.
+4. Add a Windows record branch to the existing clone-reference materializer.
+5. Admit reviewed `.exe` binaries and Windows x86/x64 backend evidence without
+   executing during detection or Save.
+6. Retain spawn across cancellation and close the exact subprocess transport
+   only after the existing supervisor settles every generation resource.
+7. Enable the existing Settings/Speech Lab flow with truthful DACL and
+   saved/applied/process copy.
+8. Add a hermetic Windows 3.12 CI gate and one parameterized PowerShell UAT.
+9. Close the task only after hosted Windows evidence, clean shutdown, and human
+   audible confirmation pass; otherwise keep it In Progress.

--- a/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
+++ b/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-13208
 title: Add Windows parity for guided audio.cpp lifecycle and cloning
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-09 17:39'
 labels:
@@ -20,6 +20,7 @@ references:
   - backlog/decisions/051-private-tts-clone-reference-assets.md
 documentation:
   - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
+  - Docs/superpowers/specs/2026-08-14-audio-cpp-windows-lifecycle-parity-design.md
 priority: high
 ---
 

--- a/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
+++ b/backlog/tasks/task-13208 - Add-Windows-parity-for-guided-audio.cpp-lifecycle-and-cloning.md
@@ -22,6 +22,7 @@ documentation:
   - Docs/superpowers/specs/2026-08-09-audio-cpp-guided-model-setup-design.md
   - Docs/superpowers/specs/2026-08-14-audio-cpp-windows-lifecycle-parity-design.md
   - Docs/superpowers/plans/2026-08-14-task-13208-audio-cpp-windows-lifecycle-parity.md
+  - Docs/superpowers/qa/audio-cpp-windows-2026-08-14/README.md
 priority: high
 ---
 
@@ -70,3 +71,28 @@ Detailed executable plan:
 8. Add a hermetic Windows 3.12 CI gate and one parameterized PowerShell UAT.
 9. Close the task only after hosted Windows evidence, clean shutdown, and human
    audible confirmation pass; otherwise keep it In Progress.
+
+## Implementation Notes
+
+- Added one stdlib Win32 artifact capability and reused the existing scanner,
+  generated-config, clone-materialization, supervisor, managed-store, Settings,
+  and Speech Lab ownership boundaries. No dependency, secondary supervisor,
+  Job Object, descendant ownership claim, or Windows-only UX was added.
+- Windows 10+ x86/x64 on Python 3.12+ is capability-gated. ARM remains
+  unsupported pending separately provisioned runtime/backend evidence and UAT.
+- Amended ADR-029 only for verified protected-DACL posture on generated
+  audio.cpp configs and operation-scoped clone references; all raw native
+  failures remain behind bounded path-free outcomes.
+- Added a required hermetic `windows-latest` x86/x64 job and a generic
+  parameterized PowerShell UAT. The UAT launches a user-provided server in
+  place, copies only the clone model package into its disposable managed store,
+  requires structural text/clone WAV evidence, and cannot report final pass
+  without explicit audible-and-intelligible confirmation.
+- Host-side focused verification reached 1,037 passing tests plus two expected
+  native-Windows skips. Four sandbox-denied loopback real-child tests passed
+  when granted loopback access. Two unrelated mounted UI baseline failures
+  reproduced outside this change; changed-file Ruff, format, scoped mypy, CI
+  shape, harness, and diff gates pass.
+- Release gate: hosted Windows CI and provisioned objective/audible UAT evidence
+  are not yet available for both x86 and x64. TASK-13208 therefore remains In
+  Progress and all acceptance criteria remain unchecked.

--- a/scripts/uat_audio_cpp_windows.ps1
+++ b/scripts/uat_audio_cpp_windows.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ServerBinary,
+    [Parameter(Mandatory = $true)][string]$TextPackageRoot,
+    [Parameter(Mandatory = $true)][string]$ClonePackageRoot,
+    [Parameter(Mandatory = $true)][string]$CloneReferenceWav,
+    [Parameter(Mandatory = $true)][string]$CloneReferenceText,
+    [Parameter(Mandatory = $true)][string]$TextRecipeId,
+    [Parameter(Mandatory = $true)][int]$TextRecipeRevision,
+    [Parameter(Mandatory = $true)][string]$TextPackageVariant,
+    [Parameter(Mandatory = $true)][string]$TextModelId,
+    [Parameter(Mandatory = $true)][string]$CloneRecipeId,
+    [Parameter(Mandatory = $true)][int]$CloneRecipeRevision,
+    [Parameter(Mandatory = $true)][string]$ClonePackageVariant,
+    [Parameter(Mandatory = $true)][string]$CloneModelId,
+    [Parameter(Mandatory = $true)][string]$CloneArtifactId,
+    [Parameter(Mandatory = $true)][string]$CloneArtifactRevision,
+    [Parameter(Mandatory = $true)][string]$CloneArtifactVariant,
+    [Parameter(Mandatory = $true)][string]$EvidenceOutput,
+    [string]$PythonCommand = "python"
+)
+
+$ErrorActionPreference = "Stop"
+$privateRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("tldw-audio-cpp-uat-" + [guid]::NewGuid().ToString("N"))
+$savedEnvironment = @{}
+$environmentNames = @("HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "TLDW_CONFIG_PATH")
+
+try {
+    New-Item -ItemType Directory -Path $privateRoot | Out-Null
+    foreach ($name in $environmentNames) {
+        $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+    }
+    $env:HOME = Join-Path $privateRoot "home"
+    $env:XDG_CONFIG_HOME = Join-Path $privateRoot "config"
+    $env:XDG_DATA_HOME = Join-Path $privateRoot "data"
+    $env:TLDW_CONFIG_PATH = Join-Path $env:XDG_CONFIG_HOME "config.toml"
+    $runtimeRoot = Join-Path $privateRoot "runtime"
+    New-Item -ItemType Directory -Path $env:HOME, $env:XDG_CONFIG_HOME, $env:XDG_DATA_HOME, $runtimeRoot | Out-Null
+
+    $arguments = @(
+        "scripts/uat_audio_cpp_windows.py",
+        "--server-binary", $ServerBinary,
+        "--text-package-root", $TextPackageRoot,
+        "--clone-package-root", $ClonePackageRoot,
+        "--clone-reference-wav", $CloneReferenceWav,
+        "--clone-reference-text", $CloneReferenceText,
+        "--text-recipe-id", $TextRecipeId,
+        "--text-recipe-revision", $TextRecipeRevision,
+        "--text-package-variant", $TextPackageVariant,
+        "--text-model-id", $TextModelId,
+        "--clone-recipe-id", $CloneRecipeId,
+        "--clone-recipe-revision", $CloneRecipeRevision,
+        "--clone-package-variant", $ClonePackageVariant,
+        "--clone-model-id", $CloneModelId,
+        "--clone-artifact-id", $CloneArtifactId,
+        "--clone-artifact-revision", $CloneArtifactRevision,
+        "--clone-artifact-variant", $CloneArtifactVariant,
+        "--runtime-root", $runtimeRoot,
+        "--result-file", $EvidenceOutput
+    )
+    & $PythonCommand @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "The objective Windows audio.cpp UAT did not pass."
+    }
+
+    $player = New-Object System.Media.SoundPlayer
+    foreach ($sample in @("text.wav", "clone.wav")) {
+        $player.SoundLocation = Join-Path $runtimeRoot $sample
+        $player.PlaySync()
+    }
+    $heard = Read-Host "Were both generated samples audible and intelligible? Type yes or no"
+    $finalArguments = $arguments + @("--audible", $(if ($heard -eq "yes") { "yes" } else { "no" }))
+    & $PythonCommand @finalArguments
+    exit $LASTEXITCODE
+}
+finally {
+    foreach ($name in $environmentNames) {
+        [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], "Process")
+    }
+    if (Test-Path -LiteralPath $privateRoot) {
+        Remove-Item -LiteralPath $privateRoot -Recurse -Force
+    }
+}

--- a/scripts/uat_audio_cpp_windows.py
+++ b/scripts/uat_audio_cpp_windows.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Provisioned Windows audio.cpp lifecycle UAT.
+
+The harness consumes user-provided inputs in place. It never downloads,
+copies, imports, or installs an audio.cpp executable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import io
+import json
+import logging
+import platform
+from pathlib import Path
+import struct
+import sys
+import wave
+from typing import Literal, Mapping
+
+
+Status = Literal["pass", "fail", "partial", "inaudible"]
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedPackage:
+    """Path-free exact identity expected from one selected package."""
+
+    recipe_id: str
+    recipe_revision: int
+    package_variant: str
+    model_id: str
+
+    def as_evidence(self) -> dict[str, str | int]:
+        return {
+            "model_id": self.model_id,
+            "package_variant": self.package_variant,
+            "recipe_id": self.recipe_id,
+            "recipe_revision": self.recipe_revision,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UATEvidence:
+    """Sanitized stable evidence written for the operator and review."""
+
+    status: Status
+    objective: Literal["pass", "fail"]
+    architecture: str
+    python: str
+    checks: tuple[str, ...]
+    text_package: Mapping[str, str | int] | None
+    clone_package: Mapping[str, str | int] | None
+    text_wav: Mapping[str, int] | None
+    clone_wav: Mapping[str, int] | None
+    audible: bool | None
+    cleanup: Literal["pass", "fail"]
+
+
+def validate_host_contract(
+    system: str,
+    windows_version: tuple[int, int],
+    python_version: tuple[int, int],
+    architecture: str,
+) -> str:
+    """Return the admitted architecture or reject the unsupported host."""
+
+    normalized = architecture.casefold()
+    admitted = {
+        "amd64": "x64",
+        "x64": "x64",
+        "x86_64": "x64",
+        "x86": "x86",
+        "i386": "x86",
+        "i686": "x86",
+    }.get(normalized)
+    if (
+        system.casefold() != "windows"
+        or windows_version < (10, 0)
+        or python_version < (3, 12)
+        or admitted is None
+    ):
+        raise ValueError("unsupported Windows audio.cpp UAT host")
+    return admitted
+
+
+def validate_wav(payload: bytes) -> dict[str, int]:
+    """Validate a complete PCM WAV and return bounded structural evidence."""
+
+    try:
+        with wave.open(io.BytesIO(payload), "rb") as source:
+            channels = source.getnchannels()
+            frames = source.getnframes()
+            sample_rate = source.getframerate()
+            sample_width = source.getsampwidth()
+            compression = source.getcomptype()
+    except (EOFError, OSError, wave.Error):
+        raise ValueError("generated WAV is invalid") from None
+    if (
+        channels not in (1, 2)
+        or frames < 1
+        or not 8_000 <= sample_rate <= 192_000
+        or sample_width != 2
+        or compression != "NONE"
+    ):
+        raise ValueError("generated WAV is invalid")
+    return {
+        "channels": channels,
+        "frames": frames,
+        "sample_rate_hz": sample_rate,
+    }
+
+
+def compare_package(
+    expected: ExpectedPackage,
+    actual: Mapping[str, str | int],
+) -> dict[str, str | int]:
+    """Require one exact package identity without exposing its root."""
+
+    evidence = expected.as_evidence()
+    if dict(actual) != evidence:
+        raise ValueError("audio.cpp package identity did not match")
+    return evidence
+
+
+def final_status(*, journey: Status, audible: bool, cleanup: str) -> Status:
+    """Combine objective, human, and cleanup evidence conservatively."""
+
+    if cleanup != "pass":
+        return "fail"
+    if journey != "pass":
+        return journey
+    return "pass" if audible else "inaudible"
+
+
+def write_evidence(path: Path, evidence: UATEvidence) -> None:
+    """Atomically write only the fixed path-free evidence schema."""
+
+    payload = json.dumps(asdict(evidence), indent=2, sort_keys=True) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(payload, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _host_architecture() -> str:
+    version = sys.getwindowsversion()  # type: ignore[attr-defined]
+    machine = "x86" if struct.calcsize("P") == 4 else platform.machine()
+    return validate_host_contract(
+        platform.system(),
+        (version.major, version.minor),
+        (sys.version_info.major, sys.version_info.minor),
+        machine,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server-binary", type=Path, required=True)
+    parser.add_argument("--text-package-root", type=Path, required=True)
+    parser.add_argument("--clone-package-root", type=Path, required=True)
+    parser.add_argument("--clone-reference-wav", type=Path, required=True)
+    parser.add_argument("--clone-reference-text", required=True)
+    parser.add_argument("--text-recipe-id", required=True)
+    parser.add_argument("--text-recipe-revision", type=int, required=True)
+    parser.add_argument("--text-package-variant", required=True)
+    parser.add_argument("--text-model-id", required=True)
+    parser.add_argument("--clone-recipe-id", required=True)
+    parser.add_argument("--clone-recipe-revision", type=int, required=True)
+    parser.add_argument("--clone-package-variant", required=True)
+    parser.add_argument("--clone-model-id", required=True)
+    parser.add_argument("--clone-artifact-id", required=True)
+    parser.add_argument("--clone-artifact-revision", required=True)
+    parser.add_argument("--clone-artifact-variant", required=True)
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    parser.add_argument("--result-file", type=Path, required=True)
+    parser.add_argument(
+        "--audible",
+        choices=("yes", "no"),
+        help="Finalize an existing objective result after human playback.",
+    )
+    return parser
+
+
+def _expected_package(args: argparse.Namespace, prefix: str) -> ExpectedPackage:
+    return ExpectedPackage(
+        recipe_id=getattr(args, f"{prefix}_recipe_id"),
+        recipe_revision=getattr(args, f"{prefix}_recipe_revision"),
+        package_variant=getattr(args, f"{prefix}_package_variant"),
+        model_id=getattr(args, f"{prefix}_model_id"),
+    )
+
+
+def _scan_package(root: Path, expected: ExpectedPackage):
+    from tldw_chatbook.TTS.audio_cpp_package_scanner import (
+        AudioCppScanOutcome,
+        scan_audio_cpp_package_root,
+    )
+
+    scan = scan_audio_cpp_package_root(root)
+    candidates = tuple(
+        candidate
+        for discovery in scan.discoveries
+        for candidate in discovery.match.candidates
+        if candidate.recipe.recipe_id == expected.recipe_id
+    )
+    if scan.outcome is not AudioCppScanOutcome.COMPLETE or len(candidates) != 1:
+        raise ValueError("audio.cpp package scan was not exact")
+    candidate = candidates[0]
+    compare_package(
+        expected,
+        {
+            "model_id": expected.model_id,
+            "package_variant": candidate.recipe.package_variant,
+            "recipe_id": candidate.recipe.recipe_id,
+            "recipe_revision": candidate.recipe.recipe_revision,
+        },
+    )
+    return candidate
+
+
+async def _response_bytes(response) -> bytes:
+    try:
+        return b"".join([chunk async for chunk in response.byte_stream])
+    finally:
+        await response.aclose()
+
+
+async def _production_journey(
+    args: argparse.Namespace,
+    *,
+    architecture: str,
+) -> tuple[dict[str, int], dict[str, int], tuple[str, ...]]:
+    logging.disable(logging.CRITICAL)
+    try:
+        from loguru import logger
+
+        logger.remove()
+    except ImportError:
+        pass
+
+    from tldw_chatbook.Model_Artifacts.service import (
+        ArtifactRef,
+        ArtifactRemovalAvailability,
+        ModelArtifactService,
+    )
+    from tldw_chatbook.Model_Artifacts.store import managed_model_artifact_root
+    from tldw_chatbook.TTS.adapter_types import (
+        TTSRequest,
+        _new_admitted_audio_cpp_clone_request,
+    )
+    from tldw_chatbook.TTS.adapters.audio_cpp import AudioCppAdapter
+    from tldw_chatbook.TTS.audio_cpp_artifact_catalog import (
+        audio_cpp_curated_entries,
+    )
+    from tldw_chatbook.TTS.audio_cpp_guided_config import (
+        AudioCppBackendPreference,
+        AudioCppManagedArtifactIdentity,
+        AudioCppManagedSetupSource,
+        AudioCppSettingsConfig,
+    )
+    from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
+    from tldw_chatbook.TTS.audio_cpp_guided_launch import _validate_binary
+    from tldw_chatbook.TTS.audio_cpp_supervisor import AudioCppSupervisor
+    from tldw_chatbook.TTS.profile_reference_materialization import (
+        TTSCloneReferenceMaterializer,
+    )
+    from tldw_chatbook.TTS.profile_reference_types import (
+        CanonicalTTSCloneReference,
+    )
+
+    binary = await asyncio.to_thread(
+        _validate_binary,
+        str(args.server_binary),
+        system="windows",
+        architecture=architecture,
+    )
+    if binary is None:
+        raise ValueError("audio.cpp binary review failed")
+
+    text_expected = _expected_package(args, "text")
+    clone_expected = _expected_package(args, "clone")
+    text_candidate = await asyncio.to_thread(
+        _scan_package, args.text_package_root, text_expected
+    )
+    await asyncio.to_thread(_scan_package, args.clone_package_root, clone_expected)
+
+    managed_reference = ArtifactRef(
+        args.clone_artifact_id,
+        args.clone_artifact_revision,
+        args.clone_artifact_variant,
+    )
+    catalog_entries = tuple(
+        item
+        for item in audio_cpp_curated_entries()
+        if item[0].reference == managed_reference
+        and item[0].model_id == clone_expected.model_id
+    )
+    if len(catalog_entries) != 1:
+        raise ValueError("audio.cpp managed package identity did not match")
+    descriptor, _sources = catalog_entries[0]
+    if descriptor.reference != managed_reference:
+        raise ValueError("audio.cpp managed package identity did not match")
+
+    service = ModelArtifactService(managed_model_artifact_root())
+    installed = await asyncio.to_thread(
+        service.install,
+        descriptor,
+        args.clone_package_root,
+        declared_files_only=True,
+    )
+    if installed != managed_reference:
+        raise ValueError("audio.cpp managed package identity did not match")
+    root_lease = await asyncio.to_thread(
+        service.acquire_installed_root, managed_reference
+    )
+    try:
+        managed_root = root_lease.handle.paths[0][1]
+    finally:
+        await asyncio.to_thread(root_lease.close)
+    managed_identity = AudioCppManagedArtifactIdentity(
+        artifact_id=managed_reference.artifact_id,
+        revision=managed_reference.revision,
+        variant=managed_reference.variant,
+    )
+    clone_candidate = await asyncio.to_thread(
+        _scan_package, managed_root, clone_expected
+    )
+    text_package = text_candidate.accept(public_model_id=text_expected.model_id)
+    clone_package = clone_candidate.accept(
+        public_model_id=clone_expected.model_id,
+        managed_artifact=managed_identity,
+    )
+
+    settings = AudioCppSettingsConfig(
+        mode="managed",
+        managed_setup_source=AudioCppManagedSetupSource.GUIDED,
+        guided_binary_path=str(binary),
+        guided_packages=(text_package, clone_package),
+        guided_default_model_id=text_expected.model_id,
+        guided_backend_preference=AudioCppBackendPreference.CPU,
+    )
+    supervisor = AudioCppSupervisor()
+    adapter = AudioCppAdapter(
+        config=AudioCppConfig.from_mapping(settings.to_mapping()),
+        supervisor=supervisor,
+        guided_settings=settings,
+    )
+    materializer = TTSCloneReferenceMaterializer(args.runtime_root / "clone")
+    checks = [
+        "host",
+        "binary_review_no_launch",
+        "local_package_exact",
+        "managed_package_exact_root",
+        "guided_save_no_launch",
+    ]
+    if supervisor.snapshot().state != "stopped":
+        raise RuntimeError("guided save started a process")
+
+    text_path = args.runtime_root / "text.wav"
+    clone_path = args.runtime_root / "clone.wav"
+    try:
+        text_response = await adapter.synthesize(
+            TTSRequest(
+                provider_id="audio_cpp",
+                model_id=text_expected.model_id,
+                text="Windows audio.cpp text lifecycle verification.",
+                voice=None,
+                response_format="wav",
+            )
+        )
+        text_audio = await _response_bytes(text_response)
+        text_wav = validate_wav(text_audio)
+        text_path.write_bytes(text_audio)
+        checks.extend(("generated_json", "health_catalog", "text_wav"))
+
+        reference_audio = args.clone_reference_wav.read_bytes()
+        reference_info = validate_wav(reference_audio)
+        canonical_reference = CanonicalTTSCloneReference(
+            wav_bytes=reference_audio,
+            reference_text=args.clone_reference_text,
+            sha256=sha256(reference_audio).hexdigest(),
+            byte_length=len(reference_audio),
+            duration_ms=max(
+                1,
+                round(
+                    reference_info["frames"] * 1000 / reference_info["sample_rate_hz"]
+                ),
+            ),
+            sample_rate_hz=reference_info["sample_rate_hz"],
+            channels=reference_info["channels"],
+            sample_encoding="pcm_s16le",
+        )
+        clone_request = TTSRequest(
+            provider_id="audio_cpp",
+            model_id=clone_expected.model_id,
+            text="Windows audio.cpp clone lifecycle verification.",
+            voice=None,
+            response_format="wav",
+        )
+        capability = adapter.admit_clone_capability(clone_request)
+        materialization = await materializer.materialize(canonical_reference)
+        admitted = _new_admitted_audio_cpp_clone_request(
+            request=clone_request,
+            materialization=materialization,
+            capability=capability,
+            provider_revision=adapter._catalog.revision,
+            applied_provider_generation=0,
+        )
+        clone_response = await adapter.synthesize_clone(admitted)
+        clone_audio = await _response_bytes(clone_response)
+        clone_wav = validate_wav(clone_audio)
+        clone_path.write_bytes(clone_audio)
+        checks.extend(("clone_materialization", "clone_wav"))
+
+        availability = await asyncio.to_thread(
+            service.probe_removal_availability, managed_reference
+        )
+        if availability is not ArtifactRemovalAvailability.BUSY:
+            raise RuntimeError("live managed package removal was not blocked")
+        checks.append("live_removal_blocked")
+
+        await supervisor.stop()
+        cancelled_start = asyncio.create_task(adapter._refresh_catalog(force=True))
+        await asyncio.sleep(0)
+        cancelled_start.cancel()
+        try:
+            await cancelled_start
+        except asyncio.CancelledError:
+            pass
+        await adapter._refresh_catalog(force=True)
+        if supervisor.snapshot().state != "running":
+            raise RuntimeError("managed restart did not recover")
+        checks.extend(("cancelled_start_settled", "restart_recovery"))
+
+        generation = supervisor._generation
+        if generation is None:
+            raise RuntimeError("managed process ownership was unavailable")
+        generation.owned.process.kill()
+        await generation.owned.process.wait()
+        for _ in range(100):
+            if supervisor.snapshot().state != "running":
+                break
+            await asyncio.sleep(0.05)
+        await adapter._refresh_catalog(force=True)
+        if supervisor.snapshot().state != "running":
+            raise RuntimeError("managed crash recovery did not converge")
+        checks.append("crash_recovery")
+    finally:
+        await adapter.close()
+        await materializer.close()
+        await supervisor.close()
+        await supervisor.wait_closed()
+
+    availability = await asyncio.to_thread(
+        service.probe_removal_availability, managed_reference
+    )
+    if availability is not ArtifactRemovalAvailability.AVAILABLE:
+        raise RuntimeError("managed package lease remained after shutdown")
+    authority = await asyncio.to_thread(
+        service.acquire_removal_authority, managed_reference
+    )
+    try:
+        await asyncio.to_thread(authority.commit)
+    finally:
+        await asyncio.to_thread(authority.close)
+    checks.extend(("removal_after_stop", "shutdown_clean"))
+    return text_wav, clone_wav, tuple(checks)
+
+
+def run_journey(args: argparse.Namespace, *, architecture: str) -> UATEvidence:
+    """Run the retained production lifecycle and return only bounded evidence."""
+
+    try:
+        text_wav, clone_wav, checks = asyncio.run(
+            _production_journey(args, architecture=architecture)
+        )
+    except Exception:
+        return UATEvidence(
+            status="fail",
+            objective="fail",
+            architecture=architecture,
+            python=f"{sys.version_info.major}.{sys.version_info.minor}",
+            checks=(),
+            text_package=None,
+            clone_package=None,
+            text_wav=None,
+            clone_wav=None,
+            audible=None,
+            cleanup="fail",
+        )
+    return UATEvidence(
+        status="partial",
+        objective="pass",
+        architecture=architecture,
+        python=f"{sys.version_info.major}.{sys.version_info.minor}",
+        checks=checks,
+        text_package=_expected_package(args, "text").as_evidence(),
+        clone_package={
+            **_expected_package(args, "clone").as_evidence(),
+            "artifact_id": args.clone_artifact_id,
+            "artifact_revision": args.clone_artifact_revision,
+            "artifact_variant": args.clone_artifact_variant,
+        },
+        text_wav=text_wav,
+        clone_wav=clone_wav,
+        audible=None,
+        cleanup="pass",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run or finalize the provisioned UAT without printing private inputs."""
+
+    args = _parser().parse_args(argv)
+    try:
+        architecture = _host_architecture()
+    except ValueError:
+        print("Windows audio.cpp UAT: unsupported")
+        return 2
+    if args.audible is not None:
+        current = json.loads(args.result_file.read_text(encoding="utf-8"))
+        status = final_status(
+            journey=current["objective"],
+            audible=args.audible == "yes",
+            cleanup=current["cleanup"],
+        )
+        current["audible"] = args.audible == "yes"
+        current["status"] = status
+        args.result_file.write_text(
+            json.dumps(current, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Windows audio.cpp UAT: {status}")
+        return 0 if status == "pass" else 1
+
+    # The production journey is deliberately imported only after the native
+    # host contract passes, keeping ordinary tests and unsupported hosts inert.
+    evidence = run_journey(args, architecture=architecture)
+    write_evidence(args.result_file, evidence)
+    print(f"Windows audio.cpp UAT: {evidence.status}")
+    return 0 if evidence.objective == "pass" and evidence.cleanup == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tldw_chatbook/TTS/audio_cpp_guided_launch.py
+++ b/tldw_chatbook/TTS/audio_cpp_guided_launch.py
@@ -12,7 +12,7 @@ import stat
 from collections.abc import Callable
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, NoReturn, cast
 
 from tldw_chatbook.Model_Artifacts.service import (
     ArtifactRef,
@@ -455,6 +455,8 @@ class _WindowsGeneratedLaunchArtifact(AudioCppGeneratedLaunchArtifact):
 
 def _normalize_architecture(value: str, *, system: str) -> str:
     folded = value.casefold()
+    if system == "windows" and folded in {"x86", "i386", "i486", "i586", "i686"}:
+        return "x86"
     if folded in {"arm64", "aarch64"}:
         return "arm64" if system == "darwin" else "aarch64"
     return {
@@ -463,11 +465,58 @@ def _normalize_architecture(value: str, *, system: str) -> str:
     }.get(folded, folded)
 
 
-def _validate_binary(path: str) -> Path | None:
+def _windows_pe_machine(owner: Any) -> int | None:
+    header = owner.read(4096)
+    if len(header) < 0x40 or header[:2] != b"MZ":
+        return None
+    offset = int.from_bytes(header[0x3C:0x40], "little")
+    if offset < 0x40 or offset > len(header) - 6:
+        return None
+    if header[offset : offset + 4] != b"PE\0\0":
+        return None
+    return int.from_bytes(header[offset + 4 : offset + 6], "little")
+
+
+def _validate_binary(
+    path: str,
+    *,
+    system: str | None = None,
+    architecture: str | None = None,
+) -> Path | None:
     from tldw_chatbook.Utils.path_validation import validate_path_simple
 
+    host_system = (platform.system() if system is None else system).casefold()
     try:
         candidate = validate_path_simple(path, require_exists=True)
+        if host_system == "windows":
+            filesystem = _windows_artifact_filesystem
+            if (
+                filesystem is None
+                or not candidate.is_absolute()
+                or candidate.suffix.casefold() != ".exe"
+            ):
+                return None
+            host_architecture = _normalize_architecture(
+                platform.machine() if architecture is None else architecture,
+                system="windows",
+            )
+            expected_machine = {"x86": 0x014C, "x86_64": 0x8664}.get(host_architecture)
+            if expected_machine is None:
+                return None
+            owner = filesystem.open_file_no_reparse(candidate)
+            valid = (
+                owner.identity.kind == "file"
+                and owner.identity.reparse_tag == 0
+                and _windows_pe_machine(owner) == expected_machine
+            )
+            try:
+                owner.close()
+            except WindowsArtifactError:
+                try:
+                    owner.close()
+                except WindowsArtifactError:
+                    return None
+            return candidate if valid else None
         info = candidate.stat()
         if (
             not candidate.is_absolute()
@@ -475,7 +524,7 @@ def _validate_binary(path: str) -> Path | None:
             or not os.access(candidate, os.X_OK)
         ):
             return None
-    except (OSError, ValueError):
+    except (OSError, ValueError, WindowsArtifactError):
         return None
     return candidate
 
@@ -630,7 +679,7 @@ def select_audio_cpp_guided_backend(
     """
 
     host_system = (platform.system() if system is None else system).casefold()
-    if host_system not in {"darwin", "linux"}:
+    if host_system not in {"darwin", "linux", "windows"}:
         return None
     host_architecture = _normalize_architecture(
         platform.machine() if architecture is None else architecture,
@@ -1076,7 +1125,7 @@ def _managed_acquire_outcome(
 async def _raise_guided_failure_after_cleanup(
     artifact: AudioCppGeneratedLaunchArtifact,
     code: AudioCppGuidedLaunchErrorCode,
-) -> None:
+) -> NoReturn:
     if not await _cleanup_succeeded(artifact):
         raise AudioCppGuidedLaunchError(
             "artifact_cleanup_failed",
@@ -1122,7 +1171,12 @@ async def materialize_audio_cpp_guided_launch(
     ):
         raise AudioCppGuidedLaunchError("configuration_invalid") from None
 
-    binary = await asyncio.to_thread(_validate_binary, settings.guided_binary_path)
+    binary = await asyncio.to_thread(
+        _validate_binary,
+        settings.guided_binary_path,
+        system=system,
+        architecture=architecture,
+    )
     if binary is None:
         raise AudioCppGuidedLaunchError("binary_invalid") from None
     recipes: list[AudioCppPackageRecipe] = []
@@ -1141,7 +1195,10 @@ async def materialize_audio_cpp_guided_launch(
     exact_recipes = tuple(recipes)
 
     host_system = (platform.system() if system is None else system).casefold()
-    if os.name != "posix" or host_system not in {"darwin", "linux"}:
+    supported_host = (os.name == "posix" and host_system in {"darwin", "linux"}) or (
+        host_system == "windows" and _windows_artifact_filesystem is not None
+    )
+    if not supported_host:
         raise AudioCppGuidedLaunchError("backend_unsupported") from None
     backend = select_audio_cpp_guided_backend(
         settings.guided_backend_preference,

--- a/tldw_chatbook/TTS/audio_cpp_guided_launch.py
+++ b/tldw_chatbook/TTS/audio_cpp_guided_launch.py
@@ -12,7 +12,7 @@ import stat
 from collections.abc import Callable
 from hashlib import sha256
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from tldw_chatbook.Model_Artifacts.service import (
     ArtifactRef,
@@ -40,6 +40,12 @@ from .audio_cpp_recipes import (
     AUDIO_CPP_RECIPE_REGISTRY,
     AudioCppBackendEvidenceState,
     AudioCppPackageRecipe,
+)
+from .windows_artifact_fs import (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM,
+    WindowsArtifactError,
+    WindowsArtifactFilesystem,
+    windows_audio_cpp_platform_supported,
 )
 
 
@@ -77,6 +83,9 @@ _DIRECTORY_FLAGS = (
 )
 _FILE_READ_FLAGS = (
     os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+)
+_windows_artifact_filesystem: WindowsArtifactFilesystem | None = (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM if windows_audio_cpp_platform_supported() else None
 )
 
 
@@ -150,6 +159,12 @@ class AudioCppGeneratedLaunchArtifact:
         if self._cleaned:
             raise RuntimeError("generated artifact is already cleaned")
         self._managed_handles.append(handle)
+
+    @property
+    def privacy_posture(self) -> str:
+        """Project only the privacy posture verified by the artifact owner."""
+
+        return "posix_owner_only"
 
     @staticmethod
     def _identity(info: os.stat_result) -> tuple[int, int]:
@@ -265,6 +280,10 @@ class AudioCppGeneratedLaunchArtifact:
                 except OSError:
                     pass
 
+        self._cleanup_managed_handles()
+        self._cleaned = True
+
+    def _cleanup_managed_handles(self) -> None:
         remaining: list[LeasedArtifactHandle] = []
         control_flow: BaseException | None = None
         for handle in self._managed_handles:
@@ -279,6 +298,158 @@ class AudioCppGeneratedLaunchArtifact:
             raise control_flow
         if remaining:
             raise AudioCppGuidedLaunchError("artifact_cleanup_failed") from None
+
+
+class _WindowsGeneratedLaunchArtifact(AudioCppGeneratedLaunchArtifact):
+    """Exact Windows handle owner for one generated launch configuration."""
+
+    __slots__ = (
+        "_windows_directory",
+        "_windows_extras",
+        "_windows_file",
+        "_windows_parent",
+    )
+
+    def __init__(
+        self,
+        *,
+        parent: Any,
+        directory: Any | None,
+        file: Any | None,
+        server_json_path: Path,
+        digest: str,
+        size: int,
+        extras: tuple[Any, ...] = (),
+    ) -> None:
+        super().__init__(
+            parent_fd=-1,
+            directory_fd=-1,
+            directory_name=server_json_path.parent.name,
+            server_json_path=server_json_path,
+            directory_identity=(0, 0),
+            file_identity=(0, 0),
+            digest=digest,
+            size=size,
+        )
+        self._windows_parent = parent
+        self._windows_directory = directory
+        self._windows_file = file
+        self._windows_extras = list(extras)
+
+    @property
+    def privacy_posture(self) -> str:
+        """Report protected only while every published owner still verifies."""
+
+        parent = self._windows_parent
+        directory = self._windows_directory
+        file = self._windows_file
+        if self._cleaned or parent is None or directory is None or file is None:
+            return "unverified"
+        owners = (parent, directory, file)
+        return (
+            "windows_account_protected"
+            if all(
+                owner.privacy_posture == "windows_account_protected"
+                and owner.verify_private_acl()
+                for owner in owners
+            )
+            else "unverified"
+        )
+
+    def validate(self) -> None:
+        """Validate exact path identity, bounded bytes, contents, and DACL."""
+
+        filesystem = _windows_artifact_filesystem
+        failed = self.privacy_posture != "windows_account_protected"
+        observed: Any = None
+        try:
+            if failed or filesystem is None or self._windows_file is None:
+                failed = True
+            else:
+                names = tuple(
+                    entry.name for entry in os.scandir(self.server_json_path.parent)
+                )
+                if names != (_ARTIFACT_FILE,):
+                    failed = True
+                else:
+                    observed = filesystem.open_file_no_reparse(self.server_json_path)
+                    self._windows_extras.append(observed)
+                    if observed.identity != self._windows_file.identity:
+                        failed = True
+                    else:
+                        data = self._windows_file.read(self._size + 1)
+                        failed = (
+                            len(data) != self._size
+                            or sha256(data).hexdigest() != self._digest
+                        )
+        except (OSError, WindowsArtifactError):
+            failed = True
+        finally:
+            if observed is not None:
+                try:
+                    observed.close()
+                except WindowsArtifactError:
+                    failed = True
+                else:
+                    self._windows_extras.remove(observed)
+        if failed:
+            raise AudioCppGuidedLaunchError("artifact_changed") from None
+
+    @staticmethod
+    def _close_windows(owner: Any) -> bool:
+        try:
+            owner.close()
+        except WindowsArtifactError:
+            return False
+        return True
+
+    def cleanup(self) -> None:
+        """Remove exact Windows objects, close pins, then release leases."""
+
+        if self._cleaned:
+            return
+        failed = False
+        retained_extras: list[Any] = []
+        for owner in self._windows_extras:
+            if not self._close_windows(owner):
+                retained_extras.append(owner)
+        self._windows_extras = retained_extras
+        failed = bool(retained_extras)
+
+        if self._windows_file is not None:
+            try:
+                self._windows_file.delete_exact()
+            except WindowsArtifactError:
+                failed = True
+            else:
+                if self._close_windows(self._windows_file):
+                    self._windows_file = None
+                else:
+                    failed = True
+
+        directory_path = self.server_json_path.parent
+        if self._windows_directory is not None and self._windows_file is None:
+            try:
+                if directory_path.exists() and tuple(directory_path.iterdir()):
+                    failed = True
+                else:
+                    self._windows_directory.delete_exact()
+            except (OSError, WindowsArtifactError):
+                failed = True
+            else:
+                if self._close_windows(self._windows_directory):
+                    self._windows_directory = None
+                else:
+                    failed = True
+
+        if self._windows_directory is None and self._windows_parent is not None:
+            if self._close_windows(self._windows_parent):
+                self._windows_parent = None
+            else:
+                failed = True
+        if failed:
+            raise AudioCppGuidedLaunchError("artifact_cleanup_failed") from None
+        self._cleanup_managed_handles()
         self._cleaned = True
 
 
@@ -587,10 +758,101 @@ def _remove_partial_artifact(
         pass
 
 
+def _windows_artifact_bytes(document: dict[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _create_windows_artifact(
+    root: Path,
+    document: dict[str, object],
+) -> AudioCppGeneratedLaunchArtifact | None:
+    filesystem = _windows_artifact_filesystem
+    if filesystem is None:
+        return None
+    parent: Any = None
+    directory: Any = None
+    file: Any = None
+    extras: list[Any] = []
+    directory_name = ""
+    raw = _windows_artifact_bytes(document)
+    server_path = root / "unpublished" / _ARTIFACT_FILE
+    primary_error: BaseException | None = None
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        parent = filesystem.protect_private_directory(root)  # type: ignore[attr-defined]
+        for _ in range(_ARTIFACT_ATTEMPTS):
+            candidate = f"generation-{secrets.token_hex(16)}"
+            try:
+                directory = filesystem.create_private_directory(root / candidate)
+            except WindowsArtifactError as error:
+                cleanup = error.take_cleanup_owner()
+                if cleanup is not None:
+                    extras.append(cleanup)
+                    raise
+                if (root / candidate).exists():
+                    continue
+                raise
+            directory_name = candidate
+            break
+        if directory is None or not directory_name:
+            raise WindowsArtifactError("unavailable")
+        server_path = root / directory_name / _ARTIFACT_FILE
+        file = filesystem.create_private_file(server_path, raw, read_only=True)
+        artifact = _WindowsGeneratedLaunchArtifact(
+            parent=parent,
+            directory=directory,
+            file=file,
+            server_json_path=server_path,
+            digest=sha256(raw).hexdigest(),
+            size=len(raw),
+            extras=tuple(extras),
+        )
+        artifact.validate()
+        return artifact
+    except BaseException as error:
+        primary_error = error
+
+    artifact = _WindowsGeneratedLaunchArtifact(
+        parent=parent,
+        directory=directory,
+        file=file,
+        server_json_path=server_path,
+        digest=sha256(raw).hexdigest(),
+        size=len(raw),
+        extras=tuple(extras),
+    )
+    try:
+        artifact.cleanup()
+    except BaseException as cleanup_error:
+        if not isinstance(primary_error, Exception):
+            setattr(primary_error, _CLEANUP_OWNER_ATTRIBUTE, artifact)
+            raise primary_error
+        if not isinstance(cleanup_error, Exception):
+            setattr(cleanup_error, _CLEANUP_OWNER_ATTRIBUTE, artifact)
+            raise cleanup_error
+        raise AudioCppGuidedLaunchError(
+            "artifact_cleanup_failed",
+            cleanup_owner=artifact,
+        ) from None
+    if primary_error is not None and not isinstance(primary_error, Exception):
+        raise primary_error
+    return None
+
+
 def _create_artifact(
     root: Path,
     document: dict[str, object],
 ) -> AudioCppGeneratedLaunchArtifact | None:
+    if _windows_artifact_filesystem is not None:
+        return _create_windows_artifact(root, document)
     try:
         secured_root = secure_private_directory(
             root,

--- a/tldw_chatbook/TTS/audio_cpp_managed_config.py
+++ b/tldw_chatbook/TTS/audio_cpp_managed_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import re
 from collections.abc import Mapping, Set as AbstractSet
 from dataclasses import dataclass
@@ -236,6 +237,12 @@ def _expanded_path(value: str, diagnostic: str) -> Path:
 
 def _validated_binary_path(value: str) -> Path:
     path = _expanded_path(value, _BINARY_DIAGNOSTIC)
+    if platform.system().casefold() == "windows":
+        from tldw_chatbook.TTS.audio_cpp_guided_launch import _validate_binary
+
+        if _validate_binary(value) is None:
+            raise ValueError(_BINARY_DIAGNOSTIC)
+        return path
     try:
         valid = path.is_file() and os.access(path, os.X_OK)
     except (OSError, ValueError):

--- a/tldw_chatbook/TTS/audio_cpp_package_scanner.py
+++ b/tldw_chatbook/TTS/audio_cpp_package_scanner.py
@@ -30,14 +30,49 @@ from .audio_cpp_recipes import (
     AudioCppRecipeRegistry,
     _managed_artifact_matches_recipe,
 )
+from .windows_artifact_fs import (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM,
+    WindowsArtifactError,
+    WindowsArtifactFilesystem,
+    WindowsFileIdentity,
+    windows_audio_cpp_platform_supported,
+)
 
 
 _scandir = os.scandir
+_windows_artifact_filesystem: WindowsArtifactFilesystem | None = (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM if windows_audio_cpp_platform_supported() else None
+)
 _REPARSE_ATTRIBUTE = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+_SCAN_CLEANUP_OWNER = "_audio_cpp_scan_cleanup_owner"
 
 
 class AudioCppPackageScanError(ValueError):
     """Stable path-independent error for an unusable selected root."""
+
+    __slots__ = ("_cleanup_owner",)
+
+    def __init__(self, message: str, *, cleanup_owner: object | None = None) -> None:
+        self._cleanup_owner = cleanup_owner
+        super().__init__(message)
+
+    def take_cleanup_owner(self) -> object | None:
+        """Transfer one exact retained Windows handle owner once."""
+
+        owner = self._cleanup_owner
+        self._cleanup_owner = None
+        return owner
+
+
+def take_audio_cpp_scan_cleanup_owner(error: BaseException) -> object | None:
+    """Transfer one retained Windows scan handle from an error or cancellation."""
+
+    if isinstance(error, AudioCppPackageScanError):
+        return AudioCppPackageScanError.take_cleanup_owner(error)
+    owner = getattr(error, _SCAN_CLEANUP_OWNER, None)
+    if owner is not None:
+        setattr(error, _SCAN_CLEANUP_OWNER, None)
+    return owner
 
 
 class AudioCppScanOutcome(StrEnum):
@@ -187,6 +222,18 @@ def _filesystem_identity(info: os.stat_result) -> str:
     return sha256(encoded.encode("ascii")).hexdigest()
 
 
+def _windows_filesystem_identity(identity: WindowsFileIdentity) -> str:
+    encoded = b"\0".join(
+        (
+            identity.volume_serial_number.to_bytes(8, "little", signed=False),
+            identity.file_id,
+            identity.kind.encode("ascii"),
+            identity.reparse_tag.to_bytes(4, "little", signed=False),
+        )
+    )
+    return sha256(encoded).hexdigest()
+
+
 def _is_reparse_or_symlink(info: Any) -> bool:
     """Return whether a no-follow stat identifies a link/reparse object."""
     return stat.S_ISLNK(info.st_mode) or bool(
@@ -309,6 +356,178 @@ class _ScanState:
         return False
 
 
+def _close_windows_owner(
+    owner: Any,
+    *,
+    state: _ScanState | None,
+    relative_parts: tuple[str, ...],
+    safe_name: str,
+) -> None:
+    close = getattr(owner, "close", None)
+    if not callable(close):
+        raise AudioCppPackageScanError(
+            "Windows audio.cpp package handle cleanup did not complete.",
+            cleanup_owner=owner,
+        )
+    retained = owner
+    failed_once = False
+    for _attempt in range(2):
+        try:
+            close = getattr(retained, "close")
+            close()
+            if failed_once and state is not None:
+                state.add_incomplete(
+                    AudioCppScanIssueCode.UNREADABLE,
+                    relative_parts,
+                    safe_name,
+                )
+            return
+        except WindowsArtifactError as error:
+            failed_once = True
+            retained = error.take_cleanup_owner() or retained
+    raise AudioCppPackageScanError(
+        "Windows audio.cpp package handle cleanup did not complete.",
+        cleanup_owner=retained,
+    ) from None
+
+
+def _pin_windows_directory_identity(
+    path: Path,
+    *,
+    state: _ScanState | None = None,
+    relative_parts: tuple[str, ...] = (),
+) -> str:
+    filesystem = _windows_artifact_filesystem
+    if filesystem is None:
+        raise AudioCppPackageScanError(
+            "Windows audio.cpp package handles are unavailable."
+        )
+    try:
+        owner = filesystem.pin_directory_no_reparse(path)
+    except WindowsArtifactError as error:
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is unavailable.",
+            cleanup_owner=error.take_cleanup_owner(),
+        ) from None
+    except OSError:
+        raise AudioCppPackageScanError(
+            "Selected audio.cpp package root is unavailable."
+        ) from None
+    try:
+        identity = owner.identity
+        if identity.kind != "directory" or identity.reparse_tag:
+            raise AudioCppPackageScanError(
+                "Selected audio.cpp package root is unavailable."
+            )
+        return _windows_filesystem_identity(identity)
+    finally:
+        _close_windows_owner(
+            owner,
+            state=state,
+            relative_parts=relative_parts,
+            safe_name=path.name,
+        )
+
+
+def _inspect_file_windows(
+    path: Path,
+    relative_parts: tuple[str, ...],
+    info: os.stat_result,
+    signal: AudioCppFileSignal,
+    state: _ScanState,
+) -> AudioCppPackageFileEvidence:
+    filesystem = _windows_artifact_filesystem
+    if filesystem is None:
+        raise AssertionError("Windows artifact filesystem is not selected")
+    required_bytes = _required_metadata_bytes(signal.kind)
+    readable = True
+    valid = info.st_size >= signal.minimum_size_bytes
+    identity = _filesystem_identity(info)
+    if required_bytes > state.limits.max_metadata_bytes_per_file:
+        state.add_limit(AudioCppScanLimit.METADATA_PER_FILE)
+        valid = False
+        required_bytes = 0
+    elif (
+        state.metadata_bytes_read + required_bytes
+        > state.limits.max_metadata_bytes_total
+    ):
+        state.add_limit(AudioCppScanLimit.METADATA_TOTAL)
+        valid = False
+        required_bytes = 0
+
+    owner: Any = None
+    try:
+        owner = filesystem.open_file_no_reparse(path)
+        opened_identity = owner.identity
+        opened_info = os.stat(path, follow_symlinks=False)
+        if (
+            opened_identity.kind != "file"
+            or opened_identity.reparse_tag
+            or not stat.S_ISREG(opened_info.st_mode)
+            or not _same_source(info, opened_info)
+        ):
+            readable = False
+            valid = False
+            state.add_incomplete(
+                AudioCppScanIssueCode.SOURCE_CHANGED,
+                relative_parts,
+                path.name,
+            )
+        else:
+            if required_bytes:
+                data = owner.read(required_bytes)
+                state.metadata_bytes_read += len(data)
+                valid = valid and _metadata_is_valid(
+                    signal.kind,
+                    data,
+                    opened_info.st_size,
+                )
+            identity = _windows_filesystem_identity(opened_identity)
+            info = opened_info
+    except PermissionError:
+        readable = False
+        valid = False
+        state.add_permission(relative_parts, path.name)
+    except WindowsArtifactError as error:
+        cleanup = error.take_cleanup_owner()
+        if cleanup is not None:
+            raise AudioCppPackageScanError(
+                "Windows audio.cpp package handle cleanup did not complete.",
+                cleanup_owner=cleanup,
+            ) from None
+        readable = False
+        valid = False
+        state.add_incomplete(
+            AudioCppScanIssueCode.UNREADABLE,
+            relative_parts,
+            path.name,
+        )
+    except OSError:
+        readable = False
+        valid = False
+        state.add_incomplete(
+            AudioCppScanIssueCode.UNREADABLE,
+            relative_parts,
+            path.name,
+        )
+    finally:
+        if owner is not None:
+            _close_windows_owner(
+                owner,
+                state=state,
+                relative_parts=relative_parts,
+                safe_name=path.name,
+            )
+
+    return AudioCppPackageFileEvidence(
+        relative_path=signal.relative_path,
+        size_bytes=info.st_size,
+        identity=identity,
+        readable=readable,
+        metadata_valid=valid,
+    )
+
+
 def _inspect_file(
     path: Path,
     relative_parts: tuple[str, ...],
@@ -316,6 +535,8 @@ def _inspect_file(
     signal: AudioCppFileSignal,
     state: _ScanState,
 ) -> AudioCppPackageFileEvidence:
+    if _windows_artifact_filesystem is not None:
+        return _inspect_file_windows(path, relative_parts, info, signal, state)
     required_bytes = _required_metadata_bytes(signal.kind)
     readable = True
     valid = info.st_size >= signal.minimum_size_bytes
@@ -502,13 +723,14 @@ def _cancelled_result(
     canonical_root: Path,
     root_info: os.stat_result,
     root_was_symlink: bool,
+    root_identity: str | None = None,
 ) -> AudioCppPackageScanResult:
     return AudioCppPackageScanResult(
         outcome=AudioCppScanOutcome.CANCELLED,
         request_revision=request_revision,
         selected_root_name=_safe_name(canonical_root.name),
         canonical_root=str(canonical_root),
-        canonical_root_identity=_filesystem_identity(root_info),
+        canonical_root_identity=root_identity or _filesystem_identity(root_info),
         root_was_symlink=root_was_symlink,
         discoveries=(),
         limits_reached=(),
@@ -593,7 +815,11 @@ def _require_managed_exact_result(
         and result.canonical_root == expected_root == str(final_root)
         and result.canonical_root_identity
         == expected_root_identity
-        == _filesystem_identity(final_info)
+        == (
+            _pin_windows_directory_identity(final_root)
+            if _windows_artifact_filesystem is not None
+            else _filesystem_identity(final_info)
+        )
     ):
         raise AudioCppPackageScanError(
             "Managed audio.cpp package no longer matches its installed identity."
@@ -652,7 +878,11 @@ def scan_audio_cpp_package_root(
         root,
         allow_root_symlink=allow_root_symlink,
     )
-    selected_root_identity = _filesystem_identity(root_info)
+    selected_root_identity = (
+        _pin_windows_directory_identity(canonical_root)
+        if _windows_artifact_filesystem is not None
+        else _filesystem_identity(root_info)
+    )
     if managed_contract is not None and (
         str(canonical_root) != managed_contract[1] or root_was_symlink
     ):
@@ -670,14 +900,13 @@ def scan_audio_cpp_package_root(
             canonical_root=canonical_root,
             root_info=root_info,
             root_was_symlink=root_was_symlink,
+            root_identity=selected_root_identity,
         )
 
     state = _ScanState(active_limits, _monotonic(), cancellation)
     signals = _signal_index(registry)
     queue: deque[tuple[Path, tuple[str, ...], int]] = deque(((canonical_root, (), 0),))
-    directory_identities: dict[tuple[str, ...], str] = {
-        (): _filesystem_identity(root_info)
-    }
+    directory_identities: dict[tuple[str, ...], str] = {(): selected_root_identity}
     candidate_evidence: dict[
         tuple[str, ...],
         dict[str, AudioCppPackageFileEvidence],
@@ -692,43 +921,106 @@ def scan_audio_cpp_package_root(
         if state.cancellation_or_total_limit():
             break
         iterator: object | None = None
+        windows_directory_owner: Any = None
         try:
-            current_info = os.stat(directory, follow_symlinks=False)
-            if (
-                _is_reparse_or_symlink(current_info)
-                or not stat.S_ISDIR(current_info.st_mode)
-                or _filesystem_identity(current_info)
-                != directory_identities[relative_directory]
-            ):
-                state.add_incomplete(
-                    AudioCppScanIssueCode.SOURCE_CHANGED,
-                    relative_directory,
-                    directory.name,
+            if _windows_artifact_filesystem is not None:
+                windows_directory_owner = (
+                    _windows_artifact_filesystem.pin_directory_no_reparse(directory)
                 )
-                continue
+                opened_identity = windows_directory_owner.identity
+                if (
+                    opened_identity.kind != "directory"
+                    or opened_identity.reparse_tag
+                    or _windows_filesystem_identity(opened_identity)
+                    != directory_identities[relative_directory]
+                ):
+                    state.add_incomplete(
+                        AudioCppScanIssueCode.SOURCE_CHANGED,
+                        relative_directory,
+                        directory.name,
+                    )
+                    _close_windows_owner(
+                        windows_directory_owner,
+                        state=state,
+                        relative_parts=relative_directory,
+                        safe_name=directory.name,
+                    )
+                    windows_directory_owner = None
+                    continue
+            else:
+                current_info = os.stat(directory, follow_symlinks=False)
+                if (
+                    _is_reparse_or_symlink(current_info)
+                    or not stat.S_ISDIR(current_info.st_mode)
+                    or _filesystem_identity(current_info)
+                    != directory_identities[relative_directory]
+                ):
+                    state.add_incomplete(
+                        AudioCppScanIssueCode.SOURCE_CHANGED,
+                        relative_directory,
+                        directory.name,
+                    )
+                    continue
             iterator = _scandir(directory)
-            opened_info = os.stat(directory, follow_symlinks=False)
-            if (
-                _is_reparse_or_symlink(opened_info)
-                or not stat.S_ISDIR(opened_info.st_mode)
-                or _filesystem_identity(opened_info)
-                != directory_identities[relative_directory]
-            ):
-                state.add_incomplete(
-                    AudioCppScanIssueCode.SOURCE_CHANGED,
-                    relative_directory,
-                    directory.name,
-                )
-                _close_directory_iterator(iterator, state, directory.name)
-                continue
+            if _windows_artifact_filesystem is None:
+                opened_info = os.stat(directory, follow_symlinks=False)
+                if (
+                    _is_reparse_or_symlink(opened_info)
+                    or not stat.S_ISDIR(opened_info.st_mode)
+                    or _filesystem_identity(opened_info)
+                    != directory_identities[relative_directory]
+                ):
+                    state.add_incomplete(
+                        AudioCppScanIssueCode.SOURCE_CHANGED,
+                        relative_directory,
+                        directory.name,
+                    )
+                    _close_directory_iterator(iterator, state, directory.name)
+                    continue
         except PermissionError:
             if iterator is not None:
                 _close_directory_iterator(iterator, state, directory.name)
+            if windows_directory_owner is not None:
+                _close_windows_owner(
+                    windows_directory_owner,
+                    state=state,
+                    relative_parts=relative_directory,
+                    safe_name=directory.name,
+                )
             state.add_permission(relative_directory, directory.name)
+            continue
+        except WindowsArtifactError as error:
+            cleanup = error.take_cleanup_owner()
+            if cleanup is not None:
+                raise AudioCppPackageScanError(
+                    "Windows audio.cpp package handle cleanup did not complete.",
+                    cleanup_owner=cleanup,
+                ) from None
+            if iterator is not None:
+                _close_directory_iterator(iterator, state, directory.name)
+            if windows_directory_owner is not None:
+                _close_windows_owner(
+                    windows_directory_owner,
+                    state=state,
+                    relative_parts=relative_directory,
+                    safe_name=directory.name,
+                )
+            state.add_incomplete(
+                AudioCppScanIssueCode.UNREADABLE,
+                relative_directory,
+                directory.name,
+            )
             continue
         except OSError:
             if iterator is not None:
                 _close_directory_iterator(iterator, state, directory.name)
+            if windows_directory_owner is not None:
+                _close_windows_owner(
+                    windows_directory_owner,
+                    state=state,
+                    relative_parts=relative_directory,
+                    safe_name=directory.name,
+                )
             state.add_incomplete(
                 AudioCppScanIssueCode.UNREADABLE,
                 relative_directory,
@@ -736,6 +1028,7 @@ def scan_audio_cpp_package_root(
             )
             continue
         try:
+            windows_names: set[str] = set()
             for entry in iterator:
                 if state.cancellation_or_total_limit():
                     break
@@ -746,6 +1039,16 @@ def scan_audio_cpp_package_root(
                 state.visited_entries += 1
                 entry_started = _monotonic()
                 relative_parts = (*relative_directory, entry.name)
+                if _windows_artifact_filesystem is not None:
+                    folded_name = entry.name.casefold()
+                    if folded_name in windows_names:
+                        state.add_incomplete(
+                            AudioCppScanIssueCode.SOURCE_CHANGED,
+                            relative_directory,
+                            entry.name,
+                        )
+                        continue
+                    windows_names.add(folded_name)
                 try:
                     info = entry.stat(follow_symlinks=False)
                 except PermissionError:
@@ -774,8 +1077,14 @@ def scan_audio_cpp_package_root(
                     if depth >= active_limits.max_depth:
                         state.add_limit(AudioCppScanLimit.DEPTH)
                     else:
-                        directory_identities[relative_parts] = _filesystem_identity(
-                            info
+                        directory_identities[relative_parts] = (
+                            _pin_windows_directory_identity(
+                                entry_path,
+                                state=state,
+                                relative_parts=relative_parts,
+                            )
+                            if _windows_artifact_filesystem is not None
+                            else _filesystem_identity(info)
                         )
                         queue.append((entry_path, relative_parts, depth + 1))
                 elif stat.S_ISREG(info.st_mode):
@@ -842,6 +1151,13 @@ def scan_audio_cpp_package_root(
             )
         finally:
             _close_directory_iterator(iterator, state, directory.name)
+            if windows_directory_owner is not None:
+                _close_windows_owner(
+                    windows_directory_owner,
+                    state=state,
+                    relative_parts=relative_directory,
+                    safe_name=directory.name,
+                )
 
     state.cancellation_or_total_limit()
     if cancellation.is_set():
@@ -850,6 +1166,7 @@ def scan_audio_cpp_package_root(
             canonical_root=canonical_root,
             root_info=root_info,
             root_was_symlink=root_was_symlink,
+            root_identity=selected_root_identity,
         )
 
     global_partial = bool(state.limits_reached)
@@ -931,7 +1248,7 @@ def scan_audio_cpp_package_root(
         request_revision=request_revision,
         selected_root_name=_safe_name(canonical_root.name),
         canonical_root=str(canonical_root),
-        canonical_root_identity=_filesystem_identity(root_info),
+        canonical_root_identity=selected_root_identity,
         root_was_symlink=root_was_symlink,
         discoveries=tuple(discoveries),
         limits_reached=limits_reached,
@@ -997,10 +1314,23 @@ async def scan_audio_cpp_package_root_async(
         )
     )
     try:
-        return await work
-    except asyncio.CancelledError:
+        return await asyncio.shield(work)
+    except asyncio.CancelledError as cancelled:
         cancellation.set()
-        raise
+        while not work.done():
+            try:
+                await asyncio.shield(work)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+        if work.done() and not work.cancelled():
+            error = work.exception()
+            if isinstance(error, AudioCppPackageScanError):
+                cleanup = error.take_cleanup_owner()
+                if cleanup is not None:
+                    setattr(cancelled, _SCAN_CLEANUP_OWNER, cleanup)
+        raise cancelled
 
 
 __all__ = (
@@ -1014,4 +1344,5 @@ __all__ = (
     "AudioCppScanOutcome",
     "scan_audio_cpp_package_root",
     "scan_audio_cpp_package_root_async",
+    "take_audio_cpp_scan_cleanup_owner",
 )

--- a/tldw_chatbook/TTS/audio_cpp_recipes.py
+++ b/tldw_chatbook/TTS/audio_cpp_recipes.py
@@ -863,6 +863,7 @@ _EXPECTED_CPU_BACKENDS = tuple(
         ("darwin", "x86_64"),
         ("linux", "aarch64"),
         ("linux", "x86_64"),
+        ("windows", "x86"),
         ("windows", "x86_64"),
     )
 )

--- a/tldw_chatbook/TTS/audio_cpp_supervisor.py
+++ b/tldw_chatbook/TTS/audio_cpp_supervisor.py
@@ -12,7 +12,7 @@ from collections.abc import Awaitable, Callable, Mapping, Set as AbstractSet
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 from urllib.parse import urlsplit
 
 from rich.markup import escape as escape_rich_markup
@@ -259,6 +259,12 @@ AudioCppProcessState = Literal[
     "stopping",
     "unavailable",
 ]
+AudioCppArtifactPrivacyPosture = Literal[
+    "not_applicable",
+    "unverified",
+    "posix_owner_only",
+    "windows_account_protected",
+]
 AudioCppTTSCapability = Literal["available", "not_configured", "unknown"]
 AudioCppContractProbe = Callable[[], Awaitable[AudioCppTTSCapability]]
 AudioCppHealthProbe = Callable[[], Awaitable[bool]]
@@ -322,12 +328,16 @@ class AudioCppProcessSnapshot:
     last_failure: AudioCppProcessFailure | None
     diagnostics: tuple[AudioCppDiagnosticLine, ...]
     dropped_diagnostic_lines: int
+    generated_artifact_privacy_posture: AudioCppArtifactPrivacyPosture = (
+        "not_applicable"
+    )
 
 
 @dataclass(frozen=True, slots=True)
 class _OwnedAudioCppProcess:
     process: Any
     close_parent_pipes: Callable[[], None]
+    close_native_transport: Callable[[], None] = lambda: None
 
 
 _ProcessLauncher = Callable[
@@ -430,6 +440,7 @@ class _ProcessGeneration:
     artifact_cleanup_succeeded: bool = False
     cleanup_failure: AudioCppProcessFailure | None = None
     parent_pipes_closed: bool = False
+    native_transport_closed: bool = False
 
 
 def _failure_for(
@@ -468,6 +479,22 @@ def _close_process_parent_pipes(process: Any) -> None:
             close()
 
 
+def _process_native_transport_closer(process: Any) -> Callable[[], None]:
+    closed = False
+
+    def close_once() -> None:
+        nonlocal closed
+        if closed:
+            return
+        transport = getattr(process, "_transport", None)
+        close = getattr(transport, "close", None)
+        if callable(close):
+            close()
+        closed = True
+
+    return close_once
+
+
 async def _default_process_launcher(
     launch: AudioCppManagedLaunchConfig,
     child_environment: dict[str, str],
@@ -492,7 +519,50 @@ async def _default_process_launcher(
     return _OwnedAudioCppProcess(
         process=process,
         close_parent_pipes=lambda: _close_process_parent_pipes(process),
+        close_native_transport=_process_native_transport_closer(process),
     )
+
+
+async def _settle_process_launcher(
+    launcher: Awaitable[_OwnedAudioCppProcess],
+    *,
+    timeout: float,
+) -> tuple[
+    asyncio.CancelledError | None,
+    bool,
+    _OwnedAudioCppProcess | None,
+    BaseException | None,
+]:
+    """Settle one retained spawn task before exposing cancellation or timeout."""
+
+    task: asyncio.Future[_OwnedAudioCppProcess] = asyncio.ensure_future(launcher)
+    cancellation: asyncio.CancelledError | None = None
+    timed_out = False
+    waiter = asyncio.current_task()
+    cancellation_requests = waiter.cancelling() if waiter is not None else 0
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=max(0.0, timeout))
+        timed_out = task not in done
+    except asyncio.CancelledError as error:
+        cancellation = error
+    if (timed_out or cancellation is not None) and not task.done():
+        task.cancel()
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as error:
+            next_requests = waiter.cancelling() if waiter is not None else 0
+            if next_requests > cancellation_requests:
+                cancellation = cancellation or error
+                cancellation_requests = next_requests
+        except BaseException:
+            if not task.done():
+                raise
+            break
+    try:
+        return cancellation, timed_out, task.result(), None
+    except BaseException as error:
+        return cancellation, timed_out, None, error
 
 
 async def _default_port_preflight(port: int, timeout: float) -> _PortPreflightResult:
@@ -561,6 +631,20 @@ class AudioCppSupervisor:
     def snapshot(self) -> AudioCppProcessSnapshot:
         """Return the current immutable process observation."""
         diagnostics, dropped = self._diagnostics.snapshot()
+        launch = (
+            self._generation.launch
+            if self._generation is not None
+            else self._pre_spawn_launch
+        )
+        artifact = launch.generated_artifact if launch is not None else None
+        posture = getattr(artifact, "privacy_posture", "not_applicable")
+        if posture not in {
+            "not_applicable",
+            "unverified",
+            "posix_owner_only",
+            "windows_account_protected",
+        }:
+            posture = "unverified"
         return AudioCppProcessSnapshot(
             state=self._state,
             process_generation=self._process_generation,
@@ -571,6 +655,10 @@ class AudioCppSupervisor:
             last_failure=self._last_failure,
             diagnostics=diagnostics,
             dropped_diagnostic_lines=dropped,
+            generated_artifact_privacy_posture=cast(
+                AudioCppArtifactPrivacyPosture,
+                posture,
+            ),
         )
 
     def _record_internal_diagnostic(
@@ -895,23 +983,27 @@ class AudioCppSupervisor:
             spawn_timeout = _remaining(deadline, self._monotonic)
             if spawn_timeout <= 0:
                 raise _operation_error(_failure_for(_STARTUP_TIMEOUT_FAILURE, None))
-            spawn_failed = False
-            try:
-                owned = await asyncio.wait_for(
-                    self._process_launcher(validated, dict(self._child_environment)),
-                    timeout=spawn_timeout,
-                )
-            except asyncio.TimeoutError:
-                spawn_failed = True
-            except asyncio.CancelledError:
-                raise
-            except BaseException:
-                spawn_failed = True
-            if spawn_failed:
+            (
+                spawn_cancellation,
+                spawn_timed_out,
+                owned,
+                spawn_error,
+            ) = await _settle_process_launcher(
+                self._process_launcher(validated, dict(self._child_environment)),
+                timeout=spawn_timeout,
+            )
+            if owned is None:
+                if spawn_cancellation is not None:
+                    raise spawn_cancellation
                 raise _operation_error(_failure_for(_SPAWN_FAILURE, None))
 
             async with self._lock:
-                stale = self._lifecycle_epoch != epoch or self._state != "starting"
+                stale = (
+                    spawn_cancellation is not None
+                    or spawn_timed_out
+                    or self._lifecycle_epoch != epoch
+                    or self._state != "starting"
+                )
                 if self._generation is not None:
                     raise RuntimeError("audio.cpp process ownership invariant failed")
                 self._process_generation += 1
@@ -939,6 +1031,14 @@ class AudioCppSupervisor:
                 )
                 record.exit_monitor = asyncio.create_task(self._monitor_exit(record))
                 self._observation_version += 1
+            if spawn_cancellation is not None:
+                record.hooks_ready.set()
+                raise spawn_cancellation
+            if spawn_timed_out or spawn_error is not None:
+                record.hooks_ready.set()
+                failure = _failure_for(_SPAWN_FAILURE, record.generation)
+                await self._rollback_generation(record, failure, deadline=deadline)
+                raise _operation_error(failure)
             if stale:
                 record.hooks_ready.set()
                 raise asyncio.CancelledError
@@ -1436,12 +1536,12 @@ class AudioCppSupervisor:
 
         await self._join_output_drains(record)
         self._close_parent_pipes(record)
-        cleanup_succeeded, artifact_succeeded = await self._cleanup_generation(record)
+        cleanup_succeeded, ownership_succeeded = await self._cleanup_generation(record)
 
         async with self._lock:
             if self._generation is not record:
                 return
-            if artifact_succeeded:
+            if ownership_succeeded:
                 self._generation = None
             if not cleanup_succeeded:
                 cleanup_failure = _failure_for(
@@ -1534,12 +1634,26 @@ class AudioCppSupervisor:
             record.artifact_cleanup_succeeded = await self._cleanup_launch_artifact(
                 record.launch
             )
+        transport_succeeded = self._close_native_transport(record)
         if control_flow is not None:
             raise control_flow
         return (
-            record.hooks_cleanup_succeeded and record.artifact_cleanup_succeeded,
-            record.artifact_cleanup_succeeded,
+            record.hooks_cleanup_succeeded
+            and record.artifact_cleanup_succeeded
+            and transport_succeeded,
+            record.artifact_cleanup_succeeded and transport_succeeded,
         )
+
+    @staticmethod
+    def _close_native_transport(record: _ProcessGeneration) -> bool:
+        if record.native_transport_closed:
+            return True
+        try:
+            record.owned.close_native_transport()
+        except Exception:
+            return False
+        record.native_transport_closed = True
+        return True
 
     async def _cleanup_launch_artifact(
         self,
@@ -1724,10 +1838,10 @@ class AudioCppSupervisor:
                 ):
                     (
                         cleanup_succeeded,
-                        artifact_succeeded,
+                        ownership_succeeded,
                     ) = await self._cleanup_generation(record)
                     async with self._lock:
-                        if self._generation is record and artifact_succeeded:
+                        if self._generation is record and ownership_succeeded:
                             self._generation = None
                         if cleanup_succeeded:
                             record.cleanup_failure = None

--- a/tldw_chatbook/TTS/profile_reference_materialization.py
+++ b/tldw_chatbook/TTS/profile_reference_materialization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import re
 import stat
@@ -23,6 +24,15 @@ from tldw_chatbook.TTS.profile_reference_types import (
 )
 from tldw_chatbook.Utils.private_paths import secure_private_directory
 
+from .windows_artifact_fs import (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM,
+    WindowsArtifactFilesystem,
+    WindowsFileIdentity,
+    WindowsPinnedHandle,
+    take_windows_artifact_cleanup_owner,
+    windows_audio_cpp_platform_supported,
+)
+
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _CLOEXEC = getattr(os, "O_CLOEXEC", 0)
@@ -41,6 +51,9 @@ _OWNER_PATTERN: Final = re.compile(r"clone-v1-[0-9a-f]{32}\Z")
 _ASSET_PATTERN: Final = re.compile(r"asset-[0-9a-f]{32}\.wav\Z")
 _HANDLE_TOKEN = object()
 _T = TypeVar("_T")
+_windows_artifact_filesystem: WindowsArtifactFilesystem | None = (
+    OS_WINDOWS_ARTIFACT_FILESYSTEM if windows_audio_cpp_platform_supported() else None
+)
 
 
 class TTSCloneMaterializationError(RuntimeError):
@@ -76,6 +89,87 @@ class _MaterializationRecord:
     lock_identity: tuple[int, int]
 
 
+@dataclass(slots=True)
+class _WindowsMaterializationRecord:
+    filesystem: WindowsArtifactFilesystem
+    owner_name: str
+    asset_name: str
+    asset_path: Path
+    root_handle: WindowsPinnedHandle
+    owner_handle: WindowsPinnedHandle
+    lock_handle: WindowsPinnedHandle
+    asset_handle: WindowsPinnedHandle
+    root_identity: WindowsFileIdentity
+    owner_identity: WindowsFileIdentity
+    asset_identity: WindowsFileIdentity
+    lock_identity: WindowsFileIdentity
+    asset_size: int
+    asset_sha256: str
+    cleanup_started: bool = False
+    asset_removed: bool = False
+    lock_released: bool = False
+    lock_removed: bool = False
+    owner_removed: bool = False
+    root_closed: bool = False
+
+
+_OwnedMaterializationRecord = _MaterializationRecord | _WindowsMaterializationRecord
+
+
+@dataclass(slots=True)
+class _WindowsPartialCleanup:
+    root_handle: WindowsPinnedHandle | None
+    owner_handle: WindowsPinnedHandle | None
+    lock_handle: WindowsPinnedHandle | None
+    asset_handle: WindowsPinnedHandle | None
+    extras: list[WindowsPinnedHandle]
+    lock_released: bool = False
+
+    def cleanup(self) -> None:
+        """Retire only the exact partially-created objects, retaining failures."""
+
+        retained_extras: list[WindowsPinnedHandle] = []
+        for handle in self.extras:
+            try:
+                handle.close()
+            except Exception:
+                retained_extras.append(handle)
+        self.extras = retained_extras
+        if self.asset_handle is not None:
+            self.asset_handle.delete_exact()
+            self.asset_handle.close()
+            self.asset_handle = None
+        if self.lock_handle is not None:
+            if not self.lock_released:
+                self.lock_handle.unlock()
+                self.lock_released = True
+            self.lock_handle.delete_exact()
+            self.lock_handle.close()
+            self.lock_handle = None
+        if self.owner_handle is not None:
+            self.owner_handle.delete_exact()
+            self.owner_handle.close()
+            self.owner_handle = None
+        if self.root_handle is not None:
+            self.root_handle.close()
+            self.root_handle = None
+        if self.extras:
+            raise OSError("partial cleanup incomplete")
+
+
+class _WindowsPartialCleanupFailure(RuntimeError):
+    __slots__ = ("cleanup", "primary")
+
+    def __init__(
+        self,
+        cleanup: _WindowsPartialCleanup,
+        primary: BaseException,
+    ) -> None:
+        super().__init__("Windows clone cleanup is incomplete")
+        self.cleanup = cleanup
+        self.primary = primary
+
+
 class TTSCloneReferenceMaterialization:
     """An opaque live owner of one materialized clone reference."""
 
@@ -85,7 +179,7 @@ class TTSCloneReferenceMaterialization:
         self,
         token: object,
         materializer: TTSCloneReferenceMaterializer,
-        record: _MaterializationRecord,
+        record: _OwnedMaterializationRecord,
         reference_text: str,
     ) -> None:
         if token is not _HANDLE_TOKEN:
@@ -130,11 +224,12 @@ class TTSCloneReferenceMaterializer:
         self._sweep_lock = asyncio.Lock()
         self._cleanup_lock = asyncio.Lock()
         self._sweep_complete = False
-        self._root_identity: tuple[int, int] | None = None
+        self._root_identity: tuple[int, int] | WindowsFileIdentity | None = None
         self._worker_tasks: set[asyncio.Task[object]] = set()
         self._materialize_calls: set[asyncio.Task[object]] = set()
         self._handle_calls: set[asyncio.Task[object]] = set()
         self._active: dict[object, TTSCloneReferenceMaterialization] = {}
+        self._pending_windows_cleanup: list[_WindowsPartialCleanup] = []
 
     async def materialize(
         self,
@@ -157,15 +252,16 @@ class TTSCloneReferenceMaterializer:
         call = cast(asyncio.Task[object] | None, asyncio.current_task())
         if call is not None:
             self._materialize_calls.add(call)
-        record: _MaterializationRecord | None = None
+        record: _OwnedMaterializationRecord | None = None
         try:
             if self._closed:
                 raise TTSCloneMaterializationError("closed")
-            if not _POSIX_SUPPORTED:
+            if not _POSIX_SUPPORTED and _windows_artifact_filesystem is None:
                 raise TTSCloneMaterializationError("unsupported")
             if type(reference) not in (TTSCloneReference, CanonicalTTSCloneReference):
                 raise TTSCloneMaterializationError("unavailable")
 
+            await self._drain_pending_windows_cleanup()
             await self._ensure_swept()
             if self._closed:
                 raise TTSCloneMaterializationError("closed")
@@ -179,20 +275,15 @@ class TTSCloneReferenceMaterializer:
             cancelled, result, failure = await _await_retained_result(worker)
             self._worker_tasks.discard(worker)
             if failure is not None:
+                if isinstance(failure, _WindowsPartialCleanupFailure):
+                    self._pending_windows_cleanup.append(failure.cleanup)
+                    if _is_control_flow(failure.primary):
+                        raise failure.primary
+                    raise TTSCloneMaterializationError("cleanup_failed") from None
                 if _is_control_flow(failure):
                     raise failure
                 raise TTSCloneMaterializationError("unavailable") from None
-            record = cast(_MaterializationRecord, result)
-
-            if cancelled is not None or self._closed:
-                cleanup = self._start_worker(_cleanup_materialization_sync, record)
-                _, _, cleanup_failure = await _await_retained_result(cleanup)
-                self._worker_tasks.discard(cleanup)
-                if cleanup_failure is not None:
-                    _abandon_record(record)
-                if cancelled is not None:
-                    raise cancelled
-                raise TTSCloneMaterializationError("closed")
+            record = cast(_OwnedMaterializationRecord, result)
 
             handle = TTSCloneReferenceMaterialization(
                 _HANDLE_TOKEN,
@@ -201,6 +292,19 @@ class TTSCloneReferenceMaterializer:
                 reference.reference_text,
             )
             self._active[handle._token] = handle
+
+            if cancelled is not None or self._closed:
+                cleanup = self._start_worker(_cleanup_materialization_sync, record)
+                _, _, cleanup_failure = await _await_retained_result(cleanup)
+                self._worker_tasks.discard(cleanup)
+                if cleanup_failure is None:
+                    self._active.pop(handle._token, None)
+                if cancelled is not None:
+                    raise cancelled
+                if cleanup_failure is not None and _is_control_flow(cleanup_failure):
+                    raise cleanup_failure
+                raise TTSCloneMaterializationError("closed")
+
             return handle
         finally:
             if call is not None:
@@ -216,13 +320,31 @@ class TTSCloneReferenceMaterializer:
             if cancelled is not None:
                 raise cancelled
             if failure is not None:
+                if isinstance(failure, _WindowsPartialCleanupFailure):
+                    self._pending_windows_cleanup.append(failure.cleanup)
+                    if _is_control_flow(failure.primary):
+                        raise failure.primary
+                    raise TTSCloneMaterializationError("cleanup_failed") from None
+                cleanup_owner = take_windows_artifact_cleanup_owner(failure)
+                if cleanup_owner is not None:
+                    self._pending_windows_cleanup.append(
+                        _WindowsPartialCleanup(
+                            root_handle=None,
+                            owner_handle=None,
+                            lock_handle=None,
+                            asset_handle=None,
+                            extras=[cleanup_owner],
+                            lock_released=True,
+                        )
+                    )
+                    raise TTSCloneMaterializationError("cleanup_failed") from None
                 if _is_control_flow(failure):
                     raise failure
                 raise TTSCloneMaterializationError("unavailable") from None
             if self._closed:
                 raise TTSCloneMaterializationError("closed")
             self._root, self._root_identity = cast(
-                tuple[Path, tuple[int, int]], prepared_root
+                tuple[Path, tuple[int, int] | WindowsFileIdentity], prepared_root
             )
             self._sweep_complete = True
 
@@ -242,10 +364,13 @@ class TTSCloneReferenceMaterializer:
         if self._close_task is None:
             self.seal()
             self._close_task = asyncio.create_task(self._complete_close())
-        cancelled, _, failure = await _await_retained_result(self._close_task)
+        close_task = self._close_task
+        cancelled, _, failure = await _await_retained_result(close_task)
         if cancelled is not None:
             raise cancelled
         if failure is not None:
+            if self._close_task is close_task:
+                self._close_task = None
             if _is_control_flow(failure):
                 raise failure
             raise TTSCloneMaterializationError("cleanup_failed") from None
@@ -267,6 +392,16 @@ class TTSCloneReferenceMaterializer:
         failed = False
         control_flow: BaseException | None = None
         async with self._cleanup_lock:
+            for cleanup in tuple(self._pending_windows_cleanup):
+                worker = self._start_worker(cleanup.cleanup)
+                _, _, failure = await _await_retained_result(worker)
+                self._worker_tasks.discard(worker)
+                if failure is None:
+                    self._pending_windows_cleanup.remove(cleanup)
+                else:
+                    failed = True
+                    if _is_control_flow(failure) and control_flow is None:
+                        control_flow = failure
             for handle in tuple(self._active.values()):
                 record = handle._record
                 worker = self._start_worker(_cleanup_materialization_sync, record)
@@ -278,12 +413,28 @@ class TTSCloneReferenceMaterializer:
                     failed = True
                     if _is_control_flow(failure) and control_flow is None:
                         control_flow = failure
-                    _abandon_record(record)
-                    self._active.pop(handle._token, None)
         if control_flow is not None:
             raise control_flow
         if failed:
             raise TTSCloneMaterializationError("cleanup_failed")
+
+    async def _drain_pending_windows_cleanup(self) -> None:
+        async with self._cleanup_lock:
+            failed = False
+            for cleanup in tuple(self._pending_windows_cleanup):
+                worker = self._start_worker(cleanup.cleanup)
+                cancelled, _, failure = await _await_retained_result(worker)
+                self._worker_tasks.discard(worker)
+                if failure is None:
+                    self._pending_windows_cleanup.remove(cleanup)
+                else:
+                    failed = True
+                    if _is_control_flow(failure):
+                        raise failure
+                if cancelled is not None:
+                    raise cancelled
+            if failed:
+                raise TTSCloneMaterializationError("cleanup_failed")
 
     async def _close_handle(self, handle: TTSCloneReferenceMaterialization) -> None:
         call = cast(asyncio.Task[object] | None, asyncio.current_task())
@@ -383,7 +534,7 @@ def _identity(info: os.stat_result) -> tuple[int, int]:
 
 
 def _is_control_flow(error: BaseException) -> bool:
-    return isinstance(error, (asyncio.CancelledError, KeyboardInterrupt, SystemExit))
+    return not isinstance(error, Exception)
 
 
 def _private_directory(info: os.stat_result) -> bool:
@@ -437,6 +588,25 @@ def _unlock(descriptor: int) -> None:
 
 
 def _create_materialization_sync(
+    root: Path,
+    expected_root_identity: tuple[int, int] | WindowsFileIdentity | None,
+    wav_bytes: bytes,
+) -> _OwnedMaterializationRecord:
+    if _windows_artifact_filesystem is not None:
+        return _create_windows_materialization_sync(
+            _windows_artifact_filesystem,
+            root,
+            cast(WindowsFileIdentity | None, expected_root_identity),
+            wav_bytes,
+        )
+    return _create_posix_materialization_sync(
+        root,
+        cast(tuple[int, int] | None, expected_root_identity),
+        wav_bytes,
+    )
+
+
+def _create_posix_materialization_sync(
     root: Path,
     expected_root_identity: tuple[int, int] | None,
     wav_bytes: bytes,
@@ -565,7 +735,13 @@ def _create_materialization_sync(
         raise
 
 
-def _validate_materialization_sync(record: _MaterializationRecord) -> Path:
+def _validate_materialization_sync(record: _OwnedMaterializationRecord) -> Path:
+    if isinstance(record, _WindowsMaterializationRecord):
+        return _validate_windows_materialization_sync(record.filesystem, record)
+    return _validate_posix_materialization_sync(record)
+
+
+def _validate_posix_materialization_sync(record: _MaterializationRecord) -> Path:
     root_info = os.fstat(record.root_fd)
     named_root_info = os.stat(
         record.asset_path.parent.parent,
@@ -627,7 +803,15 @@ def _validate_materialization_sync(record: _MaterializationRecord) -> Path:
     return record.asset_path
 
 
-def _prepare_runtime_root_sync(root: Path) -> tuple[Path, tuple[int, int]]:
+def _prepare_runtime_root_sync(
+    root: Path,
+) -> tuple[Path, tuple[int, int] | WindowsFileIdentity]:
+    if _windows_artifact_filesystem is not None:
+        return _prepare_windows_runtime_root_sync(_windows_artifact_filesystem, root)
+    return _prepare_posix_runtime_root_sync(root)
+
+
+def _prepare_posix_runtime_root_sync(root: Path) -> tuple[Path, tuple[int, int]]:
     result = secure_private_directory(root, create=True, application_owned=True)
     selected = result.lexical_path
     root_fd = os.open(selected, _DIRECTORY_FLAGS)
@@ -737,7 +921,294 @@ def _sweep_orphans(root_fd: int) -> None:
                 os.close(owner_fd)
 
 
-def _cleanup_materialization_sync(record: _MaterializationRecord) -> None:
+def _prepare_windows_runtime_root_sync(
+    filesystem: WindowsArtifactFilesystem,
+    root: Path,
+) -> tuple[Path, WindowsFileIdentity]:
+    root.parent.mkdir(parents=True, exist_ok=True)
+    root_handle = (
+        filesystem.protect_private_directory(root)
+        if root.exists()
+        else filesystem.create_private_directory(root)
+    )
+    try:
+        if (
+            root_handle.identity.kind != "directory"
+            or root_handle.identity.reparse_tag
+            or not root_handle.verify_private_acl()
+        ):
+            raise OSError("unsafe runtime root")
+        _sweep_windows_orphans(filesystem, root, root_handle.identity)
+        return root, root_handle.identity
+    finally:
+        root_handle.close()
+
+
+def _sweep_windows_orphans(
+    filesystem: WindowsArtifactFilesystem,
+    root: Path,
+    root_identity: WindowsFileIdentity,
+) -> None:
+    """Remove only recognized, unlocked, completely pinned orphan owners."""
+
+    for owner_path in tuple(root.iterdir()):
+        if _OWNER_PATTERN.fullmatch(owner_path.name) is None:
+            continue
+        owner_handle: WindowsPinnedHandle | None = None
+        lock_handle: WindowsPinnedHandle | None = None
+        asset_handle: WindowsPinnedHandle | None = None
+        locked = False
+        try:
+            root_check = filesystem.pin_directory_no_reparse(root)
+            try:
+                if root_check.identity != root_identity:
+                    continue
+            finally:
+                root_check.close()
+            owner_handle = filesystem.pin_directory_no_reparse(owner_path)
+            if not owner_handle.verify_private_acl():
+                continue
+            entries = tuple(owner_path.iterdir())
+            names = {entry.name for entry in entries}
+            assets = tuple(
+                entry for entry in entries if _ASSET_PATTERN.fullmatch(entry.name)
+            )
+            if not entries:
+                owner_handle.delete_exact()
+                owner_handle.close()
+                owner_handle = None
+                continue
+            if (
+                "owner.lock" not in names
+                or len(assets) > 1
+                or names != {"owner.lock", *(entry.name for entry in assets)}
+            ):
+                continue
+            lock_handle = filesystem.open_file_no_reparse(
+                owner_path / "owner.lock", writable=True
+            )
+            if not lock_handle.verify_private_acl():
+                continue
+            try:
+                lock_handle.lock_exclusive_nonblocking()
+                locked = True
+            except Exception as error:
+                if getattr(error, "code", None) == "busy":
+                    continue
+                raise
+            if assets:
+                asset_handle = filesystem.open_file_no_reparse(assets[0])
+                if not asset_handle.verify_private_acl():
+                    continue
+                asset_handle.delete_exact()
+                asset_handle.close()
+                asset_handle = None
+            lock_handle.unlock()
+            locked = False
+            lock_handle.delete_exact()
+            lock_handle.close()
+            lock_handle = None
+            owner_handle.delete_exact()
+            owner_handle.close()
+            owner_handle = None
+        except Exception:
+            continue
+        finally:
+            if locked and lock_handle is not None:
+                try:
+                    lock_handle.unlock()
+                except Exception:
+                    pass
+            for handle in (asset_handle, lock_handle, owner_handle):
+                if handle is not None:
+                    try:
+                        handle.close()
+                    except Exception:
+                        pass
+
+
+def _create_windows_materialization_sync(
+    filesystem: WindowsArtifactFilesystem,
+    root: Path,
+    expected_root_identity: WindowsFileIdentity | None,
+    wav_bytes: bytes,
+) -> _WindowsMaterializationRecord:
+    root_handle = filesystem.pin_directory_no_reparse(root)
+    owner_handle: WindowsPinnedHandle | None = None
+    lock_handle: WindowsPinnedHandle | None = None
+    asset_handle: WindowsPinnedHandle | None = None
+    extras: list[WindowsPinnedHandle] = []
+    lock_acquired = False
+    owner_name = ""
+    asset_name = ""
+    try:
+        if (
+            expected_root_identity is None
+            or root_handle.identity != expected_root_identity
+            or not root_handle.verify_private_acl()
+        ):
+            raise OSError("unsafe runtime root")
+        for _ in range(16):
+            owner_name = f"clone-v1-{token_hex(16)}"
+            try:
+                owner_handle = filesystem.create_private_directory(root / owner_name)
+                break
+            except Exception as error:
+                if getattr(error, "code", None) != "unavailable":
+                    raise
+        if owner_handle is None:
+            raise OSError("could not allocate owner")
+        if not owner_handle.verify_private_acl():
+            raise OSError("unsafe owner")
+
+        lock_handle = filesystem.create_private_file(
+            root / owner_name / "owner.lock",
+            b"",
+        )
+        if not lock_handle.verify_private_acl():
+            raise OSError("unsafe lock")
+        lock_handle.lock_exclusive_nonblocking()
+        lock_acquired = True
+
+        asset_name = f"asset-{token_hex(16)}.wav"
+        asset_handle = filesystem.create_private_file(
+            root / owner_name / asset_name,
+            wav_bytes,
+            read_only=True,
+        )
+        if not asset_handle.verify_private_acl():
+            raise OSError("unsafe asset")
+        if {path.name for path in (root / owner_name).iterdir()} != {
+            "owner.lock",
+            asset_name,
+        }:
+            raise OSError("unsafe owner entries")
+        return _WindowsMaterializationRecord(
+            filesystem=filesystem,
+            owner_name=owner_name,
+            asset_name=asset_name,
+            asset_path=root / owner_name / asset_name,
+            root_handle=root_handle,
+            owner_handle=owner_handle,
+            lock_handle=lock_handle,
+            asset_handle=asset_handle,
+            root_identity=root_handle.identity,
+            owner_identity=owner_handle.identity,
+            lock_identity=lock_handle.identity,
+            asset_identity=asset_handle.identity,
+            asset_size=len(wav_bytes),
+            asset_sha256=hashlib.sha256(wav_bytes).hexdigest(),
+        )
+    except BaseException as error:
+        attached = take_windows_artifact_cleanup_owner(error)
+        if attached is not None:
+            extras.append(attached)
+        cleanup = _WindowsPartialCleanup(
+            root_handle=root_handle,
+            owner_handle=owner_handle,
+            lock_handle=lock_handle,
+            asset_handle=asset_handle,
+            extras=extras,
+            lock_released=not lock_acquired,
+        )
+        try:
+            cleanup.cleanup()
+        except BaseException as cleanup_error:
+            if _is_control_flow(cleanup_error):
+                raise _WindowsPartialCleanupFailure(cleanup, cleanup_error) from None
+            raise _WindowsPartialCleanupFailure(cleanup, error) from None
+        raise error
+
+
+def _open_matching_windows_handle(
+    filesystem: WindowsArtifactFilesystem,
+    path: Path,
+    expected: WindowsFileIdentity,
+) -> None:
+    handle = (
+        filesystem.pin_directory_no_reparse(path)
+        if expected.kind == "directory"
+        else filesystem.open_file_no_reparse(path)
+    )
+    try:
+        if handle.identity != expected or not handle.verify_private_acl():
+            raise OSError("owned materialization changed")
+    finally:
+        handle.close()
+
+
+def _validate_windows_materialization_sync(
+    filesystem: WindowsArtifactFilesystem,
+    record: _WindowsMaterializationRecord,
+) -> Path:
+    if record.cleanup_started:
+        raise OSError("owned materialization is closing")
+    for handle, expected in (
+        (record.root_handle, record.root_identity),
+        (record.owner_handle, record.owner_identity),
+        (record.lock_handle, record.lock_identity),
+        (record.asset_handle, record.asset_identity),
+    ):
+        if handle.identity != expected or not handle.verify_private_acl():
+            raise OSError("owned materialization changed")
+    _open_matching_windows_handle(
+        filesystem, record.asset_path.parent.parent, record.root_identity
+    )
+    _open_matching_windows_handle(
+        filesystem, record.asset_path.parent, record.owner_identity
+    )
+    _open_matching_windows_handle(
+        filesystem, record.asset_path.parent / "owner.lock", record.lock_identity
+    )
+    _open_matching_windows_handle(filesystem, record.asset_path, record.asset_identity)
+    if {path.name for path in record.asset_path.parent.iterdir()} != {
+        "owner.lock",
+        record.asset_name,
+    }:
+        raise OSError("owned materialization changed")
+    data = record.asset_handle.read(record.asset_size + 1)
+    if (
+        len(data) != record.asset_size
+        or hashlib.sha256(data).hexdigest() != record.asset_sha256
+    ):
+        raise OSError("owned materialization changed")
+    return record.asset_path
+
+
+def _cleanup_windows_materialization_sync(
+    record: _WindowsMaterializationRecord,
+) -> None:
+    if not record.cleanup_started:
+        _validate_windows_materialization_sync(record.filesystem, record)
+        record.cleanup_started = True
+    if not record.asset_removed:
+        record.asset_handle.delete_exact()
+        record.asset_handle.close()
+        record.asset_removed = True
+    if not record.lock_released:
+        record.lock_handle.unlock()
+        record.lock_released = True
+    if not record.lock_removed:
+        record.lock_handle.delete_exact()
+        record.lock_handle.close()
+        record.lock_removed = True
+    if not record.owner_removed:
+        record.owner_handle.delete_exact()
+        record.owner_handle.close()
+        record.owner_removed = True
+    if not record.root_closed:
+        record.root_handle.close()
+        record.root_closed = True
+
+
+def _cleanup_materialization_sync(record: _OwnedMaterializationRecord) -> None:
+    if isinstance(record, _WindowsMaterializationRecord):
+        _cleanup_windows_materialization_sync(record)
+        return
+    _cleanup_posix_materialization_sync(record)
+
+
+def _cleanup_posix_materialization_sync(record: _MaterializationRecord) -> None:
     root_info = os.fstat(record.root_fd)
     if _identity(root_info) != record.root_identity or not _private_directory(
         root_info
@@ -804,7 +1275,9 @@ def _cleanup_materialization_sync(record: _MaterializationRecord) -> None:
     _abandon_record(record)
 
 
-def _abandon_record(record: _MaterializationRecord) -> None:
+def _abandon_record(record: _OwnedMaterializationRecord) -> None:
+    if isinstance(record, _WindowsMaterializationRecord):
+        return
     for descriptor in (record.lock_fd, record.owner_fd, record.root_fd):
         try:
             os.close(descriptor)

--- a/tldw_chatbook/TTS/windows_artifact_fs.py
+++ b/tldw_chatbook/TTS/windows_artifact_fs.py
@@ -1,0 +1,1423 @@
+"""Native Windows filesystem boundary for owned audio.cpp artifacts.
+
+The module remains import-safe on non-Windows hosts. Concrete native
+capabilities are added only behind the explicit Windows implementation.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import platform
+import struct
+import sys
+from dataclasses import dataclass, field
+from pathlib import PureWindowsPath
+from typing import Any, Literal, Protocol
+
+from ctypes import wintypes
+
+
+WindowsProcessArchitecture = Literal["x86", "x86_64"]
+WindowsArtifactKind = Literal["directory", "file"]
+WindowsArtifactPrivacyPosture = Literal[
+    "unverified",
+    "windows_account_protected",
+]
+WindowsArtifactErrorCode = Literal[
+    "unsupported",
+    "unavailable",
+    "changed",
+    "privacy_unavailable",
+    "busy",
+    "cleanup_failed",
+]
+
+_PATH_ERROR = "Windows artifact path is unavailable"
+_DEVICE_PREFIXES = ("\\\\?\\", "\\\\.\\", "\\device\\", "\\??\\")
+_RESERVED_NAMES = frozenset(
+    {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        *(f"com{index}" for index in range(1, 10)),
+        *(f"lpt{index}" for index in range(1, 10)),
+    }
+)
+_INVALID_COMPONENT_CHARACTERS = frozenset('<>:"/\\|?*')
+_X86_MACHINES = frozenset(
+    {"x86", "i386", "i486", "i586", "i686", "amd64", "x86_64", "x64"}
+)
+_X64_MACHINES = frozenset({"amd64", "x86_64", "x64"})
+_ERROR_MESSAGES: dict[WindowsArtifactErrorCode, str] = {
+    "unsupported": "Windows audio.cpp artifacts are unsupported",
+    "unavailable": "Windows artifact storage is unavailable",
+    "changed": "Windows artifact identity changed",
+    "privacy_unavailable": "Windows artifact privacy is unavailable",
+    "busy": "Windows artifact storage is busy",
+    "cleanup_failed": "Windows artifact cleanup did not complete",
+}
+_CONTROL_CLEANUP_OWNER = "_windows_artifact_cleanup_owner"
+
+_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+_FILE_ATTRIBUTE_READONLY = 0x00000001
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_FILE_LIST_DIRECTORY = 0x00000001
+_FILE_READ_ATTRIBUTES = 0x00000080
+_FILE_SHARE_READ = 0x00000001
+_FILE_SHARE_WRITE = 0x00000002
+_FILE_WRITE_ATTRIBUTES = 0x00000100
+_GENERIC_READ = 0x80000000
+_GENERIC_WRITE = 0x40000000
+_DELETE = 0x00010000
+_READ_CONTROL = 0x00020000
+_WRITE_DAC = 0x00040000
+_OPEN_EXISTING = 3
+_CREATE_NEW = 1
+_HANDLE_FLAG_INHERIT = 0x00000001
+_FILE_BEGIN = 0
+_LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
+_LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
+_FILE_BASIC_INFO_CLASS = 0
+_FILE_DISPOSITION_INFO_CLASS = 4
+_FILE_ATTRIBUTE_TAG_INFO_CLASS = 9
+_FILE_ID_INFO_CLASS = 18
+_SE_FILE_OBJECT = 1
+_DACL_SECURITY_INFORMATION = 0x00000004
+_PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+_SE_DACL_PROTECTED = 0x1000
+_TOKEN_QUERY = 0x0008
+_TOKEN_USER_CLASS = 1
+_SDDL_REVISION_1 = 1
+_ACCESS_ALLOWED_ACE_TYPE = 0
+_OBJECT_INHERIT_ACE = 0x01
+_CONTAINER_INHERIT_ACE = 0x02
+_FILE_ALL_ACCESS = 0x001F01FF
+_SYSTEM_SID = "S-1-5-18"
+_ADMINISTRATORS_SID = "S-1-5-32-544"
+
+
+class _FileIdInfo(ctypes.Structure):
+    _fields_ = [
+        ("VolumeSerialNumber", ctypes.c_ulonglong),
+        ("FileId", ctypes.c_ubyte * 16),
+    ]
+
+
+class _FileAttributeTagInfo(ctypes.Structure):
+    _fields_ = [
+        ("FileAttributes", wintypes.DWORD),
+        ("ReparseTag", wintypes.DWORD),
+    ]
+
+
+class _FileBasicInfo(ctypes.Structure):
+    _fields_ = [
+        ("CreationTime", ctypes.c_longlong),
+        ("LastAccessTime", ctypes.c_longlong),
+        ("LastWriteTime", ctypes.c_longlong),
+        ("ChangeTime", ctypes.c_longlong),
+        ("FileAttributes", wintypes.DWORD),
+    ]
+
+
+class _FileDispositionInfo(ctypes.Structure):
+    _fields_ = [("DeleteFile", wintypes.BOOLEAN)]
+
+
+class _Overlapped(ctypes.Structure):
+    _fields_ = [
+        ("Internal", ctypes.c_size_t),
+        ("InternalHigh", ctypes.c_size_t),
+        ("Offset", wintypes.DWORD),
+        ("OffsetHigh", wintypes.DWORD),
+        ("hEvent", wintypes.HANDLE),
+    ]
+
+
+class _SecurityAttributes(ctypes.Structure):
+    _fields_ = [
+        ("nLength", wintypes.DWORD),
+        ("lpSecurityDescriptor", wintypes.LPVOID),
+        ("bInheritHandle", wintypes.BOOL),
+    ]
+
+
+class _SidAndAttributes(ctypes.Structure):
+    _fields_ = [("Sid", wintypes.LPVOID), ("Attributes", wintypes.DWORD)]
+
+
+class _TokenUser(ctypes.Structure):
+    _fields_ = [("User", _SidAndAttributes)]
+
+
+class _Acl(ctypes.Structure):
+    _fields_ = [
+        ("AclRevision", ctypes.c_ubyte),
+        ("Sbz1", ctypes.c_ubyte),
+        ("AclSize", wintypes.WORD),
+        ("AceCount", wintypes.WORD),
+        ("Sbz2", wintypes.WORD),
+    ]
+
+
+class _AceHeader(ctypes.Structure):
+    _fields_ = [
+        ("AceType", ctypes.c_ubyte),
+        ("AceFlags", ctypes.c_ubyte),
+        ("AceSize", wintypes.WORD),
+    ]
+
+
+class _AccessAllowedAce(ctypes.Structure):
+    _fields_ = [
+        ("Header", _AceHeader),
+        ("Mask", wintypes.DWORD),
+        ("SidStart", wintypes.DWORD),
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class WindowsFileIdentity:
+    """Stable native object identity with no public path or handle value."""
+
+    volume_serial_number: int
+    file_id: bytes = field(repr=False)
+    kind: WindowsArtifactKind
+    reparse_tag: int
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.volume_serial_number) is not int
+            or type(self.file_id) is not bytes
+            or len(self.file_id) != 16
+            or self.kind not in ("directory", "file")
+            or type(self.reparse_tag) is not int
+            or self.reparse_tag < 0
+        ):
+            raise ValueError("Windows file identity is invalid")
+
+
+class _WindowsKernel(Protocol):
+    """Small injectable native-call boundary used by the artifact owner."""
+
+    def open_handle(
+        self,
+        path: str,
+        *,
+        kind: WindowsArtifactKind,
+        create_new: bool,
+        writable: bool,
+    ) -> int: ...
+
+    def set_inheritable(self, handle: int, inheritable: bool) -> None: ...
+
+    def identity(self, handle: int) -> WindowsFileIdentity: ...
+
+    def current_user_sid(self) -> bytes: ...
+
+    def set_private_acl(
+        self,
+        handle: int,
+        user_sid: bytes,
+        directory: bool,
+    ) -> None: ...
+
+    def verify_private_acl(
+        self,
+        handle: int,
+        user_sid: bytes,
+        directory: bool,
+    ) -> bool: ...
+
+    def write_all(self, handle: int, data: bytes) -> None: ...
+
+    def read(self, handle: int, count: int, offset: int) -> bytes: ...
+
+    def flush(self, handle: int) -> None: ...
+
+    def set_read_only(self, handle: int) -> None: ...
+
+    def lock_exclusive_nonblocking(self, handle: int) -> None: ...
+
+    def unlock(self, handle: int) -> None: ...
+
+    def delete_handle(self, handle: int) -> None: ...
+
+    def close_handle(self, handle: int) -> None: ...
+
+
+class WindowsArtifactError(RuntimeError):
+    """Stable path-independent failure with optional cleanup ownership."""
+
+    __slots__ = ("_cleanup_owner", "code")
+
+    def __init__(
+        self,
+        code: WindowsArtifactErrorCode,
+        *,
+        cleanup_owner: WindowsPinnedHandle | None = None,
+    ) -> None:
+        self.code = code
+        self._cleanup_owner = cleanup_owner
+        super().__init__(_ERROR_MESSAGES[code])
+
+    def take_cleanup_owner(self) -> WindowsPinnedHandle | None:
+        """Transfer the exact retained handle once."""
+
+        owner = self._cleanup_owner
+        self._cleanup_owner = None
+        return owner
+
+
+def _sanitize_control(error: BaseException) -> BaseException:
+    """Bound one synchronous control signal without changing its family."""
+
+    if isinstance(error, BaseExceptionGroup):
+        bounded = BaseExceptionGroup(
+            "Windows artifact operation interrupted",
+            tuple(_sanitize_control(child) for child in error.exceptions),
+        )
+        bounded.__suppress_context__ = True
+        return bounded
+    if isinstance(error, SystemExit):
+        code = error.code
+        error.code = code if code is None or type(code) is int else 1
+        error.args = () if error.code is None else (error.code,)
+    else:
+        error.args = ()
+    error.__cause__ = None
+    error.__context__ = None
+    error.__traceback__ = None
+    error.__suppress_context__ = True
+    return error
+
+
+def _attach_control_cleanup_owner(
+    error: BaseException,
+    owner: WindowsPinnedHandle,
+) -> None:
+    setattr(error, _CONTROL_CLEANUP_OWNER, owner)
+
+
+def take_windows_artifact_cleanup_owner(
+    error: BaseException,
+) -> WindowsPinnedHandle | None:
+    """Take one exact cleanup owner from a bounded public failure."""
+
+    if isinstance(error, WindowsArtifactError):
+        return WindowsArtifactError.take_cleanup_owner(error)
+    owner = getattr(error, _CONTROL_CLEANUP_OWNER, None)
+    if not isinstance(owner, WindowsPinnedHandle):
+        return None
+    setattr(error, _CONTROL_CLEANUP_OWNER, None)
+    return owner
+
+
+def _raise_control(error: BaseException) -> None:
+    """Raise a sanitized control without retaining an active private context."""
+
+    try:
+        raise error from None
+    except BaseException as reraised:
+        reraised.__cause__ = None
+        reraised.__context__ = None
+        reraised.__suppress_context__ = True
+        raise
+
+
+class WindowsPinnedHandle:
+    """Opaque owner of one non-inheritable native file or directory handle."""
+
+    __slots__ = (
+        "_cleanup_delete_pending",
+        "_cleanup_only",
+        "_closed",
+        "_deleted",
+        "_handle",
+        "_identity",
+        "_kernel",
+        "_private",
+        "_user_sid",
+    )
+
+    def __init__(
+        self,
+        kernel: _WindowsKernel,
+        handle: int,
+        identity: WindowsFileIdentity | None,
+        *,
+        private: bool,
+        user_sid: bytes,
+    ) -> None:
+        self._kernel = kernel
+        self._handle = handle
+        self._identity = identity
+        self._private = private
+        self._user_sid = user_sid
+        self._closed = False
+        self._deleted = False
+        self._cleanup_only = identity is None
+        self._cleanup_delete_pending = False
+
+    @property
+    def identity(self) -> WindowsFileIdentity:
+        """Return the immutable identity captured at open."""
+
+        if self._identity is None:
+            raise WindowsArtifactError("unavailable")
+        return self._identity
+
+    @property
+    def privacy_posture(self) -> WindowsArtifactPrivacyPosture:
+        """Return only the posture actually verified on this open object."""
+
+        return "windows_account_protected" if self._private else "unverified"
+
+    def read(self, count: int, *, offset: int = 0) -> bytes:
+        """Read bounded bytes through the exact retained handle."""
+
+        if self._closed or self._cleanup_only or type(count) is not int or count < 0:
+            raise WindowsArtifactError("unavailable")
+        try:
+            return self._kernel.read(self._handle, count, offset)
+        except Exception:
+            pass
+        raise WindowsArtifactError("unavailable") from None
+
+    def lock_exclusive_nonblocking(self) -> None:
+        """Acquire one exact nonblocking owner lock."""
+
+        if self._closed or self._cleanup_only:
+            raise WindowsArtifactError("unavailable")
+        busy = False
+        failed = False
+        try:
+            self._kernel.lock_exclusive_nonblocking(self._handle)
+        except BlockingIOError:
+            busy = True
+        except Exception:
+            failed = True
+        if busy:
+            raise WindowsArtifactError("busy") from None
+        if failed:
+            raise WindowsArtifactError("unavailable") from None
+
+    def unlock(self) -> None:
+        """Release the exact owner lock."""
+
+        if self._closed:
+            return
+        failed = False
+        try:
+            self._kernel.unlock(self._handle)
+        except Exception:
+            failed = True
+        if failed:
+            raise WindowsArtifactError("cleanup_failed") from None
+
+    def verify_private_acl(self) -> bool:
+        """Re-read the approved protected DACL on the exact handle."""
+
+        if self._closed or not self._private:
+            return False
+        try:
+            return self._kernel.verify_private_acl(
+                self._handle,
+                self._user_sid,
+                self._identity is not None and self._identity.kind == "directory",
+            )
+        except Exception:
+            return False
+
+    def delete_exact(self) -> None:
+        """Mark only the unchanged, private, exact object for deletion."""
+
+        if self._closed or self._deleted or self._cleanup_only:
+            return
+        changed = False
+        privacy_failed = False
+        delete_failed = False
+        try:
+            changed = self._kernel.identity(self._handle) != self._identity
+            if not changed:
+                privacy_failed = not self.verify_private_acl()
+            if not changed and not privacy_failed:
+                self._kernel.delete_handle(self._handle)
+        except Exception:
+            delete_failed = True
+        if changed:
+            raise WindowsArtifactError("changed") from None
+        if privacy_failed:
+            raise WindowsArtifactError("privacy_unavailable") from None
+        if delete_failed:
+            raise WindowsArtifactError("cleanup_failed", cleanup_owner=self) from None
+        self._deleted = True
+
+    def close(self) -> None:
+        """Close once, retaining this exact owner after an ordinary failure."""
+
+        if self._closed:
+            return
+        if self._cleanup_delete_pending and not self._deleted:
+            try:
+                self._kernel.delete_handle(self._handle)
+            except Exception:
+                raise WindowsArtifactError(
+                    "cleanup_failed", cleanup_owner=self
+                ) from None
+            self._deleted = True
+        failed = False
+        try:
+            self._kernel.close_handle(self._handle)
+        except BaseException as error:
+            if isinstance(error, Exception):
+                failed = True
+            else:
+                control = _sanitize_control(error)
+                _attach_control_cleanup_owner(control, self)
+                _raise_control(control)
+        if failed:
+            raise WindowsArtifactError("cleanup_failed", cleanup_owner=self) from None
+        self._closed = True
+
+    def __repr__(self) -> str:
+        return "WindowsPinnedHandle(<opaque>)"
+
+
+class WindowsArtifactFilesystem(Protocol):
+    """Minimal injectable capability consumed by audio.cpp owners."""
+
+    def pin_directory_no_reparse(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle: ...
+
+    def open_file_no_reparse(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        writable: bool = False,
+    ) -> WindowsPinnedHandle: ...
+
+    def create_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle: ...
+
+    def create_private_file(
+        self,
+        path: str | os.PathLike[str],
+        data: bytes,
+        *,
+        read_only: bool = False,
+    ) -> WindowsPinnedHandle: ...
+
+
+class NativeWindowsArtifactFilesystem:
+    """Handle-pinned Windows artifact operations over one native kernel."""
+
+    def __init__(self, *, kernel: _WindowsKernel | None = None) -> None:
+        self._kernel = _native_windows_kernel() if kernel is None else kernel
+        try:
+            self._user_sid = self._kernel.current_user_sid()
+        except Exception:
+            raise WindowsArtifactError("privacy_unavailable") from None
+
+    def pin_directory_no_reparse(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        """Pin one existing ordinary directory without following reparse data."""
+
+        return self._open(path, kind="directory", create_new=False, writable=False)
+
+    def open_file_no_reparse(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        writable: bool = False,
+    ) -> WindowsPinnedHandle:
+        """Open one existing regular file without following reparse data."""
+
+        return self._open(
+            path,
+            kind="file",
+            create_new=False,
+            writable=writable,
+        )
+
+    def create_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        """Create and verify one protected private directory."""
+
+        owner = self._open(
+            path,
+            kind="directory",
+            create_new=True,
+            writable=True,
+        )
+        return self._make_private(owner, directory=True)
+
+    def create_private_file(
+        self,
+        path: str | os.PathLike[str],
+        data: bytes,
+        *,
+        read_only: bool = False,
+    ) -> WindowsPinnedHandle:
+        """Create, flush, protect, and verify one private file."""
+
+        if type(data) is not bytes:
+            raise WindowsArtifactError("unavailable")
+        owner = self._open(path, kind="file", create_new=True, writable=True)
+        failed = False
+        control: BaseException | None = None
+        try:
+            self._kernel.write_all(owner._handle, data)
+            self._kernel.flush(owner._handle)
+        except BaseException as error:
+            if isinstance(error, Exception):
+                failed = True
+            else:
+                control = _sanitize_control(error)
+        if control is not None:
+            try:
+                self._retire_failed_creation(owner)
+            except WindowsArtifactError as cleanup_error:
+                cleanup = cleanup_error.take_cleanup_owner()
+                if cleanup is not None:
+                    _attach_control_cleanup_owner(control, cleanup)
+            _raise_control(control)
+        if failed:
+            self._retire_failed_creation(owner)
+            raise WindowsArtifactError("unavailable") from None
+        owner = self._make_private(owner, directory=False)
+        if read_only:
+            read_only_failed = False
+            try:
+                self._kernel.set_read_only(owner._handle)
+            except Exception:
+                read_only_failed = True
+            if read_only_failed:
+                self._retire_failed_creation(owner)
+                raise WindowsArtifactError("privacy_unavailable") from None
+        return owner
+
+    def _open(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        kind: WindowsArtifactKind,
+        create_new: bool,
+        writable: bool,
+    ) -> WindowsPinnedHandle:
+        try:
+            normalized = normalize_windows_artifact_path(path)
+        except ValueError:
+            raise WindowsArtifactError("unavailable") from None
+        handle: int | None = None
+        identity: WindowsFileIdentity | None = None
+        failed = False
+        try:
+            handle = self._kernel.open_handle(
+                normalized,
+                kind=kind,
+                create_new=create_new,
+                writable=writable,
+            )
+            self._kernel.set_inheritable(handle, False)
+            identity = self._kernel.identity(handle)
+        except Exception:
+            failed = True
+        if failed or handle is None or identity is None:
+            if handle is not None:
+                cleanup = WindowsPinnedHandle(
+                    self._kernel,
+                    handle,
+                    identity,
+                    private=False,
+                    user_sid=self._user_sid,
+                )
+                cleanup._cleanup_only = True
+                try:
+                    cleanup.close()
+                except WindowsArtifactError:
+                    raise WindowsArtifactError(
+                        "cleanup_failed", cleanup_owner=cleanup
+                    ) from None
+            raise WindowsArtifactError("unavailable") from None
+        owner = WindowsPinnedHandle(
+            self._kernel,
+            handle,
+            identity,
+            private=False,
+            user_sid=self._user_sid,
+        )
+        if identity.kind != kind or identity.reparse_tag:
+            owner._cleanup_only = True
+            try:
+                owner.close()
+            except WindowsArtifactError:
+                raise WindowsArtifactError(
+                    "cleanup_failed", cleanup_owner=owner
+                ) from None
+            raise WindowsArtifactError("changed") from None
+        return owner
+
+    def _make_private(
+        self,
+        owner: WindowsPinnedHandle,
+        *,
+        directory: bool,
+    ) -> WindowsPinnedHandle:
+        failed = False
+        try:
+            self._kernel.set_private_acl(owner._handle, self._user_sid, directory)
+            failed = not self._kernel.verify_private_acl(
+                owner._handle,
+                self._user_sid,
+                directory,
+            )
+        except Exception:
+            failed = True
+        if failed:
+            self._retire_failed_creation(owner)
+            raise WindowsArtifactError("privacy_unavailable") from None
+        owner._private = True
+        return owner
+
+    @staticmethod
+    def _retire_failed_creation(owner: WindowsPinnedHandle) -> None:
+        owner._cleanup_only = True
+        owner._cleanup_delete_pending = True
+        owner.close()
+
+
+class UnavailableWindowsArtifactFilesystem:
+    """Import-safe placeholder for hosts outside the supported Windows tuple."""
+
+    @staticmethod
+    def _unsupported() -> WindowsPinnedHandle:
+        raise WindowsArtifactError("unsupported")
+
+    def pin_directory_no_reparse(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        del path
+        return self._unsupported()
+
+    def open_file_no_reparse(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        writable: bool = False,
+    ) -> WindowsPinnedHandle:
+        del path, writable
+        return self._unsupported()
+
+    def create_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        del path
+        return self._unsupported()
+
+    def create_private_file(
+        self,
+        path: str | os.PathLike[str],
+        data: bytes,
+        *,
+        read_only: bool = False,
+    ) -> WindowsPinnedHandle:
+        del path, data, read_only
+        return self._unsupported()
+
+
+class _CtypesWindowsKernel:
+    """Private, explicitly signed Win32 calls used by the public capability."""
+
+    def __init__(self) -> None:
+        if os.name != "nt" or not hasattr(ctypes, "WinDLL"):
+            raise WindowsArtifactError("unsupported")
+        win_dll = getattr(ctypes, "WinDLL")
+        self._kernel32 = win_dll("kernel32", use_last_error=True)
+        self._advapi32 = win_dll("advapi32", use_last_error=True)
+        self._configure_signatures()
+
+    @staticmethod
+    def _handle(value: int) -> wintypes.HANDLE:
+        return wintypes.HANDLE(value)
+
+    @staticmethod
+    def _native_failed() -> OSError:
+        return OSError("native Windows artifact operation failed")
+
+    @staticmethod
+    def _valid_handle(handle: Any) -> int:
+        value = ctypes.cast(handle, ctypes.c_void_p).value
+        if value in {None, ctypes.c_void_p(-1).value}:
+            raise _CtypesWindowsKernel._native_failed()
+        return int(value)
+
+    def _configure_signatures(self) -> None:
+        kernel32 = self._kernel32
+        advapi32 = self._advapi32
+
+        kernel32.CreateFileW.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(_SecurityAttributes),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        )
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.CreateDirectoryW.argtypes = (
+            wintypes.LPCWSTR,
+            ctypes.POINTER(_SecurityAttributes),
+        )
+        kernel32.CreateDirectoryW.restype = wintypes.BOOL
+        kernel32.RemoveDirectoryW.argtypes = (wintypes.LPCWSTR,)
+        kernel32.RemoveDirectoryW.restype = wintypes.BOOL
+        kernel32.SetHandleInformation.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.DWORD,
+        )
+        kernel32.SetHandleInformation.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandleEx.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.SetFileInformationByHandle.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        )
+        kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+        kernel32.SetFilePointerEx.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_longlong,
+            ctypes.POINTER(ctypes.c_longlong),
+            wintypes.DWORD,
+        )
+        kernel32.SetFilePointerEx.restype = wintypes.BOOL
+        kernel32.ReadFile.argtypes = (
+            wintypes.HANDLE,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(_Overlapped),
+        )
+        kernel32.ReadFile.restype = wintypes.BOOL
+        kernel32.WriteFile.argtypes = kernel32.ReadFile.argtypes
+        kernel32.WriteFile.restype = wintypes.BOOL
+        kernel32.FlushFileBuffers.argtypes = (wintypes.HANDLE,)
+        kernel32.FlushFileBuffers.restype = wintypes.BOOL
+        kernel32.LockFileEx.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(_Overlapped),
+        )
+        kernel32.LockFileEx.restype = wintypes.BOOL
+        kernel32.UnlockFileEx.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(_Overlapped),
+        )
+        kernel32.UnlockFileEx.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.GetCurrentProcess.argtypes = ()
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        kernel32.LocalFree.argtypes = (wintypes.HLOCAL,)
+        kernel32.LocalFree.restype = wintypes.HLOCAL
+
+        advapi32.OpenProcessToken.argtypes = (
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.HANDLE),
+        )
+        advapi32.OpenProcessToken.restype = wintypes.BOOL
+        advapi32.GetTokenInformation.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        )
+        advapi32.GetTokenInformation.restype = wintypes.BOOL
+        advapi32.GetLengthSid.argtypes = (wintypes.LPVOID,)
+        advapi32.GetLengthSid.restype = wintypes.DWORD
+        advapi32.IsValidSid.argtypes = (wintypes.LPVOID,)
+        advapi32.IsValidSid.restype = wintypes.BOOL
+        advapi32.ConvertSidToStringSidW.argtypes = (
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.LPWSTR),
+        )
+        advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+        advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = (
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.DWORD),
+        )
+        advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.restype = (
+            wintypes.BOOL
+        )
+        advapi32.GetSecurityDescriptorDacl.argtypes = (
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.BOOL),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.BOOL),
+        )
+        advapi32.GetSecurityDescriptorDacl.restype = wintypes.BOOL
+        advapi32.GetSecurityDescriptorControl.argtypes = (
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.WORD),
+            ctypes.POINTER(wintypes.DWORD),
+        )
+        advapi32.GetSecurityDescriptorControl.restype = wintypes.BOOL
+        advapi32.SetSecurityInfo.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+        )
+        advapi32.SetSecurityInfo.restype = wintypes.DWORD
+        advapi32.GetSecurityInfo.argtypes = (
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+        )
+        advapi32.GetSecurityInfo.restype = wintypes.DWORD
+        advapi32.GetAce.argtypes = (
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+        )
+        advapi32.GetAce.restype = wintypes.BOOL
+
+    def _sid_string(self, sid: bytes) -> str:
+        buffer = ctypes.create_string_buffer(sid)
+        pointer = ctypes.cast(buffer, wintypes.LPVOID)
+        if not self._advapi32.IsValidSid(pointer):
+            raise self._native_failed()
+        rendered = wintypes.LPWSTR()
+        if not self._advapi32.ConvertSidToStringSidW(pointer, ctypes.byref(rendered)):
+            raise self._native_failed()
+        try:
+            return str(rendered.value)
+        finally:
+            self._kernel32.LocalFree(rendered)
+
+    def _private_descriptor(self, user_sid: bytes, directory: bool) -> wintypes.LPVOID:
+        sid = self._sid_string(user_sid)
+        flags = "OICI" if directory else ""
+        sddl = (
+            f"D:P(A;{flags};FA;;;{sid})"
+            f"(A;{flags};FA;;;{_SYSTEM_SID})"
+            f"(A;{flags};FA;;;{_ADMINISTRATORS_SID})"
+        )
+        descriptor = wintypes.LPVOID()
+        if not self._advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl,
+            _SDDL_REVISION_1,
+            ctypes.byref(descriptor),
+            None,
+        ):
+            raise self._native_failed()
+        return descriptor
+
+    def _security_attributes(
+        self, directory: bool
+    ) -> tuple[_SecurityAttributes, wintypes.LPVOID]:
+        descriptor = self._private_descriptor(self.current_user_sid(), directory)
+        attributes = _SecurityAttributes(
+            ctypes.sizeof(_SecurityAttributes), descriptor, False
+        )
+        return attributes, descriptor
+
+    def open_handle(
+        self,
+        path: str,
+        *,
+        kind: WindowsArtifactKind,
+        create_new: bool,
+        writable: bool,
+    ) -> int:
+        descriptor: wintypes.LPVOID | None = None
+        attributes: _SecurityAttributes | None = None
+        created_directory = False
+        try:
+            if create_new:
+                attributes, descriptor = self._security_attributes(kind == "directory")
+            if kind == "directory" and create_new:
+                if attributes is None:
+                    raise self._native_failed()
+                if not self._kernel32.CreateDirectoryW(path, ctypes.byref(attributes)):
+                    raise self._native_failed()
+                created_directory = True
+
+            access = _FILE_READ_ATTRIBUTES | _READ_CONTROL
+            if kind == "directory":
+                access |= _FILE_LIST_DIRECTORY
+            else:
+                access |= _GENERIC_READ
+            if writable:
+                access |= _GENERIC_WRITE | _FILE_WRITE_ATTRIBUTES
+            if create_new:
+                access |= _DELETE | _WRITE_DAC
+            disposition = (
+                _CREATE_NEW if create_new and kind == "file" else _OPEN_EXISTING
+            )
+            flags = _FILE_FLAG_OPEN_REPARSE_POINT
+            if kind == "directory":
+                flags |= _FILE_FLAG_BACKUP_SEMANTICS
+            handle = self._kernel32.CreateFileW(
+                path,
+                access,
+                _FILE_SHARE_READ | _FILE_SHARE_WRITE,
+                ctypes.byref(attributes) if attributes is not None else None,
+                disposition,
+                flags,
+                None,
+            )
+            return self._valid_handle(handle)
+        except BaseException:
+            if created_directory:
+                self._kernel32.RemoveDirectoryW(path)
+            raise
+        finally:
+            if descriptor is not None:
+                self._kernel32.LocalFree(descriptor)
+
+    def set_inheritable(self, handle: int, inheritable: bool) -> None:
+        value = _HANDLE_FLAG_INHERIT if inheritable else 0
+        if not self._kernel32.SetHandleInformation(
+            self._handle(handle), _HANDLE_FLAG_INHERIT, value
+        ):
+            raise self._native_failed()
+
+    def identity(self, handle: int) -> WindowsFileIdentity:
+        file_id = _FileIdInfo()
+        attributes = _FileAttributeTagInfo()
+        native = self._handle(handle)
+        if not self._kernel32.GetFileInformationByHandleEx(
+            native,
+            _FILE_ID_INFO_CLASS,
+            ctypes.byref(file_id),
+            ctypes.sizeof(file_id),
+        ) or not self._kernel32.GetFileInformationByHandleEx(
+            native,
+            _FILE_ATTRIBUTE_TAG_INFO_CLASS,
+            ctypes.byref(attributes),
+            ctypes.sizeof(attributes),
+        ):
+            raise self._native_failed()
+        kind: WindowsArtifactKind = (
+            "directory"
+            if attributes.FileAttributes & _FILE_ATTRIBUTE_DIRECTORY
+            else "file"
+        )
+        tag = (
+            int(attributes.ReparseTag)
+            if attributes.FileAttributes & _FILE_ATTRIBUTE_REPARSE_POINT
+            else 0
+        )
+        return WindowsFileIdentity(
+            volume_serial_number=int(file_id.VolumeSerialNumber),
+            file_id=bytes(file_id.FileId),
+            kind=kind,
+            reparse_tag=tag,
+        )
+
+    def current_user_sid(self) -> bytes:
+        token = wintypes.HANDLE()
+        if not self._advapi32.OpenProcessToken(
+            self._kernel32.GetCurrentProcess(), _TOKEN_QUERY, ctypes.byref(token)
+        ):
+            raise self._native_failed()
+        try:
+            required = wintypes.DWORD()
+            self._advapi32.GetTokenInformation(
+                token, _TOKEN_USER_CLASS, None, 0, ctypes.byref(required)
+            )
+            if not required.value:
+                raise self._native_failed()
+            buffer = ctypes.create_string_buffer(required.value)
+            if not self._advapi32.GetTokenInformation(
+                token,
+                _TOKEN_USER_CLASS,
+                buffer,
+                required,
+                ctypes.byref(required),
+            ):
+                raise self._native_failed()
+            user = ctypes.cast(buffer, ctypes.POINTER(_TokenUser)).contents
+            length = self._advapi32.GetLengthSid(user.User.Sid)
+            if not length:
+                raise self._native_failed()
+            return ctypes.string_at(user.User.Sid, length)
+        finally:
+            self._kernel32.CloseHandle(token)
+
+    def set_private_acl(self, handle: int, user_sid: bytes, directory: bool) -> None:
+        descriptor = self._private_descriptor(user_sid, directory)
+        try:
+            present = wintypes.BOOL()
+            defaulted = wintypes.BOOL()
+            dacl = wintypes.LPVOID()
+            if (
+                not self._advapi32.GetSecurityDescriptorDacl(
+                    descriptor,
+                    ctypes.byref(present),
+                    ctypes.byref(dacl),
+                    ctypes.byref(defaulted),
+                )
+                or not present.value
+                or not dacl
+            ):
+                raise self._native_failed()
+            result = self._advapi32.SetSecurityInfo(
+                self._handle(handle),
+                _SE_FILE_OBJECT,
+                _DACL_SECURITY_INFORMATION | _PROTECTED_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                dacl,
+                None,
+            )
+            if result:
+                raise self._native_failed()
+        finally:
+            self._kernel32.LocalFree(descriptor)
+
+    def verify_private_acl(self, handle: int, user_sid: bytes, directory: bool) -> bool:
+        dacl = wintypes.LPVOID()
+        descriptor = wintypes.LPVOID()
+        result = self._advapi32.GetSecurityInfo(
+            self._handle(handle),
+            _SE_FILE_OBJECT,
+            _DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            ctypes.byref(dacl),
+            None,
+            ctypes.byref(descriptor),
+        )
+        if result or not descriptor or not dacl:
+            if descriptor:
+                self._kernel32.LocalFree(descriptor)
+            return False
+        try:
+            control = wintypes.WORD()
+            revision = wintypes.DWORD()
+            if (
+                not self._advapi32.GetSecurityDescriptorControl(
+                    descriptor, ctypes.byref(control), ctypes.byref(revision)
+                )
+                or not control.value & _SE_DACL_PROTECTED
+            ):
+                return False
+            acl = ctypes.cast(dacl, ctypes.POINTER(_Acl)).contents
+            if acl.AceCount != 3:
+                return False
+            expected = sorted(
+                [self._sid_string(user_sid), _SYSTEM_SID, _ADMINISTRATORS_SID]
+            )
+            trustees: list[str] = []
+            required_flags = _OBJECT_INHERIT_ACE | _CONTAINER_INHERIT_ACE
+            for index in range(acl.AceCount):
+                pointer = wintypes.LPVOID()
+                if not self._advapi32.GetAce(dacl, index, ctypes.byref(pointer)):
+                    return False
+                ace = ctypes.cast(pointer, ctypes.POINTER(_AccessAllowedAce)).contents
+                if (
+                    ace.Header.AceType != _ACCESS_ALLOWED_ACE_TYPE
+                    or ace.Mask != _FILE_ALL_ACCESS
+                    or (
+                        directory
+                        and ace.Header.AceFlags & required_flags != required_flags
+                    )
+                    or (not directory and ace.Header.AceFlags & required_flags)
+                ):
+                    return False
+                sid_pointer = ctypes.c_void_p(
+                    int(ctypes.cast(pointer, ctypes.c_void_p).value or 0)
+                    + _AccessAllowedAce.SidStart.offset
+                )
+                length = self._advapi32.GetLengthSid(sid_pointer)
+                if not length:
+                    return False
+                trustees.append(self._sid_string(ctypes.string_at(sid_pointer, length)))
+            return sorted(trustees) == expected
+        finally:
+            self._kernel32.LocalFree(descriptor)
+
+    def write_all(self, handle: int, data: bytes) -> None:
+        if len(data) > 0xFFFFFFFF:
+            raise self._native_failed()
+        written = wintypes.DWORD()
+        buffer = ctypes.create_string_buffer(data)
+        if not self._kernel32.WriteFile(
+            self._handle(handle), buffer, len(data), ctypes.byref(written), None
+        ) or written.value != len(data):
+            raise self._native_failed()
+
+    def read(self, handle: int, count: int, offset: int) -> bytes:
+        if count > 0xFFFFFFFF or offset < 0:
+            raise self._native_failed()
+        if not self._kernel32.SetFilePointerEx(
+            self._handle(handle), offset, None, _FILE_BEGIN
+        ):
+            raise self._native_failed()
+        buffer = ctypes.create_string_buffer(count)
+        read = wintypes.DWORD()
+        if not self._kernel32.ReadFile(
+            self._handle(handle), buffer, count, ctypes.byref(read), None
+        ):
+            raise self._native_failed()
+        return bytes(buffer.raw[: read.value])
+
+    def flush(self, handle: int) -> None:
+        if not self._kernel32.FlushFileBuffers(self._handle(handle)):
+            raise self._native_failed()
+
+    def set_read_only(self, handle: int) -> None:
+        information = _FileBasicInfo()
+        native = self._handle(handle)
+        if not self._kernel32.GetFileInformationByHandleEx(
+            native,
+            _FILE_BASIC_INFO_CLASS,
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+        ):
+            raise self._native_failed()
+        information.FileAttributes |= _FILE_ATTRIBUTE_READONLY
+        if not self._kernel32.SetFileInformationByHandle(
+            native,
+            _FILE_BASIC_INFO_CLASS,
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+        ):
+            raise self._native_failed()
+
+    def lock_exclusive_nonblocking(self, handle: int) -> None:
+        overlapped = _Overlapped()
+        if not self._kernel32.LockFileEx(
+            self._handle(handle),
+            _LOCKFILE_EXCLUSIVE_LOCK | _LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            ctypes.byref(overlapped),
+        ):
+            get_last_error = getattr(ctypes, "get_last_error", lambda: 0)
+            if get_last_error() in {32, 33}:
+                raise BlockingIOError("native Windows artifact lock is busy")
+            raise self._native_failed()
+
+    def unlock(self, handle: int) -> None:
+        overlapped = _Overlapped()
+        if not self._kernel32.UnlockFileEx(
+            self._handle(handle), 0, 1, 0, ctypes.byref(overlapped)
+        ):
+            raise self._native_failed()
+
+    def delete_handle(self, handle: int) -> None:
+        native = self._handle(handle)
+        information = _FileBasicInfo()
+        if not self._kernel32.GetFileInformationByHandleEx(
+            native,
+            _FILE_BASIC_INFO_CLASS,
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+        ):
+            raise self._native_failed()
+        if information.FileAttributes & _FILE_ATTRIBUTE_READONLY:
+            information.FileAttributes &= ~_FILE_ATTRIBUTE_READONLY
+            if not self._kernel32.SetFileInformationByHandle(
+                native,
+                _FILE_BASIC_INFO_CLASS,
+                ctypes.byref(information),
+                ctypes.sizeof(information),
+            ):
+                raise self._native_failed()
+        disposition = _FileDispositionInfo(True)
+        if not self._kernel32.SetFileInformationByHandle(
+            native,
+            _FILE_DISPOSITION_INFO_CLASS,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise self._native_failed()
+
+    def close_handle(self, handle: int) -> None:
+        if not self._kernel32.CloseHandle(self._handle(handle)):
+            raise self._native_failed()
+
+
+def _native_windows_kernel() -> _WindowsKernel:
+    """Construct the native kernel only for the admitted Windows tuple."""
+
+    if not windows_audio_cpp_platform_supported():
+        raise WindowsArtifactError("unsupported")
+    return _CtypesWindowsKernel()
+
+
+def _invalid_component(component: str) -> bool:
+    if component in {"", ".."} or component.endswith((" ", ".")):
+        return True
+    if any(ord(character) < 32 for character in component):
+        return True
+    if any(character in _INVALID_COMPONENT_CHARACTERS for character in component):
+        return True
+    basename = component.split(".", 1)[0].casefold()
+    return basename in _RESERVED_NAMES
+
+
+def normalize_windows_artifact_path(value: str | os.PathLike[str]) -> str:
+    """Return one validated extended-length drive or UNC path.
+
+    User-provided device namespaces are rejected. The extended namespace is
+    introduced only after the ordinary path has passed lexical validation.
+
+    Args:
+        value: Ordinary absolute Windows drive or UNC path.
+
+    Returns:
+        The equivalent extended-length path used by native calls.
+
+    Raises:
+        ValueError: If the value is relative, ambiguous, or unsafe.
+    """
+
+    try:
+        raw = os.fspath(value)
+    except (TypeError, ValueError):
+        raise ValueError(_PATH_ERROR) from None
+    if type(raw) is not str or not raw or "\x00" in raw:
+        raise ValueError(_PATH_ERROR)
+    normalized_separators = raw.replace("/", "\\")
+    folded = normalized_separators.casefold()
+    if folded.startswith(_DEVICE_PREFIXES):
+        raise ValueError(_PATH_ERROR)
+
+    selected = PureWindowsPath(normalized_separators)
+    if not selected.is_absolute() or not selected.drive or selected.root != "\\":
+        raise ValueError(_PATH_ERROR)
+    if any(_invalid_component(component) for component in selected.parts[1:]):
+        raise ValueError(_PATH_ERROR)
+
+    ordinary = str(selected)
+    if selected.drive.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + ordinary.removeprefix("\\\\")
+    if len(selected.drive) != 2 or selected.drive[1] != ":":
+        raise ValueError(_PATH_ERROR)
+    return f"\\\\?\\{ordinary}"
+
+
+def normalize_windows_process_architecture(
+    machine: str,
+    pointer_bits: int,
+) -> WindowsProcessArchitecture | None:
+    """Return the supported process architecture without projecting ARM."""
+
+    if type(machine) is not str or type(pointer_bits) is not int:
+        return None
+    folded = machine.casefold()
+    if folded not in _X86_MACHINES:
+        return None
+    if pointer_bits == 32:
+        return "x86"
+    if pointer_bits == 64 and folded in _X64_MACHINES:
+        return "x86_64"
+    return None
+
+
+def windows_audio_cpp_platform_supported(
+    *,
+    system_name: str | None = None,
+    windows_major: int | None = None,
+    python_version: tuple[int, int] | None = None,
+    machine: str | None = None,
+    pointer_bits: int | None = None,
+) -> bool:
+    """Return whether the current or supplied tuple meets the Windows floor."""
+
+    selected_system = platform.system() if system_name is None else system_name
+    if selected_system.casefold() != "windows":
+        return False
+    if windows_major is None:
+        get_windows_version = getattr(sys, "getwindowsversion", None)
+        selected_windows_major = (
+            int(get_windows_version().major) if callable(get_windows_version) else 0
+        )
+    else:
+        selected_windows_major = windows_major
+    selected_python = (
+        (sys.version_info.major, sys.version_info.minor)
+        if python_version is None
+        else python_version
+    )
+    selected_machine = platform.machine() if machine is None else machine
+    selected_pointer_bits = (
+        struct.calcsize("P") * 8 if pointer_bits is None else pointer_bits
+    )
+    return bool(
+        type(selected_windows_major) is int
+        and selected_windows_major >= 10
+        and type(selected_python) is tuple
+        and len(selected_python) == 2
+        and selected_python >= (3, 12)
+        and normalize_windows_process_architecture(
+            selected_machine,
+            selected_pointer_bits,
+        )
+        is not None
+    )
+
+
+OS_WINDOWS_ARTIFACT_FILESYSTEM: WindowsArtifactFilesystem = (
+    NativeWindowsArtifactFilesystem()
+    if windows_audio_cpp_platform_supported()
+    else UnavailableWindowsArtifactFilesystem()
+)
+
+
+__all__ = (
+    "NativeWindowsArtifactFilesystem",
+    "OS_WINDOWS_ARTIFACT_FILESYSTEM",
+    "UnavailableWindowsArtifactFilesystem",
+    "WindowsArtifactError",
+    "WindowsArtifactFilesystem",
+    "WindowsArtifactKind",
+    "WindowsArtifactPrivacyPosture",
+    "WindowsFileIdentity",
+    "WindowsPinnedHandle",
+    "WindowsProcessArchitecture",
+    "normalize_windows_artifact_path",
+    "normalize_windows_process_architecture",
+    "take_windows_artifact_cleanup_owner",
+    "windows_audio_cpp_platform_supported",
+)

--- a/tldw_chatbook/TTS/windows_artifact_fs.py
+++ b/tldw_chatbook/TTS/windows_artifact_fs.py
@@ -506,6 +506,10 @@ class WindowsArtifactFilesystem(Protocol):
         self, path: str | os.PathLike[str]
     ) -> WindowsPinnedHandle: ...
 
+    def protect_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle: ...
+
     def create_private_file(
         self,
         path: str | os.PathLike[str],
@@ -556,6 +560,19 @@ class NativeWindowsArtifactFilesystem:
             path,
             kind="directory",
             create_new=True,
+            writable=True,
+        )
+        return self._make_private(owner, directory=True)
+
+    def protect_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        """Protect and verify one existing ordinary directory."""
+
+        owner = self._open(
+            path,
+            kind="directory",
+            create_new=False,
             writable=True,
         )
         return self._make_private(owner, directory=True)
@@ -718,6 +735,12 @@ class UnavailableWindowsArtifactFilesystem:
         return self._unsupported()
 
     def create_private_directory(
+        self, path: str | os.PathLike[str]
+    ) -> WindowsPinnedHandle:
+        del path
+        return self._unsupported()
+
+    def protect_private_directory(
         self, path: str | os.PathLike[str]
     ) -> WindowsPinnedHandle:
         del path
@@ -985,7 +1008,7 @@ class _CtypesWindowsKernel:
                 access |= _GENERIC_READ
             if writable:
                 access |= _GENERIC_WRITE | _FILE_WRITE_ATTRIBUTES
-            if create_new:
+            if create_new or (kind == "directory" and writable):
                 access |= _DELETE | _WRITE_DAC
             disposition = (
                 _CREATE_NEW if create_new and kind == "file" else _OPEN_EXISTING

--- a/tldw_chatbook/UI/Screens/settings_speech_tts.py
+++ b/tldw_chatbook/UI/Screens/settings_speech_tts.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import math
 import os
+import platform
 import shutil
-import stat
 import unicodedata
 from collections.abc import Mapping
 from copy import deepcopy
@@ -29,6 +29,7 @@ from tldw_chatbook.TTS.audio_cpp_guided_config import (
     AudioCppSettingsConfig,
 )
 from tldw_chatbook.TTS.audio_cpp_guided_launch import (
+    _validate_binary,
     select_audio_cpp_guided_backend,
 )
 from tldw_chatbook.TTS.audio_cpp_managed_config import (
@@ -60,7 +61,6 @@ from tldw_chatbook.Utils.input_validation import (
     provider_api_key_validation_error,
     validate_url,
 )
-from tldw_chatbook.Utils.path_validation import validate_path_simple
 
 BUILT_IN_TTS_PROVIDER_ORDER = (
     "audio_cpp",
@@ -1361,7 +1361,12 @@ def detect_audio_cpp_server_binary() -> str | None:
         The exact detected executable path, or ``None`` when it is unavailable.
     """
 
-    detected = shutil.which("audiocpp_server")
+    command = (
+        "audiocpp_server.exe"
+        if platform.system().casefold() == "windows"
+        else "audiocpp_server"
+    )
+    detected = shutil.which(command)
     return detected if isinstance(detected, str) and detected else None
 
 
@@ -1397,19 +1402,7 @@ def validate_audio_cpp_managed_settings(values: Mapping[str, object]) -> None:
                 "managed_setup_source",
                 "Review the Guided audio.cpp settings.",
             ) from None
-        try:
-            binary = validate_path_simple(
-                config.guided_binary_path,
-                require_exists=True,
-            )
-            info = binary.stat()
-            executable = (
-                binary.is_absolute()
-                and stat.S_ISREG(info.st_mode)
-                and os.access(binary, os.X_OK)
-            )
-        except OSError:
-            executable = False
+        executable = _validate_binary(config.guided_binary_path) is not None
         if not executable:
             raise GlobalSpeechTTSValidationError(
                 "audio_cpp",

--- a/tldw_chatbook/UI/Speech/audio_cpp_runtime_card.py
+++ b/tldw_chatbook/UI/Speech/audio_cpp_runtime_card.py
@@ -60,6 +60,7 @@ class AudioCppRuntimeCardProjection:
     endpoint_copy: str
     capability_copy: str
     catalog_copy: str
+    artifact_privacy_copy: str
     primary_action: AudioCppRuntimeAction
     restart_action: AudioCppRuntimeAction
     shutdown_action: AudioCppRuntimeAction
@@ -415,6 +416,21 @@ def _configuration_copy(
     )
 
 
+def _artifact_privacy_copy(posture: str) -> str:
+    detail = {
+        "windows_account_protected": (
+            "Account protected · administrators and SYSTEM retain access · "
+            "plaintext, not encryption"
+        ),
+        "posix_owner_only": ("Owner-only filesystem mode · plaintext, not encryption"),
+        "unverified": "Not verified — review required",
+        "not_applicable": (
+            "Not active · protection is applied only for a Guided start"
+        ),
+    }.get(posture, "Not verified — review required")
+    return f"Generated launch privacy: {detail}"
+
+
 def project_audio_cpp_runtime_card(
     observation: AudioCppRuntimeObservation | AudioCppRuntimeCardObservation,
 ) -> AudioCppRuntimeCardProjection:
@@ -465,6 +481,9 @@ def project_audio_cpp_runtime_card(
             f"TTS capability: {runtime.tts_capability.replace('_', ' ').title()}"
         ),
         catalog_copy=catalog_copy,
+        artifact_privacy_copy=_artifact_privacy_copy(
+            process.generated_artifact_privacy_posture
+        ),
         primary_action=primary,
         restart_action=restart,
         shutdown_action=shutdown,
@@ -565,6 +584,11 @@ class AudioCppRuntimeCard(Vertical):
                 "Catalog: Not checked", id="audio-cpp-runtime-catalog", markup=False
             ),
             Static(
+                "Generated launch privacy: Not active",
+                id="audio-cpp-runtime-artifact-privacy",
+                markup=False,
+            ),
+            Static(
                 "Saved binary: None", id="audio-cpp-runtime-saved-binary", markup=False
             ),
             Static(
@@ -654,6 +678,7 @@ class AudioCppRuntimeCard(Vertical):
             "#audio-cpp-runtime-endpoint": projection.endpoint_copy,
             "#audio-cpp-runtime-capability": projection.capability_copy,
             "#audio-cpp-runtime-catalog": projection.catalog_copy,
+            "#audio-cpp-runtime-artifact-privacy": (projection.artifact_privacy_copy),
             "#audio-cpp-runtime-saved-binary": (
                 f"Saved binary: {projection.saved_binary_path or 'None'}"
             ),

--- a/tldw_chatbook/UI/Speech/speech_clone_setup.py
+++ b/tldw_chatbook/UI/Speech/speech_clone_setup.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
@@ -9,6 +11,9 @@ from textual.widgets import Button, Static, TextArea
 
 from tldw_chatbook.TTS import AudioCppCloneSetupProjection
 from tldw_chatbook.TTS.profile_reference_types import MAX_REFERENCE_TEXT_CHARACTERS
+from tldw_chatbook.TTS.windows_artifact_fs import (
+    windows_audio_cpp_platform_supported,
+)
 from .audio_cpp_runtime_card import AudioCppCloneDraftState
 
 
@@ -53,8 +58,7 @@ class SpeechCloneSetup(Vertical):
             markup=False,
         )
         yield Static(
-            "Reference audio and transcript remain local plaintext while in use. "
-            "Filesystem permissions are not encryption; deletion is best effort.",
+            self._privacy_copy(),
             id="speech-clone-privacy",
             classes="speech-clone-privacy",
             markup=False,
@@ -106,6 +110,27 @@ class SpeechCloneSetup(Vertical):
                 classes="workbench-action",
                 compact=True,
             )
+
+    @staticmethod
+    def _privacy_copy() -> str:
+        if windows_audio_cpp_platform_supported():
+            return (
+                "Operation-scoped reference audio and transcript remain local "
+                "plaintext and are account protected while in use. Administrators "
+                "and SYSTEM retain access; this is not encryption. Deletion is "
+                "best effort."
+            )
+        if os.name == "nt":
+            return (
+                "Reference audio and transcript remain local plaintext while in "
+                "use. Windows account protection is not verified; deletion is "
+                "best effort."
+            )
+        return (
+            "Reference audio and transcript remain local plaintext while in use. "
+            "Owner-only filesystem permissions are not encryption; deletion is "
+            "best effort."
+        )
 
     @staticmethod
     def _transcript_guidance(transcript: str) -> str:

--- a/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
@@ -71,6 +71,9 @@ from tldw_chatbook.TTS.audio_cpp_recipes import (
     AudioCppMatchState,
     AudioCppReferenceRequirement,
 )
+from tldw_chatbook.TTS.windows_artifact_fs import (
+    windows_audio_cpp_platform_supported,
+)
 from tldw_chatbook.Third_Party.textual_fspicker import (
     FileOpen,
     Filters,
@@ -184,7 +187,14 @@ _LANGUAGE_OPTIONS = [
 LeaveChoice = Literal["save", "discard", "cancel"]
 _GLOBAL_SPEECH_TTS_STACK_WIDTH = 104
 _COLLAPSIBLE_TITLE_FOCUS_SUFFIX = "::collapsible-title"
-_AUDIO_CPP_MANAGED_UI_SUPPORTED = os.name != "nt"
+
+
+def _audio_cpp_managed_ui_supported(*, platform_name: str | None = None) -> bool:
+    selected_platform = os.name if platform_name is None else platform_name
+    return selected_platform != "nt" or windows_audio_cpp_platform_supported()
+
+
+_AUDIO_CPP_MANAGED_UI_SUPPORTED = _audio_cpp_managed_ui_supported()
 _AUDIO_CPP_MANAGED_FIELD_IDS = frozenset(
     {
         "managed_binary_path",
@@ -2979,7 +2989,7 @@ class SpeechTTSSettingsPanel(Vertical):
                 elif configured_mode == "managed":
                     mode_options.append(
                         (
-                            "Managed local server (unavailable on Windows)",
+                            "Managed local server (unsupported on this Windows host)",
                             "managed",
                         )
                     )
@@ -2991,8 +3001,9 @@ class SpeechTTSSettingsPanel(Vertical):
                 )
                 if not _AUDIO_CPP_MANAGED_UI_SUPPORTED:
                     yield Static(
-                        "Managed local server is unavailable on Windows until its "
-                        "native process lifecycle is qualified. Use External server.",
+                        "Managed local server requires Windows 10 or later, x86 or "
+                        "x64, and Python 3.12 or later. Windows ARM is not supported. "
+                        "Use External server on this host.",
                         id="settings-speech-audio-cpp-managed-platform-notice",
                         classes="settings-status-row",
                         markup=False,
@@ -3032,6 +3043,16 @@ class SpeechTTSSettingsPanel(Vertical):
                         "file only after a deliberate Speech Lab, Console, or "
                         "Roleplay speech action. Review and trust the binary first.",
                         id="settings-speech-audio-cpp-managed-trust",
+                        classes="settings-status-row",
+                        markup=False,
+                    )
+                    yield Static(
+                        "Generated Guided launch files are local plaintext, not "
+                        "encryption. On supported Windows, account protection "
+                        "will be applied; administrators and SYSTEM retain access. "
+                        "Applied protection is reported only after launch-time "
+                        "verification.",
+                        id="settings-speech-audio-cpp-managed-privacy",
                         classes="settings-status-row",
                         markup=False,
                     )
@@ -5123,8 +5144,8 @@ class SpeechTTSSettingsPanel(Vertical):
             self.state.providers["audio_cpp"]["mode"] = "external"
             self._apply_audio_cpp_mode_visibility()
             self._set_result(
-                "Managed local server is unavailable on Windows. Use External "
-                "server instead.",
+                "Managed local server requires Windows 10 or later, x86 or x64, "
+                "and Python 3.12 or later. Use External server on this host.",
                 severity="warning",
             )
             return


### PR DESCRIPTION
## Summary

- add standard-library Win32 ownership primitives for exact audio.cpp package, generated-config, and clone paths
- enable the existing Guided audio.cpp lifecycle on Windows 10+ for x86/x64 with Python 3.12+, including clone materialization and exact subprocess settlement
- add hosted x86/x64 Windows coverage and a generic provisioned PowerShell UAT that uses a user-provided server executable in place; no executable is imported, copied into the app, or bundled

## Verification

- [x] focused host matrix: 1,036 passed
- [x] four supervisor real-child tests passed with loopback access
- [x] suite-load Textual mount-readiness miss passed in isolation
- [x] changed-file Ruff and format checks
- [x] scoped mypy checks
- [x] CI-shape, UAT-harness, and diff checks
- [ ] hosted Windows Python 3.12 x86 job: queued in [workflow run 31856771953](https://github.com/rmusser01/tldw_chatbook/actions/runs/31856771953)
- [ ] hosted Windows Python 3.12 x64 job: queued in [workflow run 31856771953](https://github.com/rmusser01/tldw_chatbook/actions/runs/31856771953)
- [ ] provisioned objective and audible UAT on both claimed architectures

## Known baseline

Two unrelated mounted UI tests also fail on the parent revision and remain outside this change:

- `test_details_and_scope_start_collapsed_on_every_mount`
- `test_playground_status_keeps_external_provider_and_local_deps_independent`

## Release gate

This PR intentionally remains a draft and TASK-13208 remains In Progress. Do not merge until the hosted x86/x64 jobs and provisioned audible UAT pass. Windows ARM is not claimed in this change.

Tracks TASK-13208.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows parity for the guided `audio.cpp` lifecycle and clone references. Previously Windows was unsupported; now Windows 10+ (x86/x64, Python 3.12) hosts get native path/ACL-safe artifact handling, UI gating, CI coverage, and a provisioned UAT harness. The app never bundles or copies an `audio.cpp` executable; it launches a user-provided binary in place.

- Integrates a native Windows artifact boundary in `tldw_chatbook/TTS/windows_artifact_fs.py` and uses it in guided launch, package scanning, supervisor snapshots, and clone materialization to pin identities, verify ACLs, and clean up handles.
- Updates UI to gate managed mode on Windows via shared capability, detect `audiocpp_server.exe`, and surface generated-artifact privacy posture.
- Adds Windows backend evidence to recipes and adjusts validation to accept x86/x64 CPU on Windows.
- Introduces `scripts/uat_audio_cpp_windows.py` and `scripts/uat_audio_cpp_windows.ps1` for provisioned UAT; executable is reviewed/launched in place.
- Extends CI with a Windows matrix job (x86, x64) running Python 3.12 and targeted tests; includes new Windows-specific unit/integration coverage.

**Review focus**
- `tldw_chatbook/TTS/windows_artifact_fs.py`: handle identity, ACL verification, cleanup semantics, and platform gate.
- Guided launch and supervisor: artifact privacy posture propagation and Windows-specific error handling.
- Package scanner and clone materializer: Windows pinned identities, cleanup ownership, and privacy posture mapping.
- UI: managed-mode gate, `.exe` detection, and privacy copy rendering.
- Workflow: new `windows-audio-cpp` job and targeted test selection.

**Rollout and gates (TASK-13208)**
- Supported only on Windows 10+ x86/x64 with Python 3.12; ARM is not claimed.
- Required action: operators must provide a compatible `audio.cpp` server executable and packages for UAT; no executable is imported or bundled.
- Do not merge until hosted Windows jobs and provisioned audible UAT pass; two unrelated mounted UI tests remain failing on the parent revision.

<sup>Written for commit a1e4c2920a9d566496a7be8c4d76023972089c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

