### PR TITLE
docs(backlog): trajectory export/import tasks

### DIFF
--- a/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
+++ b/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
@@ -1,0 +1,23 @@
+---
+id: TASK-16319
+title: 'Trajectory export: versioned JSON trace format and writer'
+status: To Do
+assignee: []
+created_date: '2026-08-15 13:53'
+labels:
+  - trajectory
+  - export
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let users export a conversation's trajectory (trace) to a shareable, self-contained file, building on the Console trajectory view (task-16311..16315, ADR-066). Purpose: sharing/debugging agent runs outside the local DB. Export folds the same inputs as the projection (messages incl. usage_json, sidecar rows, variant sets where available, compaction records) into one versioned JSON document. Privacy: tool payloads may contain file contents -- export defaults to redacted payload previews, full payloads only behind an explicit opt-in flag. ADR required: yes (export format is a data contract) -- create before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Export produces a schema-versioned single-file JSON trace of one conversation,Tool payloads redacted by default; full payloads only with explicit opt-in flag,Import validator round-trips the exported file (task-2 seam),Export of a conversation lacking sidecar rows still succeeds (legacy fallback),Unit tests cover format, redaction, and edge cases
+<!-- AC:END -->

--- a/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
+++ b/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
@@ -1,0 +1,24 @@
+---
+id: TASK-16320
+title: 'Trajectory import: open shared traces read-only'
+status: To Do
+assignee: []
+created_date: '2026-08-15 13:53'
+labels:
+  - trajectory
+  - import
+dependencies:
+  - TASK-16319
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Import a trajectory export file (task-16319 format) and render it in the existing TrajectoryScreen as a detached, read-only view. Imported traces must never write into the local conversations/messages/sidecar tables -- they exist only as an ephemeral snapshot for viewing, preserving sync integrity. Malformed or wrong-version files are rejected with actionable errors. ADR: extend the task-16319 export-format ADR rather than creating a new one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Imported file renders in the TrajectoryScreen (ledger, inspector, timeline) without any DB writes,Malformed files fail with actionable error messages,Version mismatches are detected and reported,Import action accessible from the Console trajectory surface,Tests cover happy path, malformed input, and version mismatch
+<!-- AC:END -->


### PR DESCRIPTION
Adds two backlog tasks following the Console trajectory view (PR #1662):

- **task-16319 — Trajectory export**: versioned single-file JSON trace format + writer; tool payloads redacted by default (privacy), full payloads opt-in; validator round-trip seam for import.
- **task-16320 — Trajectory import**: open shared traces read-only in the existing TrajectoryScreen; imported data never writes to local conversations/messages/sidecar tables (sync integrity); malformed/version-mismatch handling.

Docs-only change (two new task files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two backlog tasks that define trajectory export/import, clarifying the JSON trace format, default redaction, and read-only import to protect sync integrity.

- Adds `TASK-16319` (export): schema-versioned single-file JSON trace; tool payloads redacted by default with an opt-in for full payloads; validator round-trip seam; ADR required before implementation.
- Adds `TASK-16320` (import): opens exported traces in `TrajectoryScreen` as read-only; never writes to local conversations/messages/sidecar tables; rejects malformed and version-mismatched files; extends the export-format ADR.
- Docs-only scope: two new backlog files; no runtime or code changes.

<sup>Written for commit 05f6b7319bd15dbc2d113bc474679b521f195752. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

