### PR TITLE
chore(notes): trim the dead SyncProfile CRUD surface from NotesSyncService (TASK-15781)

### DIFF
--- a/backlog/tasks/task-15781 - Verify-then-trim-NotesSyncServices-SyncProfile-CRUD-surface.md
+++ b/backlog/tasks/task-15781 - Verify-then-trim-NotesSyncServices-SyncProfile-CRUD-surface.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15781
 title: Verify-then-trim NotesSyncService's SyncProfile CRUD surface
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-13 12:31'
 labels:
@@ -34,14 +34,155 @@ this finding.)
 
 ## Acceptance Criteria
 
-- [ ] Re-verify at implementation time that `SyncProfile`, `get_profile`,
+- [x] Re-verify at implementation time that `SyncProfile`, `get_profile`,
       `list_profiles`, and `sync_with_profile` in `Notes/sync_service.py`
       have zero production callers (grep, not trusting this task's finding
       blind)
-- [ ] If still dead: remove the CRUD surface (with git-log provenance
+- [x] If still dead: remove the CRUD surface (with git-log provenance
       recorded) and its now-orphaned test-only coverage, keeping
       `NotesSyncService.sync_folder` and everything it depends on untouched
-- [ ] If a live caller is found: the task closes as "not dead," with the
+- [x] If a live caller is found: the task closes as "not dead," with the
       caller documented, and no removal happens
-- [ ] `Tests/Notes/` and `Tests/Sync_Interop/` stay green; a final grep
+- [x] `Tests/Notes/` and `Tests/Sync_Interop/` stay green; a final grep
       sweep for the removed names returns no production hits
+
+## Implementation Plan
+
+1. Re-verify reachability of `SyncProfile`, `get_profile`, `list_profiles`,
+   `sync_with_profile` (and their unlisted support machinery --
+   `delete_profile`, `_load_profiles`, `_save_profiles`, `self.profiles`,
+   `config_path`, `sync_profiles.json`) via repo-wide grep across
+   production code, tests, and docs. Confirm `library_screen.py` (the sole
+   production importer of `NotesSyncService`) only calls the constructor
+   and `.sync_folder(...)`. Confirm no test file calls the profile-CRUD
+   methods either (dead-with-no-test, not dead-with-a-test).
+2. Confirm the profile CRUD surface has no DB-layer counterpart (it is a
+   flat `sync_profiles.json` file next to the app config, not a DB table)
+   so there is no schema-orphan question to defer.
+3. Baseline `Tests/Notes/` + `Tests/Sync_Interop/` before touching code.
+4. Trim: remove `SyncProfile`, `get_profile`, `list_profiles`,
+   `sync_with_profile`, `delete_profile`, `_load_profiles`,
+   `_save_profiles` from `Notes/sync_service.py`; strip the now-dead
+   `config_path`/`self.profiles` plumbing from `__init__` (including the
+   local `_get_effective_config_path` import it existed only to feed).
+   Keep `sync_folder`, `get_sync_history`, `get_conflicts_for_session`,
+   `resolve_conflict`, `get_notes_sync_status`, and `sync_engine`
+   untouched.
+5. Re-run `Tests/Notes/` + `Tests/Sync_Interop/`; final grep sweep for the
+   removed names; ruff check/format on the touched file.
+6. Record git-log provenance and evidence table in Implementation Notes.
+
+## Implementation Notes
+
+Re-verified the task's own finding with a fresh repo-wide grep and found the
+dead surface was actually *wider* than the four named symbols: the CRUD
+surface's private support methods (`_load_profiles`, `_save_profiles`,
+`config_path`) and one more public method the task didn't name
+(`delete_profile`) are also unreachable, since their only callers were the
+four already-dead public methods. All of it lived only in
+`tldw_chatbook/Notes/sync_service.py`; no DB table backs it (`SyncProfile`
+round-trips through a flat `sync_profiles.json` file next to the app config,
+not `ChaChaNotes_DB.py`), so there is no schema-orphan question to defer to
+a migration.
+
+### Per-method verdict
+
+| Symbol | Verdict | Evidence |
+|---|---|---|
+| `SyncProfile` (class) | **DEAD** | Zero constructions anywhere outside its own `from_dict`; zero external imports. Two unrelated classes elsewhere (`Sync_Interop.sync_state.SyncProfileState`, `Sync_Interop.sync_profile_status_state.SyncProfileStatusDisplay`) share the `SyncProfile` prefix but are distinct types with no relationship to `Notes/sync_service.py` -- confirmed via `\bSyncProfile\b` word-boundary grep, which returns zero hits post-trim. |
+| `NotesSyncService.get_profile` | **DEAD** | Zero `.get_profile(`/`.list_profiles(`/etc. calls resolve to a `NotesSyncService`/`Notes.sync_service` instance anywhere in `tldw_chatbook/` or `Tests/`. Other `get_profile`/`list_profiles` hits repo-wide are unrelated TTS voice-profile managers, RAG config-profile managers, and the MCP local-control store -- verified by reading each hit's owning class. |
+| `NotesSyncService.list_profiles` | **DEAD** | Same evidence as above. |
+| `NotesSyncService.sync_with_profile` | **DEAD** | Zero callers anywhere, production or test (`sync_with_profile` is a unique-enough string that grep alone is conclusive -- no other symbol collides). |
+| `NotesSyncService.delete_profile` | **DEAD** (not named in the task's AC, found during verification) | Zero callers pointing at `Notes.sync_service`; other `delete_profile` hits are TTS/RAG/MCP profile managers, confirmed unrelated the same way. |
+| `NotesSyncService._load_profiles` | **DEAD-IN-EFFECT** | Called unconditionally from `__init__` (so technically reachable on every `library_screen.py` sync run), but its only effect -- populating `self.profiles` -- had zero remaining readers once the four public accessors above are gone. Kept, it would silently read a JSON file and log a line for a dict nothing ever consults. Removed together with its only consumers. |
+| `NotesSyncService._save_profiles` | **DEAD** | Only called from `delete_profile` and `sync_with_profile`, both dead. |
+| `NotesSyncService.config_path` / `self.profiles` / `__init__`'s `config_path=` kwarg | **DEAD** | Support-only state for the above. No caller anywhere passes `config_path=` to `NotesSyncService(...)` (both production and test construction sites use the 2-arg `notes_service=`/`db=` form), and nothing outside the class reads `.config_path` or `.profiles`. |
+| `NotesSyncService.sync_folder` | **LIVE -- untouched** | Sole method `library_screen.py`'s `_run_library_notes_sync` calls on the `NotesSyncService` it constructs; `library_screen.py` is the sole production importer of the class. |
+| `get_sync_history`, `get_conflicts_for_session`, `resolve_conflict`, `get_notes_sync_status` | **out of AC scope -- left untouched, not investigated** | Unrelated to the `SyncProfile` CRUD surface (they read/write `sync_sessions`/`sync_conflicts`/`notes` DB tables, not the profile JSON file); the task's AC names only the profile-CRUD symbols, so their reachability was not re-verified here. |
+
+### What was trimmed vs preserved
+
+Removed from `tldw_chatbook/Notes/sync_service.py` (138 lines, pure deletion,
+no other file touched): the `SyncProfile` class in full (`to_dict`/
+`from_dict`), and `NotesSyncService.get_profile`, `.list_profiles`,
+`.sync_with_profile`, `.delete_profile`, `._load_profiles`,
+`._save_profiles`. `__init__` lost its `config_path` parameter and the
+`self.config_path` / `self.profiles` / `self._load_profiles()` lines, along
+with the now-pointless local `from ..config import _get_effective_config_path`
+import that existed only to compute the default `sync_profiles.json` path.
+
+Preserved untouched: `sync_folder` (and everything it depends on --
+`sync_engine`, `NotesSyncEngine`, `SyncDirection`, `ConflictResolution`,
+`SyncProgress`), `get_sync_history`, `get_conflicts_for_session`,
+`resolve_conflict`, `get_notes_sync_status`.
+
+No orphaned test-only coverage was found to delete -- a full sweep of
+`Tests/` for `SyncProfile`, `.get_profile(`/`.list_profiles(` against a sync
+instance, `sync_with_profile`, and `delete_profile` (in a `Notes.sync_service`
+context) turned up zero test references. This subset was dead-with-no-test,
+not dead-with-a-test: `Tests/Notes/test_library_notes_sync_integration.py`
+only exercises `sync_folder`, and `Tests/UI/test_library_shell.py`'s
+`_RecordingNotesSyncService` mock only records `sync_folder` calls.
+
+### Git-log provenance
+
+`SyncProfile` and the CRUD methods were part of the file's original add
+(`c137cd54b`). Task-15481 (`13a179c8f`, "chore: trim dead auto-sync loop
+from Notes/sync_service.py") most recently touched this file, removing the
+dead auto-sync scheduler (`create_profile`, `start_auto_sync`,
+`stop_auto_sync`, `stop_all_auto_syncs`) but explicitly leaving `SyncProfile`
+and the rest of the CRUD surface in place as out-of-scope rather than
+verified-live. This task closes that gap.
+
+### Schema implications
+
+None -- `SyncProfile` was never DB-backed. It round-tripped through a flat
+JSON file (`<config dir>/sync_profiles.json`), not a `ChaChaNotes_DB.py`
+table, so there is no orphaned schema/migration to flag. A pre-existing
+`sync_profiles.json` on a user's disk (if one was ever hand-created or
+survived from an older build) simply becomes inert -- nothing reads or
+writes it anymore.
+
+### Documentation note (not acted on, out of AC scope)
+
+`Docs/Features/notes_bidirectional_sync.md` documents the now-removed
+`SyncProfile`/auto-sync surface (its "Sync Profiles" feature bullet, "Creating
+a Sync Profile"/"Using Sync Profiles"/"Auto-Sync" usage walkthrough, and a
+`sync_profiles.json` config example) and also references UI files
+(`notes_sync_widget.py`, `notes_sync_events.py`) that no longer exist in the
+repo -- this doc was already stale before this task (task-15481 removed the
+auto-sync scheduler it also describes) and describes a pre-Library-embed
+standalone Notes sync panel. Per CLAUDE.md's "do not implement anything not
+in the AC" rule, this doc rewrite was left out of scope rather than done
+piecemeal; flagging here in case the owner wants a dedicated doc-refresh
+task.
+
+### Tests
+
+- Baseline (pre-trim, HEAD `edf357154`): `pytest Tests/Notes/ Tests/Sync_Interop/`
+  -> 9 failed, 2656 passed, 5 skipped (209.51s). All 9 failures are in
+  `Tests/Notes/test_note_import_planner.py` (`AttributeError: module 'os' has
+  no attribute 'ScandirIterator'`), unrelated to `sync_service.py` and
+  pre-existing on this environment/Python version.
+- Post-trim: `pytest Tests/Notes/ Tests/Sync_Interop/` -> identical
+  9 failed, 2656 passed, 5 skipped (192.60s) -- same 9 failures, same
+  file/line, zero regressions.
+- Targeted: `pytest Tests/Notes/test_library_notes_sync_integration.py
+  Tests/Notes/test_sync_engine.py Tests/Notes/test_sync_containment.py` ->
+  32 passed.
+- `ruff check tldw_chatbook/Notes/sync_service.py` -> All checks passed
+  (confirms no leftover unused imports from the trim).
+- `ruff format --check tldw_chatbook/Notes/sync_service.py` -> already
+  formatted.
+- Final grep sweep for `SyncProfile`, `.get_profile(`, `.list_profiles(`,
+  `sync_with_profile`, `.delete_profile(`, `_load_profiles`,
+  `_save_profiles`, `sync_profiles.json`, and `NotesSyncService(...
+  config_path=` across `tldw_chatbook/` and `Tests/` -> zero hits pointing at
+  `Notes/sync_service.py`'s removed surface (remaining hits are the
+  unrelated TTS/RAG/MCP profile managers and one unrelated
+  `Voice_Cloning_Window._load_profiles` method, confirmed by owning class).
+
+### Files changed
+
+- `tldw_chatbook/Notes/sync_service.py` -- 138-line deletion (`SyncProfile`
+  class + dead CRUD/support methods), no other lines touched.

--- a/tldw_chatbook/Notes/sync_service.py
+++ b/tldw_chatbook/Notes/sync_service.py
@@ -27,63 +27,6 @@ from ..DB.ChaChaNotes_DB import CharactersRAGDB
 # Classes:
 
 
-class SyncProfile:
-    """Represents a saved sync configuration."""
-
-    def __init__(
-        self,
-        name: str,
-        root_folder: Path,
-        direction: SyncDirection,
-        conflict_resolution: ConflictResolution,
-        extensions: List[str] = None,
-        auto_sync: bool = False,
-        sync_interval: int = 300,
-    ):
-        self.name = name
-        self.root_folder = root_folder
-        self.direction = direction
-        self.conflict_resolution = conflict_resolution
-        self.extensions = extensions or [".md", ".txt"]
-        self.auto_sync = auto_sync
-        self.sync_interval = sync_interval  # seconds
-        self.last_sync: Optional[datetime] = None
-        self.last_session_id: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert profile to dictionary for serialization."""
-        return {
-            "name": self.name,
-            "root_folder": str(self.root_folder),
-            "direction": self.direction.value,
-            "conflict_resolution": self.conflict_resolution.value,
-            "extensions": self.extensions,
-            "auto_sync": self.auto_sync,
-            "sync_interval": self.sync_interval,
-            "last_sync": self.last_sync.isoformat() if self.last_sync else None,
-            "last_session_id": self.last_session_id,
-        }
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SyncProfile":
-        """Create profile from dictionary."""
-        profile = cls(
-            name=data["name"],
-            root_folder=Path(data["root_folder"]),
-            direction=SyncDirection(data["direction"]),
-            conflict_resolution=ConflictResolution(data["conflict_resolution"]),
-            extensions=data.get("extensions", [".md", ".txt"]),
-            auto_sync=data.get("auto_sync", False),
-            sync_interval=data.get("sync_interval", 300),
-        )
-
-        if data.get("last_sync"):
-            profile.last_sync = datetime.fromisoformat(data["last_sync"])
-        profile.last_session_id = data.get("last_session_id")
-
-        return profile
-
-
 class NotesSyncService:
     """High-level service for note synchronization."""
 
@@ -91,7 +34,6 @@ class NotesSyncService:
         self,
         notes_service: NotesInteropService,
         db: CharactersRAGDB,
-        config_path: Optional[Path] = None,
     ):
         """
         Initialize sync service.
@@ -99,90 +41,10 @@ class NotesSyncService:
         Args:
             notes_service: Notes service for database operations
             db: Database instance
-            config_path: Path to store sync profiles and configuration
         """
-        from ..config import _get_effective_config_path
-
         self.notes_service = notes_service
         self.db = db
-        self.config_path = config_path or (
-            _get_effective_config_path().parent / "sync_profiles.json"
-        )
         self.sync_engine = NotesSyncEngine(notes_service, db)
-        self.profiles: Dict[str, SyncProfile] = {}
-        self._load_profiles()
-
-    def _load_profiles(self):
-        """Load sync profiles from configuration file."""
-        if self.config_path.exists():
-            try:
-                with open(self.config_path, "r") as f:
-                    data = json.load(f)
-                    for profile_data in data.get("profiles", []):
-                        profile = SyncProfile.from_dict(profile_data)
-                        self.profiles[profile.name] = profile
-                logger.info(f"Loaded {len(self.profiles)} sync profiles")
-            except Exception as e:
-                logger.error(f"Error loading sync profiles: {e}")
-
-    def _save_profiles(self):
-        """Save sync profiles to configuration file."""
-        try:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            profiles_data = [profile.to_dict() for profile in self.profiles.values()]
-
-            with open(self.config_path, "w") as f:
-                json.dump({"profiles": profiles_data}, f, indent=2)
-
-            logger.info(f"Saved {len(self.profiles)} sync profiles")
-        except Exception as e:
-            logger.error(f"Error saving sync profiles: {e}")
-
-    def delete_profile(self, name: str) -> bool:
-        """Delete a sync profile."""
-        if name in self.profiles:
-            del self.profiles[name]
-            self._save_profiles()
-            return True
-        return False
-
-    def get_profile(self, name: str) -> Optional[SyncProfile]:
-        """Get a sync profile by name."""
-        return self.profiles.get(name)
-
-    def list_profiles(self) -> List[SyncProfile]:
-        """List all sync profiles."""
-        return list(self.profiles.values())
-
-    async def sync_with_profile(
-        self,
-        profile_name: str,
-        user_id: str,
-        progress_callback: Optional[Callable[[SyncProgress], None]] = None,
-    ) -> Tuple[str, SyncProgress]:
-        """Execute sync using a saved profile."""
-        profile = self.profiles.get(profile_name)
-        if not profile:
-            raise ValueError(f"Profile '{profile_name}' not found")
-
-        # Update sync engine with progress callback
-        self.sync_engine.progress_callback = progress_callback
-
-        # Execute sync
-        session_id, progress = await self.sync_engine.sync(
-            root_path=profile.root_folder,
-            user_id=user_id,
-            direction=profile.direction,
-            conflict_resolution=profile.conflict_resolution,
-            extensions=profile.extensions,
-        )
-
-        # Update profile
-        profile.last_sync = datetime.now()
-        profile.last_session_id = session_id
-        self._save_profiles()
-
-        return session_id, progress
 
     async def sync_folder(
         self,


### PR DESCRIPTION
## Summary

The Notes sync service carried a 138-line SyncProfile CRUD surface (the class, get/list/delete/sync_with_profile, JSON profile load/save plumbing, and the `config_path` constructor param) with zero callers anywhere — production or tests. The live sync feature is untouched: `library_screen.py` is the sole production construction site and calls only `sync_folder` (review verified the signature change breaks no caller; the library-shell mocks replace the class wholesale).

- Per-method verdict table with caller evidence; review independently re-ran the dead greps AT BASE (zero external references existed before the deletion, not just after)
- `SyncProfileState`/`SyncProfileStatusDisplay` confirmed unrelated (server-parity sync-v2 subsystem)
- No schema implications — profiles round-tripped through a flat JSON file, never a DB table
- Before/after suite runs identical (9 pre-existing `test_note_import_planner` failures — a Python 3.12 `os.ScandirIterator` patch-target issue — same IDs both sides); 32 targeted + 13 library-shell call-path tests green; collection clean
- Stale `notes_bidirectional_sync.md` docs (documenting the removed surface + two nonexistent widget files) confirmed and queued for the follow-up filing batch

Review: independent pass → MERGE, all claims reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead SyncProfile CRUD surface from NotesSyncService to reduce API surface and maintenance risk. Previously the service loaded/saved profiles in a JSON file and accepted a config_path; now those are gone, while sync_folder and sync-history/conflict APIs remain unchanged. Side effects: the constructor no longer accepts config_path and any existing sync_profiles.json is unused.

**Reviewer notes**
- Deleted: SyncProfile class; get_profile, list_profiles, sync_with_profile, delete_profile; _load_profiles, _save_profiles; config_path/self.profiles plumbing and its config import.
- Kept: sync_folder (the only production call site via library_screen) and sync history/conflict methods.
- Verified zero production or test callers before removal; no signature breaks in live code.
- No DB/schema impact; profiles were file-backed only.
- Tests match baseline; targeted sync tests pass; lints clean.
- Satisfies TASK-15781 acceptance criteria.

**Migration**
- No action required. If any downstream code used the removed APIs, call sync_folder directly.

<sup>Written for commit cea5e15801848bd8a34da9c99279df948d5bf22b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

