### PR TITLE
feat(console): New Workspace setup modal with required folder binding

### DIFF
--- a/Tests/UI/test_console_modal_dismissal.py
+++ b/Tests/UI/test_console_modal_dismissal.py
@@ -71,6 +71,10 @@ from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
 from tldw_chatbook.Widgets.Console.console_system_prompt_modal import (
     ConsoleSystemPromptModal,
 )
+from tldw_chatbook.Widgets.Console.console_workspace_setup_modal import (
+    ConsoleWorkspaceSetupModal,
+    ConsoleWorkspaceSetupResult,
+)
 from tldw_chatbook.Widgets.Console.console_workspace_switcher_modal import (
     ConsoleWorkspaceRenameModal,
     ConsoleWorkspaceSwitcherModal,
@@ -546,6 +550,21 @@ TASK3_MODAL_CONTRACTS = (
         _RESTORE_OPENER,
     ),
     _Task3ModalContract(
+        ConsoleWorkspaceSetupModal,
+        lambda: ConsoleWorkspaceSetupModal(
+            suggested_name="Workspace 1",
+            validate=lambda name, path: None,
+            debounce_seconds=0.001,
+        ),
+        "#console-workspace-setup-modal",
+        None,
+        (ConsoleWorkspaceSetupResult,),
+        "Console New Workspace action",
+        None,
+        "none",
+        _RESTORE_OPENER,
+    ),
+    _Task3ModalContract(
         PromptVariablesDialog,
         _prompt_variables_factory,
         "#prompt-variables-dialog",
@@ -1013,7 +1032,7 @@ def test_console_modal_inventory_matches_runtime_ast_and_transitive_launches() -
     }
     discovered_console_types = _discover_console_modal_types()
 
-    assert len(discovered_console_types) == 28
+    assert len(discovered_console_types) == 29
     assert discovered_console_types == console_contract_types
 
     reachable = _walk_modal_launch_graph(_CONSOLE_ROOT, CONSOLE_MODAL_LAUNCH_EDGES)
@@ -1023,7 +1042,7 @@ def test_console_modal_inventory_matches_runtime_ast_and_transitive_launches() -
         for node in reachable
         if inspect.isclass(node) and issubclass(node, ModalScreen)
     }
-    assert len(reachable_modal_types) == 37
+    assert len(reachable_modal_types) == 38
     all_contract_types = console_contract_types | {
         contract.modal_type for contract in TASK4_MODAL_CONTRACTS
     }
@@ -1188,7 +1207,7 @@ def test_task2_modal_contract_table_is_complete_and_adopted() -> None:
 
 
 def test_task3_modal_contract_table_is_complete_and_adopted() -> None:
-    assert len(TASK3_MODAL_CONTRACTS) == 12
+    assert len(TASK3_MODAL_CONTRACTS) == 13
     assert {contract.modal_type.__name__ for contract in TASK3_MODAL_CONTRACTS} == {
         "ConsoleComposerMenuModal",
         "ConsoleEditMessageModal",
@@ -1200,6 +1219,7 @@ def test_task3_modal_contract_table_is_complete_and_adopted() -> None:
         "ConsoleSessionSwitcherModal",
         "ConsoleSystemPromptModal",
         "ConsoleWorkspaceRenameModal",
+        "ConsoleWorkspaceSetupModal",
         "ConsoleWorkspaceSwitcherModal",
         "PromptVariablesDialog",
     }

--- a/Tests/UI/test_console_workspace_create_flow.py
+++ b/Tests/UI/test_console_workspace_create_flow.py
@@ -1,0 +1,153 @@
+"""Console new-workspace creation flow (setup modal -> create+bind+activate).
+
+The controller's ``_confirm_console_workspace_create`` is exercised on a
+bare controller instance (``object.__new__`` -- the repo's established
+pattern for testing moved method bodies without wiring 30 constructor
+deps) with a REAL ``LocalWorkspaceRegistryService``, covering the happy
+path, the None (cancel) path, and the bind-race path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
+from tldw_chatbook.Widgets.Console.console_workspace_setup_modal import (
+    ConsoleWorkspaceSetupResult,
+)
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+
+class _Notifier:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def notify(self, message: str, severity: str = "information") -> None:
+        self.messages.append((severity, message))
+
+
+class _AppStub:
+    def __init__(self, registry: LocalWorkspaceRegistryService) -> None:
+        self.workspace_registry_service = registry
+        self.notifier = _Notifier()
+
+    def notify(self, message: str, severity: str = "information") -> None:
+        self.notifier.notify(message, severity=severity)
+
+
+class _ControllerHarness:
+    """Bare controller + call log for the sync hooks the confirm body uses.
+
+    The three sync hooks are read-only properties on the real class, so a
+    plain instance-attribute stub cannot shadow them; a shim subclass
+    replaces them with assignable attributes instead.
+    """
+
+    def __init__(self, registry: LocalWorkspaceRegistryService) -> None:
+        self.calls: list = []
+        self.app = _AppStub(registry)
+
+        harness = self
+
+        class _ConfirmShim(ConsoleWorkspaceController):
+            _sync_console_chat_core_state = None
+            _activate_console_session_for_workspace = None
+            _sync_console_workspace_context = None
+
+            def run_worker(self, work, **kwargs):  # noqa: D102
+                harness.calls.append("sync-ui")
+
+        self.controller = _ConfirmShim.__new__(_ConfirmShim)
+        self.controller.app_instance = self.app
+        self.controller._sync_console_chat_core_state = lambda: self.calls.append(
+            "sync-core"
+        )
+        self.controller._activate_console_session_for_workspace = (
+            lambda ws_id: self.calls.append(("activate", ws_id))
+        )
+        self.controller._sync_console_workspace_context = lambda: self.calls.append(
+            "sync-context"
+        )
+        # ``_sync_native_console_chat_ui`` is a property over the stored
+        # constructor callable; the confirm body calls it to get the
+        # coroutine it hands to ``run_worker``.
+        self.controller._sync_native_console_chat_ui_fn = lambda: (lambda: None)
+
+
+def _registry(tmp_path: Path) -> LocalWorkspaceRegistryService:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="create-flow-tests")
+    )
+    registry.ensure_default_workspace()
+    return registry
+
+
+def test_confirm_creates_binds_and_activates(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    harness = _ControllerHarness(registry)
+    folder = tmp_path / "proj"
+    folder.mkdir()
+
+    harness.controller._confirm_console_workspace_create(
+        ConsoleWorkspaceSetupResult(
+            name="My Project", folder_path=str(folder), allow_write=True
+        )
+    )
+
+    workspace = registry.get_workspace("workspace-local-1")
+    assert workspace is not None and workspace.name == "My Project"
+    bindings = registry.list_folder_bindings("workspace-local-1")
+    assert len(bindings) == 1
+    assert bindings[0].locator == str(folder.resolve())
+    assert bindings[0].metadata["access"] == "rw"
+    assert registry.get_active_workspace().workspace_id == "workspace-local-1"
+    assert ("activate", "workspace-local-1") in harness.calls
+    assert not harness.app.notifier.messages or all(
+        sev == "information" for sev, _ in harness.app.notifier.messages
+    )
+
+
+def test_confirm_none_result_creates_nothing(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    harness = _ControllerHarness(registry)
+
+    harness.controller._confirm_console_workspace_create(None)
+
+    assert registry.list_workspaces(include_archived=True) == (
+        registry.list_workspaces(include_archived=True)
+    )
+    # Only the ensured default workspace exists; nothing was created,
+    # bound, activated, or synced.
+    ids = {ws.workspace_id for ws in registry.list_workspaces()}
+    assert ids == {"workspace-default"}
+    assert harness.calls == []
+
+
+def test_confirm_bind_race_keeps_workspace_and_warns(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    registry = _registry(tmp_path)
+    harness = _ControllerHarness(registry)
+    folder = tmp_path / "proj"
+    folder.mkdir()
+
+    def _failing_add(workspace_id: str, path: str, *, allow_write: bool = False):
+        raise RuntimeError("race: folder vanished between validation and write")
+
+    monkeypatch.setattr(registry, "add_folder_binding", _failing_add)
+
+    harness.controller._confirm_console_workspace_create(
+        ConsoleWorkspaceSetupResult(
+            name="Raced", folder_path=str(folder), allow_write=False
+        )
+    )
+
+    workspace = registry.get_workspace("workspace-local-1")
+    assert workspace is not None and workspace.name == "Raced"
+    warnings = [m for sev, m in harness.app.notifier.messages if sev == "warning"]
+    assert any("folder binding failed" in m for m in warnings)
+    # The workspace is still activated; no re-prompt, no orphaned modal state.
+    assert registry.get_active_workspace().workspace_id == "workspace-local-1"

--- a/Tests/UI/test_console_workspace_setup_modal.py
+++ b/Tests/UI/test_console_workspace_setup_modal.py
@@ -1,0 +1,147 @@
+"""Console new-workspace setup modal: validation gating and dismiss results.
+
+"New Workspace" in the Console must no longer silently create a bare
+workspace -- it opens this modal, which requires a validated folder
+binding before Create enables, and dismisses with the confirmed
+(name, path, access) triple (or ``None`` on cancel).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Widgets.Console.console_workspace_setup_modal import (
+    ConsoleWorkspaceSetupModal,
+    ConsoleWorkspaceSetupResult,
+)
+
+CREATE_BTN_ID = "#console-workspace-setup-create"
+CANCEL_BTN_ID = "#console-workspace-setup-cancel"
+NAME_INPUT_ID = "#console-workspace-setup-name"
+PATH_INPUT_ID = "#console-workspace-setup-path"
+WRITE_CHECKBOX_ID = "#console-workspace-setup-write"
+ERROR_STATIC_ID = "#console-workspace-setup-error"
+
+
+class _SetupHarness(App[None]):
+    """Push the setup modal and record what it dismisses with."""
+
+    def __init__(self, suggested_name: str, validate) -> None:
+        super().__init__()
+        self._suggested = suggested_name
+        self._validate = validate
+        self.dismissed_with: object = "--never-dismissed--"
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def on_mount(self) -> None:
+        modal = ConsoleWorkspaceSetupModal(
+            suggested_name=self._suggested,
+            validate=self._validate,
+            debounce_seconds=0.001,
+        )
+
+        def _record(result: object) -> None:
+            self.dismissed_with = result
+
+        self.push_screen(modal, callback=_record)
+
+
+@pytest.mark.asyncio
+async def test_create_disabled_until_folder_valid() -> None:
+    app = _SetupHarness(
+        "Workspace 4", lambda name, path: "nope" if not path else None
+    )
+    async with app.run_test() as pilot:
+        modal = app.screen
+        assert isinstance(modal, ConsoleWorkspaceSetupModal)
+        # Path starts empty -> validator errors -> Create disabled.
+        await pilot.pause()
+        await pilot.pause()
+        assert modal.query_one(CREATE_BTN_ID).disabled
+        assert "nope" in str(modal.query_one(ERROR_STATIC_ID).render())
+
+        modal.query_one(PATH_INPUT_ID).value = "/tmp/some-project"
+        await pilot.pause()
+        await pilot.pause()
+        assert not modal.query_one(CREATE_BTN_ID).disabled
+        assert str(modal.query_one(ERROR_STATIC_ID).render()).strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_cancel_dismisses_none_and_creates_nothing() -> None:
+    app = _SetupHarness("Workspace 4", lambda name, path: None)
+    async with app.run_test() as pilot:
+        modal = app.screen
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.click(CANCEL_BTN_ID)
+        await pilot.pause()
+        assert app.screen is not modal
+        assert app.dismissed_with is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_carries_name_path_and_read_only_default() -> None:
+    app = _SetupHarness("Workspace 4", lambda name, path: None)
+    async with app.run_test() as pilot:
+        modal = app.screen
+        assert isinstance(modal, ConsoleWorkspaceSetupModal)
+        modal.query_one(NAME_INPUT_ID).value = "My Project"
+        modal.query_one(PATH_INPUT_ID).value = "/tmp/some-project"
+        await pilot.pause()
+        await pilot.pause()
+        assert not modal.query_one(CREATE_BTN_ID).disabled
+        await pilot.click(CREATE_BTN_ID)
+        await pilot.pause()
+        assert app.dismissed_with == ConsoleWorkspaceSetupResult(
+            name="My Project",
+            folder_path="/tmp/some-project",
+            allow_write=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_write_checkbox_flips_access() -> None:
+    app = _SetupHarness("Workspace 4", lambda name, path: None)
+    async with app.run_test() as pilot:
+        modal = app.screen
+        assert isinstance(modal, ConsoleWorkspaceSetupModal)
+        modal.query_one(PATH_INPUT_ID).value = "/tmp/some-project"
+        await pilot.pause()
+        await pilot.pause()
+        assert not modal.query_one(WRITE_CHECKBOX_ID).value
+        await pilot.click(WRITE_CHECKBOX_ID)
+        await pilot.pause()
+        assert modal.query_one(WRITE_CHECKBOX_ID).value
+        await pilot.click(CREATE_BTN_ID)
+        await pilot.pause()
+        result = app.dismissed_with
+        assert isinstance(result, ConsoleWorkspaceSetupResult)
+        assert result.allow_write is True
+
+
+@pytest.mark.asyncio
+async def test_submit_on_invalid_path_does_not_dismiss() -> None:
+    def validator(name: str, path: str) -> Optional[str]:
+        return "Folder does not exist" if not Path(path).is_dir() else None
+
+    app = _SetupHarness("Workspace 4", validator)
+    async with app.run_test() as pilot:
+        modal = app.screen
+        assert isinstance(modal, ConsoleWorkspaceSetupModal)
+        modal.query_one(PATH_INPUT_ID).value = "/definitely/not/a/dir"
+        await pilot.pause()
+        await pilot.pause()
+        assert modal.query_one(CREATE_BTN_ID).disabled
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.screen is modal
+        assert "Folder does not exist" in str(
+            modal.query_one(ERROR_STATIC_ID).render()
+        )

--- a/Tests/Workspaces/test_workspace_folder_bindings.py
+++ b/Tests/Workspaces/test_workspace_folder_bindings.py
@@ -240,3 +240,37 @@ def test_remove_and_toggle_access(
         service.remove_runtime_binding(binding.binding_id)
     with pytest.raises(BindingNotFound):
         service.set_folder_binding_access(binding.binding_id, allow_write=False)
+
+
+def test_validate_folder_binding_mirrors_add_folder_binding_rejections(
+    service: LocalWorkspaceRegistryService, tmp_path: Path
+) -> None:
+    """The read-only pre-check must return the same verdicts as the write."""
+    good = tmp_path / "good"
+    good.mkdir()
+
+    assert service.validate_folder_binding("ws-a", good) is None
+    assert (
+        service.validate_folder_binding("ws-a", tmp_path / "does-not-exist")
+        is not None
+    )
+    assert service.validate_folder_binding("ws-a", str(Path.home())) is not None
+
+    # Duplicate/nested rules are checked against the workspace's existing
+    # bindings, same as the write path.
+    service.add_folder_binding("ws-a", good)
+    assert service.validate_folder_binding("ws-a", good) is not None
+    nested = good / "nested"
+    nested.mkdir()
+    assert service.validate_folder_binding("ws-a", nested) is not None
+
+
+def test_validate_workspace_name_rejects_blank_and_duplicates(
+    service: LocalWorkspaceRegistryService,
+) -> None:
+    assert service.validate_workspace_name("   ") is not None
+    assert service.validate_workspace_name("Client A") is not None
+    assert (
+        service.validate_workspace_name("client a") is not None
+    )  # case-insensitive
+    assert service.validate_workspace_name("Fresh Name") is None

--- a/backlog/tasks/task-16316 - Console-New-Workspace-setup-modal-with-required-folder-binding.md
+++ b/backlog/tasks/task-16316 - Console-New-Workspace-setup-modal-with-required-folder-binding.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16316
+title: Console New Workspace setup modal with required folder binding
+status: Done
+assignee: []
+created_date: '2026-08-15 02:22'
+updated_date: '2026-08-15 02:23'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+New Workspace in the Console created a bare workspace with no folder binding and no hint of what it maps to. Creation now opens a setup modal capturing name and a required, validated folder binding.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New Workspace opens a setup modal (name prefilled, folder required, read-only default)
+- [x] #2 Create only enables when name and folder pass the same validation rules as add_folder_binding
+- [x] #3 Cancel/Escape creates nothing
+- [x] #4 Bind-race at write time keeps the workspace and warns instead of failing silently
+- [x] #5 Unit tests cover modal gating, dismiss results, and the confirm create+bind+activate sequence
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no — direct implementation of existing workspace-registry and SafeModalDismissMixin patterns; no schema or interface change. Steps: 1) extract shared folder-candidate validation into _folder_binding_error + public validate_folder_binding/validate_workspace_name. 2) New ConsoleWorkspaceSetupModal (SafeModalDismissMixin, debounced validation). 3) Rewire ConsoleWorkspaceController._create_console_workspace to open the modal; confirm-time identity; bind-race keeps workspace. 4) Tests: registry parity, modal gating, controller flow. 5) Update modal inventory contracts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `LocalWorkspaceRegistryService`: the guards inside `add_folder_binding` were extracted verbatim into `_folder_binding_error()` (returns the error string or None), now the single source of truth for the binding gate. New read-only pre-checks `validate_folder_binding()` and `validate_workspace_name()` (blank + case-insensitive duplicate) wrap it; the write path raises from the same rules so pre-check and write cannot drift.
+- New `Widgets/Console/console_workspace_setup_modal.py`: `ConsoleWorkspaceSetupModal` (SafeModalDismissMixin, Esc=request_safe_cancel, backdrop-safe) with prefilled name, required folder path, read-only/read-write checkbox (ro default), inline debounced (0.3s) validation, Create disabled until valid; Enter in the path field re-validates before dismissing. Dismisses `ConsoleWorkspaceSetupResult(name, folder_path, allow_write)` or None on cancel.
+- `ConsoleWorkspaceController._create_console_workspace` now only opens the modal (suggested name from `next_local_workspace_identity`). New `_confirm_console_workspace_create` computes the collision-free identity at CONFIRM time (stale-open race), creates, binds, activates, then runs the existing sync/notify sequence. A write-time bind race keeps the workspace, warns, and points at the Folders settings — no half-state re-prompt.
+- Tests: `Tests/UI/test_console_workspace_setup_modal.py` (gating, cancel, result payload, rw toggle, submit-on-invalid), `Tests/UI/test_console_workspace_create_flow.py` (create+bind+activate, None path, bind-race on a real registry), registry parity tests appended to `Tests/Workspaces/test_workspace_folder_bindings.py`, and the modal-inventory contracts in `Tests/UI/test_console_modal_dismissal.py` updated (Task3 table 12→13, inventory 28→29, reachable 37→38).
+- Files: tldw_chatbook/Workspaces/registry_service.py, tldw_chatbook/UI/Console_Modules/workspace.py, tldw_chatbook/Widgets/Console/console_workspace_setup_modal.py (new), plus the three test files.
+- Follow-up candidate (not done here): the Library screen still creates unbound workspaces via the same identity helper; aligning it with this flow deserves its own task.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -118,7 +118,6 @@ from ...Chat.console_display_state import evidence_bundle_from_launch
 from ...Chat.console_live_work import ConsoleLiveWorkLaunch
 from ...Chat.console_roleplay_metadata import parse_console_roleplay_context
 from ...Chat.rag_scope import RagScope
-from ...Workspaces.models import DEFAULT_WORKSPACE_ID
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.Console import (
     ConsoleWorkspaceContextTray,
@@ -126,6 +125,10 @@ from ...Widgets.Console import (
     ConsoleWorkspaceSwitcherModal,
 )
 from ...Widgets.Console.console_scope_picker_modal import ConsoleScopePickerModal
+from ...Widgets.Console.console_workspace_setup_modal import (
+    ConsoleWorkspaceSetupResult,
+    ConsoleWorkspaceSetupModal,
+)
 from ...Workspaces import (
     ConsoleConversationBrowserRow,
     DEFAULT_WORKSPACE_ID,
@@ -849,7 +852,73 @@ class ConsoleWorkspaceController:
         )
 
     def _create_console_workspace(self) -> None:
-        """Create a new local workspace and activate it."""
+        """Open the new-workspace setup modal (name + required folder).
+
+        Creation itself happens in ``_confirm_console_workspace_create``
+        only on a confirmed result; Cancel/Escape creates nothing. The
+        suggested name is generated here but the collision-free identity
+        (id AND name) is recomputed at confirm time -- the user may sit
+        on the modal while another surface (e.g. Library) takes the next
+        "Workspace N" pair.
+        """
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+
+        def _validate(name: str, path: str) -> str | None:
+            try:
+                name_error = registry_service.validate_workspace_name(name)
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Unable to pre-check workspace name for the setup modal"
+                )
+                return "Workspace registry could not be read."
+            if name_error is not None:
+                return name_error
+            try:
+                return registry_service.validate_folder_binding(
+                    "workspace-pending", path
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Unable to pre-check folder binding for the setup modal"
+                )
+                return "Folder binding could not be checked."
+
+        try:
+            _, suggested_name = next_local_workspace_identity(registry_service)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to suggest a Console workspace name"
+            )
+            suggested_name = ""
+        self.push_screen(
+            ConsoleWorkspaceSetupModal(
+                suggested_name=suggested_name,
+                validate=_validate,
+            ),
+            callback=self._confirm_console_workspace_create,
+        )
+
+    def _confirm_console_workspace_create(
+        self, result: ConsoleWorkspaceSetupResult | None
+    ) -> None:
+        """Create + bind + activate a workspace confirmed in the setup modal.
+
+        ``None`` (Cancel/Escape) creates nothing. The workspace identity
+        is computed HERE, at confirm time, so a stale suggested name from
+        modal-open cannot collide. If the binding fails at write time
+        (a race the read-only pre-check cannot see), the workspace is
+        kept, the error is surfaced, and the user can add the binding
+        from the workspace details surface -- no half-state re-prompt.
+        """
+        if result is None:
+            return
         registry_service = getattr(
             self.app_instance, "workspace_registry_service", None
         )
@@ -859,15 +928,15 @@ class ConsoleWorkspaceController:
             )
             return
         try:
-            workspace_id, workspace_name = next_local_workspace_identity(
+            workspace_id, fallback_name = next_local_workspace_identity(
                 registry_service
             )
+            workspace_name = result.name or fallback_name
             registry_service.create_workspace(
                 workspace_id=workspace_id,
                 name=workspace_name,
                 description="Local workspace created from Console.",
             )
-            registry_service.set_active_workspace(workspace_id)
         except WorkspaceRegistryServiceError:
             logger.opt(exception=True).warning("Unable to create Console workspace")
             self.app_instance.notify(
@@ -880,6 +949,36 @@ class ConsoleWorkspaceController:
             )
             self.app_instance.notify(
                 "Workspace could not be created.", severity="error"
+            )
+            return
+        try:
+            registry_service.add_folder_binding(
+                workspace_id,
+                result.folder_path,
+                allow_write=result.allow_write,
+            )
+        except Exception:
+            # Binding raced (folder deleted/locked since validation, or a
+            # name-bound duplicate landed). Keep the workspace; do NOT
+            # reopen the modal -- the details surface can add the binding.
+            logger.opt(exception=True).warning(
+                "Console workspace '{}' created but its folder binding failed",
+                workspace_name,
+            )
+            self.app_instance.notify(
+                f"Created {workspace_name}, but the folder binding failed. "
+                "Add it from the workspace's Folders settings.",
+                severity="warning",
+            )
+        try:
+            registry_service.set_active_workspace(workspace_id)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Unable to activate new Console workspace {}", workspace_id
+            )
+            self.app_instance.notify(
+                f"Created {workspace_name}, but it could not be activated.",
+                severity="warning",
             )
             return
         self._sync_console_chat_core_state()

--- a/tldw_chatbook/Widgets/Console/console_workspace_setup_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_setup_modal.py
@@ -1,0 +1,243 @@
+"""Console new-workspace setup modal.
+
+Task: "New Workspace" in the Console used to create a bare "Workspace N"
+record with no folder binding and no hint of what it maps to. This modal
+makes creation a two-field setup step: a (prefilled) name and a REQUIRED
+folder binding, validated inline against the exact same rules
+``LocalWorkspaceRegistryService.add_folder_binding`` enforces, so Create
+only fires on a bindable path and the workspace is never created
+unlabeled.
+
+Cancel/Escape dismisses with ``None`` and creates nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, NamedTuple, Optional
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.timer import Timer
+from textual.widgets import Button, Checkbox, Input, Static
+
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+#: Debounce for inline validation -- each check does a ``Path.resolve()``
+#: plus a folder-bindings SELECT, so keystrokes must not trigger it
+#: directly (mirrors the Console conversation-search debounce).
+VALIDATION_DEBOUNCE_SECONDS = 0.3
+
+MODAL_ID = "console-workspace-setup-modal"
+NAME_INPUT_ID = "console-workspace-setup-name"
+PATH_INPUT_ID = "console-workspace-setup-path"
+WRITE_CHECKBOX_ID = "console-workspace-setup-write"
+ERROR_STATIC_ID = "console-workspace-setup-error"
+HINT_STATIC_ID = "console-workspace-setup-hint"
+CANCEL_BTN_ID = "console-workspace-setup-cancel"
+CREATE_BTN_ID = "console-workspace-setup-create"
+
+
+class ConsoleWorkspaceSetupResult(NamedTuple):
+    """What a confirmed setup carries back to the opener."""
+
+    name: str
+    folder_path: str
+    allow_write: bool
+
+
+#: Returns the human-readable reason a (name, path) pair is invalid, or
+#: ``None`` when both are acceptable. Injected so tests can stub the
+#: registry without a database; the production seam is built in
+#: ``ConsoleWorkspaceController._open_console_workspace_setup_modal``.
+SetupFieldValidator = Callable[[str, str], Optional[str]]
+
+
+class ConsoleWorkspaceSetupModal(
+    SafeModalDismissMixin, ModalScreen[Optional[ConsoleWorkspaceSetupResult]]
+):
+    """Create a named workspace bound to one agent-accessible folder."""
+
+    DEFAULT_CSS = """
+    ConsoleWorkspaceSetupModal {
+        align: center middle;
+    }
+
+    #console-workspace-setup-modal {
+        width: 64;
+        height: auto;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #console-workspace-setup-modal Input {
+        width: 100%;
+        margin: 0 0 1 0;
+    }
+
+    #console-workspace-setup-modal Label {
+        margin: 0;
+    }
+
+    #console-workspace-setup-write {
+        margin: 0 0 1 0;
+    }
+
+    #console-workspace-setup-hint {
+        height: auto;
+        color: grey;
+        margin: 0 0 1 0;
+    }
+
+    #console-workspace-setup-error {
+        height: auto;
+        min-height: 1;
+        color: red;
+        margin: 0 0 1 0;
+    }
+
+    #console-workspace-setup-actions {
+        height: 3;
+        min-height: 3;
+        align-horizontal: right;
+    }
+
+    #console-workspace-setup-cancel,
+    #console-workspace-setup-create {
+        width: 10;
+        min-width: 10;
+        height: 3;
+        min-height: 3;
+    }
+    """
+
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
+    SAFE_MODAL_CONTENT = f"#{MODAL_ID}"
+
+    def __init__(
+        self,
+        *,
+        suggested_name: str,
+        validate: SetupFieldValidator,
+        debounce_seconds: float = VALIDATION_DEBOUNCE_SECONDS,
+    ) -> None:
+        """Initialize the setup modal.
+
+        Args:
+            suggested_name: Prefilled workspace name (the auto-generated
+                ``Workspace N``); the user may replace it.
+            validate: Read-only pre-check for (name, folder path).
+                Returns an error string or ``None``.
+            debounce_seconds: Validation debounce; overridable to a small
+                positive value (never 0 -- Textual's ``set_timer`` divides
+                by the interval) in tests so it fires within one pause.
+        """
+        super().__init__()
+        self._suggested_name = suggested_name
+        self._validate = validate
+        self._debounce_seconds = debounce_seconds
+        self._validation_timer: Timer | None = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id=MODAL_ID):
+            yield Static("New Workspace", classes="console-modal-header")
+            yield Static("Name", classes="console-modal-label")
+            yield Input(
+                value=self._suggested_name,
+                id=NAME_INPUT_ID,
+                placeholder="Workspace name",
+            )
+            yield Static("Folder (agent file-tool access)", classes="console-modal-label")
+            yield Input(
+                value="",
+                id=PATH_INPUT_ID,
+                placeholder="~/projects/my-project",
+            )
+            yield Checkbox(
+                "Read-write access (agent can modify files)",
+                id=WRITE_CHECKBOX_ID,
+            )
+            yield Static(
+                "A folder is required: the workspace is created bound to it, "
+                "read-only by default.",
+                id=HINT_STATIC_ID,
+                markup=False,
+            )
+            yield Static("", id=ERROR_STATIC_ID, markup=False)
+            with Horizontal(id="console-workspace-setup-actions"):
+                yield Button("Cancel", id=CANCEL_BTN_ID)
+                yield Button(
+                    "Create",
+                    id=CREATE_BTN_ID,
+                    variant="primary",
+                    disabled=True,
+                )
+
+    def on_mount(self) -> None:
+        """Focus the name field (fully selected) after mixin setup."""
+        super().on_mount()
+        name_input = self.query_one(f"#{NAME_INPUT_ID}", Input)
+        name_input.focus()
+        name_input.select_all()
+        # Validate the initial (empty-path) state so Create is disabled
+        # for a reason the user can see, not just disabled-by-default.
+        self.call_after_refresh(self._run_validation)
+
+    @on(Input.Changed, f"#{NAME_INPUT_ID}")
+    @on(Input.Changed, f"#{PATH_INPUT_ID}")
+    def _schedule_validation(self, event: Input.Changed) -> None:
+        event.stop()
+        self._create_button.disabled = True
+        if self._validation_timer is not None:
+            self._validation_timer.stop()
+        self._validation_timer = self.set_timer(
+            self._debounce_seconds, self._run_validation
+        )
+
+    @on(Input.Submitted, f"#{PATH_INPUT_ID}")
+    def _submit(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._create()
+
+    @on(Button.Pressed, f"#{CANCEL_BTN_ID}")
+    async def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="button")
+
+    @on(Button.Pressed, f"#{CREATE_BTN_ID}")
+    def _create_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._create()
+
+    @property
+    def _create_button(self) -> Button:
+        return self.query_one(f"#{CREATE_BTN_ID}", Button)
+
+    def _run_validation(self) -> None:
+        self._validation_timer = None
+        name = self.query_one(f"#{NAME_INPUT_ID}", Input).value.strip()
+        path = self.query_one(f"#{PATH_INPUT_ID}", Input).value.strip()
+        error = self._validate(name, path)
+        error_static = self.query_one(f"#{ERROR_STATIC_ID}", Static)
+        error_static.update(error or "")
+        self._create_button.disabled = error is not None
+
+    def _create(self) -> None:
+        name = self.query_one(f"#{NAME_INPUT_ID}", Input).value.strip()
+        path = self.query_one(f"#{PATH_INPUT_ID}", Input).value.strip()
+        error = self._validate(name, path)
+        if error is not None:
+            # Create can only be pressed while enabled, but Input.Submitted
+            # bypasses the disabled check -- validate again here.
+            self.query_one(f"#{ERROR_STATIC_ID}", Static).update(error)
+            self._create_button.disabled = True
+            return
+        self.dismiss(
+            ConsoleWorkspaceSetupResult(
+                name=name,
+                folder_path=path,
+                allow_write=self.query_one(f"#{WRITE_CHECKBOX_ID}", Checkbox).value,
+            )
+        )

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -356,6 +356,27 @@ class LocalWorkspaceRegistryService:
                     f"A workspace named {name} already exists."
                 )
 
+    def validate_workspace_name(
+        self, name: str, *, exclude_workspace_id: str | None = None
+    ) -> str | None:
+        """Read-only pre-check of a workspace-name candidate (no write).
+
+        Returns the human-readable reason the name is unusable (blank, or
+        a case-insensitive duplicate of a non-archived workspace), or
+        ``None``. UI pre-checks call this instead of reaching into
+        ``_reject_duplicate_name``; ``create_workspace``/``rename``
+        still enforce it at write time.
+        """
+        if not str(name).strip():
+            return "Workspace name cannot be blank."
+        try:
+            self._reject_duplicate_name(
+                name, exclude_workspace_id=exclude_workspace_id
+            )
+        except WorkspaceRegistryServiceError as exc:
+            return str(exc)
+        return None
+
     def set_active_workspace(self, workspace_id: str) -> WorkspaceRecord:
         """Set exactly one active workspace."""
 
@@ -677,6 +698,74 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError("Runtime binding save failed.")
         return stored
 
+    def _folder_binding_error(
+        self, workspace_id: str, path: str | Path
+    ) -> str | None:
+        """Return why ``path`` cannot bind to ``workspace_id``, or ``None``.
+
+        Single source of truth for the folder-binding gate: both
+        ``validate_folder_binding`` (read-only UI pre-check) and
+        ``add_folder_binding`` (write) run these exact rules, so the two
+        can never drift.
+        """
+        candidate = Path(path).expanduser()
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return f"Folder path could not be resolved: {candidate}"
+        if not resolved.is_dir():
+            return f"Folder does not exist or is not a directory: {resolved}"
+        if resolved == Path(resolved.anchor):
+            return "The filesystem root cannot be bound to a workspace."
+        if resolved == Path.home().resolve():
+            return (
+                "Your home directory itself cannot be bound; choose a "
+                "project folder inside it."
+            )
+        # TASK-857: the sensitive-path denylist used to only be consulted
+        # at file-tool READ/WRITE time, never here at the binding gate --
+        # so binding e.g. ~/.config/tldw_cli (this app's own config,
+        # API keys included), get_user_data_dir() (every app database), or
+        # ~/.ssh as a workspace folder root all passed this check, widening
+        # what the agent file tools can reach up to the edge of whatever
+        # the denylist enumerates. See ``find_root_binding_conflict`` for
+        # the exact "is, or contains, or is contained by" rule.
+        conflict = find_root_binding_conflict(resolved)
+        if conflict is not None:
+            return (
+                f"'{resolved}' cannot be bound: it is, or contains, the "
+                f"protected path '{conflict}'. Choose a folder that does "
+                f"not overlap this application's own data, configuration, "
+                f"or credential directories."
+            )
+        for existing in self.list_folder_bindings(workspace_id):
+            existing_path = Path(existing.locator)
+            if resolved == existing_path:
+                return f"{resolved} is already bound to this workspace."
+            if existing_path in resolved.parents:
+                return (
+                    f"{resolved} is inside the already-bound folder "
+                    f"{existing_path}."
+                )
+            if resolved in existing_path.parents:
+                return (
+                    f"The already-bound folder {existing_path} is inside "
+                    f"{resolved}; remove it first."
+                )
+        return None
+
+    def validate_folder_binding(
+        self, workspace_id: str, path: str | Path
+    ) -> str | None:
+        """Read-only pre-check of a folder-binding candidate (no write).
+
+        Returns the human-readable reason the path is unacceptable, or
+        ``None`` when it can be bound. Used by the Console new-workspace
+        setup modal so Create only enables on a bindable path; races at
+        write time are still rejected by ``add_folder_binding`` itself.
+        """
+        return self._folder_binding_error(workspace_id, path)
+
     def add_folder_binding(
         self,
         workspace_id: str,
@@ -693,58 +782,10 @@ class LocalWorkspaceRegistryService:
         (TASK-857). Default-workspace and unknown-workspace rejection is
         delegated to ``save_runtime_binding``.
         """
-        candidate = Path(path).expanduser()
-        try:
-            resolved = candidate.resolve()
-        except OSError as exc:
-            raise WorkspaceRegistryServiceError(
-                f"Folder path could not be resolved: {candidate}"
-            ) from exc
-        if not resolved.is_dir():
-            raise WorkspaceRegistryServiceError(
-                f"Folder does not exist or is not a directory: {resolved}"
-            )
-        if resolved == Path(resolved.anchor):
-            raise WorkspaceRegistryServiceError(
-                "The filesystem root cannot be bound to a workspace."
-            )
-        if resolved == Path.home().resolve():
-            raise WorkspaceRegistryServiceError(
-                "Your home directory itself cannot be bound; choose a "
-                "project folder inside it."
-            )
-        # TASK-857: the sensitive-path denylist used to only be consulted
-        # at file-tool READ/WRITE time, never here at the binding gate --
-        # so binding e.g. ~/.config/tldw_cli (this app's own config,
-        # API keys included), get_user_data_dir() (every app database), or
-        # ~/.ssh as a workspace folder root all passed this check, widening
-        # what the agent file tools can reach up to the edge of whatever
-        # the denylist enumerates. See ``find_root_binding_conflict`` for
-        # the exact "is, or contains, or is contained by" rule.
-        conflict = find_root_binding_conflict(resolved)
-        if conflict is not None:
-            raise WorkspaceRegistryServiceError(
-                f"'{resolved}' cannot be bound: it is, or contains, the "
-                f"protected path '{conflict}'. Choose a folder that does "
-                f"not overlap this application's own data, configuration, "
-                f"or credential directories."
-            )
-        for existing in self.list_folder_bindings(workspace_id):
-            existing_path = Path(existing.locator)
-            if resolved == existing_path:
-                raise WorkspaceRegistryServiceError(
-                    f"{resolved} is already bound to this workspace."
-                )
-            if existing_path in resolved.parents:
-                raise WorkspaceRegistryServiceError(
-                    f"{resolved} is inside the already-bound folder "
-                    f"{existing_path}."
-                )
-            if resolved in existing_path.parents:
-                raise WorkspaceRegistryServiceError(
-                    f"The already-bound folder {existing_path} is inside "
-                    f"{resolved}; remove it first."
-                )
+        error = self._folder_binding_error(workspace_id, path)
+        if error is not None:
+            raise WorkspaceRegistryServiceError(error)
+        resolved = Path(path).expanduser().resolve()
         binding = WorkspaceRuntimeBinding(
             workspace_id=workspace_id,
             binding_id=f"folder-{uuid4().hex[:12]}",


### PR DESCRIPTION
## What

"New Workspace" in the Console no longer silently creates a bare workspace with no indication of what it maps to. It now opens a setup modal capturing:

- **Name** — prefilled with the auto-generated `Workspace N`, editable
- **Folder binding (required)** — the agent file-tool access root, validated inline
- **Access** — read-only by default, opt-in read/write

Create is disabled until name + folder pass validation; Cancel/Escape creates nothing.

## How

- `LocalWorkspaceRegistryService`: `add_folder_binding`'s guards extracted verbatim into shared `_folder_binding_error()`; new read-only pre-checks `validate_folder_binding()` / `validate_workspace_name()` wrap the same rules, so pre-check and write cannot drift.
- New `ConsoleWorkspaceSetupModal` (`SafeModalDismissMixin`, Esc-safe, 0.3s debounced validation).
- `ConsoleWorkspaceController`: `_create_console_workspace` opens the modal; `_confirm_console_workspace_create` computes the collision-free identity at **confirm time** (avoids the stale-open race), then create → bind → activate with the existing sync/notify sequence. A write-time bind race keeps the workspace and warns (points at Folders settings) — no half-state re-prompt.

## Tests

- `Tests/UI/test_console_workspace_setup_modal.py` — gating, cancel, result payload, rw toggle, Enter-on-invalid
- `Tests/UI/test_console_workspace_create_flow.py` — create+bind+activate, cancel, bind-race on a real registry
- Registry parity tests in `Tests/Workspaces/test_workspace_folder_bindings.py`
- Modal-inventory contracts updated (28→29 modals) in `Tests/UI/test_console_modal_dismissal.py`

Related suites: 398 passed; ruff clean on touched files. (Two pre-existing `test_console_chat_controller` failures confirmed on clean dev.)

ADR: not required — direct implementation of existing registry/SafeModalDismissMixin patterns; no schema or interface change.

Task: TASK-16316

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New Workspace in the Console now opens a setup modal that requires a valid folder binding before creation. Previously it created an unbound workspace; now Create stays disabled until name and folder pass registry validation, and Cancel/Escape creates nothing.

- Controller: `_create_console_workspace` launches the modal; `_confirm_console_workspace_create` recomputes identity at confirm time, then create → bind → activate. Bind failures at write time keep the workspace and warn.
- Registry: extracted shared `_folder_binding_error` and added `validate_folder_binding` and `validate_workspace_name` so UI pre-checks match write-time rules.
- UI: new `ConsoleWorkspaceSetupModal` with prefilled name, required folder, read-only default, debounced inline validation, and safe dismissal.
- Tests: added flow and modal tests; updated modal-inventory counts; parity tests ensure pre-checks mirror write-time rejections.
- Meets TASK-16316 acceptance criteria (gating, cancel, drift-safe validation, bind-race behavior, tests).

<sup>Written for commit 8a3ae0cbb53812166d5a0e3e3e5d14c79e755081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

