### PR TITLE
test(css): CSS_PATH-overriding harnesses keep the generated screen sheets (TASK-15995)

### DIFF
--- a/Tests/UI/consolidated_css.py
+++ b/Tests/UI/consolidated_css.py
@@ -11,8 +11,15 @@
 # became `BUNDLED_SCREEN_CSS`: Textual used to register that automatically when
 # the screen was pushed, so a harness that pushes one now gets a modal with no
 # CSS at all unless the screen sheets are loaded too. `CSS_PATH` carries those.
-# A subclass that declares its own `CSS_PATH` (most do, pointing at the bundle)
-# overrides it -- which matches what those harnesses had before.
+#
+# A subclass that declares its own `CSS_PATH` (most do, pointing at the app
+# bundle) would ordinarily shadow that class attribute outright via normal
+# Python attribute lookup, and Textual's own `App.__init__` resolves a
+# `css_path=` constructor kwarg the same way (`css_path or self.CSS_PATH`) --
+# either form drops the screen sheets entirely, unlike before TASK-15450 where
+# a pushed screen's own CSS registered itself regardless of the harness's
+# `CSS_PATH` (TASK-15995). `__init__` below merges the screen sheets around
+# whichever form a subclass uses, so both keep working.
 #
 # Inherit `ConsolidatedCSSApp` instead of `App` to get exactly what production
 # gets -- same sheets, same tie-breakers, same cascade position -- via the same
@@ -21,7 +28,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+from textual._path import CSSPathType, _css_path_type_as_list
 from textual.app import App
 
 from tldw_chatbook.css import build_css
@@ -31,11 +40,57 @@ CSS_DIR = Path(build_css.__file__).parent
 #: The app bundle, for harnesses that want the app-CSS tier as well.
 BUNDLED_STYLESHEET = CSS_DIR / "tldw_cli_modular.tcss"
 
+#: The screen/modal sheets (TASK-15450), scope-prefixed stream first and self
+#: stream last -- the exact pair and order `TldwCli.CSS_PATH` brackets its app
+#: bundle with. `screen_css_paths` is the single ordering source; nothing else
+#: in this module hardcodes the pair.
+_SCREEN_CSS_SCOPED, _SCREEN_CSS_SELF = build_css.screen_css_paths(CSS_DIR)
+
+
+def _merge_screen_css_paths(css_path: CSSPathType | None) -> list[str]:
+    """Bracket ``css_path`` with the screen/modal sheets, production order.
+
+    ``css_path`` is whatever a subclass/instance ultimately supplied -- a
+    ``CSS_PATH`` class attribute or a ``css_path=`` constructor kwarg, either
+    of which replaces `ConsolidatedCSSApp.CSS_PATH` wholesale on its own.
+    Re-adds the two screen sheets around it without duplicating them if they
+    are already present (e.g. a subclass that does not override ``CSS_PATH``
+    at all, where ``css_path`` already *is* the pair).
+
+    Args:
+        css_path: The effective CSS_PATH a subclass/instance supplied, or
+            ``None``.
+
+    Returns:
+        ``[scoped_sheet, *own_entries, self_sheet]``, as strings.
+    """
+    own_paths = (
+        [Path(path) for path in _css_path_type_as_list(css_path)] if css_path else []
+    )
+    middle = [
+        path for path in own_paths if path not in (_SCREEN_CSS_SCOPED, _SCREEN_CSS_SELF)
+    ]
+    return [
+        str(_SCREEN_CSS_SCOPED),
+        *(str(path) for path in middle),
+        str(_SCREEN_CSS_SELF),
+    ]
+
 
 class ConsolidatedCSSApp(App):
     """An ``App`` that loads the consolidated widget CSS, as the real app does."""
 
-    CSS_PATH = [str(path) for path in build_css.screen_css_paths(CSS_DIR)]
+    CSS_PATH = [str(_SCREEN_CSS_SCOPED), str(_SCREEN_CSS_SELF)]
+
+    def __init__(
+        self, *args: Any, css_path: CSSPathType | None = None, **kwargs: Any
+    ) -> None:
+        # Mirrors Textual's own `css_path or self.CSS_PATH` resolution so the
+        # merge sees whichever form actually won -- the kwarg if the caller
+        # passed one, else whatever `CSS_PATH` resolves to on this instance's
+        # (possibly subclassed) type.
+        effective = css_path if css_path is not None else self.CSS_PATH
+        super().__init__(*args, css_path=_merge_screen_css_paths(effective), **kwargs)
 
     def _get_default_css(self):  # noqa: D102 - see module docstring
         return build_css.widget_defaults_sources(CSS_DIR) + super()._get_default_css()

--- a/Tests/UI/test_consolidated_css_harness.py
+++ b/Tests/UI/test_consolidated_css_harness.py
@@ -1,0 +1,94 @@
+# test_consolidated_css_harness.py
+# Description: Pins Tests/UI/consolidated_css.py's own CSS_PATH-merge behavior
+# (TASK-15995).
+#
+# `ConsolidatedCSSApp.CSS_PATH` carries the two generated screen/modal sheets
+# (TASK-15450) so a harness that pushes one of the seven `BUNDLED_SCREEN_CSS`
+# modals gets its class-level CSS. But it is an ordinary class attribute, and
+# ~27 real test harnesses declare their own `CSS_PATH` (most to also load the
+# app bundle) -- which, absent a merge, shadows it wholesale via normal Python
+# attribute lookup and drops the screen sheets. Textual's `App.__init__` also
+# accepts a `css_path=` constructor kwarg that short-circuits the
+# `self.CSS_PATH` class-attribute branch entirely (`css_path or
+# self.CSS_PATH`), so the merge has to intercept both forms. This module pins
+# both rather than relying on any of the 27 real harnesses, since none of them
+# currently happens to push a `BUNDLED_SCREEN_CSS` modal (a vacuous-pass trap
+# noted in the task).
+
+from __future__ import annotations
+
+import pytest
+from textual.color import Color
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Widgets.Note_Widgets.note_selection_dialog import (
+    NoteSelectionDialog,
+)
+
+
+class _StyledHarness(ConsolidatedCSSApp):
+    """Mirrors the real combiners: a subclass that declares its own CSS_PATH."""
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+
+@pytest.mark.asyncio
+async def test_css_path_class_attr_override_still_loads_screen_sheets():
+    """A subclass ``CSS_PATH`` class attribute must not drop the screen sheets.
+
+    `NoteSelectionDialog` (one of the seven `BUNDLED_SCREEN_CSS` modals) gives
+    `#note-selection-container` a fixed `width: 80` only via its screen sheet
+    entry; absent that sheet the container falls back to `Container`'s own
+    `width: 1fr` default and fills the whole content area instead. This is a
+    computed-geometry consequence of the CSS actually applying, not merely a
+    check that pushing the modal raised no exception.
+    """
+    app = _StyledHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.push_screen(NoteSelectionDialog([]))
+        await pilot.pause()
+
+        container = app.screen.query_one("#note-selection-container")
+        assert container.region.width == 80, (
+            "NoteSelectionDialog's BUNDLED_SCREEN_CSS width:80 rule for "
+            "#note-selection-container did not apply (region.width="
+            f"{container.region.width}) -- a subclass CSS_PATH class "
+            "attribute override dropped ConsolidatedCSSApp's screen sheets"
+        )
+
+
+@pytest.mark.asyncio
+async def test_css_path_kwarg_override_loads_screen_sheets_and_keeps_own_entry(
+    tmp_path,
+):
+    """A ``css_path=`` constructor kwarg override must survive the merge too.
+
+    Textual's ``App.__init__`` resolves ``css_path or self.CSS_PATH`` -- a
+    kwarg short-circuits the class-attribute branch entirely, so the merge
+    has to intercept it independently of a subclass's ``CSS_PATH`` attribute.
+    None of the real harnesses use this form today, but the mechanism must
+    still compose with it. Asserts both halves: the harness's own supplied
+    stylesheet still applies, and the screen sheets are still merged in
+    alongside it.
+    """
+    custom_css = tmp_path / "harness_only.tcss"
+    custom_css.write_text("#note-search-input { background: red; }\n", encoding="utf-8")
+
+    app = ConsolidatedCSSApp(css_path=str(custom_css))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.push_screen(NoteSelectionDialog([]))
+        await pilot.pause()
+
+        search_input = app.screen.query_one("#note-search-input")
+        assert search_input.styles.background == Color.parse("red"), (
+            "the harness's own css_path= entry did not apply -- the merge "
+            "must not replace it, only bracket it with the screen sheets"
+        )
+
+        container = app.screen.query_one("#note-selection-container")
+        assert container.region.width == 80, (
+            "a css_path= constructor kwarg override dropped the screen "
+            "sheets (region.width=" + str(container.region.width) + ")"
+        )

--- a/backlog/tasks/task-15995 - Screen-sheet-CSS-gap-for-CSS_PATH-overriding-test-harnesses.md
+++ b/backlog/tasks/task-15995 - Screen-sheet-CSS-gap-for-CSS_PATH-overriding-test-harnesses.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15995
 title: 'Screen-sheet CSS gap for CSS_PATH-overriding test harnesses'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:10'
 labels:
   - tests
@@ -18,7 +19,115 @@ Before consolidation, Textual auto-registered a pushed screen's class-level CSS 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A ConsolidatedCSSApp subclass with its own CSS_PATH still loads the generated screen sheets when pushing a BUNDLED_SCREEN_CSS modal
-- [ ] #2 A test pins that behavior (a modal pushed under a CSS_PATH-carrying harness has its styles applied)
-- [ ] #3 The inaccurate comment is corrected
+- [x] #1 A ConsolidatedCSSApp subclass with its own CSS_PATH still loads the generated screen sheets when pushing a BUNDLED_SCREEN_CSS modal
+- [x] #2 A test pins that behavior (a modal pushed under a CSS_PATH-carrying harness has its styles applied)
+- [x] #3 The inaccurate comment is corrected
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Read Textual 8.2.8's `App.__init__` CSS_PATH resolution (`css_path = css_path or
+   self.CSS_PATH`, then `_css_path_type_as_list` + `_make_path_object_relative`).
+   Confirmed: a subclass shadows `CSS_PATH` via ordinary attribute lookup for the
+   class-attribute path, and a `css_path=` constructor kwarg short-circuits the
+   `self.CSS_PATH` branch entirely for the kwarg path -- both need to be handled by
+   the same mechanism, so it must live in `__init__`, not `__init_subclass__` (which
+   only rewrites the class attribute and would miss a subclass instantiated with an
+   explicit `css_path=` kwarg).
+2. Add `ConsolidatedCSSApp.__init__` that computes the effective incoming CSS path
+   (`css_path` kwarg if given, else `self.CSS_PATH`, mirroring Textual's own
+   resolution) and rebuilds the final `css_path` passed to `super().__init__()` as
+   `[scoped_sheet] + [effective entries, minus the two sheets if already present] +
+   [self_sheet]` -- same pair, same order as `build_css.screen_css_paths` (the single
+   ordering source per TASK-15450), matching production's
+   `[scoped, bundle, self]` bracket with the subclass's own CSS_PATH occupying the
+   "bundle" slot.
+3. Correct the inaccurate module comment (~:10-16 claims the override "matches what
+   those harnesses had before", which is false -- they used to get the class CSS
+   auto-registered).
+4. Add a new test module (`Tests/UI/test_consolidated_css_harness.py`, additive/new
+   file to avoid touching `test_widget_css_consolidation.py`, which a concurrent
+   session (task-15994) just changed on origin/dev) with a `ConsolidatedCSSApp`
+   subclass that overrides `CSS_PATH` (mirroring the ~27 real combiners) and pushes
+   `NoteSelectionDialog` (one of the 7 `BUNDLED_SCREEN_CSS` modals). Assert a
+   computed geometry consequence of its screen CSS (`#note-selection-container`'s
+   `width: 80` rule) rather than absence-of-exception. Confirm the test fails
+   against the pre-fix module (born red), then passes after the fix.
+5. Run the new test, `test_widget_css_consolidation.py`, `test_selection_dialogs.py`,
+   `test_library_prompts_canvas.py`, and a sample of the heaviest real CSS_PATH
+   combiners (test_library_shell.py, test_mcp_inspector.py, test_console_workbench_contract.py,
+   test_evals_screen.py, test_home_screen.py, test_mcp_rail.py) to confirm no
+   regressions. ruff check + format on touched files only.
+
+## Implementation Notes
+
+**Mechanism.** `ConsolidatedCSSApp.__init__` now intercepts CSS_PATH resolution
+before delegating to `App.__init__`: it computes `effective = css_path if
+css_path is not None else self.CSS_PATH` (the exact same `css_path or
+self.CSS_PATH` logic Textual's own `App.__init__` uses), then calls a new
+`_merge_screen_css_paths()` helper that returns `[scoped_sheet, *own_entries,
+self_sheet]` (own entries de-duplicated against the two sheets), and passes
+that explicit list to `super().__init__(css_path=...)`. This was chosen over
+`__init_subclass__` because a class-attribute rewrite only fixes the
+`CSS_PATH`-class-attribute path -- it cannot see a `css_path=` constructor
+kwarg, which short-circuits `self.CSS_PATH` entirely in Textual's own
+resolution (`textual/app.py:731`, `css_path = css_path or self.CSS_PATH`).
+Intercepting in `__init__` sees whichever form actually won, for both forms,
+uniformly. Verified this composes correctly with the real usage pattern in
+this codebase: every one of the ~27 real combiners sets `CSS_PATH` as a class
+attribute (none use the `css_path=` kwarg today), and a subclass's own
+`__init__` commonly calls `super().__init__()` with no arguments (e.g.
+`test_library_prompts_canvas.py`'s `_CanvasHost`) -- both keep working
+because `*args`/`**kwargs` pass through untouched and only `css_path` is
+special-cased. `_merge_screen_css_paths` was sanity-checked directly (no
+override, single-string override, multi-entry list override, `None`) to
+confirm the middle slot preserves the caller's own entries in order without
+duplicating the bracketing sheets. Ordering matches production exactly by
+construction: both `ConsolidatedCSSApp.CSS_PATH` and the merge helper source
+the pair from `build_css.screen_css_paths()`, the same single ordering
+authority `TldwCli.CSS_PATH` uses to bracket its app bundle
+(`[scoped, bundle, self]`) -- a subclass's own CSS_PATH now occupies the same
+"bundle" slot.
+
+**Born-red evidence.** `Tests/UI/test_consolidated_css_harness.py` (new file,
+kept separate from `test_widget_css_consolidation.py` since a concurrent
+session's task-15994 had just changed that file on origin/dev) pins two
+paths: a `CSS_PATH`-class-attribute override (mirroring the real ~27
+combiners, pointed at the real app bundle) and a `css_path=` constructor
+kwarg override (no real harness does this yet, but the mechanism must
+compose with it). Both push `NoteSelectionDialog` (one of the seven
+`BUNDLED_SCREEN_CSS` modals) and assert a computed geometry consequence of
+its screen-sheet CSS (`#note-selection-container`'s `width: 80` rule)
+rather than absence-of-exception. Ran both tests against the pre-fix module
+first: both failed at exactly the expected point (`region.width == 120`, the
+full unstyled `Container` default, instead of `80`); the kwarg test's own
+custom-stylesheet assertion (which comes first) passed even pre-fix,
+isolating the failure specifically to the screen-sheet drop. After the fix,
+both pass.
+
+**Regression coverage.** An AST scan of `Tests/UI/*.py` for classes whose
+bases literally include `ConsolidatedCSSApp` AND that declare their own
+`CSS_PATH` in the same class body found 27 real combiners across 22 files
+(the naive `grep` list of 33 files included several false positives, e.g.
+`test_console_command_popup.py`, where the two symbols appear in the same
+file but never combine on one class). Ran every one of those 22 files
+(~2,000+ individual tests) against the fixed module -- all pass except a
+small number of pre-existing failures, each independently confirmed
+pre-existing by swapping in the original (unfixed) `consolidated_css.py` and
+re-running the identical failing test(s), which reproduced the identical
+failure/traceback both times (edit-based restore back to the fix
+immediately after each check): 3 in `test_library_prompts_canvas.py`
+(unrelated focus-race assertions in save/import flows), 1 in
+`test_console_workbench_contract.py` (a `ConsoleHarness`-based test with no
+`CSS_PATH` override at all, so untouched by this change either way), 3 in
+`test_console_native_transcript.py` (unrelated `pilot.pause` timing waits),
+and 3 in `test_library_shell.py` (1 was a full-suite-only ordering flake that
+passed in isolation; 2 -- a tab-order keyboard-capability test -- reproduced
+identically pre- and post-fix, and independently confirmed unaffected since
+neither generated screen sheet contains any selector touching
+`LibraryScreen`/`nav-lab`/`library-notes-new`). No new failures were
+introduced by the fix anywhere in this coverage.
+
+**Files changed:**
+- `Tests/UI/consolidated_css.py` -- the merge mechanism and corrected comment.
+- `Tests/UI/test_consolidated_css_harness.py` -- new, the AC2 pinning tests.


### PR DESCRIPTION
## Summary

Closes the vacuous-pass trap TASK-15450's review flagged: before consolidation, Textual auto-registered a pushed screen's class CSS regardless of the harness's `CSS_PATH`; after it, a `ConsolidatedCSSApp` subclass declaring its own `CSS_PATH` (or passing `css_path=`) silently dropped the generated screen sheets, so a pushed `BUNDLED_SCREEN_CSS` modal mounted styleless — and its comment claimed this matched pre-consolidation behavior, which was false.

- `ConsolidatedCSSApp.__init__` intercepts CSS_PATH resolution (mirroring Textual 8.2.8's `css_path or self.CSS_PATH` — review verified at app.py:731) and merges the two screen sheets around whatever the caller supplied. `__init_subclass__` was rejected on evidence: a `css_path=` kwarg short-circuits the class attribute entirely, and only `__init__` sees whichever form won
- Ordering by construction: both production (`TldwCli.CSS_PATH`) and the harness source the pair from `build_css.screen_css_paths()` (review confirmed the single shared authority); the no-override case de-dupes via Path equality (probed)
- Born-red pins for BOTH override forms with a computed-geometry consequence (`region.width` 120→80), reproduced in review
- All 27 statically-found combiner files run (~2,000+ tests); every failure baselined pre-existing by swapping the unfixed module in — review re-verified attributions and characterized the pre-existing flake surface in two files as fix-state-independent

Review: independent pass → MERGE; minor precision notes (the interceptor is `is not None` rather than a literal `or` — divergent only for falsy-non-None values no harness passes; the static census misses cross-file transitive combiners, verified working) recorded in the review report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores styling for `BUNDLED_SCREEN_CSS` modals by merging the generated screen sheets into `ConsolidatedCSSApp` when a harness overrides `CSS_PATH` or passes `css_path=`. Previously those overrides dropped the screen sheets, mounting modals unstyled; now we bracket the effective path with the two screen sheets without duplication.

- **Review notes**
  - Intercepts `css_path` resolution in `ConsolidatedCSSApp.__init__` (mirrors `textual.App.__init__` `css_path or self.CSS_PATH`) and merges `[scoped, *own, self]` from `build_css.screen_css_paths`, de-duping if already present and preserving production order.
  - Harnesses keep their own CSS entries; only the `css_path` path is touched. Visible consequence: `NoteSelectionDialog` container width is 80 instead of 120.
  - Adds `Tests/UI/test_consolidated_css_harness.py` pinning both override forms against a real `BUNDLED_SCREEN_CSS` modal; fixes an inaccurate comment in `Tests/UI/consolidated_css.py`.
  - Migration: none. Existing harnesses need no changes. Satisfies TASK-15995 (AC1–AC3).

<sup>Written for commit 0982fe21584e3f5b10fe39373dbe09c33e528f10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

