### PR TITLE
test(watchlists): port the 15764 review-hardened delta onto the incumbent implementation

### DIFF
--- a/Tests/Subscriptions/test_url_monitor_off_loop.py
+++ b/Tests/Subscriptions/test_url_monitor_off_loop.py
@@ -1,0 +1,331 @@
+"""task-15764: URLMonitor's extraction and diff work runs off the event loop.
+
+task-15463 moved the watchlist check path's sqlite hops and the feed-body
+parse off the loop, and deliberately left `URLMonitor`'s own CPU work inline
+as "a separate, larger change". That work is this task's scope, and it is
+pure CPU with no sqlite involvement:
+
+* `ContentExtractor.extract_text_from_html` -- BeautifulSoup over a page of
+  up to `MAX_FETCH_BYTES_PAGE` (10 MB), run on EVERY check of a
+  `url`/`url_list`/`sitemap` source, including the common unchanged case;
+* the difflib work on the changed path: `calculate_change_percentage`
+  (`SequenceMatcher.ratio` over both full texts -- the largest single
+  difflib cost here, though task-15764's AC enumeration missed it),
+  `_segment_for_diff` twice, `build_change_diff`, `added_and_removed_text`,
+  and `classify_change_type`.
+
+Reconciliation note (task-596 playbook, 4th duplicate-implementation event):
+two independent sessions implemented task-15764; the merged-first
+implementation (commits 8f638f815 + 8fbd1426d, PR #1650) stands, and this
+file is the ported delta from the reviewed second implementation (verdict
+MERGE; semantically byte-identical to the incumbent, verified across 11
+baseline+change cycles). It adds what the incumbent's own tests in
+`test_watchlists_db_instance_and_off_loop.py` do not cover: the whole-check
+extraction path through `check_url` (theirs probes `_fetch_url_content`
+directly), and -- the incumbent's AC#3 had no test at all -- a `url_list`
+source driven through the real `launch_run`/`execute_run` path, two URLs x
+two runs, proving every URL's extraction AND diff work leaves the loop, not
+just the first URL's.
+
+Like task-15463's `test_watchlists_db_instance_and_off_loop.py`, everything
+below is mechanical thread identity -- no durations, nothing timing-flaky.
+The spies call straight through to the real functions, so every test also
+asserts the OUTPUT it always produced (baseline row, diff body, added and
+removed text, dispositions): a hop that changed what the check computes
+would redden here, not just a hop that never happened.
+
+Threading note: the file-backed DBs under `tmp_path` are load-bearing --
+`SubscriptionsDB` keeps thread-local connections, so `URLMonitor`'s
+`run_db_off_loop` hops need a database whose file another thread can open.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+import tldw_chatbook.Subscriptions.monitoring_engine as monitoring_engine
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    LocalWatchlistsService,
+)
+from tldw_chatbook.Subscriptions.monitoring_engine import (
+    DISPOSITION_BASELINE_STORED,
+    DISPOSITION_CHANGED,
+    ContentExtractor,
+    URLMonitor,
+)
+from tldw_chatbook.Subscriptions.watchlist_rule_matching import (
+    RULE_MATCH_ADDED_TEXT_KEY,
+    RULE_MATCH_REMOVED_TEXT_KEY,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_PAGE_ONE = (
+    "<html><body><p>alpha bravo charlie.</p>\n<p>delta echo foxtrot.</p></body></html>"
+)
+_PAGE_TWO = (
+    "<html><body><p>alpha bravo charlie.</p>\n<p>golf hotel india.</p></body></html>"
+)
+
+
+def _url_subscription(db: SubscriptionsDB) -> dict:
+    """A real subscriptions row (`url_snapshots.subscription_id` is a
+    foreign key under `PRAGMA foreign_keys = ON`), as the dict `check_url`
+    takes."""
+    source_id = db.add_subscription(
+        name="Watched page", type="url", source="https://example.com/page"
+    )
+    return {
+        "id": source_id,
+        "name": "Watched page",
+        "type": "url",
+        "source": "https://example.com/page",
+    }
+
+
+#: The difflib work `check_url` owes the changed path, exactly as the task's
+#: AC enumerates it -- plus `calculate_change_percentage`, which is also
+#: difflib (`SequenceMatcher.ratio` over both full texts) and also ran inline.
+_DIFF_WORK = (
+    "_segment_for_diff",
+    "build_change_diff",
+    "added_and_removed_text",
+    "classify_change_type",
+)
+
+
+def _response(text: str, url: str):
+    """Stand in for the `httpx.Response` `guarded_fetch_httpx_async` returns."""
+    return SimpleNamespace(
+        status_code=200,
+        headers={"content-type": "text/html"},
+        text=text,
+        final_url=url,
+        raise_for_status=lambda: None,
+    )
+
+
+def _serve(monkeypatch, body_for) -> list[str]:
+    """Serve HTML from the real fetch seam. Returns the fetch log.
+
+    ``body_for(url, call_number)`` picks the body, with ``call_number``
+    starting at 1, so one test can serve a baseline and then a changed page.
+    """
+    fetched: list[str] = []
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        fetched.append(url)
+        return _response(body_for(url, len(fetched)), url)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+    return fetched
+
+
+def _spy_extraction(monkeypatch) -> list[tuple[str, int]]:
+    """Record ``(html, thread_ident)`` per extraction; call the real one."""
+    extractions: list[tuple[str, int]] = []
+    real_extract = ContentExtractor.extract_text_from_html
+
+    def spy(html, ignore_selectors=None):
+        extractions.append((html, threading.get_ident()))
+        return real_extract(html, ignore_selectors)
+
+    monkeypatch.setattr(ContentExtractor, "extract_text_from_html", staticmethod(spy))
+    return extractions
+
+
+def _spy_diff_work(monkeypatch) -> dict[str, list[int]]:
+    """Record the thread each diff-work call ran on; call the real ones.
+
+    Module-global lookups are late-bound, so these spies see the calls
+    whether `check_url` makes them inline (the pre-task-15764 shape) or from
+    inside a `to_thread` hop -- which is what lets the same test be born red.
+    """
+    threads: dict[str, list[int]] = {}
+
+    for name in _DIFF_WORK:
+        real = getattr(monitoring_engine, name)
+
+        def spy(*args, _real=real, _name=name, **kwargs):
+            threads.setdefault(_name, []).append(threading.get_ident())
+            return _real(*args, **kwargs)
+
+        monkeypatch.setattr(monitoring_engine, name, spy)
+
+    real_percentage = ContentExtractor.calculate_change_percentage
+
+    def percentage_spy(old_content, new_content):
+        threads.setdefault("calculate_change_percentage", []).append(
+            threading.get_ident()
+        )
+        return real_percentage(old_content, new_content)
+
+    monkeypatch.setattr(
+        ContentExtractor, "calculate_change_percentage", staticmethod(percentage_spy)
+    )
+    return threads
+
+
+# --- AC#1: the HTML extraction ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_html_extraction_runs_off_the_event_loop_thread(tmp_path, monkeypatch):
+    """BeautifulSoup over a fetched page is not loop work.
+
+    This is the cost EVERY url-family check pays, changed or not, so it is
+    asserted on the plain first-check path with nothing else in play.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    monitor = URLMonitor(db)
+    subscription = _url_subscription(db)
+    _serve(monkeypatch, lambda url, n: _PAGE_ONE)
+    extractions = _spy_extraction(monkeypatch)
+
+    result, disposition = await monitor.check_url(subscription)
+
+    # Never vacuous: the check must have done its usual first-check work.
+    assert result is None and disposition["kind"] == DISPOSITION_BASELINE_STORED
+    with db.transaction() as conn:
+        rows = conn.execute(
+            "SELECT extracted_content FROM url_snapshots WHERE subscription_id = ?",
+            (subscription["id"],),
+        ).fetchall()
+    assert len(rows) == 1 and "alpha bravo charlie." in rows[0]["extracted_content"], (
+        "the baseline snapshot must hold the extracted text, or the spy "
+        "proves nothing about where the extraction ran"
+    )
+
+    assert len(extractions) == 1, "the extraction must have run exactly once"
+    assert extractions[0][1] != threading.get_ident(), (
+        "extract_text_from_html must run under asyncio.to_thread, not inline "
+        "on the event loop"
+    )
+
+
+# --- AC#2: the difflib work ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_diff_work_runs_off_the_event_loop_thread(tmp_path, monkeypatch):
+    """Every difflib call on the changed path leaves the loop -- and still
+    produces byte-for-byte the diff, rule-match text and classification it
+    always did."""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    monitor = URLMonitor(db)
+    subscription = _url_subscription(db)
+    bodies = {1: _PAGE_ONE, 2: _PAGE_TWO}
+    _serve(monkeypatch, lambda url, n: bodies[n])
+    threads = _spy_diff_work(monkeypatch)
+
+    baseline, first_disposition = await monitor.check_url(subscription)
+    assert baseline is None
+    assert first_disposition["kind"] == DISPOSITION_BASELINE_STORED
+    assert not threads, "no diff work exists on a first check"
+
+    change, disposition = await monitor.check_url(subscription)
+
+    # Semantics pinned first: same item the inline code produced.
+    assert disposition["kind"] == DISPOSITION_CHANGED
+    assert change is not None and change["type"] == "url_change"
+    assert "+golf hotel india." in change["content"]
+    assert "-delta echo foxtrot." in change["content"]
+    assert change["diff_summary"] == "1 line(s) added, 1 removed"
+    assert change["change_type"] == "content"
+    assert change[RULE_MATCH_ADDED_TEXT_KEY] == "golf hotel india."
+    assert change[RULE_MATCH_REMOVED_TEXT_KEY] == "delta echo foxtrot."
+
+    expected = set(_DIFF_WORK) | {"calculate_change_percentage"}
+    assert set(threads) == expected, (
+        f"every difflib call must have happened (saw {sorted(threads)})"
+    )
+    assert len(threads["_segment_for_diff"]) == 2, (
+        "each side is segmented once and shared (the Qodo segment-once rule) "
+        "-- a third call means the sharing broke in the move"
+    )
+    loop_thread = threading.get_ident()
+    for name, idents in threads.items():
+        assert all(ident != loop_thread for ident in idents), (
+            f"{name} ran on the event-loop thread during a URL check"
+        )
+
+
+# --- AC#3: url_list -- every URL, not just the first --------------------------
+
+
+@pytest.mark.asyncio
+async def test_url_list_runs_extraction_and_diff_off_loop_for_every_url(
+    tmp_path, monkeypatch
+):
+    """The real `url_list` execution path, two URLs, two runs.
+
+    Run one baselines both URLs (extraction only); run two changes both
+    (extraction + diff). Every one of those per-URL costs must be off the
+    loop -- a `url_list` source multiplies them by its URL count, which is
+    exactly why the task calls it out.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    source_id = db.add_subscription(
+        name="Two pages",
+        type="url_list",
+        source="https://a.example/one\nhttps://b.example/two",
+    )
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    def body_for(url, call_number):
+        version = 1 if call_number <= 2 else 2
+        return f"<html><body><p>page {url} version {version}.</p></body></html>"
+
+    fetched = _serve(monkeypatch, body_for)
+    extractions = _spy_extraction(monkeypatch)
+    threads = _spy_diff_work(monkeypatch)
+
+    first = await service.launch_run(source_id=source_id)
+    first_run = await service.execute_run(first["run_id"])
+    second = await service.launch_run(source_id=source_id)
+    second_run = await service.execute_run(second["run_id"])
+
+    # Never vacuous: both runs completed and every URL took its real path.
+    assert first_run["status"] == "completed"
+    assert first_run["stats"]["dispositions"]["baseline"] == 2
+    assert second_run["status"] == "completed"
+    assert second_run["stats"]["dispositions"]["changed"] == 2
+    assert fetched == [
+        "https://a.example/one",
+        "https://b.example/two",
+        "https://a.example/one",
+        "https://b.example/two",
+    ]
+
+    loop_thread = threading.get_ident()
+    assert len(extractions) == 4, "two URLs, two runs: four extractions"
+    for html, ident in extractions:
+        assert ident != loop_thread, (
+            f"extraction ran on the event-loop thread for {html[:60]!r}"
+        )
+    # Each URL's own page is what was extracted -- the per-URL loop, not one
+    # URL four times.
+    assert [
+        ("a.example/one" in html, "b.example/two" in html) for html, _ in extractions
+    ] == [
+        (True, False),
+        (False, True),
+        (True, False),
+        (False, True),
+    ]
+
+    assert len(threads.get("build_change_diff", [])) == 2, (
+        "run two must diff BOTH URLs, not just the first"
+    )
+    for name, idents in threads.items():
+        assert all(ident != loop_thread for ident in idents), (
+            f"{name} ran on the event-loop thread during a url_list run"
+        )

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -268,6 +268,31 @@ corroboration commit on top of the existing tip (PR #1640) instead of a competin
 fix. Independent evidence is worth keeping; a second fix for the same defect is
 not.
 
+**TASK-15764, 2026-08-15 — fourth instance, and this time the duplicate was
+already MERGED before the second session even started.** A Codex session
+implemented the task on `codex/task-15764-urlmonitor-offloop` (commits
+`8f638f815` + `8fbd1426d`, eleven minutes from first commit to PR #1650
+merging at 2026-08-14 17:38) and marked the task file Done on dev. The second
+session, launched by a burn-down controller with a base pinned to `bb91fef73`
+(cut 2026-08-13 20:14 -0700 — ~21 hours BEFORE the incumbent merged, and a
+further ~21 hours before the second session implemented on 2026-08-15), read
+the task file AT ITS BASE — where it still said `To Do` — and re-implemented
+the whole task:
+three hops, born-red tests, latency probes, an independent review with verdict
+MERGE. Nobody ran the two cheap commands above against the REMOTES, and a
+pinned base makes the board check worse than useless: it faithfully shows the
+world as of the pin, so `git fetch && git log origin/dev --grep=<id>` (plus
+`git branch -a | grep -i <id>` — the Codex branch name carried the id) is the
+check that would have caught it in seconds, before implementation rather than
+at reconciliation. Two mitigations with teeth: (1) a pinned-base session must
+run its staleness check against `origin/dev`, not its own checkout; (2) the
+recovery was again contribution, not competition — the incumbent stood
+(byte-identical semantics, verified across 11 full-cycle cases), and the
+second implementation's delta ported on top: the url_list-through-
+`launch_run`/`execute_run` coverage the incumbent's ticked AC#3 never had a
+test for, plus the review-corrected latency lesson (the 16.2 s headline
+figure did not survive the reviewer re-running it).
+
 ---
 
 ## Check for an in-flight PR before designing — claiming the task does not reserve it

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4315,3 +4315,30 @@ version participates in the atomic mutation that grants the effect. Reproduce th
 read/write interleaving deterministically, assert the stale write changes nothing,
 and cover every idempotent write shape (new row, revive, and already-active row).
 Green sequential and crash-recovery suites do not substitute for either probe.
+
+## An AC's enumeration of hot call sites is not the cost profile (task-15764, 2026-08-15)
+
+Task-15764's AC enumerated the difflib work to move off the event loop by name --
+`_segment_for_diff` x2, `build_change_diff`, `added_and_removed_text`,
+`classify_change_type` -- and an implementation scoped to that list would have been
+green on every thread-identity test while leaving most of the stall in place. The
+dominant cost was `ContentExtractor.calculate_change_percentage`, a
+`difflib.SequenceMatcher.ratio` over the two full raw texts that sits three lines
+above the enumerated block and is not in the enumeration. Mechanism, corrected by
+the independent review (the implementer's 16.2 s / "99.8%" figure on a 160 KB Latin
+page pair did NOT reproduce -- Latin text at that size hits `autojunk`'s fast path,
+20-40 ms across four content shapes, and autojunk incidentally returns a
+meaningless `pct` for it, a separate pre-existing oddity): character-level
+`ratio()` goes quadratic only when the character repertoire is large enough that
+autojunk junks nothing (CJK / unicode-heavy pages) -- measured clean 4x per
+doubling, extrapolating to ~1 s at 160 K chars and **~7 minutes at the 10 MB
+fetch cap**. The off-loop move is thus MORE justified than the original numbers
+suggested, and the review's own stall probe corroborated the shape independently
+(164.7 ms -> 18.4 ms max stall on the same seam). Keep both halves of this
+incident: measure the whole operation, and expect your headline number to be
+re-run by a skeptic. The lesson: before implementing a perf task scoped by a list of
+call sites, run one measurement that would catch an omission -- a wall/stall probe
+around the whole operation, not around the listed calls. If the numbers do not drop
+when the listed sites move, the list was wrong, and the AC's own wording ("the
+difflib work") almost always licenses fixing the omission in the same change --
+record the addition explicitly rather than silently widening scope.

--- a/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
+++ b/backlog/tasks/task-15764 - Watchlists-URLMonitor-extraction-and-diff-work-off-the-event-loop.md
@@ -119,3 +119,54 @@ shapes remain unchanged.
 - Lessons hygiene: no reusable lesson was added because the work surfaced no
   new generalizable repository trap.
 <!-- SECTION:NOTES:END -->
+
+## Reconciliation (2026-08-15, duplicate-implementation event -- task-596 playbook)
+
+Two sessions implemented this task independently: the merged-first
+implementation above (Codex, commits `8f638f815` + `8fbd1426d`, PR #1650,
+merged 2026-08-14 17:38 -0700) STANDS; a second session on burn-down base
+`bb91fef73` (task file still `To Do` at that base) produced a structurally
+convergent implementation (`d07cfc50f` on `task/15764-burn`, independently
+reviewed with verdict MERGE), whose review-hardened delta is ported on top.
+Incident recorded in `lessons-backlog-hygiene.md` (4th "status is not a
+lock" instance).
+
+**Incumbent audit (by the second session, against base `bb91fef73`):**
+
+- Segment-once sharing: PRESERVED -- `_build_significant_change_details`
+  segments each side exactly once and hands the segments to both consumers.
+- Semantic identity: VERIFIED byte-identical across 11 full baseline+change
+  cycles (whole `change_info` minus `published_date`, both dispositions,
+  all persisted snapshot rows) covering the truncation path, unicode,
+  markup-only/unchanged, additions/removals-only, empty-page both
+  directions, and the below-threshold withheld path. No defect found; no
+  production change needed.
+- `response.text` decode placement: identical to the reviewed version
+  (decoded once on the loop, ~0.5 ms at the 10 MB cap per the review's
+  measurement); the incumbent's comments make no claims, so nothing
+  overclaims.
+
+**Ported delta:**
+
+- `Tests/Subscriptions/test_url_monitor_off_loop.py` -- whole-check
+  extraction thread-identity through `check_url` (the incumbent probes
+  `_fetch_url_content` directly); the url_list coverage AC #3 was ticked
+  without: two URLs x two runs through the real `launch_run`/`execute_run`
+  path, every URL's extraction AND diff off-loop; the `_segment_for_diff`
+  called-exactly-twice pin. Born-red evidence against the incumbent
+  implementation via per-hop runtime re-inlining (a shim replacing only
+  `monitoring_engine.asyncio.to_thread` for one target at a time):
+  extract -> extraction+url_list tests fail; percentage -> diff+url_list
+  fail; details -> diff+url_list fail; clean run 3/3 green.
+- `lessons-testing-evidence.md`: the review-CORRECTED cost-profile lesson
+  (the original 16.2 s / "99.8%" figures on 160 KB Latin text did not
+  reproduce -- autojunk fast path, 20-40 ms; the quadratic regime is
+  repertoire-dependent, ~7 min at the 10 MB cap on CJK/unicode-heavy text,
+  so the off-loop move is MORE justified than the original numbers implied).
+
+**Review follow-ups queued for filing:** per-(subscription,url) in-flight
+guard (pre-existing scheduled-vs-Check-Now double-report window, present at
+`bb91fef73`); bound `calculate_change_percentage` by input size (a worker
+thread can hold the GIL for minutes at the fetch cap on large-repertoire
+text); autojunk makes the reported change percentage meaningless for large
+Latin-text pages (pre-existing correctness oddity).


### PR DESCRIPTION
## Summary

TASK-15764 (URLMonitor extraction/diff off the event loop) was implemented twice concurrently — the programme's fourth duplicate — and the incumbent (PR #1650) merged first. Per the standing reconciliation playbook, the incumbent stands; this PR ports the review-hardened delta from our independently-reviewed version (verdict MERGE) on top:

- **Incumbent audited, verdict clean**: 11 full baseline+change cycles comparing complete `change_info`, dispositions, and persisted snapshot rows between the incumbent and the pre-change base — all byte-identical; segment-once sharing preserved; decode placement identical to the reviewed version. No production change needed or made — this PR is tests + docs only.
- **Real gap closed**: the incumbent's every-URL AC was ticked with zero url_list coverage behind it, and its extraction test probes the private fetch helper rather than `check_url`. Ported: 3 per-hop thread-identity tests through the real `launch_run`/`execute_run` path (two URLs × two runs), with whole-check semantic receipts and the segment-once pin. Born-red re-proven against the incumbent's code via runtime per-hop re-inlining — the review's exact sensitivity matrix.
- **Corrected lessons entry** (dev had none): the original 16.2s/99.8% headline did NOT reproduce — SequenceMatcher's autojunk fast-paths Latin text (20–40ms); the quadratic regime is repertoire-dependent (~7 minutes at the 10MB fetch cap on CJK-scale repertoires), so the off-loop move is MORE justified than the original numbers implied. Recorded with both halves: measure the whole operation, and expect the headline number to be re-run by a skeptic.
- **Fourth status-is-not-a-lock incident** recorded in lessons-backlog-hygiene with the commit-level timeline.

Follow-ups queued for filing: per-(subscription,url) in-flight guard (pre-existing double-report window); bound `calculate_change_percentage` by input size; autojunk makes the change percentage meaningless on large Latin text.

`Tests/Subscriptions/` 790 passed / 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports review-hardened tests and docs for TASK-15764 onto the merged `URLMonitor` off-loop implementation to prove extraction and diff work leave the event loop and that semantics match the incumbent. No production behavior changes; adds missing `url_list` coverage and documents reconciliation.

- Adds `Tests/Subscriptions/test_url_monitor_off_loop.py`:
  - Verifies HTML extraction runs off-loop through `check_url`.
  - Verifies all diff-path calls (including `calculate_change_percentage`) run off-loop and produce the same outputs.
  - Drives `url_list` via real `launch_run`/`execute_run` (two URLs × two runs) to ensure every URL’s extraction and diff are off-loop; pins segment-once behavior.
  - Includes born-red checks by re-inlining individual hops at runtime.
- Updates docs: records duplicate-implementation reconciliation and staleness checks in `backlog/docs/lessons-backlog-hygiene.md`, corrects the cost profile and justification in `backlog/docs/lessons-testing-evidence.md`, and logs reconciliation/follow-ups in the task file.
- Safety: no production code changes; incumbent audited byte-identical across 11 baseline+change cycles; no migrations.

<sup>Written for commit f8402cb9040624159749f90d8e75061db8698934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

