### PR TITLE
docs: close task-15741 as not reproducible; file TASK-16480 for the new dev-red six

### DIFF
--- a/backlog/tasks/task-15741 - Blank-note-GC-test-fails-only-in-a-multi-module-run.md
+++ b/backlog/tasks/task-15741 - Blank-note-GC-test-fails-only-in-a-multi-module-run.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15741
 title: Blank-note GC test fails only in a multi-module run
-status: To Do
+status: Done
 assignee: []
 labels:
   - test-health
@@ -43,7 +43,30 @@ expose.
 
 ## Acceptance Criteria
 
-- [ ] The 5-module set is run on base dev and on the branch, and the failure is attributed to one or the other with the run output as evidence
-- [ ] If branch-caused, the interaction is fixed rather than the test reordered around
-- [ ] If pre-existing, the polluting test is identified by name and the shared state it leaks is stated
-- [ ] The test passes in whatever multi-module ordering CI actually uses
+- [x] The 5-module set is run on base dev and on the branch, and the failure is attributed to one or the other with the run output as evidence (superseded: the branch merged as #1554; the run happened on merged dev instead)
+- [x] If branch-caused, the interaction is fixed rather than the test reordered around (n/a -- not reproducible)
+- [x] If pre-existing, the polluting test is identified by name and the shared state it leaks is stated (n/a -- see notes: the failure cannot be reproduced anywhere)
+- [x] The test passes in whatever multi-module ordering CI actually uses
+
+## Implementation Notes
+
+Closed as **not reproducible**, on accumulated negative evidence rather than a
+found polluter:
+
+1. The task-15211 FULL Tests/UI sweep (10,811 tests, all 503 modules,
+   including `test_library_shell.py` whole in chunk 8) never produced the
+   ConflictError -- the chunk-8 library_shell failures were all focus/rows
+   drift, explicitly not this shape.
+2. A dedicated re-run of the EXACT original 5-module combination on merged
+   dev (2026-08-15, 1,019 passed): the target test passed and the string
+   "ConflictError"/"version mismatch" appears zero times in the output.
+3. The original observation was a single occurrence, in a run under heavy
+   CPU contention from four concurrent suites.
+
+The branch-vs-dev attribution the ACs asked for dissolved when the suspect
+branch merged (#1554); with the failure unreproducible on the merged result,
+there is no polluter to name. If it ever recurs, the shape to grep for is
+`ConflictError .* version mismatch` on a note soft-delete.
+
+The re-run surfaced SIX NEW dev-red rows (2 days of dev churn), none of them
+this task's shape -- filed as TASK-16480 rather than absorbed here.

--- a/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
+++ b/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
@@ -1,0 +1,35 @@
+---
+id: TASK-16480
+title: Six new dev-red rows from the mid-August churn
+status: To Do
+assignee: []
+labels:
+  - test-health
+priority: medium
+---
+
+## Description
+
+Found 2026-08-15 while closing task-15741 (a 5-module verification run on
+dev `2e115cf04`-era): six tests are red on untouched dev, none previously
+inventoried -- fresh drift from the last two days' heavy merge traffic.
+
+- `test_settings_configuration_hub.py::test_settings_provider_picker_initial_known_provider_enter_is_noop_for_drafts`
+- `test_settings_configuration_hub.py::test_settings_provider_route_echoes_do_not_survive_widget_lifecycle[category_departure]`
+- `test_settings_configuration_hub.py::test_settings_provider_route_echoes_do_not_survive_widget_lifecycle[recompose]`
+- `test_console_workbench_contract.py::test_console_left_rail_keeps_session_and_moves_staged_context_out`
+- `test_library_shell.py::test_library_note_keyboard_capability_matrix[create_discard-terminal_size0]`
+- `test_library_shell.py::test_library_note_keyboard_capability_matrix[create_discard-terminal_size1]`
+
+Per the standing 15512 discipline: attribute each to its causing commit
+before adjusting any expectation; the route-echo pair touches the
+task-15673/15740 echo family, so check whether a new repopulation site
+missed the prevent()/nav-echo convention before calling the tests stale.
+Another session may already be on some of these -- check `.worktrees/` and
+open branches before starting (a task's status is not a lock).
+
+## Acceptance Criteria
+
+- [ ] Each of the six is attributed to its causing commit
+- [ ] Genuine product breaks are fixed rather than absorbed into expectations
+- [ ] The three modules pass whole on dev


### PR DESCRIPTION
## What

Docs-only. Closes **TASK-15741** (the multi-module blank-note `ConflictError` flake) as **not reproducible**, on accumulated negative evidence:

1. The 10,811-test full sweep (all 503 modules, `library_shell` whole in chunk 8) never produced it
2. A dedicated re-run of the exact original 5-module combination on merged dev: 1,019 passed, zero occurrences of the error signature
3. The single original observation was under four-suite CPU contention

The branch-vs-dev attribution the ACs asked for dissolved when #1554 merged. The recurrence signature (`ConflictError … version mismatch` on a note soft-delete) is recorded in the task for the future.

Also files **TASK-16480**: the re-run surfaced six *new* dev-red rows from the last two days' merge traffic (settings provider-picker/route-echo ×3, workbench rail contract, notes keyboard matrix ×2) — filed with the 15512 discipline rather than absorbed, with a pointer that the route-echo pair may be the 15673/15740 echo family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes `TASK-15741` as not reproducible and adds `TASK-16480` to track six new dev-red tests. This consolidates investigation results and creates a focused follow-up for current failures.

- Verify `backlog/tasks/task-15741 - Blank-note-GC-test-fails-only-in-a-multi-module-run.md` now has status "Done", ACs checked, and records the recurrence signature `ConflictError .* version mismatch` on note soft-delete with the negative evidence (full sweep and 5-module re-run) summarized.
- Verify `backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md` is added with the six failing tests listed and ACs to attribute each to a causing commit per the 15512 discipline.
- No code changes, migrations, or behavior changes.

<sup>Written for commit c0168e4bc13b2dd3af1cc1460f9cc124f70d64c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

