### PR TITLE
test(db): one rollback registry + ratchet + replay sweep for the migration-fixture family (TASKS 15765+16197)

### DIFF
--- a/Tests/ChaChaNotesDB/schema_rollback.py
+++ b/Tests/ChaChaNotesDB/schema_rollback.py
@@ -23,11 +23,25 @@ That is not a hypothetical: it fired three times in three days.
   fixture), each then repaired separately (task-16201, task-16207).
 
 The registry below is the single place that knowledge now lives. Each key is
-a schema version ``v``; its value removes exactly what the ``(v-1)->v``
-migration adds, in a safe order (triggers that reference a column before the
-column itself). ``rollback_chachanotes_schema`` walks the registry from the
-recorded version down to the requested target, so every fixture — current and
-future — shares one drop list instead of hand-maintaining its own.
+a schema version ``v``; its value removes the ``(v-1)->v`` migration's
+artifacts whose baked presence would collide on replay (plus a few removed
+so the migration under test genuinely re-creates them), in a safe order
+(triggers that reference a column before the column itself). Be precise
+about what the rolled-back DB IS: a current-version DB with those SPECIFIC
+artifacts removed — sufficient for replaying the migrations under test, NOT
+a faithful historical vN snapshot. Replay-tolerant migrations' artifacts
+survive at the rolled-back stamp (measured at a v17 stamp: 7 post-v17
+tables, 9 indexes, 5 columns), and the sync triggers a real vN DB has are
+deliberately absent until replay recreates them. After replay, column ORDER
+may also diverge from a fresh bootstrap (a dropped column is re-appended at
+the end of its table), so compare column membership as a set, never by
+position. ``rollback_chachanotes_schema`` walks the registry from the
+recorded version down to the requested target, so every fixture — current
+and future — shares one drop list instead of hand-maintaining its own. For
+a genuinely vN-shaped fixture, bootstrap under a patched
+``_CURRENT_SCHEMA_VERSION`` instead (as
+``Tests/DB/test_chachanotes_note_folders_migration.py`` does) — the
+knowledge-free direction a follow-up will evaluate for these fixtures.
 
 Contract for migration authors: when you bump ``_CURRENT_SCHEMA_VERSION``,
 add an entry here for the new version. Declare an empty tuple if (and only

--- a/Tests/ChaChaNotesDB/schema_rollback.py
+++ b/Tests/ChaChaNotesDB/schema_rollback.py
@@ -1,0 +1,203 @@
+"""Shared rollback registry for ChaChaNotes historical-migration fixtures.
+
+Several tests build a "historical" ChaChaNotes DB top-down: bootstrap a fresh
+DB (which lands at ``_CURRENT_SCHEMA_VERSION``), remove the artifacts newer
+migrations added, stamp ``db_schema_version`` back to the historical version,
+and reopen so the production migration chain replays. That approach bakes a
+trap: every time a migration ships a non-idempotent artifact (a bare
+``CREATE TABLE`` or an unguarded ``ALTER TABLE ... ADD COLUMN``), every
+rollback fixture that does not also remove that artifact starts failing with
+"already exists" at the new migration's step — while the version stamp claims
+the artifact should not exist yet.
+
+That is not a hypothetical: it fired three times in three days.
+
+* ``88f5f535a`` (V33->V34 ``compaction_representation``) broke the rollback
+  fixtures; task-15730 repaired them one by one.
+* ``9174975b0`` (V35->V36 ``note_folders``, task-15705) broke them again. Its
+  author fixed the ONE fixture they knew about
+  (``Tests/Character_Chat/test_dictionary_attachment_index.py``) and missed
+  the other two, producing task-15765
+  (``Tests/ChaChaNotesDB/test_chachanotes_db.py`` V17 fixture) and
+  task-16197 (``Tests/Chat/test_conversation_local_marks_service.py`` V16
+  fixture), each then repaired separately (task-16201, task-16207).
+
+The registry below is the single place that knowledge now lives. Each key is
+a schema version ``v``; its value removes exactly what the ``(v-1)->v``
+migration adds, in a safe order (triggers that reference a column before the
+column itself). ``rollback_chachanotes_schema`` walks the registry from the
+recorded version down to the requested target, so every fixture — current and
+future — shares one drop list instead of hand-maintaining its own.
+
+Contract for migration authors: when you bump ``_CURRENT_SCHEMA_VERSION``,
+add an entry here for the new version. Declare an empty tuple if (and only
+if) your migration tolerates replaying over its own artifacts (``IF NOT
+EXISTS`` / guarded ``ALTER``). ``test_schema_rollback.py`` enforces both
+halves: a completeness ratchet fails the moment a version has no entry, and
+a rollback-replay sweep fails if a declared entry does not actually return
+the schema to a replayable state.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
+
+#: The oldest version a fixture may roll back to. Fixtures that need an even
+#: older shape should build bottom-up instead (see legacy_conversation_schema).
+MINIMUM_ROLLBACK_VERSION = 16
+
+#: version v -> statements removing what the (v-1)->v migration adds.
+#: An empty tuple is an explicit declaration that the migration tolerates
+#: replaying over its own baked artifacts.
+POST_VERSION_SCHEMA_REMOVALS: dict[int, tuple[str, ...]] = {
+    # V16->V17: durable local-only conversation marks.
+    17: (
+        "DROP INDEX IF EXISTS idx_conversation_local_marks_type",
+        "DROP TABLE IF EXISTS conversation_local_marks",
+    ),
+    # V17->V18: conversations.system_prompt, plus redefined conversations
+    # sync triggers that reference it (SQLite refuses to drop a column a
+    # trigger references, so the triggers go first; replay recreates them).
+    18: (
+        "DROP TRIGGER IF EXISTS conversations_sync_create",
+        "DROP TRIGGER IF EXISTS conversations_sync_update",
+        "DROP TRIGGER IF EXISTS conversations_sync_delete",
+        "DROP TRIGGER IF EXISTS conversations_sync_undelete",
+        "ALTER TABLE conversations DROP COLUMN system_prompt",
+    ),
+    # V18->V19 through V25->V26 replay-tolerantly over a baked current-shape
+    # DB (guarded ALTERs / IF NOT EXISTS), so no removals are required.
+    19: (),
+    20: (),
+    21: (),
+    22: (),
+    23: (),
+    24: (),
+    25: (),
+    26: (),
+    # V26->V27: citation-provenance tables. That migration deliberately
+    # rejects pre-existing/partial tables, so every one must be removed.
+    27: (
+        "DROP TABLE IF EXISTS rag_artifact_owner_operations",
+        "DROP TABLE IF EXISTS rag_artifact_owner_leases",
+        "DROP TABLE IF EXISTS rag_source_observations",
+        "DROP TABLE IF EXISTS rag_message_trace_owners",
+        "DROP TABLE IF EXISTS rag_trace_evidence_refs",
+        "DROP TABLE IF EXISTS rag_answer_attempt_payloads",
+        "DROP TABLE IF EXISTS rag_evidence_runs",
+        "DROP TABLE IF EXISTS rag_citation_traces",
+        "DROP TABLE IF EXISTS rag_evidence_snapshots",
+        "DROP TABLE IF EXISTS rag_payload_tombstones",
+        "DROP TABLE IF EXISTS rag_legacy_migration_journal",
+        "DROP TABLE IF EXISTS rag_identity_context",
+    ),
+    # V27->V28: conversations.assistant_authority_id. The conversations sync
+    # triggers (last redefined by V19->V20) do not reference it, so the
+    # column drops cleanly on its own — do NOT drop the triggers here:
+    # no migration after V19->V20 recreates them, and the sweep proves a
+    # trigger drop at this step leaves the replayed DB silently missing all
+    # conversations sync triggers for targets in V20..V27.
+    28: ("ALTER TABLE conversations DROP COLUMN assistant_authority_id",),
+    # V28->V29 (kept briefings) replays tolerantly.
+    29: (),
+    # V29->V30: local-only messages.usage_json (excluded from sync triggers).
+    30: ("ALTER TABLE messages DROP COLUMN usage_json",),
+    # V30->V31 through V32->V33 replay tolerantly.
+    31: (),
+    32: (),
+    33: (),
+    # V33->V34: unguarded ALTER (the task-15730 incident's collision).
+    34: (
+        "ALTER TABLE console_conversation_context_policy "
+        "DROP COLUMN compaction_representation",
+    ),
+    # V34->V35: the derived dictionary-attachment index. Tables/indexes are
+    # IF NOT EXISTS and triggers are dropped-then-created on replay, but the
+    # fixtures remove them anyway so replay genuinely rebuilds (and the
+    # dictionary backfill test depends on exactly that).
+    35: (
+        "DROP TRIGGER IF EXISTS conversation_dictionary_index_ai",
+        "DROP TRIGGER IF EXISTS conversation_dictionary_index_au",
+        "DROP TRIGGER IF EXISTS conversation_dictionary_index_ad",
+        "DROP TABLE IF EXISTS conversation_dictionary_attachments",
+        "DROP TABLE IF EXISTS conversation_dictionary_unresolved",
+    ),
+    # V35->V36: note folders — bare CREATE TABLE, the task-15765/task-16197
+    # collision. Memberships first (FK child of note_folders).
+    36: (
+        "DROP TABLE IF EXISTS note_folder_memberships",
+        "DROP TABLE IF EXISTS note_folders",
+    ),
+    # V36->V37: messages.provider_continuation_json, referenced by the
+    # redefined messages sync triggers (replay recreates them). The
+    # migration would tolerate a baked column, but removing it makes the
+    # fixture genuinely pre-V37 and exercises the real ALTER path.
+    37: (
+        "DROP TRIGGER IF EXISTS messages_sync_create",
+        "DROP TRIGGER IF EXISTS messages_sync_update",
+        "DROP TRIGGER IF EXISTS messages_sync_delete",
+        "DROP TRIGGER IF EXISTS messages_sync_undelete",
+        "ALTER TABLE messages DROP COLUMN provider_continuation_json",
+    ),
+    # V37->V38: local-only trajectory sidecar (IF NOT EXISTS, but removed so
+    # replay genuinely creates it). Its indexes drop with the table.
+    38: ("DROP TABLE IF EXISTS message_trajectory_metadata",),
+}
+
+
+def rollback_chachanotes_schema(conn: sqlite3.Connection, target_version: int) -> None:
+    """Rewind a freshly-bootstrapped ChaChaNotes DB to ``target_version``.
+
+    Walks ``POST_VERSION_SCHEMA_REMOVALS`` from the recorded schema version
+    down to ``target_version + 1`` and stamps ``db_schema_version`` so that
+    reopening the DB replays the production migration chain from a genuinely
+    ``target_version``-shaped schema.
+
+    The caller owns the transaction (commit after calling) and the
+    connection. Intended for connections whose recorded version is the
+    current one (a fresh bootstrap); statements are applied exactly once per
+    version on the way down.
+
+    Args:
+        conn: An open connection to a freshly-bootstrapped ChaChaNotes DB.
+        target_version: The historical schema version to rewind to. Must be
+            at least ``MINIMUM_ROLLBACK_VERSION`` and below the recorded
+            version.
+
+    Raises:
+        AssertionError: If the target is out of range or the registry has no
+            entry for a version in the walk (the actionable signal that a new
+            migration shipped without declaring its rollback).
+    """
+    row = conn.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()
+    assert row is not None, "ChaChaNotes DB has no recorded schema version"
+    recorded = row[0]
+    assert MINIMUM_ROLLBACK_VERSION <= target_version < recorded, (
+        f"rollback target {target_version} must be in "
+        f"[{MINIMUM_ROLLBACK_VERSION}, {recorded - 1}]"
+    )
+    missing = [
+        version
+        for version in range(target_version + 1, recorded + 1)
+        if version not in POST_VERSION_SCHEMA_REMOVALS
+    ]
+    assert not missing, (
+        f"POST_VERSION_SCHEMA_REMOVALS has no entry for schema version(s) "
+        f"{missing}. Every migration must declare how to remove what it adds "
+        f"(an empty tuple if replay tolerates the baked artifacts) in "
+        f"Tests/ChaChaNotesDB/schema_rollback.py."
+    )
+    for version in range(recorded, target_version, -1):
+        for statement in POST_VERSION_SCHEMA_REMOVALS[version]:
+            conn.execute(statement)
+    conn.execute(
+        "UPDATE db_schema_version SET version = ? WHERE schema_name = ?",
+        (target_version, SCHEMA_NAME),
+    )

--- a/Tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -22,6 +22,7 @@ from tldw_chatbook.DB.ChaChaNotes_DB import (
     InputError,
     ConflictError,
 )
+from Tests.ChaChaNotesDB.schema_rollback import rollback_chachanotes_schema
 
 
 #
@@ -223,49 +224,42 @@ class TestDBInitialization:
         db = CharactersRAGDB(db_path, client_id)
         conn = db.get_connection()
 
-        # Simulate a v17-shaped DB: drop the sync triggers that reference the
-        # new column (SQLite refuses to drop a column referenced by a
-        # trigger), drop the column itself, then roll the recorded schema
-        # version back to 17 so re-opening replays the V17->V18 migration.
-        conn.execute("DROP TRIGGER IF EXISTS conversations_sync_create")
-        conn.execute("DROP TRIGGER IF EXISTS conversations_sync_update")
-        conn.execute("DROP TRIGGER IF EXISTS conversations_sync_delete")
-        conn.execute("DROP TRIGGER IF EXISTS conversations_sync_undelete")
-        # A version-only rollback is not a valid pre-v25 fixture because the
-        # citation migration deliberately rejects pre-existing/partial tables.
-        # Remove the current provenance schema before replaying from v17.
-        for table in (
-            "note_folder_memberships",
-            "note_folders",
-            "rag_artifact_owner_operations",
-            "rag_artifact_owner_leases",
-            "rag_source_observations",
-            "rag_message_trace_owners",
-            "rag_trace_evidence_refs",
-            "rag_answer_attempt_payloads",
-            "rag_evidence_runs",
-            "rag_citation_traces",
-            "rag_evidence_snapshots",
-            "rag_payload_tombstones",
-            "rag_legacy_migration_journal",
-            "rag_identity_context",
-        ):
-            conn.execute(f"DROP TABLE {table}")
-        # A V17 fixture also predates the V27->V28 character-authority column.
-        conn.execute("ALTER TABLE conversations DROP COLUMN assistant_authority_id")
-        # A V17 fixture also predates the V29->V30 local-only usage_json column.
-        conn.execute("ALTER TABLE messages DROP COLUMN usage_json")
-        # A V17 fixture predates the V33->V34 visual-compaction preference.
-        conn.execute(
-            "ALTER TABLE console_conversation_context_policy "
-            "DROP COLUMN compaction_representation"
-        )
-        conn.execute("ALTER TABLE conversations DROP COLUMN system_prompt")
-        conn.execute(
-            "UPDATE db_schema_version SET version = 17 WHERE schema_name = ?",
-            (db._SCHEMA_NAME,),
-        )
+        # Simulate a v17-shaped DB: the shared registry removes everything
+        # newer migrations added (columns, triggers, tables) and rolls the
+        # recorded schema version back so re-opening replays V17->current.
+        rollback_chachanotes_schema(conn, 17)
         conn.commit()
+
+        # Assert the v17 preconditions before reopening: the column and the
+        # triggers under test, and the post-v17 tables whose baked presence
+        # broke this fixture before (task-15765: note_folders "already
+        # exists" at the V35->V36 replay step).
+        columns_before = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
+        }
+        assert "system_prompt" not in columns_before
+        trigger_names = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                "AND name LIKE 'conversations_sync_%'"
+            ).fetchall()
+        }
+        assert trigger_names == set()
+        table_names = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "note_folders" not in table_names
+        assert "note_folder_memberships" not in table_names
+        version_before = conn.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (db._SCHEMA_NAME,),
+        ).fetchone()
+        assert version_before["version"] == 17
         db.close_connection()
 
         migrated = CharactersRAGDB(db_path, client_id)

--- a/Tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/Tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -224,16 +224,21 @@ class TestDBInitialization:
         db = CharactersRAGDB(db_path, client_id)
         conn = db.get_connection()
 
-        # Simulate a v17-shaped DB: the shared registry removes everything
-        # newer migrations added (columns, triggers, tables) and rolls the
-        # recorded schema version back so re-opening replays V17->current.
+        # Roll back to a replayable v17 stamp: the shared registry removes
+        # the post-v17 artifacts that would collide on replay and rewinds
+        # the recorded version. The result is NOT a faithful v17 snapshot
+        # (replay-tolerant migrations' tables/columns survive) — it is
+        # exactly sufficient for replaying the migrations under test.
         rollback_chachanotes_schema(conn, 17)
         conn.commit()
 
-        # Assert the v17 preconditions before reopening: the column and the
-        # triggers under test, and the post-v17 tables whose baked presence
-        # broke this fixture before (task-15765: note_folders "already
-        # exists" at the V35->V36 replay step).
+        # Guard the replay preconditions before reopening: the column and
+        # triggers the V17->V18 migration must (re)create are genuinely
+        # absent (a real v17 DB HAS sync triggers; the fixture drops them so
+        # SQLite lets the column go, and replay recreates them), and so are
+        # the post-v17 tables whose baked presence broke this fixture before
+        # (task-15765: note_folders "already exists" at the V35->V36 replay
+        # step). These pin the fixture's own bake-guards, not a v17 shape.
         columns_before = {
             row["name"]
             for row in conn.execute("PRAGMA table_info(conversations)").fetchall()

--- a/Tests/ChaChaNotesDB/test_schema_rollback.py
+++ b/Tests/ChaChaNotesDB/test_schema_rollback.py
@@ -1,0 +1,108 @@
+"""Guards for the shared ChaChaNotes rollback registry (schema_rollback.py).
+
+Two enforcement halves for the fixture class that produced task-15730,
+task-15765, and task-16197 ("table note_folders already exists"):
+
+* a completeness ratchet — bumping ``_CURRENT_SCHEMA_VERSION`` without
+  declaring a rollback entry for the new version fails HERE, by name, with
+  instructions, instead of failing three scattered historical fixtures with
+  a confusing "already exists" at an unrelated migration's step;
+* a rollback-replay sweep — every historical version a fixture could target
+  is rewound and replayed through the production migration chain, and the
+  result must reach the current version with a schema identical (by object
+  type and name) to a fresh bootstrap, so a wrong or incomplete registry
+  entry cannot hide.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.ChaChaNotesDB.schema_rollback import (
+    MINIMUM_ROLLBACK_VERSION,
+    POST_VERSION_SCHEMA_REMOVALS,
+    SCHEMA_NAME,
+    rollback_chachanotes_schema,
+)
+
+
+def test_rollback_registry_covers_every_schema_version():
+    declared = set(POST_VERSION_SCHEMA_REMOVALS)
+    required = set(
+        range(
+            MINIMUM_ROLLBACK_VERSION + 1,
+            CharactersRAGDB._CURRENT_SCHEMA_VERSION + 1,
+        )
+    )
+    assert declared == required, (
+        "POST_VERSION_SCHEMA_REMOVALS must declare exactly versions "
+        f"{min(required)}..{max(required)}. "
+        f"Missing: {sorted(required - declared)}; "
+        f"stale: {sorted(declared - required)}. If you just added a schema "
+        "migration, add an entry to Tests/ChaChaNotesDB/schema_rollback.py "
+        "removing what it creates (an empty tuple only if replaying the "
+        "migration over its own baked artifacts is tolerated)."
+    )
+
+
+@pytest.fixture(scope="module")
+def fresh_template_db(tmp_path_factory):
+    """Bootstrap one current-version DB per module; sweep cases copy it."""
+    path = tmp_path_factory.mktemp("chacha_template") / "template.sqlite"
+    db = CharactersRAGDB(str(path), client_id="template-client")
+    db.close_connection()
+    return path
+
+
+def _schema_objects(conn: sqlite3.Connection) -> set[tuple[str, str]]:
+    return {
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    "target_version",
+    range(MINIMUM_ROLLBACK_VERSION, CharactersRAGDB._CURRENT_SCHEMA_VERSION),
+)
+def test_rollback_then_replay_reaches_current_schema(
+    fresh_template_db, tmp_path, target_version
+):
+    db_path = tmp_path / f"rollback_v{target_version}.sqlite"
+    shutil.copy(fresh_template_db, db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rollback_chachanotes_schema(conn, target_version)
+        conn.commit()
+    finally:
+        conn.close()
+
+    migrated = CharactersRAGDB(str(db_path), client_id="sweep-client")
+    try:
+        migrated_conn = migrated.get_connection()
+        version = migrated_conn.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (SCHEMA_NAME,),
+        ).fetchone()[0]
+        assert version == migrated._CURRENT_SCHEMA_VERSION
+
+        fresh_conn = sqlite3.connect(fresh_template_db)
+        try:
+            fresh_objects = _schema_objects(fresh_conn)
+        finally:
+            fresh_conn.close()
+        replayed_objects = _schema_objects(migrated_conn)
+        assert replayed_objects == fresh_objects, (
+            f"rollback to v{target_version} + replay diverged from a fresh "
+            f"bootstrap: missing={sorted(fresh_objects - replayed_objects)} "
+            f"extra={sorted(replayed_objects - fresh_objects)}"
+        )
+    finally:
+        migrated.close_connection()

--- a/Tests/ChaChaNotesDB/test_schema_rollback.py
+++ b/Tests/ChaChaNotesDB/test_schema_rollback.py
@@ -9,9 +9,13 @@ task-15765, and task-16197 ("table note_folders already exists"):
   a confusing "already exists" at an unrelated migration's step;
 * a rollback-replay sweep — every historical version a fixture could target
   is rewound and replayed through the production migration chain, and the
-  result must reach the current version with a schema identical (by object
-  type and name) to a fresh bootstrap, so a wrong or incomplete registry
-  entry cannot hide.
+  result must reach the current version with a schema identical to a fresh
+  bootstrap: object inventory (type, name) PLUS per-table column sets.
+  Columns are not sqlite_master rows, so an object-only oracle is blind to a
+  wrong ``DROP COLUMN`` registry entry — half the registry is column drops.
+  Column comparison is by SET, not position: replay legitimately re-appends
+  a dropped column at the end of the table (fresh has ``messages.usage_json``
+  before ``metadata_json``; a v16..v29 replay has the reverse).
 """
 
 from __future__ import annotations
@@ -59,12 +63,27 @@ def fresh_template_db(tmp_path_factory):
 
 
 def _schema_objects(conn: sqlite3.Connection) -> set[tuple[str, str]]:
-    return {
+    """Object inventory plus per-table column membership.
+
+    Each table contributes a ``("column", "<table>.<column>")`` entry per
+    column, so column loss (invisible in sqlite_master) fails the parity
+    assertion by name. Membership is a set on purpose — column ORDER may
+    legitimately diverge between a replayed and a fresh DB.
+    """
+    objects = {
         (row[0], row[1])
         for row in conn.execute(
             "SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'"
         )
     }
+    for object_type, name in sorted(objects):
+        if object_type != "table":
+            continue
+        objects.update(
+            ("column", f"{name}.{column_row[1]}")
+            for column_row in conn.execute(f'PRAGMA table_info("{name}")')
+        )
+    return objects
 
 
 @pytest.mark.parametrize(

--- a/Tests/Character_Chat/test_dictionary_attachment_index.py
+++ b/Tests/Character_Chat/test_dictionary_attachment_index.py
@@ -31,6 +31,7 @@ from tldw_chatbook.Character_Chat.chat_dictionary_scope_service import (
     ChatDictionaryScopeService,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.ChaChaNotesDB.schema_rollback import rollback_chachanotes_schema
 
 
 @pytest.fixture
@@ -721,19 +722,10 @@ class TestMigrationBackfill:
         db.close_connection()
 
         raw = sqlite3.connect(db_path)
-        raw.executescript(
-            """
-            DROP TRIGGER IF EXISTS conversation_dictionary_index_ai;
-            DROP TRIGGER IF EXISTS conversation_dictionary_index_au;
-            DROP TRIGGER IF EXISTS conversation_dictionary_index_ad;
-            DROP TABLE IF EXISTS conversation_dictionary_attachments;
-            DROP TABLE IF EXISTS conversation_dictionary_unresolved;
-            DROP TABLE IF EXISTS note_folder_memberships;
-            DROP TABLE IF EXISTS note_folders;
-            UPDATE db_schema_version SET version = 34
-             WHERE schema_name = 'rag_char_chat_schema';
-            """
-        )
+        # The shared registry removes everything the post-V34 migrations
+        # added (derived dictionary tables/triggers, note folders, ...) and
+        # rolls the recorded version back to 34.
+        rollback_chachanotes_schema(raw, 34)
         raw.commit()
         raw.close()
 

--- a/Tests/Chat/test_conversation_local_marks_service.py
+++ b/Tests/Chat/test_conversation_local_marks_service.py
@@ -7,6 +7,7 @@ from tldw_chatbook.Chat.conversation_local_marks_service import (
 )
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.ChaChaNotesDB.schema_rollback import rollback_chachanotes_schema
 
 
 def _db(tmp_path):
@@ -65,54 +66,30 @@ def test_local_marks_migrate_from_v16_to_v17_with_expected_schema(tmp_path):
     db_path = tmp_path / "chacha.sqlite"
     db = CharactersRAGDB(str(db_path), client_id="test-client")
     conn = db.get_connection()
-    conn.execute("DROP INDEX IF EXISTS idx_conversation_local_marks_type")
-    conn.execute("DROP TABLE IF EXISTS conversation_local_marks")
-    # A fresh DB is created at the current schema version (>= V18), which
-    # already includes the V17->V18 `system_prompt` column/triggers. Undo
-    # that too so replaying V16->V17->V18 from a true V16-shaped DB doesn't
-    # hit "duplicate column name" when V17->V18 re-adds it.
-    conn.execute("DROP TRIGGER IF EXISTS conversations_sync_create")
-    conn.execute("DROP TRIGGER IF EXISTS conversations_sync_update")
-    conn.execute("DROP TRIGGER IF EXISTS conversations_sync_delete")
-    conn.execute("DROP TRIGGER IF EXISTS conversations_sync_undelete")
-    # A V16 fixture also predates the V27->V28 character-authority column.
-    conn.execute("ALTER TABLE conversations DROP COLUMN assistant_authority_id")
-    # A V16 fixture also predates the V29->V30 local-only usage_json column.
-    conn.execute("ALTER TABLE messages DROP COLUMN usage_json")
-    # A V16 fixture predates the V33->V34 visual-compaction preference.
-    conn.execute(
-        "ALTER TABLE console_conversation_context_policy "
-        "DROP COLUMN compaction_representation"
-    )
-    conn.execute("ALTER TABLE conversations DROP COLUMN system_prompt")
-    # A V16 fixture predates the V35->V36 note-folder tables.
-    conn.execute("DROP TABLE IF EXISTS note_folder_memberships")
-    conn.execute("DROP TABLE IF EXISTS note_folders")
-    # A V16 fixture must not retain citation tables introduced at V26->V27.
-    for table in (
-        "rag_artifact_owner_operations",
-        "rag_artifact_owner_leases",
-        "rag_source_observations",
-        "rag_message_trace_owners",
-        "rag_trace_evidence_refs",
-        "rag_answer_attempt_payloads",
-        "rag_evidence_runs",
-        "rag_citation_traces",
-        "rag_evidence_snapshots",
-        "rag_payload_tombstones",
-        "rag_legacy_migration_journal",
-        "rag_identity_context",
-    ):
-        conn.execute(f"DROP TABLE {table}")
-    conn.execute(
-        """
-        UPDATE db_schema_version
-           SET version = 16
-         WHERE schema_name = ?
-        """,
-        (db._SCHEMA_NAME,),
-    )
+    # A fresh DB bootstraps at the current schema version; the shared
+    # registry removes everything the post-V16 migrations added and rolls
+    # the recorded version back so reopening replays V16->current.
+    rollback_chachanotes_schema(conn, 16)
     conn.commit()
+
+    # Assert the V16 preconditions before reopening: the marks table the
+    # V16->V17 migration must create, and the post-V16 tables whose baked
+    # presence broke this fixture before (task-16197: note_folders "already
+    # exists" at the V35->V36 replay step).
+    table_names = {
+        row["name"]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    assert "conversation_local_marks" not in table_names
+    assert "note_folders" not in table_names
+    assert "note_folder_memberships" not in table_names
+    version_before = conn.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (db._SCHEMA_NAME,),
+    ).fetchone()
+    assert version_before["version"] == 16
     db.close_connection()
 
     migrated = CharactersRAGDB(str(db_path), client_id="test-client")
@@ -253,9 +230,7 @@ def test_fleet_unseen_mark_survives_into_a_fresh_service_handle(tmp_path):
 
     fresh_db = CharactersRAGDB(path, client_id="reader")
     fresh = ConversationLocalMarksService(fresh_db)
-    assert fresh.has_mark(
-        "conv-restart", ConversationLocalMarksService.FLEET_UNSEEN
-    )
+    assert fresh.has_mark("conv-restart", ConversationLocalMarksService.FLEET_UNSEEN)
     assert fresh.list_marked_conversation_ids(
         ConversationLocalMarksService.FLEET_UNSEEN
     ) == ("conv-restart",)
@@ -273,8 +248,7 @@ def test_get_mark_returns_timestamps_with_created_at_stable_across_refreshes(
     db = _db(tmp_path)
     service = ConversationLocalMarksService(db)
     assert (
-        service.get_mark("conv-a", ConversationLocalMarksService.FLEET_UNSEEN)
-        is None
+        service.get_mark("conv-a", ConversationLocalMarksService.FLEET_UNSEEN) is None
     )
 
     service.set_mark("conv-a", ConversationLocalMarksService.FLEET_UNSEEN)
@@ -285,9 +259,7 @@ def test_get_mark_returns_timestamps_with_created_at_stable_across_refreshes(
     assert first.created_at and first.updated_at
 
     service.set_mark("conv-a", ConversationLocalMarksService.FLEET_UNSEEN)
-    refreshed = service.get_mark(
-        "conv-a", ConversationLocalMarksService.FLEET_UNSEEN
-    )
+    refreshed = service.get_mark("conv-a", ConversationLocalMarksService.FLEET_UNSEEN)
     assert refreshed is not None
     assert refreshed.created_at == first.created_at
     assert refreshed.updated_at >= first.updated_at

--- a/Tests/Chat/test_conversation_local_marks_service.py
+++ b/Tests/Chat/test_conversation_local_marks_service.py
@@ -67,15 +67,18 @@ def test_local_marks_migrate_from_v16_to_v17_with_expected_schema(tmp_path):
     db = CharactersRAGDB(str(db_path), client_id="test-client")
     conn = db.get_connection()
     # A fresh DB bootstraps at the current schema version; the shared
-    # registry removes everything the post-V16 migrations added and rolls
-    # the recorded version back so reopening replays V16->current.
+    # registry removes the post-V16 artifacts that would collide on replay
+    # and rewinds the recorded version. The result is NOT a faithful V16
+    # snapshot (replay-tolerant migrations' tables/columns survive) — it is
+    # exactly sufficient for replaying the migrations under test.
     rollback_chachanotes_schema(conn, 16)
     conn.commit()
 
-    # Assert the V16 preconditions before reopening: the marks table the
-    # V16->V17 migration must create, and the post-V16 tables whose baked
-    # presence broke this fixture before (task-16197: note_folders "already
-    # exists" at the V35->V36 replay step).
+    # Guard the replay preconditions before reopening: the marks table the
+    # V16->V17 migration must (re)create is genuinely absent, as are the
+    # post-V16 tables whose baked presence broke this fixture before
+    # (task-16197: note_folders "already exists" at the V35->V36 replay
+    # step). These pin the fixture's own bake-guards, not a full V16 shape.
     table_names = {
         row["name"]
         for row in conn.execute(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4342,3 +4342,30 @@ around the whole operation, not around the listed calls. If the numbers do not d
 when the listed sites move, the list was wrong, and the AC's own wording ("the
 difflib work") almost always licenses fixing the omission in the same change --
 record the addition explicitly rather than silently widening scope.
+
+## A version-stamp rollback fixture is a promise every future migration must keep — centralize it or it breaks serially (task-15765/task-16197, 2026-08-15)
+
+Three "historical" ChaChaNotes fixtures were built top-down: bootstrap a fresh
+DB (which lands at `_CURRENT_SCHEMA_VERSION`), hand-drop the newer artifacts,
+stamp `db_schema_version` back, reopen, and let the migration chain replay.
+Each fixture carried its own private drop list — and every migration that
+shipped a non-idempotent artifact broke them serially: `88f5f535a` (V33→V34
+unguarded `ADD COLUMN compaction_representation`) broke them and task-15730
+repaired them one by one; two days later `9174975b0` (V35→V36 bare
+`CREATE TABLE note_folders`, task-15705) broke them AGAIN — and, decisively,
+its author fixed the ONE fixture they knew about
+(`test_dictionary_attachment_index.py`) and missed the other two, producing
+task-15765 and task-16197 with the identical "table note_folders already
+exists" error, each then repaired in a separate task (16201, 16207). Four
+repair tasks for two migrations is the signature of state duplicated where no
+gate forces it to stay in sync. The fix is structural, not another patch: one
+shared per-version removal registry (`Tests/ChaChaNotesDB/schema_rollback.py`)
+consumed by every rollback fixture, a completeness ratchet that fails BY NAME
+with instructions the moment `_CURRENT_SCHEMA_VERSION` outruns the registry,
+and a rollback-replay sweep over every historical target that compares the
+replayed schema's object inventory against a fresh bootstrap. The sweep paid
+for itself on its first run: a defensively-copied trigger drop in the V28
+entry left DBs rolled back to V20..V27 silently missing ALL conversations
+sync triggers after replay — a corruption no per-test fixture would ever
+notice, caught only because the sweep asserts parity with a fresh DB rather
+than "the test I care about passes".

--- a/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
+++ b/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
@@ -105,3 +105,32 @@ killed the class instead of re-patching the instance:
   untouched by this diff) — zero regressions from this change.
 - No production migration or schema code changed (diff is Tests/ + backlog/
   only).
+
+### Review follow-up (same session, pre-merge)
+
+Independent review verdict: MERGE, two pre-merge fixes applied:
+
+- **F1 (oracle depth)**: the sweep's parity oracle compared sqlite_master
+  (type, name) only — blind to column loss, though half the registry is
+  `DROP COLUMN`. `_schema_objects` now also emits a
+  ("column", "<table>.<column>") entry per table column (SETS, not
+  positions — F4: replay legitimately re-appends dropped columns at the
+  table end). Born-red with the reviewer's exact mutation (a seeded
+  `DROP COLUMN active_leaf_message_id` in entry 28): previously 22/22
+  green; now exactly v24..v27 red naming the lost column, v16..v23
+  repaired by the V23->V24 replay, v28..v37 unaffected. Restored
+  Edit-based; unmutated registry green (23/23) — replayed column sets are
+  identical to a fresh bootstrap.
+- **F2 (comment truth)**: the registry docstring and both fixture comments
+  no longer claim a "historical"/"genuine vN" schema. They now state what
+  the fixture is — a current-version DB with the specific colliding
+  artifacts removed, sufficient for replaying the migrations under test,
+  NOT a faithful vN snapshot (at a v17 stamp: 7 post-v17 tables, 9
+  indexes, 5 columns survive; real-vN sync triggers deliberately absent
+  until replay). Precondition asserts relabelled as the fixture's own
+  bake-guards. Docstring also records the F4 column-order caveat and
+  points to the knowledge-free alternative (bootstrap under a patched
+  `_CURRENT_SCHEMA_VERSION`, as test_chachanotes_note_folders_migration.py
+  does) as the follow-up direction.
+- Re-run: guards+sweep 23 passed; both formerly-red tests + dictionary
+  suite green (53 passed total); ruff check/format clean.

--- a/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
+++ b/backlog/tasks/task-15765 - Repair-the-v17-to-v18-ChaChaNotes-migration-fixture-broken-by-v35-to-v36.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15765
 title: Repair the v17-to-v18 ChaChaNotes migration fixture broken by v35-to-v36
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - database
@@ -44,14 +45,63 @@ target state did not.
 
 ## Acceptance Criteria
 
-- [ ] The v17 fixture in `test_conversations_migrate_from_v17_to_v18_adds_system_prompt_column`
+- [x] The v17 fixture in `test_conversations_migrate_from_v17_to_v18_adds_system_prompt_column`
       also removes `note_folders` (and any note_folders-only triggers) before
       rolling `db_schema_version` back to 17, so replaying v35->v36 finds a
       genuine pre-v36 shape
-- [ ] The test asserts its v17/v18 preconditions (column and trigger absence)
+- [x] The test asserts its v17/v18 preconditions (column and trigger absence)
       before reopening at the current version, matching task-15707's pattern
-- [ ] `Tests/ChaChaNotesDB/test_chachanotes_db.py` and
+- [x] `Tests/ChaChaNotesDB/test_chachanotes_db.py` and
       `Tests/DB/test_chachanotes_console_context_memory_migration.py` pass
       with zero regressions elsewhere in `Tests/DB/` + `Tests/ChaChaNotesDB/`
-- [ ] No production migration or schema code changes — this is a test-fixture
+- [x] No production migration or schema code changes — this is a test-fixture
       correction only
+
+## Implementation Plan
+
+1. Reproduce the red at HEAD; discover whether interim repairs landed (task-16201
+   `c983320fb` already added the note_folders drops to this fixture — verify).
+2. Root-cause the class with task-16197: three hand-maintained rollback drop
+   lists (this test, the local-marks v16 test, the dictionary v34 test) each
+   break whenever a migration adds a non-idempotent artifact.
+3. Replace the per-test drop lists with a shared per-version rollback registry
+   (`Tests/ChaChaNotesDB/schema_rollback.py`) used by all three fixtures.
+4. Add the v17/v18 precondition assertions (column/trigger/table absence)
+   before reopening, matching task-15707's pattern.
+5. Add a completeness ratchet (registry must cover every version up to
+   `_CURRENT_SCHEMA_VERSION`) and a rollback-replay sweep over historical
+   versions so the next migration fails ONE named guard, not three fixtures.
+6. Mutation-verify (remove the v36 entry → the original error returns), then
+   run the named suites + Tests/DB + Tests/ChaChaNotesDB; ruff on touched files.
+
+## Implementation Notes
+
+By the time this task was picked up, another session had already applied the
+per-test repair (task-16201, commit `c983320fb`: the fixture drops
+`note_folder_memberships` + `note_folders`), so the named test was green at
+base. This task therefore closed the REMAINING ACs and, with task-16197,
+killed the class instead of re-patching the instance:
+
+- Replaced the fixture's hand-rolled drop list with the new shared
+  per-version rollback registry
+  (`Tests/ChaChaNotesDB/schema_rollback.py::rollback_chachanotes_schema`),
+  which removes everything post-v17 migrations added (incl. the note-folder
+  tables) before stamping the version back to 17.
+- Added the AC2 precondition assertions before reopening: `system_prompt`
+  column absent, all `conversations_sync_*` triggers absent, `note_folders` /
+  `note_folder_memberships` absent, recorded version == 17 (task-15707's
+  pattern).
+- Class guards (shared with task-16197): a registry-completeness ratchet and
+  a rollback-replay sweep with schema-object parity against a fresh bootstrap
+  (`Tests/ChaChaNotesDB/test_schema_rollback.py`).
+- Verification: the historical red reproduced verbatim with the repair
+  reverted ("table note_folders already exists" at V35->V36); mutation runs
+  (v36 entry emptied / removed) fail 23 tests with the original error or the
+  ratchet's actionable message. Full `Tests/DB/` + `Tests/ChaChaNotesDB/` +
+  marks + dictionary suites: 1215 passed, 1 skipped, 1 failed — the single
+  failure is `test_chachanotes_default_assistant_enrichment_migration.py::
+  test_current_schema_version_is_37`, a PRE-EXISTING dev red (stale contract
+  vs `_CURRENT_SCHEMA_VERSION == 38`; present on origin/dev `48ad9e7de`,
+  untouched by this diff) — zero regressions from this change.
+- No production migration or schema code changed (diff is Tests/ + backlog/
+  only).

--- a/backlog/tasks/task-16197 - Fix-dev-red-marks-migration-test-note_folders-already-exists-(v35-to-v36).md
+++ b/backlog/tasks/task-16197 - Fix-dev-red-marks-migration-test-note_folders-already-exists-(v35-to-v36).md
@@ -89,3 +89,32 @@ Introducing commits per instance:
   stale contract vs v38, present on origin/dev `48ad9e7de`, unrelated).
 - Lessons: incident chain recorded in
   `backlog/docs/lessons-testing-evidence.md`.
+
+### Review follow-up (same session, pre-merge)
+
+Independent review verdict: MERGE, two pre-merge fixes applied:
+
+- **F1 (oracle depth)**: the sweep's parity oracle compared sqlite_master
+  (type, name) only — blind to column loss, though half the registry is
+  `DROP COLUMN`. `_schema_objects` now also emits a
+  ("column", "<table>.<column>") entry per table column (SETS, not
+  positions — F4: replay legitimately re-appends dropped columns at the
+  table end). Born-red with the reviewer's exact mutation (a seeded
+  `DROP COLUMN active_leaf_message_id` in entry 28): previously 22/22
+  green; now exactly v24..v27 red naming the lost column, v16..v23
+  repaired by the V23->V24 replay, v28..v37 unaffected. Restored
+  Edit-based; unmutated registry green (23/23) — replayed column sets are
+  identical to a fresh bootstrap.
+- **F2 (comment truth)**: the registry docstring and both fixture comments
+  no longer claim a "historical"/"genuine vN" schema. They now state what
+  the fixture is — a current-version DB with the specific colliding
+  artifacts removed, sufficient for replaying the migrations under test,
+  NOT a faithful vN snapshot (at a v17 stamp: 7 post-v17 tables, 9
+  indexes, 5 columns survive; real-vN sync triggers deliberately absent
+  until replay). Precondition asserts relabelled as the fixture's own
+  bake-guards. Docstring also records the F4 column-order caveat and
+  points to the knowledge-free alternative (bootstrap under a patched
+  `_CURRENT_SCHEMA_VERSION`, as test_chachanotes_note_folders_migration.py
+  does) as the follow-up direction.
+- Re-run: guards+sweep 23 passed; both formerly-red tests + dictionary
+  suite green (53 passed total); ruff check/format clean.

--- a/backlog/tasks/task-16197 - Fix-dev-red-marks-migration-test-note_folders-already-exists-(v35-to-v36).md
+++ b/backlog/tasks/task-16197 - Fix-dev-red-marks-migration-test-note_folders-already-exists-(v35-to-v36).md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16197
 title: 'Fix dev-red marks migration test: note_folders already exists (v35 to v36)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-14 03:05'
 labels:
   - tests
@@ -18,7 +19,73 @@ The conversation-marks migration test fails on pristine dev (`c3ed2854a` and aft
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The marks migration test passes on a pristine checkout
-- [ ] #2 Root cause named (migration vs fixture) with the introducing commit
-- [ ] #3 If the three-instance pattern shares one cause, the fix or a follow-up covers the class, not just this test
+- [x] #1 The marks migration test passes on a pristine checkout
+- [x] #2 Root cause named (migration vs fixture) with the introducing commit
+- [x] #3 If the three-instance pattern shares one cause, the fix or a follow-up covers the class, not just this test
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce at HEAD; verify whether the per-test repair already landed
+   (task-16207 `5300077fd` added note_folders drops to the marks fixture).
+2. Name the root cause and introducing commits: the fixture-generation
+   approach (fresh current-version DB + hand-rolled drop list + version-stamp
+   rollback) bakes future artifacts; `88f5f535a` (v33→v34 column) broke the
+   lists first, `9174975b0` (v35→v36 note_folders, task-15705) broke them
+   again — that commit even fixed the ONE fixture its author knew about
+   (dictionary v34) and missed the other two.
+3. Kill the class: shared per-version rollback registry + helper consumed by
+   all three fixtures, a registry-completeness ratchet against
+   `_CURRENT_SCHEMA_VERSION`, and a rollback-replay sweep across historical
+   versions with schema-parity assertion against a fresh DB.
+4. Mutation-verify the guard actually catches the original failure mode; run
+   the marks suite, Tests/DB, Tests/ChaChaNotesDB, dictionary suite; ruff.
+
+## Implementation Notes
+
+The failing test is
+`Tests/Chat/test_conversation_local_marks_service.py::test_local_marks_migrate_from_v16_to_v17_with_expected_schema`.
+Another session had already applied the per-test repair (task-16207, commit
+`5300077fd`) before this task was picked up, so it was green at base; this
+task delivered the root-cause naming (AC2) and the class-wide fix (AC3).
+
+**Root cause: the fixture chain, not the migration.** The fixture bootstraps
+a FRESH DB (current version), hand-drops newer artifacts, stamps
+`db_schema_version` back to 16, and reopens — so every artifact the drop
+list misses is baked into the "historical" DB and collides on replay.
+Introducing commits per instance:
+
+- Instance 1 (task-15730 cluster): `88f5f535a` (V33->V34, unguarded
+  `ALTER TABLE ... ADD COLUMN compaction_representation`).
+- Instances 2+3 (task-15765 + this task): `9174975b0` (V35->V36
+  `note_folders`, task-15705 — bare `CREATE TABLE`, unlike the IF-NOT-EXISTS
+  V34->V35 and V37->V38 neighbours). Decisive class evidence: that commit
+  itself patched the ONE rollback fixture its author knew about
+  (`test_dictionary_attachment_index.py`) and missed the other two.
+
+**Class fix (test layer; production migrations untouched):**
+
+- `Tests/ChaChaNotesDB/schema_rollback.py` — a single per-version removal
+  registry + `rollback_chachanotes_schema()`; all three top-down rollback
+  fixtures (marks v16, chachanotes v17, dictionary v34) now consume it.
+- `Tests/ChaChaNotesDB/test_schema_rollback.py` — a completeness ratchet
+  (bumping `_CURRENT_SCHEMA_VERSION` without a registry entry fails by name
+  with instructions) and a rollback-replay sweep over every target v16..v37
+  asserting schema-object parity with a fresh bootstrap.
+- The sweep caught a real latent bug during development: a defensive trigger
+  drop in the V28 entry left targets V20..V27 silently missing ALL
+  conversations sync triggers after replay — the parity assertion is what
+  makes wrong registry entries unable to hide.
+- Sweep of other fixture-built versions: only the three rollback-style
+  fixtures exist (`grep "UPDATE db_schema_version"`); the bottom-up
+  `Tests/DB/test_chachanotes_*_migration.py` fixtures build legacy schemas
+  from scratch and are not exposed to the bake.
+- Mutation evidence: emptying the v36 entry reproduces the exact filed error
+  in 23 tests; deleting it trips the ratchet and the helper's actionable
+  assertion.
+- Verification: marks suite 19 passed; rollback guards 23 passed;
+  full `Tests/DB/` + `Tests/ChaChaNotesDB/` + dictionary suite: 1215 passed,
+  1 skipped, 1 pre-existing dev red (`test_current_schema_version_is_37`,
+  stale contract vs v38, present on origin/dev `48ad9e7de`, unrelated).
+- Lessons: incident chain recorded in
+  `backlog/docs/lessons-testing-evidence.md`.


### PR DESCRIPTION
## Summary

Kills the "table note_folders already exists" migration-fixture family at the class level (third and fourth instances; task-15730 fixed the first per-test). Root cause across all instances: rollback-style fixtures bootstrap a CURRENT-version DB and hand-drop newer artifacts from private per-test lists — every non-idempotent artifact a list misses is baked in and collides on replay. The decisive evidence: the introducing commit (`9174975b0`, a bare `CREATE TABLE note_folders`) patched the ONE rollback fixture its author knew about and missed the other two.

Test-layer only, zero production changes:
- **One per-version removal registry** (`Tests/ChaChaNotesDB/schema_rollback.py`, v17–v38) consumed by all three rollback fixtures — private drop lists gone
- **A completeness ratchet**: bumping `_CURRENT_SCHEMA_VERSION` without a registry entry fails by name with instructions (mutation-verified)
- **A replay sweep** over all 22 historical targets asserting parity with a fresh bootstrap — it caught a real latent bug in the fix's own first cut (v20–v27 replays silently missing all conversation sync triggers), and per review the oracle now also compares per-table column SETS (the review's mutation proved the name-only oracle passed 22/22 while four targets lost a production column; the deepened oracle reds exactly v24–v27 on that same mutation)
- Comment truth per review: the fixtures are documented as replayable rollbacks, NOT faithful vN snapshots (measured divergence recorded), with a pointer to the knowledge-free bootstrap alternative being filed as the future direction
- Both named tests were already green at base via concurrent per-test repairs (16201/16207) — stated plainly; the historical reds were reproduced verbatim by reverting those hunks; the class work is what these tasks still demanded
- Lessons entry records the 15730 → 15765/16197 chain

1215+ tests green across the DB suites (the single failure is the pre-existing `version_is_37` stale contract, red on dev, being filed separately). Review: independent opus pass → MERGE; micro-round applied its two findings with its exact mutations as born-red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes ChaChaNotes rollback fixtures into a single per-version registry and adds guards to prevent “already exists” collisions in historical migration tests. Replaces per-test drop lists with one source of truth and enforces coverage when `_CURRENT_SCHEMA_VERSION` advances, addressing TASK-15765 and TASK-16197. Test-only; no production schema or migration changes.

- Introduces `Tests/ChaChaNotesDB/schema_rollback.py`: a shared `POST_VERSION_SCHEMA_REMOVALS` registry (v17–v38) and `rollback_chachanotes_schema()` used by the v16 marks, v17 chachanotes, and v34 dictionary fixtures.
- Adds `Tests/ChaChaNotesDB/test_schema_rollback.py`: a completeness ratchet (fails by name if a new version lacks a registry entry) and a rollback→replay sweep across v16..current-1 that asserts parity with a fresh bootstrap by object inventory and per-table column sets.
- Updates `Tests/ChaChaNotesDB/test_chachanotes_db.py` and `Tests/Chat/test_conversation_local_marks_service.py` to call the helper and assert fixture preconditions; clarifies these fixtures are replayable rollbacks, not faithful vN snapshots.
- Required for migration authors: when you bump `_CURRENT_SCHEMA_VERSION`, add an entry to `POST_VERSION_SCHEMA_REMOVALS` (use an empty tuple only if the migration safely replays over baked artifacts). The ratchet test enforces this.

<sup>Written for commit 5d1d8a19416471ed3ffdd4a26dd5e36f1d8bb002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

