### PR TITLE
fix: Media hub local-mode reading highlights — all four CRUD paths dead on a leaf-name drift (TASK-15768)

### DIFF
--- a/Tests/Media/test_local_media_reading_service.py
+++ b/Tests/Media/test_local_media_reading_service.py
@@ -832,20 +832,18 @@ def test_scope_service_local_highlight_seam_persists_against_real_db(memory_db_f
     The Library viewer (``LibraryScreen._add_library_media_highlight`` /
     ``_fetch_library_media_highlights`` / ``_delete_library_media_highlight``)
     calls ``media_reading_scope_service.create_highlight``/``list_highlights``/
-    ``delete_highlight`` with ``mode="local"`` -- NOT the ``reading_``-prefixed
-    ``create_reading_highlight``/``list_reading_highlights``/
-    ``delete_reading_highlight`` methods, which ``MediaReadingScopeService``
-    only ever forwards to ``ServerMediaReadingService`` (see
-    ``Tests/Media/test_media_reading_scope_service.py``'s
-    ``test_scope_service_routes_reading_highlights_and_enforces_actions``,
-    which only exercises ``mode="server"``); calling those against a local
-    service raises ``AttributeError`` because ``LocalMediaReadingService``
-    only implements the non-prefixed names. This test drives the actual
-    working seam through ``MediaReadingScopeService`` against a real
-    ``LocalMediaReadingService`` backed by a real in-memory ``MediaDatabase``,
-    proving the UI's create/list/delete round-trip persists for real (a fake
-    scope service could hide a signature/field-name mismatch that this test
-    would catch).
+    ``delete_highlight`` with ``mode="local"`` -- the unprefixed scope
+    methods, distinct from the ``reading_``-prefixed scope methods the Media
+    hub uses (those historically dispatched leaf names only
+    ``ServerMediaReadingService`` had and AttributeError'd against a local
+    service; task-15768 fixed their dispatch to the unprefixed leaf contract,
+    covered by ``Tests/Media/test_media_reading_scope_service.py``'s
+    ``test_scope_service_reading_highlight_crud_reaches_real_local_service``).
+    This test drives the Library seam through ``MediaReadingScopeService``
+    against a real ``LocalMediaReadingService`` backed by a real in-memory
+    ``MediaDatabase``, proving the UI's create/list/delete round-trip
+    persists for real (a fake scope service could hide a signature/field-name
+    mismatch that this test would catch).
     """
     db = memory_db_factory()
     media_id, _, _ = db.add_media_with_keywords(

--- a/Tests/Media/test_media_reading_scope_service.py
+++ b/Tests/Media/test_media_reading_scope_service.py
@@ -403,56 +403,12 @@ class FakeLocalMediaService:
         self.calls.append(("delete_reading_progress", media_id))
         return True
 
-    def create_reading_highlight(self, item_id, **kwargs):
-        self.calls.append(("create_reading_highlight", item_id, kwargs))
-        return {
-            "id": 5,
-            "item_id": item_id,
-            "quote": kwargs["quote"],
-            "start_offset": kwargs.get("start_offset"),
-            "end_offset": kwargs.get("end_offset"),
-            "color": kwargs.get("color"),
-            "note": kwargs.get("note"),
-            "created_at": "2026-04-22T12:00:00Z",
-            "anchor_strategy": kwargs.get("anchor_strategy", "fuzzy_quote"),
-            "state": "active",
-        }
-
-    def list_reading_highlights(self, item_id):
-        self.calls.append(("list_reading_highlights", item_id))
-        return [
-            {
-                "id": 5,
-                "item_id": item_id,
-                "quote": "Important sentence",
-                "start_offset": 10,
-                "end_offset": 28,
-                "color": "yellow",
-                "note": "Check this",
-                "created_at": "2026-04-22T12:00:00Z",
-                "anchor_strategy": "fuzzy_quote",
-                "state": "active",
-            }
-        ]
-
-    def update_reading_highlight(self, highlight_id, **changes):
-        self.calls.append(("update_reading_highlight", highlight_id, changes))
-        return {
-            "id": highlight_id,
-            "item_id": 12,
-            "quote": "Important sentence",
-            "start_offset": 10,
-            "end_offset": 28,
-            "color": changes.get("color"),
-            "note": changes.get("note"),
-            "created_at": "2026-04-22T12:00:00Z",
-            "anchor_strategy": "fuzzy_quote",
-            "state": changes.get("state", "active"),
-        }
-
-    def delete_reading_highlight(self, highlight_id):
-        self.calls.append(("delete_reading_highlight", highlight_id))
-        return True
+    # task-15768: this fake deliberately implements ONLY the unprefixed
+    # highlight methods (create_highlight/list_highlights/update_highlight/
+    # delete_highlight, further down) -- the real LocalMediaReadingService has
+    # no reading_-prefixed highlight methods, and a fake that grows them hides
+    # exactly the AttributeError that broke every local-mode Media hub
+    # highlight operation.
 
     def create_reading_saved_search(self, **kwargs):
         self.calls.append(("create_reading_saved_search", kwargs))
@@ -3821,11 +3777,14 @@ async def test_scope_service_routes_reading_highlights_and_enforces_actions():
     ]
     assert created["id"] == "server:reading_highlight:5"
     assert created["item_id"] == "41"
-    assert listed[0]["quote"] == "Important sentence"
+    assert listed[0]["quote"] == "important"
     assert updated["color"] == "blue"
     assert deleted == {"success": True}
+    # task-15768: the scope service dispatches the unprefixed leaf contract
+    # (the server service's primary methods; its reading_-prefixed names are
+    # back-compat aliases the local service never had).
     assert (
-        "create_reading_highlight",
+        "create_highlight",
         41,
         {
             "quote": "Important sentence",
@@ -5437,6 +5396,82 @@ async def test_scope_service_routes_local_highlights_with_media_reading_actions(
         ("update_highlight", 5, {"color": None, "note": "recheck", "state": None}),
         ("delete_highlight", 5),
     ]
+
+
+@pytest.mark.asyncio
+async def test_scope_service_reading_highlight_crud_reaches_real_local_service():
+    """task-15768: the Media hub bridge must reach the REAL local leaf methods.
+
+    ``MediaWindow_v2`` drives highlights through the scope service's
+    ``*_reading_highlight*`` methods. Those must dispatch the leaf names the
+    real ``LocalMediaReadingService`` actually implements
+    (``create_highlight``/``list_highlights``/``update_highlight``/
+    ``delete_highlight``) -- the fakes in this file previously implemented the
+    ``reading_``-prefixed names the real local service never had, hiding an
+    ``AttributeError`` that every local-mode Media hub highlight operation hit
+    in production.
+    """
+    db = Database(db_path=":memory:", client_id="scope_hub_highlights")
+    try:
+        media_id, _, _ = db.add_media_with_keywords(
+            title="Hub Highlighted",
+            content="Important local content for the media hub.",
+            media_type="article",
+            keywords=[],
+        )
+        local_service = LocalMediaReadingService(db)
+        seeded = local_service.create_highlight(
+            media_id, quote="Important", start_offset=0, end_offset=9
+        )
+        scope_service = MediaReadingScopeService(
+            local_service=local_service,
+            server_service=None,
+        )
+        record = {
+            "id": f"local:media:{media_id}",
+            "backend": "local",
+            "source_id": str(media_id),
+            "backing_media_id": media_id,
+        }
+
+        listed = await scope_service.list_reading_highlights(
+            mode="local", record=record
+        )
+        assert [h["source_id"] for h in listed] == [str(seeded["id"])]
+        assert listed[0]["quote"] == "Important"
+        assert listed[0]["backend"] == "local"
+
+        created = await scope_service.create_reading_highlight(
+            mode="local",
+            record=record,
+            quote="local content",
+            color="yellow",
+            note="revisit",
+        )
+        assert created["quote"] == "local content"
+        assert created["color"] == "yellow"
+        assert len(local_service.list_highlights(media_id)) == 2
+
+        updated = await scope_service.update_reading_highlight(
+            mode="local",
+            highlight_id=created["source_id"],
+            color="blue",
+            note="done",
+            state="stale",
+        )
+        assert updated["color"] == "blue"
+        assert updated["note"] == "done"
+        assert updated["state"] == "stale"
+
+        await scope_service.delete_reading_highlight(
+            mode="local", highlight_id=created["source_id"]
+        )
+        remaining = await scope_service.list_reading_highlights(
+            mode="local", record=record
+        )
+        assert [h["source_id"] for h in remaining] == [str(seeded["id"])]
+    finally:
+        db.close_connection()
 
 
 @pytest.mark.asyncio

--- a/Tests/Media/test_media_reading_scope_service_off_loop.py
+++ b/Tests/Media/test_media_reading_scope_service_off_loop.py
@@ -69,8 +69,8 @@ class _RecordingLocalService:
         self._record("get_reading_progress", media_id)
         return {"media_id": media_id, "current_page": 1, "total_pages": 5}
 
-    def list_reading_highlights(self, item_id):
-        self._record("list_reading_highlights", item_id)
+    def list_highlights(self, item_id):
+        self._record("list_highlights", item_id)
         return []
 
     def list_document_versions(self, media_id, include_deleted=False):
@@ -85,16 +85,18 @@ class _RecordingLocalService:
         self._record("undelete_media", media_id)
         return True
 
-    def create_reading_highlight(self, item_id, **kwargs):
-        self._record("create_reading_highlight", item_id)
+    # task-15768: the scope service dispatches the unprefixed highlight leaf
+    # names -- the only ones the real LocalMediaReadingService implements.
+    def create_highlight(self, item_id, **kwargs):
+        self._record("create_highlight", item_id)
         return {"id": 5, "item_id": item_id, "quote": kwargs.get("quote", "")}
 
-    def update_reading_highlight(self, highlight_id, **changes):
-        self._record("update_reading_highlight", highlight_id)
+    def update_highlight(self, highlight_id, **changes):
+        self._record("update_highlight", highlight_id)
         return {"id": highlight_id, "item_id": 1, "quote": "q"}
 
-    def delete_reading_highlight(self, highlight_id):
-        self._record("delete_reading_highlight", highlight_id)
+    def delete_highlight(self, highlight_id):
+        self._record("delete_highlight", highlight_id)
         return True
 
     def save_analysis_version(
@@ -181,7 +183,7 @@ LOCAL_LEAF_CASES: list[tuple[str, Any, list[str]]] = [
     (
         "list_reading_highlights",
         lambda s: s.list_reading_highlights(mode="local", media_id=1),
-        ["list_reading_highlights"],
+        ["list_highlights"],
     ),
     (
         "list_document_versions",
@@ -201,19 +203,17 @@ LOCAL_LEAF_CASES: list[tuple[str, Any, list[str]]] = [
     (
         "create_reading_highlight",
         lambda s: s.create_reading_highlight(mode="local", media_id=1, quote="hi"),
-        ["create_reading_highlight"],
+        ["create_highlight"],
     ),
     (
         "update_reading_highlight",
-        lambda s: s.update_reading_highlight(
-            mode="local", highlight_id=5, quote="hi"
-        ),
-        ["update_reading_highlight"],
+        lambda s: s.update_reading_highlight(mode="local", highlight_id=5, note="hi"),
+        ["update_highlight"],
     ),
     (
         "delete_reading_highlight",
         lambda s: s.delete_reading_highlight(mode="local", highlight_id=5),
-        ["delete_reading_highlight"],
+        ["delete_highlight"],
     ),
     (
         "save_analysis_version",
@@ -402,26 +402,23 @@ async def test_item_click_detail_chain_runs_no_sqlite_on_the_event_loop(
     real_local_scope,
 ):
     """AC#1: the item-click chain -- detail (which internally also fetches
-    reading progress) and document versions -- the sequential queries the
-    audit named at `MediaWindow_v2.py:1188-1191`.
+    reading progress), reading highlights, and document versions -- the
+    sequential queries the audit named at `MediaWindow_v2.py:1188-1191`.
 
-    ``list_reading_highlights`` is deliberately NOT exercised here against
-    the real ``LocalMediaReadingService``: the scope service's local branch
-    calls ``service.list_reading_highlights(...)``, but
-    ``LocalMediaReadingService`` only implements ``list_highlights`` (no
-    ``reading_`` prefix) -- a pre-existing production gap (every local-mode
-    item click already hits `AttributeError` there today, caught by
-    `MediaWindow_v2._load_media_item_detail`'s broad `except Exception` and
-    presented as zero highlights) that predates and is unrelated to this
-    task's event-loop fix; see `test_local_leaf_threads_off_the_calling_
-    thread_when_file_backed[list_reading_highlights]` above for proof that
-    threading is correctly applied to that leaf whenever it exists.
+    ``list_reading_highlights`` is exercised against the real
+    ``LocalMediaReadingService`` since task-15768 fixed the scope service's
+    highlight dispatch to the unprefixed leaf names the local service
+    actually implements (it previously AttributeError'd here, which is why
+    an older revision of this test had to leave it out).
     """
     scope, db, media_id = real_local_scope
     loop_statements: list[str] = []
     db.get_connection().set_trace_callback(loop_statements.append)
     try:
         detail = await scope.get_media_detail(mode="local", media_id=media_id)
+        highlights = await scope.list_reading_highlights(
+            mode="local", media_id=media_id
+        )
         versions = await scope.list_document_versions(
             mode="local", media_id=media_id
         )
@@ -437,6 +434,7 @@ async def test_item_click_detail_chain_runs_no_sqlite_on_the_event_loop(
     # document version `add_media_with_keywords` creates automatically.
     assert detail["title"] == "Offloop Fixture"
     assert "reading_progress" in detail
+    assert highlights == []
     assert len(versions) == 1
     assert versions[0]["media_id"] == media_id
 

--- a/Tests/UI/test_media_window_v2_parity.py
+++ b/Tests/UI/test_media_window_v2_parity.py
@@ -8,6 +8,7 @@ from textual import on
 from textual.app import App, ComposeResult
 from textual.widgets import Button, Collapsible, Select, Static
 
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Event_Handlers.media_events import (
     MediaAnalysisRequestEvent,
     MediaAnalysisSaveEvent,
@@ -16,6 +17,8 @@ from tldw_chatbook.Event_Handlers.media_events import (
     MediaReadingHighlightUpdateEvent,
     MediaReadItLaterToggleEvent,
 )
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
 from tldw_chatbook.UI.MediaWindow_v2 import MEDIA_EMPTY_STATE_COPY, MediaWindow
 from tldw_chatbook.Widgets.Media.media_list_panel import (
     MediaItemSelectedEvent,
@@ -516,10 +519,11 @@ async def test_media_window_routes_reading_highlight_crud_through_scope_service(
         note="Created note",
         anchor_strategy="fuzzy_quote",
     )
+    # task-15768: `quote` is not forwarded -- it is not an updatable field on
+    # either backend's highlight-update contract.
     scope_service.update_reading_highlight.assert_awaited_once_with(
         mode="server",
         highlight_id="6",
-        quote="Created quote",
         color="blue",
         note="Updated note",
         state="active",
@@ -529,6 +533,156 @@ async def test_media_window_routes_reading_highlight_crud_through_scope_service(
         highlight_id="6",
     )
     assert window.viewer_panel.load_media.call_args.args[0]["reading_highlights"] == []
+
+
+@pytest.mark.asyncio
+async def test_media_window_local_highlight_crud_end_to_end_against_real_service():
+    """task-15768: local-mode Media hub highlight CRUD against the real seam.
+
+    Every scope call runs through a REAL ``MediaReadingScopeService`` wired to
+    a REAL ``LocalMediaReadingService`` on a real ``MediaDatabase`` -- a mocked
+    scope service is exactly what hid the ``reading_``-prefixed leaf-name
+    mismatch that made all four local-mode CRUD paths ``AttributeError`` in
+    production (list swallowed to an empty panel; create/update/delete
+    surfaced as error toasts).
+    """
+    db = MediaDatabase(":memory:", client_id="media_window_local_highlights")
+    try:
+        media_id, _, _ = db.add_media_with_keywords(
+            title="Hub Local Article",
+            content="Important local content for the media hub.",
+            media_type="article",
+            keywords=[],
+        )
+        local_service = LocalMediaReadingService(db)
+        seeded = local_service.create_highlight(
+            media_id, quote="Important", start_offset=0, end_offset=9
+        )
+        scope_service = MediaReadingScopeService(
+            local_service=local_service, server_service=None
+        )
+        window, app = _build_media_window(
+            runtime_backend="local", scope_service=scope_service
+        )
+        record = {
+            "id": f"local:media:{media_id}",
+            "backend": "local",
+            "source_id": str(media_id),
+            "backing_media_id": media_id,
+            "title": "Hub Local Article",
+        }
+        window.runtime_state.detail_by_record_id[record["id"]] = record
+
+        # Item detail's highlight load shows the pre-existing highlight.
+        highlights = await window.load_reading_highlights(record)
+        assert [h["source_id"] for h in highlights] == [str(seeded["id"])]
+        assert highlights[0]["quote"] == "Important"
+
+        # Create.
+        await window._handle_reading_highlight_create_async(
+            MediaReadingHighlightCreateEvent(
+                media_id=str(media_id),
+                record_id=record["id"],
+                quote="local content",
+                color="yellow",
+                note="revisit",
+                media_data=record,
+            )
+        )
+        stored = local_service.list_highlights(media_id)
+        assert len(stored) == 2
+        created_id = next(h["id"] for h in stored if h["quote"] == "local content")
+        presented = window.viewer_panel.load_media.call_args.args[0]
+        assert {h["quote"] for h in presented["reading_highlights"]} == {
+            "Important",
+            "local content",
+        }
+
+        # Update.
+        await window._handle_reading_highlight_update_async(
+            MediaReadingHighlightUpdateEvent(
+                media_id=str(media_id),
+                record_id=record["id"],
+                highlight_id=created_id,
+                color="blue",
+                note="done",
+                state="stale",
+                media_data=record,
+            )
+        )
+        updated_row = next(
+            h for h in local_service.list_highlights(media_id) if h["id"] == created_id
+        )
+        assert updated_row["color"] == "blue"
+        assert updated_row["note"] == "done"
+        assert updated_row["state"] == "stale"
+
+        # Delete.
+        await window._handle_reading_highlight_delete_async(
+            MediaReadingHighlightDeleteEvent(
+                media_id=str(media_id),
+                record_id=record["id"],
+                highlight_id=created_id,
+                media_data=record,
+            )
+        )
+        assert [h["id"] for h in local_service.list_highlights(media_id)] == [
+            seeded["id"]
+        ]
+        presented = window.viewer_panel.load_media.call_args.args[0]
+        assert [h["source_id"] for h in presented["reading_highlights"]] == [
+            str(seeded["id"])
+        ]
+
+        app.notify.assert_any_call("Reading highlight created", severity="information")
+        app.notify.assert_any_call("Reading highlight updated", severity="information")
+        app.notify.assert_any_call("Reading highlight deleted", severity="information")
+        error_calls = [
+            call
+            for call in app.notify.call_args_list
+            if call.kwargs.get("severity") == "error"
+        ]
+        assert error_calls == []
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_media_window_logs_highlight_contract_drift_with_traceback():
+    """task-15768 AC4: a naming/contract drift must be loudly visible.
+
+    An ``AttributeError`` from the highlights seam previously produced only a
+    message-text log line (no exception type, no traceback) and an empty
+    panel. The drift branch must log the traceback so the next contract drift
+    cannot masquerade as 'this item has no highlights'.
+    """
+    from loguru import logger as loguru_logger
+
+    scope_service = Mock()
+    scope_service.list_reading_highlights = Mock(
+        side_effect=AttributeError(
+            "'LocalMediaReadingService' object has no attribute "
+            "'list_reading_highlights'"
+        )
+    )
+    window, _app = _build_media_window(
+        runtime_backend="local", scope_service=scope_service
+    )
+    captured: list[str] = []
+    sink_id = loguru_logger.add(
+        lambda message: captured.append(str(message)), level="ERROR"
+    )
+    try:
+        result = await window.load_reading_highlights(
+            {"id": "local:media:1", "backend": "local", "backing_media_id": 1}
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+
+    assert result == []
+    joined = "".join(captured)
+    assert "contract" in joined.lower()
+    assert "AttributeError" in joined
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-15768 - Media-hub-local-mode-reading-highlights-all-four-CRUD-methods-AttributeError.md
+++ b/backlog/tasks/task-15768 - Media-hub-local-mode-reading-highlights-all-four-CRUD-methods-AttributeError.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15768
 title: 'Media hub local mode: reading-highlights CRUD all AttributeError against the real service'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-13 12:31'
 labels:
@@ -33,15 +33,151 @@ names.
 
 ## Acceptance Criteria
 
-- [ ] `MediaReadingScopeService`'s local-mode calls for list/create/update/delete
+- [x] `MediaReadingScopeService`'s local-mode calls for list/create/update/delete
       reading highlights reach `LocalMediaReadingService`'s real methods (no
       `AttributeError`), by renaming one side to match the other
-- [ ] A local-mode media item with existing highlights shows them in the
+- [x] A local-mode media item with existing highlights shows them in the
       Media hub item detail (regression test against a real
       `LocalMediaReadingService`, not a mock that hides the name mismatch)
-- [ ] Creating, updating, and deleting a highlight from the Media hub in
+- [x] Creating, updating, and deleting a highlight from the Media hub in
       local mode works end-to-end (tests)
-- [ ] The broad `except Exception` around the detail load in
+- [x] The broad `except Exception` around the detail load in
       `_load_media_item_detail` is narrowed or logged so a future
       naming/contract drift is visible instead of silently presenting empty
       state
+
+## Implementation Plan
+
+1. Re-locate the mismatch at HEAD (`bb91fef73`): confirm
+   `MediaReadingScopeService.{create,list,update,delete}_reading_highlight(s)`
+   dispatch the *prefixed* leaf names via `_call_local_leaf`, while
+   `LocalMediaReadingService` only implements the unprefixed
+   `create_highlight`/`list_highlights`/`update_highlight`/`delete_highlight`.
+2. Establish drift direction from git history (`git log -S`): the prefixed
+   scope methods were born in the server-parity work calling
+   `service.create_reading_highlight(...)` — written against
+   `ServerMediaReadingService`'s back-compat aliases; both leaves' primary
+   contract is the unprefixed names (server implements unprefixed as primary,
+   prefixed only as thin aliases; local implements only unprefixed). So the
+   scope-service dispatch is the drifted side: fix the four leaf-dispatch
+   name strings there. No public API changes — the Media hub keeps calling
+   the scope's `*_reading_highlight*` methods.
+3. Born-red tests first (fail with the current `AttributeError` signature):
+   - Scope-level: drive all four prefixed scope methods in local mode against
+     a REAL `LocalMediaReadingService` + real `MediaDatabase` (no fake).
+   - Media-hub level (`Tests/UI/test_media_window_v2_parity.py` harness):
+     item-detail highlight load shows seeded highlights, and
+     create/update/delete handlers round-trip end-to-end against the real
+     local service.
+4. AC3 completeness: the Media hub's update handler forwards
+   `quote=event.quote` but `quote` is not an updatable field on EITHER leaf
+   (server `ReadingHighlightUpdateRequest` = color/note/state; local
+   `update_highlight` = color/note/state) — any non-None quote TypeErrors.
+   Stop forwarding it.
+5. AC4: in `MediaWindow_v2`, log contract drift (`AttributeError`/`TypeError`)
+   from the item-detail highlight load and the detail load with a full
+   traceback at error level instead of the current message-only/category-only
+   swallow.
+6. Align the fakes/tests that encoded the wrong contract:
+   `FakeLocalMediaService`'s prefixed highlight methods (the mismatch-hiding
+   mock) removed; server-mode routing test assertions moved to the unprefixed
+   leaf calls; off-loop (task-15467) probe doubles renamed to the real leaf
+   names; stale "always AttributeErrors" docstrings updated.
+7. ruff check + format on touched files; targeted pytest for the touched test
+   modules; baseline any unrelated reds against origin/dev.
+
+## Implementation Notes
+
+Confirmed at HEAD `bb91fef73` and fixed on the scope-service side — the side
+git history shows drifted.
+
+**The mismatch.** `MediaReadingScopeService.{create,list,update,delete}_
+reading_highlight(s)` dispatched the *prefixed* leaf names
+(`_call_local_leaf(..., "create_reading_highlight", ...)` etc.), but
+`LocalMediaReadingService` implements only the unprefixed
+`create_highlight`/`list_highlights`/`update_highlight`/`delete_highlight`
+(`tldw_chatbook/Media/local_media_reading_service.py:1875-1983`).
+`ServerMediaReadingService`'s primary methods are ALSO the unprefixed names —
+the prefixed ones there are thin back-compat aliases
+(`server_media_reading_service.py:1603-1613`), which is why server mode
+worked and local mode `AttributeError`'d. History
+(`git show 7a6129009:...media_reading_scope_service.py` /
+`git show 435c9dac7 --`): the prefixed scope methods were born in the
+server-parity work calling `service.create_reading_highlight(...)` — written
+against the server aliases, never matching the local leaf; task-15467 later
+converted the same names to `_call_local_leaf` and documented the pre-existing
+AttributeError. So the scope dispatch was the drift; both leaves' documented
+contract is unprefixed.
+
+**Fix (production).**
+- `tldw_chatbook/Media/media_reading_scope_service.py`: the four
+  `_call_local_leaf` dispatch names changed to the unprefixed leaf contract
+  (`create_highlight`/`list_highlights`/`update_highlight`/
+  `delete_highlight`). Scope-service public API (what `MediaWindow_v2`
+  calls) unchanged.
+- `tldw_chatbook/UI/MediaWindow_v2.py`:
+  - `load_reading_highlights`: new `(AttributeError, TypeError)` branch logs
+    the full traceback at error level (contract drift can no longer
+    masquerade as "no highlights"); generic runtime failures keep the prior
+    degrade-to-empty behavior (AC4).
+  - `_load_media_item_detail`'s broad except now logs
+    `AttributeError`/`TypeError` with `logger.opt(exception=True).error`
+    instead of only the exception category (AC4).
+  - `_handle_reading_highlight_update_async` no longer forwards
+    `quote=event.quote`: `quote` is not an updatable field on EITHER backend
+    (server `ReadingHighlightUpdateRequest` = color/note/state;
+    local `update_highlight` = color/note/state), so any quote-carrying
+    update TypeError'd against both real services — required for AC3 to hold
+    in general.
+
+**Born-red evidence** (all three watched failing with the current defect's
+signature before the fix, command:
+`PYTHONPATH=<worktree> .venv/bin/python -m pytest <nodeids>`):
+- `Tests/Media/test_media_reading_scope_service.py::
+  test_scope_service_reading_highlight_crud_reaches_real_local_service` —
+  failed `AttributeError: 'LocalMediaReadingService' object has no attribute
+  'list_reading_highlights'` at `media_reading_scope_service.py:170`.
+- `Tests/UI/test_media_window_v2_parity.py::
+  test_media_window_local_highlight_crud_end_to_end_against_real_service` —
+  failed `assert [] == ['1']` (the silent empty-highlights symptom).
+- `Tests/UI/test_media_window_v2_parity.py::
+  test_media_window_logs_highlight_contract_drift_with_traceback` — failed:
+  captured log was the message-only swallow, no traceback/"contract" marker.
+All three pass after the fix (`3 passed`).
+
+**Test-suite alignment** (the fakes that hid the mismatch):
+- `Tests/Media/test_media_reading_scope_service.py`:
+  `FakeLocalMediaService`'s four prefixed highlight methods REMOVED (real
+  local service never had them); server-mode routing test now asserts the
+  unprefixed leaf call (`create_highlight`, ...) and the unprefixed fake
+  payload shapes.
+- `Tests/Media/test_media_reading_scope_service_off_loop.py` (task-15467
+  probes): recording-double leaves renamed to the real contract; the real-DB
+  item-click chain test now EXERCISES `list_reading_highlights` against the
+  real `LocalMediaReadingService` (its previous exclusion note documented
+  exactly this defect and is superseded).
+- `Tests/Media/test_local_media_reading_service.py`: stale
+  "prefixed methods always AttributeError" docstring updated.
+- `Tests/UI/test_media_window_v2_parity.py`: server-mode mocked CRUD test no
+  longer asserts a forwarded `quote` on update.
+
+**Verification** (`PYTHONPATH=<worktree> .venv/bin/python -m pytest ...`):
+the four touched modules `Tests/Media/test_media_reading_scope_service.py
+test_media_reading_scope_service_off_loop.py
+test_local_media_reading_service.py Tests/UI/test_media_window_v2_parity.py`
+→ **216 passed**. Blast radius (13 modules referencing the touched services,
+incl. `Tests/ProductionApp/test_media_state_ownership.py`,
+`test_service_composition_lifecycle.py`, Library/MCP/RuntimePolicy suites) →
+372 passed; the 14 failures + ~22 teardown errors were **reproduced
+identically on a throwaway baseline worktree at base `bb91fef73`**
+(`14 failed, 155 passed, 24 errors` — same FAILED set, same `_no_network_io`
+teardown-error family), i.e. pre-existing dev reds, not this change.
+`ruff check` clean on all touched files; `ruff format --check` clean on all
+touched files except two test files whose drift **pre-exists at base**
+(verified via `git show bb91fef73:<file> | ruff format --check -`); only the
+one drift hunk this task introduced was hand-formatted.
+
+**Not fixed here (adjacent, pre-existing):** the
+`MediaReadingHighlightUpdateEvent.quote` field remains accepted-but-ignored
+by the update path on both backends; no production widget posts these events
+yet (grep: only tests construct them).

--- a/tldw_chatbook/Media/media_reading_scope_service.py
+++ b/tldw_chatbook/Media/media_reading_scope_service.py
@@ -2719,10 +2719,14 @@ class MediaReadingScopeService:
             }.items()
             if value is not None
         }
+        # task-15768: dispatch the leaf contract both backends actually
+        # implement -- LocalMediaReadingService only has the unprefixed
+        # names; ServerMediaReadingService's primary methods are unprefixed
+        # too (the reading_-prefixed ones are back-compat aliases).
         highlight = await self._call_local_leaf(
             normalized_mode,
             service,
-            "create_reading_highlight",
+            "create_highlight",
             resolved_item_id,
             **payload,
         )
@@ -2746,7 +2750,7 @@ class MediaReadingScopeService:
             media_id=media_id,
         )
         highlights = await self._call_local_leaf(
-            normalized_mode, service, "list_reading_highlights", resolved_item_id
+            normalized_mode, service, "list_highlights", resolved_item_id
         )
         return [
             normalize_reading_highlight(highlight, backend=normalized_mode.value)
@@ -2768,7 +2772,7 @@ class MediaReadingScopeService:
         highlight = await self._call_local_leaf(
             normalized_mode,
             service,
-            "update_reading_highlight",
+            "update_highlight",
             highlight_id,
             **{key: value for key, value in changes.items() if value is not None},
         )
@@ -2786,7 +2790,7 @@ class MediaReadingScopeService:
         )
         service = self._service_for_mode(normalized_mode)
         return await self._call_local_leaf(
-            normalized_mode, service, "delete_reading_highlight", highlight_id
+            normalized_mode, service, "delete_highlight", highlight_id
         )
 
     async def create_highlight(

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -827,6 +827,15 @@ class MediaWindow(Container):
                 f"Reading highlights unavailable for record {record.get('id')}: {exc}"
             )
             return []
+        except (AttributeError, TypeError) as exc:
+            # task-15768: a naming/signature mismatch between this bridge and
+            # the backend service is a programming error, not runtime noise --
+            # log the traceback so it cannot masquerade as "no highlights".
+            logger.opt(exception=True).error(
+                f"Reading-highlights scope/service contract drift for record "
+                f"{record.get('id')}: {exc}"
+            )
+            return []
         except Exception as exc:
             logger.error(
                 f"Failed to load reading highlights for record {record.get('id')}: {exc}"
@@ -927,10 +936,15 @@ class MediaWindow(Container):
             return
         try:
             updated = await self._maybe_await(
+                # task-15768: `quote` is deliberately not forwarded -- it is
+                # not an updatable field on either backend (server
+                # ReadingHighlightUpdateRequest and local update_highlight
+                # both accept only color/note/state), and forwarding it made
+                # every quote-carrying update TypeError against the real
+                # services.
                 self._scope_service().update_reading_highlight(
                     mode=self._record_backend(record),
                     highlight_id=event.highlight_id,
-                    quote=event.quote,
                     color=event.color,
                     note=event.note,
                     state=event.state,
@@ -1223,11 +1237,21 @@ class MediaWindow(Container):
                 if isinstance(scoped_detail, dict):
                     detail = scoped_detail
             except Exception as exc:
-                logger.warning(
-                    "Media detail load failed (backend={}, category={}).",
-                    request.mode,
-                    type(exc).__name__,
-                )
+                if isinstance(exc, (AttributeError, TypeError)):
+                    # task-15768: contract drift between this window and the
+                    # scope/backend services must be loudly diagnosable, not
+                    # reduced to a category name.
+                    logger.opt(exception=True).error(
+                        "Media detail load hit a scope/service contract drift "
+                        "(backend={}).",
+                        request.mode,
+                    )
+                else:
+                    logger.warning(
+                        "Media detail load failed (backend={}, category={}).",
+                        request.mode,
+                        type(exc).__name__,
+                    )
                 if self._detail_presentation_is_current(request):
                     self.app_instance.notify(
                         "Media details could not be loaded; showing available summary.",


### PR DESCRIPTION
## Summary

`MediaReadingScopeService` dispatched `reading_`-prefixed leaf names (`list_reading_highlights` etc.) that exist only as back-compat aliases on the SERVER reading service — `LocalMediaReadingService` has only the unprefixed methods, so create/list/update/delete of reading highlights all died in AttributeError in local mode. Git archaeology shows the prefixed dispatch was born in the server-parity work written against those aliases; the scope service was the drifted side, and both leaves' real contract is unprefixed.

- Four dispatch strings fixed to the unprefixed contract (public scope API unchanged)
- `MediaWindow_v2`: contract drift (AttributeError/TypeError) in the highlights/detail loads now logs full tracebacks instead of masquerading as "no highlights"; the update handler no longer forwards `quote=` (neither backend accepts quote updates — forwarding TypeError'd against both)
- The mismatch-hiding fixture surgery: `FakeLocalMediaService`'s prefixed methods (which production never had) removed so the fake mirrors the real leaf; server-alias route still covered by its own untouched test
- Born-red ×3 with exact signatures (independently reproduced in review); 216 tests green on the touched modules; 14 blast-radius failures verified pre-existing at base (reviewer re-confirmed 2 on a throwaway base worktree)

Review: independent pass → MERGE, no blockers; every claim reproduced rather than taken on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local-mode reading-highlight CRUD by routing `MediaReadingScopeService`’s `*_reading_highlight*` calls to the unprefixed leaf methods. Previously these dispatched `reading_`-prefixed names (server-only aliases), causing `AttributeError` in local mode and empty highlight panels; now local CRUD works end to end and drift is logged clearly.

- `MediaReadingScopeService`: dispatches to `create_highlight`/`list_highlights`/`update_highlight`/`delete_highlight`; public scope API unchanged; server behavior unaffected.
- `MediaWindow_v2`: logs `AttributeError`/`TypeError` with tracebacks for detail/highlight loads; stops forwarding `quote` on update (not supported by either backend).
- Tests: fakes now implement only unprefixed highlight methods; added real `LocalMediaReadingService` + DB coverage and end-to-end local-mode UI tests. Satisfies TASK-15768 acceptance criteria.
- Migration: Update any custom local fakes/adapters using `create_reading_highlight`/`list_reading_highlights`/`update_reading_highlight`/`delete_reading_highlight` to the unprefixed names.

<sup>Written for commit 95aa4a57d5017b868459c9c1d60460d9ef4ea515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

