### PR TITLE
feat: Console trajectory view (turn-grouped trace ledger, timing/token inspector, live tail-follow)

### DIFF
--- a/Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+++ b/Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
@@ -1,0 +1,196 @@
+# Console Trajectory View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A trajectory (trace) screen over Console conversations: turn-grouped event ledger with tool-call nesting, per-record token/timing inspector, search, and live tail-follow.
+
+**Architecture:** Schema v38 local-only sidecar table `message_trajectory_metadata` is the sole persisted home for turn identity, per-record timing, and tool records (TOOL messages are deliberately never persisted to `messages`). A pure projection module folds messages + usage + sidecar + variants + compaction into a `TrajectorySnapshot`; a Console-launched screen renders it. Brushable timeline is a follow-up task.
+
+**Tech Stack:** Python 3.11, Textual 8.x DataTable, SQLite (existing migration runner pattern), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md` — read it first; this plan argues from it.
+**ADR:** `backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`
+
+## Global Constraints
+
+- Sidecar table is **local-only**: never added to sync triggers, never serialized to sync payloads (same rule as `usage_json`/`metadata_json`, ADR-010).
+- Never violate the TOOL-marker invariant: tool records go **only** in the sidecar.
+- Never fabricate timing: NULL timing renders blank.
+- Keybindings per ADR-031: single-letter htop-style, no terminal-convention keys; footer hints 1:1 with implemented actions.
+- All SQL parameterized; `seq` assigned inside the same transaction as the insert.
+- Package root is `tldw_chatbook/tldw_chatbook/`; tests under `tldw_chatbook/Tests/`.
+
+---
+
+### Task 1: Schema v38 migration + sidecar DB accessors
+
+**Files:**
+- Create: `tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql`
+- Modify: `tldw_chatbook/DB/ChaChaNotes_DB.py` (bump `_CURRENT_SCHEMA_VERSION` 37→38; add `_migrate_from_v37_to_v38` next to `_migrate_from_v36_to_v37` at ~line 4964; add accessor methods near `update_message_usage_local` at ~line 9778)
+- Test: `tldw_chatbook/Tests/DB/test_chachanotes_trajectory_metadata_migration.py`
+
+**Interfaces:**
+- Consumes: existing migration-runner pattern (`_get_db_version`, `SchemaError`, `self.transaction()`); `update_message_usage_local` precedent for local-only columns.
+- Produces (Task 2/3 consume):
+  - `upsert_trajectory_rows(rows: Sequence[TrajectoryRowWrite]) -> None` where `TrajectoryRowWrite` is a dataclass `(message_id: str, conversation_id: str, turn_id: str, seq: int, event_kind: str, step_started_at: float | None, first_token_at: float | None, completed_at: float | None, model: str | None, provider: str | None, payload_json: str | None)`. Seq assignment: rows written with `seq=None` get `max(seq)+1` per conversation inside one transaction; explicit seqs are honored (upsert-by-seq: `INSERT ... ON CONFLICT(message_id, event_kind, seq) DO UPDATE`).
+  - `get_trajectory_rows(conversation_id: str) -> list[TrajectoryRowRead]` ordered by `seq` (includes rows whose message was soft-deleted; the projection filters).
+  - `get_next_trajectory_seq(conversation_id: str) -> int` (used inside transactions by the store).
+
+- [ ] **Step 1: Write the failing migration test** (NOTE: `db.get_schema_version`/`db.create_conversation`/`db.add_message`/`db.execute` below are illustrative — match the real signatures in `ChaChaNotes_DB.py` and existing `Tests/DB/test_chachanotes_*_migration.py` files)
+
+```python
+# tldw_chatbook/Tests/DB/test_chachanotes_trajectory_metadata_migration.py
+import pytest
+from tldw_chatbook.DB.ChaChaNotes_DB import ChaChaNotesDB, SchemaError
+
+def test_migrates_v37_to_v38_and_creates_table(tmp_path):
+    db = ChaChaNotesDB(tmp_path / "test.db", client_id="test")
+    assert db.get_schema_version() == 38  # or equivalent version accessor
+    cols = {r["name"] for r in db.execute("PRAGMA table_info(message_trajectory_metadata)")}
+    assert {"message_id", "conversation_id", "turn_id", "seq", "event_kind",
+            "step_started_at", "first_token_at", "completed_at",
+            "model", "provider", "payload_json"} <= cols
+    idx = {r["name"] for r in db.execute("PRAGMA index_list(message_trajectory_metadata)")}
+    assert any("conv_seq" in n for n in idx)
+
+def test_upsert_and_read_roundtrip(tmp_path):
+    db = ChaChaNotesDB(tmp_path / "test.db", client_id="test")
+    conv = db.create_conversation(name="t")  # match existing factory signature
+    msg = db.add_message(conversation_id=conv, sender="user", content="hi")
+    db.upsert_trajectory_rows([TrajectoryRowWrite(
+        message_id=msg, conversation_id=conv, turn_id=msg, seq=None,
+        event_kind="user", step_started_at=1.0, first_token_at=None,
+        completed_at=None, model=None, provider=None, payload_json=None)])
+    rows = db.get_trajectory_rows(conv)
+    assert len(rows) == 1 and rows[0].seq == 1 and rows[0].event_kind == "user"
+    # multiple tool_calls under one assistant message: distinct seqs
+    db.upsert_trajectory_rows([
+        TrajectoryRowWrite(message_id=msg, conversation_id=conv, turn_id=msg, seq=None,
+                           event_kind="tool_call", step_started_at=1.0, first_token_at=None,
+                           completed_at=2.0, model="m", provider="p", payload_json='{"n":1}'),
+        TrajectoryRowWrite(message_id=msg, conversation_id=conv, turn_id=msg, seq=None,
+                           event_kind="tool_call", step_started_at=1.0, first_token_at=None,
+                           completed_at=3.0, model="m", provider="p", payload_json='{"n":2}'),
+    ])
+    rows = db.get_trajectory_rows(conv)
+    assert [r.seq for r in rows] == [1, 2, 3]
+```
+
+- [ ] **Step 2: Run it to verify it fails** — `pytest Tests/DB/test_chachanotes_trajectory_metadata_migration.py -v`; expect failures (version still 37, table missing).
+- [ ] **Step 3: Write the migration SQL** — table + indexes exactly as in the spec's schema block, ending with `UPDATE db_schema_version SET version = 38;` (copy the header-comment style of `chachanotes_v36_to_v37_provider_continuation.sql`).
+- [ ] **Step 4: Add the runner** — `_migrate_from_v37_to_v38` mirroring `_migrate_from_v36_to_v37` (version guard → PRAGMA table_info idempotence check on `message_trajectory_metadata` → statement-split execution via `sqlite3.complete_statement`), registered in the migration dispatch chain; bump `_CURRENT_SCHEMA_VERSION` to 38. Define `TrajectoryRowWrite`/`TrajectoryRowRead` dataclasses in `ChaChaNotes_DB.py` and implement `upsert_trajectory_rows`/`get_trajectory_rows`/`get_next_trajectory_seq` with parameterized SQL and transactional seq assignment.
+- [ ] **Step 5: Run tests** — the new file passes; also run `pytest Tests/DB/ -q` for migration regressions.
+- [ ] **Step 6: Commit** — `git commit -m "feat(db): schema v38 message_trajectory_metadata sidecar + accessors"`
+
+### Task 2: Capture timing + tool records in the Console persistence seam
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` (persist-time hook where `turn_id` is assigned, ~lines 4521/4604; tool-marker append path ~line 2112)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`_stream_assistant_response_inner` ~line 8939: stamp `step_started_at` before the provider call and `first_token_at` on first chunk; `_attach_stream_usage` ~line 9487: stamp `completed_at` and write sidecar rows via `upsert_trajectory_rows`)
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py` (thread the writes through the same seam as `update_message_usage`)
+- Test: `tldw_chatbook/Tests/Chat/test_trajectory_capture.py`
+
+**Interfaces:**
+- Consumes: Task 1's `upsert_trajectory_rows`/`TrajectoryRowWrite`; `ConsoleChatMessage.turn_id`, `usage`, `tool_output_full`.
+- Produces: every persisted Console message gets a `user`/`assistant` sidecar row; every tool marker gets `tool_call` and/or `tool_result` rows keyed to its parent assistant message with `payload_json = json.dumps({"name": ..., "args": ..., "result": full_output})`. Timing fields populated for streamed assistant rows.
+
+- [ ] **Step 1: Write failing tests** — unit tests with an in-memory store + temp DB: (a) persisted user message produces a `user` row with `turn_id == message.turn_id`; (b) tool marker append produces `tool_call` + `tool_result` rows with full payload and parent assistant `message_id`; (c) a simulated stream (fake chunk callback) yields `first_token_at` set and `first_token_at - step_started_at > 0`, `completed_at >= first_token_at`; (d) concurrent `upsert_trajectory_rows` calls (two threads, same conversation) produce unique seqs.
+- [ ] **Step 2: Verify they fail.**
+- [ ] **Step 3: Implement** — timing stamps as module-level mutable capture attached to the turn in the controller (plain dict on the streamSignals-like object passed to `_attach_stream_usage`); sidecar writes batched at finalize (same place usage is attached) so one turn = one upsert call; tool payload written at marker-append time using the existing `tool_output_full` argument. **Cap the stored result** at 256 KiB with a `{"truncated": true}` marker in `payload_json` (full output remains available live in-session via `tool_output_full`). Guard all writes in try/except that logs with context and never fails the turn.
+- [ ] **Step 4: Run** — new tests pass; `pytest Tests/Chat/ -q` green.
+- [ ] **Step 5: Commit** — `git commit -m "feat(console): capture trajectory timing and tool records to sidecar"`
+
+### Task 3: Pure projection module
+
+**Files:**
+- Create: `tldw_chatbook/Chat/trajectory.py`
+- Test: `tldw_chatbook/Tests/Chat/test_trajectory_projection.py`
+
+**Interfaces:**
+- Consumes: message rows from DB (or `ConsoleChatMessage` models), `ProviderUsage.from_json(usage_json)`, `TrajectoryRowRead`, variant sets, compaction records from `console_context_repository`, and the conversation's **`active_leaf_message_id`** (local-only column from the v23→24 migration). Active path = walk `parent_message_id` from that leaf to the root; siblings off that chain are variants.
+- Produces:
+
+```python
+@dataclass(frozen=True)
+class TrajectoryRecord:
+    seq: int
+    kind: str                    # user | assistant | tool_call | tool_result | compaction
+    turn_id: str
+    message_id: str | None
+    content_preview: str         # first 120 chars, single line
+    usage: ProviderUsage | None
+    step_started_at: float | None
+    first_token_at: float | None
+    completed_at: float | None
+    model: str | None
+    provider: str | None
+    payload: dict | None         # tool records only
+    variants: tuple[str, ...]    # superseded variant contents, active-path rendering
+    depth: int                   # 0 = top-level, 1 = tool record under assistant step
+
+@dataclass(frozen=True)
+class TrajectoryTurn:
+    turn_id: str
+    records: tuple[TrajectoryRecord, ...]
+
+@dataclass(frozen=True)
+class TrajectorySnapshot:
+    turns: tuple[TrajectoryTurn, ...]
+
+def derive_trajectory(messages, usage_by_id, traj_rows, variant_sets, compaction_records) -> TrajectorySnapshot: ...
+```
+
+- [ ] **Step 1: Write failing tests** — grouping (turn starts at each `user` record), tool nesting (`depth=1`, ordered by seq under the owning assistant record), NULL timing → None fields (never derived/fabricated), seq tie-break ordering, soft-deleted messages excluded, variants surfaced on the owning record not as rows, compaction records rendered as between-turn records with `message_id=None`, empty conversation → empty snapshot.
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement** `derive_trajectory` — pure stdlib only, no Textual/DB imports; takes plain sequences. Legacy fallback: messages without sidecar rows group by timestamp adjacency (same calendar second as the preceding user message joins its turn).
+- [ ] **Step 4: Run tests** — pass; `pytest Tests/Chat/test_trajectory_projection.py -q`.
+- [ ] **Step 5: Commit** — `git commit -m "feat(chat): trajectory projection module"`
+
+### Task 4: Trajectory screen (ledger, collapse, inspector, search)
+
+**Files:**
+- Create: `tldw_chatbook/UI/Screens/trajectory_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (launch binding only — see Task 5 for the live wiring if split)
+- Test: `tldw_chatbook/Tests/UI/test_trajectory_screen.py`
+
+**Interfaces:**
+- Consumes: `TrajectorySnapshot` from Task 3; `register_footer_shortcuts`/`clear_footer_shortcuts` pattern from `evals_screen.py`.
+- Produces: `TrajectoryScreen(screen_title=..., conversation_id=...)` — App.push_screen-compatible Screen with `BINDINGS` for `escape` (dismiss), `t` (collapse/expand turn), `i` (inspector toggle), `/` (search focus), `enter` (open inspector on cursor row).
+
+- [ ] **Step 1: Write failing tests** (Textual pilot, pattern from existing UI tests): mounting with a snapshot renders one row per record plus turn header rows; `t` toggles collapse of the focused turn (child rows hidden); cursor-on-row + `enter` shows inspector pane with usage breakdown (uncached input / cache read / cache write / output), timing (start → first token → completed, blank when NULL), model/provider, full tool payload for tool records; `/` + query filters rows (turn header survives if any child matches); ADR-031 governance test passes (footer hints 1:1 with bindings).
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement** — vertical layout: search Input on top, DataTable (`cursor_type="row"`) middle, inspector LogRich/Static bottom (hidden until toggled). Render newest page first: if `len(records) > 500`, mount the last 500 and put a "load earlier" key (`e`) row at top. No worker requirement at this size; large-conversation loading moves to a worker (`run_worker`) when records > 5000.
+- [ ] **Step 4: Run** — new tests pass; run the ADR-031 footer suite (`pytest Tests/UI/ -q -k footer or keybinding`).
+- [ ] **Step 5: Commit** — `git commit -m "feat(ui): trajectory screen with ledger, inspector, search"`
+
+### Task 5: Launch from Console + live tail-follow
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` or the snapshot-revision bus the Console already uses (`_bump_payload_revision`) — subscribe-and-refresh
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (single-letter binding, ADR-031-legal, to push `TrajectoryScreen`; footer hint registration)
+- Modify: `tldw_chatbook/UI/Screens/trajectory_screen.py` (follow logic)
+- Test: `tldw_chatbook/Tests/UI/test_trajectory_live.py`
+
+**Interfaces:**
+- Consumes: a **public revision getter on the store** — `get_payload_revision(session_id) -> int` (expose the existing `_payload_revisions` counter; there is no observer bus, and streaming does not bump it, so the screen must ALSO treat `len(session messages)` as part of its revision check, or bump `_bump_payload_revision` in the Task 2 write path — do the latter: make the trajectory write path call `_bump_payload_revision(session_id)` so the counter moves on every trajectory-visible change).
+- Produces: trajectory refreshes on revision; follows tail (scroll to bottom) unless the user scrolled up; footer action `f` re-enables follow.
+
+- [ ] **Step 1: Write failing tests** — appending a message to the open conversation updates the open trajectory screen; scrolling up suspends follow (new records do not scroll); `f` resumes follow.
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement** — `TrajectoryScreen` polls `get_payload_revision(conversation_id)` via `set_interval(0.5)`; on change, recompute the snapshot in a worker; DataTable diffed by row key `(seq)` so selection survives refresh; escape pops the screen and clears footer shortcuts.
+- [ ] **Step 4: Run** — new tests pass; `pytest Tests/UI/ Tests/Chat/ -q`.
+- [ ] **Step 5: Full suite + commit** — `pytest` (whole suite), then `git commit -m "feat(console): trajectory screen launch + live tail-follow"`.
+
+### Task 6: Docs + backlog hygiene
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md` (status → implemented), ADR-066 if deviations occurred.
+- Backlog task files updated (Implementation Notes, ACs checked) via `backlog task edit`.
+
+- [ ] **Step 1:** Verify every AC in the backlog tasks; write Implementation Notes; mark Done via CLI.
+- [ ] **Step 2:** Add a lessons entry ONLY if something non-obvious was learned (e.g., TOOL-marker invariant interplay).
+- [ ] **Step 3:** Commit docs.
+
+---
+
+**Follow-up (separate backlog task, not in this plan):** brushable/zoomable timeline strip widget using `seq` + timestamps, with brush-to-filter synced to the ledger.

--- a/Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md
+++ b/Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md
@@ -1,7 +1,7 @@
 # Console Trajectory View — Design
 
 Date: 2026-08-14
-Status: Approved direction (this doc pending user review)
+Status: Implemented (2026-08-14)
 Inspirational reference: deepseek-harness `packages/client/ui-trajectory` ("Trajectory" tab; server-side `traceSession`/`traceEvent` query APIs)
 
 ## Goal

--- a/Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md
+++ b/Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md
@@ -1,0 +1,193 @@
+# Console Trajectory View — Design
+
+Date: 2026-08-14
+Status: Approved direction (this doc pending user review)
+Inspirational reference: deepseek-harness `packages/client/ui-trajectory` ("Trajectory" tab; server-side `traceSession`/`traceEvent` query APIs)
+
+## Goal
+
+Give the Console a trajectory (trace) view over a conversation: an event ledger
+grouped by turn with tool-call nesting, a per-record inspector showing token
+usage and timing, search, and live tail-follow during streaming. A brushable
+duration timeline is planned as a follow-up task and is deliberately out of
+scope here, but the data model must support it.
+
+Scope: **all Console conversations** (character conversations included — they
+are Console conversations with tool-calling capability).
+
+Non-goals (v1):
+
+- Brushable/zoomable timeline strip (follow-up task; data model must enable it).
+- dsh-style append-only parallel event log. Chatbook's `messages` table +
+  variant sets + compaction repository already form the normalized event
+  history; we do not duplicate it.
+- Synced trajectory data. All new storage is local-only, like `usage_json`
+  and `metadata_json`.
+- Editing or replaying from the trajectory view; it is read-only.
+
+## What exists today (verified)
+
+- Schema v37 (`ChaChaNotes_DB.py`). `messages` has `timestamp`,
+  `last_modified`, local-only `usage_json` (v30) and `metadata_json` (v31).
+- `ProviderUsage` (`Chat/provider_usage.py`) already normalizes
+  uncached_input / cache_read / cache_write / output (+audio, partial) per
+  provider payload, persisted per message via `update_message_usage`.
+- Turn identity exists **in memory only**: `ConsoleChatMessage.turn_id`,
+  assigned at persist time in `console_chat_store.py`.
+- Forking = per-turn regenerated variants (`ConsoleVariantSet`), persisted as
+  message rows. Compaction = transactional, branch-safe
+  (`Chat/console_context_compaction.py` + `console_context_repository.py`).
+- Timing (step start / first token / completion) is captured **nowhere**.
+- Console screen: `UI/Screens/chat_screen.py` with `UI/Console_Modules/*`;
+  DataTable + footer-shortcut patterns in `evals_screen.py`; keybinding rules
+  in ADR-031.
+
+## Data model — schema v38 sidecar table
+
+New local-only table `message_trajectory_metadata`, following the
+`message_generation_metadata` (v24→25) precedent:
+
+```sql
+CREATE TABLE IF NOT EXISTS message_trajectory_metadata(
+  message_id      TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  turn_id         TEXT NOT NULL,
+  seq             INTEGER NOT NULL,           -- per-conversation monotonic order
+  event_kind      TEXT NOT NULL,              -- user | assistant | tool_call | tool_result
+  step_started_at REAL,                       -- unix seconds; NULL when unknown
+  first_token_at  REAL,
+  completed_at    REAL,
+  model           TEXT,
+  provider        TEXT,
+  payload_json    TEXT,                       -- tool records ONLY: name/args/result
+                                              -- (incl. full untruncated output);
+                                              -- NULL for user/assistant rows
+  PRIMARY KEY (message_id, event_kind, seq)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trajmeta_conv_seq
+  ON message_trajectory_metadata(conversation_id, seq);
+CREATE INDEX IF NOT EXISTS idx_trajmeta_msg ON message_trajectory_metadata(message_id);
+```
+
+Design points:
+
+- **Sidecar, not ALTER on `messages`**: trajectory facts evolve independently
+  of the synced message core. Future columns (timeline filter ranges, lineage
+  seqs, cost roll-ups) are added here via new migrations without touching sync
+  triggers. This is the long-term-stability/extendability trade: stable synced
+  core, evolvable local edge.
+- **The sidecar is the sole persisted home for tool records.** Verified:
+  TOOL-role messages are deliberately session-only display markers in
+  `console_chat_store.py` (never persisted, never tree nodes — the
+  TOOL-marker invariant), and `tool_output_full` is likewise session-only.
+  Writing tool records into `messages` would violate that invariant, so
+  `tool_call`/`tool_result` rows live entirely in this table, with
+  `payload_json` carrying the tool result, capped at 256 KiB with a
+  `{"truncated": true}` marker beyond that (full output stays available live
+  in-session). The trajectory view becomes the only place historical tool
+  output is reviewable — a feature, not a workaround. Both kinds key on the
+  *parent assistant message's* `message_id`; `seq` orders multiple tool calls
+  within one assistant step.
+- **PK is `(message_id, event_kind, seq)`**: one assistant message may emit
+  several tool calls, so `(message_id, event_kind)` alone would collide. The
+  unique `(conversation_id, seq)` index enforces ledger ordering; writes are
+  upsert-by-seq.
+- **NULLable timing**: older messages and non-streamed records simply have
+  NULL timing; the view renders blanks (mirrors dsh: never fabricate
+  durations for in-flight rows).
+- **`seq`** is assigned at write time (max+1 per conversation) *inside the
+  same transaction as the insert*, so concurrent writers (hands-free,
+  compaction auxiliary turns) cannot collide.
+- **Turn boundaries are derived, not stored as rows**: a turn starts at each
+  user record. Compaction markers are likewise NOT sidecar rows — compaction
+  produces no persisted message row; the projection reads compaction
+  transactions from `console_context_repository` and renders them as
+  between-turn markers.
+- **Branch semantics**: the ledger renders the **active path** by default —
+  derived by walking `parent_message_id` from the persisted local-only
+  `conversations.active_leaf_message_id` (v23→24) to the root.
+  Superseded variants (tree siblings off the active path) are not top-level
+  rows; the inspector of a record with variants lists them (contents +
+  selection state), keeping forking history visible without cluttering the
+  ledger.
+- **Soft-deleted messages are excluded**: the projection joins `messages`
+  and filters `deleted = 0`; orphaned sidecar rows are ignored (`ON DELETE
+  CASCADE` only fires on hard deletes).
+- Migration: `chachanotes_v37_to_v38_message_trajectory_metadata.sql` +
+  PRAGMA-checked Python runner + per-migration test (existing pattern).
+
+## Timing capture
+
+In `console_chat_controller.py` streaming path (`_stream_assistant_response_inner`,
+`_attach_stream_usage` vicinity): record step start (before provider call),
+first-token time (first chunk arrival), completion (stream end), then persist
+through the same seam that writes `usage_json`. Tool-call records get
+start/completion from tool executor boundaries; user/compaction records get
+`step_started_at` only. No provider-layer changes required.
+
+## Projection module
+
+New `tldw_chatbook/Chat/trajectory.py` (pure, no Textual imports):
+
+```
+derive_trajectory(messages, usage_by_id, traj_rows, variant_sets, compaction_records)
+    -> TrajectorySnapshot
+```
+
+- Folds into `turns -> records`, nesting `tool_call`/`tool_result` under the
+  assistant step within the turn (dsh `deriveTrajectoryLayout()` is the
+  reference shape).
+- Each record carries: kind, content preview, token facts
+  (input/cache_read/cache_write/output), timing facts, model/provider,
+  variant annotation (superseded variants shown but marked), compaction
+  markers between turns.
+- Fully unit-testable with plain dataclasses/factories.
+
+## UI — Trajectory screen
+
+Launched from the Console (keybinding on `chat_screen.py`, single-letter per
+ADR-031; footer hint registered via `register_footer_shortcuts`):
+
+- `DataTable` ledger: one row per record; turn-header rows with collapse
+  (per-turn collapse state), nested tool rows indented under assistant steps.
+- Selection inspector pane: tokens (input / cache read / cache write /
+  output), timing (step start → first token → completion, derived duration),
+  model/provider, full tool payload access (from the sidecar's `payload_json`
+  for history; the live in-memory `tool_output_full` while the session is
+  open).
+- Search box filtering rows (turn headers match if any child matches).
+- Live tail-follow: the screen polls a public payload-revision getter on the
+  Console store via `set_interval` (there is no observer bus; the trajectory
+  write path bumps the existing per-session revision counter so polling sees
+  changes) and refreshes in a worker; follows the tail unless the user has
+  scrolled up (follow suspends, resumes via a footer action).
+- Keybindings/footer per ADR-031; modal opens with safe Escape.
+
+## Error handling & performance
+
+- Projection runs in a worker (`run_worker`) for large conversations; ledger
+  renders incrementally (DataTable is virtualized; load newest page first,
+  "load earlier" control at top mirrors dsh pagination).
+- Conversations predating v38 render fine — timing columns are blank; turn
+  grouping falls back to `turn_id` derivation from in-memory restore or
+  timestamp adjacency heuristic (defined once, in the projection module).
+- Missing sidecar rows never block rendering.
+
+## Testing
+
+- Migration test (`Tests/DB/test_chachanotes_trajectory_metadata_migration.py`).
+- Unit tests: timing capture seam, `derive_trajectory` (turn grouping,
+  nesting, variants, compaction, NULL timing, tie-ordering by `seq`).
+- UI tests: screen mounting, collapse, inspector contents, search filter,
+  tail-follow suspend/resume; footer-hint governance test per ADR-031 suite.
+
+## ADR
+
+Required: schema + cross-module decision.
+Path: `backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`
+(created before implementation; linked from the backlog tasks).
+
+## Follow-up (separate tasks, out of scope here)
+
+1. Brushable/zoomable timeline strip widget (uses `seq` + timestamps).
+2. Optional: lineage view over variants/compaction (dsh `traceEvent` analog).

--- a/Tests/Chat/test_trajectory_capture.py
+++ b/Tests/Chat/test_trajectory_capture.py
@@ -1,0 +1,319 @@
+"""Trajectory sidecar capture (schema v38, task 2).
+
+Covers the Console persistence seam: every persisted Console message gets a
+``user``/``assistant`` sidecar row, every TOOL marker gets ``tool_call`` +
+``tool_result`` rows keyed to the parent assistant message (TOOL-marker
+invariant: markers themselves are never persisted to ``messages``), and
+streamed assistant rows carry step-start/first-token/completion timing.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, TrajectoryRowWrite
+
+
+def _store_with_db(tmp_path):
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    return db, store
+
+
+def test_persisted_user_message_produces_user_trajectory_row(tmp_path):
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        user = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="hello",
+            persist=True,
+        )
+
+        rows = db.get_trajectory_rows(conversation_id)
+        assert [row.event_kind for row in rows] == ["user"]
+        row = rows[0]
+        assert row.message_id == user.persisted_message_id
+        assert row.turn_id == store.get_message(user.id).turn_id
+        assert row.payload_json is None
+    finally:
+        db.close()
+
+
+def test_tool_marker_append_produces_tool_call_and_result_rows(tmp_path):
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="list the files",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="working on it",
+            persist=True,
+        )
+
+        marker = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_list → (3 files)",
+            tool_output_full="file-a\nfile-b\nfile-c",
+        )
+        assert marker.role is ConsoleMessageRole.TOOL
+        # TOOL-marker invariant: the marker itself is never a persisted row.
+        assert marker.persisted_message_id is None
+
+        rows = db.get_trajectory_rows(conversation_id)
+        tool_rows = [row for row in rows if row.event_kind.startswith("tool_")]
+        assert sorted(row.event_kind for row in tool_rows) == [
+            "tool_call",
+            "tool_result",
+        ]
+        for row in tool_rows:
+            assert row.message_id == assistant.persisted_message_id
+            payload = json.loads(row.payload_json)
+            assert payload["name"] == "fs_list"
+            assert payload["result"] == "file-a\nfile-b\nfile-c"
+            assert payload.get("truncated") is not True
+    finally:
+        db.close()
+
+
+def test_tool_marker_before_assistant_persist_flushes_on_assistant_persist(tmp_path):
+    """A marker appended while the assistant row is still streaming is buffered
+    and flushed (remapped to the persisted id) when the assistant persists."""
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="go",
+            persist=True,
+        )
+        # Streaming assistant placeholder: NOT yet persisted.
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+        assert assistant.persisted_message_id is None
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_read → preview",
+            tool_output_full="full file contents",
+        )
+        # Nothing writable yet: the marker waits for the parent's durable id.
+        assert db.get_trajectory_rows(conversation_id) == [] or all(
+            row.event_kind == "user"
+            for row in db.get_trajectory_rows(conversation_id)
+        )
+
+        store.append_stream_chunk(assistant.id, "done")
+        completed = store.mark_message_complete(assistant.id)
+        assert completed.persisted_message_id is not None
+
+        tool_rows = [
+            row
+            for row in db.get_trajectory_rows(conversation_id)
+            if row.event_kind.startswith("tool_")
+        ]
+        assert sorted(row.event_kind for row in tool_rows) == [
+            "tool_call",
+            "tool_result",
+        ]
+        for row in tool_rows:
+            assert row.message_id == completed.persisted_message_id
+    finally:
+        db.close()
+
+
+def test_streamed_assistant_row_carries_timing(tmp_path):
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="hi",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            persist=True,
+        )
+
+        step_started = time.time()
+        store.record_trajectory_timing(
+            assistant.id, step_started_at=step_started, model="test-model",
+            provider="test-provider",
+        )
+        time.sleep(0.01)
+        store.append_stream_chunk(assistant.id, "first")
+        time.sleep(0.01)
+        store.record_trajectory_timing(assistant.id, completed_at=time.time())
+
+        completed = store.mark_message_complete(assistant.id)
+        rows = [
+            row
+            for row in db.get_trajectory_rows(conversation_id)
+            if row.event_kind == "assistant"
+        ]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.message_id == completed.persisted_message_id
+        assert row.model == "test-model"
+        assert row.provider == "test-provider"
+        assert row.step_started_at == pytest.approx(step_started, abs=1.0)
+        assert row.first_token_at is not None
+        assert row.first_token_at - row.step_started_at > 0
+        assert row.completed_at >= row.first_token_at
+    finally:
+        db.close()
+
+
+def test_tool_result_capped_at_256kib_with_truncated_marker(tmp_path):
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="go",
+            persist=True,
+        )
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="answer",
+            persist=True,
+        )
+        huge = "x" * (300 * 1024)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_read → preview",
+            tool_output_full=huge,
+        )
+
+        tool_rows = [
+            row
+            for row in db.get_trajectory_rows(conversation_id)
+            if row.event_kind.startswith("tool_")
+        ]
+        assert len(tool_rows) == 2
+        for row in tool_rows:
+            payload = json.loads(row.payload_json)
+            assert payload["truncated"] is True
+            assert len(payload["result"].encode("utf-8")) <= 256 * 1024
+            assert payload["result"] != huge
+    finally:
+        db.close()
+
+
+def test_trajectory_write_failure_never_fails_the_turn(tmp_path):
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        store.persist_session_if_needed(session.id)
+
+        def exploding_writer(**kwargs):
+            raise RuntimeError("sidecar unavailable")
+
+        store.persistence.write_trajectory_rows = exploding_writer
+        # The turn itself must still persist and complete normally.
+        user = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="hello",
+            persist=True,
+        )
+        assert user.persisted_message_id is not None
+        marker = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_read → preview",
+            tool_output_full="ok",
+        )
+        assert marker.persisted_message_id is None
+    finally:
+        db.close()
+
+
+def test_concurrent_upserts_produce_unique_seqs(tmp_path):
+    """Two threads writing trajectory rows for one conversation must produce
+    unique, gap-free seqs. Exercises the Console's write seam
+    (``ChatPersistenceService.write_trajectory_rows``), whose bounded retry
+    absorbs the transient write-write lock contention of concurrent turns;
+    every row lands exactly once with a distinct per-conversation seq."""
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    try:
+        service = ChatPersistenceService(db)
+        conversation_id = db.add_conversation(
+            {"chat_id": 1, "conversation_id": "traj-concurrency", "fragmentation": 0}
+        )
+        assert conversation_id is not None
+
+        message_ids = [
+            db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "assistant",
+                    "content": f"message {index}",
+                }
+            )
+            for index in range(50)
+        ]
+
+        def write_batch(prefix: str, ids: list) -> None:
+            for index in range(25):
+                assert service.write_trajectory_rows(
+                    [
+                        TrajectoryRowWrite(
+                            message_id=ids.pop(),
+                            conversation_id=conversation_id,
+                            turn_id=f"{prefix}-turn",
+                            seq=None,
+                            event_kind="assistant",
+                        )
+                    ]
+                )
+
+        batch_a = message_ids[:25]
+        batch_b = message_ids[25:]
+
+        threads = [
+            threading.Thread(target=write_batch, args=("t0", batch_a)),
+            threading.Thread(target=write_batch, args=("t1", batch_b)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        rows = db.get_trajectory_rows(conversation_id)
+        assert len(rows) == 50
+        seqs = [row.seq for row in rows]
+        assert sorted(seqs) == list(range(1, 51))
+        assert len(set(seqs)) == 50
+    finally:
+        db.close()

--- a/Tests/Chat/test_trajectory_capture.py
+++ b/Tests/Chat/test_trajectory_capture.py
@@ -230,6 +230,54 @@ def test_tool_result_capped_at_256kib_with_truncated_marker(tmp_path):
         db.close()
 
 
+def test_tool_result_cap_is_byte_safe_for_multibyte_content(tmp_path):
+    """The cap is BYTES, not characters: 4-byte emoji content truncated by a
+    character slice could leave the stored result up to 4x over budget."""
+    db, store = _store_with_db(tmp_path)
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="go",
+            persist=True,
+        )
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="answer",
+            persist=True,
+        )
+        # U+1F600 encodes to 4 UTF-8 bytes per character: ~100k chars is
+        # ~400 KiB, well over the 256 KiB byte cap.
+        huge = "😀" * (100 * 1024)
+        assert len(huge) < 256 * 1024  # characters under, bytes over
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_read → preview",
+            tool_output_full=huge,
+        )
+
+        tool_rows = [
+            row
+            for row in db.get_trajectory_rows(conversation_id)
+            if row.event_kind.startswith("tool_")
+        ]
+        assert len(tool_rows) == 2
+        for row in tool_rows:
+            payload = json.loads(row.payload_json)
+            assert payload["truncated"] is True
+            stored = payload["result"]
+            assert len(stored.encode("utf-8")) <= 256 * 1024
+            # The split codepoint at the byte boundary was dropped cleanly.
+            assert stored.endswith("😀") or stored == ""
+            assert stored != huge
+    finally:
+        db.close()
+
+
 def test_trajectory_write_failure_never_fails_the_turn(tmp_path):
     db, store = _store_with_db(tmp_path)
     try:
@@ -304,6 +352,59 @@ def test_concurrent_upserts_produce_unique_seqs(tmp_path):
         threads = [
             threading.Thread(target=write_batch, args=("t0", batch_a)),
             threading.Thread(target=write_batch, args=("t1", batch_b)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        rows = db.get_trajectory_rows(conversation_id)
+        assert len(rows) == 50
+        seqs = [row.seq for row in rows]
+        assert sorted(seqs) == list(range(1, 51))
+        assert len(set(seqs)) == 50
+    finally:
+        db.close()
+
+
+def test_concurrent_direct_db_upserts_produce_unique_seqs(tmp_path):
+    """The DB-layer upsert itself must be safe under cross-thread concurrency
+    (BEGIN IMMEDIATE write lock): no thread's batch may roll back with the
+    deferred-upgrade "database is locked" deadlock, and seqs stay unique."""
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    try:
+        conversation_id = db.add_conversation(
+            {"chat_id": 1, "conversation_id": "traj-db-concurrency", "fragmentation": 0}
+        )
+        assert conversation_id is not None
+        message_ids = [
+            db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "assistant",
+                    "content": f"message {index}",
+                }
+            )
+            for index in range(50)
+        ]
+
+        def write_direct_batch(ids: list) -> None:
+            for message_id in ids:
+                db.upsert_trajectory_rows(
+                    [
+                        TrajectoryRowWrite(
+                            message_id=message_id,
+                            conversation_id=conversation_id,
+                            turn_id="db-turn",
+                            seq=None,
+                            event_kind="assistant",
+                        )
+                    ]
+                )
+
+        threads = [
+            threading.Thread(target=write_direct_batch, args=(message_ids[:25],)),
+            threading.Thread(target=write_direct_batch, args=(message_ids[25:],)),
         ]
         for thread in threads:
             thread.start()

--- a/Tests/Chat/test_trajectory_projection.py
+++ b/Tests/Chat/test_trajectory_projection.py
@@ -334,6 +334,29 @@ def test_soft_deleted_messages_excluded_but_chain_traversed_through() -> None:
     assert ids == ["u1", "u2", "a2"]
 
 
+def test_mid_chain_gap_in_inputs_renders_all_not_partial_path() -> None:
+    # a1 is ABSENT from inputs mid-chain -- what the real DB seam produces
+    # for a hard-deleted row (get_messages_for_conversation filters
+    # deleted=0), unlike the soft-deleted node above which stays in the
+    # map. The walk cannot know which pre-gap messages are on the path,
+    # so it must yield "unknown" and the snapshot must degrade to
+    # render-all instead of silently rendering only post-gap messages.
+    rows, leaf = linear_chain(
+        ("u1", "user"), ("a1", "assistant"), ("u2", "user"), ("a2", "assistant")
+    )
+    rows = [row for row in rows if row["id"] != "a1"]
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("u2", turn_id="t2", seq=3, event_kind="user"),
+        TrajRow("a2", turn_id="t2", seq=4, event_kind="assistant"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    # Render-all: u1 still appears (a partial-path walk would drop it).
+    ids = [r.message_id for t in snapshot.turns for r in t.records]
+    assert ids == ["u1", "u2", "a2"]
+
+
 def test_off_path_tree_siblings_surface_as_variants_not_rows() -> None:
     # u1 has two assistant children: a1 (active) and a1b (superseded fork).
     rows = [

--- a/Tests/Chat/test_trajectory_projection.py
+++ b/Tests/Chat/test_trajectory_projection.py
@@ -1,0 +1,588 @@
+"""Unit tests for the pure trajectory projection (``Chat/trajectory.py``).
+
+The projection is deliberately stdlib-pure: these tests feed it plain
+dicts / local dataclass stand-ins (NOT ``TrajectoryRowRead`` from the DB
+module) to prove it duck-types its inputs instead of importing the DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleChatMessage
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Chat.trajectory import (
+    TrajectoryRecord,
+    TrajectorySnapshot,
+    derive_trajectory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Input stand-ins (duck-typed mirrors of the DB / store shapes)
+# ---------------------------------------------------------------------------
+
+
+def msg(
+    mid: str,
+    sender: str,
+    *,
+    content: str = "content",
+    ts: object = "2026-08-14 10:00:00",
+    parent: str | None = None,
+    deleted: bool = False,
+) -> dict:
+    """A ``messages``-table-shaped row (mapping form)."""
+    return {
+        "id": mid,
+        "sender": sender,
+        "content": content,
+        "timestamp": ts,
+        "parent_message_id": parent,
+        "deleted": deleted,
+    }
+
+
+@dataclass(frozen=True)
+class TrajRow:
+    """Duck-typed stand-in for ``TrajectoryRowRead`` (proves no DB import)."""
+
+    message_id: str
+    conversation_id: str = "conv-1"
+    turn_id: str = "t1"
+    seq: int = 0
+    event_kind: str = "assistant"
+    step_started_at: float | None = None
+    first_token_at: float | None = None
+    completed_at: float | None = None
+    model: str | None = None
+    provider: str | None = None
+    payload_json: str | None = None
+
+
+@dataclass(frozen=True)
+class VariantLike:
+    """One variant content (``ConsoleVariant`` stand-in)."""
+
+    content: str
+
+
+@dataclass(frozen=True)
+class VariantSetLike:
+    """Duck-typed stand-in for ``ConsoleVariantSet``."""
+
+    turn_id: str
+    variants: tuple[VariantLike, ...]
+    selected_index: int = 0
+
+
+def compaction_record(
+    *,
+    started_at: str = "2026-08-14T10:00:30+00:00",
+    finished_at: str | None = "2026-08-14T10:00:35+00:00",
+    status: str = "succeeded",
+    provider: str | None = "openai",
+    model: str | None = "gpt-test",
+    usage_json: str | None = None,
+) -> dict:
+    """A ``list_auxiliary_attempts``-shaped mapping."""
+    return {
+        "operation_id": "op-1",
+        "conversation_id": "conv-1",
+        "purpose": "conversation_compaction",
+        "provider": provider,
+        "model": model,
+        "requested_output_cap": 2048,
+        "estimated_input_tokens": 12345,
+        "status": status,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "elapsed_ms": 5000,
+        "provider_usage_json": usage_json,
+        "pricing_provenance_json": None,
+    }
+
+
+def linear_chain(*sends: tuple[str, str]) -> tuple[list[dict], str]:
+    """Build a linear parent chain of ``(id, sender)`` message rows.
+
+    Returns ``(rows, leaf_id)`` with each node parented on the previous one.
+    """
+    rows: list[dict] = []
+    previous: str | None = None
+    for index, (mid, sender) in enumerate(sends):
+        rows.append(msg(mid, sender, ts=f"2026-08-14 10:00:0{index}", parent=previous))
+        previous = mid
+    return rows, previous
+
+
+def record_kinds(snapshot: TrajectorySnapshot) -> list[list[str]]:
+    return [[r.kind for r in turn.records] for turn in snapshot.turns]
+
+
+# ---------------------------------------------------------------------------
+# Grouping: a turn starts at each user record
+# ---------------------------------------------------------------------------
+
+
+def test_turn_starts_at_each_user_record() -> None:
+    rows, leaf = linear_chain(
+        ("u1", "user"), ("a1", "assistant"), ("u2", "user"), ("a2", "assistant")
+    )
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("u2", turn_id="t2", seq=3, event_kind="user"),
+        TrajRow("a2", turn_id="t2", seq=4, event_kind="assistant"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    assert [t.turn_id for t in snapshot.turns] == ["t1", "t2"]
+    assert record_kinds(snapshot) == [
+        ["user", "assistant"],
+        ["user", "assistant"],
+    ]
+    # The user record is the FIRST record of its turn.
+    assert snapshot.turns[0].records[0].message_id == "u1"
+    assert snapshot.turns[1].records[0].message_id == "u2"
+
+
+# ---------------------------------------------------------------------------
+# Tool nesting
+# ---------------------------------------------------------------------------
+
+
+def test_tool_records_nest_under_owning_assistant_at_depth_one() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    payload = '{"name": "fs_read", "args": null, "result": "file body"}'
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow(
+            "a1", turn_id="t1", seq=3, event_kind="tool_call", payload_json=payload
+        ),
+        TrajRow(
+            "a1", turn_id="t1", seq=4, event_kind="tool_result", payload_json=payload
+        ),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    (turn,) = snapshot.turns
+    assert [(r.kind, r.depth) for r in turn.records] == [
+        ("user", 0),
+        ("assistant", 0),
+        ("tool_call", 1),
+        ("tool_result", 1),
+    ]
+    tool_call = turn.records[2]
+    assert tool_call.payload == {"name": "fs_read", "args": None, "result": "file body"}
+    assert tool_call.message_id == "a1"  # keyed on the parent assistant row
+    assert tool_call.usage is None  # tool records never carry message usage
+    assert tool_call.content_preview == "fs_read -> file body"
+
+
+def test_tool_records_ordered_by_seq_under_owner() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    # Two markers = four tool rows; input deliberately NOT seq-ordered.
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("a1", turn_id="t1", seq=6, event_kind="tool_result", payload_json='{"result": "b"}'),
+        TrajRow("a1", turn_id="t1", seq=5, event_kind="tool_call", payload_json='{"result": "b"}'),
+        TrajRow("a1", turn_id="t1", seq=3, event_kind="tool_call", payload_json='{"result": "a"}'),
+        TrajRow("a1", turn_id="t1", seq=4, event_kind="tool_result", payload_json='{"result": "a"}'),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    (turn,) = snapshot.turns
+    tool_records = [r for r in turn.records if r.depth == 1]
+    assert [(r.kind, r.payload["result"]) for r in tool_records] == [
+        ("tool_call", "a"),
+        ("tool_result", "a"),
+        ("tool_call", "b"),
+        ("tool_result", "b"),
+    ]
+
+
+def test_orphaned_tool_rows_are_dropped() -> None:
+    # Tool rows keyed on an assistant that was soft-deleted must vanish.
+    rows, leaf = linear_chain(
+        ("u1", "user"), ("a1", "assistant", ), ("u2", "user")
+    )
+    rows[1]["deleted"] = True
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("a1", turn_id="t1", seq=3, event_kind="tool_call", payload_json='{"result": "x"}'),
+        TrajRow("a1", turn_id="t1", seq=4, event_kind="tool_result", payload_json='{"result": "x"}'),
+        TrajRow("u2", turn_id="t2", seq=5, event_kind="user"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    kinds = [r.kind for t in snapshot.turns for r in t.records]
+    assert kinds == ["user", "user"]  # no assistant, no tool rows
+
+
+# ---------------------------------------------------------------------------
+# Timing: NULL stays None; append-time timing surfaces as-is
+# ---------------------------------------------------------------------------
+
+
+def test_null_timing_renders_none_fields() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),  # all timing NULL
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    assistant = snapshot.turns[0].records[1]
+    assert assistant.step_started_at is None
+    assert assistant.first_token_at is None
+    assert assistant.completed_at is None
+
+
+def test_tool_append_time_timing_surfaces_as_is() -> None:
+    # Marker-append rows carry zero-duration append-time stamps; the
+    # projection must surface them verbatim -- never derive, never drop.
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user", step_started_at=10.0),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=2,
+            event_kind="assistant",
+            step_started_at=11.0,
+            first_token_at=12.0,
+            completed_at=13.0,
+        ),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=3,
+            event_kind="tool_result",
+            payload_json='{"result": "x"}',
+            step_started_at=99.5,
+            completed_at=99.5,  # append-time zero duration
+        ),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    records = snapshot.turns[0].records
+    assert (records[1].step_started_at, records[1].first_token_at, records[1].completed_at) == (
+        11.0,
+        12.0,
+        13.0,
+    )
+    tool = records[2]
+    assert (tool.step_started_at, tool.first_token_at, tool.completed_at) == (
+        99.5,
+        None,
+        99.5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering: seq breaks timestamp ties
+# ---------------------------------------------------------------------------
+
+
+def test_seq_breaks_timestamp_ties() -> None:
+    rows = [
+        msg("a1", "assistant", ts="2026-08-14 10:00:05", parent="u1"),
+        msg("a2", "assistant", ts="2026-08-14 10:00:05", parent="a1"),
+        msg("u1", "user", ts="2026-08-14 10:00:04"),
+    ]
+    # Same timestamp for a1/a2; seq says a2 (4) precedes a1 (5).
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=5, event_kind="assistant"),
+        TrajRow("a2", turn_id="t1", seq=4, event_kind="assistant"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id="a2")
+    ids = [r.message_id for r in snapshot.turns[0].records]
+    assert ids == ["u1", "a2", "a1"]
+
+
+def test_records_carry_running_ledger_seq() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("a1", turn_id="t1", seq=3, event_kind="tool_call", payload_json='{"result": "x"}'),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    records = [r for t in snapshot.turns for r in t.records]
+    assert [r.seq for r in records] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Active path + soft deletion + variants
+# ---------------------------------------------------------------------------
+
+
+def test_soft_deleted_messages_excluded_but_chain_traversed_through() -> None:
+    # a1 is soft-deleted MID-CHAIN: the walk must pass through it to reach
+    # u1, or every ancestor of a deleted node would vanish too.
+    rows, leaf = linear_chain(
+        ("u1", "user"), ("a1", "assistant"), ("u2", "user"), ("a2", "assistant")
+    )
+    rows[1]["deleted"] = True
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("u2", turn_id="t2", seq=3, event_kind="user"),
+        TrajRow("a2", turn_id="t2", seq=4, event_kind="assistant"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    ids = [r.message_id for t in snapshot.turns for r in t.records]
+    assert ids == ["u1", "u2", "a2"]
+
+
+def test_off_path_tree_siblings_surface_as_variants_not_rows() -> None:
+    # u1 has two assistant children: a1 (active) and a1b (superseded fork).
+    rows = [
+        msg("u1", "user", ts="2026-08-14 10:00:00"),
+        msg("a1", "assistant", content="active reply", ts="2026-08-14 10:00:01", parent="u1"),
+        msg("a1b", "assistant", content="superseded fork", ts="2026-08-14 10:00:02", parent="u1"),
+        msg("u2", "user", ts="2026-08-14 10:00:03", parent="a1"),
+    ]
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("u2", turn_id="t2", seq=3, event_kind="user"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id="u2")
+    ids = [r.message_id for t in snapshot.turns for r in t.records]
+    assert ids == ["u1", "a1", "u2"]  # a1b is NOT a row
+    a1_record = snapshot.turns[0].records[1]
+    assert a1_record.variants == ("superseded fork",)
+    # The user record owns no variants here.
+    assert snapshot.turns[0].records[0].variants == ()
+
+
+def test_none_leaf_renders_all_undeleted_messages() -> None:
+    rows = [
+        msg("u1", "user", ts="2026-08-14 10:00:00"),
+        msg("a1", "assistant", ts="2026-08-14 10:00:01", parent="u1"),
+        msg("a1b", "assistant", content="fork", ts="2026-08-14 10:00:02", parent="u1"),
+    ]
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("a1b", turn_id="t1b", seq=3, event_kind="assistant"),
+    ]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=None)
+    ids = [r.message_id for t in snapshot.turns for r in t.records]
+    assert ids == ["u1", "a1", "a1b"]
+
+
+def test_variant_set_superseded_contents_attach_to_assistant_record() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    variant_set = VariantSetLike(
+        turn_id="t1",
+        variants=(VariantLike("base reply"), VariantLike("regenerated reply")),
+        selected_index=1,  # regenerated is current; base is superseded
+    )
+    snapshot = derive_trajectory(
+        rows, {}, traj_rows, [variant_set], [], active_leaf_message_id=leaf
+    )
+    user_rec, assistant_rec = snapshot.turns[0].records
+    assert assistant_rec.variants == ("base reply",)
+    assert user_rec.variants == ()
+
+
+# ---------------------------------------------------------------------------
+# Compaction markers
+# ---------------------------------------------------------------------------
+
+
+def test_compaction_renders_between_turns_with_null_message_id() -> None:
+    # Message timestamps (not sidecar timing) place the marker: turn t1
+    # spans 10:00, turn t2 spans 11:00, compaction ran at 10:30.
+    rows = [
+        msg("u1", "user", ts="2026-08-14 10:00:00"),
+        msg("a1", "assistant", ts="2026-08-14 10:00:01", parent="u1"),
+        msg("u2", "user", ts="2026-08-14 11:00:00", parent="a1"),
+        msg("a2", "assistant", ts="2026-08-14 11:00:01", parent="u2"),
+    ]
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+        TrajRow("u2", turn_id="t2", seq=3, event_kind="user"),
+        TrajRow("a2", turn_id="t2", seq=4, event_kind="assistant"),
+    ]
+    compactions = [
+        compaction_record(
+            started_at="2026-08-14T10:30:00+00:00",
+            finished_at="2026-08-14T10:30:05+00:00",
+            usage_json='{"uncached_input": 10, "output": 2, "provider": "openai"}',
+        )
+    ]
+    snapshot = derive_trajectory(
+        rows, {}, traj_rows, [], compactions, active_leaf_message_id="a2"
+    )
+    assert len(snapshot.turns) == 2
+    # The marker trails turn t1 -- i.e. between the two turns.
+    t1_kinds = [r.kind for r in snapshot.turns[0].records]
+    assert t1_kinds == ["user", "assistant", "compaction"]
+    marker = snapshot.turns[0].records[-1]
+    assert isinstance(marker, TrajectoryRecord)
+    assert marker.message_id is None
+    assert marker.depth == 0
+    assert marker.model == "gpt-test"
+    assert marker.provider == "openai"
+    assert marker.usage is not None
+    assert marker.usage.uncached_input == 10
+    assert marker.usage.output == 2
+    assert "succeeded" in marker.content_preview
+    assert snapshot.turns[1].records[0].kind == "user"
+
+
+def test_compaction_before_first_turn_leads_the_ledger() -> None:
+    rows = [
+        msg("u1", "user", ts="2026-08-14 10:00:00"),
+        msg("a1", "assistant", ts="2026-08-14 10:00:01", parent="u1"),
+    ]
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    compactions = [
+        compaction_record(started_at="2026-08-13T09:00:00+00:00")  # before everything
+    ]
+    snapshot = derive_trajectory(
+        rows, {}, traj_rows, [], compactions, active_leaf_message_id="a1"
+    )
+    (turn,) = snapshot.turns
+    assert [r.kind for r in turn.records] == ["compaction", "user", "assistant"]
+
+
+# ---------------------------------------------------------------------------
+# Usage + preview
+# ---------------------------------------------------------------------------
+
+
+def test_usage_by_id_attaches_to_records() -> None:
+    rows, leaf = linear_chain(("u1", "user"), ("a1", "assistant"))
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    usage = ProviderUsage(uncached_input=7, cache_read=3, output=5, provider="anthropic")
+    snapshot = derive_trajectory(
+        rows, {"a1": usage}, traj_rows, [], [], active_leaf_message_id=leaf
+    )
+    user_rec, assistant_rec = snapshot.turns[0].records
+    assert assistant_rec.usage is usage
+    assert user_rec.usage is None
+
+
+def test_content_preview_single_line_capped_at_120() -> None:
+    rows, leaf = linear_chain(("u1", "user"))
+    rows[0]["content"] = "line one\nline two " + "x" * 300
+    traj_rows = [TrajRow("u1", turn_id="t1", seq=1, event_kind="user")]
+    snapshot = derive_trajectory(rows, {}, traj_rows, [], [], active_leaf_message_id=leaf)
+    preview = snapshot.turns[0].records[0].content_preview
+    assert "\n" not in preview
+    assert len(preview) == 120
+    assert preview.startswith("line one line two")
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback (no sidecar rows)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_grouping_by_timestamp_adjacency() -> None:
+    # Same-calendar-second reply joins the preceding user message's turn;
+    # the later reply (next second) still joins the open turn.
+    rows = [
+        msg("a1", "assistant", content="fast reply", ts="2026-08-14 10:00:01", parent="u1"),
+        msg("u1", "user", content="question", ts="2026-08-14 10:00:01"),
+        msg("a1b", "assistant", content="slow followup", ts="2026-08-14 10:00:07", parent="a1"),
+        msg("u2", "user", content="next question", ts="2026-08-14 10:00:20", parent="a1b"),
+        msg("a2", "assistant", content="answer two", ts="2026-08-14 10:00:22", parent="u2"),
+    ]
+    snapshot = derive_trajectory(rows, {}, [], [], [], active_leaf_message_id="a2")
+    assert [t.turn_id for t in snapshot.turns] == ["u1", "u2"]
+    assert record_kinds(snapshot) == [
+        ["user", "assistant", "assistant"],
+        ["user", "assistant"],
+    ]
+    # No sidecar facts: timing and model stay None.
+    assert all(
+        r.step_started_at is None and r.model is None
+        for t in snapshot.turns
+        for r in t.records
+    )
+
+
+def test_legacy_assistant_first_opens_own_turn() -> None:
+    rows = [
+        msg("a0", "assistant", ts="2026-08-14 10:00:00"),
+        msg("u1", "user", ts="2026-08-14 10:00:05", parent="a0"),
+        msg("a1", "assistant", ts="2026-08-14 10:00:06", parent="u1"),
+    ]
+    snapshot = derive_trajectory(rows, {}, [], [], [], active_leaf_message_id="a1")
+    assert [t.turn_id for t in snapshot.turns] == ["a0", "u1"]
+    assert record_kinds(snapshot) == [["assistant"], ["user", "assistant"]]
+
+
+def test_legacy_messages_take_usage_and_variants() -> None:
+    rows = [
+        msg("u1", "user", ts="2026-08-14 10:00:00"),
+        msg("a1", "assistant", content="kept", ts="2026-08-14 10:00:01", parent="u1"),
+        msg("a1b", "assistant", content="dropped", ts="2026-08-14 10:00:02", parent="u1"),
+    ]
+    usage = ProviderUsage(output=4)
+    snapshot = derive_trajectory(
+        rows, {"a1": usage}, [], [], [], active_leaf_message_id="a1"
+    )
+    assistant_rec = snapshot.turns[0].records[1]
+    assert assistant_rec.usage is usage
+    assert assistant_rec.variants == ("dropped",)
+
+
+# ---------------------------------------------------------------------------
+# ConsoleChatMessage inputs (in-memory turn ids)
+# ---------------------------------------------------------------------------
+
+
+def test_console_chat_message_inputs_group_by_turn_id() -> None:
+    messages = [
+        ConsoleChatMessage(role="user", content="hello", id="m1", turn_id="tA", persisted_message_id="p1"),
+        ConsoleChatMessage(role="assistant", content="hi", id="m2", turn_id="tA", persisted_message_id="p2"),
+        ConsoleChatMessage(role="user", content="again", id="m3", turn_id="tB", persisted_message_id="p3"),
+    ]
+    usage = ProviderUsage(output=9)
+    snapshot = derive_trajectory(
+        messages, {"p2": usage}, [], [], [], active_leaf_message_id=None
+    )
+    assert [t.turn_id for t in snapshot.turns] == ["tA", "tB"]
+    assistant_rec = snapshot.turns[0].records[1]
+    # Usage join happens on the PERSISTED id.
+    assert assistant_rec.usage is usage
+    assert assistant_rec.message_id == "p2"
+
+
+# ---------------------------------------------------------------------------
+# Empty + purity
+# ---------------------------------------------------------------------------
+
+
+def test_empty_conversation_yields_empty_snapshot() -> None:
+    snapshot = derive_trajectory([], {}, [], [], [], active_leaf_message_id=None)
+    assert snapshot.turns == ()
+
+
+def test_module_is_pure_stdlib() -> None:
+    import inspect
+    import tldw_chatbook.Chat.trajectory as trajectory_module
+
+    source = inspect.getsource(trajectory_module)
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("import ") or stripped.startswith("from "):
+            assert "textual" not in stripped, f"forbidden import: {stripped}"
+            assert "tldw_chatbook.DB" not in stripped, f"forbidden import: {stripped}"
+            assert "ConsoleChatStore" not in stripped, f"forbidden import: {stripped}"

--- a/Tests/DB/test_chachanotes_provider_continuation_migration.py
+++ b/Tests/DB/test_chachanotes_provider_continuation_migration.py
@@ -174,7 +174,10 @@ def test_v36_to_v37_preserves_messages_schema_objects_and_fts(
     db_path = tmp_path / "chachanotes.db"
     before = _seed_v36_database(db_path, monkeypatch)
 
-    db = CharactersRAGDB(db_path, client_id="migration-test")
+    # Pin the target so only the V36 -> V37 step runs (schema has moved on).
+    with monkeypatch.context() as v37_patch:
+        v37_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 37)
+        db = CharactersRAGDB(db_path, client_id="migration-test")
     connection = db.get_connection()
 
     assert _version(connection) == 37
@@ -239,7 +242,10 @@ def test_v37_message_sync_triggers_include_continuation_only_where_required(
 ) -> None:
     db_path = tmp_path / "chachanotes.db"
     seeded = _seed_v36_database(db_path, monkeypatch)
-    db = CharactersRAGDB(db_path, client_id="migration-test")
+    # Pin the target so only the V36 -> V37 step runs (schema has moved on).
+    with monkeypatch.context() as v37_patch:
+        v37_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 37)
+        db = CharactersRAGDB(db_path, client_id="migration-test")
     connection = db.get_connection()
 
     trigger_sql = _schema_objects(connection, "trigger")
@@ -288,7 +294,10 @@ def test_v36_to_v37_requires_exact_precondition_and_handles_preadded_column(
         connection.commit()
         db.close_connection()
 
-    db = CharactersRAGDB(db_path, client_id="migration-test")
+    # Pin the target so only the V36 -> V37 step runs (schema has moved on).
+    with monkeypatch.context() as v37_patch:
+        v37_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 37)
+        db = CharactersRAGDB(db_path, client_id="migration-test")
     assert _version(db.get_connection()) == 37
     with pytest.raises(SchemaError, match="requires schema version 36"):
         db._migrate_from_v36_to_v37(db.get_connection())

--- a/Tests/DB/test_chachanotes_trajectory_metadata_migration.py
+++ b/Tests/DB/test_chachanotes_trajectory_metadata_migration.py
@@ -46,10 +46,14 @@ def test_migrates_v37_to_v38_and_creates_table(tmp_path: Path) -> None:
         "PRAGMA table_info(message_trajectory_metadata)"
     )}
     assert TRAJECTORY_COLUMNS <= cols
-    idx = {row["name"] for row in connection.execute(
+    indexes = list(connection.execute(
         "PRAGMA index_list(message_trajectory_metadata)"
-    )}
+    ))
+    idx = {row["name"] for row in indexes}
     assert any("conv_seq" in name for name in idx), idx
+    # Ledger-ordering guarantee: the (conversation_id, seq) index is UNIQUE.
+    conv_seq = next(row for row in indexes if "conv_seq" in row["name"])
+    assert conv_seq["unique"] == 1, conv_seq
     # Local-only: no sync triggers may mention the sidecar table.
     triggers = {
         row[0]

--- a/Tests/DB/test_chachanotes_trajectory_metadata_migration.py
+++ b/Tests/DB/test_chachanotes_trajectory_metadata_migration.py
@@ -1,0 +1,220 @@
+"""V37 -> V38 message_trajectory_metadata sidecar migration and accessors."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    SchemaError,
+    TrajectoryRowWrite,
+)
+
+SCHEMA_NAME = "rag_char_chat_schema"
+
+TRAJECTORY_COLUMNS = {
+    "message_id",
+    "conversation_id",
+    "turn_id",
+    "seq",
+    "event_kind",
+    "step_started_at",
+    "first_token_at",
+    "completed_at",
+    "model",
+    "provider",
+    "payload_json",
+}
+
+
+def _version(connection) -> int:
+    row = connection.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()
+    return int(row[0])
+
+
+def test_migrates_v37_to_v38_and_creates_table(tmp_path: Path) -> None:
+    db = CharactersRAGDB(tmp_path / "test.db", client_id="test")
+    connection = db.get_connection()
+    assert _version(connection) == 38
+    cols = {row["name"] for row in connection.execute(
+        "PRAGMA table_info(message_trajectory_metadata)"
+    )}
+    assert TRAJECTORY_COLUMNS <= cols
+    idx = {row["name"] for row in connection.execute(
+        "PRAGMA index_list(message_trajectory_metadata)"
+    )}
+    assert any("conv_seq" in name for name in idx), idx
+    # Local-only: no sync triggers may mention the sidecar table.
+    triggers = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        )
+    }
+    assert not any("trajectory" in t.lower() for t in triggers), triggers
+
+
+def test_upsert_and_read_roundtrip(tmp_path: Path) -> None:
+    db = CharactersRAGDB(tmp_path / "test.db", client_id="test")
+    conv = db.add_conversation({"title": "t"})
+    msg = db.add_message(
+        {"conversation_id": conv, "sender": "user", "content": "hi"}
+    )
+    db.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=None,
+                event_kind="user",
+                step_started_at=1.0,
+                first_token_at=None,
+                completed_at=None,
+                model=None,
+                provider=None,
+                payload_json=None,
+            )
+        ]
+    )
+    rows = db.get_trajectory_rows(conv)
+    assert len(rows) == 1
+    assert rows[0].seq == 1
+    assert rows[0].event_kind == "user"
+
+    # Multiple tool_calls under one assistant message: distinct seqs.
+    db.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=None,
+                event_kind="tool_call",
+                step_started_at=1.0,
+                first_token_at=None,
+                completed_at=2.0,
+                model="m",
+                provider="p",
+                payload_json='{"n":1}',
+            ),
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=None,
+                event_kind="tool_call",
+                step_started_at=1.0,
+                first_token_at=None,
+                completed_at=3.0,
+                model="m",
+                provider="p",
+                payload_json='{"n":2}',
+            ),
+        ]
+    )
+    rows = db.get_trajectory_rows(conv)
+    assert [r.seq for r in rows] == [1, 2, 3]
+
+
+def test_explicit_seq_upsert_updates_existing_row(tmp_path: Path) -> None:
+    db = CharactersRAGDB(tmp_path / "test.db", client_id="test")
+    conv = db.add_conversation({"title": "t"})
+    msg = db.add_message(
+        {"conversation_id": conv, "sender": "assistant", "content": "hi"}
+    )
+    db.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=1,
+                event_kind="assistant",
+                step_started_at=1.0,
+                first_token_at=1.5,
+                completed_at=2.0,
+                model="m",
+                provider="p",
+                payload_json=None,
+            )
+        ]
+    )
+    # Same (message_id, event_kind, seq): update in place, not a new row.
+    db.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=1,
+                event_kind="assistant",
+                step_started_at=1.0,
+                first_token_at=1.4,
+                completed_at=2.5,
+                model="m2",
+                provider="p2",
+                payload_json='{"updated":true}',
+            )
+        ]
+    )
+    rows = db.get_trajectory_rows(conv)
+    assert len(rows) == 1
+    assert rows[0].completed_at == 2.5
+    assert rows[0].model == "m2"
+    assert db.get_next_trajectory_seq(conv) == 2
+
+
+def test_get_trajectory_rows_includes_soft_deleted_messages(
+    tmp_path: Path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "test.db", client_id="test")
+    conv = db.add_conversation({"title": "t"})
+    msg = db.add_message(
+        {"conversation_id": conv, "sender": "user", "content": "hi"}
+    )
+    db.upsert_trajectory_rows(
+        [
+            TrajectoryRowWrite(
+                message_id=msg,
+                conversation_id=conv,
+                turn_id=msg,
+                seq=None,
+                event_kind="user",
+                step_started_at=1.0,
+                first_token_at=None,
+                completed_at=None,
+                model=None,
+                provider=None,
+                payload_json=None,
+            )
+        ]
+    )
+    db.soft_delete_message(msg, expected_version=1)
+    # Sidecar rows survive message soft deletion; the projection filters.
+    rows = db.get_trajectory_rows(conv)
+    assert len(rows) == 1
+
+
+def test_v37_database_upgrades(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with monkeypatch.context() as v37_patch:
+        v37_patch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 37)
+        seed = CharactersRAGDB(tmp_path / "seed.db", client_id="seed")
+        conversation_id = seed.add_conversation({"title": "seed"})
+        seed.add_message(
+            {"conversation_id": conversation_id, "sender": "user", "content": "hi"}
+        )
+        seed.close()
+    db = CharactersRAGDB(tmp_path / "seed.db", client_id="upgraded")
+    connection = db.get_connection()
+    assert _version(connection) == 38
+    cols = {row["name"] for row in connection.execute(
+        "PRAGMA table_info(message_trajectory_metadata)"
+    )}
+    assert TRAJECTORY_COLUMNS <= cols

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -1481,8 +1481,9 @@ async def test_console_registers_footer_workbench_shortcuts():
         assert footer.shortcut_text == (
             # task-15512: "/ queue" was added by 14cc326e4 (visible prompt
             # queue); the shortcut genuinely does both now.
+            # task-5 (trajectory view): "Y trajectory" launches the ledger.
             "F6 next pane | Shift+F6 previous pane | F1 help | Enter send / queue | "
-            "Ctrl+K switch session | Ctrl+T new tab | Ctrl+P palette | "
+            "Y trajectory | Ctrl+K switch session | Ctrl+T new tab | Ctrl+P palette | "
             "Ctrl+Q quit"
         )
 

--- a/Tests/UI/test_trajectory_live.py
+++ b/Tests/UI/test_trajectory_live.py
@@ -24,10 +24,16 @@ from dataclasses import dataclass
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Static
 
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_context_repository import (
+    AuxiliaryAttemptStart,
+    ConsoleContextRepository,
+)
 from tldw_chatbook.Chat.trajectory import derive_trajectory
-from tldw_chatbook.DB.ChaChaNotes_DB import TrajectoryRowWrite
-from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, TrajectoryRowWrite
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen, _build_trajectory_snapshot
 from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
 
 # ---------------------------------------------------------------------------
@@ -289,10 +295,80 @@ def test_follow_binding_registered_and_hints_stay_one_to_one():
 
 def test_console_binds_single_letter_trajectory_launch():
     bindings = {b.key: b.action for b in ChatScreen.BINDINGS}
-    assert bindings.get("j") == "open_trajectory_view"
+    assert bindings.get("y") == "open_trajectory_view"
     assert hasattr(ChatScreen, "action_open_trajectory_view")
+    # 'j' stays owned by the focused transcript (next-message selection in
+    # console_transcript.on_key); the launch key must not collide with it.
+    assert "j" not in bindings
     # ADR-031: single-letter htop-style key, no terminal-convention chord.
-    assert len("j") == 1
+    assert len("y") == 1
+
+
+def test_build_trajectory_snapshot_renders_compaction_and_variants(tmp_path):
+    """Real-seam integration: no getattr-probed phantom sources.
+
+    Drives ``_build_trajectory_snapshot`` against a real temp DB + store:
+    message/tool rows land via the Task 2 write path, a compaction attempt
+    via ``ConsoleContextRepository``, and a variant set in-memory -- then
+    asserts compaction and superseded variants actually reach the snapshot.
+    """
+    db = CharactersRAGDB(str(tmp_path / "chachanotes.sqlite"), "test_client")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    try:
+        session = store.ensure_session(title="Trajectory")
+        conversation_id = store.persist_session_if_needed(session.id)
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.USER,
+            content="hello",
+            persist=True,
+        )
+        assistant = store.append_message(
+            session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="first draft",
+            persist=True,
+        )
+        store.append_message(
+            session.id,
+            role=ConsoleMessageRole.TOOL,
+            content="⚙ fs_list → (3 files)",
+            tool_output_full="file-a\nfile-b\nfile-c",
+        )
+        # In-memory variant: 'first draft' becomes superseded content.
+        store.add_variant(assistant.id, "second draft wins")
+
+        # Durable compaction attempt through the real repository seam.
+        ConsoleContextRepository(db).start_auxiliary_attempt(
+            AuxiliaryAttemptStart(
+                operation_id="op-compaction-1",
+                conversation_id=conversation_id,
+                purpose="conversation_compaction",
+                provider="test-provider",
+                model="test-model",
+                requested_output_cap=100,
+                estimated_input_tokens=50,
+                started_at="2026-08-14T00:00:00Z",
+            )
+        )
+
+        snapshot = _build_trajectory_snapshot(store, conversation_id)
+
+        kinds = [r.kind for turn in snapshot.turns for r in turn.records]
+        assert "user" in kinds and "assistant" in kinds
+        assert "tool_call" in kinds and "tool_result" in kinds
+        assert "compaction" in kinds
+
+        superseded = [
+            variant
+            for turn in snapshot.turns
+            for record in turn.records
+            for variant in record.variants
+        ]
+        assert "first draft" in superseded
+        assert "second draft wins" not in superseded  # selected == current
+    finally:
+        db.close()
 
 
 def test_trajectory_launch_action_presents_screen():

--- a/Tests/UI/test_trajectory_live.py
+++ b/Tests/UI/test_trajectory_live.py
@@ -1,0 +1,326 @@
+"""Task 5: Console trajectory launch binding + live tail-follow.
+
+Three seams, per the task brief:
+
+1. **Store revision bus** (unit, no app): the Task 2 trajectory write path
+   bumps the payload-revision counter so a polling screen sees changes, and
+   the new public getter reads it by conversation id.
+2. **Live tail-follow** (pilot-driven, seam-level): a minimal app hosts
+   TrajectoryScreen with fake ``revision_provider``/``snapshot_builder``
+   callables -- the exact callables the Console launcher passes -- and the
+   poll/worker/follow state machine is driven deterministically.
+3. **Launch binding registration** (unit, non-async): ChatScreen binds a
+   single-letter ADR-031-legal key that pushes the trajectory screen.
+
+Full-app construction is deliberately avoided (the Console workbench pilot
+is far heavier than this feature needs); the seam callables are the real
+integration surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Static
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.trajectory import derive_trajectory
+from tldw_chatbook.DB.ChaChaNotes_DB import TrajectoryRowWrite
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
+
+# ---------------------------------------------------------------------------
+# Duck-typed projection inputs (same mirrors as the trajectory screen suite)
+# ---------------------------------------------------------------------------
+
+_T0 = 1_755_165_600.0
+
+
+def msg(
+    mid: str, sender: str, *, content: str, ts: float, parent: str | None = None
+) -> dict:
+    return {
+        "id": mid,
+        "sender": sender,
+        "content": content,
+        "timestamp": ts,
+        "parent_message_id": parent,
+        "deleted": False,
+    }
+
+
+@dataclass(frozen=True)
+class TrajRow:
+    message_id: str
+    conversation_id: str = "conv-1"
+    turn_id: str = "t1"
+    seq: int = 0
+    event_kind: str = "assistant"
+    step_started_at: float | None = None
+    first_token_at: float | None = None
+    completed_at: float | None = None
+    model: str | None = None
+    provider: str | None = None
+    payload_json: str | None = None
+
+
+@dataclass(frozen=True)
+class VariantSetLike:
+    turn_id: str
+    variants: tuple[str, ...]
+    selected_index: int = 0
+
+
+def snapshot_with_turns(turn_count: int):
+    """A linear conversation: ``turn_count`` user+assistant record pairs."""
+    messages = []
+    rows = []
+    seq = 0
+    parent = None
+    for index in range(turn_count):
+        user_id = f"u{index}"
+        assistant_id = f"a{index}"
+        turn_id = f"t{index}"
+        messages.append(
+            msg(user_id, "user", content=f"question {index}", ts=_T0 + index * 10.0, parent=parent)
+        )
+        seq += 1
+        rows.append(
+            TrajRow(user_id, turn_id=turn_id, seq=seq, event_kind="user", step_started_at=_T0 + index * 10.0)
+        )
+        messages.append(
+            msg(
+                assistant_id,
+                "assistant",
+                content=f"answer {index}",
+                ts=_T0 + index * 10.0 + 1.0,
+                parent=user_id,
+            )
+        )
+        seq += 1
+        rows.append(
+            TrajRow(
+                assistant_id,
+                turn_id=turn_id,
+                seq=seq,
+                event_kind="assistant",
+                model="test-model",
+                provider="test-provider",
+            )
+        )
+        parent = assistant_id
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+# ---------------------------------------------------------------------------
+# 1. Store revision bus
+# ---------------------------------------------------------------------------
+
+
+class _FakePersistence:
+    """Duck-typed persistence adapter: only the trajectory write method."""
+
+    def __init__(self) -> None:
+        self.written: list[TrajectoryRowWrite] = []
+
+    def write_trajectory_rows(self, rows):
+        self.written.extend(rows)
+        return True
+
+
+def test_trajectory_write_bumps_payload_revision_for_conversation():
+    store = ConsoleChatStore(persistence=_FakePersistence())  # type: ignore[arg-type]
+    session = store.create_session(title="s")
+    session.persisted_conversation_id = "conv-1"
+
+    before = store.get_payload_revision("conv-1")
+    row = TrajectoryRowWrite(
+        message_id="m1",
+        conversation_id="conv-1",
+        turn_id="t1",
+        seq=None,
+        event_kind="user",
+    )
+    assert store.write_trajectory_rows([row]) is True
+    after = store.get_payload_revision("conv-1")
+    assert after > before
+
+
+def test_get_payload_revision_defaults_to_zero_for_unknown_conversation():
+    store = ConsoleChatStore()
+    assert store.get_payload_revision("nope") == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Live tail-follow (seam pilot)
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryHostApp(App[None]):
+    """Hosts TrajectoryScreen with pluggable revision/snapshot callables.
+
+    The screen is PUSHED (like the Console does) rather than composed --
+    only an active screen's BINDINGS take part in key routing.
+    """
+
+    def __init__(self, snapshot, revision_provider, snapshot_builder) -> None:
+        super().__init__()
+        self._snapshot = snapshot
+        self._revision_provider = revision_provider
+        self._snapshot_builder = snapshot_builder
+        self.screen_instance: TrajectoryScreen | None = None
+
+    def compose(self) -> ComposeResult:
+
+        yield Static("base")
+
+    def on_mount(self) -> None:
+        self.screen_instance = TrajectoryScreen(
+            self._snapshot,
+            screen_title="live",
+            conversation_id="conv-1",
+            revision_provider=self._revision_provider,
+            snapshot_builder=self._snapshot_builder,
+        )
+        self.push_screen(self.screen_instance)
+
+
+async def test_live_revision_change_appends_rows_and_follows_tail():
+    state = {"revision": 7, "turns": 3}
+    builder = lambda: snapshot_with_turns(state["turns"])  # noqa: E731
+    app = TrajectoryHostApp(snapshot_with_turns(3), lambda: state["revision"], builder)
+    async with app.run_test() as pilot:
+        screen = app.screen_instance
+        table = screen.query_one("#trajectory-table", DataTable)
+        rows_before = table.row_count
+        assert rows_before == 6 + 3  # 6 records + 3 turn headers
+
+        # A new turn lands (revision moves); the poll tick rebuilds.
+        state["turns"] = 4
+        state["revision"] += 1
+        screen._poll_revision()
+        for _ in range(40):
+            if table.row_count >= rows_before + 3:
+                break
+            await pilot.pause(0.05)
+        # new turn header + user + assistant rows
+        assert table.row_count == 8 + 4
+        # follow was never suspended: the ledger sits at the tail
+        assert screen._follow is True
+        assert table.scroll_y == table.max_scroll_y
+        # live screen advertises the follow key
+        assert "follow" in str(
+            screen.query_one("#trajectory-hints").render()
+        )
+
+
+async def test_scrolling_up_suspends_follow_until_f_resumes():
+    # 60 turns overflow any pilot viewport, so scrolling is real.
+    state = {"revision": 3, "turns": 60}
+    builder = lambda: snapshot_with_turns(state["turns"])  # noqa: E731
+    app = TrajectoryHostApp(snapshot_with_turns(60), lambda: state["revision"], builder)
+    async with app.run_test() as pilot:
+        screen = app.screen_instance
+        table = screen.query_one("#trajectory-table", DataTable)
+        table.scroll_end(animate=False)
+        await pilot.pause()
+        assert screen._follow is True
+
+        # The reader scrolls up to inspect history.
+        table.scroll_to(y=0, animate=False)
+        await pilot.pause()
+        screen._sync_follow_from_scroll()
+        assert screen._follow is False
+
+        # New records arrive while reading: no tail jump.
+        state["turns"] = 61
+        state["revision"] += 1
+        screen._poll_revision()
+        for _ in range(40):
+            if table.row_count > 123:
+                break
+            await pilot.pause(0.05)
+        assert screen._follow is False
+        assert table.scroll_y == 0  # reading position preserved
+
+        # f re-enables follow and jumps to the tail.
+        await pilot.press("f")
+        assert screen._follow is True
+        assert table.scroll_y == table.max_scroll_y
+
+
+async def test_unchanged_revision_does_not_rebuild():
+    state = {"revision": 5, "turns": 3}
+    builder_calls = []
+
+    def builder():
+        builder_calls.append(1)
+        return snapshot_with_turns(state["turns"])
+
+    app = TrajectoryHostApp(snapshot_with_turns(3), lambda: state["revision"], builder)
+    async with app.run_test() as pilot:
+        screen = app.screen_instance
+        screen._poll_revision()
+        for _ in range(10):
+            await pilot.pause(0.05)
+        assert builder_calls == []  # revision static: no recompute scheduled
+
+
+def test_follow_binding_registered_and_hints_stay_one_to_one():
+    """`f` is bound with an implemented action; class-level hints stay 1:1.
+
+    The rendered hint drops on non-live screens (``_refresh_hints`` filter);
+    class-level equality is what the ADR-031 governance suite asserts.
+    """
+    binding_keys = {
+        binding.key for binding in TrajectoryScreen.BINDINGS if binding.key != "escape"
+    }
+    hint_keys = {key for key, _label in TrajectoryScreen.TRAJECTORY_SHORTCUTS}
+    assert "f" in binding_keys
+    assert hasattr(TrajectoryScreen, "action_resume_follow")
+    assert hint_keys == binding_keys
+
+
+# ---------------------------------------------------------------------------
+# 3. Launch binding registration (ADR-031 governance, non-async)
+# ---------------------------------------------------------------------------
+
+
+def test_console_binds_single_letter_trajectory_launch():
+    bindings = {b.key: b.action for b in ChatScreen.BINDINGS}
+    assert bindings.get("j") == "open_trajectory_view"
+    assert hasattr(ChatScreen, "action_open_trajectory_view")
+    # ADR-031: single-letter htop-style key, no terminal-convention chord.
+    assert len("j") == 1
+
+
+def test_trajectory_launch_action_presents_screen():
+    """The action pushes a TrajectoryScreen built from the active session."""
+    instance = ChatScreen.__new__(ChatScreen)  # bypass heavy __init__
+    pushed: list[object] = []
+
+    class _Store:
+        active_session_id = "sess-1"
+
+        class _Session:  # noqa: N801 - namespace stand-in
+            id = "sess-1"
+            title = "active conv"
+            persisted_conversation_id = "conv-1"
+
+        _sessions = {"sess-1": _Session}
+        _messages_by_session = {"sess-1": []}
+
+        def get_payload_revision(self, conversation_id):
+            return 1
+
+    instance._console_chat_store = _Store()
+    instance.push_screen = lambda screen, **kwargs: pushed.append(screen)
+    instance.notify = lambda *args, **kwargs: None
+    # Run the launch worker synchronously: build -> present -> push_screen.
+    instance.run_worker = lambda fn, **kwargs: fn()
+    instance.call_from_thread = lambda fn, *args: fn(*args)
+
+    ChatScreen.action_open_trajectory_view(instance)
+    assert pushed and isinstance(pushed[0], TrajectoryScreen)
+    assert pushed[0]._conversation_id == "conv-1"

--- a/Tests/UI/test_trajectory_screen.py
+++ b/Tests/UI/test_trajectory_screen.py
@@ -1,0 +1,573 @@
+"""UI tests for the Console trajectory screen (task-4 of the trajectory view).
+
+Pilot-driven per the repo's Textual test patterns; snapshots come from the
+REAL projection (``derive_trajectory``) fed the same duck-typed row
+stand-ins as ``Tests/Chat/test_trajectory_projection.py``, so the screen
+is tested against the exact shape Task 3 produces -- never a
+fixture-invented one. Keybinding/footer assertions follow the ADR-031
+governance suite pattern (``test_schedules_ux_fixes.py``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Input, Static
+
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Chat.trajectory import derive_trajectory
+from tldw_chatbook.UI.Screens.trajectory_screen import (
+    PAGE_SIZE,
+    WORKER_THRESHOLD,
+    TrajectoryScreen,
+)
+
+# ---------------------------------------------------------------------------
+# Duck-typed projection inputs (same mirrors as the projection unit tests)
+# ---------------------------------------------------------------------------
+
+LONG_TOOL_RESULT = "R" * 300  # longer than the 120-char preview cap
+
+_T0 = 1_755_165_600.0  # arbitrary unix epoch base
+
+
+def msg(
+    mid: str, sender: str, *, content: str, ts: float, parent: str | None = None
+) -> dict:
+    return {
+        "id": mid,
+        "sender": sender,
+        "content": content,
+        "timestamp": ts,
+        "parent_message_id": parent,
+        "deleted": False,
+    }
+
+
+@dataclass(frozen=True)
+class TrajRow:
+    message_id: str
+    conversation_id: str = "conv-1"
+    turn_id: str = "t1"
+    seq: int = 0
+    event_kind: str = "assistant"
+    step_started_at: float | None = None
+    first_token_at: float | None = None
+    completed_at: float | None = None
+    model: str | None = None
+    provider: str | None = None
+    payload_json: str | None = None
+
+
+@dataclass(frozen=True)
+class VariantSetLike:
+    turn_id: str
+    variants: tuple[str, ...]
+    selected_index: int = 0
+
+
+def base_snapshot():
+    """Two turns; turn 1 has tool rows, timing and usage; turn 2 has variants.
+
+    Ledger order (seq): 1 u1, 2 a1, 3 tool_call, 4 tool_result, 5 u2, 6 a2.
+    """
+    messages = [
+        msg("u1", "user", content="hello trajectory world", ts=_T0, parent=None),
+        msg(
+            "a1",
+            "assistant",
+            content="checking that for you",
+            ts=_T0 + 2.0,
+            parent="u1",
+        ),
+        msg(
+            "u2",
+            "user",
+            content="second question about zebras",
+            ts=_T0 + 60.0,
+            parent="a1",
+        ),
+        msg(
+            "a2", "assistant", content="zebras have stripes", ts=_T0 + 65.0, parent="u2"
+        ),
+    ]
+    tool_payload = (
+        '{"name": "fs_read", "args": {"path": "/tmp/report.txt"}, '
+        f'"result": "{LONG_TOOL_RESULT}"}}'
+    )
+    traj_rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user", step_started_at=_T0),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=2,
+            event_kind="assistant",
+            step_started_at=_T0,
+            first_token_at=_T0 + 2.0,
+            completed_at=_T0 + 5.0,
+            model="test-model",
+            provider="test-provider",
+        ),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=3,
+            event_kind="tool_call",
+            step_started_at=_T0 + 2.5,
+            completed_at=_T0 + 3.0,
+            payload_json=tool_payload,
+        ),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=4,
+            event_kind="tool_result",
+            step_started_at=_T0 + 3.0,
+            completed_at=_T0 + 3.5,
+            payload_json=tool_payload,
+        ),
+        TrajRow(
+            "u2", turn_id="t2", seq=5, event_kind="user", step_started_at=_T0 + 60.0
+        ),
+        TrajRow(
+            "a2",
+            turn_id="t2",
+            seq=6,
+            event_kind="assistant",
+            model="test-model",
+            provider="test-provider",
+        ),
+    ]
+    usage = {
+        "a1": ProviderUsage(
+            uncached_input=10,
+            cache_read=5,
+            cache_write=2,
+            output=7,
+            provider="test-provider",
+            model="test-model",
+        ),
+    }
+    variant_sets = [
+        VariantSetLike(
+            "t2", ("old zebra draft one", "old zebra draft two"), selected_index=1
+        ),
+    ]
+    return derive_trajectory(messages, usage, traj_rows, variant_sets, [])
+
+
+def many_records_snapshot(record_count: int):
+    """``record_count`` records across user/assistant turns, no sidecar rows."""
+    half = record_count // 2
+    messages = []
+    for i in range(half):
+        messages.append(
+            msg(f"mu{i}", "user", content=f"user message {i}", ts=_T0 + i * 10.0)
+        )
+        messages.append(
+            msg(
+                f"ma{i}",
+                "assistant",
+                content=f"assistant message {i}",
+                ts=_T0 + i * 10.0 + 1.0,
+                parent=f"mu{i}",
+            )
+        )
+    return derive_trajectory(messages, {}, [], [], [])
+
+
+class _Harness(App[None]):
+    """Minimal host so the screen can be pushed like the Console would."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+@contextlib.asynccontextmanager
+async def _mounted(snapshot, **kwargs):
+    """Push a TrajectoryScreen on a harness app, keeping the app running.
+
+    Everything (assertions included) must happen INSIDE this context:
+    leaving ``run_test()`` tears the app down, so a plain returning helper
+    would hand back a dead screen.
+    """
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(snapshot, **kwargs)
+        await app.push_screen(screen)
+        await pilot.pause()
+        yield app, pilot, screen
+
+
+async def _wait_for_rows(pilot, table: DataTable, minimum: int) -> None:
+    """Wait for a (worker-rendered) ledger to land, bounded."""
+    for _ in range(200):
+        if table.row_count >= minimum:
+            return
+        await pilot.pause(delay=0.02)
+    raise AssertionError(f"ledger never reached {minimum} rows (has {table.row_count})")
+
+
+# ---------------------------------------------------------------------------
+# Ledger rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mount_renders_one_row_per_record_plus_turn_headers() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        # 6 records + 2 turn-header rows.
+        assert table.row_count == 8
+        # TrajectoryRecord.seq is the row key (1-based ledger position).
+        for seq in range(1, 7):
+            assert table.get_row_index(str(seq)) is not None
+        # Tool rows are present and nested under the assistant step.
+        tool_row = table.get_row(str(3))
+        assert "tool_call" in str(tool_row[1])
+
+
+@pytest.mark.asyncio
+async def test_title_bar_shows_screen_title_and_conversation_id() -> None:
+    async with _mounted(
+        base_snapshot(), screen_title="My Conversation", conversation_id="conv-42"
+    ) as (app, pilot, screen):
+        title = screen.query_one("#trajectory-title", Static)
+        text = str(title.render())
+        assert "My Conversation" in text
+        assert "conv-42" in text
+
+
+@pytest.mark.asyncio
+async def test_t_toggles_collapse_of_focused_turn() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        assert table.row_count == 8
+        # Cursor starts on the first turn header; t collapses it (4 records hidden).
+        await pilot.press("t")
+        await pilot.pause()
+        assert table.row_count == 8 - 4
+        # The turn's record rows are gone; the later turn's rows are intact.
+        with pytest.raises(Exception):
+            table.get_row_index("1")
+        assert table.get_row_index("6") is not None
+        # t again expands it.
+        await pilot.press("t")
+        await pilot.pause()
+        assert table.row_count == 8
+
+
+@pytest.mark.asyncio
+async def test_t_on_record_row_collapses_its_turn() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        row = table.get_row_index("6")  # a2, second turn
+        table.move_cursor(row=row)
+        await pilot.pause()
+        await pilot.press("t")
+        await pilot.pause()
+        assert table.row_count == 8 - 2  # only turn 2's records hidden
+        assert table.get_row_index("1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Inspector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inspector_hidden_until_toggled() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        inspector = screen.query_one("#trajectory-inspector", Static)
+        assert inspector.display is False
+        await pilot.press("i")
+        await pilot.pause()
+        assert inspector.display is True
+        await pilot.press("i")
+        await pilot.pause()
+        assert inspector.display is False
+
+
+@pytest.mark.asyncio
+async def test_enter_shows_inspector_with_usage_timing_model() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        row = table.get_row_index("2")  # assistant record with usage + timing
+        table.move_cursor(row=row)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        inspector = screen.query_one("#trajectory-inspector", Static)
+        assert inspector.display is True
+        text = str(inspector.render())
+        # Usage breakdown: uncached input / cache read / cache write / output.
+        assert "uncached input 10" in text
+        assert "cache read 5" in text
+        assert "cache write 2" in text
+        assert "output 7" in text
+        # Model + provider.
+        assert "test-model" in text
+        assert "test-provider" in text
+        # Timing: start -> first token -> completed, with elapsed between facts.
+        assert "first token" in text
+        assert "2.00s" in text  # start -> first token
+        assert "elapsed" in text
+        assert "5.00s" in text  # start -> completed
+        # The inspected record is identified by its ledger position.
+        assert "#2" in text
+
+
+@pytest.mark.asyncio
+async def test_inspector_shows_full_tool_payload() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        row = table.get_row_index("3")  # tool_call record
+        table.move_cursor(row=row)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        inspector = screen.query_one("#trajectory-inspector", Static)
+        text = str(inspector.render())
+        assert inspector.display is True
+        assert "fs_read" in text
+        assert "/tmp/report.txt" in text
+        # FULL untruncated tool output, not the 120-char preview.
+        assert LONG_TOOL_RESULT in text
+
+
+@pytest.mark.asyncio
+async def test_inspector_timing_blank_when_null() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        row = table.get_row_index("1")  # user record: no first token/completion
+        table.move_cursor(row=row)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        inspector = screen.query_one("#trajectory-inspector", Static)
+        text = str(inspector.render())
+        assert inspector.display is True
+        # Blanks for the missing timing facts; no fabricated durations.
+        assert "—" in text
+        assert "elapsed" not in text
+
+
+@pytest.mark.asyncio
+async def test_inspector_lists_turn_level_superseded_variants() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        row = table.get_row_index("6")  # a2, turn with a variant set
+        table.move_cursor(row=row)
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        inspector = screen.query_one("#trajectory-inspector", Static)
+        text = str(inspector.render())
+        # Variant contents attach at TURN level; the label must say so.
+        assert "superseded variants (turn-level)" in text
+        assert "old zebra draft one" in text
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_focuses_search_and_filters_rows() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        await pilot.press("/")
+        await pilot.pause()
+        search = screen.query_one("#trajectory-search", Input)
+        assert search.has_focus
+        search.value = "zebras"
+        await pilot.pause()
+        # Only turn 2 survives: header + its 2 matching records.
+        assert table.row_count == 3
+        assert table.get_row_index("5") is not None
+        assert table.get_row_index("6") is not None
+        with pytest.raises(Exception):
+            table.get_row_index("1")
+        # Turn header row survives only because a child matched (it leads
+        # the filtered ledger).
+        assert table.get_row_index("turn:t2") == 0
+
+
+@pytest.mark.asyncio
+async def test_search_cleared_restores_all_rows() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        search = screen.query_one("#trajectory-search", Input)
+        search.value = "zebras"
+        await pilot.pause()
+        assert table.row_count == 3
+        search.value = ""
+        await pilot.pause()
+        assert table.row_count == 8
+
+
+@pytest.mark.asyncio
+async def test_search_matches_tool_args_and_result_payload() -> None:
+    """Tool records are searchable by their payload, not just the preview.
+
+    The preview caps at 120 chars, but tool results are a primary reason to
+    search a trajectory -- the query must reach the full args/result.
+    """
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        search = screen.query_one("#trajectory-search", Input)
+        # Args text (beyond the preview's "fs_read -> RRR..." content).
+        search.value = "report.txt"
+        await pilot.pause()
+        assert table.get_row_index("3") is not None
+        assert table.get_row_index("4") is not None
+        # Result text far past the 120-char preview cap.
+        search.value = "R" * 200
+        await pilot.pause()
+        assert table.get_row_index("3") is not None
+
+
+@pytest.mark.asyncio
+async def test_escape_from_search_refocuses_table_not_dismiss() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        await pilot.press("/")
+        await pilot.pause()
+        search = screen.query_one("#trajectory-search", Input)
+        assert search.has_focus
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is screen  # still mounted
+        assert screen.query_one("#trajectory-table", DataTable).has_focus
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_screen_from_table() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        assert screen.query_one("#trajectory-table", DataTable).has_focus
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is not screen
+
+
+# ---------------------------------------------------------------------------
+# Pagination + worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_large_ledger_mounts_newest_page_with_load_earlier_row() -> None:
+    snapshot = many_records_snapshot(record_count=600)
+    async with _mounted(snapshot) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        # Newest 500 records + their 250 turn headers + the load-earlier row.
+        assert table.row_count == 1 + 250 + 500
+        assert table.get_row_index("__load_earlier__") == 0
+        # e loads one more page: all 600 records + 300 headers, no control row.
+        await pilot.press("e")
+        await pilot.pause()
+        assert table.row_count == 300 + 600
+        with pytest.raises(Exception):
+            table.get_row_index("__load_earlier__")
+
+
+@pytest.mark.asyncio
+async def test_earlier_hint_advertised_only_while_records_remain() -> None:
+    snapshot = many_records_snapshot(record_count=PAGE_SIZE + 10)
+    async with _mounted(snapshot) as (app, pilot, screen):
+        hints = screen.query_one("#trajectory-hints", Static)
+        assert "earlier" in str(hints.render())
+        await pilot.press("e")
+        await pilot.pause()
+        assert "earlier" not in str(hints.render())
+
+
+@pytest.mark.asyncio
+async def test_oversize_ledger_renders_via_worker() -> None:
+    snapshot = many_records_snapshot(record_count=WORKER_THRESHOLD + 2)
+    async with _mounted(snapshot) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        await _wait_for_rows(pilot, table, 1 + 250 + 500)
+        assert table.get_row_index("__load_earlier__") == 0
+
+
+@pytest.mark.asyncio
+async def test_stale_worker_render_is_dropped() -> None:
+    """A worker-built ledger arriving after a newer render must not land.
+
+    The race: the >WORKER_THRESHOLD worker snapshots the render generation,
+    builds its specs off-thread, and dispatches; if the user typed a search
+    (or pressed e/t) in between, the sync render already superseded those
+    specs -- applying them would silently un-filter the ledger. The guard
+    is exercised at the seam because the pilot cannot interleave keystrokes
+    inside a worker dispatch deterministically.
+    """
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        search = screen.query_one("#trajectory-search", Input)
+        search.value = "zebras"
+        await pilot.pause()
+        assert table.row_count == 3  # filtered
+        # Specs "built at generation 0" (before the search) arriving late.
+        search.value = ""
+        await pilot.pause()  # generation moves on again; unfiltered is current
+        assert table.row_count == 8
+        stale = [
+            (key, cells)
+            for key, cells in screen._build_row_specs()
+            if key.startswith("turn:t1") or key in {"1", "2", "3", "4"}
+        ]
+        screen._apply_row_specs(stale, generation=0)
+        assert table.row_count == 8  # stale render dropped, ledger unchanged
+
+
+# ---------------------------------------------------------------------------
+# ADR-031 governance (pattern: Tests/UI/test_schedules_ux_fixes.py)
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_KEYS = {
+    "ctrl+c",
+    "ctrl+v",
+    "ctrl+x",
+    "ctrl+s",
+    "ctrl+d",
+    "ctrl+z",
+    "ctrl+a",
+    "ctrl+r",
+    "ctrl+w",
+    "ctrl+p",
+    "ctrl+q",
+}
+
+
+def test_bindings_avoid_terminal_conventions() -> None:
+    bound = {binding.key for binding in TrajectoryScreen.BINDINGS}
+    assert bound.isdisjoint(_FORBIDDEN_KEYS), (
+        f"TrajectoryScreen binds terminal-convention keys: {bound & _FORBIDDEN_KEYS}"
+    )
+
+
+def test_bindings_use_single_letter_htop_style() -> None:
+    bound = {binding.key for binding in TrajectoryScreen.BINDINGS}
+    assert {"t", "i", "e", "/"} <= bound
+
+
+def test_every_binding_has_an_implemented_action() -> None:
+    for binding in TrajectoryScreen.BINDINGS:
+        action = binding.action
+        assert hasattr(TrajectoryScreen, f"action_{action}"), (
+            f"Binding '{binding.key}' advertises unimplemented action '{action}'"
+        )
+
+
+def test_footer_hints_match_bindings_exactly() -> None:
+    binding_keys = {
+        binding.key for binding in TrajectoryScreen.BINDINGS if binding.key != "escape"
+    }
+    hint_keys = {key for key, _label in TrajectoryScreen.TRAJECTORY_SHORTCUTS}
+    assert hint_keys == binding_keys, (
+        f"Footer hints {hint_keys} are not 1:1 with BINDINGS {binding_keys}"
+    )

--- a/Tests/UI/test_trajectory_timeline.py
+++ b/Tests/UI/test_trajectory_timeline.py
@@ -1,0 +1,603 @@
+"""Tests for the brushable trajectory timeline (task-16315, part 1).
+
+Pure ``TimelineModel`` unit tests cover where correctness lives (domain
+padding, mapping, lane packing, active-in-range, zoom/pan math). Widget
+tests are pilot-driven per the repo's Textual patterns
+(``test_trajectory_screen.py``): snapshots come from the REAL projection
+(``derive_trajectory``) fed duck-typed row mirrors, and mouse-drag brush
+logic goes through the same ``brush_columns`` seam the mouse handlers
+delegate to (the pilot has no drag primitive).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from textual import events
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.trajectory import (
+    KIND_ASSISTANT,
+    KIND_TOOL_CALL,
+    KIND_USER,
+    TrajectoryRecord,
+    derive_trajectory,
+)
+from tldw_chatbook.UI.Widgets.trajectory_timeline import (
+    LANE_COUNT,
+    ZOOM_FACTOR,
+    TimelineModel,
+    TrajectoryTimeline,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-model fixtures
+# ---------------------------------------------------------------------------
+
+_T0 = 1_755_165_600.0  # arbitrary unix epoch base
+
+
+def rec(
+    seq: int,
+    kind: str = KIND_USER,
+    *,
+    start: float | None,
+    end: float | None = None,
+) -> TrajectoryRecord:
+    return TrajectoryRecord(
+        seq=seq,
+        kind=kind,
+        turn_id="t1",
+        message_id=f"m{seq}",
+        content_preview="",
+        usage=None,
+        step_started_at=start,
+        first_token_at=None,
+        completed_at=end,
+        model=None,
+        provider=None,
+        payload=None,
+        variants=(),
+        depth=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TimelineModel unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineModel:
+    def test_domain_padding(self) -> None:
+        model = TimelineModel(
+            [rec(1, start=10.0, end=20.0), rec(2, start=15.0, end=30.0)]
+        )
+        assert model.domain == (9.0, 31.0)  # 5% of the 20s span on each side
+
+    def test_null_timing_skipped(self) -> None:
+        model = TimelineModel([rec(1, start=None), rec(2, start=10.0, end=12.0)])
+        assert [r.seq for r in model.timed_records] == [2]
+
+    def test_all_null_has_no_data(self) -> None:
+        model = TimelineModel([rec(1, start=None), rec(2, start=None, end=5.0)])
+        assert model.has_data is False
+        assert model.domain is None
+
+    def test_instantaneous_span_uses_unit_pad(self) -> None:
+        model = TimelineModel([rec(1, start=10.0, end=10.0)])
+        assert model.domain == (10.0 - 0.05, 10.0 + 0.05)
+
+    def test_fraction_mapping_and_clamp(self) -> None:
+        window = (0.0, 10.0)
+        assert TimelineModel.fraction(0.0, window) == 0.0
+        assert TimelineModel.fraction(5.0, window) == pytest.approx(0.5)
+        assert TimelineModel.fraction(10.0, window) == 1.0
+        assert TimelineModel.fraction(-3.0, window) == 0.0
+        assert TimelineModel.fraction(99.0, window) == 1.0
+        assert TimelineModel.time_at(0.25, window) == pytest.approx(2.5)
+
+    def test_lane_assignment_overlap_and_reuse(self) -> None:
+        model = TimelineModel(
+            [
+                rec(1, start=0.0, end=10.0),
+                rec(2, KIND_ASSISTANT, start=2.0, end=8.0),  # overlaps rec 1
+                rec(3, KIND_TOOL_CALL, start=3.0, end=4.0),  # overlaps both
+                rec(4, start=11.0, end=12.0),  # after everything: lane 0 free
+            ]
+        )
+        assert model.lanes == (0, 1, 2, 0)
+
+    def test_lane_overflow_caps_at_last_lane(self) -> None:
+        records = [rec(i + 1, start=float(i), end=100.0) for i in range(LANE_COUNT + 2)]
+        model = TimelineModel(records)
+        assert model.lanes == (0, 1, 2, 3, 3, 3)
+        assert max(model.lanes) == LANE_COUNT - 1  # strip never grows
+
+    def test_records_in_range(self) -> None:
+        model = TimelineModel(
+            [
+                rec(1, start=0.0, end=10.0),
+                rec(2, KIND_ASSISTANT, start=12.0, end=18.0),
+                rec(3, KIND_TOOL_CALL, start=13.0, end=16.0),
+                rec(4, start=30.0, end=31.0),
+            ]
+        )
+        assert [r.seq for r in model.records_in_range(5.0, 11.0)] == [1]
+        assert [r.seq for r in model.records_in_range(14.0, 14.5)] == [2, 3]
+        # touching endpoints count as intersecting
+        assert [r.seq for r in model.records_in_range(10.0, 12.0)] == [1, 2]
+        assert [r.seq for r in model.records_in_range(100.0, 200.0)] == []
+
+    def test_zoom_in_preserves_focal_point(self) -> None:
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        window = model.zoom(domain, ZOOM_FACTOR, focal_fraction=0.5)
+        span = domain[1] - domain[0]
+        focal = domain[0] + 0.5 * span
+        assert window[1] - window[0] == pytest.approx(span / ZOOM_FACTOR)
+        assert (window[0] + window[1]) / 2 == pytest.approx(focal)
+        assert domain[0] <= window[0] and window[1] <= domain[1]
+
+    def test_zoom_out_at_domain_is_identity(self) -> None:
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        zoomed = model.zoom(domain, ZOOM_FACTOR, 0.5)
+        assert model.zoom(zoomed, 1 / ZOOM_FACTOR, 0.5) == domain
+
+    def test_zoom_clamps_inside_domain(self) -> None:
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        window = model.zoom(domain, 4.0, focal_fraction=0.0)
+        assert window[0] == domain[0]  # pinned to the left edge, not past it
+        window = model.zoom(domain, 4.0, focal_fraction=1.0)
+        assert window[1] == domain[1]
+
+    def test_zoom_clamps_focal_fraction_once(self) -> None:
+        """Out-of-range focal fractions clamp consistently everywhere."""
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        assert model.zoom(domain, 4.0, focal_fraction=2.0) == model.zoom(
+            domain, 4.0, focal_fraction=1.0
+        )
+        assert model.zoom(domain, 4.0, focal_fraction=-1.0) == model.zoom(
+            domain, 4.0, focal_fraction=0.0
+        )
+
+    def test_pan_noop_at_full_domain(self) -> None:
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        assert model.pan(domain, -0.25) == domain
+        assert model.pan(domain, 0.9) == domain
+
+    def test_pan_clamps_at_edges(self) -> None:
+        model = TimelineModel([rec(1, start=0.0, end=100.0)])
+        domain = model.domain
+        assert domain is not None
+        window = model.zoom(domain, 2.0, 0.5)
+        span = window[1] - window[0]
+        left = model.pan(window, -10.0)
+        assert left[0] == domain[0] and left[1] - left[0] == pytest.approx(span)
+        right = model.pan(window, 10.0)
+        assert right[1] == domain[1]
+        small = model.pan(window, 0.25)
+        assert small[0] - window[0] == pytest.approx(0.25 * span)
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed projection inputs (same mirrors as the trajectory screen tests)
+# ---------------------------------------------------------------------------
+
+
+def msg(
+    mid: str, sender: str, *, content: str, ts: float, parent: str | None = None
+) -> dict:
+    return {
+        "id": mid,
+        "sender": sender,
+        "content": content,
+        "timestamp": ts,
+        "parent_message_id": parent,
+        "deleted": False,
+    }
+
+
+@dataclass(frozen=True)
+class TrajRow:
+    message_id: str
+    conversation_id: str = "conv-1"
+    turn_id: str = "t1"
+    seq: int = 0
+    event_kind: str = "assistant"
+    step_started_at: float | None = None
+    first_token_at: float | None = None
+    completed_at: float | None = None
+    model: str | None = None
+    provider: str | None = None
+    payload_json: str | None = None
+
+
+def timed_snapshot():
+    """u1 [0,10] lane0; a1 [12,18] lane0; tool [13,16] lane1 (overlaps a1)."""
+    messages = [
+        msg("u1", "user", content="hello", ts=_T0, parent=None),
+        msg("a1", "assistant", content="working", ts=_T0 + 1.0, parent="u1"),
+    ]
+    rows = [
+        TrajRow(
+            "u1",
+            turn_id="t1",
+            seq=1,
+            event_kind="user",
+            step_started_at=_T0,
+            completed_at=_T0 + 10.0,
+        ),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=2,
+            event_kind="assistant",
+            step_started_at=_T0 + 12.0,
+            completed_at=_T0 + 18.0,
+        ),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=3,
+            event_kind="tool_call",
+            step_started_at=_T0 + 13.0,
+            completed_at=_T0 + 16.0,
+            payload_json='{"name": "fs_read", "args": {}, "result": "ok"}',
+        ),
+    ]
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+def untimed_snapshot():
+    """Same shape but every sidecar row lacks timing: NULL-only."""
+    messages = [
+        msg("u1", "user", content="hello", ts=_T0, parent=None),
+        msg("a1", "assistant", content="working", ts=_T0 + 1.0, parent="u1"),
+    ]
+    rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+class TimelineApp(App[None]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured: list[object] = []
+
+    def compose(self) -> ComposeResult:
+        yield TrajectoryTimeline()
+
+    def on_trajectory_timeline_trajectory_brush_changed(self, event) -> None:
+        self.captured.append(event)
+
+    def on_trajectory_timeline_trajectory_bar_selected(self, event) -> None:
+        self.captured.append(event)
+
+    def on_trajectory_timeline_trajectory_viewport_changed(self, event) -> None:
+        self.captured.append(event)
+
+
+def _brush_events(app: TimelineApp):
+    return [
+        e
+        for e in app.captured
+        if isinstance(e, TrajectoryTimeline.TrajectoryBrushChanged)
+    ]
+
+
+def _bar_events(app: TimelineApp):
+    return [
+        e
+        for e in app.captured
+        if isinstance(e, TrajectoryTimeline.TrajectoryBarSelected)
+    ]
+
+
+def _viewport_events(app: TimelineApp):
+    return [
+        e
+        for e in app.captured
+        if isinstance(e, TrajectoryTimeline.TrajectoryViewportChanged)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Widget pilot tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrajectoryTimelineWidget:
+    async def test_set_snapshot_initializes_viewport_to_domain(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            assert tl.model.has_data
+            assert tl.viewport == tl.model.domain
+            assert tl.brush is None
+
+    async def test_untimed_snapshot_renders_placeholder(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(untimed_snapshot())
+            await pilot.pause()
+            assert not tl.model.has_data
+            assert "no timing data" in str(tl.render())
+
+    async def test_render_draws_bars_and_caption(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            lines = str(tl.render()).splitlines()
+            assert len(lines) == 6  # 4 lanes + axis + caption
+            assert "█" in lines[0]  # u1 lives on lane 0
+            assert "no brush" in lines[-1]
+
+    async def test_click_on_bar_selects_and_clears_brush(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            # Pre-existing brush must be cleared by a bar click.
+            tl.brush_columns(4, 8)
+            await pilot.pause()
+            app.captured.clear()
+
+            # u1 spans columns ~3..44 on lane 0 at width 80.
+            clicked = await pilot.click(tl, offset=(10, 0))
+            assert clicked
+            await pilot.pause()
+            bars = _bar_events(app)
+            assert len(bars) == 1
+            assert bars[0].record_key == 1  # u1's ledger seq
+            cleared = _brush_events(app)
+            assert cleared[-1].brush_range is None
+            assert tl.brush is None
+
+    async def test_click_empty_space_clears_brush(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            tl.brush_columns(4, 8)
+            await pilot.pause()
+            assert tl.brush is not None
+            app.captured.clear()
+
+            # Column 48, lane 0 sits in the gap between u1 and a1.
+            await pilot.click(tl, offset=(48, 0))
+            await pilot.pause()
+            assert _bar_events(app) == []
+            assert _brush_events(app)[-1].brush_range is None
+            assert tl.brush is None
+
+    async def test_drag_brush_posts_range_and_counts_active(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+
+            tl.brush_columns(5, 30)  # same seam the mouse-drag handlers use
+            await pilot.pause()
+            events = _brush_events(app)
+            assert events, "brush drag should post TrajectoryBrushChanged"
+            lo, hi = events[-1].brush_range
+            assert lo < hi
+            assert [r.seq for r in tl.model.records_in_range(lo, hi)] == [1]
+            assert tl.brush == (lo, hi)
+
+            # The caption now reports the brush instead of "no brush".
+            caption = str(tl.render()).splitlines()[-1]
+            assert "no brush" not in caption
+            assert "1 active" in caption
+
+    async def test_zoom_keys_change_window_and_post_viewport(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            tl.focus()
+            domain = tl.model.domain
+            assert domain is not None
+
+            await pilot.press("]")  # zoom in at center
+            await pilot.pause()
+            events = _viewport_events(app)
+            assert len(events) == 1
+            assert events[0].domain_window == tl.viewport
+            assert tl.viewport[1] - tl.viewport[0] < domain[1] - domain[0]
+
+            await pilot.press("[")  # zoom back out: returns to the domain
+            await pilot.pause()
+            assert tl.viewport == domain
+            assert _viewport_events(app)[-1].domain_window == domain
+
+    async def test_pan_keys_clamp_at_domain_edges(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            tl.focus()
+            domain = tl.model.domain
+            assert domain is not None
+
+            await pilot.press(",")  # pan left at full domain: no-op
+            await pilot.pause()
+            assert tl.viewport == domain
+            assert _viewport_events(app) == []
+
+            await pilot.press("]")  # zoom in, then pan left hits the edge
+            await pilot.pause()
+            app.captured.clear()
+            await pilot.press(",")
+            await pilot.pause()
+            assert tl.viewport[0] == domain[0]
+            panned = tl.viewport
+            await pilot.press(",")  # further pans stay clamped
+            await pilot.pause()
+            assert tl.viewport == panned
+
+            await pilot.press(".")  # pan right moves the window
+            await pilot.pause()
+            assert tl.viewport[0] > domain[0]
+
+    async def test_zoom_at_mouse_focal(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            domain = tl.model.domain
+            assert domain is not None
+            before = tl.viewport
+            tl.zoom_at(ZOOM_FACTOR, focal_fraction=0.75)  # wheel-up seam
+            await pilot.pause()
+            after = tl.viewport
+            assert after != before
+            span = domain[1] - domain[0]
+            focal = domain[0] + 0.75 * span
+            # 75% point of the old window stays at 75% of the new window.
+            assert after[0] + 0.75 * (after[1] - after[0]) == pytest.approx(focal)
+            assert _viewport_events(app)[-1].domain_window == after
+
+
+def _mouse(
+    tl: TrajectoryTimeline,
+    event_cls: type,
+    x: float,
+    y: float,
+    *,
+    button: int = 0,
+) -> object:
+    """Build a widget-relative MouseEvent of the given class for posting."""
+    return event_cls(
+        widget=tl,
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=button,
+        shift=False,
+        meta=False,
+        ctrl=False,
+    )
+
+
+class TestTimelineMouseGlue:
+    """Hand-posted real mouse events through the handler glue.
+
+    The pilot has no drag/scroll primitives, so these drive
+    ``MouseDown``/``MouseMove``/``MouseUp``/``MouseScroll*`` events
+    directly at the mounted widget (widget-relative coordinates, the
+    same shape Textual's own dispatch delivers).
+    """
+
+    async def test_drag_brush_via_posted_events_captures_mouse(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+
+            tl.post_message(_mouse(tl, events.MouseDown, 10, 0, button=1))
+            await pilot.pause()
+            assert app.mouse_captured is tl  # gesture keeps the moves
+
+            tl.post_message(_mouse(tl, events.MouseMove, 30, 0, button=1))
+            await pilot.pause()
+            tl.post_message(_mouse(tl, events.MouseUp, 30, 0, button=1))
+            await pilot.pause()
+
+            assert app.mouse_captured is None  # released on mouse up
+            assert _bar_events(app) == []
+            events_ = _brush_events(app)
+            assert events_, "down+move+up must post brush changes"
+            lo, hi = events_[-1].brush_range
+            assert lo < hi
+            assert tl.brush == (lo, hi)
+
+    async def test_move_without_prior_down_is_ignored(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+
+            tl.post_message(_mouse(tl, events.MouseMove, 30, 0, button=1))
+            await pilot.pause()
+            assert tl.brush is None
+            assert _brush_events(app) == []
+            assert app.mouse_captured is None
+
+    async def test_scroll_events_zoom_at_mouse_x(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+            domain = tl.model.domain
+            assert domain is not None
+            span = domain[1] - domain[0]
+
+            tl.post_message(_mouse(tl, events.MouseScrollUp, 60, 0))
+            await pilot.pause()
+            after = tl.viewport
+            assert after is not None
+            assert after != domain
+            # Column 60 (fraction (60+0.5)/80) stays fixed by the zoom.
+            f = (60 + 0.5) / 80
+            assert after[0] + f * (after[1] - after[0]) == pytest.approx(
+                domain[0] + f * span
+            )
+            assert _viewport_events(app)[-1].domain_window == after
+
+            tl.post_message(_mouse(tl, events.MouseScrollDown, 60, 0))
+            await pilot.pause()
+            assert tl.viewport == domain  # zoom back out: full domain
+
+    async def test_click_vs_drag_discrimination(self) -> None:
+        app = TimelineApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            tl = app.query_one(TrajectoryTimeline)
+            tl.set_snapshot(timed_snapshot())
+            await pilot.pause()
+
+            # Down + up at the same spot on u1's bar: a click, not a drag.
+            tl.post_message(_mouse(tl, events.MouseDown, 10, 0, button=1))
+            await pilot.pause()
+            tl.post_message(_mouse(tl, events.MouseUp, 10, 0, button=1))
+            await pilot.pause()
+            bars = _bar_events(app)
+            assert len(bars) == 1 and bars[0].record_key == 1
+            assert tl.brush is None
+
+            # Down + move + up: a drag, never a bar selection.
+            app.captured.clear()
+            tl.post_message(_mouse(tl, events.MouseDown, 10, 0, button=1))
+            tl.post_message(_mouse(tl, events.MouseMove, 30, 0, button=1))
+            tl.post_message(_mouse(tl, events.MouseUp, 30, 0, button=1))
+            await pilot.pause()
+            assert _bar_events(app) == []
+            assert _brush_events(app)
+            assert tl.brush is not None

--- a/Tests/UI/test_trajectory_timeline_integration.py
+++ b/Tests/UI/test_trajectory_timeline_integration.py
@@ -1,0 +1,299 @@
+"""Integration tests: brushable timeline strip inside TrajectoryScreen (task-16315).
+
+Covers the screen <-> :class:`TrajectoryTimeline` seams only (geometry and
+standalone widget behaviour live in ``test_trajectory_timeline.py``):
+
+- the strip mounts between the search box and the ledger, always;
+- a brush filters the ledger to ACTIVE-in-range records, composing with
+  the search query (AND), and clearing restores;
+- bar click moves the ledger cursor (paging in older records when
+  needed) and clears only the brush -- the search stays;
+- ledger cursor moves highlight the record's bar;
+- live refreshes feed the strip the new snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import DataTable, Input
+
+from tldw_chatbook.Chat.trajectory import derive_trajectory
+from tldw_chatbook.UI.Widgets.trajectory_timeline import TrajectoryTimeline
+
+# Same duck-typed projection stand-ins as the screen tests (Tests is a
+# package, so the sibling module is importable).
+from Tests.UI.test_trajectory_screen import (  # noqa: I001
+    _T0,
+    _mounted,
+    base_snapshot,
+    many_records_snapshot,
+    msg,
+    TrajRow,
+)
+
+
+def untimed_snapshot():
+    """Two records with NULL timing: the strip must show its placeholder."""
+    messages = [
+        msg("u1", "user", content="hello", ts=_T0),
+        msg("a1", "assistant", content="hi", ts=_T0 + 1.0, parent="u1"),
+    ]
+    rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
+        TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+def grown_snapshot():
+    """base_snapshot plus a third, later turn (all timed)."""
+    messages = [
+        msg("u1", "user", content="hello trajectory world", ts=_T0),
+        msg(
+            "a1",
+            "assistant",
+            content="checking that for you",
+            ts=_T0 + 2.0,
+            parent="u1",
+        ),
+        msg(
+            "u2",
+            "user",
+            content="second question about zebras",
+            ts=_T0 + 60.0,
+            parent="a1",
+        ),
+        msg(
+            "a2", "assistant", content="zebras have stripes", ts=_T0 + 65.0, parent="u2"
+        ),
+        msg("u3", "user", content="third question", ts=_T0 + 120.0, parent="a2"),
+        msg("a3", "assistant", content="third answer", ts=_T0 + 122.0, parent="u3"),
+    ]
+    rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user", step_started_at=_T0),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=2,
+            event_kind="assistant",
+            step_started_at=_T0,
+            completed_at=_T0 + 5.0,
+        ),
+        TrajRow(
+            "u2", turn_id="t2", seq=3, event_kind="user", step_started_at=_T0 + 60.0
+        ),
+        TrajRow(
+            "a2",
+            turn_id="t2",
+            seq=4,
+            event_kind="assistant",
+            step_started_at=_T0 + 65.0,
+            completed_at=_T0 + 70.0,
+        ),
+        TrajRow(
+            "u3", turn_id="t3", seq=5, event_kind="user", step_started_at=_T0 + 120.0
+        ),
+        TrajRow(
+            "a3",
+            turn_id="t3",
+            seq=6,
+            event_kind="assistant",
+            step_started_at=_T0 + 120.0,
+            completed_at=_T0 + 123.0,
+        ),
+    ]
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+async def _brush(pilot, timeline: TrajectoryTimeline, lo: float, hi: float) -> None:
+    timeline.post_message(TrajectoryTimeline.TrajectoryBrushChanged((lo, hi)))
+    await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# Layout + data feed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeline_mounts_between_search_and_table() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        ids = [widget.id for widget in screen.query_one("#trajectory-screen").children]
+        assert ids.index("trajectory-search") < ids.index("trajectory-timeline")
+        assert ids.index("trajectory-timeline") < ids.index("trajectory-table")
+
+
+@pytest.mark.asyncio
+async def test_timeline_renders_bars_for_timed_snapshot() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        assert timeline.size.height == 6  # the 6-line strip
+        assert "█" in str(timeline.render())
+
+
+@pytest.mark.asyncio
+async def test_timeline_shows_placeholder_without_timing() -> None:
+    async with _mounted(untimed_snapshot()) as (app, pilot, screen):
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        assert "no timing data" in str(timeline.render())
+
+
+# ---------------------------------------------------------------------------
+# Brush filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brush_filters_ledger_to_active_records() -> None:
+    """A range over turn 1 keeps seq 1-4; u2 (outside) and a2 (untimed) drop."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        assert table.row_count == 8
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        # Turn 1 header + its 4 records; turn 2 header hidden (no child
+        # visible) exactly like the search rule.
+        assert table.row_count == 5
+        assert table.get_row_index("turn:t1") == 0
+        for seq in ("1", "2", "3", "4"):
+            assert table.get_row_index(seq) is not None
+        for seq in ("5", "6"):
+            with pytest.raises(Exception):
+                table.get_row_index(seq)
+
+
+@pytest.mark.asyncio
+async def test_brush_composes_with_search_as_and() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        search = screen.query_one("#trajectory-search", Input)
+        search.value = "zebras"  # only seq 5/6 match
+        await pilot.pause()
+        assert table.row_count == 3
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)  # only seq 1-4 active
+        assert table.row_count == 0  # intersection is empty: headers hidden too
+
+
+@pytest.mark.asyncio
+async def test_brush_clear_restores_all_rows() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        assert table.row_count == 5
+        timeline.post_message(TrajectoryTimeline.TrajectoryBrushChanged(None))
+        await pilot.pause()
+        assert table.row_count == 8
+
+
+@pytest.mark.asyncio
+async def test_widget_drag_seam_posts_brush_that_filters() -> None:
+    """brush_columns (the mouse-drag seam) reaches the ledger too."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        timeline.brush_columns(3, 10)  # left edge of the strip: turn 1 only
+        await pilot.pause()
+        assert screen._brush_range == timeline.brush
+        assert table.row_count == 5
+        # The strip's caption doubles as the brush status note.
+        assert "active" in str(timeline.render())
+
+
+@pytest.mark.asyncio
+async def test_brush_reveals_collapsed_turn_with_active_children() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await pilot.press("t")  # collapse turn 1 (cursor starts on its header)
+        await pilot.pause()
+        assert table.row_count == 4
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        # Same reveal rule as search: filtering shows the active children.
+        assert table.row_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Selection sync (both ways)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bar_select_moves_ledger_cursor_and_highlights() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        timeline.post_message(TrajectoryTimeline.TrajectoryBarSelected(3))
+        await pilot.pause()
+        assert table.cursor_row == table.get_row_index("3")
+        assert timeline.selected == 3  # mirrored via RowHighlighted
+
+
+@pytest.mark.asyncio
+async def test_bar_select_clears_brush_but_not_search() -> None:
+    """A record hidden by the search: clear only the brush, keep the query."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        search = screen.query_one("#trajectory-search", Input)
+        search.value = "zebras"
+        await pilot.pause()
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        assert table.row_count == 0
+        timeline.post_message(TrajectoryTimeline.TrajectoryBarSelected(2))
+        await pilot.pause()
+        # Brush filter dropped; search filter intact.
+        assert screen._brush_range is None
+        assert table.row_count == 3
+        with pytest.raises(Exception):
+            table.get_row_index("2")  # still search-hidden: no cursor move
+
+
+@pytest.mark.asyncio
+async def test_bar_select_pages_in_older_record() -> None:
+    snapshot = many_records_snapshot(record_count=600)
+    async with _mounted(snapshot) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        with pytest.raises(Exception):
+            table.get_row_index("1")  # paginated out at mount
+        timeline.post_message(TrajectoryTimeline.TrajectoryBarSelected(1))
+        await pilot.pause()
+        assert table.get_row_index("1") is not None
+        assert table.cursor_row == table.get_row_index("1")
+
+
+@pytest.mark.asyncio
+async def test_ledger_cursor_move_highlights_timeline_bar() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        table.move_cursor(row=table.get_row_index("6"))
+        await pilot.pause()
+        assert timeline.selected == 6
+        table.move_cursor(row=0)  # back to the turn header
+        await pilot.pause()
+        assert timeline.selected is None
+
+
+# ---------------------------------------------------------------------------
+# Live refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_refresh_feeds_timeline_and_clears_brush() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        assert table.row_count == 5
+        screen._apply_live_snapshot(grown_snapshot())
+        await pilot.pause()
+        # The strip renders the new snapshot's records...
+        assert len(timeline.model.timed_records) == 6
+        # ...and the widget-side brush reset is mirrored by the screen.
+        assert screen._brush_range is None
+        assert timeline.brush is None
+        assert table.row_count == 9  # 3 turn headers + 6 records

--- a/Tests/UI/test_trajectory_timeline_integration.py
+++ b/Tests/UI/test_trajectory_timeline_integration.py
@@ -14,6 +14,8 @@ standalone widget behaviour live in ``test_trajectory_timeline.py``):
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 from textual.widgets import DataTable, Input
 
@@ -41,6 +43,27 @@ def untimed_snapshot():
     rows = [
         TrajRow("u1", turn_id="t1", seq=1, event_kind="user"),
         TrajRow("a1", turn_id="t1", seq=2, event_kind="assistant"),
+    ]
+    return derive_trajectory(messages, {}, rows, [], [])
+
+
+def disjoint_snapshot():
+    """All timing far beyond base_snapshot's domain (a full snapshot swap)."""
+    base = _T0 + 100_000.0
+    messages = [
+        msg("u1", "user", content="later hello", ts=base),
+        msg("a1", "assistant", content="later answer", ts=base + 1.0, parent="u1"),
+    ]
+    rows = [
+        TrajRow("u1", turn_id="t1", seq=1, event_kind="user", step_started_at=base),
+        TrajRow(
+            "a1",
+            turn_id="t1",
+            seq=2,
+            event_kind="assistant",
+            step_started_at=base,
+            completed_at=base + 2.0,
+        ),
     ]
     return derive_trajectory(messages, {}, rows, [], [])
 
@@ -283,7 +306,13 @@ async def test_ledger_cursor_move_highlights_timeline_bar() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_refresh_feeds_timeline_and_clears_brush() -> None:
+async def test_live_refresh_feeds_timeline_and_preserves_brush() -> None:
+    """A revision tick must not destroy an active brush.
+
+    The grown snapshot extends the domain (appends); a brush still
+    intersecting it survives on BOTH sides and keeps filtering the
+    rebuilt ledger.
+    """
     async with _mounted(base_snapshot()) as (app, pilot, screen):
         table = screen.query_one("#trajectory-table", DataTable)
         timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
@@ -293,7 +322,36 @@ async def test_live_refresh_feeds_timeline_and_clears_brush() -> None:
         await pilot.pause()
         # The strip renders the new snapshot's records...
         assert len(timeline.model.timed_records) == 6
-        # ...and the widget-side brush reset is mirrored by the screen.
+        # ...and the brush survives: widget, screen state and ledger
+        # filter all still agree (grown seqs 1/2 are the turn-1 records).
+        assert timeline.brush == (_T0 - 1.0, _T0 + 6.0)
+        assert screen._brush_range == (_T0 - 1.0, _T0 + 6.0)
+        assert table.row_count == 3  # turn:t1 header + records 1, 2
+
+
+@pytest.mark.asyncio
+async def test_live_refresh_clears_brush_outside_new_domain() -> None:
+    """A brush disjoint from the swapped-in domain clears cleanly."""
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        timeline = screen.query_one("#trajectory-timeline", TrajectoryTimeline)
+        await _brush(pilot, timeline, _T0 - 1.0, _T0 + 6.0)
+        assert table.row_count == 5
+        screen._apply_live_snapshot(disjoint_snapshot())
+        await pilot.pause()
         assert screen._brush_range is None
         assert timeline.brush is None
-        assert table.row_count == 9  # 3 turn headers + 6 records
+        assert table.row_count == 3  # unfiltered: header + 2 records
+
+
+# ---------------------------------------------------------------------------
+# Brush caption clock matches the ledger's local-time columns
+# ---------------------------------------------------------------------------
+
+
+def test_widget_clock_formats_local_time_like_ledger() -> None:
+    from tldw_chatbook.UI.Widgets.trajectory_timeline import _fmt_clock as strip_clock
+    from tldw_chatbook.UI.Screens.trajectory_screen import _fmt_clock as ledger_clock
+
+    assert strip_clock(_T0) == ledger_clock(_T0)
+    assert strip_clock(_T0) == datetime.fromtimestamp(_T0).strftime("%H:%M:%S")

--- a/backlog/decisions/066-console-trajectory-view-and-trace-metadata.md
+++ b/backlog/decisions/066-console-trajectory-view-and-trace-metadata.md
@@ -1,0 +1,67 @@
+# ADR-066: Console Trajectory View and Trace Metadata Sidecar
+
+- Status: Accepted
+- Date: 2026-08-14
+- Spec: `Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md`
+- Reference: deepseek-harness `packages/client/ui-trajectory` (Trajectory screen) and
+  `packages/session-query` (`traceSession`/`traceEvent`)
+
+## Context
+
+The Console needs a trajectory (trace) view over conversations: an event
+ledger grouped by turn with tool-call nesting, per-record token usage and
+timing inspector, search, and live tail-follow. Verified substrate facts:
+
+- Schema v37 already persists per-message token usage (`usage_json`) and
+  provenance (`metadata_json`), both local-only.
+- Timing (step start / first token / completion) is captured nowhere.
+- `turn_id` exists only in memory (`ConsoleChatMessage.turn_id`).
+- TOOL-role messages are **deliberately session-only display markers**
+  (TOOL-marker invariant in `console_chat_store.py`); tool activity and
+  `tool_output_full` are never persisted.
+- Forking = variant tree siblings; compaction = transactional records in
+  `console_context_repository` (no persisted message row).
+
+## Decision
+
+1. **New local-only sidecar table `message_trajectory_metadata` (schema
+   v38)**, PK `(message_id, event_kind, seq)`, unique `(conversation_id,
+   seq)`. It holds: turn identity, per-record timing, model/provider, and —
+   for `tool_call`/`tool_result` records — the full payload including
+   untruncated output in `payload_json`. Never synced.
+2. **Tool records live only in the sidecar** — writing them to `messages`
+   would violate the TOOL-marker invariant. The trajectory view is the only
+   surface where historical tool output is reviewable.
+3. **Timing captured in the Console controller streaming path** (step start,
+   first chunk, completion) and persisted through the existing usage/metadata
+   persistence seam. No provider-layer changes.
+4. **Pure projection module `Chat/trajectory.py`**: folds messages +
+   usage_json + sidecar rows + variant sets + compaction records into a
+   `TrajectorySnapshot`. No Textual dependency. Turn boundaries derived; the
+   ledger renders the active path with variants surfaced in the inspector;
+   soft-deleted messages excluded.
+5. **Trajectory screen launched from the Console** (ADR-031 keybindings):
+   DataTable ledger with turn collapse, inspector, search, live tail-follow.
+   Brushable timeline widget is a deliberate follow-up, enabled by the
+   sidecar's `seq` + timestamps.
+
+## Alternatives considered
+
+- **JSON keys in existing `metadata_json`**: no migration, but weakest
+  long-term extendability — lineage/timing facts deserve typed, evolvable,
+  queryable storage (forking/compaction already exist and will grow).
+- **ALTER `messages` with new columns**: couples trajectory facts to the
+  synced core and its sync triggers; migrations on the sidecar are cheaper
+  and independently evolvable.
+- **dsh-faithful append-only event log table**: duplicates the normalized
+  history `messages` + variants + compaction repo already record; doubles
+  write paths for no v1-visible gain. Lineage/tracing views can be built
+  later on the sidecar + variants if needed.
+
+## Consequences
+
+- One migration (v37→v38) with the standard runner + per-migration test.
+- Local DB grows for tool-heavy conversations (full tool outputs). Accepted:
+  local-only, and it restores reviewability of past tool activity.
+- Conversations predating v38 render with blank timing and timestamp-derived
+  grouping; no backfill.

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -1,0 +1,53 @@
+# Lessons: Textual framework traps
+
+Working knowledge about the Textual version this repo pins (8.x, currently 8.2.8) —
+API gotchas that cost a debug cycle when first met. Not decisions (see
+`backlog/decisions/`) — these are traps that have actually cost time here, kept so the
+next person does not rediscover them.
+
+**Every entry states the incident that produced it.** A lesson without its evidence
+decays into folklore, and folklore gets ignored. If you add one, bring the incident.
+
+---
+
+## `run_worker` does not forward positional arguments to the callable
+
+**TASK-16314 review round, 2026-08-14 (commit `14373a7ac`).** The trajectory screen's
+live poller needed to run `self._live_rebuild_worker(revision)` in an exclusive worker
+carrying the revision the rebuild was built for, so a slow older rebuild could be
+identified and dropped when a newer revision had since been observed. The natural call
+— `run_worker(self._live_rebuild_worker, revision, thread=True, exclusive=True)` —
+cannot work: Textual 8.2.8's signature is
+`run_worker(work, name='', group='default', description='', exit_on_error=True,
+start=True, exclusive=False, thread=False)` with **no `*args` passthrough**. The extra
+positional binds to `name` (verified by introspection against the installed 8.2.8),
+and the worker invokes the callable with zero arguments — for a method with a required
+parameter that surfaces as a confusing `TypeError` inside the worker; for a callable
+with optional parameters it would run silently on defaults, which is worse. The pilot
+caught it; the fix is a closure:
+
+```python
+self.run_worker(
+    lambda: self._live_rebuild_worker(revision),
+    thread=True,
+    group="trajectory-live",
+    exclusive=True,
+)
+```
+
+**What to do.** When a worker callable needs arguments, close over them (a `lambda`
+or `functools.partial`) — never pass them positionally after the callable to
+`run_worker`; they are constructor parameters of the worker, not arguments of your
+function, and nothing warns you. Same discipline for `timer`/`set_interval` callbacks
+that need captured state. If the arguments are cheap to recompute inside the worker,
+prefer passing a zero-argument method and re-reading state there — it also avoids
+holding stale references across `exclusive=True` cancellations.
+
+---
+
+## Related
+
+- `lessons-testing-evidence.md` — includes the Pilot-harness traps (detached widget
+  references after recompose, bare-`App` harnesses that never load the app stylesheet)
+- `lessons-live-verification.md` — why a green suite can still miss live-only defects
+- `lessons-backlog-hygiene.md` — task IDs, CLI quirks, git plumbing traps

--- a/backlog/tasks/task-16311 - Schema-v38-trajectory-metadata-sidecar.md
+++ b/backlog/tasks/task-16311 - Schema-v38-trajectory-metadata-sidecar.md
@@ -1,0 +1,21 @@
+---
+id: TASK-16311
+title: Schema v38 trajectory metadata sidecar
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:10'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Local-only message_trajectory_metadata table (turn_id, seq, timing, tool payload_json) with migration, accessors, and tests. Per ADR-066 and Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md; plan task 1 in Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Migration v37->v38 runs idempotently,Accessors roundtrip rows,Per-migration tests pass
+<!-- AC:END -->

--- a/backlog/tasks/task-16311 - Schema-v38-trajectory-metadata-sidecar.md
+++ b/backlog/tasks/task-16311 - Schema-v38-trajectory-metadata-sidecar.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16311
 title: Schema v38 trajectory metadata sidecar
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-15 00:10'
+updated_date: '2026-08-15 05:48'
 labels: []
 dependencies: []
 priority: high
@@ -17,5 +18,41 @@ Local-only message_trajectory_metadata table (turn_id, seq, timing, tool payload
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Migration v37->v38 runs idempotently,Accessors roundtrip rows,Per-migration tests pass
+- [x] #1 Migration v37->v38 runs idempotently,Accessors roundtrip rows,Per-migration tests pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commits 380ea19e4/d74d8851e/f53b656f4: schema v38 sidecar, accessors, BEGIN IMMEDIATE concurrency fix; 5 migration tests green; see Implementation Notes and ADR-066
+
+- **Approach**: local-only `message_trajectory_metadata` sidecar per ADR-066
+  (`backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`) and the design
+  spec (`Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md`). Stable
+  synced `messages` core, evolvable local edge — future trajectory columns land here
+  without touching sync triggers.
+- **Key files**: `tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql`
+  (new); `tldw_chatbook/DB/ChaChaNotes_DB.py` (dataclasses `TrajectoryRowWrite`/`TrajectoryRowRead`,
+  `_CURRENT_SCHEMA_VERSION = 38`, `_migrate_from_v37_to_v38` + dispatch entry, accessors
+  `upsert_trajectory_rows` / `get_trajectory_rows` / `get_next_trajectory_seq`);
+  `tldw_chatbook/DB/sql_validation.py` (table allowlist entry);
+  `Tests/DB/test_chachanotes_trajectory_metadata_migration.py` (5 tests, green).
+- **Decisions**: tool records are **sidecar-only** — TOOL-role messages are deliberately
+  never persisted to `messages` (the TOOL-marker invariant), so `tool_call`/`tool_result`
+  rows live entirely in this table keyed to the parent assistant message, with
+  `payload_json` carrying name/args/result. PK `(message_id, event_kind, seq)` allows
+  multiple tool calls per assistant step. Review round made `conv_seq` a UNIQUE index
+  (ledger-ordering guarantee), added the `conversations` FK, and an `message_id` index.
+- **Concurrency**: `upsert_trajectory_rows` assigns `max(seq)+1` inside the write
+  transaction, which now opens with `BEGIN IMMEDIATE` (`transaction(immediate=True)`,
+  opt-in — all other callers keep DEFERRED). Under deferred BEGIN, two concurrent
+  writers hit SQLite's non-retryable snapshot-upgrade deadlock; IMMEDIATE makes them
+  queue on the busy timeout. Pinned by `test_concurrent_direct_db_upserts_produce_unique_seqs`
+  (2 threads x 25 rows -> unique, gap-free 1..50). `get_next_trajectory_seq` opens its
+  own transaction and must not be nested.
+- **Deviations**: version bump required two out-of-brief fixes to hold the DB baseline —
+  sql_validation allowlist entry and v37 pins at three reopen sites in
+  `test_chachanotes_provider_continuation_migration.py`. Tests live at repo-root
+  `Tests/DB/` (no `tldw_chatbook/Tests/` exists). 4 pre-existing `Tests/DB/` failures
+  (stale v36 pins from the v37 merge) verified unchanged by this work.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16311.1 - Capture-trajectory-timing-and-tool-records.md
+++ b/backlog/tasks/task-16311.1 - Capture-trajectory-timing-and-tool-records.md
@@ -1,0 +1,22 @@
+---
+id: TASK-16311.1
+title: Capture trajectory timing and tool records
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:11'
+labels: []
+dependencies:
+  - TASK-16311
+parent_task_id: TASK-16311
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stamp step-start/first-token/completion in the Console controller streaming path; write user/assistant/tool_call/tool_result sidecar rows through the persistence seam. Plan task 2 in Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Persisted messages get sidecar rows with turn_id,Streamed assistant rows have timing fields,Tool markers produce payload rows with full output,Capture never fails a turn
+<!-- AC:END -->

--- a/backlog/tasks/task-16311.1 - Capture-trajectory-timing-and-tool-records.md
+++ b/backlog/tasks/task-16311.1 - Capture-trajectory-timing-and-tool-records.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16311.1
 title: Capture trajectory timing and tool records
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-15 00:11'
+updated_date: '2026-08-15 05:48'
 labels: []
 dependencies:
   - TASK-16311
@@ -18,5 +19,43 @@ Stamp step-start/first-token/completion in the Console controller streaming path
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Persisted messages get sidecar rows with turn_id,Streamed assistant rows have timing fields,Tool markers produce payload rows with full output,Capture never fails a turn
+- [x] #1 Persisted messages get sidecar rows with turn_id,Streamed assistant rows have timing fields,Tool markers produce payload rows with full output,Capture never fails a turn
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commits 517d34b6d/f53b656f4: capture seam in store/controller/service, byte-safe 256 KiB payload cap; 9 tests green; see Implementation Notes and ADR-066
+
+- **Approach**: per ADR-066
+  (`backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`), the Console
+  persistence seam captures trajectory facts opportunistically — every write is guarded
+  try/except with loguru context (ids/counts only), so capture can never fail a turn.
+- **Key files**: `tldw_chatbook/Chat/console_chat_store.py` (persist-seam
+  `_write_trajectory_row_for_message`, turn identity `_trajectory_turn_id`,
+  `_record_trajectory_tool_marker`, first-token stamp in `append_stream_chunk`, public
+  `record_trajectory_timing` / `write_trajectory_rows`);
+  `tldw_chatbook/Chat/console_chat_controller.py` (`step_started_at` armed at the
+  `_stream_assistant_response_inner` dispatch choke point; `completed_at` + model/provider
+  stamped + flushed in `_attach_stream_usage` before its usage early-returns);
+  `tldw_chatbook/Chat/chat_persistence_service.py` (`write_trajectory_rows` with bounded
+  5-attempt retry/backoff for write-lock contention);
+  `Tests/Chat/test_trajectory_capture.py` (9 tests, green).
+- **Decisions**: tool records stay **sidecar-only** per the TOOL-marker invariant — the
+  marker itself is never persisted to `messages` (tested); `tool_call`/`tool_result` rows
+  key on the anchor assistant message's persisted id, with streaming-anchor payloads
+  stashed under the native id and remapped at persist time. Tool result payload is capped
+  at **256 KiB byte-safe**: the encoded bytes are truncated and decoded back with
+  `errors="ignore"` (a character-count slice could leave 4x over-budget for multibyte
+  content — review fix, pinned by `test_tool_result_cap_is_byte_safe_for_multibyte_content`)
+  with `{"truncated": true}` marker. One `upsert_trajectory_rows` batch per turn. USER rows
+  get `step_started_at` only; NULL timing is never fabricated.
+- **Deviations**: the first-token stamp lives in the store's `append_stream_chunk` rather
+  than the brief's `_stream_assistant_response_inner` — the chunk loop was extracted to
+  `_run_direct_provider_reply` and the agent path streams through the bridge, so the store
+  seam is the one place both paths flow through. `args` in tool payloads is `null` for now:
+  the marker-append seam carries only marker text + `tool_output_full`; plumbing the arg
+  dict through `console_agent_bridge.py` is a one-line follow-up. Console-side
+  in-process lock + service retry kept as belt-and-braces on top of the DB-layer
+  `BEGIN IMMEDIATE` fix (task-16311).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16312 - Trajectory-projection-module.md
+++ b/backlog/tasks/task-16312 - Trajectory-projection-module.md
@@ -1,0 +1,21 @@
+---
+id: TASK-16312
+title: Trajectory projection module
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:16'
+labels: []
+dependencies:
+  - TASK-16311.1
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pure Chat/trajectory.py folding messages+usage+sidecar+variants+compaction into TrajectorySnapshot (turns/records, nesting, NULL timing, active-path variants). Plan task 3 in Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 derive_trajectory unit tests pass,No Textual dependency,Legacy fallback grouping works
+<!-- AC:END -->

--- a/backlog/tasks/task-16312 - Trajectory-projection-module.md
+++ b/backlog/tasks/task-16312 - Trajectory-projection-module.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16312
 title: Trajectory projection module
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-15 00:16'
+updated_date: '2026-08-15 05:48'
 labels: []
 dependencies:
   - TASK-16311.1
@@ -17,5 +18,37 @@ Pure Chat/trajectory.py folding messages+usage+sidecar+variants+compaction into 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 derive_trajectory unit tests pass,No Textual dependency,Legacy fallback grouping works
+- [x] #1 derive_trajectory unit tests pass,No Textual dependency,Legacy fallback grouping works
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commit 74bb35389: pure Chat/trajectory.py projection, no Textual imports, legacy fallback grouping; 22 tests green; see Implementation Notes and ADR-066
+
+- **Approach**: pure projection implementing ADR-066
+  (`backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`) — the module
+  never queries the DB and never imports Textual (stdlib + `ProviderUsage` only; enforced
+  by a source-scan import-ban test). `derive_trajectory(messages, usage_by_id, traj_rows,
+  variant_sets, compaction_records, active_leaf_message_id=None) -> TrajectorySnapshot`
+  folds everything into frozen `TrajectoryTurn`/`TrajectoryRecord` dataclasses.
+- **Key files**: `tldw_chatbook/Chat/trajectory.py` (new);
+  `Tests/Chat/test_trajectory_projection.py` (22 tests, green — grouping, tool nesting,
+  NULL timing, seq tie-breaks, variants, compaction placement, legacy fallback, purity ban).
+- **Decisions**: active path walks `parent_message_id` from `active_leaf_message_id` to
+  the root over the full map (soft-deleted nodes traversed, not emitted) — added as a
+  trailing optional 6th parameter per the spec's binding note, so the brief's 5-arg shape
+  still works. Variants merge two sources: tree siblings off the active chain, and
+  `variant_sets` superseded contents attached at turn granularity (a variant set
+  identifies a turn, not a message). Turn-grouping precedence: sidecar `turn_id` →
+  in-memory `turn_id` → legacy adjacency (user opens a turn; assistant-first opens its
+  own; same-second ties break user-first only for messages with no turn identity).
+  Record `seq` is the 1-based ledger render position (sidecar seq still drives ordering);
+  compaction markers render from `list_auxiliary_attempts`-shaped rows as `message_id=None`
+  depth-0 entries. Never fabricate: NULL timing stays `None`, no duration is computed.
+- **Deviations**: inputs are duck-typed via a single `_field` seam (Mapping /
+  `sqlite3.Row` / attribute objects) so tests run on local stand-ins; a manual end-to-end
+  sanity pass against the real `TrajectoryRowRead`/`ConsoleVariantSet` shapes was done.
+  Tests live at repo-root `Tests/Chat/` per repo convention (brief's
+  `tldw_chatbook/Tests/...` path does not exist).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16313 - Trajectory-screen-with-ledger-inspector-search.md
+++ b/backlog/tasks/task-16313 - Trajectory-screen-with-ledger-inspector-search.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16313
 title: 'Trajectory screen with ledger, inspector, search'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-15 00:20'
+updated_date: '2026-08-15 05:48'
 labels: []
 dependencies:
   - TASK-16312
@@ -17,5 +18,35 @@ Console-launched screen: DataTable ledger with turn grouping/collapse, per-recor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Ledger renders snapshot with collapse,Inspector shows usage+timing+payload,Search filters rows,ADR-031 footer governance passes
+- [x] #1 Ledger renders snapshot with collapse,Inspector shows usage+timing+payload,Search filters rows,ADR-031 footer governance passes
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commit 45459ff50: trajectory screen with ledger/collapse/inspector/search, modal Static footer hints per video-player precedent; 22 tests green; see Implementation Notes and ADR-066
+
+- **Approach**: read-only `TrajectoryScreen(ModalScreen[None])` rendering a
+  `TrajectorySnapshot` from the pure projection (ADR-066,
+  `backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`); the screen
+  never queries the DB itself.
+- **Key files**: `tldw_chatbook/UI/Screens/trajectory_screen.py` (new);
+  `Tests/UI/test_trajectory_screen.py` (22 pilot-driven tests fed by the real
+  `derive_trajectory`, green — ledger/collapse, inspector contents, search, pagination,
+  worker threshold, ADR-031 governance).
+- **Decisions**: DataTable ledger (`cursor_type="row"`, 8 columns) with turn-header
+  rows and indented nested tool rows; `t` collapse, `i` inspector (live-follows cursor),
+  `e` load-earlier (dsh-style: newest `PAGE_SIZE = 500` page first, control row at top),
+  `/` search (matches content/kind/model/provider AND tool payload name/args/result —
+  tool output lives only in the payload; an active query reveals collapsed turns);
+  safe two-stage `escape` (blur search first). Durations are computed only between two
+  PROVIDED endpoints — never fabricated. Above `WORKER_THRESHOLD = 5000` records the
+  initial render moves to a worker with a generation counter + `_alive` guard against
+  stale/late results. **Footer hints are the modal's own one-line Static**, per the
+  video-player precedent (`video_player_screen.py` hints line) — NOT
+  `register_footer_shortcuts` — and stay exactly 1:1 with non-escape `BINDINGS`
+  (ADR-031 governance tests enforce this); the `e earlier` hint drops when exhausted.
+- **Deviations**: none of note; the screen was committed self-contained (launch wiring
+  is task-16314). The stale-worker test exercises the generation guard at the seam
+  because the pilot cannot deterministically interleave keystrokes with a worker build.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16313 - Trajectory-screen-with-ledger-inspector-search.md
+++ b/backlog/tasks/task-16313 - Trajectory-screen-with-ledger-inspector-search.md
@@ -1,0 +1,21 @@
+---
+id: TASK-16313
+title: 'Trajectory screen with ledger, inspector, search'
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:20'
+labels: []
+dependencies:
+  - TASK-16312
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Console-launched screen: DataTable ledger with turn grouping/collapse, per-record inspector (tokens incl. cache read/write, timing, tool payload), search, ADR-031 keybindings/footer. Plan task 4 in Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Ledger renders snapshot with collapse,Inspector shows usage+timing+payload,Search filters rows,ADR-031 footer governance passes
+<!-- AC:END -->

--- a/backlog/tasks/task-16314 - Console-launch-and-live-tail-follow.md
+++ b/backlog/tasks/task-16314 - Console-launch-and-live-tail-follow.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16314
 title: Console launch and live tail-follow
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-15 00:21'
+updated_date: '2026-08-15 05:48'
 labels: []
 dependencies:
   - TASK-16313
@@ -17,5 +18,45 @@ Launch trajectory from chat_screen with single-letter binding; refresh on store 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Trajectory opens from Console,Live updates arrive without user action,Scroll-up suspends follow,f resumes follow
+- [x] #1 Trajectory opens from Console,Live updates arrive without user action,Scroll-up suspends follow,f resumes follow
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in commits 47905905b/14373a7ac: y-key Console launch, revision-polled live tail-follow with suspend/resume; 9 tests green; see Implementation Notes and ADR-066
+
+- **Approach**: per ADR-066 (`backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`)
+  the Console launches the screen in a worker and the screen live-follows via revision
+  polling (there is no observer bus).
+- **Key files**: `tldw_chatbook/Chat/console_chat_store.py` (public
+  `get_payload_revision` accepting session or conversation id; `write_trajectory_rows`
+  bumps the revision per conversation + live session; `variant_sets_for_conversation`);
+  `tldw_chatbook/UI/Screens/chat_screen.py` (`Binding("y", "open_trajectory_view")`,
+  `action_open_trajectory_view`, module-level `_build_trajectory_snapshot`);
+  `tldw_chatbook/UI/Screens/trajectory_screen.py` (`revision_provider`/`snapshot_builder`
+  ctor kwargs, `set_interval(0.5, _poll_revision)`, follow state machine, `f` binding);
+  `Tests/UI/test_trajectory_live.py` (9 tests, green — revision bus, live follow,
+  suspend/resume, launch registration, real-DB snapshot integration).
+- **Decisions**: **launch key is `y`** — the initial `j` binding was a lie on the surface
+  a trajectory reader comes from: `console_transcript.py`'s focused key handler consumes
+  `j`/`k` with `event.stop()`; the binding test now asserts `"j" not in bindings`.
+  Live worker ordering: `_poll_revision` schedules `exclusive=True` workers carrying
+  their revision; `_apply_live_snapshot` drops results whose revision no longer matches,
+  so a slow older rebuild can never regress the ledger. Follow is pull-based from scroll
+  geometry (checked each tick), with `call_after_refresh` scroll landing and a 1s grace
+  window so the geometry poll cannot cancel an in-flight `f`; rebuilds preserve collapsed
+  turns, search query and the visible window, scrolling to end only while following.
+  `_build_trajectory_snapshot` uses the REAL seams (review fix): compaction via
+  `ConsoleContextRepository.list_auxiliary_attempts` (projection filters
+  `purpose == "conversation_compaction"`), variants via
+  `store.variant_sets_for_conversation`; every seam degrades to empty rather than failing
+  launch. **Variants are in-memory-only for cold DB**: variant CONTENTS are process-local
+  (only selection metadata persists), so a conversation restored purely from disk
+  legitimately renders without superseded variants — documented at the store method.
+- **Deviations**: Textual 8.2.8's `run_worker` does not forward extra positional args to
+  the callable, so the live rebuild dispatches through a lambda wrapper
+  (`lambda: self._live_rebuild_worker(revision)`) — recorded in
+  `backlog/docs/lessons-textual.md`. The pinned footer-text test in
+  `test_console_workbench_contract.py` was updated for the "Y trajectory" hint.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16314 - Console-launch-and-live-tail-follow.md
+++ b/backlog/tasks/task-16314 - Console-launch-and-live-tail-follow.md
@@ -1,0 +1,21 @@
+---
+id: TASK-16314
+title: Console launch and live tail-follow
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:21'
+labels: []
+dependencies:
+  - TASK-16313
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Launch trajectory from chat_screen with single-letter binding; refresh on store revision; follow tail unless scrolled up, f resumes. Plan task 5 in Docs/superpowers/plans/2026-08-14-console-trajectory-view.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Trajectory opens from Console,Live updates arrive without user action,Scroll-up suspends follow,f resumes follow
+<!-- AC:END -->

--- a/backlog/tasks/task-16315 - Trajectory-brushable-timeline-strip.md
+++ b/backlog/tasks/task-16315 - Trajectory-brushable-timeline-strip.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-16315
 title: Trajectory brushable timeline strip
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@robert'
 created_date: '2026-08-15 00:21'
+updated_date: '2026-08-15 06:55'
 labels: []
 dependencies:
   - TASK-16314
@@ -17,5 +19,25 @@ Follow-up: brushable/zoomable duration timeline widget over TrajectorySnapshot (
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Timeline renders start/duration per record,Brush filters ledger rows,Zoom and pan work,Selection syncs both ways
+- [x] #1 Timeline renders start/duration per record,Brush filters ledger rows,Zoom and pan work,Selection syncs both ways
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TrajectoryTimeline widget: time-domain render model (lanes, bars by kind), zoom/pan math, brush->range math; unit tests. 2. Integrate into TrajectoryScreen: layout above ledger, brush filters ledger records (composable with search), click-select syncs ledger cursor both ways, clear-brush control; ADR-031 hints + governance tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented brushable timeline strip: TimelineModel + TrajectoryTimeline widget and TrajectoryScreen integration.
+
+Approach: pure `TimelineModel` (no Textual symbols) backed by a thin `TrajectoryTimeline` widget — greedy 4-lane interval packing for bars, 1.25x focal-point zoom (focal fraction clamped once), pan as fraction-of-span shift, brush via mouse drag with `capture_mouse()` so gestures survive leaving the strip. Screen integration composes brush AND search through the existing generation-guarded render pipeline; `apply_brush` re-applies settled brushes across live refreshes (cleared when the new domain no longer intersects), and the axis/brush clocks format local time to match the ledger. Selection syncs both ways via a pull-only `set_selected` seam (bar→ledger moves/grows the cursor; ledger cursor moves highlight the bar).
+
+Key files: `tldw_chatbook/UI/Widgets/trajectory_timeline.py`, `tldw_chatbook/UI/Screens/trajectory_screen.py`, `Tests/UI/test_trajectory_timeline.py`, `Tests/UI/test_trajectory_timeline_integration.py`.
+
+Deviations/deferrals: widget zoom/pan keys ([ ] , .) unadvertised at screen level to keep footer hints 1:1 with actions (ADR-031); brush matching only unloaded records shows just the load-earlier row; mid-drag gesture still aborted by a live refresh (settled brush is preserved); one redundant re-render per tick while brushed. Governance: ADR-066 (console trajectory view); keybinding hints per ADR-031.
+
+Tests: 64 passed across widget/screen/integration suites; ruff check + format clean. Commits: ebab888e9 (widget), ace2447ca + 8c79a8ee0 (integration + review fixes).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16315 - Trajectory-brushable-timeline-strip.md
+++ b/backlog/tasks/task-16315 - Trajectory-brushable-timeline-strip.md
@@ -1,0 +1,21 @@
+---
+id: TASK-16315
+title: Trajectory brushable timeline strip
+status: To Do
+assignee: []
+created_date: '2026-08-15 00:21'
+labels: []
+dependencies:
+  - TASK-16314
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up: brushable/zoomable duration timeline widget over TrajectorySnapshot (seq+timestamps), brush-to-filter synced with the ledger. Out of scope of the v1 plan; see spec follow-ups section in Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Timeline renders start/duration per record,Brush filters ledger rows,Zoom and pan work,Selection syncs both ways
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import time
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, cast
 
 from loguru import logger as _logger
@@ -26,7 +27,11 @@ from tldw_chatbook.Chat.console_speech_preferences import (
     parse_console_speech_preferences,
 )
 from tldw_chatbook.Chat.message_metadata import MessageMetadata
-from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+from tldw_chatbook.DB.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+    TrajectoryRowWrite,
+)
 
 logger = _logger.bind(module="ChatPersistenceService")
 _ASSISTANT_AUTHORITY_UNSET = cast(Optional[str], object())
@@ -853,6 +858,42 @@ class ChatPersistenceService:
             message_id,
             expected_version=current_message["version"],
         )
+
+    def write_trajectory_rows(self, rows: Sequence[TrajectoryRowWrite]) -> bool:
+        """Persist trajectory sidecar rows; LOCAL-ONLY, never raises.
+
+        The trajectory sibling of :meth:`update_message_usage`: the
+        ``message_trajectory_metadata`` sidecar (schema v38) is local-only
+        with no sync triggers, so it never routes through the
+        version-bumping general-purpose row updater. A small bounded retry
+        absorbs transient write-write lock contention (concurrent Console
+        sessions, compaction auxiliary turns): ``upsert_trajectory_rows``
+        assigns ``seq`` inside its own transaction, so a rolled-back
+        attempt simply re-derives seqs on retry. Returns ``False`` (after
+        logging with row COUNT only -- never message contents or payloads)
+        when every attempt failed, so the store's best-effort capture knows
+        the batch was dropped.
+
+        Args:
+            rows: Sidecar rows to upsert.
+
+        Returns:
+            True when the rows were written; False when all attempts failed.
+        """
+        last_error: Exception | None = None
+        for attempt in range(5):
+            try:
+                self.db.upsert_trajectory_rows(rows)
+                return True
+            except Exception as exc:  # noqa: BLE001 -- never fail the turn
+                last_error = exc
+                # Brief escalating backoff: the losing writer of a
+                # concurrent pair only needs the winner's commit to land.
+                time.sleep(0.02 * (attempt + 1))
+        logger.bind(row_count=len(rows), error=repr(last_error)).warning(
+            "trajectory_rows_write_failed"
+        )
+        return False
 
     def update_message_metadata(self, *, message_id: str, metadata_json: str) -> bool:
         """Persist structured message metadata WITHOUT touching sync metadata.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -9140,6 +9140,19 @@ class ConsoleChatController:
         # the path virtually every real send takes. Cost is not an opt-in
         # feature of one repair mode; every run needs its own signals object.
         stream_signals = ConsoleProviderStreamSignals()
+        # Trajectory sidecar (schema v38): arm this turn's timing capture at
+        # the single dispatch choke point covering BOTH the direct-provider
+        # and agent paths, BEFORE the provider call. First-token is stamped
+        # at the store's chunk seam; completion at usage-attach. Best-effort
+        # -- a sidecar failure must never fail the send.
+        try:
+            self.store.record_trajectory_timing(
+                assistant_message_id, step_started_at=time.time()
+            )
+        except Exception as exc:
+            logger.bind(message_id=assistant_message_id, error=repr(exc)).warning(
+                "trajectory_step_start_failed"
+            )
         try:
             if (
                 bool(
@@ -9503,6 +9516,22 @@ class ConsoleChatController:
         call's ``prompt_tokens`` would be priced against an earlier call's
         stale ``prompt_tokens_details.cached_tokens``.
         """
+        # Trajectory sidecar (schema v38): completion stamp + finalize flush.
+        # Runs BEFORE the usage early-returns so a turn with no usage still
+        # gets its completed_at stamped and its assistant row flushed. Never
+        # fails the send (same posture as the usage attach below).
+        try:
+            self.store.record_trajectory_timing(
+                assistant_message_id,
+                completed_at=time.time(),
+                model=str(getattr(resolution, "model", "") or "") or None,
+                provider=str(getattr(resolution, "provider", "") or "") or None,
+                flush=True,
+            )
+        except Exception as exc:
+            logger.bind(message_id=assistant_message_id, error=repr(exc)).warning(
+                "trajectory_completion_failed"
+            )
         if stream_signals is None:
             return
         payloads = self._usage_payloads(stream_signals)

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4344,8 +4344,16 @@ class ConsoleChatStore:
             name = text[2:].split(" →", 1)[0].strip() or None
         result = tool_output_full if tool_output_full is not None else text
         payload: dict[str, Any] = {"name": name, "args": None, "result": result}
-        if len(result.encode("utf-8")) > TRAJECTORY_RESULT_CAP_BYTES:
-            payload["result"] = result[:TRAJECTORY_RESULT_CAP_BYTES]
+        encoded = result.encode("utf-8")
+        if len(encoded) > TRAJECTORY_RESULT_CAP_BYTES:
+            # Cap BYTES, not characters: a character slice of multibyte
+            # text (up to 4 bytes/codepoint) could leave the stored result
+            # up to 4x over budget. Truncate the encoded form and decode
+            # back with errors="ignore" so a split codepoint is dropped
+            # rather than crashing or being replaced by a longer escape.
+            payload["result"] = encoded[:TRAJECTORY_RESULT_CAP_BYTES].decode(
+                "utf-8", errors="ignore"
+            )
             payload["truncated"] = True
         return json.dumps(payload)
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -753,7 +753,6 @@ class ConsoleChatStore:
         # stopped terminal must advance the context epoch when the row becomes
         # provider-visible history. A repeat failure stays excluded and stable.
         self._failed_retry_message_ids: set[str] = set()
-<<<<<<< HEAD
         # Process-local observers for the first LIVE transition of a message
         # into the complete state. Restored/already-complete rows never pass
         # through the publisher, so hydration cannot replay speech.
@@ -762,6 +761,22 @@ class ConsoleChatStore:
         ] = {}
         self._next_message_completed_subscriber_id = 1
         self._speech_preference_epochs: dict[str, int] = {}
+
+        # Trajectory sidecar (schema v38) capture state. LOCAL-ONLY: the
+        # ``message_trajectory_metadata`` table is never synced. Timing is
+        # armed by the controller (step start / completion) and stamped here
+        # (first token, at the chunk seam); rows are written through the
+        # persistence adapter in ONE batched upsert per turn. Every write is
+        # best-effort: a sidecar failure must never fail the turn.
+        self._trajectory_lock = threading.Lock()
+        self._trajectory_timing: dict[str, dict[str, Any]] = {}
+        self._trajectory_written_ids: set[str] = set()
+        self._session_turn_ids: dict[str, str] = {}
+        # TOOL markers appended while their parent assistant row is still
+        # streaming (no durable id yet): payload captured at marker-append
+        # time, flushed -- remapped to the parent's persisted id -- when the
+        # parent message persists. Keyed by the parent's NATIVE message id.
+        self._pending_trajectory_tool_rows: dict[str, list[dict[str, Any]]] = {}
 
     def subscribe_message_completed(
         self,
@@ -810,23 +825,6 @@ class ConsoleChatStore:
         """Return the process-local generation of a live successful completion."""
         self._message_or_raise(message_id)
         return self._message_completion_generations[message_id]
-=======
-        # Trajectory sidecar (schema v38) capture state. LOCAL-ONLY: the
-        # ``message_trajectory_metadata`` table is never synced. Timing is
-        # armed by the controller (step start / completion) and stamped here
-        # (first token, at the chunk seam); rows are written through the
-        # persistence adapter in ONE batched upsert per turn. Every write is
-        # best-effort: a sidecar failure must never fail the turn.
-        self._trajectory_lock = threading.Lock()
-        self._trajectory_timing: dict[str, dict[str, Any]] = {}
-        self._trajectory_written_ids: set[str] = set()
-        self._session_turn_ids: dict[str, str] = {}
-        # TOOL markers appended while their parent assistant row is still
-        # streaming (no durable id yet): payload captured at marker-append
-        # time, flushed -- remapped to the parent's persisted id -- when the
-        # parent message persists. Keyed by the parent's NATIVE message id.
-        self._pending_trajectory_tool_rows: dict[str, list[dict[str, Any]]] = {}
->>>>>>> 517d34b6d (feat(console): capture trajectory timing and tool records to sidecar)
 
     def ensure_session(
         self,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4501,6 +4501,14 @@ class ConsoleChatStore:
         once written, later flushes are no-ops. Never raises.
         """
         try:
+            # LOAD-BEARING invariant (final review): this write is TERMINAL.
+            # The row snapshots ``self._trajectory_timing`` at write time and
+            # the ``_trajectory_written_ids`` guard below makes every later
+            # flush a no-op. ``completed_at``/``model``/``provider`` therefore
+            # land ONLY if usage/timing is attached (via
+            # ``record_trajectory_timing``) BEFORE the terminal persist mark.
+            # A future path that persists first will silently lose those
+            # facts -- there is no update, only a dropped write.
             if message.id in self._trajectory_written_ids:
                 return
             if message.role not in (

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4318,6 +4318,18 @@ class ConsoleChatStore:
                     "trajectory_rows_write_failed"
                 )
                 return False
+        if result is not False:
+            # task-5: a successful sidecar write is trajectory-visible state.
+            # Bump the revision bus (conversation key + every live session
+            # bound to that conversation) so the polling trajectory screen
+            # rebuilds its snapshot; without this, tail-follow sees nothing.
+            for conversation_id in dict.fromkeys(
+                row.conversation_id for row in rows
+            ):
+                self._bump_payload_revision(conversation_id)
+                for session in self._sessions.values():
+                    if session.persisted_conversation_id == conversation_id:
+                        self._bump_payload_revision(session.id)
         return result is not False
 
     def _nodes_lookup(self, message_id: str) -> ConsoleChatMessage | None:
@@ -6582,6 +6594,21 @@ class ConsoleChatStore:
         self._payload_revisions[session_id] = (
             self._payload_revisions.get(session_id, 0) + 1
         )
+
+    def get_payload_revision(self, session_or_conversation_id: str) -> int:
+        """Return the payload-revision counter for a session or conversation.
+
+        Public read side of the revision bus the trajectory live view polls
+        (task-5): the counter has no observer interface, so the screen
+        ``set_interval``-polls this getter. Accepts either a Console session
+        id or a persisted conversation id -- the trajectory write path bumps
+        BOTH keys -- returning the newest of the matches (0 when unknown).
+        """
+        revision = self._payload_revisions.get(session_or_conversation_id, 0)
+        for session in self._sessions.values():
+            if session.persisted_conversation_id == session_or_conversation_id:
+                revision = max(revision, self._payload_revisions.get(session.id, 0))
+        return revision
 
     def _bump_conversation_context_epoch(self, session_id: str) -> None:
         """Advance one live session's provider-context change token."""

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import inspect
+import json
+import threading
+import time
 from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -20,6 +23,7 @@ from tldw_chatbook.Agents.agent_models import (
 )
 from tldw_chatbook.Agents.session_todo_store import SessionTodoStore
 from tldw_chatbook.Chat.attachment_core import PendingAttachment
+from tldw_chatbook.DB.ChaChaNotes_DB import TrajectoryRowWrite
 from tldw_chatbook.Chat.citation_trace_models import (
     ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX,
     SealedCitationWrite,
@@ -74,6 +78,12 @@ from tldw_chatbook.Video_Generation.video_store import video_content_marker
 
 #: Maximum number of attachments a Console session may stage before send.
 MAX_PENDING_ATTACHMENTS = 5
+
+#: Trajectory sidecar (schema v38): stored tool-result payload cap. The full
+#: untruncated output remains available live in-session via
+#: ``ConsoleChatMessage.tool_output_full``; beyond this cap the sidecar row
+#: stores a truncated result plus ``{"truncated": true}`` in its payload.
+TRAJECTORY_RESULT_CAP_BYTES = 256 * 1024
 
 TerminalCitationFinalizer = Callable[[str], SealedCitationWrite | None]
 
@@ -743,6 +753,7 @@ class ConsoleChatStore:
         # stopped terminal must advance the context epoch when the row becomes
         # provider-visible history. A repeat failure stays excluded and stable.
         self._failed_retry_message_ids: set[str] = set()
+<<<<<<< HEAD
         # Process-local observers for the first LIVE transition of a message
         # into the complete state. Restored/already-complete rows never pass
         # through the publisher, so hydration cannot replay speech.
@@ -799,6 +810,23 @@ class ConsoleChatStore:
         """Return the process-local generation of a live successful completion."""
         self._message_or_raise(message_id)
         return self._message_completion_generations[message_id]
+=======
+        # Trajectory sidecar (schema v38) capture state. LOCAL-ONLY: the
+        # ``message_trajectory_metadata`` table is never synced. Timing is
+        # armed by the controller (step start / completion) and stamped here
+        # (first token, at the chunk seam); rows are written through the
+        # persistence adapter in ONE batched upsert per turn. Every write is
+        # best-effort: a sidecar failure must never fail the turn.
+        self._trajectory_lock = threading.Lock()
+        self._trajectory_timing: dict[str, dict[str, Any]] = {}
+        self._trajectory_written_ids: set[str] = set()
+        self._session_turn_ids: dict[str, str] = {}
+        # TOOL markers appended while their parent assistant row is still
+        # streaming (no durable id yet): payload captured at marker-append
+        # time, flushed -- remapped to the parent's persisted id -- when the
+        # parent message persists. Keyed by the parent's NATIVE message id.
+        self._pending_trajectory_tool_rows: dict[str, list[dict[str, Any]]] = {}
+>>>>>>> 517d34b6d (feat(console): capture trajectory timing and tool records to sidecar)
 
     def ensure_session(
         self,
@@ -2131,6 +2159,13 @@ class ConsoleChatStore:
                 (anchor, message)
             )
             self._messages_by_session[session_id].append(message)
+            # Trajectory sidecar (schema v38): the marker itself is never
+            # persisted, but its tool_call/tool_result records ARE -- keyed
+            # to the anchor (parent assistant) message. Best-effort.
+            anchor_node = self._nodes_by_session.get(session_id, {}).get(anchor)
+            self._record_trajectory_tool_marker(
+                session_id, anchor_node, content, tool_output_full
+            )
             return self._snapshot(message)
         old_leaf = self._active_leaf_by_session[session_id]
         self._register_tree_node(session_id, message, parent_native_id=old_leaf)
@@ -4198,7 +4233,285 @@ class ConsoleChatStore:
         buffer.append(chunk)
         message.status = "streaming"
         self._bump_message_speech_revision(message.id)
+        # Trajectory sidecar (schema v38): the first provider chunk is the
+        # first-token boundary. Stamped at THIS seam (rather than in the
+        # controller's direct-provider loop) because it is the single point
+        # both streaming paths -- direct provider and agent bridge -- flow
+        # through. Only stamps an armed capture: no step-start, no timing.
+        stash = self._trajectory_timing.get(message.id)
+        if (
+            stash is not None
+            and stash.get("step_started_at") is not None
+            and stash.get("first_token_at") is None
+        ):
+            stash["first_token_at"] = time.time()
         return self._snapshot(message)
+
+    # --- Trajectory sidecar (schema v38) -----------------------------------
+    #
+    # LOCAL-ONLY capture of per-turn step observations for the Console
+    # trajectory view. All methods on this seam are best-effort: a sidecar
+    # failure is logged with context and NEVER fails the turn/chat action
+    # that triggered it.
+
+    def record_trajectory_timing(
+        self,
+        message_id: str,
+        *,
+        step_started_at: float | None = None,
+        first_token_at: float | None = None,
+        completed_at: float | None = None,
+        model: str | None = None,
+        provider: str | None = None,
+        flush: bool = False,
+    ) -> None:
+        """Merge timing facts for one message's trajectory capture; never raises.
+
+        ``step_started_at``/``first_token_at``/``model``/``provider`` are
+        set-once (first writer wins); ``completed_at`` is last-write-wins so
+        a finalize path can refine a provisional completion stamp. With
+        ``flush=True``, a message that is already persisted gets its
+        assistant/user sidecar row written immediately (the finalize path --
+        usage attachment time); an unpersisted message's row is written by
+        the persist seam instead, reading this same stash.
+        """
+        try:
+            stash = self._trajectory_timing.setdefault(message_id, {})
+            for key, value in (
+                ("step_started_at", step_started_at),
+                ("first_token_at", first_token_at),
+                ("model", model),
+                ("provider", provider),
+            ):
+                if value is not None and stash.get(key) is None:
+                    stash[key] = value
+            if completed_at is not None:
+                stash["completed_at"] = completed_at
+            if not flush:
+                return
+            message = self._nodes_lookup(message_id)
+            if message is not None:
+                self._write_trajectory_row_for_message(message)
+        except Exception as exc:
+            logger.bind(message_id=message_id, error=repr(exc)).warning(
+                "trajectory_timing_record_failed"
+            )
+
+    def write_trajectory_rows(self, rows: Sequence[TrajectoryRowWrite]) -> bool:
+        """Route sidecar rows through the persistence adapter; never raises.
+
+        Serialized by an in-process lock so concurrent Console writers
+        (hands-free sessions, compaction auxiliary turns) cannot interleave
+        ``seq`` assignments. Fakes without the adapter method are skipped
+        silently (pre-existing test doubles keep working).
+        """
+        if self.persistence is None or not rows:
+            return False
+        writer = getattr(self.persistence, "write_trajectory_rows", None)
+        if not callable(writer):
+            return False
+        with self._trajectory_lock:
+            try:
+                result = writer(list(rows))
+            except Exception as exc:
+                logger.bind(row_count=len(rows), error=repr(exc)).warning(
+                    "trajectory_rows_write_failed"
+                )
+                return False
+        return result is not False
+
+    def _nodes_lookup(self, message_id: str) -> ConsoleChatMessage | None:
+        session_id = self._message_session_index.get(message_id)
+        if session_id is None:
+            return None
+        return self._nodes_by_session.get(session_id, {}).get(message_id)
+
+    @staticmethod
+    def _trajectory_tool_payload(content: str, tool_output_full: str | None) -> str:
+        """Build the ``payload_json`` for one tool record.
+
+        ``name`` is best-effort parsed from the marker text (the live bridge
+        formats tool markers as ``⚙ <tool_name> → <preview>``); ``result``
+        is the full untruncated output when available, capped at
+        ``TRAJECTORY_RESULT_CAP_BYTES`` with a ``{"truncated": true}``
+        marker beyond that. ``args`` is ``None``: the marker-append seam
+        carries no argument dict, and fabricating one from display text
+        would be worse than absent.
+        """
+        text = content or ""
+        name: str | None = None
+        if text.startswith("⚙ "):
+            name = text[2:].split(" →", 1)[0].strip() or None
+        result = tool_output_full if tool_output_full is not None else text
+        payload: dict[str, Any] = {"name": name, "args": None, "result": result}
+        if len(result.encode("utf-8")) > TRAJECTORY_RESULT_CAP_BYTES:
+            payload["result"] = result[:TRAJECTORY_RESULT_CAP_BYTES]
+            payload["truncated"] = True
+        return json.dumps(payload)
+
+    def _record_trajectory_tool_marker(
+        self,
+        session_id: str,
+        anchor: ConsoleChatMessage | None,
+        content: str,
+        tool_output_full: str | None,
+    ) -> None:
+        """Capture one TOOL marker's trajectory records at append time.
+
+        TOOL-marker invariant: the marker itself is NEVER persisted to
+        ``messages`` -- its ``tool_call``/``tool_result`` rows live entirely
+        in the sidecar, keyed to the parent (anchor) assistant message's
+        persisted id. When the anchor has no durable id yet (a marker that
+        arrives while the assistant row is still streaming), the payload is
+        stashed and flushed -- remapped -- when the anchor persists.
+        """
+        try:
+            session = self._sessions.get(session_id)
+            conversation_id = (
+                session.persisted_conversation_id if session is not None else None
+            )
+            payload_json = self._trajectory_tool_payload(content, tool_output_full)
+            now = time.time()
+            if (
+                conversation_id is not None
+                and anchor is not None
+                and anchor.persisted_message_id is not None
+            ):
+                turn_id = self._trajectory_turn_id(session_id, anchor)
+                rows = self._trajectory_tool_rows(
+                    message_id=anchor.persisted_message_id,
+                    conversation_id=conversation_id,
+                    turn_id=turn_id,
+                    payload_json=payload_json,
+                    captured_at=now,
+                )
+                self.write_trajectory_rows(rows)
+                return
+            anchor_key = anchor.id if anchor is not None else "__unanchored__"
+            self._pending_trajectory_tool_rows.setdefault(anchor_key, []).append(
+                {
+                    "session_id": session_id,
+                    "payload_json": payload_json,
+                    "captured_at": now,
+                }
+            )
+        except Exception as exc:
+            logger.bind(session_id=session_id, error=repr(exc)).warning(
+                "trajectory_tool_marker_capture_failed"
+            )
+
+    @staticmethod
+    def _trajectory_tool_rows(
+        *,
+        message_id: str,
+        conversation_id: str,
+        turn_id: str,
+        payload_json: str,
+        captured_at: float,
+    ) -> list[TrajectoryRowWrite]:
+        """Build the ``tool_call`` + ``tool_result`` row pair for one marker."""
+        shared = dict(
+            message_id=message_id,
+            conversation_id=conversation_id,
+            turn_id=turn_id,
+            seq=None,
+            payload_json=payload_json,
+            step_started_at=captured_at,
+            completed_at=captured_at,
+        )
+        return [
+            TrajectoryRowWrite(event_kind="tool_call", **shared),
+            TrajectoryRowWrite(event_kind="tool_result", **shared),
+        ]
+
+    def _trajectory_turn_id(
+        self, session_id: str, message: ConsoleChatMessage
+    ) -> str:
+        """Resolve (and memoize) the turn id for a persisted message.
+
+        A USER message opens a turn and registers its id as the session's
+        current turn; an ASSISTANT message inherits the open turn, falling
+        back to its own id for assistant-first sessions.
+        """
+        if message.turn_id:
+            return message.turn_id
+        if message.role is ConsoleMessageRole.USER:
+            turn_id = message.persisted_message_id or message.id
+            self._session_turn_ids[session_id] = turn_id
+        else:
+            turn_id = self._session_turn_ids.get(session_id) or message.id
+        message.turn_id = turn_id
+        return turn_id
+
+    def _write_trajectory_row_for_message(self, message: ConsoleChatMessage) -> None:
+        """Write one persisted message's sidecar row (and any stashed tool rows).
+
+        The single writer for ``user``/``assistant`` rows, called from the
+        persist seam (``_persist_new_message``) and the finalize flush
+        (``record_trajectory_timing(flush=True)``). Idempotent per message:
+        once written, later flushes are no-ops. Never raises.
+        """
+        try:
+            if message.id in self._trajectory_written_ids:
+                return
+            if message.role not in (
+                ConsoleMessageRole.USER,
+                ConsoleMessageRole.ASSISTANT,
+            ):
+                return
+            if message.persisted_message_id is None:
+                return
+            session_id = self._message_session_index.get(message.id)
+            session = self._sessions.get(session_id) if session_id else None
+            conversation_id = (
+                session.persisted_conversation_id if session is not None else None
+            )
+            if conversation_id is None:
+                return
+            turn_id = self._trajectory_turn_id(session_id, message)
+            timing = self._trajectory_timing.get(message.id, {})
+            event_kind = (
+                "user" if message.role is ConsoleMessageRole.USER else "assistant"
+            )
+            rows: list[TrajectoryRowWrite] = [
+                TrajectoryRowWrite(
+                    message_id=message.persisted_message_id,
+                    conversation_id=conversation_id,
+                    turn_id=turn_id,
+                    seq=None,
+                    event_kind=event_kind,
+                    # User records get a step-start only (spec: no token
+                    # boundaries on the user's own action); assistant rows
+                    # carry whatever the controller's capture armed --
+                    # NULL timing when nothing was armed (never fabricated).
+                    step_started_at=(
+                        time.time()
+                        if event_kind == "user"
+                        else timing.get("step_started_at")
+                    ),
+                    first_token_at=timing.get("first_token_at"),
+                    completed_at=timing.get("completed_at"),
+                    model=timing.get("model"),
+                    provider=timing.get("provider"),
+                )
+            ]
+            pending = self._pending_trajectory_tool_rows.pop(message.id, None)
+            for entry in pending or ():
+                rows.extend(
+                    self._trajectory_tool_rows(
+                        message_id=message.persisted_message_id,
+                        conversation_id=conversation_id,
+                        turn_id=turn_id,
+                        payload_json=entry["payload_json"],
+                        captured_at=entry["captured_at"],
+                    )
+                )
+            if self.write_trajectory_rows(rows):
+                self._trajectory_written_ids.add(message.id)
+        except Exception as exc:
+            logger.bind(message_id=message.id, error=repr(exc)).warning(
+                "trajectory_row_write_failed"
+            )
 
     def reset_stream_content(self, message_id: str) -> ConsoleChatMessage:
         """Discard streamed content once a turn is reclassified as a tool call.
@@ -5462,6 +5775,11 @@ class ConsoleChatStore:
             if message.id == self._active_leaf_by_session.get(session_id):
                 self._persist_active_leaf(session_id, message.id)
             self._enqueue_sync_v2_message_if_ready(message)
+        # Trajectory sidecar (schema v38): every persisted Console message
+        # gets a user/assistant row in the LOCAL-ONLY sidecar, batched with
+        # any tool rows stashed while this row was still streaming.
+        # Best-effort -- never fails the persist that triggered it.
+        self._write_trajectory_row_for_message(message)
 
     def _create_terminal_message(
         self,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -4332,6 +4332,35 @@ class ConsoleChatStore:
                         self._bump_payload_revision(session.id)
         return result is not False
 
+    def variant_sets_for_conversation(
+        self, conversation_id: str
+    ) -> list[ConsoleVariantSet]:
+        """Collect the live in-memory variant sets for one conversation.
+
+        Variant CONTENTS are process-local (only selection metadata
+        persists), so this covers sessions currently open in THIS store; a
+        cold conversation restored purely from the DB legitimately
+        contributes no variant contents and the trajectory ledger renders
+        without superseded variants. Deduplicated per ``turn_id``, newest
+        selection state last (the projection over-attaches a set to every
+        assistant record of its turn; duplicates would double the contents).
+        """
+        sets_by_turn: dict[str, ConsoleVariantSet] = {}
+        for session in self._sessions.values():
+            if session.persisted_conversation_id != conversation_id:
+                continue
+            for message in self._nodes_by_session.get(session.id, {}).values():
+                variants = getattr(message, "variants", None)
+                if variants is None:
+                    continue
+                turn_id = getattr(variants, "turn_id", None) or getattr(
+                    message, "turn_id", None
+                )
+                if not turn_id:
+                    continue
+                sets_by_turn[str(turn_id)] = variants
+        return list(sets_by_turn.values())
+
     def _nodes_lookup(self, message_id: str) -> ConsoleChatMessage | None:
         session_id = self._message_session_index.get(message_id)
         if session_id is None:

--- a/tldw_chatbook/Chat/trajectory.py
+++ b/tldw_chatbook/Chat/trajectory.py
@@ -1,0 +1,750 @@
+"""Pure projection of a Console conversation into a trajectory snapshot.
+
+Folds persisted message rows, the schema-v38 trajectory sidecar
+(``message_trajectory_metadata``), per-message usage, variant sets, and
+compaction-attempt records into the turn/record shape the trajectory view
+renders (spec: ``Docs/superpowers/specs/
+2026-08-14-console-trajectory-view-design.md``, "Projection module").
+
+Purity contract
+    This module is stdlib-only plus ``ProviderUsage`` (itself stdlib-only).
+    It never imports Textual or the DB layer, and it never queries
+    anything: every fact arrives as a plain sequence of dataclasses /
+    mappings, so the projection is fully unit-testable and safe to run in
+    any worker. Input shapes are duck-typed:
+
+    - ``messages``: ``messages``-table-shaped rows (mappings such as
+      ``sqlite3.Row``/dict with ``id``, ``sender``, ``content``,
+      ``timestamp``, ``parent_message_id``, ``deleted``) OR
+      ``ConsoleChatMessage`` models (joined on
+      ``persisted_message_id or id``).
+    - ``usage_by_id``: mapping of message id -> ``ProviderUsage | None``.
+    - ``traj_rows``: ``TrajectoryRowRead``-shaped objects (attributes
+      ``message_id``, ``turn_id``, ``seq``, ``event_kind``,
+      ``step_started_at``, ``first_token_at``, ``completed_at``,
+      ``model``, ``provider``, ``payload_json``), ordered or not.
+    - ``variant_sets``: ``ConsoleVariantSet``-shaped objects
+      (``turn_id``, ``variants`` items exposing ``content``,
+      ``selected_index``).
+    - ``compaction_records``: ``list_auxiliary_attempts``-shaped mappings
+      (``purpose``, ``status``, ``started_at``, ``finished_at``,
+      ``provider``, ``model``, ``provider_usage_json``).
+
+Never-fabricate contract
+    Timing is surfaced exactly as stored. NULL sidecar timing becomes
+    ``None`` fields, and tool rows created at marker-append time keep
+    their append-time (zero-duration) stamps verbatim -- the projection
+    never derives, defaults, or "corrects" a timestamp.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+
+__all__ = [
+    "TrajectoryRecord",
+    "TrajectorySnapshot",
+    "TrajectoryTurn",
+    "derive_trajectory",
+]
+
+#: Cap for ``TrajectoryRecord.content_preview`` (spec: first 120 chars).
+PREVIEW_MAX_CHARS = 120
+
+#: Ledger ``kind`` values (spec data model).
+KIND_USER = "user"
+KIND_ASSISTANT = "assistant"
+KIND_TOOL_CALL = "tool_call"
+KIND_TOOL_RESULT = "tool_result"
+KIND_COMPACTION = "compaction"
+
+_TOOL_KINDS = frozenset({KIND_TOOL_CALL, KIND_TOOL_RESULT})
+_RENDERED_ROLES = frozenset({KIND_USER, KIND_ASSISTANT})
+_COMPACTION_PURPOSE = "conversation_compaction"
+
+# Sentinel for "no sidecar seq" in sort keys; larger than any real seq.
+_NO_SEQ = float("inf")
+
+
+@dataclass(frozen=True)
+class TrajectoryRecord:
+    """One ledger row: a message event, a nested tool record, or a marker.
+
+    Attributes:
+        seq: 1-based position of this record in the rendered snapshot
+            (ledger order), assigned by the projection. Not the sidecar
+            ``seq`` -- legacy and compaction records have no sidecar row,
+            so the render position is the only total ordering.
+        kind: One of ``user`` | ``assistant`` | ``tool_call`` |
+            ``tool_result`` | ``compaction``.
+        turn_id: Sidecar ``turn_id`` when known; otherwise the opening
+            user message's id (legacy adjacency / in-memory restore).
+        message_id: Persisted message id. ``None`` for compaction markers
+            and only those.
+        content_preview: First 120 characters of the content, collapsed
+            to a single line.
+        usage: Normalized token usage for this message, or ``None``.
+        step_started_at: Unix-seconds step start, or ``None`` when
+            unknown. Surfaced as stored, never derived.
+        first_token_at: Unix-seconds first-token time, or ``None``.
+        completed_at: Unix-seconds completion time, or ``None``.
+        model: Model identifier for the generating step, or ``None``.
+        provider: Provider identifier for the generating step, or ``None``.
+        payload: Parsed ``payload_json`` for tool records (name/args/
+            result and optional ``truncated`` flag); ``None`` otherwise.
+        variants: Contents of superseded variants for this record --
+            active-path rendering keeps fork history visible without
+            adding ledger rows. Empty tuple when none.
+        depth: 0 for top-level records, 1 for tool records nested under
+            their owning assistant step.
+    """
+
+    seq: int
+    kind: str
+    turn_id: str
+    message_id: str | None
+    content_preview: str
+    usage: ProviderUsage | None
+    step_started_at: float | None
+    first_token_at: float | None
+    completed_at: float | None
+    model: str | None
+    provider: str | None
+    payload: dict | None
+    variants: tuple[str, ...]
+    depth: int
+
+
+@dataclass(frozen=True)
+class TrajectoryTurn:
+    """One turn: the records from a user record to the next user record."""
+
+    turn_id: str
+    records: tuple[TrajectoryRecord, ...]
+
+
+@dataclass(frozen=True)
+class TrajectorySnapshot:
+    """The full trajectory of a conversation, grouped into turns."""
+
+    turns: tuple[TrajectoryTurn, ...]
+
+
+# ---------------------------------------------------------------------------
+# Input normalization helpers
+# ---------------------------------------------------------------------------
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` from a mapping (dict/``sqlite3.Row``) or an object.
+
+    The projection accepts both row shapes and model shapes; this is the
+    single seam that tolerates them all.
+    """
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    try:
+        return obj[name]
+    except Exception:  # noqa: BLE001 - sqlite3.Row/dataclass/str all differ here
+        pass
+    return getattr(obj, name, default)
+
+
+def _parse_timestamp(value: Any) -> float | None:
+    """Coerce a stored timestamp to unix seconds; ``None`` when unusable.
+
+    Accepts numeric epochs, epoch strings, and ISO-8601 strings (naive
+    values are read as UTC, matching SQLite's UTC ``CURRENT_TIMESTAMP``).
+    This is representation conversion only -- it never invents a value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            pass
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    return None
+
+
+def _parse_payload(raw: Any) -> dict | None:
+    """Parse a sidecar ``payload_json`` string; ``None`` when absent/bad."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _preview(content: Any) -> str:
+    """Collapse content to a single line and cap at ``PREVIEW_MAX_CHARS``."""
+    text = " ".join(str(content or "").split())
+    return text[:PREVIEW_MAX_CHARS]
+
+
+@dataclass
+class _Msg:
+    """Normalized view of one persisted message."""
+
+    mid: str
+    role: str
+    content: str
+    parent: str | None
+    deleted: bool
+    ts: float | None
+    turn_hint: str | None
+    index: int
+
+
+def _normalize_message(raw: Any, index: int) -> _Msg | None:
+    """Build a ``_Msg`` from a row or model; ``None`` when unusable."""
+    mid = _field(raw, "persisted_message_id") or _field(raw, "id")
+    if not mid:
+        return None
+    role_raw = _field(raw, "sender") or _field(raw, "role")
+    role_value = getattr(role_raw, "value", role_raw)
+    role = str(role_value).lower() if role_value is not None else ""
+    return _Msg(
+        mid=str(mid),
+        role=role,
+        content=str(_field(raw, "content") or ""),
+        parent=_field(raw, "parent_message_id") or None,
+        deleted=bool(_field(raw, "deleted") or False),
+        ts=_parse_timestamp(_field(raw, "timestamp")),
+        turn_hint=_field(raw, "turn_id") or None,
+        index=index,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivation
+# ---------------------------------------------------------------------------
+
+
+def derive_trajectory(
+    messages: Iterable[Any],
+    usage_by_id: Mapping[str, ProviderUsage | None],
+    traj_rows: Iterable[Any],
+    variant_sets: Iterable[Any],
+    compaction_records: Iterable[Any],
+    active_leaf_message_id: str | None = None,
+) -> TrajectorySnapshot:
+    """Project a conversation's persisted facts into a trajectory snapshot.
+
+    The ledger renders the ACTIVE PATH: walking ``parent_message_id`` from
+    ``active_leaf_message_id`` (the local-only ``conversations`` column) to
+    the root. Soft-deleted messages (``deleted=1``) are skipped for
+    rendering but still traversed, so deleting one mid-chain message never
+    hides its ancestors. Tree siblings off the active chain are surfaced on
+    the owning record's ``variants`` tuple instead of as rows.
+
+    Turn boundaries are derived, never stored as rows: a turn starts at
+    each ``user`` record. Compaction records render between turns with
+    ``message_id=None``. Messages without sidecar rows (conversations
+    predating schema v38) fall back to in-memory ``turn_id`` hints, then to
+    timestamp adjacency: a message in the same calendar second as the
+    preceding user message joins that user's turn (second-granularity
+    legacy timestamps tie-break user-first, then by sidecar ``seq``).
+
+    Args:
+        messages: Message rows or ``ConsoleChatMessage`` models (see the
+            module docstring's purity contract for the accepted shapes).
+        usage_by_id: Message id -> parsed ``ProviderUsage`` (``None``
+            values allowed and simply yield ``usage=None``).
+        traj_rows: ``TrajectoryRowRead``-shaped sidecar rows. Rows whose
+            message is not rendered (soft-deleted, off the active path, or
+            absent) are ignored -- including ``tool_call``/``tool_result``
+            rows keyed on such a message.
+        variant_sets: ``ConsoleVariantSet``-shaped objects; superseded
+            variant contents (every entry except ``selected_index``)
+            attach to the assistant records of the matching turn.
+        compaction_records: ``list_auxiliary_attempts``-shaped mappings
+            with ``purpose == "conversation_compaction"``. Markers are
+            ordered by ``started_at`` and placed after the last turn whose
+            message timestamps precede them (markers that predate every
+            turn lead the ledger; unplaceable ones trail it). With no
+            turns at all there is no "between" -- markers are dropped.
+        active_leaf_message_id: The conversation's active leaf (input
+            argument; the projection never queries the DB). ``None`` or a
+            dangling id degrades to rendering every non-deleted message in
+            order, with no tree-derived variant suppression.
+
+    Returns:
+        The snapshot; ``turns`` is empty for an empty conversation.
+    """
+    normalized = []
+    for index, raw in enumerate(messages):
+        m = _normalize_message(raw, index)
+        if m is not None:
+            normalized.append(m)
+
+    by_id = {m.mid: m for m in normalized}
+    children_by_parent: dict[str | None, list[_Msg]] = {}
+    for m in normalized:
+        children_by_parent.setdefault(m.parent, []).append(m)
+
+    active_ids = _active_path_ids(by_id, active_leaf_message_id)
+
+    # Sidecar rows: message rows by message id, tool rows by owning id.
+    message_rows: dict[str, Any] = {}
+    tool_rows: dict[str, list[Any]] = {}
+    for row in traj_rows:
+        mid = _field(row, "message_id")
+        kind = str(_field(row, "event_kind") or "")
+        if not mid:
+            continue
+        if kind in _TOOL_KINDS:
+            tool_rows.setdefault(str(mid), []).append(row)
+        else:
+            message_rows[str(mid)] = row
+
+    rendered = [
+        m
+        for m in normalized
+        if not m.deleted
+        and m.role in _RENDERED_ROLES
+        and (active_ids is None or m.mid in active_ids)
+    ]
+    rendered.sort(key=lambda m: _sort_key(m, message_rows))
+
+    # Events: (turn_id, record-builder) in ledger order, tool rows nested
+    # directly under their owning assistant record.
+    events: list[tuple[str, TrajectoryRecord]] = []
+    turn_msg_times: dict[str, float] = {}
+    open_turn: str | None = None
+    for m in rendered:
+        row = message_rows.get(m.mid)
+        if row is not None:
+            turn_id = str(_field(row, "turn_id") or m.mid)
+        elif m.turn_hint:
+            turn_id = str(m.turn_hint)
+        elif m.role == KIND_USER:
+            turn_id = m.mid
+        elif open_turn is not None:
+            turn_id = open_turn
+        else:
+            # Assistant-first conversation: the assistant opens its own
+            # turn (mirrors the store's turn-id fallback).
+            turn_id = m.mid
+        if m.role == KIND_USER:
+            open_turn = turn_id
+        if m.ts is not None:
+            prior = turn_msg_times.get(turn_id)
+            if prior is None or m.ts > prior:
+                turn_msg_times[turn_id] = m.ts
+
+        row_kind = str(_field(row, "event_kind") or "") if row is not None else ""
+        kind = row_kind if row_kind in _RENDERED_ROLES else m.role
+        events.append(
+            (
+                turn_id,
+                _message_record(
+                    m=m,
+                    kind=kind,
+                    turn_id=turn_id,
+                    row=row,
+                    usage=usage_by_id.get(m.mid),
+                    variants=_tree_variant_contents(
+                        m=m,
+                        children_by_parent=children_by_parent,
+                        active_ids=active_ids,
+                    ),
+                ),
+            )
+        )
+        for tool_row in sorted(
+            tool_rows.get(m.mid, ()),
+            key=lambda r: _as_int(_field(r, "seq")),
+        ):
+            events.append(
+                (
+                    turn_id,
+                    _tool_record(tool_row, turn_id=turn_id),
+                )
+            )
+
+    turns = _group_turns(events)
+    turns = _insert_compaction_markers(turns, compaction_records, turn_msg_times)
+    turns = _apply_variant_sets(turns, variant_sets)
+    turns = _assign_ledger_seq(turns)
+    return TrajectorySnapshot(turns=tuple(turns))
+
+
+def _assign_ledger_seq(turns: list[TrajectoryTurn]) -> list[TrajectoryTurn]:
+    """Stamp every record with its 1-based ledger position (render order)."""
+    stamped: list[TrajectoryTurn] = []
+    position = 0
+    for turn in turns:
+        records = []
+        for record in turn.records:
+            position += 1
+            records.append(_with_seq(record, position))
+        stamped.append(TrajectoryTurn(turn.turn_id, tuple(records)))
+    return stamped
+
+
+def _with_seq(record: TrajectoryRecord, seq: int) -> TrajectoryRecord:
+    """Return a copy of ``record`` carrying the given ledger ``seq``."""
+    return TrajectoryRecord(
+        seq=seq,
+        kind=record.kind,
+        turn_id=record.turn_id,
+        message_id=record.message_id,
+        content_preview=record.content_preview,
+        usage=record.usage,
+        step_started_at=record.step_started_at,
+        first_token_at=record.first_token_at,
+        completed_at=record.completed_at,
+        model=record.model,
+        provider=record.provider,
+        payload=record.payload,
+        variants=record.variants,
+        depth=record.depth,
+    )
+
+
+def _as_int(value: Any) -> int:
+    """Best-effort int for seq sorting; unparseable sorts last."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 2**31 - 1
+
+
+def _active_path_ids(
+    by_id: Mapping[str, _Msg], leaf: str | None
+) -> frozenset[str] | None:
+    """Ids on the active path (leaf -> root), or ``None`` when unknown.
+
+    Traversal walks the FULL map (soft-deleted nodes included) so a
+    deleted mid-chain node does not hide its ancestors; a visited-set
+    guards against malformed cyclic chains (mirrors the store's walk).
+    """
+    if not leaf or leaf not in by_id:
+        return None
+    chain: list[str] = []
+    seen: set[str] = set()
+    current: str | None = leaf
+    while current is not None and current in by_id and current not in seen:
+        seen.add(current)
+        chain.append(current)
+        current = by_id[current].parent
+    return frozenset(chain)
+
+
+def _sort_key(m: _Msg, message_rows: Mapping[str, Any]) -> tuple:
+    """Master ledger order: timestamp, then adjacency/seq tie-breaks.
+
+    - Timestamp primary (message rows always carry one; models without
+      one keep input order among themselves, after timestamped rows).
+    - Exact-timestamp ties break user-first, but ONLY for messages with
+      no turn identity of their own (no sidecar row, no ``turn_id``
+      hint): second-granularity legacy rows persist a fast reply with the
+      same stamp as its user message, and the user message opens the
+      turn, so it must sort first. Messages that already know their turn
+      never reorder.
+    - Sidecar ``seq`` breaks remaining ties (authoritative monotonic
+      order), then input position.
+    """
+    has_identity = message_rows.get(m.mid) is not None or m.turn_hint is not None
+    user_first = 0 if (m.role == KIND_USER or has_identity) else 1
+    row = message_rows.get(m.mid)
+    seq = _as_int(_field(row, "seq")) if row is not None else _NO_SEQ
+    return (
+        m.ts is None,  # timestamped rows first
+        m.ts if m.ts is not None else 0.0,
+        user_first,
+        seq,
+        m.index,
+    )
+
+
+def _tree_variant_contents(
+    m: _Msg,
+    children_by_parent: Mapping[str | None, list[_Msg]],
+    active_ids: frozenset[str] | None,
+) -> tuple[str, ...]:
+    """Contents of this node's tree siblings that are off the active path.
+
+    A sibling sharing ``m``'s parent but not on the active chain is a
+    superseded fork at the same tree position; its content surfaces on
+    ``m``'s record instead of as a ledger row. Only direct siblings
+    count -- deeper divergence inside a sibling's subtree is its history,
+    not a variant of ``m``. Requires a known active path; with none
+    (``active_leaf_message_id`` unset/dangling) there is no chain to be
+    off of, so no tree variants are derived.
+    """
+    if active_ids is None or m.parent is None:
+        return ()
+    siblings = [
+        s
+        for s in children_by_parent.get(m.parent, ())
+        if s.mid != m.mid
+        and not s.deleted
+        and s.role in _RENDERED_ROLES
+        and s.mid not in active_ids
+    ]
+    siblings.sort(key=lambda s: (s.ts is None, s.ts or 0.0, s.index))
+    return tuple(s.content for s in siblings)
+
+
+def _message_record(
+    *,
+    m: _Msg,
+    kind: str,
+    turn_id: str,
+    row: Any,
+    usage: ProviderUsage | None,
+    variants: tuple[str, ...],
+) -> TrajectoryRecord:
+    """Build a top-level user/assistant record from a message + its row."""
+    return TrajectoryRecord(
+        seq=0,  # assigned by the final pass
+        kind=kind,
+        turn_id=turn_id,
+        message_id=m.mid,
+        content_preview=_preview(m.content),
+        usage=usage,
+        step_started_at=_field(row, "step_started_at") if row is not None else None,
+        first_token_at=_field(row, "first_token_at") if row is not None else None,
+        completed_at=_field(row, "completed_at") if row is not None else None,
+        model=_field(row, "model") if row is not None else None,
+        provider=_field(row, "provider") if row is not None else None,
+        payload=None,
+        variants=variants,
+        depth=0,
+    )
+
+
+def _tool_record(row: Any, *, turn_id: str) -> TrajectoryRecord:
+    """Build a depth-1 tool record from a sidecar ``tool_*`` row.
+
+    ``message_id`` is the OWNING assistant message's id (both tool kinds
+    key on it). Timing is surfaced exactly as stored -- append-time
+    zero-duration stamps stay verbatim. The preview shows the tool name
+    and result text (marker convention: ``name -> result``), never the
+    raw ``payload_json`` envelope.
+    """
+    payload = _parse_payload(_field(row, "payload_json"))
+    return TrajectoryRecord(
+        seq=0,  # assigned by the final pass
+        kind=str(_field(row, "event_kind") or ""),
+        turn_id=turn_id,
+        message_id=str(_field(row, "message_id") or "") or None,
+        content_preview=_tool_preview(payload),
+        usage=None,
+        step_started_at=_field(row, "step_started_at"),
+        first_token_at=_field(row, "first_token_at"),
+        completed_at=_field(row, "completed_at"),
+        model=_field(row, "model"),
+        provider=_field(row, "provider"),
+        payload=payload,
+        variants=(),
+        depth=1,
+    )
+
+
+def _tool_preview(payload: dict | None) -> str:
+    """Single-line preview of a tool payload: ``name -> result``."""
+    if not payload:
+        return ""
+    name = str(payload.get("name") or "").strip()
+    result = payload.get("result")
+    body = _preview(result)
+    if name and body:
+        return f"{name} -> {body}"[:PREVIEW_MAX_CHARS]
+    return body or name[:PREVIEW_MAX_CHARS]
+
+
+def _group_turns(events: list[tuple[str, TrajectoryRecord]]) -> list[TrajectoryTurn]:
+    """Fold the ordered event stream into contiguous turns."""
+    turns: list[TrajectoryTurn] = []
+    current_id: str | None = None
+    current_records: list[TrajectoryRecord] = []
+    for turn_id, record in events:
+        if turn_id != current_id:
+            if current_id is not None:
+                turns.append(TrajectoryTurn(current_id, tuple(current_records)))
+            current_id = turn_id
+            current_records = []
+        current_records.append(record)
+    if current_id is not None:
+        turns.append(TrajectoryTurn(current_id, tuple(current_records)))
+    return turns
+
+
+def _insert_compaction_markers(
+    turns: list[TrajectoryTurn],
+    compaction_records: Iterable[Any],
+    turn_msg_times: Mapping[str, float],
+) -> list[TrajectoryTurn]:
+    """Place compaction markers between turns (trailing the turn they follow).
+
+    Placement keys off message timestamps only -- the persisted message
+    time is the message's canonical DB fact, immune to the sidecar's
+    nullable timing. Markers sort by ``started_at``; one predating every
+    turn leads the ledger; one after the last turn (or without a usable
+    time) trails it. With no turns there is no "between": markers drop.
+    """
+    markers = [
+        rec
+        for rec in compaction_records
+        if str(_field(rec, "purpose") or _COMPACTION_PURPOSE)
+        == _COMPACTION_PURPOSE
+    ]
+    if not markers or not turns:
+        return turns
+
+    markers = sorted(
+        enumerate(markers),
+        key=lambda pair: (_parse_timestamp(_field(pair[1], "started_at")) or 0.0, pair[0]),
+    )
+    turn_ends = [turn_msg_times.get(turn.turn_id) for turn in turns]
+
+    # buckets[i] = markers trailing turn i (in marker order).
+    buckets: list[list[Any]] = [[] for _ in turns]
+    lead: list[Any] = []
+    for _, rec in markers:
+        when = _parse_timestamp(_field(rec, "started_at"))
+        home = len(turns) - 1  # untimeable / after everything
+        if when is not None:
+            home = -1  # before everything until proven otherwise
+            for i, end in enumerate(turn_ends):
+                if end is not None and end <= when:
+                    home = i
+        (lead if home == -1 else buckets[home]).append(rec)
+
+    result: list[TrajectoryTurn] = []
+    for i, turn in enumerate(turns):
+        records: list[TrajectoryRecord] = []
+        if i == 0:
+            records.extend(_marker_record(rec, turn_id=turn.turn_id) for rec in lead)
+        records.extend(turn.records)
+        records.extend(_marker_record(rec, turn_id=turn.turn_id) for rec in buckets[i])
+        result.append(TrajectoryTurn(turn.turn_id, tuple(records)))
+    return result
+
+
+def _marker_record(rec: Any, *, turn_id: str) -> TrajectoryRecord:
+    """Build a between-turn compaction marker record."""
+    status = str(_field(rec, "status") or "")
+    usage = ProviderUsage.from_json(_field(rec, "provider_usage_json"))
+    return TrajectoryRecord(
+        seq=0,  # assigned by the final pass
+        kind=KIND_COMPACTION,
+        turn_id=turn_id,
+        message_id=None,
+        content_preview=f"compaction: {status}" if status else "compaction",
+        usage=usage,
+        step_started_at=_parse_timestamp(_field(rec, "started_at")),
+        first_token_at=None,  # compaction has no token boundary
+        completed_at=_parse_timestamp(_field(rec, "finished_at")),
+        model=_field(rec, "model") or None,
+        provider=_field(rec, "provider") or None,
+        payload=None,
+        variants=(),
+        depth=0,
+    )
+
+
+def _apply_variant_sets(
+    turns: list[TrajectoryTurn], variant_sets: Iterable[Any]
+) -> list[TrajectoryTurn]:
+    """Attach superseded variant-set contents to their turn's assistant records.
+
+    A set's superseded contents are every entry except ``selected_index``
+    (the selected entry is the current rendering). The set identifies a
+    turn, not a message, so contents attach to the turn's assistant
+    records -- merged after tree-derived variants, deduplicated in order.
+    """
+    sets = list(variant_sets)
+    if not sets:
+        return turns
+    superseded_by_turn: dict[str, tuple[str, ...]] = {}
+    for vs in sets:
+        turn_id = _field(vs, "turn_id")
+        if not turn_id:
+            continue
+        selected = _as_int(_field(vs, "selected_index", 0))
+        contents = tuple(
+            content
+            for index, item in enumerate(_field(vs, "variants") or ())
+            if index != selected
+            for content in (_variant_content(item),)
+            if content is not None
+        )
+        superseded_by_turn.setdefault(str(turn_id), ())
+        superseded_by_turn[str(turn_id)] = (
+            superseded_by_turn[str(turn_id)] + contents
+        )
+
+    if not superseded_by_turn:
+        return turns
+
+    result: list[TrajectoryTurn] = []
+    for turn in turns:
+        extra = superseded_by_turn.get(turn.turn_id)
+        if not extra:
+            result.append(turn)
+            continue
+        records = tuple(
+            _merge_variants(record, extra)
+            if record.kind == KIND_ASSISTANT
+            else record
+            for record in turn.records
+        )
+        result.append(TrajectoryTurn(turn.turn_id, records))
+    return result
+
+
+def _variant_content(item: Any) -> str | None:
+    """Extract one variant's content: ``.content``, a "content" key, or str."""
+    if isinstance(item, str):
+        return item
+    content = _field(item, "content")
+    return str(content) if content is not None else None
+
+
+def _merge_variants(
+    record: TrajectoryRecord, extra: tuple[str, ...]
+) -> TrajectoryRecord:
+    """Return ``record`` with ``extra`` contents appended, deduplicated."""
+    merged: list[str] = list(record.variants)
+    for content in extra:
+        if content not in merged:
+            merged.append(content)
+    return TrajectoryRecord(
+        seq=record.seq,
+        kind=record.kind,
+        turn_id=record.turn_id,
+        message_id=record.message_id,
+        content_preview=record.content_preview,
+        usage=record.usage,
+        step_started_at=record.step_started_at,
+        first_token_at=record.first_token_at,
+        completed_at=record.completed_at,
+        model=record.model,
+        provider=record.provider,
+        payload=record.payload,
+        variants=tuple(merged),
+        depth=record.depth,
+    )

--- a/tldw_chatbook/Chat/trajectory.py
+++ b/tldw_chatbook/Chat/trajectory.py
@@ -438,13 +438,19 @@ def _active_path_ids(
     Traversal walks the FULL map (soft-deleted nodes included) so a
     deleted mid-chain node does not hide its ancestors; a visited-set
     guards against malformed cyclic chains (mirrors the store's walk).
+    A walk that ends at a non-root gap -- an ancestor id missing from
+    the input map (the DB seam filters ``deleted = 0``) -- yields
+    ``None`` too: the true path is unknowable, so the caller degrades
+    to render-all instead of silently rendering only post-gap messages.
     """
     if not leaf or leaf not in by_id:
         return None
     chain: list[str] = []
     seen: set[str] = set()
     current: str | None = leaf
-    while current is not None and current in by_id and current not in seen:
+    while current is not None and current not in seen:
+        if current not in by_id:
+            return None
         seen.add(current)
         chain.append(current)
         current = by_id[current].parent

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -3238,7 +3238,7 @@ UPDATE db_schema_version
             raise CharactersRAGDBError(f"Execute Many failed: {e}") from e
 
     # --- Transaction Context ---
-    def transaction(self) -> "TransactionContextManager":
+    def transaction(self, *, immediate: bool = False) -> "TransactionContextManager":
         """
         Returns a context manager for database transactions.
 
@@ -3255,10 +3255,18 @@ UPDATE db_schema_version
         managed contexts only track depth and defer completion to their outer
         transaction.
 
+        Args:
+            immediate: Start the outermost manager-owned transaction with
+                ``BEGIN IMMEDIATE`` (write lock up front). Required for
+                read-then-write transactions (e.g. seq assignment via
+                MAX(seq)+1) that would otherwise risk SQLite's
+                non-retryable deferred-upgrade deadlock under concurrent
+                writers. Ignored for nested/borrowed transactions.
+
         Returns:
             TransactionContextManager: An object to be used in a `with` statement.
         """
-        return TransactionContextManager(self)
+        return TransactionContextManager(self, immediate=immediate)
 
     # --- Schema Initialization and Migration ---
     def _get_db_version(self, conn: sqlite3.Connection) -> int:
@@ -10026,7 +10034,14 @@ UPDATE db_schema_version
         if not rows:
             return
         try:
-            with self.transaction() as conn:
+            # IMMEDIATE (write lock up front): this is a read-then-write
+            # transaction (MAX(seq)+1 assignment before the inserts). With a
+            # DEFERRED begin, two concurrent writers on one conversation hit
+            # SQLite's non-retryable snapshot/upgrade deadlock and the loser
+            # rolls back with "database is locked" regardless of the busy
+            # timeout. IMMEDIATE makes concurrent writers queue on the busy
+            # timeout instead, so seq assignment stays unique.
+            with self.transaction(immediate=True) as conn:
                 next_seq: Dict[str, int] = {}
                 for row in rows:
                     if row.seq is None:
@@ -16242,11 +16257,26 @@ UPDATE db_schema_version
 
 # --- Transaction Context Manager Class (Helper for `with db.transaction():`) ---
 class TransactionContextManager:
-    def __init__(self, db_instance: CharactersRAGDB):
+    def __init__(
+        self,
+        db_instance: CharactersRAGDB,
+        *,
+        immediate: bool = False,
+    ):
         self.db = db_instance
         self.conn: Optional[sqlite3.Connection] = None
         self.is_outermost_transaction = False
         self.borrows_native_transaction = False
+        # RESERVED up front (``BEGIN IMMEDIATE``) for read-then-write
+        # transactions: a DEFERRED begin that reads (e.g. MAX(seq)) before
+        # writing can hit SQLite's non-retryable snapshot/upgrade deadlock
+        # when a concurrent writer commits in between -- the losing
+        # transaction rolls back with "database is locked" no matter how
+        # long the busy timeout is. IMMEDIATE takes the write lock before
+        # the first read, so concurrent writers queue on the busy timeout
+        # instead of deadlocking. Only affects the OUTERMOST
+        # manager-owned transaction; nested/borrowed paths are untouched.
+        self.immediate = bool(immediate)
 
     def __enter__(self):
         # Ensure transaction_depth is initialized for this thread
@@ -16273,7 +16303,7 @@ class TransactionContextManager:
                 return self.conn.cursor()
 
             # Set depth only after BEGIN succeeds so a failed BEGIN cannot corrupt it.
-            self.conn.execute("BEGIN")
+            self.conn.execute("BEGIN IMMEDIATE" if self.immediate else "BEGIN")
             self.is_outermost_transaction = True
             self.db._local.transaction_depth = 1
             logger.debug(

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -9990,9 +9990,12 @@ UPDATE db_schema_version
     def get_next_trajectory_seq(self, conversation_id: str) -> int:
         """Return the next trajectory seq for a conversation (max(seq) + 1).
 
-        Local-only read against the ``message_trajectory_metadata``
-        sidecar; safe to call inside a transaction (uses the caller's
-        connection state via a fresh read on the thread connection).
+        Standalone read against the ``message_trajectory_metadata``
+        sidecar. This opens its own transaction, so it must NOT be called
+        from inside another transaction on this DB instance; code already
+        inside a transaction should use the private
+        :meth:`_next_trajectory_seq` helper instead (as
+        :meth:`upsert_trajectory_rows` does).
         """
         with self.transaction() as conn:
             return self._next_trajectory_seq(conn, conversation_id)

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -42,6 +42,7 @@ import json
 import re
 import uuid
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 import threading
@@ -174,6 +175,48 @@ class ConflictError(CharactersRAGDBError):
 _EXPRESSION_IMAGE_STATE_IDS = frozenset({"thinking", "speaking", "error"})
 
 
+# --- Trajectory metadata sidecar (schema v38) ---
+# ``message_trajectory_metadata`` is LOCAL-ONLY: no sync triggers, no sync
+# serialization. It records this device's own per-turn step observations for
+# the Console trajectory view.
+@dataclass
+class TrajectoryRowWrite:
+    """Input row for :meth:`CharactersRAGDB.upsert_trajectory_rows`.
+
+    ``seq=None`` means "assign the next seq for this conversation inside
+    the write transaction"; explicit seqs are honored as-is.
+    """
+
+    message_id: str
+    conversation_id: str
+    turn_id: str
+    seq: Optional[int]
+    event_kind: str
+    step_started_at: Optional[float] = None
+    first_token_at: Optional[float] = None
+    completed_at: Optional[float] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    payload_json: Optional[str] = None
+
+
+@dataclass
+class TrajectoryRowRead:
+    """A stored trajectory sidecar row, as returned by reads."""
+
+    message_id: str
+    conversation_id: str
+    turn_id: str
+    seq: int
+    event_kind: str
+    step_started_at: Optional[float] = None
+    first_token_at: Optional[float] = None
+    completed_at: Optional[float] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    payload_json: Optional[str] = None
+
+
 # --- Database Class ---
 class CharactersRAGDB:
     """
@@ -201,7 +244,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 37  # Durable provider continuation on assistant messages.
+    _CURRENT_SCHEMA_VERSION = 38  # Message trajectory metadata sidecar.
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -5029,6 +5072,46 @@ UPDATE db_schema_version
                 f"Migration from V36 to V37 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _migrate_from_v37_to_v38(self, conn: sqlite3.Connection) -> None:
+        """Add the local-only message trajectory metadata sidecar table."""
+        if self._get_db_version(conn) != 37:
+            raise SchemaError(
+                f"[{self._SCHEMA_NAME} V37→V38] Migration requires schema version 37"
+            )
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v37_to_v38_message_trajectory_metadata.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                pending = ""
+                for line in migration_path.read_text(encoding="utf-8").splitlines(
+                    keepends=True
+                ):
+                    pending += line
+                    if not sqlite3.complete_statement(pending):
+                        continue
+                    statement = pending
+                    pending = ""
+                    cursor.execute(statement)
+                if pending.strip():
+                    raise SchemaError(
+                        "Trajectory metadata migration contains incomplete SQL"
+                    )
+                row = cursor.execute(
+                    "SELECT version FROM db_schema_version WHERE schema_name = ?",
+                    (self._SCHEMA_NAME,),
+                ).fetchone()
+                if row is None or row["version"] != 38:
+                    raise SchemaError(
+                        "Trajectory metadata schema version verification failed"
+                    )
+        except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
+            raise SchemaError(
+                f"Migration from V37 to V38 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -5197,6 +5280,7 @@ UPDATE db_schema_version
                     34: self._migrate_from_v34_to_v35,
                     35: self._migrate_from_v35_to_v36,
                     36: self._migrate_from_v36_to_v37,
+                    37: self._migrate_from_v37_to_v38,
                 }
 
                 if current_db_version == 0:
@@ -9901,6 +9985,146 @@ UPDATE db_schema_version
             )
             raise CharactersRAGDBError(
                 f"Database error writing local metadata: {e}"
+            ) from e
+
+    def get_next_trajectory_seq(self, conversation_id: str) -> int:
+        """Return the next trajectory seq for a conversation (max(seq) + 1).
+
+        Local-only read against the ``message_trajectory_metadata``
+        sidecar; safe to call inside a transaction (uses the caller's
+        connection state via a fresh read on the thread connection).
+        """
+        with self.transaction() as conn:
+            return self._next_trajectory_seq(conn, conversation_id)
+
+    def _next_trajectory_seq(self, conn: sqlite3.Connection, conversation_id: str) -> int:
+        row = conn.execute(
+            "SELECT COALESCE(MAX(seq), 0) FROM message_trajectory_metadata"
+            " WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        return int(row[0]) + 1
+
+    def upsert_trajectory_rows(self, rows: Sequence[TrajectoryRowWrite]) -> None:
+        """Upsert trajectory sidecar rows for one or more conversations.
+
+        LOCAL-ONLY: the ``message_trajectory_metadata`` table has no sync
+        triggers and is never serialized into sync payloads. Rows written
+        with ``seq=None`` are assigned ``max(seq) + 1`` per conversation
+        inside the same transaction as the insert; explicit seqs are
+        honored. Upsert key: ``(message_id, event_kind, seq)``.
+
+        Args:
+            rows: The rows to write.
+
+        Raises:
+            CharactersRAGDBError: On database errors.
+        """
+        if not rows:
+            return
+        try:
+            with self.transaction() as conn:
+                next_seq: Dict[str, int] = {}
+                for row in rows:
+                    if row.seq is None:
+                        if row.conversation_id not in next_seq:
+                            next_seq[row.conversation_id] = (
+                                self._next_trajectory_seq(conn, row.conversation_id)
+                            )
+                        seq = next_seq[row.conversation_id]
+                        next_seq[row.conversation_id] = seq + 1
+                    else:
+                        seq = row.seq
+                    conn.execute(
+                        """
+                        INSERT INTO message_trajectory_metadata (
+                            message_id, conversation_id, turn_id, seq,
+                            event_kind, step_started_at, first_token_at,
+                            completed_at, model, provider, payload_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(message_id, event_kind, seq) DO UPDATE SET
+                            conversation_id = excluded.conversation_id,
+                            turn_id = excluded.turn_id,
+                            step_started_at = excluded.step_started_at,
+                            first_token_at = excluded.first_token_at,
+                            completed_at = excluded.completed_at,
+                            model = excluded.model,
+                            provider = excluded.provider,
+                            payload_json = excluded.payload_json
+                        """,
+                        (
+                            row.message_id,
+                            row.conversation_id,
+                            row.turn_id,
+                            seq,
+                            row.event_kind,
+                            row.step_started_at,
+                            row.first_token_at,
+                            row.completed_at,
+                            row.model,
+                            row.provider,
+                            row.payload_json,
+                        ),
+                    )
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(
+                f"Database error upserting trajectory rows: {e}"
+            )
+            raise CharactersRAGDBError(
+                f"Database error upserting trajectory rows: {e}"
+            ) from e
+
+    def get_trajectory_rows(self, conversation_id: str) -> List[TrajectoryRowRead]:
+        """Return a conversation's trajectory sidecar rows ordered by ``seq``.
+
+        Includes rows whose message was later soft-deleted: the trajectory
+        projection layer (not the DB) decides how to render deleted turns.
+
+        Args:
+            conversation_id: The conversation whose rows to read.
+
+        Returns:
+            Rows ordered by ``seq`` ascending.
+
+        Raises:
+            CharactersRAGDBError: On database errors.
+        """
+        try:
+            with self.transaction() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT message_id, conversation_id, turn_id, seq,
+                           event_kind, step_started_at, first_token_at,
+                           completed_at, model, provider, payload_json
+                      FROM message_trajectory_metadata
+                     WHERE conversation_id = ?
+                     ORDER BY seq ASC
+                    """,
+                    (conversation_id,),
+                )
+                return [
+                    TrajectoryRowRead(
+                        message_id=r["message_id"],
+                        conversation_id=r["conversation_id"],
+                        turn_id=r["turn_id"],
+                        seq=int(r["seq"]),
+                        event_kind=r["event_kind"],
+                        step_started_at=r["step_started_at"],
+                        first_token_at=r["first_token_at"],
+                        completed_at=r["completed_at"],
+                        model=r["model"],
+                        provider=r["provider"],
+                        payload_json=r["payload_json"],
+                    )
+                    for r in cursor.fetchall()
+                ]
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error(
+                f"Database error reading trajectory rows for conversation"
+                f" {conversation_id}: {e}"
+            )
+            raise CharactersRAGDBError(
+                f"Database error reading trajectory rows: {e}"
             ) from e
 
     def soft_delete_message(

--- a/tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql
@@ -8,7 +8,7 @@
 
 CREATE TABLE IF NOT EXISTS message_trajectory_metadata (
     message_id TEXT NOT NULL,
-    conversation_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
     turn_id TEXT NOT NULL,
     seq INTEGER NOT NULL,
     event_kind TEXT NOT NULL,
@@ -22,11 +22,15 @@ CREATE TABLE IF NOT EXISTS message_trajectory_metadata (
     FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_message_trajectory_conv_seq
+-- Ledger-ordering guarantee: seq is strictly unique per conversation.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_message_trajectory_conv_seq
     ON message_trajectory_metadata (conversation_id, seq);
 
 CREATE INDEX IF NOT EXISTS idx_message_trajectory_turn
     ON message_trajectory_metadata (conversation_id, turn_id, seq);
+
+CREATE INDEX IF NOT EXISTS idx_message_trajectory_msg
+    ON message_trajectory_metadata (message_id);
 
 UPDATE db_schema_version
    SET version = 38

--- a/tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v37_to_v38_message_trajectory_metadata.sql
@@ -1,0 +1,34 @@
+-- Migration: ChaChaNotes V37 to V38 message trajectory metadata sidecar.
+--
+-- The trajectory ledger is a LOCAL-ONLY projection of per-turn step timing:
+-- it records what THIS device observed while producing messages (event
+-- kinds, first-token/completion timestamps, model/provider, step payloads).
+-- It is deliberately excluded from sync triggers and sync serialization;
+-- every device rebuilds its own copy from its own runs.
+
+CREATE TABLE IF NOT EXISTS message_trajectory_metadata (
+    message_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    event_kind TEXT NOT NULL,
+    step_started_at REAL,
+    first_token_at REAL,
+    completed_at REAL,
+    model TEXT,
+    provider TEXT,
+    payload_json TEXT,
+    PRIMARY KEY (message_id, event_kind, seq),
+    FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_trajectory_conv_seq
+    ON message_trajectory_metadata (conversation_id, seq);
+
+CREATE INDEX IF NOT EXISTS idx_message_trajectory_turn
+    ON message_trajectory_metadata (conversation_id, turn_id, seq);
+
+UPDATE db_schema_version
+   SET version = 38
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version = 37;

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -62,6 +62,7 @@ VALID_TABLES = {
         "learning_paths",
         "message_attachments",
         "message_generation_metadata",
+        "message_trajectory_metadata",
         "messages",
         "mindmap_nodes",
         "mindmaps",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1172,7 +1172,12 @@ def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectoryS
     if db is not None:
         try:
             messages = list(
-                db.get_messages_for_conversation(conversation_id, limit=1_000_000)
+                db.get_messages_for_conversation(
+                    conversation_id,
+                    limit=1_000_000,
+                    # Text-only projection: skip the image BLOB I/O (task-260).
+                    include_image_data=False,
+                )
             )
         except Exception:  # noqa: BLE001 - launch must degrade, not fail
             messages = []
@@ -2986,7 +2991,7 @@ class ChatScreen(BaseAppScreen):
         )
 
     def action_open_trajectory_view(self) -> None:
-        """Open the trajectory ledger for the active Console conversation (``j``).
+        """Open the trajectory ledger for the active Console conversation (``y``).
 
         task-5: the snapshot is built off the UI thread (DB reads); the
         screen is pushed with live tail-follow callables wired to the

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1136,7 +1136,7 @@ CONSOLE_WORKBENCH_SHORTCUTS = (
     ("Shift+F6", "previous pane"),
     ("F1", "help"),
     ("Enter", "send / queue"),
-    ("J", "trajectory"),
+    ("Y", "trajectory"),
     ("Ctrl+K", "switch session"),
     ("Ctrl+T", "new tab"),
     ("Ctrl+P", "palette"),
@@ -1158,6 +1158,9 @@ def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectoryS
     task-5 (console trajectory view). Best-effort at every seam: any source
     that is unavailable contributes an empty iterable rather than failing
     the launch -- the ledger degrades to fewer records, never to no screen.
+    Variant contents are process-local (see
+    ``ConsoleChatStore.variant_sets_for_conversation``): cold conversations
+    render without superseded variants by design.
     """
     messages: list[Any] = []
     traj_rows: list[Any] = []
@@ -1188,20 +1191,19 @@ def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectoryS
         usage = ProviderUsage.from_json(message.get("usage_json"))
         if usage is not None:
             usage_by_id[str(message.get("id"))] = usage
-    variant_provider = getattr(store, "variant_sets_for_conversation", None)
-    if callable(variant_provider):
+    try:
+        variant_sets = list(store.variant_sets_for_conversation(conversation_id))
+    except Exception:  # noqa: BLE001
+        variant_sets = []
+    context_repository = getattr(persistence, "context_repository", None)
+    if context_repository is not None:
         try:
-            variant_sets = list(variant_provider(conversation_id))
-        except Exception:  # noqa: BLE001
-            variant_sets = []
-    compaction_lister = getattr(
-        getattr(persistence, "context_repository", None),
-        "list_compaction_records",
-        None,
-    )
-    if callable(compaction_lister):
-        try:
-            compaction_records = list(compaction_lister(conversation_id))
+            # The projection itself filters purpose == "conversation_compaction".
+            compaction_records = list(
+                context_repository.list_auxiliary_attempts(
+                    conversation_id, limit=500
+                )
+            )
         except Exception:  # noqa: BLE001
             compaction_records = []
     return derive_trajectory(
@@ -1787,10 +1789,13 @@ class ChatScreen(BaseAppScreen):
         ),
         Binding("ctrl+k", "open_console_session_switcher", "Switch session", show=True),
         # task-5 (console trajectory view): single-letter htop-style launch
-        # key per ADR-031; 'j' was unbound on this screen. The footer hint is
-        # registered via CONSOLE_WORKBENCH_SHORTCUTS like the rest of the
-        # Console vocabulary.
-        Binding("j", "open_trajectory_view", "Trajectory", show=True),
+        # key per ADR-031. 'y', NOT 'j': the focused transcript consumes
+        # j/k for next/previous-message selection (console_transcript.py
+        # on_key), which would make the advertised footer hint a lie in
+        # exactly the surface a trajectory reader comes from. The footer
+        # hint is registered via CONSOLE_WORKBENCH_SHORTCUTS like the rest
+        # of the Console vocabulary.
+        Binding("y", "open_trajectory_view", "Trajectory", show=True),
         Binding("alt+m", "open_console_model_popover", "Model", show=True),
         Binding("alt+w", "open_console_workspace_switcher", "Workspace", show=True),
         Binding("alt+v", "paste_clipboard_image", "Paste image", show=True),

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -42,6 +42,7 @@ from ..Navigation.pending_handoff_store import (
 )
 from ..Navigation.screen_state_store import ConsolePromptTargetProjection
 from .chat_screen_state import TaskResumeState
+from .trajectory_screen import TrajectoryScreen
 from .provider_model_resolution import (
     ResolvedProviderModelOption,
     resolve_effective_provider_model,
@@ -119,6 +120,7 @@ from ...Chat.console_cost_tracker import (
 )
 from ...Chat.message_metadata import MessageMetadata
 from ...Chat.provider_usage import ProviderUsage, as_seconds
+from ...Chat.trajectory import TrajectorySnapshot, derive_trajectory
 from ...LLM_Calls.pricing_catalog import get_pricing_catalog
 from ...Event_Handlers.Chat_Events.chat_events_console_dictionaries import (
     console_attachable_dictionaries,
@@ -1134,6 +1136,7 @@ CONSOLE_WORKBENCH_SHORTCUTS = (
     ("Shift+F6", "previous pane"),
     ("F1", "help"),
     ("Enter", "send / queue"),
+    ("J", "trajectory"),
     ("Ctrl+K", "switch session"),
     ("Ctrl+T", "new tab"),
     ("Ctrl+P", "palette"),
@@ -1147,6 +1150,68 @@ CONSOLE_WORKBENCH_SHORTCUTS_SETUP_BLOCKED = tuple(
     ("Enter", "continue setup") if pair == ("Enter", "send / queue") else pair
     for pair in CONSOLE_WORKBENCH_SHORTCUTS
 )
+
+
+def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectorySnapshot":
+    """Assemble the ``derive_trajectory`` inputs for one persisted conversation.
+
+    task-5 (console trajectory view). Best-effort at every seam: any source
+    that is unavailable contributes an empty iterable rather than failing
+    the launch -- the ledger degrades to fewer records, never to no screen.
+    """
+    messages: list[Any] = []
+    traj_rows: list[Any] = []
+    variant_sets: list[Any] = []
+    compaction_records: list[Any] = []
+    active_leaf: str | None = None
+    persistence = getattr(store, "persistence", None)
+    db = getattr(persistence, "db", None)
+    if db is not None:
+        try:
+            messages = list(
+                db.get_messages_for_conversation(conversation_id, limit=1_000_000)
+            )
+        except Exception:  # noqa: BLE001 - launch must degrade, not fail
+            messages = []
+        try:
+            traj_rows = list(db.get_trajectory_rows(conversation_id))
+        except Exception:  # noqa: BLE001
+            traj_rows = []
+        try:
+            active_leaf = db.get_conversation_active_leaf(conversation_id)
+        except Exception:  # noqa: BLE001
+            active_leaf = None
+    usage_by_id: dict[str, ProviderUsage] = {}
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        usage = ProviderUsage.from_json(message.get("usage_json"))
+        if usage is not None:
+            usage_by_id[str(message.get("id"))] = usage
+    variant_provider = getattr(store, "variant_sets_for_conversation", None)
+    if callable(variant_provider):
+        try:
+            variant_sets = list(variant_provider(conversation_id))
+        except Exception:  # noqa: BLE001
+            variant_sets = []
+    compaction_lister = getattr(
+        getattr(persistence, "context_repository", None),
+        "list_compaction_records",
+        None,
+    )
+    if callable(compaction_lister):
+        try:
+            compaction_records = list(compaction_lister(conversation_id))
+        except Exception:  # noqa: BLE001
+            compaction_records = []
+    return derive_trajectory(
+        messages,
+        usage_by_id,
+        traj_rows,
+        variant_sets,
+        compaction_records,
+        active_leaf_message_id=active_leaf,
+    )
 
 #: TASK-362: the full Console keyboard vocabulary for the F1 help panel, grouped
 #: by surface. The flat CONSOLE_WORKBENCH_SHORTCUTS above stays the compact
@@ -1721,6 +1786,11 @@ class ChatScreen(BaseAppScreen):
             priority=True,
         ),
         Binding("ctrl+k", "open_console_session_switcher", "Switch session", show=True),
+        # task-5 (console trajectory view): single-letter htop-style launch
+        # key per ADR-031; 'j' was unbound on this screen. The footer hint is
+        # registered via CONSOLE_WORKBENCH_SHORTCUTS like the rest of the
+        # Console vocabulary.
+        Binding("j", "open_trajectory_view", "Trajectory", show=True),
         Binding("alt+m", "open_console_model_popover", "Model", show=True),
         Binding("alt+w", "open_console_workspace_switcher", "Workspace", show=True),
         Binding("alt+v", "paste_clipboard_image", "Paste image", show=True),
@@ -2908,6 +2978,47 @@ class ChatScreen(BaseAppScreen):
         self.app.push_screen(
             ConsoleSessionSwitcherModal(rows=tuple(rows)),
             callback=self._session._apply_console_switcher_choice,
+        )
+
+    def action_open_trajectory_view(self) -> None:
+        """Open the trajectory ledger for the active Console conversation (``j``).
+
+        task-5: the snapshot is built off the UI thread (DB reads); the
+        screen is pushed with live tail-follow callables wired to the
+        store's payload-revision bus.
+        """
+        store = self._console_chat_store or self._ensure_console_chat_store()
+        session = getattr(store, "_sessions", {}).get(
+            getattr(store, "active_session_id", None)
+        )
+        conversation_id = getattr(session, "persisted_conversation_id", None)
+        if not conversation_id:
+            self.notify("The active conversation has no persisted trajectory yet.")
+            return
+        conv_id = str(conversation_id)
+        screen_title = str(getattr(session, "title", "") or "Console")
+
+        def build() -> TrajectorySnapshot:
+            return _build_trajectory_snapshot(store, conv_id)
+
+        def present(snapshot: TrajectorySnapshot) -> None:
+            self.push_screen(
+                TrajectoryScreen(
+                    snapshot,
+                    screen_title=screen_title,
+                    conversation_id=conv_id,
+                    revision_provider=lambda: store.get_payload_revision(conv_id),
+                    snapshot_builder=build,
+                )
+            )
+
+        def build_worker() -> None:
+            snapshot = build()
+            self.call_from_thread(present, snapshot)
+
+        self.notify("Building trajectory…")
+        self.run_worker(
+            build_worker, thread=True, exclusive=True, group="trajectory-launch"
         )
 
     async def action_open_console_model_popover(self) -> None:

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -344,12 +344,19 @@ class TrajectoryScreen(ModalScreen[None]):
             turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
         }
         # Feed the strip the same data the ledger renders. set_snapshot
-        # resets the widget's brush/selection WITHOUT posting, so mirror
-        # the brush clear here -- the ledger's time filter can never
-        # outlive the visual brush. (Follow still scrolls to the tail;
-        # the brush only ever filtered, so nothing fights it.)
+        # resets the widget's brush/selection WITHOUT posting, so keep an
+        # active brush alive across the swap (a 0.5s revision tick must
+        # not destroy it): re-apply it iff it still intersects the new
+        # domain (appends only grow it), else clear both sides so the
+        # ledger's time filter can never outlive the visual brush.
         self._timeline.set_snapshot(snapshot)
-        self._brush_range = None
+        if self._brush_range is not None:
+            lo, hi = self._brush_range
+            domain = self._timeline.model.domain
+            if domain is not None and lo <= domain[1] and hi >= domain[0]:
+                self._timeline.apply_brush(self._brush_range)
+            else:
+                self._brush_range = None
         # Keep collapsed turns and the search query; never shrink the window.
         self._visible_count = max(
             self._visible_count, min(self._total_records, PAGE_SIZE)

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -6,9 +6,26 @@ Modal over the Console (task-4 of the trajectory view; spec:
 from the pure projection (``Chat/trajectory.py``) and never queries the
 DB itself.
 
-Layout (vertical): title line, search ``Input``, ``DataTable`` ledger
+Layout (vertical): title line, search ``Input``, brushable timeline strip
+(:class:`TrajectoryTimeline`, task-16315 -- always mounted so its zoom
+state survives; the widget itself collapses to a ``no timing data``
+placeholder when the snapshot has no timing), ``DataTable`` ledger
 (``cursor_type="row"``), inspector ``Static`` (hidden until toggled),
 footer hints line.
+
+Timeline <-> ledger integration:
+
+- The strip is fed the same snapshot as the ledger, live refreshes
+  included (``_apply_live_snapshot``).
+- A brush range filters the ledger to records ACTIVE in the range (the
+  widget model's ``records_in_range`` semantics), composed with the
+  search query (AND); brush=None clears only the time filter. The
+  strip's caption is the brush status note (range + active count) --
+  deliberately not duplicated elsewhere.
+- Bar click moves the ledger cursor to that record (growing the mounted
+  window if the record is only paginated out); the ledger cursor
+  highlights the bar via ``set_selected``. The search filter is never
+  touched by the timeline.
 
 Ledger semantics pinned by the projection's contracts:
 
@@ -55,6 +72,7 @@ from tldw_chatbook.Chat.trajectory import (
     TrajectorySnapshot,
     TrajectoryTurn,
 )
+from tldw_chatbook.UI.Widgets.trajectory_timeline import TrajectoryTimeline
 
 __all__ = [
     "LOAD_EARLIER_ROW_KEY",
@@ -205,6 +223,12 @@ class TrajectoryScreen(ModalScreen[None]):
         }
         self._collapsed: set[str] = set()
         self._query = ""
+        #: Active brush time range from the timeline strip (None = no
+        #: time filter); mirrors the widget's brush state.
+        self._brush_range: tuple[float, float] | None = None
+        #: The always-mounted timeline strip (created here so filters,
+        #: pagination growth and selection sync can reach it pre-mount).
+        self._timeline = TrajectoryTimeline(id="trajectory-timeline")
         #: Number of newest records mounted (grows one page per `e` press).
         self._visible_count = min(self._total_records, PAGE_SIZE)
         #: Row key -> record (None for header/control rows), in row order.
@@ -227,6 +251,7 @@ class TrajectoryScreen(ModalScreen[None]):
         with Vertical(id="trajectory-screen"):
             yield Static(self._title_text(), id="trajectory-title", markup=False)
             yield Input(placeholder="Search records…", id="trajectory-search")
+            yield self._timeline  # always mounted: zoom state survives
             yield DataTable(id="trajectory-table", cursor_type="row")
             inspector = Static("", id="trajectory-inspector", markup=False)
             inspector.display = False  # hidden until toggled (spec)
@@ -237,6 +262,7 @@ class TrajectoryScreen(ModalScreen[None]):
         table = self.query_one("#trajectory-table", DataTable)
         for label, width in _COLUMNS:
             table.add_column(label, width=width)
+        self._timeline.set_snapshot(self._snapshot)
         self._refresh_hints()
         if self._total_records > WORKER_THRESHOLD:
             # Large conversation: build the row specs off the UI thread.
@@ -317,6 +343,13 @@ class TrajectoryScreen(ModalScreen[None]):
         self._turn_numbers = {
             turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
         }
+        # Feed the strip the same data the ledger renders. set_snapshot
+        # resets the widget's brush/selection WITHOUT posting, so mirror
+        # the brush clear here -- the ledger's time filter can never
+        # outlive the visual brush. (Follow still scrolls to the tail;
+        # the brush only ever filtered, so nothing fights it.)
+        self._timeline.set_snapshot(snapshot)
+        self._brush_range = None
         # Keep collapsed turns and the search query; never shrink the window.
         self._visible_count = max(
             self._visible_count, min(self._total_records, PAGE_SIZE)
@@ -428,31 +461,62 @@ class TrajectoryScreen(ModalScreen[None]):
             )
 
         query = self._query.lower()
+        brush_seqs = self._brush_active_seqs()
         open_turn: TrajectoryTurn | None = None
         turn_records: list[TrajectoryRecord] = []
         for turn, record in self._flat_slice():
             if open_turn is not None and turn.turn_id != open_turn.turn_id:
-                specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+                specs.extend(
+                    self._turn_row_specs(open_turn, turn_records, query, brush_seqs)
+                )
                 turn_records = []
             open_turn = turn
             turn_records.append(record)
         if open_turn is not None:
-            specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+            specs.extend(
+                self._turn_row_specs(open_turn, turn_records, query, brush_seqs)
+            )
         return specs
 
+    def _brush_active_seqs(self) -> frozenset[int] | None:
+        """Seqs of records ACTIVE in the brush; ``None`` when no brush.
+
+        Reuses the timeline model's ``records_in_range`` semantics (a
+        record is active when its interval intersects the range; untimed
+        records are never in the model, so a brush hides them) instead
+        of reimplementing the interval math here.
+        """
+        if self._brush_range is None:
+            return None
+        lo, hi = self._brush_range
+        return frozenset(
+            record.seq for record in self._timeline.model.records_in_range(lo, hi)
+        )
+
     def _turn_row_specs(
-        self, turn: TrajectoryTurn, records: list[TrajectoryRecord], query: str
+        self,
+        turn: TrajectoryTurn,
+        records: list[TrajectoryRecord],
+        query: str,
+        brush_seqs: frozenset[int] | None = None,
     ) -> list[tuple[str, tuple[Text, ...]]]:
         """Header row + child rows for one turn under the current filter.
 
         Search semantics (spec): child rows match on their own text; the
         turn header survives iff any child matches. A search overrides
         collapse (searching reveals), otherwise collapsed turns show the
-        header only.
+        header only. A brush composes with the search (AND) and follows
+        the same header-survival and reveal rules.
         """
-        matching = [rec for rec in records if self._record_matches(rec, query)]
-        if query and not matching:
-            return []  # nothing in this turn matches: header included, hidden
+        matching = [
+            rec
+            for rec in records
+            if self._record_matches(rec, query)
+            and (brush_seqs is None or rec.seq in brush_seqs)
+        ]
+        filtering = bool(query) or brush_seqs is not None
+        if filtering and not matching:
+            return []  # nothing in this turn is visible: header included, hidden
         header_key = f"turn:{turn.turn_id}"
         collapsed = turn.turn_id in self._collapsed
         number = self._turn_numbers.get(turn.turn_id, 0)
@@ -473,7 +537,7 @@ class TrajectoryScreen(ModalScreen[None]):
                 ),
             )
         ]
-        if collapsed and not query:
+        if collapsed and not filtering:
             return specs
         for rec in matching:
             specs.append((str(rec.seq), self._record_cells(rec)))
@@ -589,6 +653,7 @@ class TrajectoryScreen(ModalScreen[None]):
                     "Trajectory cursor restore skipped: {}", type(exc).__name__
                 )
         self._refresh_hints()
+        self._sync_timeline_selection()
         if self.query_one("#trajectory-inspector", Static).display:
             self._refresh_inspector()
 
@@ -746,8 +811,71 @@ class TrajectoryScreen(ModalScreen[None]):
     def _on_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
         """Cursor moves refresh an OPEN inspector (live follow)."""
         event.stop()
+        self._sync_timeline_selection()
         if self.query_one("#trajectory-inspector", Static).display:
             self._refresh_inspector()
+
+    # -- timeline integration (task-16315) -----------------------------------
+
+    def _sync_timeline_selection(self) -> None:
+        """Highlight the bar for the record under the ledger cursor.
+
+        Header/control rows (and a missing record) clear the highlight;
+        ``set_selected`` is pull-only so this cannot echo a bar-click
+        event back into the ledger.
+        """
+        key = self._cursor_key()
+        record = self._row_records.get(key) if key is not None else None
+        self._timeline.set_selected(record.seq if record is not None else None)
+
+    @on(TrajectoryTimeline.TrajectoryBrushChanged)
+    def _on_brush_changed(
+        self, event: TrajectoryTimeline.TrajectoryBrushChanged
+    ) -> None:
+        """Brush range filters the ledger (AND with the search query)."""
+        self._brush_range = event.brush_range
+        self._render_ledger()
+
+    @on(TrajectoryTimeline.TrajectoryBarSelected)
+    def _on_bar_selected(self, event: TrajectoryTimeline.TrajectoryBarSelected) -> None:
+        """Bar click: move the ledger cursor to that record's row.
+
+        The widget clears its own brush before posting, so mirror that
+        here (the time filter drops; the SEARCH stays). If the record is
+        only paginated out, grow the mounted window to cover it; if the
+        search still hides it, that is a no-op on the cursor.
+        """
+        if self._brush_range is not None:
+            self._brush_range = None
+            self._render_ledger()
+        key = str(event.record_key)
+        if key in self._visible_keys:
+            self._move_cursor_to_key(key)
+            return
+        flat = [record for turn in self._turns for record in turn.records]
+        try:
+            flat_index = next(
+                i for i, record in enumerate(flat) if record.seq == event.record_key
+            )
+        except StopIteration:
+            return  # unknown record (stale bar from a live snapshot): no-op
+        if flat_index < len(flat) - self._visible_count:
+            self._visible_count = len(flat) - flat_index
+            self._render_ledger()
+        if key in self._visible_keys:
+            self._move_cursor_to_key(key)
+
+    def _move_cursor_to_key(self, key: str) -> None:
+        """Best-effort cursor move to the row with ``key``."""
+        try:
+            index = self._visible_keys.index(key)
+        except ValueError:
+            return
+        table = self.query_one("#trajectory-table", DataTable)
+        try:
+            table.move_cursor(row=index, animate=False)
+        except Exception as exc:  # noqa: BLE001 - cursor clamp is best-effort
+            logger.debug("Trajectory bar-select cursor move skipped: {}", type(exc))
 
     # -- actions (ADR-031: single-letter htop-style) ----------------------------
 

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -1,0 +1,669 @@
+"""Console trajectory (trace) screen: ledger, inspector, search, pagination.
+
+Modal over the Console (task-4 of the trajectory view; spec:
+``Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md``,
+"UI — Trajectory screen"). Read-only: it renders a ``TrajectorySnapshot``
+from the pure projection (``Chat/trajectory.py``) and never queries the
+DB itself.
+
+Layout (vertical): title line, search ``Input``, ``DataTable`` ledger
+(``cursor_type="row"``), inspector ``Static`` (hidden until toggled),
+footer hints line.
+
+Ledger semantics pinned by the projection's contracts:
+
+- ``TrajectoryRecord.seq`` is the 1-based LEDGER RENDER POSITION -- it is
+  used as the DataTable row key and nothing else (never a DB seq).
+- Tool records (``depth == 1``) render indented under their owning
+  assistant step; their ``payload`` carries name/args/result (result is
+  the full untruncated output -- the inspector shows it verbatim).
+- Variant contents over-attach to ALL assistant records of a turn, so
+  the inspector labels that list "superseded variants (turn-level)".
+- Timing fields may be ``None``: blanks are rendered, and durations are
+  only ever computed between two PROVIDED endpoints (display-only
+  elapsed, never a fabricated fact).
+
+Pagination mirrors dsh: the newest ``PAGE_SIZE`` records mount first; a
+"load earlier" row sits above them while older records remain. Rendering
+moves off the UI thread (``run_worker``) once the conversation exceeds
+``WORKER_THRESHOLD`` records.
+
+Keybindings follow ADR-031: single-letter htop-style actions, no
+terminal-convention chords, safe ``escape`` (blur the search box first,
+dismiss second), and the footer hints line stays 1:1 with ``BINDINGS``
+(enforced by ``Tests/UI/test_trajectory_screen.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from loguru import logger
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Input, Static
+
+from tldw_chatbook.Chat.trajectory import (
+    TrajectoryRecord,
+    TrajectorySnapshot,
+    TrajectoryTurn,
+)
+
+__all__ = [
+    "LOAD_EARLIER_ROW_KEY",
+    "PAGE_SIZE",
+    "WORKER_THRESHOLD",
+    "TrajectoryScreen",
+]
+
+#: Ledger page size: newest records mounted first (dsh-style pagination).
+PAGE_SIZE = 500
+
+#: Above this many records the initial ledger render moves to a worker.
+WORKER_THRESHOLD = 5000
+
+#: DataTable row key of the "load earlier" control row.
+LOAD_EARLIER_ROW_KEY = "__load_earlier__"
+
+_COLUMNS = (
+    ("#", 5),
+    ("Kind", 11),
+    ("Content", 56),
+    ("In", 6),
+    ("Cache", 7),
+    ("Out", 6),
+    ("Start", 9),
+    ("Done", 9),
+)
+
+
+def _fmt_clock(unix: float | None) -> str:
+    """Format a unix timestamp as local ``HH:MM:SS``; em dash when ``None``."""
+    if unix is None:
+        return "—"
+    try:
+        return datetime.fromtimestamp(unix).strftime("%H:%M:%S")
+    except (OverflowError, OSError, ValueError):
+        return "—"
+
+
+def _fmt_span(start: float | None, end: float | None) -> str | None:
+    """Elapsed seconds between two PROVIDED facts; ``None`` when either is missing.
+
+    Display-only derivation from stored endpoints -- never a fabricated
+    duration for partially known records.
+    """
+    if start is None or end is None:
+        return None
+    return f"{end - start:.2f}s"
+
+
+class TrajectoryScreen(ModalScreen[None]):
+    """Read-only trajectory ledger + inspector for one Console conversation."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=False),
+        Binding("enter", "inspect_cursor_row", "Inspect"),
+        Binding("t", "toggle_turn", "Collapse"),
+        Binding("i", "toggle_inspector", "Inspector"),
+        Binding("e", "load_earlier", "Earlier"),
+        Binding("/", "focus_search", "Search"),
+    ]
+
+    #: Footer hints, 1:1 with the non-escape BINDINGS (ADR-031; tested).
+    TRAJECTORY_SHORTCUTS = (
+        ("enter", "inspect"),
+        ("t", "collapse"),
+        ("i", "inspector"),
+        ("/", "search"),
+        ("e", "earlier"),
+    )
+
+    DEFAULT_CSS = """
+    TrajectoryScreen {
+        align: left top;
+        background: $background;
+    }
+    #trajectory-screen {
+        width: 100%;
+        height: 100%;
+        layout: vertical;
+        padding: 0 1;
+    }
+    #trajectory-title {
+        height: 1;
+        color: $text;
+        background: $panel;
+    }
+    #trajectory-search {
+        height: 3;
+    }
+    #trajectory-table {
+        height: 1fr;
+        min-height: 3;
+    }
+    #trajectory-inspector {
+        height: auto;
+        max-height: 40%;
+        border-top: solid $primary;
+        padding: 0 1;
+    }
+    #trajectory-hints {
+        height: 1;
+        color: $text-disabled;
+    }
+    """
+
+    def __init__(
+        self,
+        snapshot: TrajectorySnapshot,
+        *,
+        screen_title: str = "",
+        conversation_id: str | None = None,
+    ) -> None:
+        """Store the projection output; all rendering happens on mount.
+
+        Args:
+            snapshot: The ``derive_trajectory`` output to render.
+            screen_title: Display title (typically the conversation name).
+            conversation_id: Conversation id, shown in the title line.
+        """
+        super().__init__()
+        self._snapshot = snapshot
+        self._screen_title = screen_title
+        self._conversation_id = conversation_id
+        self._turns: tuple[TrajectoryTurn, ...] = snapshot.turns
+        self._turn_numbers: dict[str, int] = {
+            turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
+        }
+        self._collapsed: set[str] = set()
+        self._query = ""
+        #: Number of newest records mounted (grows one page per `e` press).
+        self._visible_count = min(self._total_records, PAGE_SIZE)
+        #: Row key -> record (None for header/control rows), in row order.
+        self._row_records: dict[str, TrajectoryRecord | None] = {}
+        self._row_turn_ids: dict[str, str] = {}
+        self._visible_keys: list[str] = []
+        #: Bumped by every ledger render; a worker-built page carries the
+        #: generation it was built at and is DROPPED if a newer render
+        #: landed first (typing a search or pressing t/e mid-build must
+        #: never be overwritten by a stale off-thread snapshot).
+        self._render_generation = 0
+        #: False once unmounted: a worker-built ledger arriving late is
+        #: dropped instead of poking a dead screen. (``Widget.is_mounted``
+        #: is still False DURING ``on_mount``, so the flag is explicit.)
+        self._alive = True
+
+    # -- layout -------------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="trajectory-screen"):
+            yield Static(self._title_text(), id="trajectory-title", markup=False)
+            yield Input(placeholder="Search records…", id="trajectory-search")
+            yield DataTable(id="trajectory-table", cursor_type="row")
+            inspector = Static("", id="trajectory-inspector", markup=False)
+            inspector.display = False  # hidden until toggled (spec)
+            yield inspector
+            yield Static("", id="trajectory-hints", markup=False)
+
+    def on_mount(self) -> None:
+        table = self.query_one("#trajectory-table", DataTable)
+        for label, width in _COLUMNS:
+            table.add_column(label, width=width)
+        self._refresh_hints()
+        if self._total_records > WORKER_THRESHOLD:
+            # Large conversation: build the row specs off the UI thread.
+            self.run_worker(self._render_worker, thread=True, group="trajectory-ledger")
+        else:
+            self._render_ledger()
+        table.focus()
+
+    def on_unmount(self) -> None:
+        self._alive = False
+
+    def _title_text(self) -> str:
+        parts = ["Trajectory"]
+        if self._screen_title:
+            parts.append(self._screen_title)
+        if self._conversation_id:
+            parts.append(f"conv {self._conversation_id}")
+        parts.append(f"{self._total_records} records")
+        return " · ".join(parts)
+
+    # -- ledger rendering ------------------------------------------------------
+
+    @property
+    def _total_records(self) -> int:
+        return sum(len(turn.records) for turn in self._turns)
+
+    @property
+    def _hidden_earlier(self) -> int:
+        return max(0, self._total_records - self._visible_count)
+
+    def _render_ledger(self) -> None:
+        self._render_generation += 1
+        self._apply_row_specs(self._build_row_specs())
+
+    def _render_worker(self) -> None:
+        """Worker-thread half of the >WORKER_THRESHOLD path (video-player pattern)."""
+        try:
+            generation = self._render_generation
+            specs = self._build_row_specs()
+            self.app.call_from_thread(self._apply_row_specs, specs, generation)
+        except Exception as exc:  # noqa: BLE001 - worker boundary
+            logger.warning(
+                "Trajectory ledger render failed: component=trajectory_screen "
+                "error_type={}",
+                type(exc).__name__,
+            )
+
+    def _flat_slice(self) -> list[tuple[TrajectoryTurn, TrajectoryRecord]]:
+        """(turn, record) pairs for the mounted window (newest ``visible_count``)."""
+        flat = [(turn, rec) for turn in self._turns for rec in turn.records]
+        start = max(0, len(flat) - self._visible_count)
+        return flat[start:]
+
+    def _build_row_specs(self) -> list[tuple[str, tuple[Text, ...]]]:
+        """Row specs (key, cells) for the current window/filter/collapse state."""
+        specs: list[tuple[str, tuple[Text, ...]]] = []
+        if self._hidden_earlier:
+            specs.append(
+                (
+                    LOAD_EARLIER_ROW_KEY,
+                    (
+                        Text(""),
+                        Text(""),
+                        Text(
+                            f"… load earlier ({self._hidden_earlier} older records) — press e",
+                        ),
+                        Text(""),
+                        Text(""),
+                        Text(""),
+                        Text(""),
+                        Text(""),
+                    ),
+                )
+            )
+
+        query = self._query.lower()
+        open_turn: TrajectoryTurn | None = None
+        turn_records: list[TrajectoryRecord] = []
+        for turn, record in self._flat_slice():
+            if open_turn is not None and turn.turn_id != open_turn.turn_id:
+                specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+                turn_records = []
+            open_turn = turn
+            turn_records.append(record)
+        if open_turn is not None:
+            specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+        return specs
+
+    def _turn_row_specs(
+        self, turn: TrajectoryTurn, records: list[TrajectoryRecord], query: str
+    ) -> list[tuple[str, tuple[Text, ...]]]:
+        """Header row + child rows for one turn under the current filter.
+
+        Search semantics (spec): child rows match on their own text; the
+        turn header survives iff any child matches. A search overrides
+        collapse (searching reveals), otherwise collapsed turns show the
+        header only.
+        """
+        matching = [rec for rec in records if self._record_matches(rec, query)]
+        if query and not matching:
+            return []  # nothing in this turn matches: header included, hidden
+        header_key = f"turn:{turn.turn_id}"
+        collapsed = turn.turn_id in self._collapsed
+        number = self._turn_numbers.get(turn.turn_id, 0)
+        marker = "▸" if collapsed else "▾"
+        label = Text(f"{marker} Turn {number} · {len(records)} records", style="bold")
+        specs = [
+            (
+                header_key,
+                (
+                    Text(""),
+                    Text("turn"),
+                    label,
+                    Text(""),
+                    Text(""),
+                    Text(""),
+                    Text(""),
+                    Text(""),
+                ),
+            )
+        ]
+        if collapsed and not query:
+            return specs
+        for rec in matching:
+            specs.append((str(rec.seq), self._record_cells(rec)))
+        return specs
+
+    def _record_cells(self, rec: TrajectoryRecord) -> tuple[Text, ...]:
+        usage = rec.usage
+        if usage is None:
+            tokens = ("", "", "")
+        else:
+            tokens = (
+                str(usage.uncached_input),
+                str(usage.cache_read + usage.cache_write),
+                str(usage.output),
+            )
+        indent = "    ↳ " if rec.depth else ""
+        content = Text(f"{indent}{rec.content_preview}")
+        return (
+            Text(str(rec.seq)),
+            Text(rec.kind),
+            content,
+            Text(tokens[0]),
+            Text(tokens[1]),
+            Text(tokens[2]),
+            Text(_fmt_clock(rec.step_started_at)),
+            Text(_fmt_clock(rec.completed_at)),
+        )
+
+    def _record_matches(self, rec: TrajectoryRecord, query: str) -> bool:
+        """Case-insensitive match over the record's searchable text.
+
+        Covers everything the user can see (preview, kind, model/provider)
+        plus the tool payload's name/args/result -- tool output lives only
+        here, and the 120-char preview would otherwise hide it from search.
+        """
+        if not query:
+            return True
+        if query in rec.content_preview.lower():
+            return True
+        if query in rec.kind:
+            return True
+        if rec.model and query in rec.model.lower():
+            return True
+        if rec.provider and query in rec.provider.lower():
+            return True
+        payload = rec.payload
+        if payload:
+            name = str(payload.get("name") or "")
+            if query in name.lower():
+                return True
+            args = payload.get("args")
+            if args is not None:
+                try:
+                    args_text = json.dumps(args, sort_keys=True)
+                except (TypeError, ValueError):
+                    args_text = str(args)
+                if query in args_text.lower():
+                    return True
+            result = payload.get("result")
+            if result is not None and query in str(result).lower():
+                return True
+        return False
+
+    def _apply_row_specs(
+        self,
+        specs: list[tuple[str, tuple[Text, ...]]],
+        generation: int | None = None,
+    ) -> None:
+        """Rebuild the DataTable from row specs, preserving the cursor by key.
+
+        ``generation`` is the render generation the specs were BUILT at; a
+        mismatch against the current one means a newer render already
+        landed (the user typed a search or pressed t/e while a worker was
+        building) and the stale specs are dropped. ``None`` is the current
+        synchronous render, which always applies.
+        """
+        if not self._alive:
+            return
+        if generation is not None and generation != self._render_generation:
+            return
+        table = self.query_one("#trajectory-table", DataTable)
+        previous_key: str | None = None
+        if self._visible_keys:
+            row = table.cursor_row
+            if 0 <= row < len(self._visible_keys):
+                previous_key = self._visible_keys[row]
+        table.clear(columns=False)
+        self._row_records = {}
+        self._row_turn_ids = {}
+        self._visible_keys = []
+        for key, cells in specs:
+            table.add_row(*cells, key=key)
+            self._visible_keys.append(key)
+            if key.startswith("turn:"):
+                self._row_turn_ids[key] = key.removeprefix("turn:")
+            elif key != LOAD_EARLIER_ROW_KEY:
+                self._row_records[key] = None  # resolved below
+        for turn in self._turns:
+            for rec in turn.records:
+                if str(rec.seq) in self._row_records:
+                    self._row_records[str(rec.seq)] = rec
+        if self._visible_keys:
+            index = 0
+            if previous_key is not None:
+                try:
+                    index = self._visible_keys.index(previous_key)
+                except ValueError:
+                    index = 0
+            try:
+                table.move_cursor(row=index, animate=False)
+            except Exception as exc:  # noqa: BLE001 - cursor clamp is best-effort
+                logger.debug(
+                    "Trajectory cursor restore skipped: {}", type(exc).__name__
+                )
+        self._refresh_hints()
+        if self.query_one("#trajectory-inspector", Static).display:
+            self._refresh_inspector()
+
+    # -- footer hints ------------------------------------------------------
+
+    def _refresh_hints(self) -> None:
+        """Render the hints line: 1:1 with BINDINGS minus what has no target.
+
+        The ``e earlier`` hint drops while no older records remain (the
+        ADR-031 task-1340 refinement: advertised == working in the active
+        context; pressing ``e`` then answers with guidance instead).
+        """
+        pairs = [
+            (key, label)
+            for key, label in self.TRAJECTORY_SHORTCUTS
+            if key != "e" or self._hidden_earlier > 0
+        ]
+        text = " · ".join(f"{key} {label}" for key, label in pairs)
+        try:
+            self.query_one("#trajectory-hints", Static).update(text)
+        except Exception:  # noqa: BLE001 - pre-mount refresh
+            pass
+
+    # -- inspector -----------------------------------------------------------
+
+    def _inspector_text_for_record(self, rec: TrajectoryRecord) -> str:
+        lines = [f"#{rec.seq} {rec.kind} · turn {rec.turn_id}"]
+        model = rec.model or "—"
+        provider = rec.provider or "—"
+        lines.append(f"model {model} · provider {provider}")
+        usage = rec.usage
+        if usage is None:
+            lines.append("tokens —")
+        else:
+            lines.append(
+                f"tokens uncached input {usage.uncached_input} · "
+                f"cache read {usage.cache_read} · "
+                f"cache write {usage.cache_write} · "
+                f"output {usage.output}"
+            )
+        ttft = _fmt_span(rec.step_started_at, rec.first_token_at)
+        elapsed = _fmt_span(rec.step_started_at, rec.completed_at)
+        first = _fmt_clock(rec.first_token_at)
+        if ttft is not None:
+            first = f"{first} (+{ttft})"
+        completed = _fmt_clock(rec.completed_at)
+        if elapsed is not None:
+            completed = f"{completed} (elapsed {elapsed})"
+        lines.append(
+            f"timing start {_fmt_clock(rec.step_started_at)} · "
+            f"first token {first} · completed {completed}"
+        )
+        if rec.content_preview:
+            lines.append(f"content {rec.content_preview}")
+        payload = rec.payload
+        if payload:
+            name = str(payload.get("name") or "—")
+            lines.append(f"tool {name}")
+            args = payload.get("args")
+            if args is not None:
+                try:
+                    lines.append(f"args {json.dumps(args, sort_keys=True)}")
+                except (TypeError, ValueError):
+                    lines.append(f"args {args!r}")
+            result = payload.get("result")
+            if result is not None:
+                lines.append(f"result {result}")  # full, untruncated
+            if payload.get("truncated"):
+                lines.append("truncated yes (stored payload hit the 256 KiB cap)")
+        if rec.variants:
+            # Variant-set contents attach at TURN level to every assistant
+            # record of that turn -- the label says so explicitly.
+            lines.append("superseded variants (turn-level)")
+            lines.extend(
+                f"  {i}. {content}" for i, content in enumerate(rec.variants, start=1)
+            )
+        return "\n".join(lines)
+
+    def _inspector_text_for_turn(self, turn_id: str) -> str:
+        number = self._turn_numbers.get(turn_id, 0)
+        state = "collapsed" if turn_id in self._collapsed else "expanded"
+        count = next(
+            (len(turn.records) for turn in self._turns if turn.turn_id == turn_id), 0
+        )
+        return f"Turn {number} · {count} records · {state} · id {turn_id}"
+
+    def _cursor_key(self) -> str | None:
+        if not self._visible_keys:
+            return None
+        table = self.query_one("#trajectory-table", DataTable)
+        row = table.cursor_row
+        if 0 <= row < len(self._visible_keys):
+            return self._visible_keys[row]
+        return None
+
+    def _inspect_cursor(self) -> None:
+        key = self._cursor_key()
+        if key is None:
+            return
+        if key == LOAD_EARLIER_ROW_KEY:
+            self.action_load_earlier()
+            return
+        if key in self._row_turn_ids:
+            text = self._inspector_text_for_turn(self._row_turn_ids[key])
+        else:
+            record = self._row_records.get(key)
+            if record is None:
+                return
+            text = self._inspector_text_for_record(record)
+        self._show_inspector(text)
+
+    def _show_inspector(self, text: str) -> None:
+        inspector = self.query_one("#trajectory-inspector", Static)
+        inspector.update(text)
+        inspector.display = True
+
+    def _refresh_inspector(self) -> None:
+        key = self._cursor_key()
+        if key is None:
+            return
+        if key == LOAD_EARLIER_ROW_KEY:
+            self._show_inspector(
+                f"{self._hidden_earlier} older records not loaded — press e"
+            )
+        elif key in self._row_turn_ids:
+            self._show_inspector(self._inspector_text_for_turn(self._row_turn_ids[key]))
+        else:
+            record = self._row_records.get(key)
+            if record is not None:
+                self._show_inspector(self._inspector_text_for_record(record))
+
+    # -- events -----------------------------------------------------------------
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Live search: every keystroke re-filters the ledger."""
+        if event.input.id != "trajectory-search":
+            return
+        self._query = event.value.strip()
+        self._render_ledger()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Enter in the search box applies the filter and returns to the table."""
+        if event.input.id != "trajectory-search":
+            return
+        self.query_one("#trajectory-table", DataTable).focus()
+
+    @on(DataTable.RowSelected)
+    def _on_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Enter on a cursor row opens the inspector (the table consumes enter)."""
+        event.stop()
+        self._inspect_cursor()
+
+    @on(DataTable.RowHighlighted)
+    def _on_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Cursor moves refresh an OPEN inspector (live follow)."""
+        event.stop()
+        if self.query_one("#trajectory-inspector", Static).display:
+            self._refresh_inspector()
+
+    # -- actions (ADR-031: single-letter htop-style) ----------------------------
+
+    def action_dismiss(self) -> None:
+        """Safe escape: blur the search box first, dismiss the modal second."""
+        search = self.query_one("#trajectory-search", Input)
+        if search.has_focus:
+            self.query_one("#trajectory-table", DataTable).focus()
+            return
+        self.dismiss(None)
+
+    def action_toggle_turn(self) -> None:
+        """`t`: collapse/expand the turn under (or owning) the cursor row."""
+        key = self._cursor_key()
+        if key is None or key == LOAD_EARLIER_ROW_KEY:
+            return
+        turn_id = self._row_turn_ids.get(key)
+        if turn_id is None:
+            record = self._row_records.get(key)
+            if record is None:
+                return
+            turn_id = record.turn_id
+        if turn_id in self._collapsed:
+            self._collapsed.discard(turn_id)
+        else:
+            self._collapsed.add(turn_id)
+        self._render_ledger()
+
+    def action_toggle_inspector(self) -> None:
+        """`i`: show/hide the inspector pane."""
+        inspector = self.query_one("#trajectory-inspector", Static)
+        if inspector.display:
+            inspector.display = False
+        else:
+            self._refresh_inspector()
+            inspector.display = True
+
+    def action_load_earlier(self) -> None:
+        """`e`: mount one more page of older records (guidance when exhausted)."""
+        if self._hidden_earlier <= 0:
+            self.app.notify("All records are already loaded.", severity="information")
+            return
+        self._visible_count += PAGE_SIZE
+        self._render_ledger()
+
+    def action_focus_search(self) -> None:
+        """`/`: focus the search box."""
+        self.query_one("#trajectory-search", Input).focus()
+
+    def action_inspect_cursor_row(self) -> None:
+        """`enter`: open the inspector on the cursor row.
+
+        The focused DataTable consumes enter itself (its own binding posts
+        ``RowSelected``, handled above); this screen-level binding covers
+        the case where focus sits elsewhere on the screen.
+        """
+        self._inspect_cursor()

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -37,6 +37,8 @@ dismiss second), and the footer hints line stays 1:1 with ``BINDINGS``
 from __future__ import annotations
 
 import json
+import time
+from collections.abc import Callable
 from datetime import datetime
 
 from loguru import logger
@@ -113,15 +115,18 @@ class TrajectoryScreen(ModalScreen[None]):
         Binding("i", "toggle_inspector", "Inspector"),
         Binding("e", "load_earlier", "Earlier"),
         Binding("/", "focus_search", "Search"),
+        Binding("f", "resume_follow", "Follow"),
     ]
 
     #: Footer hints, 1:1 with the non-escape BINDINGS (ADR-031; tested).
+    #: ``f follow`` is only RENDERED on live screens (``_refresh_hints``).
     TRAJECTORY_SHORTCUTS = (
         ("enter", "inspect"),
         ("t", "collapse"),
         ("i", "inspector"),
         ("/", "search"),
         ("e", "earlier"),
+        ("f", "follow"),
     )
 
     DEFAULT_CSS = """
@@ -165,6 +170,8 @@ class TrajectoryScreen(ModalScreen[None]):
         *,
         screen_title: str = "",
         conversation_id: str | None = None,
+        revision_provider: Callable[[], int] | None = None,
+        snapshot_builder: Callable[[], TrajectorySnapshot] | None = None,
     ) -> None:
         """Store the projection output; all rendering happens on mount.
 
@@ -172,11 +179,26 @@ class TrajectoryScreen(ModalScreen[None]):
             snapshot: The ``derive_trajectory`` output to render.
             screen_title: Display title (typically the conversation name).
             conversation_id: Conversation id, shown in the title line.
+            revision_provider: Live-mode callable returning the store's
+                payload revision for this conversation (task-5 tail-follow).
+                When provided together with ``snapshot_builder`` the screen
+                polls it every 0.5s and rebuilds on change.
+            snapshot_builder: Live-mode callable rebuilding the snapshot
+                from current persisted state; run in a worker thread.
         """
         super().__init__()
         self._snapshot = snapshot
         self._screen_title = screen_title
         self._conversation_id = conversation_id
+        self._revision_provider = revision_provider
+        self._snapshot_builder = snapshot_builder
+        self._last_revision: int | None = None
+        #: Tail-follow: True while the reader is at the bottom; scrolling
+        #: up suspends it, ``f`` re-enables.
+        self._follow = True
+        #: Explicit resume grace: geometry-polling must not cancel an
+        #: in-flight ``f`` before its deferred ``scroll_end`` lands.
+        self._follow_grace_until = 0.0
         self._turns: tuple[TrajectoryTurn, ...] = snapshot.turns
         self._turn_numbers: dict[str, int] = {
             turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
@@ -222,9 +244,109 @@ class TrajectoryScreen(ModalScreen[None]):
         else:
             self._render_ledger()
         table.focus()
+        if self._revision_provider is not None and self._snapshot_builder is not None:
+            try:
+                self._last_revision = self._revision_provider()
+            except Exception:  # noqa: BLE001 - provider is external state
+                self._last_revision = None
+            self.set_interval(0.5, self._poll_revision)
 
     def on_unmount(self) -> None:
         self._alive = False
+
+    # -- live tail-follow (task-5) --------------------------------------------
+
+    def _poll_revision(self) -> None:
+        """Interval tick: rebuild the snapshot when the store revision moves."""
+        if not self._alive or self._snapshot_builder is None:
+            return
+        if self._revision_provider is None:
+            return
+        self._sync_follow_from_scroll()
+        try:
+            revision = self._revision_provider()
+        except Exception:  # noqa: BLE001 - provider is external state
+            return
+        if revision == self._last_revision:
+            return
+        self._last_revision = revision
+        self.run_worker(
+            self._live_rebuild_worker, thread=True, group="trajectory-live"
+        )
+
+    def _live_rebuild_worker(self) -> None:
+        """Worker-thread half of the live rebuild (video-player pattern)."""
+        builder = self._snapshot_builder
+        if builder is None:
+            return
+        try:
+            snapshot = builder()
+        except Exception as exc:  # noqa: BLE001 - worker boundary
+            logger.warning(
+                "Trajectory live rebuild failed: component=trajectory_screen "
+                "error_type={}",
+                type(exc).__name__,
+            )
+            return
+        try:
+            self.app.call_from_thread(self._apply_live_snapshot, snapshot)
+        except Exception:  # noqa: BLE001 - worker boundary
+            return
+
+    def _apply_live_snapshot(self, snapshot: TrajectorySnapshot) -> None:
+        """Swap in a rebuilt snapshot, preserving reader state; follow tail."""
+        if not self._alive:
+            return
+        self._snapshot = snapshot
+        self._turns = snapshot.turns
+        self._turn_numbers = {
+            turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
+        }
+        # Keep collapsed turns and the search query; never shrink the window.
+        self._visible_count = max(
+            self._visible_count, min(self._total_records, PAGE_SIZE)
+        )
+        self._render_ledger()
+        try:
+            self.query_one("#trajectory-title", Static).update(self._title_text())
+        except Exception:  # noqa: BLE001 - pre-mount refresh
+            pass
+        self._refresh_hints()
+        if self._follow:
+            try:
+                table = self.query_one("#trajectory-table", DataTable)
+                # The re-render resets scroll geometry; scrolling must land
+                # after the table re-lays out, not at the stale range.
+                table.call_after_refresh(table.scroll_end, animate=False)
+            except Exception:  # noqa: BLE001 - pre-mount refresh
+                pass
+
+    def _sync_follow_from_scroll(self) -> None:
+        """Suspend follow while the reader is off the bottom edge.
+
+        Pull-based (checked on every poll tick) rather than event-based:
+        DataTable scroll geometry is authoritative and needs no message
+        plumbing, and a table that cannot scroll at all keeps following.
+        """
+        try:
+            table = self.query_one("#trajectory-table", DataTable)
+        except Exception:  # noqa: BLE001 - pre-mount refresh
+            return
+        if table.max_scroll_y <= 0:
+            return
+        if time.monotonic() < self._follow_grace_until:
+            return
+        self._follow = table.scroll_y >= table.max_scroll_y - 1
+
+    def action_resume_follow(self) -> None:
+        """Re-enable tail-follow and jump to the newest records (``f``)."""
+        self._follow = True
+        self._follow_grace_until = time.monotonic() + 1.0
+        try:
+            table = self.query_one("#trajectory-table", DataTable)
+            table.call_after_refresh(table.scroll_end, animate=False)
+        except Exception:  # noqa: BLE001 - pre-mount refresh
+            pass
 
     def _title_text(self) -> str:
         parts = ["Trajectory"]
@@ -467,7 +589,8 @@ class TrajectoryScreen(ModalScreen[None]):
         pairs = [
             (key, label)
             for key, label in self.TRAJECTORY_SHORTCUTS
-            if key != "e" or self._hidden_earlier > 0
+            if (key != "e" or self._hidden_earlier > 0)
+            and (key != "f" or self._snapshot_builder is not None)
         ]
         text = " · ".join(f"{key} {label}" for key, label in pairs)
         try:

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -270,11 +270,17 @@ class TrajectoryScreen(ModalScreen[None]):
         if revision == self._last_revision:
             return
         self._last_revision = revision
+        # exclusive: a slow rebuild from an older revision cannot be
+        # overtaken and land after a newer one started; the revision guard
+        # below additionally drops results built for a stale revision.
         self.run_worker(
-            self._live_rebuild_worker, thread=True, group="trajectory-live"
+            lambda: self._live_rebuild_worker(revision),
+            thread=True,
+            group="trajectory-live",
+            exclusive=True,
         )
 
-    def _live_rebuild_worker(self) -> None:
+    def _live_rebuild_worker(self, revision: int) -> None:
         """Worker-thread half of the live rebuild (video-player pattern)."""
         builder = self._snapshot_builder
         if builder is None:
@@ -289,13 +295,22 @@ class TrajectoryScreen(ModalScreen[None]):
             )
             return
         try:
-            self.app.call_from_thread(self._apply_live_snapshot, snapshot)
+            self.app.call_from_thread(self._apply_live_snapshot, snapshot, revision)
         except Exception:  # noqa: BLE001 - worker boundary
             return
 
-    def _apply_live_snapshot(self, snapshot: TrajectorySnapshot) -> None:
-        """Swap in a rebuilt snapshot, preserving reader state; follow tail."""
+    def _apply_live_snapshot(
+        self, snapshot: TrajectorySnapshot, revision: int | None = None
+    ) -> None:
+        """Swap in a rebuilt snapshot, preserving reader state; follow tail.
+
+        ``revision`` is the store revision the snapshot was built for; a
+        result arriving after a NEWER revision was observed is dropped so
+        out-of-order workers can never regress the ledger.
+        """
         if not self._alive:
+            return
+        if revision is not None and revision != self._last_revision:
             return
         self._snapshot = snapshot
         self._turns = snapshot.turns

--- a/tldw_chatbook/UI/Widgets/trajectory_timeline.py
+++ b/tldw_chatbook/UI/Widgets/trajectory_timeline.py
@@ -20,7 +20,7 @@ integration with ``TrajectoryScreen`` yet.
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime
 from itertools import groupby
 from typing import Sequence
 
@@ -89,8 +89,13 @@ _CAPTION_STYLE = Style(color="grey62")
 
 
 def _fmt_clock(t: float) -> str:
-    """Format a unix timestamp as HH:MM:SS (UTC)."""
-    return datetime.fromtimestamp(t, tz=timezone.utc).strftime("%H:%M:%S")
+    """Format a unix timestamp as local ``HH:MM:SS``.
+
+    Local time on purpose: the trajectory ledger's Start/Done columns
+    format local time, so the strip's axis and brush caption must match
+    the rows they select.
+    """
+    return datetime.fromtimestamp(t).strftime("%H:%M:%S")
 
 
 class TimelineModel:
@@ -456,6 +461,17 @@ class TrajectoryTimeline(Widget):
         self._brush = brush
         self.refresh()
         self.post_message(self.TrajectoryBrushChanged(brush))
+
+    def apply_brush(self, brush_range: tuple[float, float] | None) -> None:
+        """Public re-brush seam for hosts (``None`` clears).
+
+        ``set_snapshot`` resets the brush without posting; a host that
+        swaps in a new snapshot (e.g. a live-refreshed trajectory
+        screen) uses this to re-apply a brush that is still relevant,
+        keeping its own filters in sync via the posted
+        :class:`TrajectoryBrushChanged`.
+        """
+        self._set_brush(brush_range)
 
     def record_at(self, x: int, y: int) -> TrajectoryRecord | None:
         """The record whose rendered bar covers column ``x`` on row ``y``."""

--- a/tldw_chatbook/UI/Widgets/trajectory_timeline.py
+++ b/tldw_chatbook/UI/Widgets/trajectory_timeline.py
@@ -1,0 +1,526 @@
+"""Brushable time-domain strip over a ``TrajectorySnapshot`` (task-16315).
+
+A compact 6-line widget that renders every *timed* trajectory record as a
+horizontal bar (``█``) positioned by its ``[step_started_at,
+completed_at]`` interval, on one of 4 greedily-packed lanes. The strip
+supports zoom (wheel / ``[`` ``]``), pan (```,`' ``/`` .``), drag-brush
+range selection, and click-to-select on a bar. Geometry lives in
+:class:`TimelineModel`, a pure class that never touches Textual so the
+math (domain padding, mapping, lanes, zoom/pan clamping) is unit-testable
+in isolation; the widget is a thin event/render shell.
+
+Records with NULL timing are skipped (blank, never fabricated -- dsh
+precedent); a snapshot with no usable timing renders a centered
+``no timing data`` placeholder.
+
+Part 1 of the trajectory timeline follow-up: standalone widget only, no
+integration with ``TrajectoryScreen`` yet.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from itertools import groupby
+from typing import Sequence
+
+from rich.style import Style
+from rich.text import Text
+from textual.binding import Binding
+from textual.events import MouseEvent
+from textual.message import Message
+from textual.widget import Widget
+
+from tldw_chatbook.Chat.trajectory import (
+    KIND_ASSISTANT,
+    KIND_COMPACTION,
+    KIND_TOOL_CALL,
+    KIND_TOOL_RESULT,
+    KIND_USER,
+    TrajectoryRecord,
+    TrajectorySnapshot,
+)
+
+__all__ = [
+    "LANE_COUNT",
+    "STRIP_HEIGHT",
+    "TimelineModel",
+    "TrajectoryTimeline",
+]
+
+#: Lanes stacked top (0) to bottom in the strip.
+LANE_COUNT = 4
+
+#: Total rendered lines: LANE_COUNT lane rows + an axis row + the caption.
+STRIP_HEIGHT = LANE_COUNT + 2
+
+#: Domain padding on each side, as a fraction of the data time span.
+DOMAIN_PADDING = 0.05
+
+#: Wheel/keyboard zoom factor (>1 zooms in).
+ZOOM_FACTOR = 1.25
+
+#: Keyboard pan step, as a fraction of the current window span.
+PAN_FRACTION = 0.25
+
+#: Bar glyph; instantaneous records render as a single cell.
+BAR_CHAR = "█"
+
+_PLACEHOLDER = "no timing data"
+
+#: Distinct bar styles per ledger kind. The trajectory ledger screen has
+#: no kind->color scheme (plain per-cell Text), so the strip defines one.
+KIND_STYLES: dict[str, Style] = {
+    KIND_USER: Style(color="cyan"),
+    KIND_ASSISTANT: Style(color="green"),
+    KIND_TOOL_CALL: Style(color="yellow"),
+    KIND_TOOL_RESULT: Style(color="magenta"),
+    KIND_COMPACTION: Style(color="red"),
+}
+_FALLBACK_STYLE = Style(color="white")
+
+#: Background applied to every cell inside the brushed region.
+BRUSH_STYLE = Style(bgcolor="#264f78")
+
+_CAPTION_STYLE = Style(color="grey62")
+
+
+def _fmt_clock(t: float) -> str:
+    """Format a unix timestamp as HH:MM:SS (UTC)."""
+    return datetime.fromtimestamp(t, tz=timezone.utc).strftime("%H:%M:%S")
+
+
+class TimelineModel:
+    """Pure time-domain geometry for the trajectory strip.
+
+    No Textual dependency: everything here is arithmetic over the
+    snapshot's timed records, so correctness (domain padding, mapping,
+    lane packing, active-in-range, zoom/pan clamping) is unit-testable
+    without a widget. Never mutates the records and never derives a
+    timestamp -- NULL timing simply drops the record from the strip.
+    """
+
+    def __init__(self, records: Sequence[TrajectoryRecord] = ()) -> None:
+        self._timed: tuple[TrajectoryRecord, ...] = tuple(
+            r for r in records if r.step_started_at is not None
+        )
+        if self._timed:
+            lo = min(r.step_started_at for r in self._timed)
+            hi = max(self.interval(r)[1] for r in self._timed)
+            span = hi - lo
+            pad = (span if span > 0 else 1.0) * DOMAIN_PADDING
+            self._domain: tuple[float, float] | None = (lo - pad, hi + pad)
+        else:
+            self._domain = None
+        self._lanes = self._assign_lanes()
+
+    # -- data ---------------------------------------------------------------
+
+    @property
+    def timed_records(self) -> tuple[TrajectoryRecord, ...]:
+        """Records with a usable start stamp, in ledger order."""
+        return self._timed
+
+    @property
+    def domain(self) -> tuple[float, float] | None:
+        """Padded time domain ``[min start, max end]``; ``None`` if empty."""
+        return self._domain
+
+    @property
+    def has_data(self) -> bool:
+        """Whether any record has timing to draw."""
+        return self._domain is not None
+
+    @property
+    def lanes(self) -> tuple[int, ...]:
+        """Lane index per timed record, parallel to ``timed_records``."""
+        return self._lanes
+
+    @staticmethod
+    def interval(record: TrajectoryRecord) -> tuple[float, float]:
+        """Render interval ``[start, end]``; end falls back to start.
+
+        A NULL ``completed_at`` (or a stored end before the start) yields
+        a zero-width interval -- the widget draws it as one cell rather
+        than fabricating a duration.
+        """
+        start = float(record.step_started_at)  # type: ignore[arg-type]
+        end = record.completed_at
+        if end is None or end < start:
+            end = start
+        return start, float(end)
+
+    def _assign_lanes(self) -> tuple[int, ...]:
+        """Greedy lane packing: lowest lane free at each record's start.
+
+        Stable in ledger order; a record overlapping all ``LANE_COUNT``
+        lanes piles onto the last lane (capped, never grows the strip).
+        """
+        last_end = [-math.inf] * LANE_COUNT
+        lanes: list[int] = []
+        for record in self._timed:
+            start, end = self.interval(record)
+            lane = next(
+                (i for i in range(LANE_COUNT) if last_end[i] <= start),
+                LANE_COUNT - 1,
+            )
+            last_end[lane] = max(last_end[lane], end)
+            lanes.append(lane)
+        return tuple(lanes)
+
+    # -- mapping ------------------------------------------------------------
+
+    @staticmethod
+    def fraction(time: float, window: tuple[float, float]) -> float:
+        """Map a time to a [0, 1] fraction of ``window`` (clamped)."""
+        start, end = window
+        span = end - start
+        if span <= 0:
+            return 0.0
+        return min(1.0, max(0.0, (time - start) / span))
+
+    @staticmethod
+    def time_at(fraction: float, window: tuple[float, float]) -> float:
+        """Map a [0, 1] fraction of ``window`` back to a time (clamped)."""
+        start, end = window
+        f = min(1.0, max(0.0, fraction))
+        return start + f * (end - start)
+
+    def records_in_range(self, lo: float, hi: float) -> tuple[TrajectoryRecord, ...]:
+        """Timed records whose interval intersects ``[lo, hi]``."""
+        a, b = (lo, hi) if lo <= hi else (hi, lo)
+        return tuple(
+            r
+            for r in self._timed
+            if self.interval(r)[0] <= b and self.interval(r)[1] >= a
+        )
+
+    # -- viewport -----------------------------------------------------------
+
+    def zoom(
+        self,
+        window: tuple[float, float],
+        factor: float,
+        focal_fraction: float = 0.5,
+    ) -> tuple[float, float]:
+        """Zoom ``window`` by ``factor`` keeping ``focal_fraction`` fixed.
+
+        ``factor > 1`` zooms in (narrower span). The result is clamped
+        inside the domain; a zoomed-out span covering the whole domain is
+        the domain itself (identity). Returns ``window`` unchanged when
+        there is no data.
+        """
+        if self._domain is None:
+            return window
+        d0, d1 = self._domain
+        w0, w1 = window
+        span = w1 - w0
+        new_span = span / factor
+        if new_span >= (d1 - d0):
+            return (d0, d1)
+        focal_fraction = min(1.0, max(0.0, focal_fraction))
+        focal = w0 + focal_fraction * span
+        start = focal - focal_fraction * new_span
+        start = min(max(start, d0), d1 - new_span)
+        return (start, start + new_span)
+
+    def pan(
+        self, window: tuple[float, float], fraction_of_span: float
+    ) -> tuple[float, float]:
+        """Shift ``window`` by ``fraction_of_span`` of its own width.
+
+        Clamped to the domain; a no-op (identity) when the window already
+        is the full domain. Returns ``window`` unchanged when there is no
+        data.
+        """
+        if self._domain is None:
+            return window
+        d0, d1 = self._domain
+        w0, w1 = window
+        span = w1 - w0
+        if w0 <= d0 and w1 >= d1:
+            return window  # already the full domain: nothing to pan to
+        start = min(max(w0 + fraction_of_span * span, d0), d1 - span)
+        return (start, start + span)
+
+
+class TrajectoryTimeline(Widget):
+    """Compact brushable time-domain strip over a trajectory snapshot.
+
+    Interactions:
+
+    - drag (left button, horizontal): brush range selection -- posts
+      :class:`TrajectoryBrushChanged` with the time range (or ``None``
+      when cleared).
+    - click on a bar: posts :class:`TrajectoryBarSelected` with the
+      record's ledger ``seq`` and clears any brush.
+    - click on empty space: clears the brush.
+    - wheel / ``[`` ``]``: zoom out/in (wheel centers on the mouse x,
+      keys on the strip center); ```,`' ``/`` .`` pan left/right. Every
+      viewport change posts :class:`TrajectoryViewportChanged`.
+
+    All keys are single-character (ADR-031 legal).
+    """
+
+    can_focus = True
+
+    DEFAULT_CSS = """
+    TrajectoryTimeline {
+        height: 6;
+        width: 1fr;
+    }
+    """
+
+    class TrajectoryBrushChanged(Message):
+        """Brush range changed; ``brush_range`` is a (lo, hi) time tuple or None."""
+
+        def __init__(self, brush_range: tuple[float, float] | None) -> None:
+            super().__init__()
+            self.brush_range = brush_range
+
+    class TrajectoryBarSelected(Message):
+        """A record bar was clicked; ``record_key`` is its ledger seq."""
+
+        def __init__(self, record_key: int) -> None:
+            super().__init__()
+            self.record_key = record_key
+
+    class TrajectoryViewportChanged(Message):
+        """Zoom/pan moved the time window; ``domain_window`` is (lo, hi)."""
+
+        def __init__(self, domain_window: tuple[float, float]) -> None:
+            super().__init__()
+            self.domain_window = domain_window
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._model = TimelineModel()
+        self._window: tuple[float, float] | None = None
+        self._brush: tuple[float, float] | None = None
+        self._drag_x: int | None = None
+        self._drag_moved = False
+
+    # -- state --------------------------------------------------------------
+
+    @property
+    def model(self) -> TimelineModel:
+        """The pure geometry model (read-only view for callers/tests)."""
+        return self._model
+
+    @property
+    def viewport(self) -> tuple[float, float] | None:
+        """Current time window ``(lo, hi)``; ``None`` when no data."""
+        return self._window
+
+    @property
+    def brush(self) -> tuple[float, float] | None:
+        """Current brush range ``(lo, hi)`` in time, or ``None``."""
+        return self._brush
+
+    def set_snapshot(self, snapshot: TrajectorySnapshot) -> None:
+        """Load a snapshot: flatten turns, reset viewport to the domain."""
+        records = [record for turn in snapshot.turns for record in turn.records]
+        self._model = TimelineModel(records)
+        self._window = self._model.domain
+        self._brush = None
+        self._drag_x = None
+        self.refresh()
+
+    # -- rendering ----------------------------------------------------------
+
+    def render(self) -> Text:
+        model = self._model
+        width = max(self.size.width, 1)
+        if not model.has_data or self._window is None:
+            placeholder = Text(_PLACEHOLDER, style="dim")
+            lines = [Text("")] * (STRIP_HEIGHT - 1) + [placeholder]
+            return Text("\n").join(lines)
+        window = self._window
+        lines = [self._lane_line(lane, width, window) for lane in range(LANE_COUNT)]
+        left = _fmt_clock(window[0])
+        right = _fmt_clock(window[1])
+        middle = " " * max(width - len(left) - len(right), 0)
+        lines.append(Text(left + middle + right, style=_CAPTION_STYLE))
+        lines.append(self._caption_line(width))
+        return Text("\n").join(lines)
+
+    def _lane_line(self, lane: int, width: int, window: tuple[float, float]) -> Text:
+        """One lane row: bars for its records, brush background overlaid."""
+        model = self._model
+        cells: list[tuple[str, Style | None]] = [(" ", None)] * width
+        for record, record_lane in zip(model.timed_records, model.lanes):
+            if record_lane != lane:
+                continue
+            cols = self._record_columns(record, width, window)
+            if cols is None:
+                continue
+            style = KIND_STYLES.get(record.kind, _FALLBACK_STYLE)
+            for col in range(cols[0], cols[1] + 1):
+                cells[col] = (BAR_CHAR, style)
+        if self._brush is not None:
+            b0, b1 = self._brush_columns(width, window)
+            for col in range(b0, b1 + 1):
+                char, style = cells[col]
+                cells[col] = (char, (style or Style()) + BRUSH_STYLE)
+        return Text.assemble(*self._runs(cells), no_wrap=True, overflow="ignore")
+
+    @staticmethod
+    def _runs(cells: list[tuple[str, Style | None]]) -> list[tuple[str, Style | None]]:
+        """Collapse per-cell (char, style) into run segments for Text.assemble."""
+        return [
+            ("".join(char for char, _ in run), style)
+            for style, run in groupby(cells, key=lambda cell: cell[1])
+        ]
+
+    def _record_columns(
+        self, record: TrajectoryRecord, width: int, window: tuple[float, float]
+    ) -> tuple[int, int] | None:
+        """Column span [c0, c1] for a record; None when fully off-screen.
+
+        Zero-width (instantaneous) intervals get c1 == c0 so they render
+        as exactly one cell.
+        """
+        start, end = TimelineModel.interval(record)
+        c0 = int(TimelineModel.fraction(start, window) * width)
+        c1 = max(c0, int(TimelineModel.fraction(end, window) * width))
+        if c1 < 0 or c0 >= width:
+            return None
+        return max(c0, 0), min(c1, width - 1)
+
+    def _brush_columns(
+        self, width: int, window: tuple[float, float]
+    ) -> tuple[int, int]:
+        """Inclusive column span of the brush (whole strip when unset)."""
+        assert self._brush is not None
+        lo, hi = self._brush
+        b0 = int(TimelineModel.fraction(lo, window) * width)
+        b1 = int(TimelineModel.fraction(hi, window) * width)
+        return max(min(b0, b1), 0), min(max(b0, b1), width - 1)
+
+    def _caption_line(self, width: int) -> Text:
+        """Right-aligned brush window + active count (or ``no brush``)."""
+        if self._brush is not None:
+            lo, hi = self._brush
+            active = len(self._model.records_in_range(lo, hi))
+            caption = f"{_fmt_clock(lo)}–{_fmt_clock(hi)} · {active} active"
+        else:
+            caption = "no brush"
+        pad = " " * max(width - len(caption), 0)
+        return Text(pad + caption, style=_CAPTION_STYLE)
+
+    # -- geometry helpers (shared by mouse + tests) --------------------------
+
+    def _fraction_from_column(self, column: int, width: int) -> float:
+        return min(1.0, max(0.0, (column + 0.5) / width))
+
+    def brush_columns(self, x1: int, x2: int) -> None:
+        """Set the brush from two strip columns (the mouse-drag seam)."""
+        if self._model.domain is None or self._window is None:
+            return
+        width = max(self.size.width, 1)
+        t1 = TimelineModel.time_at(self._fraction_from_column(x1, width), self._window)
+        t2 = TimelineModel.time_at(self._fraction_from_column(x2, width), self._window)
+        self._set_brush((min(t1, t2), max(t1, t2)))
+
+    def _set_brush(self, brush: tuple[float, float] | None) -> None:
+        if self._brush == brush:
+            return
+        self._brush = brush
+        self.refresh()
+        self.post_message(self.TrajectoryBrushChanged(brush))
+
+    def record_at(self, x: int, y: int) -> TrajectoryRecord | None:
+        """The record whose rendered bar covers column ``x`` on row ``y``."""
+        if y < 0 or y >= LANE_COUNT or self._window is None:
+            return None
+        width = max(self.size.width, 1)
+        for record, lane in zip(self._model.timed_records, self._model.lanes):
+            if lane != y:
+                continue
+            cols = self._record_columns(record, width, self._window)
+            if cols is not None and cols[0] <= x <= cols[1]:
+                return record
+        return None
+
+    # -- zoom / pan ----------------------------------------------------------
+
+    def zoom_at(self, factor: float, focal_fraction: float = 0.5) -> None:
+        """Zoom by ``factor`` around ``focal_fraction`` of the strip."""
+        if self._window is None:
+            return
+        new_window = self._model.zoom(self._window, factor, focal_fraction)
+        if new_window != self._window:
+            self._window = new_window
+            self.refresh()
+            self.post_message(self.TrajectoryViewportChanged(new_window))
+
+    def pan_by(self, fraction_of_span: float) -> None:
+        """Pan by ``fraction_of_span`` of the window width (clamped)."""
+        if self._window is None:
+            return
+        new_window = self._model.pan(self._window, fraction_of_span)
+        if new_window != self._window:
+            self._window = new_window
+            self.refresh()
+            self.post_message(self.TrajectoryViewportChanged(new_window))
+
+    # -- mouse ----------------------------------------------------------------
+
+    def on_mouse_down(self, event: MouseEvent) -> None:
+        if event.button == 1:
+            # Capture for the gesture: a drag that leaves the 6-line
+            # strip must keep feeding us moves, not strand the brush.
+            self.capture_mouse()
+            self._drag_x = event.x
+            self._drag_moved = False
+
+    def on_mouse_move(self, event: MouseEvent) -> None:
+        if self._drag_x is not None and event.button == 1:
+            if event.x != self._drag_x:
+                self._drag_moved = True
+                self.brush_columns(self._drag_x, event.x)
+
+    def on_mouse_up(self, event: MouseEvent) -> None:
+        if event.button != 1 or self._drag_x is None:
+            return
+        self.release_mouse()
+        start_x, self._drag_x = self._drag_x, None
+        if not self._drag_moved:
+            # Plain click: bar select (and clear brush) or clear brush.
+            record = self.record_at(event.x, event.y)
+            if record is not None:
+                self._set_brush(None)
+                self.post_message(self.TrajectoryBarSelected(record.seq))
+            else:
+                self._set_brush(None)
+        else:
+            self.brush_columns(start_x, event.x)
+
+    def on_mouse_scroll_up(self, event: MouseEvent) -> None:
+        width = max(self.size.width, 1)
+        self.zoom_at(ZOOM_FACTOR, self._fraction_from_column(event.x, width))
+
+    def on_mouse_scroll_down(self, event: MouseEvent) -> None:
+        width = max(self.size.width, 1)
+        self.zoom_at(1 / ZOOM_FACTOR, self._fraction_from_column(event.x, width))
+
+    # -- keys -----------------------------------------------------------------
+
+    BINDINGS = [
+        Binding("left_square_bracket", "zoom_out", "Zoom out"),
+        Binding("right_square_bracket", "zoom_in", "Zoom in"),
+        Binding("comma", "pan_left", "Pan left"),
+        Binding("full_stop", "pan_right", "Pan right"),
+    ]
+
+    def action_zoom_out(self) -> None:
+        self.zoom_at(1 / ZOOM_FACTOR, 0.5)
+
+    def action_zoom_in(self) -> None:
+        self.zoom_at(ZOOM_FACTOR, 0.5)
+
+    def action_pan_left(self) -> None:
+        self.pan_by(-PAN_FRACTION)
+
+    def action_pan_right(self) -> None:
+        self.pan_by(PAN_FRACTION)

--- a/tldw_chatbook/UI/Widgets/trajectory_timeline.py
+++ b/tldw_chatbook/UI/Widgets/trajectory_timeline.py
@@ -82,6 +82,9 @@ _FALLBACK_STYLE = Style(color="white")
 #: Background applied to every cell inside the brushed region.
 BRUSH_STYLE = Style(bgcolor="#264f78")
 
+#: Overlay for the selected record's bar (host-screen ledger cursor).
+_SELECTED_STYLE = Style(reverse=True)
+
 _CAPTION_STYLE = Style(color="grey62")
 
 
@@ -259,6 +262,10 @@ class TrajectoryTimeline(Widget):
       keys on the strip center); ```,`' ``/`` .`` pan left/right. Every
       viewport change posts :class:`TrajectoryViewportChanged`.
 
+    The host screen drives bar highlighting via :meth:`set_selected`
+    (pull-only: it posts no messages, so a ledger cursor move can
+    highlight a bar without echoing a selection event back).
+
     All keys are single-character (ADR-031 legal).
     """
 
@@ -297,6 +304,7 @@ class TrajectoryTimeline(Widget):
         self._model = TimelineModel()
         self._window: tuple[float, float] | None = None
         self._brush: tuple[float, float] | None = None
+        self._selected: int | None = None
         self._drag_x: int | None = None
         self._drag_moved = False
 
@@ -317,12 +325,30 @@ class TrajectoryTimeline(Widget):
         """Current brush range ``(lo, hi)`` in time, or ``None``."""
         return self._brush
 
+    @property
+    def selected(self) -> int | None:
+        """Ledger seq of the highlighted bar, or ``None``."""
+        return self._selected
+
+    def set_selected(self, record_key: int | None) -> None:
+        """Highlight the bar for ``record_key`` (``None`` clears it).
+
+        Dumb, pull-only selection driven by the host screen's ledger
+        cursor: no message is posted, so highlighting cannot echo back
+        into a ledger cursor move (the bar-click path owns that arc).
+        """
+        if self._selected == record_key:
+            return
+        self._selected = record_key
+        self.refresh()
+
     def set_snapshot(self, snapshot: TrajectorySnapshot) -> None:
         """Load a snapshot: flatten turns, reset viewport to the domain."""
         records = [record for turn in snapshot.turns for record in turn.records]
         self._model = TimelineModel(records)
         self._window = self._model.domain
         self._brush = None
+        self._selected = None
         self._drag_x = None
         self.refresh()
 
@@ -355,6 +381,8 @@ class TrajectoryTimeline(Widget):
             if cols is None:
                 continue
             style = KIND_STYLES.get(record.kind, _FALLBACK_STYLE)
+            if record.seq == self._selected:
+                style = style + _SELECTED_STYLE
             for col in range(cols[0], cols[1] + 1):
                 cells[col] = (BAR_CHAR, style)
         if self._brush is not None:


### PR DESCRIPTION
## Summary

Adds a deepseek-harness-style trajectory (trace) view to the Console, per the approved spec (`Docs/superpowers/specs/2026-08-14-console-trajectory-view-design.md`) and ADR-066 (`backlog/decisions/066-console-trajectory-view-and-trace-metadata.md`). Backlog tasks 16311–16314 (task-16315, the brushable timeline strip, is the planned follow-up).

- **Schema v38** local-only sidecar `message_trajectory_metadata`: turn identity, per-conversation monotonic `seq`, per-record timing, and — as the *sole* persisted home for tool records (TOOL-marker invariant preserved) — tool payloads capped at 256 KiB (byte-safe).
- **Capture**: step-start / first-token / completion timing stamped in the Console streaming path; tool records written at marker-append time; all writes failure-isolated (never fail a turn), `BEGIN IMMEDIATE` seq assignment.
- **Projection** (`Chat/trajectory.py`): pure module folding messages + usage + sidecar + variants + compaction into a `TrajectorySnapshot`; active-path derivation from `active_leaf_message_id`; never-fabricated timing.
- **Screen** (`UI/Screens/trajectory_screen.py`): DataTable ledger with turn grouping/collapse, inspector (tokens incl. cache read/write, timing, full tool payload, turn-level variants), search reaching tool payloads, load-earlier pagination. ADR-031-compliant bindings, governance-tested.
- **Launch + live**: `y` from the Console opens the view; revision-polling live tail-follow with scroll-up suspend and `f` resume.

## Test evidence

132 tests across the six affected suites (migration, capture, projection, screen, live, workbench-contract) pass; ruff clean on changed files. Review trail: per-task reviews + final whole-branch review (merge-ready; final fixes: skip image BLOBs in snapshot builds, gap-safe active-path walk).

## Known deferrals

- Tool-call `args` render as null until a small `console_agent_bridge.py` follow-up plumbs the argument dict.
- Cold-DB conversations don't show superseded variant contents (process-local by nature; live sessions do).
- Brushable timeline strip: task-16315.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a turn-grouped trajectory view to the Console with a trace ledger, per-turn timing/token inspector, live tail-follow, and a brushable timeline. Previously there was no per-turn trace; now the Console stamps step/start/first-token/completion timing, persists tool records in a local sidecar, and lets you search/inspect them without affecting message delivery.

- Schema v38 auto-migrates a local-only `message_trajectory_metadata` sidecar (tool payloads live only here, 256 KiB cap). Writes are failure‑isolated and never block a turn.
- Projection builds a `TrajectorySnapshot` from messages/usage/sidecar/variants; the active path derives from `active_leaf_message_id`, timing is never fabricated, and image BLOBs are skipped.
- UI: press y to open the trajectory. Ledger supports turn grouping/collapse, search, load‑earlier; the inspector shows timing, tokens (incl. cache read/write), full tool payload, and turn‑level variants. Live tail‑follow suspends on scroll‑up and resumes with f.
- Timeline: zoom/pan/brush strip above the ledger; brushing filters to active‑in‑range records (composes with search), bar clicks move the ledger cursor, and brushes persist across live refresh with local‑time rendering.

- Known deferrals: tool‑call args render as null pending a small `console_agent_bridge.py` follow‑up; cold‑DB conversations do not show superseded variant contents.

<sup>Written for commit 26c343aa1ee836a2c2674d5e5ee115188e7c2ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added performance and input-latency audit reports with measured findings, affected areas, and prioritized follow-up items.
  - Documented the server ingest field contract, supported mappings, limitations, and validation coverage.
  - Updated MCP guidance for installation, configuration, tools, permissions, security, and troubleshooting.
  - Added UX input documents covering planned navigation, feedback, accessibility, layout, and interaction improvements.
  - Recorded CSS-splitting investigation results and alternatives.
  - Updated workbench terminology and refined related design references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->