### PR TITLE
perf(watchlists): collapse ArticleRow/DayHeader into self-rendering ListItems (TASK-15776)

### DIFF
--- a/Tests/UI/test_watchlists_content_pane.py
+++ b/Tests/UI/test_watchlists_content_pane.py
@@ -1202,7 +1202,8 @@ async def test_opening_an_item_repaints_its_row_in_the_list():
         list_view = pane.query_one("#items-table", ListView)
         for node in list_view.children:
             if isinstance(node, _ArticleRow) and node.item_id_key == str(item_id):
-                return node.children[0].render().plain
+                # task-15776: the row renders itself -- no inner Static.
+                return node.render().plain
         raise AssertionError(f"no rendered row for {item_id!r}")
 
     host = DestinationHarness(app, "watchlists_collections")

--- a/Tests/UI/test_watchlists_inspector.py
+++ b/Tests/UI/test_watchlists_inspector.py
@@ -1455,7 +1455,8 @@ def _queued_indicator_shown(pane: ArticleListPane, row_key: str) -> bool:
     list_view = pane.query_one("#items-table", ListView)
     for node in list_view.children:
         if isinstance(node, _ArticleRow) and node.item_id_key == row_key:
-            return ArticleListPane._QUEUED_GLYPH in node.children[0].render().plain
+            # task-15776: the row renders itself -- no inner Static.
+            return ArticleListPane._QUEUED_GLYPH in node.render().plain
     return False
 
 

--- a/Tests/UI/test_watchlists_items_status_filter.py
+++ b/Tests/UI/test_watchlists_items_status_filter.py
@@ -116,8 +116,8 @@ def _row_texts_by_id(pane: ArticleListPane) -> dict[str, str]:
     out: dict[str, str] = {}
     for node in list_view.children:
         if isinstance(node, _ArticleRow):
-            static = node.children[0]
-            out[node.item_id_key] = static.render().plain
+            # task-15776: the row renders itself -- there is no inner Static.
+            out[node.item_id_key] = node.render().plain
     return out
 
 

--- a/Tests/Watchlists/test_watchlists_article_list.py
+++ b/Tests/Watchlists/test_watchlists_article_list.py
@@ -124,7 +124,7 @@ class ProductionCssArticleListHarness(ArticleListHarness):
 def _row_texts(pane: ArticleListPane) -> list[str]:
     """One plain-text string per ListView node (headers included)."""
     list_view = pane.query_one("#items-table", ListView)
-    return [str(node.query_one(Static).renderable) for node in list_view.children]
+    return [str(node.render()) for node in list_view.children]
 
 
 def _item_rows(pane: ArticleListPane) -> list:
@@ -136,7 +136,7 @@ def _item_rows(pane: ArticleListPane) -> list:
 def _header_texts(pane: ArticleListPane) -> list[str]:
     list_view = pane.query_one("#items-table", ListView)
     return [
-        str(node.query_one(Static).renderable)
+        str(node.render())
         for node in list_view.children
         if node.disabled
     ]
@@ -153,8 +153,8 @@ async def test_unread_row_is_bold_with_dot_and_read_row_is_plain():
         await pilot.pause()
 
         rows = _item_rows(pane)
-        unread_renderable = rows[0].query_one(Static).renderable
-        read_renderable = rows[1].query_one(Static).renderable
+        unread_renderable = rows[0].render()
+        read_renderable = rows[1].render()
 
         assert isinstance(unread_renderable, Text)
         assert pane._UNREAD_DOT in str(unread_renderable)
@@ -184,7 +184,7 @@ async def test_starred_and_queued_rows_show_their_glyphs():
         ]
         await pilot.pause()
 
-        texts = [str(row.query_one(Static).renderable) for row in _item_rows(pane)]
+        texts = [str(row.render()) for row in _item_rows(pane)]
         assert pane._STAR_GLYPH in texts[0]
         assert pane._QUEUED_GLYPH not in texts[0]
         assert pane._QUEUED_GLYPH in texts[1]
@@ -199,7 +199,7 @@ async def test_ingested_row_renders_read_styled_with_a_marker():
         pane.items = [_item(1, status="ingested")]
         await pilot.pause()
 
-        renderable = _item_rows(pane)[0].query_one(Static).renderable
+        renderable = _item_rows(pane)[0].render()
         assert "ingested" in str(renderable)
         assert pane._UNREAD_DOT not in str(renderable)
         assert not [span for span in renderable.spans if "bold" in str(span.style)]
@@ -214,7 +214,7 @@ async def test_hostile_title_renders_as_literal_text():
         pane.items = [_item(1, title="[bold red]x[/]\x1b[31m")]
         await pilot.pause()
 
-        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        rendered = str(_item_rows(pane)[0].render())
         assert "[bold red]x[/]" in rendered
         assert "\x1b" not in rendered
 
@@ -559,7 +559,7 @@ async def test_update_item_status_cell_repaints_in_place_without_recompose():
         assert pane.query_one("#items-table", ListView) is list_view_before, (
             "a status repaint must never recompose the list"
         )
-        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        rendered = str(_item_rows(pane)[0].render())
         assert pane._UNREAD_DOT not in rendered
 
 
@@ -573,11 +573,11 @@ async def test_update_item_queued_cell_toggles_the_glyph_in_place():
 
         pane.update_item_queued_cell(items[0]["id"], True)
         await pilot.pause()
-        assert pane._QUEUED_GLYPH in str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert pane._QUEUED_GLYPH in str(_item_rows(pane)[0].render())
 
         pane.update_item_queued_cell(items[0]["id"], False)
         await pilot.pause()
-        assert pane._QUEUED_GLYPH not in str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert pane._QUEUED_GLYPH not in str(_item_rows(pane)[0].render())
 
 
 async def test_repaints_never_write_back_to_the_stored_item_dict():
@@ -610,7 +610,7 @@ async def test_repaints_never_write_back_to_the_stored_item_dict():
         assert not items[0].get("queued_for_briefing"), (
             "same for the queued flag"
         )
-        rendered = str(_item_rows(pane)[0].query_one(Static).renderable)
+        rendered = str(_item_rows(pane)[0].render())
         assert "· ingested" in rendered and pane._QUEUED_GLYPH in rendered, (
             "and the row itself must still show both"
         )
@@ -630,7 +630,7 @@ async def test_select_and_reveal_selects_and_moves_the_cursor():
         list_view = pane.query_one("#items-table", ListView)
         highlighted = list_view.children[list_view.index]
         assert not highlighted.disabled
-        assert "Article 3" in str(highlighted.query_one(Static).renderable)
+        assert "Article 3" in str(highlighted.render())
 
 
 async def test_filter_change_is_mirrored_for_the_screen():
@@ -702,11 +702,11 @@ async def test_update_item_starred_cell_toggles_the_glyph_in_place():
 
         pane.update_item_starred_cell(items[0]["id"], True)
         await pilot.pause()
-        assert pane._STAR_GLYPH in str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert pane._STAR_GLYPH in str(_item_rows(pane)[0].render())
 
         pane.update_item_starred_cell(items[0]["id"], False)
         await pilot.pause()
-        assert pane._STAR_GLYPH not in str(_item_rows(pane)[0].query_one(Static).renderable)
+        assert pane._STAR_GLYPH not in str(_item_rows(pane)[0].render())
 
         assert not items[0].get("is_flagged"), (
             "display-only: the repaint must not freshen the shared dict "
@@ -799,3 +799,35 @@ def test_render_row_snippet_falls_back_to_content_when_no_preview():
     rendered = str(_render_row(item))
 
     assert item["content"] in rendered
+
+
+async def test_rows_and_headers_are_single_widgets_with_no_children():
+    """task-15776: each `_ArticleRow`/`_DayHeader` IS the widget.
+
+    Task-15462's audit measured ~15-18% of the Watchlists screen push going
+    to widget-count overhead because every row was a `ListItem` wrapping one
+    `Static` -- two DOM nodes, two style computations, two layout passes per
+    row. The collapse makes each row a single self-rendering `ListItem`, so
+    the ListView subtree census equals the row count exactly: no row or
+    header may mount a child widget.
+    """
+    app = ArticleListHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        pane = app.query_one(ArticleListPane)
+        pane.items = [
+            _item(index, published_offset_hours=index * 12 + 1)
+            for index in range(1, 11)
+        ]
+        await pilot.pause()
+
+        list_view = pane.query_one("#items-table", ListView)
+        rows = list(list_view.children)
+        assert rows, "precondition: the feed rendered rows"
+        for node in rows:
+            assert len(node.children) == 0, (
+                f"{node!r} must render its own content, not wrap a child widget"
+            )
+        assert len(list_view.query("*")) == len(rows), (
+            "the ListView subtree must be exactly the rows -- one widget per "
+            "row/header, half the pre-task-15776 census"
+        )

--- a/Tests/Watchlists/test_watchlists_collections_screen.py
+++ b/Tests/Watchlists/test_watchlists_collections_screen.py
@@ -722,8 +722,6 @@ async def test_s_toggles_star_on_the_open_item():
     """`s` stars, then unstars, the open item through the service; the row's
     star repaints in place and the Starred badge catches up through the
     debounced counts path."""
-    from textual.widgets import Static
-
     from tldw_chatbook.UI.Watchlists_Modules.watchlist_tree import STARRED_BUCKET
 
     app = _build_test_app()
@@ -752,7 +750,7 @@ async def test_s_toggles_star_on_the_open_item():
         assert _flagged_value(db, item_id) == 1, "`s` must star the open item"
 
         row_widget = pane._find_row(str(pane.items[0]["id"]))
-        assert pane._STAR_GLYPH in str(row_widget.query_one(Static).renderable), (
+        assert pane._STAR_GLYPH in str(row_widget.render()), (
             "the row's star repaints in place -- no recompose"
         )
 
@@ -1145,7 +1143,7 @@ async def test_a_hostile_item_stars_queues_and_still_renders_inert():
 
         # The row renders the attacks as literal characters, control-stripped.
         row_widget = pane._find_row(str(pane.items[0]["id"]))
-        row_text = str(row_widget.query_one(Static).renderable)
+        row_text = str(row_widget.render())
         assert "[bold red]x[/]" in row_text, "markup-shaped text stays literal"
         assert "\x1b" not in row_text, "no escape sequence survives into a row"
 
@@ -3125,10 +3123,9 @@ async def test_a_hostile_search_query_renders_inert_and_never_raises():
             if len(screen._loaded_items) == 1:
                 break
         await pilot.pause(0.5)  # let the restore recompose land
-        from textual.widgets import Static
 
         row_widget = pane._find_row(str(pane.items[0]["id"]))
-        row_text = str(row_widget.query_one(Static).renderable)
+        row_text = str(row_widget.render())
         assert "[bold red]Evil Feed[/]" in row_text
         assert "[script]" in row_text
 

--- a/Tests/Watchlists/test_watchlists_pagination.py
+++ b/Tests/Watchlists/test_watchlists_pagination.py
@@ -760,7 +760,9 @@ async def test_content_only_backend_match_survives_authoritative_search_load():
         assert [str(item["id"]) for item in pane.displayed_items()] == ["77"]
         article_rows = list(pane.query(".article-row"))
         assert len(article_rows) == 1
-        assert article_rows[0].parent.display is True
+        # task-15776: `.article-row` is the ListItem itself now, so the
+        # display check reads the row directly, not a wrapper parent.
+        assert article_rows[0].display is True
 
 
 @pytest.mark.asyncio

--- a/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
+++ b/Tests/Watchlists/test_watchlists_pane_filter_in_place.py
@@ -110,7 +110,7 @@ def _visible_rows(pane: ArticleListPane) -> list[str]:
     not yield at all when nothing matched.
     """
     return [
-        str(node.query_one(Static).renderable)
+        str(node.render())
         for node in _list_nodes(pane)
         if node.display and not node.disabled
     ]
@@ -118,7 +118,7 @@ def _visible_rows(pane: ArticleListPane) -> list[str]:
 
 def _visible_headers(pane: ArticleListPane) -> list[str]:
     return [
-        str(node.query_one(Static).renderable)
+        str(node.render())
         for node in _list_nodes(pane)
         if node.display and node.disabled
     ]

--- a/backlog/tasks/task-15776 - Watchlists-collapse-ArticleRow-DayHeader-from-a-ListItem-wrapping-a-Static-into-one-widget.md
+++ b/backlog/tasks/task-15776 - Watchlists-collapse-ArticleRow-DayHeader-from-a-ListItem-wrapping-a-Static-into-one-widget.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-15776
 title: 'Watchlists: collapse _ArticleRow/_DayHeader from a ListItem-wrapping-a-Static into one widget'
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-13 12:31'
 labels:
   - perf
@@ -39,14 +39,113 @@ without the structural rewrite.
 
 ## Acceptance Criteria
 
-- [ ] `_ArticleRow`/`_DayHeader` render as a single self-rendering `ListItem`
+- [x] `_ArticleRow`/`_DayHeader` render as a single self-rendering `ListItem`
       instead of a `ListItem` wrapping a child `Static`, removing ~half the
       feed's mounted widgets
-- [ ] Every `.article-row`/`.article-day-header`/`ListItem > Static` CSS
+- [x] Every `.article-row`/`.article-day-header`/`ListItem > Static` CSS
       selector affected by the change is audited and updated; visual
       appearance is unchanged
-- [ ] `_repaint_row`, in-place filtering (task-15460), `j`/`k` cursor
+- [x] `_repaint_row`, in-place filtering (task-15460), `j`/`k` cursor
       skipping, and selection/highlight styling all keep their current
       behavior (tests)
-- [ ] A measured before/after on a 100-item feed shows the predicted
+- [x] A measured before/after on a 100-item feed shows the predicted
       ~15-18% reduction in screen-push cost, recorded in the task notes
+
+## Implementation Plan
+
+1. Audit consumers at HEAD: CSS bundle sources for `.article-row` /
+   `.article-day-header` / `ListItem > Static` selectors; every test and
+   screen site that reaches through a row to its inner `Static`
+   (`query_one(Static)`, `node.children[0]`, `pane.query(".article-row")`).
+2. Born-red pin first: a test asserting each `_ArticleRow`/`_DayHeader` is a
+   single childless widget (ListView subtree census == row count). Red at
+   HEAD.
+3. Before-measures at HEAD with a probe run under the test harness (config
+   isolation via conftest): populate time for a 100-item feed (median of
+   interleavable repeats), widget census, and a compositor
+   `render_strips()` text+style capture of a small deterministic feed
+   (including a highlighted row) saved for parity diffing.
+4. Collapse: `_DayHeader`/`_ArticleRow` become self-rendering `ListItem`
+   subclasses (`render()` returns the row `Text`; classes move onto the
+   ListItem; `_repaint_row` routes through a new `update_content()` that
+   mirrors `Static.update`'s refresh(layout=True) contract).
+5. Re-anchor every consumer from the audit table; re-run the probe for
+   after-numbers and byte-identical parity; run the Watchlists blast-radius
+   suites + ruff.
+
+## Implementation Notes
+
+The collapse is exactly the task's shape: `_DayHeader` and `_ArticleRow`
+are now childless self-rendering `ListItem` subclasses. Each carries its
+`Text` in `_content`, returns it from `render()`, and moves the old inner
+`Static`'s class (`article-day-header` / `article-row`) onto itself. A
+childless `ListItem` declares no `layout`, so Textual's
+`Widget.get_content_height` measures the widget's own render -- the same
+wrapped-`Text` sizing the inner `Static` produced. `_repaint_row` routes
+through a new `_ArticleRow.update_content()` that mirrors `Static.update`
+verbatim (swap renderable, `refresh(layout=True)`, which clears the cached
+content dimensions). Day-header labels are rendered as literal `Text`
+where `Static(label)` used to markup-parse them -- app-derived
+`day_bucket` strings, so no visible change, strictly safer.
+
+**CSS audit**: no selector in any bundle source (`tldw_chatbook/css/`)
+targets `.article-row`, `.article-day-header`, or a `ListItem > Static`
+under `#items-table` -- the only row styling is the generic
+`ListView ListItem` padding/hover/`-highlight` rules plus Textual's own
+`ListView > ListItem` defaults, all anchored on the ListItem itself and
+unaffected. Zero CSS edits needed (verified by grep over `css/**/*.tcss`
+and by the byte-identical production-CSS parity capture below).
+
+**Consumer re-anchoring** (every site that reached through a row to its
+inner `Static`):
+- `article_list.py::_repaint_row`: `row.query_one(Static).update(...)` ->
+  `row.update_content(...)`
+- `Tests/Watchlists/test_watchlists_article_list.py` (helpers + 12 sites),
+  `test_watchlists_pane_filter_in_place.py` (2),
+  `test_watchlists_collections_screen.py` (3):
+  `node.query_one(Static).renderable` -> `node.render()` (same `Text`,
+  spans included; two now-dead local `Static` imports removed)
+- `Tests/UI/test_watchlists_items_status_filter.py`,
+  `test_watchlists_content_pane.py`, `test_watchlists_inspector.py`:
+  `node.children[0].render().plain` -> `node.render().plain`
+- `Tests/Watchlists/test_watchlists_pagination.py`:
+  `pane.query(".article-row")` now matches the row itself, so
+  `.parent.display` -> `.display`
+- The screen (`watchlists_collections_screen.py`) only uses the pane API
+  and needed no change.
+
+**Born-red pin**:
+`test_rows_and_headers_are_single_widgets_with_no_children` (ListView
+subtree census == row count, every node childless) -- failed at HEAD
+`99ecb5890`, green after.
+
+**Measured before/after** (100-article feed in 12 day buckets = 112 rows,
+the audit's shape; median of 21 fresh-app populate runs,
+`pane.items = <100 items>` -> idle, Textual pilot at 120x40):
+- widgets in the ListView subtree: 224 -> 112 (exactly half)
+- populate path: 144.61 ms -> 78.28 ms (-66.3 ms, -45.9% of the pane
+  build). The absolute saving matches task-15462's dose-response
+  prediction (~62 ms), which as a share of the audit's measured 414-479 ms
+  screen push is the predicted ~15-18%; on the pane's own populate path it
+  is a far larger share, since that path is mostly widgets.
+
+**Rendered parity**: normalized per-cell (char, style) captures of
+`compositor.render_strips()` for a deterministic 3-item feed
+(unread+star, reviewed+queued, ingested; two day headers), in both the
+plain and the focused+highlighted state, under BOTH the default-CSS
+harness and the production-bundle harness
+(`ProductionCssArticleListHarness`): all four captures byte-identical
+before vs after.
+
+**Tests**: `Tests/Watchlists/` 668 passed;
+the nine `Tests/UI/test_watchlists_*` suites 255 passed + 1 failed --
+`test_watchlists_select_option_overlays.py::test_a_bordered_compact_select_keeps_its_frame_under_focus_and_hover`,
+a Settings-screen Select-frame pin reproduced identically at unmodified
+HEAD `99ecb5890` in a clean baseline worktree (pre-existing, unrelated).
+`ruff check` clean on all touched files (the 14 `App` F401s in
+`test_watchlists_content_pane.py` are pre-existing at HEAD and untouched);
+`ruff format --check` drift on `article_list.py` is pre-existing at HEAD
+in three untouched hunks -- none of the new code reformats.
+
+**Files**: `tldw_chatbook/UI/Watchlists_Modules/article_list.py` plus the
+seven test files listed above.

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -129,10 +129,23 @@ class _DayHeader(ListItem):
     movement skips disabled children (`action_cursor_down` loops to the next
     enabled node), so `j`/`k` and the arrow keys walk ITEMS only while the
     headers stay visually interleaved.
+
+    task-15776: self-rendering -- the header IS the `ListItem`, no wrapped
+    child `Static`. Half the feed's mounted widgets were wrapper overhead
+    (two DOM nodes, two style computations, two layout passes per row),
+    measured at ~15-18% of the whole Watchlists screen push in task-15462's
+    audit. A childless `ListItem` declares no `layout`, so Textual sizes it
+    from its own `render()` exactly the way it sized the old inner `Static`.
+    The label is app-derived (`day_bucket`) and rendered as literal `Text`,
+    never markup-parsed.
     """
 
     def __init__(self, label: str) -> None:
-        super().__init__(Static(label, classes="article-day-header"), disabled=True)
+        self._content = Text(label)
+        super().__init__(disabled=True, classes="article-day-header")
+
+    def render(self) -> Text:
+        return self._content
 
 
 class _ArticleRow(ListItem):
@@ -152,13 +165,37 @@ class _ArticleRow(ListItem):
     disabled children and knows nothing about `display`, so a hidden row
     that stayed enabled would silently take the cursor (and `j`/`k`) while
     being invisible.
+
+    task-15776: self-rendering, same collapse as `_DayHeader` -- the row IS
+    the `ListItem` and `render()` returns the `_render_row` `Text` directly.
+    Repaints go through `update_content` (the `Static.update` contract:
+    swap the renderable, `refresh(layout=True)`), never through a child
+    widget that no longer exists.
     """
 
     def __init__(self, item: dict[str, Any], *, visible: bool = True) -> None:
         self.item_id_key = str(item.get("id") or "")
         self.display_overrides: dict[str, Any] = {}
-        super().__init__(Static(_render_row(item), classes="article-row"))
+        self._content = _render_row(item)
+        super().__init__(classes="article-row")
         self.set_row_visible(visible)
+
+    def render(self) -> Text:
+        return self._content
+
+    def update_content(self, content: Text) -> None:
+        """Swap the rendered `Text` in place (`_repaint_row`'s sink).
+
+        `refresh(layout=True)` mirrors `Static.update` exactly: it clears
+        the cached content dimensions and relayouts, because a repaint can
+        legitimately change the row's height (a snippet appearing on an
+        item whose full body arrived, for one).
+
+        Args:
+            content: The freshly rendered row.
+        """
+        self._content = content
+        self.refresh(layout=True)
 
     def set_row_visible(self, visible: bool) -> None:
         """Show or hide this row (see the class docstring on `disabled`).
@@ -718,12 +755,7 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
         if item is None:
             return
         row.display_overrides.update(writes)
-        try:
-            row.query_one(Static).update(
-                _render_row({**item, **row.display_overrides})
-            )
-        except NoMatches:
-            return
+        row.update_content(_render_row({**item, **row.display_overrides}))
 
     def update_item_status_cell(self, item_id: Any, status: str) -> None:
         """Repaint one row after a status write.


### PR DESCRIPTION
## Summary

Watchlists' article list built two widgets per row — a `ListItem` wrapping a `Static` — doubling DOM nodes, style computations, and layout passes on the hot populate path. Both row types are now childless self-rendering `ListItem` subclasses: `render()` returns the row `Text`, the inner Static's classes ride the ListItem, and `_repaint_row` routes through an `update_content()` mirroring `Static.update` (review verified cache-invalidation parity in Textual source).

- **Build time 144.6ms → 78.3ms (−45.9%) at 112 rows; widget census 224 → 112** — landing the audit's predicted ~15-18% share of the screen push almost exactly; reviewer re-probed the after-arm live (77.8ms) as corroboration
- Sizing identity verified against Textual 8.2.8's `get_content_height` container branch — the reviewer's own probe compared old-vs-new at three widths INCLUDING wrapped multi-line rows and got byte-identical regions
- Rendered parity: normalized per-cell compositor strips, plain AND focused+highlighted, default CSS AND production bundle — four-way byte-identical; the header label's str→Text handoff is a hardening (markup can no longer be parsed from data, and `day_bucket` strings can't carry brackets anyway)
- CSS audit reconfirmed independently: zero selectors target the collapsed inner Static; consumer adjustments across 6 test files documented in-notes
- Born-red single-widget census pin (reproduced); `Tests/Watchlists/` 668 green + the touched UI suites; the one failure is the known pre-existing Settings-Select frame red

Review: independent pass → MERGE, all eight items verified (perf before-arm recovered from surviving artifacts + decompiled probe bytecode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses Watchlists rows and day headers from a `ListItem` wrapping a `Static` into self-rendering `ListItem`s, halving mounted widgets and cutting populate time by ~46%. Old: `ListItem` + child `Static`; new: the row/header `ListItem` renders its own `Text`. Side effect: day header labels now render as literal text (no markup parsing), and row repaints use `_ArticleRow.update_content()`.

**Migration**
- Read content with `node.render()` instead of `node.query_one(Static).renderable`.
- Stop using `node.children[0]`; use the row/header node directly.
- For `.article-row` visibility, check `row.display` instead of `row.parent.display`.
- Repaint via `_ArticleRow.update_content(Text)`; do not update a child `Static`.

**Performance and parity (TASK-15776)**
- ListView subtree widgets: 224 → 112 on a 100-article/12-bucket page; populate: 144.6 ms → 78.3 ms.
- Sizing, selection/highlight, and filter behavior unchanged (tests cover).
- Header labels render safely as literal `Text`; no user-visible change expected.
- No CSS changes required; no selectors targeted the removed inner `Static`.

<sup>Written for commit ec0354ae529afcdc987635daa73de101ed6f8edf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

