### PR TITLE
Close TASK-15810 on live post-merge evidence; file task-16450

### DIFF
--- a/backlog/tasks/task-15810 - Library-RAG-Answers-first-query-on-a-fresh-profile-never-returns-CPU-bound-reproduced-twice.md
+++ b/backlog/tasks/task-15810 - Library-RAG-Answers-first-query-on-a-fresh-profile-never-returns-CPU-bound-reproduced-twice.md
@@ -3,7 +3,7 @@ id: TASK-15810
 title: >-
   Library RAG Answer's first query on a fresh profile never returns — CPU-bound,
   reproduced twice
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-13 20:28'
@@ -23,9 +23,9 @@ Live verification of TASK-15400 (2026-08-12) and again of TASK-15700 (2026-08-13
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The first RAG Answer run on a fresh profile renders Evidence rows in a bounded, stated time (or discloses progress honestly if a one-time warm-up is unavoidable)
-- [ ] #2 The spin is attributed to a named Python frame with a profile (py-spy/cProfile), not to 'the embedding stack' by assumption — the 2026-08-13 sample contradicts that attribution
-- [ ] #3 A live retrieval verification on a scratch profile can complete end-to-end through the UI, so a future arc's live check does not have to fall back to the engine
+- [x] #1 The first RAG Answer run on a fresh profile renders Evidence rows in a bounded, stated time (or discloses progress honestly if a one-time warm-up is unavoidable)
+- [x] #2 The spin is attributed to a named Python frame with a profile (py-spy/cProfile), not to 'the embedding stack' by assumption — the 2026-08-13 sample contradicts that attribution
+- [x] #3 A live retrieval verification on a scratch profile can complete end-to-end through the UI, so a future arc's live check does not have to fall back to the engine
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,3 +52,42 @@ profiling requires a new runtime, storage, or service-contract boundary, stop
 and revisit the ADR decision before implementation.
 
 Detailed plan: `Docs/superpowers/plans/2026-08-13-task-15810-library-rag-first-query.md`
+
+## Implementation Notes
+
+Diagnosed and fixed across two concurrent sessions; shipped as **PR #1640**
+(merged 2026-08-15, dev merge `f542f0c2a`).
+
+**Cause (profiled, not guessed — AC#2):** an input-mirror feedback loop
+between the rail search box and the canvas RAG box. The sibling-patch
+helper assigned the other widget's value; the assignment fired
+`Input.Changed`; the handler re-entered and mirrored back. cProfile over
+15.003s of the stall: 525 rail-handler / 1,556 canvas-handler / 1,043
+sibling-patch calls, 1,568 panel refreshes, 692,228 selector checks
+(`Docs/superpowers/qa/2026-08-13-task-15810.../profile-report.md`). The
+15400-era "embedding stack" attribution was refuted twice over: an
+independent reproduction showed the event loop was NEVER blocked (Ctrl-P
+rendered the command palette 11 minutes in at 100.1% CPU) and the same
+coroutine headless returns in 5.43s vs 14m25s under the TUI — retrieval
+was never the cost; the TUI was the multiplier, which is also why both
+prior arcs' engine-level A/B fallbacks always completed.
+
+**Fix:** `with sibling.prevent(Input.Changed):` around the mirror write
+(the TASK-15740/15673 pattern — the value-equality guard could not stop
+already-queued events), an app-lifetime `asyncio.Lock` admitting one
+Library retrieval at a time, and normalisation of a snapshotted transient
+`searching` status on screen restore.
+
+**AC#1 + AC#3 evidence (live, post-merge, 2026-08-15):** on merged dev, a
+fresh 36-note/282-chunk scratch profile driven end-to-end through the real
+RAG Answer UI: first Evidence row at **t=5.08s** ("Evidence · top 15",
+15 results), CPU peaking at 20% — vs 14m25s at 90-99% CPU with no row
+pre-fix. The reproduction artifacts are committed
+(`Docs/superpowers/qa/2026-08-14-rag-answer-first-query-hang/`) with the
+headless control `Tests/Library/test_rag_answer_first_query_latency.py`.
+
+**Residue:** Qodo finding 5 (the shielded-cancellation drain loop never
+uncancels; theoretical hot-spin under repeated cancel) deliberately not
+patched on the snapshot — filed as task-16450. Lesson filed in
+`lessons-backlog-hygiene.md`: a task's status is not a lock — check
+`.worktrees/` and branches for a live claim before starting an arc.

--- a/backlog/tasks/task-16450 - Shielded-cancellation-loop-in-_execute_library_rag_search-never-uncancels.md
+++ b/backlog/tasks/task-16450 - Shielded-cancellation-loop-in-_execute_library_rag_search-never-uncancels.md
@@ -1,0 +1,52 @@
+---
+id: task-16450
+title: Shielded-cancellation loop in _execute_library_rag_search never uncancels
+status: To Do
+assignee: []
+created_date: '2026-08-15'
+labels: [library, rag, async, reliability]
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+PR #1640 (TASK-15810) fixed the Library RAG first-query spin. Its worker
+drains an admitted retrieval under `asyncio.shield` and retains the first
+`CancelledError` to re-raise after the outcome settles
+(`UI/Screens/library_screen.py`, `_execute_library_rag_search`):
+
+```python
+while not retrieval_task.done():
+    try:
+        await asyncio.shield(retrieval_task)
+    except asyncio.CancelledError as error:
+        cancellation = cancellation or error
+```
+
+Qodo (PR #1640, finding 5) observed the loop never clears the accumulated
+cancellation request on the CURRENT task. A single `cancel()` is fine: one
+delivery, one catch, and the next `await` blocks normally. The risk is a
+caller that cancels REPEATEDLY until the task reports done — each new
+`await` then raises immediately and the loop hot-spins until the retrieval
+settles, delaying teardown at high CPU. Nobody has constructed that spin:
+Textual's `Worker.cancel()` and asyncio's shutdown each cancel once, which
+is why this was flagged on the PR rather than patched (cancellation
+semantics there are load-bearing: cancelled workers must still drain the
+admitted retrieval under the app-lifetime lock, then re-raise before stale
+outcomes can apply). There is an irony worth respecting: this is a CPU-spin
+fix carrying a potential CPU-spin under teardown.
+
+## Acceptance Criteria (the what)
+
+- [ ] A test demonstrates the repeated-cancel scenario against the drain
+      loop (or the investigation documents concretely why no caller in the
+      app can produce it — with the callers named, not assumed)
+- [ ] If reachable: the loop clears the pending cancellation between
+      catches (the 3.11+ idiom is `asyncio.current_task().uncancel()` after
+      each catch — NOT `retrieval_task.uncancel()`) while preserving the
+      retain-and-re-raise contract the worker's docstring states
+- [ ] Cancelled workers still drain the admitted retrieval before
+      re-raising, and no stale outcome is applied (the existing
+      Tests/UI/test_library_shell.py supersession tests stay green —
+      run the targeted selection, never the whole file)


### PR DESCRIPTION
Docs-only close-out for TASK-15810, whose fix merged as PR #1640.

## What closes it

- **AC#1 + AC#3, verified live on merged dev (2026-08-15):** a fresh 36-note/282-chunk scratch profile driven end-to-end through the real RAG Answer UI — first Evidence row at **t=5.08s** ("Evidence · top 15", 15 results), CPU peaking at **20%**, versus **14m25s at 90–99% CPU with no row** pre-fix. This is the live-through-the-UI verification two prior arcs could not complete; the engine A/B fallback is no longer the only option.
- **AC#2** was closed by the merged cProfile attribution (input-mirror feedback loop; 692,228 selector checks in 15.003s).

## Also in this PR

- **task-16450 filed** for Qodo's finding 5 on #1640: the shielded-cancellation drain loop never uncancels the current task, a theoretical hot-spin under repeated cancel. Deliberately not patched blind — the retain-and-re-raise semantics are load-bearing, nobody has constructed the spin (Textual and asyncio each cancel once), and changing cancellation behaviour without a failing reproduction is the kind of clever-over-stable trade the owner has ruled against. The task records the 3.11+ idiom (`current_task().uncancel()`) for whoever takes it.

One operational note from the live run: the committed driver's 4s settle after the Library click is now too short on dev (defer-past-first-paint work) — the run above navigated with longer settles. The reproduce script itself is unchanged here; worth a bump only if it misfires again.

Refs TASK-15810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-15810 with docs-only evidence of the already-merged fix and files `task-16450` to track a cancellation-loop follow-up. This confirms the first RAG Answer on a fresh profile now renders an Evidence row in ~5s at ~20% CPU through the UI; before, it stalled ~14m at 90–99% CPU with no row.

- Updates `task-15810` backlog: marks AC#1–#3 as met with live post-merge verification; adds concise implementation notes on the input-mirror feedback loop and the applied fixes (event-guard on `Input.Changed`, a single retrieval `asyncio.Lock`, and status normalization). No runtime changes in this PR.
- Adds `task-16450` backlog: documents a potential hot-spin if repeated cancels occur during the shielded drain loop, and records the intended fix direction (clearing pending cancellation on the current task while retaining re-raise semantics). No behavior change here.

<sup>Written for commit ea22fd611624cc10fc1906ca46b31ea3a2c74446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

