### PR TITLE
fix(console): harden runtime attach and the construction-site pin (#1648 follow-up)

### DIFF
--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -20,6 +20,7 @@ dead view.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -41,26 +42,39 @@ from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 #: `ConsoleProviderGateway(` is deliberately NOT here -- the Personas
 #: preview controller builds its own, unrelated to the Console runtime
 #: (`UI/Persona_Modules/personas_preview_controller.py`).
-_RUNTIME_OWNED_CONSTRUCTIONS = ("ConsoleChatStore(", "ConsoleChatController(")
+_RUNTIME_OWNED_CONSTRUCTIONS = ("ConsoleChatStore", "ConsoleChatController")
 
 _PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
 _RUNTIME_MODULE = "tldw_chatbook/Chat/console_runtime.py"
 
 
-def _construction_sites(token: str) -> list[str]:
-    """Every `<path>:<line>` in the shipped package containing `token`."""
+def _construction_sites(class_name: str) -> list[str]:
+    """Every `<path>:<line>` in the shipped package CALLING `class_name(...)`.
+
+    AST-based on purpose (PR #1648 follow-up): a raw substring scan counts
+    innocuous mentions in comments, docstrings, and string literals as
+    construction sites and false-fails the pin. Only actual call nodes
+    count here.
+    """
     sites: list[str] = []
     for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
         try:
             source = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
-            continue
-        if token not in source:
+            tree = ast.parse(source)
+        except (OSError, UnicodeDecodeError, SyntaxError):  # pragma: no cover
             continue
         rel = path.relative_to(_PACKAGE_ROOT.parent).as_posix()
-        for lineno, line in enumerate(source.splitlines(), start=1):
-            if token in line:
-                sites.append(f"{rel}:{lineno}: {line.strip()}")
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            called = (
+                func.id if isinstance(func, ast.Name) else func.attr
+                if isinstance(func, ast.Attribute) else None
+            )
+            if called == class_name:
+                line = source.splitlines()[node.lineno - 1].strip()
+                sites.append(f"{rel}:{node.lineno}: {line}")
     return sites
 
 

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -691,7 +691,18 @@ def _attach(app: Any, runtime: ConsoleRuntime | None) -> None:
             CONSOLE_RUNTIME_ATTR,
         )
         return
-    if getattr(app, CONSOLE_RUNTIME_ATTR, None) is not runtime:
+    # Read back inside its own guard: a custom __getattribute__ that raises
+    # must not break _attach's never-raise contract either.
+    try:
+        attached = getattr(app, CONSOLE_RUNTIME_ATTR, None)
+    except Exception:  # noqa: BLE001 - never raise from the post-check
+        logger.opt(exception=True).warning(
+            "Console runtime: could not read back the app's %s attribute "
+            "to confirm the attach.",
+            CONSOLE_RUNTIME_ATTR,
+        )
+        return
+    if attached is not runtime:
         logger.warning(
             "Console runtime: the app's %s attribute is not the runtime "
             "just attached (a property or validator rewrote it); future "

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -671,14 +671,31 @@ class ConsoleRuntime:
 
 
 def _attach(app: Any, runtime: ConsoleRuntime | None) -> None:
-    """Write `runtime` (or `None`) onto the app's runtime attribute."""
+    """Write `runtime` (or `None`) onto the app's runtime attribute.
+
+    A failed or rewritten attach never raises -- read-only app doubles in
+    tests are an expected, tolerated case -- but it is recorded loudly:
+    a silently unattached runtime breaks the ownership invariant
+    ``ensure_console_runtime`` exists to guarantee (every later call would
+    miss the attribute and construct a duplicate runtime).
+    """
     if app is None:
         return
     try:
         setattr(app, CONSOLE_RUNTIME_ATTR, runtime)
     except Exception:  # noqa: BLE001 - a read-only app double is not an error
-        logger.debug(
-            "Console runtime: could not write the app's %s attribute.",
+        logger.opt(exception=True).warning(
+            "Console runtime: could not write the app's %s attribute; the "
+            "runtime stays detached and future Console visits will each "
+            "build their own.",
+            CONSOLE_RUNTIME_ATTR,
+        )
+        return
+    if getattr(app, CONSOLE_RUNTIME_ATTR, None) is not runtime:
+        logger.warning(
+            "Console runtime: the app's %s attribute is not the runtime "
+            "just attached (a property or validator rewrote it); future "
+            "Console visits will each build their own.",
             CONSOLE_RUNTIME_ATTR,
         )
 


### PR DESCRIPTION
## What

Addresses the two actionable findings from Qodo's post-merge review of #1648 (its review landed seven minutes after that PR merged, so the threads stayed untriaged):

1. **Silent runtime attach failure** (`Chat/console_runtime.py`): `_attach()` still never raises — read-only app doubles in tests stay tolerated — but a swallowed `setattr` now logs at warning level with exception context, and a new post-condition warns when a property/validator on the app rewrote the attribute right after attach. Either failure mode silently broke the ownership invariant `ensure_console_runtime` exists to guarantee (every later call misses the attribute and builds a duplicate runtime); now it is visible in the log.

2. **Brittle construction-site pin** (`Tests/UI/test_console_runtime_ownership.py`): `test_console_runtime_is_the_single_construction_site` now finds construction sites via AST call nodes instead of raw substring scans, so a mention of `ConsoleChatStore(` / `ConsoleChatController(` in a comment, docstring, or string literal no longer false-fails the pin. Same intent, same assertion shape.

## Declined from the same review (replies on the #1648 threads)

- **`db_path` validation for `AgentRunsDB`**: the path is the parent directory of an already-open, app-owned database plus a fixed filename — no user input flows in, matching the repo-wide convention for internal sibling-DB paths (`app.py` reserves `path_validation` for user-supplied import/export paths).
- **`tmp_path` missing from an `Args:` docstring**: the flagged test (`test_second_console_visit_gets_a_new_runtime`) no longer exists on `dev` — it was replaced by `test_second_console_visit_reuses_the_runtime` in the lifetime landing.

## Verification

`Tests/UI/test_console_runtime_ownership.py` + `Tests/UI/test_console_moved_seam_guard.py`: 12 passed on this branch. The AST scanner still finds the pinned construction sites inside `Chat/console_runtime.py` (the pin's non-empty assertion guarantees that) while ignoring textual mentions by construction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops silent Console runtime attach failures and de-flakes the construction-site pin. Previously `_attach()` swallowed write/overwrite issues and the pin used substring scans that misflagged comments; now `_attach()` logs warnings with exception context on write and readback failures and warns on rewrites, and the pin inspects AST call nodes. This makes duplicate runtime creation visible and prevents false test failures.

- `tldw_chatbook/Chat/console_runtime.py`: `_attach()` still never raises, but now (1) logs a warning with exception context if `setattr` fails, (2) guards the post-attach readback with its own try/except and logs on failure, and (3) warns when the attached attribute is not the just-created runtime.
- `Tests/UI/test_console_runtime_ownership.py`: the pin finds `ConsoleChatStore` and `ConsoleChatController` via AST call nodes instead of substring scans, ignoring mentions in comments, docstrings, and string literals.

<sup>Written for commit 59ca7827310a35cbbeb12add008ad8981122cd2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

