### PR TITLE
feat(console): ephemeral side chat — More Details / Ask in Side Chat (phase 2)

### DIFF
--- a/Docs/superpowers/plans/2026-08-15-console-side-chat-phase2.md
+++ b/Docs/superpowers/plans/2026-08-15-console-side-chat-phase2.md
@@ -1,0 +1,185 @@
+# Console Side Chat — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ephemeral side-chat modal answering questions about selected transcript text — `More Details` (auto-send template) and `Ask in Side Chat` (freeform) from the selection menu — using a user-configurable model + prompt template, streaming, nothing persisted.
+
+**Architecture:** A headless service (`Chat/console_side_chat.py`) resolves the side-chat model (falling back to the session model) and streams via `ConsoleProviderGateway.stream_chat` — the same persistence-free seam the prompt-improvement flow uses (proven precedent: it bypasses Console history and persistence entirely). `ConsoleSideChatModal` (ModalScreen + `SafeModalDismissMixin`) owns the ephemeral message list, runs a non-exclusive worker in group `console-side-chat`, and never touches the chat store. Menu/transcript handlers reuse the exact Phase-1 quote plumbing (`cap_quote` → message → screen handler → push modal).
+
+**Tech Stack:** Textual 8.2.8 ModalScreen + workers; existing `ConsoleProviderGateway`; pytest with fake gateway via `console_provider_gateway_factory`.
+
+**Spec:** `Docs/superpowers/specs/2026-08-14-console-selection-annotations-design.md` §2 (Menu Actions, Settings, Side-chat execution isolation), §4 (error handling), §5 (testing), §7 phase 2.
+
+```text
+ADR required: no
+ADR path: N/A (implements existing ADR-066 + spec §2; no schema, no new cross-module interface beyond the side-chat service seam, which follows the prompt-improvement precedent)
+Reason: direct implementation of the approved design; ADR-066 already records the system decision.
+```
+
+## Global Constraints
+
+- Side chat is ephemeral: NO chat-store session, NO persistence, NO transcript interaction — modal-local message list only; `gateway.stream_chat`/`complete_auxiliary` are the only provider seams (their docstrings guarantee persistence-free).
+- Worker: `run_worker(..., exclusive=False, group="console-side-chat")` — must never cancel or block `console-run-{session_id}` workers (spec §2 isolation).
+- Model resolution: `[console] sidechat_model` when set; else fall back to the current session's `turn_context.provider_selection`. Template default: `"Give me more details about: {selection}"`; `{selection}` is the only placeholder.
+- Selection quote capped by `cap_quote` (4000) before entering the modal; modal reply buffer keeps the tail, capped at `SIDE_CHAT_BUFFER_CAP = 100_000` chars.
+- Failures surface inline in the modal with Retry; modal always escapable (task-16211 contract via `SafeModalDismissMixin`); cancellation shows "Cancelling…" then resolves.
+- The new modal MUST be added to the dismissal inventory in `Tests/UI/test_console_modal_dismissal.py` (AST-based completeness test at ~line 1005 enforces it).
+- No API keys logged; provider errors go through `safe_provider_error_copy` semantics (the gateway already does this).
+- Baselines on this branch: `test_console_native_transcript.py` 3 pre-existing failures, `test_console_native_chat_flow.py` 1, markdown-widget 4 — no new failures allowed.
+
+---
+
+### Task 1: Config keys
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (template block ~2685-2701, loader coercion block ~1278-1327)
+- Test: `Tests/test_config_console_defaults.py` (extend)
+
+**Interfaces:**
+- Produces: config keys `[console] sidechat_model` (str, default `""` = session model fallback) and `[console] sidechat_prompt_template` (str, default `"Give me more details about: {selection}"`), readable via `get_cli_setting("console", "sidechat_model", "")` etc.
+
+- [ ] **Step 1: Write failing tests** — default values present in `CONFIG_TOML_CONTENT` template, coercion round-trips through the loader (string keys survive as strings; missing keys fall back to defaults). Mirror the existing `stack_collapsed_rail_labels` tests at the top of the file (~lines 79-136) but for string coercion.
+
+```python
+def test_console_sidechat_model_default_is_empty_string():
+    from tldw_chatbook.config import get_cli_setting
+    assert get_cli_setting("console", "sidechat_model", "") == ""
+
+def test_console_sidechat_prompt_template_default():
+    from tldw_chatbook.config import get_cli_setting
+    assert (
+        get_cli_setting("console", "sidechat_prompt_template", "")
+        == "Give me more details about: {selection}"
+    )
+
+def test_console_sidechat_keys_survive_loader_coercion(tmp_path, monkeypatch):
+    # point the config dir at tmp_path, write a config.toml with custom values,
+    # load, assert both come back as the custom strings (follow the existing
+    # loader tests' tmp_path/monkeypatch pattern in this file)
+    ...
+```
+
+- [ ] **Step 2: Run to verify fail** — `.venv/bin/pytest Tests/test_config_console_defaults.py -k sidechat -v` → FAIL (keys absent).
+- [ ] **Step 3: Implement** — add both keys to the `[console]` template block with a comment (`# Ephemeral side chat (selection menu) — empty model = session model`), and string coercion entries in the loader block (follow neighboring `coerce_*` lines; strings need presence-validation only).
+- [ ] **Step 4: Verify pass** + full file green.
+- [ ] **Step 5: Commit** — `feat(console): sidechat_model and sidechat_prompt_template config keys`
+
+### Task 2: Settings surface
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py` (Console Behavior category)
+- Test: `Tests/UI/test_settings_console_side_chat.py` (new, modeled on `Tests/UI/test_settings_console_rail_labels.py`)
+
+**Interfaces:**
+- Consumes: Task 1 keys.
+- Produces: both settings visible/editable/savable in the canonical settings screen under Console Behavior.
+
+- [ ] **Step 1: Write failing tests** (mirror `test_settings_console_rail_labels.py` structure): model + template render with loaded values; staging a change doesn't mutate runtime config until save; exact save payload via monkeypatched `SettingsConfigAdapter` (assert `console.sidechat_model` / `console.sidechat_prompt_template` in sections); failed save keeps draft; revert restores.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** — follow the `stack_collapsed_rail_labels` trail exactly: add both keys to `CONSOLE_BEHAVIOR_CONSOLE_KEYS` (~626) and `CONSOLE_BEHAVIOR_SAVE_ORDER` (~695); ownership records (~3663); compose widgets — `Input` for the model (placeholder "empty = current session model") and `Input` (or TextArea if multi-line is idiomatic) for the template with help Static mentioning `{selection}` (~12354); loaded-value getter + map (~3825/~3983); staging via `_stage_console_default_value` (~6120); change handler (~17995); focused-field inspector copy (~6277); save rides `_save_console_behavior_values` (~20996).
+- [ ] **Step 4: Verify pass** + `test_settings_console_rail_labels.py` still green (no category regressions).
+- [ ] **Step 5: Commit** — `feat(console): side chat settings in Console Behavior category`
+
+### Task 3: Side-chat service (headless)
+
+**Files:**
+- Create: `tldw_chatbook/Chat/console_side_chat.py`
+- Test: `Tests/Chat/test_console_side_chat_service.py`
+
+**Interfaces:**
+- Consumes: `ConsoleProviderGateway` (`resolve_for_send(selection) -> resolution`, `stream_chat(resolution, messages) -> async iterator of chunks`), `ConsoleProviderSelection` (`provider`, `explicit_model`, `streaming`), `cap_quote`.
+- Produces:
+
+```python
+DEFAULT_SIDE_CHAT_PROMPT_TEMPLATE = "Give me more details about: {selection}"
+SIDE_CHAT_BUFFER_CAP = 100_000
+
+@dataclass(frozen=True)
+class SideChatOutcome:
+    text: str            # joined reply, tail-capped at SIDE_CHAT_BUFFER_CAP
+    provider: str
+    model: str
+    status: str          # "complete" | "cancelled" | "provider_error"
+    error: str = ""      # safe copy only, when status == "provider_error"
+
+class ConsoleSideChatService:
+    def __init__(self, gateway) -> None: ...          # gateway: ConsoleProviderGatewayProtocol-shaped
+    def render_prompt(self, template: str, selection: str) -> str:
+        # template.format-safe: only {selection} substituted; missing placeholder appends
+        # the selection on a new line; other placeholders left literal (use replace, not str.format)
+    async def run(
+        self,
+        *,
+        selection_quote: str,          # already cap_quote()d by the caller
+        prompt: str,                   # fully-rendered user prompt
+        provider_selection: ConsoleProviderSelection | None,  # session fallback when config model empty
+        sidechat_model: str = "",      # raw config value
+    ) -> AsyncIterator[SideChatEvent]: # "chunk" (delta str) / "done" (SideChatOutcome) events
+```
+
+(The exact event shape may be `async for delta, done_outcome` or a small event dataclass — implementer's choice, but cancellation must surface as `status="cancelled"`, provider errors as `status="provider_error"` with safe copy, never raise through the modal boundary except `asyncio.CancelledError` semantics.)
+
+- [ ] **Step 1: Write failing tests** with a FakeGateway (constructor-injected): chunked stream joins to full text; provider error → provider_error outcome with safe copy and no raise; cancellation (cancel the consuming task mid-stream) → cancelled outcome; `render_prompt`: `{selection}` substituted, missing placeholder appends selection, literal other braces untouched, empty template → default template; buffer tail-cap truncates a huge reply; model resolution: `sidechat_model="x"` wins over session selection; empty → session selection used; explicit streaming selection built with `explicit_model` set.
+- [ ] **Step 2: Verify fail** — module not found.
+- [ ] **Step 3: Implement** — mirror `prompt_improvement_service.py`'s shape (validation → single provider call → typed outcome; no store imports). Model resolution mirrors `prompts.py:482-489` identity pattern: build `ConsoleProviderSelection(provider=..., explicit_model=sidechat_model or None, streaming=True)`.
+- [ ] **Step 4: Verify pass.**
+- [ ] **Step 5: Commit** — `feat(console): headless side-chat service over provider gateway`
+
+### Task 4: ConsoleSideChatModal
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Console/console_side_chat_modal.py`
+- Modify: `Tests/UI/test_console_modal_dismissal.py` (inventory + contract rows)
+- Test: `Tests/UI/test_console_side_chat_modal.py` (new)
+
+**Interfaces:**
+- Consumes: `ConsoleSideChatService.run` (Task 3), `SafeModalDismissMixin` (`Widgets/modal_dismissal.py`), prompt-improvement choreography (`console_prompts_modal.py:1050-1157, 1695-1703`).
+- Produces:
+
+```python
+class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
+    def __init__(self, *, service, provider_selection, sidechat_model: str,
+                 quote: str, auto_send_prompt: str | None) -> None: ...
+    # auto_send_prompt: rendered prompt for More Details (service started on mount)
+    # None → Ask in Side Chat mode: quote shown read-only, prompt TextArea empty, Send button
+    # API: push from ChatScreen; dismiss(result=None); Escape/backdrop ≡ Cancel per mixin
+```
+
+- [ ] **Step 1: Write failing tests**: More Details mode auto-sends on mount and streams chunks into the reply area (fake service/gateway); Ask mode waits for Send with typed prompt; Stop cancels (status "Cancelling…", then cancelled outcome shown, Retry visible); provider error shows inline + Retry works; Escape mid-stream cancels the worker and dismisses; reply buffer capped; quote displayed read-only; provider·model summary line shows resolved identity. All with a fake service injected — no live LLM.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** — skeleton from `ConsoleEditMessageModal` (`SAFE_MODAL_CONTENT = "#console-side-chat-modal"`, `escape → request_safe_cancel`); worker `run_worker(self._run(...), exclusive=False, group="console-side-chat")` with monotonic request-id stale guard; Cancel/Retry/Close buttons per prompts-modal pattern; `on_unmount` cancels worker; reply `Static` updated via `call_from_thread`-safe pattern used by prompts modal (worker is a thread worker? NO — `stream_chat` is async, use an async worker; follow `console_prompts_modal`'s async worker + `post_message`/direct-update pattern). Add inventory + contract rows to `test_console_modal_dismissal.py` (import + `_Task2ModalContract` entry; the AST test enforces completeness).
+- [ ] **Step 4: Verify pass** incl. the full dismissal suite.
+- [ ] **Step 5: Commit** — `feat(console): ephemeral side-chat modal with streaming, cancel, retry`
+
+### Task 5: Menu entries + transcript + screen wiring
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_selection_menu.py` (messages + buttons + handlers)
+- Modify: `tldw_chatbook/Widgets/Console/console_transcript.py` (two `@on` handlers mirroring `_selection_add_to_chat` ~3501-3525)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (handler beside `_console_selection_quote_requested` ~19788)
+- Test: extend `Tests/UI/test_console_selection_menu.py`, `Tests/UI/test_console_selection_end_to_end.py`
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: `ConsoleSelectionMenu.MoreDetails` / `.AskInSideChat` messages; `ConsoleSideChatRequested(quote: str, mode: str)` message from transcript ("more-details" | "ask"); ChatScreen handler resolves config + gateway (`_ensure_console_provider_gateway` ~5239), renders the template for more-details mode, and pushes `ConsoleSideChatModal`.
+
+- [ ] **Step 1: Write failing tests**: menu shows all three stacked options in order (Add to chat / More Details / Ask in Side Chat); pressing More Details clears selection+menu and the screen receives `ConsoleSideChatRequested(mode="more-details")` with capped quote (app-level capture harness); Ask mode likewise with `mode="ask"`; screen handler pushes exactly one modal with rendered template for more-details (fake service seam) and empty-prompt ask mode; end-to-end: drag → More Details → modal mounted with the quote visible.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** per interfaces; template rendering lives in the screen handler via the service's `render_prompt`; provider fallback from the active session's `turn_context.provider_selection`.
+- [ ] **Step 4: Verify pass** + all selection suites + baselines (3/1/4) unchanged.
+- [ ] **Step 5: Commit** — `feat(console): More Details and Ask in Side Chat from selection menu`
+
+### Task 6: Wrap-up
+
+**Files:**
+- Modify: backlog task (create via CLI: "Console side chat phase 2"), ADR-066 (one-line consequence noting phase 2 landed), `Docs/superpowers/specs/2026-08-14-console-selection-annotations-design.md` (unchanged — spec already covers).
+
+- [ ] **Step 1:** Full selection + side-chat + dismissal + settings suites green; `uvx ruff check` on branch-owned files; baselines 3/1/4 unchanged.
+- [ ] **Step 2:** Backlog task with honest ACs checked + Implementation Notes; ADR-066 consequence line; do NOT mark Done (live spike pending like phase 1).
+- [ ] **Step 3:** Commit — `feat(console): side chat wrap-up docs`.
+
+## Self-Review Notes
+
+- Spec §2 coverage: entries+modal (T4/T5), auto-vs-freeform (T5), settings (T1/T2), isolation (T3 gateway-only + non-exclusive worker group, enforced in T3/T4 tests), cap (T1 quote cap reuse + T3 buffer cap), error handling inline+retry (T3/T4), nothing persisted (T3/T4 tests assert no store interaction).
+- The modal-dismissal inventory constraint (would otherwise fail an AST test) is explicitly in T4.
+- Deviations allowed with documentation: exact modal layout, event-shape details, whether the settings widget is Input vs TextArea.

--- a/Tests/Chat/test_console_side_chat_service.py
+++ b/Tests/Chat/test_console_side_chat_service.py
@@ -1,0 +1,345 @@
+"""Tests for the headless console side-chat service.
+
+Covers: streaming delta join + final outcome, provider-error and cancellation
+outcomes, prompt rendering rules, reply buffer capping, model-resolution
+precedence (qualified / bare / empty / missing session selection), and the
+messages/streaming flags handed to the provider gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_side_chat import (
+    DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE,
+    SIDE_CHAT_BUFFER_CAP,
+    SIDE_CHAT_SYSTEM_PROMPT,
+    ConsoleSideChatService,
+    SideChatOutcome,
+    cap_reply_buffer,
+    render_prompt,
+)
+from tldw_chatbook.config import (
+    DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE as CONFIG_DEFAULT_TEMPLATE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeResolution:
+    """Stand-in for ConsoleProviderResolution; service reads provider/model."""
+
+    provider: str = "openai"
+    model: str = "gpt-test"
+
+
+class FakeGateway:
+    """Records selections/messages; replays chunks, errors, or blocking."""
+
+    def __init__(
+        self,
+        chunks: list[Any] | None = None,
+        error: Exception | None = None,
+        resolution: FakeResolution | None = None,
+        block_after_first_chunk: bool = False,
+    ) -> None:
+        self.chunks = chunks if chunks is not None else ["Hello", " world"]
+        self.error = error
+        self.resolution = resolution or FakeResolution()
+        self.block_after_first_chunk = block_after_first_chunk
+        self.first_chunk_sent = asyncio.Event()
+        self.selections: list[ConsoleProviderSelection] = []
+        self.messages: list[list[dict[str, str]]] = []
+
+    @property
+    def call_count(self) -> int:
+        return len(self.selections)
+
+    async def resolve_for_send(self, selection: ConsoleProviderSelection) -> FakeResolution:
+        self.selections.append(selection)
+        return self.resolution
+
+    async def stream_chat(self, resolution: FakeResolution, messages: list[dict[str, str]]):
+        self.messages.append(messages)
+        if self.error is not None:
+            raise self.error
+        for index, chunk in enumerate(self.chunks):
+            yield chunk
+            if self.block_after_first_chunk and index == 0:
+                self.first_chunk_sent.set()
+                await asyncio.Event().wait()  # never set: holds the stream open
+
+
+async def collect(service: ConsoleSideChatService, **kwargs: Any) -> list[Any]:
+    items: list[Any] = []
+    async for item in service.run(**kwargs):
+        items.append(item)
+    return items
+
+
+def default_run_kwargs(**overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "selection_quote": "the quoted transcript text",
+        "prompt": "Explain this",
+        "provider_selection": ConsoleProviderSelection(provider="openai"),
+        "sidechat_model": "",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Streaming semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_deltas_then_complete_outcome_with_identity() -> None:
+    gateway = FakeGateway(chunks=["Hel", "lo ", "world"], resolution=FakeResolution(provider="zai", model="glm-test"))
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    deltas = [item for item in items if isinstance(item, str)]
+    assert deltas == ["Hel", "lo ", "world"]
+    assert items[-1] == SideChatOutcome(
+        text="Hello world", provider="zai", model="glm-test", status="complete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_str_stream_items_are_ignored() -> None:
+    tool_calls = object()  # stand-in for ProviderToolCalls
+    gateway = FakeGateway(chunks=["Hel", tool_calls, "lo"])
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    deltas = [item for item in items if isinstance(item, str)]
+    assert deltas == ["Hel", "lo"]
+    assert items[-1].text == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_messages_shape_system_then_user_with_selection() -> None:
+    gateway = FakeGateway()
+    service = ConsoleSideChatService(gateway)
+
+    await collect(service, **default_run_kwargs(prompt="Summarize", selection_quote="QUOTE"))
+
+    assert gateway.messages == [
+        [
+            {"role": "system", "content": SIDE_CHAT_SYSTEM_PROMPT},
+            {"role": "user", "content": "Summarize\n\nSelected text:\nQUOTE"},
+        ]
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_error_yields_error_outcome_with_empty_text() -> None:
+    gateway = FakeGateway(error=ChatProviderError("safe copy"))
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    assert items == [
+        SideChatOutcome(
+            text="",
+            provider="openai",
+            model="gpt-test",
+            status="provider_error",
+            error="safe copy",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_yields_cancelled_outcome_then_reraises() -> None:
+    gateway = FakeGateway(
+        chunks=["partial "],
+        resolution=FakeResolution(provider="anthropic", model="claude-x"),
+        block_after_first_chunk=True,
+    )
+    service = ConsoleSideChatService(gateway)
+    collected: list[Any] = []
+
+    async def consume() -> None:
+        async for item in service.run(**default_run_kwargs()):
+            collected.append(item)
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert collected == [
+        "partial ",
+        SideChatOutcome(
+            text="partial ",
+            provider="anthropic",
+            model="claude-x",
+            status="cancelled",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_qualified_model_overrides_provider_and_model() -> None:
+    gateway = FakeGateway(resolution=FakeResolution(provider="mistral", model="mistral-large"))
+    service = ConsoleSideChatService(gateway)
+
+    await collect(
+        service,
+        **default_run_kwargs(
+            provider_selection=ConsoleProviderSelection(provider="openai", base_url="https://session"),
+            sidechat_model="mistral/mistral-large-latest",
+        ),
+    )
+
+    assert gateway.call_count == 1
+    recorded = gateway.selections[0]
+    assert recorded.provider == "mistral"
+    assert recorded.explicit_model == "mistral-large-latest"
+    assert recorded.streaming is True
+
+
+@pytest.mark.asyncio
+async def test_qualified_model_works_without_session_selection() -> None:
+    gateway = FakeGateway()
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs(provider_selection=None, sidechat_model="openai/gpt-5"))
+
+    assert gateway.call_count == 1
+    recorded = gateway.selections[0]
+    assert recorded.provider == "openai"
+    assert recorded.explicit_model == "gpt-5"
+    assert recorded.streaming is True
+    assert items[-1].status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_bare_model_keeps_session_provider_and_overrides_model() -> None:
+    gateway = FakeGateway()
+    service = ConsoleSideChatService(gateway)
+
+    await collect(
+        service,
+        **default_run_kwargs(
+            provider_selection=ConsoleProviderSelection(
+                provider="openai", base_url="https://session", explicit_model="gpt-3"
+            ),
+            sidechat_model="gpt-4o",
+        ),
+    )
+
+    recorded = gateway.selections[0]
+    assert recorded.provider == "openai"
+    assert recorded.base_url == "https://session"
+    assert recorded.explicit_model == "gpt-4o"
+    assert recorded.streaming is True
+
+
+@pytest.mark.asyncio
+async def test_empty_model_uses_session_selection_with_streaming_forced_on() -> None:
+    gateway = FakeGateway()
+    service = ConsoleSideChatService(gateway)
+
+    await collect(
+        service,
+        **default_run_kwargs(
+            provider_selection=ConsoleProviderSelection(
+                provider="anthropic", explicit_model="claude-3", streaming=False
+            ),
+            sidechat_model="",
+        ),
+    )
+
+    recorded = gateway.selections[0]
+    assert recorded.provider == "anthropic"
+    assert recorded.explicit_model == "claude-3"
+    assert recorded.streaming is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sidechat_model", ["", "gpt-4o", "   "])
+async def test_missing_session_selection_without_qualified_model_errors_before_gateway(
+    sidechat_model: str,
+) -> None:
+    gateway = FakeGateway()
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs(provider_selection=None, sidechat_model=sidechat_model))
+
+    assert gateway.call_count == 0
+    assert items == [
+        SideChatOutcome(
+            text="",
+            provider="",
+            model="",
+            status="provider_error",
+            error="No provider available for the side chat.",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# render_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_render_prompt_substitutes_selection() -> None:
+    assert render_prompt("Summarize: {selection}", "abc") == "Summarize: abc"
+
+
+def test_render_prompt_leaves_other_braces_literal() -> None:
+    assert render_prompt("Use {foo} and {selection} here", "x") == "Use {foo} and x here"
+
+
+def test_render_prompt_blank_template_falls_back_to_default() -> None:
+    assert render_prompt("   ", "sel") == CONFIG_DEFAULT_TEMPLATE.format(selection="sel")
+
+
+def test_render_prompt_missing_placeholder_appends_selection_on_new_line() -> None:
+    assert render_prompt("Explain this.", "sel") == "Explain this.\nsel"
+
+
+# ---------------------------------------------------------------------------
+# cap_reply_buffer
+# ---------------------------------------------------------------------------
+
+
+def test_cap_reply_buffer_keeps_short_text_untouched() -> None:
+    assert cap_reply_buffer("abc") == "abc"
+
+
+def test_cap_reply_buffer_keeps_tail_of_oversized_reply() -> None:
+    text = "a" * (SIDE_CHAT_BUFFER_CAP + 10)
+    capped = cap_reply_buffer(text)
+    assert capped == "…\n" + text[-SIDE_CHAT_BUFFER_CAP:]
+    assert len(capped) == SIDE_CHAT_BUFFER_CAP + 2
+
+
+# ---------------------------------------------------------------------------
+# Constants re-export sanity
+# ---------------------------------------------------------------------------
+
+
+def test_default_template_matches_config_constant() -> None:
+    assert DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE == CONFIG_DEFAULT_TEMPLATE

--- a/Tests/Chat/test_console_side_chat_service.py
+++ b/Tests/Chat/test_console_side_chat_service.py
@@ -41,6 +41,8 @@ class FakeResolution:
 
     provider: str = "openai"
     model: str = "gpt-test"
+    ready: bool = True
+    visible_copy: str = ""
 
 
 class FakeGateway:
@@ -60,6 +62,7 @@ class FakeGateway:
         self.first_chunk_sent = asyncio.Event()
         self.selections: list[ConsoleProviderSelection] = []
         self.messages: list[list[dict[str, str]]] = []
+        self.stream_calls = 0
 
     @property
     def call_count(self) -> int:
@@ -70,6 +73,7 @@ class FakeGateway:
         return self.resolution
 
     async def stream_chat(self, resolution: FakeResolution, messages: list[dict[str, str]]):
+        self.stream_calls += 1
         self.messages.append(messages)
         if self.error is not None:
             raise self.error
@@ -159,6 +163,50 @@ async def test_provider_error_yields_error_outcome_with_empty_text() -> None:
             model="gpt-test",
             status="provider_error",
             error="safe copy",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_blocked_resolution_yields_provider_error_without_stream_chat() -> None:
+    gateway = FakeGateway(
+        resolution=FakeResolution(provider="openai", model="", ready=False, visible_copy="API key missing for openai")
+    )
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    assert gateway.call_count == 1
+    assert gateway.stream_calls == 0
+    assert items == [
+        SideChatOutcome(
+            text="",
+            provider="openai",
+            model="",
+            status="provider_error",
+            error="API key missing for openai",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["", "   ", None])
+async def test_ready_resolution_with_blank_model_yields_provider_error_with_fallback_copy(
+    model: str | None,
+) -> None:
+    gateway = FakeGateway(resolution=FakeResolution(provider="mistral", model=model, ready=True, visible_copy=""))
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    assert gateway.stream_calls == 0
+    assert items == [
+        SideChatOutcome(
+            text="",
+            provider="mistral",
+            model="",
+            status="provider_error",
+            error="Choose a ready provider and model, then reopen the side chat.",
         )
     ]
 

--- a/Tests/Chat/test_console_side_chat_service.py
+++ b/Tests/Chat/test_console_side_chat_service.py
@@ -9,7 +9,7 @@ messages/streaming flags handed to the provider gateway.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -28,7 +28,6 @@ from tldw_chatbook.Chat.console_side_chat import (
 from tldw_chatbook.config import (
     DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE as CONFIG_DEFAULT_TEMPLATE,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fakes

--- a/Tests/Chat/test_console_side_chat_service.py
+++ b/Tests/Chat/test_console_side_chat_service.py
@@ -53,11 +53,15 @@ class FakeGateway:
         error: Exception | None = None,
         resolution: FakeResolution | None = None,
         block_after_first_chunk: bool = False,
+        error_after_chunks: bool = False,
     ) -> None:
         self.chunks = chunks if chunks is not None else ["Hello", " world"]
         self.error = error
         self.resolution = resolution or FakeResolution()
         self.block_after_first_chunk = block_after_first_chunk
+        # When False (default) the error fires before any chunk; when True
+        # all chunks stream first and the error lands mid-stream afterwards.
+        self.error_after_chunks = error_after_chunks
         self.first_chunk_sent = asyncio.Event()
         self.selections: list[ConsoleProviderSelection] = []
         self.messages: list[list[dict[str, str]]] = []
@@ -74,13 +78,15 @@ class FakeGateway:
     async def stream_chat(self, resolution: FakeResolution, messages: list[dict[str, str]]):
         self.stream_calls += 1
         self.messages.append(messages)
-        if self.error is not None:
+        if self.error is not None and not self.error_after_chunks:
             raise self.error
         for index, chunk in enumerate(self.chunks):
             yield chunk
             if self.block_after_first_chunk and index == 0:
                 self.first_chunk_sent.set()
                 await asyncio.Event().wait()  # never set: holds the stream open
+        if self.error is not None:
+            raise self.error
 
 
 async def collect(service: ConsoleSideChatService, **kwargs: Any) -> list[Any]:
@@ -163,6 +169,32 @@ async def test_provider_error_yields_error_outcome_with_empty_text() -> None:
             status="provider_error",
             error="safe copy",
         )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_error_mid_stream_preserves_partial_text() -> None:
+    """A provider error after deltas must not wipe the streamed partial reply."""
+    gateway = FakeGateway(
+        chunks=["Hel", "lo ", "wor"],
+        error=ChatProviderError("mid-stream boom"),
+        error_after_chunks=True,
+    )
+    service = ConsoleSideChatService(gateway)
+
+    items = await collect(service, **default_run_kwargs())
+
+    assert items == [
+        "Hel",
+        "lo ",
+        "wor",
+        SideChatOutcome(
+            text="Hello wor",
+            provider="openai",
+            model="gpt-test",
+            status="provider_error",
+            error="mid-stream boom",
+        ),
     ]
 
 

--- a/Tests/UI/test_console_modal_dismissal.py
+++ b/Tests/UI/test_console_modal_dismissal.py
@@ -103,6 +103,9 @@ from tldw_chatbook.Widgets.Console.console_settings_modal import (
     _settings_screen_region,
 )
 from tldw_chatbook.Widgets.Console.console_setup_modal import ConsoleSetupModal
+from tldw_chatbook.Widgets.Console.console_side_chat_modal import (
+    ConsoleSideChatModal,
+)
 from tldw_chatbook.Widgets.Console.console_scope_picker_modal import (
     ScopeListPage,
     TagCount,
@@ -269,6 +272,25 @@ async def _save_system_prompt(_name: str, _text: str) -> str:
     return "saved"
 
 
+class _IdleSideChatService:
+    """Contract-fixture side-chat service: an async generator that yields
+    nothing, so the dismissal factory never starts a stream."""
+
+    async def run(self, **_kwargs: object) -> Any:
+        return
+        yield  # pragma: no cover -- makes run() an async generator
+
+
+def _side_chat_factory() -> ConsoleSideChatModal:
+    return ConsoleSideChatModal(
+        service=_IdleSideChatService(),  # type: ignore[arg-type]
+        provider_selection=None,
+        sidechat_model="",
+        quote="selected transcript text",
+        auto_send_prompt=None,
+    )
+
+
 def _prompt_variables_factory() -> PromptVariablesDialog:
     return PromptVariablesDialog(
         PromptVariablesDialogRequest(
@@ -415,6 +437,16 @@ TASK2_MODAL_CONTRACTS = (
         None,
         "Console image style action",
         "_cancel_search_debounce",
+        "none",
+        _RESTORE_OPENER,
+    ),
+    _Task2ModalContract(
+        ConsoleSideChatModal,
+        _side_chat_factory,
+        "#console-side-chat-modal",
+        None,
+        "Console selection More Details / Ask in Side Chat actions",
+        "cancel side-chat worker",
         "none",
         _RESTORE_OPENER,
     ),
@@ -764,10 +796,16 @@ _CONSOLE_ROOT_SOURCE_PATHS = (
         )
     ),
 )
+# The side-chat modal is contracted and inventoried but has no launch site
+# yet: the Console selection-menu wiring lands with phase 2 task 5, so it is
+# excluded from the declared root launches (the AST walk would otherwise
+# report it missing).
+_SIDE_CHAT_MODAL_NOT_YET_LAUNCHED = {ConsoleSideChatModal}
 _CONSOLE_DIRECT_MODAL_TYPES = tuple(
     contract.modal_type
     for contract in (*TASK2_MODAL_CONTRACTS, *TASK3_MODAL_CONTRACTS)
     if contract.modal_type is not ConsoleWorkspaceRenameModal
+    and contract.modal_type is not ConsoleSideChatModal
 ) + tuple(contract.modal_type for contract in TASK567_MODAL_CONTRACTS)
 _DIRECT_SHARED_MODAL_TYPES = tuple(
     contract.modal_type
@@ -1013,7 +1051,7 @@ def test_console_modal_inventory_matches_runtime_ast_and_transitive_launches() -
     }
     discovered_console_types = _discover_console_modal_types()
 
-    assert len(discovered_console_types) == 28
+    assert len(discovered_console_types) == 29
     assert discovered_console_types == console_contract_types
 
     reachable = _walk_modal_launch_graph(_CONSOLE_ROOT, CONSOLE_MODAL_LAUNCH_EDGES)
@@ -1027,7 +1065,10 @@ def test_console_modal_inventory_matches_runtime_ast_and_transitive_launches() -
     all_contract_types = console_contract_types | {
         contract.modal_type for contract in TASK4_MODAL_CONTRACTS
     }
-    assert reachable_modal_types == all_contract_types
+    assert (
+        reachable_modal_types
+        == all_contract_types - _SIDE_CHAT_MODAL_NOT_YET_LAUNCHED
+    )
     assert {EnhancedFileOpen, EnhancedFileSave} <= reachable_modal_types
     assert CancelConfirmationDialog in reachable_modal_types
     assert ChangeRevertConfirmModal in reachable_modal_types
@@ -1143,7 +1184,7 @@ class _SyntheticDeclaredOwner:
 
 
 def test_task2_modal_contract_table_is_complete_and_adopted() -> None:
-    assert len(TASK2_MODAL_CONTRACTS) == 13
+    assert len(TASK2_MODAL_CONTRACTS) == 14
     assert {contract.modal_type.__name__ for contract in TASK2_MODAL_CONTRACTS} == {
         "AutoSpeakConsentModal",
         "ConsoleCharacterPickerModal",
@@ -1156,12 +1197,14 @@ def test_task2_modal_contract_table_is_complete_and_adopted() -> None:
         "ConsolePromptQueueModal",
         "ConsoleRunLogModal",
         "ConsoleScopePickerModal",
+        "ConsoleSideChatModal",
         "ConsoleSkillPickerModal",
         "ConsoleStylePickerModal",
     }
     expected_hooks = {
         "ConsoleCharacterPickerModal": "_cancel_query_debounce",
         "ConsoleCitationSourcesModal": "increment _request_generation",
+        "ConsoleSideChatModal": "cancel side-chat worker",
         "ConsoleStylePickerModal": "_cancel_search_debounce",
     }
     for contract in TASK2_MODAL_CONTRACTS:

--- a/Tests/UI/test_console_modal_dismissal.py
+++ b/Tests/UI/test_console_modal_dismissal.py
@@ -796,16 +796,14 @@ _CONSOLE_ROOT_SOURCE_PATHS = (
         )
     ),
 )
-# The side-chat modal is contracted and inventoried but has no launch site
-# yet: the Console selection-menu wiring lands with phase 2 task 5, so it is
-# excluded from the declared root launches (the AST walk would otherwise
-# report it missing).
-_SIDE_CHAT_MODAL_NOT_YET_LAUNCHED = {ConsoleSideChatModal}
+# The side-chat modal launches from the Console root (phase 2 task 5:
+# ChatScreen's ConsoleSideChatRequested handler pushes it after the
+# selection menu's More Details / Ask in Side Chat actions), so it rides
+# the declared root launches like every other root-owned modal.
 _CONSOLE_DIRECT_MODAL_TYPES = tuple(
     contract.modal_type
     for contract in (*TASK2_MODAL_CONTRACTS, *TASK3_MODAL_CONTRACTS)
     if contract.modal_type is not ConsoleWorkspaceRenameModal
-    and contract.modal_type is not ConsoleSideChatModal
 ) + tuple(contract.modal_type for contract in TASK567_MODAL_CONTRACTS)
 _DIRECT_SHARED_MODAL_TYPES = tuple(
     contract.modal_type
@@ -1061,14 +1059,11 @@ def test_console_modal_inventory_matches_runtime_ast_and_transitive_launches() -
         for node in reachable
         if inspect.isclass(node) and issubclass(node, ModalScreen)
     }
-    assert len(reachable_modal_types) == 37
+    assert len(reachable_modal_types) == 38
     all_contract_types = console_contract_types | {
         contract.modal_type for contract in TASK4_MODAL_CONTRACTS
     }
-    assert (
-        reachable_modal_types
-        == all_contract_types - _SIDE_CHAT_MODAL_NOT_YET_LAUNCHED
-    )
+    assert reachable_modal_types == all_contract_types
     assert {EnhancedFileOpen, EnhancedFileSave} <= reachable_modal_types
     assert CancelConfirmationDialog in reachable_modal_types
     assert ChangeRevertConfirmModal in reachable_modal_types

--- a/Tests/UI/test_console_selection_end_to_end.py
+++ b/Tests/UI/test_console_selection_end_to_end.py
@@ -5,20 +5,46 @@ bubbles from the transcript to ``ChatScreen``, which inserts the selection
 as a block quote into the native composer at the caret. Also covers the
 screen-level click-outside dismissal of a mounted selection menu (a click
 on any non-transcript widget, e.g. the composer, folds the menu).
+
+Phase 2 (task 5): ``ConsoleSideChatRequested`` bubbles from the transcript
+to ``ChatScreen``, which resolves the configured side-chat model + prompt
+template, builds the ephemeral side-chat service over the (fake) provider
+gateway, and pushes ``ConsoleSideChatModal`` exactly once -- More Details
+with the rendered template auto-sent, Ask in Side Chat freeform.
 """
 
 from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
 import pytest
 from textual.app import App, ComposeResult
 
 from Tests.UI.test_console_left_rail import make_console_pilot
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
 from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_selection import TextSelection
 from tldw_chatbook.Widgets.Console.console_selection_menu import (
     ConsoleSelectionMenu,
     ConsoleSelectionQuoteRequested,
+    ConsoleSideChatRequested,
 )
-from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+from tldw_chatbook.Widgets.Console.console_side_chat_modal import ConsoleSideChatModal
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    ConsoleTranscript,
+    ConsoleTranscriptMessage,
+)
 
 
 class _ComposerApp(App[None]):
@@ -138,3 +164,248 @@ async def test_click_outside_transcript_dismisses_selection_menu():
         await pilot.click("#console-native-composer")
         await pilot.pause()
         assert not screen.query(ConsoleSelectionMenu)
+
+
+# ---------------------------------------------------------------------------
+# Side chat (phase 2, task 5)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResolution:
+    provider: str = "llama_cpp"
+    model: str = "local-model"
+    ready: bool = True
+    visible_copy: str = ""
+
+
+class _FakeSideChatGateway:
+    """Offline provider gateway: records sends, streams one short reply."""
+
+    def __init__(self) -> None:
+        self.messages: list[list[dict[str, str]]] = []
+        self.stream_calls = 0
+
+    async def resolve_for_send(self, selection):
+        del selection
+        return _FakeResolution()
+
+    async def stream_chat(self, resolution, messages):
+        self.stream_calls += 1
+        self.messages.append(messages)
+        del resolution
+        yield "ok"
+
+
+@asynccontextmanager
+async def _side_chat_console_pilot(gateway: _FakeSideChatGateway):
+    """Real ChatScreen console with the provider gateway injected offline."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        await pilot.pause(0.2)
+        yield pilot, console
+
+
+def _capture_side_chat_pushes(app) -> list[ConsoleSideChatModal]:
+    """Wrap ``app.push_screen`` so each pushed screen lands in a list."""
+    pushed: list[object] = []
+    original_push = app.push_screen
+
+    def capturing_push(screen_arg, *args, **kwargs):
+        pushed.append(screen_arg)
+        return original_push(screen_arg, *args, **kwargs)
+
+    app.push_screen = capturing_push  # type: ignore[method-assign]
+    return pushed
+
+
+def _patch_side_chat_config(monkeypatch, *, model: str, template: str) -> None:
+    """Pin the two side-chat config reads the screen handler makes."""
+    real_get = chat_screen_module.get_cli_setting
+
+    def pinned_get(section, *args, **kwargs):
+        if section == "console" and args:
+            if args[0] == "sidechat_model":
+                return model
+            if args[0] == "sidechat_prompt_template":
+                return template
+        return real_get(section, *args, **kwargs)
+
+    monkeypatch.setattr(chat_screen_module, "get_cli_setting", pinned_get)
+
+
+async def _await_condition(condition, timeout: float = 5.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not condition():
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail("condition was not met in time")
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_screen_pushes_one_side_chat_modal_with_rendered_template(
+    monkeypatch,
+):
+    """More Details: one modal, auto-sending the rendered prompt template."""
+    gateway = _FakeSideChatGateway()
+    _patch_side_chat_config(
+        monkeypatch,
+        model="zai/glm-test",
+        template="Explain {selection} in depth",
+    )
+    async with _side_chat_console_pilot(gateway) as (pilot, console):
+        pushed = _capture_side_chat_pushes(pilot.app)
+        console.post_message(
+            ConsoleSideChatRequested(quote="hello world", mode="more-details")
+        )
+        await pilot.pause()
+
+        modals = [item for item in pushed if isinstance(item, ConsoleSideChatModal)]
+        assert len(pushed) == 1
+        assert len(modals) == 1
+        modal = modals[0]
+        assert modal._auto_send_prompt == "Explain hello world in depth"
+        assert modal._quote == "hello world"
+        assert modal._sidechat_model == "zai/glm-test"
+        assert modal._service.gateway is gateway
+        # Session fallback: derived from the ready llama.cpp session config.
+        assert modal._provider_selection.provider == "llama_cpp"
+
+        # More Details auto-sends on mount (offline fake gateway).
+        await _await_condition(lambda: gateway.stream_calls == 1)
+        user_content = gateway.messages[0][1]["content"]
+        assert "Explain hello world in depth" in user_content
+        assert "hello world" in user_content
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_screen_pushes_ask_mode_modal_without_auto_prompt(monkeypatch):
+    """Ask in Side Chat: one modal, no auto-send, freeform prompt visible."""
+    gateway = _FakeSideChatGateway()
+    _patch_side_chat_config(
+        monkeypatch,
+        model="",
+        template="Give me more details about: {selection}",
+    )
+    async with _side_chat_console_pilot(gateway) as (pilot, console):
+        pushed = _capture_side_chat_pushes(pilot.app)
+        console.post_message(ConsoleSideChatRequested(quote="a quote", mode="ask"))
+        await pilot.pause()
+        await pilot.pause()
+
+        modals = [item for item in pushed if isinstance(item, ConsoleSideChatModal)]
+        assert len(pushed) == 1
+        assert len(modals) == 1
+        modal = modals[0]
+        assert modal._auto_send_prompt is None
+        assert modal._quote == "a quote"
+        assert modal._sidechat_model == ""
+        assert gateway.stream_calls == 0  # nothing sent until the user asks
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_drag_more_details_opens_side_chat_modal_end_to_end():
+    """Drag → menu → More Details: the modal mounts showing the selection."""
+    gateway = _FakeSideChatGateway()
+    async with _side_chat_console_pilot(gateway) as (pilot, console):
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.USER,
+                    content="hello selectable world",
+                    id="m1",
+                )
+            ]
+        )
+        await transcript.refresh_messages()
+        await pilot.pause()
+        row = console.query_one("#console-message-m1", ConsoleTranscriptMessage)
+        region = transcript.region
+
+        transcript.selection_manager.begin_drag(row.id, 0)
+        transcript.selection_manager.extend_drag(row.id, 5)
+        row.set_selection_range(0, 5)
+        transcript.selection_manager.finish_drag()
+        transcript.post_message(
+            ConsoleTranscript.TranscriptTextSelected(
+                selection=TextSelection(row.id, 0, 5),
+                screen_x=region.x + 4,
+                screen_y=region.y + 2,
+            )
+        )
+        await pilot.pause()
+        assert console.query_one(ConsoleSelectionMenu)  # menu mounted at release
+
+        await pilot.click("#console-selection-more-details")
+        await pilot.pause()
+        await pilot.pause()
+
+        modal = pilot.app.screen
+        assert isinstance(modal, ConsoleSideChatModal)
+        assert modal._quote == "hello"
+        assert modal._auto_send_prompt is not None
+        assert "hello" in modal._auto_send_prompt
+        assert not console.query(ConsoleSelectionMenu)  # menu cleaned up
+        await _await_condition(lambda: gateway.stream_calls == 1)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_drag_ask_mode_opens_side_chat_modal_end_to_end():
+    """Drag → menu → Ask in Side Chat: modal mounts waiting for a question."""
+    gateway = _FakeSideChatGateway()
+    async with _side_chat_console_pilot(gateway) as (pilot, console):
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.USER,
+                    content="hello selectable world",
+                    id="m1",
+                )
+            ]
+        )
+        await transcript.refresh_messages()
+        await pilot.pause()
+        row = console.query_one("#console-message-m1", ConsoleTranscriptMessage)
+        region = transcript.region
+
+        transcript.selection_manager.begin_drag(row.id, 0)
+        transcript.selection_manager.extend_drag(row.id, 5)
+        row.set_selection_range(0, 5)
+        transcript.selection_manager.finish_drag()
+        transcript.post_message(
+            ConsoleTranscript.TranscriptTextSelected(
+                selection=TextSelection(row.id, 0, 5),
+                screen_x=region.x + 4,
+                screen_y=region.y + 2,
+            )
+        )
+        await pilot.pause()
+
+        await pilot.click("#console-selection-ask-side-chat")
+        await pilot.pause()
+        await pilot.pause()
+
+        modal = pilot.app.screen
+        assert isinstance(modal, ConsoleSideChatModal)
+        assert modal._quote == "hello"
+        assert modal._auto_send_prompt is None
+        assert gateway.stream_calls == 0
+
+        await pilot.press("escape")
+        await pilot.pause()

--- a/Tests/UI/test_console_selection_end_to_end.py
+++ b/Tests/UI/test_console_selection_end_to_end.py
@@ -315,6 +315,46 @@ async def test_screen_pushes_ask_mode_modal_without_auto_prompt(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_empty_side_chat_quote_pushes_no_modal(monkeypatch):
+    """A cleared row range opens nothing -- no modal, no send (T5 review).
+
+    Same blank-selection window as the add-to-chat guard: if the row
+    range was cleared while the menu was open (streaming replace,
+    reconciliation), More Details posts an empty quote, and the screen
+    must not push a modal (let alone auto-send a contentless prompt).
+    Mirrors ``test_empty_quote_request_notifies_nothing``.
+    """
+    gateway = _FakeSideChatGateway()
+    _patch_side_chat_config(
+        monkeypatch,
+        model="",
+        template="Give me more details about: {selection}",
+    )
+    async with _side_chat_console_pilot(gateway) as (pilot, console):
+        pushed = _capture_side_chat_pushes(pilot.app)
+        console.post_message(
+            ConsoleSideChatRequested(quote="   \n  ", mode="more-details")
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert pushed == []  # whitespace-only quote: no modal at all
+        assert gateway.stream_calls == 0
+
+        # Control: a real quote still pushes exactly one modal.
+        console.post_message(
+            ConsoleSideChatRequested(quote="real text", mode="more-details")
+        )
+        await pilot.pause()
+        modals = [item for item in pushed if isinstance(item, ConsoleSideChatModal)]
+        assert len(pushed) == 1
+        assert len(modals) == 1
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
 async def test_drag_more_details_opens_side_chat_modal_end_to_end():
     """Drag → menu → More Details: the modal mounts showing the selection."""
     gateway = _FakeSideChatGateway()

--- a/Tests/UI/test_console_selection_menu.py
+++ b/Tests/UI/test_console_selection_menu.py
@@ -18,10 +18,15 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
 )
 from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
-from tldw_chatbook.Widgets.Console.console_selection import TextSelection
+from tldw_chatbook.Widgets.Console.console_selection import (
+    SELECTION_QUOTE_CAP,
+    TextSelection,
+    cap_quote,
+)
 from tldw_chatbook.Widgets.Console.console_selection_menu import (
     ConsoleSelectionMenu,
     ConsoleSelectionQuoteRequested,
+    ConsoleSideChatRequested,
 )
 from tldw_chatbook.Widgets.Console.console_transcript import (
     ConsoleTranscript,
@@ -33,6 +38,8 @@ class _MenuApp(App[None]):
     def __init__(self) -> None:
         super().__init__()
         self.add_to_chat_events: list[ConsoleSelectionMenu.AddToChat] = []
+        self.more_details_events: list[ConsoleSelectionMenu.MoreDetails] = []
+        self.ask_side_chat_events: list[ConsoleSelectionMenu.AskInSideChat] = []
 
     def compose(self) -> ComposeResult:
         yield ConsoleSelectionMenu(local_x=4, local_y=6)
@@ -42,6 +49,16 @@ class _MenuApp(App[None]):
     ) -> None:
         self.add_to_chat_events.append(event)
 
+    def on_console_selection_menu_more_details(
+        self, event: ConsoleSelectionMenu.MoreDetails
+    ) -> None:
+        self.more_details_events.append(event)
+
+    def on_console_selection_menu_ask_in_side_chat(
+        self, event: ConsoleSelectionMenu.AskInSideChat
+    ) -> None:
+        self.ask_side_chat_events.append(event)
+
 
 @pytest.mark.asyncio
 async def test_menu_offers_add_to_chat_and_posts_message():
@@ -50,6 +67,47 @@ async def test_menu_offers_add_to_chat_and_posts_message():
         await pilot.click("#console-selection-add-to-chat")
         await pilot.pause()
         assert len(app.add_to_chat_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_menu_offers_three_stacked_options_in_order():
+    """Phase 2: Add to chat, More Details, Ask in Side Chat stack in order."""
+    app = _MenuApp()
+    async with app.run_test() as pilot:
+        del pilot
+        buttons = app.query_one(ConsoleSelectionMenu).query("Button")
+        assert [button.id for button in buttons] == [
+            "console-selection-add-to-chat",
+            "console-selection-more-details",
+            "console-selection-ask-side-chat",
+        ]
+        assert [str(button.label) for button in buttons] == [
+            "Add to chat",
+            "More Details",
+            "Ask in Side Chat",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_more_details_button_posts_more_details_message():
+    app = _MenuApp()
+    async with app.run_test() as pilot:
+        await pilot.click("#console-selection-more-details")
+        await pilot.pause()
+        assert len(app.more_details_events) == 1
+        assert app.add_to_chat_events == []
+        assert app.ask_side_chat_events == []
+
+
+@pytest.mark.asyncio
+async def test_ask_side_chat_button_posts_ask_message():
+    app = _MenuApp()
+    async with app.run_test() as pilot:
+        await pilot.click("#console-selection-ask-side-chat")
+        await pilot.pause()
+        assert len(app.ask_side_chat_events) == 1
+        assert app.add_to_chat_events == []
+        assert app.more_details_events == []
 
 
 @pytest.mark.asyncio
@@ -78,6 +136,7 @@ class _TranscriptMenuApp(App[None]):
     def __init__(self) -> None:
         super().__init__()
         self.quote_requests: list[ConsoleSelectionQuoteRequested] = []
+        self.side_chat_requests: list[ConsoleSideChatRequested] = []
 
     def compose(self) -> ComposeResult:
         transcript = ConsoleTranscript(id="console-native-transcript")
@@ -94,6 +153,11 @@ class _TranscriptMenuApp(App[None]):
         self, event: ConsoleSelectionQuoteRequested
     ) -> None:
         self.quote_requests.append(event)
+
+    def on_console_side_chat_requested(
+        self, event: ConsoleSideChatRequested
+    ) -> None:
+        self.side_chat_requests.append(event)
 
 
 async def _finish_drag_selection(pilot) -> None:
@@ -191,6 +255,113 @@ async def test_click_outside_removes_menu():
         await pilot.click(ConsoleTranscript)
         await pilot.pause()
         assert not app.query(ConsoleSelectionMenu)
+
+
+class _LongTranscriptMenuApp(_TranscriptMenuApp):
+    """Transcript whose single row dwarfs the selection quote cap."""
+
+    _LONG_CONTENT = "x" * (SELECTION_QUOTE_CAP + 1000)
+
+    def compose(self) -> ComposeResult:
+        transcript = ConsoleTranscript(id="console-native-transcript")
+        transcript.set_messages(
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.USER, content=self._LONG_CONTENT, id="m1"
+                )
+            ]
+        )
+        yield transcript
+
+
+async def _select_whole_row(pilot) -> None:
+    """Drag-select the entire first row and mount the selection menu."""
+    transcript = pilot.app.query_one(ConsoleTranscript)
+    row = pilot.app.query_one("#console-message-m1", ConsoleTranscriptMessage)
+    length = len(_LongTranscriptMenuApp._LONG_CONTENT)
+    transcript.selection_manager.begin_drag(row.id, 0)
+    transcript.selection_manager.extend_drag(row.id, length)
+    row.set_selection_range(0, length)
+    transcript.selection_manager.finish_drag()
+    region = transcript.region
+    transcript.post_message(
+        ConsoleTranscript.TranscriptTextSelected(
+            selection=TextSelection(row.id, 0, length),
+            screen_x=region.x + 4,
+            screen_y=region.y + 2,
+        )
+    )
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _assert_side_chat_cleanup(app: _TranscriptMenuApp) -> None:
+    assert not app.query(ConsoleSelectionMenu)  # menu removed
+    transcript = app.query_one(ConsoleTranscript)
+    assert transcript.selection_manager.state.selection is None
+    assert (
+        app.query_one(
+            "#console-message-m1", ConsoleTranscriptMessage
+        ).get_selection_text()
+        == ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_more_details_requests_side_chat_and_cleans_up():
+    """More Details posts ConsoleSideChatRequested(mode="more-details")."""
+    app = _TranscriptMenuApp()
+    async with app.run_test() as pilot:
+        await _finish_drag_selection(pilot)
+        await pilot.click("#console-selection-more-details")
+        await pilot.pause()
+        assert len(app.side_chat_requests) == 1
+        assert app.side_chat_requests[0].mode == "more-details"
+        assert app.side_chat_requests[0].quote == "hello"
+        assert app.quote_requests == []
+        _assert_side_chat_cleanup(app)
+
+
+@pytest.mark.asyncio
+async def test_ask_side_chat_requests_side_chat_and_cleans_up():
+    """Ask in Side Chat posts ConsoleSideChatRequested(mode="ask")."""
+    app = _TranscriptMenuApp()
+    async with app.run_test() as pilot:
+        await _finish_drag_selection(pilot)
+        await pilot.click("#console-selection-ask-side-chat")
+        await pilot.pause()
+        assert len(app.side_chat_requests) == 1
+        assert app.side_chat_requests[0].mode == "ask"
+        assert app.side_chat_requests[0].quote == "hello"
+        assert app.quote_requests == []
+        _assert_side_chat_cleanup(app)
+
+
+@pytest.mark.asyncio
+async def test_side_chat_quote_is_capped_more_details():
+    """A row longer than the quote cap reaches the side chat capped."""
+    app = _LongTranscriptMenuApp()
+    async with app.run_test(size=(120, 32)) as pilot:
+        await _select_whole_row(pilot)
+        await pilot.click("#console-selection-more-details")
+        await pilot.pause()
+        assert len(app.side_chat_requests) == 1
+        expected = cap_quote(_LongTranscriptMenuApp._LONG_CONTENT)
+        assert app.side_chat_requests[0].quote == expected
+        assert len(app.side_chat_requests[0].quote) <= SELECTION_QUOTE_CAP
+
+
+@pytest.mark.asyncio
+async def test_side_chat_quote_is_capped_ask():
+    app = _LongTranscriptMenuApp()
+    async with app.run_test(size=(120, 32)) as pilot:
+        await _select_whole_row(pilot)
+        await pilot.click("#console-selection-ask-side-chat")
+        await pilot.pause()
+        assert len(app.side_chat_requests) == 1
+        assert app.side_chat_requests[0].quote == cap_quote(
+            _LongTranscriptMenuApp._LONG_CONTENT
+        )
 
 
 class _TallTranscriptMenuApp(App[None]):

--- a/Tests/UI/test_console_side_chat_modal.py
+++ b/Tests/UI/test_console_side_chat_modal.py
@@ -1,0 +1,435 @@
+"""Ephemeral Console side-chat modal (selection menu phase 2, task 4).
+
+Covers: More Details auto-send on mount + streaming into the reply area, Ask
+mode waiting for Send, Stop cancellation (Cancelling… then the cancelled
+outcome with Retry), provider errors surfacing inline with Retry, Escape
+mid-stream cancelling the worker and dismissing, reply-buffer tail capping,
+the read-only quote block, the provider·model summary line, and worker
+isolation (non-exclusive ``console-side-chat`` group). All against the real
+``ConsoleSideChatService`` backed by a fake gateway — no live LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from textual.app import App
+from textual.screen import Screen
+from textual.widgets import Button, Static, TextArea
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_side_chat import (
+    SIDE_CHAT_BUFFER_CAP,
+    ConsoleSideChatService,
+)
+from tldw_chatbook.Widgets.Console.console_side_chat_modal import (
+    ConsoleSideChatModal,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes (mirrors Tests/Chat/test_console_side_chat_service.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeResolution:
+    provider: str = "openai"
+    model: str = "gpt-test"
+    ready: bool = True
+    visible_copy: str = ""
+
+
+class FakeGateway:
+    """Records selections/messages; replays chunks, errors, or blocks."""
+
+    def __init__(
+        self,
+        chunks: list[Any] | None = None,
+        error: Exception | None = None,
+        resolution: FakeResolution | None = None,
+        block_after_first_chunk: bool = False,
+    ) -> None:
+        self.chunks = chunks if chunks is not None else ["Hello", " world"]
+        self.error = error
+        self.resolution = resolution or FakeResolution()
+        self.block_after_first_chunk = block_after_first_chunk
+        self.first_chunk_sent = asyncio.Event()
+        self.messages: list[list[dict[str, str]]] = []
+        self.stream_calls = 0
+
+    async def resolve_for_send(
+        self, selection: ConsoleProviderSelection
+    ) -> FakeResolution:
+        return self.resolution
+
+    async def stream_chat(
+        self, resolution: FakeResolution, messages: list[dict[str, str]]
+    ):
+        self.stream_calls += 1
+        self.messages.append(messages)
+        if self.error is not None:
+            raise self.error
+        for index, chunk in enumerate(self.chunks):
+            yield chunk
+            if self.block_after_first_chunk and index == 0:
+                self.first_chunk_sent.set()
+                await asyncio.Event().wait()  # never set: holds the stream open
+
+
+QUOTE = "the quoted transcript text"
+AUTO_PROMPT = "Explain this"
+_SESSION_SELECTION = ConsoleProviderSelection(provider="openai")
+
+
+def _service(gateway: FakeGateway) -> ConsoleSideChatService:
+    return ConsoleSideChatService(gateway)
+
+
+def _modal(
+    gateway: FakeGateway,
+    *,
+    auto: bool = True,
+    quote: str = QUOTE,
+    provider_selection: ConsoleProviderSelection | None = _SESSION_SELECTION,
+    sidechat_model: str = "",
+    callback: Any = None,
+) -> ConsoleSideChatModal:
+    return ConsoleSideChatModal(
+        service=_service(gateway),
+        provider_selection=provider_selection,
+        sidechat_model=sidechat_model,
+        quote=quote,
+        auto_send_prompt=AUTO_PROMPT if auto else None,
+        callback=callback,
+    )
+
+
+class _SideChatApp(App[None]):
+    CSS = "Screen { align: center middle; }"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results: list[object] = []
+
+
+def _text(modal: ConsoleSideChatModal, selector: str) -> str:
+    return str(modal.query_one(selector, Static).render())
+
+
+def _displayed(modal: ConsoleSideChatModal, selector: str) -> bool:
+    return bool(modal.query_one(selector).display)
+
+
+async def _await_status(
+    modal: ConsoleSideChatModal, expected: str, timeout: float = 5.0
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while _text(modal, "#console-side-chat-status") != expected:
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(
+                f"status never became {expected!r}; "
+                f"last={_text(modal, '#console-side-chat-status')!r}"
+            )
+        await asyncio.sleep(0.02)
+
+
+async def _await_button_settled(
+    modal: ConsoleSideChatModal, selector: str, timeout: float = 5.0
+) -> None:
+    """Wait out Textual's ``-active`` click debounce: a second click on a
+    still-``-active`` Button is intentionally swallowed by ``_on_click``."""
+    button = modal.query_one(selector, Button)
+    deadline = asyncio.get_running_loop().time() + timeout
+    while button.has_class("-active"):
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"{selector} never settled after its click animation")
+        await asyncio.sleep(0.02)
+
+
+# ---------------------------------------------------------------------------
+# More Details (auto-send) mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_more_details_auto_sends_on_mount_and_streams_into_reply():
+    gateway = FakeGateway(chunks=["Hel", "lo ", "world"])
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as _pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await _await_status(modal, "Complete.")
+
+        assert _text(modal, "#console-side-chat-reply") == "Hello world"
+        # One send, carrying the rendered prompt and the quoted selection.
+        assert gateway.stream_calls == 1
+        user_content = gateway.messages[0][1]["content"]
+        assert AUTO_PROMPT in user_content
+        assert QUOTE in user_content
+        # Auto mode hides the prompt input and all ask/stream affordances.
+        assert not _displayed(modal, "#console-side-chat-prompt")
+        assert not _displayed(modal, "#console-side-chat-send")
+        assert not _displayed(modal, "#console-side-chat-stop")
+        assert not _displayed(modal, "#console-side-chat-retry")
+        assert _displayed(modal, "#console-side-chat-close")
+        # Worker isolation: non-exclusive, side-chat-only group (spec §2).
+        worker = modal._sidechat_worker
+        assert worker is not None
+        assert worker.group == "console-side-chat"
+
+
+# ---------------------------------------------------------------------------
+# Ask (freeform) mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ask_mode_waits_for_send_then_streams():
+    gateway = FakeGateway(chunks=["Answer"])
+    modal = _modal(gateway, auto=False)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await pilot.pause()
+
+        prompt_area = modal.query_one("#console-side-chat-prompt", TextArea)
+        assert prompt_area.display  # visible and empty in Ask mode
+        assert prompt_area.text == ""
+        assert gateway.stream_calls == 0  # nothing sent until Send
+
+        # Blank Send is refused inline.
+        await pilot.click("#console-side-chat-send")
+        await pilot.pause()
+        assert gateway.stream_calls == 0
+        assert _text(modal, "#console-side-chat-status") == "Type a question first."
+
+        prompt_area.text = "What does this mean?"
+        await _await_button_settled(modal, "#console-side-chat-send")
+        await pilot.click("#console-side-chat-send")
+        await _await_status(modal, "Complete.")
+
+        assert gateway.stream_calls == 1
+        assert "What does this mean?" in gateway.messages[0][1]["content"]
+        assert _text(modal, "#console-side-chat-reply") == "Answer"
+
+
+# ---------------------------------------------------------------------------
+# Stop / cancellation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_then_shows_cancelled_outcome_and_retry_reruns():
+    gateway = FakeGateway(chunks=["partial "], block_after_first_chunk=True)
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+
+        # The intermediate "Cancelling…" state is set synchronously by Stop.
+        modal._stop_streaming()
+        assert _text(modal, "#console-side-chat-status") == "Cancelling…"
+
+        await _await_status(modal, "Cancelled.")
+        assert "partial" in _text(modal, "#console-side-chat-reply")
+        assert _displayed(modal, "#console-side-chat-retry")
+        assert not _displayed(modal, "#console-side-chat-stop")
+
+        # Retry re-runs the same prompt.
+        await pilot.click("#console-side-chat-retry")
+        await pilot.pause()
+        assert gateway.stream_calls == 2
+        assert "Explain this" in gateway.messages[1][1]["content"]
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_stop_button_cancels_a_streaming_side_chat():
+    gateway = FakeGateway(chunks=["partial "], block_after_first_chunk=True)
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+
+        await pilot.click("#console-side-chat-stop")
+        await _await_status(modal, "Cancelled.")
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# Provider errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_error_shows_inline_and_retry_reruns():
+    gateway = FakeGateway(error=ChatProviderError("safe copy"))
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await _await_status(modal, "Provider error: safe copy")
+
+        assert _displayed(modal, "#console-side-chat-retry")
+        assert not _displayed(modal, "#console-side-chat-stop")
+        assert _text(modal, "#console-side-chat-reply") == ""
+
+        await pilot.click("#console-side-chat-retry")
+        await pilot.pause()
+        assert gateway.stream_calls == 2
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# Escape mid-stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escape_mid_stream_cancels_worker_and_dismisses():
+    gateway = FakeGateway(chunks=["partial "], block_after_first_chunk=True)
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    host: Screen[None] | None = None
+    async with app.run_test(size=(100, 40)) as pilot:
+        host = app.screen
+        await app.push_screen(modal, callback=app.results.append)
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.screen is host
+        assert app.results == [None]
+        worker = modal._sidechat_worker
+        assert worker is not None
+        assert worker.is_cancelled or worker.is_finished
+
+
+# ---------------------------------------------------------------------------
+# Reply buffer cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reply_buffer_is_tail_capped():
+    raw = "a" * (SIDE_CHAT_BUFFER_CAP + 10_000)
+    gateway = FakeGateway(chunks=[raw])
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as _pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await _await_status(modal, "Complete.")
+
+        displayed = _text(modal, "#console-side-chat-reply")
+        assert displayed.startswith("…\n")
+        assert len(displayed) == SIDE_CHAT_BUFFER_CAP + 2
+        assert displayed.endswith(raw[-SIDE_CHAT_BUFFER_CAP:])
+
+
+# ---------------------------------------------------------------------------
+# Quote + identity lines
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quote_is_displayed_read_only():
+    gateway = FakeGateway(chunks=["ok"])
+    modal = _modal(gateway, auto=False, quote="a very specific quote")
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await pilot.pause()
+        assert _text(modal, "#console-side-chat-quote") == "a very specific quote"
+        assert gateway.stream_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_line_shows_requested_then_resolved_identity():
+    gateway = FakeGateway(
+        chunks=["ok"],
+        resolution=FakeResolution(provider="zai", model="glm-test"),
+        block_after_first_chunk=True,
+    )
+    modal = _modal(
+        gateway,
+        provider_selection=ConsoleProviderSelection(
+            provider="openai", explicit_model="gpt-4o"
+        ),
+        sidechat_model="",
+    )
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as _pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+
+        # Mid-stream the header still shows the REQUESTED identity.
+        identity = _text(modal, "#console-side-chat-identity")
+        assert "openai" in identity and "gpt-4o" in identity
+
+        # The resolution arrives with the outcome and replaces it.
+        modal._sidechat_worker.cancel()
+        await _await_status(modal, "Cancelled.")
+        resolved = _text(modal, "#console-side-chat-identity")
+        assert "zai" in resolved and "glm-test" in resolved
+
+
+@pytest.mark.asyncio
+async def test_summary_line_prefers_configured_sidechat_model():
+    gateway = FakeGateway(chunks=["ok"], block_after_first_chunk=True)
+    modal = _modal(
+        gateway,
+        provider_selection=ConsoleProviderSelection(
+            provider="openai", explicit_model="gpt-4o"
+        ),
+        sidechat_model="mistral/mistral-large-latest",
+    )
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+        identity = _text(modal, "#console-side-chat-identity")
+        assert "mistral/mistral-large-latest" in identity
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_close_button_dismisses_without_result():
+    gateway = FakeGateway(chunks=["ok"])
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        host = app.screen
+        await app.push_screen(modal, callback=app.results.append)
+        await _await_status(modal, "Complete.")
+
+        await pilot.click("#console-side-chat-close")
+        await pilot.pause()
+        assert app.screen is host
+        assert app.results == [None]

--- a/Tests/UI/test_console_side_chat_modal.py
+++ b/Tests/UI/test_console_side_chat_modal.py
@@ -2,11 +2,14 @@
 
 Covers: More Details auto-send on mount + streaming into the reply area, Ask
 mode waiting for Send, Stop cancellation (Cancelling… then the cancelled
-outcome with Retry), provider errors surfacing inline with Retry, Escape
-mid-stream cancelling the worker and dismissing, reply-buffer tail capping,
-the read-only quote block, the provider·model summary line, and worker
-isolation (non-exclusive ``console-side-chat`` group). All against the real
-``ConsoleSideChatService`` backed by a fake gateway — no live LLM.
+outcome with Retry — and, in Ask mode, Send returning so an edited prompt is
+submittable while Retry resends the last prompt unchanged), provider errors
+surfacing inline with Retry (mid-stream errors keep the streamed partial
+text), Escape mid-stream cancelling the worker and dismissing, reply-buffer
+tail capping, the read-only quote block, the provider·model summary line,
+and worker isolation (non-exclusive ``console-side-chat`` group). All
+against the real ``ConsoleSideChatService`` backed by a fake gateway — no
+live LLM.
 """
 
 from __future__ import annotations
@@ -52,11 +55,15 @@ class FakeGateway:
         error: Exception | None = None,
         resolution: FakeResolution | None = None,
         block_after_first_chunk: bool = False,
+        error_after_chunks: bool = False,
     ) -> None:
         self.chunks = chunks if chunks is not None else ["Hello", " world"]
         self.error = error
         self.resolution = resolution or FakeResolution()
         self.block_after_first_chunk = block_after_first_chunk
+        # When False (default) the error fires before any chunk; when True
+        # all chunks stream first and the error lands mid-stream afterwards.
+        self.error_after_chunks = error_after_chunks
         self.first_chunk_sent = asyncio.Event()
         self.messages: list[list[dict[str, str]]] = []
         self.stream_calls = 0
@@ -71,13 +78,15 @@ class FakeGateway:
     ):
         self.stream_calls += 1
         self.messages.append(messages)
-        if self.error is not None:
+        if self.error is not None and not self.error_after_chunks:
             raise self.error
         for index, chunk in enumerate(self.chunks):
             yield chunk
             if self.block_after_first_chunk and index == 0:
                 self.first_chunk_sent.set()
                 await asyncio.Event().wait()  # never set: holds the stream open
+        if self.error is not None:
+            raise self.error
 
 
 QUOTE = "the quoted transcript text"
@@ -147,6 +156,20 @@ async def _await_button_settled(
     while button.has_class("-active"):
         if asyncio.get_running_loop().time() > deadline:
             pytest.fail(f"{selector} never settled after its click animation")
+        await asyncio.sleep(0.02)
+
+
+async def _await_stream_calls(
+    gateway: FakeGateway, expected: int, timeout: float = 5.0
+) -> None:
+    """Wait until the gateway has seen ``expected`` stream_chat calls."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while gateway.stream_calls < expected:
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(
+                f"stream_calls never reached {expected}; "
+                f"last={gateway.stream_calls}"
+            )
         await asyncio.sleep(0.02)
 
 
@@ -270,6 +293,51 @@ async def test_stop_button_cancels_a_streaming_side_chat():
         await pilot.pause()
 
 
+@pytest.mark.asyncio
+async def test_ask_mode_after_stop_send_uses_edited_text_and_retry_uses_original():
+    """Ask mode must not dead-end after a stop: the editable prompt area is
+    still up, so Send (reads the TextArea) returns alongside Retry (resends
+    the last prompt unchanged)."""
+    gateway = FakeGateway(chunks=["partial "], block_after_first_chunk=True)
+    modal = _modal(gateway, auto=False)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await pilot.pause()
+
+        prompt_area = modal.query_one("#console-side-chat-prompt", TextArea)
+        prompt_area.text = "original question"
+        await _await_button_settled(modal, "#console-side-chat-send")
+        await pilot.click("#console-side-chat-send")
+        await asyncio.wait_for(gateway.first_chunk_sent.wait(), timeout=5)
+
+        modal._stop_streaming()
+        await _await_status(modal, "Cancelled.")
+        assert _displayed(modal, "#console-side-chat-send")
+        assert _displayed(modal, "#console-side-chat-retry")
+        assert not _displayed(modal, "#console-side-chat-stop")
+
+        # Retry resends the last prompt unchanged, ignoring the edited area.
+        prompt_area.text = "edited question"
+        await _await_button_settled(modal, "#console-side-chat-retry")
+        await pilot.click("#console-side-chat-retry")
+        await _await_stream_calls(gateway, 2)
+        assert "original question" in gateway.messages[1][1]["content"]
+        assert "edited question" not in gateway.messages[1][1]["content"]
+
+        # Stop again, then Send submits the edited TextArea content.
+        modal._stop_streaming()
+        await _await_status(modal, "Cancelled.")
+        await _await_button_settled(modal, "#console-side-chat-send")
+        await pilot.click("#console-side-chat-send")
+        await _await_stream_calls(gateway, 3)
+        assert "edited question" in gateway.messages[2][1]["content"]
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
 # ---------------------------------------------------------------------------
 # Provider errors
 # ---------------------------------------------------------------------------
@@ -292,6 +360,59 @@ async def test_provider_error_shows_inline_and_retry_reruns():
         await pilot.click("#console-side-chat-retry")
         await pilot.pause()
         assert gateway.stream_calls == 2
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_ask_mode_provider_error_keeps_send_for_edited_prompt():
+    gateway = FakeGateway(error=ChatProviderError("safe copy"))
+    modal = _modal(gateway, auto=False)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await pilot.pause()
+
+        prompt_area = modal.query_one("#console-side-chat-prompt", TextArea)
+        prompt_area.text = "first question"
+        await _await_button_settled(modal, "#console-side-chat-send")
+        await pilot.click("#console-side-chat-send")
+        await _await_status(modal, "Provider error: safe copy")
+
+        # Send must stay available alongside Retry so an edited prompt can
+        # be submitted without reopening the modal.
+        assert _displayed(modal, "#console-side-chat-send")
+        assert _displayed(modal, "#console-side-chat-retry")
+
+        prompt_area.text = "second question"
+        await _await_button_settled(modal, "#console-side-chat-send")
+        await pilot.click("#console-side-chat-send")
+        await _await_stream_calls(gateway, 2)
+        assert "second question" in gateway.messages[1][1]["content"]
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_mid_stream_keeps_partial_reply():
+    """A mid-stream provider error must not blank the already-streamed text."""
+    gateway = FakeGateway(
+        chunks=["partial answer"],
+        error=ChatProviderError("mid-stream boom"),
+        error_after_chunks=True,
+    )
+    modal = _modal(gateway)
+
+    app = _SideChatApp()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await app.push_screen(modal, callback=app.results.append)
+        await _await_status(modal, "Provider error: mid-stream boom")
+
+        assert _text(modal, "#console-side-chat-reply") == "partial answer"
+        assert _displayed(modal, "#console-side-chat-retry")
 
         await pilot.press("escape")
         await pilot.pause()

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -773,6 +773,9 @@ def test_settings_ownership_records_cover_categories_and_runtime_boundaries():
         "console.collapse_large_pastes",
         "console.paste_collapse_threshold",
         "console.max_parallel_runs",
+        # Side-chat phase 2 (task-2): ephemeral selection side-chat prefs.
+        "console.sidechat_model",
+        "console.sidechat_prompt_template",
         "console.background_effects.*",
         # task-15512: same commit as the context-window entry above
         # (2d88425ba) -- new owned sections, tuple left behind.

--- a/Tests/UI/test_settings_console_side_chat.py
+++ b/Tests/UI/test_settings_console_side_chat.py
@@ -1,0 +1,227 @@
+"""Settings contracts for the ephemeral selection side-chat preferences."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Input, Static
+
+import tldw_chatbook.UI.Screens.settings_screen as settings_screen_module
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _visible_text,
+)
+from Tests.UI.test_settings_configuration_hub import (
+    _open_settings_category,
+    _settle_settings_mount_storm,
+    _wait_for_settings_search_focus,
+    _wait_for_settings_text,
+)
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+
+SIDECAT_MODEL_INPUT = "#settings-console-sidechat-model"
+SIDECAT_TEMPLATE_INPUT = "#settings-console-sidechat-prompt-template"
+
+
+@pytest.mark.asyncio
+async def test_console_side_chat_settings_render_loaded_values_and_stage_edits():
+    """Both inputs show the saved values; typing stages without mutating config."""
+    app = _build_test_app()
+    app.app_config["console"] = {
+        "sidechat_model": "saved-sidechat-model",
+        "sidechat_prompt_template": "Summarize this: {selection}",
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        model_input = screen.query_one(SIDECAT_MODEL_INPUT, Input)
+        template_input = screen.query_one(SIDECAT_TEMPLATE_INPUT, Input)
+
+        assert model_input.value == "saved-sidechat-model"
+        assert model_input.placeholder == "empty = current session model"
+        assert template_input.value == "Summarize this: {selection}"
+        help_text = str(
+            screen.query_one(
+                "#settings-console-sidechat-prompt-template-help", Static
+            ).renderable
+        )
+        assert "{selection}" in help_text
+
+        model_input.value = "draft-sidechat-model"
+        await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.CONSOLE_BEHAVIOR]
+        assert draft.dirty_keys == {"sidechat_model"}
+        assert draft.values["sidechat_model"] == "draft-sidechat-model"
+        assert app.app_config["console"]["sidechat_model"] == "saved-sidechat-model"
+
+        template_input.value = "Explain this: {selection}"
+        await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.CONSOLE_BEHAVIOR]
+        assert draft.dirty_keys == {"sidechat_model", "sidechat_prompt_template"}
+        assert (
+            app.app_config["console"]["sidechat_prompt_template"]
+            == "Summarize this: {selection}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_console_side_chat_settings_are_searchable_and_have_focused_guidance():
+    """The side-chat model field is findable via "/" and explains its contract."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+        await pilot.press("/")
+        await _wait_for_settings_search_focus(screen, pilot)
+        search = screen.query_one("#settings-category-search", Input)
+        assert search.has_focus
+        await pilot.press(*"side chat model")
+        await _wait_for_settings_text(screen, pilot, "Console Behavior › Side chat model")
+        await pilot.press("enter")
+        for _ in range(8):
+            await pilot.pause()
+
+        assert screen.active_category == SettingsCategoryId.CONSOLE_BEHAVIOR.value
+        assert host.focused is not None and host.focused.id == (
+            "settings-console-sidechat-model"
+        )
+        visible = _visible_text(screen)
+        assert "Purpose: Model used by the ephemeral selection side chat." in visible
+        assert "Saved as: console.sidechat_model" in visible
+        assert "Save: staged - press s to save, r to revert" in visible
+
+
+@pytest.mark.asyncio
+async def test_console_side_chat_save_payload_is_exact_and_updates_runtime(
+    monkeypatch,
+):
+    """Successful category Save persists exactly the two staged string keys."""
+    app = _build_test_app()
+    app.app_config["console"] = {}
+    saved: list[dict[str, dict[str, str]]] = []
+
+    class FakeAdapter:
+        def save_sections(self, section_values):
+            saved.append(section_values)
+            return True
+
+    monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        model_input = screen.query_one(SIDECAT_MODEL_INPUT, Input)
+        template_input = screen.query_one(SIDECAT_TEMPLATE_INPUT, Input)
+        assert model_input.value == ""
+        assert template_input.value == "Give me more details about: {selection}"
+
+        model_input.value = "gpt-sidechat-test"
+        template_input.value = "Explain this: {selection}"
+        await pilot.pause()
+
+        assert app.app_config["console"].get("sidechat_model") in (None, "")
+        await pilot.click("#settings-save-category")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert saved == [
+            {
+                "console": {
+                    "sidechat_model": "gpt-sidechat-test",
+                    "sidechat_prompt_template": "Explain this: {selection}",
+                }
+            }
+        ]
+        assert app.app_config["console"]["sidechat_model"] == "gpt-sidechat-test"
+        assert (
+            app.app_config["console"]["sidechat_prompt_template"]
+            == "Explain this: {selection}"
+        )
+        assert screen.query_one(SIDECAT_MODEL_INPUT, Input).value == "gpt-sidechat-test"
+        assert (
+            screen.query_one(SIDECAT_TEMPLATE_INPUT, Input).value
+            == "Explain this: {selection}"
+        )
+        assert SettingsCategoryId.CONSOLE_BEHAVIOR not in screen._settings_drafts
+        assert "Console behavior settings saved." in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_console_side_chat_failed_save_keeps_draft(monkeypatch):
+    """Persistence failure keeps the staged strings without touching runtime."""
+    app = _build_test_app()
+    app.app_config["console"] = {}
+
+    class FailingAdapter:
+        def save_sections(self, section_values):
+            return False
+
+    monkeypatch.setattr(
+        settings_screen_module,
+        "SettingsConfigAdapter",
+        FailingAdapter,
+    )
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        screen.query_one(SIDECAT_MODEL_INPUT, Input).value = "draft-model"
+        screen.query_one(SIDECAT_TEMPLATE_INPUT, Input).value = "Draft: {selection}"
+        await pilot.pause()
+
+        await pilot.click("#settings-save-category")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert (
+            screen.query_one(SIDECAT_MODEL_INPUT, Input).value == "draft-model"
+        )
+        assert (
+            screen.query_one(SIDECAT_TEMPLATE_INPUT, Input).value
+            == "Draft: {selection}"
+        )
+        draft = screen._settings_drafts[SettingsCategoryId.CONSOLE_BEHAVIOR]
+        assert draft.dirty_keys == {"sidechat_model", "sidechat_prompt_template"}
+        assert app.app_config["console"].get("sidechat_model") in (None, "")
+        assert "Your draft is still here" in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+async def test_console_side_chat_revert_restores_loaded_values():
+    """Category Revert discards staged side-chat strings and reloads inputs."""
+    app = _build_test_app()
+    app.app_config["console"] = {
+        "sidechat_model": "saved-model",
+        "sidechat_prompt_template": "Saved: {selection}",
+    }
+    host = DestinationHarness(app, "settings")
+
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        screen.query_one(SIDECAT_MODEL_INPUT, Input).value = "unsaved-model"
+        screen.query_one(SIDECAT_TEMPLATE_INPUT, Input).value = "Unsaved: {selection}"
+        await pilot.pause()
+
+        draft = screen._settings_drafts[SettingsCategoryId.CONSOLE_BEHAVIOR]
+        assert draft.dirty_keys == {"sidechat_model", "sidechat_prompt_template"}
+
+        screen._revert_category(SettingsCategoryId.CONSOLE_BEHAVIOR)
+        await pilot.pause()
+
+        assert SettingsCategoryId.CONSOLE_BEHAVIOR not in screen._settings_drafts
+        assert screen.query_one(SIDECAT_MODEL_INPUT, Input).value == "saved-model"
+        assert (
+            screen.query_one(SIDECAT_TEMPLATE_INPUT, Input).value
+            == "Saved: {selection}"
+        )
+        assert app.app_config["console"]["sidechat_model"] == "saved-model"

--- a/Tests/test_config_console_defaults.py
+++ b/Tests/test_config_console_defaults.py
@@ -136,6 +136,80 @@ def test_load_settings_normalizes_console_rail_label_style(
     assert settings["console"]["stack_collapsed_rail_labels"] is expected
 
 
+def test_console_sidechat_model_default_is_empty_string():
+    from tldw_chatbook.config import get_cli_setting
+
+    assert config_module.DEFAULT_CONFIG_FROM_TOML["console"]["sidechat_model"] == ""
+    assert get_cli_setting("console", "sidechat_model", "") == ""
+
+
+def test_console_sidechat_prompt_template_default():
+    from tldw_chatbook.config import get_cli_setting
+
+    assert (
+        config_module.DEFAULT_CONFIG_FROM_TOML["console"][
+            "sidechat_prompt_template"
+        ]
+        == "Give me more details about: {selection}"
+    )
+    assert (
+        get_cli_setting("console", "sidechat_prompt_template", "")
+        == "Give me more details about: {selection}"
+    )
+
+
+def test_load_settings_exposes_console_sidechat_defaults(tmp_path, monkeypatch):
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(tmp_path / "missing-config.toml"))
+
+    settings = config_module.load_settings(force_reload=True)
+
+    assert settings["console"]["sidechat_model"] == ""
+    assert (
+        settings["console"]["sidechat_prompt_template"]
+        == "Give me more details about: {selection}"
+    )
+
+
+def test_console_sidechat_keys_survive_loader_coercion(tmp_path, monkeypatch):
+    """String side-chat keys round-trip through the loader as strings."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[console]\n"
+        'sidechat_model = "openai/gpt-5-mini"\n'
+        'sidechat_prompt_template = "Summarize this simply: {selection}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    settings = config_module.load_settings(force_reload=True)
+
+    assert settings["console"]["sidechat_model"] == "openai/gpt-5-mini"
+    assert (
+        settings["console"]["sidechat_prompt_template"]
+        == "Summarize this simply: {selection}"
+    )
+
+
+def test_console_sidechat_non_string_values_fall_back_to_defaults(
+    tmp_path, monkeypatch
+):
+    """Presence-validation only: non-string values reset to the defaults."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[console]\nsidechat_model = 123\nsidechat_prompt_template = 789\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    settings = config_module.load_settings(force_reload=True)
+
+    assert settings["console"]["sidechat_model"] == ""
+    assert (
+        settings["console"]["sidechat_prompt_template"]
+        == "Give me more details about: {selection}"
+    )
+
+
 def test_load_settings_coerces_console_paste_threshold(tmp_path, monkeypatch):
     config_path = tmp_path / "config.toml"
     config_path.write_text(

--- a/backlog/decisions/066-console-text-selection-and-annotations.md
+++ b/backlog/decisions/066-console-text-selection-and-annotations.md
@@ -100,6 +100,12 @@ across the stack.
   streaming append that grows the markdown source re-snaps the stored
   line range, so a selection touching the last line intentionally GROWS
   with the stream, while plain rows hold their last stable range.
+- Phase 2 (ephemeral side chat) landed: `More Details` / `Ask in Side
+  Chat` push `ConsoleSideChatModal`, whose `ConsoleSideChatService` is
+  gateway-only and persistence-free (`stream_chat` alone; the reply
+  never leaves the modal), and whose worker runs in the
+  non-exclusive `console-side-chat` group so it never cancels or
+  blocks `console-run-{session_id}` session workers.
 
 ## Links
 

--- a/backlog/tasks/task-16312 - Console-side-chat-phase-2.md
+++ b/backlog/tasks/task-16312 - Console-side-chat-phase-2.md
@@ -1,0 +1,55 @@
+---
+id: TASK-16312
+title: Console side chat phase 2
+status: In Progress
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 17:27'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ephemeral side chat modal for selected transcript text (More Details / Ask in Side Chat)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 More Details auto-sends rendered template
+- [x] #2 Ask in Side Chat freeform
+- [x] #3 sidechat model/template settings saved via Console Behavior
+- [x] #4 Streaming with stop/retry
+- [x] #5 Nothing persisted
+- [x] #6 Tests green
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Per Docs/superpowers/plans/2026-08-15-console-side-chat-phase2.md (tasks 1-6: config keys → settings surface → headless service → modal → menu/transcript/screen wiring → wrap-up)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ADR: backlog/decisions/066-console-text-selection-and-annotations.md (phase-2 consequence line added). Plan: Docs/superpowers/plans/2026-08-15-console-side-chat-phase2.md. Spec: Docs/superpowers/specs/2026-08-14-console-selection-annotations-design.md §2/§4/§5/§7.
+
+Phase 2 implemented across commits f87a111c9..41eb62744 (+ this wrap-up) on feat/console-side-chat:
+
+- **Config keys** (`tldw_chatbook/config.py`): `[console] sidechat_model` (default `""` = fall back to the session's provider selection) and `[console] sidechat_prompt_template` (default `"Give me more details about: {selection}"`), template block + loader string coercion. Decision: model uses qualified `provider/model` syntax (e.g. `openai/gpt-4o`) parsed at send time (a bare `model` keeps the session provider, an empty value reuses the session selection as-is); an EMPTY template falls back to the default template (never sends a blank prompt).
+- **Settings surface** (`tldw_chatbook/UI/Screens/settings_screen.py`): both keys in the canonical Console Behavior category — model `Input` (placeholder "empty = current session model"), template `Input` with help text mentioning `{selection}`; staged-edit/save/revert rides the existing `_save_console_behavior_values` trail (no runtime mutation before save).
+- **Headless service** (`tldw_chatbook/Chat/console_side_chat.py`): `ConsoleSideChatService` over `ConsoleProviderGateway.stream_chat` only — persistence-free by construction (the gateway's own contract bypasses Console history and the chat store; no store imports). `render_prompt` substitutes `{selection}` via `str.replace` (never `str.format`), missing placeholder appends the selection on a new line, other braces stay literal, empty template → default. `SideChatOutcome` status is `complete | cancelled | provider_error`; reply buffer tail-capped at `SIDE_CHAT_BUFFER_CAP = 100_000`. Decision: a gateway-blocked resolution surfaces as `status="provider_error"` with safe copy (never raises through the modal boundary).
+- **Modal** (`tldw_chatbook/Widgets/Console/console_side_chat_modal.py`): `ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None])` — More Details auto-sends the rendered prompt on mount; Ask mode shows the quote read-only with a freeform prompt + Send. Streaming reply updates live; Stop cancels (shows "Cancelling…", then the cancelled outcome with Retry); provider errors render inline with Retry; Escape/backdrop cancels the worker and dismisses (task-16211 contract). Async worker runs `exclusive=False, group="console-side-chat"` so it never cancels or blocks `console-run-{session_id}` session workers; monotonic request-id stale guard; `on_unmount` cancels. Added to the dismissal inventory (reachable 38).
+- **Menu + wiring** (`console_selection_menu.py` / `console_transcript.py` / `chat_screen.py`): menu trio Add to chat / More Details / Ask in Side Chat; transcript `MoreDetails`/`AskInSideChat` handlers post `ConsoleSideChatRequested(quote=cap_quote(...), mode=...)` with the same cleanup as Add to chat; ChatScreen handler resolves config + gateway, renders the template for more-details, pushes exactly one modal. Decision (T5 review): a whitespace-only quote (row range cleared while the menu was open) no-ops exactly like the add-to-chat guard — no modal pushed, no send, no toast.
+
+**Tests** (all green): `Tests/test_config_console_defaults.py -k sidechat` (5), `Tests/UI/test_settings_console_side_chat.py`, `Tests/Chat/test_console_side_chat_service.py` (23), `Tests/UI/test_console_side_chat_modal.py`, `Tests/UI/test_console_modal_dismissal.py` (inventory + AST completeness), plus the full selection suites `_core/_rows/_transcript/_menu/_end_to_end/_app_smoke` (87) incl. the new empty-quote-guard test and drag→More Details/Ask end-to-end paths.
+
+**Baselines (pre-existing, unchanged)**: native transcript 3 / chat-flow 1 / markdown-widget 4 — verified after the wrap-up guard; failing tests (speak action-rows, inline image row, markdown flavor) are untouched by the branch.
+
+**Ruff**: `uvx ruff check` on every file this phase touched; all remaining findings intersected against branch-added line ranges (base 08513b5da) are pre-existing main-branch findings — the 3 branch-owned ones (UP035/I001/F401) were fixed in this wrap-up.
+
+**Live-terminal-only verification outstanding** (same as phase 1, per `backlog/docs/lessons-live-verification.md`): real-provider streaming feel, Stop/Retry timing against a live stream, and modal dismissal feel in a real terminal. Task stays In Progress pending that live spike.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_side_chat.py
+++ b/tldw_chatbook/Chat/console_side_chat.py
@@ -1,0 +1,161 @@
+"""Ephemeral console side chat: answer questions about selected transcript text.
+
+Persistence-free by construction: only ConsoleProviderGateway.stream_chat is
+used (its contract bypasses Console history and persistence). The message
+list never leaves the calling modal.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from typing import Any, AsyncIterator
+
+from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.config import DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+
+__all__ = [
+    "DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE",
+    "SIDE_CHAT_BUFFER_CAP",
+    "SIDE_CHAT_SYSTEM_PROMPT",
+    "ConsoleSideChatService",
+    "SideChatOutcome",
+    "cap_reply_buffer",
+    "render_prompt",
+]
+
+SIDE_CHAT_BUFFER_CAP = 100_000
+SIDE_CHAT_SYSTEM_PROMPT = (
+    "You are a helpful assistant answering questions about text the user "
+    "selected in their console session. Be concise and specific."
+)
+
+
+@dataclass(frozen=True)
+class SideChatOutcome:
+    text: str
+    provider: str
+    model: str
+    status: str  # "complete" | "cancelled" | "provider_error"
+    error: str = ""
+
+
+def render_prompt(template: str, selection: str) -> str:
+    """Render the side-chat prompt.
+
+    ``{selection}`` is replaced via ``str.replace`` (other braces stay
+    literal); a blank template falls back to the default; a template missing
+    the placeholder gets the selection appended on a new line.
+    """
+    tmpl = template.strip() or DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+    if "{selection}" in tmpl:
+        return tmpl.replace("{selection}", selection)
+    return f"{tmpl}\n{selection}"
+
+
+def cap_reply_buffer(text: str) -> str:
+    """Keep the tail of an oversized reply."""
+    if len(text) <= SIDE_CHAT_BUFFER_CAP:
+        return text
+    return "…\n" + text[-SIDE_CHAT_BUFFER_CAP:]
+
+
+def _build_selection(
+    provider_selection: ConsoleProviderSelection | None,
+    sidechat_model: str,
+) -> ConsoleProviderSelection | None:
+    """Apply the side-chat model-resolution precedence rules.
+
+    - "provider/model" (contains "/"): derive both from the string.
+    - bare model: keep the session provider, override ``explicit_model``.
+    - empty: reuse the session selection as-is.
+    - no session selection and no qualified model: nothing to send with.
+    """
+    model = (sidechat_model or "").strip()
+    if model and "/" in model:
+        provider_part, _, model_part = model.partition("/")
+        return ConsoleProviderSelection(
+            provider=provider_part, explicit_model=model_part, streaming=True
+        )
+    if provider_selection is None:
+        return None
+    if model:
+        return replace(provider_selection, explicit_model=model, streaming=True)
+    return replace(provider_selection, streaming=True)
+
+
+class ConsoleSideChatService:
+    """Streams one side-chat completion over the provider gateway.
+
+    The service is headless (no Textual widgets, no store writes): callers
+    drive ``run`` from a modal and keep ownership of the message list.
+    """
+
+    def __init__(self, gateway: Any) -> None:
+        self.gateway = gateway
+
+    async def run(
+        self,
+        *,
+        selection_quote: str,
+        prompt: str,
+        provider_selection: ConsoleProviderSelection | None = None,
+        sidechat_model: str = "",
+    ) -> AsyncIterator[str | SideChatOutcome]:
+        """Stream one side-chat completion.
+
+        Yields ``str`` deltas as produced; the final yield is a
+        :class:`SideChatOutcome` (callers detect it via ``isinstance``).
+        """
+        selection = _build_selection(provider_selection, sidechat_model)
+        if selection is None:
+            yield SideChatOutcome(
+                text="",
+                provider="",
+                model="",
+                status="provider_error",
+                error="No provider available for the side chat.",
+            )
+            return
+
+        messages = [
+            {"role": "system", "content": SIDE_CHAT_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt + "\n\nSelected text:\n" + selection_quote},
+        ]
+
+        provider = selection.provider
+        model = selection.explicit_model or ""
+        parts: list[str] = []
+        try:
+            resolution = await self.gateway.resolve_for_send(selection)
+            provider = getattr(resolution, "provider", "") or ""
+            model = getattr(resolution, "model", "") or ""
+            async for item in self.gateway.stream_chat(resolution, messages):
+                if not isinstance(item, str):
+                    continue  # non-str items (tool calls) are not side-chat text
+                parts.append(item)
+                yield item
+        except ChatProviderError as exc:
+            yield SideChatOutcome(
+                text="",
+                provider=provider,
+                model=model,
+                status="provider_error",
+                error=str(exc),
+            )
+            return
+        except asyncio.CancelledError:
+            yield SideChatOutcome(
+                text=cap_reply_buffer("".join(parts)),
+                provider=provider,
+                model=model,
+                status="cancelled",
+            )
+            raise
+
+        yield SideChatOutcome(
+            text=cap_reply_buffer("".join(parts)),
+            provider=provider,
+            model=model,
+            status="complete",
+        )

--- a/tldw_chatbook/Chat/console_side_chat.py
+++ b/tldw_chatbook/Chat/console_side_chat.py
@@ -7,8 +7,9 @@ list never leaves the calling modal.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, replace
-from typing import Any, AsyncIterator
+from typing import Any
 
 from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
 from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection

--- a/tldw_chatbook/Chat/console_side_chat.py
+++ b/tldw_chatbook/Chat/console_side_chat.py
@@ -150,8 +150,11 @@ class ConsoleSideChatService:
                 parts.append(item)
                 yield item
         except ChatProviderError as exc:
+            # Keep any already-streamed deltas in the outcome: the modal
+            # renders outcome.text as the final reply, so text="" would wipe
+            # a partial answer the user was reading mid-stream.
             yield SideChatOutcome(
-                text="",
+                text=cap_reply_buffer("".join(parts)),
                 provider=provider,
                 model=model,
                 status="provider_error",

--- a/tldw_chatbook/Chat/console_side_chat.py
+++ b/tldw_chatbook/Chat/console_side_chat.py
@@ -128,8 +128,21 @@ class ConsoleSideChatService:
         parts: list[str] = []
         try:
             resolution = await self.gateway.resolve_for_send(selection)
-            provider = getattr(resolution, "provider", "") or ""
-            model = getattr(resolution, "model", "") or ""
+            provider = str(getattr(resolution, "provider", "") or "")
+            model = str(getattr(resolution, "model", "") or "").strip()
+            if not getattr(resolution, "ready", True) or not model:
+                # Blocked resolutions (missing key, model-less provider) do not
+                # raise; stream_chat would silently yield zero chunks. Surface
+                # the blocker instead (cf. UI/Console_Modules/prompts.py).
+                yield SideChatOutcome(
+                    text="",
+                    provider=provider,
+                    model=model,
+                    status="provider_error",
+                    error=str(getattr(resolution, "visible_copy", "") or "")
+                    or "Choose a ready provider and model, then reopen the side chat.",
+                )
+                return
             async for item in self.gateway.stream_chat(resolution, messages):
                 if not isinstance(item, str):
                     continue  # non-str items (tool calls) are not side-chat text

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -185,6 +185,7 @@ from ...Chat.console_prefill import (
     parse_prefill_args,
 )
 from ...Chat.console_generate_image import insert_style_token_into_draft
+from ...Chat.console_side_chat import ConsoleSideChatService, render_prompt
 from ...Chat.console_skill_resolver import (
     MENTION_SIGIL,
     SKILL_UNTRUSTED_REFUSE,
@@ -382,6 +383,7 @@ from ...Chat.console_rail_state import (
 )
 from ...config import (
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
+    DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE,
     MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MIN_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     _get_effective_config_path,
@@ -478,7 +480,9 @@ from ...Widgets.Console.console_command_popup import ConsoleCommandPopup
 from ...Widgets.Console.console_selection_menu import (
     ConsoleSelectionMenu,
     ConsoleSelectionQuoteRequested,
+    ConsoleSideChatRequested,
 )
+from ...Widgets.Console.console_side_chat_modal import ConsoleSideChatModal
 from ...Widgets.Console.console_context_modal import ConsoleContextModal
 from ...Widgets.Console.console_cost_modal import ConsoleCostModal
 from ...Widgets.Console.console_citation_sources_modal import (
@@ -19810,6 +19814,48 @@ class ChatScreen(BaseAppScreen):
             # review).
             return
         self.notify("Added selection to composer")
+
+    @on(ConsoleSideChatRequested)
+    def _console_side_chat_requested(self, event: ConsoleSideChatRequested) -> None:
+        """Open the ephemeral side-chat modal about a transcript selection.
+
+        Console selection phase 2: the transcript's floating menu posted
+        this after its "More Details" / "Ask in Side Chat" action. More
+        Details renders the configured prompt template with the capped
+        quote and auto-sends on mount; Ask opens the modal freeform. The
+        model resolves from ``[console] sidechat_model`` when set, else
+        falls back to the active session's provider selection (the modal's
+        identity line shows the request; the service applies the
+        precedence). Nothing is persisted: the side-chat service streams
+        through the provider gateway only, and the reply never leaves the
+        modal. ``event.stop()`` because nothing above this screen
+        subscribes -- the transcript already consumed the originating
+        menu action.
+        """
+        event.stop()
+        sidechat_model = str(get_cli_setting("console", "sidechat_model", "") or "")
+        template = str(
+            get_cli_setting(
+                "console",
+                "sidechat_prompt_template",
+                DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE,
+            )
+            or ""
+        )
+        auto_send_prompt = (
+            render_prompt(template, event.quote)
+            if event.mode == ConsoleSideChatRequested.MODE_MORE_DETAILS
+            else None
+        )
+        self.app.push_screen(
+            ConsoleSideChatModal(
+                service=ConsoleSideChatService(self._ensure_console_provider_gateway()),
+                provider_selection=self._build_console_provider_selection(),
+                sidechat_model=sidechat_model,
+                quote=event.quote,
+                auto_send_prompt=auto_send_prompt,
+            )
+        )
 
     def _recover_stuck_console_send_stash(
         self, stash: "ConsoleDraftStash | None"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -19833,6 +19833,14 @@ class ChatScreen(BaseAppScreen):
         menu action.
         """
         event.stop()
+        if not event.quote.strip():
+            # Same blank-selection window as ``_console_selection_quote_
+            # requested`` above: the row range was cleared while the menu
+            # was open (streaming replace, reconciliation), so there is
+            # nothing to ask about -- pushing the modal (or auto-sending
+            # a contentless More Details prompt) would be a lie (T5 final
+            # review).
+            return
         sidechat_model = str(get_cli_setting("console", "sidechat_model", "") or "")
         template = str(
             get_cli_setting(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -119,6 +119,7 @@ from ...config import (
     ConfigMutationResult,
     DEFAULT_CONFIG_FROM_TOML,
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
+    DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE,
     DEFAULT_CONSOLE_TOOL_RESULT_DISPLAY_CHARS,
     MAX_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
     MAX_CONSOLE_TOOL_RESULT_DISPLAY_CHARS,
@@ -630,6 +631,8 @@ CONSOLE_BEHAVIOR_CONSOLE_KEYS = frozenset(
         "paste_collapse_threshold",
         "max_parallel_runs",
         "tool_result_display_chars",
+        "sidechat_model",
+        "sidechat_prompt_template",
         *CONTEXT_MEMORY_CONFIG_KEYS,
     }
 )
@@ -698,6 +701,8 @@ CONSOLE_BEHAVIOR_SAVE_ORDER = (
     "paste_collapse_threshold",
     "max_parallel_runs",
     "tool_result_display_chars",
+    "sidechat_model",
+    "sidechat_prompt_template",
     *CONTEXT_MEMORY_CONFIG_KEYS,
     "user_display_name",
     "streaming",
@@ -1181,6 +1186,15 @@ def _build_field_search_index() -> None:
                 ("settings-console-paste-collapse-threshold", "Threshold (chars)"),
                 ("settings-console-max-parallel-runs", "Max parallel agent runs"),
                 ("settings-console-tool-result-display-chars", "Display cap (chars)"),
+                ("settings-console-sidechat-model", "Side chat model"),
+                (
+                    "settings-console-sidechat-prompt-template",
+                    "Side chat prompt template",
+                ),
+                (
+                    "settings-console-sidechat-prompt-template",
+                    "More Details prompt",
+                ),
                 (
                     "settings-console-context-budget-mode",
                     "Conversation budget strategy",
@@ -2313,6 +2327,7 @@ class SettingsScreen(BaseAppScreen):
         self._syncing_console_threshold = False
         self._syncing_console_max_parallel_runs = False
         self._syncing_console_tool_result_display_chars = False
+        self._syncing_console_sidechat = False
         self._syncing_console_paste_toggle = False
         self._syncing_console_rail_label_style = False
         self._syncing_console_defaults = False
@@ -3667,6 +3682,8 @@ class SettingsScreen(BaseAppScreen):
                     "console.collapse_large_pastes",
                     "console.paste_collapse_threshold",
                     "console.max_parallel_runs",
+                    "console.sidechat_model",
+                    "console.sidechat_prompt_template",
                     "console.background_effects.*",
                     "console.conversation_budget_*",
                     "console.compaction_*",
@@ -3866,6 +3883,23 @@ class SettingsScreen(BaseAppScreen):
             maximum=MAX_CONSOLE_TOOL_RESULT_DISPLAY_CHARS,
         )
 
+    def _loaded_console_sidechat_model(self) -> str:
+        # Side-chat phase 2 (task-2): empty string means "use the current
+        # session's model" -- the fallback lives in the side-chat service.
+        value = self._console_settings().get("sidechat_model", "")
+        return value.strip() if isinstance(value, str) else ""
+
+    def _loaded_console_sidechat_prompt_template(self) -> str:
+        # Mirrors the loader's coercion (config.py): non-strings fall back
+        # to the default; a blank string stays blank and the runtime side
+        # chat falls back to the default template.
+        value = self._console_settings().get(
+            "sidechat_prompt_template", DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+        )
+        if not isinstance(value, str):
+            return DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+        return value.strip()
+
     @staticmethod
     def _coerce_float_default(
         value: object,
@@ -3984,6 +4018,10 @@ class SettingsScreen(BaseAppScreen):
             "paste_collapse_threshold": self._loaded_paste_collapse_threshold(),
             "max_parallel_runs": self._loaded_console_max_parallel_runs(),
             "tool_result_display_chars": self._loaded_tool_result_display_chars(),
+            "sidechat_model": self._loaded_console_sidechat_model(),
+            "sidechat_prompt_template": (
+                self._loaded_console_sidechat_prompt_template()
+            ),
             "user_display_name": self._loaded_console_default_user_display_name(),
             "streaming": self._loaded_console_default_streaming(),
             "temperature": self._loaded_console_default_temperature(),
@@ -6287,6 +6325,39 @@ class SettingsScreen(BaseAppScreen):
                 ),
                 ("Saved as", "console.stack_collapsed_rail_labels"),
                 ("Applies", "After saving, when Console is next opened."),
+            )
+        if self._active_settings_field_id == "settings-console-sidechat-model":
+            return (
+                ("Purpose", "Model used by the ephemeral selection side chat."),
+                (
+                    "Consequences",
+                    (
+                        "Empty uses the current Console session's provider and "
+                        "model; side-chat replies are never persisted."
+                    ),
+                ),
+                ("Saved as", "console.sidechat_model"),
+                ("Applies", "Side chats opened after saving."),
+            )
+        if (
+            self._active_settings_field_id
+            == "settings-console-sidechat-prompt-template"
+        ):
+            return (
+                (
+                    "Purpose",
+                    "Prompt sent by the selection menu's More Details action.",
+                ),
+                (
+                    "Consequences",
+                    (
+                        "{selection} inserts the selected transcript text; "
+                        "without it the selection is appended. Empty uses the "
+                        "built-in default."
+                    ),
+                ),
+                ("Saved as", "console.sidechat_prompt_template"),
+                ("Applies", "Side chats opened after saving."),
             )
         if (
             self._active_settings_field_id
@@ -12347,7 +12418,7 @@ class SettingsScreen(BaseAppScreen):
             )
             yield Static(
                 "Also in this category: rail presentation, paste handling, images, "
-                "agent limits, and generation defaults.",
+                "agent limits, selection side chat, and generation defaults.",
                 id="settings-console-behavior-section-index",
                 classes="settings-detail-row",
             )
@@ -12439,6 +12510,39 @@ class SettingsScreen(BaseAppScreen):
                 "everything beyond this cap.",
                 id="settings-console-tool-result-display-chars-help",
                 classes="settings-detail-row",
+            )
+            yield Static("Selection side chat", classes="destination-section")
+            yield Static(
+                "Ephemeral chat about selected transcript text (More Details / "
+                "Ask in Side Chat). Nothing is persisted.",
+                id="settings-console-sidechat-help",
+                classes="settings-detail-row",
+            )
+            with Horizontal(classes="settings-input-row"):
+                yield Static("Side chat model", classes="settings-input-label")
+                yield Input(
+                    value=self._console_input_value(
+                        self._console_behavior_value("sidechat_model")
+                    ),
+                    id="settings-console-sidechat-model",
+                    classes="settings-compact-input",
+                    placeholder="empty = current session model",
+                )
+            with Horizontal(classes="settings-input-row"):
+                yield Static("Prompt template", classes="settings-input-label")
+                yield Input(
+                    value=self._console_input_value(
+                        self._console_behavior_value("sidechat_prompt_template")
+                    ),
+                    id="settings-console-sidechat-prompt-template",
+                    classes="settings-compact-input",
+                    placeholder=DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE,
+                )
+            yield Static(
+                "Template used by More Details: {selection} inserts the selected "
+                "text; without it the selection is appended. An empty template "
+                "uses the built-in default.",
+                id="settings-console-sidechat-prompt-template-help",
             )
             yield Static(
                 "Conversation context and memory",
@@ -17075,6 +17179,8 @@ class SettingsScreen(BaseAppScreen):
                 "settings-console-paste-collapse-threshold",
                 "settings-console-max-parallel-runs",
                 "settings-console-tool-result-display-chars",
+                "settings-console-sidechat-model",
+                "settings-console-sidechat-prompt-template",
                 "settings-console-default-user-display-name",
             }
             self._active_settings_field_id = (
@@ -18056,6 +18162,27 @@ class SettingsScreen(BaseAppScreen):
         if self._syncing_console_tool_result_display_chars:
             return
         self._stage_tool_result_display_chars_value(event.value)
+        self._console_behavior_result = "Console behavior settings staged."
+        self._set_static_text(
+            "#settings-console-behavior-result", self._console_behavior_result_text()
+        )
+        self._update_draft_status_widgets(SettingsCategoryId.CONSOLE_BEHAVIOR)
+
+    @on(Input.Changed, "#settings-console-sidechat-model")
+    @on(Input.Changed, "#settings-console-sidechat-prompt-template")
+    def handle_console_sidechat_changed(self, event: Input.Changed) -> None:
+        """Stage a selection side-chat string preference (phase 2 task-2)."""
+        event.stop()
+        if self._syncing_console_sidechat:
+            return
+        key_by_id = {
+            "settings-console-sidechat-model": "sidechat_model",
+            "settings-console-sidechat-prompt-template": "sidechat_prompt_template",
+        }
+        key = key_by_id.get(event.input.id or "")
+        if key is None:
+            return
+        self._stage_console_default_value(key, event.value)
         self._console_behavior_result = "Console behavior settings staged."
         self._set_static_text(
             "#settings-console-behavior-result", self._console_behavior_result_text()
@@ -20479,6 +20606,19 @@ class SettingsScreen(BaseAppScreen):
                             dirty_values["tool_result_display_chars"]
                         )
                     )
+                if "sidechat_model" in dirty_values:
+                    # Plain strings: strip only, mirroring the loader's
+                    # presence-validation coercion (config.py). An empty model
+                    # legitimately means "use the session model".
+                    dirty_values["sidechat_model"] = str(
+                        dirty_values["sidechat_model"]
+                    ).strip()
+                if "sidechat_prompt_template" in dirty_values:
+                    # An empty template legitimately means "use the built-in
+                    # default" at runtime; no placeholder validation here.
+                    dirty_values["sidechat_prompt_template"] = str(
+                        dirty_values["sidechat_prompt_template"]
+                    ).strip()
                 if any(key in dirty_values for key in CONTEXT_MEMORY_CONFIG_KEYS):
                     normalized_context = normalize_context_memory_values(
                         self._current_context_memory_values()
@@ -21536,6 +21676,23 @@ class SettingsScreen(BaseAppScreen):
                 ).value = str(self._tool_result_display_chars_value())
             finally:
                 self._syncing_console_tool_result_display_chars = False
+        except QueryError:
+            pass
+        try:
+            self._syncing_console_sidechat = True
+            try:
+                self.query_one("#settings-console-sidechat-model", Input).value = (
+                    self._console_input_value(
+                        self._console_behavior_value("sidechat_model")
+                    )
+                )
+                self.query_one(
+                    "#settings-console-sidechat-prompt-template", Input
+                ).value = self._console_input_value(
+                    self._console_behavior_value("sidechat_prompt_template")
+                )
+            finally:
+                self._syncing_console_sidechat = False
         except QueryError:
             pass
         self._syncing_console_context_memory = True

--- a/tldw_chatbook/Widgets/Console/console_selection_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_selection_menu.py
@@ -29,6 +29,24 @@ class ConsoleSelectionQuoteRequested(Message):
         self.quote = quote
 
 
+class ConsoleSideChatRequested(Message):
+    """Bubbled when the user opens an ephemeral side chat about a selection.
+
+    Console selection phase 2: the transcript posts this after the menu's
+    "More Details" (``mode="more-details"``) or "Ask in Side Chat"
+    (``mode="ask"``) action; the owning ``ChatScreen`` resolves config +
+    gateway and pushes ``ConsoleSideChatModal``.
+    """
+
+    MODE_MORE_DETAILS = "more-details"
+    MODE_ASK = "ask"
+
+    def __init__(self, quote: str, mode: str) -> None:
+        super().__init__()
+        self.quote = quote
+        self.mode = mode
+
+
 class ConsoleSelectionMenu(Vertical):
     """Floating stacked menu anchored at the selection release cell."""
 
@@ -50,6 +68,12 @@ class ConsoleSelectionMenu(Vertical):
 
     class AddToChat(Message):
         """User chose 'Add to chat' for the active selection."""
+
+    class MoreDetails(Message):
+        """User chose 'More Details' (auto-send side chat) for the selection."""
+
+    class AskInSideChat(Message):
+        """User chose 'Ask in Side Chat' (freeform) for the selection."""
 
     def __init__(self, *, local_x: int, local_y: int, has_add_to_chat: bool = True) -> None:
         """Anchor the menu at transcript-local coordinates.
@@ -73,6 +97,8 @@ class ConsoleSelectionMenu(Vertical):
     def compose(self):
         if self._has_add_to_chat:
             yield Button("Add to chat", id="console-selection-add-to-chat", variant="primary")
+        yield Button("More Details", id="console-selection-more-details")
+        yield Button("Ask in Side Chat", id="console-selection-ask-side-chat")
 
     def on_mount(self) -> None:
         x, y = self._anchor
@@ -130,6 +156,14 @@ class ConsoleSelectionMenu(Vertical):
     @on(Button.Pressed, "#console-selection-add-to-chat")
     def _add_to_chat(self) -> None:
         self.post_message(self.AddToChat())
+
+    @on(Button.Pressed, "#console-selection-more-details")
+    def _more_details(self) -> None:
+        self.post_message(self.MoreDetails())
+
+    @on(Button.Pressed, "#console-selection-ask-side-chat")
+    def _ask_side_chat(self) -> None:
+        self.post_message(self.AskInSideChat())
 
     def action_dismiss(self) -> None:
         self.remove()

--- a/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
@@ -1,0 +1,394 @@
+"""Ephemeral Console side-chat modal (selection menu phase 2).
+
+Answers questions about selected transcript text without touching the chat
+store: the reply lives only in this modal, streamed through
+:class:`~tldw_chatbook.Chat.console_side_chat.ConsoleSideChatService` in a
+non-exclusive ``console-side-chat`` worker (never the session run group).
+
+Two entry modes:
+
+- ``auto_send_prompt`` (More Details): the rendered prompt is sent
+  automatically on mount.
+- ``None`` (Ask in Side Chat): the quote is shown read-only and the user
+  types a freeform prompt.
+
+Escape / backdrop / Close cancel any in-flight stream and dismiss (safe
+modal contract); Stop and Retry ride the same worker choreography as the
+prompt-improvement flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+from loguru import logger
+from textual import events, on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static, TextArea
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleProviderSelection
+from tldw_chatbook.Chat.console_side_chat import (
+    ConsoleSideChatService,
+    SideChatOutcome,
+    cap_reply_buffer,
+)
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+_CONTENT = "#console-side-chat-modal"
+_IDENTITY = "#console-side-chat-identity"
+_QUOTE = "#console-side-chat-quote"
+_PROMPT = "#console-side-chat-prompt"
+_REPLY = "#console-side-chat-reply"
+_STATUS = "#console-side-chat-status"
+_SEND = "#console-side-chat-send"
+_STOP = "#console-side-chat-stop"
+_RETRY = "#console-side-chat-retry"
+_CLOSE = "#console-side-chat-close"
+
+# Bare widget ids (Textual identifiers must not include the ``#``).
+_ID_MODAL = "console-side-chat-modal"
+_ID_IDENTITY = "console-side-chat-identity"
+_ID_QUOTE = "console-side-chat-quote"
+_ID_PROMPT = "console-side-chat-prompt"
+_ID_REPLY = "console-side-chat-reply"
+_ID_STATUS = "console-side-chat-status"
+_ID_SEND = "console-side-chat-send"
+_ID_STOP = "console-side-chat-stop"
+_ID_RETRY = "console-side-chat-retry"
+_ID_CLOSE = "console-side-chat-close"
+
+SIDE_CHAT_WORKER_GROUP = "console-side-chat"
+
+
+class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
+    """Ephemeral side chat about a quoted transcript selection."""
+
+    DEFAULT_CSS = """
+    ConsoleSideChatModal {
+        align: center middle;
+    }
+
+    #console-side-chat-modal {
+        width: 92;
+        height: 30;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #console-side-chat-identity {
+        height: auto;
+        color: gray;
+    }
+
+    #console-side-chat-quote {
+        height: 5;
+        border: round gray;
+        padding: 0 1;
+        margin: 1 0;
+        color: $text-muted;
+    }
+
+    #console-side-chat-prompt {
+        height: 3;
+        margin: 0 0 1 0;
+    }
+
+    #console-side-chat-reply-scroll {
+        height: 1fr;
+        min-height: 3;
+        margin: 0 0 1 0;
+    }
+
+    #console-side-chat-status {
+        height: auto;
+        min-height: 1;
+        color: $text-muted;
+    }
+
+    #console-side-chat-actions {
+        height: 3;
+        min-height: 3;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+
+    #console-side-chat-close,
+    #console-side-chat-retry,
+    #console-side-chat-send,
+    #console-side-chat-stop {
+        width: 10;
+        min-width: 10;
+        height: 3;
+        min-height: 3;
+    }
+    """
+
+    SAFE_MODAL_CONTENT = _CONTENT
+    BINDINGS = (("escape", "request_safe_cancel", "Cancel"),)
+
+    def __init__(
+        self,
+        *,
+        service: ConsoleSideChatService,
+        provider_selection: ConsoleProviderSelection | None,
+        sidechat_model: str,
+        quote: str,
+        auto_send_prompt: str | None,
+        callback: Callable[[SideChatOutcome], object] | None = None,
+    ) -> None:
+        super().__init__()
+        self._service = service
+        self._provider_selection = provider_selection
+        self._sidechat_model = sidechat_model
+        self._quote = quote
+        self._auto_send_prompt = auto_send_prompt
+        self._callback = callback
+        self._sidechat_worker = None
+        self._request_counter = 0
+        self._active_request_id: int | None = None
+        self._last_prompt: str | None = None
+        self._reply_text = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id=_ID_MODAL):
+            yield Static("Side Chat", classes="console-modal-header")
+            yield Static(
+                self._requested_identity(),
+                id=_ID_IDENTITY,
+                markup=False,
+            )
+            yield Static(self._quote, id=_ID_QUOTE, markup=False)
+            yield TextArea("", id=_ID_PROMPT)
+            with VerticalScroll(id="console-side-chat-reply-scroll"):
+                yield Static("", id=_ID_REPLY, markup=False)
+            yield Static("", id=_ID_STATUS, markup=False)
+            with Horizontal(id="console-side-chat-actions"):
+                yield Button("Send", id=_ID_SEND, variant="primary")
+                yield Button("Stop", id=_ID_STOP)
+                yield Button("Retry", id=_ID_RETRY)
+                yield Button("Close", id=_ID_CLOSE)
+
+    # Textual composes MRO message handlers, so this event-shaped handler
+    # runs alongside (not instead of) the mixin's opener-focus capture.
+    def on_mount(self, event: events.Mount) -> None:  # type: ignore[override]
+        del event
+        auto_mode = self._auto_send_prompt is not None
+        try:
+            self.query_one(_PROMPT, TextArea).display = not auto_mode
+        except NoMatches:
+            pass
+        self._set_action_visible(_SEND, not auto_mode)
+        self._set_action_visible(_STOP, False)
+        self._set_action_visible(_RETRY, False)
+        if auto_mode:
+            self._start_sidechat(self._auto_send_prompt or "")
+        else:
+            self.query_one(_PROMPT, TextArea).focus()
+
+    def on_unmount(self) -> None:
+        # The mixin's own on_unmount (opener-ref release) also runs via the
+        # composed MRO dispatch.
+        self._active_request_id = None
+        worker = self._sidechat_worker
+        if worker is not None and not worker.is_finished:
+            worker.cancel()
+
+    # ------------------------------------------------------------------
+    # Worker choreography (mirrors the prompt-improvement flow)
+    # ------------------------------------------------------------------
+
+    def _next_request_id(self) -> int:
+        self._request_counter += 1
+        return self._request_counter
+
+    def _start_sidechat(self, prompt: str) -> None:
+        self._last_prompt = prompt
+        self._reply_text = ""
+        self._update_reply("")
+        request_id = self._next_request_id()
+        self._active_request_id = request_id
+        self._set_streaming(True)
+        self._set_status("Streaming…")
+        self._sidechat_worker = self.run_worker(
+            self._run_sidechat(request_id, prompt),
+            exclusive=False,
+            group=SIDE_CHAT_WORKER_GROUP,
+        )
+
+    async def _run_sidechat(self, request_id: int, prompt: str) -> None:
+        try:
+            async for item in self._service.run(
+                selection_quote=self._quote,
+                prompt=prompt,
+                provider_selection=self._provider_selection,
+                sidechat_model=self._sidechat_model,
+            ):
+                if self._active_request_id != request_id:
+                    return  # a newer request (or dismissal) owns the UI now
+                if isinstance(item, SideChatOutcome):
+                    self._finish_sidechat(request_id, item)
+                    return
+                if isinstance(item, str):
+                    self._append_delta(item)
+        except asyncio.CancelledError:
+            # The service yields its cancelled outcome before re-raising;
+            # the outcome was handled above, so let cancellation finish.
+            raise
+        except Exception:  # noqa: BLE001 - worker guard must surface any failure inline
+            logger.exception("Console side-chat worker failed unexpectedly")
+            if self._active_request_id == request_id:
+                self._active_request_id = None
+                self._set_streaming(False)
+                self._set_status(
+                    "The side chat could not run. Check the provider and retry."
+                )
+                self._set_action_visible(_RETRY, True)
+
+    def _finish_sidechat(self, request_id: int, outcome: SideChatOutcome) -> None:
+        if self._active_request_id != request_id:
+            return
+        self._active_request_id = None
+        self._set_streaming(False)
+        # Resolution arrives with the outcome; until then the header keeps
+        # the requested identity.
+        if outcome.provider or outcome.model:
+            self._update_identity(
+                self._identity_text(outcome.provider, outcome.model)
+            )
+        self._update_reply(cap_reply_buffer(outcome.text))
+        if outcome.status == "complete":
+            self._set_status("Complete.")
+            self._set_action_visible(_SEND, self._auto_send_prompt is None)
+        elif outcome.status == "cancelled":
+            self._set_status("Cancelled.")
+            self._set_action_visible(_RETRY, True)
+        else:
+            error = outcome.error or "the provider reported an error"
+            self._set_status(f"Provider error: {error}")
+            self._set_action_visible(_RETRY, True)
+        if self._callback is not None:
+            try:
+                self._callback(outcome)
+            except Exception:  # noqa: BLE001 - a failing callback must not break the modal
+                logger.exception("Console side-chat callback failed")
+
+    def _stop_streaming(self) -> None:
+        worker = self._sidechat_worker
+        if self._active_request_id is None or worker is None:
+            return
+        self._set_status("Cancelling…")
+        # Keep _active_request_id so the cancelled outcome the service yields
+        # on the way out still lands in the reply area.
+        worker.cancel()
+
+    # ------------------------------------------------------------------
+    # Dismissal contract
+    # ------------------------------------------------------------------
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        del source
+        await self.run_cancel_effect_once(self._cancel_sidechat_worker)
+        self.dismiss_safe_once(None)
+
+    async def _cancel_sidechat_worker(self) -> None:
+        self._active_request_id = None  # dismissing: in-flight outcomes stale
+        worker = self._sidechat_worker
+        if worker is not None and not worker.is_finished:
+            worker.cancel()
+
+    # ------------------------------------------------------------------
+    # Buttons
+    # ------------------------------------------------------------------
+
+    @on(Button.Pressed, _SEND)
+    def _send(self, event: Button.Pressed) -> None:
+        event.stop()
+        prompt = self.query_one(_PROMPT, TextArea).text
+        if not prompt.strip():
+            self._set_status("Type a question first.")
+            return
+        self._start_sidechat(prompt)
+
+    @on(Button.Pressed, _STOP)
+    def _stop(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._stop_streaming()
+
+    @on(Button.Pressed, _RETRY)
+    def _retry(self, event: Button.Pressed) -> None:
+        event.stop()
+        prompt = self._last_prompt or self._auto_send_prompt
+        if prompt is None:
+            prompt = self.query_one(_PROMPT, TextArea).text
+        if not prompt.strip():
+            self._set_status("Type a question first.")
+            return
+        self._start_sidechat(prompt)
+
+    @on(Button.Pressed, _CLOSE)
+    async def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="button")
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+
+    def _set_status(self, message: str) -> None:
+        try:
+            self.query_one(_STATUS, Static).update(message)
+        except NoMatches:
+            return
+
+    def _set_action_visible(self, selector: str, visible: bool) -> None:
+        try:
+            self.query_one(selector, Button).display = visible
+        except NoMatches:
+            return
+
+    def _set_streaming(self, active: bool) -> None:
+        self._set_action_visible(_STOP, active)
+        if active:
+            self._set_action_visible(_SEND, False)
+            self._set_action_visible(_RETRY, False)
+
+    def _append_delta(self, delta: str) -> None:
+        self._reply_text += delta
+        self._update_reply(cap_reply_buffer(self._reply_text))
+
+    def _update_reply(self, text: str) -> None:
+        try:
+            self.query_one(_REPLY, Static).update(text)
+        except NoMatches:
+            return
+
+    def _update_identity(self, text: str) -> None:
+        try:
+            self.query_one(_IDENTITY, Static).update(text)
+        except NoMatches:
+            return
+
+    # ------------------------------------------------------------------
+    # Requested provider·model identity
+    # ------------------------------------------------------------------
+
+    def _requested_identity(self) -> str:
+        configured = (self._sidechat_model or "").strip()
+        if configured and "/" in configured:
+            return configured
+        provider = str(getattr(self._provider_selection, "provider", "") or "")
+        model = configured or str(
+            getattr(self._provider_selection, "explicit_model", "") or ""
+        )
+        return self._identity_text(provider, model)
+
+    @staticmethod
+    def _identity_text(provider: str, model: str) -> str:
+        if provider and model:
+            return f"{provider}·{model}"
+        return provider or model or "session model"

--- a/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
@@ -211,6 +211,13 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
         self._reply_text = ""
         self._update_reply("")
         request_id = self._next_request_id()
+        # Deliberately weaker than the prompts-modal choreography: a
+        # superseded worker is NOT cancelled here. Only Send/Retry can call
+        # this while a stream is live, and _set_streaming hides both, so the
+        # race needs a second press to land before the display update —
+        # unreachable in practice. If it ever fires, the stale worker is
+        # wasted background work only; its deltas/outcome are dropped by the
+        # request-id fence below and in _finish_sidechat.
         self._active_request_id = request_id
         self._set_streaming(True)
         self._set_status("Streaming…")
@@ -247,7 +254,7 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
                 self._set_status(
                     "The side chat could not run. Check the provider and retry."
                 )
-                self._set_action_visible(_RETRY, True)
+                self._show_retry_actions()
 
     def _finish_sidechat(self, request_id: int, outcome: SideChatOutcome) -> None:
         if self._active_request_id != request_id:
@@ -266,11 +273,11 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
             self._set_action_visible(_SEND, self._auto_send_prompt is None)
         elif outcome.status == "cancelled":
             self._set_status("Cancelled.")
-            self._set_action_visible(_RETRY, True)
+            self._show_retry_actions()
         else:
             error = outcome.error or "the provider reported an error"
             self._set_status(f"Provider error: {error}")
-            self._set_action_visible(_RETRY, True)
+            self._show_retry_actions()
         if self._callback is not None:
             try:
                 self._callback(outcome)
@@ -308,6 +315,7 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
     @on(Button.Pressed, _SEND)
     def _send(self, event: Button.Pressed) -> None:
         event.stop()
+        # Send always submits the CURRENT TextArea content (Ask mode only).
         prompt = self.query_one(_PROMPT, TextArea).text
         if not prompt.strip():
             self._set_status("Type a question first.")
@@ -322,6 +330,8 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
     @on(Button.Pressed, _RETRY)
     def _retry(self, event: Button.Pressed) -> None:
         event.stop()
+        # Retry re-sends the last prompt UNCHANGED — it deliberately does
+        # not read the TextArea; edited text goes through Send instead.
         prompt = self._last_prompt or self._auto_send_prompt
         if prompt is None:
             prompt = self.query_one(_PROMPT, TextArea).text
@@ -350,6 +360,18 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
             self.query_one(selector, Button).display = visible
         except NoMatches:
             return
+
+    def _show_retry_actions(self) -> None:
+        """Actions after a cancelled/errored stream.
+
+        Retry always re-sends the last prompt unchanged (``_last_prompt``).
+        In Ask mode the prompt TextArea is still visible and editable, so
+        Send must come back alongside Retry — otherwise an edited prompt
+        could only be silently re-sent unchanged. Send always reads the
+        TextArea. In auto mode there is no prompt area, so Retry alone.
+        """
+        self._set_action_visible(_RETRY, True)
+        self._set_action_visible(_SEND, self._auto_send_prompt is None)
 
     def _set_streaming(self, active: bool) -> None:
         self._set_action_visible(_STOP, active)

--- a/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_side_chat_modal.py
@@ -358,7 +358,10 @@ class ConsoleSideChatModal(SafeModalDismissMixin, ModalScreen[None]):
             self._set_action_visible(_RETRY, False)
 
     def _append_delta(self, delta: str) -> None:
-        self._reply_text += delta
+        # Cap the in-memory accumulator too, not just the rendered copy: a
+        # multi-gigabyte stream would otherwise grow ``_reply_text``
+        # without bound between renders (T4 review).
+        self._reply_text = cap_reply_buffer(self._reply_text + delta)
         self._update_reply(cap_reply_buffer(self._reply_text))
 
     def _update_reply(self, text: str) -> None:

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -70,6 +70,7 @@ from tldw_chatbook.Widgets.Console.console_selection import (
 from tldw_chatbook.Widgets.Console.console_selection_menu import (
     ConsoleSelectionMenu,
     ConsoleSelectionQuoteRequested,
+    ConsoleSideChatRequested,
 )
 from tldw_chatbook.Widgets.Console.console_video_card import (
     ConsoleVideoCard,
@@ -3502,27 +3503,69 @@ class ConsoleTranscript(VerticalScroll):
     def _selection_add_to_chat(self, event: ConsoleSelectionMenu.AddToChat) -> None:
         """Quote the active row selection up to the owning screen and clean up."""
         event.stop()
-        manager = self.selection_manager
-        sel = manager.state.selection
-        row: ConsoleTranscriptMessage | ConsoleMarkdownMessage | None = None
-        if sel is not None:
-            # Query by id without a type expectation: the selected row may be
-            # a plain OR a markdown row (task G), and a typed query_one would
-            # raise WrongType on the other kind.
-            try:
-                widget = self.query_one(f"#{sel.row_key}")
-            except NoMatches:
-                widget = None
-            if isinstance(widget, (ConsoleTranscriptMessage, ConsoleMarkdownMessage)):
-                row = widget
+        row = self._active_selection_row()
         if row is not None:
             self.post_message(
                 ConsoleSelectionQuoteRequested(quote=cap_quote(row.get_selection_text()))
             )
             row.clear_selection()
-        manager.cancel()
+        self.selection_manager.cancel()
         self._selection_origin_row = None
         self._remove_selection_menu()
+
+    @on(ConsoleSelectionMenu.MoreDetails)
+    def _selection_more_details(
+        self, event: ConsoleSelectionMenu.MoreDetails
+    ) -> None:
+        """Open a More Details side chat about the active selection."""
+        event.stop()
+        self._request_side_chat(ConsoleSideChatRequested.MODE_MORE_DETAILS)
+
+    @on(ConsoleSelectionMenu.AskInSideChat)
+    def _selection_ask_side_chat(
+        self, event: ConsoleSelectionMenu.AskInSideChat
+    ) -> None:
+        """Open a freeform Ask in Side Chat about the active selection."""
+        event.stop()
+        self._request_side_chat(ConsoleSideChatRequested.MODE_ASK)
+
+    def _request_side_chat(self, mode: str) -> None:
+        """Post a capped-selection side-chat request and clean up (phase 2).
+
+        Same quote plumbing and cleanup as ``_selection_add_to_chat``: the
+        selection text is capped by ``cap_quote`` before it leaves the
+        transcript, the row range is cleared, the drag manager cancelled,
+        and the menu removed.
+        """
+        row = self._active_selection_row()
+        if row is not None:
+            self.post_message(
+                ConsoleSideChatRequested(
+                    quote=cap_quote(row.get_selection_text()), mode=mode
+                )
+            )
+            row.clear_selection()
+        self.selection_manager.cancel()
+        self._selection_origin_row = None
+        self._remove_selection_menu()
+
+    def _active_selection_row(
+        self,
+    ) -> ConsoleTranscriptMessage | ConsoleMarkdownMessage | None:
+        """Resolve the row widget holding the active selection, if any."""
+        sel = self.selection_manager.state.selection
+        if sel is None:
+            return None
+        # Query by id without a type expectation: the selected row may be
+        # a plain OR a markdown row (task G), and a typed query_one would
+        # raise WrongType on the other kind.
+        try:
+            widget = self.query_one(f"#{sel.row_key}")
+        except NoMatches:
+            return None
+        if isinstance(widget, (ConsoleTranscriptMessage, ConsoleMarkdownMessage)):
+            return widget
+        return None
 
     def _attached_selection_menus(self) -> list[ConsoleSelectionMenu]:
         """Menus still attached whose removal is not already scheduled.

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -732,6 +732,11 @@ DEFAULT_CONSOLE_TOOL_RESULT_DISPLAY_CHARS = 160
 MIN_CONSOLE_TOOL_RESULT_DISPLAY_CHARS = 20
 MAX_CONSOLE_TOOL_RESULT_DISPLAY_CHARS = 2000
 
+# Ephemeral side chat (Console selection menu): the default prompt template
+# for the "More Details" action. ``{selection}`` is the only placeholder the
+# side-chat service substitutes (Task-3 renders it via replace, not format).
+DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE = "Give me more details about: {selection}"
+
 
 def coerce_bool_setting(value: Any, default: bool = True) -> bool:
     """Coerce config/app setting values with the same bool rules as load_settings.
@@ -1319,6 +1324,20 @@ def load_settings(force_reload: bool = False) -> Dict:
     if not isinstance(workspace_root, str):
         workspace_root = ""
     final_console_settings_cli["workspace_root"] = workspace_root.strip()
+    # Ephemeral side chat (selection menu): strings need presence-validation
+    # only -- non-strings fall back, mirroring workspace_root above.
+    sidechat_model = final_console_settings_cli.get("sidechat_model", "")
+    if not isinstance(sidechat_model, str):
+        sidechat_model = ""
+    final_console_settings_cli["sidechat_model"] = sidechat_model.strip()
+    sidechat_prompt_template = final_console_settings_cli.get(
+        "sidechat_prompt_template", DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+    )
+    if not isinstance(sidechat_prompt_template, str):
+        sidechat_prompt_template = DEFAULT_CONSOLE_SIDECHAT_PROMPT_TEMPLATE
+    final_console_settings_cli["sidechat_prompt_template"] = (
+        sidechat_prompt_template.strip()
+    )
     background_effects = final_console_settings_cli.get("background_effects")
     if not isinstance(background_effects, dict):
         background_effects = {}
@@ -2699,6 +2718,9 @@ compaction_summary_max_tokens = 1024
 compaction_failure_behavior = "stop_and_ask"  # stop_and_ask, omit_older_context
 compaction_carry_forward_mode = "memory_with_recent_turns"  # memory_with_recent_turns, memory_with_latest_exchange
 # workspace_root = ""           # confinement root for fs_* tools; empty = app cwd at startup
+# Ephemeral side chat (selection menu) — empty model = session model
+sidechat_model = ""  # e.g. "openai/gpt-5-mini"; empty = follow the current session's model
+sidechat_prompt_template = "Give me more details about: {selection}"  # {selection} = the quoted text
 
 [console.background_effects]
 enabled = false  # Optional Console ambience. Off by default for readability.


### PR DESCRIPTION
## Summary

Phase 2 of console selection (stacked on #1663 — merge that first): the ephemeral side chat. The selection menu now offers **Add to chat | More Details | Ask in Side Chat**:

- **More Details** opens `ConsoleSideChatModal` and auto-sends the rendered prompt template (default `Give me more details about: {selection}`) against the configured side-chat model.
- **Ask in Side Chat** opens the same modal with the selection quoted read-only and a freeform prompt — Send / Stop / Retry, with post-stop Send-vs-Retry semantics (Retry resends the original; Send reads the edited prompt).
- **Settings** (Settings → Console Behavior): `console.sidechat_model` (accepts `provider/model`; empty = current session model) and `console.sidechat_prompt_template` (empty = built-in default).
- **Ephemeral by construction**: `Chat/console_side_chat.py` is a gateway-only streaming service (zero store imports, no session context, no persistence — same guarantee as the prompt-improvement seam); the modal runs a non-exclusive worker in group `console-side-chat` so it can never cancel or block a running agent turn. Blocked provider resolutions surface as errors with visible copy + Retry rather than silently streaming nothing.

Docs: ADR-066 consequence line; TASK-16312 (In Progress pending the live-terminal spike, same as TASK-16311 in #1663).

## Testing

- 75/75 phase tests: service (model resolution incl. `provider/model` syntax, blocked-resolutions→provider_error, cancellation keeps partial text, buffer tail-cap), modal (auto-send vs freeform, Stop/Retry/Send state machine, mid-stream Escape via SafeModalDismissMixin, capped streaming display), settings (staging/save-payload/revert), menu trio ordering + end-to-end (drag → modal with rendered template; empty-quote no-op), plus the modal-dismissal AST inventory (reachable count 37→38, self-destructing exclusion removed).
- All provider interactions tested via fakes (no live LLM in CI); red-first TDD throughout, including the final-review fix wave (Ask-mode retry dead-end, partial-text preservation on provider error).
- Pre-existing dev baselines unchanged: native transcript 3, chat-flow 1, markdown-widget 4.

## Known limitations (documented in ADR-066 / task notes)

- Live-terminal spike outstanding (both phases gate their backlog tasks on it): real-provider streaming feel, Stop/Retry timing, dismissal feel.
- Identity header briefly switches format (`provider/model` → `provider·model`) after resolution; superseded-worker double-press race is request-id-fenced rather than cancelled (commented in code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ephemeral side chat for console text selections. Previously selections only supported Add to chat; now the menu offers More Details and Ask in Side Chat, opening a streaming modal that never persists messages and never interrupts a running agent turn.

**Review notes**
- Behavior: More Details auto-sends a rendered template prompt; Ask in Side Chat shows the quoted selection read-only and accepts a freeform prompt. Send/Stop/Retry follow the prompt-improvement semantics; Escape/backdrop/Close cancel the stream and dismiss. Empty selections no-op.
- Service: `ConsoleSideChatService` streams via the provider gateway only (no store, no session context, no persistence) and runs in non-exclusive worker group `console-side-chat`. Model resolution accepts `provider/model`; an empty `console.sidechat_model` falls back to the current session model. Provider resolution errors surface inline with Retry; cancellation and errors preserve partial text; replies cap at 100k chars.
- Settings: Adds `console.sidechat_model` and `console.sidechat_prompt_template` (default: "Give me more details about: {selection}") under Console Behavior. Leaving the model empty preserves current behavior by using the session model.
- Touchpoints: new `Chat/console_side_chat.py` and `Widgets/Console/console_side_chat_modal.py`; menu and transcript emit `ConsoleSideChatRequested`; `chat_screen` resolves config and pushes the modal; `settings_screen` and `config.py` add the two settings. Extensive tests cover service, modal, menu wiring, settings, and defaults.

**Rollout**
- No migrations or flags. Defaults keep existing behavior unless users set a side-chat model or template.

<sup>Written for commit a377bc2bf3056f79c21701277c8f5a3aeff4310d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

