### PR TITLE
fix(console): settings crashes — unvalidatable-lineage guard + Select.NULL popover sentinel (tasks 16501/16502)

### DIFF
--- a/Tests/Chat/test_console_context_compaction.py
+++ b/Tests/Chat/test_console_context_compaction.py
@@ -1354,3 +1354,48 @@ async def test_manual_compact_now_is_explicit_and_transcript_neutral() -> None:
     assert gateway.calls == 1
     assert before == after
     assert len(controller._context_repository.memories) == 1
+
+
+def test_context_control_inputs_tolerate_unvalidatable_lineage() -> None:
+    """Settings inputs degrade to no memory when the lineage cannot be validated.
+
+    TASK-16501: an unpersisted user message on the active path makes
+    ``_durable_context_snapshots`` return None; the settings seam must not
+    crash on it (user-reported TypeError while opening Console settings).
+    """
+    controller, store, session, _assistant, _gateway, _provider_messages = (
+        _controller_preflight_fixture(ContextCompactionMode.AUTOMATIC)
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="not yet persisted",
+    )
+    assert controller._durable_context_snapshots(session.id) is None
+    controller._context_repository.memories.append(
+        _memory((_message("u1", "user", "one"),))
+    )
+
+    _overrides, _global_overrides, memory = controller.context_control_inputs(
+        session.id
+    )
+
+    assert memory is None
+
+
+def test_reset_active_context_memory_tolerates_unvalidatable_lineage() -> None:
+    """Reset deactivates nothing when the lineage cannot be validated (TASK-16501)."""
+    controller, store, session, _assistant, _gateway, _provider_messages = (
+        _controller_preflight_fixture(ContextCompactionMode.AUTOMATIC)
+    )
+    store.append_message(
+        session.id,
+        role=ConsoleMessageRole.USER,
+        content="not yet persisted",
+    )
+    assert controller._durable_context_snapshots(session.id) is None
+    controller._context_repository.memories.append(
+        _memory((_message("u1", "user", "one"),))
+    )
+
+    assert controller.reset_active_context_memory(session.id) is None

--- a/Tests/UI/test_console_context_controls.py
+++ b/Tests/UI/test_console_context_controls.py
@@ -513,3 +513,32 @@ async def test_unverified_model_capacity_is_labeled_as_estimated() -> None:
         assert "Model window (est.)" in window
         assert "model capacity is unverified" in status
         assert "Providers & Models" in status
+
+
+@pytest.mark.asyncio
+async def test_quick_popover_mounts_with_no_model_selected() -> None:
+    """A session with no model opens the popover on the blank model row.
+
+    TASK-16502: on Textual 8.x ``Select.BLANK`` silently resolves to
+    ``Widget.BLANK`` (``False``), which is not a legal Select value, so the
+    popover crashed at mount with InvalidSelectValueError for any session
+    whose settings carry no model.
+    """
+    app = _ContextHarness()
+    async with app.run_test(size=(90, 34)) as pilot:
+        await app.push_screen(
+            ConsoleModelPopover(
+                settings=ConsoleSessionSettings(
+                    provider="llama_cpp",
+                    model=None,
+                    max_tokens=4_000,
+                ),
+                providers_models={"llama_cpp": ["model-a"]},
+                context_state=_state(),
+            ),
+            callback=app.capture,
+        )
+        await pilot.pause()
+
+        model_select = app.screen.query_one("#console-popover-model", Select)
+        assert model_select.value is Select.NULL

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4369,3 +4369,30 @@ entry left DBs rolled back to V20..V27 silently missing ALL conversations
 sync triggers after replay — a corruption no per-test fixture would ever
 notice, caught only because the sweep asserts parity with a fresh DB rather
 than "the test I care about passes".
+
+## A silently-shadowed upstream sentinel is a defect class, not a file-local bug (task-16502, 2026-08-15)
+
+Textual 8.x removed `Select.BLANK` (the blank-selection sentinel, renamed
+`Select.NULL`) — but referencing it does NOT raise: the lookup falls through the
+MRO to `Widget.BLANK: ClassVar[bool] = False`, an unrelated render flag added in
+the same major version. Every use of the old sentinel silently became the boolean
+`False`: comparisons went permanently dead, and passing it as a Select's initial
+`value=` crashed at mount with `InvalidSelectValueError: Illegal select value
+False.` Task-565 (2026-07-25) established exactly this mechanism and swept it —
+**scoped to settings_screen.py only**, because that was the file under review.
+Three weeks later the identical construct in `console_model_popover.py` crashed
+the Alt+M popover at mount for any session without a configured model, and was
+reported by a user. A grep at that point found **66 remaining `Select.BLANK`
+usages across 23 files**, including several sites that had independently
+discovered the trap and worked around it locally with comments, and several that
+deliberately exploit the `False` value as a synthetic placeholder option — so the
+eventual sweep (task-16503) needs per-site classification, not find-and-replace.
+
+**What to do.** When a fix reveals that an upstream rename/removal fails
+*silently* (shadowed attribute, `getattr` default, `__getattr__` fallback) rather
+than loudly, the first grep result count is the real scope of the defect. Sweep
+repo-wide in the same arc, or file the sweep task immediately with the grep count
+and the classification burden recorded — a Done task documenting the mechanism
+does not stop the next file from shipping the same crash. Evidence here: the
+mechanism was fully documented on the board for three weeks while the
+user-reachable crash sat live in another file.

--- a/backlog/tasks/task-16501 - Console-settings-crash-when-durable-lineage-cannot-be-validated.md
+++ b/backlog/tasks/task-16501 - Console-settings-crash-when-durable-lineage-cannot-be-validated.md
@@ -1,0 +1,51 @@
+---
+id: TASK-16501
+title: Console settings crash when durable lineage cannot be validated
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-15 16:10'
+updated_date: '2026-08-15 16:45'
+labels:
+  - console
+  - bug
+  - context-memory
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User-reported crash: opening Console settings raises `TypeError: 'NoneType' object is not iterable` in `select_valid_memory()` (console_context_compaction.py:236), with `active_messages=None` and `candidates=()`.
+
+`ConsoleChatController._durable_context_snapshots()` is typed `tuple[...] | None` and returns `None` whenever the active lineage cannot be validated (a user message on the active path with no `persisted_message_id` yet, a store `KeyError`, a missing/failing `get_message_version` reader, broken variant state). The two send-path consumers (`_compaction_admission`, `_apply_conversation_memory_preflight`) guard with `if not snapshots:`, but the two settings-surface consumers — `context_control_inputs()` and `reset_active_context_memory()` — pass the result straight into `select_valid_memory()`. The chat_screen caller catches only `(KeyError, ValueError)`, so the `TypeError` escapes and takes down settings opening (both the full modal and the Alt+M popover call `_active_console_context_control_state()`). The crash fires even with zero stored memories because the positions dict is built before candidates are iterated.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Opening Console settings does not crash when the active durable lineage cannot be validated; the memory input degrades to None
+- [x] #2 Reset-current-memory returns None (no deactivation) instead of crashing when the lineage cannot be validated
+- [x] #3 Regression tests reproduce the None-snapshots state through the controller seam and were verified RED before the fix
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add regression tests in Tests/Chat/test_console_context_compaction.py using the controller preflight fixture plus an unpersisted user message on the active path (which makes `_durable_context_snapshots` return None); verify both tests RED with the reported TypeError.
+2. Guard both settings-surface call sites in `console_chat_controller.py` with the same `if not snapshots:` pattern the send-path consumers already use, keeping `select_valid_memory`'s contract unchanged.
+3. Verify tests GREEN; run the compaction and context-controls suites.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Guarded the two settings-surface consumers of `_durable_context_snapshots()` in console_chat_controller.py — `context_control_inputs()` and `reset_active_context_memory()` — with the same `if not snapshots:` degradation the send-path consumers (`_compaction_admission`, `_apply_conversation_memory_preflight`) already used. `select_valid_memory()`'s contract is unchanged: None still means "lineage cannot be validated right now", which correctly selects no memory rather than being coerced to an empty prefix.
+
+Regression tests in Tests/Chat/test_console_context_compaction.py reach the None state through the product path: the controller preflight fixture plus one unpersisted user message on the active path (the realistic mid-persistence state from the user report), with a seeded active memory proving nothing gets selected or deactivated. Both tests verified RED with the exact reported `TypeError: 'NoneType' object is not iterable` at console_context_compaction.py:236 before the fix, GREEN after.
+
+Not changed: chat_screen's `(KeyError, ValueError)` catch around `context_control_inputs` — after this fix the seam no longer raises for unvalidatable lineage, and widening that catch would hide real programming errors.
+
+Files: tldw_chatbook/Chat/console_chat_controller.py, Tests/Chat/test_console_context_compaction.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16502 - Console-model-popover-crashes-at-mount-when-session-has-no-model.md
+++ b/backlog/tasks/task-16502 - Console-model-popover-crashes-at-mount-when-session-has-no-model.md
@@ -1,0 +1,53 @@
+---
+id: TASK-16502
+title: Console model popover crashes at mount when session has no model
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-15 16:10'
+updated_date: '2026-08-15 16:45'
+labels:
+  - console
+  - bug
+  - textual-upgrade
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User-reported crash: `InvalidSelectValueError: Illegal select value False.` from `Select(id='console-popover-model')` during `_on_mount`.
+
+Same trap TASK-565 documented and swept in settings_screen.py: on Textual 8.x the Select no-selection sentinel is `Select.NULL`; `Select.BLANK` no longer exists on the widget and silently resolves through the MRO to `Widget.BLANK: ClassVar[bool] = False` (an unrelated render-optimization flag), so no AttributeError fires. `console_model_popover.py` passes `value=Select.BLANK` (== `False`) to the model Select whenever the session has no model set (fresh install, or a provider without a configured default model). `Select.__init__` stores the value unvalidated and validation runs at mount, where `False` is not a legal value — reproducing the reported traceback byte-for-byte. The `_apply` handler's `model_value in (None, Select.BLANK)` membership carries the same dead sentinel (inert today because `ModelSearchPicker.value` is `str | None`, but wrong-intent).
+
+A repo-wide audit of the remaining `Select.BLANK` usages is TASK-16503; this task fixes only the crashing popover site.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 The Alt+M quick popover mounts without error for a session whose settings have no model, showing the blank model row
+- [x] #2 The popover no longer references the nonexistent `Select.BLANK` sentinel
+- [x] #3 A mounted regression test covers the no-model popover open and was verified RED before the fix
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a mounted regression test in Tests/UI/test_console_context_controls.py pushing ConsoleModelPopover with `model=None`; verify RED with `InvalidSelectValueError: Illegal select value False.`
+2. Replace both `Select.BLANK` references in console_model_popover.py with `Select.NULL`.
+3. Verify the test GREEN; run the console context-controls suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced both `Select.BLANK` references in console_model_popover.py with `Select.NULL` — the mount-time `value=` seed (the crashing site: on Textual 8.2.8, `Select.BLANK` resolves to `Widget.BLANK == False`, which `Select.__init__` stores unvalidated and mount-time validation rejects) and the `_apply` membership check (inert today since `ModelSearchPicker.value` is `str | None`, fixed for intent). A comment at the seed site records why NULL, mirroring the settings_screen.py precedent from TASK-565.
+
+Mounted regression test in Tests/UI/test_console_context_controls.py pushes the popover with `model=None` through the existing `_ContextHarness` and asserts the model Select sits on `Select.NULL`. Verified RED with the byte-identical user traceback (`InvalidSelectValueError: Illegal select value False.` on `Select(id='console-popover-model')` in `_on_mount`) before the fix, GREEN after.
+
+The repo-wide audit of the ~60 remaining `Select.BLANK` usages (including deliberate False-placeholder sites that must NOT be blind-renamed) is filed as TASK-16503, with a lessons-testing-evidence.md entry recording that the mechanism was board-documented for three weeks (TASK-565) while this crash sat live in another file.
+
+Files: tldw_chatbook/Widgets/Console/console_model_popover.py, Tests/UI/test_console_context_controls.py, backlog/docs/lessons-testing-evidence.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16503 - Audit-remaining-Select.BLANK-usages-outside-settings_screen.md
+++ b/backlog/tasks/task-16503 - Audit-remaining-Select.BLANK-usages-outside-settings_screen.md
@@ -1,0 +1,32 @@
+---
+id: TASK-16503
+title: Audit remaining Select.BLANK usages outside settings_screen
+status: To Do
+assignee: []
+created_date: '2026-08-15 16:10'
+labels:
+  - tech-debt
+  - textual-upgrade
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-565 swept `Select.BLANK` out of settings_screen.py after establishing that on Textual 8.x it silently resolves to `Widget.BLANK == False` instead of the real blank sentinel `Select.NULL`. TASK-16502 fixed the crashing site in console_model_popover.py. Roughly 60 usages across ~20 other files remain, in three distinct behavior classes that need different treatment:
+
+1. Sentinel-intent comparisons that are now dead (`value == Select.BLANK` never matches a genuine blank selection): STTS_Window.py, character_voice_widget.py, media_viewer_panel.py, compact_model_bar.py, Outputs_Panel.py, library_note_folder_dialog.py (`value is not Select.BLANK`), speech mixins, Tools_Settings_Window.py (deprecated, nav-unreachable), bench_editor.py. These silently misbehave and should become `Select.NULL`.
+2. Assignments `select.value = Select.BLANK` (Utils/ui_helpers.py:75/112, Outputs_Panel.py:208, mcp_inspector.py:2737) — assigning `False` raises `InvalidSelectValueError` at that line unless the options deliberately contain the `False` placeholder; ui_helpers' broad `except Exception` currently downgrades this to an error log.
+3. Deliberate `False`-placeholder option values with explanatory comments (mcp_rail.py, mcp_inspector.py, mcp_server_mutations.py, Study_Window.py + flashcards/quizzes handlers) — these treat `Select.BLANK` as a synthetic option value on purpose and MUST NOT be blindly renamed to `Select.NULL`; if touched, introduce a named module-level placeholder constant instead.
+
+A blind find-and-replace is wrong for class 3; each site needs classification first.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Every remaining `Select.BLANK` usage is classified as sentinel-intent, crashing assignment, or deliberate placeholder, with the classification recorded in the task
+- [ ] #2 Sentinel-intent comparisons and crashing assignments behave correctly against the real `Select.NULL` sentinel, with regression coverage for the user-reachable ones
+- [ ] #3 Deliberate placeholder sites either keep their current behavior or move to a named constant; no behavior change ships without a test
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -8526,12 +8526,14 @@ class ConsoleChatController:
             self._context_repository is not None
             and owner.persisted_conversation_id is not None
         ):
-            memory = select_valid_memory(
-                self._context_repository.list_active_memories(
-                    owner.persisted_conversation_id
-                ),
-                self._durable_context_snapshots(session_id),
-            )
+            snapshots = self._durable_context_snapshots(session_id)
+            if snapshots:
+                memory = select_valid_memory(
+                    self._context_repository.list_active_memories(
+                        owner.persisted_conversation_id
+                    ),
+                    snapshots,
+                )
         return owner.context_policy_overrides, global_overrides, memory
 
     def reset_active_context_memory(self, session_id: str) -> tuple[str, int] | None:
@@ -8546,9 +8548,12 @@ class ConsoleChatController:
             or owner.persisted_conversation_id is None
         ):
             return None
+        snapshots = self._durable_context_snapshots(session_id)
+        if not snapshots:
+            return None
         memory = select_valid_memory(
             repository.list_active_memories(owner.persisted_conversation_id),
-            self._durable_context_snapshots(session_id),
+            snapshots,
         )
         if memory is None:
             return None

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -8527,6 +8527,9 @@ class ConsoleChatController:
             and owner.persisted_conversation_id is not None
         ):
             snapshots = self._durable_context_snapshots(session_id)
+            # Truthiness on purpose: None (unvalidatable lineage) and ()
+            # (no durable rows yet) both select no memory — an empty prefix
+            # can't validate any candidate — matching the send-path guards.
             if snapshots:
                 memory = select_valid_memory(
                     self._context_repository.list_active_memories(
@@ -8549,6 +8552,7 @@ class ConsoleChatController:
         ):
             return None
         snapshots = self._durable_context_snapshots(session_id)
+        # Truthiness on purpose: None and () both mean nothing can be reset.
         if not snapshots:
             return None
         memory = select_valid_memory(

--- a/tldw_chatbook/Widgets/Console/console_model_popover.py
+++ b/tldw_chatbook/Widgets/Console/console_model_popover.py
@@ -196,10 +196,14 @@ class ConsoleModelPopover(
                 )
                 model_select = Select(
                     model_options,
+                    # Select.NULL, not Select.BLANK: on this Textual version
+                    # BLANK doesn't exist on Select and silently resolves to
+                    # Widget.BLANK (False), an illegal value that crashes the
+                    # Select at mount (TASK-16502).
                     value=(
                         self._settings.model
                         if self._settings.model
-                        else Select.BLANK
+                        else Select.NULL
                     ),
                     id="console-popover-model",
                     allow_blank=True,
@@ -416,7 +420,7 @@ class ConsoleModelPopover(
         settings = replace(
             self._settings,
             provider=str(provider_value),
-            model=None if model_value in (None, Select.BLANK) else str(model_value),
+            model=None if model_value in (None, Select.NULL) else str(model_value),
             temperature=temperature,
             streaming=self._streaming,
         )


### PR DESCRIPTION
Fixes two user-reported crashes that both block opening Console settings (tasks 16501, 16502; follow-up audit filed as task 16503).

## Crash 1 — `TypeError: 'NoneType' object is not iterable` (task-16501)

`select_valid_memory()` (console_context_compaction.py:236) received `active_messages=None` while opening Console settings. `ConsoleChatController._durable_context_snapshots()` legitimately returns `None` whenever the active lineage cannot be validated (e.g. a user message on the active path whose persistence write hasn't landed, a failing `get_message_version` reader, broken variant state). The two send-path consumers already guard with `if not snapshots:`; the two settings-surface consumers — `context_control_inputs()` and `reset_active_context_memory()` — did not, and the chat_screen caller catches only `(KeyError, ValueError)`, so the `TypeError` escaped. The crash fires even with zero stored memories, on both the full settings modal and the Alt+M popover.

**Fix:** the same `if not snapshots:` degradation the send-path consumers use — settings open with no active memory shown, reset deactivates nothing. `select_valid_memory()`'s contract is unchanged (`None` means "lineage cannot be validated", not "no messages").

## Crash 2 — `InvalidSelectValueError: Illegal select value False.` (task-16502)

On Textual 8.x the Select blank sentinel is `Select.NULL`; `Select.BLANK` was removed from the widget but resolves **silently** through the MRO to `Widget.BLANK: ClassVar[bool] = False` (an unrelated render flag). `console_model_popover.py` passed `value=Select.BLANK` whenever the session has no model (fresh install, or a provider without a configured default), and mount-time validation rejects `False` — reproducing the reported traceback byte-for-byte. Same mechanism task-565 documented and swept in settings_screen.py; this site was outside that sweep.

**Fix:** `Select.NULL` at both popover sites (the crashing `value=` seed and the inert-but-wrong `_apply` membership). The repo still carries ~60 `Select.BLANK` usages in ~20 other files, including deliberate `False`-placeholder sites that must NOT be blind-renamed — filed as task-16503 with per-site classification required, plus a lessons-testing-evidence entry (the mechanism was board-documented for three weeks while this crash sat live in another file).

## Tests

- `test_context_control_inputs_tolerate_unvalidatable_lineage` and `test_reset_active_context_memory_tolerates_unvalidatable_lineage` (Tests/Chat/test_console_context_compaction.py) reach the `None` state through the product path (controller fixture + one unpersisted user message) with a seeded active memory proving nothing is selected/deactivated. Verified RED with the exact reported `TypeError` before the fix.
- `test_quick_popover_mounts_with_no_model_selected` (Tests/UI/test_console_context_controls.py) mounts the popover with `model=None`. Verified RED with the byte-identical `InvalidSelectValueError` before the fix.

Suite evidence (failure **sets** compared from identical commands, branch vs clean `origin/dev`): the seven console suite files (Chat compaction/session-settings + five UI files) show the identical failure set on both trees — 459 passed / 2 failed on this branch vs 456 passed / 2 failed on clean dev (the +3 are this PR's tests), the 2 being pre-existing dev-tip contract failures (`test_context_controls_add_no_forbidden_keybindings`: `'Binding' object is not subscriptable`; `test_console_modal_inventory_matches_runtime_ast_and_transitive_launches`: `TrajectoryScreen` missing from the modal contract). `Tests/ProductionApp/test_provider_selection_ownership.py` likewise fails identically on both trees (`production Settings provider control did not stabilize`). None of the three pre-existing failures are touched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents two crashes that blocked opening Console settings. Old: settings raised TypeError on unvalidatable lineage and the Alt+M popover raised InvalidSelectValueError when no model was set. New: settings open with no active memory and reset is a no‑op; the popover seeds Select.NULL and mounts cleanly.

- Guard None and empty snapshots in context_control_inputs() and reset_active_context_memory(); skip selection/reset when snapshots are falsy. select_valid_memory() contract unchanged. Treating None and () equivalently is now documented. Addresses task-16501.
- Replace Select.BLANK with Select.NULL in the popover’s initial value and _apply check; the blank row shows when no model is configured. Addresses task-16502. Follow-up audit is task-16503.
- Tests added: test_context_control_inputs_tolerate_unvalidatable_lineage, test_reset_active_context_memory_tolerates_unvalidatable_lineage, test_quick_popover_mounts_with_no_model_selected. No migration required.

<sup>Written for commit f134e4c1d6a27480516485c02f232ba2f6fae685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

