### PR TITLE
feat(research): live hardening, relevance gate, window UX, cloud usage (stack 3/3)

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -32,7 +32,38 @@ recorded the same way:
 | `claim_support_rate` | 0.75 |
 | `cited_sentence_ratio` | 0.625 |
 
-## Recording a live baseline
+## Recorded live baseline (2026-08-15)
+
+Configuration: academic lane (arXiv, phrase-quoted queries; Semantic Scholar
+429-rate-limited from this network), web lane blocked (DuckDuckGo/Baidu bot
+challenge, no keyed engines configured), relevance + synthesis LLMs =
+local llama.cpp Qwen3.8-27B at `127.0.0.1:52864`. Bounded: 5 results/query,
+no sub-query fan-out, 3 questions.
+
+Command:
+`python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --llm-base-url http://127.0.0.1:52864/v1`
+
+| Metric | Live (n=2 scored runs) | Notes |
+|---|---|---|
+| `citation_accuracy` | **1.00** | 20/20 `[n]` markers resolved across scored runs |
+| `quote_grounding` | 0.00 | model emitted no quoted spans (0 checked) — untested, not failing |
+| `claim_support_rate` | 1.00 | every cited claim verified |
+| `cited_sentence_ratio` | 0.68 | runs 0.44 / 0.93 |
+
+Observations worth keeping:
+
+- The weak link is the RELEVANCE GATE, not citation integrity: 1 of 3
+  questions produced no synthesis because the strict "answers the question
+  comprehensively" bar (temp 0.7) rejected application papers. With the
+  local 27B model, gate pass-rate varies between identical runs.
+- arXiv phrase-quoting was required: token queries surfaced off-topic
+  papers (cognitive augmentation, image generation) that the gate then
+  correctly rejected (fixed in `academic_providers.search_arxiv`).
+- Local OpenAI-compatible providers previously returned raw response dicts
+  that broke every string consumer; fixed at the `chat_api_call` seam
+  during this live verification.
+
+## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,
    `final_answer_llm`) and run several research runs from the Research

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -63,6 +63,27 @@ Observations worth keeping:
   that broke every string consumer; fixed at the `chat_api_call` seam
   during this live verification.
 
+## Post gate-hardening re-measurement (2026-08-15, task-16333)
+
+Same configuration, same command, after hardening the relevance gate
+(usefulness-based prompt, 0.1 judgment temperature, zero-relevant flagged
+fallback) and priming `max_tokens=16384` for the thinking model:
+
+| Metric | Before (n=2 of 3 scored) | After (n=3 of 3 scored) |
+|---|---|---|
+| `citation_accuracy` | 1.00 (20/20 markers) | **1.00 (49/49 markers)** |
+| `quote_grounding` | 0.00 (no quotes emitted) | **0.67** (quotes emitted in 2/3 runs; all verified) |
+| `claim_support_rate` | 1.00 | 1.00 |
+| `cited_sentence_ratio` | 0.68 | 0.63 |
+| `gate_pass_rate` | whole runs lost to the gate | **0.93** (question 3: 4/5 passed) |
+
+The measured weak link moved: before, the gate silently killed whole runs
+(1 of 3 questions produced nothing); after, all three questions produced
+verified reports. Remaining failure mode observed en route: a thinking
+model can exhaust the default 4096 `max_tokens` on reasoning alone and
+return an empty completion -- the baseline script now primes 16384 for
+local endpoints.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -135,10 +135,12 @@ async def _run_question(engine, service, question: str) -> dict | None:
         print(f"  [run failed: {final.get('status')} — {final.get('progress_message')}]")
         return None
     verification = service.get_artifact(run["id"], "verification_summary.json") or {}
-    payload = (verification.get("content") or {}).get("citation_verification")
-    if not payload:
+    payload = verification.get("content") or {}
+    if not payload.get("citation_verification"):
         print("  [no citation verification on the synthesis branch]")
         return None
+    # The full summary (not just the citation block) so gate counts flow
+    # into gate_pass_rate (task-16333).
     return payload
 
 
@@ -184,12 +186,18 @@ async def main_async(args: argparse.Namespace) -> int:
             payload = await _run_question(engine, service, question)
             if payload is not None:
                 metrics = score_research_report(payload)
+                cv = payload.get("citation_verification") or {}
+                gate = payload.get("gate") or {}
+                gate_note = (
+                    f" gate_pass={metrics['gate_pass_rate']:.2f}" if "gate_pass_rate" in metrics else ""
+                )
+                fallback_note = " [GATE FALLBACK]" if gate.get("fallback") else ""
                 print(
                     f"  citation_accuracy={metrics['citation_accuracy']:.2f} "
                     f"quote_grounding={metrics['quote_grounding']:.2f} "
                     f"claim_support={metrics['claim_support_rate']:.2f} "
-                    f"cited_sentences={metrics['cited_sentence_ratio']:.2f} "
-                    f"(markers {payload.get('markers_resolved')}/{payload.get('markers_total')})"
+                    f"cited_sentences={metrics['cited_sentence_ratio']:.2f}{gate_note}"
+                    f" (markers {cv.get('markers_resolved')}/{cv.get('markers_total')}){fallback_note}"
                 )
                 payloads.append(payload)
 

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Live baseline recorder for the research-report self-eval (task-16330).
+
+Runs N real research questions through the local research engine (ADR-066)
+with the configured deep-search pipeline settings, scores each completed
+run's verification payload with the existing self-eval scorer, and prints
+the aggregated live baseline (mean metrics + per-run detail) plus JSON.
+
+Spend bounds are the point: small result counts, no sub-query fan-out, a
+handful of questions. Expect real network search traffic and LLM calls --
+both relevance and synthesis LLMs must be configured ([SearchSettings]).
+
+Usage:
+    python3 Helper_Scripts/Benchmarks/record_research_baseline.py [--questions 3]
+        [--max-results 5] [--json-out PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Default question set: neutral, stable topics so future re-runs stay
+# comparable; single-facet questions keep verification payloads small.
+# Academic-topic questions: with --academic the evidence pool is arXiv/S2
+# papers, so non-research topics (product features, protocols) legitimately
+# score zero relevance and produce no synthesis to verify.
+DEFAULT_QUESTIONS = [
+    "What is retrieval augmented generation?",
+    "What are mixture of experts language models?",
+    "How do graph neural networks work?",
+]
+
+
+# Credential requirements per engine (None = keyless). The preflight fails
+# fast BEFORE any spend when the chosen engine cannot search.
+_ENGINE_CREDENTIALS: dict[str, list[tuple[str, str]]] = {
+    "google": [("API", "google_api_key"), ("API", "google_cse_id")],
+    "brave": [("API", "brave_api_key")],
+    "serper": [("API", "serper_api_key")],
+    "tavily": [("API", "tavily_api_key")],
+    "kagi": [("API", "kagi_api_key")],
+    "duckduckgo": [],
+    "searx": [],
+}
+
+
+def missing_engine_credentials(engine: str) -> list[str]:
+    """Config slots (with env-var alternates) the engine needs but does not
+    have; empty list means the engine can search."""
+    from tldw_chatbook.config import get_cli_setting
+
+    missing: list[str] = []
+    for section, key in _ENGINE_CREDENTIALS.get(engine, []):
+        env_var = key.upper()
+        if not (os.getenv(env_var) or get_cli_setting(section, key, None)):
+            missing.append(f"[{section}] {key} (or env {env_var})")
+    return missing
+
+
+def _prime_local_llm_url(llm_endpoint: str, base_url: str) -> None:
+    """Point a local provider (e.g. llama_cpp) at ``base_url`` for THIS
+    process only: the handlers read api_settings.<provider>.api_url from the
+    load_settings cache, so priming the cache routes them without touching
+    the user's config file."""
+    from tldw_chatbook.config import load_settings
+
+    settings = load_settings()
+    provider_table = settings.setdefault("api_settings", {}).setdefault(llm_endpoint, {})
+    provider_table["api_url"] = base_url
+    # Local models are slow (big thinking models can take minutes for a full
+    # report); the provider default timeout is tuned for quick chat turns.
+    provider_table["api_timeout"] = 600
+
+
+def _build_search_params(
+    max_results: int,
+    engine_override: str | None = None,
+    llm_override: str | None = None,
+) -> dict:
+    """Assemble engine search params exactly like the web_deep_search tool
+    does, so the baseline measures the shipped pipeline configuration."""
+    from tldw_chatbook.Tools.web_tool_impls import _deep_search_settings
+
+    settings = _deep_search_settings()
+    relevance_llm = llm_override or settings.get("relevance_analysis_llm")
+    final_llm = llm_override or settings.get("final_answer_llm")
+    if not relevance_llm or not final_llm:
+        raise SystemExit(
+            "[config] [SearchSettings] relevance_analysis_llm and final_answer_llm "
+            "must both be configured before recording a live baseline."
+        )
+    engine = engine_override or settings.get("search_provider_default", "google")
+    missing = missing_engine_credentials(engine)
+    if missing:
+        raise SystemExit(
+            f"[config] search engine {engine!r} is missing credentials: "
+            + "; ".join(missing)
+            + ". Configure them, or pass --engine duckduckgo (keyless)."
+        )
+    return {
+        "engine": engine,
+        "content_country": "US",
+        "search_lang": "en",
+        "output_lang": "en",
+        "result_count": max_results,
+        "subquery_generation": False,  # spend bound: single query per run
+        "subquery_generation_llm": relevance_llm,
+        "relevance_analysis_llm": relevance_llm,
+        "final_answer_llm": final_llm,
+        "relevance_llm_timeout_s": settings.get("relevance_llm_timeout_s", 30),
+        "relevance_scrape_timeout_s": settings.get("relevance_scrape_timeout_s", 30),
+        "search_default_max_queries": 1,  # spend bound: no fan-out
+        "deep_search_timeout_s": settings.get("deep_search_timeout_s", 240),
+        "respect_robots_txt": True,
+    }
+
+
+async def _run_question(engine, service, question: str) -> dict | None:
+    """Execute one bounded research run; return its verification payload (or
+    None with the failure printed -- one failed question must not sink the
+    baseline)."""
+    run = service.launch_run(query=question)
+    final = await engine.execute_run(run["id"])
+    if final.get("status") != "completed":
+        print(f"  [run failed: {final.get('status')} — {final.get('progress_message')}]")
+        return None
+    verification = service.get_artifact(run["id"], "verification_summary.json") or {}
+    payload = (verification.get("content") or {}).get("citation_verification")
+    if not payload:
+        print("  [no citation verification on the synthesis branch]")
+        return None
+    return payload
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    from tldw_chatbook.Evals.research_report_scorer import (
+        aggregate_metrics,
+        score_research_report,
+    )
+    from tldw_chatbook.Research_Interop.local_research_engine import LocalResearchEngine
+    from tldw_chatbook.Research_Interop.local_research_service import (
+        LocalResearchService,
+    )
+
+    if args.llm_base_url:
+        llm_endpoint = args.llm or "llama_cpp"
+        _prime_local_llm_url(llm_endpoint, args.llm_base_url)
+        args.llm = llm_endpoint
+    search_params = _build_search_params(
+        args.max_results,
+        engine_override=args.engine,
+        llm_override=args.llm,
+    )
+    print(
+        f"engine={search_params['engine']} relevance={search_params['relevance_analysis_llm']} "
+        f"synthesis={search_params['final_answer_llm']} max_results={args.max_results}"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="tldw-research-baseline-") as tmp:
+        service = LocalResearchService(Path(tmp) / "research.db")
+        paper_search_fn = None
+        if args.academic:
+            from tldw_chatbook.Research_Interop.academic_providers import search_papers
+
+            paper_search_fn = search_papers
+            print("academic lane: ON (arXiv + Semantic Scholar join the evidence pool)")
+        engine = LocalResearchEngine(
+            service, search_params=search_params, paper_search_fn=paper_search_fn
+        )
+
+        payloads = []
+        for question in DEFAULT_QUESTIONS[: args.questions]:
+            print(f"Running: {question}")
+            payload = await _run_question(engine, service, question)
+            if payload is not None:
+                metrics = score_research_report(payload)
+                print(
+                    f"  citation_accuracy={metrics['citation_accuracy']:.2f} "
+                    f"quote_grounding={metrics['quote_grounding']:.2f} "
+                    f"claim_support={metrics['claim_support_rate']:.2f} "
+                    f"cited_sentences={metrics['cited_sentence_ratio']:.2f} "
+                    f"(markers {payload.get('markers_resolved')}/{payload.get('markers_total')})"
+                )
+                payloads.append(payload)
+
+    if not payloads:
+        print(
+            "\n[no scored samples] No run produced a verification payload -- "
+            "check the per-run diagnostics above (engine/LLM credentials, "
+            "timeouts) before relying on this baseline."
+        )
+        return 1
+    aggregate = aggregate_metrics(payloads)
+    print("\n=== Live baseline (mean over runs) ===")
+    print(json.dumps(aggregate, indent=2))
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(aggregate, indent=2))
+        print(f"\nWritten to {args.json_out}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--questions", type=int, default=3, help="number of questions to run")
+    parser.add_argument(
+        "--max-results", type=int, default=5, help="search results per query (spend bound)"
+    )
+    parser.add_argument("--json-out", default=None, help="optional path for the aggregate JSON")
+    parser.add_argument(
+        "--llm",
+        default=None,
+        help="override both [SearchSettings] LLM endpoints (e.g. llama_cpp for a local server)",
+    )
+    parser.add_argument(
+        "--llm-base-url",
+        default=None,
+        help="prime api_settings.<--llm>.api_url for this process (no config file writes); implies --llm",
+    )
+    parser.add_argument(
+        "--academic",
+        action="store_true",
+        help="enable the keyless academic lane (arXiv + Semantic Scholar) alongside the web engine",
+    )
+    parser.add_argument(
+        "--engine",
+        default=None,
+        help="override [SearchSettings] search_provider_default (e.g. duckduckgo, keyless)",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Live baseline recorder for the research-report self-eval (task-16330).
 
-Runs N real research questions through the local research engine (ADR-066)
+Runs N real research questions through the local research engine (ADR-068)
 with the configured deep-search pipeline settings, scores each completed
 run's verification payload with the existing self-eval scorer, and prints
 the aggregated live baseline (mean metrics + per-run detail) plus JSON.

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -80,6 +80,10 @@ def _prime_local_llm_url(llm_endpoint: str, base_url: str) -> None:
     # Local models are slow (big thinking models can take minutes for a full
     # report); the provider default timeout is tuned for quick chat turns.
     provider_table["api_timeout"] = 600
+    # Thinking models spend the budget on reasoning before content -- the
+    # 4096 default can be exhausted by reasoning alone, yielding an EMPTY
+    # completion (observed live: a 5-minute synthesis returning length=0).
+    provider_table["max_tokens"] = 16384
 
 
 def _build_search_params(

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -93,7 +93,10 @@ def _build_search_params(
 ) -> dict:
     """Assemble engine search params exactly like the web_deep_search tool
     does, so the baseline measures the shipped pipeline configuration."""
-    from tldw_chatbook.Tools.web_tool_impls import _deep_search_settings
+    from tldw_chatbook.Tools.web_tool_impls import (
+        _deep_search_settings,
+        deep_search_pipeline_params,
+    )
 
     settings = _deep_search_settings()
     relevance_llm = llm_override or settings.get("relevance_analysis_llm")
@@ -111,22 +114,19 @@ def _build_search_params(
             + "; ".join(missing)
             + ". Configure them, or pass --engine duckduckgo (keyless)."
         )
-    return {
-        "engine": engine,
-        "content_country": "US",
-        "search_lang": "en",
-        "output_lang": "en",
-        "result_count": max_results,
-        "subquery_generation": False,  # spend bound: single query per run
-        "subquery_generation_llm": relevance_llm,
-        "relevance_analysis_llm": relevance_llm,
-        "final_answer_llm": final_llm,
-        "relevance_llm_timeout_s": settings.get("relevance_llm_timeout_s", 30),
-        "relevance_scrape_timeout_s": settings.get("relevance_scrape_timeout_s", 30),
-        "search_default_max_queries": 1,  # spend bound: no fan-out
-        "deep_search_timeout_s": settings.get("deep_search_timeout_s", 240),
-        "respect_robots_txt": True,
-    }
+    # task-16484: shared assembly with the tool; spend bounds via overrides.
+    return deep_search_pipeline_params(
+        engine=engine,
+        max_results=max_results,
+        subquery=False,  # spend bound: single query per run
+        max_queries=1,  # spend bound: no fan-out
+        respect_robots=True,
+        extra={
+            "subquery_generation_llm": relevance_llm,
+            "relevance_analysis_llm": relevance_llm,
+            "final_answer_llm": final_llm,
+        },
+    )
 
 
 async def _run_question(engine, service, question: str) -> dict | None:

--- a/Tests/Chat/test_console_command_grammar.py
+++ b/Tests/Chat/test_console_command_grammar.py
@@ -101,6 +101,7 @@ def test_default_console_registry_registers_prompt_system_skills_prefill_and_gen
         "generate-video",
         "stream-video",
         "rewind",
+        "research",
     )
     assert registry.parse("/prompt") == CommandParse("command", "prompt", "")
     assert registry.parse("/system") == CommandParse("command", "system", "")

--- a/Tests/Chat/test_console_command_suggestions.py
+++ b/Tests/Chat/test_console_command_suggestions.py
@@ -22,7 +22,7 @@ def _labels(result):
     return [s.label for s in result]
 
 
-COMMANDS = ["/prompt", "/system", "/skills", "/prefill", "/generate-image", "/generate-video", "/stream-video", "/rewind"]
+COMMANDS = ["/prompt", "/system", "/skills", "/prefill", "/generate-image", "/generate-video", "/stream-video", "/rewind", "/research"]
 
 
 def test_bare_slash_lists_commands_then_skills():

--- a/Tests/Chat/test_usage_recorder.py
+++ b/Tests/Chat/test_usage_recorder.py
@@ -111,3 +111,84 @@ def test_chat_api_call_records_nothing_without_active_recorder(monkeypatch):
 
     assert result == "hello world"
     assert active_recorder() is None
+
+
+# --- OpenAI-shaped dict normalization (task-16330 live-baseline unblock) --------
+
+def test_chat_api_call_normalizes_openai_dict_to_content_string(monkeypatch):
+    payload = {
+        "choices": [
+            {"index": 0, "finish_reason": "stop",
+             "message": {"role": "assistant", "content": "the answer"}}
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+    }
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "llama_cpp", _fake_handler(payload)
+    )
+
+    result = chat_api_call(
+        api_endpoint="llama_cpp",
+        messages_payload=[{"role": "user", "content": "prompt"}],
+        api_key=None, temp=0.5, system_message=None, streaming=False,
+        minp=None, maxp=None, model=None, topk=None, topp=None,
+    )
+
+    assert result == "the answer"
+
+
+def test_chat_api_call_records_real_usage_from_dict_responses(monkeypatch):
+    payload = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "answer text"}}
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+    }
+    handler = _fake_handler(payload)
+    monkeypatch.setitem(Chat_Functions.API_CALL_HANDLERS, "llama_cpp", handler)
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": "a much longer prompt text here"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    # EXACT counts from the provider, not character estimates.
+    assert recorder.prompt_tokens() == 11
+    assert recorder.completion_tokens() == 7
+
+
+def test_chat_api_call_dict_without_usage_falls_back_to_estimates(monkeypatch):
+    payload = {"choices": [{"message": {"role": "assistant", "content": "abcde"}}]}
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "llama_cpp", _fake_handler(payload)
+    )
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": "abcdefg"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert recorder.prompt_tokens() == estimate_tokens("abcdefg")
+    assert recorder.completion_tokens() == estimate_tokens("abcde")
+
+
+def test_chat_api_call_unknown_dict_shape_passes_through(monkeypatch):
+    payload = {"error": "odd provider payload"}
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "llama_cpp", _fake_handler(payload)
+    )
+
+    result = chat_api_call(
+        api_endpoint="llama_cpp",
+        messages_payload=[{"role": "user", "content": "prompt"}],
+        api_key=None, temp=0.5, system_message=None, streaming=False,
+        minp=None, maxp=None, model=None, topk=None, topp=None,
+    )
+
+    assert result == {"error": "odd provider payload"}

--- a/Tests/Chat/test_usage_recorder.py
+++ b/Tests/Chat/test_usage_recorder.py
@@ -192,3 +192,69 @@ def test_chat_api_call_unknown_dict_shape_passes_through(monkeypatch):
     )
 
     assert result == {"error": "odd provider payload"}
+
+
+# --- cloud provider usage key variants (task-16335) -------------------------------
+
+def test_chat_api_call_records_anthropic_style_usage_keys(monkeypatch):
+    # Anthropic normalizes its response to the OpenAI chat shape but keeps
+    # its own usage field names (input_tokens/output_tokens).
+    payload = {
+        "choices": [{"message": {"role": "assistant", "content": "answer"}}],
+        "usage": {"input_tokens": 31, "output_tokens": 13},
+    }
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "anthropic", _fake_handler(payload)
+    )
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="anthropic",
+            messages_payload=[{"role": "user", "content": "a long enough prompt"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert recorder.prompt_tokens() == 31
+    assert recorder.completion_tokens() == 13
+
+
+def test_chat_api_call_openai_style_usage_still_exact(monkeypatch):
+    payload = {
+        "choices": [{"message": {"role": "assistant", "content": "answer"}}],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 6},
+    }
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "anthropic", _fake_handler(payload)
+    )
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="anthropic",
+            messages_payload=[{"role": "user", "content": "prompt"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert (recorder.prompt_tokens(), recorder.completion_tokens()) == (5, 6)
+
+
+def test_chat_api_call_mixed_usage_keys_prefer_openai_names(monkeypatch):
+    payload = {
+        "choices": [{"message": {"role": "assistant", "content": "answer"}}],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 9,
+                  "input_tokens": 100, "output_tokens": 100},
+    }
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "anthropic", _fake_handler(payload)
+    )
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="anthropic",
+            messages_payload=[{"role": "user", "content": "prompt"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert (recorder.prompt_tokens(), recorder.completion_tokens()) == (8, 9)

--- a/Tests/Chat/test_usage_recorder.py
+++ b/Tests/Chat/test_usage_recorder.py
@@ -115,7 +115,10 @@ def test_chat_api_call_records_nothing_without_active_recorder(monkeypatch):
 
 # --- OpenAI-shaped dict normalization (task-16330 live-baseline unblock) --------
 
-def test_chat_api_call_normalizes_openai_dict_to_content_string(monkeypatch):
+def test_chat_api_call_passes_provider_dicts_through_unchanged(monkeypatch):
+    # The Console gateway parses tool_calls/finish_reason/usage from these
+    # dicts -- chat_api_call must NOT normalize them to content strings
+    # (task-16331 correction). String consumers use chat_reply_text.
     payload = {
         "choices": [
             {"index": 0, "finish_reason": "stop",
@@ -134,7 +137,20 @@ def test_chat_api_call_normalizes_openai_dict_to_content_string(monkeypatch):
         minp=None, maxp=None, model=None, topk=None, topp=None,
     )
 
-    assert result == "the answer"
+    assert result == payload
+
+
+def test_chat_reply_text_extracts_known_shapes_and_empty_for_unknown():
+    from tldw_chatbook.Chat.Chat_Functions import chat_reply_text
+
+    assert chat_reply_text("plain") == "plain"
+    assert chat_reply_text(
+        {"choices": [{"message": {"role": "assistant", "content": "duck"}}]}
+    ) == "duck"
+    assert chat_reply_text({"choices": [{"text": "legacy"}]}) == "legacy"
+    assert chat_reply_text({"choices": [{"message": {"content": None}}]}) == ""
+    assert chat_reply_text({"error": "odd"}) == ""
+    assert chat_reply_text(None) == ""
 
 
 def test_chat_api_call_records_real_usage_from_dict_responses(monkeypatch):
@@ -166,14 +182,16 @@ def test_chat_api_call_dict_without_usage_falls_back_to_estimates(monkeypatch):
         Chat_Functions.API_CALL_HANDLERS, "llama_cpp", _fake_handler(payload)
     )
 
+    result = None
     with usage_scope() as recorder:
-        chat_api_call(
+        result = chat_api_call(
             api_endpoint="llama_cpp",
             messages_payload=[{"role": "user", "content": "abcdefg"}],
             api_key=None, temp=0.5, system_message=None, streaming=False,
             minp=None, maxp=None, model=None, topk=None, topp=None,
         )
 
+    assert result == payload  # passthrough preserved
     assert recorder.prompt_tokens() == estimate_tokens("abcdefg")
     assert recorder.completion_tokens() == estimate_tokens("abcde")
 

--- a/Tests/Evals/test_research_report_scorer.py
+++ b/Tests/Evals/test_research_report_scorer.py
@@ -1,7 +1,7 @@
 """Research-report self-eval scorer (task-16327).
 
 Deterministic scoring of deep-search research reports from the verification
-outcomes the pipeline already produces (task-16319's citation_verification
+outcomes the pipeline already produces (task-16331's citation_verification
 payload / task-16325's claims). The runner plugs into the existing Evals
 framework (specialized runner + category dispatch) -- no parallel harness.
 """

--- a/Tests/Evals/test_research_report_scorer.py
+++ b/Tests/Evals/test_research_report_scorer.py
@@ -177,3 +177,37 @@ def test_aggregate_averages_gate_rate_only_over_payloads_that_have_it():
     assert aggregate["sample_count"] == 3
     assert aggregate["gate_pass_rate"] == pytest.approx((0.8 + 0.4) / 2)
     assert aggregate["citation_accuracy"] == pytest.approx((1.0 + 0.5 + 1.0) / 3)
+
+
+# --- Evals-UI task registration (task-16485) --------------------------------------
+
+def test_research_report_template_loads_and_runs_end_to_end():
+    import asyncio
+    from pathlib import Path
+
+    from tldw_chatbook.Evals.dataset_loader import DatasetLoader
+    from tldw_chatbook.Evals.eval_runner import EvalRunner
+    from tldw_chatbook.Evals.specialized_runners import ResearchReportRunner
+    from tldw_chatbook.Evals.task_loader import TaskLoader
+
+    task_config = TaskLoader().create_task_from_template("research_report")
+    assert task_config.task_type == "research_report"
+    assert task_config.metadata.get("category") == "research"
+    assert Path(task_config.dataset_name).exists()
+
+    runner = EvalRunner(task_config, {"provider": "mock", "model_id": "scorer"})
+    assert isinstance(runner.runner, ResearchReportRunner)
+
+    samples = DatasetLoader.load_dataset_samples(task_config)
+    assert len(samples) == 3
+    assert all("verification" in (sample.metadata or {}) for sample in samples)
+
+    results = [
+        asyncio.run(runner.run_single_sample(task_config, sample))
+        for sample in samples
+    ]
+    by_id = {r.sample_id: r for r in results}
+    assert by_id["synthetic-clean-run"].metrics["citation_accuracy"] == 1.0
+    assert by_id["synthetic-clean-run"].metrics["gate_pass_rate"] == 1.0
+    assert by_id["synthetic-degraded-run"].metrics["citation_accuracy"] == 0.75
+    assert by_id["synthetic-gate-fallback-run"].metrics["gate_pass_rate"] == 0.6

--- a/Tests/Evals/test_research_report_scorer.py
+++ b/Tests/Evals/test_research_report_scorer.py
@@ -106,3 +106,33 @@ def test_baseline_payload_reproduces_recorded_baseline():
     assert 0.0 <= metrics["quote_grounding"] <= 1.0
     assert 0.0 <= metrics["claim_support_rate"] <= 1.0
     assert 0.0 <= metrics["cited_sentence_ratio"] <= 1.0
+
+
+# --- aggregation for the live baseline (task-16330) ------------------------------
+
+def test_aggregate_metrics_averages_across_payloads():
+    from tldw_chatbook.Evals.research_report_scorer import aggregate_metrics
+
+    payloads = [
+        {"markers_total": 4, "markers_resolved": 4, "quotes_checked": 0,
+         "quotes_verified": 0, "uncited_sentences": 0},
+        {"markers_total": 4, "markers_resolved": 2, "quotes_checked": 2,
+         "quotes_verified": 1, "uncited_sentences": 4},
+    ]
+
+    aggregate = aggregate_metrics(payloads)
+
+    assert aggregate["sample_count"] == 2
+    assert aggregate["citation_accuracy"] == pytest.approx((1.0 + 0.5) / 2)
+    assert aggregate["quote_grounding"] == pytest.approx((0.0 + 0.5) / 2)
+    assert aggregate["claim_support_rate"] == pytest.approx(0.75)
+    assert aggregate["cited_sentence_ratio"] == pytest.approx((1.0 + 0.5) / 2)
+
+
+def test_aggregate_metrics_empty_payloads():
+    from tldw_chatbook.Evals.research_report_scorer import aggregate_metrics
+
+    aggregate = aggregate_metrics([])
+
+    assert aggregate["sample_count"] == 0
+    assert aggregate["citation_accuracy"] == 0.0

--- a/Tests/Evals/test_research_report_scorer.py
+++ b/Tests/Evals/test_research_report_scorer.py
@@ -136,3 +136,44 @@ def test_aggregate_metrics_empty_payloads():
 
     assert aggregate["sample_count"] == 0
     assert aggregate["citation_accuracy"] == 0.0
+
+
+# --- gate pass-rate (task-16333) ---------------------------------------------------
+
+def test_score_unwraps_nested_citation_verification_and_adds_gate_rate():
+    metrics = score_research_report(
+        {
+            "confidence": 0.7,
+            "gate": {"relevant": 2, "raw": 5, "fallback": False},
+            "citation_verification": {
+                "markers_total": 4, "markers_resolved": 4,
+                "quotes_checked": 0, "quotes_verified": 0, "uncited_sentences": 1,
+            },
+        }
+    )
+
+    assert metrics["citation_accuracy"] == 1.0
+    assert metrics["gate_pass_rate"] == pytest.approx(2 / 5)
+
+
+def test_score_omits_gate_rate_without_gate_counts():
+    metrics = score_research_report({"markers_total": 1, "markers_resolved": 1})
+    assert "gate_pass_rate" not in metrics
+
+
+def test_aggregate_averages_gate_rate_only_over_payloads_that_have_it():
+    from tldw_chatbook.Evals.research_report_scorer import aggregate_metrics
+
+    payloads = [
+        {"markers_total": 2, "markers_resolved": 2,
+         "gate": {"relevant": 4, "raw": 5}},
+        {"markers_total": 2, "markers_resolved": 1},  # no gate block
+        {"markers_total": 2, "markers_resolved": 2,
+         "gate": {"relevant": 2, "raw": 5}},
+    ]
+
+    aggregate = aggregate_metrics(payloads)
+
+    assert aggregate["sample_count"] == 3
+    assert aggregate["gate_pass_rate"] == pytest.approx((0.8 + 0.4) / 2)
+    assert aggregate["citation_accuracy"] == pytest.approx((1.0 + 0.5 + 1.0) / 3)

--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -313,3 +313,37 @@ def test_search_papers_raises_only_when_all_providers_fail(monkeypatch):
 
     with pytest.raises(AcademicProviderError):
         asyncio.run(search_papers("agents"))
+
+
+def test_paper_query_normalizes_questions_to_topics():
+    from tldw_chatbook.Research_Interop.academic_providers import _paper_query
+
+    assert _paper_query("What is retrieval augmented generation?") == "retrieval augmented generation"
+    assert _paper_query("What are the main differences between HTTP/2 and HTTP/3?") == "differences between HTTP/2 and HTTP/3"
+    assert _paper_query("How does SQLite FTS5 ranking work?") == "SQLite FTS5 ranking work"
+    assert _paper_query("already a topic query") == "already a topic query"
+
+
+def test_arxiv_phrases_multi_word_queries(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=_ATOM)])
+
+    search_arxiv(query="retrieval augmented generation", client=client)
+
+    sent = client.request.calls[0]["params"]
+    assert sent["search_query"] == 'all:"retrieval augmented generation"'
+
+
+def test_arxiv_single_word_queries_stay_unquoted(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=_ATOM)])
+
+    search_arxiv(query="transformers", client=client)
+
+    assert client.request.calls[0]["params"]["search_query"] == "all:transformers"

--- a/Tests/Research/test_chat_handoff.py
+++ b/Tests/Research/test_chat_handoff.py
@@ -1,0 +1,74 @@
+"""Chat handoff insertion (task-16481)."""
+
+from tldw_chatbook.Research_Interop.chat_handoff import (
+    insert_research_completion_message,
+)
+
+
+class FakeDB:
+    def __init__(self, fail=False):
+        self.messages = []
+        self.fail = fail
+
+    def add_message(self, msg_data):
+        if self.fail:
+            raise RuntimeError("db down")
+        self.messages.append(msg_data)
+        return f"msg-{len(self.messages)}"
+
+
+_PAYLOAD = {
+    "run_id": "run-1",
+    "question": "What is RAG?",
+    "chat_handoff": {"conversation_id": "conv-42", "origin": "console"},
+    "report_markdown": "Answer citing [1].\n\nSources:\n[1] T — https://t.example/",
+    "bundle": {"source_count": 2},
+    "verification_summary": {"confidence": 0.9, "gate": {"relevant": 2, "raw": 5, "fallback": False}},
+}
+
+
+def test_inserts_assistant_message_with_report_and_metadata():
+    db = FakeDB()
+
+    message_id = insert_research_completion_message(db, _PAYLOAD)
+
+    assert message_id == "msg-1"
+    msg = db.messages[0]
+    assert msg["conversation_id"] == "conv-42"
+    assert msg["sender"] == "assistant"
+    assert "Deep research completed for: What is RAG?" in msg["content"]
+    assert "Answer citing [1]." in msg["content"]
+    block = msg["metadata_json"]["deep_research_completion"]
+    assert block["run_id"] == "run-1"
+    assert block["source_count"] == 2
+    assert block["confidence"] == 0.9
+
+
+def test_missing_conversation_id_returns_none_without_raising():
+    payload = dict(_PAYLOAD)
+    payload["chat_handoff"] = {}
+    db = FakeDB()
+
+    assert insert_research_completion_message(db, payload) is None
+    assert db.messages == []
+
+
+def test_db_failure_returns_none_without_raising():
+    db = FakeDB(fail=True)
+
+    assert insert_research_completion_message(db, _PAYLOAD) is None
+
+
+def test_research_command_registered_in_default_console_registry():
+    from tldw_chatbook.Chat.console_command_grammar import (
+        RESEARCH_COMMAND_HANDLER_ID,
+        RESEARCH_COMMAND_NAME,
+        default_console_registry,
+    )
+
+    parse = default_console_registry().parse("/research what is RAG?")
+
+    assert parse.kind == "command"
+    assert parse.name == RESEARCH_COMMAND_NAME == "research"
+    assert parse.args == "what is RAG?"
+    assert RESEARCH_COMMAND_HANDLER_ID == "research"

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -719,3 +719,65 @@ def test_engine_verification_summary_carries_gate_block():
     assert final["status"] == "completed"
     summary = _artifact_content(service.get_bundle(run["id"]), "verification_summary.json")
     assert summary["gate"] == {"relevant": 3, "raw": 5, "fallback": True}
+
+
+# --- chat handoff on completion (task-16481) --------------------------------------
+
+def test_engine_fires_completion_handoff_with_report_bundle():
+    service = _make_service()
+    run = service.launch_run(
+        query="Handoff question",
+        chat_handoff={"conversation_id": "conv-42", "origin": "console"},
+    )
+    search_fn, analyze_fn, _ = _make_pipeline("Handoff question")
+    fired = []
+
+    def handoff(payload):
+        fired.append(payload)
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn, completion_handoff=handoff
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    assert len(fired) == 1
+    payload = fired[0]
+    assert payload["run_id"] == run["id"]
+    assert payload["question"] == "Handoff question"
+    assert payload["chat_handoff"] == {"conversation_id": "conv-42", "origin": "console"}
+    assert "Answer citing" in payload["report_markdown"]
+    assert payload["bundle"]["query"] == "Handoff question"
+
+
+def test_engine_skips_handoff_without_chat_handoff_target():
+    service = _make_service()
+    run = service.launch_run(query="No handoff")
+    search_fn, analyze_fn, _ = _make_pipeline("No handoff")
+    fired = []
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn,
+        completion_handoff=fired.append,
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+    assert fired == []
+
+
+def test_engine_handoff_failure_never_fails_the_run():
+    service = _make_service()
+    run = service.launch_run(query="Boom handoff", chat_handoff={"conversation_id": "x"})
+    search_fn, analyze_fn, _ = _make_pipeline("Boom handoff")
+
+    def exploding_handoff(payload):
+        raise RuntimeError("handoff sink down")
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn,
+        completion_handoff=exploding_handoff,
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+    assert final["status"] == "completed"  # handoff failure is a warning only

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -688,3 +688,34 @@ def test_engine_enforces_max_tokens_between_llm_calls():
     names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
     assert "report_v1.md" not in names
     assert "budget_ledger.json" in names
+
+
+# --- gate block in verification summary (task-16333) -----------------------------
+
+def test_engine_verification_summary_carries_gate_block():
+    service = _make_service()
+    run = service.launch_run(query="Gate question")
+
+    def search_fn(q, params):
+        return ({"results": [{"title": "T", "url": "https://t.example/"}], "warnings": []},
+                {"sub_questions": [], "main_goal": q})
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        return {
+            "final_answer": {
+                "text": "Answer[1].", "confidence": 0.6, "chunks": [],
+                "evidence": [{"id": 1, "url": "https://t.example/", "title": "T",
+                              "content": "c", "original_content": "o", "reasoning": "r",
+                              "chunk_index": 1, "gate_unverified": True}],
+                "gate": {"relevant": 3, "raw": 5, "fallback": True},
+            },
+            "relevant_results": {"1": {}},
+            "web_search_results_dict": wsr,
+        }
+
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    summary = _artifact_content(service.get_bundle(run["id"]), "verification_summary.json")
+    assert summary["gate"] == {"relevant": 3, "raw": 5, "fallback": True}

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -76,7 +76,7 @@ def _artifact_content(bundle, name):
 
 def test_engine_executes_phases_and_completes_run():
     service = _make_service()
-    run = service.launch_run(query="How do persistent agents checkpoint?")
+    run = service.launch_run(query="How do persistent agents checkpoint?", autonomy_mode="autonomous")
     search_fn, analyze_fn, calls = _make_pipeline(run["query"])
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -106,7 +106,7 @@ def test_engine_executes_phases_and_completes_run():
 
 def test_engine_artifacts_carry_plan_sources_and_citation_verdict():
     service = _make_service()
-    run = service.launch_run(query="What changed in SQLite 3.50?")
+    run = service.launch_run(query="What changed in SQLite 3.50?", autonomy_mode="autonomous")
     search_fn, analyze_fn, _ = _make_pipeline(run["query"])
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -132,7 +132,7 @@ def test_engine_artifacts_carry_plan_sources_and_citation_verdict():
 
 def test_engine_normalizes_draft_run_to_running():
     service = _make_service()
-    draft = service.create_run(query="Draft question")
+    draft = service.create_run(query="Draft question", autonomy_mode="autonomous")
     assert draft["status"] == "draft"
     search_fn, analyze_fn, _ = _make_pipeline("Draft question")
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
@@ -145,7 +145,7 @@ def test_engine_normalizes_draft_run_to_running():
 
 def test_engine_fails_run_and_keeps_partial_artifacts_on_pipeline_error():
     service = _make_service()
-    run = service.launch_run(query="Exploding question")
+    run = service.launch_run(query="Exploding question", autonomy_mode="autonomous")
 
     def search_fn(q, params):
         return ({"results": [{"title": "T", "url": "https://t.example/"}], "warnings": []},
@@ -167,7 +167,7 @@ def test_engine_fails_run_and_keeps_partial_artifacts_on_pipeline_error():
 
 def test_engine_pause_between_phases_leaves_run_resumable():
     service = _make_service()
-    run = service.launch_run(query="Pause me mid-run")
+    run = service.launch_run(query="Pause me mid-run", autonomy_mode="autonomous")
 
     def search_fn(q, params):
         service.pause_run(run["id"])  # user pauses while collecting runs
@@ -192,7 +192,7 @@ def test_engine_pause_between_phases_leaves_run_resumable():
 
 def test_engine_cancel_between_phases_resolves_cancelled_once():
     service = _make_service()
-    run = service.launch_run(query="Cancel me mid-run")
+    run = service.launch_run(query="Cancel me mid-run", autonomy_mode="autonomous")
 
     def search_fn(q, params):
         service.cancel_run(run["id"])  # user cancels while collecting runs
@@ -211,7 +211,7 @@ def test_engine_cancel_between_phases_resolves_cancelled_once():
 
 def test_engine_rejects_terminal_run():
     service = _make_service()
-    run = service.launch_run(query="Already done")
+    run = service.launch_run(query="Already done", autonomy_mode="autonomous")
     service.complete_run(run["id"])
     search_fn, analyze_fn, _ = _make_pipeline(run["query"])
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
@@ -250,7 +250,7 @@ def _budget_pipeline(question, *, results=2, captured_params=None):
 
 def test_engine_caps_search_fanout_at_budget_before_spend():
     service = _make_service()
-    run = service.launch_run(query="Budgeted", limits_json={"max_searches": 2})
+    run = service.launch_run(query="Budgeted", autonomy_mode="autonomous", limits_json={"max_searches": 2})
     captured: dict = {}
     search_fn, analyze_fn, _ = _budget_pipeline("Budgeted", captured_params=captured)
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
@@ -266,7 +266,7 @@ def test_engine_caps_search_fanout_at_budget_before_spend():
 
 def test_engine_truncates_docs_to_budget():
     service = _make_service()
-    run = service.launch_run(query="Budgeted docs", limits_json={"max_fetched_docs": 1})
+    run = service.launch_run(query="Budgeted docs", autonomy_mode="autonomous", limits_json={"max_fetched_docs": 1})
     search_fn, analyze_fn, seen = _budget_pipeline("Budgeted docs", results=3)
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -280,7 +280,7 @@ def test_engine_truncates_docs_to_budget():
 
 def test_engine_stops_cleanly_when_doc_budget_exhausted():
     service = _make_service()
-    run = service.launch_run(query="No docs allowed", limits_json={"max_fetched_docs": 0})
+    run = service.launch_run(query="No docs allowed", autonomy_mode="autonomous", limits_json={"max_fetched_docs": 0})
     search_fn, analyze_fn, seen = _budget_pipeline("No docs allowed", results=3)
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -296,7 +296,7 @@ def test_engine_stops_cleanly_when_doc_budget_exhausted():
 
 def test_engine_runtime_budget_stops_run_at_phase_boundary():
     service = _make_service()
-    run = service.launch_run(query="No time", limits_json={"max_runtime_seconds": 0})
+    run = service.launch_run(query="No time", autonomy_mode="autonomous", limits_json={"max_runtime_seconds": 0})
     search_fn, analyze_fn, seen = _budget_pipeline("No time")
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -347,7 +347,7 @@ def _iter_pipeline(question):
 
 def test_engine_single_pass_by_default_without_gap_llm():
     service = _make_service()
-    run = service.launch_run(query="Single pass")
+    run = service.launch_run(query="Single pass", autonomy_mode="autonomous")
     search_fn, analyze_fn, state = _iter_pipeline("Single pass")
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
     # No gap_fn injected and no final_answer_llm in params -> default gap
@@ -361,7 +361,7 @@ def test_engine_single_pass_by_default_without_gap_llm():
 
 def test_engine_iterates_until_gaps_resolve_within_max_iterations():
     service = _make_service()
-    run = service.launch_run(query="Iterate", limits_json={"max_iterations": 3})
+    run = service.launch_run(query="Iterate", autonomy_mode="autonomous", limits_json={"max_iterations": 3})
     search_fn, analyze_fn, state = _iter_pipeline("Iterate")
     gap_calls = []
 
@@ -394,7 +394,7 @@ def test_engine_iterates_until_gaps_resolve_within_max_iterations():
 
 def test_engine_stops_at_max_iterations_and_reports_remaining_gaps():
     service = _make_service()
-    run = service.launch_run(query="Always gappy", limits_json={"max_iterations": 2})
+    run = service.launch_run(query="Always gappy", autonomy_mode="autonomous", limits_json={"max_iterations": 2})
     search_fn, analyze_fn, state = _iter_pipeline("Always gappy")
 
     async def gap_fn(context):
@@ -418,7 +418,9 @@ def test_engine_stops_at_max_iterations_and_reports_remaining_gaps():
 def test_engine_gap_iteration_stops_cleanly_when_search_budget_exhausted():
     service = _make_service()
     run = service.launch_run(
-        query="Budgeted iteration", limits_json={"max_iterations": 5, "max_searches": 1}
+        query="Budgeted iteration",
+        autonomy_mode="autonomous",
+        limits_json={"max_iterations": 5, "max_searches": 1},
     )
     search_fn, analyze_fn, state = _iter_pipeline("Budgeted iteration")
 
@@ -483,7 +485,7 @@ def _claims_pipeline(question):
 
 def test_engine_persists_claims_artifact_with_counts():
     service = _make_service()
-    run = service.launch_run(query="Claims question")
+    run = service.launch_run(query="Claims question", autonomy_mode="autonomous")
     search_fn, analyze_fn = _claims_pipeline("Claims question")
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
 
@@ -498,7 +500,7 @@ def test_engine_persists_claims_artifact_with_counts():
 
 
 def _completed_claims_run(service):
-    run = service.launch_run(query="Claims question")
+    run = service.launch_run(query="Claims question", autonomy_mode="autonomous")
     search_fn, analyze_fn = _claims_pipeline("Claims question")
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
     asyncio.run(engine.execute_run(run["id"]))
@@ -555,7 +557,7 @@ def test_follow_up_insufficient_evidence_falls_back_explicitly():
 
 def test_follow_up_without_claims_artifact_never_calls_the_llm():
     service = _make_service()
-    run = service.launch_run(query="No claims here")
+    run = service.launch_run(query="No claims here", autonomy_mode="autonomous")
     called = {"n": 0}
 
     async def answer_fn(seed, question):
@@ -573,7 +575,7 @@ def test_follow_up_without_claims_artifact_never_calls_the_llm():
 
 def test_engine_merges_academic_papers_with_doi_dedup():
     service = _make_service()
-    run = service.launch_run(query="Papers question", limits_json={"max_iterations": 2})
+    run = service.launch_run(query="Papers question", autonomy_mode="autonomous", limits_json={"max_iterations": 2})
     search_fn, analyze_fn, state = _iter_pipeline("Papers question")
     paper_rounds = [
         [
@@ -632,7 +634,7 @@ def test_engine_settles_recorded_usage_into_ledger():
     from tldw_chatbook.Chat.usage_recorder import active_recorder
 
     service = _make_service()
-    run = service.launch_run(query="Tokens question")
+    run = service.launch_run(query="Tokens question", autonomy_mode="autonomous")
     search_fn, analyze_fn, _ = _make_pipeline("Tokens question")
 
     async def analyze_with_usage(wsr, sqd, params, cancel_event=None):
@@ -657,7 +659,7 @@ def test_engine_enforces_max_tokens_between_llm_calls():
     from tldw_chatbook.Chat.usage_recorder import active_recorder
 
     service = _make_service()
-    run = service.launch_run(query="Token capped", limits_json={"max_tokens": 25})
+    run = service.launch_run(query="Token capped", autonomy_mode="autonomous", limits_json={"max_tokens": 25})
     search_fn, analyze_fn, _ = _make_pipeline("Token capped")
 
     async def analyze_with_usage(wsr, sqd, params, cancel_event=None):
@@ -694,7 +696,7 @@ def test_engine_enforces_max_tokens_between_llm_calls():
 
 def test_engine_verification_summary_carries_gate_block():
     service = _make_service()
-    run = service.launch_run(query="Gate question")
+    run = service.launch_run(query="Gate question", autonomy_mode="autonomous")
 
     def search_fn(q, params):
         return ({"results": [{"title": "T", "url": "https://t.example/"}], "warnings": []},
@@ -727,6 +729,7 @@ def test_engine_fires_completion_handoff_with_report_bundle():
     service = _make_service()
     run = service.launch_run(
         query="Handoff question",
+        autonomy_mode="autonomous",
         chat_handoff={"conversation_id": "conv-42", "origin": "console"},
     )
     search_fn, analyze_fn, _ = _make_pipeline("Handoff question")
@@ -753,7 +756,7 @@ def test_engine_fires_completion_handoff_with_report_bundle():
 
 def test_engine_skips_handoff_without_chat_handoff_target():
     service = _make_service()
-    run = service.launch_run(query="No handoff")
+    run = service.launch_run(query="No handoff", autonomy_mode="autonomous")
     search_fn, analyze_fn, _ = _make_pipeline("No handoff")
     fired = []
 
@@ -768,7 +771,10 @@ def test_engine_skips_handoff_without_chat_handoff_target():
 
 def test_engine_handoff_failure_never_fails_the_run():
     service = _make_service()
-    run = service.launch_run(query="Boom handoff", chat_handoff={"conversation_id": "x"})
+    run = service.launch_run(
+        query="Boom handoff", autonomy_mode="autonomous",
+        chat_handoff={"conversation_id": "x"},
+    )
     search_fn, analyze_fn, _ = _make_pipeline("Boom handoff")
 
     def exploding_handoff(payload):
@@ -781,3 +787,136 @@ def test_engine_handoff_failure_never_fails_the_run():
 
     final = asyncio.run(engine.execute_run(run["id"]))
     assert final["status"] == "completed"  # handoff failure is a warning only
+
+
+# --- checkpointed autonomy (task-16482) -------------------------------------------
+
+_cp_state = {"search": 0, "analyze": 0}
+
+
+def _mk_cp_engine(service, question):
+    def search_fn(q, params):
+        _cp_state["search"] += 1
+        return (
+            {"results": [{"title": "S1", "url": "https://s1.example/"},
+                         {"title": "S2", "url": "https://s2.example/"}], "warnings": []},
+            {"sub_questions": [], "main_goal": q},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        _cp_state["analyze"] += 1
+        return {
+            "final_answer": {"text": "Report[1].", "confidence": 0.6, "chunks": [],
+                             "evidence": [{"id": 1, "url": "https://s1.example/", "title": "S1",
+                                           "content": "c", "original_content": "o", "reasoning": "r",
+                                           "chunk_index": 1}]},
+            "relevant_results": {"1": {}},
+            "web_search_results_dict": wsr,
+        }
+
+    return LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+
+
+def test_checkpointed_run_pauses_at_plan_review():
+    service = _make_service()
+    run = service.launch_run(query="Checkpointed question")  # default: checkpointed
+    engine = _mk_cp_engine(service, "Checkpointed question")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "running"  # non-terminal
+    assert final["control_state"] == "awaiting_plan_review"
+    pending = service.latest_pending_checkpoint(run["id"])
+    assert pending["checkpoint_type"] == "plan_review"
+    names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
+    assert "plan.json" in names and "report_v1.md" not in names
+    assert _cp_state["search"] == 0
+
+
+def test_approved_plan_checkpoint_advances_to_sources_review():
+    _cp_state.update(search=0, analyze=0)
+    service = _make_service()
+    run = service.launch_run(query="Checkpointed question")
+    engine = _mk_cp_engine(service, "Checkpointed question")
+    asyncio.run(engine.execute_run(run["id"]))
+    plan_cp = service.latest_pending_checkpoint(run["id"])
+    service.patch_and_approve_checkpoint(run["id"], plan_cp["id"], patch_payload={"limits": {}})
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["control_state"] == "awaiting_sources_review"
+    pending = service.latest_pending_checkpoint(run["id"])
+    assert pending["checkpoint_type"] == "sources_review"
+    assert set(pending["proposed_payload"]["source_ids"]) == {
+        "https://s1.example/", "https://s2.example/",
+    }
+    assert _cp_state["search"] == 1  # collected once
+    assert _cp_state["analyze"] == 0  # synthesis not reached
+
+
+def test_approved_sources_checkpoint_completes_and_applies_dropped():
+    _cp_state.update(search=0, analyze=0)
+    service = _make_service()
+    run = service.launch_run(query="Checkpointed question")
+    engine = _mk_cp_engine(service, "Checkpointed question")
+    asyncio.run(engine.execute_run(run["id"]))
+    service.patch_and_approve_checkpoint(
+        run["id"], service.latest_pending_checkpoint(run["id"])["id"]
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+    service.patch_and_approve_checkpoint(
+        run["id"],
+        service.latest_pending_checkpoint(run["id"])["id"],
+        patch_payload={"dropped_source_ids": ["https://s2.example/"]},
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    sources = _artifact_content(service.get_bundle(run["id"]), "sources.json")
+    urls = [e.get("url") for e in sources["evidence"]]
+    assert urls == ["https://s1.example/"]
+
+
+def test_sources_recollect_loops_back_to_collecting():
+    _cp_state.update(search=0, analyze=0)
+    service = _make_service()
+    run = service.launch_run(query="Checkpointed question")
+    engine = _mk_cp_engine(service, "Checkpointed question")
+    asyncio.run(engine.execute_run(run["id"]))
+    service.patch_and_approve_checkpoint(
+        run["id"], service.latest_pending_checkpoint(run["id"])["id"]
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+    service.patch_and_approve_checkpoint(
+        run["id"],
+        service.latest_pending_checkpoint(run["id"])["id"],
+        patch_payload={"recollect": {"enabled": True}},
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    # Re-collected and waiting at a NEW sources review, not completed.
+    assert _cp_state["search"] == 2
+    assert final["control_state"] == "awaiting_sources_review"
+    assert service.latest_pending_checkpoint(run["id"])["checkpoint_type"] == "sources_review"
+
+
+def test_approved_sources_checkpoint_with_empty_patch_still_passes():
+    _cp_state.update(search=0, analyze=0)
+    service = _make_service()
+    run = service.launch_run(query="Checkpointed question")
+    engine = _mk_cp_engine(service, "Checkpointed question")
+    asyncio.run(engine.execute_run(run["id"]))
+    service.patch_and_approve_checkpoint(
+        run["id"], service.latest_pending_checkpoint(run["id"])["id"]
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+    # Approve with NO patch: the boundary must PASS, not re-await forever.
+    service.patch_and_approve_checkpoint(
+        run["id"], service.latest_pending_checkpoint(run["id"])["id"]
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"

--- a/Tests/Research/test_local_research_service.py
+++ b/Tests/Research/test_local_research_service.py
@@ -178,3 +178,84 @@ def test_update_run_progress_missing_run_raises(tmp_path):
     service = LocalResearchService(tmp_path / "research.db")
     with pytest.raises(ValueError, match="research run not found"):
         service.update_run_progress("local:research_run:nope", phase="collecting")
+
+
+# --- checkpoints (task-16482) -----------------------------------------------------
+
+def _launch_checkpoint_run(service, **kwargs):
+    return service.launch_run(query="Checkpoint question", **kwargs)
+
+
+def test_checkpoint_create_list_latest_pending(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = _launch_checkpoint_run(service)
+
+    checkpoint = service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+
+    assert checkpoint["checkpoint_type"] == "plan_review"
+    assert checkpoint["status"] == "pending"
+    listed = service.list_checkpoints(run["id"])
+    assert [c["id"] for c in listed] == [checkpoint["id"]]
+    assert service.latest_pending_checkpoint(run["id"])["id"] == checkpoint["id"]
+
+
+def test_patch_and_approve_stores_patch_bumps_version_and_records_event(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = _launch_checkpoint_run(service)
+    checkpoint = service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+
+    approved = service.patch_and_approve_checkpoint(
+        run["id"], checkpoint["id"], patch_payload={"limits": {"max_searches": 3}}
+    )
+
+    assert approved["status"] == "approved"
+    assert approved["resolution"] == "approved"
+    assert approved["user_patch"] == {"limits": {"max_searches": 3}}
+    assert approved["version"] == checkpoint["version"] + 1
+    assert service.latest_pending_checkpoint(run["id"]) is None
+    events = [e["event"] for e in service.list_run_events(run["id"])]
+    assert "checkpoint_approved" in events
+
+
+def test_patch_validation_rejects_unknown_keys_and_bad_inventory(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = _launch_checkpoint_run(service)
+    plan = service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+    with pytest.raises(ValueError, match="unexpected patch keys"):
+        service.patch_and_approve_checkpoint(
+            run["id"], plan["id"], patch_payload={"bogus_key": 1}
+        )
+
+    sources = service.create_checkpoint(
+        run["id"],
+        checkpoint_type="sources_review",
+        proposed_payload={"source_ids": ["s1", "s2"]},
+    )
+    with pytest.raises(ValueError, match="not in the proposed inventory"):
+        service.patch_and_approve_checkpoint(
+            run["id"], sources["id"], patch_payload={"pinned_source_ids": ["sX"]}
+        )
+    with pytest.raises(ValueError, match="disjoint"):
+        service.patch_and_approve_checkpoint(
+            run["id"],
+            sources["id"],
+            patch_payload={"pinned_source_ids": ["s1"], "dropped_source_ids": ["s1"]},
+        )
+
+
+def test_approve_requires_pending_checkpoint(tmp_path):
+    service = LocalResearchService(tmp_path / "research.db")
+    run = _launch_checkpoint_run(service)
+    checkpoint = service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+    service.patch_and_approve_checkpoint(run["id"], checkpoint["id"])
+
+    with pytest.raises(ValueError, match="not pending"):
+        service.patch_and_approve_checkpoint(run["id"], checkpoint["id"])

--- a/Tests/Tools/test_web_deep_search.py
+++ b/Tests/Tools/test_web_deep_search.py
@@ -730,3 +730,21 @@ def test_deep_search_footer_deadline_note_says_may_be_incomplete(deep_env, monke
     assert "Deep answer [1]." in out  # the run DID fully succeed
     assert "deadline reached: partial synthesis" not in out.lower()
     assert "deadline reached" in out.lower() and "may be incomplete" in out.lower()
+
+
+def test_deep_search_footer_discloses_gate_fallback(deep_env, monkeypatch):
+    final_answer = dict(_FINAL)
+    final_answer["gate"] = {"relevant": 3, "raw": 5, "fallback": True}
+    final_answer["evidence"] = [
+        {"id": 1, "url": "https://e.com/", "title": "T", "content": "c",
+         "original_content": "o", "reasoning": "gate fallback", "chunk_index": 0,
+         "gate_unverified": True},
+    ]
+
+    async def fake_aa(wsr, sqd, params, cancel_event=None):
+        return {"final_answer": final_answer, "relevant_results": {"1": {}},
+                "web_search_results_dict": wsr}
+
+    monkeypatch.setattr(WebSearch_APIs, "analyze_and_aggregate", fake_aa)
+    out = web_deep_search("what is love")
+    assert "not relevance-verified" in out

--- a/Tests/Tools/test_web_deep_search.py
+++ b/Tests/Tools/test_web_deep_search.py
@@ -748,3 +748,27 @@ def test_deep_search_footer_discloses_gate_fallback(deep_env, monkeypatch):
     monkeypatch.setattr(WebSearch_APIs, "analyze_and_aggregate", fake_aa)
     out = web_deep_search("what is love")
     assert "not relevance-verified" in out
+
+
+# --- shared pipeline param assembly (task-16484) ----------------------------------
+
+def test_deep_search_pipeline_params_shape_and_overrides():
+    from tldw_chatbook.Tools.web_tool_impls import deep_search_pipeline_params
+
+    params = deep_search_pipeline_params()
+
+    for key in (
+        "engine", "relevance_analysis_llm", "final_answer_llm",
+        "relevance_llm_timeout_s", "relevance_scrape_timeout_s",
+        "search_default_max_queries", "result_count", "subquery_generation",
+        "phase1_time_budget_s", "respect_robots_txt",
+    ):
+        assert key in params, key
+
+    bounded = deep_search_pipeline_params(
+        engine="duckduckgo", max_results=3, subquery=False, max_queries=1
+    )
+    assert bounded["engine"] == "duckduckgo"
+    assert bounded["result_count"] == 3
+    assert bounded["subquery_generation"] is False
+    assert bounded["search_default_max_queries"] == 1

--- a/Tests/UI/test_bundle_rendering.py
+++ b/Tests/UI/test_bundle_rendering.py
@@ -1,0 +1,102 @@
+"""Bundle/artifact rendering for the Research window (task-16483)."""
+
+from tldw_chatbook.UI.Research_Modules.bundle_rendering import (
+    default_artifact_for_bundle,
+    render_artifact,
+    render_bundle_summary,
+)
+
+_LOCAL_BUNDLE = {
+    "run": {
+        "id": "run-1", "query": "What is RAG?", "status": "completed",
+        "phase": "completed", "confidence": None,
+    },
+    "artifacts": [
+        {"artifact_name": "plan.json", "content_type": "application/json",
+         "content": {"query": "What is RAG?"}},
+        {"artifact_name": "report_v1.md", "content_type": "text/markdown",
+         "content": "# Report\nAnswer[1]."},
+        {"artifact_name": "verification_summary.json", "content_type": "application/json",
+         "content": {"confidence": 0.9, "relevant_count": 2,
+                     "citation_verification": {"markers_total": 4, "markers_resolved": 4,
+                                               "quotes_checked": 1, "quotes_verified": 1,
+                                               "uncited_sentences": 1},
+                     "gate": {"relevant": 4, "raw": 5, "fallback": False}}},
+        {"artifact_name": "claims.json", "content_type": "application/json",
+         "content": {"claims": [
+             {"claim_id": "claim-1", "text": "Supported fact[1].", "status": "supported"},
+             {"claim_id": "claim-2", "text": "Shaky[2?].", "status": "unverified"}],
+             "claim_count": 2}},
+        {"artifact_name": "sources.json", "content_type": "application/json",
+         "content": {"evidence": [{"id": 1, "title": "One", "url": "https://one.example/"}]}},
+        {"artifact_name": "budget_ledger.json", "content_type": "application/json",
+         "content": {"searches_used": 2, "docs_used": 5, "tokens_settled": 40,
+                     "runtime_elapsed_s": 12.5}},
+    ],
+}
+
+
+def test_bundle_summary_local_shape_lists_run_and_inventory():
+    out = render_bundle_summary(_LOCAL_BUNDLE)
+
+    assert "run-1" in out and "completed" in out
+    for name in ("plan.json", "report_v1.md", "verification_summary.json"):
+        assert name in out
+
+
+def test_bundle_summary_server_shape_and_empty():
+    out = render_bundle_summary({"report_v1.md": "# R", "bundle.json": {}})
+    assert "report_v1.md" in out and "bundle.json" in out
+
+    assert render_bundle_summary(None) == "No bundle loaded."
+    assert render_bundle_summary({}) != "No bundle loaded."
+
+
+def test_default_artifact_prefers_report_and_never_the_run_record():
+    assert default_artifact_for_bundle(_LOCAL_BUNDLE) == "report_v1.md"
+    assert default_artifact_for_bundle({"run": {}, "artifacts": [
+        {"artifact_name": "plan.json", "content": {}}]}) == "plan.json"
+    assert default_artifact_for_bundle({"bundle.json": {}}) == "bundle.json"
+    assert default_artifact_for_bundle(None) is None
+
+
+def test_render_artifact_structured_per_known_type():
+    def artifact(name, content, content_type="application/json"):
+        return {"artifact_name": name, "content_type": content_type,
+                "artifact_version": 1, "content": content}
+
+    report = render_artifact(artifact("report_v1.md", "# Report\nAnswer[1].", "text/markdown"))
+    assert "# Report" in report and "Answer[1]." in report
+
+    verification = render_artifact(
+        _LOCAL_BUNDLE["artifacts"][2]
+    )
+    assert "confidence: 0.9" in verification
+    assert "markers 4/4" in verification and "quotes 1/1" in verification
+    assert "gate: 4/5" in verification
+
+    claims = render_artifact(_LOCAL_BUNDLE["artifacts"][3])
+    assert "claim-1" in claims and "supported" in claims and "Supported fact[1]." in claims
+
+    sources = render_artifact(_LOCAL_BUNDLE["artifacts"][4])
+    assert "[1] One — https://one.example/" in sources
+
+    budget = render_artifact(_LOCAL_BUNDLE["artifacts"][5])
+    assert "searches 2" in budget and "docs 5" in budget and "40" in budget
+
+
+def test_render_artifact_falls_back_to_pretty_json():
+    out = render_artifact({"artifact_name": "custom.json", "content_type": "application/json",
+                           "content": {"z": 1, "a": [1, 2]}})
+    assert '"a"' in out and '"z"' in out
+
+    assert render_artifact(None) == "No artifact loaded."
+
+
+def test_render_artifact_namespace_tolerant():
+    from types import SimpleNamespace
+
+    out = render_artifact(SimpleNamespace(
+        artifact_name="report_v1.md", content_type="text/markdown",
+        artifact_version=2, content="Namespaced report."))
+    assert "Namespaced report." in out and "Version: 2" in out

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -615,3 +615,42 @@ async def test_window_approves_latest_local_checkpoint_and_restarts_engine(monke
     assert updated["status"] == "approved"
     assert local_service.latest_pending_checkpoint(run["id"]) is None
     assert restarted == [run["id"]]
+
+
+# --- readable bundle inspection (task-16483) --------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_bundle_auto_loads_the_report(monkeypatch):
+    service = FakeResearchScopeService()
+
+    async def get_bundle(run_id, *, mode):
+        return {
+            "run": {"id": run_id, "status": "completed", "phase": "completed",
+                    "query": "What is RAG?"},
+            "artifacts": [
+                {"artifact_name": "plan.json", "content_type": "application/json",
+                 "content": {"query": "What is RAG?"}},
+                {"artifact_name": "report_v1.md", "content_type": "text/markdown",
+                 "content": "# Report\nAnswer[1]."},
+            ],
+        }
+
+    async def get_artifact(run_id, artifact_name, *, mode):
+        return {"artifact_name": artifact_name, "content_type": "text/markdown",
+                "artifact_version": 1, "content": "# Report\nAnswer[1]."}
+
+    service.get_bundle = get_bundle
+    service.get_artifact = get_artifact
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    monkeypatch.setattr(window, "_start_local_engine", lambda run_id: None)
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+
+    bundle = await window.load_selected_run_bundle()
+
+    assert bundle is not None
+    # The run record is NOT selected as the artifact; the report is.
+    assert window.current_artifact is not None
+    assert window.current_artifact["artifact_name"] == "report_v1.md"
+    assert "Answer[1]." in window.current_artifact["content"]

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from tldw_chatbook.UI.Research_Modules.research_controller import ResearchController
-from tldw_chatbook.UI.Research_Window import ResearchWindow
+from tldw_chatbook.UI.Research_Window import ResearchWindow, _parse_limits_text
 
 # NOTE (task-16322, ADR-068): ``ResearchScreen`` is back -- the local
 # research execution engine drives launched local runs, so the window is
@@ -370,10 +370,10 @@ def test_window_academic_toggle_defaults_off_and_persists_in_state():
     window = ResearchWindow(app_instance=app)
 
     assert window.academic_enabled is False
-    assert window.save_state() == {"source": "local", "academic": False}
+    assert window.save_state() == {"source": "local", "academic": False, "limits": ""}
 
     window.academic_enabled = True
-    assert window.save_state() == {"source": "local", "academic": True}
+    assert window.save_state() == {"source": "local", "academic": True, "limits": ""}
 
 
 def test_window_academic_toggle_restores_from_state():
@@ -424,3 +424,149 @@ def test_window_engine_start_passes_paper_fn_only_when_toggle_on(monkeypatch):
     window_on.academic_enabled = True
     window_on._start_local_engine("run-2")
     assert captured["paper_search_fn"] is academic_providers.search_papers
+
+
+# --- budgets + follow-up Q&A in the window (task-16334) ---------------------------
+
+
+def test_parse_limits_text_numeric_pairs():
+    limits, warnings = _parse_limits_text("max_searches=5, max_runtime_seconds=120")
+    assert limits == {"max_searches": 5, "max_runtime_seconds": 120.0}
+    assert warnings == []
+
+
+def test_parse_limits_text_invalid_pairs_warn_and_are_excluded():
+    limits, warnings = _parse_limits_text("max_searches=five, junk, max_tokens=100")
+    assert limits == {"max_tokens": 100}
+    assert len(warnings) == 2
+
+
+def test_parse_limits_text_empty():
+    assert _parse_limits_text("") == ({}, [])
+    assert _parse_limits_text("   ") == ({}, [])
+
+
+@pytest.mark.asyncio
+async def test_create_run_carries_parsed_limits(monkeypatch):
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    monkeypatch.setattr(window, "_start_local_engine", lambda run_id: None)
+
+    window.limits_text = "max_searches=3, max_fetched_docs=10"
+    await window.create_run({"query": "Budgeted question"})
+
+    create_call = [c for c in service.calls if c[0] == "create_run"][0]
+    assert create_call[2]["limits_json"] == {
+        "max_searches": 3, "max_fetched_docs": 10.0,
+    }
+
+
+def test_limits_text_persists_in_state():
+    app = SimpleNamespace(research_scope_service=FakeResearchScopeService(),
+                          local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    window.limits_text = "max_searches=3"
+    assert window.save_state()["limits"] == "max_searches=3"
+
+    window2 = ResearchWindow(app_instance=app)
+    window2.restore_state({"source": "local", "limits": "max_searches=4"})
+    assert window2.limits_text == "max_searches=4"
+
+
+@pytest.mark.asyncio
+async def test_ask_follow_up_answers_from_selected_local_run(monkeypatch):
+    from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+    asked = {}
+
+    class FakeEngine:
+        def __init__(self, service, **kwargs):
+            asked["params"] = kwargs.get("search_params")
+
+        async def answer_follow_up(self, run_id, question, **kwargs):
+            asked["run_id"] = run_id
+            asked["question"] = question
+            return {"status": "answered", "answer": "Because the claims say so.",
+                    "question": question}
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.local_research_engine.LocalResearchEngine",
+        FakeEngine,
+    )
+    local_service = LocalResearchService(":memory:")
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service,
+                          local_research_service=local_service)
+    window = ResearchWindow(app_instance=app)
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+
+    result = await window.ask_follow_up("Why is that?")
+
+    assert asked["run_id"] == "local-run"
+    assert asked["question"] == "Why is that?"
+    assert result["status"] == "answered"
+    assert "Because the claims say so." in window.followup_answer_text
+
+
+@pytest.mark.asyncio
+async def test_ask_follow_up_insufficient_verdict_is_displayed_not_faked(monkeypatch):
+    from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+    class FakeEngine:
+        def __init__(self, service, **kwargs):
+            pass
+
+        async def answer_follow_up(self, run_id, question, **kwargs):
+            return {"status": "insufficient_evidence", "answer": None,
+                    "reason": "no stored claims",
+                    "suggestion": "Launch a new research run."}
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.local_research_engine.LocalResearchEngine",
+        FakeEngine,
+    )
+    app = SimpleNamespace(research_scope_service=FakeResearchScopeService(),
+                          local_research_service=LocalResearchService(":memory:"))
+    window = ResearchWindow(app_instance=app)
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+
+    result = await window.ask_follow_up("Anything?")
+
+    assert result["status"] == "insufficient_evidence"
+    assert "insufficient" in window.followup_answer_text
+    assert "Launch a new research run." in window.followup_answer_text
+
+
+@pytest.mark.asyncio
+async def test_ask_follow_up_requires_selection_and_local_source(monkeypatch):
+    constructed = {"n": 0}
+
+    class FakeEngine:
+        def __init__(self, *a, **k):
+            constructed["n"] += 1
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.local_research_engine.LocalResearchEngine",
+        FakeEngine,
+    )
+    app = SimpleNamespace(research_scope_service=FakeResearchScopeService(),
+                          local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+
+    result = await window.ask_follow_up("No run selected")  # no selection
+    assert result is None
+    assert constructed["n"] == 0
+    assert "Select a research run" in window.status_message
+
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+    # Set the source directly: switch_source() clears the selection, which
+    # would trip the no-selection guard instead of the source guard.
+    window.current_source = "server"
+    result = await window.ask_follow_up("Server run")
+    assert result is None
+    assert constructed["n"] == 0
+    assert "local" in window.status_message

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -273,7 +273,7 @@ async def test_research_window_approves_selected_server_checkpoint():
 
 
 @pytest.mark.asyncio
-async def test_research_window_reports_local_checkpoint_approval_unavailable():
+async def test_research_window_reports_no_pending_local_checkpoint():
     service = FakeResearchScopeService()
     app = SimpleNamespace(research_scope_service=service)
     window = ResearchWindow(app)
@@ -283,8 +283,10 @@ async def test_research_window_reports_local_checkpoint_approval_unavailable():
 
     updated = await window.approve_selected_checkpoint()
 
+    # task-16482: local approval EXISTS now; the unavailable case is "no
+    # pending checkpoint" (no local service wired in this test).
     assert updated is None
-    assert "Local research checkpoints" in window.status_message
+    assert "No pending checkpoint" in window.status_message
 
 
 # --- local engine start wiring (task-16322, ADR-068) ---------------------------
@@ -570,3 +572,46 @@ async def test_ask_follow_up_requires_selection_and_local_source(monkeypatch):
     assert result is None
     assert constructed["n"] == 0
     assert "local" in window.status_message
+
+
+# --- local checkpoint approval (task-16482) ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_window_approves_latest_local_checkpoint_and_restarts_engine(monkeypatch):
+    from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+    local_service = LocalResearchService(":memory:")
+    run = local_service.launch_run(query="Checkpointed run")
+    checkpoint = local_service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+    service = FakeResearchScopeService()
+    service.runs["local"] = [
+        SimpleNamespace(id=run["id"], query="Checkpointed run", status="running",
+                        phase="planning", control_state="awaiting_plan_review",
+                        latest_checkpoint_id=checkpoint["id"])
+    ]
+    app = SimpleNamespace(research_scope_service=service,
+                          local_research_service=local_service)
+    window = ResearchWindow(app_instance=app)
+    restarted = []
+    monkeypatch.setattr(window, "_start_local_engine", restarted.append)
+
+    async def approve(scope_run_id, checkpoint_id, patch_payload):
+        return local_service.patch_and_approve_checkpoint(
+            scope_run_id, checkpoint_id, patch_payload=patch_payload
+        )
+
+    async def fake_scope_approve(run_id_arg, checkpoint_id, *, mode, patch_payload):
+        assert mode == "local"
+        return await approve(run_id_arg, checkpoint_id, patch_payload)
+
+    service.patch_and_approve_checkpoint = fake_scope_approve
+
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+    updated = await window.approve_selected_checkpoint(patch_payload={"limits": {}})
+
+    assert updated["status"] == "approved"
+    assert local_service.latest_pending_checkpoint(run["id"]) is None
+    assert restarted == [run["id"]]

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -654,3 +654,55 @@ async def test_load_bundle_auto_loads_the_report(monkeypatch):
     assert window.current_artifact is not None
     assert window.current_artifact["artifact_name"] == "report_v1.md"
     assert "Answer[1]." in window.current_artifact["content"]
+
+
+# --- selected-run auto-refresh (task-16486) ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_auto_refresh_updates_non_terminal_local_run_preserving_payload():
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+    window.runs[0].status = "running"
+    window.current_bundle = {"kept": True}
+
+    calls = {"n": 0}
+
+    async def get_run(run_id, *, mode):
+        calls["n"] += 1
+        return SimpleNamespace(id=run_id, query="Local query", status="running",
+                               phase="synthesizing", control_state="running")
+
+    service.get_run = get_run
+    await window._auto_refresh_selected_run()
+
+    assert calls["n"] == 1
+    assert window.selected_run.phase == "synthesizing"
+    assert window.current_bundle == {"kept": True}  # payload state preserved
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_skips_terminal_and_non_local():
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    await window.load_runs("local")
+    window.select_run(window.runs[0])
+    window.runs[0].status = "completed"  # terminal: no refresh
+
+    calls = {"n": 0}
+
+    async def get_run(run_id, *, mode):
+        calls["n"] += 1
+        return window.runs[0]
+
+    service.get_run = get_run
+    await window._auto_refresh_selected_run()
+    assert calls["n"] == 0
+
+    window.runs[0].status = "running"
+    window.current_source = "server"  # server source: not our engine
+    await window._auto_refresh_selected_run()
+    assert calls["n"] == 0

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1214,3 +1214,93 @@ async def test_analyze_and_aggregate_forwards_respect_robots_txt_false_when_abse
 
     await WebSearch_APIs.analyze_and_aggregate(wsr, sqd, params)
     assert captured["respect_robots_txt"] is False
+
+
+# --- relevance gate robustness (task-16333) --------------------------------------
+
+@pytest.mark.asyncio
+async def test_relevance_judgment_runs_at_classification_temperature(monkeypatch):
+    captured = []
+
+    def fake_chat(**kwargs):
+        captured.append(kwargs)
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    monkeypatch.setattr(WebSearch_APIs, "scrape_article", failing_scrape_noop)
+    results = [_std_result("T", "https://e.example/", "c")]
+    await WebSearch_APIs.search_result_relevance(results, "q", [], "openai")
+
+    eval_calls = [
+        c for c in captured
+        if str(c["messages_payload"][0]["content"]).startswith("Evaluate the relevance")
+    ]
+    assert eval_calls, "the judgment call must be identifiable by its input"
+    assert all(c["temp"] <= 0.2 for c in eval_calls)
+
+
+async def failing_scrape_noop(url, **k):
+    raise RuntimeError("no scrape")
+
+
+@pytest.mark.asyncio
+async def test_zero_relevant_falls_back_to_flagged_top_results(monkeypatch):
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call",
+                        _fake_chat(["Selected Answer: False\nReasoning: off-topic"] * 5))
+    results = [_std_result(f"T{i}", f"https://e{i}.example/", f"snippet {i}") for i in range(5)]
+
+    out = await WebSearch_APIs.search_result_relevance(results, "q", [], "openai")
+
+    assert out, "all-rejected must not produce an empty evidence set when raw results exist"
+    assert len(out) <= 3  # bounded fallback
+    first = next(iter(out.values()))
+    assert first["gate_unverified"] is True
+    assert first["url"] == "https://e0.example/"  # original rank order
+    assert "snippet 0" in (first["content"] or "")  # snippet-level, no summarize spend
+
+
+@pytest.mark.asyncio
+async def test_zero_relevant_with_cancel_keeps_empty(monkeypatch):
+    import asyncio
+    evt = asyncio.Event()
+
+    def fake_chat(**kwargs):
+        evt.set()
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    results = [_std_result("T", "https://e.example/", "c")]
+
+    out = await WebSearch_APIs.search_result_relevance(results, "q", [], "openai", cancel_event=evt)
+
+    assert out == {}  # a cancelled/deadline run reports honestly, no fallback
+
+
+@pytest.mark.asyncio
+async def test_zero_relevant_with_unevaluated_results_keeps_empty(monkeypatch):
+    import time as _t
+
+    def hanging_chat(**kwargs):
+        _t.sleep(0.3)
+        return "Selected Answer: True\nReasoning: slow"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", hanging_chat)
+    results = [_std_result("T", "https://e.example/", "c")]
+
+    out = await WebSearch_APIs.search_result_relevance(results, "q", [], "openai", llm_timeout_s=0.05)
+
+    assert out == {}  # never-evaluated results are not promoted (existing pin, unchanged)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_carries_gate_unverified_flag_into_evidence(monkeypatch):
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", lambda **kwargs: "A[1].")
+    from tldw_chatbook.LLM_Calls import Summarization_General_Lib
+    monkeypatch.setattr(Summarization_General_Lib, "analyze", lambda *a, **k: "s")
+
+    out = WebSearch_APIs.aggregate_results(
+        {"1": {"content": "c", "original_content": "o", "reasoning": "gate fallback",
+               "url": "https://e.example/", "title": "T", "gate_unverified": True}},
+        "q", [], "openai",
+    )
+    assert out["evidence"][0]["gate_unverified"] is True

--- a/backlog/decisions/068-local-research-execution-engine.md
+++ b/backlog/decisions/068-local-research-execution-engine.md
@@ -93,3 +93,22 @@ contract `ServerResearchService` already mirrors.
 - **Fork the pipeline into the engine** — rejected: guarantees behavioral
   drift from the tool path (deadlines, robots, citation verification) the
   moment either side changes.
+
+## Addendum (2026-08-15, task-16482): checkpoint enforcement activated
+
+Clause 6's deferral is resolved: runs with `autonomy_mode="checkpointed"`
+(the schema default) now pause at phase boundaries for review — a
+`plan_review` checkpoint before any search spend and a `sources_review`
+checkpoint before synthesis — parking in a non-terminal
+`awaiting_<type>` control state with partial artifacts preserved.
+Approval goes through `LocalResearchService.patch_and_approve_checkpoint`
+with per-type patch validation (plan: `limits`; sources:
+`pinned_source_ids`/`dropped_source_ids`/`recollect`, inventory-checked
+and disjoint); an approved plan `limits` patch supersedes the run's
+originals for budget enforcement, an approved sources patch drops the
+named sources, and `recollect.enabled` loops the run back to collecting
+for a fresh sources review (server parity). Outline review remains
+unimplemented locally: the local engine has no separate outline phase
+(its plan covers focus areas), so the server's third checkpoint type
+does not map. The window's Approve Checkpoint action resolves the
+latest pending local checkpoint and restarts the engine on approval.

--- a/backlog/tasks/task-16330 - Record-a-live-baseline-for-the-research-report-self-eval.md
+++ b/backlog/tasks/task-16330 - Record-a-live-baseline-for-the-research-report-self-eval.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16330
+title: Record a live baseline for the research report self-eval
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-15 16:46'
+updated_date: '2026-08-15 20:56'
+labels:
+  - research
+  - evals
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The self-eval baseline (task-16327) is synthetic: it pins metric definitions but measures nothing about the real pipeline. Add a committed helper that runs real research questions through the engine, scores the resulting verification payloads, and records the aggregate live baseline; then run it and record the numbers.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A committed helper script runs N research questions through the local engine with the configured pipeline settings, collects each run's verification payload, and prints or writes the aggregated live metrics,The baseline doc gains a live section with real numbers and the questions used,Script defaults keep spend bounded (small result counts, no subquery fan-out) and are documented,Scoring uses the existing scorer unchanged
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD the aggregation logic (mean metrics over scored payloads) as a small function reused by the script
+2. Write Helper_Scripts/Benchmarks/record_research_baseline.py: builds a temp LocalResearchService, assembles search params from the tool settings, runs N bounded questions through the real engine defaults, scores each run's verification payload, prints aggregate metrics + JSON
+3. Run it live against the configured pipeline (google + both LLMs, bounded spend: 5 results, no subquery fan-out, 3 questions)
+4. Record the live numbers in the baseline doc; tests plus lint plus task close
+ADR required: no - offline tooling over existing seams
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `aggregate_metrics` added to the scorer (TDD) — mean metrics + sample_count over payload lists; the script is I/O glue over it (mirroring the RAG benchmark precedent).
+- `Helper_Scripts/Benchmarks/record_research_baseline.py`: assembles engine params exactly like the `web_deep_search` tool, preflights engine credentials (fails fast with actionable output; `--engine duckduckgo` documented as keyless), supports `--academic` (keyless arXiv+S2 lane), `--llm/--llm-base-url` (primes `api_settings.<provider>.api_url`/`api_timeout` in-process — no config file writes; local models need a bumped request timeout), exits non-zero when no run produced a scorable payload, and writes aggregate JSON via `--json-out`.
+- **Live baseline recorded** (2026-08-15, duckduckgo+academic lane, local llama.cpp Qwen3.8-27B): citation_accuracy **1.00** (20/20 markers), claim_support **1.00**, cited_sentence_ratio **0.68** (n=2 scored of 3 questions; 1 run rejected entirely by the relevance gate — recorded as the observed weak link, not hidden). quote_grounding 0.00 because the model emitted no quoted spans (nothing checked — untested, not failing). Numbers + command + configuration in `Docs/Development/research-report-eval-baseline.md`.
+- Deviations/limitations (documented): web-lane engines unreachable from this network (DDG/Baidu bot challenge; all keyed engines unconfigured), so the live baseline measures the ACADEMIC-lane configuration; sample size 2 is thin but honestly reported with the one-command procedure to extend.
+- Live verification surfaced and fixed three real bugs on the way (each its own commit): OpenAI-dict normalization at `chat_api_call` (local providers returned raw dicts breaking every string consumer — also unlocked REAL token-usage recording for task-16329), arXiv phrase-quoting (token queries surfaced off-topic papers), and question→topic normalization for paper queries. Default questions are academic topics since the evidence pool (with the web lane blocked) is papers.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16333 - Harden-the-deep-search-relevance-gate.md
+++ b/backlog/tasks/task-16333 - Harden-the-deep-search-relevance-gate.md
@@ -1,0 +1,36 @@
+---
+id: TASK-16333
+title: Harden the deep-search relevance gate
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-15 21:32'
+updated_date: '2026-08-15 21:32'
+labels:
+  - research
+  - web-tools
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The recorded live baseline (task-16330) measured citation integrity at 1.00 but showed the relevance gate is the pipeline's weak link: the prompt demands results comprehensively answer the question, the judgment runs at temperature 0.7 (a classification call), and when the gate rejects every result the run produces NO report at all. 1 of 3 baseline questions died this way and verdicts flipped between identical runs. Make the gate judge usefulness, run deterministically, and degrade to a flagged report instead of nothing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The gate prompt judges usefulness (partial coverage counts, False only for essentially unrelated results) instead of requiring comprehensive coverage,The relevance judgment LLM call runs at a classification temperature at or below 0.2 while the summarization call temperature is unchanged,When the gate rejects every result but raw results exist the pipeline proceeds with the top-ranked results flagged gate-unverified - the flag reaches the evidence entries, the verification summary gains a gate block (relevant and raw counts plus fallback marker), and the web_deep_search footer discloses unverified evidence,A genuinely empty result set keeps today's explanatory no-results path,Gate pass-rate is computed by the self-eval scorer when the payload carries gate counts and the aggregate averages per-key over payloads that have it,Tests pin the temperature the fallback flagging the footer disclosure and the scorer metric
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD prompt plus temperature: rewrite websearch.result_relevance_eval instruction to usefulness semantics and pin the judgment call to a low classification temperature (constant), summarization temp unchanged
+2. TDD zero-relevant fallback in search_result_relevance: track evaluated results, and when all are rejected but raw results exist, return the top-ranked few as gate-unverified entries (snippet-level content, no scrape or summarize spend)
+3. TDD flag propagation: aggregate_results carries gate_unverified into evidence entries, analyze_and_aggregate attaches a gate block (relevant, raw, fallback) to the final answer, the web_deep_search footer discloses fallback evidence, and the engine verification summary includes the gate block
+4. TDD scorer: unwrap citation_verification when present, compute gate_pass_rate from gate counts, aggregate averages per-key over payloads that carry the key
+5. Full suites plus lint; re-run the live baseline against the local llamacpp endpoint to measure the improvement; close task
+ADR required: no - behavior tuning and a degradation path inside the existing deep-search tool contract; decision recorded in the task and code comments
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-16333 - Harden-the-deep-search-relevance-gate.md
+++ b/backlog/tasks/task-16333 - Harden-the-deep-search-relevance-gate.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-16333
 title: Harden the deep-search relevance gate
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-15 21:32'
-updated_date: '2026-08-15 21:32'
+updated_date: '2026-08-15 22:32'
 labels:
   - research
   - web-tools
@@ -21,7 +21,7 @@ The recorded live baseline (task-16330) measured citation integrity at 1.00 but 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The gate prompt judges usefulness (partial coverage counts, False only for essentially unrelated results) instead of requiring comprehensive coverage,The relevance judgment LLM call runs at a classification temperature at or below 0.2 while the summarization call temperature is unchanged,When the gate rejects every result but raw results exist the pipeline proceeds with the top-ranked results flagged gate-unverified - the flag reaches the evidence entries, the verification summary gains a gate block (relevant and raw counts plus fallback marker), and the web_deep_search footer discloses unverified evidence,A genuinely empty result set keeps today's explanatory no-results path,Gate pass-rate is computed by the self-eval scorer when the payload carries gate counts and the aggregate averages per-key over payloads that have it,Tests pin the temperature the fallback flagging the footer disclosure and the scorer metric
+- [x] #1 The gate prompt judges usefulness (partial coverage counts, False only for essentially unrelated results) instead of requiring comprehensive coverage,The relevance judgment LLM call runs at a classification temperature at or below 0.2 while the summarization call temperature is unchanged,When the gate rejects every result but raw results exist the pipeline proceeds with the top-ranked results flagged gate-unverified - the flag reaches the evidence entries, the verification summary gains a gate block (relevant and raw counts plus fallback marker), and the web_deep_search footer discloses unverified evidence,A genuinely empty result set keeps today's explanatory no-results path,Gate pass-rate is computed by the self-eval scorer when the payload carries gate counts and the aggregate averages per-key over payloads that have it,Tests pin the temperature the fallback flagging the footer disclosure and the scorer metric
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -34,3 +34,14 @@ The recorded live baseline (task-16330) measured citation integrity at 1.00 but 
 5. Full suites plus lint; re-run the live baseline against the local llamacpp endpoint to measure the improvement; close task
 ADR required: no - behavior tuning and a degradation path inside the existing deep-search tool contract; decision recorded in the task and code comments
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Prompt (`websearch.result_relevance_eval`): relevance now means "provides USEFUL information about the subject, even partially"; False only for essentially unrelated results. Judgment temperature pinned to `_RELEVANCE_JUDGMENT_TEMP = 0.1` (classification; the old 0.7 flipped verdicts between identical runs); summarization temp untouched.
+- Zero-relevant fallback in `search_result_relevance`: only results the gate EVALUATED and rejected (verdict False) are eligible -- timeout/cancel/no-content skips are never promoted, and a cancelled run keeps the honest cutoff path. Fallback keeps the top `_GATE_FALLBACK_MAX_RESULTS` (3) in rank order as snippet-level evidence (`gate_unverified: True`, no scrape/summarize spend). The flag flows: evidence entries -> `final_answer["gate"] = {relevant, raw, fallback}` -> web_deep_search footer ("evidence not relevance-verified (gate fallback)") -> engine `verification_summary.json` gate block.
+- Scorer: `score_research_report` unwraps a nested `citation_verification` (so the full verification summary can be handed over), computes `gate_pass_rate` from gate counts when present; `aggregate_metrics` averages per-key over payloads that carry the key. Baseline script passes the full summary and prints gate metrics + a `[GATE FALLBACK]` marker.
+- **Live re-measurement (same config/command as the recorded baseline)**: before -- 2 of 3 questions scored, whole runs lost to the gate; after -- **3 of 3 scored, 49/49 markers resolved, gate_pass_rate 0.93, quote_grounding 0.67** (the model began emitting quotes and all verified). Before/after table added to the baseline doc.
+- Extra finding fixed in the script: thinking models can exhaust the default 4096 max_tokens on reasoning alone and return an EMPTY completion (observed as a 5-minute synthesis returning length 0) -- `_prime_local_llm_url` now also primes `max_tokens=16384` for local endpoints.
+- Verified TDD: 10 new tests written first and watched failing (temp pin, fallback bounds/order/flag, cancel + unevaluated exclusions, evidence flag, footer disclosure, engine gate block, scorer unwrap/rate/per-key aggregate); combined suites 363 passed; ruff findings on touched files are pre-existing baseline drift only.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16334 - Expose-budgets-and-follow-up-QA-in-the-Research-window.md
+++ b/backlog/tasks/task-16334 - Expose-budgets-and-follow-up-QA-in-the-Research-window.md
@@ -1,0 +1,44 @@
+---
+id: TASK-16334
+title: Expose budgets and follow-up Q&A in the Research window
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-15 22:39'
+updated_date: '2026-08-15 22:43'
+labels:
+  - research
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The engine enforces limits_json budgets (task-16323) and answers follow-up questions from stored claims (task-16325), but neither has window controls: every local run launches unbudgeted and follow-up Q&A is unreachable from the UI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The Research window has a limits input parsed into limits_json on run creation (numeric key=value pairs; invalid pairs warn in the status line without blocking creation),Follow-up questions can be asked against the selected completed local run and the answer or explicit insufficient-evidence verdict is displayed,Follow-up ask requires a selected run on the local source and reports a clear status otherwise,The limits text persists through save_state and restore_state,Tests cover limits parsing, payload wiring, follow-up display, and the no-selection guard
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD a module-level limits parser in Research_Window (numeric key=value pairs; invalid pairs excluded with warnings)
+2. TDD window wiring: limits input in the create row parsed into limits_json on create_run (warnings to the status line without blocking), limits text persisted via save_state/restore_state
+3. TDD follow-up Q&A: question input plus Ask button calling LocalResearchEngine.answer_follow_up on the selected local run with the tool-assembled synthesis LLM params; answer or explicit insufficient verdict rendered to a dedicated Static; no-selection and non-local guards report status without constructing the engine
+4. Tests plus lint plus task close
+ADR required: no - UI controls over existing engine seams
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `_parse_limits_text` (module-level in Research_Window): numeric `key=value` pairs; invalid pairs are excluded with warnings surfaced in the status line — one typo never blocks creation. The limits input sits in the create row (`#research-limits-input`), parsed into `limits_json` on `create_run`, and persists via save/restore state (`limits` key).
+- Follow-up Q&A: `#research-followup-input` + Ask button + `#research-followup-answer` Static. `ask_follow_up(question)` guards no-selection (the existing `_selected_run_id` raises — caught), non-local source, missing local service, and empty question before constructing a transient `LocalResearchEngine` with the tool-assembled `final_answer_llm` search params (so the default answerer uses the configured pipeline). Answered results render `Q: …` + answer; insufficient results render the engine's explicit verdict + suggestion — never a fabricated answer.
+- Guard ordering note surfaced by the tests: `switch_source` clears the selection, so the no-selection guard legitimately precedes the source guard when both apply.
+- Verified TDD: 8 new tests written first and watched failing (parser valid/invalid/empty, limits payload wiring, state persistence, answered + insufficient rendering, no-selection and source guards); `Tests/UI/test_research_screen.py + Tests/Research/` = 128 passed; ruff clean.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16335 - Record-real-token-usage-from-cloud-providers.md
+++ b/backlog/tasks/task-16335 - Record-real-token-usage-from-cloud-providers.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-16335
 title: Record real token usage from cloud providers
-status: To Do
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-15 22:39'
+updated_date: '2026-08-15 22:45'
 labels:
   - research
   - budget
@@ -20,5 +21,23 @@ Task-16331 records exact token counts for local OpenAI-compatible providers (the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A provider-side usage reporting seam lets handlers publish exact prompt and completion token counts for the current call,chat_api_call consumes published usage into the active recorder instead of estimates and clears it per call,OpenAI and Anthropic non-streaming paths publish usage when their responses carry it,Paths without usage keep the estimate fallback unchanged,Tests with mocked handlers or HTTP cover publication, dispatcher consumption, and the fallback
+- [x] #1 A provider-side usage reporting seam lets handlers publish exact prompt and completion token counts for the current call,chat_api_call consumes published usage into the active recorder instead of estimates and clears it per call,OpenAI and Anthropic non-streaming paths publish usage when their responses carry it,Paths without usage keep the estimate fallback unchanged,Tests with mocked handlers or HTTP cover publication, dispatcher consumption, and the fallback
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Survey chat_with_openai and chat_with_anthropic non-streaming response paths for where usage is available
+2. TDD a provider-side usage publication seam in usage_recorder (contextvar hand-off consumed by chat_api_call per call) plus dispatcher consumption replacing estimates
+3. Wire OpenAI and Anthropic non-streaming paths to publish usage when their responses carry it
+4. Tests with mocked handlers plus lint plus task close
+ADR required: no - completes the task-16331 recorder seam for cloud providers
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Survey finding that shrank the task: the cloud handlers ALREADY publish usage — `chat_with_openai` (classic and Responses-API, via `_normalize_openai_responses_payload`) and `chat_with_anthropic` (via its OpenAI-shape normalization) all return OpenAI-shaped dicts carrying `usage`, and the task-16331 dict normalization in `chat_api_call` already extracts content and records exact counts. The handler-side seam the AC anticipated turned out to be the return-dict itself; no handler changes were needed.
+- The one real gap: Anthropic preserves its own usage field names (`input_tokens`/`output_tokens`) inside the normalized dict, which the recorder's gate (OpenAI names only) did not recognize — those calls silently fell back to estimates. `chat_api_call`'s recording block now maps both naming schemes (OpenAI names win when both are present, which also pins the mixed-key case).
+- Verified TDD: 3 new tests written first and watched failing (Anthropic-style keys recorded exactly; OpenAI-style still exact; mixed keys prefer OpenAI names); `Tests/Chat/ + Tests/Research/` = 116 passed; ruff clean. Estimate fallback for usage-less paths is pinned by the pre-existing tests.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16335 - Record-real-token-usage-from-cloud-providers.md
+++ b/backlog/tasks/task-16335 - Record-real-token-usage-from-cloud-providers.md
@@ -1,0 +1,24 @@
+---
+id: TASK-16335
+title: Record real token usage from cloud providers
+status: To Do
+assignee:
+  - '@robert'
+created_date: '2026-08-15 22:39'
+labels:
+  - research
+  - budget
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Task-16331 records exact token counts for local OpenAI-compatible providers (their raw dict responses carry usage), but cloud paths still fall back to estimates: chat_with_openai and chat_with_anthropic receive usage in their API responses and discard it while returning content strings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A provider-side usage reporting seam lets handlers publish exact prompt and completion token counts for the current call,chat_api_call consumes published usage into the active recorder instead of estimates and clears it per call,OpenAI and Anthropic non-streaming paths publish usage when their responses carry it,Paths without usage keep the estimate fallback unchanged,Tests with mocked handlers or HTTP cover publication, dispatcher consumption, and the fallback
+<!-- AC:END -->

--- a/backlog/tasks/task-16481 - Deliver-completed-research-runs-into-the-originating-chat.md
+++ b/backlog/tasks/task-16481 - Deliver-completed-research-runs-into-the-originating-chat.md
@@ -1,0 +1,35 @@
+---
+id: TASK-16481
+title: Deliver completed research runs into the originating chat
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:00'
+updated_date: '2026-08-16 03:18'
+labels:
+  - research
+  - console
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The deep-research flow lives isolated in the Research window: nothing can launch a run from where users actually work (the Console chat), and completed reports land in a window the user must remember to check. The run schema already carries an unused chat_handoff_json, and the server solved exactly this with its chat_handoff machinery (assistant message with deep_research_completion metadata on packaging, notification fallback).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A run launched with a chat handoff target records it in chat_handoff_json,The engine fires an injectable completion callback with the report and bundle summary when such a run completes (callback failures never fail the run),The app wires the callback to insert an assistant message into the target conversation carrying the report and deep_research_completion metadata, with the existing terminal-run notification as fallback when insertion is impossible,A Console chat entry point launches a local research run with the handoff wired to the current conversation,Tests cover the engine callback contract (fire on completion with handoff, silence without, callback errors swallowed) and the message insertion wiring
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Engine (`local_research_engine.py`): `completion_handoff` constructor seam; fired after `complete_run` when the run's `chat_handoff` dict is non-empty and the run completed. Payload: `{run_id, question, chat_handoff, report_markdown, bundle, verification_summary}`. Awaitable callbacks are awaited; handoff exceptions are warnings — the terminal state is already recorded and a delivery problem must never retroactively fail a run.
+- New `Research_Interop/chat_handoff.py`: `insert_research_completion_message(db, payload)` inserts an assistant message into `chat_handoff.conversation_id` with the report content and a `deep_research_completion` metadata block (run id, question, source count, confidence, gate verdict). Missing target or DB failure returns None (the existing terminal-run notification stays the fallback) — never raises.
+- Console entry point: `/research <question>` registered in the command grammar + suggestions description ("Run deep research in the background; the report is delivered into this conversation") + `chat_screen` dispatch (`_console_command_research`). Guards: empty question, no active conversation, missing local service. The run launches in a worker with the tool-assembled LLM params, the academic lane when enabled, and the handoff wired to `chachanotes_db`; a native system message confirms the start and where the report will land.
+- Verified TDD: 3 engine handoff tests + 3 inserter tests + 1 registration test written first and watched failing; command-grammar/suggestions pins updated for the new built-in (their own invariant test correctly caught the missing popup description — added). Suites: Research + grammar + suggestions = 142 passed; screen_navigation = 129 passed (one earlier failure was the known cross-run flake, green on re-run); ruff findings on touched files are pre-existing only.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16482 - Enforce-checkpointed-autonomy-for-local-research-runs.md
+++ b/backlog/tasks/task-16482 - Enforce-checkpointed-autonomy-for-local-research-runs.md
@@ -1,0 +1,44 @@
+---
+id: TASK-16482
+title: Enforce checkpointed autonomy for local research runs
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:19'
+updated_date: '2026-08-16 03:28'
+labels:
+  - research
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ADR-068 deferred local checkpoint enforcement: runs record autonomy_mode (default checkpointed) but the engine always executes autonomously, and local checkpoint approval in the window uses a placeholder id against a scope path that only supports the server. Port the server's review-loop semantics: the engine pauses at phase boundaries to create reviewable checkpoints, approval (with validated patches) advances the run, and sources approval can loop back to collecting for recollection.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The service stores checkpoints (type, status, proposed payload, user patch) with create, list, latest-pending, and patch-and-approve operations recording run events and versioning rows,The engine honors checkpointed autonomy: it creates a plan review checkpoint before collecting and a sources review checkpoint before synthesizing, entering a non-terminal awaiting state and exiting cleanly (no report yet, partial artifacts preserved),Approving a checkpoint validates patches per type (unknown keys rejected; sources patches must reference the proposed inventory) and resumes the run past that boundary on re-execution without recreating an already-approved checkpoint,Sources approval with recollect enabled loops the run back to collecting; autonomous runs (autonomy_mode autonomous) never pause,The window's Approve Checkpoint action works for local runs against the latest pending checkpoint and restarts the engine,Tests cover the service operations and validation, the engine pause/resume matrix, and the window approval path
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD LocalResearchService checkpoints: research_checkpoints table plus create, list, latest-pending, and patch-and-approve with per-type patch validation, run events, and optimistic versioning
+2. TDD engine enforcement: checkpointed runs pause at plan-review (before collecting) and sources-review (before synthesizing) boundaries in a non-terminal awaiting state with partial artifacts; approved checkpoints let re-execution pass without recreating; sources recollect loops back to collecting; autonomous runs never pause
+3. Wire the scope service local checkpoint path and the window approve flow (latest pending for local, engine restart after approval); ADR-068 gains a dated addendum noting the deferred item is now implemented
+4. Tests plus lint plus task close
+ADR required: no - implements ADR-068's explicitly deferred checkpoint clause; a dated addendum records the activation
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Service**: `research_checkpoints` table (soft-delete + versioning, house pattern) with `create_checkpoint`, `list_checkpoints`, `latest_pending_checkpoint`, `approved_checkpoint(run_id, type)` (the engine's pass-through signal), and `patch_and_approve_checkpoint` with per-type validation — plan patches allow `limits`; sources patches allow `pinned_source_ids`/`dropped_source_ids`/`recollect` with inventory membership and disjointness checks; non-pending approvals and wrong-run checkpoints raise. Approvals record `checkpoint_approved` events. The scope service's checkpoint routing needed no change — it already dispatched via `getattr` on the backend, so the local method lights it up.
+- **Engine**: checkpointed runs (the schema default) pause at a `plan_review` boundary before any search spend and a `sources_review` boundary before synthesis — `_await_review` creates the pending checkpoint, parks the run non-terminally (`control_state=awaiting_<type>`), and exits via the `_RunAwaitingReview` path (partial artifacts preserved; report never produced early). Re-execution passes an APPROVED boundary without recreating it (existence-based, not patch-truthiness — approving with no patch passes). An approved plan `limits` patch supersedes the run's originals for ledger enforcement; an approved sources patch drops the named sources; `recollect.enabled` re-collects and presents a fresh sources review (server parity). Autonomous runs never pause; all pre-existing engine tests were migrated to `autonomy_mode="autonomous"` since the default is checkpointed. Outline review stays unimplemented: the local engine has no separate outline phase.
+- **Window**: local approval resolves the latest PENDING checkpoint (the placeholder-id era ends), reports clearly when none is pending, and restarts the engine on approval so the run advances. The old "local checkpoints unavailable" pin updated to the new contract and renamed.
+- **ADR-068** gained a dated addendum recording the activation, semantics, and the outline-review non-mapping.
+- Verified TDD: 4 service tests + 5 engine tests (pause, plan→sources advance, dropped-filter completion, recollect loop, empty-patch pass) + 1 window test written first and watched failing; suites 174 passed; ruff clean.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16483 - Readable-bundle-and-artifact-inspection-in-the-Research-window.md
+++ b/backlog/tasks/task-16483 - Readable-bundle-and-artifact-inspection-in-the-Research-window.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16483
+title: Readable bundle and artifact inspection in the Research window
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:31'
+updated_date: '2026-08-16 03:35'
+labels:
+  - research
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The window renders loaded bundles and artifacts as raw JSON dumps, and its first-artifact heuristic assumes the server bundle shape (name-to-content) so local bundles select the run record instead of an artifact. Make run outputs legible: structured rendering for the known artifact types and a sensible default that opens the report.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Bundle summaries render run status plus an artifact inventory for the local bundle shape and a names summary for the server shape instead of raw JSON,Known artifact types render structurally (report markdown as text, verification metrics, budget usage, claims with statuses, sources list) with a pretty-JSON fallback for unknown content,The default artifact after loading a bundle prefers the report and never selects the run record for local bundles,Loading a bundle auto-loads the default artifact so the report is visible immediately,Tests cover both bundle shapes, each structured renderer, the fallback, and the window auto-load path
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD UI/Research_Modules/bundle_rendering.py: pure render_bundle_summary (local run+artifacts shape and server name-to-content shape), render_artifact (structured per known type with pretty-JSON fallback), default_artifact_for_bundle (report-first, never the run record)
+2. Wire the window: bundle detail uses the summary renderer, artifact detail uses the structured renderer, and loading a bundle auto-loads the default artifact
+3. Tests plus lint plus task close
+ADR required: no - presentation-only rendering over existing artifacts
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- New `UI/Research_Modules/bundle_rendering.py` (pure functions, both record shapes tolerated): `render_bundle_summary` (run status/phase/query + artifact inventory for the local shape; name listing for the server name-to-content shape), `render_artifact` (header + structured content: report markdown as capped text, verification metrics incl. citation/gate lines, claims with statuses, sources list, budget usage with the estimated-tokens flag; pretty-JSON fallback), and `default_artifact_for_bundle` (report-first, never the local shape's `run` record — fixing the old first-key heuristic that selected it).
+- Window: bundle detail renders the summary; artifact detail renders structurally; `load_selected_run_bundle` auto-loads the default artifact (setting the artifact input when mounted), so Load Bundle immediately shows the report.
+- Verified TDD: 6 renderer tests + 1 window auto-load test written first and watched failing; suites 181 passed; ruff clean.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16484 - Dedupe-deep-search-pipeline-param-assembly.md
+++ b/backlog/tasks/task-16484 - Dedupe-deep-search-pipeline-param-assembly.md
@@ -1,0 +1,31 @@
+---
+id: TASK-16484
+title: Dedupe deep-search pipeline param assembly
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:39'
+updated_date: '2026-08-16 03:41'
+labels:
+  - research
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The web_deep_search tool, the Console /research handler, and the baseline script each hand-assemble the search_params dict from _deep_search_settings - three copies of the same ~15-key mapping that will drift.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 One shared public helper assembles the pipeline params from tool settings with override support,The tool, the Console handler, and the baseline script all use it,Tests pin the helper output shape and override behavior
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `deep_search_pipeline_params(*, engine, max_results, subquery, max_queries, respect_robots, extra)` in web_tool_impls: one assembly from `[SearchSettings]` with per-key overrides and an `extra` merge. The web_deep_search tool, the Console `/research` handler, and the baseline script now all call it (the script's spend bounds -- subquery off, one query, robots on -- are overrides, not a fourth copy). Tool behavior unchanged (its suite passes untouched).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16485 - Register-a-research-report-eval-task-for-the-Evals-UI.md
+++ b/backlog/tasks/task-16485 - Register-a-research-report-eval-task-for-the-Evals-UI.md
@@ -1,0 +1,31 @@
+---
+id: TASK-16485
+title: Register a research-report eval task for the Evals UI
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:39'
+updated_date: '2026-08-16 03:45'
+labels:
+  - research
+  - evals
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The research self-eval runner is dispatched by category but has no task template or dataset, so it cannot be selected and run from the Evals UI - only the baseline script exercises it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] A research_report template registers with the eval template manager pointing at a bundled verification-payload dataset,The task loads via the task loader with task_type research_report and metadata category research,The dataset samples carry verification payloads the runner scores (deterministic metrics on the bundled data),Tests cover template registration, task loading, and end-to-end scoring of the bundled samples through the runner
+<!-- AC:END -->
+
+## Implementation Notes
+
+- Survey correction: `eval_templates.py` is shadowed by the `eval_templates/` PACKAGE (Python prefers the package), so the registration landed in dead code first -- reverted, and a proper `ResearchTemplates` category (`eval_templates/research.py`, BaseTemplates subclass) was added as the manager's seventh category instead.
+- The `research_report` template points at a bundled dataset (`Evals/eval_datasets/research_report_verification.json`, three synthetic verification payloads: clean, degraded, gate-fallback) via an absolute path resolved from the module (the dataset loader only accepts existing paths). Samples load with `metadata["verification"]` exactly as the runner reads (the JSON loader maps whole items to metadata). Task loads via `TaskLoader.create_task_from_template("research_report")`.
+- End-to-end test pins: template -> TaskConfig (task_type research_report, category research) -> EvalRunner dispatch -> ResearchReportRunner -> dataset (3 samples) -> per-sample metrics (clean 1.0 accuracy/gate, degraded 0.75, fallback 0.6 gate). Real runs' payloads from the baseline script can replace the bundled dataset.

--- a/backlog/tasks/task-16486 - Auto-refresh-the-selected-research-run-in-the-window.md
+++ b/backlog/tasks/task-16486 - Auto-refresh-the-selected-research-run-in-the-window.md
@@ -1,0 +1,32 @@
+---
+id: TASK-16486
+title: Auto-refresh the selected research run in the window
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 03:39'
+updated_date: '2026-08-16 03:47'
+labels:
+  - research
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase and progress events stream into research_run_events, but the window only shows them after manual actions - a running run's status goes stale in the detail pane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A mounted interval refreshes the selected local run while it is non-terminal without disturbing payload state (bundle or artifact selections),Terminal runs and server-source selections stop refreshing,Tests cover the refresh path, the non-terminal guard, and payload-state preservation
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `on_mount` sets a 2s interval calling `_auto_refresh_selected_run`: refreshes the selected LOCAL run's detail while its status is non-terminal (completed/failed/cancelled/draft skip), preserving payload state (bundle/artifact selections untouched -- only `selected_run` + detail render update). Controller errors are swallowed silently (a dead scope service must not spam the status line every 2s). Server-source selections skip (server observation has its own streaming surface via Watch Events).
+- Tests: refresh updates phase + preserves bundle; terminal and server-source guards verified silent (controller never called).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -997,17 +997,27 @@ def chat_api_call(
                         from .usage_recorder import active_recorder
 
                         recorder = active_recorder()
+                        # Cloud providers normalize to the OpenAI chat
+                        # shape but may keep their own usage field names
+                        # (Anthropic: input_tokens/output_tokens); OpenAI
+                        # names win when both are present (task-16335).
+                        usage_prompt = usage.get("prompt_tokens")
+                        if usage_prompt is None:
+                            usage_prompt = usage.get("input_tokens")
+                        usage_completion = usage.get("completion_tokens")
+                        if usage_completion is None:
+                            usage_completion = usage.get("output_tokens")
                         if (
                             recorder is not None
                             and isinstance(usage, dict)
                             and (
-                                usage.get("prompt_tokens") is not None
-                                or usage.get("completion_tokens") is not None
+                                usage_prompt is not None
+                                or usage_completion is not None
                             )
                         ):
                             recorder.record_usage(
-                                prompt_tokens=usage.get("prompt_tokens") or 0,
-                                completion_tokens=usage.get("completion_tokens") or 0,
+                                prompt_tokens=usage_prompt or 0,
+                                completion_tokens=usage_completion or 0,
                             )
                             usage_recorded = True
                     except Exception:  # noqa: BLE001 - accounting must never break a call

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -977,29 +977,68 @@ def chat_api_call(
         )
         log_counter("chat_api_call_success", labels={"api_endpoint": endpoint_lower})
 
+        # OpenAI-shaped dict normalization: the local OpenAI-compatible
+        # handlers (llama.cpp/vLLM/...) return the raw decoded response body,
+        # while every string consumer (deep-search pipeline, chat windows,
+        # cloud providers) expects the assistant content. Extract the
+        # content when the shape allows; unknown dict shapes pass through
+        # untouched so specialized consumers keep working.
+        usage_recorded = False
+        if isinstance(response, dict):
+            choices = response.get("choices")
+            if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                message = choices[0].get("message")
+                content = message.get("content") if isinstance(message, dict) else None
+                if isinstance(content, str):
+                    # task-16329 upgrade: local providers report REAL usage
+                    # -- record exact counts instead of estimates.
+                    usage = response.get("usage")
+                    try:
+                        from .usage_recorder import active_recorder
+
+                        recorder = active_recorder()
+                        if (
+                            recorder is not None
+                            and isinstance(usage, dict)
+                            and (
+                                usage.get("prompt_tokens") is not None
+                                or usage.get("completion_tokens") is not None
+                            )
+                        ):
+                            recorder.record_usage(
+                                prompt_tokens=usage.get("prompt_tokens") or 0,
+                                completion_tokens=usage.get("completion_tokens") or 0,
+                            )
+                            usage_recorded = True
+                    except Exception:  # noqa: BLE001 - accounting must never break a call
+                        logger.debug("usage recording skipped", exc_info=True)
+                    response = content
+
         if isinstance(response, str):
             logger.debug(
                 f"Debug - Chat API Call - Response type=str; length={len(response)}"
             )
             # task-16329: token-usage plumbing. When a usage scope is active
             # (research budget ledger), record estimated prompt/completion
-            # tokens for this exchange. One contextvar get when no scope is
+            # tokens for this exchange unless exact provider usage was
+            # already recorded above. One contextvar get when no scope is
             # active -- zero behavior change for every other caller.
-            try:
-                from .usage_recorder import active_recorder
+            if not usage_recorded:
+                try:
+                    from .usage_recorder import active_recorder
 
-                recorder = active_recorder()
-                if recorder is not None:
-                    recorder.record_exchange(
-                        prompt_text="\n".join(
-                            str(message.get("content") or "")
-                            for message in (messages_payload or [])
-                            if isinstance(message, dict)
-                        ),
-                        completion_text=response,
-                    )
-            except Exception:  # noqa: BLE001 - accounting must never break a call
-                logger.debug("usage recording skipped", exc_info=True)
+                    recorder = active_recorder()
+                    if recorder is not None:
+                        recorder.record_exchange(
+                            prompt_text="\n".join(
+                                str(message.get("content") or "")
+                                for message in (messages_payload or [])
+                                if isinstance(message, dict)
+                            ),
+                            completion_text=response,
+                        )
+                except Exception:  # noqa: BLE001 - accounting must never break a call
+                    logger.debug("usage recording skipped", exc_info=True)
         elif hasattr(response, "__iter__") and not isinstance(
             response, (str, bytes, dict)
         ):

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -977,52 +977,56 @@ def chat_api_call(
         )
         log_counter("chat_api_call_success", labels={"api_endpoint": endpoint_lower})
 
-        # OpenAI-shaped dict normalization: the local OpenAI-compatible
-        # handlers (llama.cpp/vLLM/...) return the raw decoded response body,
-        # while every string consumer (deep-search pipeline, chat windows,
-        # cloud providers) expects the assistant content. Extract the
-        # content when the shape allows; unknown dict shapes pass through
-        # untouched so specialized consumers keep working.
-        usage_recorded = False
+        # Provider handlers disagree on return shape: cloud and local
+        # OpenAI-compatible handlers return the raw normalized response DICT
+        # (tool_calls, finish_reason, usage -- the Console gateway parses
+        # all of these), so chat_api_call must pass dicts through UNCHANGED
+        # (an earlier normalization to content strings here broke the
+        # Console's tool/continuation paths). String-expecting consumers
+        # extract content via ``chat_reply_text`` (task-16331 correction).
+        # Usage recording reads the dict without altering it.
         if isinstance(response, dict):
             choices = response.get("choices")
             if isinstance(choices, list) and choices and isinstance(choices[0], dict):
                 message = choices[0].get("message")
                 content = message.get("content") if isinstance(message, dict) else None
                 if isinstance(content, str):
-                    # task-16329 upgrade: local providers report REAL usage
-                    # -- record exact counts instead of estimates.
                     usage = response.get("usage")
+                    if not isinstance(usage, dict):
+                        usage = {}  # absent usage -> estimates path, not an AttributeError
                     try:
                         from .usage_recorder import active_recorder
 
                         recorder = active_recorder()
-                        # Cloud providers normalize to the OpenAI chat
-                        # shape but may keep their own usage field names
-                        # (Anthropic: input_tokens/output_tokens); OpenAI
-                        # names win when both are present (task-16335).
+                        # Providers normalize to the OpenAI chat shape but
+                        # may keep their own usage field names (Anthropic:
+                        # input_tokens/output_tokens); OpenAI names win when
+                        # both are present (task-16335). Exact counts when
+                        # the provider reported usage, estimates otherwise.
                         usage_prompt = usage.get("prompt_tokens")
                         if usage_prompt is None:
                             usage_prompt = usage.get("input_tokens")
                         usage_completion = usage.get("completion_tokens")
                         if usage_completion is None:
                             usage_completion = usage.get("output_tokens")
-                        if (
-                            recorder is not None
-                            and isinstance(usage, dict)
-                            and (
-                                usage_prompt is not None
-                                or usage_completion is not None
-                            )
+                        if recorder is not None and isinstance(usage, dict) and (
+                            usage_prompt is not None or usage_completion is not None
                         ):
                             recorder.record_usage(
                                 prompt_tokens=usage_prompt or 0,
                                 completion_tokens=usage_completion or 0,
                             )
-                            usage_recorded = True
+                        elif recorder is not None:
+                            recorder.record_exchange(
+                                prompt_text="\n".join(
+                                    str(message.get("content") or "")
+                                    for message in (messages_payload or [])
+                                    if isinstance(message, dict)
+                                ),
+                                completion_text=content,
+                            )
                     except Exception:  # noqa: BLE001 - accounting must never break a call
                         logger.debug("usage recording skipped", exc_info=True)
-                    response = content
 
         if isinstance(response, str):
             logger.debug(
@@ -1030,25 +1034,23 @@ def chat_api_call(
             )
             # task-16329: token-usage plumbing. When a usage scope is active
             # (research budget ledger), record estimated prompt/completion
-            # tokens for this exchange unless exact provider usage was
-            # already recorded above. One contextvar get when no scope is
+            # tokens for this exchange. One contextvar get when no scope is
             # active -- zero behavior change for every other caller.
-            if not usage_recorded:
-                try:
-                    from .usage_recorder import active_recorder
+            try:
+                from .usage_recorder import active_recorder
 
-                    recorder = active_recorder()
-                    if recorder is not None:
-                        recorder.record_exchange(
-                            prompt_text="\n".join(
-                                str(message.get("content") or "")
-                                for message in (messages_payload or [])
-                                if isinstance(message, dict)
-                            ),
-                            completion_text=response,
-                        )
-                except Exception:  # noqa: BLE001 - accounting must never break a call
-                    logger.debug("usage recording skipped", exc_info=True)
+                recorder = active_recorder()
+                if recorder is not None:
+                    recorder.record_exchange(
+                        prompt_text="\n".join(
+                            str(message.get("content") or "")
+                            for message in (messages_payload or [])
+                            if isinstance(message, dict)
+                        ),
+                        completion_text=response,
+                    )
+            except Exception:  # noqa: BLE001 - accounting must never break a call
+                logger.debug("usage recording skipped", exc_info=True)
         elif hasattr(response, "__iter__") and not isinstance(
             response, (str, bytes, dict)
         ):
@@ -1190,6 +1192,36 @@ def chat_api_call(
             ),
             status_code=500,
         )
+
+
+def chat_reply_text(response: Any) -> str:
+    """Best-effort assistant text out of one ``chat_api_call`` reply
+    (task-16331 correction).
+
+    Provider handlers disagree on shape: handlers returning strings pass
+    through; handlers returning OpenAI-shaped response dicts (cloud AND
+    local OpenAI-compatible providers -- tool_calls/finish_reason/usage for
+    the Console gateway) extract ``choices[0].message.content`` (or the
+    legacy ``choices[0].text``). Anything unparseable yields "" so string
+    consumers' existing falsy/fallback handling applies -- never a dict
+    that would silently fail every downstream parse.
+    """
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        choices = response.get("choices")
+        if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+            message = choices[0].get("message")
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str):
+                    return content
+            text = choices[0].get("text")
+            if isinstance(text, str):
+                return text
+    return ""
 
 
 _CHAT_API_GENERIC_PARAMS = frozenset(inspect.signature(chat_api_call).parameters) - {

--- a/tldw_chatbook/Chat/console_command_grammar.py
+++ b/tldw_chatbook/Chat/console_command_grammar.py
@@ -65,6 +65,11 @@ REWIND_COMMAND_NAME = "rewind"
 REWIND_COMMAND_ARGUMENT_HINT = ""
 REWIND_COMMAND_HANDLER_ID = "rewind"
 
+# Help text: "Run deep research in the background: /research <question>"
+RESEARCH_COMMAND_NAME = "research"
+RESEARCH_COMMAND_ARGUMENT_HINT = "<question>"
+RESEARCH_COMMAND_HANDLER_ID = "research"
+
 
 @dataclass(frozen=True)
 class ConsoleCommand:
@@ -245,6 +250,13 @@ def default_console_registry() -> ConsoleCommandRegistry:
             name=REWIND_COMMAND_NAME,
             argument_hint=REWIND_COMMAND_ARGUMENT_HINT,
             handler_id=REWIND_COMMAND_HANDLER_ID,
+        )
+    )
+    registry.register(
+        ConsoleCommand(
+            name=RESEARCH_COMMAND_NAME,
+            argument_hint=RESEARCH_COMMAND_ARGUMENT_HINT,
+            handler_id=RESEARCH_COMMAND_HANDLER_ID,
         )
     )
     return registry

--- a/tldw_chatbook/Chat/console_command_suggestions.py
+++ b/tldw_chatbook/Chat/console_command_suggestions.py
@@ -36,6 +36,7 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "generate-video": "Generate a video (optionally via a chosen backend)",
     "stream-video": "Stream a video from a URL into the transcript",
     "rewind": "Rewind the session to an earlier user prompt",
+    "research": "Run deep research in the background; the report is delivered into this conversation",
 }
 
 #: Shown for a registered command with no ``_COMMAND_DESCRIPTIONS`` entry --

--- a/tldw_chatbook/Evals/eval_datasets/research_report_verification.json
+++ b/tldw_chatbook/Evals/eval_datasets/research_report_verification.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "synthetic-clean-run",
+    "input": "What is retrieval augmented generation?",
+    "verification": {
+      "markers_total": 10, "markers_resolved": 10,
+      "quotes_checked": 2, "quotes_verified": 2,
+      "uncited_sentences": 2,
+      "claims": [
+        {"claim_id": "claim-1", "text": "Fully cited claim[1].", "status": "supported"},
+        {"claim_id": "claim-2", "text": "Quoted and verified claim[2].", "status": "supported"}
+      ],
+      "gate": {"relevant": 5, "raw": 5, "fallback": false}
+    }
+  },
+  {
+    "id": "synthetic-degraded-run",
+    "input": "What are mixture of experts language models?",
+    "verification": {
+      "markers_total": 8, "markers_resolved": 6,
+      "quotes_checked": 1, "quotes_verified": 0,
+      "uncited_sentences": 4,
+      "claims": [
+        {"claim_id": "claim-1", "text": "Supported claim[1].", "status": "supported"},
+        {"claim_id": "claim-2", "text": "Unsupported claim[9?].", "status": "unverified"}
+      ],
+      "gate": {"relevant": 4, "raw": 5, "fallback": false}
+    }
+  },
+  {
+    "id": "synthetic-gate-fallback-run",
+    "input": "How do graph neural networks work?",
+    "verification": {
+      "markers_total": 6, "markers_resolved": 6,
+      "quotes_checked": 0, "quotes_verified": 0,
+      "uncited_sentences": 3,
+      "claims": [
+        {"claim_id": "claim-1", "text": "Fallback evidence claim[1].", "status": "supported"}
+      ],
+      "gate": {"relevant": 3, "raw": 5, "fallback": true}
+    }
+  }
+]

--- a/tldw_chatbook/Evals/eval_templates/__init__.py
+++ b/tldw_chatbook/Evals/eval_templates/__init__.py
@@ -16,6 +16,7 @@ from .coding import CodingTemplates
 from .safety import SafetyTemplates
 from .creative import CreativeTemplates
 from .multimodal import MultimodalTemplates
+from .research import ResearchTemplates
 
 
 class EvalTemplateManager:
@@ -33,6 +34,7 @@ class EvalTemplateManager:
         self.safety = SafetyTemplates()
         self.creative = CreativeTemplates()
         self.multimodal = MultimodalTemplates()
+        self.research = ResearchTemplates()
 
         # Cache for templates
         self._template_cache = {}
@@ -59,6 +61,7 @@ class EvalTemplateManager:
             self.safety,
             self.creative,
             self.multimodal,
+            self.research,
         ]:
             template = category.get_template(template_name)
             if template:

--- a/tldw_chatbook/Evals/eval_templates/research.py
+++ b/tldw_chatbook/Evals/eval_templates/research.py
@@ -1,0 +1,79 @@
+# eval_templates/research.py
+# Description: Research-report self-eval templates (task-16485)
+"""
+Research Templates
+------------------
+
+Templates for scoring deep-search research reports from stored verification
+payloads (citation accuracy, quote grounding, claim support, gate pass-rate).
+Deterministic -- no LLM is consulted.
+"""
+
+from pathlib import Path
+from typing import Dict, Any
+
+from .base import BaseTemplates
+
+_RESEARCH_DATASET_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "eval_datasets"
+    / "research_report_verification.json"
+)
+
+
+class ResearchTemplates(BaseTemplates):
+    """Templates for research-report self-evaluation."""
+
+    def _initialize_templates(self):
+        """Initialize research templates."""
+        self._templates = {
+            "research_report": self._research_report_template(),
+        }
+
+    def _create_base_template(
+        self,
+        name: str,
+        description: str,
+        task_type: str,
+        metric: str,
+        category: str,
+        subcategory: str,
+        dataset_name: str,
+        generation_kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            "name": name,
+            "description": description,
+            "task_type": task_type,
+            "dataset_name": dataset_name,
+            "metric": metric,
+            "generation_kwargs": generation_kwargs,
+            "metadata": {
+                "category": category,
+                "subcategory": subcategory,
+            },
+        }
+
+    def _research_report_template(self) -> Dict[str, Any]:
+        """Score research reports from stored verification payloads.
+
+        The bundled dataset carries synthetic payloads shaped like a
+        completed run's ``citation_verification`` block plus gate counts;
+        swap in payloads recorded by the live baseline script
+        (Helper_Scripts/Benchmarks/record_research_baseline.py) to score
+        real runs.
+        """
+        return self._create_base_template(
+            name="Research Report Self-Eval",
+            description=(
+                "Scores deep-search research reports on citation accuracy, "
+                "quote grounding, claim support, cited-sentence ratio, and "
+                "gate pass-rate from stored verification payloads"
+            ),
+            task_type="research_report",
+            metric="research_report_metrics",
+            category="research",
+            subcategory="self_eval",
+            dataset_name=str(_RESEARCH_DATASET_PATH),
+            generation_kwargs={},
+        )

--- a/tldw_chatbook/Evals/research_report_scorer.py
+++ b/tldw_chatbook/Evals/research_report_scorer.py
@@ -1,7 +1,7 @@
 """Research-report self-eval scorer (task-16327).
 
 Deterministic scoring of deep-search research reports from the verification
-outcomes the pipeline already produces: task-16319's ``citation_verification``
+outcomes the pipeline already produces: task-16331's ``citation_verification``
 payload (marker resolution, quote grounding, uncited sentences) and
 task-16325's claims (supported/unverified). No LLM is consulted -- the
 metrics are computed from the stored payload, so the same run always scores

--- a/tldw_chatbook/Evals/research_report_scorer.py
+++ b/tldw_chatbook/Evals/research_report_scorer.py
@@ -99,3 +99,22 @@ BASELINE_VERIFICATION_PAYLOAD: Dict[str, Any] = {
 BASELINE_METRICS: Dict[str, float] = score_research_report(
     BASELINE_VERIFICATION_PAYLOAD
 )
+
+
+def aggregate_metrics(payloads: list) -> Dict[str, float]:
+    """Mean metrics across a list of verification payloads (task-16330 --
+    live-baseline aggregation); an empty list scores all zeros with
+    ``sample_count`` 0."""
+    scored = [score_research_report(payload) for payload in payloads]
+    aggregate: Dict[str, float] = {"sample_count": float(len(scored))}
+    for key in (
+        "citation_accuracy",
+        "quote_grounding",
+        "claim_support_rate",
+        "cited_sentence_ratio",
+    ):
+        if scored:
+            aggregate[key] = sum(metric[key] for metric in scored) / len(scored)
+        else:
+            aggregate[key] = 0.0
+    return aggregate

--- a/tldw_chatbook/Evals/research_report_scorer.py
+++ b/tldw_chatbook/Evals/research_report_scorer.py
@@ -41,9 +41,20 @@ def _ratio(numerator: Any, denominator: Any) -> float:
 
 
 def score_research_report(verification: Mapping[str, Any]) -> Dict[str, float]:
-    """Score one research report from its verification payload."""
+    """Score one research report from its verification payload.
+
+    Accepts either the flat ``citation_verification`` block or a full
+    ``verification_summary`` artifact (the ``citation_verification`` key is
+    unwrapped when present, so the live-baseline flow can hand over the
+    whole summary including the gate block)."""
     if not isinstance(verification, Mapping):
         verification = {}
+    if isinstance(verification.get("citation_verification"), Mapping):
+        nested = dict(verification["citation_verification"])
+        gate = verification.get("gate")
+        if isinstance(gate, Mapping):
+            nested.setdefault("gate", gate)
+        verification = nested
     markers_total = verification.get("markers_total") or 0
     markers_resolved = verification.get("markers_resolved") or 0
     citation_accuracy = _ratio(markers_resolved, markers_total)
@@ -68,12 +79,21 @@ def score_research_report(verification: Mapping[str, Any]) -> Dict[str, float]:
         markers_total, float(markers_total or 0) + float(uncited_sentences or 0)
     )
 
-    return {
+    metrics = {
         "citation_accuracy": citation_accuracy,
         "quote_grounding": quote_grounding,
         "claim_support_rate": claim_support_rate,
         "cited_sentence_ratio": cited_sentence_ratio,
     }
+    # Gate pass-rate (task-16333): relevant/raw from the gate block; present
+    # only when the pipeline reported gate outcomes.
+    gate = verification.get("gate")
+    if isinstance(gate, Mapping):
+        raw = gate.get("raw") or 0
+        relevant = gate.get("relevant") or 0
+        if raw:
+            metrics["gate_pass_rate"] = _ratio(relevant, raw)
+    return metrics
 
 
 # Baseline (task-16327): the synthetic verification payload the recorded
@@ -107,14 +127,21 @@ def aggregate_metrics(payloads: list) -> Dict[str, float]:
     ``sample_count`` 0."""
     scored = [score_research_report(payload) for payload in payloads]
     aggregate: Dict[str, float] = {"sample_count": float(len(scored))}
-    for key in (
+    keys = [
         "citation_accuracy",
         "quote_grounding",
         "claim_support_rate",
         "cited_sentence_ratio",
-    ):
-        if scored:
-            aggregate[key] = sum(metric[key] for metric in scored) / len(scored)
-        else:
-            aggregate[key] = 0.0
+        "gate_pass_rate",
+    ]
+    for key in keys:
+        # Per-key means over the payloads that CARRY the key (gate counts
+        # only exist once the pipeline reports them) -- always-defined
+        # metrics still average over every payload.
+        values = [metric[key] for metric in scored if key in metric]
+        if key == "gate_pass_rate":
+            if values:
+                aggregate[key] = sum(values) / len(values)
+            continue
+        aggregate[key] = (sum(values) / len(values)) if values else 0.0
     return aggregate

--- a/tldw_chatbook/Internal_Prompts/websearch_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/websearch_prompts.py
@@ -71,7 +71,7 @@ register(
 
                 Instructions:
                 1. You MUST only answer TRUE or False while providing your reasoning for your answer.
-                2. A result is relevant if the result most likely contains comprehensive and relevant information to answer the user's question.
+                2. A result is relevant if it provides USEFUL information about the subject of the user's question, even if it only partially addresses the question. Answer False only when the result is essentially unrelated to the question's subject.
                 3. Provide a brief reason for selection.
 
                 You MUST respond using EXACTLY this format and nothing else:

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -119,7 +119,14 @@ def search_arxiv(
     shape with each item additionally carrying ``doi`` and ``source``."""
     search_parts: list[str] = []
     if query:
-        search_parts.append(f"all:{query}")
+        # Phrase-quote multi-word queries: arXiv token matching ranks papers
+        # sharing ANY tokens (a "retrieval augmented generation" token search
+        # surfaces cognitive-augmentation and image-generation papers), while
+        # a phrase match returns papers that actually use the term.
+        if " " in query.strip():
+            search_parts.append(f'all:"{query.strip()}"')
+        else:
+            search_parts.append(f"all:{query}")
     if author:
         search_parts.append(f"au:{author}")
     if year:
@@ -390,6 +397,40 @@ def merge_evidence_pools(
     return merged
 
 
+_QUESTION_PREFIXES = (
+    "what is",
+    "what are",
+    "what was",
+    "what were",
+    "how does",
+    "how do",
+    "how to",
+    "why is",
+    "why does",
+    "explain",
+    "describe",
+    "tell me about",
+)
+
+
+def _paper_query(question: str) -> str:
+    """Normalize a natural-language question into a topical search query:
+    paper engines tokenize everything, so interrogative prefixes ("what
+    is...") pollute arXiv/S2 ranking with off-topic matches."""
+    query = str(question or "").strip().rstrip("?.!").strip()
+    lowered = query.casefold()
+    for prefix in _QUESTION_PREFIXES:
+        if lowered.startswith(prefix + " "):
+            query = query[len(prefix) + 1 :].strip()
+            break
+    # "the main differences between X and Y" -> "differences between X and Y"
+    for filler in ("the main ", "the "):
+        if query.casefold().startswith(filler):
+            query = query[len(filler) :].strip()
+            break
+    return query
+
+
 async def search_papers(
     query: str,
     *,
@@ -409,6 +450,7 @@ async def search_papers(
     failures: list[str] = []
     papers: list[dict[str, Any]] = []
     seen_dois: set[str] = set()
+    topic_query = _paper_query(query)
 
     def _collect(items: list[Any]) -> None:
         for item in items:
@@ -423,7 +465,7 @@ async def search_papers(
 
     try:
         arxiv_out = await to_thread(
-            search_arxiv, query=query, results_per_page=results_per_page
+            search_arxiv, query=topic_query, results_per_page=results_per_page
         )
         _collect(arxiv_out.get("items") or [])
     except AcademicProviderError as exc:
@@ -433,7 +475,7 @@ async def search_papers(
     try:
         s2_out = await to_thread(
             search_semantic_scholar,
-            query=query,
+            query=topic_query,
             results_per_page=results_per_page,
             api_key=semantic_scholar_api_key
             if semantic_scholar_api_key is not None

--- a/tldw_chatbook/Research_Interop/chat_handoff.py
+++ b/tldw_chatbook/Research_Interop/chat_handoff.py
@@ -1,0 +1,77 @@
+"""Chat handoff for completed research runs (task-16481).
+
+Port of the server's ``chat_handoff`` behavior onto the local engine: when a
+run launched with a chat target completes, insert an assistant message into
+the originating conversation carrying the report and a
+``deep_research_completion`` metadata block. Insertion failures return None
+(the existing terminal-run notification remains the fallback path) rather
+than raising -- the run is already completed and must not be retroactively
+failed by a delivery problem.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from loguru import logger
+
+__all__ = ["insert_research_completion_message"]
+
+_METADATA_BLOCK_KEY = "deep_research_completion"
+
+
+def _handoff_message_content(payload: Mapping[str, Any]) -> str:
+    question = str(payload.get("question") or "")
+    report = str(payload.get("report_markdown") or "").strip()
+    parts = [f"Deep research completed for: {question}", ""]
+    if report:
+        parts.append(report)
+    else:
+        parts.append("(no report was produced)")
+    return "\n".join(parts)
+
+
+def insert_research_completion_message(db: Any, payload: Mapping[str, Any]) -> str | None:
+    """Insert the completion handoff message into the target conversation.
+
+    Args:
+        db: A ChaChaNotes-style DB exposing ``add_message(msg_data)``.
+        payload: The engine's completion-handoff payload (``run_id``,
+            ``question``, ``chat_handoff.conversation_id``,
+            ``report_markdown``, ``bundle``, ``verification_summary``).
+
+    Returns:
+        The new message id, or None when the handoff could not be delivered
+        (missing target, DB failure) -- never raises.
+    """
+    chat_handoff = payload.get("chat_handoff") or {}
+    conversation_id = chat_handoff.get("conversation_id")
+    if not conversation_id:
+        logger.warning("Research handoff has no conversation_id; skipping insertion")
+        return None
+    verification = payload.get("verification_summary") or {}
+    metadata = {
+        _METADATA_BLOCK_KEY: {
+            "run_id": payload.get("run_id"),
+            "question": payload.get("question"),
+            "source_count": (payload.get("bundle") or {}).get("source_count"),
+            "confidence": verification.get("confidence"),
+            "gate": verification.get("gate"),
+        }
+    }
+    try:
+        message_id = db.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "assistant",
+                "content": _handoff_message_content(payload),
+                "metadata_json": metadata,
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 - delivery degrades to the notification fallback
+        logger.warning(
+            f"Research handoff message insertion failed for conversation "
+            f"{conversation_id}: {exc}"
+        )
+        return None
+    return message_id

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -124,18 +124,22 @@ class LocalResearchEngine:
             f"Synthesized answer:\n{context.get('answer_text')}"
         )
         try:
-            response = chat_api_call(
-                api_endpoint=llm,
-                messages_payload=[{"role": "user", "content": prompt}],
-                api_key=None,
-                temp=0.2,
-                system_message=None,
-                streaming=False,
-                minp=None,
-                maxp=None,
-                model=None,
-                topk=None,
-                topp=None,
+            from ..Chat.Chat_Functions import chat_reply_text
+
+            response = chat_reply_text(
+                chat_api_call(
+                    api_endpoint=llm,
+                    messages_payload=[{"role": "user", "content": prompt}],
+                    api_key=None,
+                    temp=0.2,
+                    system_message=None,
+                    streaming=False,
+                    minp=None,
+                    maxp=None,
+                    model=None,
+                    topk=None,
+                    topp=None,
+                )
             )
             parsed = json.loads(str(response or "[]"))
             if isinstance(parsed, list):
@@ -635,7 +639,9 @@ class LocalResearchEngine:
             f"Follow-up question: {question}"
         )
         try:
-            response = str(
+            from ..Chat.Chat_Functions import chat_reply_text
+
+            response = chat_reply_text(
                 chat_api_call(
                     api_endpoint=llm,
                     messages_payload=[{"role": "user", "content": prompt}],
@@ -649,7 +655,6 @@ class LocalResearchEngine:
                     topk=None,
                     topp=None,
                 )
-                or ""
             ).strip()
         except Exception as exc:  # noqa: BLE001 - follow-up degrades, never fails hard
             logger.warning(f"Follow-up answer call failed: {exc}")

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -66,6 +66,7 @@ class LocalResearchEngine:
         gap_fn: "GapFn | None" = None,
         search_params: dict[str, Any] | None = None,
         paper_search_fn: "Callable[[str], Any] | None" = None,
+        completion_handoff: "Callable[[dict[str, Any]], Any] | None" = None,
     ) -> None:
         self.service = local_service
         self.search_fn = search_fn or self._default_search_fn
@@ -79,6 +80,11 @@ class LocalResearchEngine:
         # Set for the duration of execute_run so _llm_bounded_call can
         # settle usage without threading the ledger through every seam.
         self._active_ledger: BudgetLedger | None = None
+        # task-16481: fired when a run that carried a chat_handoff target
+        # completes; the app wires this to insert the report into the
+        # originating conversation. Failures are warnings, never run
+        # failures -- the terminal state is already recorded.
+        self.completion_handoff = completion_handoff
 
     @staticmethod
     def _default_search_fn(question: str, params: dict[str, Any]) -> Any:
@@ -548,25 +554,49 @@ class LocalResearchEngine:
                     "unverified_claim_count": len(claims) - supported,
                 },
             )
+        bundle_content = {
+            "query": question,
+            "sub_questions": all_sub_questions,
+            "confidence": final_answer.get("confidence"),
+            "report_markdown": report_markdown,
+            "source_count": len(evidence),
+            "iterations": iteration,
+            "remaining_gaps": remaining_gaps,
+        }
         self.service.save_artifact(
             run_id,
             artifact_name="bundle.json",
             content_type="application/json",
-            content={
-                "query": question,
-                "sub_questions": all_sub_questions,
-                "confidence": final_answer.get("confidence"),
-                "report_markdown": report_markdown,
-                "source_count": len(evidence),
-                "iterations": iteration,
-                "remaining_gaps": remaining_gaps,
-            },
+            content=bundle_content,
         )
 
-        return self.service.complete_run(
+        completed = self.service.complete_run(
             run_id,
             progress_message=f"Completed with {len(evidence)} source(s)",
         )
+        chat_handoff = run.get("chat_handoff")
+        if (
+            self.completion_handoff is not None
+            and isinstance(chat_handoff, dict)
+            and chat_handoff
+            and completed.get("status") == "completed"
+        ):
+            try:
+                result = self.completion_handoff(
+                    {
+                        "run_id": run_id,
+                        "question": question,
+                        "chat_handoff": chat_handoff,
+                        "report_markdown": report_markdown,
+                        "bundle": bundle_content,
+                        "verification_summary": verification_summary,
+                    }
+                )
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:  # noqa: BLE001 - handoff degrades, never fails
+                logger.warning(f"Research completion handoff failed: {exc}")
+        return completed
 
     # -- follow-up Q&A over stored claims (task-16325) ----------------------
 

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -513,6 +513,8 @@ class LocalResearchEngine:
             "relevant_count": len(relevant_results),
             "chunk_count": len(final_answer.get("chunks") or []),
         }
+        if "gate" in final_answer:
+            verification_summary["gate"] = final_answer["gate"]
         if "citation_verification" in final_answer:
             verification_summary["citation_verification"] = final_answer[
                 "citation_verification"

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -54,6 +54,17 @@ class _RunCancelled(Exception):
     """Internal control-flow signal: the run was cancelled between phases."""
 
 
+class _RunAwaitingReview(Exception):
+    """Internal control-flow signal: a checkpointed run paused at a review
+    boundary (task-16482); the engine exits non-terminally and the run
+    resumes when the checkpoint is approved."""
+
+    def __init__(self, run: dict[str, Any]) -> None:
+        super().__init__("run awaiting checkpoint review")
+        self.run = run
+    """Internal control-flow signal: the run was cancelled between phases."""
+
+
 class LocalResearchEngine:
     """Executes local research runs against the deep-search pipeline."""
 
@@ -201,6 +212,32 @@ class LocalResearchEngine:
             raise _RunCancelled(run)
         return run
 
+    def _is_checkpointed(self, run: dict[str, Any]) -> bool:
+        return str(run.get("autonomy_mode") or "") == "checkpointed"
+
+    def _approved_patch(self, run_id: str, checkpoint_type: str) -> dict[str, Any]:
+        approved = self.service.approved_checkpoint(run_id, checkpoint_type)
+        if not approved:
+            return {}
+        return dict(approved.get("user_patch") or {})
+
+    def _await_review(
+        self, run_id: str, checkpoint_type: str, proposed_payload: dict[str, Any]
+    ) -> None:
+        """Create the pending checkpoint and park the run in a non-terminal
+        awaiting state (task-16482). Raises _RunAwaitingReview."""
+        checkpoint = self.service.create_checkpoint(
+            run_id, checkpoint_type=checkpoint_type, proposed_payload=proposed_payload
+        )
+        updated = self.service.update_run_progress(
+            run_id,
+            control_state=f"awaiting_{checkpoint_type}",
+            progress_message=f"Awaiting {checkpoint_type} ({checkpoint['id']})",
+            event="awaiting_review",
+            data={"checkpoint_id": checkpoint["id"], "checkpoint_type": checkpoint_type},
+        )
+        raise _RunAwaitingReview(updated)
+
     async def execute_run(self, run_id: str) -> dict[str, Any]:
         """Run the full phase machine for ``run_id`` to a terminal state.
 
@@ -213,13 +250,20 @@ class LocalResearchEngine:
             raise ValueError(
                 f"run {run_id} is already terminal ({status}); engine will not re-execute"
             )
-        ledger = BudgetLedger.from_limits(
-            run.get("limits") if isinstance(run.get("limits"), dict) else None
-        )
+        limits = run.get("limits") if isinstance(run.get("limits"), dict) else {}
+        # task-16482: an approved plan-review limits patch supersedes the
+        # run's original limits for subsequent (post-approval) executions.
+        plan_patch_limits = self._approved_patch(run_id, "plan_review").get("limits")
+        if isinstance(plan_patch_limits, dict) and plan_patch_limits:
+            limits = {**limits, **plan_patch_limits}
+        ledger = BudgetLedger.from_limits(limits)
         self._active_ledger = ledger
 
         try:
             return await self._execute_phases(run, ledger)
+        except _RunAwaitingReview as awaiting:
+            logger.info(f"Research run {run_id} awaiting checkpoint review")
+            return awaiting.run
         except _RunPaused as paused:
             logger.info(f"Research run {run_id} paused between phases")
             return paused.args[0]
@@ -322,6 +366,15 @@ class LocalResearchEngine:
             content_type="application/json",
             content={"query": question, "limits": limits},
         )
+        # task-16482: checkpointed runs pause for plan review before any
+        # search spend; an approved plan checkpoint passes (its limits
+        # patch was already merged into the ledger at execute_run entry).
+        if self._is_checkpointed(run) and not self.service.approved_checkpoint(
+            run_id, "plan_review"
+        ):
+            self._await_review(
+                run_id, "plan_review", {"query": question, "limits": limits}
+            )
 
         # -- iterate: collecting + synthesizing + gap analysis ----------
         # task-16324: collect, synthesize, then let gap analysis decide
@@ -428,6 +481,41 @@ class LocalResearchEngine:
                 )
             ledger.settle_docs(allotted_docs)
             self._save_ledger(run_id, ledger)
+
+            # task-16482: sources review before synthesis. An approved
+            # patch passes the boundary (dropped sources filtered, pinned
+            # kept); recollect.enabled does NOT pass -- the run re-collects
+            # and presents a fresh sources review.
+            if self._is_checkpointed(run):
+                approved_sources = self.service.approved_checkpoint(
+                    run_id, "sources_review"
+                )
+                sources_patch = (
+                    dict(approved_sources.get("user_patch") or {})
+                    if approved_sources is not None
+                    else {}
+                )
+                recollect = sources_patch.get("recollect") or {}
+                if approved_sources is None or recollect.get("enabled"):
+                    # No approval yet, or an approved recollect request:
+                    # present (a fresh) sources review and wait.
+                    self._await_review(
+                        run_id,
+                        "sources_review",
+                        {
+                            "source_ids": [
+                                str(r.get("url") or "") for r in merged_results
+                            ],
+                            "sub_questions": all_sub_questions,
+                        },
+                    )
+                else:
+                    dropped = set(sources_patch.get("dropped_source_ids") or [])
+                    if dropped:
+                        merged_results = [
+                            r for r in merged_results
+                            if str(r.get("url") or "") not in dropped
+                        ]
 
             self._check_control(run_id, "synthesizing")
             ledger.check_runtime()

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -212,6 +212,20 @@ class LocalResearchService:
                     created_at TEXT NOT NULL,
                     FOREIGN KEY(run_id) REFERENCES research_runs(id)
                 );
+                CREATE TABLE IF NOT EXISTS research_checkpoints (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    checkpoint_type TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    resolution TEXT,
+                    proposed_payload_json TEXT NOT NULL DEFAULT '{}',
+                    user_patch_payload_json TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    deleted INTEGER NOT NULL DEFAULT 0,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+                );
                 CREATE TABLE IF NOT EXISTS research_artifacts (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     run_id TEXT NOT NULL,
@@ -319,6 +333,17 @@ class LocalResearchService:
             "content_type": row["content_type"],
             "content": content,
         }
+
+    @staticmethod
+    def _normalize_checkpoint(row: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(row)
+        payload["proposed_payload"] = LocalResearchService._load_json(
+            payload.pop("proposed_payload_json", None)
+        )
+        payload["user_patch"] = LocalResearchService._load_json(
+            payload.pop("user_patch_payload_json", None)
+        )
+        return payload
 
     @staticmethod
     def _normalize_event(row: dict[str, Any]) -> dict[str, Any]:
@@ -651,6 +676,151 @@ class LocalResearchService:
         if error_msg is not None:
             fields["progress_message"] = error_msg
         return self._update_run_state(run_id, "failed", **fields)
+
+    # Patch keys allowed per checkpoint type (task-16482; server
+    # checkpoint_service parity, scoped to the local engine's phases).
+    _CHECKPOINT_PATCH_KEYS = {
+        "plan_review": {"limits"},
+        "sources_review": {"pinned_source_ids", "dropped_source_ids", "recollect"},
+    }
+
+    def create_checkpoint(
+        self,
+        run_id: str,
+        *,
+        checkpoint_type: str,
+        proposed_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create a pending review checkpoint for a run (task-16482)."""
+        self._require_one("research_runs", run_id, "research run")
+        checkpoint_id = f"chk-{self._new_id()}"
+        now = self._now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO research_checkpoints (
+                    id, run_id, checkpoint_type, status,
+                    proposed_payload_json, created_at, updated_at
+                ) VALUES (?, ?, ?, 'pending', ?, ?, ?)
+                """,
+                (
+                    checkpoint_id,
+                    run_id,
+                    checkpoint_type,
+                    self._dump_json(proposed_payload),
+                    now,
+                    now,
+                ),
+            )
+            self._record_event(
+                conn,
+                run_id,
+                "checkpoint_created",
+                {"checkpoint_id": checkpoint_id, "checkpoint_type": checkpoint_type},
+            )
+        return self._normalize_checkpoint(
+            self._require_one("research_checkpoints", checkpoint_id, "research checkpoint")
+        )
+
+    def list_checkpoints(self, run_id: str) -> list[dict[str, Any]]:
+        self._require_one("research_runs", run_id, "research run")
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM research_checkpoints WHERE run_id = ? ORDER BY rowid ASC",
+                (run_id,),
+            ).fetchall()
+        return [self._normalize_checkpoint(dict(row)) for row in rows]
+
+    def latest_pending_checkpoint(self, run_id: str) -> dict[str, Any] | None:
+        for checkpoint in reversed(self.list_checkpoints(run_id)):
+            if checkpoint.get("status") == "pending":
+                return checkpoint
+        return None
+
+    def approved_checkpoint(
+        self, run_id: str, checkpoint_type: str
+    ) -> dict[str, Any] | None:
+        """The most recent APPROVED checkpoint of one type (the engine's
+        pass-through signal on re-execution)."""
+        for checkpoint in reversed(self.list_checkpoints(run_id)):
+            if (
+                checkpoint.get("checkpoint_type") == checkpoint_type
+                and checkpoint.get("status") == "approved"
+            ):
+                return checkpoint
+        return None
+
+    def patch_and_approve_checkpoint(
+        self,
+        run_id: str,
+        checkpoint_id: str,
+        *,
+        patch_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Approve a pending checkpoint with a type-validated patch
+        (task-16482). Raises ValueError on non-pending state, unexpected
+        patch keys, or sources patches referencing unknown/overlapping ids.
+        """
+        self._require_one("research_runs", run_id, "research run")
+        row = self._require_one(
+            "research_checkpoints", checkpoint_id, "research checkpoint"
+        )
+        if row.get("run_id") != run_id:
+            raise ValueError("research checkpoint belongs to a different run")
+        if row.get("status") != "pending":
+            raise ValueError(f"research checkpoint {checkpoint_id} is not pending")
+        patch = dict(patch_payload or {})
+        checkpoint_type = row.get("checkpoint_type")
+        allowed = self._CHECKPOINT_PATCH_KEYS.get(checkpoint_type)
+        if allowed is None:
+            raise ValueError(f"unsupported checkpoint type: {checkpoint_type!r}")
+        unexpected = set(patch) - allowed
+        if unexpected:
+            raise ValueError(
+                f"unexpected patch keys for {checkpoint_type}: {sorted(unexpected)}"
+            )
+        if checkpoint_type == "sources_review":
+            proposed_ids = set(
+                (self._load_json(row.get("proposed_payload_json")) or {}).get(
+                    "source_ids"
+                )
+                or []
+            )
+            pinned = set(patch.get("pinned_source_ids") or [])
+            dropped = set(patch.get("dropped_source_ids") or [])
+            unknown = (pinned | dropped) - proposed_ids
+            if unknown:
+                raise ValueError(
+                    f"patch references ids not in the proposed inventory: {sorted(unknown)}"
+                )
+            if pinned & dropped:
+                raise ValueError(
+                    "pinned and dropped source ids must be disjoint"
+                )
+            recollect = patch.get("recollect")
+            if recollect is not None and not isinstance(recollect, dict):
+                raise ValueError("recollect patch must be an object")
+        updates = {
+            "status": "approved",
+            "resolution": "approved",
+            "user_patch_payload_json": self._dump_json(patch),
+            "updated_at": self._now(),
+            "version": int(row["version"]) + 1,
+        }
+        assignments = ", ".join(f"{key} = ?" for key in updates)
+        with self._connect() as conn:
+            conn.execute(
+                f"UPDATE research_checkpoints SET {assignments} WHERE id = ?",
+                (*updates.values(), checkpoint_id),
+            )
+            self._record_event(
+                conn, run_id, "checkpoint_approved", {"checkpoint_id": checkpoint_id}
+            )
+        return self._normalize_checkpoint(
+            self._require_one(
+                "research_checkpoints", checkpoint_id, "research checkpoint"
+            )
+        )
 
     def update_run_progress(
         self,

--- a/tldw_chatbook/Tools/web_tool_impls.py
+++ b/tldw_chatbook/Tools/web_tool_impls.py
@@ -2191,6 +2191,77 @@ def _run_coro_loop_safe(coro, timeout_s: float):
     return outcome["value"]
 
 
+def deep_search_pipeline_params(
+    *,
+    engine: Optional[str] = None,
+    max_results: Optional[int] = None,
+    subquery: Optional[bool] = None,
+    max_queries: Optional[int] = None,
+    respect_robots: Optional[bool] = None,
+    extra: Optional[dict] = None,
+) -> dict:
+    """Assemble the deep-search pipeline search_params from [SearchSettings]
+    (task-16484) -- ONE assembly shared by the web_deep_search tool, the
+    Console /research command, and the baseline script, with per-key
+    overrides for callers that need tighter bounds (e.g. spend-capped
+    baseline runs force subquery off and one query).
+    """
+    settings = _deep_search_settings()
+
+    try:
+        result_ceiling = int(settings.get("search_result_max", SEARCH_MAX_RESULT_COUNT))
+    except (TypeError, ValueError):
+        result_ceiling = SEARCH_MAX_RESULT_COUNT
+    if result_ceiling < 1:
+        result_ceiling = SEARCH_MAX_RESULT_COUNT
+    resolved_max_results = max_results if max_results is not None else result_ceiling
+    try:
+        resolved_max_results = max(1, min(int(resolved_max_results), result_ceiling))
+    except (TypeError, ValueError):
+        resolved_max_results = result_ceiling
+
+    deadline_s = float(settings.get("deep_search_timeout_s", 240) or 240)
+
+    params: dict = {
+        "engine": engine or settings.get("search_provider_default", SEARCH_DEFAULT_ENGINE),
+        "content_country": "US",
+        "search_lang": "en",
+        "output_lang": "en",
+        "result_count": resolved_max_results,
+        "subquery_generation": bool(
+            settings.get("search_enable_subquery", False)
+            if subquery is None
+            else subquery
+        ),
+        "subquery_generation_llm": settings.get("relevance_analysis_llm"),
+        "relevance_analysis_llm": settings.get("relevance_analysis_llm"),
+        "final_answer_llm": settings.get("final_answer_llm"),
+        # CRITICAL: analyze_and_aggregate reads these two straight out of
+        # search_params -- omitting them means the config knobs silently
+        # never reach the pipeline and it falls back to its own 30s defaults.
+        "relevance_llm_timeout_s": settings.get("relevance_llm_timeout_s", 30),
+        "relevance_scrape_timeout_s": settings.get("relevance_scrape_timeout_s", 30),
+        # generate_and_search reads this to cap total fan-out.
+        "search_default_max_queries": (
+            settings.get("search_default_max_queries", 5)
+            if max_queries is None
+            else max_queries
+        ),
+        # The caller's remaining deadline (full configured timeout when the
+        # run has not started yet).
+        "phase1_time_budget_s": deadline_s,
+        "respect_robots_txt": (
+            _webfetch_settings()["respect_robots_txt"]
+            if respect_robots is None
+            else respect_robots
+        ),
+        "deep_search_timeout_s": deadline_s,
+    }
+    if extra:
+        params.update(extra)
+    return params
+
+
 def web_deep_search(question: str, engine: Optional[str] = None, max_results: Optional[int] = None) -> str:
     """Multi-query web research: sub-questions, relevance filtering, a cited answer.
 
@@ -2303,42 +2374,11 @@ def web_deep_search(question: str, engine: Optional[str] = None, max_results: Op
 
     deadline_s = float(settings.get("deep_search_timeout_s", 240) or 240)
 
-    search_params = {
-        "engine": engine,
-        "content_country": "US",
-        "search_lang": "en",
-        "output_lang": "en",
-        "result_count": max_results,
-        "subquery_generation": bool(settings.get("search_enable_subquery", False)),
-        "subquery_generation_llm": relevance_llm,
-        "relevance_analysis_llm": relevance_llm,
-        "final_answer_llm": final_answer_llm,
-        # CRITICAL: analyze_and_aggregate reads these two straight out of
-        # search_params -- omitting them means the config knobs silently
-        # never reach the pipeline and it falls back to its own 30s defaults.
-        "relevance_llm_timeout_s": settings.get("relevance_llm_timeout_s", 30),
-        "relevance_scrape_timeout_s": settings.get("relevance_scrape_timeout_s", 30),
-        # Important 2 (final review): generate_and_search reads this to cap
-        # total fan-out (question + sub-queries) at search_default_max_queries
-        # -- resolved by _deep_search_settings() but previously never handed
-        # to the pipeline, so subquery generation could fan out far past the
-        # description's "~25 LLM calls at defaults".
-        "search_default_max_queries": settings.get("search_default_max_queries", 5),
-        # Important 3a (final review): the tool's remaining phase-1 budget,
-        # computed here at entry (phase 1 hasn't run yet, so this is the
-        # full configured deadline). generate_and_search checks it between
-        # per-query searches and stops the fan-out early on expiry -- a
-        # cheap bound on top of the per-request backend timeouts (Important
-        # 3b), covering the six engines that still have none.
-        "phase1_time_budget_s": deadline_s,
-        # task-3260: same toggle, plumbed like the timeouts above -- the
-        # pydantic-safe channel into analyze_and_aggregate/search_result_
-        # relevance, which read it from search_params (default False when
-        # absent, so the dead-wired research-service caller that never sets
-        # this key keeps today's behavior unchanged; this tool is the only
-        # user-facing caller and passes the real, configured setting).
-        "respect_robots_txt": _webfetch_settings()["respect_robots_txt"],
-    }
+    # task-16484: ONE shared assembly (this tool, the Console /research
+    # command, and the baseline script all build these params).
+    search_params = deep_search_pipeline_params(
+        engine=engine, max_results=max_results
+    )
 
     from ..Web_Scraping import WebSearch_APIs  # local import: keep module import cheap
 

--- a/tldw_chatbook/Tools/web_tool_impls.py
+++ b/tldw_chatbook/Tools/web_tool_impls.py
@@ -2469,6 +2469,12 @@ def web_deep_search(question: str, engine: Optional[str] = None, max_results: Op
     # successfully -- deadline_hit only means the deadline was reached,
     # not that anything was actually cut short.
     deadline_note = " · deadline reached — results may be incomplete" if deadline_hit else ""
+    # task-16333: a gate-fallback report must never masquerade as a
+    # relevance-verified one.
+    gate_block = final_answer.get("gate") or {}
+    gate_note = (
+        " · evidence not relevance-verified (gate fallback)" if gate_block.get("fallback") else ""
+    )
     # "scored" is only accurate when the relevance loop ran to completion --
     # a deadline hit means some of `results` were never examined at all, so
     # say "found" instead of implying full coverage the run never had
@@ -2488,7 +2494,7 @@ def web_deep_search(question: str, engine: Optional[str] = None, max_results: Op
     footer = (
         f"Confidence: {confidence:.2f} · Engine: {engine} · Sub-queries: {len(sub_questions)} · "
         f"Relevant: {len(relevant_results)} of {len(results)} {coverage_verb}"
-        f"{fallback_note}{warning_note}{deadline_note}{citation_note}"
+        f"{fallback_note}{warning_note}{deadline_note}{citation_note}{gate_note}"
     )
 
     text = _truncate_to_bytes(str(final_answer.get("text") or ""), DEEP_SEARCH_ANSWER_MAX_BYTES)

--- a/tldw_chatbook/UI/Research_Modules/bundle_rendering.py
+++ b/tldw_chatbook/UI/Research_Modules/bundle_rendering.py
@@ -1,0 +1,156 @@
+"""Readable bundle/artifact rendering for the Research window (task-16483).
+
+Pure functions over the two bundle shapes the window sees — the local
+engine's ``{"run": ..., "artifacts": [...]}`` and the server's
+name-to-content mapping — so run outputs are legible instead of raw JSON
+dumps. Known artifact types render structurally; anything else falls back
+to pretty-printed JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+__all__ = [
+    "default_artifact_for_bundle",
+    "render_artifact",
+    "render_bundle_summary",
+]
+
+_MAX_TEXT_CHARS = 8000
+
+
+def _field(record: Any, key: str, default: Any = None) -> Any:
+    if isinstance(record, Mapping):
+        return record.get(key, default)
+    return getattr(record, key, default)
+
+
+def _artifact_names(bundle: Any) -> list[str]:
+    if isinstance(bundle, Mapping):
+        artifacts = bundle.get("artifacts")
+        if isinstance(artifacts, list):
+            return [
+                str(_field(artifact, "artifact_name") or "")
+                for artifact in artifacts
+                if _field(artifact, "artifact_name")
+            ]
+        # Server shape: the mapping's own keys ARE artifact names.
+        return [str(key) for key in bundle.keys()]
+    return []
+
+
+def render_bundle_summary(bundle: Any) -> str:
+    """One-screen bundle overview: run status plus the artifact inventory."""
+    if bundle is None:
+        return "No bundle loaded."
+    lines: list[str] = []
+    if isinstance(bundle, Mapping) and isinstance(bundle.get("run"), Mapping):
+        run = bundle["run"]
+        phase = f" ({run['phase']})" if run.get("phase") else ""
+        lines.append(f"Run {run.get('id')} — {run.get('status')}{phase}")
+        if run.get("query"):
+            lines.append(f"Query: {run['query']}")
+    names = _artifact_names(bundle)
+    lines.append(f"Artifacts ({len(names)}):")
+    lines.extend(f"  - {name}" for name in names)
+    return "\n".join(lines) if lines else "Empty bundle."
+
+
+def default_artifact_for_bundle(bundle: Any) -> str | None:
+    """The artifact to open after a bundle load: the report when present,
+    else the first artifact. Never the local shape's ``run`` record."""
+    names = _artifact_names(bundle)
+    if not names:
+        return None
+    for preferred in ("report_v1.md", "report.md"):
+        if preferred in names:
+            return preferred
+    return names[0]
+
+
+def _render_verification(content: Mapping) -> str:
+    lines = [f"confidence: {content.get('confidence')}"]
+    cv = content.get("citation_verification") or {}
+    if cv:
+        lines.append(
+            f"citations: markers {cv.get('markers_resolved')}/{cv.get('markers_total')}"
+            f" · quotes {cv.get('quotes_verified')}/{cv.get('quotes_checked')}"
+            f" · uncited sentences {cv.get('uncited_sentences')}"
+        )
+    gate = content.get("gate")
+    if isinstance(gate, Mapping) and gate.get("raw"):
+        fallback = " (gate fallback)" if gate.get("fallback") else ""
+        lines.append(f"gate: {gate.get('relevant')}/{gate.get('raw')}{fallback}")
+    if content.get("relevant_count") is not None:
+        lines.append(f"relevant results: {content.get('relevant_count')}")
+    return "\n".join(lines)
+
+
+def _render_claims(content: Mapping) -> str:
+    claims = content.get("claims") or []
+    lines = [f"claims: {content.get('claim_count', len(claims))}"]
+    for claim in claims:
+        if not isinstance(claim, Mapping):
+            continue
+        text = str(claim.get("text") or "")
+        if len(text) > 120:
+            text = text[:117] + "..."
+        lines.append(f"  [{claim.get('status', '?')}] {claim.get('claim_id')}: {text}")
+    return "\n".join(lines)
+
+
+def _render_sources(content: Mapping) -> str:
+    lines = []
+    for item in content.get("evidence") or []:
+        if not isinstance(item, Mapping):
+            continue
+        lines.append(
+            f"[{item.get('id')}] {item.get('title') or 'Untitled'} — {item.get('url') or ''}"
+        )
+    return "\n".join(lines) if lines else "No sources."
+
+
+def _render_budget(content: Mapping) -> str:
+    return "\n".join(
+        [
+            f"searches {content.get('searches_used', 0)}",
+            f"docs {content.get('docs_used', 0)}",
+            f"tokens {content.get('tokens_settled', 0)}"
+            + (" (estimated)" if content.get("tokens_estimated") else ""),
+            f"runtime {content.get('runtime_elapsed_s', 0.0)}s",
+        ]
+    )
+
+
+def _render_content(artifact_name: str, content: Any) -> str:
+    if isinstance(content, str):
+        text = content
+        if len(text) > _MAX_TEXT_CHARS:
+            text = text[:_MAX_TEXT_CHARS] + "\n… [truncated]"
+        return text
+    if isinstance(content, Mapping):
+        if artifact_name == "verification_summary.json":
+            return _render_verification(content)
+        if artifact_name == "claims.json":
+            return _render_claims(content)
+        if artifact_name == "sources.json":
+            return _render_sources(content)
+        if artifact_name == "budget_ledger.json":
+            return _render_budget(content)
+    return json.dumps(content, indent=2, sort_keys=True, default=str)
+
+
+def render_artifact(artifact: Any) -> str:
+    """Structured rendering for one loaded artifact."""
+    if artifact is None:
+        return "No artifact loaded."
+    name = str(_field(artifact, "artifact_name", "") or "")
+    header = (
+        f"Artifact: {name}\n"
+        f"Type: {_field(artifact, 'content_type', '')}\n"
+        f"Version: {_field(artifact, 'artifact_version', 1)}\n"
+        "Content:\n"
+    )
+    return header + _render_content(name, _field(artifact, "content"))

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -547,6 +547,32 @@ class ResearchWindow(Vertical):
             raise ValueError("No research run is selected.")
         return str(self._record_get(self.selected_run, "id") or "")
 
+    def on_mount(self) -> None:
+        # task-16486: while a local engine run is in flight, keep the
+        # selected run's detail current without manual Refresh.
+        self.set_interval(2.0, self._auto_refresh_selected_run)
+
+    async def _auto_refresh_selected_run(self) -> None:
+        """Refresh the selected LOCAL run's detail while it is non-terminal
+        (task-16486). Payload state (bundle/artifact selections) is
+        preserved; server-source selections and terminal runs are skipped
+        (server observation already has its own streaming surface)."""
+        if self.current_source != "local" or self.selected_run is None:
+            return
+        if self._record_field(self.selected_run, "status") in {
+            "completed", "failed", "cancelled", "draft",
+        }:
+            return
+        try:
+            run_id = self._selected_run_id()
+            updated = await self.controller.get_run(self.current_source, run_id)
+        except Exception:
+            return  # transient controller errors must not spam the status line
+        if updated is None:
+            return
+        self.selected_run = updated
+        self._update_detail(updated)
+
     def _set_selected_run(self, run: Any, *, reset_payload_state: bool) -> None:
         self.selected_run = run
         if reset_payload_state:

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -407,8 +407,22 @@ class ResearchWindow(Vertical):
             if not resolved_checkpoint_id and self.current_source != "local":
                 self._set_status("Checkpoint id is required.")
                 return None
+            run_id = self._selected_run_id()
             if not resolved_checkpoint_id:
-                resolved_checkpoint_id = "local-checkpoint-unavailable"
+                # task-16482: local runs resolve their latest PENDING
+                # checkpoint (the engine parks at one boundary at a time).
+                local_service = getattr(
+                    self.app_instance, "local_research_service", None
+                )
+                pending = (
+                    local_service.latest_pending_checkpoint(run_id)
+                    if local_service is not None
+                    else None
+                )
+                if pending is None:
+                    self._set_status("No pending checkpoint for this run.")
+                    return None
+                resolved_checkpoint_id = str(pending["id"])
             resolved_patch_payload = (
                 patch_payload
                 if patch_payload is not None
@@ -425,6 +439,10 @@ class ResearchWindow(Vertical):
             return None
         self._set_selected_run(updated, reset_payload_state=False)
         self._set_status(f"Approved research checkpoint {resolved_checkpoint_id}.")
+        if self.current_source == "local":
+            # task-16482: approval unblocks the boundary -- restart the
+            # engine so the run continues to its next phase/checkpoint.
+            self._start_local_engine(run_id)
         return updated
 
     async def watch_selected_run_events(

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -21,6 +21,11 @@ from textual.widgets import (
 )
 
 from tldw_chatbook.UI.Research_Modules import ResearchController
+from tldw_chatbook.UI.Research_Modules.bundle_rendering import (
+    default_artifact_for_bundle,
+    render_artifact,
+    render_bundle_summary,
+)
 
 
 def _parse_limits_text(text: str | None) -> tuple[dict[str, float], list[str]]:
@@ -370,15 +375,16 @@ class ResearchWindow(Vertical):
         bundle = await self.controller.get_bundle(self.current_source, run_id)
         self.current_bundle = dict(bundle or {})
         self._render_bundle_detail()
-        if self.current_bundle and self.is_mounted:
-            first_artifact_name = next(iter(self.current_bundle.keys()), "")
-            if first_artifact_name:
+        # task-16483: open the most useful artifact right away (the report
+        # when present -- never the local shape's run record).
+        default_name = default_artifact_for_bundle(self.current_bundle)
+        if default_name:
+            if self.is_mounted:
                 try:
-                    self.query_one("#research-artifact-name", Input).value = str(
-                        first_artifact_name
-                    )
+                    self.query_one("#research-artifact-name", Input).value = default_name
                 except Exception:
                     pass
+            await self.load_selected_run_artifact(default_name)
         self._set_status(f"Loaded research bundle for {run_id}.")
         return self.current_bundle
 
@@ -562,11 +568,7 @@ class ResearchWindow(Vertical):
     def _render_bundle_detail(self) -> None:
         if not self.is_mounted:
             return
-        renderable = "No bundle loaded."
-        if self.current_bundle is not None:
-            renderable = json.dumps(
-                self.current_bundle, indent=2, sort_keys=True, default=str
-            )
+        renderable = render_bundle_summary(self.current_bundle)
         try:
             self.query_one("#research-bundle-detail", Static).update(renderable)
         except Exception:
@@ -575,15 +577,7 @@ class ResearchWindow(Vertical):
     def _render_artifact_detail(self) -> None:
         if not self.is_mounted:
             return
-        renderable = "No artifact loaded."
-        if self.current_artifact is not None:
-            artifact = self.current_artifact
-            renderable = (
-                f"Artifact: {self._record_get(artifact, 'artifact_name', '')}\n"
-                f"Type: {self._record_get(artifact, 'content_type', '')}\n"
-                f"Version: {self._record_get(artifact, 'artifact_version', 1)}\n"
-                f"Content:\n{self._render_value(self._record_get(artifact, 'content'))}"
-            )
+        renderable = render_artifact(self.current_artifact)
         try:
             self.query_one("#research-artifact-detail", Static).update(renderable)
         except Exception:

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -23,6 +23,31 @@ from textual.widgets import (
 from tldw_chatbook.UI.Research_Modules import ResearchController
 
 
+def _parse_limits_text(text: str | None) -> tuple[dict[str, float], list[str]]:
+    """Parse a limits input like "max_searches=5, max_runtime_seconds=120"
+    into a limits_json dict (task-16334). Invalid pairs are excluded and
+    reported as warnings so one typo never blocks run creation."""
+    limits: dict[str, float] = {}
+    warnings: list[str] = []
+    for raw_pair in str(text or "").split(","):
+        pair = raw_pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            warnings.append(f"unparsed limit (expected key=value): {pair!r}")
+            continue
+        key, _, raw_value = pair.partition("=")
+        key = key.strip()
+        try:
+            value = float(raw_value.strip())
+        except ValueError:
+            warnings.append(f"non-numeric limit for {key!r}: {raw_value.strip()!r}")
+            continue
+        if key:
+            limits[key] = value
+    return limits, warnings
+
+
 def _academic_lane_default() -> bool:
     """Config default for the academic lane toggle: [SearchSettings]
     research_academic_lane (default False). Failures default OFF -- the
@@ -51,6 +76,10 @@ class ResearchWindow(Vertical):
         # task-16328: academic lane toggle (arXiv + Semantic Scholar papers
         # join the run's evidence pool when enabled).
         self.academic_enabled = _academic_lane_default()
+        # task-16334: budget limits text (parsed into limits_json on create)
+        # and the rendered follow-up answer.
+        self.limits_text = ""
+        self.followup_answer_text = ""
         self.controller = ResearchController(
             getattr(app_instance, "research_scope_service", None)
         )
@@ -72,6 +101,10 @@ class ResearchWindow(Vertical):
             )
         with Horizontal(id="research-create-row"):
             yield Input(placeholder="Research question", id="research-query-input")
+            yield Input(
+                placeholder="Limits: max_searches=5, max_runtime_seconds=120",
+                id="research-limits-input",
+            )
             yield Button("Create Run", id="research-create-run", variant="primary")
         yield Static(self.status_message, id="research-status")
         with Horizontal(id="research-body"):
@@ -97,6 +130,13 @@ class ResearchWindow(Vertical):
                 with Horizontal(id="research-checkpoint-actions"):
                     yield Button("Approve Checkpoint", id="research-approve-checkpoint")
                     yield Button("Clear Events", id="research-clear-events")
+                with Horizontal(id="research-followup-row"):
+                    yield Input(
+                        placeholder="Ask a follow-up about the selected run",
+                        id="research-followup-input",
+                    )
+                    yield Button("Ask Follow-up", id="research-followup-ask")
+                yield Static("No follow-up yet.", id="research-followup-answer")
                 yield Static("No bundle loaded.", id="research-bundle-detail")
                 yield Static("No artifact loaded.", id="research-artifact-detail")
                 yield Static(
@@ -104,13 +144,22 @@ class ResearchWindow(Vertical):
                 )
 
     def save_state(self) -> dict[str, Any]:
-        return {"source": self.current_source, "academic": self.academic_enabled}
+        return {
+            "source": self.current_source,
+            "academic": self.academic_enabled,
+            "limits": self.limits_text,
+        }
 
     def restore_state(self, state: dict[str, Any]) -> None:
         source = str((state or {}).get("source") or "local").strip().lower()
         self.current_source = source if source in {"local", "server"} else "local"
         self.academic_enabled = bool((state or {}).get("academic"))
+        self.limits_text = str((state or {}).get("limits") or "")
         self._sync_academic_toggle()
+        try:
+            self.query_one("#research-limits-input", Input).value = self.limits_text
+        except Exception:
+            pass  # not mounted yet; compose()'s initial value covers it
 
     def _sync_academic_toggle(self) -> None:
         try:
@@ -119,6 +168,77 @@ class ResearchWindow(Vertical):
             )
         except Exception:
             pass  # not mounted yet; the compose() initial value covers it
+
+    @on(Button.Pressed, "#research-followup-ask")
+    async def _on_followup_ask(self, event: Button.Pressed) -> None:
+        try:
+            question = self.query_one("#research-followup-input", Input).value
+        except Exception:
+            question = ""
+        await self.ask_follow_up(question or None)
+
+    async def ask_follow_up(self, question: str | None) -> Any:
+        """Answer a follow-up from the selected local run's stored claims
+        (task-16334). Renders the answer, or the engine's explicit
+        insufficient-evidence verdict -- never a fabricated one."""
+        try:
+            run_id = self._selected_run_id()
+        except ValueError:
+            run_id = ""
+        if not run_id:
+            self._set_status("Select a research run before asking a follow-up.")
+            return None
+        if self.current_source != "local":
+            self._set_status("Follow-up Q&A is available for local runs only.")
+            return None
+        local_service = getattr(self.app_instance, "local_research_service", None)
+        if local_service is None:
+            self._set_status("Local research service unavailable for follow-ups.")
+            return None
+        if not question or not str(question).strip():
+            self._set_status("Type a follow-up question first.")
+            return None
+        question = str(question).strip()
+
+        # The default follow-up answerer reads the synthesis LLM from
+        # search_params; assemble them the same way the tool does so the
+        # window uses the configured pipeline.
+        search_params: dict[str, Any] = {}
+        try:
+            from ..Tools.web_tool_impls import _deep_search_settings
+
+            final_llm = _deep_search_settings().get("final_answer_llm")
+            if final_llm:
+                search_params["final_answer_llm"] = final_llm
+        except Exception:
+            pass
+
+        from ..Research_Interop.local_research_engine import LocalResearchEngine
+
+        engine = LocalResearchEngine(local_service, search_params=search_params)
+        try:
+            result = await engine.answer_follow_up(run_id, question)
+        except Exception as exc:  # noqa: BLE001 - report, never crash the window
+            self._set_status(f"Follow-up failed: {exc}")
+            return None
+        if result.get("status") == "answered":
+            self.followup_answer_text = (
+                f"Q: {question}\n{result.get('answer') or ''}"
+            )
+        else:
+            self.followup_answer_text = (
+                f"Q: {question}\n[insufficient evidence] "
+                f"{result.get('reason') or 'stored evidence does not support this question'}\n"
+                f"{result.get('suggestion') or ''}"
+            )
+        try:
+            self.query_one("#research-followup-answer", Static).update(
+                self.followup_answer_text
+            )
+        except Exception:
+            pass  # not mounted (tests); the state carries the text
+        self._set_status(f"Follow-up {result.get('status')}.")
+        return result
 
     @on(Checkbox.Changed, "#research-academic-toggle")
     def _on_academic_toggle_changed(self, event: Checkbox.Changed) -> None:
@@ -152,6 +272,11 @@ class ResearchWindow(Vertical):
         return self.runs
 
     async def create_run(self, payload: dict[str, Any]) -> Any:
+        limits, warnings = _parse_limits_text(self.limits_text)
+        if warnings:
+            self._set_status("Limits: " + "; ".join(warnings))
+        if limits:
+            payload = {**payload, "limits_json": limits}
         created = await self.controller.create_run(self.current_source, payload)
         if self.current_source == "local":
             created_id = (

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -163,6 +163,8 @@ from ...Chat.console_command_grammar import (
     PREFILL_COMMAND_NAME,
     PROMPT_COMMAND_HANDLER_ID,
     PROMPT_COMMAND_NAME,
+    RESEARCH_COMMAND_HANDLER_ID,
+    RESEARCH_COMMAND_NAME,
     REWIND_COMMAND_HANDLER_ID,
     REWIND_COMMAND_NAME,
     SKILLS_COMMAND_HANDLER_ID,
@@ -16491,6 +16493,7 @@ class ChatScreen(BaseAppScreen):
         GENERATE_VIDEO_COMMAND_NAME: GENERATE_VIDEO_COMMAND_HANDLER_ID,
         STREAM_VIDEO_COMMAND_NAME: STREAM_VIDEO_COMMAND_HANDLER_ID,
         REWIND_COMMAND_NAME: REWIND_COMMAND_HANDLER_ID,
+        RESEARCH_COMMAND_NAME: RESEARCH_COMMAND_HANDLER_ID,
     }
 
     def _console_unknown_command_hint(self, name: str) -> str:
@@ -16555,6 +16558,7 @@ class ChatScreen(BaseAppScreen):
             GENERATE_VIDEO_COMMAND_HANDLER_ID: self._console_command_generate_video,
             STREAM_VIDEO_COMMAND_HANDLER_ID: self._console_command_stream_video,
             REWIND_COMMAND_HANDLER_ID: self._console_command_rewind,
+            RESEARCH_COMMAND_HANDLER_ID: self._console_command_research,
         }
         handler = dispatch_map.get(handler_id)
         if handler is None:
@@ -16767,6 +16771,97 @@ class ChatScreen(BaseAppScreen):
                 "prefilled sends."
             )
         return
+
+    async def _console_command_research(self, parse: CommandParse) -> None:
+        """``/research <question>``: launch a local deep-research run whose
+        completed report is delivered back into THIS conversation (task-16481).
+
+        The run executes in a worker; the handoff inserts an assistant
+        message on completion, and the existing terminal-run notification
+        remains the fallback when insertion is impossible.
+        """
+        question = (parse.args or "").strip()
+        if not question:
+            await self._append_native_console_system_message(
+                "Usage: /research <question>"
+            )
+            return
+        conversation_id = self._current_console_conversation_id()
+        if not conversation_id:
+            await self._append_native_console_system_message(
+                "Deep research needs an active conversation to deliver its "
+                "report into."
+            )
+            return
+        app = self.app
+        local_service = getattr(app, "local_research_service", None)
+        if local_service is None:
+            await self._append_native_console_system_message(
+                "Local research service is unavailable; cannot start a run."
+            )
+            return
+
+        from tldw_chatbook.Research_Interop.chat_handoff import (
+            insert_research_completion_message,
+        )
+        from tldw_chatbook.Research_Interop.local_research_engine import (
+            LocalResearchEngine,
+        )
+
+        search_params: dict = {}
+        paper_search_fn = None
+        try:
+            from tldw_chatbook.Tools.web_tool_impls import _deep_search_settings
+
+            settings = _deep_search_settings()
+            relevance_llm = settings.get("relevance_analysis_llm")
+            final_llm = settings.get("final_answer_llm")
+            if final_llm:
+                search_params["final_answer_llm"] = final_llm
+            if relevance_llm:
+                search_params["relevance_analysis_llm"] = relevance_llm
+            if getattr(app, "research_window_academic_enabled", False):
+                from tldw_chatbook.Research_Interop.academic_providers import (
+                    search_papers,
+                )
+
+                paper_search_fn = search_papers
+        except Exception:
+            pass
+
+        db = getattr(app, "chachanotes_db", None)
+
+        async def _run_research() -> None:
+            run = local_service.launch_run(
+                query=question,
+                chat_handoff={"conversation_id": conversation_id, "origin": "console"},
+            )
+            engine = LocalResearchEngine(
+                local_service,
+                search_params=search_params,
+                paper_search_fn=paper_search_fn,
+                completion_handoff=(
+                    (lambda payload: insert_research_completion_message(db, payload))
+                    if db is not None
+                    else None
+                ),
+            )
+            try:
+                await engine.execute_run(run["id"])
+            except Exception as exc:  # noqa: BLE001 - worker must not crash the screen
+                logger.warning(f"Console research run failed: {exc}")
+
+        self.run_worker(
+            _run_research(),
+            group="console-research",
+            exclusive=False,
+            description=f"Console research: {question[:60]}",
+        )
+        await self._append_native_console_system_message(
+            f"Deep research started: {question}\n"
+            "The report will be added to this conversation when the run "
+            "completes."
+        )
 
     async def _console_command_generate_image(self, parse: CommandParse) -> None:
         """Delegate the registry-bound image command to its controller."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -16811,15 +16811,9 @@ class ChatScreen(BaseAppScreen):
         search_params: dict = {}
         paper_search_fn = None
         try:
-            from tldw_chatbook.Tools.web_tool_impls import _deep_search_settings
+            from tldw_chatbook.Tools.web_tool_impls import deep_search_pipeline_params
 
-            settings = _deep_search_settings()
-            relevance_llm = settings.get("relevance_analysis_llm")
-            final_llm = settings.get("final_answer_llm")
-            if final_llm:
-                search_params["final_answer_llm"] = final_llm
-            if relevance_llm:
-                search_params["relevance_analysis_llm"] = relevance_llm
+            search_params = deep_search_pipeline_params()
             if getattr(app, "research_window_academic_enabled", False):
                 from tldw_chatbook.Research_Interop.academic_providers import (
                     search_papers,

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -766,6 +766,14 @@ async def analyze_and_aggregate(
         },
     )
 
+    if isinstance(final_answer, dict):
+        final_answer["gate"] = {
+            "relevant": len(relevant_results),
+            "raw": len(web_search_results_dict.get("results") or []),
+            "fallback": any(
+                entry.get("gate_unverified") for entry in relevant_results.values()
+            ),
+        }
     return {
         "final_answer": final_answer,
         "relevant_results": relevant_results,
@@ -1070,6 +1078,11 @@ async def search_result_relevance(
         Dict[str, Dict]: A dictionary of relevant results, keyed by a unique ID or index.
     """
     relevant_results: Dict[str, Dict] = {}
+    # task-16333: results the gate EVALUATED and rejected (verdict False).
+    # Only these are eligible for the zero-relevant fallback -- results
+    # skipped via timeout/cancel/no-content were never judged, and promoting
+    # them would launder unevaluated evidence.
+    gate_rejected: List[tuple] = []
 
     for idx, result in enumerate(search_results):
         if cancel_event and cancel_event.is_set():
@@ -1107,7 +1120,10 @@ async def search_result_relevance(
                         api_endpoint=api_endpoint,
                         messages_payload=_mp,
                         api_key=None,
-                        temp=0.7,
+                        # Classification, not generation (task-16333): the
+                        # binary relevant/not-relevant verdict must be stable
+                        # across identical runs; 0.7 flipped verdicts.
+                        temp=_RELEVANCE_JUDGMENT_TEMP,
                         system_message=None,
                         streaming=False,
                         minp=None,
@@ -1341,6 +1357,7 @@ async def search_result_relevance(
                         )
                     else:
                         logger.info(f"Irrelevant result: {reasoning}")
+                        gate_rejected.append((idx, result, content))
 
                 else:
                     logger.warning(
@@ -1355,6 +1372,33 @@ async def search_result_relevance(
             logger.error(
                 f"Error during relevance evaluation/summarization for result idx={idx}: {e}"
             )
+
+    # task-16333 zero-relevant fallback: the live baseline showed a strict
+    # gate silently producing NO report at all. When every EVALUATED result
+    # was rejected but raw results exist (and the run was not cancelled --
+    # a deadline hit must keep reporting the honest cutoff), keep the
+    # top-ranked rejected results as snippet-level evidence flagged
+    # gate_unverified: a flagged report beats no report. No scrape or
+    # summarization spend on fallback entries.
+    if (
+        not relevant_results
+        and gate_rejected
+        and not (cancel_event and cancel_event.is_set())
+    ):
+        for fb_idx, fb_result, fb_content in gate_rejected[:_GATE_FALLBACK_MAX_RESULTS]:
+            fb_result_id = str(fb_result.get("id", fb_idx))
+            relevant_results[fb_result_id] = {
+                "content": fb_content,
+                "original_content": fb_content,
+                "reasoning": "gate fallback: evidence not relevance-verified",
+                "url": fb_result.get("url"),
+                "title": fb_result.get("title"),
+                "gate_unverified": True,
+            }
+        logger.warning(
+            f"Relevance gate rejected all {len(gate_rejected)} evaluated result(s); "
+            f"proceeding with top {len(relevant_results)} flagged gate-unverified"
+        )
 
     return relevant_results
 
@@ -1418,6 +1462,12 @@ def review_and_select_results(
 
 ######################### Result Aggregation & Combination #########################
 #
+# task-16333: binary verdicts need determinism, not creativity.
+_RELEVANCE_JUDGMENT_TEMP = 0.1
+# task-16333: bounded zero-relevant fallback (search-rank order).
+_GATE_FALLBACK_MAX_RESULTS = 3
+
+
 class FinalAnswerDict(TypedDict):
     """Structured payload returned by the aggregation phase (port of server
     WebSearch_APIs.py :1034-1039; task-1356). `evidence` entries are dicts
@@ -1432,6 +1482,10 @@ class FinalAnswerDict(TypedDict):
     # and quote-check counts from deep_search_citations.verify_citations.
     # Failure/empty branches omit it rather than fabricating a clean verdict.
     citation_verification: NotRequired[Dict[str, Any]]
+    # Present whenever relevance outcomes are known (task-16333):
+    # {"relevant": int, "raw": int, "fallback": bool} -- fallback marks a
+    # report built from gate-unverified evidence.
+    gate: NotRequired[Dict[str, Any]]
 
 
 def _build_chunk_infos(items: List[str], max_chars: int = 6000) -> List[Dict[str, Any]]:
@@ -1581,17 +1635,18 @@ def aggregate_results(
 
     evidence_payload: List[Dict[str, Any]] = []
     for n, (_rid, res) in numbered_items:
-        evidence_payload.append(
-            {
-                "id": n,
-                "url": res.get("url"),
-                "title": res.get("title"),
-                "content": res.get("content"),
-                "original_content": res.get("original_content"),
-                "reasoning": res.get("reasoning"),
-                "chunk_index": chunk_index_by_n.get(n),
-            }
-        )
+        evidence_entry = {
+            "id": n,
+            "url": res.get("url"),
+            "title": res.get("title"),
+            "content": res.get("content"),
+            "original_content": res.get("original_content"),
+            "reasoning": res.get("reasoning"),
+            "chunk_index": chunk_index_by_n.get(n),
+        }
+        if res.get("gate_unverified"):
+            evidence_entry["gate_unverified"] = True
+        evidence_payload.append(evidence_entry)
 
     concatenated_texts = "\n\n".join(entry_texts)
 

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -72,7 +72,7 @@ except ImportError:
 # Local Imports
 from tldw_chatbook.Web_Scraping.Article_Extractor_Lib import scrape_article
 from tldw_chatbook.Web_Scraping import deep_search_citations
-from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call, chat_reply_text
 from tldw_chatbook.Internal_Prompts import render_internal_prompt
 from tldw_chatbook.Utils.egress import is_public_http_url
 
@@ -853,16 +853,18 @@ def analyze_question(question: str, api_endpoint) -> Dict:
                     "content": input_data + "\n\n" + sub_question_generation_prompt,
                 }
             ]
-            response = chat_api_call(
-                api_endpoint=api_endpoint,
-                messages_payload=messages_payload,
-                api_key=None,
-                temp=0.7,
-                system_message=None,
-                streaming=False,
-                minp=None,
-                maxp=None,
-                model=None,
+            response = chat_reply_text(
+                chat_api_call(
+                    api_endpoint=api_endpoint,
+                    messages_payload=messages_payload,
+                    api_key=None,
+                    temp=0.7,
+                    system_message=None,
+                    streaming=False,
+                    minp=None,
+                    maxp=None,
+                    model=None,
+                )
             )
             if response:
                 try:
@@ -1134,7 +1136,9 @@ async def search_result_relevance(
                     )
                 )
 
-            relevancy_result = await asyncio.wait_for(_eval_call(), timeout=llm_timeout_s)
+            relevancy_result = chat_reply_text(
+                await asyncio.wait_for(_eval_call(), timeout=llm_timeout_s)
+            )
 
             # FIXME
             logger.debug(
@@ -1789,18 +1793,20 @@ def aggregate_results(
                 "content": input_data + "\n\n" + analyze_search_results_prompt_2,
             }
         ]
-        returned_response = chat_api_call(
-            api_endpoint=api_endpoint,
-            messages_payload=messages_payload,
-            api_key=None,
-            temp=0.7,
-            system_message=None,
-            streaming=False,
-            minp=None,
-            maxp=None,
-            model=None,
-            topk=None,
-            topp=None,
+        returned_response = chat_reply_text(
+            chat_api_call(
+                api_endpoint=api_endpoint,
+                messages_payload=messages_payload,
+                api_key=None,
+                temp=0.7,
+                system_message=None,
+                streaming=False,
+                minp=None,
+                maxp=None,
+                model=None,
+                topk=None,
+                topp=None,
+            )
         )
         logger.debug(f"Returned response from LLM: {returned_response}")
         if returned_response:


### PR DESCRIPTION
## Summary

Stack 3/3 (top) of the deep-research pipeline epic. Bases: #1707 (core) ← #1708 (budgets-evals). Review/merge in that order.

### Live baseline & the fixes it forced (tasks 16330 + corrections)
- `Helper_Scripts/Benchmarks/record_research_baseline.py`: runs bounded questions through the real engine, preflights credentials, supports the keyless academic lane and local llamacpp endpoints (in-process `api_url`/`api_timeout`/`max_tokens` priming — no config writes), exits non-zero when nothing scored.
- Recorded live baseline (academic lane + local Qwen3.8-27B): citation_accuracy 1.00, claim_support 1.00; doc'd before/after tables.
- **`chat_api_call` fix trail**: local/cloud handlers return OpenAI-shaped dicts; an initial normalization-to-strings here broke the Console gateway's dict consumers — corrected to pass dicts through unchanged with a shared `chat_reply_text()` extractor at the string consumers (pipeline + engine). Usage recording reads dicts in place.

### Relevance-gate hardening (task 16333)
- Usefulness-based prompt, 0.1 classification temperature, zero-relevant fallback to top-3 flagged `gate_unverified` evidence (never promotes unevaluated results; cancelled runs keep the honest cutoff). Flag reaches evidence, gate block, footer, verification summary; `gate_pass_rate` self-eval metric.
- Measured: whole runs lost to the gate → 3/3 questions scored, 49/49 markers, gate_pass 0.93, quote_grounding 0.67.

### Window UX (tasks 16328/16334)
- Academic toggle (persisted, config-defaulted `[SearchSettings] research_academic_lane`).
- Limits input parsed into `limits_json`; follow-up Q&A row rendering answers or explicit insufficient-evidence verdicts; guards for selection/source/service.

### Cloud token usage (task 16335)
- Anthropic's `input_tokens`/`output_tokens` mapped alongside OpenAI names (OpenAI wins on conflict); exact counts replace estimates wherever providers report usage.

## Test evidence
Head green across all stream suites + the previously-broken Console/native-tools tests (healed by the passthrough correction; the remaining failures in that area are pre-existing dev red, verified against the pre-change tree). Ruff clean on touched files.