### PR TITLE
perf(watchlists): serve the unread badge count from the effective-date index (TASK-15770)

### DIFF
--- a/Tests/DB/test_subscriptions_db_watchlists.py
+++ b/Tests/DB/test_subscriptions_db_watchlists.py
@@ -1509,3 +1509,222 @@ def test_get_unread_items_count_since_counts_only_newer_unread(db):
     assert db.get_unread_items_count_since("2026-08-07T00:00:00+00:00") == 1, (
         "a is before the floor, c is reviewed -- only b counts"
     )
+
+
+# --- TASK-15770: the Today-badge count is index-served ------------------------
+
+
+def _captured_count_sql(db):
+    """The SQL `get_unread_items_count_since` ACTUALLY executes, captured via
+    `set_trace_callback` -- not a copy of the string pasted into the test, so
+    the plan pin below cannot drift away from the production query."""
+    captured = []
+    db.conn.set_trace_callback(captured.append)
+    try:
+        db.get_unread_items_count_since("2026-08-07T00:00:00+00:00")
+    finally:
+        db.conn.set_trace_callback(None)
+    count_stmts = [s for s in captured if "COUNT(*)" in s and "subscription_items" in s]
+    assert len(count_stmts) == 1, (
+        f"expected exactly one COUNT statement, got: {captured}"
+    )
+    return count_stmts[0]
+
+
+def test_get_unread_items_count_since_is_index_served(db):
+    """AC#1/AC#2 (TASK-15770): the badge count query is served by
+    `idx_subscription_items_effective_date`, not a full-table scan.
+
+    The plan is pinned on the INDEX NAME appearing (lesson: EXPLAIN output
+    can hide a scan behind a table alias, so "no SCAN in the detail" alone
+    is a weaker pin), with the no-SCAN assertion kept as a secondary guard.
+    Born red against the pre-task inline-COALESCE shape: SQLite (probe-
+    verified on 3.49.1) does NOT rewrite the inline expression to the
+    generated column -- that shape full-scans.
+    """
+    source_id = db.add_subscription(
+        name="Feed", type="rss", source="https://f.example/f"
+    )
+    _insert_item(db, source_id, "https://f.example/a", "a", "body")
+
+    sql = _captured_count_sql(db)
+    # The captured statement may arrive with the bound parameter already
+    # expanded (sqlite3_expanded_sql) or still holding the placeholder,
+    # depending on the sqlite3 module build -- EXPLAIN accordingly.
+    params = ("2026-08-07T00:00:00+00:00",) if "?" in sql else ()
+    plan_rows = db.conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    details = [row[3] for row in plan_rows]
+
+    assert any("idx_subscription_items_effective_date" in d for d in details), (
+        f"badge count query is not index-served; plan: {details}"
+    )
+    assert not any(d.startswith("SCAN") for d in details), (
+        f"badge count query still scans; plan: {details}"
+    )
+
+
+def test_unread_count_parity_old_inline_expression_vs_rewritten_query(tmp_path):
+    """AC#3 (TASK-15770): the rewritten count is identical to the OLD inline
+    `COALESCE(datetime(published_date), datetime(created_at))` predicate's,
+    mirroring task-15464's ordering-parity test:
+
+    - LEGACY rows inserted into a hand-built pre-migration schema, then
+      BACKFILLED by opening through `SubscriptionsDB` (the ALTER path);
+    - NEW rows through the real `persist_subscription_item` write path;
+    - valid, NULL, and garbage `published_date`; timezone-offset dates that
+      cross the floor only after `datetime()` normalization; rows exactly AT
+      the floor (inclusive boundary); non-'new' statuses; one hard-deleted
+      row.
+
+    The expected count is the OLD expression independently recomputed
+    against the live table for each floor -- not a hand-written number.
+    """
+    path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_LEGACY_SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO subscriptions (id, name, type, source) "
+        "VALUES (1, 'Legacy', 'rss', 'https://legacy.example/f')"
+    )
+    legacy_rows = [
+        # (url, published_date, created_at, status)
+        (
+            "https://legacy.example/valid",
+            "2024-01-16T09:00:00Z",
+            "2024-01-01 00:00:00",
+            "new",
+        ),
+        ("https://legacy.example/null", None, "2024-06-01 00:00:00", "new"),
+        (
+            "https://legacy.example/garbage",
+            "not-a-real-date",
+            "2024-06-02 00:00:00",
+            "new",
+        ),
+        (
+            "https://legacy.example/at-floor",
+            "2024-05-01T00:00:00Z",
+            "2024-01-01 00:00:00",
+            "new",
+        ),
+        (
+            "https://legacy.example/reviewed",
+            "2024-07-01T00:00:00Z",
+            "2024-01-01 00:00:00",
+            "reviewed",
+        ),
+        # Says "05-01" but normalizes to 2024-04-30 22:00 UTC -- BEFORE a
+        # 2024-05-01T00:00Z floor despite the date string.
+        (
+            "https://legacy.example/tz-before",
+            "2024-05-01T01:00:00+03:00",
+            "2024-01-01 00:00:00",
+            "new",
+        ),
+    ]
+    for url, published, created, status in legacy_rows:
+        conn.execute(
+            "INSERT INTO subscription_items "
+            "(subscription_id, url, title, published_date, created_at, status, content_hash) "
+            "VALUES (1, ?, ?, ?, ?, ?, ?)",
+            (url, url, published, created, status, url),
+        )
+    conn.commit()
+    conn.close()
+
+    legacy_db = SubscriptionsDB(str(path), client_id="count-parity-probe")
+    try:
+        with legacy_db.transaction() as sconn:
+            for url, title, published, now, content_hash in (
+                (
+                    "https://new.example/valid",
+                    "new valid",
+                    "2024-06-15T00:00:00Z",
+                    "2024-01-01T00:00:00+00:00",
+                    "n1",
+                ),
+                (
+                    "https://new.example/null",
+                    "new null",
+                    None,
+                    "2024-05-20T00:00:00+00:00",
+                    "n2",
+                ),
+                (
+                    "https://new.example/garbage",
+                    "new garbage",
+                    "still-garbage",
+                    "2024-04-15T00:00:00+00:00",
+                    "n3",
+                ),
+                (
+                    "https://new.example/at-floor",
+                    "new at floor",
+                    "2024-05-01T00:00:00Z",
+                    "2024-01-01T00:00:00+00:00",
+                    "n4",
+                ),
+                # Normalizes to 2024-05-01 02:00 UTC -- AFTER the floor
+                # despite the "04-30" date string.
+                (
+                    "https://new.example/tz-after",
+                    "new tz after",
+                    "2024-04-30T22:00:00-04:00",
+                    "2024-01-01T00:00:00+00:00",
+                    "n5",
+                ),
+                (
+                    "https://new.example/doomed",
+                    "deleted later",
+                    "2024-06-20T00:00:00Z",
+                    "2024-01-01T00:00:00+00:00",
+                    "n6",
+                ),
+            ):
+                persist_subscription_item(
+                    sconn,
+                    1,
+                    {
+                        "url": url,
+                        "title": title,
+                        "published_date": published,
+                        "content_hash": content_hash,
+                    },
+                    run_id=None,
+                    now=now,
+                )
+        # Read/unread transitions after insert, plus a hard delete.
+        with legacy_db.transaction() as sconn:
+            sconn.execute(
+                "UPDATE subscription_items SET status = 'ignored' WHERE url = ?",
+                ("https://new.example/null",),
+            )
+            sconn.execute(
+                "DELETE FROM subscription_items WHERE url = ?",
+                ("https://new.example/doomed",),
+            )
+
+        floors = (
+            "2024-05-01T00:00:00Z",  # the tie/tz boundary itself
+            "2024-05-01T02:00:00+03:00",  # offset floor: normalizes BEFORE the tie rows
+            "2024-06-01T00:00:00+00:00",  # mid-range
+            "2000-01-01T00:00:00+00:00",  # everything unread
+            "2030-01-01T00:00:00+00:00",  # nothing
+        )
+        nonzero_seen = False
+        for floor in floors:
+            old_count = legacy_db.conn.execute(
+                "SELECT COUNT(*) FROM subscription_items "
+                "WHERE status = 'new' AND "
+                "COALESCE(datetime(published_date), datetime(created_at)) >= datetime(?)",
+                (floor,),
+            ).fetchone()[0]
+            assert legacy_db.get_unread_items_count_since(floor) == old_count, (
+                f"count diverged from the old inline expression at floor {floor}"
+            )
+            nonzero_seen = nonzero_seen or old_count > 0
+        # Guard against a vacuous both-sides-zero pass on a broken fixture.
+        assert nonzero_seen
+        assert legacy_db.get_unread_items_count_since("2030-01-01T00:00:00+00:00") == 0
+    finally:
+        legacy_db.close()

--- a/backlog/tasks/task-15770 - Watchlists-unread-badge-count-still-scans-instead-of-using-the-effective-date-index.md
+++ b/backlog/tasks/task-15770 - Watchlists-unread-badge-count-still-scans-instead-of-using-the-effective-date-index.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15770
 title: 'Watchlists: unread-badge count still scans instead of using the effective_date index'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - perf
@@ -26,13 +27,97 @@ using the index task-15464 built.
 
 ## Acceptance Criteria
 
-- [ ] `get_unread_items_count_since` uses the `effective_date` indexed
+- [x] `get_unread_items_count_since` uses the `effective_date` indexed
       column instead of recomputing the inline `COALESCE(datetime(...))`
       expression
-- [ ] `EXPLAIN QUERY PLAN` for the rewritten query shows the index is used
+- [x] `EXPLAIN QUERY PLAN` for the rewritten query shows the index is used
       (no full-table scan)
-- [ ] The returned count is identical to today's for both legacy rows
+- [x] The returned count is identical to today's for both legacy rows
       (pre-migration, backfilled) and newly-inserted rows (parity test,
       mirroring task-15464's own ordering-parity test)
-- [ ] The Today badge's displayed count is unchanged before/after (existing
+- [x] The Today badge's displayed count is unchanged before/after (existing
       Watchlists UI tests stay green)
+
+## Implementation Plan
+
+1. Re-locate at HEAD (`a58bdc126`): confirm `get_unread_items_count_since`
+   still carries the inline `COALESCE(datetime(published_date),
+   datetime(created_at))` predicate and that task-15464's `effective_date`
+   generated column + `idx_subscription_items_effective_date` index exist.
+2. BEFORE evidence: EXPLAIN QUERY PLAN probe on a REAL seeded SubscriptionsDB
+   (5 subscriptions, 1k/10k items across ~200 days, mixed statuses,
+   NULL/garbage published_date) capturing the full-table `SCAN` for the
+   shipped shape, plus count + timing for both shapes. (Done — the shipped
+   shape scans even on SQLite 3.49.1; the planner does NOT rewrite the
+   inline expression to the generated column.)
+3. Born-red plan-pin test: capture the SQL the method ACTUALLY executes via
+   `set_trace_callback`, EXPLAIN it, and pin on the INDEX NAME appearing
+   (per the alias-trap lesson: pin on the index name, not merely on the
+   absence of the word SCAN). Red against the scanning shape.
+4. Count-parity test mirroring task-15464's ordering-parity test: legacy
+   pre-migration rows (hand-built schema, backfilled by opening through
+   `SubscriptionsDB`) + rows inserted through `persist_subscription_item`,
+   with at/before/after-floor rows, NULL and garbage `published_date`,
+   timezone-offset dates that cross the floor only after normalization, and
+   non-`new` statuses. Expected value = the OLD inline expression
+   independently recomputed against the live table, not a hand-written
+   number.
+5. Fix the query shape only (no schema change — the index already exists):
+   `effective_date >= datetime(?)` replacing the inline COALESCE.
+6. AFTER evidence: re-run the probe (SEARCH ... USING INDEX
+   idx_subscription_items_effective_date), identical counts, timings.
+7. Gates: the SubscriptionsDB watchlists test file + Watchlists UI badge
+   tests; ruff check + format on touched files; baseline any unexplained
+   failures against origin/dev.
+
+## Implementation Notes
+
+Query-shape fix only -- no schema change, no migration. The predicate in
+`SubscriptionsDB.get_unread_items_count_since` now reads the `effective_date`
+generated column (`effective_date >= datetime(?)`) instead of respelling the
+inline `COALESCE(datetime(published_date), datetime(created_at))`, letting
+task-15464's existing `idx_subscription_items_effective_date` serve the floor
+as an index range. The column IS the old expression (GENERATED ALWAYS AS the
+same COALESCE), so the count is provably unchanged.
+
+**Why the rewrite was needed at all:** probe-verified on the shipped SQLite
+3.49.1 that the planner does NOT rewrite a byte-identical inline expression to
+the generated column for index use -- the old shape full-scans even though the
+index existed. EXPLAIN QUERY PLAN evidence from a real seeded SubscriptionsDB
+(5 subscriptions, 1k/10k items across ~200 days, mixed statuses, NULL/garbage
+`published_date`):
+
+- BEFORE: `SCAN subscription_items`
+- AFTER: `SEARCH subscription_items USING INDEX
+  idx_subscription_items_effective_date (effective_date>?)`
+- Counts identical at every scale/floor probed (129/25 @ 1k; 1286/257 @ 10k).
+- Timing @ 10k rows: broad floor 2.85 -> 1.11 ms; narrow today-like floor
+  2.93 -> 0.21 ms (~14x). @ 1k: 0.24 -> 0.02 ms narrow.
+
+**Tests** (Tests/DB/test_subscriptions_db_watchlists.py):
+- `test_get_unread_items_count_since_is_index_served` -- born-red plan pin:
+  captures the SQL the method ACTUALLY executes via `set_trace_callback`
+  (so the pin cannot drift from production), EXPLAINs it, and pins on the
+  INDEX NAME appearing (alias-trap lesson), with no-SCAN as secondary guard.
+  Red against the pre-task shape; green after.
+- `test_unread_count_parity_old_inline_expression_vs_rewritten_query` --
+  mirrors task-15464's ordering-parity test: legacy pre-migration rows
+  backfilled through the ALTER path + rows via `persist_subscription_item`;
+  at/before/after-floor rows, inclusive-boundary row, NULL and garbage
+  `published_date`, timezone-offset dates that cross the floor only after
+  `datetime()` normalization, read/unread transitions, a hard-deleted row;
+  expected value = the OLD inline expression independently recomputed per
+  floor (5 floors incl. offset-bearing), with a nonzero guard against a
+  vacuous both-zero pass.
+
+**Gates:** Tests/DB/test_subscriptions_db_watchlists.py 65/65 passed;
+Tests/Watchlists/ + Tests/UI/test_watchlists_rail_counts_and_scope.py +
+Tests/UI/test_watchlists_check_now_failure.py + Tests/Subscriptions/ =
+1496 passed, 1 pre-existing skip (briefing-voices slice gate); full
+`--collect-only` sweep 48,156 collected, no errors. ruff check clean on both
+touched files; ruff format applied to the appended test range only (the rest
+of the test file predates format enforcement and was left untouched to avoid
+unrelated churn).
+
+**Files:** `tldw_chatbook/DB/Subscriptions_DB.py`
+(`get_unread_items_count_since`), `Tests/DB/test_subscriptions_db_watchlists.py`.

--- a/tldw_chatbook/DB/Subscriptions_DB.py
+++ b/tldw_chatbook/DB/Subscriptions_DB.py
@@ -3117,9 +3117,19 @@ class SubscriptionsDB(BaseDB):
         """How many unread items fall at/after `since` -- the Today badge.
 
         TASK-3791. The floor compares the EFFECTIVE date (``published_date``,
-        falling back to ``created_at``), the same COALESCE `get_new_items`
+        falling back to ``created_at``), the same expression `get_new_items`
         orders by and its `since` predicate filters on, so the badge and the
         node's page answer the same question.
+
+        The predicate reads the ``effective_date`` generated column
+        (TASK-15770), not the inline
+        ``COALESCE(datetime(published_date), datetime(created_at))`` it used
+        to spell out: the column IS that expression (task-15464's
+        ``_ensure_watchlists_schema`` block), so the count is unchanged, but
+        the column name lets ``idx_subscription_items_effective_date`` serve
+        the floor as an index range instead of a full-table scan -- SQLite
+        (probe-verified on 3.49.1) does NOT rewrite the byte-identical
+        inline expression to the generated column on its own.
 
         Args:
             since: Inclusive ISO floor (the screen passes local midnight).
@@ -3130,7 +3140,7 @@ class SubscriptionsDB(BaseDB):
         with self.transaction() as conn:
             row = conn.execute(
                 "SELECT COUNT(*) FROM subscription_items "
-                "WHERE status = 'new' AND COALESCE(datetime(published_date), datetime(created_at)) >= datetime(?)",
+                "WHERE status = 'new' AND effective_date >= datetime(?)",
                 (since,),
             ).fetchone()
         return int(row[0]) if row else 0


### PR DESCRIPTION
## Summary

The Watchlists unread/Today badge count full-scanned `subscription_items` on every refresh despite the right index existing since task-15464: `get_unread_items_count_since` respelled the effective-date expression inline as `COALESCE(datetime(published_date), datetime(created_at))`, and SQLite 3.49 does NOT rewrite even a byte-identical inline expression to a generated column — the index sat unused.

Query-shape fix only (no schema change, no migration): the WHERE now names the generated `effective_date` column, turning `SCAN subscription_items` into `SEARCH ... USING INDEX idx_subscription_items_effective_date`. Semantic equivalence is closed by construction — review confirmed the column is `GENERATED ALWAYS AS (COALESCE(datetime(published_date), datetime(created_at))) VIRTUAL`, byte-for-byte the old expression, recomputed per read.

- Born-red plan pin captures the ACTUALLY-executed SQL via `set_trace_callback` and anchors on the index NAME (the EXPLAIN-alias-oracle lesson); red on the old shape, green after
- Count-identity parity test recomputes the OLD expression as its oracle across seeded edges: legacy pre-migration rows, NULL/garbage dates, tz-offset dates crossing the floor both directions, at-floor inclusivity, deletions, with a nonzero guard
- Perf: 10k rows, narrow today-like floor 2.93→0.21ms (~14×; reviewer independently corroborated ~21× on their hardware); broad floor 2.85→1.11ms
- Repo-wide grep confirms no second inline-COALESCE scan site remains; 65 + 1496 tests green; collect-only sweep clean

Review: independent pass → MERGE, no findings; plans, born-red, parity oracle, and caller census all reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the Watchlists Today-badge unread count from the `effective_date` index to eliminate full-table scans. Previously the WHERE recomputed `COALESCE(datetime(published_date), datetime(created_at))`, which SQLite 3.49.1 did not map to the generated column; now it filters on `effective_date`, enabling `idx_subscription_items_effective_date`. Counts are unchanged; performance improves.

- Replaces the WHERE predicate with `status = 'new' AND effective_date >= datetime(?)` (no schema change, no migration).
- EXPLAIN shows SEARCH using `idx_subscription_items_effective_date`; test pins on the index name using trace-captured SQL.
- Parity test recomputes the old inline expression over legacy (pre-migration/backfilled) and new rows, including NULL/garbage/tz/at-floor and deletions; counts match.
- Perf on 10k rows: narrow floor ~2.93→0.21 ms (~14×); broad floor ~2.85→1.11 ms.
- Satisfies `TASK-15770` ACs (index usage, no scan, count parity, UI badge unchanged).
- Touches `tldw_chatbook/DB/Subscriptions_DB.py` and adds coverage in `Tests/DB/test_subscriptions_db_watchlists.py`.

<sup>Written for commit 86eb1c7958ec64a82a28762caafe9bc6f843cf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

