### PR TITLE
Fix Console and destination contract drift

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-console-destination-sweep-closeout.md
+++ b/Docs/superpowers/plans/2026-08-14-console-destination-sweep-closeout.md
@@ -1,0 +1,126 @@
+# Console and Destination Sweep Closeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close TASK-15791 only after every failure cluster from the frozen Tests/UI sweep is attributed and every in-scope module passes whole on current `dev`.
+
+**Architecture:** Treat the original inventory as an evidence ledger, not a request for speculative code changes. Reuse the completed atomic TASK-162xx follow-ups, rerun only the named affected modules, and change production only after a current-dev RED reproduction identifies a real root cause.
+
+**Tech Stack:** Python 3.12, pytest, Textual 8, Backlog.md CLI, Ruff.
+
+---
+
+### Task 1: Reconcile the inventory with completed atomic tasks
+
+**Files:**
+- Modify: `backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md`
+
+- [x] Map every original cluster in a ledger with: original module/row, causing commit or justified non-regression attribution, owning TASK/fix commit, current-dev command, and result.
+- [x] Identify any row not covered by TASK-16220 or TASK-16244–TASK-16265.
+- [x] Record ADR status as `N/A`; this is test-health closeout, not a new boundary.
+
+### Task 2: Prove endpoint-probe and contention hypotheses
+
+**Tests:**
+- `Tests/UI/test_settings_provider_test_draft.py`
+- `Tests/UI/test_product_maturity_phase1_empty_setup_states.py`
+- `Tests/UI/test_product_maturity_phase1_first_run.py`
+- `Tests/UI/test_product_maturity_phase1_harness.py`
+- `Tests/UI/test_product_maturity_phase1_keyboard_focus.py`
+
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_settings_provider_test_draft.py::test_test_provider_button_click_runs_the_check Tests/UI/test_settings_provider_test_draft.py::test_test_provider_button_runs_with_provider_input_focused --disable-warnings`; expect 2 passed with clean teardown and no network-guard error.
+- [x] Run the four originally failing Phase 1 modules alone in one process.
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase1_empty_setup_states.py Tests/UI/test_product_maturity_phase1_first_run.py Tests/UI/test_product_maturity_phase1_harness.py Tests/UI/test_product_maturity_phase1_keyboard_focus.py --disable-warnings`; expect every collected test to pass without a 10-second timeout.
+- [x] If a failure reproduces, trace its current root cause before editing and use a minimal RED-to-GREEN test.
+
+### Task 3: Verify the original related module inventory
+
+**Tests:**
+- `Tests/UI/test_console_staged_evidence_strip.py`
+- `Tests/UI/test_console_shell_regions.py`
+- `Tests/UI/test_console_rail_width_budget.py`
+- `Tests/UI/test_console_shell_chip_actions.py`
+- `Tests/UI/test_console_dictionary_send_integration.py`
+- `Tests/UI/test_console_world_info_send_integration.py`
+- `Tests/UI/test_console_tab_scope.py`
+- `Tests/UI/test_console_citation_sources.py`
+- `Tests/UI/test_console_composer_collapse.py`
+- `Tests/UI/test_console_live_work_handoffs.py`
+- `Tests/UI/test_destination_visual_parity_correction.py`
+- `Tests/UI/test_workbench_visual_snapshots.py`
+- `Tests/UI/test_personas_generation_wiring.py`
+- `Tests/UI/test_settings_rag_profile_region.py`
+- `Tests/UI/test_settings_workspaces_category.py`
+- `Tests/UI/test_settings_model_catalog_toggles.py`
+- `Tests/UI/test_console_fleet_discoverability.py`
+- `Tests/UI/test_console_internals_decomposition.py`
+- `Tests/UI/test_console_rail_sections.py`
+- `Tests/UI/test_destination_headers.py`
+- `Tests/UI/test_settings_footer_hints.py`
+- `Tests/UI/test_speech_rail_navigation.py`
+- `Tests/UI/test_speech_tts_settings_ownership_closeout.py`
+- `Tests/UI/test_stts_profile_library.py`
+- `Tests/UI/test_schedules_ux_fixes.py`
+- `Tests/UI/test_screen_navigation.py`
+- `Tests/UI/test_ui_responsiveness.py`
+- `Tests/UI/test_watchlists_check_now_failure.py`
+- `Tests/UI/test_library_skills_canvas.py`
+- `Tests/UI/test_product_maturity_phase6_first_time_release_replay.py`
+- `Tests/UI/test_product_maturity_phase6_focus_visual_sweep.py`
+- `Tests/UI/test_product_maturity_phase6_packaging_data_safety.py`
+- `Tests/UI/test_product_maturity_phase6_power_user_replay.py`
+- `Tests/UI/test_product_maturity_phase6_recovery_docs.py`
+- `Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py`
+
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_console_staged_evidence_strip.py Tests/UI/test_console_shell_regions.py Tests/UI/test_console_rail_width_budget.py Tests/UI/test_console_shell_chip_actions.py Tests/UI/test_console_dictionary_send_integration.py Tests/UI/test_console_world_info_send_integration.py Tests/UI/test_console_tab_scope.py Tests/UI/test_console_citation_sources.py Tests/UI/test_console_composer_collapse.py Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_console_fleet_discoverability.py Tests/UI/test_console_internals_decomposition.py Tests/UI/test_console_rail_sections.py --disable-warnings`; expect all 13 Console modules to pass.
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_destination_visual_parity_correction.py Tests/UI/test_workbench_visual_snapshots.py Tests/UI/test_destination_headers.py --disable-warnings`; expect all three destination modules to pass without updating a baseline.
+- [x] Create temporary `Tests/UI/test_task15791_visual_capture_tmp.py` with the exact pytest helper below. Running it through the repository pytest entry point loads `Tests/conftest.py` before this module, which installs isolated XDG/config/data paths before app imports. Run `../../.venv/bin/python -m pytest -q Tests/UI/test_task15791_visual_capture_tmp.py --disable-warnings`; expect 1 passed and `/tmp/task15791-workbench.svg`.
+
+```python
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from Tests.UI.test_workbench_visual_snapshots import (
+    _build_test_app,
+    _mark_console_onboarding_complete,
+    _open_console,
+    _test_cli_setting,
+)
+
+
+@pytest.mark.asyncio
+async def test_capture_task15791_workbench() -> None:
+    app = _build_test_app()
+    app.app_config = getattr(app, "app_config", {}) or {}
+    app.app_config.setdefault("appearance", {})["ui_density"] = "normal"
+    _mark_console_onboarding_complete(app)
+    with patch("tldw_chatbook.app.get_cli_setting", side_effect=_test_cli_setting):
+        async with app.run_test(size=(160, 42)) as pilot:
+            await _open_console(app, pilot)
+            Path("/tmp/task15791-workbench.svg").write_text(
+                app.export_screenshot(title="TASK-15791 Workbench", simplify=True),
+                encoding="utf-8",
+            )
+```
+
+- [x] Run `/usr/bin/qlmanage -t -s 1600 -o /tmp /tmp/task15791-workbench.svg`; expect `/tmp/task15791-workbench.svg.png`. Inspect it with `view_image(path="/tmp/task15791-workbench.svg.png", detail="original")` and reject clipped/overlapping rails, unreadable controls, raw exceptions, or stale copy.
+- [x] Delete `Tests/UI/test_task15791_visual_capture_tmp.py` with `apply_patch`, then run `rm -f /tmp/task15791-workbench.svg /tmp/task15791-workbench.svg.png`; confirm all three paths are absent before commit.
+
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_personas_generation_wiring.py Tests/UI/test_settings_rag_profile_region.py Tests/UI/test_settings_workspaces_category.py Tests/UI/test_settings_model_catalog_toggles.py Tests/UI/test_settings_footer_hints.py --disable-warnings`; expect Personas plus all four Settings modules to pass.
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_speech_rail_navigation.py Tests/UI/test_speech_tts_settings_ownership_closeout.py Tests/UI/test_stts_profile_library.py Tests/UI/test_schedules_ux_fixes.py Tests/UI/test_screen_navigation.py Tests/UI/test_ui_responsiveness.py Tests/UI/test_watchlists_check_now_failure.py Tests/UI/test_library_skills_canvas.py --disable-warnings`; expect all eight singleton modules to pass.
+- [x] Run `../../.venv/bin/python -m pytest -q Tests/UI/test_product_maturity_phase6_first_time_release_replay.py Tests/UI/test_product_maturity_phase6_focus_visual_sweep.py Tests/UI/test_product_maturity_phase6_packaging_data_safety.py Tests/UI/test_product_maturity_phase6_power_user_replay.py Tests/UI/test_product_maturity_phase6_recovery_docs.py Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py --disable-warnings`; expect all five Phase-6 modules and recovery taxonomy to pass.
+
+### Task 4: Close the task with fresh evidence
+
+**Files:**
+- Modify: `backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md`
+- Modify only if an incident generalizes: `backlog/docs/lessons-testing-evidence.md`
+
+- [x] Run `../../.venv/bin/ruff check` and `../../.venv/bin/ruff format --check` on every changed Python file (if any), plus `git diff --check`; expect exit 0 or an exact documented unchanged baseline finding.
+- [x] Add concise implementation notes with exact pass/failure counts and ownership mapping.
+- [x] Re-evaluate ADR need before any newly discovered production fix; keep `N/A` only if this remains an evidence/test-harness closeout.
+- [x] Hard gate: if any in-scope module remains red or any inventory row lacks attribution, leave TASK-15791 In Progress and do not check AC #5.
+- [x] Only when the hard gate passes, check every acceptance criterion and run `backlog task edit 15791 -s Done`; if the CLI renames the canonical task file, restore the canonical name before proceeding.
+- [x] Review the final diff and commit only task-owned files.

--- a/Tests/UI/test_console_citation_sources.py
+++ b/Tests/UI/test_console_citation_sources.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from rich.console import Console as RichConsole
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -492,6 +492,7 @@ def _bare_screen(
         screen,
         context="test_console_citation_sources._bare_screen",
     )
+    screen._video = SimpleNamespace(_build_video_card_specs=lambda _messages: {})
     return screen
 
 
@@ -989,7 +990,6 @@ async def test_zero_only_count_cache_does_not_refresh_unchanged_transcript() -> 
     screen._console_presentation_context = lambda: None
     screen._image._build_console_image_specs = lambda _messages: {}
     screen._image._build_generation_card_specs = lambda _messages: {}
-    screen._build_video_card_specs = lambda _messages: {}
     screen._ensure_console_image_view = lambda: (
         None,
         SimpleNamespace(pending_ids=lambda _message_ids: ()),

--- a/Tests/UI/test_product_maturity_phase6_power_user_replay.py
+++ b/Tests/UI/test_product_maturity_phase6_power_user_replay.py
@@ -218,6 +218,10 @@ async def test_phase6_power_user_release_replay_exposes_fast_repeat_paths() -> N
                     and app.screen.__class__.__name__ == "LibraryScreen"
                 ),
             )
+            await _wait_until(
+                pilot,
+                lambda: bool(app.screen.query("#library-row-ingest-import-media")),
+            )
             # Import media is now a first-class canvas row (not a deep-link
             # to the standalone Ingest screen): pressing it mounts the real
             # ingest canvas (L3b Task 4) in place rather than navigating

--- a/Tests/UI/test_ui_responsiveness.py
+++ b/Tests/UI/test_ui_responsiveness.py
@@ -364,6 +364,7 @@ def _make_sync_probe_screen(monitor):
         setattr(screen, slot, MagicMock())
     screen._console_sync_in_progress = False
     screen._console_sync_requested = False
+    screen._console_chat_store = None
     # Console decomposition wave 2 (PR #1381) moved stages onto instance-held
     # delegate objects created in __init__ (`_session`, `_workspace`).
     # `spec=ChatScreen` auto-stubs only CLASS attributes, so these fall

--- a/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
+++ b/Tests/UI/test_unified_shell_phase5_recovery_taxonomy.py
@@ -246,24 +246,35 @@ def test_service_backed_policy_destinations_use_async_workers_without_asyncio_ru
     # exceptions cannot proliferate silently. Only genuine call sites
     # count: the AST walk skips prose mentions in comments/docstrings.
     allowed_annotated_asyncio_run = {
-        Path("tldw_chatbook/UI/Screens/library_screen.py"): 3,
+        Path("tldw_chatbook/UI/Screens/library_screen.py"): 6,
     }
     # @work(thread=True) is likewise a deliberate, reviewable exception on
-    # these service-backed screens (Library computes export counts, runs
-    # sync-body export service calls, persists rail/search preferences,
-    # installs the verified Parakeet model, and scans ingest paths on
-    # dedicated OS threads). Exact decorator counts per file keep new thread
-    # workers from slipping in silently; personas and skills stay on async
-    # workers only.
+    # these service-backed screens. Library computes export counts, runs
+    # sync-body export and ingest preparation calls, persists rail/search/
+    # Notes/ingest preferences, installs verified transcription models, and
+    # scans ingest paths on dedicated OS threads. Exact decorator counts per
+    # file keep new thread workers from slipping in silently; personas and
+    # skills stay on async workers only.
     allowed_thread_workers = {
-        Path("tldw_chatbook/UI/Screens/library_screen.py"): 6,
+        Path("tldw_chatbook/UI/Screens/library_screen.py"): 13,
     }
     for screen_path in screen_paths:
         source = _text(screen_path)
+        tree = ast.parse(source)
         thread_workers = sum(
             1
-            for line in source.splitlines()
-            if line.lstrip().startswith("@work(thread=True")
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Name)
+            and decorator.func.id == "work"
+            and any(
+                keyword.arg == "thread"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in decorator.keywords
+            )
         )
         assert thread_workers == allowed_thread_workers.get(screen_path, 0), (
             screen_path,
@@ -271,7 +282,7 @@ def test_service_backed_policy_destinations_use_async_workers_without_asyncio_ru
         )
         annotated = 0
         source_lines = source.splitlines()
-        for node in ast.walk(ast.parse(source)):
+        for node in ast.walk(tree):
             if not (
                 isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Attribute)

--- a/Tests/UI/test_watchlists_check_now_failure.py
+++ b/Tests/UI/test_watchlists_check_now_failure.py
@@ -332,7 +332,7 @@ USER_INITIATED_MUTATIONS = (
     "_delete_source",
     "_delete_run",
     "_delete_rule",
-    "_delete_item",
+    "handle_delete_requested",
 )
 
 

--- a/Tests/UI/test_workbench_visual_snapshots.py
+++ b/Tests/UI/test_workbench_visual_snapshots.py
@@ -91,6 +91,7 @@ def _assert_svg_healthy(svg: str) -> None:
 
 def _assert_console_density_evidence(svg: str) -> None:
     normalized_svg = unescape(svg).replace("\xa0", " ")
+    rendered_text = _rendered_svg_text(svg)
     assert normalized_svg.count("Provider:") == 1
     assert normalized_svg.count("Model:") == 1
     assert normalized_svg.count("Assistant:") == 1
@@ -100,7 +101,7 @@ def _assert_console_density_evidence(svg: str) -> None:
     assert "Settings" in normalized_svg
     assert "Attach" in normalized_svg
     assert "Search Library" in normalized_svg
-    assert "Model: not selected" in normalized_svg
+    assert "Model: gpt-5.6-terra" in rendered_text
     assert "Send disabled" not in normalized_svg
     assert "Setup required" not in normalized_svg
 
@@ -111,17 +112,12 @@ def _assert_console_inspector_evidence(svg: str) -> None:
     assert "Status: Blocked" in normalized_svg
     assert "Run recipe" in normalized_svg
     assert "Blocked impact" in normalized_svg
-    assert "Next action" in normalized_svg
-    assert "Choose provider" in normalized_svg
-    assert "Provider: blocked" in normalized_svg
     assert "Send disabled" not in normalized_svg
     assert "Setup required" not in normalized_svg
     assert (
         normalized_svg.index("Status: Blocked")
         < normalized_svg.index("Run recipe")
         < normalized_svg.index("Blocked impact")
-        < normalized_svg.index("Next action")
-        < normalized_svg.index("Provider: blocked")
     )
 
 
@@ -146,10 +142,11 @@ def _assert_command_palette_evidence(svg: str) -> None:
 
 def _assert_console_focus_evidence(svg: str) -> None:
     normalized_svg = unescape(svg).replace("\xa0", " ")
+    rendered_text = _rendered_svg_text(svg)
     assert "Console Workbench Focus State" in normalized_svg
     assert "Settings" in normalized_svg
     assert "Provider:" in normalized_svg
-    assert "Model: not selected" in normalized_svg
+    assert "Model: gpt-5.6-terra" in rendered_text
 
 
 def _assert_visible_ancestors(widget) -> None:
@@ -233,6 +230,8 @@ async def test_console_workbench_normal_and_compact_snapshots(density: str) -> N
                 simplify=True,
             )
             _assert_svg_healthy(svg)
+            send = app.screen.query_one("#console-send-message", Button)
+            assert send.render_line(0).text.strip() == "Send"
             _assert_console_density_evidence(svg)
 
 
@@ -351,7 +350,7 @@ async def test_task_15783_console_collapsed_inspector_rail_visual_parity_sweep(
     ),
     (
         ((140, 42), "context-open-inspector-collapsed", True, False, (30, 0)),
-        ((140, 42), "both-open", True, True, (30, 34)),
+        ((140, 42), "inspector-priority-after-both-open", True, True, (0, 34)),
         ((140, 42), "context-collapsed-inspector-open", False, True, (0, 34)),
         ((140, 42), "both-collapsed", False, False, (0, 0)),
         ((160, 45), "context-open-inspector-collapsed", True, False, (30, 0)),
@@ -457,6 +456,9 @@ async def test_task_16001_console_directional_rail_buttons_visual_sweep(
             )
             await pilot.pause(0.5)
 
+            effective_context_open = expected_rail_widths[0] > 0
+            effective_inspector_open = expected_rail_widths[1] > 0
+
             assert (
                 app.screen.query_one("#console-left-rail").region.width,
                 app.screen.query_one("#console-right-rail").region.width,
@@ -464,19 +466,19 @@ async def test_task_16001_console_directional_rail_buttons_visual_sweep(
 
             context_selector = (
                 "#console-context-rail-collapse"
-                if context_open
+                if effective_context_open
                 else "#console-context-rail-open"
             )
             inspector_selector = (
                 "#console-inspector-rail-collapse"
-                if inspector_open
+                if effective_inspector_open
                 else "#console-inspector-rail-open"
             )
             context_button, context_header = assert_control_preconditions(
                 rail_selector="#console-left-rail",
                 handle_selector="#console-context-rail-handle",
                 button_selector=context_selector,
-                open_state=context_open,
+                open_state=effective_context_open,
                 handle_width=13,
                 content_width=11,
             )
@@ -484,7 +486,7 @@ async def test_task_16001_console_directional_rail_buttons_visual_sweep(
                 rail_selector="#console-right-rail",
                 handle_selector="#console-inspector-rail-handle",
                 button_selector=inspector_selector,
-                open_state=inspector_open,
+                open_state=effective_inspector_open,
                 handle_width=11,
                 content_width=9,
             )
@@ -502,13 +504,21 @@ async def test_task_16001_console_directional_rail_buttons_visual_sweep(
             assert rendered_text.strip()
             assert "Console" in rendered_text
 
-            context_label = "<---------|Context" if context_open else "Context->"
-            inspector_label = "Inspect|--------->" if inspector_open else "<-Inspect"
+            context_label = (
+                "<---------|Context" if effective_context_open else "Context->"
+            )
+            inspector_label = (
+                "Inspect|--------->" if effective_inspector_open else "<-Inspect"
+            )
             context_tooltip = (
-                "Collapse Console context rail" if context_open else "Open Context rail"
+                "Collapse Console context rail"
+                if effective_context_open
+                else "Open Context rail"
             )
             inspector_tooltip = (
-                "Collapse Inspector rail" if inspector_open else "Open Inspector rail"
+                "Collapse Inspector rail"
+                if effective_inspector_open
+                else "Open Inspector rail"
             )
 
             assert (
@@ -522,14 +532,14 @@ async def test_task_16001_console_directional_rail_buttons_visual_sweep(
             assert context_button.tooltip == context_tooltip
             assert inspector_button.tooltip == inspector_tooltip
 
-            if context_open:
+            if effective_context_open:
                 assert context_header is not None
                 assert not app.screen.query("#console-context-rail-title")
                 assert list(context_header.children) == [context_button]
                 assert (
                     context_button.region.width == context_header.content_region.width
                 )
-            if inspector_open:
+            if effective_inspector_open:
                 assert inspector_header is not None
                 assert not app.screen.query("#console-inspector-rail-title")
                 assert list(inspector_header.children) == [inspector_button]
@@ -553,6 +563,10 @@ async def test_console_workbench_standard_width_inspector_snapshot() -> None:
             right_rail = app.screen.query_one("#console-right-rail")
             assert right_rail.display is True
             assert right_rail.region.width > 0
+            next_action = app.screen.query_one("#console-inspector-next-action", Static)
+            assert next_action.render_line(0).text.strip() == (
+                "Next action: Set up provider"
+            )
             svg = app.export_screenshot(
                 title="Console Workbench Standard Width Inspector",
                 simplify=True,

--- a/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
+++ b/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
@@ -1,16 +1,21 @@
 ---
 id: TASK-15791
 title: 'Sweep inventory: console and destination contract drift (~38 tests)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
+created_date: ''
+updated_date: '2026-08-14 19:57'
 labels:
   - test-health
   - console
+dependencies: []
 priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 From the task-15211 full-suite sweep (`Docs/Design/2026-08-13-tests-ui-sweep-inventory.md`,
 chunks 2-5, 15): console and destination-frame contract drift on dev:
 
@@ -36,14 +41,32 @@ Also: chunk 12 recorded two teardown errors on the settings provider-Test
 button pair — check whether `settings_screen`'s endpoint-probe worker can
 outlive its test the way the LLM screen's Ollama probe did (fixed in #1596);
 if so, the same worker-lifetime + harness-seam remedy applies.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Sources-staged copy question is decided (product vs tests) with the 7dbbc401b context, then applied consistently
+- [x] #2 The settings endpoint-probe teardown pair is attributed, and fixed with the #1596 pattern if it is the same class
+- [x] #3 The maturity-phase1 timeouts are re-run without contention before being treated as failures
+- [x] #4 Each remaining cluster is attributed to its causing commit; genuine breaks fixed, not absorbed
+- [x] #5 The listed modules pass whole on dev
+<!-- AC:END -->
 
-- [x] The Sources-staged copy question is decided (product vs tests) with the 7dbbc401b context, then applied consistently
-- [ ] The settings endpoint-probe teardown pair is attributed, and fixed with the #1596 pattern if it is the same class
-- [ ] The maturity-phase1 timeouts are re-run without contention before being treated as failures
-- [ ] Each remaining cluster is attributed to its causing commit; genuine breaks fixed, not absorbed
-- [ ] The listed modules pass whole on dev
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Build an attribution ledger from TASK-16220 and the completed TASK-16244–TASK-16265 follow-ups, and identify any original sweep row without current evidence.
+2. Re-run the two original clickable Settings provider-Test paths and the four originally failing Product Maturity Phase 1 modules in isolation.
+3. Run every named Console, destination snapshot/parity, Personas, Settings, and singleton module as bounded related batches; generate and inspect a temporary current-dev render instead of blindly refreshing snapshots.
+4. Apply only root-cause fixes supported by a reproducible current-dev failure, using RED-to-GREEN coverage for any production change.
+5. Run scoped static checks, update the task with a per-cluster causal ledger and exact evidence, and close only if every named module is green and the canonical filename is preserved.
+
+Detailed plan: [2026-08-14 Console and destination sweep closeout](../../Docs/superpowers/plans/2026-08-14-console-destination-sweep-closeout.md)
+
+ADR required: no
+ADR path: N/A
+Reason: this closes a test-health inventory using existing product and test boundaries; any newly discovered architectural issue must be split into its own task before implementation.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes (batch 1)
 
@@ -67,3 +90,66 @@ something production's children add. Full probe evidence in the task.
 Remaining clusters for batch 2: rail_width x3 + rail_sections/internals
 (likely the same 16220 geometry family), send-integration x4, snapshots x4
 (need a human eye), visual parity, personas x5, singletons.
+
+## Implementation Notes (closeout)
+
+Closed the frozen inventory against current `dev` without running a broad or
+full suite. The completed atomic follow-ups supplied the first attribution
+layer: TASK-16220 owns the Console geometry regression; TASK-16244–TASK-16249
+own the Console integration/controller/rail rows; TASK-16250–TASK-16253 own the
+destination CSS, viewport, Schedules, and focus rows; TASK-16254–TASK-16258 own
+the Library/privacy harness rows; and TASK-16259–TASK-16265 own Personas,
+product-maturity, Settings-probe/responsiveness, and Settings interaction rows.
+
+Fresh attribution and fixes for the remaining live drift:
+
+- `0b8e9e408` moved video-card derivation behind `screen._video`; the citation
+  fixture now installs that controller seam instead of a retired screen method.
+- `42851b309`/`a2f7b8498` changed the default model evidence, `1edcd3dc9`
+  established compact Inspector priority, and `51acb2d646` expanded the
+  Inspector rows. Snapshot assertions now distinguish requested rail state
+  from effective width and verify offscreen mounted content directly.
+- `7dbbc401b` narrowed Send/Stop to six cells. Textual's default two-cell line
+  padding clipped `Send` to `Se`; a mounted RED proved the product defect, and
+  both mutually exclusive buttons now use zero line padding.
+- `c072f9c592` added the instance-owned Console chat store; the app-free
+  responsiveness fixture now initializes it explicitly.
+- `6385771b2` retired Watchlists `_delete_item`; the mutation inventory now
+  audits the live `handle_delete_requested` boundary.
+- Rapid Speech view pruning reproduced the repository's documented TASK-1960
+  `SelectCurrent/#label` race. The Playground axes and Studio preference
+  selects now reuse the existing `PruneSafeSelect`; three race nodes passed
+  three consecutive runs, the whole STTS module passed 163 tests, and the
+  prune-safe widget contract passed 14 tests.
+- `99bc69829c`, `ae1a23fbad`, `e610fac691`, and `d9be16a583` expanded Library's
+  reviewed thread-worker/event-loop exceptions. The recovery sentinel now
+  counts decorators with AST (including multiline decorators) and pins the
+  factual totals: 13 thread workers and six annotated worker-thread loops.
+- The Phase-6 power replay now waits for Library's deferred Import-media row,
+  matching the existing current-shell replay contract before pressing it.
+
+Hypotheses and evidence:
+
+- The two Settings provider-Test paths passed 2/2. TASK-16264's harness
+  stub-and-await already owned their teardown; this was not the production
+  worker-lifetime defect fixed in #1596.
+- The four Phase-1 modules passed 34/34 alone, confirming the original
+  10-second failures were shared-machine contention rather than product bugs.
+- Current bounded runs: Console 481 passed; destination/snapshot/header 141
+  passed; Personas plus Settings 159 passed; singleton inventory 459 passed
+  with two STTS batch-contention failures that both passed immediately alone
+  (and within the separate 163/163 STTS run); maturity/recovery 19 passed.
+- A temporary 160-column SVG was rendered to PNG and inspected. Rails and
+  controls did not overlap, Send rendered fully, and no stale/raw-error copy
+  appeared. All temporary capture artifacts were removed.
+
+Static closeout: Ruff lint passes all changed Python files; six previously
+formatted changed files pass Ruff format. The other three files reproduce the
+same formatter debt at `HEAD`, and their changed ranges are formatter-clean.
+Compileall and `git diff --check` pass. Targeted MyPy reports only four existing
+unchanged-line errors in `console_composer_bar.py`; the two Speech files and all
+new production lines add no diagnostic.
+
+ADR required: no. This used existing controller, worker-policy, and
+`PruneSafeSelect` boundaries. No new lesson was added because the Textual prune
+mechanism and its tested remedy were already documented in the repository.

--- a/tldw_chatbook/UI/Speech/speech_axis_row.py
+++ b/tldw_chatbook/UI/Speech/speech_axis_row.py
@@ -31,6 +31,7 @@ from textual.widgets import Input, Select, Static
 from tldw_chatbook.UI.stts_playground_catalog import (
     LOADING_SELECT_VALUE,
 )
+from tldw_chatbook.Widgets.prune_safe_select import PruneSafeSelect
 
 from .speech_playground_model import AXIS_CONTROLS
 
@@ -189,7 +190,7 @@ class SpeechAxisRow(Grid):
             # at that point states a fact not yet in evidence, and the shared
             # catalog code overwrites it with UNAVAILABLE if the catalog
             # really does come back empty.
-            return Select(
+            return PruneSafeSelect(
                 [(AXIS_LOADING_LABELS[axis], LOADING_SELECT_VALUE)],
                 id=axis,
                 classes="speech-axis-control",
@@ -197,7 +198,7 @@ class SpeechAxisRow(Grid):
                 value=LOADING_SELECT_VALUE,
                 prompt=AXIS_EMPTY_PROMPTS[axis],
             )
-        select: Select[str] = Select(
+        select: Select[str] = PruneSafeSelect(
             [(label, value) for label, value in options],
             id=axis,
             classes="speech-axis-control",

--- a/tldw_chatbook/UI/Speech/speech_settings_pane.py
+++ b/tldw_chatbook/UI/Speech/speech_settings_pane.py
@@ -39,6 +39,7 @@ from tldw_chatbook.TTS.studio_preferences import (
     StudioTTSWriteStatus,
 )
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.Widgets.prune_safe_select import PruneSafeSelect
 
 from ..Workbench.workbench_state import WorkbenchAction
 from .speech_action_strip import SpeechActionStrip
@@ -460,7 +461,7 @@ class SpeechSettingsPane(SpeechSettingsMixin, Vertical):
             )
             yield _field_row(
                 "Provider override",
-                Select(
+                PruneSafeSelect(
                     (("Inherit global", _INHERIT), *_PROVIDER_OPTIONS),
                     id="studio-tts-provider",
                     allow_blank=False,
@@ -471,7 +472,7 @@ class SpeechSettingsPane(SpeechSettingsMixin, Vertical):
             )
             yield _field_row(
                 "Model policy",
-                Select(
+                PruneSafeSelect(
                     (
                         ("Inherit", _INHERIT),
                         ("Exact", "exact"),
@@ -496,7 +497,7 @@ class SpeechSettingsPane(SpeechSettingsMixin, Vertical):
             )
             yield _field_row(
                 "Voice policy",
-                Select(
+                PruneSafeSelect(
                     (
                         ("Inherit", _INHERIT),
                         ("Exact", "exact"),
@@ -521,7 +522,7 @@ class SpeechSettingsPane(SpeechSettingsMixin, Vertical):
             )
             yield _field_row(
                 "Output format",
-                Select(
+                PruneSafeSelect(
                     (
                         ("Inherit", _INHERIT),
                         *((value.upper(), value) for value in _FORMATS),

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -5166,7 +5166,7 @@ class ConsoleComposerBar(Horizontal):
                 # so Stop's hidden budget never parks between draft and
                 # Send), then Dictate follows across the MIC_SEND_GAP buffer
                 # so a press aimed at one cannot land on the other.
-                yield self._bounded_button(
+                send_button = self._bounded_button(
                     "Send",
                     width=6,
                     id="console-send-message",
@@ -5179,6 +5179,8 @@ class ConsoleComposerBar(Horizontal):
                     # something to send.
                     disabled=True,
                 )
+                send_button.styles.line_pad = 0
+                yield send_button
                 mic_button = self._bounded_button(
                     "Dictate",
                     width=11,
@@ -5199,6 +5201,7 @@ class ConsoleComposerBar(Horizontal):
                     # THIS tab's own run (behavior unchanged) -- say so.
                     tooltip="Stop this tab's run.",
                 )
+                stop_button.styles.line_pad = 0
                 stop_button.styles.display = "none"
                 yield stop_button
                 # Attach and Save Chatbook moved into the composer Menu: this


### PR DESCRIPTION
## Summary
- reconcile stale Console, destination, Library, Watchlists, and responsiveness contracts with current dev ownership
- fix clipped Console Send/Stop labels and reuse PruneSafeSelect for Speech view teardown races
- close TASK-15791 with an attributed inventory ledger and inspected visual evidence

## Test plan
- 138 focused PR-gate tests passed across changed modules and Speech/prune regressions
- 481 Console tests passed
- 141 destination/snapshot/header tests passed
- 159 Personas and Settings tests passed
- 163 STTS tests passed
- 34 Phase-1 and 19 maturity/recovery tests passed
- Ruff check and git diff --check passed

## Notes
- no full-suite run; verification was intentionally limited to the original inventory and touched functionality
- existing formatter/MyPy baseline debt is documented in the task notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles Console, destination, Library, Watchlists, and Speech contracts with current `dev` to close TASK-15791. Fixes Send/Stop label clipping and updates tests to align with current UI and worker boundaries.

- Console: `#console-send-message` and `#console-stop-message` now render fully by setting `styles.line_pad = 0`; inspector/context rail expectations updated to assert effective widths and inspector priority; snapshot assertions expect rendered model text (“Model: gpt-5.6-terra”) and “Next action: Set up provider.”
- Speech: replaces Textual `Select` with `PruneSafeSelect` in Playground axes and Studio settings to avoid prune races during rapid view teardown.
- Library recovery taxonomy: decorator counting switched to AST-based detection; expected counts pinned (13 thread workers, 6 annotated `asyncio.run` exceptions).
- Tests/harness: citation sources fixture patches `screen._video._build_video_card_specs`; responsiveness fixture initializes `_console_chat_store`; Watchlists inventory now audits `handle_delete_requested`; Phase-6 replay waits for Library’s deferred Import-media row.
- Evidence: destination and snapshot modules pass without baseline refresh; a temporary 160-column Console SVG was inspected for overlap and stale copy; scoped static checks (`ruff`, compileall, `git diff --check`) pass.

**Rollout/Migration**
- Use `PruneSafeSelect` for new Speech select controls subject to prune.
- Update any remaining references to retired Watchlists `_delete_item` to `handle_delete_requested`.
- Tests that stub video card derivation should patch `screen._video._build_video_card_specs`.

<sup>Written for commit a9e8c4ddf91608165e951407822296767856e28b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

