### PR TITLE
feat(console): read-only trajectory trace import (task-16320)

### DIFF
--- a/Tests/Chat/test_trajectory_import.py
+++ b/Tests/Chat/test_trajectory_import.py
@@ -1,0 +1,209 @@
+"""Trajectory import: read shared traces into read-only snapshots (task-16320).
+
+Round-trip tests build a REAL export file (real ``CharactersRAGDB`` temp
+DB via the task-16319 test fixtures, real writer) and feed it to the
+import seam, proving the ADR-067 consumer contract: the shared validator
+is the only validation, mapping covers compaction + variants + usage +
+redaction, and the pure module never references the app DB.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Chat import trajectory_import
+from tldw_chatbook.Chat.trajectory_export import (
+    TrajectoryExportError,
+    build_trajectory_export,
+    write_trajectory_export,
+)
+from tldw_chatbook.Chat.trajectory_import import (
+    TrajectoryImportError,
+    load_trajectory_snapshot,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.Chat.test_trajectory_export import LONG_TOOL_RESULT, _seed_conversation
+
+
+@dataclass(frozen=True)
+class VariantSetLike:
+    """Duck-typed ``ConsoleVariantSet`` stand-in (same mirror as export tests)."""
+
+    turn_id: str
+    variants: tuple[str, ...]
+    selected_index: int = 0
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> CharactersRAGDB:
+    return CharactersRAGDB(tmp_path / "test.db", client_id="test")
+
+
+def _trace_file(tmp_path: Path, database: CharactersRAGDB, **export_kwargs) -> Path:
+    """Build + write a real export file for one seeded conversation."""
+    conv = _seed_conversation(database)
+    payload = build_trajectory_export(database, conv, **export_kwargs)
+    return write_trajectory_export(tmp_path / "shared-trace.json", payload)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: file -> snapshot through the real mapping
+# ---------------------------------------------------------------------------
+
+
+def test_import_file_renders_records_compaction_and_variants(db, tmp_path) -> None:
+    trace = _trace_file(
+        tmp_path,
+        db,
+        variant_sets=(VariantSetLike("t2", ("first draft", "winning draft"), 1),),
+    )
+
+    snapshot = load_trajectory_snapshot(trace)
+
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+    assert kinds == [
+        "user",
+        "assistant",
+        "tool_call",
+        "tool_result",
+        "user",
+        "assistant",
+        "compaction",
+    ]
+    # Usage travels through usage_json -> ProviderUsage.
+    assistant_records = [
+        record
+        for turn in snapshot.turns
+        for record in turn.records
+        if record.kind == "assistant"
+    ]
+    assert assistant_records[-1].usage is not None
+    assert assistant_records[-1].usage.output == 4
+    # Variant sets travel: superseded content attaches to turn t2's assistant.
+    assert "first draft" in assistant_records[-1].variants
+    # ISO-string timestamps in the file parse into timing fields.
+    assert assistant_records[-1].step_started_at is None  # a2 row has no timing
+    first_user = snapshot.turns[0].records[0]
+    assert first_user.step_started_at == 1_755_165_600.0
+
+
+def test_redacted_payloads_render_with_redaction_marker(db, tmp_path) -> None:
+    trace = _trace_file(tmp_path, db)  # default export = redacted
+
+    snapshot = load_trajectory_snapshot(trace)
+
+    tool_call = next(
+        record
+        for turn in snapshot.turns
+        for record in turn.records
+        if record.kind == "tool_call"
+    )
+    assert tool_call.payload is not None
+    assert tool_call.payload.get("redacted") is True
+    assert tool_call.payload.get("result_preview")
+    # The full un-redacted payload never entered the snapshot.
+    assert LONG_TOOL_RESULT not in json.dumps(tool_call.payload)
+
+
+def test_import_accepts_path_str_and_parsed_dict(db, tmp_path) -> None:
+    trace = _trace_file(tmp_path, db)
+    from_path = load_trajectory_snapshot(trace)
+    from_str = load_trajectory_snapshot(str(trace))
+    document = json.loads(trace.read_text(encoding="utf-8"))
+    from_dict = load_trajectory_snapshot(document)
+
+    assert from_path.turns == from_str.turns == from_dict.turns
+    assert from_path.turns  # snapshots are non-empty
+
+
+def test_import_legacy_conversation_without_sidecar(db, tmp_path) -> None:
+    conv = _seed_conversation(db, with_sidecar=False)
+    payload = build_trajectory_export(db, conv)
+    trace = write_trajectory_export(tmp_path / "legacy.json", payload)
+
+    snapshot = load_trajectory_snapshot(trace)
+
+    kinds = [record.kind for turn in snapshot.turns for record in turn.records]
+    assert kinds == ["user", "assistant", "user", "assistant", "compaction"]
+
+
+# ---------------------------------------------------------------------------
+# Malformed input -> actionable TrajectoryImportError
+# ---------------------------------------------------------------------------
+
+
+def test_not_json_file_is_rejected_with_actionable_message(tmp_path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json at all", encoding="utf-8")
+    with pytest.raises(TrajectoryImportError, match="bad.json.*not valid JSON"):
+        load_trajectory_snapshot(bad)
+
+
+def test_missing_file_is_rejected_with_named_path(tmp_path) -> None:
+    with pytest.raises(TrajectoryImportError, match="Cannot read.*nope.json"):
+        load_trajectory_snapshot(tmp_path / "nope.json")
+
+
+def test_wrong_format_marker_is_rejected_via_shared_validator(db) -> None:
+    payload = build_trajectory_export(db, _seed_conversation(db))
+    payload["format"] = "something-else"
+    with pytest.raises(TrajectoryImportError, match="'format'"):
+        load_trajectory_snapshot(payload)
+    # The shared-validator lineage is preserved (ADR-067 seam).
+    with pytest.raises(TrajectoryExportError):
+        load_trajectory_snapshot(payload)
+
+
+def test_unsupported_version_is_rejected(db) -> None:
+    payload = build_trajectory_export(db, _seed_conversation(db))
+    payload["version"] = 2
+    with pytest.raises(TrajectoryImportError, match="version 2"):
+        load_trajectory_snapshot(payload)
+
+
+def test_missing_section_is_rejected(db) -> None:
+    payload = build_trajectory_export(db, _seed_conversation(db))
+    del payload["messages"]
+    with pytest.raises(TrajectoryImportError, match="'messages'"):
+        load_trajectory_snapshot(payload)
+
+
+def test_json_array_top_level_is_rejected(tmp_path) -> None:
+    bad = tmp_path / "array.json"
+    bad.write_text("[]", encoding="utf-8")
+    with pytest.raises(TrajectoryImportError, match="JSON object"):
+        load_trajectory_snapshot(bad)
+
+
+# ---------------------------------------------------------------------------
+# Read-only proof: no DB references in the pure module (structural)
+# ---------------------------------------------------------------------------
+
+
+def test_pure_module_never_imports_or_names_the_db() -> None:
+    """Structural no-DB-write proof: the import module cannot touch the DB.
+
+    It holds no DB imports and never names the DB module, so it cannot
+    open, read, or write the application database. (The behavioral
+    counterpart -- DB row counts unchanged across a UI import -- lives in
+    ``Tests/UI/test_trajectory_import_ui.py``.)
+    """
+    source = Path(trajectory_import.__file__).read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module or ""]
+        else:
+            continue
+        for name in names:
+            assert not name.startswith("tldw_chatbook.DB"), (
+                f"trajectory_import must not import the DB layer (found {name!r})"
+            )
+    assert "ChaChaNotes_DB" not in source
+    assert "import sqlite3" not in source

--- a/Tests/UI/test_trajectory_import_ui.py
+++ b/Tests/UI/test_trajectory_import_ui.py
@@ -1,0 +1,226 @@
+"""UI tests for `o` open-trace import on TrajectoryScreen (task-16320).
+
+The file picker is stubbed at its seam (``_pick_trace_file`` -- the
+fspicker modal is not pilot-friendly); everything downstream of the pick
+(validation through the shared seam, snapshot mapping, read-only screen
+push, error notifications) runs for real. Includes the behavioral
+no-DB-write proof: an import performed through the screen leaves every
+app-DB row count unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Static
+
+from tldw_chatbook.Chat.trajectory_export import (
+    build_trajectory_export,
+    write_trajectory_export,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.trajectory_screen import TrajectoryScreen
+from Tests.Chat.test_trajectory_export import _seed_conversation
+from Tests.UI.test_trajectory_screen import base_snapshot
+
+
+class _Harness(App[None]):
+    """Minimal host so the screen can be pushed like the Console would."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+def _stub_picker(path: Path):
+    """Replacement for ``_pick_trace_file`` returning ``path`` immediately."""
+
+    async def pick() -> Path:
+        return path
+
+    return pick
+
+
+def _stub_dismissed():
+    async def pick() -> None:
+        return None
+
+    return pick
+
+
+def _last_notification(app: App):
+    """Newest notification posted to ``app`` (or ``None``)."""
+    posted = list(app._notifications._notifications.values())
+    return posted[-1] if posted else None
+
+
+def _build_trace(tmp_path: Path, name: str = "shared-trace") -> Path:
+    """Build a real export file from a real temp DB (export-test fixtures)."""
+    db = CharactersRAGDB(tmp_path / f"{name}-src.db", client_id="test")
+    conv = _seed_conversation(db)
+    payload = build_trajectory_export(db, conv)
+    return write_trajectory_export(tmp_path / f"{name}.json", payload)
+
+
+# ---------------------------------------------------------------------------
+# `o` opens the trace as a read-only screen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_o_mounts_imported_readonly_screen_with_records(tmp_path) -> None:
+    trace = _build_trace(tmp_path)
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_picker(trace)
+
+        await pilot.press("o")
+        await pilot.pause()
+
+        imported = app.screen
+        assert isinstance(imported, TrajectoryScreen)
+        assert imported is not screen  # a NEW screen, not a mutation
+        title = str(imported.query_one("#trajectory-title", Static).render())
+        assert "Imported trace — shared-trace (read-only)" in title
+        # The seeded conversation renders: 7 records + 2 turn-header rows.
+        table = imported.query_one("#trajectory-table", DataTable)
+        assert table.row_count == 9
+        assert table.get_row_index("7") is not None  # compaction record
+
+
+@pytest.mark.asyncio
+async def test_imported_screen_has_no_live_polling(tmp_path) -> None:
+    """No conversation_id / providers -> no revision interval, no follow hint."""
+    trace = _build_trace(tmp_path)
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_picker(trace)
+        await pilot.press("o")
+        await pilot.pause()
+
+        imported = app.screen
+        assert imported._revision_provider is None
+        assert imported._snapshot_builder is None
+        # on_mount only arms the 0.5s revision interval when BOTH live-mode
+        # callables exist; without them no extra timer is armed (the screen
+        # baseline itself carries whatever framework timers it has).
+        assert len(imported._timers) == len(screen._timers)
+        hints = str(imported.query_one("#trajectory-hints", Static).render())
+        assert "follow" not in hints  # live-only action never advertised
+        assert "open" in hints  # 1:1 governance: o is advertised
+
+
+@pytest.mark.asyncio
+async def test_dismissed_picker_is_a_noop(tmp_path) -> None:
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_dismissed()
+        await pilot.press("o")
+        await pilot.pause()
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
+async def test_malformed_trace_notifies_and_keeps_screen(tmp_path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_picker(bad)
+
+        await pilot.press("o")
+        await pilot.pause()
+
+        assert app.screen is screen  # nothing was mounted
+        notification = _last_notification(app)
+        assert notification is not None, "import failure must surface a notification"
+        assert notification.severity == "error"
+        assert "not valid JSON" in notification.message
+        assert "bad.json" in notification.message
+
+
+@pytest.mark.asyncio
+async def test_version_mismatch_notifies_with_validator_message(tmp_path) -> None:
+    trace = _build_trace(tmp_path, name="future-trace")
+    import json as _json
+
+    payload = _json.loads(trace.read_text(encoding="utf-8"))
+    payload["version"] = 2
+    trace.write_text(_json.dumps(payload), encoding="utf-8")
+
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_picker(trace)
+        await pilot.press("o")
+        await pilot.pause()
+
+        assert app.screen is screen
+        notification = _last_notification(app)
+        assert notification is not None, "version mismatch must surface a notification"
+        assert "version 2" in notification.message
+
+
+# ---------------------------------------------------------------------------
+# Behavioral no-DB-write proof (UI-level import against an attached temp DB)
+# ---------------------------------------------------------------------------
+
+
+def _row_counts(database: CharactersRAGDB) -> dict[str, int]:
+    counts = {}
+    for table in (
+        "conversations",
+        "messages",
+        "message_trajectory_metadata",
+        "console_auxiliary_attempts",
+    ):
+        counts[table] = database.execute_query(
+            f"SELECT COUNT(*) FROM {table}"  # noqa: S608 - static table name
+        ).fetchone()[0]
+    return counts
+
+
+@pytest.mark.asyncio
+async def test_import_through_the_screen_never_writes_the_db(tmp_path) -> None:
+    """The honest no-write assertion: row counts unchanged across an import.
+
+    The app DB is a real temp ``CharactersRAGDB`` with seeded rows; the
+    imported trace is a file built from a DIFFERENT DB. A UI-level import
+    (press ``o`` -> load -> mount the read-only screen) must leave every
+    table byte-identical in count.
+    """
+    db = CharactersRAGDB(tmp_path / "local-app.db", client_id="local")
+    _seed_conversation(db)  # local app data the import must not touch
+    trace = _build_trace(tmp_path)  # from its own separate source DB
+    before = _row_counts(db)
+    assert before["messages"] > 0
+    assert before["message_trajectory_metadata"] > 0
+
+    app = _Harness()
+    async with app.run_test() as pilot:
+        screen = TrajectoryScreen(base_snapshot())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._pick_trace_file = _stub_picker(trace)
+        await pilot.press("o")
+        await pilot.pause()
+        # The imported view really rendered someone else's trace.
+        title = str(app.screen.query_one("#trajectory-title", Static).render())
+        assert "read-only" in title
+
+    assert _row_counts(db) == before

--- a/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
+++ b/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-16320
 title: 'Trajectory import: open shared traces read-only'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-15 13:53'
+updated_date: '2026-08-15 17:39'
 labels:
   - trajectory
   - import
@@ -22,3 +23,9 @@ Import a trajectory export file (task-16319 format) and render it in the existin
 <!-- AC:BEGIN -->
 - [ ] #1 Imported file renders in the TrajectoryScreen (ledger, inspector, timeline) without any DB writes,Malformed files fail with actionable error messages,Version mismatches are detected and reported,Import action accessible from the Console trajectory surface,Tests cover happy path, malformed input, and version mismatch
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Chat/trajectory_import.py: load file -> validate_trajectory_export (ADR-067 seam) -> map export sections to derive_trajectory inputs -> TrajectorySnapshot; no DB writes anywhere. 2. UI: import action on the trajectory surface (single-letter ADR-031 binding + file open), renders read-only snapshot; errors surfaced as notifications. 3. Tests: mapping unit tests, malformed/version rejection, no-write assertion (DB row counts unchanged), UI pilot test.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
+++ b/backlog/tasks/task-16320 - Trajectory-import-open-shared-traces-read-only.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-16320
 title: 'Trajectory import: open shared traces read-only'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-15 13:53'
-updated_date: '2026-08-15 17:39'
+updated_date: '2026-08-15 17:48'
 labels:
   - trajectory
   - import
@@ -21,7 +21,7 @@ Import a trajectory export file (task-16319 format) and render it in the existin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Imported file renders in the TrajectoryScreen (ledger, inspector, timeline) without any DB writes,Malformed files fail with actionable error messages,Version mismatches are detected and reported,Import action accessible from the Console trajectory surface,Tests cover happy path, malformed input, and version mismatch
+- [x] #1 Imported file renders in the TrajectoryScreen (ledger, inspector, timeline) without any DB writes,Malformed files fail with actionable error messages,Version mismatches are detected and reported,Import action accessible from the Console trajectory surface,Tests cover happy path, malformed input, and version mismatch
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -29,3 +29,9 @@ Import a trajectory export file (task-16319 format) and render it in the existin
 <!-- SECTION:PLAN:BEGIN -->
 1. Chat/trajectory_import.py: load file -> validate_trajectory_export (ADR-067 seam) -> map export sections to derive_trajectory inputs -> TrajectorySnapshot; no DB writes anywhere. 2. UI: import action on the trajectory surface (single-letter ADR-031 binding + file open), renders read-only snapshot; errors surfaced as notifications. 3. Tests: mapping unit tests, malformed/version rejection, no-write assertion (DB row counts unchanged), UI pilot test.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Import seam: Chat/trajectory_import.py (pure, no DB imports) reuses validate_trajectory_export, maps sections to derive_trajectory inputs. UI: 'o' binding on TrajectoryScreen opens file -> pushes read-only TrajectoryScreen (no conversation_id/revision providers -> no polling). Inspector shows redaction marker for redacted payloads. Tests: Tests/Chat/test_trajectory_import.py (mapping incl compaction/variants/usage/redaction, malformed+version rejection, structural no-DB proof) and Tests/UI/test_trajectory_import_ui.py (pilot 'o' import, no-live-polling, error notifications, behavioral no-write via unchanged DB row counts).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/trajectory_import.py
+++ b/tldw_chatbook/Chat/trajectory_import.py
@@ -1,0 +1,135 @@
+"""Trajectory import: open a shared trace file as a read-only snapshot.
+
+The consumer side of the ADR-067 export format (task-16320): read a
+``tldw-trajectory`` JSON document, validate it through the EXPORT
+validator (``Chat/trajectory_export.validate_trajectory_export`` -- the
+shared seam, so import and export can never drift apart), and map the
+file's sections onto ``Chat/trajectory.derive_trajectory`` inputs to
+produce the same ``TrajectorySnapshot`` the live view renders.
+
+Read-only contract (ADR-067 §5)
+    Imported traces are ephemeral view data. This module NEVER opens,
+    writes, or references the application database -- it holds no DB
+    imports at all -- and the snapshot it returns is consumed purely for
+    rendering. Nothing here persists imported data back into local
+    conversations/messages/sidecar tables.
+
+Purity contract
+    No Textual, no widget imports, no DB layer. Stdlib plus the
+    projection's own (equally pure) dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Chat.trajectory import TrajectorySnapshot, derive_trajectory
+from tldw_chatbook.Chat.trajectory_export import (
+    TrajectoryExportError,
+    validate_trajectory_export,
+)
+
+__all__ = [
+    "TrajectoryImportError",
+    "load_trajectory_snapshot",
+]
+
+
+class TrajectoryImportError(TrajectoryExportError):
+    """A trace file that could not be read, parsed, validated, or mapped.
+
+    Subclasses :class:`TrajectoryExportError` so the shared-validator
+    rejections (format marker, version, missing sections) surface as
+    import errors too; the message always names the problem file and the
+    offending field/section so the user can act on it.
+    """
+
+
+def _read_document(source: Path | str | Mapping) -> dict:
+    """Read ``source`` into a parsed JSON document.
+
+    ``str`` is treated as a file path (never inline JSON text) so error
+    messages can name the file. JSON decode failures surface as
+    ``TrajectoryImportError`` with the parser's line/column detail.
+    """
+    if isinstance(source, Mapping):
+        return dict(source)
+    path = Path(source)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TrajectoryImportError(
+            f"Cannot read trajectory trace file '{path}': {exc.strerror or exc}"
+        ) from exc
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TrajectoryImportError(
+            f"'{path}' is not a valid trajectory trace: not valid JSON "
+            f"(line {exc.lineno}, column {exc.colno}: {exc.msg})"
+        ) from exc
+    if not isinstance(document, dict):
+        raise TrajectoryImportError(
+            f"'{path}' is not a valid trajectory trace: top-level document "
+            f"must be a JSON object, got {type(document).__name__}"
+        )
+    return document
+
+
+def load_trajectory_snapshot(source: Path | str | Mapping) -> TrajectorySnapshot:
+    """Load a shared trajectory trace into a renderable snapshot.
+
+    Read (or accept) the export document, validate it through the shared
+    ADR-067 seam (``validate_trajectory_export``), and map the sections
+    onto ``derive_trajectory`` inputs: ``messages`` pass through with
+    per-message ``ProviderUsage`` parsed from ``usage_json``,
+    ``trajectory_rows`` / ``compaction_records`` / ``variants`` feed the
+    projection as-is (it accepts mappings), and ``active_leaf_message_id``
+    selects the active path. Timestamps are ISO strings in the file; the
+    projection's parser handles them.
+
+    Args:
+        source: A file path (``Path`` or ``str``) to a trace file, or an
+            already-parsed export document (mapping).
+
+    Returns:
+        The snapshot; render it with ``TrajectoryScreen`` exactly like a
+        live projection result.
+
+    Raises:
+        TrajectoryImportError: Unreadable file, invalid JSON, or any
+            contract violation named by the shared validator (wrong
+            format marker, unsupported version, missing sections, ...).
+    """
+    path = None if isinstance(source, Mapping) else Path(str(source))
+    document = _read_document(source)
+    try:
+        payload = validate_trajectory_export(document)
+    except TrajectoryExportError as exc:
+        if path is not None:
+            raise TrajectoryImportError(f"'{path}': {exc}") from exc
+        raise TrajectoryImportError(str(exc)) from exc
+
+    messages = payload["messages"]
+    usage_by_id = {
+        str(message["id"]): ProviderUsage.from_json(message.get("usage_json"))
+        for message in messages
+    }
+    try:
+        return derive_trajectory(
+            messages,
+            usage_by_id,
+            payload["trajectory_rows"],
+            payload.get("variants") or (),
+            payload["compaction_records"],
+            payload.get("active_leaf_message_id"),
+        )
+    except Exception as exc:  # noqa: BLE001 - mapping boundary; name the file
+        where = f"'{path}'" if path is not None else "trace document"
+        raise TrajectoryImportError(
+            f"{where} passed validation but could not be mapped to a "
+            f"trajectory snapshot ({type(exc).__name__}: {exc})"
+        ) from exc

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -57,6 +57,7 @@ import json
 import time
 from collections.abc import Callable
 from datetime import datetime
+from pathlib import Path
 
 from loguru import logger
 from rich.text import Text
@@ -71,6 +72,10 @@ from tldw_chatbook.Chat.trajectory import (
     TrajectoryRecord,
     TrajectorySnapshot,
     TrajectoryTurn,
+)
+from tldw_chatbook.Chat.trajectory_import import (
+    TrajectoryImportError,
+    load_trajectory_snapshot,
 )
 from tldw_chatbook.UI.Widgets.trajectory_timeline import TrajectoryTimeline
 
@@ -134,6 +139,7 @@ class TrajectoryScreen(ModalScreen[None]):
         Binding("e", "load_earlier", "Earlier"),
         Binding("/", "focus_search", "Search"),
         Binding("f", "resume_follow", "Follow"),
+        Binding("o", "open_trace", "Open trace"),
     ]
 
     #: Footer hints, 1:1 with the non-escape BINDINGS (ADR-031; tested).
@@ -145,6 +151,7 @@ class TrajectoryScreen(ModalScreen[None]):
         ("/", "search"),
         ("e", "earlier"),
         ("f", "follow"),
+        ("o", "open"),
     )
 
     DEFAULT_CSS = """
@@ -731,6 +738,10 @@ class TrajectoryScreen(ModalScreen[None]):
                 lines.append(f"result {result}")  # full, untruncated
             if payload.get("truncated"):
                 lines.append("truncated yes (stored payload hit the 256 KiB cap)")
+            if payload.get("redacted"):
+                lines.append(
+                    "result redacted (shared trace keeps payload previews only)"
+                )
         if rec.variants:
             # Variant-set contents attach at TURN level to every assistant
             # record of that turn -- the label says so explicitly.
@@ -931,6 +942,53 @@ class TrajectoryScreen(ModalScreen[None]):
     def action_focus_search(self) -> None:
         """`/`: focus the search box."""
         self.query_one("#trajectory-search", Input).focus()
+
+    # -- import (task-16320: open shared traces read-only) ----------------------
+
+    async def action_open_trace(self) -> None:
+        """`o`: open a shared trajectory trace file as a read-only view.
+
+        The picked file is loaded through the pure import seam (never the
+        app DB) and pushed as a NEW ``TrajectoryScreen`` with no
+        ``conversation_id`` / live providers -- the imported view is itself
+        the trajectory surface, fully read-only (no revision polling).
+        Import failures surface as an error notification carrying the
+        actionable message from the shared validator.
+        """
+        path = await self._pick_trace_file()
+        if path is None:
+            return  # picker dismissed: no-op, stay on the current screen
+        try:
+            snapshot = load_trajectory_snapshot(path)
+        except TrajectoryImportError as exc:
+            self.app.notify(str(exc), title="Import failed", severity="error")
+            return
+        self.app.push_screen(
+            TrajectoryScreen(
+                snapshot,
+                screen_title=f"Imported trace — {path.stem} (read-only)",
+            )
+        )
+
+    async def _pick_trace_file(self) -> Path | None:
+        """Open the repo's file picker; ``None`` when dismissed.
+
+        Separate seam so tests can stub the picker (the fspicker modal is
+        not pilot-friendly) while the binding/load/push path stays real.
+        """
+        from tldw_chatbook.Third_Party.textual_fspicker import Filters
+        from tldw_chatbook.Widgets.enhanced_file_picker import EnhancedFileOpen
+
+        picker = EnhancedFileOpen(
+            title="Open trajectory trace",
+            filters=Filters(
+                ("Trajectory traces", lambda p: p.name.lower().endswith(".json")),
+                ("All Files", lambda p: True),
+            ),
+            context="trajectory_import",
+        )
+        selected = await self.app.push_screen_wait(picker)
+        return None if selected is None else Path(str(selected))
 
     def action_inspect_cursor_row(self) -> None:
         """`enter`: open the inspector on the cursor row.


### PR DESCRIPTION
Implements task-16320 per ADR-067 (import = consumer of the export format):

- `Chat/trajectory_import.py` (pure, no Textual): `load_trajectory_snapshot(file|dict) -> TrajectorySnapshot` via the shared `validate_trajectory_export` seam — export/import cannot drift. Actionable errors for bad JSON / wrong marker / version mismatch / missing sections.
- **Read-only by construction**: the module never touches the DB (structural AST test) and a UI-level import against an attached DB leaves all four tables' row counts identical (behavioral test). The imported screen mounts with no revision provider → no polling, no write path.
- UI: `o` on the trajectory screen opens a trace file → pushes an "Imported trace (read-only)" TrajectoryScreen; inspector shows a redaction marker for redacted payloads. ADR-031 hints stay 1:1 (governance tests green).
- Mapping mirrors the live snapshot builder 1:1, so shared traces render identically to the original conversation's view.

Evidence: 52 tests across import/import-UI/export/screen suites; task review Approved (no Critical/Important findings).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only trajectory trace import to the Console so shared `tldw-trajectory` exports open in the existing TrajectoryScreen without touching the DB. Previously you could not open a shared trace; now pressing o loads a file into a new read-only screen, with validation and actionable errors.

**Review notes**
- New pure module `tldw_chatbook/Chat/trajectory_import.py`: `load_trajectory_snapshot` consumes exports via the shared `validate_trajectory_export` seam (ADR-067) to prevent drift; maps messages, usage, variants, and compaction to match live rendering; raises actionable `TrajectoryImportError` for bad JSON, wrong format marker, version mismatch, or missing sections.
- UI: `TrajectoryScreen` adds `o` (“Open trace”) and a stub-able picker; successful imports push a new screen titled “Imported trace — <file> (read-only)” with no `conversation_id` or live providers (no polling, no write path); errors notify with validator messages; inspector shows a redaction marker for redacted payloads.
- Read-only guarantees: structural test enforces no DB imports in the import module; UI-level test asserts all app-DB table row counts remain unchanged across an import.
- Tests: cover happy path (compaction, variants, usage, redaction), malformed input and version mismatch, dismissed picker, no-live-polling behavior, and DB no-write proof. Satisfies task-16320 acceptance criteria.

<sup>Written for commit 0e9efeb5f8f5ea8c6fe232fd482f338ba6168ff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

