### PR TITLE
test(css): extend the invalid-CSS parse guard to Tests/ and Helper_Scripts/ (TASK-15997)

### DIFF
--- a/Tests/UI/test_widget_css_consolidation.py
+++ b/Tests/UI/test_widget_css_consolidation.py
@@ -36,6 +36,16 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PACKAGE_ROOT = _REPO_ROOT / "tldw_chatbook"
 _CSS_ROOT = _PACKAGE_ROOT / "css"
 
+#: TASK-15997: the other two trees the class-level-CSS parse guard covers.
+#: Neither is a "vendored/standalone" case the way ``widget_css.EXCLUDED_DIRS``
+#: means it (that exclusion is about code with its own App that never loads
+#: *this* app's bundle) -- a harness ``App`` under ``Tests/`` or a runnable
+#: script under ``Helper_Scripts/`` both parse their own CSS at their own
+#: runtime, so an invalid property there is worth catching on exactly the same
+#: grounds, and the walk below applies no directory exclusions to either.
+_TESTS_ROOT = _REPO_ROOT / "Tests"
+_HELPER_SCRIPTS_ROOT = _REPO_ROOT / "Helper_Scripts"
+
 #: Textual's parse cache size (``textual/css/stylesheet.py``). The whole point of
 #: the consolidation is to keep the live source count comfortably below it.
 _PARSE_CACHE_CAPACITY = 64
@@ -53,18 +63,35 @@ def _css_variables() -> dict:
     return tokenize_values(App().get_css_variables())
 
 
-def _class_css_blocks() -> list[tuple[str, str, str]]:
-    """Every class-level CSS string literal in the package.
+def _class_css_blocks(
+    root: Path | None = None,
+    *,
+    excluded_dirs: tuple[str, ...] = widget_css.EXCLUDED_DIRS,
+) -> list[tuple[str, str, str]]:
+    """Every class-level CSS string literal under ``root``.
+
+    The one block-extraction helper every parse-guard test shares (TASK-15997):
+    called with no arguments it walks the ``tldw_chatbook`` package exactly as
+    it always did; passing a different ``root`` (and, typically, no exclusions)
+    reuses the identical AST scan for ``Tests/`` or ``Helper_Scripts/`` instead
+    of forking a copy of it.
+
+    Args:
+        root: Directory to walk. Defaults to the ``tldw_chatbook`` package.
+        excluded_dirs: Path components that exclude a file from the walk.
+            Defaults to ``widget_css.EXCLUDED_DIRS`` (vendored/standalone code
+            under the package); pass ``()`` for trees with no such carve-out.
 
     Returns:
         ``(module, class_name, css)`` triples, covering the consolidated
         attributes and any ``DEFAULT_CSS``/``CSS`` that has not moved.
     """
+    root = _PACKAGE_ROOT if root is None else root
     wanted = {"DEFAULT_CSS", "CSS", widget_css.WIDGET_ATTR, widget_css.SCREEN_ATTR}
     blocks: list[tuple[str, str, str]] = []
-    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
-        relative = path.relative_to(_PACKAGE_ROOT)
-        if any(part in widget_css.EXCLUDED_DIRS for part in relative.parts):
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root)
+        if any(part in excluded_dirs for part in relative.parts):
             continue
         source = path.read_text(encoding="utf-8")
         if not any(name in source for name in wanted):
@@ -499,10 +526,54 @@ def test_every_class_level_css_block_parses_as_a_stylesheet():
     ``test_scope_rewrite_matches_textuals_own_scoping`` would not catch this:
     it calls ``textual.css.parse.parse`` directly, which collects errors onto
     ``rule.errors`` instead of raising. Only ``Stylesheet.parse`` raises.
+
+    TASK-15997 swept ``Tests/`` and ``Helper_Scripts/`` for the same defect
+    class -- see ``test_class_level_css_blocks_outside_the_package_parse``,
+    which shares ``_assert_class_css_blocks_parse`` with this test rather than
+    forking the check.
+    """
+    _assert_class_css_blocks_parse(_class_css_blocks(), allowlist={})
+
+
+#: TASK-15997: deliberate invalid-CSS fixtures that exist to negative-test the
+#: CSS machinery itself (e.g. a harness asserting Textual raises
+#: ``StylesheetParseError`` when the fixture is pushed). This is an EXPLICIT
+#: per-``(module, class_name)`` allowlist, not a directory or filename skip --
+#: a fixture that needs to stay invalid must be named here, with a reason, or
+#: the sweep below fails on it. Empty today: no such fixture exists yet under
+#: ``Tests/`` or ``Helper_Scripts/``; ``test_css_parse_guard_catches_seeded_
+#: invalid_blocks_in_newly_covered_trees`` proves the mechanism itself works
+#: without needing a real one committed.
+_KNOWN_INVALID_CSS_FIXTURES: dict[tuple[str, str], str] = {}
+
+
+def _assert_class_css_blocks_parse(
+    blocks: list[tuple[str, str, str]],
+    *,
+    allowlist: dict[tuple[str, str], str],
+) -> None:
+    """Run every ``(module, class_name, css)`` block through ``Stylesheet.parse()``.
+
+    Shared by every tree the guard covers (the package, ``Tests/``,
+    ``Helper_Scripts/``) so a fix to the check itself applies everywhere at
+    once, rather than three copies drifting apart.
+
+    Args:
+        blocks: ``(module, class_name, css)`` triples from ``_class_css_blocks``.
+        allowlist: ``(module, class_name) -> reason`` for fixtures that are
+            *deliberately* invalid CSS (negative tests of the CSS machinery
+            itself). An allowlisted block is excluded from the failure list,
+            but must actually still fail to parse today -- a block that starts
+            parsing cleanly again (fixed, or the fixture rewritten) makes its
+            entry stale, which is also asserted here rather than left to rot.
     """
     variables = App().get_css_variables()
-    failures = []
-    for module, class_name, css in _class_css_blocks():
+    failures: list[str] = []
+    stale_allowlist_entries: list[str] = []
+    seen_keys: set[tuple[str, str]] = set()
+    for module, class_name, css in blocks:
+        key = (module, class_name)
+        seen_keys.add(key)
         stylesheet = Stylesheet(variables=variables)
         stylesheet.add_source(
             css, read_from=(module, class_name), is_default_css=True, scope=class_name
@@ -510,11 +581,90 @@ def test_every_class_level_css_block_parses_as_a_stylesheet():
         try:
             stylesheet.parse()
         except Exception as exc:  # noqa: BLE001 - report every offender at once
-            failures.append(f"{module}::{class_name}: {type(exc).__name__}")
+            if key not in allowlist:
+                failures.append(f"{module}::{class_name}: {type(exc).__name__}")
+        else:
+            if key in allowlist:
+                stale_allowlist_entries.append(f"{module}::{class_name}")
     assert not failures, (
         "class-level CSS that Textual cannot parse -- this fails the whole "
         "stylesheet at runtime, not just the offending rule:\n" + "\n".join(failures)
     )
+    assert not stale_allowlist_entries, (
+        "allowlisted invalid-CSS fixture now parses cleanly -- remove its "
+        "entry from _KNOWN_INVALID_CSS_FIXTURES:\n" + "\n".join(stale_allowlist_entries)
+    )
+    unused_allowlist_entries = [
+        f"{module}::{class_name}: {reason}"
+        for (module, class_name), reason in allowlist.items()
+        if (module, class_name) not in seen_keys
+    ]
+    assert not unused_allowlist_entries, (
+        "allowlist entry does not match any scanned block -- the fixture was "
+        "renamed, moved, or removed; update or delete the entry:\n"
+        + "\n".join(unused_allowlist_entries)
+    )
+
+
+@pytest.mark.parametrize(
+    "root",
+    [
+        pytest.param(_TESTS_ROOT, id="Tests"),
+        pytest.param(_HELPER_SCRIPTS_ROOT, id="Helper_Scripts"),
+    ],
+)
+def test_class_level_css_blocks_outside_the_package_parse(root: Path):
+    """TASK-15997: the same parse guard, swept over ``Tests/`` and ``Helper_Scripts/``.
+
+    ``test_every_class_level_css_block_parses_as_a_stylesheet`` only ever
+    walked the ``tldw_chatbook`` package -- nothing checked a test harness's
+    own ``App.CSS`` or a ``Helper_Scripts/`` example for the identical defect
+    class (an invalid property poisons the *whole* stylesheet, not just its
+    own declaration). Swept once while adding this test: 28 class-level CSS
+    blocks under ``Tests/`` (test-harness ``App``/``Screen`` subclasses'
+    ``CSS`` -- none declare ``BUNDLED_CSS``/``BUNDLED_SCREEN_CSS``, since the
+    consolidation only applies inside the package), 0 under
+    ``Helper_Scripts/`` (its custom-splash-card examples are ``.toml`` data,
+    not Python classes, and the one ``.py`` helper there declares no
+    class-level CSS attribute at all). All 28 parsed cleanly -- no crashers
+    found in either tree.
+    """
+    blocks = _class_css_blocks(root, excluded_dirs=())
+    _assert_class_css_blocks_parse(blocks, allowlist=_KNOWN_INVALID_CSS_FIXTURES)
+
+
+def test_css_parse_guard_catches_seeded_invalid_blocks_in_newly_covered_trees(
+    tmp_path,
+):
+    """Born-red proof: the Tests/Helper_Scripts sweep is not a no-op.
+
+    Both real trees currently come back clean (see
+    ``test_class_level_css_blocks_outside_the_package_parse``), which on its
+    own does not distinguish "nothing is broken" from "the check never ran".
+    Seed one throwaway module per newly-covered tree with the exact defect
+    class TASK-15450 found in the package (``font-size:`` is not a Textual
+    property) and assert the shared check -- the same
+    ``_assert_class_css_blocks_parse`` the real sweep uses -- raises for both.
+    """
+    invalid_css_module = (
+        "from textual.app import App\n\n\n"
+        "class _SeededInvalidCssHarness(App):\n"
+        '    CSS = """\n'
+        "    Widget { font-size: 10; }\n"
+        '    """\n'
+    )
+    for tree_name in ("Tests", "Helper_Scripts"):
+        tree_root = tmp_path / tree_name
+        tree_root.mkdir()
+        (tree_root / "seeded_invalid_css.py").write_text(invalid_css_module)
+
+        blocks = _class_css_blocks(tree_root, excluded_dirs=())
+        assert [b[:2] for b in blocks] == [
+            ("seeded_invalid_css.py", "_SeededInvalidCssHarness")
+        ], f"extractor did not find the seeded block under {tree_name}/"
+
+        with pytest.raises(AssertionError, match="StylesheetParseError"):
+            _assert_class_css_blocks_parse(blocks, allowlist={})
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-15997 - Extend-the-invalid-CSS-parse-guard-beyond-the-package-Tests--and-Helper_Scripts-.md
+++ b/backlog/tasks/task-15997 - Extend-the-invalid-CSS-parse-guard-beyond-the-package-Tests--and-Helper_Scripts-.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15997
 title: 'Extend the invalid-CSS parse guard beyond the package: Tests/ and Helper_Scripts/'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:10'
 labels:
   - tests
@@ -18,7 +19,101 @@ TASK-15450's `test_every_class_level_css_block_parses_as_a_stylesheet` runs ever
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The parse guard covers class-level CSS blocks under Tests/ and Helper_Scripts/
-- [ ] #2 Any newly-found invalid blocks are fixed (removal or translation, with the never-parsed rationale applied as in TASK-15450)
-- [ ] #3 Notes record the found-count so the sweep's value is measurable
+- [x] #1 The parse guard covers class-level CSS blocks under Tests/ and Helper_Scripts/
+- [x] #2 Any newly-found invalid blocks are fixed (removal or translation, with the never-parsed rationale applied as in TASK-15450)
+- [x] #3 Notes record the found-count so the sweep's value is measurable
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Confirm the existing guard's block-extraction helper: `_class_css_blocks()` in
+   `Tests/UI/test_widget_css_consolidation.py` walks `_PACKAGE_ROOT` (the
+   `tldw_chatbook` package) for class-level `DEFAULT_CSS`/`CSS`/`BUNDLED_CSS`/
+   `BUNDLED_SCREEN_CSS` string literals via AST, applying `widget_css.EXCLUDED_DIRS`.
+2. Generalize `_class_css_blocks()` to take an optional `root` (default: the
+   package root, preserving every existing call site's behaviour byte-for-byte)
+   and `excluded_dirs` so Tests/ and Helper_Scripts/ can reuse the exact same
+   scan/AST logic instead of a forked copy.
+3. Run the generalized helper + the existing `Stylesheet.parse()` check against
+   `Tests/` and `Helper_Scripts/` as a one-off probe to get the found-count and
+   see whether anything is actually broken today.
+4. Extract the existing test's parse-check body into a shared
+   `_assert_class_css_blocks_parse()` helper (used by the original package-scope
+   test too, so there is one check, not two), adding an explicit
+   per-`(module, class_name)` allowlist mechanism (with a required reason
+   string) for deliberately-invalid negative-test fixtures, plus a staleness
+   check so an allowlist entry that has been fixed (or renamed away) is flagged.
+5. Add a new parametrized test sweeping `Tests/` and `Helper_Scripts/` through
+   the shared helper.
+6. Add a permanent born-red regression test that seeds an invalid CSS block
+   into a synthetic `tmp_path` tree shaped like each newly-covered root and
+   asserts the shared check catches it -- proving the guard is not a no-op
+   because both real trees currently come back clean.
+7. Fix whatever the real sweep finds (expected: nothing, based on the probe;
+   record the found-count either way).
+8. Run the new/changed tests plus the full `test_widget_css_consolidation.py`
+   module; ruff check/format on touched files; record notes.
+
+## Implementation Notes
+
+**Approach.** `_class_css_blocks()` (`Tests/UI/test_widget_css_consolidation.py`)
+was the guard's one block-extraction helper -- an AST walk over
+`_PACKAGE_ROOT` collecting every class-level `DEFAULT_CSS`/`CSS`/`BUNDLED_CSS`/
+`BUNDLED_SCREEN_CSS` string literal. It took a `root: Path | None = None`
+(defaulting to the package, so all three existing call sites are byte-for-byte
+unchanged) and an `excluded_dirs` override, so `Tests/` and `Helper_Scripts/`
+reuse the identical scan instead of a forked copy. The parse-check body of
+`test_every_class_level_css_block_parses_as_a_stylesheet` was pulled out into
+`_assert_class_css_blocks_parse(blocks, *, allowlist)`, shared by the original
+package-scope test and the new sweep, so a fix to the check itself (or to the
+`Stylesheet.parse()` call it makes) never has to be applied twice.
+
+**Found-count (AC3).** Swept once while adding the new test:
+- `Tests/`: **28** class-level CSS blocks (all plain `CSS` on test-harness
+  `App`/`Screen`/`ModalScreen` subclasses across 20 files under `Tests/Chat/`
+  and `Tests/UI/`, plus one top-level `Tests/test_enhanced_filepicker.py` and
+  `Tests/test_splash_fullscreen.py` each). **0 failed** `Stylesheet.parse()`.
+- `Helper_Scripts/`: **0** class-level CSS blocks. The custom-splash-card
+  examples (`Helper_Scripts/Examples/custom_splash_cards/*`) are `.toml` data
+  files, not Python classes with a CSS attribute; the tree's few `.py` files
+  that mention "CSS" (`Helper_Scripts/UI/visualize_textual_*.py`) don't declare
+  one. **0 failed** (vacuously).
+
+So AC2 ("fix what's found") had nothing to fix -- no crashers exist in either
+tree today. That null result is exactly why the born-red test exists: it seeds
+one throwaway module per tree (`tmp_path`, never written into the real trees)
+with the identical defect class TASK-15450 found in the package
+(`font-size: 10;` -- not a Textual property) and asserts
+`_assert_class_css_blocks_parse` raises for both, proving "0 found" means
+"nothing is broken" and not "the sweep never ran". Ran red before the fix (no
+`root` parameter existed to point the extractor anywhere but the package) and
+green after; see `test_css_parse_guard_catches_seeded_invalid_blocks_in_newly_covered_trees`.
+
+**Allowlist mechanism.** No `Tests/`/`Helper_Scripts/` fixture today declares
+deliberately-invalid CSS as a negative test, but the sweep needed a real
+mechanism ready for when one shows up rather than a silent directory/filename
+skip: `_KNOWN_INVALID_CSS_FIXTURES: dict[tuple[str, str], str]` maps
+`(module, class_name) -> reason`. An allowlisted block is excluded from the
+failure list but is asserted to still actually fail (a "stale" entry -- one
+whose fixture now parses cleanly -- fails the test, so a fixed bug can't hide
+behind a forgotten allowlist row), and an allowlist entry that matches no
+scanned block at all (renamed/removed fixture) also fails the test. Currently
+empty; `test_css_parse_guard_catches_seeded_invalid_blocks_in_newly_covered_trees`
+exercises the underlying check (not the allowlist itself, since there is
+nothing yet to allowlist).
+
+**Files changed.**
+- `Tests/UI/test_widget_css_consolidation.py`: generalized `_class_css_blocks`
+  (`root`/`excluded_dirs` params); extracted `_assert_class_css_blocks_parse`
+  with the allowlist + staleness/unused checks; added
+  `_KNOWN_INVALID_CSS_FIXTURES`, `_TESTS_ROOT`, `_HELPER_SCRIPTS_ROOT`;
+  added `test_class_level_css_blocks_outside_the_package_parse` (parametrized
+  over `Tests`/`Helper_Scripts`) and
+  `test_css_parse_guard_catches_seeded_invalid_blocks_in_newly_covered_trees`.
+  No production code touched -- there was nothing to fix.
+
+**Verification.** `Tests/UI/test_widget_css_consolidation.py`: 20 passed (was
+17; +3 for the two new parametrize cases and the born-red test), no skips.
+`pytest Tests/UI/ -q --collect-only`: 12555 tests collected, no collection
+errors (confirms no naming collisions or import breakage from the refactor).
+`ruff check` and `ruff format --check` clean on the touched file.


### PR DESCRIPTION
## Summary

TASK-15450's class-level CSS parse guard (`Stylesheet.parse()`, the API that actually raises — `parse.parse` only collects errors) found two live crashers in production on its first run; nothing swept `Tests/` or `Helper_Scripts/` for the same defect class. Now it does:

- The block-extraction helper generalized with root/excluded-dirs params (defaults preserve prior behavior for the three existing call sites — shared machinery, not a fork); the parse-check body extracted and shared by the package test and the new parametrized sweep
- **Found-count, the sweep's measurable value: zero.** `Tests/` carries 28 class-level CSS blocks across 22 harness files — all parse clean; `Helper_Scripts/` has none (custom splash cards are TOML data). Nothing needed fixing — the sweep now guards against the class arriving
- An explicit per-(module, class) allowlist for future deliberately-invalid negative-test fixtures, with staleness (entry must still fail) and unused-entry checks — no silent skips
- A permanent born-red regression test seeds the exact `font-size: 10` defect into a synthetic tree per newly-covered root and proves the shared check catches it

Test-only; 20 passed (was 17); collect-only clean at 12,555; controller-verified (proportionate for a zero-findings guard extension with in-file born-red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the invalid-CSS parse guard from only the `tldw_chatbook` package to also sweep `Tests/` and `Helper_Scripts/`, ensuring harnesses and scripts can’t ship CSS that crashes `Stylesheet.parse()`. Previously only package classes were checked; now the same AST scan and parse check run on those roots as well, with no change to existing call-site behavior.

- Generalized `_class_css_blocks(root=None, *, excluded_dirs=...)`; defaults preserve prior behavior. Extracted `_assert_class_css_blocks_parse(...)` and reused in both the original and new sweep.
- Added `_KNOWN_INVALID_CSS_FIXTURES` allowlist with staleness and unused-entry checks; no entries yet.
- Born-red test seeds `font-size: 10;` into synthetic `Tests/` and `Helper_Scripts/` trees to prove the guard triggers.
- Found-count: `Tests/` 28 class-level CSS blocks, 0 failures; `Helper_Scripts/` 0 blocks. Test-only change; +3 tests (now 20 pass).
- For future deliberately invalid fixtures, add `(module, class_name) -> reason` to `_KNOWN_INVALID_CSS_FIXTURES`. Addresses TASK-15997.

<sup>Written for commit 17bfad3c8dbc9995755185acc0000f94fc03f1d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

