### PR TITLE
fix(tts): shutdown sweep skips export-claimed audio sources (TASK-16199)

### DIFF
--- a/Tests/TTS/test_tts_improvements.py
+++ b/Tests/TTS/test_tts_improvements.py
@@ -676,6 +676,76 @@ class TestTTSEventHandler:
         assert not test_audio.exists()
         assert "msg-claim" not in handler._audio_files
 
+    @pytest.mark.asyncio
+    async def test_shutdown_sweep_skips_a_source_an_export_is_still_copying(
+        self, handler, tmp_path, monkeypatch
+    ):
+        """Quitting mid-copy must not zero the export's source (task-16199).
+
+        The task-15471 review's N1: `cleanup_tts_resources`'s shutdown
+        sweep deleted every cached artifact WITHOUT consulting
+        `_exporting_audio_refcounts`. Worse, the sweep first CANCELS the
+        export task, whose `finally` then releases the claim even though
+        the already-running pool thread keeps copying (cancellation cannot
+        stop a thread) -- so even a claim-aware sweep reading only the
+        live refcounts would miss it. The sweep must snapshot the claims
+        BEFORE the cancel pass and skip those files; the still-running
+        copy then finishes against an intact source.
+        """
+        import shutil as shutil_module
+        import threading
+
+        payload = b"real audio payload"
+        test_audio = tmp_path / "claimed-at-quit.mp3"
+        test_audio.write_bytes(payload)
+        handler._audio_files["msg-quit"] = test_audio
+
+        copy_started = threading.Event()
+        release_copy = threading.Event()
+        real_copy2 = shutil_module.copy2
+
+        def gated_copy2(src, dst, **kwargs):
+            copy_started.set()
+            assert release_copy.wait(5), "test never released the gated copy"
+            return real_copy2(src, dst, **kwargs)
+
+        monkeypatch.setattr(shutil_module, "copy2", gated_copy2)
+
+        export_path = tmp_path / "exports" / "out.mp3"
+        export_task = asyncio.create_task(
+            handler.handle_tts_export(
+                TTSExportEvent("msg-quit", export_path, include_metadata=False)
+            )
+        )
+        # Register the task exactly as production's `on_tts_export_event`
+        # does, so the shutdown sweep's cancel pass reaches it -- that
+        # cancel-releases-the-claim interleaving is the window under test.
+        await handler._add_active_task(export_task)
+
+        # Wait (off-loop) until the pool thread is inside the gated copy.
+        assert await asyncio.to_thread(copy_started.wait, 5)
+
+        # Quit the app mid-copy. Must return promptly: the sweep skips the
+        # claimed file rather than waiting out the (gated, i.e. "hung") copy.
+        await asyncio.wait_for(handler.cleanup_tts_resources(), timeout=10)
+
+        # The sweep skipped the claimed source: still present, NOT zeroed
+        # in place (the secure delete overwrites with zeros before unlink).
+        assert test_audio.exists(), "shutdown sweep destroyed the source mid-copy"
+        assert test_audio.read_bytes() == payload
+
+        # Shutdown cancelled the export task without waiting on its thread.
+        assert export_task.cancelled()
+
+        # Let the still-running pool thread finish: the export it writes
+        # must carry the real bytes, not zeros.
+        release_copy.set()
+        for _ in range(200):
+            if export_path.exists() and export_path.read_bytes() == payload:
+                break
+            await asyncio.sleep(0.05)
+        assert export_path.read_bytes() == payload
+
 
 class TestAudioPlayer:
     """Test audio player improvements"""

--- a/backlog/tasks/task-16199 - TTS-shutdown-sweep-can-still-zero-an-in-flight-export-source.md
+++ b/backlog/tasks/task-16199 - TTS-shutdown-sweep-can-still-zero-an-in-flight-export-source.md
@@ -40,3 +40,13 @@ Extended the task-15471 claim invariant to the shutdown sweep in `cleanup_tts_re
 - **Born-red evidence**: new forced-interleave test `test_shutdown_sweep_skips_a_source_an_export_is_still_copying` (`Tests/TTS/test_tts_improvements.py`) gates `shutil.copy2`, registers the export via `_add_active_task` exactly as production's `on_tts_export_event` does (so the cancel-releases-the-claim interleaving is real), fires `cleanup_tts_resources()` mid-copy, and asserts the source survives un-zeroed, shutdown returned promptly, and the finished copy carries the real bytes. Failed on unfixed code at exactly `AssertionError: shutdown sweep destroyed the source mid-copy`; passes after.
 - **Tests**: `Tests/TTS/test_tts_improvements.py` 26 passed; full `Tests/TTS/` 4075 passed / 6 failed — the identical 6 fail at the untouched base commit `573de5dd0` (verified in a throwaway baseline worktree; unrelated subsystems: audio_cpp guided-text readiness, OpenAI backend key seam, request-admission publication). `ruff check` clean on both touched files; `ruff format` diff on `tts_events.py` is pre-existing whole-file churn (base fails format-check too) and none of its hunks touch the added lines.
 - Files: `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py`, `Tests/TTS/test_tts_improvements.py`.
+
+**Review scope note (post-review, controller):** the independent review confirmed the fix and
+proved the one uncovered window (export admitted between snapshot and cancel pass) unreachable
+by construction — but found the hazard is LATENT, not user-facing today: `TTSExportEvent` is
+never constructed or posted in production, and `TTSEventHandler` is not a MessagePump, so the
+export path is currently test-only. The fix pays forward for when export is wired. Review
+follow-ups to file: `_discard_tts_artifact` still ignores claims (the last unguarded
+secure-delete path); the claim should key by PATH not message id (the id→path join breaks when
+the cache entry is evicted); wire-or-retire the export path; a test pinning the union's live
+half. The AC#3 comment's shutdown-cancellation clause was trimmed to the primary bound.

--- a/backlog/tasks/task-16199 - TTS-shutdown-sweep-can-still-zero-an-in-flight-export-source.md
+++ b/backlog/tasks/task-16199 - TTS-shutdown-sweep-can-still-zero-an-in-flight-export-source.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16199
 title: 'TTS shutdown sweep can still zero an in-flight export source'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-14 03:05'
 labels:
@@ -18,7 +18,25 @@ TASK-15471's fix round made TTS export and the 5s per-file cleanup mutually excl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The shutdown sweep cannot destroy a file an export currently claims (test or forced-interleave probe as evidence)
-- [ ] #2 Shutdown still completes promptly when an export hangs (bounded wait or skip, stated)
-- [ ] #3 The cleanup poll loop's termination bound is documented at the loop
+- [x] #1 The shutdown sweep cannot destroy a file an export currently claims (test or forced-interleave probe as evidence)
+- [x] #2 Shutdown still completes promptly when an export hangs (bounded wait or skip, stated)
+- [x] #3 The cleanup poll loop's termination bound is documented at the loop
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Born-red forced-interleave test in `Tests/TTS/test_tts_improvements.py`: gate `shutil.copy2` (same pattern as the task-15471 test), start an export registered through `_add_active_task` exactly as production's `on_tts_export_event` does, fire `cleanup_tts_resources()` mid-copy, assert the source survives un-zeroed and the export output carries the real payload. Must fail against current code.
+2. Fix in `cleanup_tts_resources` (`Event_Handlers/TTS_Events/tts_events.py`): snapshot `_exporting_audio_refcounts` BEFORE cancelling active tasks — the cancel makes each export's `finally` release its claim while the pool thread keeps copying, so sweep-time refcounts alone under-report in-flight copies. At the sweep, skip-and-log any file whose message id is in that snapshot OR in the live refcounts (the union also covers an export admitted after the cancel pass). Apply the same skip to the `_artifact_cleanup_retry` pass by path. SKIP, not bounded-wait: shutdown stays O(0) on export duration; the cost is leaking at most the in-flight exports' temp files at quit.
+3. AC #3: one-sentence termination-bound comment at `_cleanup_audio_file`'s claim-poll loop (why a claim always clears: the export's `finally` runs even under shutdown cancellation because releasing only needs `_audio_files_lock` and `Lock.acquire()` on a free lock has no suspension point).
+4. Run the new test (red then green), the TTS test file, ruff check + format on touched files.
+
+## Implementation Notes
+
+Extended the task-15471 claim invariant to the shutdown sweep in `cleanup_tts_resources` (`tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py`) — no change to the claim mechanism itself.
+
+- **The subtle half of N1**: a sweep that consulted `_exporting_audio_refcounts` only at sweep time would still miss the window, because the sweep's own cancel pass makes each cancelled export's `finally` release its claim while the copy keeps running on a pool thread (cancellation cannot stop a thread). Fix: snapshot the claims BEFORE cancelling active tasks, then at the sweep skip-and-log any id in that snapshot ∪ the live refcounts (the union covers an export admitted after the cancel pass, which was never cancelled and still holds its claim). The retry-set pass (`_artifact_cleanup_retry`) skips the same files by path — it is part of the same shutdown sweep and runs the same zero-in-place delete.
+- **SKIP, not bounded-wait (AC #2)**: shutdown never waits on an export thread at all — the cancel is immediate and claimed files are skipped, so shutdown latency is independent of copy duration (a hung copy included). A bounded wait would add per-export shutdown latency and still need the skip as its fallback. **Trade-off**: at most the temp audio files of exports in flight at the moment of quit are left on disk un-shredded (ordinary OS temp-dir hygiene applies); that beats either blocking shutdown on a possibly-hung copy or shipping zeroed exports under a success toast.
+- **AC #3**: added the termination-bound sentence at `_cleanup_audio_file`'s claim-poll loop (review N2): every claim is released by `handle_tts_export`'s `finally`, which completes even for a cancelled export because the release only needs `_audio_files_lock` and `Lock.acquire()` on a free lock has no suspension point for a further cancellation to land in; shutdown additionally cancels the cleanup task outright.
+- **Born-red evidence**: new forced-interleave test `test_shutdown_sweep_skips_a_source_an_export_is_still_copying` (`Tests/TTS/test_tts_improvements.py`) gates `shutil.copy2`, registers the export via `_add_active_task` exactly as production's `on_tts_export_event` does (so the cancel-releases-the-claim interleaving is real), fires `cleanup_tts_resources()` mid-copy, and asserts the source survives un-zeroed, shutdown returned promptly, and the finished copy carries the real bytes. Failed on unfixed code at exactly `AssertionError: shutdown sweep destroyed the source mid-copy`; passes after.
+- **Tests**: `Tests/TTS/test_tts_improvements.py` 26 passed; full `Tests/TTS/` 4075 passed / 6 failed — the identical 6 fail at the untouched base commit `573de5dd0` (verified in a throwaway baseline worktree; unrelated subsystems: audio_cpp guided-text readiness, OpenAI backend key seam, request-admission publication). `ruff check` clean on both touched files; `ruff format` diff on `tts_events.py` is pre-existing whole-file churn (base fails format-check too) and none of its hunks touch the added lines.
+- Files: `tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py`, `Tests/TTS/test_tts_improvements.py`.

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -3788,6 +3788,12 @@ class TTSEventHandler:
         # is still copying -- the secure delete zeroes it in place, and the
         # overlapping copy would silently write zeros. Wait for the claim to
         # clear (bounded in practice by one copy's duration), then delete.
+        # Termination bound (task-16199, review N2): this loop always ends
+        # because every claim is released by `handle_tts_export`'s `finally`,
+        # which completes even for a cancelled export -- the release only
+        # needs `_audio_files_lock`, and `Lock.acquire()` on a free lock has
+        # no suspension point for a further cancellation to land in -- and
+        # at shutdown `cleanup_tts_resources` cancels this task outright.
         while True:
             async with self._audio_files_lock:
                 if message_id not in self._exporting_audio_refcounts:
@@ -3878,6 +3884,16 @@ class TTSEventHandler:
         if pending_legacy_timers:
             await asyncio.gather(*pending_legacy_timers, return_exceptions=True)
 
+        # task-16199 (task-15471 review N1): snapshot export claims BEFORE
+        # the cancel pass below. Cancelling an export task makes its
+        # `finally` release the claim even though the copy already running
+        # on a pool thread keeps going (cancellation cannot stop a thread),
+        # so by sweep time the live refcounts under-report the copies still
+        # in flight -- and the secure delete would zero their source in
+        # place mid-copy. The sweep skips these ids.
+        async with self._audio_files_lock:
+            exports_in_flight_at_shutdown = set(self._exporting_audio_refcounts)
+
         # Cancel all active tasks with lock
         async with self._active_tasks_lock:
             tasks_to_cancel = list(self._active_tasks)
@@ -3906,9 +3922,30 @@ class TTSEventHandler:
                 for message_id, audio_file in self._audio_files.items()
             ]
             retries_to_clean = list(self._artifact_cleanup_retry)
+            # Union with the LIVE claims too: an export admitted after the
+            # cancel pass above was never cancelled, so its claim is still
+            # held here and stays held until its copy truly finishes.
+            claimed_message_ids = exports_in_flight_at_shutdown | set(
+                self._exporting_audio_refcounts
+            )
+            claimed_paths = {
+                self._audio_files[message_id]
+                for message_id in claimed_message_ids
+                if message_id in self._audio_files
+            }
             self._last_played = None
 
         for message_id, audio_file, artifact_owner in files_to_clean:
+            if message_id in claimed_message_ids:
+                # SKIP, never bounded-wait (task-16199): shutdown must not
+                # inherit the duration of a slow or hung copy, and a wait
+                # would still need this skip as its fallback. Cost: at most
+                # the in-flight exports' temp files leak at quit.
+                logger.info(
+                    "Skipping shutdown cleanup of an audio file an export "
+                    f"is still copying (message {message_id})"
+                )
+                continue
             if await self._try_secure_delete_tts_artifact(
                 audio_file,
                 on_late_success=partial(
@@ -3926,6 +3963,14 @@ class TTSEventHandler:
                 logger.debug(f"Cleaned up audio file for message {message_id}")
 
         for audio_file in retries_to_clean:
+            if audio_file in claimed_paths:
+                # Same invariant as above: a path a live export claims must
+                # not be zeroed by the retry pass either.
+                logger.info(
+                    "Skipping shutdown retry-cleanup of an audio file an "
+                    "export is still copying"
+                )
+                continue
             if await self._try_secure_delete_tts_artifact(audio_file):
                 async with self._audio_files_lock:
                     self._artifact_cleanup_retry.discard(audio_file)

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -3792,8 +3792,9 @@ class TTSEventHandler:
         # because every claim is released by `handle_tts_export`'s `finally`,
         # which completes even for a cancelled export -- the release only
         # needs `_audio_files_lock`, and `Lock.acquire()` on a free lock has
-        # no suspension point for a further cancellation to land in -- and
-        # at shutdown `cleanup_tts_resources` cancels this task outright.
+        # no suspension point for a further cancellation to land in. (A
+        # cleanup task spawned via the untracked `create_task` site is not
+        # cancelled at shutdown; the release bound above stands on its own.)
         while True:
             async with self._audio_files_lock:
                 if message_id not in self._exporting_audio_refcounts:


### PR DESCRIPTION
## Summary

Closes the one window TASK-15471's export-claim invariant left open: `cleanup_tts_resources`'s shutdown sweep deleted every artifact without consulting claims, and cancelling an export task can't stop its pool thread mid-copy — so quitting mid-export could zero the source in place (the secure delete zeroes before unlinking).

The subtle half, found by the implementer: a sweep consulting refcounts only at sweep time would STILL miss, because the sweep's own cancel pass makes each cancelled export's `finally` release its claim while the copy continues on the pool thread. The fix snapshots the claim set BEFORE the cancel pass and skips (never waits on) any file in snapshot ∪ live refcounts; the retry pass skips the same files by path. Trade-off stated in code and notes: at most the temp files of exports in flight at quit leak un-shredded — better than blocking shutdown or shipping zeroed exports.

Review (opus, adversarial): MERGE. The load-bearing snapshot was mutation-verified (a live-refcounts-only variant still fails the test); the one unhandled interleaving was PROVEN unreachable — an AST scan of all 25 lock blocks shows neither lock is ever held across a suspension point, so no export can claim inside the snapshot→cancel window. Born-red forced-interleave test reproduced independently; `Tests/TTS/` failures verified identical at base.

Honest scope (review finding, recorded in notes): the export path is currently unwired in production (`TTSExportEvent` never posted; handler not a MessagePump), so the hazard is latent — this pays forward for when export lands. Review follow-ups queued for filing: the last unguarded delete path (`_discard_tts_artifact`), keying claims by path rather than id, and wire-or-retire for the export feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents shutdown from zeroing a TTS export’s source mid-copy by skipping files claimed by exports during the sweep. Previously, the sweep canceled tasks and then deleted cached artifacts; cancellation released the claim while the copy thread kept running, so the secure delete could zero the source.

- Snapshots `_exporting_audio_refcounts` before canceling active tasks and unions with live refcounts; skips claimed files in both the owned-files and retry passes. Never waits on copy threads; shutdown stays prompt. Trade-off: temp files for in-flight exports may remain.
- Adds forced-interleave test `test_shutdown_sweep_skips_a_source_an_export_is_still_copying` that gates `shutil.copy2`, registers via `_add_active_task`, triggers shutdown mid-copy, and asserts the source and output remain correct and shutdown returns promptly.
- Documents the termination bound in `_cleanup_audio_file`’s claim-poll loop.
- Satisfies TASK-16199: shutdown cannot destroy an export-claimed source and does not inherit a hung copy’s duration.

<sup>Written for commit b65c29da33f186d5575974dbf6a16b4a1f886a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

