### PR TITLE
fix(reactive): make all 41 mutable reactive defaults callable factories (TASK-15771)

### DIFF
--- a/Tests/Architecture/test_reactive_mutable_default_inventory.py
+++ b/Tests/Architecture/test_reactive_mutable_default_inventory.py
@@ -12,14 +12,24 @@ mutation then leaks across instances and screen remounts.
 The idiom is a callable default: ``reactive(list)`` / ``reactive(dict)`` /
 ``reactive(set)`` (or ``reactive(lambda: [seed, ...])`` for a non-empty
 default). This inventory sweep asserts the package contains ZERO
-``reactive(...)``/``var(...)`` declarations whose default is:
+``reactive(...)``/``var(...)`` declarations — including the
+subscripted-generic spelling ``reactive[list[dict[str, Any]]](...)`` — whose
+default is:
 
 * a list/dict/set literal (empty or not) or a comprehension,
 * the *result* of a ``list()``/``dict()``/``set()`` call (not callable), or
 * a name bound to a module-level mutable literal (one shared object).
 
-Born red against the pre-fix tree (27 sites); if it fails, replace the
-default with a callable, never with a "reassign before use" workaround.
+NOT covered: a shared mutable *instance* default (``reactive(SomeClass())``)
+is the same one-object-per-class bug and this detector does not see it —
+5 known occurrences at the time of writing, tracked as a follow-up; do not
+read a green run as clearance for that form.
+
+Born red twice: against the pre-fix tree (27 sites), and again after the
+task-15771 review taught ``_call_name`` the ``ast.Subscript`` form the first
+sweep was structurally blind to (14 more sites, all in
+``UI/Watchlists_Modules/`` — 41 total). If it fails, replace the default
+with a callable, never with a "reassign before use" workaround.
 """
 
 from __future__ import annotations
@@ -43,6 +53,12 @@ MUTABLE_FACTORY_NAMES = {"list", "dict", "set"}
 
 def _call_name(node: ast.Call) -> str | None:
     func = node.func
+    if isinstance(func, ast.Subscript):
+        # The subscripted-generic form: reactive[list[dict[str, Any]]]([]) /
+        # Reactive[list]([]). Same descriptor, same shared-default bug — the
+        # review of the first sweep found 14 sites written this way that a
+        # Name/Attribute-only match was structurally blind to.
+        func = func.value
     if isinstance(func, ast.Name):
         return func.id
     if isinstance(func, ast.Attribute):

--- a/Tests/Architecture/test_reactive_mutable_default_inventory.py
+++ b/Tests/Architecture/test_reactive_mutable_default_inventory.py
@@ -1,0 +1,117 @@
+# test_reactive_mutable_default_inventory.py
+# Description: Guard against non-callable mutable reactive defaults (task-15771)
+"""
+task-15771: Textual's ``Reactive._initialize_reactive`` installs
+``default_or_callable() if callable(...) else default_or_callable`` — a bare
+``[]``/``{}``/``set()`` result default is therefore installed as the *same
+object* on every instance of the widget class that never explicitly
+reassigns it, and reassigning an empty-equal value is a no-op
+(``Reactive._set`` only stores when ``current_value != value``). Any in-place
+mutation then leaks across instances and screen remounts.
+
+The idiom is a callable default: ``reactive(list)`` / ``reactive(dict)`` /
+``reactive(set)`` (or ``reactive(lambda: [seed, ...])`` for a non-empty
+default). This inventory sweep asserts the package contains ZERO
+``reactive(...)``/``var(...)`` declarations whose default is:
+
+* a list/dict/set literal (empty or not) or a comprehension,
+* the *result* of a ``list()``/``dict()``/``set()`` call (not callable), or
+* a name bound to a module-level mutable literal (one shared object).
+
+Born red against the pre-fix tree (27 sites); if it fails, replace the
+default with a callable, never with a "reassign before use" workaround.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "tldw_chatbook"
+
+REACTIVE_NAMES = {"reactive", "var", "Reactive"}
+MUTABLE_LITERALS = (
+    ast.List,
+    ast.Dict,
+    ast.Set,
+    ast.ListComp,
+    ast.DictComp,
+    ast.SetComp,
+)
+MUTABLE_FACTORY_NAMES = {"list", "dict", "set"}
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _default_arg(node: ast.Call) -> ast.expr | None:
+    if node.args:
+        return node.args[0]
+    for keyword in node.keywords:
+        if keyword.arg == "default":
+            return keyword.value
+    return None
+
+
+def _module_level_mutables(tree: ast.Module) -> set[str]:
+    """Names assigned a mutable literal at module level (one shared object)."""
+    names: set[str] = set()
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.value, MUTABLE_LITERALS):
+            names.update(t.id for t in stmt.targets if isinstance(t, ast.Name))
+        elif (
+            isinstance(stmt, ast.AnnAssign)
+            and stmt.value is not None
+            and isinstance(stmt.value, MUTABLE_LITERALS)
+            and isinstance(stmt.target, ast.Name)
+        ):
+            names.add(stmt.target.id)
+    return names
+
+
+def _violations_in_file(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    module_mutables = _module_level_mutables(tree)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node) not in REACTIVE_NAMES:
+            continue
+        default = _default_arg(node)
+        if default is None:
+            continue
+        reason: str | None = None
+        if isinstance(default, MUTABLE_LITERALS):
+            reason = f"mutable literal default {ast.unparse(default)!r}"
+        elif isinstance(default, ast.Name) and default.id in module_mutables:
+            reason = f"module-level shared mutable {default.id!r}"
+        elif (
+            isinstance(default, ast.Call)
+            and _call_name(default) in MUTABLE_FACTORY_NAMES
+        ):
+            reason = (
+                f"non-callable call result {ast.unparse(default)!r}"
+                " (pass the factory itself, without parentheses)"
+            )
+        if reason is not None:
+            relative = path.relative_to(PACKAGE_ROOT.parent)
+            violations.append(f"{relative}:{node.lineno}: {reason}")
+    return violations
+
+
+def test_no_non_callable_mutable_reactive_defaults() -> None:
+    """Every reactive()/var() default in the package must be callable-or-immutable."""
+    assert PACKAGE_ROOT.is_dir(), f"package root not found: {PACKAGE_ROOT}"
+    violations: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        violations.extend(_violations_in_file(path))
+    assert not violations, (
+        "reactive()/var() declarations with a shared (non-callable) mutable "
+        "default — use reactive(list)/reactive(dict)/reactive(set) or a "
+        "lambda instead:\n" + "\n".join(violations)
+    )

--- a/Tests/Widgets/test_character_voice_widget.py
+++ b/Tests/Widgets/test_character_voice_widget.py
@@ -26,6 +26,15 @@ pytest session (an earlier test's ``.append()`` onto the shared default
 leaked into a later test's row count). Assigning a fresh list breaks the
 aliasing for that instance going forward. Out of scope for task-15479's
 self-assignment-trigger fix; worth filing separately.
+
+Update (task-15771): filed and fixed — ``characters`` (and every other
+mutable reactive default in the package) is now a callable default
+(``reactive(list)``), so each instance gets its own list and the defensive
+``widget.characters = []`` lines below are redundant-but-harmless. They are
+kept so these tests stay valid against trees that predate the fix; the
+cross-instance aliasing itself is pinned by
+``test_reactive_default_aliasing.py`` and the AST inventory guard in
+``Tests/Architecture/test_reactive_mutable_default_inventory.py``.
 """
 
 from __future__ import annotations

--- a/Tests/Widgets/test_reactive_default_aliasing.py
+++ b/Tests/Widgets/test_reactive_default_aliasing.py
@@ -1,0 +1,179 @@
+# test_reactive_default_aliasing.py
+# Description: Cross-instance leak regressions for shared mutable reactive defaults (task-15771)
+"""
+task-15771: ``reactive([])`` / ``reactive({})`` with a non-callable mutable
+default installs the *same* list/dict object as the backing value on every
+instance of the widget class that has not explicitly reassigned it
+(``Reactive._initialize_reactive`` does ``default_or_callable() if
+callable(...) else default_or_callable``). Any instance that then mutates the
+value in place (``.append``/``[k] =``/``.insert``/...) leaks that state into
+every other instance — and into instances created later, including across
+screen remounts.
+
+Worse, "reassigns before use" is not a defense when the reassigned value is
+empty-equal: Textual's ``Reactive._set`` only stores the new object when
+``current_value != value``, so ``self.attr = []`` over the pristine shared
+``[]`` default is a complete no-op and the instance keeps aliasing the shared
+object (verified against Textual 8.2.8).
+
+These tests demonstrate the cross-instance leak on the three most user-facing
+live cases found by the task's sweep, driving the same mutations the
+production handlers perform. They were born red against the pre-fix tree
+(instance B observed instance A's mutation) and are green once the defaults
+are callables (``reactive(list)`` / ``reactive(dict)``).
+
+The final test pins that the fix did not change ``recompose=True`` behavior:
+a recompose reactive with a callable default still rebuilds its children on
+reassignment.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from tldw_chatbook.TTS.audiobook_generator import Chapter
+from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane
+from tldw_chatbook.Widgets.collections_tag_window import CollectionsTagWindow
+from tldw_chatbook.Widgets.TTS.chapter_editor_widget import ChapterEditorWidget
+from tldw_chatbook.Widgets.TTS.character_voice_widget import CharacterVoiceWidget
+
+
+class _CharacterVoiceApp(App[None]):
+    """Minimal host mounting a single CharacterVoiceWidget."""
+
+    def compose(self) -> ComposeResult:
+        yield CharacterVoiceWidget(provider="openai", id="character-voice-widget")
+
+
+@pytest.mark.asyncio
+async def test_character_voice_widget_characters_do_not_leak_across_instances() -> None:
+    """Instance A adds a character via the real button handler; a second,
+    pristine instance must not see it.
+
+    Born red pre-fix: ``_add_character_manually`` appends to the class-shared
+    default list, so the fresh instance B started life already containing A's
+    "Character 1".
+    """
+    app = _CharacterVoiceApp()
+    async with app.run_test() as pilot:
+        widget_a = app.query_one("#character-voice-widget", CharacterVoiceWidget)
+        widget_a._add_character_manually()
+        await pilot.pause()
+        assert len(widget_a.characters) == 1
+
+        widget_b = CharacterVoiceWidget(provider="openai")
+        assert widget_b.characters is not widget_a.characters
+        assert list(widget_b.characters) == []
+        # A's instance keeps its own state.
+        assert len(widget_a.characters) == 1
+
+
+@pytest.mark.asyncio
+async def test_character_voice_widget_voice_assignments_do_not_leak() -> None:
+    """Same class, dict-shaped default: assigning a voice on instance A
+    (the exact mutation ``_on_voice_selected``/``_apply_voice_to_all``
+    perform: ``self.voice_assignments[name] = voice_id``) must not appear in
+    a pristine instance B."""
+    app = _CharacterVoiceApp()
+    async with app.run_test() as pilot:
+        widget_a = app.query_one("#character-voice-widget", CharacterVoiceWidget)
+        widget_a.voice_assignments["Narrator"] = "voice-1"
+        await pilot.pause()
+
+        widget_b = CharacterVoiceWidget(provider="openai")
+        assert widget_b.voice_assignments is not widget_a.voice_assignments
+        assert dict(widget_b.voice_assignments) == {}
+
+
+def test_chapter_editor_widgets_do_not_share_chapters() -> None:
+    """Two ChapterEditorWidgets must not alias one chapters list.
+
+    ``__init__`` does ``self.chapters = chapters if chapters else []`` — with
+    no chapters argument that assignment is equality-skipped by the reactive
+    (``[] != []`` is False), so pre-fix both instances still aliased the
+    class-shared default, and the ``self.chapters.insert(...)`` mutation the
+    add/split handlers perform leaked into every other editor instance.
+    """
+    editor_a = ChapterEditorWidget()
+    editor_b = ChapterEditorWidget()
+
+    editor_a.chapters.insert(
+        0,
+        Chapter(
+            number=1,
+            title="Leaked chapter",
+            content="",
+            start_position=0,
+            end_position=0,
+        ),
+    )
+
+    assert editor_b.chapters is not editor_a.chapters
+    assert list(editor_b.chapters) == []
+    assert len(editor_a.chapters) == 1
+
+
+def test_collections_tag_windows_do_not_share_selected_keywords() -> None:
+    """Two CollectionsTagWindows must not share keyword selection state.
+
+    ``handle_keyword_selection`` appends the selected keyword in place
+    (``self.selected_keywords.append(keyword)``); pre-fix that mutated the
+    class-shared default, so a selection made in one window instance appeared
+    pre-selected in any other (including a remounted screen's new instance).
+    """
+    window_a = CollectionsTagWindow(app_instance=MagicMock())
+    window_b = CollectionsTagWindow(app_instance=MagicMock())
+
+    window_a.selected_keywords.append({"id": 1, "keyword": "leak", "usage_count": 0})
+
+    assert window_b.selected_keywords is not window_a.selected_keywords
+    assert list(window_b.selected_keywords) == []
+    assert len(window_a.selected_keywords) == 1
+
+
+class _OverviewPaneApp(App[None]):
+    """Minimal host mounting an OverviewPane (data = reactive({}, recompose=True))."""
+
+    def compose(self) -> ComposeResult:
+        yield OverviewPane(id="overview-pane")
+
+
+@pytest.mark.asyncio
+async def test_recompose_reactive_still_recomposes_with_callable_default() -> None:
+    """The callable-default fix must not change recompose behavior.
+
+    OverviewPane.data is ``reactive(..., recompose=True)``: while the value is
+    the (now per-instance) default ``{}`` the pane composes its loading state,
+    and reassigning a populated payload must rebuild the children into the
+    dashboard grid.
+    """
+    app = _OverviewPaneApp()
+    async with app.run_test() as pilot:
+        pane = app.query_one("#overview-pane", OverviewPane)
+        assert pane.query("#overview-loading").nodes, (
+            "expected the loading state while data is the default {}"
+        )
+        assert not pane.query("#watchlists-overview-grid").nodes
+
+        pane.data = {
+            "total_sources": 3,
+            "active_sources": 2,
+            "sources_in_error": 0,
+            "total_items": 5,
+            "new_items": 1,
+            "latest_run_status": "success",
+            "active_alert_rules": 0,
+            "failed_runs": [],
+        }
+        await pilot.pause()
+
+        assert pane.query("#watchlists-overview-grid").nodes, (
+            "expected recompose to rebuild the pane into the dashboard grid"
+        )
+        card = pane.query_one("#overview-total-sources", Static)
+        assert "3" in str(card.renderable)
+        assert not pane.query("#overview-loading").nodes

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -53,7 +53,13 @@ installs the *same* list/dict object on every instance of the widget class:
 default_or_callable`, and a literal is not callable. Any in-place mutation
 (`.append`, `[k] =`, `.insert`, `.clear`, ...) then leaks across every instance and
 every future instance, including screen remounts. The package-wide AST sweep found
-**27** such declarations; born-red two-instance tests demonstrated the leak on
+**41** such declarations — in two rounds: the first sweep reported 27, and the task
+review proved it structurally blind to the subscripted-generic spelling
+`reactive[list[dict[str, Any]]]([])`, which parses as `Call(func=Subscript(...))`
+and slipped past a `Name`/`Attribute`-only function-name match (14 more sites, all
+in `UI/Watchlists_Modules/`; runtime-identical bug). An AST detector for a call
+must unwrap `ast.Subscript`, or the generically-annotated spelling of the exact
+same call is invisible to it. Born-red two-instance tests demonstrated the leak on
 `CharacterVoiceWidget.characters`/`voice_assignments`,
 `ChapterEditorWidget.chapters`, and `CollectionsTagWindow.selected_keywords`
 (`Tests/Widgets/test_reactive_default_aliasing.py`).
@@ -71,9 +77,13 @@ classifies correctly.
 **What to do.** Always declare mutable reactive defaults as callables —
 `reactive(list)` / `reactive(dict)` / `reactive(set)`, or
 `reactive(lambda: [seed])` for non-empty defaults.
-`Tests/Architecture/test_reactive_mutable_default_inventory.py` now pins the class
-at zero package-wide; if it fails, fix the default — never a "reassign before use"
-workaround.
+`Tests/Architecture/test_reactive_mutable_default_inventory.py` pins the package
+at zero for the forms it detects — mutable literals, comprehensions, module-level
+shared mutables, and `list()/dict()/set()` call results, in both the bare and the
+subscripted-generic call spellings. It does NOT see shared mutable *instance*
+defaults (`reactive(SomeClass())`; 5 known occurrences at review time) — a green
+run is not clearance for that form. If the guard fails, fix the default — never a
+"reassign before use" workaround.
 
 ---
 

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -45,6 +45,38 @@ holding stale references across `exclusive=True` cancellations.
 
 ---
 
+## A mutable `reactive([])` default is one shared object — and reassigning an empty-equal value does not un-share it
+
+**TASK-15771, 2026-08-15.** `reactive([])` / `reactive({})` with a literal default
+installs the *same* list/dict object on every instance of the widget class:
+`Reactive._initialize_reactive` does `default_or_callable() if callable(...) else
+default_or_callable`, and a literal is not callable. Any in-place mutation
+(`.append`, `[k] =`, `.insert`, `.clear`, ...) then leaks across every instance and
+every future instance, including screen remounts. The package-wide AST sweep found
+**27** such declarations; born-red two-instance tests demonstrated the leak on
+`CharacterVoiceWidget.characters`/`voice_assignments`,
+`ChapterEditorWidget.chapters`, and `CollectionsTagWindow.selected_keywords`
+(`Tests/Widgets/test_reactive_default_aliasing.py`).
+
+The half of the trap that reverses classifications: **"reassigns before use" is not
+a defense when the reassigned value is empty-equal.** `Reactive._set` in 8.2.8 only
+runs `setattr(obj, self.internal_name, value)` inside
+`if always or self._always_update or current_value != value:` — so
+`self.chapters = chapters if chapters else []` in `ChapterEditorWidget.__init__`
+compared `[] != []`, stored nothing, and the instance kept aliasing the class-shared
+default it then `.insert()`ed into. The site read as safe in review; the born-red
+test proved it was not. Only a mutation-sites trace plus this mechanism check
+classifies correctly.
+
+**What to do.** Always declare mutable reactive defaults as callables —
+`reactive(list)` / `reactive(dict)` / `reactive(set)`, or
+`reactive(lambda: [seed])` for non-empty defaults.
+`Tests/Architecture/test_reactive_mutable_default_inventory.py` now pins the class
+at zero package-wide; if it fails, fix the default — never a "reassign before use"
+workaround.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md` — includes the Pilot-harness traps (detached widget

--- a/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
+++ b/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
@@ -46,11 +46,15 @@ widget class that both rely on the declared default will alias state.
       app session where cross-instance aliasing is plausible; sites that are
       genuinely singleton-per-app or already reassign the attribute before
       first read are recorded as reviewed, not touched
-      (note: ALL 27 hits were converted to callable defaults, not only the
+      (note: ALL 41 hits were converted to callable defaults, not only the
       live ones — the classification below records live vs latent, but the
       "already reassigns before first read" defense turned out to be unsound
       for empty-equal reassignment, see Implementation Notes, so leaving
-      latent literals in place would have left loaded guns)
+      latent literals in place would have left loaded guns. The population
+      is 41, not the first sweep's 27: the task-15771 review found the first
+      sweep structurally blind to the subscripted-generic spelling
+      `reactive[list[dict[str, Any]]]([])` — 14 more sites, all in
+      `UI/Watchlists_Modules/`, fixed in the review round)
 - [x] Existing `character_voice_widget` and STTS test suites stay green
 
 ## Implementation Plan
@@ -86,11 +90,23 @@ widget class that both rely on the declared default will alias state.
 
 ## Implementation Notes
 
-Converted every non-callable mutable `reactive()` default in the package — 27
-sites — to a callable factory (`reactive(list)` / `reactive(dict)`; all 27 were
-empty literals, so no lambda wrappers were needed), demonstrated the
-cross-instance leak born-red on the three most user-facing live cases before
-fixing, and pinned the bug class with a permanent AST inventory guard.
+Converted every non-callable mutable `reactive()` default in the package — **41
+sites, in two rounds** — to a callable factory (`reactive(list)` /
+`reactive(dict)`; all 41 were empty literals, so no lambda wrappers were
+needed), demonstrated the cross-instance leak born-red on the three most
+user-facing live cases before fixing, and pinned the bug class with a
+permanent AST inventory guard.
+
+Round 1 (commit `ae4bfb532`) found and fixed 27 sites. The task review then
+proved the sweep — and the shipped guard — structurally blind to the
+subscripted-generic spelling `reactive[list[dict[str, Any]]]([])`: the
+guard's `_call_name()` handled only `ast.Name`/`ast.Attribute`, and
+`reactive[T](...)` parses as `Call(func=Subscript(...))`. The review's
+runtime probe confirmed the form produces the identical shared-default bug.
+Round 2 taught `_call_name` to unwrap `ast.Subscript` (also covering
+`Reactive[list]([])`), re-ran the guard born-red against the round-1 tree —
+it failed listing **exactly the 14 missed sites**, all in
+`UI/Watchlists_Modules/` — and converted all 14.
 
 ### The mechanism, including the half that reverses classifications
 
@@ -146,9 +162,29 @@ Cross-file grep hits on generic names (`activity_log.entries` deque,
 `Chat_Dictionary_Lib diagnostics.entries`, `chatbook_creator
 content.characters`) were verified to be OTHER classes' plain attributes.
 
+ROUND 2 — the 14 subscripted-generic sites (`reactive[T](...)`) the first
+sweep missed, all LATENT: `UI/Watchlists_Modules/article_list.py:257`
+`items`, `artifacts_pane.py:655/677/706/788` `briefings`/`presets`/
+`scripts`/`citations` + `:732` `scripts_with_audio` (`{}`),
+`inspector_pane.py:225` `breadcrumb_labels`, `items_pane.py:76` `items`,
+`notifications_pane.py:51` `notifications`, `rules_pane.py:72` `rules`,
+`runs_pane.py:70` `runs` + `:79` `run_items`, `sources_pane.py:120`
+`sources` + `:174` `watchlist_choices`. Mutation trace over all 14 names
+(Watchlists modules + the collections screen, plus package-wide on the
+distinctive names) found exactly one in-place candidate —
+`runs_pane.py:548` `self.runs[index] = run` — and it sits inside
+`for index, candidate in enumerate(self.runs)`, unreachable while the value
+is the empty shared default: latent (independently re-derived; matches the
+review's finding). No user-facing leak shipped from the missed 14.
+
 No code depended on the shared identity: no `is` comparisons against these
 attrs, no class-level default reads (`mutate_reactive(Class.attr)` passes the
-descriptor and is unaffected).
+descriptor and is unaffected). The only identity-coupled tests in the repo —
+`Tests/Watchlists/test_watchlists_pagination.py`'s nine
+`assert pane.items is prior_rows` assertions on `ItemsPane.items` (a round-2
+site) — pin identity-across-re-renders of assigned non-empty rows, not
+identity-with-the-default, and the file passes 34/34 after the conversion
+(run, not assumed).
 
 ### Born-red evidence
 
@@ -160,8 +196,16 @@ instance B observed instance A's mutation — e.g.
 `Tests/Architecture/test_reactive_mutable_default_inventory.py` (new AST
 guard, list/dict/set literals + comprehensions + module-level shared mutables
 + `list()`/`dict()`/`set()` call results, in `reactive`/`var`/`Reactive`
-positional-or-`default=` position) FAILED listing all 27 sites. Post-fix: all
-green. The guard makes the class unable to regrow.
+positional-or-`default=` position, bare and subscripted-generic call forms)
+was born red twice: round 1 FAILED listing the 27 bare-form sites; round 2,
+after the Subscript fix, FAILED against the round-1 tree listing exactly the
+14 missed `reactive[T](...)` sites. Post-fix: green at zero. The guard pins
+the class at zero for the forms it detects — literals, comprehensions,
+module-level shared mutables, and `list()/dict()/set()` call results, in
+both call spellings. It does NOT detect shared mutable *instance* defaults
+(`reactive(SomeClass())`; 5 known occurrences per the review, e.g.
+`reactive(RegionLayout())`), which is the natural next hole — follow-up to
+be filed.
 
 ### recompose verification
 
@@ -172,11 +216,25 @@ reassignment recomposes to the dashboard grid
 
 ### Verification
 
-- Targeted suites over every touched widget/screen (TTS widgets, theme
-  editor, media panels/windows, collections tags, chat sidebar-state,
+- Round 1: targeted suites over every touched widget/screen (TTS widgets,
+  theme editor, media panels/windows, collections tags, chat sidebar-state,
   watchlists overview, full `Tests/Wizards`, study, chatbooks, file
   extraction, processing dashboard, STTS profile library, console speech
-  snapshot): **1,721 passed** across four batches.
+  snapshot): 1,721 tests reported passed across four batch runs **in this
+  session's specific runs** — honesty caveat from the review (F4):
+  `Tests/UI/test_stts_profile_library.py` is a pre-existing flake family
+  that the reviewer could NOT get clean on either tree (two recurring ids
+  fail on base under load), so "passed" for that file describes these runs,
+  not a stable property; it is being filed separately. The review also
+  baselined **3 pre-existing `Tests/Architecture` failures at `c03a2fef5`**
+  (console_wave6 inventory, persistent-diagnostic inventory, chat_screen
+  size ratchet) — same ids fail on base, unrelated to this change, and not
+  runs this session's own batches covered.
+- Round 2: `test_watchlists_pagination.py` 34/34 (the nine identity
+  assertions survive); pane-suite sample over all 8 modules holding the 14
+  sites (items/sources/runs/rules/notifications/artifacts panes,
+  article_list, filter-in-place, scoped rebuilds, inspector): **333
+  passed**; guard + leak tests **6 passed**.
 - `Tests/UI` collect-only sweep: 12,532 collected, exit 0.
 - Two `test_first_run_wizard_live_contract.py` failures in one batch were
   baselined against a detached worktree at dev `c03a2fef5`: the identical
@@ -199,8 +257,8 @@ task.
 
 ### Files
 
-- Fixed (27 sites): see LIVE/LATENT lists above (24 files under
-  `tldw_chatbook/`).
+- Fixed (41 sites): see LIVE/LATENT lists above (24 files in round 1 + 8
+  Watchlists module files in round 2, under `tldw_chatbook/`).
 - New: `Tests/Widgets/test_reactive_default_aliasing.py`,
   `Tests/Architecture/test_reactive_mutable_default_inventory.py`.
 - Updated: `Tests/Widgets/test_character_voice_widget.py` (stale workaround

--- a/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
+++ b/backlog/tasks/task-15771 - Sweep-non-callable-reactive-list-dict-defaults-shared-by-identity-across-widget-instances.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15771
 title: Sweep non-callable reactive list/dict defaults shared by identity across widget instances
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - bug
@@ -34,15 +35,173 @@ widget class that both rely on the declared default will alias state.
 
 ## Acceptance Criteria
 
-- [ ] `character_voice_widget.py`'s `characters` reactive uses a factory
+- [x] `character_voice_widget.py`'s `characters` reactive uses a factory
       (e.g. `reactive(list)` / a `default=` callable) so each instance gets
       its own list, not a shared one
-- [ ] A test proves two `CharacterVoiceWidget` instances no longer alias:
+- [x] A test proves two `CharacterVoiceWidget` instances no longer alias:
       mutating one's `characters` does not affect the other's
-- [ ] A repo-wide sweep for the same shape — `reactive([...])` /
+- [x] A repo-wide sweep for the same shape — `reactive([...])` /
       `reactive({...})` with a literal (not a callable) default — classifies
       each hit and fixes any other widget instantiated more than once per
       app session where cross-instance aliasing is plausible; sites that are
       genuinely singleton-per-app or already reassign the attribute before
       first read are recorded as reviewed, not touched
-- [ ] Existing `character_voice_widget` and STTS test suites stay green
+      (note: ALL 27 hits were converted to callable defaults, not only the
+      live ones — the classification below records live vs latent, but the
+      "already reassigns before first read" defense turned out to be unsound
+      for empty-equal reassignment, see Implementation Notes, so leaving
+      latent literals in place would have left loaded guns)
+- [x] Existing `character_voice_widget` and STTS test suites stay green
+
+## Implementation Plan
+
+1. AST sweep (not grep) over `tldw_chatbook/` for every `reactive(...)`/`var(...)`
+   whose first arg (or `default=`) is a List/Dict/Set literal, a comprehension, a
+   module-level shared mutable, or a `list()/dict()/set()` call result. Produce
+   the full site table.
+2. Classify each hit live vs latent by tracing in-place mutation sites
+   (`.append`/`[k]=`/`.update`/`.pop`/`.insert`/`.clear`/`del`/`.sort`) on the
+   reactive's value, same-file and cross-file, without an intervening
+   reassignment. Key mechanic (verified against installed Textual 8.2.8
+   `Reactive._set`): the internal `setattr` only runs when
+   `current_value != value`, so reassigning `[]`/`{}` over the pristine shared
+   default is a NO-OP and the instance keeps aliasing the class-shared object —
+   "reassigns in `__init__`/reset" is not a defense when the value is
+   empty-equal.
+3. Born-red two-instance leak tests for the most user-facing live cases
+   (CharacterVoiceWidget.characters via the real add handler;
+   ChapterEditorWidget.chapters; CollectionsTagWindow.selected_keywords) BEFORE
+   fixing; run against the pre-fix tree and capture the red.
+4. Fix ALL hits to callable defaults (`reactive(list)` / `reactive(dict)` — all
+   27 hits use empty literals, so no lambda wrappers needed), checking for any
+   code depending on the shared identity first.
+5. Permanent guard: the AST sweep as
+   `Tests/Architecture/test_reactive_mutable_default_inventory.py` asserting
+   zero non-callable mutable reactive defaults in the package; born-red against
+   the pre-fix tree.
+6. Verify one `recompose=True` site still recomposes after the fix
+   (FileListEnhanced/EnhancedStatusWidget), run touched-widget suites +
+   `Tests/UI` collect-only sweep + heaviest touched suites, ruff on touched
+   files.
+
+## Implementation Notes
+
+Converted every non-callable mutable `reactive()` default in the package — 27
+sites — to a callable factory (`reactive(list)` / `reactive(dict)`; all 27 were
+empty literals, so no lambda wrappers were needed), demonstrated the
+cross-instance leak born-red on the three most user-facing live cases before
+fixing, and pinned the bug class with a permanent AST inventory guard.
+
+### The mechanism, including the half that reverses classifications
+
+`Reactive._initialize_reactive` (Textual 8.2.8) installs
+`default_or_callable() if callable(...) else default_or_callable` — a literal
+`[]`/`{}` is one shared object across all instances. The critical second half:
+`Reactive._set` only stores the new value inside
+`if always or self._always_update or current_value != value:` — so
+**reassigning an empty-equal value (`self.attr = []` over the pristine shared
+`[]`) is a complete no-op** and the instance keeps aliasing the shared object.
+"Reassigns in `__init__`/reset before use" is therefore NOT a defense:
+`ChapterEditorWidget.__init__`'s `self.chapters = chapters if chapters else []`
+read as safe and was not (born-red test proved the leak through it).
+
+### Sweep table (site → classification → mutation evidence)
+
+LIVE (in-place mutation of a possibly-shared value reachable):
+1. `Widgets/TTS/character_voice_widget.py:143` `characters` — `.append` (469), `.pop` (481); proven leak (task-15479 test order-dependence)
+2. `Widgets/TTS/character_voice_widget.py:145` `voice_assignments` — `[k]=` (552/611/678), `del` (484), `.clear()` (496)
+3. `Widgets/TTS/chapter_editor_widget.py:129` `chapters` (recompose=True) — `.insert` (362/394), `.pop` (416/432); init's `= []` is equality-skipped
+4. `Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py:385` `entries` — `[k]=` (818/835), `del` (849); `= {}` (671) equality-skipped
+5. `Widgets/CCP_Widgets/ccp_prompt_editor_widget.py:347` `variables` — `.append` (841), `del` (858); `= []` (644) equality-skipped
+6. `Widgets/collections_tag_window.py:134` `selected_keywords` — `.append` (296/311); `= []` equality-skipped
+7. `Widgets/settings_theme_editor.py:38` `current_theme_data` — `[k]=` (467/772), `.update()` (815); exposure gated by on_mount's non-empty extract, mutation sites nevertheless present
+8. `Widgets/Media/media_viewer_panel.py:582` `all_analyses` — external `.insert(0, …)` from `UI/MediaWindow_v2.py:1947` reachable while the value is the equality-skipped shared default; internal `.pop` (2122)
+
+LATENT (never mutated in place; only ever reassigned or read — fixed anyway,
+uniform rule): `UI/Chatbooks_Window.py:60` `chatbooks`,
+`UI/Chatbooks_Window_Improved.py:382` `chatbooks` (both mutate a LOCAL list
+then assign), `UI/Screens/chat_screen.py:3326` `sidebar_state` (always
+reassigned via `dict(...)`; its own comments already document the
+equality-no-op), `UI/Screens/chatbooks_screen.py:25` `chatbook_list`,
+`UI/Screens/study_screen.py:92` `study_materials`,
+`UI/Screens/watchlists_collections_screen.py:528` `overview_data`,
+`UI/Watchlists_Modules/overview_pane.py:16` `data` (recompose=True, read-only
+in pane), `UI/Wizards/BaseWizard.py:100` `validation_errors` / `:324`
+`step_titles`, `ccp_dictionary_editor_widget.py:382` `dictionary_data`
+(always `.copy()`d), `ccp_prompt_editor_widget.py:344` `prompt_data`
+(mutation at 880 is on a `get_prompt_data()` copy),
+`Widgets/Media/media_list_panel.py:158` `items`,
+`Widgets/Media/media_viewer_panel.py:575` `search_matches`,
+`Widgets/chunk_preview.py:26` `chunks` (`chunk_preview_modal.py`'s
+`.append`s are a different class's plain attribute),
+`Widgets/dictation_performance_widget.py:109` `metrics_data`,
+`Widgets/file_extraction_dialog.py:77` `extracted_files` (element-field
+mutation only, list itself never mutated),
+`Widgets/file_list_item_enhanced.py:173` `files` (add path reassigns
+`self.files + [x]`), `Widgets/media_details_widget.py:47` `search_matches`,
+`Widgets/status_widget.py:82` `messages` (assigned from `_messages.copy()`).
+Cross-file grep hits on generic names (`activity_log.entries` deque,
+`state/chat_state.messages`, `Tamagotchi/tamagotchi_storage.data`,
+`voice_bundle_service operation.files`, `world_info_processor.entries`,
+`Chat_Dictionary_Lib diagnostics.entries`, `chatbook_creator
+content.characters`) were verified to be OTHER classes' plain attributes.
+
+No code depended on the shared identity: no `is` comparisons against these
+attrs, no class-level default reads (`mutate_reactive(Class.attr)` passes the
+descriptor and is unaffected).
+
+### Born-red evidence
+
+`Tests/Widgets/test_reactive_default_aliasing.py` (new) run against the
+pre-fix tree: 4 leak tests FAILED exactly as the bug predicts (a pristine
+instance B observed instance A's mutation — e.g.
+`assert [...leak...] is not [...leak...]` on two distinct
+`CollectionsTagWindow`s) while the recompose-behavior baseline passed;
+`Tests/Architecture/test_reactive_mutable_default_inventory.py` (new AST
+guard, list/dict/set literals + comprehensions + module-level shared mutables
++ `list()`/`dict()`/`set()` call results, in `reactive`/`var`/`Reactive`
+positional-or-`default=` position) FAILED listing all 27 sites. Post-fix: all
+green. The guard makes the class unable to regrow.
+
+### recompose verification
+
+`OverviewPane.data` (`reactive(dict, recompose=True)`) verified end-to-end
+post-fix: loading state composed from the per-instance default `{}`,
+reassignment recomposes to the dashboard grid
+(`test_recompose_reactive_still_recomposes_with_callable_default`).
+
+### Verification
+
+- Targeted suites over every touched widget/screen (TTS widgets, theme
+  editor, media panels/windows, collections tags, chat sidebar-state,
+  watchlists overview, full `Tests/Wizards`, study, chatbooks, file
+  extraction, processing dashboard, STTS profile library, console speech
+  snapshot): **1,721 passed** across four batches.
+- `Tests/UI` collect-only sweep: 12,532 collected, exit 0.
+- Two `test_first_run_wizard_live_contract.py` failures in one batch were
+  baselined against a detached worktree at dev `c03a2fef5`: the identical
+  batch fails 2 tests of the same file there too — **different test ids** —
+  and both pairs pass in isolation on both trees; the file passes 78/78
+  standalone on the fixed tree. Pre-existing order/timing flakiness on dev,
+  not a regression from this change.
+- ruff check clean on all touched files (including fixing a pre-existing
+  duplicate `textual.events` import in `settings_theme_editor.py`); the 4
+  files `ruff format` would reformat carry pre-existing drift verified
+  present at the dev baseline (untouched regions; my lines are format-clean).
+
+### Incidental pre-existing defect (out of scope, not fixed here)
+
+`FileListItemEnhanced.compose` passes `tooltip=` to `Static` (line 126) —
+Textual 8.2.8's `Static.__init__` has no such kwarg, so any
+`FileListEnhanced` with a non-empty file list crashes on compose. Found when
+the first recompose-verification attempt used that widget. Needs its own
+task.
+
+### Files
+
+- Fixed (27 sites): see LIVE/LATENT lists above (24 files under
+  `tldw_chatbook/`).
+- New: `Tests/Widgets/test_reactive_default_aliasing.py`,
+  `Tests/Architecture/test_reactive_mutable_default_inventory.py`.
+- Updated: `Tests/Widgets/test_character_voice_widget.py` (stale workaround
+  docstring), `backlog/docs/lessons-textual.md` (equality-skip entry).

--- a/tldw_chatbook/UI/Chatbooks_Window.py
+++ b/tldw_chatbook/UI/Chatbooks_Window.py
@@ -57,7 +57,7 @@ class ChatbooksWindow(Widget):
     ]
 
     # Reactive properties
-    chatbooks = reactive([], recompose=False)
+    chatbooks = reactive(list, recompose=False)
     selected_chatbook = reactive(None)
     current_view = reactive("welcome")  # welcome, create, load, templates
 

--- a/tldw_chatbook/UI/Chatbooks_Window_Improved.py
+++ b/tldw_chatbook/UI/Chatbooks_Window_Improved.py
@@ -379,7 +379,7 @@ class ChatbooksWindowImproved(RecomposeCaptureGuard, Screen):
     # `#chatbooks-container` imperatively via `_update_content()` instead
     # (task-671; see the class docstring for why `recompose=True` on
     # `chatbooks` was actively harmful here).
-    chatbooks = reactive([])
+    chatbooks = reactive(list)
     view_mode = reactive("grid")
     search_query = reactive("")
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3323,7 +3323,7 @@ class ChatScreen(BaseAppScreen):
         )
 
     # Reactive property for sidebar state persistence
-    sidebar_state = reactive({}, layout=False)
+    sidebar_state = reactive(dict, layout=False)
 
     #: task-15475: one-shot "the mount already did this visit's refreshes"
     #: token. Textual posts ``ScreenResume`` when a screen is PUSHED, so

--- a/tldw_chatbook/UI/Screens/chatbooks_screen.py
+++ b/tldw_chatbook/UI/Screens/chatbooks_screen.py
@@ -22,7 +22,7 @@ class ChatbooksScreen(BaseAppScreen):
 
     # Screen-specific state
     current_chatbook: reactive[Optional[Dict[str, Any]]] = reactive(None)
-    chatbook_list: reactive[List[Dict[str, Any]]] = reactive([])
+    chatbook_list: reactive[List[Dict[str, Any]]] = reactive(list)
     is_editing: reactive[bool] = reactive(False)
     selected_chatbook_id: reactive[Optional[int]] = reactive(None)
 

--- a/tldw_chatbook/UI/Screens/study_screen.py
+++ b/tldw_chatbook/UI/Screens/study_screen.py
@@ -89,7 +89,7 @@ class StudyScreen(BaseAppScreen):
     # Screen-specific state
     current_section: reactive[str] = reactive("dashboard")
     current_study_session: reactive[Optional[Dict[str, Any]]] = reactive(None)
-    study_materials: reactive[List[str]] = reactive([])
+    study_materials: reactive[List[str]] = reactive(list)
     is_studying: reactive[bool] = reactive(False)
     current_topic: reactive[str] = reactive("")
     scope_state: reactive[StudyScopeState] = reactive(StudyScopeState)

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -525,7 +525,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     # (see `_update_item_status`'s `refresh=False` path, which exists solely
     # to dodge it). `watch_overview_data` pushes the payload into the three
     # live surfaces that read it instead.
-    overview_data = reactive({})
+    overview_data = reactive(dict)
     # Through Phase C, CONTENT held only a placeholder stub and started
     # collapsed to avoid spending screen space on it. Phase D wires a real
     # reader (`ContentPane`) into CONTENT, so it now starts expanded like

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -254,7 +254,7 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
     #: the debounced reload from destroying the search box the user is
     #: still typing into 0.3 s later. `runtime_backend` is read by nothing
     #: in `compose()` at all; it was rebuilding the pane for free.
-    items = reactive[list[dict[str, Any]]]([])
+    items = reactive[list[dict[str, Any]]](list)
     selected_item = reactive[dict[str, Any] | None](None)
     status_filter = reactive("all")
     search_query = reactive("")

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -49,7 +49,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Button, DataTable, Select, Static
 
-from ...Subscriptions.briefing_audio import audio_file_path_is_safe, briefing_audio_dir
+from ...Subscriptions.briefing_audio import audio_file_path_is_safe
 from ...Subscriptions.briefing_selection import (
     MODE_AUTO,
     MODE_AUTO_FEATURED,
@@ -652,7 +652,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     _AUDIO_FAILED_MARK = "✗"
     _AUDIO_FAILED_STYLE = "bold red"
 
-    briefings = reactive[list[dict[str, Any]]]([], recompose=True)
+    briefings = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_briefing = reactive[dict[str, Any] | None](None, recompose=True)
     #: The scope line, supplied by the screen: which watchlist these
     #: briefings belong to, or the reason there are none to show.
@@ -674,7 +674,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     selection_mode = reactive[str](MODE_AUTO_FEATURED, recompose=True)
     #: Every stored `briefing_presets` row, name-ASC (screen-supplied,
     #: watchlist-independent).
-    presets = reactive[list[dict[str, Any]]]([], recompose=True)
+    presets = reactive[list[dict[str, Any]]](list, recompose=True)
     #: The watchlist's stored `default_briefing_preset_id`, or `None` for
     #: "use the app default" -- the value `_generate_briefing` passes to
     #: `generate_briefing(..., preset_id=...)`.
@@ -703,7 +703,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: across the whole watchlist, since a script belongs to exactly one
     #: briefing and this pane only ever shows one briefing's detail at a
     #: time.
-    scripts = reactive[list[dict[str, Any]]]([], recompose=True)
+    scripts = reactive[list[dict[str, Any]]](list, recompose=True)
     #: The script whose detail is rendered below the scripts table, or
     #: `None` when nothing is selected.
     selected_script = reactive[dict[str, Any] | None](None, recompose=True)
@@ -729,7 +729,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: shape could not do: a failed synthesis rendered visually identical
     #: to a successful one. Screen-supplied, resolved alongside `scripts`
     #: inside `_load_briefings`.
-    scripts_with_audio = reactive[dict[int, str]]({}, recompose=True)
+    scripts_with_audio = reactive[dict[int, str]](dict, recompose=True)
     #: Task 5 (phase 3): whether the WHOLE watchlist -- not merely the
     #: selected script -- has at least one export-ready audio episode
     #: (`SubscriptionsDB.list_watchlist_audio_episodes`'s own `complete`
@@ -785,7 +785,7 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
     #: `rich.text.Text`, never a bare `str`: an item title is remote text
     #: (the same reasoning `_script_turns_renderable` states for a turn),
     #: so it must never reach a markup parser.
-    citations = reactive[list[dict[str, Any]]]([], recompose=True)
+    citations = reactive[list[dict[str, Any]]](list, recompose=True)
 
     def _preset_select_options(self) -> list[tuple[str, int | None]]:
         """Options for the default-preset picker: "App default" then every

--- a/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/inspector_pane.py
@@ -222,7 +222,7 @@ class InspectorPane(RecomposeCaptureGuard, Vertical):
 
     selected_entity = reactive[dict[str, Any] | None](None, recompose=True)
     scope = reactive[TreeScope | None](None, recompose=True)
-    breadcrumb_labels = reactive[list[str]]([], recompose=True)
+    breadcrumb_labels = reactive[list[str]](list, recompose=True)
     #: TASK-998, widened by TASK-1020. What the profile behind this Inspector
     #: reports: `loading`, `empty` or `populated` (`OverviewPane.LOADING` and
     #: friends). Screen-seeded like the three reactives above, for the same

--- a/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/items_pane.py
@@ -73,7 +73,7 @@ class ItemsPane(RecomposeCaptureGuard, Vertical):
     #: `str` content") cannot bite here the way it could for a title or URL.
     _QUEUED_GLYPH = "●"
 
-    items = reactive[list[dict[str, Any]]]([], recompose=True)
+    items = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_item = reactive[dict[str, Any] | None](None)
     #: task-15460: plain reactives, all three. The two filters were
     #: `recompose=True`, so every character typed into the search box tore

--- a/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/notifications_pane.py
@@ -48,7 +48,7 @@ class DismissNotificationRequested(Message):
 class NotificationsPane(RecomposeCaptureGuard, Vertical):
     """Review and update the local client-notification inbox."""
 
-    notifications = reactive[list[dict[str, Any]]]([], recompose=True)
+    notifications = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_notification = reactive[dict[str, Any] | None](None, recompose=True)
 
     #: task-876: Rich's own terminal-agnostic "current item" idiom (see

--- a/tldw_chatbook/UI/Watchlists_Modules/overview_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/overview_pane.py
@@ -13,7 +13,7 @@ from .watchlists_backend_controller import WatchlistsBackendController
 class OverviewPane(RecomposeCaptureGuard, Vertical):
     """Dashboard cards and recent failed runs for watchlists."""
 
-    data = reactive({}, recompose=True)
+    data = reactive(dict, recompose=True)
     #: TASK-998. How many watchlists exist, so the first-run panel can tell a
     #: user who has already made one that their remaining step is a source.
     #: Screen-seeded like every other reactive on these panes -- the pane has

--- a/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
@@ -69,7 +69,7 @@ class RuleFormVisibilityChanged(Message):
 class RulesPane(RecomposeCaptureGuard, Vertical):
     """Alert rule list and editor for watchlists."""
 
-    rules = reactive[list[dict[str, Any]]]([], recompose=True)
+    rules = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_rule = reactive[dict[str, Any] | None](None)
     show_rule_form = reactive(False, recompose=True)
     runtime_backend = reactive("local", recompose=True)

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -67,7 +67,7 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
     #: `SourcesPane._SELECTED_ROW_STYLE` -- see that attribute's docstring.
     _SELECTED_ROW_STYLE = "reverse bold"
 
-    runs = reactive[list[dict[str, Any]]]([], recompose=True)
+    runs = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_run = reactive[dict[str, Any] | None](None)
     #: task-2306. Deliberately NOT `recompose=True`, unlike `runs`: both are
     #: rewritten on every run selection, and a pane recompose rebuilds
@@ -76,7 +76,7 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
     #: would then read as a non-user highlight. They are pushed into the live
     #: detail widgets instead, the same in-place discipline
     #: `_update_selection_highlight` already uses for the table itself.
-    run_items = reactive[list[dict[str, Any]]]([])
+    run_items = reactive[list[dict[str, Any]]](list)
     run_logs = reactive("")
     #: Why the Items table looks the way it does, whenever the rows alone
     #: would mislead (review wave, Important 1 / Minor 2). An empty items

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -117,7 +117,7 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
     #: `compose()`.
     _SELECTED_ROW_STYLE = "reverse bold"
 
-    sources = reactive[list[dict[str, Any]]]([], recompose=True)
+    sources = reactive[list[dict[str, Any]]](list, recompose=True)
     selected_source = reactive[dict[str, Any] | None](None)
     #: TASK-2309. The source ids ("id" field, the same namespaced form
     #: `selected_source` carries) with a check currently in flight anywhere
@@ -171,7 +171,7 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
     # workbench rebuild constructs a brand new pane, and re-deriving the
     # destination from the scope there would silently overwrite a choice the
     # user had already made in a form that is still open.
-    watchlist_choices = reactive[list[dict[str, Any]]]([])
+    watchlist_choices = reactive[list[dict[str, Any]]](list)
     default_destination = reactive[Any]("unassigned")
     create_draft_destination = reactive[Any]("unassigned")
     # TASK-2302. The chosen source type, which decides whether the

--- a/tldw_chatbook/UI/Wizards/BaseWizard.py
+++ b/tldw_chatbook/UI/Wizards/BaseWizard.py
@@ -97,7 +97,7 @@ class WizardStep(Container):
     is_valid = reactive(True)
 
     # Validation
-    validation_errors: reactive[List[str]] = reactive([])
+    validation_errors: reactive[List[str]] = reactive(list)
 
     def __init__(
         self,
@@ -321,7 +321,7 @@ class WizardProgress(Horizontal):
 
     current_step = reactive(1)
     total_steps = reactive(1)
-    step_titles: reactive[List[str]] = reactive([])
+    step_titles: reactive[List[str]] = reactive(list)
 
     def compose(self) -> ComposeResult:
         """Compose progress indicators."""

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_dictionary_editor_widget.py
@@ -379,10 +379,10 @@ class CCPDictionaryEditorWidget(Container):
     state: reactive[Optional[Any]] = reactive(None)
 
     # Current dictionary data being edited
-    dictionary_data: reactive[Dict[str, Any]] = reactive({})
+    dictionary_data: reactive[Dict[str, Any]] = reactive(dict)
 
     # Dictionary entries
-    entries: reactive[Dict[str, str]] = reactive({})
+    entries: reactive[Dict[str, str]] = reactive(dict)
 
     # Selected entry for editing
     selected_entry_key: reactive[Optional[str]] = reactive(None)

--- a/tldw_chatbook/Widgets/CCP_Widgets/ccp_prompt_editor_widget.py
+++ b/tldw_chatbook/Widgets/CCP_Widgets/ccp_prompt_editor_widget.py
@@ -341,10 +341,10 @@ class CCPPromptEditorWidget(Container):
     state: reactive[Optional[Any]] = reactive(None)
 
     # Current prompt data being edited
-    prompt_data: reactive[Dict[str, Any]] = reactive({})
+    prompt_data: reactive[Dict[str, Any]] = reactive(dict)
 
     # Variables list
-    variables: reactive[List[Dict[str, str]]] = reactive([])
+    variables: reactive[List[Dict[str, str]]] = reactive(list)
 
     # Is system prompt
     is_system_prompt: reactive[bool] = reactive(False)

--- a/tldw_chatbook/Widgets/Media/media_list_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_list_panel.py
@@ -155,7 +155,7 @@ class MediaListPanel(Container):
     """
 
     # Reactive properties
-    items: reactive[List[Dict[str, Any]]] = reactive([])
+    items: reactive[List[Dict[str, Any]]] = reactive(list)
     current_page: reactive[int] = reactive(1)
     total_pages: reactive[int] = reactive(1)
     selected_id: reactive[Optional[str]] = reactive(None)

--- a/tldw_chatbook/Widgets/Media/media_viewer_panel.py
+++ b/tldw_chatbook/Widgets/Media/media_viewer_panel.py
@@ -572,14 +572,14 @@ class MediaViewerPanel(Container):
     media_data: reactive[Optional[Dict[str, Any]]] = reactive(None)
     edit_mode: reactive[bool] = reactive(False)
     format_for_reading: reactive[bool] = reactive(False)
-    search_matches: reactive[List[Tuple[int, int]]] = reactive([])
+    search_matches: reactive[List[Tuple[int, int]]] = reactive(list)
     current_match: reactive[int] = reactive(-1)
     current_analysis: reactive[Optional[str]] = reactive(None)
     has_existing_analysis: reactive[bool] = reactive(False)
     analysis_edit_mode: reactive[bool] = reactive(False)
 
     # Multiple analyses support
-    all_analyses: reactive[List[Dict[str, Any]]] = reactive([])
+    all_analyses: reactive[List[Dict[str, Any]]] = reactive(list)
     current_analysis_index: reactive[int] = reactive(0)
 
     def __init__(self, app_instance: "TldwCli", **kwargs):

--- a/tldw_chatbook/Widgets/TTS/chapter_editor_widget.py
+++ b/tldw_chatbook/Widgets/TTS/chapter_editor_widget.py
@@ -126,7 +126,7 @@ class ChapterEditorWidget(RecomposeCaptureGuard, Widget):
     """
 
     # Reactive properties
-    chapters = reactive([], recompose=True)
+    chapters = reactive(list, recompose=True)
     selected_chapter_index = reactive(-1)
     preview_content = reactive("")
 

--- a/tldw_chatbook/Widgets/TTS/character_voice_widget.py
+++ b/tldw_chatbook/Widgets/TTS/character_voice_widget.py
@@ -140,9 +140,9 @@ class CharacterVoiceWidget(RecomposeCaptureGuard, Widget):
     # Confirmed live: with `recompose=True` restored, a fresh
     # `#character-table` query after settling reports `row_count == 0` even
     # though `self.characters` holds the added item.
-    characters = reactive([])
+    characters = reactive(list)
     selected_character_index = reactive(-1)
-    voice_assignments = reactive({})
+    voice_assignments = reactive(dict)
     provider = reactive("openai")
 
     def __init__(self, provider: str = "openai", **kwargs):

--- a/tldw_chatbook/Widgets/chunk_preview.py
+++ b/tldw_chatbook/Widgets/chunk_preview.py
@@ -23,7 +23,7 @@ class ChunkPreview(Widget):
     DEFAULT_CLASSES = "chunk-preview-widget"
 
     # Reactive data
-    chunks: reactive[List[Tuple[str, int, int]]] = reactive([])  # (text, start, end)
+    chunks: reactive[List[Tuple[str, int, int]]] = reactive(list)  # (text, start, end)
     overlap_size: reactive[int] = reactive(0)
 
     def __init__(self, max_chunks: int = 5, **kwargs):

--- a/tldw_chatbook/Widgets/collections_tag_window.py
+++ b/tldw_chatbook/Widgets/collections_tag_window.py
@@ -131,7 +131,7 @@ class CollectionsTagWindow(Container):
     Provides functionality for viewing, editing, merging, and deleting keywords.
     """
 
-    selected_keywords: reactive[List[Dict[str, Any]]] = reactive([])
+    selected_keywords: reactive[List[Dict[str, Any]]] = reactive(list)
     keyword_search: reactive[str] = reactive("")
 
     def __init__(self, app_instance: "TldwCli", **kwargs):

--- a/tldw_chatbook/Widgets/dictation_performance_widget.py
+++ b/tldw_chatbook/Widgets/dictation_performance_widget.py
@@ -106,7 +106,7 @@ class DictationPerformanceWidget(Widget):
     """
 
     # Reactive data
-    metrics_data = reactive({})
+    metrics_data = reactive(dict)
 
     def compose(self) -> ComposeResult:
         """Compose performance dashboard."""

--- a/tldw_chatbook/Widgets/file_extraction_dialog.py
+++ b/tldw_chatbook/Widgets/file_extraction_dialog.py
@@ -74,7 +74,7 @@ class FileExtractionDialog(ModalScreen):
     """
 
     # Store the extracted files
-    extracted_files: reactive[List[ExtractedFile]] = reactive([])
+    extracted_files: reactive[List[ExtractedFile]] = reactive(list)
     selected_index: reactive[Optional[int]] = reactive(None)
 
     def __init__(

--- a/tldw_chatbook/Widgets/file_list_item_enhanced.py
+++ b/tldw_chatbook/Widgets/file_list_item_enhanced.py
@@ -170,7 +170,7 @@ class FileListEnhanced(RecomposeCaptureGuard, Widget):
     - Keyboard navigation
     """
 
-    files = reactive([], recompose=True)
+    files = reactive(list, recompose=True)
 
     def __init__(
         self,

--- a/tldw_chatbook/Widgets/media_details_widget.py
+++ b/tldw_chatbook/Widgets/media_details_widget.py
@@ -44,7 +44,7 @@ class MediaDetailsWidget(Container):
     format_for_reading = reactive(False)
 
     # Search-related state
-    search_matches: reactive[List[Tuple[int, int]]] = reactive([])
+    search_matches: reactive[List[Tuple[int, int]]] = reactive(list)
     current_match_index: reactive[int] = reactive(-1)
 
     def __init__(self, app_instance: "TldwCli", type_slug: str, **kwargs):

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -12,7 +12,6 @@ from textual.app import ComposeResult
 from textual.color import Color
 from textual.containers import Horizontal, Vertical
 from textual.css.query import QueryError
-from textual.events import Click, DescendantFocus
 from textual.events import Click, DescendantFocus, Key
 from textual.message import Message
 from textual.reactive import reactive
@@ -35,7 +34,7 @@ class SettingsThemeEditor(Vertical):
             super().__init__()
 
     current_theme_name = reactive("textual-dark")
-    current_theme_data: reactive[dict[str, str]] = reactive({}, layout=False)
+    current_theme_data: reactive[dict[str, str]] = reactive(dict, layout=False)
     is_dark_theme = reactive(True)
     # init=False: the init-time watch call would post ThemeModifiedStatus(False)
     # on every mount, and SettingsScreen recomposes on that reactive -- paired

--- a/tldw_chatbook/Widgets/status_widget.py
+++ b/tldw_chatbook/Widgets/status_widget.py
@@ -79,7 +79,7 @@ class EnhancedStatusWidget(RecomposeCaptureGuard, Widget):
     }
     """
 
-    messages: reactive[List[StatusMessage]] = reactive([], recompose=True)
+    messages: reactive[List[StatusMessage]] = reactive(list, recompose=True)
     max_messages: reactive[int] = reactive(100)
     show_timestamp: reactive[bool] = reactive(True)
     title: reactive[str] = reactive("Status")


### PR DESCRIPTION
## Summary

Textual's `reactive([])`/`reactive({})` shares ONE mutable object by identity across every instance of the class — and the subtler half, verified against Textual 8.2.8 source: `Reactive._set` equality-skips, so reassigning `[]` over the pristine shared `[]` is a NO-OP that keeps the aliasing. "Reassigns before use" is not a defense, which reversed several would-be-safe classifications.

- **All 41 sites converted** to callable defaults across two review rounds: 27 found by the original sweep (8 LIVE — in-place mutation reachable on the shared value, each demonstrated with a cross-instance leak test born-red: a pristine instance B observing A's mutation), plus 14 the review's independent sweep caught in the subscripted-generic spelling `reactive[T]([])` the first AST matcher couldn't see (all latent; the one mutation candidate sits inside an enumerate over the empty default, unreachable)
- **A permanent AST guard** (`Tests/Architecture/test_reactive_mutable_default_inventory.py`) pins the class at zero for the covered forms — now unwrapping `ast.Subscript`, born-red against the round-1 tree listing exactly the 14 — with its docstring explicitly scoping what it does NOT cover (shared mutable INSTANCE defaults, 5 known occurrences, filed separately)
- Live-leak highlights: the media viewer's `all_analyses` could carry a stale unsaved analysis into a remounted viewer for a DIFFERENT media item; voice assignments, chapter lists (recompose), theme-editor state, CCP editors — review confirmed all 8 LIVE classifications and that no code depended on the shared identity (zero `is`-comparisons/`id()` uses outside the new tests)
- The nine identity assertions in `test_watchlists_pagination.py` run, not assumed: 34/34 (they pin identity-across-re-renders, untouched by the fix)
- Watcher/init/recompose parity byte-identical between literal and factory defaults (probed side-by-side in review); lessons entry records the equality-skip trap with the incident
- 6 + 34 + 333 + 140 green this round atop ~1,400 review-run tests; pre-existing flake family and 3 base-red Architecture tests named honestly in the notes

Review: independent opus pass (FIX-FIRST on completeness — 27 of 41) → fix round with the reviewer's own sweep as the born-red predicate → merged. Follow-ups queued: instance-form guard extension, `FileListItemEnhanced` tooltip crash, stts flake family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates cross‑instance state leaks by converting all 41 mutable `reactive([])`/`reactive({})` defaults to callable factories. Previously the same list/dict object was installed per class and empty-equal reassignments were skipped; now each instance gets a fresh container with `recompose` behavior unchanged.

- Verifies the bug and the fix with new tests: `Tests/Widgets/test_reactive_default_aliasing.py` (born‑red pre‑fix) and an AST guard `Tests/Architecture/test_reactive_mutable_default_inventory.py` that blocks non‑callable mutable defaults (including `reactive[T](...)` forms).
- Converts all occurrences, including 14 subscripted‑generic sites that were structurally missed in the first sweep. No code relied on shared identity; existing identity‑across‑rerender tests remain green.
- Targeted live cases covered: `CharacterVoiceWidget.characters`/`voice_assignments`, `ChapterEditorWidget.chapters`, `CollectionsTagWindow.selected_keywords`. Confirms `OverviewPane.data (recompose=True)` still recomposes.
- Minor cleanup: removes a dead import in `artifacts_pane.py` and documents the equality‑skip trap in `backlog/docs/lessons-textual.md`.

**Required migration for contributors**
- When declaring mutable reactives, use factories: `reactive(list)`, `reactive(dict)`, or `reactive(set)`; for non‑empty defaults, use a callable (e.g., `lambda: [seed]`). Do not pass `[]`, `{}`, or `list()/dict()/set()` results.
- The guard does not detect `reactive(SomeClass())` instance defaults; avoid shared mutable instances in new code.

<sup>Written for commit d744c3d61220ae301b6642abcf9c5f8e8f6792aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

