### PR TITLE
fix(study): remove the dead Add Topic controls (TASK-16195)

### DIFF
--- a/Tests/UI/test_study_screen.py
+++ b/Tests/UI/test_study_screen.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.containers import Container
-from textual.widgets import Button, Static
+from textual.widgets import Button, Static, Tree
 
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_study_dashboard import (
@@ -725,3 +725,31 @@ async def test_study_window_switch_to_global_button_clears_scope_and_hides_banne
         assert screen.current_scope.scope_type == StudyScopeType.GLOBAL
         assert banner.display is False
         app_instance.open_notes_workspace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_structured_learning_pane_composes_no_orphaned_add_topic_controls():
+    """task-16195: the Study rebuild left the legacy add-topic flow without a
+    dispatcher, and nothing in the app reads the topics table, so the
+    Structured Learning pane must not render the dead 'Add New Topic'
+    affordance (button + title input) while still rendering its topic tree."""
+    StudyScopeContext, StudyScopeType = _load_study_scope_models()
+    app_instance = SimpleNamespace(
+        scope_context=StudyScopeContext(scope_type=StudyScopeType.GLOBAL),
+        current_runtime_backend="local",
+        runtime_backend=None,
+        open_notes_workspace=Mock(),
+        open_study_screen=Mock(),
+        notify=Mock(),
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        study_window = app.screen.query_one(StudyWindow)
+        # The pane itself still renders: the topic tree is composed...
+        study_window.query_one("#topic-tree", Tree)
+        # ...but the orphaned add-topic affordance is gone end-to-end.
+        assert not study_window.query("#add-topic-btn")
+        assert not study_window.query("#new-topic-title")

--- a/backlog/tasks/task-16195 - Study-add-topic-button-has-no-handler-at-HEAD.md
+++ b/backlog/tasks/task-16195 - Study-add-topic-button-has-no-handler-at-HEAD.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16195
 title: 'Study add-topic button has no handler at HEAD'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-14 03:05'
 labels:
@@ -17,7 +17,37 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The add-topic button either performs its intended action end-to-end or is removed from compose
-- [ ] #2 A test pins whichever behavior is chosen
-- [ ] #3 The decision is recorded in the notes
+- [x] #1 The add-topic button either performs its intended action end-to-end or is removed from compose
+- [x] #2 A test pins whichever behavior is chosen
+- [x] #3 The decision is recorded in the notes
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Evidence pass at HEAD: who dispatches `STUDY_BUTTON_HANDLERS`; who reads the `topics` table (DB methods, Study_Interop services, dashboard widgets); does the legacy `handle_add_topic` payload still map onto `ChaChaNotes_DB.create_topic`.
+2. Decide restore-vs-remove on that evidence (recorded in Implementation Notes).
+3. Born-red pinning test in `Tests/UI/test_study_screen.py` using the existing `_build_full_study_app` harness: the Structured Learning pane renders its topic tree but composes NO add-topic affordance (`#add-topic-btn`, `#new-topic-title`). Run at HEAD to show it red.
+4. Implement the chosen behavior (removal of the dead "Add New Topic" row from `StructuredLearningWidget.compose`), re-run test green plus the surrounding Study UI test files.
+5. ruff check + format on touched files; hand-edit task file to Done with notes (backlog CLI mangles five-digit IDs).
+
+## Implementation Notes
+
+**Decision: REMOVE the dead "Add New Topic" affordance** (Label + `#new-topic-title` Input + `#add-topic-btn` Button) from `StructuredLearningWidget.compose` in `tldw_chatbook/UI/Study_Window.py`, with an explanatory comment left at the removal site.
+
+**Evidence chain (why removal, not restore):**
+
+1. **No dispatcher at HEAD.** The legacy `STUDY_BUTTON_HANDLERS` table in `Event_Handlers/Study_Events/study_events.py` is imported only by its own package `__init__.py`; nothing in `tldw_chatbook/` or `Tests/` imports the `Study_Events` package. The handler is unreachable.
+2. **Topics are a write-only concept in the app.** `ChaChaNotes_DB` has `create_topic` and `update_topic_progress` but NO read/list method for topics anywhere; `Study_Interop/local_study_service.py` covers decks/flashcards/templates only, `server_study_service.py` never touches the topics table, and the Study dashboard has no topic surface. A row the button created could never be displayed, in any session.
+3. **The Structured Learning pane is placeholder-grade at HEAD.** `#topic-tree` composes empty ("Learning Paths" root) with no population code; `#topic-content` is a disabled TextArea with placeholder text; the companion `Tree.NodeSelected` handler lives in the same orphaned legacy module. Even when the legacy wiring was live, the tree add was in-session only — restart showed an empty tree.
+4. **The legacy handler's payload doesn't map onto the live schema.** Topics belong to a learning path (`path_id` FK into `learning_paths`); the button had no path context (would insert NULL `path_id`) and passed `created_by`/`last_modified_by` keys that `create_topic` ignores in favor of `client_id`.
+5. **The Study rebuild deliberately scoped its module architecture (Study_Modules controllers + Study_Interop scope services) to flashcards + quizzes.** The live "topic" concepts elsewhere (quiz `focus_topics`/`selected_topic_ids`, conversation `topic_label`) are different features, not the `topics` table.
+
+Restoring would have required building an entire read/display path (DB list method, scope-service plumbing, tree population) for a mock pane — a feature build, not a wiring fix — and porting only the write would ship a silent write-only data sink that fakes success. Removal is the durable choice (per the stability-over-quick-wins ruling).
+
+**Pinning test (born red):** `Tests/UI/test_study_screen.py::test_structured_learning_pane_composes_no_orphaned_add_topic_controls` mounts the production app on the Study screen via the existing `_build_full_study_app` harness, asserts `#topic-tree` still composes, and asserts `#add-topic-btn`/`#new-topic-title` are absent. Run at HEAD before the product change it failed on exactly the button's presence (`assert not study_window.query("#add-topic-btn")` → `AssertionError`); green after the removal.
+
+**Tests run:** `test_study_screen.py` 19 passed; `test_study_flashcards_screen.py` + `test_study_quizzes_screen.py` + `test_study_dashboard.py` + `test_study_origin_navigation.py` + `test_mount_io_off_pump.py` 56 passed; `test_product_maturity_phase3_library_study_context.py` + `test_product_maturity_phase3_source_study_generation.py` + `Tests/ChaChaNotesDB/test_study_functionality.py` 78 passed; `Tests/UI` collect-only sweep 12,531 collected clean. ruff check + format clean on touched files. No user-guide page documents the control (none exists for Study), so no docs update.
+
+**Coordination with task-16196 (legacy module deletion):** nothing needs preserving. With removal chosen, `handle_add_topic`, `handle_topic_selected`, `StudyTopicSelectedEvent`, and the whole `STUDY_BUTTON_HANDLERS` table can be deleted with the module. Note for the record: the table's other entries (`add-child-btn`, `create-course-btn`, `generate-guide-btn`, `add-milestone-btn`) are equally undispatched at HEAD — those buttons remain composed in their (also placeholder) panes and are out of this task's scope.
+
+**Files changed:** `tldw_chatbook/UI/Study_Window.py` (removal), `Tests/UI/test_study_screen.py` (pinning test + `Tree` import).

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -97,11 +97,12 @@ class StructuredLearningWidget(Widget):
                         disabled=True,
                     )
 
-            # Add new topic section
-            yield Label("Add New Topic:", classes="subsection-title")
-            with Horizontal(classes="form-row"):
-                yield Input(placeholder="Topic title...", id="new-topic-title")
-                yield Button("Add Topic", id="add-topic-btn", variant="primary")
+            # task-16195: the "Add New Topic" row (Input #new-topic-title +
+            # Button #add-topic-btn) was removed here. Its only handler lived
+            # in the legacy Event_Handlers/Study_Events table, which nothing
+            # dispatches since the Study rebuild, and no code in the app reads
+            # the topics table back -- the button was a dead affordance whose
+            # restored flow would have been a write-only sink.
 
 
 class AnkiFlashcardsWidget(Widget):


### PR DESCRIPTION
## Summary

The Study surface's "Add New Topic" Label + Input + Button were dead UI: `StudyWindow.on_button_pressed` special-cases two IDs and a `view-` prefix, so a press on `#add-topic-btn` was a SILENT NO-OP in the live event path — the legacy handler table that once served it (`Event_Handlers/Study_Events/study_events.py`) is imported by nothing (review verified: not even its own package `__init__` imports it).

Removal chosen over restoration on a five-link evidence chain, each independently verified in review: no dispatcher at HEAD; topics are WRITE-ONLY in the app (create/update exist, no read path reaches any UI — the one aggregate count is test-only); the Structured Learning pane is placeholder-grade (empty tree, disabled content area, population code only in the orphaned module); the legacy payload silently inserts an orphaned `path_id = NULL` row against live schema; and the Study rebuild deliberately scoped its modules to flashcards + quizzes. Restoring would have been a feature build behind a mock pane or a silent write-only sink.

Born-red pinning test (reproduced in review); 19 + 56 + 78 tests green across the Study suites; ruff clean. Sets up TASK-16196 (delete the legacy handler module — nothing needs preserving; its other four handler entries are equally undispatched, follow-up material for the remaining placeholder buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the orphaned “Add New Topic” controls from the Study Structured Learning pane because they had no dispatcher and button presses were silent no-ops. Previously the UI rendered `#new-topic-title` and `#add-topic-btn`; now those controls are not rendered, while the topic tree still renders. Satisfies TASK-16195.

- Removes the controls in `StructuredLearningWidget.compose` and documents the rationale in-line; adds a compose test that asserts the tree exists and the controls are absent.
- Rationale: the only handler lived in an undispatched legacy table; nothing in the app reads topics; restoring would create a write-only sink in a placeholder pane.
- No data or runtime behavior changes beyond hiding dead UI; no migrations or docs updates.
- Follow-up: enables TASK-16196 to delete the unused legacy study event module and its handlers.

<sup>Written for commit d77082c8b7d6fb09ed068b6b1c4419991c93c3e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

