### PR TITLE
feat(chat): trajectory export — versioned JSON trace format (task-16319)

### DIFF
--- a/Tests/Chat/test_trajectory_export.py
+++ b/Tests/Chat/test_trajectory_export.py
@@ -1,0 +1,420 @@
+"""Trajectory export: format, redaction, writer, validator (task-16319).
+
+Round-trip tests prove the ADR-067 contract: a real ``CharactersRAGDB``
+(temp file, real schema-v38 sidecar + real auxiliary-attempt rows) is
+exported, validated, written/read through the atomic writer, and the
+file's data re-renders through the REAL projection
+(``derive_trajectory``) -- the file carries everything the view needs.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Chat.console_context_repository import (
+    AuxiliaryAttemptStart,
+    AuxiliaryAttemptStatus,
+    ConsoleContextRepository,
+)
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Chat.trajectory import derive_trajectory
+from tldw_chatbook.Chat.trajectory_export import (
+    PREVIEW_MAX_CHARS,
+    TrajectoryExportError,
+    build_trajectory_export,
+    validate_trajectory_export,
+    write_trajectory_export,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, TrajectoryRowWrite
+
+LONG_TOOL_RESULT = "R" * 300  # longer than the preview cap
+
+_TOOL_PAYLOAD = json.dumps(
+    {
+        "name": "fs_read",
+        "args": {"path": "/tmp/report.txt"},
+        "result": LONG_TOOL_RESULT,
+    }
+)
+
+_T0 = "2026-08-14T12:00:00"  # deterministic message timestamps
+
+
+@dataclass(frozen=True)
+class VariantSetLike:
+    """Duck-typed ``ConsoleVariantSet`` stand-in (same mirror as UI tests)."""
+
+    turn_id: str
+    variants: tuple[str, ...]
+    selected_index: int = 0
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    return CharactersRAGDB(tmp_path / "test.db", client_id="test")
+
+
+def _seed_conversation(database: CharactersRAGDB, *, with_sidecar: bool = True) -> str:
+    """Seed one conversation: 2 turns, tool rows, usage, compaction attempt.
+
+    Ledger order mirrors ``Tests/UI/test_trajectory_screen.py`` fixtures:
+    u1, a1, tool_call, tool_result (turn t1); u2, a2 (turn t2).
+    """
+    conv = database.add_conversation({"title": "trajectory export conv"})
+    u1 = database.add_message(
+        {
+            "conversation_id": conv,
+            "sender": "user",
+            "content": "hello trajectory world",
+            "timestamp": _T0,
+        }
+    )
+    a1 = database.add_message(
+        {
+            "conversation_id": conv,
+            "sender": "assistant",
+            "content": "checking that for you",
+            "parent_message_id": u1,
+            "timestamp": "2026-08-14T12:00:02",
+        }
+    )
+    u2 = database.add_message(
+        {
+            "conversation_id": conv,
+            "sender": "user",
+            "content": "second question about zebras",
+            "parent_message_id": a1,
+            "timestamp": "2026-08-14T12:01:00",
+        }
+    )
+    a2 = database.add_message(
+        {
+            "conversation_id": conv,
+            "sender": "assistant",
+            "content": "zebras have stripes",
+            "parent_message_id": u2,
+            "timestamp": "2026-08-14T12:01:05",
+            "usage_json": json.dumps(
+                {
+                    "uncached_input": 10,
+                    "output": 4,
+                    "provider": "test-provider",
+                    "model": "test-model",
+                }
+            ),
+        }
+    )
+    database.set_conversation_active_leaf(conv, a2)
+
+    if with_sidecar:
+        database.upsert_trajectory_rows(
+            [
+                TrajectoryRowWrite(
+                    message_id=u1,
+                    conversation_id=conv,
+                    turn_id="t1",
+                    seq=1,
+                    event_kind="user",
+                    step_started_at=1_755_165_600.0,
+                ),
+                TrajectoryRowWrite(
+                    message_id=a1,
+                    conversation_id=conv,
+                    turn_id="t1",
+                    seq=2,
+                    event_kind="assistant",
+                    step_started_at=1_755_165_600.0,
+                    first_token_at=1_755_165_602.0,
+                    completed_at=1_755_165_605.0,
+                    model="test-model",
+                    provider="test-provider",
+                ),
+                TrajectoryRowWrite(
+                    message_id=a1,
+                    conversation_id=conv,
+                    turn_id="t1",
+                    seq=3,
+                    event_kind="tool_call",
+                    payload_json=_TOOL_PAYLOAD,
+                ),
+                TrajectoryRowWrite(
+                    message_id=a1,
+                    conversation_id=conv,
+                    turn_id="t1",
+                    seq=4,
+                    event_kind="tool_result",
+                    payload_json=_TOOL_PAYLOAD,
+                ),
+                TrajectoryRowWrite(
+                    message_id=u2,
+                    conversation_id=conv,
+                    turn_id="t2",
+                    seq=5,
+                    event_kind="user",
+                    step_started_at=1_755_165_660.0,
+                ),
+                TrajectoryRowWrite(
+                    message_id=a2,
+                    conversation_id=conv,
+                    turn_id="t2",
+                    seq=6,
+                    event_kind="assistant",
+                    model="test-model",
+                    provider="test-provider",
+                ),
+            ]
+        )
+
+    repository = ConsoleContextRepository(database)
+    repository.start_auxiliary_attempt(
+        AuxiliaryAttemptStart(
+            operation_id="op-compaction-1",
+            conversation_id=conv,
+            purpose="conversation_compaction",
+            provider="test-provider",
+            model="test-model",
+            requested_output_cap=100,
+            estimated_input_tokens=50,
+            started_at="2026-08-14T12:05:00Z",
+        )
+    )
+    repository.finish_auxiliary_attempt(
+        "op-compaction-1",
+        status=AuxiliaryAttemptStatus.SUCCEEDED,
+        finished_at="2026-08-14T12:05:03Z",
+        elapsed_ms=3_000,
+        usage=ProviderUsage(output=2),
+    )
+    return conv
+
+
+def _snapshot_from_export(payload: dict):
+    """Re-render through the REAL projection using only export-file data."""
+    return derive_trajectory(
+        payload["messages"],
+        {
+            message["id"]: ProviderUsage.from_json(message["usage_json"])
+            for message in payload["messages"]
+        },
+        payload["trajectory_rows"],
+        payload.get("variants") or (),
+        payload["compaction_records"],
+        payload.get("active_leaf_message_id"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_file_renders_through_projection(db, tmp_path) -> None:
+    conv = _seed_conversation(db)
+    payload = build_trajectory_export(
+        db,
+        conv,
+        variant_sets=(VariantSetLike("t2", ("first draft", "winning draft"), 1),),
+    )
+    normalized = validate_trajectory_export(payload)
+    path = write_trajectory_export(tmp_path / "trace.json", normalized)
+    # What an importer sees: read the file back, validate, re-render.
+    on_disk = validate_trajectory_export(json.loads(path.read_text(encoding="utf-8")))
+
+    assert on_disk["format"] == "tldw-trajectory"
+    assert on_disk["version"] == 1
+    assert on_disk["conversation"]["id"] == conv
+    assert on_disk["conversation"]["title"] == "trajectory export conv"
+    assert on_disk["redacted"] is True
+    assert [m["id"] for m in on_disk["messages"]] == [
+        m["id"] for m in payload["messages"]
+    ]
+    assert len(on_disk["trajectory_rows"]) == 6
+    assert on_disk["compaction_records"][0]["purpose"] == "conversation_compaction"
+    assert on_disk["variants"][0]["selected_index"] == 1
+
+    snapshot = _snapshot_from_export(on_disk)
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+    assert kinds == [
+        "user",
+        "assistant",
+        "tool_call",
+        "tool_result",
+        "user",
+        "assistant",
+        "compaction",
+    ]
+    # Usage travels: the assistant record carries the seeded tokens.
+    assistant_records = [
+        record
+        for turn in snapshot.turns
+        for record in turn.records
+        if record.kind == "assistant"
+    ]
+    assert assistant_records[-1].usage is not None
+    assert assistant_records[-1].usage.output == 4
+    # Variant sets travel: superseded content attaches to turn t2's assistant.
+    assert "first draft" in assistant_records[-1].variants
+    # Redacted tool payload still renders a preview.
+    tool_call = next(r for r in snapshot.turns[0].records if r.kind == "tool_call")
+    assert tool_call.payload is not None
+    assert tool_call.payload.get("redacted") is True
+
+
+def test_export_omits_image_blobs_and_message_keys(db) -> None:
+    conv = _seed_conversation(db)
+    payload = build_trajectory_export(db, conv)
+    assert set(payload["messages"][0]) == {
+        "id",
+        "sender",
+        "content",
+        "timestamp",
+        "parent_message_id",
+        "usage_json",
+    }
+    assert "image_data" not in payload["messages"][0]
+
+
+def test_unknown_conversation_raises(db) -> None:
+    with pytest.raises(TrajectoryExportError, match="not found"):
+        build_trajectory_export(db, "no-such-conversation")
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_default_replaces_tool_payloads(db) -> None:
+    conv = _seed_conversation(db)
+    payload = build_trajectory_export(db, conv)
+
+    assert payload["redacted"] is True
+    tool_rows = [
+        r
+        for r in payload["trajectory_rows"]
+        if r["event_kind"] in ("tool_call", "tool_result")
+    ]
+    assert len(tool_rows) == 2
+    for row in tool_rows:
+        stub = json.loads(row["payload_json"])
+        assert stub == {
+            "name": "fs_read",
+            "result_preview": LONG_TOOL_RESULT[:PREVIEW_MAX_CHARS],
+            "args_preview": '{"path": "/tmp/report.txt"}',
+            "redacted": True,
+        }
+        assert len(stub["result_preview"]) <= PREVIEW_MAX_CHARS
+        assert "\n" not in stub["result_preview"]
+        # The full payload must not leak anywhere in the document.
+        assert LONG_TOOL_RESULT not in json.dumps(payload)
+    # Non-tool rows are untouched.
+    user_row = next(r for r in payload["trajectory_rows"] if r["event_kind"] == "user")
+    assert user_row["payload_json"] is None
+
+
+def test_include_payloads_opt_in_keeps_verbatim(db) -> None:
+    conv = _seed_conversation(db)
+    payload = build_trajectory_export(db, conv, include_payloads=True)
+
+    assert payload["redacted"] is False
+    tool_row = next(
+        r for r in payload["trajectory_rows"] if r["event_kind"] == "tool_call"
+    )
+    assert tool_row["payload_json"] == _TOOL_PAYLOAD
+
+
+# ---------------------------------------------------------------------------
+# Legacy (no sidecar rows)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_conversation_without_sidecar_exports(db) -> None:
+    conv = _seed_conversation(db, with_sidecar=False)
+    payload = build_trajectory_export(db, conv)
+    normalized = validate_trajectory_export(payload)
+
+    assert normalized["trajectory_rows"] == []
+    assert len(normalized["messages"]) == 4
+    snapshot = _snapshot_from_export(normalized)
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+    assert kinds == ["user", "assistant", "user", "assistant", "compaction"]
+
+
+# ---------------------------------------------------------------------------
+# Validator rejections
+# ---------------------------------------------------------------------------
+
+
+def _valid_payload(db) -> dict:
+    return build_trajectory_export(db, _seed_conversation(db))
+
+
+def test_rejects_wrong_format_marker(db) -> None:
+    payload = _valid_payload(db)
+    payload["format"] = "something-else"
+    with pytest.raises(TrajectoryExportError, match="'format'"):
+        validate_trajectory_export(payload)
+
+
+def test_rejects_higher_version(db) -> None:
+    payload = _valid_payload(db)
+    payload["version"] = 2
+    with pytest.raises(TrajectoryExportError, match="version 2"):
+        validate_trajectory_export(payload)
+
+
+def test_rejects_missing_messages_section(db) -> None:
+    payload = _valid_payload(db)
+    del payload["messages"]
+    with pytest.raises(TrajectoryExportError, match="'messages'"):
+        validate_trajectory_export(payload)
+
+
+def test_rejects_missing_trajectory_rows_section(db) -> None:
+    payload = _valid_payload(db)
+    del payload["trajectory_rows"]
+    with pytest.raises(TrajectoryExportError, match="'trajectory_rows'"):
+        validate_trajectory_export(payload)
+
+
+def test_rejects_message_missing_id(db) -> None:
+    payload = _valid_payload(db)
+    del payload["messages"][1]["id"]
+    with pytest.raises(TrajectoryExportError, match=r"messages\[1\]\.id"):
+        validate_trajectory_export(payload)
+
+
+def test_validator_normalizes_optional_sections(db) -> None:
+    payload = _valid_payload(db)
+    for key in ("compaction_records", "variants", "active_leaf_message_id"):
+        payload.pop(key, None)
+    normalized = validate_trajectory_export(payload)
+    assert normalized["compaction_records"] == []
+    assert normalized["variants"] == []
+    assert normalized["active_leaf_message_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write
+# ---------------------------------------------------------------------------
+
+
+def test_write_is_atomic_and_overwrites(tmp_path) -> None:
+    payload = _valid_payload(CharactersRAGDB(tmp_path / "test.db", client_id="test"))
+    target = tmp_path / "trace.json"
+
+    first = write_trajectory_export(target, payload)
+    assert first == target
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+    assert list(tmp_path.glob("*.tmp")) == []  # no temp leftovers
+
+    payload["redacted"] = False
+    write_trajectory_export(str(target), payload)  # str path + overwrite
+    assert json.loads(target.read_text(encoding="utf-8"))["redacted"] is False
+    # Only the target (plus the DB's own files) remains -- no temp artifacts.
+    leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []

--- a/backlog/decisions/067-trajectory-export-format.md
+++ b/backlog/decisions/067-trajectory-export-format.md
@@ -1,0 +1,69 @@
+# ADR-067: Trajectory Export Format
+
+- Status: Accepted
+- Date: 2026-08-15
+- Related: ADR-066 (trajectory view + sidecar), task-16319 (export), task-16320 (import)
+
+## Context
+
+Users need to share or archive a conversation's trajectory (trace) as a
+single portable file — for debugging agent runs, attaching to issues, or
+viewing on another machine (task-16320 renders imports read-only). The data
+lives across `messages` (with `usage_json`), the local-only
+`message_trajectory_metadata` sidecar, `conversations.active_leaf_message_id`,
+compaction attempts (`console_context_repository.list_auxiliary_attempts`),
+and process-local variant sets.
+
+## Decision
+
+1. **Format**: one JSON document per conversation:
+   `{"format": "tldw-trajectory", "version": 1, "exported_at": <ISO-8601 UTC>,
+   "redacted": <bool>, "conversation": {id, title, created_at},
+   "active_leaf_message_id": <str|null>, "messages": [...non-deleted rows with
+   id/sender/content/timestamp/parent_message_id/usage_json...],
+   "trajectory_rows": [...sidecar rows as-is...], "compaction_records":
+   [...], "variants": [...] (only when exported from a live session; may be
+   empty)}`. Everything the existing projection (`Chat/trajectory.derive_trajectory`)
+   needs to render the exact TrajectoryScreen view travels in the file.
+2. **Versioning**: `version` is an integer starting at 1. Readers must accept
+   the exact versions they were built for and reject higher ones with an
+   actionable error; additive fields within a version are allowed and must be
+   ignored by older readers.
+3. **Redaction is the default**: tool payloads may contain file contents.
+   Unless the caller passes an explicit opt-in, `payload_json` is replaced by
+   `{"name": ..., "result_preview": <first 120 chars>, "args_preview": <first
+   120 chars or null>, "redacted": true}`; `"redacted": true` at the document
+   level marks the mode. Full payloads (`payload_json` verbatim) only on
+   explicit opt-in.
+4. **No secrets**: the file contains conversation content and metadata only —
+   never API keys, config, or provider credentials.
+5. **Export is a user-initiated egress of local-only data**: the sidecar is
+   local-only in the DB (ADR-066); exporting copies it out of the machine by
+   explicit action, which is the feature's purpose. Import (task-16320) never
+   writes imported data back into local tables — imports render read-only.
+6. **Implementation seam**: `Chat/trajectory_export.py` is pure (no Textual):
+   `build_trajectory_export(...) -> dict`, `write_trajectory_export(path, payload)`
+   (atomic tmp+rename), and `validate_trajectory_export(payload)` which
+   returns normalized data or raises `TrajectoryExportError` — the same
+   validator is the import seam, so export/import can never drift apart.
+
+## Alternatives considered
+
+- **Reuse `document_generator.py` export formats (md/html/pdf)**: those export
+  chat transcripts for humans; the trajectory needs a machine-round-trippable
+  projection input, i.e. structured JSON.
+- **Two files (trace + manifest)**: single-file is the shareability
+  requirement; a manifest adds failure modes for no gain.
+- **SQLite snapshot file**: opaque to humans and diff tools; JSON matches the
+  "shareable artifact" goal and validates cheaply.
+
+## Consequences
+
+- `version: 1` is now a public contract; breaking changes require a bump and
+  reader rejection logic.
+- Redaction means shared default exports lose full tool output; the opt-in is
+  the escape hatch, and the document-level `redacted` flag keeps receivers
+  honest.
+- Legacy conversations (no sidecar rows) export fine — empty
+  `trajectory_rows` with messages present is valid; the projection's legacy
+  fallback applies on import rendering.

--- a/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
+++ b/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-16319
 title: 'Trajectory export: versioned JSON trace format and writer'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-15 13:53'
-updated_date: '2026-08-15 17:24'
+updated_date: '2026-08-15 17:35'
 labels:
   - trajectory
   - export
@@ -31,11 +31,6 @@ Let users export a conversation's trajectory (trace) to a shareable, self-contai
 
 ## Implementation Notes
 
-- Approach: `tldw_chatbook/Chat/trajectory_export.py` is pure (no Textual/widget imports) and exposes three seams per ADR-067 §6: `build_trajectory_export(db, conversation_id, *, include_payloads=False, variant_sets=())`, `write_trajectory_export(path, payload)` (pretty JSON, sibling mkstemp + `os.replace`, temp cleanup on failure), and `validate_trajectory_export(payload)` returning the normalized payload — the task-16320 import seam.
-- Build reads the same accessors the live projection uses: `get_conversation_by_id`, `get_messages_for_conversation(include_image_data=False)` (image blobs never exported; only id/sender/content/timestamp/parent_message_id/usage_json per message), `get_trajectory_rows` (all `TrajectoryRowRead` fields), `get_conversation_active_leaf`, and compaction records via `ConsoleContextRepository.list_auxiliary_attempts(limit=500)` filtered to `purpose == "conversation_compaction"`.
-- Redaction default (ADR-067 §3): tool_call/tool_result `payload_json` becomes `{"name", "result_preview" (<=120 chars, single line), "args_preview" (<=120 chars or null), "redacted": true}`; unparseable payloads degrade to empty previews rather than leaking. `include_payloads=True` keeps `payload_json` verbatim; the document-level `redacted` flag records the mode.
-- Validator enforces format marker, `version == 1` (higher -> `TrajectoryExportError` naming the version), required sections/types (`exported_at`, `redacted`, `conversation.id`, `messages` with all six keys, `trajectory_rows` with the load-bearing row keys), fills optional sections (`compaction_records`, `variants`, `active_leaf_message_id`) to `[]`/`None`, and ignores additive fields (ADR-067 §2).
-- Gotcha found: the DB layer returns `datetime` objects for timestamp columns; a `_jsonable` coercion (datetime -> ISO string) makes payloads JSON-serializable AND keeps `_parse_timestamp` working on import rendering.
-- Tests (`Tests/Chat/test_trajectory_export.py`, real temp `CharactersRAGDB` with sidecar rows + real aux-attempt rows): round trip build -> validate -> write/read -> `derive_trajectory` re-renders the exact ledger (user/assistant/tool_call/tool_result/user/assistant/compaction, usage + variants carried), redaction default/opt-in, legacy no-sidecar export, malformed rejections naming the offending field, atomic write with no temp leftovers. 36/36 pass with `Tests/Chat/test_trajectory_projection.py`; ruff clean.
-- Files: added `tldw_chatbook/Chat/trajectory_export.py`, `Tests/Chat/test_trajectory_export.py`. Commit: 7c794e6.
-- ADR check: ADR-067 (pre-existing, linked) is the format contract; no new ADR needed.
+<!-- SECTION:NOTES:BEGIN -->
+Export module shipped: build/write/validate per ADR-067; review Approved (minors: redacted-flag cross-check deferred to task-16320 import validation)
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
+++ b/backlog/tasks/task-16319 - Trajectory-export-versioned-JSON-trace-format-and-writer.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16319
 title: 'Trajectory export: versioned JSON trace format and writer'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-15 13:53'
+updated_date: '2026-08-15 17:24'
 labels:
   - trajectory
   - export
@@ -19,5 +20,22 @@ Let users export a conversation's trajectory (trace) to a shareable, self-contai
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Export produces a schema-versioned single-file JSON trace of one conversation,Tool payloads redacted by default; full payloads only with explicit opt-in flag,Import validator round-trips the exported file (task-2 seam),Export of a conversation lacking sidecar rows still succeeds (legacy fallback),Unit tests cover format, redaction, and edge cases
+- [x] #1 Export produces a schema-versioned single-file JSON trace of one conversation,Tool payloads redacted by default; full payloads only with explicit opt-in flag,Import validator round-trips the exported file (task-2 seam),Export of a conversation lacking sidecar rows still succeeds (legacy fallback),Unit tests cover format, redaction, and edge cases
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. ADR-067 export format contract (versioned JSON, redaction default). 2. Chat/trajectory_export.py: build/write/validate; validator is the import seam. 3. Round-trip tests (export->validate->derive_trajectory renders), redaction, legacy no-sidecar, malformed/version rejection, atomic write. 4. Task notes + Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+- Approach: `tldw_chatbook/Chat/trajectory_export.py` is pure (no Textual/widget imports) and exposes three seams per ADR-067 §6: `build_trajectory_export(db, conversation_id, *, include_payloads=False, variant_sets=())`, `write_trajectory_export(path, payload)` (pretty JSON, sibling mkstemp + `os.replace`, temp cleanup on failure), and `validate_trajectory_export(payload)` returning the normalized payload — the task-16320 import seam.
+- Build reads the same accessors the live projection uses: `get_conversation_by_id`, `get_messages_for_conversation(include_image_data=False)` (image blobs never exported; only id/sender/content/timestamp/parent_message_id/usage_json per message), `get_trajectory_rows` (all `TrajectoryRowRead` fields), `get_conversation_active_leaf`, and compaction records via `ConsoleContextRepository.list_auxiliary_attempts(limit=500)` filtered to `purpose == "conversation_compaction"`.
+- Redaction default (ADR-067 §3): tool_call/tool_result `payload_json` becomes `{"name", "result_preview" (<=120 chars, single line), "args_preview" (<=120 chars or null), "redacted": true}`; unparseable payloads degrade to empty previews rather than leaking. `include_payloads=True` keeps `payload_json` verbatim; the document-level `redacted` flag records the mode.
+- Validator enforces format marker, `version == 1` (higher -> `TrajectoryExportError` naming the version), required sections/types (`exported_at`, `redacted`, `conversation.id`, `messages` with all six keys, `trajectory_rows` with the load-bearing row keys), fills optional sections (`compaction_records`, `variants`, `active_leaf_message_id`) to `[]`/`None`, and ignores additive fields (ADR-067 §2).
+- Gotcha found: the DB layer returns `datetime` objects for timestamp columns; a `_jsonable` coercion (datetime -> ISO string) makes payloads JSON-serializable AND keeps `_parse_timestamp` working on import rendering.
+- Tests (`Tests/Chat/test_trajectory_export.py`, real temp `CharactersRAGDB` with sidecar rows + real aux-attempt rows): round trip build -> validate -> write/read -> `derive_trajectory` re-renders the exact ledger (user/assistant/tool_call/tool_result/user/assistant/compaction, usage + variants carried), redaction default/opt-in, legacy no-sidecar export, malformed rejections naming the offending field, atomic write with no temp leftovers. 36/36 pass with `Tests/Chat/test_trajectory_projection.py`; ruff clean.
+- Files: added `tldw_chatbook/Chat/trajectory_export.py`, `Tests/Chat/test_trajectory_export.py`. Commit: 7c794e6.
+- ADR check: ADR-067 (pre-existing, linked) is the format contract; no new ADR needed.

--- a/tldw_chatbook/Chat/trajectory_export.py
+++ b/tldw_chatbook/Chat/trajectory_export.py
@@ -1,0 +1,440 @@
+"""Trajectory export: versioned JSON trace format, writer, and validator.
+
+Implements ADR-067 (``backlog/decisions/067-trajectory-export-format.md``):
+one self-contained JSON document per conversation carrying everything the
+trajectory projection (``Chat/trajectory.derive_trajectory``) needs to
+render the exact TrajectoryScreen view -- messages with usage, the
+schema-v38 sidecar rows, compaction attempts, and (when exported from a
+live session) variant sets.
+
+Purity contract
+    No Textual, no widget imports. The only DB touch is ``build_...``
+    reading through the ``CharactersRAGDB`` accessors named below; the
+    writer and validator are pure stdlib. The validator is the import
+    seam (task-16320), so export and import can never drift apart.
+
+Privacy contract (ADR-067 §3/§4)
+    Tool ``payload_json`` may contain file contents, so redaction is the
+    DEFAULT: tool rows get preview-only payload stubs unless the caller
+    passes ``include_payloads=True``. The document-level ``redacted``
+    flag records the mode. The file never carries API keys, config, or
+    provider credentials -- only the conversation fields listed in
+    ``_MESSAGE_KEYS`` / ``_TRAJECTORY_ROW_KEYS``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "TRAJECTORY_EXPORT_FORMAT",
+    "TRAJECTORY_EXPORT_VERSION",
+    "PREVIEW_MAX_CHARS",
+    "TrajectoryExportError",
+    "build_trajectory_export",
+    "validate_trajectory_export",
+    "write_trajectory_export",
+]
+
+#: Document format marker (ADR-067 §1).
+TRAJECTORY_EXPORT_FORMAT = "tldw-trajectory"
+
+#: Current format version; a public contract (ADR-067 §2).
+TRAJECTORY_EXPORT_VERSION = 1
+
+#: Cap for redacted payload previews, matching the projection's cap.
+PREVIEW_MAX_CHARS = 120
+
+_TOOL_KINDS = frozenset({"tool_call", "tool_result"})
+_COMPACTION_PURPOSE = "conversation_compaction"
+
+#: Exported per-message fields; image blobs are omitted entirely (ADR-067 §1).
+_MESSAGE_KEYS = (
+    "id",
+    "sender",
+    "content",
+    "timestamp",
+    "parent_message_id",
+    "usage_json",
+)
+
+#: Exported sidecar fields, mirroring ``TrajectoryRowRead``.
+_TRAJECTORY_ROW_KEYS = (
+    "message_id",
+    "conversation_id",
+    "turn_id",
+    "seq",
+    "event_kind",
+    "step_started_at",
+    "first_token_at",
+    "completed_at",
+    "model",
+    "provider",
+    "payload_json",
+)
+
+#: Required keys on each exported sidecar row (others may be ``None``).
+_REQUIRED_ROW_KEYS = ("message_id", "conversation_id", "turn_id", "seq", "event_kind")
+
+#: Upper bound for the one-shot message read (single-file export).
+_MESSAGE_READ_LIMIT = 1_000_000
+
+#: Matches the repository's maximum ``list_auxiliary_attempts`` page.
+_AUX_ATTEMPT_LIMIT = 500
+
+
+class TrajectoryExportError(Exception):
+    """Unknown conversation, or an export payload that fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` from a mapping or an object (rows and models alike)."""
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _as_dict(obj: Any) -> dict:
+    """Convert a row/model to a plain dict (``TrajectoryRowRead``-shaped)."""
+    if isinstance(obj, Mapping):
+        return dict(obj)
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    return dict(obj)
+
+
+def _single_line(value: Any, limit: int = PREVIEW_MAX_CHARS) -> str:
+    """Collapse to one line and cap at ``limit`` chars."""
+    return " ".join(str(value or "").split())[:limit]
+
+
+def _redacted_payload_json(payload_json: str | None) -> str | None:
+    """Build the preview-only replacement for a tool ``payload_json``.
+
+    Keeps the ``name`` plus first-120-char single-line previews of the
+    result and args; anything unparseable degrades to empty previews
+    rather than leaking raw text. Returns JSON text matching the stub
+    shape from ADR-067 §3.
+    """
+    data: dict = {}
+    if payload_json:
+        try:
+            parsed = json.loads(payload_json)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            data = parsed
+    args = data.get("args")
+    if args is None:
+        args_preview = None
+    else:
+        args_text = (
+            args if isinstance(args, str) else json.dumps(args, ensure_ascii=False)
+        )
+        args_preview = _single_line(args_text)
+    stub = {
+        "name": str(data.get("name") or ""),
+        "result_preview": _single_line(data.get("result")),
+        "args_preview": args_preview,
+        "redacted": True,
+    }
+    return json.dumps(stub, ensure_ascii=False)
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce DB driver values to JSON-native ones (datetime -> ISO string)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _serialize_variant_set(variant_set: Any) -> dict:
+    """Serialize one variant set (``ConsoleVariantSet``-shaped) to JSON data."""
+    variants = []
+    for item in _field(variant_set, "variants") or ():
+        if isinstance(item, str):
+            variants.append(item)
+        else:
+            variants.append(str(_field(item, "content") or ""))
+    selected = _field(variant_set, "selected_index", 0)
+    return {
+        "turn_id": str(_field(variant_set, "turn_id") or ""),
+        "variants": variants,
+        "selected_index": int(selected) if selected is not None else 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Build (DB read -> export payload)
+# ---------------------------------------------------------------------------
+
+
+def build_trajectory_export(
+    db: Any,
+    conversation_id: str,
+    *,
+    include_payloads: bool = False,
+    variant_sets: Sequence[Any] = (),
+) -> dict:
+    """Build the export payload for one conversation (ADR-067 §1).
+
+    Reads the same seams the live projection uses:
+    ``get_conversation_by_id`` / ``get_messages_for_conversation(...,
+    include_image_data=False)`` / ``get_trajectory_rows`` /
+    ``get_conversation_active_leaf``, plus compaction attempts via
+    ``ConsoleContextRepository.list_auxiliary_attempts`` filtered to
+    ``purpose == "conversation_compaction"`` (as the projection does).
+
+    Args:
+        db: The ``CharactersRAGDB`` instance.
+        conversation_id: The conversation to export.
+        include_payloads: Explicit opt-in to keep tool ``payload_json``
+            verbatim. Default redacts tool payloads to previews.
+        variant_sets: Live-session variant sets; serialized under
+            ``variants`` only when provided.
+
+    Returns:
+        The export payload dict (not yet written to disk).
+
+    Raises:
+        TrajectoryExportError: If the conversation does not exist.
+    """
+    from tldw_chatbook.Chat.console_context_repository import ConsoleContextRepository
+
+    conversation = db.get_conversation_by_id(conversation_id)
+    if conversation is None:
+        raise TrajectoryExportError(
+            f"Conversation '{conversation_id}' not found (deleted or unknown id)"
+        )
+
+    messages = db.get_messages_for_conversation(
+        conversation_id, limit=_MESSAGE_READ_LIMIT, include_image_data=False
+    )
+    traj_rows = db.get_trajectory_rows(conversation_id)
+    aux_attempts = ConsoleContextRepository(db).list_auxiliary_attempts(
+        conversation_id, limit=_AUX_ATTEMPT_LIMIT
+    )
+    compaction_records = [
+        {key: _jsonable(value) for key, value in record.items()}
+        for record in aux_attempts
+        if str(record.get("purpose") or "") == _COMPACTION_PURPOSE
+    ]
+
+    rows_out: list[dict] = []
+    for row in traj_rows:
+        data = _as_dict(row)
+        kind = str(data.get("event_kind") or "")
+        payload_json = data.get("payload_json")
+        if not include_payloads and kind in _TOOL_KINDS and payload_json:
+            payload_json = _redacted_payload_json(payload_json)
+        exported_row = {key: _jsonable(data.get(key)) for key in _TRAJECTORY_ROW_KEYS}
+        exported_row["payload_json"] = payload_json
+        rows_out.append(exported_row)
+
+    payload: dict = {
+        "format": TRAJECTORY_EXPORT_FORMAT,
+        "version": TRAJECTORY_EXPORT_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "redacted": not include_payloads,
+        "conversation": {
+            "id": conversation.get("id"),
+            "title": _jsonable(conversation.get("title")),
+            "created_at": _jsonable(conversation.get("created_at")),
+        },
+        "active_leaf_message_id": db.get_conversation_active_leaf(conversation_id),
+        "messages": [
+            {key: _jsonable(message.get(key)) for key in _MESSAGE_KEYS}
+            for message in messages
+        ],
+        "trajectory_rows": rows_out,
+        "compaction_records": compaction_records,
+    }
+    if variant_sets:
+        payload["variants"] = [_serialize_variant_set(vs) for vs in variant_sets]
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Write (atomic)
+# ---------------------------------------------------------------------------
+
+
+def write_trajectory_export(path: Path | str, payload: dict) -> Path:
+    """Write ``payload`` as pretty JSON to ``path`` atomically.
+
+    Serializes with ``indent=2`` / ``ensure_ascii=False``, writes to a
+    sibling temp file, then ``os.replace``s it into place, so readers
+    never observe a partial file and an existing file is overwritten
+    atomically. Temp files are removed on failure.
+
+    Args:
+        path: Destination file path.
+        payload: The export payload (as built by ``build_trajectory_export``).
+
+    Returns:
+        The resolved destination path.
+
+    Raises:
+        OSError: If writing or renaming fails.
+    """
+    destination = Path(path)
+    text = json.dumps(payload, indent=2, ensure_ascii=False)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(destination.parent), prefix=f".{destination.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, destination)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return destination
+
+
+# ---------------------------------------------------------------------------
+# Validate (the import seam)
+# ---------------------------------------------------------------------------
+
+
+def _require(
+    payload: Mapping,
+    key: str,
+    types: tuple[type, ...] | type,
+    what: str,
+) -> Any:
+    """Fetch a required section with a type check; name the field on error."""
+    if key not in payload:
+        raise TrajectoryExportError(
+            f"Invalid trajectory export: missing required '{key}' section"
+        )
+    value = payload[key]
+    if not isinstance(value, types):
+        expected = " or ".join(
+            t.__name__ for t in (types if isinstance(types, tuple) else (types,))
+        )
+        raise TrajectoryExportError(
+            f"Invalid trajectory export: '{key}' must be {expected}, got {type(value).__name__}"
+        )
+    return value
+
+
+def validate_trajectory_export(payload: Any) -> dict:
+    """Validate an export payload and return it normalized (import seam).
+
+    Checks the format marker and version (rejecting higher versions with
+    an actionable error per ADR-067 §2), required sections and types, and
+    required keys on each message / trajectory row entry. Optional
+    sections (``compaction_records``, ``variants``,
+    ``active_leaf_message_id``) are filled to ``[]`` / ``None`` when
+    absent; unknown additive fields are ignored (ADR-067 §2).
+
+    Args:
+        payload: The parsed JSON document.
+
+    Returns:
+        The normalized payload dict.
+
+    Raises:
+        TrajectoryExportError: Naming the offending field for any
+            contract violation.
+    """
+    if not isinstance(payload, Mapping):
+        raise TrajectoryExportError(
+            "Invalid trajectory export: top-level document must be a JSON object, "
+            f"got {type(payload).__name__}"
+        )
+
+    fmt = payload.get("format")
+    if fmt != TRAJECTORY_EXPORT_FORMAT:
+        raise TrajectoryExportError(
+            f"Invalid trajectory export: 'format' must be "
+            f"'{TRAJECTORY_EXPORT_FORMAT}', got {fmt!r}"
+        )
+
+    version = payload.get("version")
+    if not isinstance(version, int) or isinstance(version, bool):
+        raise TrajectoryExportError(
+            f"Invalid trajectory export: 'version' must be an integer, got {version!r}"
+        )
+    if version > TRAJECTORY_EXPORT_VERSION:
+        raise TrajectoryExportError(
+            f"Unsupported trajectory export version {version}: this build reads "
+            f"version {TRAJECTORY_EXPORT_VERSION}; export with an older version "
+            f"or upgrade the app"
+        )
+    if version < TRAJECTORY_EXPORT_VERSION:
+        raise TrajectoryExportError(
+            f"Invalid trajectory export: 'version' must be "
+            f"{TRAJECTORY_EXPORT_VERSION}, got {version!r}"
+        )
+
+    _require(payload, "exported_at", str, "exported_at")
+    _require(payload, "redacted", bool, "redacted")
+    conversation = _require(payload, "conversation", dict, "conversation")
+    if "id" not in conversation:
+        raise TrajectoryExportError(
+            "Invalid trajectory export: 'conversation.id' is missing"
+        )
+
+    active_leaf = payload.get("active_leaf_message_id")
+    if active_leaf is not None and not isinstance(active_leaf, str):
+        raise TrajectoryExportError(
+            "Invalid trajectory export: 'active_leaf_message_id' must be a string or null"
+        )
+
+    messages = _require(payload, "messages", list, "messages")
+    for index, message in enumerate(messages):
+        if not isinstance(message, Mapping):
+            raise TrajectoryExportError(
+                f"Invalid trajectory export: 'messages[{index}]' must be an object"
+            )
+        for key in _MESSAGE_KEYS:
+            if key not in message:
+                raise TrajectoryExportError(
+                    f"Invalid trajectory export: 'messages[{index}].{key}' is missing"
+                )
+
+    rows = _require(payload, "trajectory_rows", list, "trajectory_rows")
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise TrajectoryExportError(
+                f"Invalid trajectory export: 'trajectory_rows[{index}]' must be an object"
+            )
+        for key in _REQUIRED_ROW_KEYS:
+            if key not in row:
+                raise TrajectoryExportError(
+                    f"Invalid trajectory export: 'trajectory_rows[{index}].{key}' is missing"
+                )
+
+    compaction = payload.get("compaction_records")
+    if compaction is not None and not isinstance(compaction, list):
+        raise TrajectoryExportError(
+            "Invalid trajectory export: 'compaction_records' must be a list"
+        )
+    variants = payload.get("variants")
+    if variants is not None and not isinstance(variants, list):
+        raise TrajectoryExportError(
+            "Invalid trajectory export: 'variants' must be a list"
+        )
+
+    normalized = dict(payload)
+    normalized.setdefault("compaction_records", [])
+    normalized.setdefault("variants", [])
+    normalized.setdefault("active_leaf_message_id", None)
+    return normalized


### PR DESCRIPTION
Implements task-16319 per ADR-067 (`backlog/decisions/067-trajectory-export-format.md`):

- `Chat/trajectory_export.py` (pure, no Textual): `build_trajectory_export` (versioned single-file JSON carrying everything the projection needs — messages, sidecar rows, compaction records, active leaf, optional live variant sets), atomic `write_trajectory_export`, and `validate_trajectory_export` — the shared export/import seam so the two can never drift.
- **Redaction by default**: tool payloads become {name, capped previews, redacted:true}; verbatim payloads only on explicit opt-in; fail-closed on unparseable payloads. No secrets/config/credentials in the file.
- Round-trip test proves an exported file alone re-renders the identical trajectory ledger via `derive_trajectory`.

Evidence: 36/36 tests (export + projection sanity), ruff clean; task review Approved. Follow-up task-16320 (read-only import) consumes the validator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a versioned JSON trajectory export with an atomic writer and strict validator, enabling single-file traces that reproduce the trajectory view via `derive_trajectory`. Previously no export existed; now tool payloads are redacted by default unless explicitly opted in.

- New pure module `tldw_chatbook/Chat/trajectory_export.py`: `build_trajectory_export`, `validate_trajectory_export`, and `write_trajectory_export` for format `tldw-trajectory` `version: 1`.
- Redaction default replaces tool `payload_json` with capped previews; pass `include_payloads=True` to keep verbatim payloads.
- Validator is the import seam (task-16320): enforces format/version, required sections, normalizes optional ones, and rejects higher versions with actionable errors.
- Atomic write uses temp+rename and overwrites safely.
- Tests `Tests/Chat/test_trajectory_export.py` cover round trip to `derive_trajectory`, legacy no-sidecar conversations, validator failures, and atomic write.
- ADR `backlog/decisions/067-trajectory-export-format.md` documents the contract; satisfies `task-16319` acceptance criteria.

<sup>Written for commit b54923e3bd054404c4be371b6ba210d203966bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

