### PR TITLE
test: pin File Notes back-nav mid-confirmation and the workspace seam contract (TASK-15767)

### DIFF
--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -1772,6 +1772,10 @@ async def test_action_library_notes_files_back_returns_to_database(
             return False if lease is None else lease.release
 
         def cancel_reload_confirmation(self):
+            # Faithful to the real workspace for this test's state: with no
+            # reload confirmation pending, ``LibraryFileNotesWorkspace.
+            # cancel_reload_confirmation`` returns False
+            # (``_dismiss_reload_confirmation``'s None guard; task-15767).
             return False
 
     workspace = WorkspaceProbe()
@@ -1802,6 +1806,181 @@ async def test_action_library_notes_files_back_returns_to_database(
     after_recompose = owner.try_acquire_mutation(binding)
     assert after_recompose is not None
     after_recompose.release()
+
+
+@pytest.mark.asyncio
+async def test_action_library_notes_files_back_cancels_open_reload_confirmation_first(
+    monkeypatch,
+    tmp_path,
+):
+    """task-15767 AC3 (task-15503's Escape contract at the screen seam):
+    pressing back while the destructive-reload confirmation is open must
+    CANCEL the confirmation and stay on Files -- it must never run the
+    leave flush/transition or navigate away while the inline decision is
+    still pending. Only the SECOND back (confirmation gone) takes the
+    normal guarded return to Database Notes."""
+    from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_NOTES
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    app = _build_test_app()
+    owner = app.file_notes_session_owner
+    binding = owner.select_root(tmp_path / "notes")
+    confirmation_open = True
+    cancel_returns = []
+
+    class WorkspaceProbe:
+        async def flush_pending_work(self):
+            assert not confirmation_open, (
+                "back-mid-confirmation must cancel the pending reload "
+                "decision, not run the leave flush"
+            )
+            return not owner.mutation_active(binding)
+
+        def acquire_transition(self, kind):
+            assert not confirmation_open, (
+                "back-mid-confirmation must cancel the pending reload "
+                "decision, not admit a source transition"
+            )
+            lease = owner.try_acquire_transition(binding, kind)
+            return False if lease is None else lease.release
+
+        def cancel_reload_confirmation(self):
+            # Faithful to the real workspace: True exactly when a pending
+            # confirmation was dismissed, False when none was open
+            # (``_dismiss_reload_confirmation``'s None guard).
+            nonlocal confirmation_open
+            was_open = confirmation_open
+            confirmation_open = False
+            cancel_returns.append(was_open)
+            return was_open
+
+    workspace = WorkspaceProbe()
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+    screen._library_file_notes_workspace = workspace
+    screen._library_notes_source = "files"
+    screen._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+    recompose_calls = []
+
+    async def recompose():
+        recompose_calls.append(True)
+
+    monkeypatch.setattr(screen, "recompose", recompose)
+    footer_calls = []
+    monkeypatch.setattr(
+        screen,
+        "_register_footer_shortcuts",
+        lambda: footer_calls.append(screen._library_notes_source),
+    )
+
+    # First back: cancels the open confirmation and STAYS on Files.
+    await screen.action_library_notes_files_back()
+    assert cancel_returns == [True]
+    assert screen._library_notes_source == "files"
+    assert recompose_calls == []
+    # The footer must drop its "esc cancel reload" hint immediately
+    # (task-15503 registered that hint while the decision is pending).
+    assert footer_calls == ["files"]
+
+    # Second back: no confirmation pending -- the normal guarded return
+    # runs and lands on Database Notes.
+    await screen.action_library_notes_files_back()
+    assert cancel_returns == [True, False]
+    assert screen._library_notes_source == "database"
+    assert recompose_calls == [True]
+    assert footer_calls == ["files", "database"]
+    after_recompose = owner.try_acquire_mutation(binding)
+    assert after_recompose is not None
+    after_recompose.release()
+
+
+def test_files_back_navigation_workspace_contract_matches_real_workspace():
+    """task-15767 AC2: the regression behind this task was production
+    widening the File Notes workspace contract (task-15503's
+    ``cancel_reload_confirmation`` call in ``action_library_notes_files_
+    back``) while this file's ``WorkspaceProbe`` doubles stayed on the old
+    shape -- surfacing as an opaque ``AttributeError`` mid-path. Pin the
+    contract structurally: enumerate every attribute the Files-mode leave
+    seams actually access on the workspace, and require (a) that set to be
+    exactly the pinned contract the probes implement, and (b) every pinned
+    name to exist on the REAL ``LibraryFileNotesWorkspace`` with the
+    async-ness the screen assumes. Future widening then fails HERE, naming
+    the probes to update, instead of deep inside an unrelated test."""
+    import ast
+    import inspect
+    import textwrap
+
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+    from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (
+        LibraryFileNotesWorkspace,
+    )
+
+    def workspace_attribute_accesses(func) -> set[str]:
+        """Attributes accessed on the workspace object inside ``func``."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+        found: set[str] = set()
+
+        class Visitor(ast.NodeVisitor):
+            def visit_Attribute(self, node: ast.Attribute) -> None:
+                value = node.value
+                if isinstance(value, ast.Name) and value.id == "workspace":
+                    found.add(node.attr)
+                elif (
+                    isinstance(value, ast.Attribute)
+                    and value.attr == "_library_file_notes_workspace"
+                ):
+                    found.add(node.attr)
+                self.generic_visit(node)
+
+        Visitor().visit(tree)
+        return found
+
+    # The seams the Files-mode back navigation runs through (Escape action,
+    # the shared strip-button return path, and its two workspace helpers).
+    back_seams = (
+        LibraryScreen.action_library_notes_files_back,
+        LibraryScreen._return_to_library_database_notes,
+        LibraryScreen._flush_active_file_notes,
+        LibraryScreen._acquire_file_notes_transition,
+    )
+    called = set()
+    for seam in back_seams:
+        called |= workspace_attribute_accesses(seam)
+    probe_contract = {
+        "flush_pending_work",
+        "acquire_transition",
+        "cancel_reload_confirmation",
+    }
+    assert called == probe_contract, (
+        "the Files-mode back-navigation seams now touch a different "
+        f"workspace contract ({sorted(called)}) than the pinned probe "
+        f"contract ({sorted(probe_contract)}) -- update every "
+        "WorkspaceProbe in this file that those seams can reach, then "
+        "re-pin here (task-15767)"
+    )
+
+    # The cancel branch also re-registers footer shortcuts, whose chooser
+    # reads ``reload_confirmation_active``; the nav tests patch
+    # ``_register_footer_shortcuts`` out, so probes never see it -- but the
+    # real widget must still satisfy it.
+    footer_contract = workspace_attribute_accesses(
+        LibraryScreen._library_footer_shortcuts_for_current_state
+    )
+    assert "reload_confirmation_active" in footer_contract
+
+    # Every pinned name must exist on the REAL workspace with the
+    # async-ness the screen assumes (flush is awaited; the rest are called
+    # synchronously) -- so this pin cannot itself drift from the widget.
+    for name in probe_contract | footer_contract:
+        assert inspect.getattr_static(LibraryFileNotesWorkspace, name) is not None
+    assert inspect.iscoroutinefunction(LibraryFileNotesWorkspace.flush_pending_work)
+    assert not inspect.iscoroutinefunction(LibraryFileNotesWorkspace.acquire_transition)
+    assert not inspect.iscoroutinefunction(
+        LibraryFileNotesWorkspace.cancel_reload_confirmation
+    )
+    assert isinstance(
+        inspect.getattr_static(LibraryFileNotesWorkspace, "reload_confirmation_active"),
+        property,
+    )
 
 
 def test_check_action_gates_media_viewer_back_to_active_viewer():

--- a/backlog/tasks/task-15767 - File-Notes-back-navigation-broke-when-the-destructive-reload-confirm-shipped.md
+++ b/backlog/tasks/task-15767 - File-Notes-back-navigation-broke-when-the-destructive-reload-confirm-shipped.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15767
 title: File Notes back-navigation broke when the destructive-reload confirm shipped
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - notes
@@ -40,16 +41,102 @@ Two things need reconciling:
 
 ## Acceptance Criteria
 
-- [ ] `test_action_library_notes_files_back_returns_to_database` passes on
+- [x] `test_action_library_notes_files_back_returns_to_database` passes on
       dev without weakening what it originally asserted (back navigation from
       File Notes returns to the database view)
-- [ ] Every `WorkspaceProbe` double in `test_screen_navigation.py` that the
+- [x] Every `WorkspaceProbe` double in `test_screen_navigation.py` that the
       back-navigation path can reach implements whatever contract production
       now expects, verified against the real
       `library_file_notes_workspace.py` shape from task-15503 (not a stub
       that merely silences the error)
-- [ ] Pressing "back" while File Notes is mid-confirmation (or in the
+- [x] Pressing "back" while File Notes is mid-confirmation (or in the
       conflict/error state task-15503 added) has explicit, tested behavior —
       not a crash
-- [ ] `Tests/UI/test_library_file_notes_workspace.py` (task-15503's own
+- [x] `Tests/UI/test_library_file_notes_workspace.py` (task-15503's own
       regression matrix) stays green
+
+## Implementation Plan
+
+1. Re-verify the named failure at HEAD (`8727a2861`) before touching anything —
+   dev commit `e917b9076` (2026-08-14, "test: reconcile phase release harness
+   contracts") already added `cancel_reload_confirmation -> False` to the one
+   `WorkspaceProbe` the back action reaches, so the named test may already be
+   green (AC1 partially dissolved by drift-forward).
+2. Reproduce the original break born-red anyway: temporarily remove the probe
+   method (exact pre-`e917b9076` shape), run the named test, capture the
+   `AttributeError: 'WorkspaceProbe' object has no attribute
+   'cancel_reload_confirmation'`, restore via Edit.
+3. AC2: pin the production-side workspace contract structurally — a drift-guard
+   test that AST-scans the Files-mode leave seams in `library_screen.py`
+   (`action_library_notes_files_back`, `_return_to_library_database_notes`,
+   `_flush_active_file_notes`, `_acquire_file_notes_transition`) for attributes
+   accessed on the workspace, asserts the set is exactly
+   {`flush_pending_work`, `acquire_transition`, `cancel_reload_confirmation`},
+   and asserts each exists on the REAL `LibraryFileNotesWorkspace` with matching
+   async-ness. Future contract widening then fails THIS test with a message
+   naming the probes to update, instead of an opaque AttributeError.
+4. AC3: add an explicit behavior pin — back pressed while a reload confirmation
+   is open cancels the confirmation and stays on Files (no flush, no
+   transition, no recompose; footer re-registered); the SECOND back navigates
+   to Database. Mutation-test it by temporarily reverting production's
+   cancel-first branch (test must go red), then restore via Edit.
+5. AC4: run the full task-15503 matrix
+   (`Tests/UI/test_library_file_notes_workspace.py`) plus the full
+   `Tests/UI/test_screen_navigation.py`; ruff check + format on touched files.
+
+## Implementation Notes
+
+**Regression mechanism.** `062c3ee30` (task-15503) widened the workspace
+contract that `action_library_notes_files_back` calls: it now calls
+`workspace.cancel_reload_confirmation()` (cancel-first, stay on Files) before
+the shared guarded return. The nav suite's `WorkspaceProbe` double stayed on
+the old two-method shape (`flush_pending_work` + `acquire_transition`), so the
+back action crashed with `AttributeError ... 'cancel_reload_confirmation'` at
+`library_screen.py:14853` before ever reaching
+`_return_to_library_database_notes`. The break lived at the harness seam —
+the real widget grew the method in the same commit, so live back-navigation
+never crashed; 15503's own matrix passed because it never runs the nav suite.
+
+**State found at HEAD (`8727a2861`).** The named test was ALREADY green:
+dev commit `e917b9076` (2026-08-14, "test: reconcile phase release harness
+contracts") had added `cancel_reload_confirmation -> False` to that one probe.
+Re-verified the mechanism born-red anyway by removing the probe method (exact
+pre-`e917b9076` shape) — the named test failed with the task's exact
+AttributeError at `library_screen.py:14853` — then restored via Edit.
+
+**What this task adds** (production untouched — its behavior was already
+intentional; the gap was coverage):
+
+- `test_action_library_notes_files_back_cancels_open_reload_confirmation_first`
+  (AC3): back pressed mid-confirmation cancels the pending decision and stays
+  on Files — the probe's `flush_pending_work`/`acquire_transition` assert they
+  are NOT reached while the confirmation is open — and the second back takes
+  the normal guarded return to Database. Mutation-verified: temporarily
+  deleting production's cancel-first branch turned the test red.
+- `test_files_back_navigation_workspace_contract_matches_real_workspace`
+  (AC2): AST-scans the four Files-mode back seams
+  (`action_library_notes_files_back`, `_return_to_library_database_notes`,
+  `_flush_active_file_notes`, `_acquire_file_notes_transition`) for attributes
+  accessed on the workspace, pins the set to exactly
+  {`flush_pending_work`, `acquire_transition`, `cancel_reload_confirmation`},
+  and verifies each name exists on the REAL `LibraryFileNotesWorkspace` with
+  the async-ness the screen assumes (plus `reload_confirmation_active` as a
+  property for the footer chooser). Mutation-verified both directions: a
+  widened contract (a bogus `workspace.dismiss_new_guard_probe()` call — the
+  original regression's failure mode) and a narrowed one each fail THIS test
+  with a message naming the probes to update, instead of an opaque
+  AttributeError deep in an unrelated test.
+- Annotated the existing probe's `cancel_reload_confirmation -> False` as
+  faithful to the real widget for its state (no confirmation pending ->
+  `_dismiss_reload_confirmation`'s None guard returns False), so it is not a
+  bare error-silencer.
+
+**Evidence.** Named test: 1 passed at HEAD; born-red AttributeError reproduced
+and restored. Full `Tests/UI/test_screen_navigation.py`: 129 passed. Full
+`Tests/UI/test_library_file_notes_workspace.py` (15503 matrix): 88 passed.
+ruff check clean; ruff format diff on the file is dev's pre-existing 61 lines
+(baseline-verified against `HEAD`'s copy) — my additions are format-clean;
+did not reformat unrelated pre-existing code (smallest honest diff).
+
+**Files.** `Tests/UI/test_screen_navigation.py` (only code change; two new
+tests + one comment), this task file.


### PR DESCRIPTION
## Summary

The filed regression (File Notes back-navigation AttributeError when the destructive-reload confirm shipped in `062c3ee30`) turned out to be a HARNESS-seam break only: the real widget gained `cancel_reload_confirmation` in the same commit that widened the contract (review verified via git history — no window where live back-nav crashed), and dev's `e917b9076` had already patched the one stale `WorkspaceProbe`. What was genuinely missing was coverage, and that's what ships (production untouched):

- **Back-mid-confirmation pin** (previously zero coverage): back with a reload confirmation open cancels it and stays on Files — flush/transition provably not reached — and a second back returns to Database. Born-red against a production mutation deleting the cancel-first branch (reproduced independently in review)
- **Contract drift guard**: an AST scan of the four back seams pins the workspace attribute surface to exactly {flush_pending_work, acquire_transition, cancel_reload_confirmation} and verifies each against the real `LibraryFileNotesWorkspace` incl. async-ness — the original regression's failure mode (a probe silently missing a newly-widened contract) now fails loudly with a message naming the probes to update. Mutation-verified in both widening and narrowing directions
- Probe fidelity annotated (its `return False` matches the real None-guard semantics)

129 + 88 tests green; review → MERGE with the AC3 born-red and the regression-mechanism history independently reproduced. One documented blind spot: the guard is name-based and would miss an arbitrarily-named local alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins File Notes back-navigation behavior and the workspace seam contract in tests to address TASK-15767. Previously, the test double could miss `cancel_reload_confirmation` and raise AttributeError; now the tests assert cancel-first behavior and the exact contract the back seams use. Production behavior is unchanged.

- Adds a test that presses back with a reload confirmation open: first back cancels the confirmation and stays on Files; second back returns to Database. Asserts no flush/transition and footer re-registering.
- Adds an AST-based guard that the Files-mode back seams access exactly {flush_pending_work, acquire_transition, cancel_reload_confirmation} and that the real `tldw_chatbook.Widgets.Library.library_file_notes_workspace.LibraryFileNotesWorkspace` provides them with the expected async/sync shape, plus the `reload_confirmation_active` property.
- Tests-only change in `Tests/UI/test_screen_navigation.py`; no rollout or migrations. If the workspace contract changes, the guard will fail and name the probes to update.

<sup>Written for commit 4254785d752495075897bf47ef08a111c6dc113e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

