### PR TITLE
fix(scraper): ScraperBuilderWindow composes — four stacked crashes fixed (TASK-15991)

### DIFF
--- a/Tests/UI/test_scraper_builder_window.py
+++ b/Tests/UI/test_scraper_builder_window.py
@@ -1,0 +1,88 @@
+"""TASK-15991: ScraperBuilderWindow must open.
+
+Born red at 11646bba0: `_compose_options` called the nonexistent
+`FormBuilder.create_switch`, so pushing the screen died in compose with
+AttributeError and the window had never been openable.
+
+The harness loads the shipped stylesheet (bare harnesses measure fiction)
+and waits on conditions, not pause counts.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.widgets import Select, Switch
+
+from tldw_chatbook.UI.ScraperBuilderWindow import ScraperBuilderWindow
+
+BUNDLE = (
+    Path(__file__).resolve().parents[2]
+    / "tldw_chatbook"
+    / "css"
+    / "tldw_cli_modular.tcss"
+)
+
+
+class _Harness(App[None]):
+    CSS_PATH = str(BUNDLE)
+
+    def on_mount(self) -> None:
+        self.push_screen(ScraperBuilderWindow())
+
+
+async def _wait_for(pilot, predicate, what: str, timeout: float = 8.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = predicate()
+        if result:
+            return result
+        await pilot.pause(0.05)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+@pytest.mark.asyncio
+async def test_scraper_builder_window_opens_and_switch_value_reaches_options():
+    """Opening the window composes without raising (AC #1/#2), and a switch's
+    value actually reaches its consumer (_format_options_code)."""
+    app = _Harness()
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: (
+                app.screen if isinstance(app.screen, ScraperBuilderWindow) else None
+            ),
+            "scraper builder screen",
+        )
+
+        # The Options tab's switches exist with their consumer-facing ids.
+        remove_scripts = await _wait_for(
+            pilot,
+            lambda: (
+                (
+                    screen.query("#remove-scripts")
+                    and screen.query_one("#remove-scripts", Switch)
+                )
+                or None
+            ),
+            "#remove-scripts switch",
+        )
+        assert screen.query_one("#remove-styles", Switch).value is True
+        assert screen.query_one("#preserve-links", Switch).value is True
+        assert screen.query_one("#wait-javascript", Switch).value is False
+
+        # The options Selects carry machine tokens as values, not labels
+        # (the tuples were (value, label)-reversed, an open-crash at compose).
+        assert screen.query_one("#text-processing", Select).value == "clean"
+
+        # Default flows through to the consumer...
+        assert remove_scripts.value is True
+        assert '"remove_scripts": True' in screen._format_options_code()
+
+        # ...and a driven change flows through too (not a constant).
+        remove_scripts.value = False
+        await pilot.pause()
+        assert '"remove_scripts": False' in screen._format_options_code()

--- a/backlog/tasks/task-15991 - ScraperBuilderWindow-cannot-be-opened-FormBuilder.create_switch-does-not-exist.md
+++ b/backlog/tasks/task-15991 - ScraperBuilderWindow-cannot-be-opened-FormBuilder.create_switch-does-not-exist.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15991
 title: 'ScraperBuilderWindow cannot be opened: FormBuilder.create_switch does not exist'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-14 01:10'
 labels:
   - bug
@@ -17,7 +18,70 @@ dependencies: []
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening ScraperBuilderWindow composes without raising
-- [ ] #2 A mounted regression test pins the open (born-red against the current crash)
-- [ ] #3 Notes state whether create_switch was added to FormBuilder or the call sites changed, and why
+- [x] #1 Opening ScraperBuilderWindow composes without raising
+- [x] #2 A mounted regression test pins the open (born-red against the current crash)
+- [x] #3 Notes state whether create_switch was added to FormBuilder or the call sites changed, and why
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reachability check: confirm whether ScraperBuilderWindow is reachable from live navigation at HEAD (registry, palette, imports) and whether any retirement decision exists — record the verdict.
+2. Convention check: read FormBuilder (Widgets/form_components.py) and its other consumers to decide the fix side (add create_switch vs compose Switch at the call sites).
+3. Write a born-red mounted test (Tests/UI/test_scraper_builder_window.py): push the screen in a bundle-CSS harness, assert compose succeeds; drive one switch's value into its consumer (_format_options_code). Run at HEAD to capture the exact AttributeError.
+4. Fix on the chosen side; re-run the test green; ruff check + format on touched files.
+5. Notes + AC tick + Done.
+
+## Implementation Notes
+
+**Fix side: the call sites changed, not FormBuilder.** FormBuilder
+(Widgets/form_components.py) deliberately has no per-widget factories at all —
+its whole API is `create_form_field(label, widget)` / `create_field_set` /
+`add_field`, and its only other consumer, `UI/SiteConfigSettings.py`, composes
+`Switch(value=..., id=...)` directly and passes it in (lines 227/311-323, with
+the very same ids `remove-scripts`/`remove-styles`/`preserve-links`). The four
+`self.form_builder.create_switch(...)` calls in `_compose_options` were changed
+to `Switch(value=<default>, id=<id>)` to match that grain; the now-dead
+`self.form_builder` attribute and `FormBuilder` import were removed.
+
+**The born-red mounted test surfaced three MORE compose crashes behind the
+first** — each was the next AttributeError/MountError once the previous was
+fixed, all pre-existing (the window had never composed end to end):
+
+1. `TextArea(language="html")` for the HTML preview raises
+   `LanguageDoesNotExist` at construction when tree-sitter is installed but the
+   `tree-sitter-html` grammar package is not (true of the project venv: only
+   python/javascript grammars resolve). Fixed with a module-level
+   `_syntax_text_area(**kwargs)` helper that retries without `language` on
+   `LanguageDoesNotExist` — a missing optional grammar costs highlighting, not
+   the screen.
+2. `Collapsible("Common Selectors", collapsed=False)` passed the title string
+   as a *child* (Collapsible's first positional is `*children`) →
+   `MountError: Can't mount <class 'str'>`. Fixed to `title=`.
+3. Both `Select`s had their option tuples `(value, label)`-reversed (Textual
+   expects `(label, value)`), so `value="clean"` raised
+   `InvalidSelectValueError` — and the rule-type/text-processing consumers
+   (`event.value == "custom"`, `query_one("#text-processing").value`) would
+   have received display labels. Swapped to `(label, value)`.
+
+**Reachability**: the window is nav-unreachable at HEAD (zero imports outside
+its own file; no screen-registry route, palette entry, or button), but no
+retirement decision exists — ADR-020 in
+Docs/Development/Subscriptions/Subscriptions-Implementation-1.md records it as
+a designed feature that simply was never wired up. Fixed per the ACs;
+wiring it into navigation is out of scope here.
+
+**Test**: `Tests/UI/test_scraper_builder_window.py` — bundle-CSS harness pushes
+the screen, asserts compose succeeds, asserts all four switches mount with
+their defaults, asserts `#text-processing` carries the machine token `clean`,
+and drives `#remove-scripts` True→False asserting the value reaches its
+consumer (`_format_options_code`) both before and after. Born red at HEAD
+`11646bba0` with exactly `AttributeError: 'FormBuilder' object has no
+attribute 'create_switch'` at ScraperBuilderWindow.py:322; green after.
+
+**Files**: tldw_chatbook/UI/ScraperBuilderWindow.py,
+Tests/UI/test_scraper_builder_window.py (new).
+
+**Known pre-existing red (not this task)**:
+`Tests/test_call_from_thread_guard.py` fails on dev/HEAD for
+`UI/Screens/chat_screen.py:3029` (bare `self.call_from_thread(` on a Screen) —
+present byte-identical on origin/dev, untouched by this change.

--- a/tldw_chatbook/UI/ScraperBuilderWindow.py
+++ b/tldw_chatbook/UI/ScraperBuilderWindow.py
@@ -31,7 +31,9 @@ from textual.widgets import (
     TabbedContent,
     TabPane,
     Collapsible,
+    Switch,
 )
+from textual.widgets.text_area import LanguageDoesNotExist
 from textual.reactive import reactive
 from textual.binding import Binding
 from rich.table import Table
@@ -41,7 +43,7 @@ from loguru import logger
 
 #
 # Local Imports
-from ..Widgets.form_components import FormBuilder, FormField, FormFieldSet
+from ..Widgets.form_components import FormField, FormFieldSet
 from ..Web_Scraping.Article_Extractor_Lib import scrape_article_sync as get_page_content
 #
 ########################################################################################################################
@@ -49,6 +51,21 @@ from ..Web_Scraping.Article_Extractor_Lib import scrape_article_sync as get_page
 # Scraper Builder Window
 #
 ########################################################################################################################
+
+
+def _syntax_text_area(**kwargs: Any) -> TextArea:
+    """Build a TextArea, degrading to plain text when a grammar is absent.
+
+    ``TextArea(language=...)`` raises LanguageDoesNotExist at construction
+    time when tree-sitter is installed but the specific grammar package is
+    not (e.g. no ``tree-sitter-html``). A missing optional grammar must cost
+    highlighting, not make the screen unopenable.
+    """
+    try:
+        return TextArea(**kwargs)
+    except LanguageDoesNotExist:
+        kwargs.pop("language", None)
+        return TextArea(**kwargs)
 
 
 class ScraperBuilderWindow(Screen):
@@ -192,7 +209,6 @@ class ScraperBuilderWindow(Screen):
         super().__init__()
         self.url = url or ""
         self.extraction_rules = []
-        self.form_builder = FormBuilder()
         self.page_html = ""
         self.page_text = ""
 
@@ -249,7 +265,7 @@ class ScraperBuilderWindow(Screen):
                 with TabbedContent():
                     # HTML Preview
                     with TabPane("HTML", id="html-preview-tab"):
-                        yield TextArea(
+                        yield _syntax_text_area(
                             id="html-preview",
                             language="html",
                             theme="monokai",
@@ -268,7 +284,7 @@ class ScraperBuilderWindow(Screen):
     def _compose_selector_builder(self) -> ComposeResult:
         """Compose selector builder section."""
         # Quick selector templates
-        with Collapsible("Common Selectors", collapsed=False):
+        with Collapsible(title="Common Selectors", collapsed=False):
             yield from self._create_selector_templates()
 
         # Custom selector testing
@@ -289,12 +305,12 @@ class ScraperBuilderWindow(Screen):
             yield Label("Add as extraction rule:")
             yield Select(
                 options=[
-                    ("title", "Title"),
-                    ("content", "Content"),
-                    ("author", "Author"),
-                    ("date", "Published Date"),
-                    ("image", "Main Image"),
-                    ("custom", "Custom Field"),
+                    ("Title", "title"),
+                    ("Content", "content"),
+                    ("Author", "author"),
+                    ("Published Date", "date"),
+                    ("Main Image", "image"),
+                    ("Custom Field", "custom"),
                 ],
                 id="rule-type-select",
             )
@@ -319,17 +335,17 @@ class ScraperBuilderWindow(Screen):
         with FormFieldSet("Page Processing"):
             yield FormField(
                 "Remove Scripts",
-                self.form_builder.create_switch("remove-scripts", default=True),
+                Switch(value=True, id="remove-scripts"),
             )
 
             yield FormField(
                 "Remove Styles",
-                self.form_builder.create_switch("remove-styles", default=True),
+                Switch(value=True, id="remove-styles"),
             )
 
             yield FormField(
                 "Preserve Links",
-                self.form_builder.create_switch("preserve-links", default=True),
+                Switch(value=True, id="preserve-links"),
             )
 
         with FormFieldSet("Content Filters"):
@@ -343,9 +359,9 @@ class ScraperBuilderWindow(Screen):
             yield Label("Text Processing:")
             yield Select(
                 options=[
-                    ("none", "No processing"),
-                    ("clean", "Clean whitespace"),
-                    ("markdown", "Convert to Markdown"),
+                    ("No processing", "none"),
+                    ("Clean whitespace", "clean"),
+                    ("Convert to Markdown", "markdown"),
                 ],
                 value="clean",
                 id="text-processing",
@@ -354,7 +370,7 @@ class ScraperBuilderWindow(Screen):
         with FormFieldSet("Advanced"):
             yield FormField(
                 "Wait for JavaScript",
-                self.form_builder.create_switch("wait-javascript", default=False),
+                Switch(value=False, id="wait-javascript"),
             )
 
             yield FormField(
@@ -513,7 +529,9 @@ class ScraperBuilderWindow(Screen):
                     {"index": i + 1, "tag": tag_name, "attrs": attrs, "text": text}
                 )
 
-            self.app.call_from_thread(self.display_selector_results, results, len(elements))
+            self.app.call_from_thread(
+                self.display_selector_results, results, len(elements)
+            )
 
         except Exception as e:
             logger.error(f"Error testing selector: {str(e)}")


### PR DESCRIPTION
## Summary

`ScraperBuilderWindow` could never be opened: the filed crash (`FormBuilder.create_switch` — a method that has never existed) turned out to be the first of FOUR compose crashes stacked behind each other; the window had never composed end-to-end in its life.

- `create_switch` call sites → direct `Switch(value=, id=)` composition, mirroring `FormBuilder`'s only other consumer (`SiteConfigSettings`) — review confirmed FormBuilder has no per-widget factories at all, so extending it would have invented a convention
- `TextArea(language="html")` raises `LanguageDoesNotExist` when the tree-sitter HTML grammar isn't installed (true of the project venv) — a narrow helper retries without the language, catching ONLY that exception (review verified highlighting is preserved when the grammar exists)
- `Collapsible("title", ...)` passed the title as a CHILD → `MountError`; now `title=`
- Both Selects had `(value, label)` reversed — the programme's fifth backwards-Select instance — fixed with consumers verified reading machine tokens
- Born-red with the exact filed AttributeError (review reproduced via a no-file-modification importlib harness); the new test drives a switch's value into its consumer both directions
- Honest scope: the window is nav-unreachable (zero references repo-wide; ADR-020 records it designed-but-never-wired, no retirement decision) — user impact is nil until a wire-up, noted for filing

Review: independent pass → MERGE, all seven items reproduced. Review found a SIXTH backwards-Select in `SiteConfigSettings` itself (swallowed by a bare except) — queued for filing along with the repo-wide sweep the recurrence now justifies, and the pre-existing `test_call_from_thread_guard` dev-red the work surfaced (verified red at origin/dev tip in a throwaway worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ScraperBuilderWindow now opens and composes. Previously, pushing the screen crashed during compose due to a call to `FormBuilder.create_switch` (method never existed). We compose `Switch`es directly and fix three follow-on compose errors; a mounted test pins the open and verifies option flow.

**Review notes**
- Replace `FormBuilder.create_switch` with direct `Switch(value=..., id=...)`; remove the `FormBuilder` import/attribute. Matches `SiteConfigSettings` and avoids inventing per-widget factories (TASK-15991 AC #3).
- Add `_syntax_text_area` to retry without `language` on `LanguageDoesNotExist`. If the HTML grammar is missing, highlighting drops but the screen still opens.
- Fix `Collapsible` usage by passing `title=` instead of a child string.
- Correct `Select` option tuples to `(label, value)`; defaults now validate and consumers get machine tokens (e.g., `value="clean"`).
- New test `Tests/UI/test_scraper_builder_window.py`: pushes the screen with bundled CSS, asserts switches mount with defaults, checks `#text-processing == "clean"`, and verifies `#remove-scripts` flows True→False into `_format_options_code`.
- Reachability: the screen is nav-unreachable; no user impact until wired. Known unrelated red test on dev remains untouched.

<sup>Written for commit 03f8dcf80aab42eda318c91783cbbe7fe35a98c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

