### PR TITLE
fix(console): guard the browser-rows refresh spawn; close the sweep's console inventory (task-15791)

### DIFF
--- a/Tests/UI/test_console_dictionary_send_integration.py
+++ b/Tests/UI/test_console_dictionary_send_integration.py
@@ -168,6 +168,12 @@ async def test_native_send_applies_conversation_dictionary_agent_branch(dictiona
 
         class _Bridge:
             run_reply = staticmethod(_fake_run_reply)
+            # task-15791: the conversation browser's poll now batch-reads
+            # sub-agent counts through the bridge (perf finding A); the
+            # double predates it -- the stale-double class.
+            subagent_counts = staticmethod(
+                lambda conversation_ids: {}
+            )
 
         bridge = _Bridge()
         screen._ensure_console_agent_bridge = lambda: bridge

--- a/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
+++ b/backlog/tasks/task-15791 - Sweep-inventory-console-and-destination-contract-drift.md
@@ -153,3 +153,39 @@ new production lines add no diagnostic.
 ADR required: no. This used existing controller, worker-policy, and
 `PruneSafeSelect` boundaries. No new lesson was added because the Textual prune
 mechanism and its tested remedy were already documented in the repository.
+
+## Implementation Notes (batch 2 -- close-out)
+
+Re-verified every remaining cluster on current dev (2026-08-15); the
+inventory resolved three ways:
+
+**Resolved by dev's own motion** (verified green, no change): the seven
+singletons (tab_scope, chip_actions, citation_sources, composer_collapse,
+live_work_handoffs, rail_sections, fleet_discoverability), personas x5
+(module 9/9), destination parity + workbench snapshots (132/132 -- the
+"needs a human eye" re-record never became necessary), 3 of the 4
+send-integration tests, and the whole TASK-16220 geometry family (fixed by
+another session's PR #1654; shell_regions + rail_width green).
+
+**Fixed here**: (1) the last send-integration red -- a stale `_Bridge`
+double predating the batched `subagent_counts` browser poll (perf finding
+A); (2) a REAL regression from TODAY's browser consolidation (520b1ec12,
+PR #1661): `_current_console_browser_rows` gained a `run_worker` spawn
+inside a state DERIVATION, which raises NoActiveAppError on the suite's
+established bare-screen builder convention -- three internals tests
+deterministic-red within hours of merge. The best-effort refresh is now
+gated on `self._screen.is_running` (the mounted path always is; the guard
+also stops minting a never-awaited coroutine). Browser tests 26/26 confirm
+the mounted refresh still schedules.
+
+**Trap recorded**: the first guard used `self.is_running` -- but `self` is
+the plain ConsoleWorkspaceController, not the screen, so every MOUNTED call
+raised AttributeError and the module collapsed 140 -> 20 passing. Running
+the module WHOLE immediately after the one-line fix is what caught it.
+
+**Attributed, no action**: the chunk-12 settings provider-Test teardown
+pair was frozen-tree residue of #1596 (settings modules 174/174 with the
+maturity modules); the maturity-phase1 "condition not met within 10s"
+timeouts were contention from four concurrent suites, green alone.
+
+Console internals module: 140/140.

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1075,16 +1075,25 @@ class ConsoleWorkspaceController:
             self._console_persisted_rows_cache_token,
         )
         if self._console_persisted_rows_refresh_key != refresh_key:
-            self._console_persisted_rows_refresh_key = refresh_key
-            self.run_worker(
-                self._refresh_console_persisted_rows_cache(
-                    query,
-                    current_conversation_id=current_conversation_id,
-                    refresh_key=refresh_key,
-                ),
-                group="console-persisted-browser-cache",
-                exclusive=True,
-            )
+            # task-15791: this sync derivation is called from state BUILDERS,
+            # which the suite's bare-screen convention runs on an unmounted
+            # ChatScreen (no active app) -- and `run_worker` on such a node
+            # raises NoActiveAppError (520b1ec12 introduced the spawn here).
+            # The refresh is best-effort by design ("without service or
+            # database access"), so skip scheduling when the pump is not
+            # running; the mounted app always is, and the guard also avoids
+            # minting a coroutine that can never be awaited.
+            if self._screen.is_running:
+                self._console_persisted_rows_refresh_key = refresh_key
+                self.run_worker(
+                    self._refresh_console_persisted_rows_cache(
+                        query,
+                        current_conversation_id=current_conversation_id,
+                        refresh_key=refresh_key,
+                    ),
+                    group="console-persisted-browser-cache",
+                    exclusive=True,
+                )
         return [], None, ""
 
     async def _refresh_console_persisted_rows_cache(


### PR DESCRIPTION
## What

Closes **TASK-15791** — the sweep's console/destination inventory (~43 rows at batch 1). Everything is now attributed and resolved; one real regression fixed along the way.

## The regression — from a merge a few hours old

`520b1ec12` (PR #1661, today's conversation-browser consolidation) put a `run_worker` spawn inside `_current_console_browser_rows` — a **state derivation** that the suite's established bare-screen builder convention calls on an unmounted `ChatScreen`. `run_worker` there raises `NoActiveAppError`; three internals tests went deterministic-red within hours of the merge.

Fix: the best-effort refresh is gated on `self._screen.is_running` — the mounted path always is (browser tests **26/26** confirm the refresh still schedules), and the guard also stops minting a coroutine that could never be awaited (the `RuntimeWarning` in the red runs).

**Trap, recorded in the task:** my first cut guarded on `self.is_running` — but `self` is the plain `ConsoleWorkspaceController`, not the screen, so every *mounted* call raised `AttributeError` and the module collapsed 140→20 passing. Running the module whole immediately after the "one-line" fix is what caught it.

## The rest of the inventory

- **stale `_Bridge` double** taught the batched `subagent_counts` poll (perf finding A) — send-integration modules 5/5
- **resolved by dev's own motion**, re-verified green: singletons ×7, personas 9/9, destination parity + workbench snapshots 132/132 (the "needs a human eye" re-record never became necessary), and the whole TASK-16220 geometry family (another session's #1654)
- **attributed, no action**: the chunk-12 settings provider-Test teardown pair was frozen-tree residue of #1596 (settings + maturity modules 174/174); the maturity-phase1 timeouts were contention from four concurrent suites

## Verification

`test_console_internals_decomposition.py` **140/140**; strip 30/30 (batch 1); send-integration 5/5; settings+maturity 174/174; parity+snapshots 132/132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the console browser rows refresh so it only schedules when a mounted screen is running. Previously, `run_worker` spawned from a state derivation on an unmounted `ChatScreen`, raising `NoActiveAppError` and creating a never-awaited coroutine; now it gates on `self._screen.is_running` and keeps the mounted path unchanged.

- In `tldw_chatbook/UI/Console_Modules/workspace.py`, gate the `run_worker` call in `_sync_persisted_console_browser_rows` with `self._screen.is_running`. Old: always spawned during derivation. New: schedules only when the app is running. Side effects: prevents `NoActiveAppError` and `RuntimeWarning`; mounted flow still schedules (browser tests remain green).
- Update the test `_Bridge` double to include `subagent_counts` to match the batched browser poll, restoring send-integration coverage. Satisfies TASK-15791; no migration required.

<sup>Written for commit e1b71bf6abccd6483e072f9745fc7531747dbb12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

