### PR TITLE
docs: update stale DEFAULT_CSS references for consolidated classes (TASK-15996)

### DIFF
--- a/Tests/UI/test_console_tab_strip_budget.py
+++ b/Tests/UI/test_console_tab_strip_budget.py
@@ -9,7 +9,7 @@ need) but per-button label budget -- Button's ``line-pad: 1`` (one blank
 cell each side, not zero-able via CSS) stacked on the strip rule's
 ``padding: 0 1`` left plain Buttons only ``width - 4`` label cells, so
 ``Temporary`` (9 chars) got 8 in its 12-wide button. (Session tabs escaped:
-``ConsoleSessionTabButton``'s nowrap+clip DEFAULT_CSS paints past the
+``ConsoleSessionTabButton``'s nowrap+clip BUNDLED_CSS paints past the
 line-pad area up to the widget edge, so their 19-char labels rendered whole
 all along.) The rule now carries ``padding: 0``; line-pad alone keeps the
 identical one-cell visual gap and leaves the label budget at ``width - 2``.

--- a/Tests/UI/test_mcp_tools_mode.py
+++ b/Tests/UI/test_mcp_tools_mode.py
@@ -848,7 +848,7 @@ async def test_filter_server_select_has_nonzero_geometry_with_bundled_css():
             "filter-server Select collapsed to zero width under the real "
             "bundled stylesheet (Defect 1, QA round mcp-hub-phase3-2026-07) "
             "-- _conversations.tcss's global `Select { width: 100%; }` rule "
-            "is clobbering MCPToolsMode's own DEFAULT_CSS override again."
+            "is clobbering MCPToolsMode's own BUNDLED_CSS override again."
         )
         assert select.size.height > 0, "filter-server Select collapsed to zero height"
 

--- a/Tests/UI/test_screen_footer_hints.py
+++ b/Tests/UI/test_screen_footer_hints.py
@@ -506,19 +506,19 @@ def _footer_section_blocks(css_path: Path) -> dict[str, dict[str, str]]:
     text = css_path.read_text(encoding="utf-8")
     assert _FOOTER_SECTION_START in text and _FOOTER_SECTION_END in text, (
         f"{css_path.name} lost its '{_FOOTER_SECTION_START}' section markers -- "
-        "the DEFAULT_CSS drift guard needs them to find the footer block."
+        "the BUNDLED_CSS drift guard needs them to find the footer block."
     )
     section = text.split(_FOOTER_SECTION_START, 1)[1].split(_FOOTER_SECTION_END, 1)[0]
     return _parse_css_blocks(section)
 
 
 def _default_css_divergences(bundle_blocks: dict[str, dict[str, str]]) -> list[str]:
-    """Every DEFAULT_CSS declaration missing/different in the bundle blocks.
+    """Every BUNDLED_CSS declaration missing/different in the bundle blocks.
 
-    DEFAULT_CSS scopes child selectors as ``AppFooterStatus #id``; the bundle
+    BUNDLED_CSS scopes child selectors as ``AppFooterStatus #id``; the bundle
     declares the same ids unscoped, so the scope prefix is stripped before
-    matching. DEFAULT_CSS is allowed to be a SUBSET (the bundle carries
-    extras); a declaration present in DEFAULT_CSS but absent or different in
+    matching. BUNDLED_CSS is allowed to be a SUBSET (the bundle carries
+    extras); a declaration present in BUNDLED_CSS but absent or different in
     the bundle is drift.
     """
     divergences = []
@@ -566,7 +566,7 @@ def test_built_bundle_carries_the_footer_rules():
     )
     assert divergences == [], (
         "The built bundle's footer block diverged from AppFooterStatus."
-        f"DEFAULT_CSS: {divergences}. If _widgets.tcss is already correct, "
+        f"BUNDLED_CSS: {divergences}. If _widgets.tcss is already correct, "
         "the bundle is stale -- rerun python3 tldw_chatbook/css/build_css.py."
     )
 

--- a/backlog/tasks/task-15996 - Update-stale-DEFAULT_CSS-references-for-consolidated-classes.md
+++ b/backlog/tasks/task-15996 - Update-stale-DEFAULT_CSS-references-for-consolidated-classes.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15996
 title: 'Update stale DEFAULT_CSS references for consolidated classes'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:10'
 labels:
   - docs
@@ -17,6 +18,34 @@ Four in-tree references still say `DEFAULT_CSS` for classes that now declare `BU
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All four cited references updated to name BUNDLED_CSS (and the contract note reads correctly)
-- [ ] #2 A grep sweep confirms no other stale comment/docstring references remain for the 57 consolidated classes
+- [x] #1 All four cited references updated to name BUNDLED_CSS (and the contract note reads correctly)
+- [x] #2 A grep sweep confirms no other stale comment/docstring references remain for the 57 consolidated classes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enumerate the currently-consolidated classes at HEAD: `grep -rn "BUNDLED_CSS\s*=\|BUNDLED_SCREEN_CSS\s*="` under `tldw_chatbook/`, mapped to their enclosing class name.
+2. Re-locate the four cited references at HEAD (lines have moved) and read enough surrounding context to fix the whole sentence, not just the token.
+3. Repo-wide sweep: `grep -rn DEFAULT_CSS` over `tldw_chatbook/` and `Tests/`, cross-reference every hit against the enumerated class list (same-line name match), and separately re-grep each of the 53 consolidated-declaring files for any OTHER `DEFAULT_CSS` mention (self-referential comments that don't repeat the class name on the same line, e.g. "this widget's own DEFAULT_CSS").
+4. Classify every hit: (a) self-referential to a consolidated class's own former attribute -> fix to BUNDLED_CSS; (b) a generic Textual CSS-tier statement ("app-tier CSS beats widget DEFAULT_CSS on ties") -> leave alone, still accurate Textual terminology; (c) about Textual's own builtin widgets (Button/Footer) -> leave alone; (d) about a different, non-consolidated class in the same file -> leave alone.
+5. Apply fixes; for chat_screen.py's harness-behavior claim, rewrite to describe the real ConsolidatedCSSApp mechanism rather than a blind rename, since the old claim ("any bare App loads widget DEFAULT_CSS") no longer holds post-15450.
+6. Verify: py_compile every touched file, run `Tests/UI/test_widget_css_consolidation.py` plus the touched tests, ruff check/format --diff on touched files only.
+7. Update this task file and commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed the 4 cited references plus 25 more found by the sweep (29 hit-sites, 20 files: 17 source + 3 tests). Enumerating `BUNDLED_CSS`/`BUNDLED_SCREEN_CSS`-declaring classes at HEAD found 53 (46 `BUNDLED_CSS` + 7 `BUNDLED_SCREEN_CSS`), not 57 — some classes from TASK-15450's original count have since been refactored/retired; not a concern, current state is what matters for accuracy.
+
+Every remaining `DEFAULT_CSS` hit repo-wide was read in context and classified, not blindly renamed:
+- **Fixed (self-referential to a consolidated class's own former attribute):** Constants.py:1390, help.py:97, mcp_tools_mode.py:140, mcp_inspector.py:848 (the 4 cited) + AppFooterStatus.py:114, main_navigation.py:824, mcp_workbench.py:314+982, mcp_audit_mode.py:279+696, mcp_permissions_mode.py:89, mcp_inspector.py:329+1124+1130+1133+1137, personas_screen.py:672+9791, persona_profile_editor_widget.py:60, personas_conversation_transcript_widget.py:21, personas_character_card_widget.py:38, personas_character_editor_widget.py:80+329, persona_profile_card_widget.py:24, console_session_surface.py:307, plus 3 test files (test_mcp_tools_mode.py:851, test_screen_footer_hints.py:509/516/518/520/521/569, test_console_tab_strip_budget.py:12).
+- **chat_screen.py:1755-1756 rewritten, not just renamed:** the old comment claimed "test harnesses ... load widget DEFAULT_CSS" — true pre-15450 (Textual auto-loads any class's literal `DEFAULT_CSS`), false now (`BUNDLED_CSS` is inert until a harness uses `ConsolidatedCSSApp`, per `Tests/UI/consolidated_css.py`'s own docstring). Rewrote to name that mechanism.
+- **Left alone, generic Textual CSS-tier statements** ("app-tier CSS beats widget DEFAULT_CSS on ties/regardless of specificity") — still accurate Textual terminology, not about a specific class's renamed attribute: mcp_workbench.py:673, mcp_servers_mode.py:302, mcp_inspector.py:732+847(Textual's own `Button.DEFAULT_CSS`), mcp_audit_mode.py:280, personas_screen.py:531, lab_mode_strip.py:49, personas_inspector_pane.py:129, personas_library_pane.py:435, main_navigation.py:224-225+233.
+- **Left alone, unrelated:** AppFooterStatus.py:106 (Textual's own `Footer.DEFAULT_CSS`), mcp_rail.py:197 (Textual's own `Button.DEFAULT_CSS`), ccp_loading_indicators.py:369 (a different, non-consolidated class — `InlineLoadingIndicator` — in the same file). `Docs/Development/css-consolidation-strategy.md` describes the pre-migration state as design rationale, not a live pointer; left untouched as historical.
+
+Verification: every touched file `py_compile`s; `Tests/UI/test_widget_css_consolidation.py` 17/17 pass (unchanged); `Tests/UI/test_screen_footer_hints.py` and `test_console_tab_strip_budget.py` pass except one pre-existing, unrelated failure (`test_production_routes_own_and_preserve_contextual_footer_hints`, a full-app integration test at a line range untouched by this diff — confirmed via `git show HEAD:...` byte-diff against the edited file, the only differences are the 6 lines this task changed, all in unrelated helper functions). `ruff check`/`format --diff` on the 20 touched files surfaced only pre-existing, unrelated debt (2 unused imports, formatting drift elsewhere in 11 files) on lines this diff never touches.
+
+Modified files: `tldw_chatbook/Constants.py`, `tldw_chatbook/UI/Workbench/help.py`, `tldw_chatbook/UI/MCP_Modules/{mcp_tools_mode,mcp_inspector,mcp_workbench,mcp_audit_mode,mcp_permissions_mode}.py`, `tldw_chatbook/UI/Navigation/main_navigation.py`, `tldw_chatbook/UI/Screens/{chat_screen,personas_screen}.py`, `tldw_chatbook/Widgets/AppFooterStatus.py`, `tldw_chatbook/Widgets/Console/console_session_surface.py`, `tldw_chatbook/Widgets/Persona_Widgets/{persona_profile_editor_widget,persona_profile_card_widget,personas_character_card_widget,personas_character_editor_widget,personas_conversation_transcript_widget}.py`, `Tests/UI/{test_mcp_tools_mode,test_screen_footer_hints,test_console_tab_strip_budget}.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -1387,7 +1387,7 @@ MetricsScreen Label.-info-message {
 /* NOTE: this css_content copy is DEAD -- production loads
    css/tldw_cli_modular.tcss, built from css/components/_widgets.tcss,
    which is the live source for these AppFooterStatus rules and carries
-   the KEEP-IN-SYNC contract with AppFooterStatus.DEFAULT_CSS (task-264). */
+   the KEEP-IN-SYNC contract with AppFooterStatus.BUNDLED_CSS (task-264). */
 AppFooterStatus {
     dock: bottom;
     height: 1;

--- a/tldw_chatbook/UI/MCP_Modules/mcp_audit_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_audit_mode.py
@@ -276,7 +276,7 @@ class MCPAuditMode(DataTableClickSelectMixin, Vertical):
     Select-width lesson (`#mcp-tools-filter-server-slot Select`,
     mcp_tools_mode.py / _agentic_terminal.tcss) applies here too --
     `_conversations.tcss`'s bare `Select { width: 100%; }` rule always wins
-    over ANY rule targeting a `Select` in this widget's own DEFAULT_CSS
+    over ANY rule targeting a `Select` in this widget's own BUNDLED_CSS
     once the real app bundle is loaded (CSS_PATH always beats DEFAULT_CSS,
     regardless of selector specificity) -- so styling
     `#mcp-audit-filter-decision`/`#mcp-audit-filter-initiator` directly
@@ -693,7 +693,7 @@ class MCPAuditMode(DataTableClickSelectMixin, Vertical):
     def _apply_subview_display(self) -> None:
         """Toggle the Executions/Findings pane visibility and the sub-view
         Buttons' `is-active` marker from `self._sub_view` -- the single
-        source of truth (see the DEFAULT_CSS comment above
+        source of truth (see the BUNDLED_CSS comment above
         `#mcp-audit-executions-view`/`#mcp-audit-findings-view` for why
         this isn't split across a CSS default too)."""
         executions_active = self._sub_view == "executions"

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -326,7 +326,7 @@ def _cascade_rungs(
     colored by its resolved verdict (`tool_state_kind()`, the T1 kind->class
     helper, via the existing `.mcp-status-{ready|warning|error}` classes);
     the other two rungs are dimmed (`.mcp-status-muted`, defined in this
-    widget's own `DEFAULT_CSS` below -- no such class existed in the shared
+    widget's own `BUNDLED_CSS` below -- no such class existed in the shared
     bundle yet). `global_default` is never `None` (a permission store always
     resolves SOME global default), so a winner always exists.
 
@@ -845,7 +845,7 @@ class MCPInspector(Vertical):
         border: none;
         /* A3: Button defaults BOTH text-align and content-align to center
         (see Textual's own Button.DEFAULT_CSS -- the same lesson already
-        documented on Button.mcp-rail-row in MCPRail.DEFAULT_CSS and
+        documented on Button.mcp-rail-row in MCPRail.BUNDLED_CSS and
         Button.mcp-callout in _agentic_terminal.tcss) -- without this, the
         action stack (and the lone Cancel button during an in-flight
         lifecycle op) renders each label centered in its full-width row
@@ -1121,20 +1121,20 @@ class MCPInspector(Vertical):
         yield Static("", id="mcp-inspector-message", classes="ds-field-row", markup=False)
         yield Vertical(id="mcp-inspector-actions")
         # T6: tool-detail container, populated by show_tool() -- hidden
-        # (display: none, see DEFAULT_CSS) until a Tools-mode row is
+        # (display: none, see BUNDLED_CSS) until a Tools-mode row is
         # selected.
         yield Vertical(id="mcp-inspector-tool")
         # T7: permission-explanation container, populated by
         # `_render_permission_container()` (via `show_tool()`'s `effective`
         # keyword or the standalone `show_permission()`) -- hidden (display:
-        # none, see DEFAULT_CSS) until a permission context is supplied.
+        # none, see BUNDLED_CSS) until a permission context is supplied.
         yield Vertical(id="mcp-inspector-permission")
         # T7 (MCP Hub Phase 5): audit-entry detail container, populated by
-        # `show_audit_entry()` -- hidden (display: none, see DEFAULT_CSS)
+        # `show_audit_entry()` -- hidden (display: none, see BUNDLED_CSS)
         # until an Audit-mode row is selected.
         yield Vertical(id="mcp-inspector-audit")
         # T8 (MCP Hub Phase 5): finding-detail container, populated by
-        # `show_finding()` -- hidden (display: none, see DEFAULT_CSS) until
+        # `show_finding()` -- hidden (display: none, see BUNDLED_CSS) until
         # an Audit-mode Findings-table row is selected.
         yield Vertical(id="mcp-inspector-finding")
         # Task 5 (MCP Hub Phase 6): the Advanced (legacy control plane)

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -86,7 +86,7 @@ _SERVER_PROFILES_POINTER = (
 # choice, not necessarily a fault, so it should read as "blocked" rather
 # than "alarm". `muted` has no color at all (the `dim` attribute only) --
 # used for a "—" no-data placeholder, the same visual weight `$text-muted`
-# gets elsewhere in this module (see `#mcp-perm-legend`'s DEFAULT_CSS rule
+# gets elsewhere in this module (see `#mcp-perm-legend`'s BUNDLED_CSS rule
 # above).
 _STATE_TEXT_STYLES: dict[str, str] = {
     "ready": "green",

--- a/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
@@ -137,7 +137,7 @@ class MCPToolsMode(DataTableClickSelectMixin, Vertical):
     #mcp-tools-filter-server-slot Select {
         width: 28;
     }
-    /* T7 (P3 UX batch): same fix as MCPServersMode.DEFAULT_CSS's
+    /* T7 (P3 UX batch): same fix as MCPServersMode.BUNDLED_CSS's
     #mcp-servers-table -- height: auto + max-height: 70% instead of height:
     1fr, so the table hugs its own row count instead of ballooning to fill
     the canvas. */

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -311,7 +311,7 @@ _LEGACY_SECTIONS = [
 
 # F-057: terminal-width threshold (cols) below which `#mcp-hub-grid` gets
 # the `.mcp-compact` class and the triad rebalances toward the canvas (see
-# DEFAULT_CSS and its _agentic_terminal.tcss mirror).
+# BUNDLED_CSS and its _agentic_terminal.tcss mirror).
 _COMPACT_WIDTH = 120
 
 # T5: local-profile lifecycle actions this workbench can dispatch, keyed by
@@ -979,7 +979,7 @@ class MCPWorkbench(Container):
     def _sync_compact_class(self) -> None:
         """Toggle `.mcp-compact` on `#mcp-hub-grid` below ~120 cols (F-057).
 
-        The class drives the triad-rebalancing rules in DEFAULT_CSS (and
+        The class drives the triad-rebalancing rules in BUNDLED_CSS (and
         their _agentic_terminal.tcss mirror): narrower rail/inspector
         shares so the canvas keeps its primary columns in-viewport. Width
         0 (pre-layout) means "not compact" -- the full triad renders first

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -821,7 +821,7 @@ class MainNavigationBar(Container):
         mid-word, e.g. "Watchlists" -> "Watc").
 
         This is purely cosmetic (`.nav-button-clip-ghost`, defined in
-        `DEFAULT_CSS`, colors every surface to match the bar's own
+        `BUNDLED_CSS`, colors every surface to match the bar's own
         background) -- it does NOT touch `display`, so the button keeps
         its normal layout box. That distinction is what makes this safe
         to call from every settle path (mount, resize, activating a

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1752,8 +1752,10 @@ class ChatScreen(BaseAppScreen):
     # controls during a ~5s toast dismisses the toast instead of pressing the
     # button. Dock the Console screen's toast rack to the TOP-right so feedback
     # never obscures, or swallows clicks aimed at, the composer's controls.
-    # Kept in DEFAULT_CSS (not the bundle) so it applies in both the real app
-    # and test harnesses, which load widget DEFAULT_CSS but not the built bundle.
+    # Kept in BUNDLED_CSS (not the CSS_PATH bundle) so it applies in both the
+    # real app and ConsolidatedCSSApp-based test harnesses, which load the
+    # generated widget-defaults sheet but not necessarily the full CSS_PATH
+    # bundle.
     BUNDLED_CSS = """
     ChatScreen ToastRack {
         dock: top;

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -669,7 +669,7 @@ class PersonasScreen(BaseAppScreen):
        card entirely at 100x30, and left a dead void between the panels at
        170x50. Each section is now a one-line collapsed header by default,
        so no explicit max-height cap is needed here (the panels' own
-       DEFAULT_CSS keeps every part height: auto, which the old cap existed
+       BUNDLED_CSS keeps every part height: auto, which the old cap existed
        to force). */
     #personas-character-attachments {
         height: auto;
@@ -9788,7 +9788,7 @@ class PersonasScreen(BaseAppScreen):
         # conversation-actions early-return below (and not depend on it
         # succeeding) - otherwise a failed actions lookup would skip setting
         # `.display` here, and the panel (which has no `display: none` of its
-        # own in DEFAULT_CSS) would default visible in every mode.
+        # own in BUNDLED_CSS) would default visible in every mode.
         try:
             dict_panel = self.query_one(PersonasCharacterDictionariesWidget)
         except Exception:

--- a/tldw_chatbook/UI/Workbench/help.py
+++ b/tldw_chatbook/UI/Workbench/help.py
@@ -94,7 +94,7 @@ class WorkbenchHelpPanel(SafeModalDismissMixin, ModalScreen[None]):
     # DEFAULT_CSS is a structural SUBSET using only built-in Textual theme
     # variables ($primary/$surface), so the panel is correctly bounded and
     # scrollable even in a stylesheet-less test harness that never loads the
-    # app's CSS bundle (mirrors AppFooterStatus.DEFAULT_CSS's own rationale
+    # app's CSS bundle (mirrors AppFooterStatus.BUNDLED_CSS's own rationale
     # -- WorkbenchHelpPanel is shared infra invoked from many screens'
     # lightweight test harnesses, not just Console's). The bundle's richer
     # `$ds-*`-token rule wins by origin in production for color/border

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -111,7 +111,7 @@ class AppFooterStatus(Widget):
     # KEEP IN SYNC with the live bundle source
     # css/components/_widgets.tcss ("Window Footer Widget" block, built
     # into tldw_cli_modular.tcss -- NOT Constants.py's css_content, which
-    # has no consumers): DEFAULT_CSS covers stylesheet-less harnesses; the
+    # has no consumers): BUNDLED_CSS covers stylesheet-less harnesses; the
     # app bundle wins by origin in production. A bundle-only edit would
     # silently diverge harness geometry from production (task-264 review).
     BUNDLED_CSS = """

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -304,7 +304,7 @@ class ConsoleSessionSurface(Vertical):
         (``console_chat_models.py``, the auto-title helper this label
         usually renders) -- one truncation convention, not two. TASK-375's
         own word-wrap fix (``ConsoleSessionTabButton``'s ``text-wrap:
-        nowrap`` DEFAULT_CSS above) is untouched and still what keeps a
+        nowrap`` BUNDLED_CSS above) is untouched and still what keeps a
         single-line label from hiding the ellipsis off-screen; only the
         cut POSITION changes here. Trade-off accepted: two conversations
         sharing a long common prefix can once again render identical tab

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_card_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_card_widget.py
@@ -21,7 +21,7 @@ class PersonaProfileCardWidget(Container):
     """Read-only persona profile card with an Edit action."""
 
     # Structure only: colors come from the app stylesheet ($ds-* tokens do not
-    # resolve in bare-App harnesses, so DEFAULT_CSS must not reference them).
+    # resolve in bare-App harnesses, so BUNDLED_CSS must not reference them).
     BUNDLED_CSS = """
     PersonaProfileCardWidget {
         width: 100%;

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -57,7 +57,7 @@ class PersonaProfileEditorWidget(Container):
     }
 
     /* Live per-field validation (Roleplay P3b Task 4): a literal color, not
-       a $ds-* token - DEFAULT_CSS must resolve in bare-App test harnesses
+       a $ds-* token - BUNDLED_CSS must resolve in bare-App test harnesses
        that never load the app stylesheet. */
     PersonaProfileEditorWidget .is-invalid {
         border: round red;

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_card_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_card_widget.py
@@ -35,7 +35,7 @@ class PersonasCharacterCardWidget(Container):
     """Flat read-only character card with an Edit action."""
 
     # Structure only: colors come from the app stylesheet ($ds-* tokens do not
-    # resolve in bare-App harnesses, so DEFAULT_CSS must not reference them).
+    # resolve in bare-App harnesses, so BUNDLED_CSS must not reference them).
     BUNDLED_CSS = """
     PersonasCharacterCardWidget {
         width: 100%;

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_character_editor_widget.py
@@ -77,7 +77,7 @@ class PersonasCharacterEditorWidget(Container):
     """ds-field-row character form with an Advanced section and avatar status."""
 
     # Structure only: colors come from the app stylesheet ($ds-* tokens do not
-    # resolve in bare-App harnesses, so DEFAULT_CSS must not reference them).
+    # resolve in bare-App harnesses, so BUNDLED_CSS must not reference them).
     BUNDLED_CSS = """
     PersonasCharacterEditorWidget {
         width: 100%;
@@ -326,7 +326,7 @@ class PersonasCharacterEditorWidget(Container):
     }
 
     /* Live per-field validation (Roleplay P3b Task 4): a literal color, not
-       a $ds-* token - DEFAULT_CSS must resolve in bare-App test harnesses
+       a $ds-* token - BUNDLED_CSS must resolve in bare-App test harnesses
        that never load the app stylesheet. */
     PersonasCharacterEditorWidget .is-invalid {
         border: round red;

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_conversation_transcript_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_conversation_transcript_widget.py
@@ -18,7 +18,7 @@ class PersonasConversationTranscriptWidget(Container):
     """Flat, read-only transcript of a saved conversation."""
 
     # Structure only: colors come from the app stylesheet ($ds-* tokens do not
-    # resolve in bare-App harnesses, so DEFAULT_CSS must not reference them).
+    # resolve in bare-App harnesses, so BUNDLED_CSS must not reference them).
     # height: 1fr (not 100%): the detail stack is a VerticalScroll (task-2231)
     # and this view is always shown WITH the 3-line conversation-actions row;
     # 100% would overflow the viewport by exactly that row, making the stack


### PR DESCRIPTION
## Summary

After TASK-15450 moved 53 classes to `BUNDLED_CSS`/`BUNDLED_SCREEN_CSS`, in-tree comments and docstrings still pointed readers at `DEFAULT_CSS` — including `Constants.py`'s KEEP-IN-SYNC contract note (task-264), which now sent a reader hunting the contract in the wrong attribute.

- The four cited sites fixed, plus 25 more found by a deeper sweep (per-file re-grep of every consolidated class's own source for self-referential mentions, not just same-line name matches): MCP modules, Personas widgets, navigation/footer, console surface, and three test files whose docstrings pinned the old naming
- Each hit read in context and classified, not blindly renamed: generic Textual CSS-tier statements, Textual builtin-widget references, a non-consolidated same-file class, and the historical design doc were verified correct and left alone
- `chat_screen.py`'s ToastRack comment REWRITTEN rather than renamed — its old harness claim became false post-consolidation; the new text names the real mechanism (`ConsolidatedCSSApp`)

Text-only diff (no logic); all touched files compile; consolidation pin 17/17; the three touched test files 46/46 green (controller-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update comments, docstrings, and test messages to reference `BUNDLED_CSS`/`BUNDLED_SCREEN_CSS` instead of `DEFAULT_CSS` for consolidated widgets, so readers hit the correct source of truth. This also fixes the AppFooterStatus KEEP-IN-SYNC note and removes misleading guidance left from TASK-15450.

- Text-only changes across 20 files; no logic or runtime effect. Builds compile and touched tests pass.
- Apply renames only where a class referenced its own former attribute; keep generic Textual statements and builtin widget references intact.
- Rewrite the `ChatScreen` ToastRack comment to correctly cite `ConsolidatedCSSApp` as the harness mechanism.
- Satisfies TASK-15996: updates the four cited sites and completes a sweep to remove other stale self-references.

<sup>Written for commit ef31a11ce2749287df5b5b1559cef9be5422233a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

