### PR TITLE
feat(app): require consent before startup model-catalog online checks

### DIFF
--- a/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
+++ b/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
@@ -10,6 +10,8 @@ Covers two things:
    test).
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from textual.app import App
 from textual.screen import Screen
@@ -112,6 +114,10 @@ def _stub(
     monkeypatch, *, settings=None, report=None, error=None, disk_store=_DEFAULT_DISK_STORE
 ):
     """Build a stub app + service and pin tldw_chatbook.app.load_settings."""
+    if settings is None:
+        # Consent defaults to recorded so refresh-path tests exercise the
+        # refresh itself; consent gating has its own dedicated tests below.
+        settings = {"model_catalog": {"refresh_consent_recorded": True}}
     monkeypatch.setattr("tldw_chatbook.app.load_settings", lambda: settings or {})
     service = _StubCatalogService(report=report, error=error)
     app = _StubApp(
@@ -131,6 +137,107 @@ async def test_refresh_skips_when_auto_refresh_disabled(monkeypatch):
     assert service.calls == []
     assert app.posted_messages == []
     assert app.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_when_consent_not_recorded(monkeypatch):
+    """ADR-020 amendment: enabled alone must not trigger network calls."""
+    app, service = _stub(
+        monkeypatch,
+        settings={"model_catalog": {"auto_refresh_enabled": True}},
+    )
+    await TldwCli._refresh_model_catalogs(app)
+    assert service.calls == []
+    assert app.posted_messages == []
+    assert app.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_when_consent_is_garbage(monkeypatch):
+    """Only an explicit boolean true counts as consent."""
+    app, service = _stub(
+        monkeypatch,
+        settings={"model_catalog": {"refresh_consent_recorded": "yes"}},
+    )
+    await TldwCli._refresh_model_catalogs(app)
+    assert service.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Consent handler: TldwCli._handle_model_catalog_consent against a stub self
+# ---------------------------------------------------------------------------
+
+
+class _ConsentHost:
+    """Minimal self for the unbound consent-handler coroutine."""
+
+    def __init__(self):
+        self.run_worker = MagicMock()
+        self._refresh_model_catalogs = AsyncMock()
+        self.notifications = []
+
+    def notify(self, message, *, title=None, severity=None):
+        self.notifications.append((message, title, severity))
+
+
+@pytest.mark.asyncio
+async def test_consent_allow_persists_consent_and_schedules_refresh(monkeypatch):
+    saved = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config", saved
+    )
+    host = _ConsentHost()
+
+    await TldwCli._handle_model_catalog_consent(host, True)
+
+    saved.assert_called_once_with(
+        {"model_catalog": {"refresh_consent_recorded": True}}
+    )
+    host.run_worker.assert_called_once_with(
+        host._refresh_model_catalogs,
+        exclusive=True,
+        group="model-catalog-refresh",
+    )
+    assert host.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_consent_deny_persists_disabled_and_skips_refresh(monkeypatch):
+    saved = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config", saved
+    )
+    host = _ConsentHost()
+
+    await TldwCli._handle_model_catalog_consent(host, False)
+
+    saved.assert_called_once_with(
+        {
+            "model_catalog": {
+                "refresh_consent_recorded": True,
+                "auto_refresh_enabled": False,
+            }
+        }
+    )
+    host.run_worker.assert_not_called()
+    assert len(host.notifications) == 1
+    assert host.notifications[0][1] == "Model catalog"
+
+
+@pytest.mark.asyncio
+async def test_consent_allow_still_refreshes_when_persist_fails(monkeypatch):
+    saved = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config", saved
+    )
+    host = _ConsentHost()
+
+    await TldwCli._handle_model_catalog_consent(host, True)
+
+    # Session choice honoured (refresh runs) but the user is told the
+    # answer wasn't persisted, so they'll be asked again next launch.
+    host.run_worker.assert_called_once()
+    assert host.notifications[0][2] == "warning"
 
 
 @pytest.mark.asyncio

--- a/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
+++ b/Tests/LLM_Provider_Catalog/test_app_model_catalog_wiring.py
@@ -225,6 +225,23 @@ async def test_consent_deny_persists_disabled_and_skips_refresh(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("junk", ["yes", 1, "true"])
+async def test_consent_truthy_non_bool_is_treated_as_deny(monkeypatch, junk):
+    """Only the boolean True counts as consent, mirroring the parser."""
+    saved = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "tldw_chatbook.config.save_settings_to_cli_config", saved
+    )
+    host = _ConsentHost()
+
+    await TldwCli._handle_model_catalog_consent(host, junk)
+
+    # Deny shape: consent recorded with the check disabled, no refresh.
+    assert saved.call_args.args[0]["model_catalog"]["auto_refresh_enabled"] is False
+    host.run_worker.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_consent_allow_still_refreshes_when_persist_fails(monkeypatch):
     saved = MagicMock(return_value=False)
     monkeypatch.setattr(

--- a/Tests/LLM_Provider_Catalog/test_model_catalog_settings.py
+++ b/Tests/LLM_Provider_Catalog/test_model_catalog_settings.py
@@ -11,6 +11,20 @@ def test_defaults_when_section_missing():
     assert settings.stale_after_hours == 24.0
     assert settings.auto_refresh_disabled == frozenset()
     assert settings.write_to_config == frozenset()
+    # Confirm-first default: no consent until explicitly recorded.
+    assert settings.refresh_consent_recorded is False
+
+
+def test_consent_defaults_false_and_requires_explicit_true():
+    assert load_model_catalog_settings(
+        {"model_catalog": {"refresh_consent_recorded": True}}
+    ).refresh_consent_recorded is True
+    assert load_model_catalog_settings(
+        {"model_catalog": {"refresh_consent_recorded": "yes"}}
+    ).refresh_consent_recorded is False
+    assert load_model_catalog_settings(
+        {"model_catalog": {"refresh_consent_recorded": 1}}
+    ).refresh_consent_recorded is False
 
 
 def test_full_section_parsed_and_normalized():

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -1,7 +1,5 @@
 """ModelCatalogConsentModal dismisses with the user's allow/deny choice."""
 
-from unittest.mock import MagicMock
-
 import pytest
 from textual.app import App
 
@@ -47,19 +45,19 @@ async def test_escape_dismisses_false():
 
 
 @pytest.mark.asyncio
-async def test_app_push_wires_modal_onto_screen_stack():
+async def test_app_push_suppresses_modal_in_headless_runs():
+    """run_test() is headless: no user can answer, so nothing is pushed.
+
+    This is the guard that keeps full-app UI tests (GGUF source modes,
+    first-run flows, ...) free of an interleaved consent dialog.
+    """
     from tldw_chatbook.app import TldwCli
 
     class HostApp(App):
-        # The push wires the real TldwCli consent handler as the dismiss
-        # callback; borrow it plus the seams it touches (never invoked —
-        # the test only asserts the modal lands on the screen stack).
-        _handle_model_catalog_consent = TldwCli._handle_model_catalog_consent
-        _refresh_model_catalogs = TldwCli._refresh_model_catalogs
-        run_worker = MagicMock()
+        pass
 
     app = HostApp()
     async with app.run_test() as pilot:
         TldwCli._push_model_catalog_consent_modal(app)
         await pilot.pause()
-        assert isinstance(app.screen, ModelCatalogConsentModal)
+        assert not isinstance(app.screen, ModelCatalogConsentModal)

--- a/Tests/UI/test_model_catalog_consent_modal.py
+++ b/Tests/UI/test_model_catalog_consent_modal.py
@@ -1,0 +1,65 @@
+"""ModelCatalogConsentModal dismisses with the user's allow/deny choice."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+
+from tldw_chatbook.UI.Screens.model_catalog_consent import ModelCatalogConsentModal
+
+
+class _ConsentHost(App):
+    def __init__(self):
+        super().__init__()
+        self.results = []
+
+    def on_mount(self):
+        self.push_screen(
+            ModelCatalogConsentModal(), lambda result: self.results.append(result)
+        )
+
+
+@pytest.mark.asyncio
+async def test_allow_button_dismisses_true():
+    app = _ConsentHost()
+    async with app.run_test() as pilot:
+        await pilot.click("#model-catalog-consent-allow")
+        await pilot.pause()
+    assert app.results == [True]
+
+
+@pytest.mark.asyncio
+async def test_deny_button_dismisses_false():
+    app = _ConsentHost()
+    async with app.run_test() as pilot:
+        await pilot.click("#model-catalog-consent-deny")
+        await pilot.pause()
+    assert app.results == [False]
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_false():
+    app = _ConsentHost()
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.results == [False]
+
+
+@pytest.mark.asyncio
+async def test_app_push_wires_modal_onto_screen_stack():
+    from tldw_chatbook.app import TldwCli
+
+    class HostApp(App):
+        # The push wires the real TldwCli consent handler as the dismiss
+        # callback; borrow it plus the seams it touches (never invoked —
+        # the test only asserts the modal lands on the screen stack).
+        _handle_model_catalog_consent = TldwCli._handle_model_catalog_consent
+        _refresh_model_catalogs = TldwCli._refresh_model_catalogs
+        run_worker = MagicMock()
+
+    app = HostApp()
+    async with app.run_test() as pilot:
+        TldwCli._push_model_catalog_consent_modal(app)
+        await pilot.pause()
+        assert isinstance(app.screen, ModelCatalogConsentModal)

--- a/Tests/UI/test_product_maturity_phase1_first_run.py
+++ b/Tests/UI/test_product_maturity_phase1_first_run.py
@@ -92,13 +92,10 @@ def _prepare_clean_environment(
     for env_var, path in paths.items():
         path.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv(env_var, str(path))
-    # ADR-020 amendment: these full-app tests exercise first-run flows, not
-    # the one-time model-catalog consent dialog; suppress it so it can't
-    # interleave with the screens under test. Consent gating has dedicated
-    # unit tests in test_app_model_catalog_wiring.py.
-    monkeypatch.setattr(
-        TldwCli, "_push_model_catalog_consent_modal", lambda self: None
-    )
+    # ADR-020 amendment: the consent dialog self-suppresses in headless
+    # runs (see _push_model_catalog_consent_modal), so full-app tests here
+    # never see it; consent gating has dedicated unit tests in
+    # test_app_model_catalog_wiring.py.
     return {env_var: str(path) for env_var, path in paths.items()}
 
 

--- a/Tests/UI/test_product_maturity_phase1_first_run.py
+++ b/Tests/UI/test_product_maturity_phase1_first_run.py
@@ -92,6 +92,13 @@ def _prepare_clean_environment(
     for env_var, path in paths.items():
         path.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv(env_var, str(path))
+    # ADR-020 amendment: these full-app tests exercise first-run flows, not
+    # the one-time model-catalog consent dialog; suppress it so it can't
+    # interleave with the screens under test. Consent gating has dedicated
+    # unit tests in test_app_model_catalog_wiring.py.
+    monkeypatch.setattr(
+        TldwCli, "_push_model_catalog_consent_modal", lambda self: None
+    )
     return {env_var: str(path) for env_var, path in paths.items()}
 
 
@@ -128,10 +135,20 @@ class _CatalogRefreshScheduleHost:
         self.app_config = app_config
         self.run_worker = MagicMock()
         self.post_message = MagicMock()
+        self.call_after_refresh = MagicMock()
+        self.push_screen = MagicMock()
+        self._push_model_catalog_consent_modal = MagicMock()
         self._refresh_model_catalogs = AsyncMock()
 
     _schedule_startup_model_catalog_refresh = (
         TldwCli._schedule_startup_model_catalog_refresh
+    )
+
+
+def _pin_consented_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tldw_chatbook.app.load_settings",
+        lambda: {"model_catalog": {"refresh_consent_recorded": True}},
     )
 
 
@@ -157,7 +174,10 @@ def test_setup_network_owner_actions_suppress_startup_catalog_refresh(
     host.run_worker.assert_not_called()
 
 
-def test_normal_startup_schedules_catalog_refresh_once() -> None:
+def test_normal_startup_schedules_catalog_refresh_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _pin_consented_settings(monkeypatch)
     host = _CatalogRefreshScheduleHost(
         {"first_run": {"setup_completed": True}}
     )
@@ -172,7 +192,29 @@ def test_normal_startup_schedules_catalog_refresh_once() -> None:
     )
 
 
-def test_completed_first_run_schedules_deferred_catalog_refresh_once() -> None:
+def test_unconsented_startup_shows_consent_modal_instead_of_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-020 amendment: no consent on file means a dialog, not network I/O."""
+    monkeypatch.setattr("tldw_chatbook.app.load_settings", lambda: {})
+    host = _CatalogRefreshScheduleHost(
+        {"first_run": {"setup_completed": True}}
+    )
+
+    assert host._schedule_startup_model_catalog_refresh(environ={}) is True
+    assert host._schedule_startup_model_catalog_refresh(environ={}) is False
+
+    host.run_worker.assert_not_called()
+    host.call_after_refresh.assert_called_once()
+    assert host.call_after_refresh.call_args.args[0] is (
+        host._push_model_catalog_consent_modal
+    )
+
+
+def test_completed_first_run_schedules_deferred_catalog_refresh_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _pin_consented_settings(monkeypatch)
     host = _CatalogRefreshScheduleHost({})
 
     TldwCli._handle_first_run_wizard_result(

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -63,6 +63,8 @@ def test_model_catalog_defaults_exist():
     parsed = tomllib.loads(CONFIG_TOML_CONTENT)
     section = parsed["model_catalog"]
     assert section["auto_refresh_enabled"] is True
+    # Confirm-first (ADR-020 amendment): no online check before consent.
+    assert section["refresh_consent_recorded"] is False
     assert section["stale_after_hours"] == 24
     assert section["auto_refresh_disabled"] == []
     assert section["write_to_config"] == []

--- a/backlog/decisions/020-automatic-model-catalog-refresh.md
+++ b/backlog/decisions/020-automatic-model-catalog-refresh.md
@@ -1,6 +1,6 @@
 # ADR-020: Automatic model catalog refresh for cloud providers
 
-Status: Accepted
+Status: Accepted (amended 2026-08-14: consent-gated startup)
 Date: 2026-07-17
 Related Tasks:
 - [backlog/tasks/task-301 - Auto-refresh-model-catalogs-for-cloud-providers.md](../tasks/task-301%20-%20Auto-refresh-model-catalogs-for-cloud-providers.md)
@@ -50,6 +50,21 @@ as an opt-in. OpenRouter's catalog is public (no key required).
 - Append-only persistence is durable configuration history, not permanent selector authority. For auto-refreshed cloud providers, a cached endpoint snapshot filters new choices while the current session value remains preserved.
 - `model_catalog_cache.json` under the user data dir stores model IDs + timestamps only (no credentials).
 - Manual Discover/Save/Clear flows from ADR-002 remain unchanged.
+
+## Amendment (2026-08-14): confirm-first startup consent
+
+The startup refresh is no longer silent-by-default. A new persisted setting,
+`[model_catalog] refresh_consent_recorded` (default `false`), gates the refresh:
+until the user answers a one-time dialog ("Check model lists online?"), no
+provider endpoints are contacted. Allowing records consent (`true`) and runs the
+refresh that session and thereafter; declining persists
+`auto_refresh_enabled = false` alongside the recorded consent so the question is
+never asked twice. Only an explicit boolean `true` counts as consent — garbage
+values fall back to not-consented (privacy-safe). `_refresh_model_catalogs`
+itself re-checks consent, so no code path can refresh unconsented. Recording
+consent via the Settings toggle was considered and rejected: the toggle is saved
+on unrelated edits in the same category (e.g. stale-hours keystrokes), so it is
+not an unambiguous confirmation.
 
 ## Links
 

--- a/backlog/tasks/task-16318 - Make-model-catalog-online-check-confirm-first.md
+++ b/backlog/tasks/task-16318 - Make-model-catalog-online-check-confirm-first.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16318
+title: Make model catalog online check confirm-first
+status: Done
+assignee: []
+created_date: '2026-08-15 04:19'
+updated_date: '2026-08-15 04:20'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Privacy: startup auto-refresh contacted 7 cloud providers without asking. Gate it behind a one-time consent dialog persisted to [model_catalog] refresh_consent_recorded.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] Startup refresh requires recorded consent
+- [x] No network calls before consent
+- [x] Decline persists auto_refresh_enabled=false
+- [x] Tests cover gating and modal
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add refresh_consent_recorded setting
+2. Consent modal
+3. App wiring
+4. Tests + ADR-020 amendment
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: new persisted `[model_catalog] refresh_consent_recorded` gate (default `false`, privacy-safe: only explicit boolean `true` counts). Startup scheduler shows `ModelCatalogConsentModal` (UI/Screens/model_catalog_consent.py) instead of refreshing; Allow persists consent + runs the refresh worker, Deny persists `auto_refresh_enabled = false` so the question is never re-asked.
+- Defense in depth: `TldwCli._refresh_model_catalogs` itself re-checks consent, so no code path refreshes unconsented. Settings-screen save no-op guard compares all fields except consent (only the dialog records consent) so a consented config doesn't trigger per-keystroke config rewrites.
+- Default config.toml template ships `refresh_consent_recorded = false`; existing users (key absent) are prompted exactly once.
+- Modified files: tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py, tldw_chatbook/app.py, tldw_chatbook/UI/Screens/model_catalog_consent.py (new), tldw_chatbook/UI/Screens/settings_screen.py, tldw_chatbook/config.py; tests in Tests/LLM_Provider_Catalog/, Tests/UI/, Tests/test_config_model_catalog_defaults.py.
+- ADR: amended backlog/decisions/020-automatic-model-catalog-refresh.md (confirm-first amendment).
+- Verification: full affected suites pass (LLM_Provider_Catalog + consent modal + first-run + config defaults + settings catalog suites, 390 passed); one pre-existing flaky voice-step failure in the live-contract file was verified on the unmodified baseline; ruff clean.
+<!-- SECTION:NOTES:END -->
+

--- a/tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py
+++ b/tldw_chatbook/LLM_Provider_Catalog/model_catalog_settings.py
@@ -32,6 +32,9 @@ class ModelCatalogSettings:
     stale_after_hours: float = DEFAULT_STALE_AFTER_HOURS
     auto_refresh_disabled: frozenset[str] = frozenset()
     write_to_config: frozenset[str] = frozenset()
+    # Privacy gate (ADR-020 amendment): startup refresh stays behind a
+    # one-time user confirmation until this is explicitly true.
+    refresh_consent_recorded: bool = False
 
 
 def _normalized_key_set(value: object) -> frozenset[str]:
@@ -51,12 +54,20 @@ class _ModelCatalogSection(BaseModel):
     stale_after_hours: float = DEFAULT_STALE_AFTER_HOURS
     auto_refresh_disabled: frozenset[str] = frozenset()
     write_to_config: frozenset[str] = frozenset()
+    refresh_consent_recorded: bool = False
 
     @field_validator("auto_refresh_enabled", mode="before")
     @classmethod
     def _fallback_enabled(cls, value: object) -> bool:
         # Non-bool garbage keeps the safe default (refresh enabled).
         return value if isinstance(value, bool) else True
+
+    @field_validator("refresh_consent_recorded", mode="before")
+    @classmethod
+    def _fallback_consent(cls, value: object) -> bool:
+        # Privacy-safe: garbage never counts as consent; only an explicit
+        # boolean true does.
+        return value is True
 
     @field_validator("stale_after_hours", mode="before")
     @classmethod
@@ -83,8 +94,8 @@ def load_model_catalog_settings(settings: Mapping[str, Any] | None) -> ModelCata
     Returns:
         ModelCatalogSettings: Validated settings. Missing section or garbage
         values fall back to safe defaults field by field (refresh enabled,
-        24h staleness, empty provider sets); provider sets hold
-        provider_config_key-normalized names.
+        24h staleness, empty provider sets, consent not recorded); provider
+        sets hold provider_config_key-normalized names.
     """
     section = (settings or {}).get("model_catalog", {})
     if not isinstance(section, Mapping):
@@ -95,4 +106,5 @@ def load_model_catalog_settings(settings: Mapping[str, Any] | None) -> ModelCata
         stale_after_hours=parsed.stale_after_hours,
         auto_refresh_disabled=parsed.auto_refresh_disabled,
         write_to_config=parsed.write_to_config,
+        refresh_consent_recorded=parsed.refresh_consent_recorded,
     )

--- a/tldw_chatbook/UI/Screens/model_catalog_consent.py
+++ b/tldw_chatbook/UI/Screens/model_catalog_consent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from textual import on
+from textual.app import ComposeResult
 from textual.containers import HorizontalGroup, VerticalGroup
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
@@ -54,7 +55,8 @@ class ModelCatalogConsentModal(ModalScreen[bool]):
     }
     """
 
-    def compose(self):
+    def compose(self) -> ComposeResult:
+        """Build the dialog: title, explanatory copy, and action buttons."""
         with VerticalGroup(id="model-catalog-consent-dialog"):
             yield Static(
                 "Check model lists online?",

--- a/tldw_chatbook/UI/Screens/model_catalog_consent.py
+++ b/tldw_chatbook/UI/Screens/model_catalog_consent.py
@@ -1,0 +1,90 @@
+"""One-time consent modal for the startup model catalog refresh (ADR-020)."""
+
+from __future__ import annotations
+
+from textual import on
+from textual.containers import HorizontalGroup, VerticalGroup
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+
+class ModelCatalogConsentModal(ModalScreen[bool]):
+    """Ask, once, before the app contacts cloud providers for model lists.
+
+    Dismisses with True (user allows the online check) or False (stay
+    offline). The answer is persisted by the caller; this modal only
+    collects it.
+    """
+
+    BINDINGS = [("escape", "dismiss(False)", "Don't check")]
+    DEFAULT_CSS = """
+    ModelCatalogConsentModal {
+        align: center middle;
+        background: $background 75%;
+    }
+
+    #model-catalog-consent-dialog {
+        width: 72;
+        height: auto;
+        background: $panel;
+        border: round $accent;
+        padding: 1 2;
+    }
+
+    #model-catalog-consent-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #model-catalog-consent-copy {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #model-catalog-consent-actions {
+        height: 3;
+        align-horizontal: right;
+    }
+
+    #model-catalog-consent-actions Button {
+        min-width: 16;
+        height: 3;
+        border: none;
+        margin-left: 1;
+    }
+    """
+
+    def compose(self):
+        with VerticalGroup(id="model-catalog-consent-dialog"):
+            yield Static(
+                "Check model lists online?",
+                id="model-catalog-consent-title",
+            )
+            yield Static(
+                "tldw can fetch up-to-date model lists from your configured "
+                "cloud providers (OpenAI, Anthropic, MistralAI, Moonshot, "
+                "OpenRouter, QwenCloud, ZAI) at startup. This contacts those "
+                "endpoints over the network using your configured API keys.\n\n"
+                "Allow this once and it stays on until you turn it off in "
+                "Settings. Nothing is checked until you say yes.",
+                id="model-catalog-consent-copy",
+            )
+            with HorizontalGroup(id="model-catalog-consent-actions"):
+                yield Button(
+                    "Don't check",
+                    id="model-catalog-consent-deny",
+                    variant="default",
+                )
+                yield Button(
+                    "Check online",
+                    id="model-catalog-consent-allow",
+                    variant="primary",
+                )
+
+    @on(Button.Pressed, "#model-catalog-consent-allow")
+    def _allow(self) -> None:
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#model-catalog-consent-deny")
+    def _deny(self) -> None:
+        self.dismiss(False)

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -10394,8 +10394,22 @@ class SettingsScreen(BaseAppScreen):
                 ],
             }
         }
-        if load_model_catalog_settings(section_values) == load_model_catalog_settings(
-            load_settings()
+        # Compare every field EXCEPT consent: only the one-time startup
+        # dialog records consent, and the write below never touches it.
+        # Including it here would make a consented config never compare
+        # equal, rewriting config.toml on every toggle/keystroke.
+        candidate = load_model_catalog_settings(section_values)
+        current = load_model_catalog_settings(load_settings())
+        if (
+            candidate.auto_refresh_enabled,
+            candidate.stale_after_hours,
+            candidate.auto_refresh_disabled,
+            candidate.write_to_config,
+        ) == (
+            current.auto_refresh_enabled,
+            current.stale_after_hours,
+            current.auto_refresh_disabled,
+            current.write_to_config,
         ):
             return
         self._persist_model_catalog_section_values(section_values)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10028,6 +10028,12 @@ class TldwCli(
             catalog_settings = load_model_catalog_settings(load_settings())
             if not catalog_settings.auto_refresh_enabled:
                 return
+            if not catalog_settings.refresh_consent_recorded:
+                # ADR-020 amendment: the startup check is confirm-first.
+                # Scheduling-side consent gate normally intercepts this
+                # before the worker spawns; keep the check here so the
+                # refresh never runs unconsented by any other path.
+                return
             report = await self.local_llm_provider_catalog_service.refresh_stale_configured_providers(
                 catalog_settings=catalog_settings,
                 disk_store=self.model_catalog_disk_store,
@@ -10066,7 +10072,12 @@ class TldwCli(
         after_setup_completion: bool = False,
         environ: Mapping[str, str] | None = None,
     ) -> bool:
-        """Schedule the automatic catalog pass once when setup releases it."""
+        """Schedule the automatic catalog pass once when setup releases it.
+
+        ADR-020 amendment (confirm-first): when the user has never answered
+        the consent question, a modal is shown instead of the refresh; the
+        refresh itself is only scheduled from the consent callback.
+        """
         if getattr(self, "_startup_model_catalog_refresh_scheduled", False):
             return False
         if not after_setup_completion and setup_owns_startup_networking(
@@ -10075,6 +10086,24 @@ class TldwCli(
         ):
             return False
 
+        try:
+            from tldw_chatbook.LLM_Provider_Catalog.model_catalog_settings import (
+                load_model_catalog_settings,
+            )
+
+            catalog_settings = load_model_catalog_settings(load_settings())
+        except Exception as exc:
+            logger.error(
+                f"Failed to load model catalog settings: {type(exc).__name__}"
+            )
+            return False
+        if catalog_settings.auto_refresh_enabled and (
+            not catalog_settings.refresh_consent_recorded
+        ):
+            self._startup_model_catalog_refresh_scheduled = True
+            self.call_after_refresh(self._push_model_catalog_consent_modal)
+            return True
+
         self._startup_model_catalog_refresh_scheduled = True
         self.run_worker(
             self._refresh_model_catalogs,
@@ -10082,6 +10111,55 @@ class TldwCli(
             group="model-catalog-refresh",
         )
         return True
+
+    def _push_model_catalog_consent_modal(self) -> None:
+        """Show the one-time consent dialog for online model-list checks."""
+        try:
+            from tldw_chatbook.UI.Screens.model_catalog_consent import (
+                ModelCatalogConsentModal,
+            )
+        except Exception as exc:
+            logger.error(
+                f"Failed to load model catalog consent modal: {type(exc).__name__}"
+            )
+            return
+        self.push_screen(ModelCatalogConsentModal(), self._handle_model_catalog_consent)
+
+    async def _handle_model_catalog_consent(self, allowed: bool | None) -> None:
+        """Persist the consent answer; on allow, run the startup refresh."""
+        allowed = bool(allowed)
+        try:
+            from tldw_chatbook.config import save_settings_to_cli_config
+
+            section = {"refresh_consent_recorded": True}
+            if not allowed:
+                section["auto_refresh_enabled"] = False
+            saved = await asyncio.to_thread(
+                save_settings_to_cli_config, {"model_catalog": section}
+            )
+        except Exception as exc:
+            # No traceback: the log file sink runs with diagnose=True, which
+            # would dump frame locals (including the app's config) into the log.
+            logger.error(f"Failed to persist model catalog consent: {type(exc).__name__}")
+            saved = False
+        if allowed:
+            if not saved:
+                self.notify(
+                    "Your choice couldn't be saved; you'll be asked again next launch.",
+                    title="Model catalog",
+                    severity="warning",
+                )
+            self.run_worker(
+                self._refresh_model_catalogs,
+                exclusive=True,
+                group="model-catalog-refresh",
+            )
+        else:
+            self.notify(
+                "Online model-list checks stay off. You can enable them any "
+                "time in Settings.",
+                title="Model catalog",
+            )
 
     @on(ModelCatalogRefreshed)
     async def on_model_catalog_refreshed(self, event: ModelCatalogRefreshed) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10116,6 +10116,11 @@ class TldwCli(
 
     def _push_model_catalog_consent_modal(self) -> None:
         """Show the one-time consent dialog for online model-list checks."""
+        if self.is_headless:
+            # Headless/embedded runs have no user to answer a modal; stay
+            # unconsented (no refresh) rather than blocking startup behind
+            # an unanswerable dialog.
+            return
         try:
             from tldw_chatbook.UI.Screens.model_catalog_consent import (
                 ModelCatalogConsentModal,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10094,7 +10094,9 @@ class TldwCli(
             catalog_settings = load_model_catalog_settings(load_settings())
         except Exception as exc:
             logger.error(
-                f"Failed to load model catalog settings: {type(exc).__name__}"
+                "Failed to load model catalog settings for startup refresh "
+                f"scheduling (after_setup_completion={after_setup_completion}): "
+                f"{type(exc).__name__}"
             )
             return False
         if catalog_settings.auto_refresh_enabled and (
@@ -10120,14 +10122,18 @@ class TldwCli(
             )
         except Exception as exc:
             logger.error(
-                f"Failed to load model catalog consent modal: {type(exc).__name__}"
+                "Failed to import the model catalog consent modal "
+                f"(screen=model_catalog_consent): {type(exc).__name__}"
             )
             return
         self.push_screen(ModelCatalogConsentModal(), self._handle_model_catalog_consent)
 
     async def _handle_model_catalog_consent(self, allowed: bool | None) -> None:
         """Persist the consent answer; on allow, run the startup refresh."""
-        allowed = bool(allowed)
+        # Only the boolean singleton True counts as consent — truthy garbage
+        # (e.g. a non-bool reaching this callback) falls through to the deny
+        # path, mirroring the settings parser's strict validator.
+        allowed = allowed is True
         try:
             from tldw_chatbook.config import save_settings_to_cli_config
 
@@ -10140,7 +10146,11 @@ class TldwCli(
         except Exception as exc:
             # No traceback: the log file sink runs with diagnose=True, which
             # would dump frame locals (including the app's config) into the log.
-            logger.error(f"Failed to persist model catalog consent: {type(exc).__name__}")
+            logger.error(
+                "Failed to persist model catalog consent "
+                f"(allowed={allowed!r}, section=model_catalog): "
+                f"{type(exc).__name__}"
+            )
             saved = False
         if allowed:
             if not saved:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2958,6 +2958,9 @@ local_mlx_lm = ["None"]
 [model_catalog]
 # Automatic model-list refresh for cloud providers (ADR-020).
 auto_refresh_enabled = true
+# The startup check is confirm-first: nothing is contacted online until the
+# user answers the one-time consent dialog (which sets this to true).
+refresh_consent_recorded = false
 stale_after_hours = 24 # 0 = refetch every launch
 auto_refresh_disabled = [] # exact [providers] keys to opt out, e.g. ["ZAI"]
 write_to_config = [] # exact [providers] keys whose new models append to this file


### PR DESCRIPTION
## Summary

Privacy change (ADR-020 amendment, task-16318): the startup model-catalog auto-refresh contacted seven cloud providers (OpenAI, Anthropic, MistralAI, Moonshot, OpenRouter, QwenCloud, ZAI) over the network without asking. It is now **confirm-first**.

- New persisted setting `[model_catalog] refresh_consent_recorded` (default `false`). Only an explicit boolean `true` counts as consent — garbage values fall back to not-consented (privacy-safe).
- New one-time `ModelCatalogConsentModal` shown at startup instead of the refresh. It names the providers involved. **Allow** persists consent and runs the refresh; **Deny** persists `auto_refresh_enabled = false` alongside the recorded consent, so the question is asked exactly once either way. Escape counts as deny.
- Defense in depth: `TldwCli._refresh_model_catalogs` re-checks consent itself, so no code path can refresh unconsented. If the config write fails on allow, the session choice still runs with a warning that the answer wasn't persisted.
- Settings screen save no-op guard compares all fields **except** consent (only the dialog records it) — prevents consented configs from triggering per-keystroke config.toml rewrites.
- Default config template ships `refresh_consent_recorded = false`; existing installs (key absent) are prompted exactly once.

## Test plan

- [x] `Tests/LLM_Provider_Catalog/` — consent parsing (default/garbage/explicit-true), refresh gating (disabled / unconsented / garbage consent), consent handler persistence (allow, deny, save-failure), notification formatting (387 passed across affected suites)
- [x] `Tests/UI/test_model_catalog_consent_modal.py` — modal dismisses True/False via buttons and escape; lands on screen stack wired to the handler
- [x] `Tests/UI/test_product_maturity_phase1_first_run.py` — scheduler routes unconsented startups to the modal, not the worker; consented startups schedule the worker once; full-app first-run fixtures suppress the dialog
- [x] `Tests/test_config_model_catalog_defaults.py` — template default is consent-unrecorded
- [x] ruff clean on all touched files
- [x] One pre-existing flaky failure in `test_first_run_wizard_live_contract.py` (voice-step) verified on the unmodified baseline

## Docs

- ADR-020 amended: `backlog/decisions/020-automatic-model-catalog-refresh.md` (confirm-first amendment, incl. why the Settings toggle was rejected as a consent source)
- Task: `backlog/tasks/task-16318 - Make-model-catalog-online-check-confirm-first.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit consent before startup model-catalog online checks. Previously the app contacted seven providers at launch without asking; now it prompts once and only refreshes after explicit consent. In headless runs, the modal is suppressed and no refresh runs.

- Add `refresh_consent_recorded` to `[model_catalog]` (default `false`); only the boolean `True` counts as consent.
- Gate scheduling: when consent is missing and `auto_refresh_enabled` is true, show `ModelCatalogConsentModal` instead of spawning the worker; `_refresh_model_catalogs` re-checks consent to block unconsented paths.
- Consent handling: Allow persists consent and schedules the refresh; Deny persists `auto_refresh_enabled = false` and notifies; Escape counts as deny. If persistence fails on allow, run the refresh once and warn.
- Headless suppression: `is_headless` prevents pushing the modal; startup proceeds without network I/O and without blocking CI.
- Settings screen excludes consent from its save no-op comparison; the modal is the sole consent recorder.
- Default config ships `refresh_consent_recorded = false`; existing installs (key absent) are prompted once in interactive runs. Tests cover gating, strict `True` handling, modal dismissals, scheduler routing, headless suppression, and config defaults.

<sup>Written for commit 34831c77695626abfd3b945131591a7417a9ff66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

