### PR TITLE
fix: replace nonexistent app.run_in_thread in multi_item_review_events (TASK-16194)

### DIFF
--- a/Tests/Event_Handlers/test_multi_item_review_events.py
+++ b/Tests/Event_Handlers/test_multi_item_review_events.py
@@ -1,0 +1,156 @@
+"""Multi-Item Review batch-analysis handlers: off-loop DB/LLM calls.
+
+task-16194 coverage. Mirrors ``Tests/Event_Handlers/test_collections_tag_events.py``
+(task-15471), which found and fixed the identical bug in
+``collections_tag_events.py``. Every threaded call in
+``multi_item_review_events.py`` used ``app.run_in_thread`` -- a method
+neither Textual 8.x's ``App`` nor ``TldwCli`` defines -- so all three paths
+below died before doing any real work:
+
+1. ``generate_single_analysis`` -- the LLM call (line 172 pre-fix) raised
+   ``AttributeError`` inside its own inner ``except``, surfacing as an
+   "Error generating analysis: ..." string instead of the real analysis.
+2. ``save_analysis_to_db`` -- the ``execute_query`` call (line 256 pre-fix)
+   raised the same ``AttributeError``, caught by the function's own
+   ``except`` and returned as ``False``. Even patched to a working
+   off-loop call, the *second* dead call right after it (``app.media_db
+   .commit``, line 262 pre-fix -- ``MediaDatabase`` has no ``commit``
+   method) would still have kept the UPDATE uncommitted; the fix folds
+   both into a single ``execute_query(..., commit=True)`` call.
+3. ``load_existing_analyses`` -- the ``execute_query`` call (line 296
+   pre-fix) raised the same ``AttributeError``, caught by the function's
+   own ``except`` and returned as ``{}``.
+
+The success-path assertions below fail against the pre-task-16194 code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.multi_item_review_events import (
+    generate_single_analysis,
+    load_existing_analyses,
+    save_analysis_to_db,
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeMediaDB:
+    # False on purpose: exercises the real asyncio.to_thread path.
+    is_memory_db = False
+
+    def __init__(self):
+        self.executed: list[tuple[str, object, bool]] = []
+        self.rows: dict[int, str] = {}
+
+    def execute_query(self, query, params=None, *, commit=False):
+        self.executed.append((query, params, commit))
+        if "UPDATE Media" in query:
+            analysis, _last_modified, media_id = params
+            self.rows[media_id] = analysis
+            return _FakeCursor([])
+        if "SELECT id, analysis_content" in query:
+            rows = [
+                {"id": media_id, "analysis_content": self.rows.get(media_id)}
+                for media_id in params
+            ]
+            return _FakeCursor(rows)
+        raise AssertionError(f"unexpected query: {query}")
+
+
+class _FakeLLMClient:
+    def __init__(self, response: str):
+        self._response = response
+        self.calls: list[dict] = []
+
+    def chat_with_model(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._response
+
+
+class _FakeApp:
+    """Duck-typed TldwCli stand-in: media_db + llm_api_client + notify.
+
+    Deliberately has no ``run_in_thread`` -- the real app never had one
+    either, which is exactly what this file pins.
+    """
+
+    def __init__(self, media_db, llm_api_client=None):
+        self.media_db = media_db
+        self.llm_api_client = llm_api_client
+        self.llm_model_var = "test-model"
+        self.llm_temperature_var = 0.7
+        self.llm_context_size_var = 4096
+        self.notifications: list[tuple[str, str]] = []
+        self.posted: list[object] = []
+
+    def notify(self, message, severity="information"):
+        self.notifications.append((str(message), severity))
+
+    def post_message(self, message):
+        self.posted.append(message)
+
+
+@pytest.mark.asyncio
+async def test_generate_single_analysis_calls_llm_without_run_in_thread():
+    llm = _FakeLLMClient("The generated analysis body.")
+    app = _FakeApp(media_db=_FakeMediaDB(), llm_api_client=llm)
+    item = {"id": 1, "title": "Doc", "content": "Some content to analyze"}
+
+    result = await generate_single_analysis(app, item, "Summarize this")
+
+    assert result is not None
+    assert "The generated analysis body." in result
+    assert llm.calls, "the LLM client must actually be invoked"
+    assert llm.calls[0]["model"] == "test-model"
+    assert llm.calls[0]["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_save_analysis_to_db_persists_in_one_committed_call():
+    db = _FakeMediaDB()
+    app = _FakeApp(media_db=db)
+
+    ok = await save_analysis_to_db(app, 42, "analysis text")
+
+    assert ok is True
+    # Exactly one execute_query call, committed inline -- no separate
+    # (nonexistent) `.commit()` follow-up call.
+    assert len(db.executed) == 1
+    query, params, commit = db.executed[0]
+    assert "UPDATE Media" in query
+    assert commit is True
+    assert params[0] == "analysis text"
+    assert params[2] == 42
+    assert db.rows[42] == "analysis text"
+
+
+@pytest.mark.asyncio
+async def test_load_existing_analyses_returns_rows_without_run_in_thread():
+    db = _FakeMediaDB()
+    db.rows[1] = "existing analysis"
+    app = _FakeApp(media_db=db)
+
+    result = await load_existing_analyses(app, [1, 2])
+
+    assert result == {1: "existing analysis", 2: None}
+
+
+@pytest.mark.asyncio
+async def test_save_analysis_to_db_off_loop_guard_still_works_for_memory_db():
+    db = _FakeMediaDB()
+    db.is_memory_db = True
+    app = _FakeApp(media_db=db)
+
+    ok = await save_analysis_to_db(app, 7, "in-memory analysis")
+
+    assert ok is True
+    assert db.rows[7] == "in-memory analysis"

--- a/backlog/tasks/task-16194 - multi_item_review_events-calls-nonexistent-app.run_in_thread-at-four-sites.md
+++ b/backlog/tasks/task-16194 - multi_item_review_events-calls-nonexistent-app.run_in_thread-at-four-sites.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16194
 title: 'multi_item_review_events calls nonexistent app.run_in_thread at four sites'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-14 03:05'
 labels:
@@ -17,7 +17,50 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All four sites execute their threaded work successfully (no AttributeError)
-- [ ] #2 Tests drive each repaired path, born-red against the current dev behavior
-- [ ] #3 A grep confirms no other run_in_thread call sites remain in the repo
+- [x] #1 All four sites execute their threaded work successfully (no AttributeError)
+- [x] #2 Tests drive each repaired path, born-red against the current dev behavior
+- [x] #3 A grep confirms no other run_in_thread call sites remain in the repo
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read TASK-15471's fix in `collections_tag_events.py` (commit `b643690a7`) and its test file `Tests/Event_Handlers/test_collections_tag_events.py` as the reference pattern: a local `_media_db_off_loop(app, func, *args)` helper using `asyncio.to_thread`, guarded by `getattr(app.media_db, "is_memory_db", False)` so a per-connection `:memory:` DB stays on the loop thread.
+2. Read all four call sites in `multi_item_review_events.py` and classify what each threaded callable touches:
+   - line 172 (`generate_single_analysis`): `app.llm_api_client.chat_with_model` — an LLM call, not `media_db`. No memory-db guard needed; plain `asyncio.to_thread`.
+   - lines 256 + 262 (`save_analysis_to_db`): `app.media_db.execute_query(...)` followed by a separate `app.media_db.commit` — the second call is *also* broken (`MediaDatabase` has no `commit` method), so even patching only `run_in_thread` would leave the UPDATE uncommitted. Fold into one `execute_query(..., commit=True)` call (the DB's own supported commit path, same kwarg `Prompts_DB.execute_query_with_retry` uses).
+   - line 296 (`load_existing_analyses`): `app.media_db.execute_query(...)` — plain DB read, needs the guard.
+3. Add a local `_media_db_off_loop` helper (mirroring the reference, extended with `**kwargs` since `execute_query`'s `commit` is keyword-only) and rewrite the three `media_db`-touching sites through it; rewrite the LLM site with a bare `asyncio.to_thread`.
+4. Write `Tests/Event_Handlers/test_multi_item_review_events.py` with duck-typed fakes (`_FakeMediaDB`, `_FakeLLMClient`, `_FakeApp` with no `run_in_thread`), one test per repaired path plus a memory-db-guard regression test.
+5. Prove born-red: temporarily revert the source file to its pre-fix content, run the new tests, confirm they fail on `AttributeError: '_FakeApp' object has no attribute 'run_in_thread'` (or the same error caught and surfaced as a string/False/`{}` by the function's own `except`), then restore the fix.
+6. Run the new tests green, run the full `Tests/Event_Handlers/` suite for regressions, grep the repo for any remaining `run_in_thread` call sites, and run ruff check/format on the touched files.
+
+## Implementation Notes
+
+Mechanical replication of TASK-15471's fix, applied to `Event_Handlers/multi_item_review_events.py`. Added a local `_media_db_off_loop(app, func, /, *args, **kwargs)` helper (same shape as `collections_tag_events._media_db_off_loop`, extended with `**kwargs` because `execute_query`'s `commit` param is keyword-only) and rewired all three `media_db`-touching call sites through it; the one non-DB site (the LLM call) got a bare `asyncio.to_thread` since it never touches `media_db` and the memory-db guard has nothing to check there.
+
+Investigating "what each threaded callable touches" (per the task's instruction) surfaced a second, independent bug at the `save_analysis_to_db` site: the pre-existing code called `app.media_db.execute_query(...)` (no `commit=True`) and then separately awaited `app.media_db.commit` — but `MediaDatabase` (`DB/Client_Media_DB_v2.py`) has no `commit` method at all. So that site was doubly broken: `run_in_thread` doesn't exist, and even a naive patch to `asyncio.to_thread` would have hit a *second* `AttributeError` on `.commit`, or — had that second call silently been a no-op — left the `UPDATE` uncommitted forever (`execute_query`'s own `commit` kwarg defaults to `False`, and this DB does not use `isolation_level=None`/autocommit). Fixed by folding the two calls into one `execute_query(..., commit=True)` — the DB's own supported commit path, the same kwarg `Prompts_DB.execute_query_with_retry` already uses elsewhere in the repo.
+
+**Per-site table:**
+
+| Site (pre-fix line) | What it touches | Fix |
+|---|---|---|
+| `generate_single_analysis`, L172 | `app.llm_api_client.chat_with_model` — LLM call, not DB | Bare `asyncio.to_thread(...)`, no memory-db guard (nothing DB-related to guard) |
+| `save_analysis_to_db`, L256 | `app.media_db.execute_query(query, params)` | `_media_db_off_loop(app, app.media_db.execute_query, query, params, commit=True)` |
+| `save_analysis_to_db`, L262 | `app.media_db.commit` — **method does not exist on `MediaDatabase`** | Removed; folded into the L256 call via `commit=True` |
+| `load_existing_analyses`, L296 | `app.media_db.execute_query(query, media_ids)` | `_media_db_off_loop(app, app.media_db.execute_query, query, media_ids)` |
+
+**Born-red evidence** (`Tests/Event_Handlers/test_multi_item_review_events.py`, run against the pre-fix file content restored via Edit/Write, then reverted the same way — no git checkout/reset used):
+- `test_generate_single_analysis_calls_llm_without_run_in_thread` — `AssertionError: assert 'The generated analysis body.' in "Error generating analysis: '_FakeApp' object has no attribute 'run_in_thread'"` (caught by the function's own `except`, surfaced as a string).
+- `test_save_analysis_to_db_persists_in_one_committed_call` — `assert False is True` (caught, surfaced as `False`); stderr: `Error saving analysis to DB: '_FakeApp' object has no attribute 'run_in_thread'`.
+- `test_load_existing_analyses_returns_rows_without_run_in_thread` — `assert {} == {1: 'existing analysis', 2: None}` (caught, surfaced as `{}`); stderr: `Error loading existing analyses: '_FakeApp' object has no attribute 'run_in_thread'`.
+- `test_save_analysis_to_db_off_loop_guard_still_works_for_memory_db` — same as the second case (this test additionally pins the `is_memory_db=True` synchronous-call branch of the new helper).
+
+All four went green after restoring the fix. Full `Tests/Event_Handlers/` suite: 58 passed, 1 skipped (pre-existing, unrelated skip), no regressions.
+
+**AC#3 grep** — `grep -rn "\.run_in_thread(" --include="*.py" .` returns zero matches (exit 1) repo-wide; `grep -rn "def run_in_thread"` also returns zero (confirms it never existed as a defined method). The only remaining textual occurrences of `run_in_thread` are in comments/docstrings/test names documenting the historical bug (this file, `collections_tag_events.py`, both test files).
+
+**Files modified:**
+- `tldw_chatbook/Event_Handlers/multi_item_review_events.py` — added `_media_db_off_loop`; fixed all four sites.
+- `Tests/Event_Handlers/test_multi_item_review_events.py` — new, 4 tests.
+
+**Lint:** `ruff check` and `ruff format --check` clean on both touched files.

--- a/tldw_chatbook/Event_Handlers/multi_item_review_events.py
+++ b/tldw_chatbook/Event_Handlers/multi_item_review_events.py
@@ -4,7 +4,7 @@ Event handlers for the Multi-Item Review functionality.
 Handles batch analysis generation and result management.
 """
 
-from typing import TYPE_CHECKING, List, Dict, Any, Optional
+from typing import TYPE_CHECKING, Callable, List, Dict, Any, Optional
 from textual.message import Message
 from loguru import logger
 from datetime import datetime
@@ -12,6 +12,25 @@ import asyncio
 
 if TYPE_CHECKING:
     from ..app import TldwCli
+
+
+async def _media_db_off_loop(
+    app: "TldwCli", func: Callable, /, *args: Any, **kwargs: Any
+) -> Any:
+    """Run one sync media-DB call off the event loop.
+
+    task-16194: every handler below called ``app.run_in_thread``, which does
+    not exist -- neither Textual 8.x's ``App`` nor ``TldwCli`` defines it --
+    so batch-analysis save/load died in ``AttributeError`` the moment either
+    path was reached. Mirrors ``collections_tag_events._media_db_off_loop``
+    (task-15471): ``asyncio.to_thread`` for the general case (the DB uses
+    thread-local connections, so a pool thread opens its own), guarded so a
+    per-connection ``:memory:`` DB -- only visible to the thread that
+    migrated it -- stays on the loop thread.
+    """
+    if bool(getattr(app.media_db, "is_memory_db", False)):
+        return func(*args, **kwargs)
+    return await asyncio.to_thread(func, *args, **kwargs)
 
 
 class BatchAnalysisStartEvent(Message):
@@ -168,8 +187,10 @@ Content:
                 temperature = app.llm_temperature_var
                 max_tokens = app.llm_context_size_var
 
-                # Generate response
-                response = await app.run_in_thread(
+                # Generate response. Not a media_db call, so no memory-db
+                # guard is needed here -- straight to a worker thread
+                # (task-16194; `app.run_in_thread` doesn't exist).
+                response = await asyncio.to_thread(
                     app.llm_api_client.chat_with_model,
                     messages=messages,
                     model=model,
@@ -248,18 +269,26 @@ async def save_analysis_to_db(app: "TldwCli", media_id: int, analysis: str) -> b
 
         # Update the analysis_content field
         query = """
-            UPDATE Media 
+            UPDATE Media
             SET analysis_content = ?, last_modified = ?
             WHERE id = ?
         """
 
-        await app.run_in_thread(
+        # task-16194: this used to be two broken calls -- `app.run_in_thread`
+        # doesn't exist, and even patched to a real off-loop call,
+        # `app.media_db.commit` doesn't exist either (MediaDatabase has no
+        # `commit` method), so the UPDATE would raise AttributeError before
+        # ever reaching sqlite, or -- had that second call been a no-op --
+        # never actually commit (execute_query's own `commit` kwarg
+        # defaults to False). Pass `commit=True` in one call instead, same
+        # as Prompts_DB.execute_query_with_retry's use of the kwarg.
+        await _media_db_off_loop(
+            app,
             app.media_db.execute_query,
             query,
             (analysis, datetime.now().isoformat(), media_id),
+            commit=True,
         )
-
-        await app.run_in_thread(app.media_db.commit)
 
         logger.debug(f"Saved analysis for media ID {media_id}")
         return True
@@ -288,12 +317,14 @@ async def load_existing_analyses(
 
         placeholders = ",".join("?" * len(media_ids))
         query = f"""
-            SELECT id, analysis_content 
-            FROM Media 
+            SELECT id, analysis_content
+            FROM Media
             WHERE id IN ({placeholders})
         """
 
-        cursor = await app.run_in_thread(app.media_db.execute_query, query, media_ids)
+        cursor = await _media_db_off_loop(
+            app, app.media_db.execute_query, query, media_ids
+        )
 
         results = {}
         for row in cursor.fetchall():


### PR DESCRIPTION
## Summary

Replicates TASK-15471's collections fix (PR #1625) for the identical bug: four sites in `Event_Handlers/multi_item_review_events.py` called `app.run_in_thread(...)` — a method that has never existed in Textual 8.x or this repo — so single-analysis generation, DB save, and analysis loading all died in AttributeError when reached.

- LLM call site → bare `asyncio.to_thread` (no DB involved)
- Both `media_db` sites → the `_media_db_off_loop` helper mirroring the collections reference (`is_memory_db` guard), extended with `**kwargs` for the keyword-only `commit` param
- Fifth corpse found in passing: `app.media_db.commit()` also never existed — folded into `execute_query(..., commit=True)`, which review verified is the DB's genuine durable commit path (and one-call write+commit avoids the cross-thread-connection commit hazard a naive port would have hit)
- 4 new tests, each born-red with the exact AttributeError signature (reproduced independently by the reviewer); `Tests/Event_Handlers/` 58 passed/1 pre-existing skip; repo-wide grep confirms zero `.run_in_thread(` call sites remain

Review: independent pass → MERGE, no blockers. One informational note carried forward: the tests prove call-shape against a fake DB (same standing pattern as the reference file); durability rests on the verified `execute_query` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces four calls to nonexistent app.run_in_thread in multi-item review handlers and fixes a second bug where a nonexistent app.media_db.commit was called. Previously, LLM generation, DB save, and analysis load raised AttributeError (or returned error defaults); now LLM and media DB work run off-loop correctly, and DB updates are committed in a single call.

- LLM generation uses asyncio.to_thread; no DB involvement.
- Adds `_media_db_off_loop(app, func, *args, **kwargs)` using asyncio.to_thread with an `is_memory_db` guard; used for DB read/write paths.
- Replaces update+commit with `execute_query(..., commit=True)` to ensure durability and avoid cross-thread commit issues.
- Adds four tests covering LLM call, DB save (committed), DB load, and the in-memory DB guard; tests were born-red against prior behavior.
- Satisfies TASK-16194 acceptance criteria; repo grep shows no remaining `.run_in_thread(` call sites.

<sup>Written for commit c5e46fa95cefd3b382af0694459bc55c0912ec74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

