### PR TITLE
fix: character JSON backup export crashed on every card (TASK-15769)

### DIFF
--- a/Tests/Character_Chat/test_character_backup_export_image.py
+++ b/Tests/Character_Chat/test_character_backup_export_image.py
@@ -1,0 +1,134 @@
+# test_character_backup_export_image.py
+"""task-15769: the character JSON backup dump must survive image-bearing cards.
+
+`Tools_Settings_Window._export_characters_worker` serializes raw
+`list_character_cards` rows. Two row-level values are not JSON-serializable:
+
+- the `image` BLOB (``bytes``) whenever a card has an avatar, and
+- `created_at`/`last_modified` (``datetime``) on EVERY row,
+
+so the backup crashed with ``TypeError: Object of type ... is not JSON
+serializable``. These tests pin the serialization helper the worker now
+uses: raw BLOB replaced by a plain-base64 ``image_base64`` string (the
+`Chat_Functions.load_characters` compatibility shape -- deliberately NOT a
+data-URI, because the import chain b64decodes the raw string), datetimes
+as ISO strings, and a full export -> re-import round trip that restores the
+image byte-for-byte.
+"""
+
+import base64
+import json
+
+import pytest
+
+from tldw_chatbook.Character_Chat.Character_Chat_Lib import (
+    import_and_save_character_from_file,
+    import_character_card_from_json_string,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Tools_Settings_Window import (
+    _serialize_character_cards_for_backup,
+)
+
+pytestmark = pytest.mark.integration
+
+# Not a decodable PNG on purpose: the export must round-trip the BLOB
+# byte-for-byte without caring what's inside it. Covers all 256 byte values.
+IMAGE_BYTES = b"\x89PNG\r\n\x1a\n" + bytes(range(256))
+
+
+@pytest.fixture
+def db_instance(tmp_path):
+    db = CharactersRAGDB(tmp_path / "backup_export.sqlite", "test_client")
+    yield db
+    db.close_connection()
+
+
+@pytest.fixture
+def backup_rows(db_instance):
+    """One image-bearing card + one imageless card, as the worker reads them."""
+    db_instance.add_character_card(
+        {
+            "name": "Image Bearer",
+            "description": "card with an avatar BLOB",
+            "first_message": "Hello.",
+            "tags": ["visual"],
+            "image": IMAGE_BYTES,
+        }
+    )
+    db_instance.add_character_card(
+        {
+            "name": "Plain Card",
+            "description": "card without an avatar",
+        }
+    )
+    # The worker's exact projection: a backup must include the image BLOBs.
+    return db_instance.list_character_cards(limit=10000, include_image=True)
+
+
+def _exported_by_name(rows):
+    exported = json.loads(_serialize_character_cards_for_backup(rows))
+    return {card["name"]: card for card in exported}
+
+
+def test_backup_export_of_image_bearing_cards_is_valid_json(backup_rows):
+    """The crash path: an image-bearing row must not kill the whole dump."""
+    assert any(isinstance(row.get("image"), bytes) for row in backup_rows), (
+        "fixture must actually contain an image BLOB row"
+    )
+
+    json_str = _serialize_character_cards_for_backup(backup_rows)
+
+    by_name = {card["name"]: card for card in json.loads(json_str)}
+    card = by_name["Image Bearer"]
+    # The raw BLOB never reaches the JSON; the image is carried as plain
+    # base64 under the load_characters-compatible key.
+    assert "image" not in card
+    assert base64.b64decode(card["image_base64"]) == IMAGE_BYTES
+
+
+def test_backup_export_serializes_datetime_rows(backup_rows):
+    """Every row carries datetime created_at/last_modified; the dump must not crash."""
+    by_name = _exported_by_name(backup_rows)
+    for card in by_name.values():
+        assert isinstance(card["created_at"], str)
+        assert isinstance(card["last_modified"], str)
+
+
+def test_backup_export_imageless_card_carries_no_image_keys(backup_rows):
+    by_name = _exported_by_name(backup_rows)
+    card = by_name["Plain Card"]
+    assert "image" not in card
+    assert "image_base64" not in card
+
+
+def test_exported_card_reimports_with_identical_image_bytes(backup_rows, tmp_path):
+    """Full round trip: export -> card file -> import into a fresh DB -> same bytes."""
+    by_name = _exported_by_name(backup_rows)
+    card_path = tmp_path / "image_bearer.json"
+    card_path.write_text(
+        json.dumps(by_name["Image Bearer"], ensure_ascii=False), encoding="utf-8"
+    )
+
+    reimport_db = CharactersRAGDB(tmp_path / "reimport.sqlite", "reimport_client")
+    try:
+        char_id = import_and_save_character_from_file(reimport_db, str(card_path))
+        assert char_id is not None
+        restored = reimport_db.get_character_card_by_id(char_id)
+        assert restored["image"] == IMAGE_BYTES
+        # Bloat guard: the base64 payload must be consumed as the image, not
+        # duplicated wholesale into the card's extensions JSON.
+        assert "image_base64" not in (restored.get("extensions") or {})
+    finally:
+        reimport_db.close_connection()
+
+
+def test_parse_path_accepts_image_base64_key_directly():
+    """parse_v1_card must treat image_base64 as an image source, not an extension."""
+    payload = base64.b64encode(IMAGE_BYTES).decode("ascii")
+    parsed = import_character_card_from_json_string(
+        json.dumps({"name": "Inline", "image_base64": payload})
+    )
+    assert parsed is not None
+    assert parsed["image_base64"] == payload
+    assert "image_base64" not in parsed["extensions"]

--- a/Tests/UI/test_tools_settings_window.py
+++ b/Tests/UI/test_tools_settings_window.py
@@ -1515,6 +1515,51 @@ def test_backup_then_restore_round_trips_at_the_resolved_path(
     assert value == "original"
 
 
+def test_export_characters_worker_survives_image_bearing_cards(monkeypatch, tmp_path):
+    """task-15769: the JSON character backup must succeed when a card has an
+    avatar image BLOB (and for the datetime columns every row carries) --
+    both previously crashed json.dumps -- and must carry the image as plain
+    base64 under image_base64, never the raw bytes."""
+    import base64
+    import json
+
+    import tldw_chatbook.UI.Tools_Settings_Window as tools_settings_module
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    data_dir = tmp_path / "data"
+    db_path = tmp_path / "live" / "chachanotes.db"
+    monkeypatch.setattr(tools_settings_module, "get_user_data_dir", lambda: data_dir)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    image_bytes = b"\x89PNG\r\n\x1a\n" + bytes(range(256))
+    setup_db = CharactersRAGDB(str(db_path), "test_setup")
+    setup_db.add_character_card({"name": "Image Bearer", "image": image_bytes})
+    setup_db.close_connection()
+
+    notify = MagicMock()
+    window = SimpleNamespace(
+        config_data={"database": {}},
+        app=SimpleNamespace(call_from_thread=lambda cb, *a, **kw: cb(*a, **kw)),
+        app_instance=SimpleNamespace(notify=notify),
+    )
+    window._get_database_path = lambda _name, _config: db_path
+
+    ToolsSettingsWindow._export_characters_worker(window)
+
+    assert _notify_calls_with_severity(notify, "success"), (
+        f"characters export did not report success: {notify.call_args_list}"
+    )
+    assert not _notify_calls_with_severity(notify, "error"), notify.call_args_list
+
+    export_files = list((data_dir / "exports").glob("characters_*.json"))
+    assert len(export_files) == 1, export_files
+    cards = json.loads(export_files[0].read_text(encoding="utf-8"))
+    by_name = {card["name"]: card for card in cards}
+    exported = by_name["Image Bearer"]
+    assert "image" not in exported
+    assert base64.b64decode(exported["image_base64"]) == image_bytes
+
+
 @pytest.mark.asyncio
 async def test_restore_refuses_live_evals_database_without_partial_replacement(
     monkeypatch, temp_config_path

--- a/backlog/tasks/task-15769 - Character-JSON-backup-export-crashes-on-any-image-bearing-card.md
+++ b/backlog/tasks/task-15769 - Character-JSON-backup-export-crashes-on-any-image-bearing-card.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-15769
 title: Character JSON backup export crashes on any image-bearing card
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-13 12:31'
 labels:
   - bug
@@ -30,15 +30,113 @@ about fixing the export path itself, not relying on the masking side effect.
 
 ## Acceptance Criteria
 
-- [ ] Exporting a character list that includes an image-bearing card via
+- [x] Exporting a character list that includes an image-bearing card via
       `Tools_Settings_Window._export_characters_worker` succeeds (no
       `TypeError: Object of type bytes is not JSON serializable`)
-- [ ] The exported JSON either base64-encodes the image (matching the
+- [x] The exported JSON either base64-encodes the image (matching the
       compatibility shape `Chat_Functions.load_characters` already uses for
       `image_base64`) or explicitly and intentionally omits it with a
       visible note in the export — pick one and make it correct, not an
       accidental silent drop
-- [ ] A round-trip test: export an image-bearing card, confirm the output is
+- [x] A round-trip test: export an image-bearing card, confirm the output is
       valid JSON, and (if images are included) confirm the image round-trips
       byte-for-byte through base64
-- [ ] Existing character-export tests stay green
+- [x] Existing character-export tests stay green
+
+## Implementation Plan
+
+1. Re-locate at HEAD (`bb91fef73`): confirm `_export_characters_worker`
+   (`UI/Tools_Settings_Window.py`) still `json.dumps()`s raw
+   `list_character_cards` rows, and that the crash is only masked by the
+   task-15474 `include_image=False` default (silent image drop today).
+2. Reproduce the crash signature on the worker's own seam: extract the
+   serialization into a module-level helper
+   `_serialize_character_cards_for_backup(...)`, have the worker opt into
+   `include_image=True` (a backup should contain the image), and write a
+   born-red round-trip test that fails with
+   `TypeError: Object of type bytes is not JSON serializable`.
+3. Fix: the helper replaces the raw `image` BLOB with a plain-base64
+   `image_base64` string (the `Chat_Functions.load_characters` compatibility
+   shape; deliberately NOT the data-URI form `export_character_card_to_json`
+   uses, because the import chain `b64decode`s the raw string and a data-URI
+   prefix would garble it).
+4. Make the export genuinely re-importable: teach `parse_v1_card`
+   (`Character_Chat/Character_Chat_Lib.py`) to accept `image_base64` as an
+   image source key (today only `char_image`/`image` are read, and an
+   unrecognized `image_base64` would be swallowed whole into `extensions`,
+   bloating the DB on re-import).
+5. Round-trip test: DB card with image bytes -> export JSON (valid, no raw
+   bytes) -> base64 decodes byte-for-byte -> full re-import via
+   `import_and_save_character_from_file` into a fresh DB restores identical
+   image bytes.
+6. Keep existing export/import tests green; ruff check + format on touched
+   files.
+
+## Implementation Notes
+
+The export worker now includes images and serializes through a new
+module-level helper instead of a bare `json.dumps` over raw DB rows.
+
+**Re-location found a SECOND crash class.** The audit diagnosed the `bytes`
+BLOB; reproducing at HEAD (`bb91fef73`) showed the masked, image-free
+projection ALSO crashes — `list_character_cards` rows carry
+`created_at`/`last_modified` as `datetime` objects, so the backup died with
+`TypeError: Object of type datetime is not JSON serializable` for EVERY
+card, image or not. Both crashes sit on the same `json.dumps` line, so both
+are fixed in the one helper (AC 1 is unverifiable otherwise — the worker
+could never succeed).
+
+**Approach** (smallest honest diff, both sides of the round trip):
+
+- `UI/Tools_Settings_Window.py`: `_export_characters_worker` opts into
+  `list_character_cards(limit=10000, include_image=True)` (a backup should
+  contain the avatar; relying on the task-15474 image-free default was the
+  accidental-silent-drop the AC forbids) and serializes via new
+  `_serialize_character_cards_for_backup()`: the raw `image` BLOB is
+  replaced by a plain-base64 `image_base64` string (the
+  `Chat_Functions.load_characters` compatibility shape; deliberately NOT
+  the data-URI form `export_character_card_to_json` embeds, because the
+  import chain b64decodes the raw string and a prefix would garble it),
+  and datetimes ISO-format via a `default=` hook that still raises for any
+  other unexpected type.
+- `Character_Chat/Character_Chat_Lib.py`: `parse_v1_card` now accepts
+  `image_base64` as an image source key (after `char_image`/`image`) and
+  lists it in the known-keys set — previously the whole base64 payload
+  would have been swallowed into `extensions` on re-import and the avatar
+  lost.
+
+**Evidence** (born-red first, then green; venv + PYTHONPATH pinned to the
+worktree):
+
+- Born-red: with the helper extracted but naive, the new test file failed
+  5/5 — 4 with `TypeError: Object of type datetime is not JSON
+  serializable` and the parse test on the unrecognized key; the bytes
+  signature (`Object of type bytes is not JSON serializable`) demonstrated
+  on the same dumps call shape. After the fix: 5/5 green.
+- Worker-level test (`Tests/UI/test_tools_settings_window.py::
+  test_export_characters_worker_survives_image_bearing_cards`, using the
+  file's TASK-927 SimpleNamespace harness) proves AC 1 on the named seam;
+  mutation check (helper body temporarily reverted, Edit-based restore)
+  fails it with the real production notify:
+  `Error exporting characters: Object of type datetime is not JSON
+  serializable`.
+- Round trip: export -> single-card JSON file ->
+  `import_and_save_character_from_file` into a fresh DB restores the image
+  byte-for-byte (256-value byte string), with a bloat guard that
+  `image_base64` is not duplicated into `extensions`.
+- Regression: `Tests/Character_Chat/` 577 passed, 1 failed —
+  `test_dictionary_attachment_index.py::TestMigrationBackfill::
+  test_v34_database_backfills_existing_attachments` (`assert 37 == 36`)
+  reproduced identically on a pristine `bb91fef73` worktree: pre-existing
+  dev red (task-16197/15765 migration-rewind family), not this change.
+  `Tests/UI/test_tools_settings_window.py` 65 passed (5:04) plus the new
+  worker test; full-suite `--collect-only` clean (43,687 collected).
+- ruff: the 3 owned files check clean; the two pre-existing modules'
+  format debt and the UI test file's E402 reproduce byte-for-byte at base
+  (`git show bb91fef73:... | ruff`), left untouched to keep the diff
+  minimal.
+
+**Files**: `tldw_chatbook/UI/Tools_Settings_Window.py`,
+`tldw_chatbook/Character_Chat/Character_Chat_Lib.py`,
+`Tests/Character_Chat/test_character_backup_export_image.py` (new),
+`Tests/UI/test_tools_settings_window.py`.

--- a/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
+++ b/tldw_chatbook/Character_Chat/Character_Chat_Lib.py
@@ -1877,8 +1877,13 @@ def parse_v1_card(card_data_json: Dict[str, Any]) -> Optional[Dict[str, Any]]:
                 card_data_json.get("character_version")
             ),
             "extensions": {},  # Initialize extensions
+            # task-15769: `image_base64` is the app's own backup-export /
+            # load_characters compatibility key -- treat it as an image
+            # source, not an unknown field (which would dump the whole
+            # base64 payload into extensions and lose the avatar).
             "image_base64": card_data_json.get("char_image")
-            or card_data_json.get("image"),
+            or card_data_json.get("image")
+            or card_data_json.get("image_base64"),
         }
 
         # Collect any non-standard V1 fields into 'extensions'
@@ -1898,6 +1903,7 @@ def parse_v1_card(card_data_json: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             "character_version",
             "char_image",
             "image",
+            "image_base64",
         }
 
         extra_extensions = {}

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -11,14 +11,15 @@
 # migrate surviving behavior to the Settings screen before this module is deleted.
 #
 # Imports
-from typing import TYPE_CHECKING, Optional, List, Dict, NamedTuple
+from typing import TYPE_CHECKING, Any, Optional, List, Dict, NamedTuple
 import asyncio
+import base64
 import io
 import json
 import os
 import sys
 import tempfile
-from datetime import datetime
+from datetime import date, datetime
 from functools import partial
 from pathlib import Path
 
@@ -147,6 +148,49 @@ WEB_DEEP_SEARCH_TOOL_NAME = "web_deep_search"
 #: TASK-2775: the About text's canonical home is Utils/about_text (rendered by
 #: the F9 Settings screen's About category); re-exported here for back-compat.
 from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN  # noqa: E402,F401
+
+
+def _character_backup_json_default(value: Any) -> str:
+    """json.dumps fallback for the row types SQLite hands back (task-15769).
+
+    `list_character_cards` rows carry `created_at`/`last_modified` as
+    ``datetime`` objects, which crashed the whole backup dump with
+    ``TypeError: Object of type datetime is not JSON serializable`` even for
+    image-free cards. Anything else unexpected still raises, so a new
+    non-serializable column can never silently ship garbage.
+    """
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _serialize_character_cards_for_backup(characters: List[Dict[str, Any]]) -> str:
+    """Serialize character-card rows into the JSON backup dump (task-15769).
+
+    The raw `image` BLOB (``bytes``) is replaced by a plain-base64
+    ``image_base64`` string -- the same compatibility shape
+    `Chat_Functions.load_characters` produces, and deliberately NOT the
+    data-URI form `export_character_card_to_json` embeds, because the import
+    chain (`parse_v1_card` -> `import_and_save_character_from_file*`)
+    b64decodes the raw string, so a prefixed value would not round-trip.
+    """
+    serializable: List[Dict[str, Any]] = []
+    for card in characters:
+        card = dict(card)
+        image = card.pop("image", None)
+        if isinstance(image, (bytes, bytearray, memoryview)):
+            card["image_base64"] = base64.b64encode(bytes(image)).decode("ascii")
+        elif image is not None:
+            # Not a BLOB (unexpected but conceivable via TEXT affinity);
+            # keep the value rather than silently dropping it.
+            card["image"] = image
+        serializable.append(card)
+    return json.dumps(
+        serializable,
+        indent=2,
+        ensure_ascii=False,
+        default=_character_backup_json_default,
+    )
 
 
 class ToolsSettingsWindow(Container):
@@ -6541,12 +6585,16 @@ class ToolsSettingsWindow(Container):
             chachanotes_path = self._get_database_path("chachanotes", db_config)
             if chachanotes_path and chachanotes_path.exists():
                 db = CharactersRAGDB(str(chachanotes_path), "export_operation")
-                characters = db.list_character_cards(limit=10000)
+                # A backup must contain the avatar image, so opt into the
+                # image-bearing projection (task-15474 made image-free the
+                # default) and serialize through the BLOB-safe helper
+                # (task-15769).
+                characters = db.list_character_cards(limit=10000, include_image=True)
 
                 export_path = export_dir / f"characters_{timestamp}.json"
                 create_private_text(
                     export_path,
-                    json.dumps(characters, indent=2, ensure_ascii=False),
+                    _serialize_character_cards_for_backup(characters),
                     application_owned_directory=export_dir,
                 )
 


### PR DESCRIPTION
## Summary

The Settings character backup export was filed as crashing on image-bearing cards; reproducing showed it was worse — it crashed on EVERY card: `list_character_cards` rows carry `datetime` objects (the app's own `PARSE_DECLTYPES` converter registration), so even image-free exports died in `TypeError: Object of type datetime is not JSON serializable`, with the bytes crash stacked behind it once images are included.

- The worker now opts into `include_image=True` (a backup silently dropping avatars is the accidental data loss the AC forbids) and serializes via a narrow helper: image BLOB → plain-base64 `image_base64` (the `load_characters` compatibility shape — deliberately NOT the data-URI card-export form, because the import chain bare-`b64decode`s and a prefix raises `binascii.Error`), datetimes → ISO via a `default=` hook that still raises on anything else (no silent-stringify drift hiding)
- `parse_v1_card` accepts `image_base64` as its lowest-priority image source key (2 lines) so a backup re-imports with the avatar intact — previously the payload was swallowed into `extensions`
- Round-trip proven against a real on-disk DB through the real import path: exported bytes re-import byte-for-byte equal
- Born-red throughout (reviewer independently reproduced, incl. tracing the datetime class to `sqlite_datetime_fix.py`); new tests 5/5, tools-settings 66/66, `Tests/Character_Chat/` 577 green with the single failure verified pre-existing at base (the known migration-fixture family)

Review: independent pass → MERGE, no blockers; one optional polish noted (docstring stating the backup format is an internal round-trip dump, not card-tool interchange — the format already dumps internal DB columns, so it is unambiguously non-portable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings “Character JSON backup” export by handling image BLOBs and datetime fields. Backups now include avatars and complete successfully; previously the worker dumped raw `list_character_cards` rows and crashed on `datetime` and `bytes`.

**Details**
- Worker now calls `list_character_cards(..., include_image=True)` and writes via `_serialize_character_cards_for_backup(...)`.
- Helper replaces `image` BLOB with plain-base64 `image_base64` (not a data URI) and serializes `datetime` to ISO; unknown types still raise.
- `parse_v1_card` accepts `image_base64` as an image source so exports re-import with avatars intact.
- Adds tests covering image export, datetime serialization, and a full export→re-import round trip.
- Satisfies TASK-15769 acceptance criteria; no migration required (export files may be larger due to included avatars).

<sup>Written for commit 3df4b64539b8773ff13f520b339b12765069d297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

