### PR TITLE
test(library): derive the ingest-options expectation from the capability schema (TASK-15782)

### DIFF
--- a/Tests/integration/test_library_ingest_flow.py
+++ b/Tests/integration/test_library_ingest_flow.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 
 from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_INGEST_MEDIA
 from tldw_chatbook.DB.Library_Ingest_Jobs_DB import LibraryIngestJobsDB
+from tldw_chatbook.Library.ingest_capabilities import get_capabilities
 from tldw_chatbook.Library.ingest_types import PreflightResult
 from tldw_chatbook.Library.library_ingest_jobs import (
     LibraryIngestJobRegistry,
@@ -199,7 +200,31 @@ async def test_real_screen_to_app_folder_member_change_rearms_without_queueing(
 
 
 def test_options_persist_to_config(monkeypatch):
-    """Submitting ingest options persists one atomic configuration batch."""
+    """Submitting ingest options persists one atomic configuration batch.
+
+    (task-15782) The "generic" group's expected persisted dict is derived
+    from ``ingest_capabilities.get_capabilities("generic").fields`` -- the
+    same schema `_build_ingest_options_snapshot` reads to fill every unset
+    field (`library_screen.py`'s `generic.setdefault(field.name,
+    field.default)`) -- instead of a hand-copied literal dict. A hardcoded
+    copy of that dict already drifted out from under this test once
+    (task-15470's notes: the assertion started failing on a "content
+    mismatch" once an earlier `run_worker` crash stopped masking it; fixed
+    reactively in 0acc6eeeb by hand-adding the seven fields the schema had
+    grown since the dict was last hand-copied -- `overwrite_existing`,
+    `custom_prompt`, `system_prompt`, `generate_embeddings`,
+    `keep_original_file`, `chunk_overlap`, `encoding`). That fix was itself
+    just another hardcoded dict, due to rot again the next time a
+    ``generic`` field is added or its default changes. Deriving the
+    expectation from the schema dataclass (never from
+    `_build_ingest_options_snapshot` itself, which would make the
+    assertion tautological) keeps the test self-updating for that class of
+    change while still catching the two regressions that actually matter:
+    a submitted override (`form.analyze`/`chunk`/`chunk_size`) failing to
+    win over the schema default, and the snapshot silently DROPPING a
+    schema field before it reaches the persisted batch (the task-3309
+    silent-drop class).
+    """
     saved_batches = []
 
     def fake_save(section_values):
@@ -245,27 +270,47 @@ def test_options_persist_to_config(monkeypatch):
     library_screen_module.LibraryScreen._do_submit_ingest(screen, "doc.pdf")
 
     assert len(submitted_jobs) == 1
+
+    # Source of truth for every "generic" field the submission did not
+    # explicitly override -- the same schema production reads from.
+    expected_generic = {
+        field.name: field.default for field in get_capabilities("generic").fields
+    }
+    expected_generic.update(
+        {
+            # Explicit form overrides (set on ``form`` above); asserted as
+            # literals rather than schema defaults because that is exactly
+            # what this test exercises -- a submitted value winning over
+            # the schema default, not just the default surviving untouched.
+            "analyze": False,  # form.analyze
+            "chunk": True,  # form.chunk
+            "chunk_size": 1024,  # form.chunk_size == "1024", coerced to int
+        }
+    )
+
+    # (task-3303 xhigh review round 2, F11) Every NEW snapshot carries the
+    # ebook chunk-method explicitly (scheme identity): the job-option
+    # builder reads an ABSENT value as "legacy snapshot, keep the
+    # pre-branch sentences scheme", so the seed persists too. Mirror
+    # production's own schema lookup + "chapters" fallback (`library_
+    # screen.py::_build_ingest_options_snapshot`) instead of hardcoding
+    # the resolved literal.
+    expected_ebook_chunk_method = next(
+        (
+            field.default
+            for field in get_capabilities("ebook").fields
+            if field.name == "chunk_method"
+        ),
+        "chapters",
+    )
+
     assert saved_batches == [
         {
             "library.ingest_options.pdf": {"pdf_engine": "pymupdf"},
-            "library.ingest_options.generic": {
-                "analyze": False,
-                "chunk": True,
-                "chunk_size": 1024,
-                "overwrite_existing": False,
-                "custom_prompt": "",
-                "system_prompt": "",
-                "generate_embeddings": True,
-                "keep_original_file": False,
-                "chunk_overlap": 100,
-                "encoding": "auto",
+            "library.ingest_options.generic": expected_generic,
+            "library.ingest_options.ebook": {
+                "chunk_method": expected_ebook_chunk_method
             },
-            # (task-3303 xhigh review round 2, F11) Every NEW snapshot
-            # carries the ebook chunk-method explicitly (scheme identity):
-            # the job-option builder reads an ABSENT value as "legacy
-            # snapshot, keep the pre-branch sentences scheme", so the seed
-            # persists too.
-            "library.ingest_options.ebook": {"chunk_method": "chapters"},
         }
     ]
 

--- a/backlog/tasks/task-15782 - Repair-the-generic-ingest-options-snapshot-test-asserting-a-stale-hardcoded-dict.md
+++ b/backlog/tasks/task-15782 - Repair-the-generic-ingest-options-snapshot-test-asserting-a-stale-hardcoded-dict.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15782
 title: Repair the generic ingest-options snapshot test asserting a stale hardcoded dict
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - test-health
@@ -25,11 +26,95 @@ options form/save path actually persists today.
 
 ## Acceptance Criteria
 
-- [ ] `test_options_persist_to_config`'s expected dict is reconciled against
+- [x] `test_options_persist_to_config`'s expected dict is reconciled against
       current production behavior — diagnosed as either a genuinely stale
       test expectation (update the test) or a real regression in what gets
       persisted (fix production and keep the test's original intent)
-- [ ] The specific drifted key(s)/value(s) are identified and documented in
+- [x] The specific drifted key(s)/value(s) are identified and documented in
       the task notes, not just "test updated"
-- [ ] The test passes on dev without weakening its coverage (it should still
+- [x] The test passes on dev without weakening its coverage (it should still
       catch a genuine future persistence regression, not just always pass)
+
+## Implementation Plan
+
+1. Re-locate `test_options_persist_to_config` at HEAD (`Tests/integration/
+   test_library_ingest_flow.py`) and run it to see its current pass/fail
+   state -- task-15470's notes describe the failure as it stood on an
+   earlier commit, not necessarily HEAD.
+2. `git log -p` the test to find whether/when the "content mismatch" was
+   already patched, and what the patch actually did.
+3. Trace production's `_build_ingest_options_snapshot`
+   (`tldw_chatbook/UI/Screens/library_screen.py`) to find the real source
+   of truth for the "generic" group's persisted defaults.
+4. Diagnose: test-side drift vs. a genuine production regression (silent
+   field drop, the task-3309 class).
+5. Rewrite the test's expected dict(s) to derive from that source of truth
+   instead of literal values, keeping explicit literals only for the
+   form-submitted overrides the test means to exercise.
+6. Mutation-verify in both directions: (a) temporarily make production
+   drop one schema field -- confirm the test goes red; (b) temporarily add
+   a brand-new schema field -- confirm the test stays green with no test
+   edit (drift resistance). Restore both probes via Edit.
+7. Run the full test file + sibling Library ingest test files; ruff check
+   the touched file.
+
+## Implementation Notes
+
+**Diagnosis: test-side drift, not a production regression.** At this
+worktree's HEAD (`0b937e31d`), `test_options_persist_to_config` already
+PASSES -- the "content mismatch" task-15470 flagged had already been
+reactively patched in commit `0acc6eeeb8` ("test(library): isolate ingest
+capability fixtures", 2026-08-14), which hand-added the seven fields the
+test's expected `generic` dict was missing (`overwrite_existing`,
+`custom_prompt`, `system_prompt`, `generate_embeddings`,
+`keep_original_file`, `chunk_overlap`, `encoding`). But that fix was
+*itself* another hardcoded literal dict -- the same class of drift that
+caused the original mismatch, primed to rot again the next time a
+`generic` field is added or a default changes.
+
+**Root of the original drift:** the "generic" capability schema
+(`tldw_chatbook/Library/ingest_capabilities.py`, `_TYPE_GROUPS["generic"]`)
+grew past what the test's literal dict tracked across two commits --
+`chunk_overlap`/`encoding` existed since the original ingest feature
+(`40fe66c01`, PR #717) and `overwrite_existing`/`custom_prompt`/
+`system_prompt`/`generate_embeddings`/`keep_original_file` were added in
+`2e2a745e4` ("feat(library): add mode-aware ingest capabilities") -- while
+the test's dict, first written at the task-3300 era, only ever asserted
+`analyze`/`chunk`/`chunk_size`. Task-15470's notes record this being
+*discovered* rather than *introduced*: an unrelated `run_worker` crash on
+the unmounted test screen was throwing first and masking the downstream
+content assertion; once task-15470 fixed that crash (patching
+`_save_library_ingest_options` instead of the module-level config
+function), the pre-existing content mismatch became the visible failure.
+
+**Fix:** rewrote `test_options_persist_to_config`'s expected `generic` and
+`ebook` dicts to derive from the same schema production reads
+(`ingest_capabilities.get_capabilities("generic"/"ebook").fields`) instead
+of hand-copied literals, mirroring exactly what
+`_build_ingest_options_snapshot` does
+(`generic.setdefault(field.name, field.default)` for every schema field;
+the `ebook.chunk_method` schema-lookup-with-"chapters"-fallback). The three
+fields the test's own submitted form overrides (`analyze`, `chunk`,
+`chunk_size`) are still asserted as explicit literals, since exercising a
+submitted value winning over the schema default is the actual behavior
+under test there. The expectation is built from the schema *dataclass*,
+never by calling `_build_ingest_options_snapshot` itself, so the assertion
+stays a real check rather than a tautology.
+
+Mutation-verified both directions (temporary edits, restored via Edit
+before committing):
+- Made `_build_ingest_options_snapshot` skip `generate_embeddings` (task-
+  3309-class silent drop) -- the test correctly went red.
+- Added a brand-new `OptionField` to the "generic" schema -- the test
+  stayed green with zero test edits, confirming the drift-resistance goal.
+
+**Tests:** `Tests/integration/test_library_ingest_flow.py` (13 passed) and
+the sibling Library ingest surfaces `Tests/UI/test_library_ingest_canvas.py`
++ `Tests/UI/test_library_ingest_retry_last.py` (161 passed combined, no
+regressions). `ruff check` clean on the touched file; `ruff format --check`
+flags pre-existing, unrelated formatting drift elsewhere in the same file
+(confirmed present before this change via a stash/pop A-B) -- left
+untouched since touching it would inflate this diff with unrelated churn.
+
+**Modified files:** `Tests/integration/test_library_ingest_flow.py` only
+-- no production change; this was a test-side fix.


### PR DESCRIPTION
## Summary

`test_options_persist_to_config` asserted a hand-copied literal dict of the generic ingest group's persisted defaults — a dict that drifted out from under the test twice (it lagged the capability schema across two commits, masked by an unrelated `run_worker` crash until task-15470 fixed that crash and exposed the mismatch; the reactive fix in `0acc6eeeb` was itself another literal dict, primed to rot again).

The expectation is now derived from `ingest_capabilities.get_capabilities("generic").fields` — the same schema production's `_build_ingest_options_snapshot` fills unset fields from — with the three form-driven fields asserted as literals since a submitted override winning over the default is exactly what the test exercises. Non-tautological: the expectation comes from the schema dataclass, never from the snapshot builder, so a snapshot-side silent field drop (the task-3309 class) still diverges.

Mutation-verified both directions: production skipping `generate_embeddings` → red; a brand-new schema field → green with zero test edits. Test-only change; 13 + 161 tests green; the incident chain is recorded in the test's docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the expected persisted ingest options in `test_options_persist_to_config` from the capability schema to eliminate brittle literals and prevent drift. Previously the test asserted a hand-copied dict; now it builds the expectation from `ingest_capabilities.get_capabilities("generic").fields` and asserts only the explicit form overrides, keeping the test meaningful and catching silent field drops.

- Expected `generic` map comes from `get_capabilities("generic").fields` with literals for `analyze`, `chunk`, and `chunk_size`; `ebook.chunk_method` mirrors the schema default with a "chapters" fallback, matching `_build_ingest_options_snapshot`.
- Test-only change; remains red on snapshot-side field drops and green when new schema fields are added. Addresses TASK-15782 by reconciling the test with production behavior and hardening it against future schema changes.

<sup>Written for commit fbdec121465506ad8f1bdbb25fa284d06b0631b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

