### PR TITLE
Agentic document expansion: gated expand_document tool, wired policy, measured 0/8→7/8 (TASK-16174)

### DIFF
--- a/Docs/Development/CHUNKING-IMPLEMENTATION-COMPLETE.md
+++ b/Docs/Development/CHUNKING-IMPLEMENTATION-COMPLETE.md
@@ -1,5 +1,36 @@
 # Chunking Implementation - Complete Summary
 
+> ## ⚠️ Correction (2026-08-15, TASK-16174): parent-document inclusion was never wired
+>
+> This document claims a **parent document inclusion** feature was
+> implemented. It was not. The three `SearchConfig` knobs it names —
+> `include_parent_docs`, `parent_size_threshold`,
+> `parent_inclusion_strategy` — existed as dataclass fields and were
+> written by three shipped RAG profiles, but a grep of the whole
+> repository found **zero reads**: nothing in the retrieval path ever
+> consulted them, so switching them on changed nothing. The
+> `ContextAssembler` class and the
+> `tldw_chatbook/RAG_Search/late_chunking_integration.py` module named
+> below **do not exist in this repository**.
+>
+> TASK-16174 Phase K **retired all three fields** from `SearchConfig` and
+> deleted the nine profile writes. `RAGConfig.from_dict` now filters
+> unknown `[search]` keys with a logged notice, so a saved config that
+> still carries them loads instead of raising `TypeError` — but the
+> `SearchConfig(...)` call shown below now raises `TypeError` if copied.
+>
+> The capability those knobs promised — following a hit into its document
+> — shipped instead as the gated `expand_document` agent tool
+> (`tldw_chatbook/Tools/document_expansion_tool.py`, `[tools]
+> expand_document_enabled`, OFF by default). It is pull-based and
+> per-hit rather than engine-side inclusion during retrieval. Its
+> answer-level measurement is
+> `Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md`.
+>
+> Everything else in this document is left as written and is **not**
+> re-verified by that task.
+
+
 ## Overview
 
 This document summarizes the complete implementation of the template-based chunking system with per-document configuration and late chunking capabilities for the tldw_chatbook RAG pipeline.
@@ -148,6 +179,9 @@ for doc in relevant_docs:
 ```
 
 ### 3. Parent Document Inclusion
+
+> **⚠️ Retired (TASK-16174):** `include_parent_docs` / `parent_size_threshold` / `parent_inclusion_strategy` were never read by any code path and have been deleted from `SearchConfig`; the snippet below no longer runs. See the correction at the top of this file.
+
 
 ```python
 # Configure parent inclusion

--- a/Docs/Development/CHUNKING-IMPLEMENTATION-SUMMARY.md
+++ b/Docs/Development/CHUNKING-IMPLEMENTATION-SUMMARY.md
@@ -1,5 +1,36 @@
 # Template-Based Chunking Implementation Summary
 
+> ## ⚠️ Correction (2026-08-15, TASK-16174): parent-document inclusion was never wired
+>
+> This document claims a **parent document inclusion** feature was
+> implemented. It was not. The three `SearchConfig` knobs it names —
+> `include_parent_docs`, `parent_size_threshold`,
+> `parent_inclusion_strategy` — existed as dataclass fields and were
+> written by three shipped RAG profiles, but a grep of the whole
+> repository found **zero reads**: nothing in the retrieval path ever
+> consulted them, so switching them on changed nothing. The
+> `ContextAssembler` class and the
+> `tldw_chatbook/RAG_Search/late_chunking_integration.py` module named
+> below **do not exist in this repository**.
+>
+> TASK-16174 Phase K **retired all three fields** from `SearchConfig` and
+> deleted the nine profile writes. `RAGConfig.from_dict` now filters
+> unknown `[search]` keys with a logged notice, so a saved config that
+> still carries them loads instead of raising `TypeError` — but the
+> `SearchConfig(...)` call shown below now raises `TypeError` if copied.
+>
+> The capability those knobs promised — following a hit into its document
+> — shipped instead as the gated `expand_document` agent tool
+> (`tldw_chatbook/Tools/document_expansion_tool.py`, `[tools]
+> expand_document_enabled`, OFF by default). It is pull-based and
+> per-hit rather than engine-side inclusion during retrieval. Its
+> answer-level measurement is
+> `Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md`.
+>
+> Everything else in this document is left as written and is **not**
+> re-verified by that task.
+
+
 ## Overview
 We've successfully implemented a comprehensive template-based chunking system with per-document configurations and late chunking capabilities. The system includes parent document inclusion as a RAG pipeline feature rather than a database option, providing maximum flexibility.
 
@@ -37,9 +68,9 @@ We've successfully implemented a comprehensive template-based chunking system wi
   - `/tldw_chatbook/RAG_Search/config_profiles.py` - Updated profiles with new settings
 - **New Settings**:
   - `enable_late_chunking` - Enable late chunking in pipeline
-  - `include_parent_docs` - Enable parent document inclusion
-  - `parent_size_threshold` - Maximum parent document size
-  - `parent_inclusion_strategy` - How to decide on inclusion
+  - `include_parent_docs` - **RETIRED (TASK-16174)**: never read by any code path; deleted from `SearchConfig`
+  - `parent_size_threshold` - **RETIRED (TASK-16174)**: never read by any code path; deleted from `SearchConfig`
+  - `parent_inclusion_strategy` - **RETIRED (TASK-16174)**: never read by any code path; deleted from `SearchConfig`
   - `max_context_size` - Total context size limit
 
 ### 5. Integration Example
@@ -74,6 +105,9 @@ await update_document_chunking_config(
 ```
 
 ### 2. Search with Late Chunking and Parent Inclusion
+
+> **⚠️ Retired (TASK-16174):** `include_parent_docs` / `parent_size_threshold` / `parent_inclusion_strategy` were never read by any code path and have been deleted from `SearchConfig`; the snippet below no longer runs. See the correction at the top of this file.
+
 ```python
 config = {
     'chunking': {

--- a/Docs/Development/CHUNKING-IMPROVE-1.md
+++ b/Docs/Development/CHUNKING-IMPROVE-1.md
@@ -1,5 +1,28 @@
 # Template-Based Chunking with Per-Document Late Chunking Plan
 
+> ## ⚠️ Correction (2026-08-15, TASK-16174): Phase 3 was never wired, and its knobs are retired
+>
+> **Phase 3 (Parent Document Inclusion) below is an unimplemented plan.**
+> Its three config keys — `include_parent_docs`, `parent_size_threshold`,
+> `parent_inclusion_strategy` — did reach `SearchConfig` and three shipped
+> RAG profiles, but nothing in the retrieval path ever read them (grep:
+> zero reads), so they were a user-switchable surface wired to nothing.
+> The `ContextAssembler` class sketched below was never written.
+>
+> TASK-16174 Phase K **retired all three fields**; `RAGConfig.from_dict`
+> now drops unknown `[search]` keys with a logged notice so saved configs
+> still load. `max_context_size`, which appears in the same snippets, is
+> **live** and was not touched.
+>
+> The capability shipped instead as the gated `expand_document` agent tool
+> (`tldw_chatbook/Tools/document_expansion_tool.py`), pull-based and
+> per-hit rather than engine-side. Measurement:
+> `Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md`.
+>
+> The rest of this plan is left as written and is **not** re-verified by
+> that task.
+
+
 ## Overview
 Implement a system that allows per-document chunking configurations with late chunking during RAG retrieval, plus parent document inclusion logic.
 
@@ -52,6 +75,9 @@ def get_chunks_for_document(media_id, default_config):
 ```
 
 ## Phase 3: Parent Document Inclusion (RAG Pipeline Feature)
+
+> **⚠️ Retired (TASK-16174):** `include_parent_docs` / `parent_size_threshold` / `parent_inclusion_strategy` were never read by any code path and have been deleted from `SearchConfig`; the snippet below no longer runs. See the correction at the top of this file.
+
 
 ### 3.1 RAG Pipeline Configuration
 - Add to RAG pipeline config:

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -92,8 +92,13 @@ Select the built-in server's row in Servers mode; its detail pane has a
 **Tool gates** group under the existing enable/expose checkboxes, split
 into two subheadings:
 
-- **Agent built-ins** — the app's own file/note tools (read/list/write a
-  file, glob/grep the workspace, create/update a note).
+- **Agent built-ins** — the app's own file, note and library tools: read /
+  list / write a file, glob / grep the workspace, create / update a note,
+  and **expand a retrieval hit into its document** (`expand_document`,
+  TASK-16174 — it opens the note, media item, conversation or prompt behind
+  a Library search result, so it reads your library and, like every
+  risk-tagged tool, is floored to **Ask**: expect one approval card per
+  call until you set Allow).
 - **Local workspace, web, and Watchlists tools** — a master switch, labeled
   **Local workspace, web, and Watchlists tools (master switch)**, mirroring the
   direct Tools-mode control. `web_deep_search` (multi-query web research that
@@ -337,4 +342,9 @@ a permission the app could not read shows as "Unknown" (never a false
 "Off") in the matrix, the State column, and the inspector alike.
 Verified against ee68f42ed — 2026-08-08 (task-3240): documented the new
 Servers-mode "Tool gates" group (builtin registration switches, at last
-reachable from live navigation) and its two discoverability breadcrumbs.*
+reachable from live navigation) and its two discoverability breadcrumbs.
+Docs pass 2026-08-15 (TASK-16174 fix wave, against the branch's code and
+tests, not a live screen): the "Agent built-ins" enumeration gained the
+eighth gate, `expand_document` — the pane renders one row per
+`_GATEABLE_BUILTINS` entry via `all_tool_gates()`, so the count follows
+that table.*

--- a/Docs/superpowers/plans/2026-08-15-rag-agentic-expansion.md
+++ b/Docs/superpowers/plans/2026-08-15-rag-agentic-expansion.md
@@ -1,0 +1,155 @@
+# TASK-16174: Agentic Document Expansion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retire the inert parent-inclusion knobs, ship one gated `expand_document` tool whose contract works from exactly what retrieval rows carry, wire an expansion policy into the payload the agent actually sees, and answer the evaluation question with a run, not an assumption.
+
+**Architecture:** Four phases in dependency order: K (knob truth — retire + compat), T (the tool), P (the wired policy), E (the oracle measurement + closure). No retrieval behaviour changes anywhere: the gated suite must read 105/105 (+0.000) at the end.
+
+**Tech Stack:** Python 3.11+, dataclass config, the `Tool` ABC + `_GATEABLE_BUILTINS` catalog, pytest, the RAG eval harness corpus.
+
+**Spec:** `Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md` — binds every task; read first.
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-16174-expansion`, branch `feat/rag-16174-agentic-expansion` (off dev `8727a2861`). **cwd resets every Bash block — cd first, EVERY block.**
+- **VENV (none exists yet):** `uv venv .venv --python 3.12 && VIRTUAL_ENV=.venv uv pip install -e ".[dev,embeddings_rag]" "transformers==5.6.2" "torch==2.11.0" "chromadb==1.5.8"`. Assert `.venv/bin/python -c "import tldw_chatbook; print(tldw_chatbook.__file__)"` resolves IN the worktree before any test run; paste the line. If dev added a dep, install it — never rebuild.
+- Never `git stash`; Edit-based restores; single foreground Bash (timeout 600000); do NOT run `Tests/UI/test_library_shell.py` (monolith, failure-to-exit). TCC "Operation not permitted" = stop and report.
+- The app regenerates `css/tldw_cli_modular.tcss` on boot — restore before committing after any live run.
+- Gate: `RAG_EVAL=1 pytest Tests/RAG_Eval/` must read **PASSED 105/105 (+0.000)** in Tasks 1 and 4. A moved cell = STOP and report.
+- Commits reference TASK-16174 and end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; push after every task.
+- API keys in the repo root are FOR AGENT USE (Task 4's live run); never echoed to logs. Pytest runs are network-blocked by default — the live run is a SCRIPT under `Docs/superpowers/qa/`, never a test.
+
+## Verified code anchors (line numbers drift; grep first)
+
+- Knobs: `RAG_Search/simplified/config.py:559-561` (`include_parent_docs`, `parent_size_threshold`, `parent_inclusion_strategy`); profile writes `RAG_Search/config_profiles.py:310-312`, `:347-349`, `:524-526`. Grep-verified 4 occurrences = 1 definition + 3 writes, 0 reads.
+- **Compat hazard (verified):** `SearchConfig(**search_data)` at `config.py:710` (`from_dict`) is a plain dataclass kwargs call over a user-editable dict — a retired key arriving from saved config raises `TypeError`. Phase K MUST filter `search_data` to `dataclasses.fields(SearchConfig)` names with a warn-once log for dropped keys (precedent for hostile-dict defence: `rag_service.py:3689` comment).
+- Row identity: keyword-leg rows carry `source_id` + `provenance.source_type`, media/conversation with `chunk_id: ""` and label snippets (`library_local_rag_search_service.py:1187/:1202`). **Semantic rows (`_semantic_row:1230`): `source_id` = metadata `source_id` || `document_id` || the chroma point id — the real document identity may live in `provenance` extras (`note_id`/`doc_id` are chroma metadata fields). The tool must accept provenance extras as identity fallbacks.**
+- Fetch APIs: `Client_Media_DB_v2.get_media_by_id:6158`, `ChaChaNotes_DB.get_conversation_by_id:7575` (+ messages via the conversation's message APIs), `ChaChaNotes_DB.get_note_by_id:11575`, `Prompts_DB.get_prompt_by_id:2918`.
+- Catalog: `Agents/tool_catalog.py:467` `GateableTool(gate_key, module, class_name, tool_name)`; rows at `:492-516`. Tool ABC + `risk_tags` in `Tools/tool_executor.py` (a risk-tagged tool is floored to `ask`). DB-handle precedent: `Tools/note_management_tools.py`.
+- Provider payload: `Agents/library_rag_tool_provider.py` `_project_row` + the sealing loop bounding `serialized_size(payload)` to `MAX_RESULT_BYTES` — an added per-row key adds bytes; the sealing loop already degrades gracefully, but Task 3 adds a test proving hints survive sealing on a normal payload.
+- Eval corpus: `Tests/RAG_Eval/fixtures/corpus.toml` (172 docs; source_type counts include media 19+8, conversation 13, prompt 6) seeded through production APIs by `Tests/RAG_Eval/harness/ingest.py` (`add_media_with_keywords`, `add_note`, `add_conversation`/`add_message`).
+
+---
+
+### Task 1: Venv + Phase K — retire the knobs, survive saved configs
+
+**Files:**
+- Modify: `tldw_chatbook/RAG_Search/simplified/config.py` (delete 3 fields; filter unknown keys in `from_dict`'s `search_data` path)
+- Modify: `tldw_chatbook/RAG_Search/config_profiles.py` (delete the 3×3 profile writes)
+- Test: `Tests/RAG_Search/test_search_config_compat.py` (new)
+
+**Interfaces (produces):** `SearchConfig` without the three fields; `from_dict` tolerant of unknown search keys (drops + warns once per key). Later tasks rely on nothing else from here.
+
+- [ ] **Step 1:** Build the venv (pinned recipe above); paste import provenance. `backlog task edit 16174 -s "In Progress"` and add `--plan` pointing at spec+plan paths.
+- [ ] **Step 2:** Write the failing tests:
+
+```python
+def test_saved_config_with_retired_parent_keys_loads(caplog):
+    data = {"search": {"include_parent_docs": True, "parent_size_threshold": 5000,
+                       "parent_inclusion_strategy": "size_based", "top_k": 7}}
+    cfg = RAGConfig.from_dict(data)          # must NOT raise TypeError
+    assert cfg.search.top_k == 7
+    assert not hasattr(cfg.search, "include_parent_docs")
+    assert any("include_parent_docs" in r.message for r in caplog.records)
+
+def test_unknown_search_key_is_dropped_with_notice(caplog):
+    cfg = RAGConfig.from_dict({"search": {"never_a_field": 1}})
+    assert not hasattr(cfg.search, "never_a_field")
+
+def test_no_profile_sets_parent_inclusion():
+    import tldw_chatbook.RAG_Search.config_profiles as m
+    src = inspect.getsource(m)
+    assert "include_parent_docs" not in src
+```
+
+- [ ] **Step 3:** Run them: first two FAIL (TypeError / field exists), third FAILS. Paste output.
+- [ ] **Step 4:** Implement: delete the three fields from `SearchConfig`; delete the nine profile lines; in `from_dict`, before `SearchConfig(**search_data)`, filter to `{f.name for f in dataclasses.fields(SearchConfig)}` and `logger.warning` each dropped key once. Apply the same filter pattern ONLY to search_data (other sections are out of scope).
+- [ ] **Step 5:** GREEN. Then the no-reads proof: `grep -rn "include_parent_docs\|parent_size_threshold\|parent_inclusion_strategy" tldw_chatbook/ Tests/` → expect ZERO in tldw_chatbook/, only this task's compat test in Tests/. Fix any test fixture that set them.
+- [ ] **Step 6:** Gate: `RAG_EVAL=1 pytest Tests/RAG_Eval/ -q` → must read PASSED 105/105 (+0.000); plus `pytest Tests/RAG_Search/ -q` counts READ.
+- [ ] **Step 7:** Commit `feat(rag): retire inert parent-inclusion knobs; saved configs survive (TASK-16174)` + trailer. Push.
+
+---
+
+### Task 2: Phase T — the `expand_document` tool
+
+**Files:**
+- Create: `tldw_chatbook/Tools/document_expansion_tool.py`
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (one `GateableTool` row)
+- Test: `Tests/Tools/test_document_expansion_tool.py` (new)
+
+**Interfaces (produces):** class `ExpandDocumentTool(Tool)`, tool name `expand_document`, gate key `expand_document_enabled`; async `execute(source_type: str, source_id: str, chunk_id: str = "", offset: int = 0, max_chars: int | None = None) -> dict`. Return shape (all types): `{"status": "ok"|"not_found"|"unsupported", "source_type", "source_id", "title", "text", "total_size", "window": {"start", "end"}, "truncated": bool, "next_offset": int | None}`. Task 3 consumes the tool name and this shape.
+
+- [ ] **Step 1:** Read `Tools/tool_executor.py` (Tool ABC + `risk_tags`) and `Tools/note_management_tools.py` (DB-handle acquisition precedent). Record in the report how DB paths are resolved there and mirror it.
+- [ ] **Step 2:** Write failing contract tests against real in-memory/scratch DBs (the repo's standard), one per branch:
+
+```python
+async def test_note_expands_to_full_body()            # seeded note; status ok, text == body, truncated False
+async def test_media_label_only_row_expands()         # ONLY source_type+source_id (chunk_id "") — the AC#4 case
+async def test_conversation_returns_role_prefixed_transcript()
+async def test_prompt_expands()
+async def test_over_budget_returns_window_and_next_offset()  # body > max_chars; window head; next_offset set
+async def test_chunk_centred_window_when_chunk_id_known()    # window contains the chunk text, not the head
+async def test_offset_continuation_walks_the_document()      # second call with next_offset returns the next window
+async def test_unknown_id_is_not_found()              # status not_found, no raise
+async def test_semantic_identity_fallbacks()          # provenance extras: note_id/doc_id accepted when source_id is a chroma point id
+def test_tool_is_gated_off_by_default()               # catalog: gate key absent/false -> tool not offered
+def test_tool_carries_risk_tags()                     # floored to ask
+```
+
+- [ ] **Step 3:** Run → all FAIL (module missing). Paste.
+- [ ] **Step 4:** Implement `ExpandDocumentTool`: per-type fetch via the anchors (`get_note_by_id` / `get_media_by_id` / `get_conversation_by_id`+messages / `get_prompt_by_id`); identity resolution order = explicit `source_id`, then provenance-style fallbacks the caller may pass (`note_id`, `doc_id`, `media_id`) — accept them as optional kwargs so an agent can paste a row's provenance verbatim; budget default from a module constant (`DEFAULT_MAX_CHARS = 8000`, cap `HARD_MAX_CHARS = 32000`); truncation window logic exactly as the tests pin. `description` states the contract AND the policy sentence (Task 3 finalises wording). `risk_tags` set (reads user data).
+- [ ] **Step 5:** Catalog row: `GateableTool("expand_document_enabled", "document_expansion_tool", "ExpandDocumentTool", "expand_document")`. Confirm the Settings ▸ Tools screen derives the switch (it derives from `_GATEABLE_BUILTINS` — assert via the existing catalog tests' pattern, and say so in the report).
+- [ ] **Step 6:** GREEN; whole-file ruff; `pytest Tests/Tools/ Tests/Agents/ -q` counts READ (name pre-existing reds if any).
+- [ ] **Step 7:** Commit `feat(tools): gated expand_document tool — chunk-to-document expansion (TASK-16174)` + trailer. Push.
+
+---
+
+### Task 3: Phase P — the policy, wired into what the agent sees
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/library_rag_tool_provider.py` (`_project_row` gains `expand_hint`)
+- Create: `tldw_chatbook/Library/library_expand_policy.py` (pure helper)
+- Modify: `tldw_chatbook/Tools/document_expansion_tool.py` (final `description` policy wording)
+- Test: `Tests/Library/test_library_expand_policy.py`, extend `Tests/Agents/test_library_rag_tool_provider.py`
+
+**Interfaces:**
+- Consumes: Task 2's tool name/shape.
+- Produces: `expand_hint(row: Mapping) -> dict | None` in `library_expand_policy.py` returning `{"expandable": bool, "reason": "label_only"|"truncated_snippet"|"text_bearing"}`; provider rows gain `"expand_hint": {...}` when the hint is not None.
+
+- [ ] **Step 1:** Failing tests:
+
+```python
+def test_media_label_row_hint_is_label_only()         # snippet 'Matched media · pdf' -> expandable True, reason label_only
+def test_conversation_label_row_hint_is_label_only()
+def test_text_bearing_note_row_hint_is_text_bearing() # expandable False
+def test_truncated_semantic_snippet_hint()            # snippet ends mid-sentence at the projection cap -> truncated_snippet
+def test_provider_rows_carry_expand_hint()            # end-to-end through _project_row
+def test_sealed_payload_survives_hints()              # normal 10-row payload with hints stays under MAX_RESULT_BYTES and keeps hints
+```
+
+- [ ] **Step 2:** RED → paste. **Step 3:** Implement: the helper is pure (string/shape inspection only — label detection by the `provenance.source_type` + empty-`chunk_id` + label-prefix triple, never by parsing the label text alone); `_project_row` attaches it; tool `description` final wording: "Expand a retrieval hit into its document. Use when a high-ranked hit is label-only (media/conversation rows) or its snippet is truncated and the answer needs the content. Re-query instead if the hit itself looks irrelevant. Never expand the same source twice — reuse the earlier result." **Step 4:** GREEN; targeted suites counts READ. **Step 5:** Commit `feat(agents): per-row expand hints wire the expansion policy into the payload (TASK-16174)` + trailer. Push.
+
+---
+
+### Task 4: Phase E — the oracle run, the gate, AC#6, closure
+
+**Files:**
+- Create: `Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py` + `questions.toml` + `report.md`
+- Modify: the TASK-16174 task file (ACs + Implementation Notes + Done); `Tests/RAG_Eval/README.md` (arc section)
+
+- [ ] **Step 1:** Author ≥6 questions with fact oracles from `corpus.toml`'s media/conversation docs — each oracle string verified (grep) to appear ONLY in that doc's body, never in titles/labels/notes. Record the verification in `questions.toml` comments.
+- [ ] **Step 2:** `oracle_run.py`: scratch profile seeded via the harness ingest path; the real agent loop (AgentService + the Library retrieval tool + `expand_document`) with a repo-root API key (cheap model, temperature 0); run each question tool-OFF then tool-ON; score = oracle-fact inclusion (case-insensitive substring/regex); print per-question table + total spend. Config-isolation per `lessons-live-verification.md`; CSS bundle restored after.
+- [ ] **Step 3:** Run it. The deliverable is the TABLE, whatever it says — an OFF≥ON result is a finding, not a failure; report honestly either way. Commit the artifacts.
+- [ ] **Step 4:** Gate + batteries: `RAG_EVAL=1 pytest Tests/RAG_Eval/ -q` → PASSED 105/105 (+0.000); `pytest Tests/Library/ Tests/Tools/ Tests/Agents/ Tests/RAG_Search/ -q` counts READ; collection sweep vs merge-base `8727a2861`.
+- [ ] **Step 5:** Close the task file: all 7 ACs against evidence (#5 cites the run artifact; #6 one recorded sentence: independent of reranking, 3502 unpresumed; #7 cites Task 1's grep-zero). Implementation Notes per house style. `Tests/RAG_Eval/README.md` arc section states what shipped + the oracle table. Status Done.
+- [ ] **Step 6:** Commit `docs(backlog): close TASK-16174 on evidence (TASK-16174)` + trailer. Push.
+
+---
+
+## Self-review (plan time)
+
+- **Spec coverage:** K→T1, T→T2, P→T3, E+closure→T4; AC#1/#2 (T2), #3 (T3), #4 (T2 label-only tests + T3 hints), #5 (T4 run), #6 (T4 sentence), #7 (T1). Out-of-scope items untouched.
+- **Placeholder scan:** clean — every test named with its assertion, every decision pre-registered.
+- **Type consistency:** `expand_document`/`ExpandDocumentTool`/`expand_document_enabled` and the return shape identical in T2's Interfaces and T3/T4's consumption; `expand_hint` shape identical in T3's Interfaces and tests.
+- **Ordering:** T1 first so no dead surface coexists with the new tool even transiently; T2 before T3 (hints reference the tool's existence in description wording); T4 last (measures the assembled loop; gate proves zero retrieval change).

--- a/Docs/superpowers/plans/2026-08-15-rag-agentic-expansion.md
+++ b/Docs/superpowers/plans/2026-08-15-rag-agentic-expansion.md
@@ -153,3 +153,29 @@ def test_sealed_payload_survives_hints()              # normal 10-row payload wi
 - **Placeholder scan:** clean — every test named with its assertion, every decision pre-registered.
 - **Type consistency:** `expand_document`/`ExpandDocumentTool`/`expand_document_enabled` and the return shape identical in T2's Interfaces and T3/T4's consumption; `expand_hint` shape identical in T3's Interfaces and tests.
 - **Ordering:** T1 first so no dead surface coexists with the new tool even transiently; T2 before T3 (hints reference the tool's existence in description wording); T4 last (measures the assembled loop; gate proves zero retrieval change).
+
+---
+
+### Task 3b (added 2026-08-15, after Task 3's report): close the identity loop in the payload
+
+**Why (T3's disclosed concern):** the provider row carries `expand_hint`
+but not the `source_type`/`source_id` that `expand_document` REQUIRES —
+for label-only rows `result_id` merely happens to equal `source_id`, and
+the seam is only inferable from label prose. The policy must be
+actionable BY CONTRACT, or Task 4's tool-ON arm measures the model's
+inference ability, not expansion's value.
+
+**Files:** Modify `Agents/library_rag_tool_provider.py` (`_project_row`);
+extend `Tests/Agents/test_library_tool_provider.py`.
+
+- [ ] **Step 1 (RED):** tests: every projected row carries `source_type`
+  and `source_id` matching the service row's `provenance.source_type` /
+  `source_id`; a semantic row additionally carries its non-empty
+  `chunk_id`; a label-only row's `source_id` equals what the row already
+  exposed as `result_id`; the sealed-payload test still passes with the
+  added keys (re-measure the per-row byte cost and state it).
+- [ ] **Step 2:** implement (payload ADDITION only — `expand_hint`'s
+  pinned `{expandable, reason}` interface and all existing keys
+  unchanged). **Step 3:** GREEN + battery counts read. **Step 4:** commit
+  `feat(agents): payload rows carry the identity expand_document requires (TASK-16174)`
+  + trailer; push.

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""TASK-16174 Phase E — the answer-level oracle run.
+
+Runs the REAL Console agent loop (`Agents/agent_service.AgentService` ->
+`Chat.Chat_Functions.chat_api_call` -> api.anthropic.com) over a REAL,
+isolated installation of the retrieval stack (the RAG-eval harness's
+`build_eval_runtime`), once per question per arm:
+
+* **tool-OFF** -- the shipped default posture. `[tools]
+  expand_document_enabled` is absent from the scratch config, so
+  `BuiltinToolProvider` never registers the tool, and the run's
+  `allowed_tools` is `("search_library_rag",)`.
+* **tool-ON** -- the user has switched the gate on. The scratch config is
+  rewritten with `expand_document_enabled = true`, settings are force-
+  reloaded, a fresh provider is built (which is what actually registers
+  the tool), and `allowed_tools` gains `"expand_document"`.
+
+Everything else is byte-identical between the arms: same corpus, same
+index, same retrieval route, same system prompt, same model, same
+temperature, same questions, same order.
+
+**Scoring is mechanical (spec Phase E): no LLM grader.** Each question
+carries a fact-oracle regex verified to appear only inside its target
+document's body (see `questions.toml`). A question scores 1 when the
+oracle matches the run's final answer text, 0 otherwise. An OFF >= ON
+result is a FINDING, reported as it lands.
+
+**The retrieval route is `plain`.** `runtime.service.config.search.
+default_search_mode = "plain"` sends the tool's `mode="rag"` request down
+`LibraryLocalRagSearchService._search_keyword`, the Library's four-seam
+scope-aware keyword path -- the shipped route for a BM25/plain RAG
+profile and the one that emits LABEL-ONLY media/conversation rows
+(`Matched media · document`, `Matched conversation · 1 message`), which is
+the regime this whole arc exists for. Pre-registered in `questions.toml`.
+
+**Isolation** (`backlog/docs/lessons-live-verification.md`). Every app
+import happens after a scratch `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME`/
+`TLDW_CONFIG_PATH`/`TLDW_TEST_MODE` are set, so nothing resolves the real
+profile; `XDG_CACHE_HOME` is deliberately NOT redirected and
+`config.get_model_cache_dir` is repointed at the harness's
+`model_cache_dir()` so the embedding model is read (read-only) from the
+real HuggingFace cache instead of being downloaded -- downloads are
+blocked outright by forcing `huggingface_hub.constants.HF_HUB_OFFLINE`.
+The real `~/.config/tldw_cli/config.toml` is sha256'd before and after and
+the two are compared. The scratch DBs the harness writes are the SAME
+files `expand_document` reads, via `[database] media_db_path /
+chachanotes_db_path / prompts_db_path` overrides in the scratch config --
+the tool resolves its handles through `config.get_*_db_lazy()`, so
+without those overrides it would read the developer's own library.
+
+**Credentials.** The API key is read from the git-excluded repo-root
+`anthropic-api-key.txt` at call time into a local variable, passed to
+`chat_api_call(api_key=...)`, and never printed, logged, or written to any
+config file.
+
+Usage::
+
+    python oracle_run.py --verify-oracles      # corpus checks only, no imports of the app
+    python oracle_run.py --dry-run             # build the runtime + probe retrieval; NO model calls
+    python oracle_run.py --live --confirm-billable
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+WORKTREE = HERE.parents[3]
+QUESTIONS_PATH = HERE / "questions.toml"
+API_KEY_PATH = Path(
+    "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/anthropic-api-key.txt"
+)
+
+#: Cheapest capable model with native tool-calls. Pricing (Anthropic first-party,
+#: cached 2026-06-24): $1.00 / MTok input, $5.00 / MTok output; cache writes
+#: 1.25x input, cache reads 0.1x input.
+MODEL = "claude-haiku-4-5"
+PRICE_IN_PER_MTOK = 1.00
+PRICE_OUT_PER_MTOK = 5.00
+
+#: Identical in both arms and deliberately tool-agnostic: it must not name
+#: `expand_document`, or the ON arm would be measuring an instruction rather
+#: than the tool's own description-borne policy.
+SYSTEM_PROMPT = (
+    "You answer questions using the user's local Library. Use the tools "
+    "available to you to retrieve evidence before you answer. Library search "
+    "is keyword-based: search with a few distinctive terms rather than a "
+    "whole sentence, and retry with different terms if a search returns "
+    "nothing. Base your answer only on evidence you actually retrieved -- if "
+    "you cannot find the fact, say plainly that you could not find it. "
+    "Answer in one or two sentences."
+)
+
+TOP_K = 10
+
+
+# --------------------------------------------------------------------------
+# stdlib-only helpers (safe to run before any app import)
+# --------------------------------------------------------------------------
+
+
+def _load_toml(path: Path) -> dict:
+    import tomllib
+
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def load_questions() -> list[dict]:
+    return list(_load_toml(QUESTIONS_PATH)["question"])
+
+
+def real_home() -> Path:
+    """The user's real home, immune to the scratch `$HOME` this script sets."""
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:  # pragma: no cover - non-POSIX
+        return Path(os.path.expanduser("~"))
+
+
+def sha256_of(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except FileNotFoundError:
+        return None
+
+
+def verify_oracles() -> int:
+    """Mechanically re-check every oracle against the corpus and the questions.
+
+    Prints one line per question and returns a process exit code. This is the
+    check whose recorded output lives in `questions.toml`'s header; it imports
+    nothing from the application.
+    """
+    corpus = _load_toml(WORKTREE / "Tests/RAG_Eval/fixtures/corpus.toml")["doc"]
+    ok = True
+    for question in load_questions():
+        pattern = re.compile(question["oracle"], re.IGNORECASE)
+        content_hits = [d["slug"] for d in corpus if pattern.search(d["content"])]
+        title_hits = [d["slug"] for d in corpus if pattern.search(d["title"])]
+        in_question = bool(pattern.search(question["question"]))
+        good = (
+            content_hits == [question["slug"]] and not title_hits and not in_question
+        )
+        ok = ok and good
+        print(
+            f"{'OK ' if good else 'BAD'} {question['slug']:32s} "
+            f"/{question['oracle']}/ content={content_hits} title={title_hits} "
+            f"in_question={in_question}"
+        )
+    print("ALL OK" if ok else "PROBLEMS")
+    return 0 if ok else 1
+
+
+# --------------------------------------------------------------------------
+# scratch profile
+# --------------------------------------------------------------------------
+
+
+def _config_text(*, media_db: Path, chacha_db: Path, prompts_db: Path, gate_on: bool) -> str:
+    """The scratch `config.toml`.
+
+    `[database]` is what makes `expand_document` (which resolves its handles
+    through `config.get_media_db_lazy()` / `get_chachanotes_db_lazy()` /
+    `get_prompts_db_lazy()`) read the very databases the harness wrote.
+    `[tools]` is the real registration gate `BuiltinToolProvider` consults.
+    """
+    return (
+        "[database]\n"
+        f'media_db_path = "{media_db}"\n'
+        f'chachanotes_db_path = "{chacha_db}"\n'
+        f'prompts_db_path = "{prompts_db}"\n'
+        "\n"
+        "[tools]\n"
+        f"expand_document_enabled = {'true' if gate_on else 'false'}\n"
+    )
+
+
+def prepare_scratch(scratch: Path, *, gate_on: bool) -> dict[str, Path]:
+    """Create the scratch profile and set the isolation env. Call BEFORE imports."""
+    home = scratch / "home"
+    for directory in (home, home / ".config", home / ".local" / "share", scratch / "run"):
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+
+    paths = {
+        "scratch": scratch,
+        "home": home,
+        "config": scratch / "config.toml",
+        "eval": scratch / "eval",
+        "media_db": scratch / "eval" / "eval_media.db",
+        "chacha_db": scratch / "eval" / "eval_chachanotes.db",
+        "prompts_db": scratch / "eval" / "eval_prompts.db",
+        "runs_db": scratch / "run" / "agent_runs.db",
+    }
+    paths["eval"].mkdir(parents=True, exist_ok=True)
+    write_scratch_config(paths, gate_on=gate_on)
+
+    os.environ["HOME"] = str(home)
+    os.environ["XDG_CONFIG_HOME"] = str(home / ".config")
+    os.environ["XDG_DATA_HOME"] = str(home / ".local" / "share")
+    os.environ["TLDW_CONFIG_PATH"] = str(paths["config"])
+    os.environ["TLDW_TEST_MODE"] = "1"
+    # Read by `Tests/RAG_Eval/harness/environment.py` at import to latch
+    # HF_HUB_OFFLINE before huggingface_hub.constants is evaluated.
+    os.environ["RAG_EVAL"] = "1"
+    # NOT set: XDG_CACHE_HOME / HF_HOME / HF_HUB_CACHE. The harness's
+    # `model_cache_dir()` must keep resolving the developer's real
+    # ~/.cache/huggingface/hub (read-only) or the embedding model is a cold
+    # miss -- and downloads are blocked, so it would abort rather than fetch.
+    return paths
+
+
+def write_scratch_config(paths: dict[str, Path], *, gate_on: bool) -> None:
+    paths["config"].write_text(
+        _config_text(
+            media_db=paths["media_db"],
+            chacha_db=paths["chacha_db"],
+            prompts_db=paths["prompts_db"],
+            gate_on=gate_on,
+        ),
+        encoding="utf-8",
+    )
+    os.chmod(paths["config"], 0o600)
+
+
+# --------------------------------------------------------------------------
+# app-facing stages (import the application; must run after prepare_scratch)
+# --------------------------------------------------------------------------
+
+
+def import_app(paths: dict[str, Path]) -> Any:
+    """Import the app, assert provenance and isolation, and block downloads."""
+    if str(WORKTREE) not in sys.path:
+        sys.path.insert(0, str(WORKTREE))
+
+    import tldw_chatbook
+
+    module_file = Path(tldw_chatbook.__file__).resolve()
+    if WORKTREE not in module_file.parents:
+        raise SystemExit(f"tldw_chatbook resolved OUTSIDE the worktree: {module_file}")
+    print(f"[provenance] tldw_chatbook -> {module_file}")
+
+    from tldw_chatbook import config as app_config
+
+    from Tests.RAG_Eval.harness.environment import model_cache_dir
+
+    from huggingface_hub import constants as hf_constants
+
+    hf_constants.HF_HUB_OFFLINE = True
+    cache_dir = model_cache_dir()
+    app_config.get_model_cache_dir = lambda: cache_dir  # type: ignore[assignment]
+    print(f"[isolation] model cache (read-only) -> {cache_dir}")
+    print(f"[isolation] user data dir -> {app_config.get_user_data_dir()}")
+    for label, getter, expected in (
+        ("media", app_config.get_media_db_path, paths["media_db"]),
+        ("chachanotes", app_config.get_chachanotes_db_path, paths["chacha_db"]),
+        ("prompts", app_config.get_prompts_db_path, paths["prompts_db"]),
+    ):
+        resolved = Path(getter())
+        if resolved != expected:
+            raise SystemExit(
+                f"{label} db override did not take: {resolved} != {expected}"
+            )
+    print("[isolation] all three DB paths resolve to the scratch eval DBs")
+    return app_config
+
+
+def build_runtime(paths: dict[str, Path]) -> Any:
+    from Tests.RAG_Eval.harness.goldenset import CORPUS_PATH, load_corpus
+    from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+
+    corpus = load_corpus(CORPUS_PATH)
+    started = time.monotonic()
+    runtime = build_eval_runtime(corpus, paths["eval"])
+    runtime.service.config.search.default_search_mode = "plain"
+    print(
+        f"[runtime] {len(corpus)} corpus docs, indexed="
+        f"{runtime.index_summary['indexed']} in {time.monotonic() - started:.1f}s; "
+        f"route=plain (four-seam keyword path)"
+    )
+    return runtime
+
+
+def build_rag_provider(runtime: Any) -> Any:
+    from tldw_chatbook.Agents.library_rag_tool_provider import LibraryRagToolProvider
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        LibraryLocalRagSearchService,
+    )
+
+    return LibraryRagToolProvider(LibraryLocalRagSearchService(runtime.app))
+
+
+def probe_retrieval(runtime: Any, rag_provider: Any, questions: list[dict]) -> list[dict]:
+    """Run the retrieval tool for every question and inspect the projected rows.
+
+    This is the pre-flight that costs nothing: it establishes that the target
+    document is retrievable at all, that its row is LABEL-ONLY (the regime
+    under measurement), that the row carries the identity `expand_document`
+    requires (TASK-16174 Task 3b), and that the tool can actually fetch it
+    through the config-resolved DB handles. It also records TASK-3b's two
+    pre-registered suspects: (a) a chunked row expanding from the document
+    HEAD because `chunk_start` is absent from the payload, and (b) a semantic
+    `source_id` that is a vector-store point id and so resolves `not_found`.
+    """
+    import asyncio
+
+    from tldw_chatbook.Tools.document_expansion_tool import ExpandDocumentTool
+
+    tool = ExpandDocumentTool()
+    rows_report: list[dict] = []
+    for question in questions:
+        expected_type, expected_id = runtime.slug_to_source[question["slug"]]
+        result = rag_provider.invoke(
+            "search_library_rag", {"query": question["probe_query"], "top_k": TOP_K}
+        )
+        record: dict[str, Any] = {
+            "id": question["id"],
+            "probe_query": question["probe_query"],
+            "slug": question["slug"],
+            "expected": [expected_type, expected_id],
+            "ok": bool(result.ok),
+        }
+        if not result.ok:
+            record["error"] = result.error
+            rows_report.append(record)
+            continue
+        payload = json.loads(result.content)
+        record["returned"] = payload.get("returned")
+        record["rows"] = [
+            {
+                "rank": index,
+                "title": row.get("title"),
+                "snippet": row.get("snippet"),
+                "source_type": row.get("source_type"),
+                "source_id": row.get("source_id"),
+                "chunk_id": row.get("chunk_id", ""),
+                "expand_hint": row.get("expand_hint"),
+            }
+            for index, row in enumerate(payload.get("results") or (), start=1)
+        ]
+        hit = next(
+            (
+                row
+                for row in record["rows"]
+                if row["source_type"] == expected_type and row["source_id"] == expected_id
+            ),
+            None,
+        )
+        record["target_rank"] = hit["rank"] if hit else None
+        record["target_hint"] = hit["expand_hint"] if hit else None
+        record["target_snippet"] = hit["snippet"] if hit else None
+        # Suspect (a): a projected row with a chunk_id expands from offset 0.
+        record["chunked_rows"] = [r["rank"] for r in record["rows"] if r["chunk_id"]]
+        if hit:
+            expansion = asyncio.run(
+                tool.execute(source_type=hit["source_type"], source_id=hit["source_id"])
+            )
+            record["expand_status"] = expansion["status"]
+            record["expand_total_size"] = expansion["total_size"]
+            record["expand_truncated"] = expansion["truncated"]
+            record["oracle_in_expansion"] = bool(
+                re.search(question["oracle"], expansion["text"], re.IGNORECASE)
+            )
+        rows_report.append(record)
+    return rows_report
+
+
+# --------------------------------------------------------------------------
+# the live arms
+# --------------------------------------------------------------------------
+
+
+class SpendRecorder:
+    """Wrap `chat_api_call`, inject the credential, and total the spend."""
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+        self.calls = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cache_write_tokens = 0
+        self.cache_read_tokens = 0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+
+        kwargs.setdefault("api_key", self._api_key)
+        kwargs.setdefault("temp", 0.0)
+        kwargs.setdefault("max_tokens", 1024)
+        response = chat_api_call(**kwargs)
+        self.calls += 1
+        usage = (response or {}).get("usage") or {}
+        if isinstance(usage, dict):
+            self.input_tokens += int(usage.get("input_tokens") or 0)
+            self.output_tokens += int(usage.get("output_tokens") or 0)
+            self.cache_write_tokens += int(usage.get("cache_creation_input_tokens") or 0)
+            self.cache_read_tokens += int(usage.get("cache_read_input_tokens") or 0)
+        return response
+
+    @property
+    def usd(self) -> float:
+        return (
+            self.input_tokens * PRICE_IN_PER_MTOK
+            + self.cache_write_tokens * PRICE_IN_PER_MTOK * 1.25
+            + self.cache_read_tokens * PRICE_IN_PER_MTOK * 0.1
+            + self.output_tokens * PRICE_OUT_PER_MTOK
+        ) / 1_000_000
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "calls": self.calls,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "usd": round(self.usd, 6),
+        }
+
+
+def build_arm(paths: dict[str, Path], rag_provider: Any, chat_call: Any, arm: str) -> tuple[Any, Any, list, list[str]]:
+    """Assemble one arm exactly as `console_chat_controller` does.
+
+    Returns `(service, config, approval_rounds, offered_tool_names)`.
+    """
+    from tldw_chatbook.Agents.agent_models import AgentConfig, RunBudget
+    from tldw_chatbook.Agents.agent_service import AgentService
+    from tldw_chatbook.Agents.builtin_tool_gate import build_builtin_gate
+    from tldw_chatbook.Agents.tool_catalog import (
+        BuiltinToolProvider,
+        ToolCatalogRegistry,
+    )
+    from tldw_chatbook.Chat.console_chat_controller import build_tool_review_hook
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+    gate = build_builtin_gate(None)
+    builtin = BuiltinToolProvider(gate=gate)
+    offered = sorted(entry.name for entry in builtin.list_catalog())
+
+    approval_rounds: list = []
+
+    def request_approvals(pending: list) -> dict[str, str]:
+        approval_rounds.append([row.llm_name for row in pending])
+        decisions: dict[str, str] = {}
+        for row in pending:
+            decisions[row.llm_name] = "approve_session"
+            call_id = str(getattr(row, "call_id", "") or "")
+            if call_id:
+                decisions[call_id] = "approve_session"
+        return decisions
+
+    registry = ToolCatalogRegistry()
+    registry.register_provider(builtin)
+    registry.register_provider(rag_provider)
+
+    service = AgentService(
+        db=AgentRunsDB(paths["runs_db"], client_id=f"rag-16174-{arm}"),
+        registry=registry,
+        chat_call=chat_call,
+        review_tool_calls=build_tool_review_hook(gate, builtin, None, request_approvals),
+    )
+    allowed = ("search_library_rag",)
+    if arm == "on":
+        allowed = ("search_library_rag", "expand_document")
+    config = AgentConfig(
+        model=MODEL,
+        system_prompt=SYSTEM_PROMPT,
+        allowed_tools=allowed,
+        budget=RunBudget(
+            max_steps=14,
+            max_model_turns=8,
+            max_subagents=0,
+            max_wall_seconds=420.0,
+        ),
+        native_tools=True,
+    )
+    return service, config, approval_rounds, offered
+
+
+def run_arm(
+    arm: str,
+    paths: dict[str, Path],
+    rag_provider: Any,
+    questions: list[dict],
+    api_key: str,
+) -> dict[str, Any]:
+    from tldw_chatbook.Agents.agent_models import STEP_TOOL_CALL, STEP_TOOL_RESULT
+
+    recorder = SpendRecorder(api_key)
+    service, config, approval_rounds, offered = build_arm(paths, rag_provider, recorder, arm)
+    print(f"[arm {arm}] builtin catalog offers: {offered}")
+    print(f"[arm {arm}] allowed_tools: {list(config.allowed_tools)}")
+
+    results = []
+    for question in questions:
+        started = time.monotonic()
+        run_id, outcome = service.run_turn(
+            conversation_id=f"rag-16174-{arm}-{question['id']}",
+            messages=[{"role": "user", "content": question["question"]}],
+            config=config,
+            api_endpoint="anthropic",
+        )
+        answer = outcome.final_text or ""
+        hit = bool(re.search(question["oracle"], answer, re.IGNORECASE))
+        calls = [
+            {"name": step.tool_name, "args": step.args}
+            for step in outcome.steps
+            if step.kind == STEP_TOOL_CALL
+        ]
+        tool_results = [
+            {"name": step.tool_name, "result": (step.result or "")[:400]}
+            for step in outcome.steps
+            if step.kind == STEP_TOOL_RESULT
+        ]
+        queries = [
+            str((call.get("args") or {}).get("query") or "")
+            for call in calls
+            if call["name"] == "search_library_rag"
+        ]
+        results.append(
+            {
+                "id": question["id"],
+                "queries": queries,
+                "slug": question["slug"],
+                "oracle": question["oracle"],
+                "hit": hit,
+                "status": outcome.status,
+                "answer": answer,
+                "tool_calls": calls,
+                "tool_results": tool_results,
+                "seconds": round(time.monotonic() - started, 1),
+                "run_id": run_id,
+            }
+        )
+        marker = "HIT " if hit else "miss"
+        names = ",".join(call["name"] for call in calls) or "-"
+        print(f"  [{arm}] {question['id']:24s} {marker} tools={names} status={outcome.status}")
+    return {
+        "arm": arm,
+        "offered_tools": offered,
+        "allowed_tools": list(config.allowed_tools),
+        "approval_rounds": approval_rounds,
+        "results": results,
+        "spend": recorder.snapshot(),
+    }
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def render_table(questions: list[dict], off: dict, on: dict) -> str:
+    by_id_off = {row["id"]: row for row in off["results"]}
+    by_id_on = {row["id"]: row for row in on["results"]}
+    lines = [
+        "| question | target (label-only row) | oracle | tool-OFF | tool-ON | ON tool calls |",
+        "|---|---|---|---|---|---|",
+    ]
+    for question in questions:
+        left = by_id_off[question["id"]]
+        right = by_id_on[question["id"]]
+        calls = ", ".join(call["name"] for call in right["tool_calls"]) or "-"
+        lines.append(
+            f"| `{question['id']}` | `{question['slug']}` ({question['source_type']}) "
+            f"| `/{question['oracle']}/` "
+            f"| {'HIT' if left['hit'] else 'miss'} "
+            f"| {'HIT' if right['hit'] else 'miss'} | {calls} |"
+        )
+    off_score = sum(1 for row in off["results"] if row["hit"])
+    on_score = sum(1 for row in on["results"] if row["hit"])
+    total = len(questions)
+    lines.append(
+        f"| **TOTAL** | | | **{off_score}/{total}** | **{on_score}/{total}** | |"
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verify-oracles", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--confirm-billable", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="run only the first N questions (smoke test)")
+    parser.add_argument("--scratch", default="")
+    parser.add_argument("--out", default=str(HERE / "run-artifacts.json"))
+    args = parser.parse_args()
+
+    if args.verify_oracles:
+        return verify_oracles()
+    if not (args.dry_run or args.live):
+        parser.error("pass --verify-oracles, --dry-run, or --live")
+    if args.live and not args.confirm_billable:
+        parser.error("--live spends real money; pass --confirm-billable too")
+
+    api_key = ""
+    if args.live:
+        api_key = API_KEY_PATH.read_text(encoding="utf-8").strip()
+        if not api_key:
+            raise SystemExit("the repo-root API key file is empty")
+
+    real_config = real_home() / ".config" / "tldw_cli" / "config.toml"
+    before = sha256_of(real_config)
+    print(f"[isolation] real config {real_config} sha256(before)={before}")
+
+    import tempfile
+
+    scratch = Path(args.scratch) if args.scratch else Path(tempfile.mkdtemp(prefix="rag16174-oracle-"))
+    scratch.mkdir(parents=True, exist_ok=True)
+    print(f"[isolation] scratch profile -> {scratch}")
+    paths = prepare_scratch(scratch, gate_on=False)
+
+    questions = load_questions()
+    if args.limit:
+        questions = questions[: args.limit]
+        print(f"[limit] running the first {len(questions)} question(s) only")
+    app_config = import_app(paths)
+    runtime = build_runtime(paths)
+    artifacts: dict[str, Any] = {
+        "model": MODEL,
+        "route": "plain (four-seam keyword path)",
+        "questions": questions,
+        "scratch": str(scratch),
+        "pid": os.getpid(),
+    }
+    try:
+        rag_provider = build_rag_provider(runtime)
+        artifacts["retrieval_probe"] = probe_retrieval(runtime, rag_provider, questions)
+        for record in artifacts["retrieval_probe"]:
+            print(
+                f"  [probe] {record['id']:24s} rank={record.get('target_rank')} "
+                f"hint={(record.get('target_hint') or {}).get('reason')} "
+                f"expand={record.get('expand_status')} "
+                f"oracle_in_expansion={record.get('oracle_in_expansion')} "
+                f"chunked_rows={record.get('chunked_rows')}"
+            )
+
+        if args.live:
+            from tldw_chatbook.config import get_cli_setting, load_settings
+
+            gate_off = get_cli_setting("tools", "expand_document_enabled", False)
+            print(f"[gate] before OFF arm: expand_document_enabled={gate_off!r}")
+            artifacts["off"] = run_arm("off", paths, rag_provider, questions, api_key)
+
+            write_scratch_config(paths, gate_on=True)
+            app_config._invalidate_config_caches()
+            load_settings(force_reload=True)
+            gate_on = get_cli_setting("tools", "expand_document_enabled", False)
+            print(f"[gate] before ON arm: expand_document_enabled={gate_on!r}")
+            if not gate_on:
+                raise SystemExit("the [tools] gate did not flip on; aborting the ON arm")
+            artifacts["on"] = run_arm("on", paths, rag_provider, questions, api_key)
+
+            table = render_table(questions, artifacts["off"], artifacts["on"])
+            artifacts["table"] = table
+            total = artifacts["off"]["spend"]["usd"] + artifacts["on"]["spend"]["usd"]
+            artifacts["total_usd"] = round(total, 6)
+            print("\n" + table)
+            print(f"\nspend OFF: {artifacts['off']['spend']}")
+            print(f"spend ON:  {artifacts['on']['spend']}")
+            print(f"TOTAL USD: {total:.4f}")
+    finally:
+        runtime.close()
+
+    after = sha256_of(real_config)
+    artifacts["real_config_sha256"] = {"before": before, "after": after}
+    print(f"[isolation] real config sha256(after)={after} unchanged={before == after}")
+
+    Path(args.out).write_text(json.dumps(artifacts, indent=2, default=str), encoding="utf-8")
+    print(f"[artifacts] {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/questions.toml
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/questions.toml
@@ -1,0 +1,142 @@
+# TASK-16174 Phase E — the answer-level oracle set.
+#
+# Eight questions over the RAG-eval fixture corpus
+# (`Tests/RAG_Eval/fixtures/corpus.toml`, 172 documents). Each names ONE
+# media or conversation document and carries a FACT ORACLE: a case-
+# insensitive regex that matches inside that document's BODY and nowhere
+# else in the corpus -- not in any title, not in any other document, and
+# not in the question text itself.
+#
+# WHY THE ORACLE MUST AVOID TITLES. The regime this arc was built for is
+# the LABEL-ONLY row: the Library's four-seam keyword path renders a media
+# hit as `Matched media · {type}` and a conversation hit as
+# `Matched conversation · N messages`
+# (`Library/library_local_rag_search_service.py`'s `_media_row`/
+# `_conversation_row`, both with `chunk_id: ""`). The agent sees the TITLE
+# and a label -- never the body. A fact that also appears in the title
+# would be answerable without expansion and would measure nothing.
+#
+# THE ROUTE. The run sets the eval runtime's
+# `config.search.default_search_mode = "plain"`, which routes the tool's
+# `mode="rag"` request through `_search_rag` -> `_search_keyword` (the
+# four-seam scope-aware path) -- the shipped route for a BM25/plain RAG
+# profile, and the one that produces label-only media/conversation rows.
+# Under `hybrid` the engine returns chunk text for every seam and there
+# are no label-only rows to expand, which would measure a different
+# question. This choice is pre-registered here, not chosen after seeing a
+# number.
+#
+# VERIFICATION (mechanical, re-runnable). Every row below was checked with
+# the loop in `oracle_run.py --verify-oracles`, which reports, per oracle:
+# the corpus documents whose CONTENT matches, the documents whose TITLE
+# matches, and whether the QUESTION text matches. The recorded result at
+# authoring time (2026-08-15) was:
+#
+#   OK  media-quillon-antenna          /rescue certification/                        content=['media-quillon-antenna']          title=[] in_question=False
+#   OK  media-pellucid-gauge           /lowest decade/                               content=['media-pellucid-gauge']           title=[] in_question=False
+#   OK  conv-ashgrove-pump             /shimming/                                    content=['conv-ashgrove-pump']             title=[] in_question=False
+#   OK  media-obsidian-lathe           /brinelling/                                  content=['media-obsidian-lathe']           title=[] in_question=False
+#   OK  conv-dunnock-row-cooling       /blown sand/                                  content=['conv-dunnock-row-cooling']       title=[] in_question=False
+#   OK  conv-gatehouse-power           /(?:ninety|90)\s*minutes/                     content=['conv-gatehouse-power']           title=[] in_question=False
+#   OK  media-filling-head-reliability /(?:nine hundred|900)\s+(?:running\s+)?hours/ content=['media-filling-head-reliability'] title=[] in_question=False
+#   OK  media-larkspur-turbine         /starved a bearing/                           content=['media-larkspur-turbine']         title=[] in_question=False
+#
+# Two oracles are alternations rather than literals, decided BEFORE the
+# run: the corpus spells both figures as words ("ninety minutes", "nine
+# hundred running hours") and a model that read the document may
+# legitimately write "90 minutes" / "900 hours". Scoring the numeral as a
+# miss would have measured transcription style, not fact inclusion. Both
+# alternations were re-verified corpus-unique above. Two other candidates
+# were TIGHTENED for the opposite reason: `/shim/` also matched
+# note-fennimore-changeover and conv-drayton-conveyor, and `/starv/` also
+# matched media-mixing-line-strip-report, so each was narrowed to the
+# exact phrase and re-verified.
+#
+# PROBE QUERIES. Each question also carries a `probe_query`: a short,
+# keyword-shaped search string used ONLY by `--dry-run`'s no-model
+# retrieval probe, to establish before any spend that the target document
+# is reachable on this route and that its row really is label-only. The
+# LIVE agent never sees it -- it composes its own queries, and every query
+# it issues is recorded in the run artifact so a retrieval difference
+# between the arms is visible rather than hidden. The probe queries exist
+# because the four-seam keyword path ANDs every token of the query
+# (`build_fts_match_query`), so a full natural-language question matches
+# nothing at all; the shared system prompt therefore tells BOTH arms,
+# identically, that Library search is keyword-based.
+#
+# DISCLOSED LIMITS (spec Phase E): N = 8, one corpus, one model,
+# temperature 0, one run per arm. Oracle-fact inclusion is not answer
+# quality -- an answer can include the fact and still be poor, and a
+# correct paraphrase that avoids the oracle string scores as a miss.
+
+[[question]]
+id = "q1-quillon-access"
+probe_query = "Quillon-6 antenna mast"
+slug = "media-quillon-antenna"
+source_type = "media"
+title = "Quillon-6 antenna mast survey"
+question = "What restriction applies to climbing access on the Quillon-6 antenna mast?"
+oracle = "rescue certification"
+
+[[question]]
+id = "q2-pellucid-lag"
+probe_query = "Pellucid-12 vacuum gauge"
+slug = "media-pellucid-gauge"
+source_type = "media"
+title = "Pellucid-12 vacuum gauge calibration record"
+question = "At which point did the Pellucid-12 vacuum gauge lag when it was calibrated against the reference standard?"
+oracle = "lowest decade"
+
+[[question]]
+id = "q3-ashgrove-seal"
+probe_query = "Ashgrove-2 coolant pump seal"
+slug = "conv-ashgrove-pump"
+source_type = "conversation"
+title = "Chat: the Ashgrove-2 coolant pump seal"
+question = "What kind of seal did maintenance fit to the Ashgrove-2 coolant pump, and what does that save on future seal changes?"
+oracle = "shimming"
+
+[[question]]
+id = "q4-obsidian-bearing"
+probe_query = "Obsidian-3 lathe spindle"
+slug = "media-obsidian-lathe"
+source_type = "media"
+title = "Obsidian-3 lathe spindle teardown"
+question = "What did the front bearing of the Obsidian-3 lathe spindle show when the spindle was pulled after chatter?"
+oracle = "brinelling"
+
+[[question]]
+id = "q5-dunnock-cooling"
+probe_query = "Dunnock Row cabinet"
+slug = "conv-dunnock-row-cooling"
+source_type = "conversation"
+title = "Chat: why the Dunnock Row cabinet is so quiet"
+question = "Why is the Dunnock Row cabinet cooled through its case rather than by drawing air in?"
+oracle = "blown sand"
+
+[[question]]
+id = "q6-gatehouse-ups"
+probe_query = "gate house UPS"
+slug = "conv-gatehouse-power"
+source_type = "conversation"
+title = "Chat: how long the gate house holds up"
+question = "How long does the gate house stay live on its UPS when the incomer drops?"
+oracle = "(?:ninety|90)\\s*minutes"
+
+[[question]]
+id = "q7-filling-head-mtbf"
+probe_query = "filling head reliability"
+slug = "media-filling-head-reliability"
+source_type = "media"
+title = "Filling head reliability study"
+question = "What mean time between failures is quoted for the filling head across the fleet of machines?"
+oracle = "(?:nine hundred|900)\\s+(?:running\\s+)?hours"
+
+[[question]]
+id = "q8-larkspur-lubrication"
+probe_query = "Larkspur-11 lubrication"
+slug = "media-larkspur-turbine"
+source_type = "media"
+title = "Larkspur-11 turbine commissioning walkthrough"
+question = "During the Larkspur-11 turbine commissioning, what was found wrong with one of the automatic lubrication delivery lines?"
+oracle = "starved a bearing"

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md
@@ -18,6 +18,16 @@ harness (`Tests/RAG_Eval/harness/ingest.build_eval_runtime`, the whole
 indexed through the production indexing helper; 166 of 172 indexed — the 6
 prompts have no vector index by design, `UNINDEXED_SOURCE_TYPES`).
 
+> **Two figures here are CONSOLE-OBSERVED, not archived** (final review,
+> finding 8). "166 of 172 indexed" is printed by `oracle_run.py`'s
+> `index_summary` and never persisted to `run-artifacts.json`, and the
+> smoke-run cost below was likewise read off the console; the run's console
+> log was not committed and cannot now be reconstructed. Both are stated as
+> observations, not as artifact-backed numbers. Everything else in this
+> report is recomputable from `run-artifacts.json` (the final review
+> re-derived the spend, the byte costs and the 0/8 → 7/8 score
+> independently, and every one reproduced exactly).
+
 | | |
 |---|---|
 | Model | `claude-haiku-4-5`, temperature 0, non-streaming, `max_tokens=1024` |
@@ -61,8 +71,10 @@ document's BODY, in no title anywhere, and not in its own question text
 | ON | 29 | 87,033 | 2,770 | $0.1009 |
 | **run total** | 54 | 149,696 | 5,390 | **$0.1766** |
 
-A one-question smoke run (both arms) preceded it at **$0.0222**, so the
-whole exercise cost **$0.199**. Priced at `claude-haiku-4-5` list rates
+A one-question smoke run (both arms) preceded it at **$0.0222**
+(console-observed; the smoke run wrote no artifact — see the note above),
+so the whole exercise cost **$0.199**, of which the $0.1766 above is
+artifact-backed. Priced at `claude-haiku-4-5` list rates
 ($1.00/MTok in, $5.00/MTok out); no cache reads or writes were reported.
 The ON arm costs ~33% more — expansion buys the answer, it does not come
 free.
@@ -138,7 +150,15 @@ It does not touch the four-question sub-result above.
 
 Both are therefore **unrefuted rather than refuted**, and remain the first
 things to check if the tool is ever measured on a semantic/hybrid route. A
-follow-up task carries them.
+follow-up task carries them (TASK-16588).
+
+> **Fix-wave update (2026-08-15, after the final review).** Suspect (a)'s
+> *cause* is now fixed, though the *measurement* is not: `_project_row`
+> emits `chunk_start` whenever a row's provenance carries a usable anchor,
+> so a chunked hit no longer expands from the document head by
+> construction. That closes TASK-16588 AC#1 at the unit level only — this
+> run still cannot exercise it, because the `plain` route emits no chunked
+> rows, so AC#3's route measurement stands. Suspect (b) is untouched.
 
 ## Disclosed limits
 

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md
@@ -1,0 +1,192 @@
+# TASK-16174 Phase E — answer-level oracle run (2026-08-15)
+
+**Result: tool-OFF 0/8, tool-ON 7/8.** The gated `expand_document` tool is
+what turns a label-only retrieval hit into an answer; without it the agent
+retrieves the right document, says so, and cannot answer.
+
+Artifacts in this directory: `questions.toml` (the pre-registered question
+set, oracles and their corpus verification), `oracle_run.py` (the run),
+`run-artifacts.json` (every query, tool call, tool result, answer, and the
+spend, verbatim).
+
+## What was run
+
+Real `AgentService` loop -> real `chat_api_call` -> `api.anthropic.com`, over
+a real, isolated installation of the retrieval stack built by the RAG-eval
+harness (`Tests/RAG_Eval/harness/ingest.build_eval_runtime`, the whole
+172-document fixture corpus written through the production writer APIs and
+indexed through the production indexing helper; 166 of 172 indexed — the 6
+prompts have no vector index by design, `UNINDEXED_SOURCE_TYPES`).
+
+| | |
+|---|---|
+| Model | `claude-haiku-4-5`, temperature 0, non-streaming, `max_tokens=1024` |
+| Retrieval route | `plain` — `config.search.default_search_mode = "plain"` sends the tool's `mode="rag"` request down `LibraryLocalRagSearchService._search_keyword`, the four-seam scope-aware keyword path |
+| Questions | 8, fixed, pre-registered in `questions.toml` |
+| Scoring | mechanical fact-oracle regex against the final answer text; no LLM grader |
+| Arms | **OFF** = shipped default (`[tools] expand_document_enabled = false`, `allowed_tools = ("search_library_rag",)`); **ON** = gate flipped true, settings force-reloaded, provider rebuilt, `allowed_tools` gains `"expand_document"` |
+| Everything else | identical: same corpus, index, route, system prompt, model, temperature, question order |
+
+**Why `plain`.** That route is what produces the LABEL-ONLY rows this arc
+exists for: `Matched media · document` / `Matched conversation · 1 message`,
+`chunk_id: ""` (`_media_row`/`_conversation_row`). Under `hybrid` the engine
+returns chunk text for every seam and there is nothing label-only to expand —
+a different question. Pre-registered in `questions.toml`, not chosen after
+seeing a number.
+
+**Why the oracles avoid titles.** The agent sees the row's TITLE and the
+label. Every oracle was grep-verified to appear in exactly one corpus
+document's BODY, in no title anywhere, and not in its own question text
+(re-runnable: `oracle_run.py --verify-oracles`).
+
+## The table
+
+| question | target (label-only row) | oracle | tool-OFF | tool-ON | ON tool calls |
+|---|---|---|---|---|---|
+| `q1-quillon-access` | `media-quillon-antenna` (media) | `/rescue certification/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q2-pellucid-lag` | `media-pellucid-gauge` (media) | `/lowest decade/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q3-ashgrove-seal` | `conv-ashgrove-pump` (conversation) | `/shimming/` | miss | HIT | search_library_rag, expand_document |
+| `q4-obsidian-bearing` | `media-obsidian-lathe` (media) | `/brinelling/` | miss | HIT | search_library_rag, expand_document |
+| `q5-dunnock-cooling` | `conv-dunnock-row-cooling` (conversation) | `/blown sand/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q6-gatehouse-ups` | `conv-gatehouse-power` (conversation) | `/(?:ninety\|90)\s*minutes/` | miss | miss | search_library_rag, search_library_rag |
+| `q7-filling-head-mtbf` | `media-filling-head-reliability` (media) | `/(?:nine hundred\|900)\s+(?:running\s+)?hours/` | miss | HIT | search_library_rag, search_library_rag, search_library_rag, expand_document |
+| `q8-larkspur-lubrication` | `media-larkspur-turbine` (media) | `/starved a bearing/` | miss | HIT | search_library_rag, expand_document |
+| **TOTAL** | | | **0/8** | **7/8** | |
+
+## Spend
+
+| arm | model calls | input tokens | output tokens | USD |
+|---|---|---|---|---|
+| OFF | 25 | 62,663 | 2,620 | $0.0758 |
+| ON | 29 | 87,033 | 2,770 | $0.1009 |
+| **run total** | 54 | 149,696 | 5,390 | **$0.1766** |
+
+A one-question smoke run (both arms) preceded it at **$0.0222**, so the
+whole exercise cost **$0.199**. Priced at `claude-haiku-4-5` list rates
+($1.00/MTok in, $5.00/MTok out); no cache reads or writes were reported.
+The ON arm costs ~33% more — expansion buys the answer, it does not come
+free.
+
+## Attribution: the one ON miss, and the four cleanest OFF misses
+
+Every arm's FIRST search query was byte-identical to the other arm's on all
+eight questions (temperature 0), so the arms are comparable at the point
+retrieval begins.
+
+**`q6` (the single ON miss) is a RETRIEVAL failure, not an expansion
+failure.** Both of its searches returned `status: "empty"` in BOTH arms —
+the model never had a row to expand. The four-seam keyword path ANDs every
+query token (`build_fts_match_query`), and the model's own phrasings
+("gate house UPS incomer drops live duration", "gate house UPS battery
+backup time") over-constrain. The document IS reachable on this route: the
+no-model probe retrieved it at rank 1 for `gate house UPS`. Conditioned on
+the target row actually being returned, the ON arm expanded and answered
+**7 of 7**.
+
+**Four OFF questions saw the label-only row and still scored zero** — q1,
+q3, q4, q8. This is the sub-result that does not depend on any search-
+persistence difference between the arms, and the OFF answers say the
+mechanism out loud, unprompted:
+
+> "I found a reference to a 'Quillon-6 antenna mast survey' document in
+> your Library. However, I can only see that it's a media document and
+> cannot access its full contents through the search results." (q1, OFF)
+
+> "I found a document titled 'Obsidian-3 lathe spindle teardown' in your
+> library, but the search results are only showing the title without the
+> detailed content." (q4, OFF)
+
+On the other three (q2, q5, q7) the ON arm ran one more search than the OFF
+arm and that is what surfaced the row. Disclosed as a confound in the ON
+arm's favour: knowing a hit can be opened plausibly makes the agent persist.
+It does not touch the four-question sub-result above.
+
+## Mechanism evidence
+
+- **The gate is the real one.** The OFF arm's built-in catalog is
+  `['calculator', 'get_current_datetime']`; after the config rewrite +
+  `load_settings(force_reload=True)` the ON arm's is
+  `['calculator', 'expand_document', 'get_current_datetime']`. The tool
+  appears because `BuiltinToolProvider.__init__` read `[tools]
+  expand_document_enabled`, not because the script added it.
+- **The risk-tag floor fired live.** `risk_tags=("reads",)` floors the tool
+  to `ask`, and the run recorded exactly **7 approval rounds in the ON arm
+  (one per `expand_document` call) and 0 in the OFF arm**. A headless run
+  auto-approved them; a real user sees one card per call. That friction is
+  a fact, not a defect.
+- **The payload identity is what the agent used.** All 7 calls passed
+  `source_type` + `source_id` verbatim from `_project_row`'s TASK-16174
+  identity keys — e.g. `{'source_type': 'media', 'source_id': '3'}`,
+  `{'source_type': 'conversation', 'source_id': '287e6e5b-...'}`. No
+  `note_id`/`doc_id` fallback was needed and no call guessed. Task 3b's
+  concern (a policy actionable only by inference would measure inference)
+  does not apply to this run.
+- **Every expansion returned `status: "ok"`.** No `not_found`, no `error`.
+
+## TASK-3b's two pre-registered suspects: neither manifested
+
+- **(a) `chunk_start` absent from the payload, so a chunked row expands from
+  the HEAD.** Not observed. Every projected row in all 8 probes carried an
+  empty `chunk_id` (`chunked_rows` was `[]` for all 8) — the `plain` route
+  emits no chunked rows at all, so no expansion was mis-anchored. The
+  suspect remains live for the `semantic`/`hybrid` routes, which this run
+  does not exercise.
+- **(b) a semantic `source_id` that is a vector-store point id, so a
+  declared-expandable row returns `not_found`.** Not observed, for the same
+  structural reason: the four-seam path's `source_id` is the real database
+  id. Zero `not_found` results, live or in the probe.
+
+Both are therefore **unrefuted rather than refuted**, and remain the first
+things to check if the tool is ever measured on a semantic/hybrid route. A
+follow-up task carries them.
+
+## Disclosed limits
+
+- N = 8, one corpus, one model, one run per arm, temperature 0. No
+  confidence interval is claimed.
+- Oracle-fact inclusion is not answer quality: an answer can contain the
+  fact and still be bad, and a correct paraphrase that avoids the oracle
+  string scores as a miss.
+- One route (`plain`). The semantic/hybrid routes are unmeasured here.
+- Two runtime tools (`search_run_log`, `run_log_slice`) are offered
+  regardless of `allowed_tools` — they are appended as `runtime_schemas`
+  after the allow-list filter in `_run_one`. The OFF arm called
+  `search_run_log` on q3 and q4; it reads the run log, never Library
+  content, so it cannot have supplied an oracle fact, and the OFF arm
+  scored zero regardless. **`q3` OFF ended `status: "stuck"`** (empty final
+  text) after spending its steps on those calls — recorded, not scored
+  differently.
+- The embedding model is read (read-only) from the developer's real
+  HuggingFace cache; downloads were blocked by forcing
+  `huggingface_hub.constants.HF_HUB_OFFLINE = True`.
+
+## Isolation, verified
+
+- Scratch `HOME` / `XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `TLDW_CONFIG_PATH`
+  / `TLDW_TEST_MODE=1`, all set BEFORE any application import.
+- `[database] media_db_path / chachanotes_db_path / prompts_db_path` in the
+  scratch config point at the harness's scratch DBs, and the run asserts
+  `config.get_*_db_path()` resolves to exactly those three files — this is
+  what makes `expand_document` (which resolves handles through
+  `config.get_*_db_lazy()`) read the eval corpus rather than the
+  developer's own library.
+- Real config `~/.config/tldw_cli/config.toml` sha256
+  `42e2f42de95915f59fcc7c36751c2cc041cb0e4ddda9b324668683a270d7ecc0`
+  **before and after — unchanged.**
+- `tldw_chatbook` import provenance asserted inside the worktree.
+- The API key was read from the git-excluded repo-root file at call time,
+  passed as `chat_api_call(api_key=...)`, and never printed, logged, or
+  written to any config.
+- No TUI was launched, so `css/tldw_cli_modular.tcss` was never
+  regenerated (`git status` clean apart from this directory).
+
+## Reproducing
+
+```
+.venv/bin/python Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py --verify-oracles
+.venv/bin/python Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py --dry-run
+.venv/bin/python Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py --live --confirm-billable
+```
+
+`--dry-run` builds the whole runtime and probes retrieval with zero model
+calls; `--live` refuses to run without `--confirm-billable`.

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/run-artifacts.json
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/run-artifacts.json
@@ -1,0 +1,1140 @@
+{
+  "model": "claude-haiku-4-5",
+  "route": "plain (four-seam keyword path)",
+  "questions": [
+    {
+      "id": "q1-quillon-access",
+      "probe_query": "Quillon-6 antenna mast",
+      "slug": "media-quillon-antenna",
+      "source_type": "media",
+      "title": "Quillon-6 antenna mast survey",
+      "question": "What restriction applies to climbing access on the Quillon-6 antenna mast?",
+      "oracle": "rescue certification"
+    },
+    {
+      "id": "q2-pellucid-lag",
+      "probe_query": "Pellucid-12 vacuum gauge",
+      "slug": "media-pellucid-gauge",
+      "source_type": "media",
+      "title": "Pellucid-12 vacuum gauge calibration record",
+      "question": "At which point did the Pellucid-12 vacuum gauge lag when it was calibrated against the reference standard?",
+      "oracle": "lowest decade"
+    },
+    {
+      "id": "q3-ashgrove-seal",
+      "probe_query": "Ashgrove-2 coolant pump seal",
+      "slug": "conv-ashgrove-pump",
+      "source_type": "conversation",
+      "title": "Chat: the Ashgrove-2 coolant pump seal",
+      "question": "What kind of seal did maintenance fit to the Ashgrove-2 coolant pump, and what does that save on future seal changes?",
+      "oracle": "shimming"
+    },
+    {
+      "id": "q4-obsidian-bearing",
+      "probe_query": "Obsidian-3 lathe spindle",
+      "slug": "media-obsidian-lathe",
+      "source_type": "media",
+      "title": "Obsidian-3 lathe spindle teardown",
+      "question": "What did the front bearing of the Obsidian-3 lathe spindle show when the spindle was pulled after chatter?",
+      "oracle": "brinelling"
+    },
+    {
+      "id": "q5-dunnock-cooling",
+      "probe_query": "Dunnock Row cabinet",
+      "slug": "conv-dunnock-row-cooling",
+      "source_type": "conversation",
+      "title": "Chat: why the Dunnock Row cabinet is so quiet",
+      "question": "Why is the Dunnock Row cabinet cooled through its case rather than by drawing air in?",
+      "oracle": "blown sand"
+    },
+    {
+      "id": "q6-gatehouse-ups",
+      "probe_query": "gate house UPS",
+      "slug": "conv-gatehouse-power",
+      "source_type": "conversation",
+      "title": "Chat: how long the gate house holds up",
+      "question": "How long does the gate house stay live on its UPS when the incomer drops?",
+      "oracle": "(?:ninety|90)\\s*minutes"
+    },
+    {
+      "id": "q7-filling-head-mtbf",
+      "probe_query": "filling head reliability",
+      "slug": "media-filling-head-reliability",
+      "source_type": "media",
+      "title": "Filling head reliability study",
+      "question": "What mean time between failures is quoted for the filling head across the fleet of machines?",
+      "oracle": "(?:nine hundred|900)\\s+(?:running\\s+)?hours"
+    },
+    {
+      "id": "q8-larkspur-lubrication",
+      "probe_query": "Larkspur-11 lubrication",
+      "slug": "media-larkspur-turbine",
+      "source_type": "media",
+      "title": "Larkspur-11 turbine commissioning walkthrough",
+      "question": "During the Larkspur-11 turbine commissioning, what was found wrong with one of the automatic lubrication delivery lines?",
+      "oracle": "starved a bearing"
+    }
+  ],
+  "scratch": "/var/folders/p_/x47tgtn57cv43r7yxxn40tyh0000gn/T/rag16174-oracle-35z6i0ck",
+  "pid": 55829,
+  "retrieval_probe": [
+    {
+      "id": "q1-quillon-access",
+      "probe_query": "Quillon-6 antenna mast",
+      "slug": "media-quillon-antenna",
+      "expected": [
+        "media",
+        "3"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Quillon-6 antenna mast survey",
+          "snippet": "Matched media \u00b7 document",
+          "source_type": "media",
+          "source_id": "3",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched media \u00b7 document",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 295,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q2-pellucid-lag",
+      "probe_query": "Pellucid-12 vacuum gauge",
+      "slug": "media-pellucid-gauge",
+      "expected": [
+        "media",
+        "5"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Pellucid-12 vacuum gauge calibration record",
+          "snippet": "Matched media \u00b7 document",
+          "source_type": "media",
+          "source_id": "5",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched media \u00b7 document",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 317,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q3-ashgrove-seal",
+      "probe_query": "Ashgrove-2 coolant pump seal",
+      "slug": "conv-ashgrove-pump",
+      "expected": [
+        "conversation",
+        "287e6e5b-6bca-4095-b9c5-d392e4c345bb"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Chat: the Ashgrove-2 coolant pump seal",
+          "snippet": "Matched conversation \u00b7 1 message",
+          "source_type": "conversation",
+          "source_id": "287e6e5b-6bca-4095-b9c5-d392e4c345bb",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched conversation \u00b7 1 message",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 299,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q4-obsidian-bearing",
+      "probe_query": "Obsidian-3 lathe spindle",
+      "slug": "media-obsidian-lathe",
+      "expected": [
+        "media",
+        "2"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Obsidian-3 lathe spindle teardown",
+          "snippet": "Matched media \u00b7 document",
+          "source_type": "media",
+          "source_id": "2",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched media \u00b7 document",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 289,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q5-dunnock-cooling",
+      "probe_query": "Dunnock Row cabinet",
+      "slug": "conv-dunnock-row-cooling",
+      "expected": [
+        "conversation",
+        "fefb5e7c-6d9a-4e87-bdc3-0605a7e2844e"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Chat: why the Dunnock Row cabinet is so quiet",
+          "snippet": "Matched conversation \u00b7 1 message",
+          "source_type": "conversation",
+          "source_id": "fefb5e7c-6d9a-4e87-bdc3-0605a7e2844e",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched conversation \u00b7 1 message",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 511,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q6-gatehouse-ups",
+      "probe_query": "gate house UPS",
+      "slug": "conv-gatehouse-power",
+      "expected": [
+        "conversation",
+        "4ae365d0-9d44-4180-a4ee-106874e7a7a4"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Chat: how long the gate house holds up",
+          "snippet": "Matched conversation \u00b7 1 message",
+          "source_type": "conversation",
+          "source_id": "4ae365d0-9d44-4180-a4ee-106874e7a7a4",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched conversation \u00b7 1 message",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 379,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q7-filling-head-mtbf",
+      "probe_query": "filling head reliability",
+      "slug": "media-filling-head-reliability",
+      "expected": [
+        "media",
+        "42"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Filling head reliability study",
+          "snippet": "Matched media \u00b7 document",
+          "source_type": "media",
+          "source_id": "42",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched media \u00b7 document",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 381,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    },
+    {
+      "id": "q8-larkspur-lubrication",
+      "probe_query": "Larkspur-11 lubrication",
+      "slug": "media-larkspur-turbine",
+      "expected": [
+        "media",
+        "20"
+      ],
+      "ok": true,
+      "returned": 1,
+      "rows": [
+        {
+          "rank": 1,
+          "title": "Larkspur-11 turbine commissioning walkthrough",
+          "snippet": "Matched media \u00b7 document",
+          "source_type": "media",
+          "source_id": "20",
+          "chunk_id": "",
+          "expand_hint": {
+            "expandable": true,
+            "reason": "label_only"
+          }
+        }
+      ],
+      "target_rank": 1,
+      "target_hint": {
+        "expandable": true,
+        "reason": "label_only"
+      },
+      "target_snippet": "Matched media \u00b7 document",
+      "chunked_rows": [],
+      "expand_status": "ok",
+      "expand_total_size": 4924,
+      "expand_truncated": false,
+      "oracle_in_expansion": true
+    }
+  ],
+  "off": {
+    "arm": "off",
+    "offered_tools": [
+      "calculator",
+      "get_current_datetime"
+    ],
+    "allowed_tools": [
+      "search_library_rag"
+    ],
+    "approval_rounds": [],
+    "results": [
+      {
+        "id": "q1-quillon-access",
+        "queries": [
+          "Quillon-6 antenna mast climbing access restriction",
+          "Quillon-6 antenna mast"
+        ],
+        "slug": "media-quillon-antenna",
+        "oracle": "rescue certification",
+        "hit": false,
+        "status": "done",
+        "answer": "I found a reference to a \"Quillon-6 antenna mast survey\" document in your Library. However, I can only see that it's a media document and cannot access its full contents through the search results. \n\nTo get the specific information about climbing access restrictions on the Quillon-6 antenna mast, you would need to:\n1. Open the \"Quillon-6 antenna mast survey\" document directly from your Library\n2. Search within that document for terms like \"climbing,\" \"access,\" or \"restriction\"\n\nCould you provide the document or share the relevant section that contains information about the climbing restrictions?",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Quillon-6 antenna mast climbing access restriction"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Quillon-6 antenna mast"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Quillon-6 antenna mast climbing access restriction\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Quillon-6 antenna mast\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"3\",\"title\":\"Quillon-6 antenna mast survey\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"3\"}]}"
+          }
+        ],
+        "seconds": 4.0,
+        "run_id": "0ac4e2a0b45e43e091507ab0bea7e8cb"
+      },
+      {
+        "id": "q2-pellucid-lag",
+        "queries": [
+          "Pellucid-12 vacuum gauge calibration reference standard lag"
+        ],
+        "slug": "media-pellucid-gauge",
+        "oracle": "lowest decade",
+        "hit": false,
+        "status": "done",
+        "answer": "I don't have any information in my Library about the Pellucid-12 vacuum gauge or its calibration characteristics. The search returned no results.\n\nCould you provide more context about this gauge? For example:\n- Do you have documentation or notes about the Pellucid-12 that you'd like me to reference?\n- Is this from a specific technical report, manual, or experiment?\n- Do you remember approximately when this calibration was performed?\n\nWith more details, I may be able to help you find or recall the specific point at which the lag occurred.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Pellucid-12 vacuum gauge calibration reference standard lag"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Pellucid-12 vacuum gauge calibration reference standard lag\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 3.1,
+        "run_id": "98f12d3c5fd1461bbcef525e1382ee85"
+      },
+      {
+        "id": "q3-ashgrove-seal",
+        "queries": [
+          "Ashgrove-2 coolant pump seal maintenance",
+          "Ashgrove-2 coolant pump seal mechanical carbon",
+          "Ashgrove-2 pump seal change maintenance cost"
+        ],
+        "slug": "conv-ashgrove-pump",
+        "oracle": "shimming",
+        "hit": false,
+        "status": "stuck",
+        "answer": "",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Ashgrove-2 coolant pump seal maintenance"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Ashgrove-2 coolant pump seal mechanical carbon",
+              "top_k": 5
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Ashgrove-2 pump seal change maintenance cost"
+            }
+          },
+          {
+            "name": "search_run_log",
+            "args": {
+              "contains": "Ashgrove-2 coolant pump seal",
+              "scope": "conversation"
+            }
+          },
+          {
+            "name": "search_run_log",
+            "args": {
+              "contains": "Ashgrove-2",
+              "scope": "conversation",
+              "context": 5
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Ashgrove-2 coolant pump seal maintenance\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"287e6e5b-6bca-4095-b9c5-d392e4c345bb\",\"title\":\"Chat: the Ashgrove-2 coolant pump seal\",\"snippet\":\"Matched conversation \u00b7 1 message\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\""
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Ashgrove-2 coolant pump seal mechanical carbon\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Ashgrove-2 pump seal change maintenance cost\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_run_log",
+            "result": "Searched 1 of 1 run(s) in this conversation.\n\n[this run]\nrecord 000001 [model]\nI'll search for information about the Ashgrove-2 coolant pump seal and maintenance details.\n\n[this run]\nrecord 000002 [tool_call/search_library_rag]\n{\"query\": \"Ashgrove-2 coolant pump seal maintenance\"}\n\n[this run]\nrecord 000003 [tool_result/search_library_rag/ok]\n{\"status\":\"ready\",\"query\":\"Ashgrove-2 coolant pump seal "
+          },
+          {
+            "name": "search_run_log",
+            "result": "Searched 1 of 1 run(s) in this conversation.\n\n[this run]\nrecord 000001 [model]\nI'll search for information about the Ashgrove-2 coolant pump seal and maintenance details.\n\n[this run]\nrecord 000002 [tool_call/search_library_rag]\n{\"query\": \"Ashgrove-2 coolant pump seal maintenance\"}\n\n[this run]\nrecord 000003 [tool_result/search_library_rag/ok]\n{\"status\":\"ready\",\"query\":\"Ashgrove-2 coolant pump seal "
+          }
+        ],
+        "seconds": 5.9,
+        "run_id": "9b170749e0ac4ee080602eaca1e670ad"
+      },
+      {
+        "id": "q4-obsidian-bearing",
+        "queries": [
+          "Obsidian-3 lathe spindle front bearing chatter pulled",
+          "Obsidian-3 front bearing damage wear chatter spindle pulled",
+          "Obsidian-3 spindle bearing"
+        ],
+        "slug": "media-obsidian-lathe",
+        "oracle": "brinelling",
+        "hit": false,
+        "status": "done",
+        "answer": "I found a document titled \"Obsidian-3 lathe spindle teardown\" in your library, but the search results are only showing the title without the detailed content. Unfortunately, the library search isn't returning the specific details about what the front bearing showed. \n\nThe document appears to be a media file (likely a PDF or image document) that contains the information you're looking for, but I don't have direct access to view its full contents through the search results.\n\nCould you either:\n1. Share the specific details from that document, or\n2. Provide more context about what you remember from the teardown?\n\nThis would help me give you the accurate answer about what the front bearing showed when the spindle was pulled after chatter.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Obsidian-3 lathe spindle front bearing chatter pulled"
+            }
+          },
+          {
+            "name": "search_run_log",
+            "args": {
+              "contains": "Obsidian-3 lathe spindle front bearing chatter"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Obsidian-3 front bearing damage wear chatter spindle pulled"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Obsidian-3 spindle bearing"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Obsidian-3 lathe spindle front bearing chatter pulled\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"2\",\"title\":\"Obsidian-3 lathe spindle teardown\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"2\"}]}"
+          },
+          {
+            "name": "search_run_log",
+            "result": "record 000002 [tool_call/search_library_rag]\n{\"query\": \"Obsidian-3 lathe spindle front bearing chatter pulled\"}\n\nrecord 000003 [tool_result/search_library_rag/ok]\n{\"status\":\"ready\",\"query\":\"Obsidian-3 lathe spindle front bearing chatter pulled\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"2\",\"title\":\"Obsidian-3 lathe spindle teardown\",\"snippet\":\"Matched me"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Obsidian-3 front bearing damage wear chatter spindle pulled\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Obsidian-3 spindle bearing\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"2\",\"title\":\"Obsidian-3 lathe spindle teardown\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"2\"}]}"
+          }
+        ],
+        "seconds": 6.1,
+        "run_id": "49cce46e26054d678f42c0501417d8b4"
+      },
+      {
+        "id": "q5-dunnock-cooling",
+        "queries": [
+          "Dunnock Row cabinet cooling case air"
+        ],
+        "slug": "conv-dunnock-row-cooling",
+        "oracle": "blown sand",
+        "hit": false,
+        "status": "done",
+        "answer": "I don't have any information about the Dunnock Row cabinet in my library. Could you provide more context about this cabinet? For example:\n\n- What field or industry is it used in (audio equipment, computing, industrial, etc.)?\n- Where did you encounter this information?\n- Do you have any additional details about its design or specifications?\n\nWith more context, I may be able to help you understand the reasoning behind its cooling design, or you could share the source material and I can help analyze it.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Dunnock Row cabinet cooling case air"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Dunnock Row cabinet cooling case air\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 2.8,
+        "run_id": "0fc244c1c12d452b83b74743ebd52b39"
+      },
+      {
+        "id": "q6-gatehouse-ups",
+        "queries": [
+          "gate house UPS incomer drops live duration",
+          "gate house UPS battery backup time"
+        ],
+        "slug": "conv-gatehouse-power",
+        "oracle": "(?:ninety|90)\\s*minutes",
+        "hit": false,
+        "status": "done",
+        "answer": "I don't have any information in my Library about the gate house UPS specifications or how long it stays live when the incomer (main power supply) drops. \n\nTo help you find this information, I would need:\n1. Documentation or specifications for the gate house UPS system\n2. Technical manuals or system design documents\n3. Previous notes or conversations about this system\n\nCould you provide more context about:\n- Which gate house system you're referring to?\n- Do you have access to the UPS specifications or technical documentation?\n- Is this related to a specific facility or installation?",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "gate house UPS incomer drops live duration"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "gate house UPS battery backup time"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"gate house UPS incomer drops live duration\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"gate house UPS battery backup time\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 3.9,
+        "run_id": "a9e4202214594c0a8ebd28252b36a55c"
+      },
+      {
+        "id": "q7-filling-head-mtbf",
+        "queries": [
+          "mean time between failures MTBF filling head fleet machines",
+          "filling head MTBF reliability"
+        ],
+        "slug": "media-filling-head-reliability",
+        "oracle": "(?:nine hundred|900)\\s+(?:running\\s+)?hours",
+        "hit": false,
+        "status": "done",
+        "answer": "I'm unable to find information about the mean time between failures (MTBF) for the filling head in the available library resources. The search returned no results. \n\nCould you provide more context about:\n1. Where this information might be located (e.g., a specific document, manual, or report)?\n2. The name or model of the machines you're referring to?\n3. Any other details that might help me locate this specification?\n\nThis would help me search more effectively for the MTBF data you're looking for.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "mean time between failures MTBF filling head fleet machines"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "filling head MTBF reliability"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"mean time between failures MTBF filling head fleet machines\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"filling head MTBF reliability\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 3.9,
+        "run_id": "17ae72444f5b47feaea9e4636d746baa"
+      },
+      {
+        "id": "q8-larkspur-lubrication",
+        "queries": [
+          "Larkspur-11 turbine commissioning automatic lubrication delivery lines",
+          "Larkspur-11 lubrication line problem defect issue"
+        ],
+        "slug": "media-larkspur-turbine",
+        "oracle": "starved a bearing",
+        "hit": false,
+        "status": "done",
+        "answer": "I found a reference to a \"Larkspur-11 turbine commissioning walkthrough\" document in your library, but I wasn't able to retrieve the specific details about the lubrication delivery line issue from the search results. The document appears to be media content that would contain this information, but I need more context to access the specific details.\n\nCould you help me by either:\n1. Providing the document directly, or\n2. Letting me know if you have additional notes or information about this commissioning that might contain the specific details about what was wrong with the automatic lubrication delivery line?",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Larkspur-11 turbine commissioning automatic lubrication delivery lines"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Larkspur-11 lubrication line problem defect issue",
+              "top_k": 5
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Larkspur-11 turbine commissioning automatic lubrication delivery lines\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"20\",\"title\":\"Larkspur-11 turbine commissioning walkthrough\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"med"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Larkspur-11 lubrication line problem defect issue\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 4.6,
+        "run_id": "5b6245f618754d04b055e99543c89f4c"
+      }
+    ],
+    "spend": {
+      "calls": 25,
+      "input_tokens": 62663,
+      "output_tokens": 2620,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "usd": 0.075763
+    }
+  },
+  "on": {
+    "arm": "on",
+    "offered_tools": [
+      "calculator",
+      "expand_document",
+      "get_current_datetime"
+    ],
+    "allowed_tools": [
+      "search_library_rag",
+      "expand_document"
+    ],
+    "approval_rounds": [
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ],
+      [
+        "expand_document"
+      ]
+    ],
+    "results": [
+      {
+        "id": "q1-quillon-access",
+        "queries": [
+          "Quillon-6 antenna mast climbing access restriction",
+          "Quillon-6 antenna mast"
+        ],
+        "slug": "media-quillon-antenna",
+        "oracle": "rescue certification",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the document, **climbing access to the Quillon-6 antenna mast is restricted to crews holding current rescue certification**.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Quillon-6 antenna mast climbing access restriction"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Quillon-6 antenna mast"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "media",
+              "source_id": "3"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Quillon-6 antenna mast climbing access restriction\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Quillon-6 antenna mast\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"3\",\"title\":\"Quillon-6 antenna mast survey\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"3\"}]}"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"media\", \"source_id\": \"3\", \"title\": \"Quillon-6 antenna mast survey\", \"text\": \"The Quillon-6 antenna mast stands on a rock outcrop above the access track and carries three sector panels.\\nGuy tensions were re-set after the second winter because the anchors had crept slightly.\\nClimbing access to the Quillon-6 remains restricted to crews holding current rescue certifi"
+          }
+        ],
+        "seconds": 4.4,
+        "run_id": "224de1f674704c43949bb2a7db266eab"
+      },
+      {
+        "id": "q2-pellucid-lag",
+        "queries": [
+          "Pellucid-12 vacuum gauge calibration reference standard lag",
+          "Pellucid-12 vacuum gauge"
+        ],
+        "slug": "media-pellucid-gauge",
+        "oracle": "lowest decade",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the calibration record, the **Pellucid-12 vacuum gauge lagged at the lowest decade point** when it was calibrated against the reference standard. \n\nSpecifically, the gauge's readings tracked within two percent at every calibration point except at the lowest decade, where the sensor exhibited lag until the chamber stabilized. A correction table was subsequently written into the Pellucid-12 to address this issue, and its calibration sticker was updated accordingly.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Pellucid-12 vacuum gauge calibration reference standard lag"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Pellucid-12 vacuum gauge"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "media",
+              "source_id": "5"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Pellucid-12 vacuum gauge calibration reference standard lag\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Pellucid-12 vacuum gauge\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"5\",\"title\":\"Pellucid-12 vacuum gauge calibration record\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"5\"}]}"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"media\", \"source_id\": \"5\", \"title\": \"Pellucid-12 vacuum gauge calibration record\", \"text\": \"The Pellucid-12 vacuum gauge was calibrated against the reference standard at five decade points.\\nReadings tracked within two percent at every point except the lowest decade, where the sensor lagged until the chamber stabilised.\\nA correction table was written into the Pellu"
+          }
+        ],
+        "seconds": 4.8,
+        "run_id": "480c896af9c643ffa481cdf6f5cf81fd"
+      },
+      {
+        "id": "q3-ashgrove-seal",
+        "queries": [
+          "Ashgrove-2 coolant pump seal maintenance"
+        ],
+        "slug": "conv-ashgrove-pump",
+        "oracle": "shimming",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the information in your library, maintenance fitted a **cartridge seal** to the Ashgrove-2 coolant pump (replacing the previous component set mechanical seal that was weeping).\n\nThe key benefit this saves on future seal changes is that **no shimming is required** when replacing the seal in the future. This eliminates a time-consuming adjustment step that would have been necessary with the component set seal, making future maintenance faster and simpler.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Ashgrove-2 coolant pump seal maintenance"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "conversation",
+              "source_id": "287e6e5b-6bca-4095-b9c5-d392e4c345bb"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Ashgrove-2 coolant pump seal maintenance\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"287e6e5b-6bca-4095-b9c5-d392e4c345bb\",\"title\":\"Chat: the Ashgrove-2 coolant pump seal\",\"snippet\":\"Matched conversation \u00b7 1 message\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\""
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"conversation\", \"source_id\": \"287e6e5b-6bca-4095-b9c5-d392e4c345bb\", \"title\": \"Chat: the Ashgrove-2 coolant pump seal\", \"text\": \"user: The Ashgrove-2 coolant pump was weeping at its mechanical seal and left a small puddle each shift.\\nMaintenance fitted a cartridge seal instead of the component set, so future changes need no shimming.\\nFlow readings on the Ashgrove-"
+          }
+        ],
+        "seconds": 4.5,
+        "run_id": "b192b2044d8046ff9b703eb859e146e3"
+      },
+      {
+        "id": "q4-obsidian-bearing",
+        "queries": [
+          "Obsidian-3 lathe spindle front bearing chatter pulled"
+        ],
+        "slug": "media-obsidian-lathe",
+        "oracle": "brinelling",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the document, when the Obsidian-3 lathe spindle was pulled after chatter appeared in fine finishing passes, **the front bearing showed brinelling on the inner race**, which was consistent with a shock load rather than gradual wear. After this discovery, a matched bearing pair was fitted and the spindle was re-trued to under two microns of runout.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Obsidian-3 lathe spindle front bearing chatter pulled"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "media",
+              "source_id": "2"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Obsidian-3 lathe spindle front bearing chatter pulled\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"2\",\"title\":\"Obsidian-3 lathe spindle teardown\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"2\"}]}"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"media\", \"source_id\": \"2\", \"title\": \"Obsidian-3 lathe spindle teardown\", \"text\": \"The Obsidian-3 lathe spindle was pulled after chatter appeared in fine finishing passes.\\nIts front bearing showed brinelling on the inner race, consistent with a shock load rather than gradual wear.\\nA matched bearing pair was fitted and the spindle re-trued to under two microns of ru"
+          }
+        ],
+        "seconds": 3.2,
+        "run_id": "286291931dcd43be9579f97d098a8dd0"
+      },
+      {
+        "id": "q5-dunnock-cooling",
+        "queries": [
+          "Dunnock Row cabinet cooling case air",
+          "Dunnock Row cabinet"
+        ],
+        "slug": "conv-dunnock-row-cooling",
+        "oracle": "blown sand",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the information in your library, the Dunnock Row cabinet is cooled through its case rather than by drawing air in because **the site sits in blown sand**. Any cabinet that draws air in would silt up within a season due to the sandy environment.\n\nThis design choice involves a trade-off:\n- **Advantage**: The cabinet runs much quieter than the rest of the chain (since there's no fan noise from air intake)\n- **Trade-off**: During the warmest weeks, the cabinet is derated (reduced power output), and the radio drops power rather than shutting down completely\n\nThe finned sides and shaded hood of the cabinet help dissipate heat through the case itself. This solution has proven worthwhile because silt damage had previously taken out the earlier cabinet twice, so the quieter operation with passive cooling is preferable to dealing with repeated silt-related failures.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Dunnock Row cabinet cooling case air"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Dunnock Row cabinet"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "conversation",
+              "source_id": "fefb5e7c-6d9a-4e87-bdc3-0605a7e2844e"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"Dunnock Row cabinet cooling case air\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Dunnock Row cabinet\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"fefb5e7c-6d9a-4e87-bdc3-0605a7e2844e\",\"title\":\"Chat: why the Dunnock Row cabinet is so quiet\",\"snippet\":\"Matched conversation \u00b7 1 message\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"conversation"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"conversation\", \"source_id\": \"fefb5e7c-6d9a-4e87-bdc3-0605a7e2844e\", \"title\": \"Chat: why the Dunnock Row cabinet is so quiet\", \"text\": \"user: Someone asked on the thread why the Dunnock Row cabinet runs so much quieter than the rest of the chain.\\nThe answer is that it is cooled through the case alone, with finned sides and a shaded hood, because the site sits in bl"
+          }
+        ],
+        "seconds": 6.2,
+        "run_id": "967bd95ac969409bbe364c8498002202"
+      },
+      {
+        "id": "q6-gatehouse-ups",
+        "queries": [
+          "gate house UPS incomer drops live duration",
+          "gate house UPS battery backup time"
+        ],
+        "slug": "conv-gatehouse-power",
+        "oracle": "(?:ninety|90)\\s*minutes",
+        "hit": false,
+        "status": "done",
+        "answer": "I'm unable to find information about the gate house UPS duration in your library. The search returned no results for queries about:\n- Gate house UPS incomer drops\n- Gate house UPS battery backup time\n\nCould you provide more context about:\n1. What system or facility this gate house is part of?\n2. Do you have documentation, notes, or specifications about this UPS system?\n3. Is this related to a specific project or location?\n\nThis information might help me locate the relevant documentation if it exists in your library, or you may need to check the UPS manufacturer's specifications or system documentation directly.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "gate house UPS incomer drops live duration"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "gate house UPS battery backup time"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"gate house UPS incomer drops live duration\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"gate house UPS battery backup time\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          }
+        ],
+        "seconds": 3.9,
+        "run_id": "86f7dd6c61ac4d81b1ca2e95fa7037c1"
+      },
+      {
+        "id": "q7-filling-head-mtbf",
+        "queries": [
+          "mean time between failures MTBF filling head fleet machines",
+          "filling head MTBF reliability",
+          "filling head mean time between failures"
+        ],
+        "slug": "media-filling-head-reliability",
+        "oracle": "(?:nine hundred|900)\\s+(?:running\\s+)?hours",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the filling head reliability study in your library, **the mean time between failures (MTBF) for the filling head is quoted at 900 running hours across the fleet of machines**.\n\nThe study also notes that:\n- The failures are dominated by the nozzle seats rather than the drive\n- Failures cluster in the weeks after a seat change, suggesting the issue is with fitting rather than wear\n- The study recommends implementing a fitting jig and torque check to replace the current \"feel method\"",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "mean time between failures MTBF filling head fleet machines"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "filling head MTBF reliability"
+            }
+          },
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "filling head mean time between failures"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "media",
+              "source_id": "42"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"mean time between failures MTBF filling head fleet machines\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"empty\",\"query\":\"filling head MTBF reliability\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":0,\"results\":[]}"
+          },
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"filling head mean time between failures\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"42\",\"title\":\"Filling head reliability study\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"media\",\"source_id\":\"42\"}]}"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"media\", \"source_id\": \"42\", \"title\": \"Filling head reliability study\", \"text\": \"The mean time between failures on the filling head is quoted at nine hundred running hours across the fleet of machines, and the figure is dominated by the nozzle seats rather than by the drive.\\nFailures cluster in the weeks after a seat change, which points at fitting rather than at we"
+          }
+        ],
+        "seconds": 6.1,
+        "run_id": "0782ee64f1814166b552b3b38f9abcdf"
+      },
+      {
+        "id": "q8-larkspur-lubrication",
+        "queries": [
+          "Larkspur-11 turbine commissioning automatic lubrication delivery lines"
+        ],
+        "slug": "media-larkspur-turbine",
+        "oracle": "starved a bearing",
+        "hit": true,
+        "status": "done",
+        "answer": "Based on the Larkspur-11 turbine commissioning walkthrough, **one of the automatic lubrication delivery lines had been run to the wrong point at the factory**. This was discovered during the commissioning process when the delivery lines were traced end to end against the schematic. The document notes that this error \"would have starved a bearing indefinitely had it not been traced.\"\n\nThis highlights the importance of thoroughly checking lubrication systems during commissioning, as this type of error could have caused serious bearing damage if it had gone undetected.",
+        "tool_calls": [
+          {
+            "name": "search_library_rag",
+            "args": {
+              "query": "Larkspur-11 turbine commissioning automatic lubrication delivery lines"
+            }
+          },
+          {
+            "name": "expand_document",
+            "args": {
+              "source_type": "media",
+              "source_id": "20"
+            }
+          }
+        ],
+        "tool_results": [
+          {
+            "name": "search_library_rag",
+            "result": "{\"status\":\"ready\",\"query\":\"Larkspur-11 turbine commissioning automatic lubrication delivery lines\",\"source_types\":[\"notes\",\"media\",\"conversations\"],\"returned\":1,\"results\":[{\"result_id\":\"20\",\"title\":\"Larkspur-11 turbine commissioning walkthrough\",\"snippet\":\"Matched media \u00b7 document\",\"score\":null,\"runtime_backend\":\"local-fts\",\"expand_hint\":{\"expandable\":true,\"reason\":\"label_only\"},\"source_type\":\"med"
+          },
+          {
+            "name": "expand_document",
+            "result": "{\"status\": \"ok\", \"source_type\": \"media\", \"source_id\": \"20\", \"title\": \"Larkspur-11 turbine commissioning walkthrough\", \"text\": \"This walkthrough covers the commissioning of the Larkspur-11 turbine from the delivery of the nacelle through to the first hours on grid. It is recorded as a teaching piece for crews who have erected towers but never taken a machine through acceptance. Nothing in it is sit"
+          }
+        ],
+        "seconds": 4.7,
+        "run_id": "178ef4410f60407f9bf29ae761b401fc"
+      }
+    ],
+    "spend": {
+      "calls": 29,
+      "input_tokens": 87033,
+      "output_tokens": 2770,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "usd": 0.100883
+    }
+  },
+  "table": "| question | target (label-only row) | oracle | tool-OFF | tool-ON | ON tool calls |\n|---|---|---|---|---|---|\n| `q1-quillon-access` | `media-quillon-antenna` (media) | `/rescue certification/` | miss | HIT | search_library_rag, search_library_rag, expand_document |\n| `q2-pellucid-lag` | `media-pellucid-gauge` (media) | `/lowest decade/` | miss | HIT | search_library_rag, search_library_rag, expand_document |\n| `q3-ashgrove-seal` | `conv-ashgrove-pump` (conversation) | `/shimming/` | miss | HIT | search_library_rag, expand_document |\n| `q4-obsidian-bearing` | `media-obsidian-lathe` (media) | `/brinelling/` | miss | HIT | search_library_rag, expand_document |\n| `q5-dunnock-cooling` | `conv-dunnock-row-cooling` (conversation) | `/blown sand/` | miss | HIT | search_library_rag, search_library_rag, expand_document |\n| `q6-gatehouse-ups` | `conv-gatehouse-power` (conversation) | `/(?:ninety|90)\\s*minutes/` | miss | miss | search_library_rag, search_library_rag |\n| `q7-filling-head-mtbf` | `media-filling-head-reliability` (media) | `/(?:nine hundred|900)\\s+(?:running\\s+)?hours/` | miss | HIT | search_library_rag, search_library_rag, search_library_rag, expand_document |\n| `q8-larkspur-lubrication` | `media-larkspur-turbine` (media) | `/starved a bearing/` | miss | HIT | search_library_rag, expand_document |\n| **TOTAL** | | | **0/8** | **7/8** | |",
+  "total_usd": 0.176646,
+  "real_config_sha256": {
+    "before": "42e2f42de95915f59fcc7c36751c2cc041cb0e4ddda9b324668683a270d7ecc0",
+    "after": "42e2f42de95915f59fcc7c36751c2cc041cb0e4ddda9b324668683a270d7ecc0"
+  }
+}

--- a/Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md
+++ b/Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md
@@ -1,0 +1,142 @@
+# Agentic document expansion: one gated tool, a wired policy, an honest measurement (TASK-16174)
+
+Date: 2026-08-15
+Status: draft-pending-user-review
+Programme: RAG server-port (ten resolved; last: 15810 via PR #1640/#1672)
+Worktree: `.worktrees/rag-16174-expansion`, branch `feat/rag-16174-agentic-expansion`, off dev `8727a2861`.
+
+## The gap, restated from the task's measured record
+
+An agent can already RETRIEVE (`RAGSearchTool`, and the default Console
+Library tool `Agents/library_rag_tool_provider.py`), but it cannot FOLLOW
+a hit into its document — and since TASK-16071's rank-fair merge, **54%
+of the rows a top-M consumer is fed are label-only** (113/211; media rows
+say `Matched media · {type}`, conversation rows say `Matched conversation
+· N messages` — `library_local_rag_search_service.py:1187/:1202`, both
+with `chunk_id: ""`). The majority of what an agent sees is a label it
+cannot see behind. Meanwhile three shipped profiles switch ON a
+parent-inclusion surface that is wired to nothing
+(`include_parent_docs`/`parent_size_threshold`/`parent_inclusion_strategy`,
+`RAG_Search/simplified/config.py:559-561`; set by `config_profiles.py:310-312`,
+`:347-349`, `:524-526`; **grep re-verified at this HEAD: 4 occurrences
+total = 1 definition + 3 profile writes, 0 reads**).
+
+## Phase K — knob truth first (AC#7): RETIRE, with the decision pre-registered
+
+**Decision rule, stated before any code:** the knobs get WIRED only if
+this arc's capability lands engine-side (inclusion during retrieval).
+It does not — the capability is an AGENT TOOL: pull-based, budgeted,
+gated, invoked per-hit after retrieval. Engine-side inclusion would
+change what retrieval returns and this arc's gate is 105/105 (+0.000),
+so wiring them here is out of scope by construction. Therefore: **retire
+all three knobs** from `SearchConfig` and from the three profiles, so no
+user-switchable dead surface survives alongside a tool that does the job.
+
+Compat obligations (plan-phase verification items): how `SearchConfig`
+construction treats unknown keys from a user's saved TOML (a removed
+field must degrade to an ignored key with a logged notice, not a crash);
+whether any Settings/UI surface renders these fields; whether any test
+fixture sets them.
+
+## Phase T — the tool (AC#1, #2, #4)
+
+One new gateable builtin, `expand_document` (final name checked against
+catalog conventions at plan time), following CLAUDE.md's recipe: `Tool`
+subclass + `GateableTool` row in `_GATEABLE_BUILTINS` + `[tools]` gate
+key, OFF by default. It reads user data (notes, media, conversations,
+prompts), so it carries `risk_tags` and is floored to `ask` — per-call
+approval cards until the user sets Allow in the MCP screen's permission
+layer. That friction is a fact to disclose, not design around.
+
+**Contract (AC#2), in terms of what rows actually carry:**
+- Input: `source_type` (the row's `provenance.source_type`) + `source_id`,
+  optional `chunk_id` (semantic note rows have one; media/conversation
+  rows ship `""`), optional `offset` for continuation.
+- Returns per type: note → note body; media → media content; conversation
+  → rendered transcript (role-prefixed messages); prompt → prompt body.
+  Every payload states `total_size`, the window returned, and whether it
+  was truncated.
+- Over budget: a window centred on the matched chunk when `chunk_id` is
+  known, else the head — plus a continuation `offset`, so navigation
+  within one document is possible without re-querying (the owner's
+  "starting points for additional information" ask).
+- Budget: a `max_chars` parameter with a config-backed default; the tool
+  never returns more than the budget regardless of what is asked.
+- **AC#4 is closed by construction**: the contract works from exactly the
+  fields label-only rows carry (`source_id` + `source_type`, empty
+  `chunk_id`), and the media/conversation branches are the acceptance
+  tests' first-class cases, not afterthoughts.
+
+## Phase P — the policy, WIRED so it cannot be inert (AC#3)
+
+A policy nothing consumes would be the same sin AC#7 condemns. So the
+policy lives where the agent actually looks:
+1. The tool's `description` states the decision rule in agent-actionable
+   terms (expand when a high-ranked hit is label-only or visibly
+   truncated and the answer needs its content; re-query instead when the
+   hit itself looks wrong; never re-expand the same document).
+2. The Library retrieval tool's result payload gains a per-row
+   `expand_hint` (e.g. `{"expandable": true, "reason": "label_only"}`)
+   computed by a pure, unit-tested helper — the agent is TOLD which rows
+   are labels rather than left to infer it. This is a payload ADDITION
+   (no row removed or reordered): the plan verifies consumers tolerate
+   the extra key.
+3. Tests exercise each policy branch (label-only high rank → expand;
+   text-bearing full snippet → no; budget exhausted → no; repeat
+   expansion of the same source → no).
+
+## Phase E — the measurement, decided not assumed (AC#5, #6)
+
+Retrieval-level scoring is NOT sufficient — the golden set scores
+whether the document arrives, and expansion's value begins after it
+arrives. So AC#5's first arm: define AND RUN a small answer-level check.
+Shape (pre-registered, mechanical, no LLM grader): N fixed questions
+whose evidence windows are label-only-dominated on the eval corpus, each
+with a FACT ORACLE — a string/regex fact that appears ONLY inside the
+media/conversation content, never in labels or note chunks. Run the real
+agent loop tool-OFF vs tool-ON (small N, low spend, keys from the repo
+root per standing rule; costs recorded); score = oracle-fact inclusion in
+the answer. Disclosed limits: N is small, inclusion ≠ answer quality,
+one corpus. That is an honest first answer-level instrument, not a P3
+grader programme.
+
+AC#6 recorded now: the tool is INDEPENDENT of reranking — it consumes
+final result rows whatever produced them; nothing presumes TASK-3502's
+unimplemented `cross_encoder`. The relationship is one sentence in the
+tool's docs and the task file.
+
+## Out of scope (declared)
+- Engine-side parent/sibling inclusion (P2's "granularity router" line) —
+  the knobs retire; the feature, if ever wanted, is its own measured arc.
+- Reranking implementation or measurement (TASK-3502).
+- Any retrieval-behaviour change: the gate must read **105/105 (+0.000)**.
+- Changing the label-only rows themselves (their snippet text is the
+  15700-era contract; the tool sees behind them instead).
+
+## Testing
+- Phase K: config-compat tests (saved TOML with retired keys loads with a
+  notice); profile tests; grep-zero assertion that no read appears.
+- Phase T: per-type contract tests incl. both label-only types; budget/
+  truncation/offset tests; catalog gate tests (OFF by default, Settings
+  switch derived, risk-tag floor to ask).
+- Phase P: one test per policy branch; payload-compat test for the added
+  `expand_hint` key.
+- Phase E: the oracle run's artifact committed (questions, oracles,
+  per-run answers, costs); the always-on Library/RAG batteries; the gated
+  suite at 105/105 (+0.000).
+
+## Plan-phase verification (before tasks are cut)
+1. `SearchConfig` unknown-key behaviour on load (crash vs ignore) and
+   every constructor/serialisation site of the three knobs.
+2. Note/prompt fetch APIs by id (media/conversation verified:
+   `get_media_by_id` `Client_Media_DB_v2.py:6158`,
+   `get_conversation_by_id` `ChaChaNotes_DB.py:7575`) — and what
+   `source_id` actually contains per seam for SEMANTIC rows (doc_id vs
+   note_id vs media id; the chroma metadata carries `note_id`/`doc_id`).
+3. The tool-catalog recipe end-to-end at this HEAD (gate key naming,
+   Settings derivation, risk-tag flooring — CLAUDE.md's caveat about
+   non-`_GATEABLE_BUILTINS` LocalToolSpec tools does not apply here).
+4. Consumers of the Library tool payload (Console agent rendering) to
+   confirm an added per-row key is tolerated.
+5. Where the eval corpus's media/conversation content lives, to author
+   oracle facts that genuinely appear only there.

--- a/Tests/Agents/test_builtin_tool_gate.py
+++ b/Tests/Agents/test_builtin_tool_gate.py
@@ -439,7 +439,7 @@ def _no_override_get_cli_setting(section, key=None, default=None):
     return default
 
 
-def test_all_tool_gates_enumerates_nine_gates_with_sections_and_groups(monkeypatch):
+def test_all_tool_gates_enumerates_every_gate_with_sections_and_groups(monkeypatch):
     import tldw_chatbook.config as config_module
     from tldw_chatbook.Agents.builtin_tool_gate import ToolGate, all_tool_gates
     from tldw_chatbook.Agents.local_tool_provider import WEB_DEEP_SEARCH_GATE_KEY
@@ -448,10 +448,13 @@ def test_all_tool_gates_enumerates_nine_gates_with_sections_and_groups(monkeypat
     monkeypatch.setattr(config_module, "get_cli_setting", _no_override_get_cli_setting)
 
     gates = all_tool_gates()
-    assert len(gates) == 9
+    # Derived, not a literal (TASK-16174): the arity is "every builtin row
+    # plus the local group's two", so adding a gateable built-in must not
+    # make this test the thing that fails.
+    assert len(gates) == len(_GATEABLE_BUILTINS) + 2
     assert all(isinstance(gate, ToolGate) for gate in gates)
 
-    # The 7 _GATEABLE_BUILTINS rows come first, in registration order,
+    # The _GATEABLE_BUILTINS rows come first, in registration order,
     # constants-not-literals (a re-typed key here would drift silently the
     # moment _GATEABLE_BUILTINS gains or reorders an entry).
     builtin_gates = gates[: len(_GATEABLE_BUILTINS)]
@@ -565,11 +568,14 @@ def test_tool_gate_breadcrumb_names_the_off_count(monkeypatch):
         tool_gate_breadcrumb,
     )
 
+    from tldw_chatbook.Agents.tool_catalog import _GATEABLE_BUILTINS
+
     monkeypatch.setattr(config_module, "get_cli_setting", _no_override_get_cli_setting)
-    gates = all_tool_gates()  # master defaults on; the other 8 gates default off
+    gates = all_tool_gates()  # master defaults on; every other gate defaults off
+    off_count = len(_GATEABLE_BUILTINS) + 1  # + web_deep_search, - the master
     text = tool_gate_breadcrumb(gates)
     assert text is not None
-    assert "8" in text
+    assert str(off_count) in text
     assert "Tools mode" in text
     assert "web_search, web_fetch, web_crawl" not in text
 
@@ -608,16 +614,18 @@ def test_count_off_tool_gates_constructs_no_tools(monkeypatch):
     (it runs on every Permissions-mode resync; construction also spams
     warnings for optional tools missing on this system)."""
     from tldw_chatbook.Agents import builtin_tool_gate, tool_catalog
+    from tldw_chatbook.Agents.tool_catalog import _GATEABLE_BUILTINS
 
     def explode(entry):
         raise AssertionError(f"count path constructed a tool: {entry}")
 
     monkeypatch.setattr(tool_catalog, "build_gateable_tool", explode)
     monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", lambda s, k, d=None: d)
-    assert builtin_tool_gate.count_off_tool_gates() == 8
+    off_count = len(_GATEABLE_BUILTINS) + 1  # + web_deep_search, - the master
+    assert builtin_tool_gate.count_off_tool_gates() == off_count
     breadcrumb = builtin_tool_gate.tool_gate_breadcrumb()
     assert breadcrumb is not None
-    assert "8 tool gate(s)" in breadcrumb
+    assert f"{off_count} tool gate(s)" in breadcrumb
     assert "workspace, web, and Watchlists master switch in Tools mode" in breadcrumb
     assert "local/web" not in breadcrumb
     assert "built-in server detail" in breadcrumb

--- a/Tests/Agents/test_library_tool_provider.py
+++ b/Tests/Agents/test_library_tool_provider.py
@@ -389,3 +389,138 @@ def test_rag_invoke_rejects_overlong_query():
     decoded = _error_payload(provider.invoke(f"library:{RAG_TOOL_NAME}", arguments))
 
     assert decoded["code"] == "invalid_argument"
+
+
+# --------------------------------------------------------------------------
+# LibraryRagToolProvider: per-row expansion hints (TASK-16174, Phase P)
+# --------------------------------------------------------------------------
+
+
+def _label_row(source_type: str, index: int) -> dict:
+    """A label-only row exactly as the local search service builds one."""
+    snippet = (
+        "Matched media · pdf"
+        if source_type == "media"
+        else "Matched conversation · 7 messages"
+    )
+    return {
+        "title": f"Label {index}",
+        "snippet": snippet,
+        "score": 0.5,
+        "source_id": f"{index}",
+        "chunk_id": "",
+        "provenance": {"source_type": source_type},
+    }
+
+
+def _text_row(index: int, *, chars: int = 300) -> dict:
+    return {
+        "title": f"Note {index}",
+        "snippet": f"note-{index}: " + ("the plan says a great deal. " * 200)[:chars],
+        "score": 0.4,
+        "source_id": f"note-{index}",
+        "chunk_id": "",
+        "provenance": {"source_type": "note"},
+    }
+
+
+def test_provider_rows_carry_expand_hint():
+    """The policy reaches the agent through the payload it actually reads."""
+    rows = [_label_row("media", 1), _label_row("conversation", 2), _text_row(3)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 3})
+
+    assert result.ok is True
+    projected = json.loads(result.content)["results"]
+    assert [row["expand_hint"] for row in projected] == [
+        {"expandable": True, "reason": "label_only"},
+        {"expandable": True, "reason": "label_only"},
+        {"expandable": False, "reason": "text_bearing"},
+    ]
+    for row in projected:
+        # Still no raw identities or provenance: the hint is derived, not raw.
+        assert set(row) <= {
+            "result_id",
+            "title",
+            "snippet",
+            "score",
+            "runtime_backend",
+            "expand_hint",
+        }
+
+
+def test_provider_row_without_expandable_identity_omits_the_hint():
+    row = _text_row(9)
+    row["provenance"] = {}
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": [row]}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    assert "expand_hint" not in json.loads(result.content)["results"][0]
+
+
+def test_provider_hint_reads_the_untruncated_snippet_length():
+    """The hint is computed against the provider's own projection cap, so a
+    snippet the payload cuts is reported as truncated, not text-bearing."""
+    row = _text_row(4, chars=4000)
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": [row]}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    projected = json.loads(result.content)["results"][0]
+    assert projected["expand_hint"] == {
+        "expandable": True,
+        "reason": "truncated_snippet",
+    }
+    assert len(projected["snippet"]) < 4000  # the payload really did cut it
+
+
+def test_sealed_payload_survives_hints():
+    """A normal ten-row payload keeps every row AND every hint under the
+    32 KiB ceiling: the added per-row key must not push the sealing loop
+    into dropping rows."""
+    rows = [_label_row("media", index) for index in range(5)]
+    rows += [_text_row(index) for index in range(5, 10)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 10})
+
+    assert result.ok is True
+    assert serialized_size(json.loads(result.content)) <= MAX_RESULT_BYTES
+    payload = json.loads(result.content)
+    assert payload["returned"] == 10
+    assert all("expand_hint" in row for row in payload["results"])
+    assert [row["expand_hint"]["reason"] for row in payload["results"]] == (
+        ["label_only"] * 5 + ["text_bearing"] * 5
+    )
+
+
+@pytest.mark.timeout(2)
+def test_sealing_loop_terminates_when_a_hinted_row_is_hostile():
+    """The shrink loop only knows four fields; a hinted row must still make
+    progress and stay bounded (the hint itself is never the last thing left
+    holding a row over the ceiling)."""
+    huge = "界" * 40_000
+    row = LibraryRagResultRow(
+        result_id=huge,
+        title=huge,
+        snippet="Matched media · pdf",
+        score=0.5,
+        source_id="12",
+        chunk_id="",
+        citations=(),
+        provenance=MappingProxyType({"source_type": "media"}),
+        runtime_backend=huge,
+    )
+    provider = LibraryRagToolProvider(
+        FakeRagService(result=LibraryRagSearchOutcome(status="ready", results=(row,)))
+    )
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    assert result.ok is True
+    payload = json.loads(result.content)
+    assert serialized_size(payload) <= MAX_RESULT_BYTES
+    for projected in payload["results"]:
+        assert projected["expand_hint"] == {"expandable": True, "reason": "label_only"}

--- a/Tests/Agents/test_library_tool_provider.py
+++ b/Tests/Agents/test_library_tool_provider.py
@@ -439,7 +439,8 @@ def test_provider_rows_carry_expand_hint():
         {"expandable": False, "reason": "text_bearing"},
     ]
     for row in projected:
-        # Still no raw identities or provenance: the hint is derived, not raw.
+        # Identity rides along ONLY as the two keys `expand_document` takes
+        # (Task 3b); citations and the provenance mapping still never leave.
         assert set(row) <= {
             "result_id",
             "title",
@@ -447,7 +448,12 @@ def test_provider_rows_carry_expand_hint():
             "score",
             "runtime_backend",
             "expand_hint",
+            "source_type",
+            "source_id",
+            "chunk_id",
         }
+        assert "provenance" not in row
+        assert "citations" not in row
 
 
 def test_provider_row_without_expandable_identity_omits_the_hint():
@@ -524,3 +530,137 @@ def test_sealing_loop_terminates_when_a_hinted_row_is_hostile():
     assert serialized_size(payload) <= MAX_RESULT_BYTES
     for projected in payload["results"]:
         assert projected["expand_hint"] == {"expandable": True, "reason": "label_only"}
+
+
+# --------------------------------------------------------------------------
+# LibraryRagToolProvider: actionable expansion identity (TASK-16174, Task 3b)
+# --------------------------------------------------------------------------
+
+
+def _chunked_row(index: int, *, chars: int = 300) -> dict:
+    """A semantic row as `_semantic_row` builds one: a real, non-empty chunk id."""
+    return {
+        "title": f"Doc {index}",
+        "snippet": (f"doc-{index}: " + "the plan says a great deal. " * 40)[:chars],
+        "score": 0.7,
+        "source_id": f"note_{index}",
+        "chunk_id": f"note_{index}_chunk_3",
+        "provenance": {"source_type": "note", "chunk_start": 1200},
+    }
+
+
+def test_provider_rows_carry_the_identity_expand_document_requires():
+    """`expand_document` needs source_type + source_id; the payload declares
+    both instead of leaving the agent to infer them from label prose."""
+    rows = [
+        _label_row("media", 1),
+        _label_row("conversation", 2),
+        _text_row(3),
+        _chunked_row(4),
+    ]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 4})
+
+    assert result.ok is True
+    projected = json.loads(result.content)["results"]
+    assert [row["source_type"] for row in projected] == [
+        row["provenance"]["source_type"] for row in rows
+    ]
+    assert [row["source_id"] for row in projected] == [
+        row["source_id"] for row in rows
+    ]
+
+
+def test_chunked_row_carries_its_chunk_id_and_a_label_row_does_not():
+    """A non-empty chunk_id is the window anchor's companion; an empty one is
+    noise, so a label-only row omits the key entirely."""
+    rows = [_chunked_row(4), _label_row("media", 1)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 2})
+
+    chunked, label = json.loads(result.content)["results"]
+    assert chunked["chunk_id"] == "note_4_chunk_3"
+    assert "chunk_id" not in label
+
+
+def test_label_only_identity_matches_the_result_id_the_row_already_exposed():
+    """The coincidence T3 flagged (`result_id` == `source_id` for label rows)
+    is now a declared contract, and a chunked row's pair is decomposed."""
+    rows = [_label_row("media", 12), _chunked_row(4)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 2})
+
+    label, chunked = json.loads(result.content)["results"]
+    assert label["source_id"] == label["result_id"] == "12"
+    assert chunked["result_id"] == f"{chunked['source_id']}:{chunked['chunk_id']}"
+
+
+def test_row_with_nothing_to_expand_carries_no_identity():
+    """Identity is emitted on exactly the rows the tool can act on: a row with
+    no expandable seam keeps task-1337's no-raw-identity projection."""
+    row = _text_row(9)
+    row["provenance"] = {}
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": [row]}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    projected = json.loads(result.content)["results"][0]
+    assert "expand_hint" not in projected
+    assert "source_type" not in projected
+    assert "source_id" not in projected
+
+
+def test_sealed_payload_survives_identity_keys():
+    """A normal ten-row payload keeps every row, every hint AND every identity
+    under the 32 KiB ceiling."""
+    rows = [_label_row("media", index) for index in range(5)]
+    rows += [_chunked_row(index) for index in range(5, 10)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 10})
+
+    assert result.ok is True
+    payload = json.loads(result.content)
+    assert serialized_size(payload) <= MAX_RESULT_BYTES
+    assert payload["returned"] == 10
+    assert all(
+        row["source_type"] and row["source_id"] and "expand_hint" in row
+        for row in payload["results"]
+    )
+    assert [row.get("chunk_id", "") for row in payload["results"]] == (
+        [""] * 5 + [f"note_{index}_chunk_3" for index in range(5, 10)]
+    )
+
+
+@pytest.mark.timeout(2)
+def test_sealing_loop_terminates_when_the_identity_itself_is_hostile():
+    """Identity is the one projected field the shrink loop must not touch --
+    a halved id is a WRONG id, not a smaller one -- so the loop shrinks the
+    four text fields around it and the identity survives verbatim."""
+    huge = "界" * 40_000
+    oversized_id = "x" * 5_000
+    row = LibraryRagResultRow(
+        result_id=huge,
+        title=huge,
+        snippet="Matched media · pdf",
+        score=0.5,
+        source_id=oversized_id,
+        chunk_id="",
+        citations=(),
+        provenance=MappingProxyType({"source_type": "media"}),
+        runtime_backend=huge,
+    )
+    provider = LibraryRagToolProvider(
+        FakeRagService(result=LibraryRagSearchOutcome(status="ready", results=(row,)))
+    )
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    assert result.ok is True
+    payload = json.loads(result.content)
+    assert serialized_size(payload) <= MAX_RESULT_BYTES
+    assert payload["returned"] == len(payload["results"]) == 1
+    assert payload["results"][0]["source_id"] == oversized_id

--- a/Tests/Agents/test_library_tool_provider.py
+++ b/Tests/Agents/test_library_tool_provider.py
@@ -266,7 +266,13 @@ def test_rag_invoke_success_projects_bounded_rows():
         "Evidence 2",
     ]
     for row in payload["results"]:
-        # Raw backing identities and provenance never leave the adapter.
+        # Raw backing identities and the provenance mapping never leave the
+        # adapter FOR A ROW WITH NOTHING TO EXPAND -- which is what this
+        # fixture's rows are (no provenance at all). TASK-16174/3b made the
+        # identity conditional, not absent: see `_project_row` and
+        # `test_row_with_nothing_to_expand_carries_no_identity` for the
+        # precondition, and the identity tests below for the other side of
+        # it. The provenance MAPPING itself never leaves on any branch.
         assert set(row) <= {"result_id", "title", "snippet", "score", "runtime_backend"}
     assert service.calls == [
         ("quarterly plan", SUPPORTED_RAG_SOURCE_TYPES, "rag", {"top_k": 2, "include_citations": True})
@@ -451,6 +457,7 @@ def test_provider_rows_carry_expand_hint():
             "source_type",
             "source_id",
             "chunk_id",
+            "chunk_start",
         }
         assert "provenance" not in row
         assert "citations" not in row
@@ -632,6 +639,70 @@ def test_sealed_payload_survives_identity_keys():
     )
     assert [row.get("chunk_id", "") for row in payload["results"]] == (
         [""] * 5 + [f"note_{index}_chunk_3" for index in range(5, 10)]
+    )
+
+
+def test_chunked_row_carries_the_chunk_start_window_anchor():
+    """`chunk_start` is the ONLY thing that moves `expand_document`'s window.
+
+    `chunk_id` is an INDEX (`f"{doc_id}_chunk_{i}"`) and, since the fix wave,
+    is not even a tool parameter. `_semantic_row` copies `chunk_start` out of
+    the chunk metadata into `provenance`; without it in the payload a chunked
+    hit expands from the document HEAD while reporting `status: "ok"` -- a
+    wrong window that looks like a right one.
+    """
+    rows = [_chunked_row(4), _label_row("media", 1)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 2})
+
+    chunked, label = json.loads(result.content)["results"]
+    assert chunked["chunk_start"] == 1200
+    assert "chunk_start" not in label, "a label-only row has no matched chunk"
+
+
+@pytest.mark.parametrize(
+    "provenance_anchor",
+    [None, 0, -1, "", "not-a-number", True],
+    ids=["absent", "head", "negative", "empty", "garbage", "bool"],
+)
+def test_chunk_start_is_omitted_when_it_would_move_nothing(provenance_anchor):
+    """Only an anchor the tool acts on is worth its bytes.
+
+    `_window_bounds` centres the window only for `anchor > 0`, so a head
+    anchor, a garbage value or an absent key must produce no key at all --
+    otherwise the payload grows to carry a field that changes nothing, which
+    is the inert surface this arc exists to remove.
+    """
+    row = _chunked_row(4)
+    if provenance_anchor is None:
+        row["provenance"].pop("chunk_start")
+    else:
+        row["provenance"]["chunk_start"] = provenance_anchor
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": [row]}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    projected = json.loads(result.content)["results"][0]
+    assert "chunk_start" not in projected
+    assert projected["source_id"] == "note_4", "the rest of the identity is intact"
+
+
+def test_sealed_payload_survives_the_chunk_start_anchor():
+    """The ceiling re-check every payload ADDITION on this seam owes: ten
+    rows, five of them anchored, all kept under 32 KiB with the anchor."""
+    rows = [_label_row("media", index) for index in range(5)]
+    rows += [_chunked_row(index) for index in range(5, 10)]
+    provider = LibraryRagToolProvider(FakeRagService(result={"results": rows}))
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q", "top_k": 10})
+
+    assert result.ok is True
+    payload = json.loads(result.content)
+    assert serialized_size(payload) <= MAX_RESULT_BYTES
+    assert payload["returned"] == 10
+    assert [row.get("chunk_start") for row in payload["results"]] == (
+        [None] * 5 + [1200] * 5
     )
 
 

--- a/Tests/Library/test_library_expand_policy.py
+++ b/Tests/Library/test_library_expand_policy.py
@@ -1,0 +1,205 @@
+"""Per-row expansion policy for Library retrieval rows (TASK-16174, Phase P).
+
+The arc's premise is that a policy nothing consumes is inert surface. This
+module's helper is the consumed half: it labels each retrieval row with
+whether following it into its document (`expand_document`, Phase T) would
+add anything, and why.
+
+Label detection is deliberately a TRIPLE -- `provenance.source_type` +
+empty `chunk_id` + the label snippet prefix -- never the label text alone:
+a real media chunk whose text happens to open with "Matched media" is a
+text-bearing row, and a user's note that quotes the label is not a media
+row at all. All three must agree before a row is called label-only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Library.library_expand_policy import (
+    DEFAULT_SNIPPET_CAP,
+    REASON_LABEL_ONLY,
+    REASON_TEXT_BEARING,
+    REASON_TRUNCATED_SNIPPET,
+    expand_hint,
+)
+
+
+def _row(**overrides) -> dict:
+    """A retrieval row shaped like `LibraryRagResultRow`'s mapping form."""
+    row = {
+        "source_id": "42",
+        "chunk_id": "",
+        "title": "Some source",
+        "snippet": "",
+        "provenance": {"source_type": "note"},
+    }
+    row.update(overrides)
+    return row
+
+
+# --------------------------------------------------------------------------
+# The plan's four policy branches
+# --------------------------------------------------------------------------
+
+
+def test_media_label_row_hint_is_label_only():
+    """`library_local_rag_search_service._media_row`'s exact shape."""
+    hint = expand_hint(
+        _row(
+            source_id="12",
+            chunk_id="",
+            snippet="Matched media · pdf",
+            provenance={"source_type": "media"},
+        )
+    )
+
+    assert hint == {"expandable": True, "reason": REASON_LABEL_ONLY}
+
+
+def test_conversation_label_row_hint_is_label_only():
+    """`_conversation_row`'s exact shape (count_noun-rendered message count)."""
+    hint = expand_hint(
+        _row(
+            source_id="conv-uuid",
+            chunk_id="",
+            snippet="Matched conversation · 7 messages",
+            provenance={"source_type": "conversation"},
+        )
+    )
+
+    assert hint == {"expandable": True, "reason": REASON_LABEL_ONLY}
+
+
+def test_text_bearing_note_row_hint_is_text_bearing():
+    hint = expand_hint(
+        _row(
+            source_id="note-uuid",
+            chunk_id="",
+            snippet="The quarterly plan sets a 12% target for the EU region.",
+            provenance={"source_type": "note"},
+        )
+    )
+
+    assert hint == {"expandable": False, "reason": REASON_TEXT_BEARING}
+
+
+def test_truncated_semantic_snippet_hint():
+    """A snippet longer than the projection cap is cut mid-sentence."""
+    long_snippet = ("The migration plan continues for a long while. " * 60)[
+        : DEFAULT_SNIPPET_CAP + 120
+    ]
+
+    hint = expand_hint(
+        _row(
+            source_id="media_12",
+            chunk_id="media_12_chunk_3",
+            snippet=long_snippet,
+            provenance={"source_type": "media", "chunk_start": 900},
+        )
+    )
+
+    assert hint == {"expandable": True, "reason": REASON_TRUNCATED_SNIPPET}
+
+
+# --------------------------------------------------------------------------
+# Edge behaviour the branches above depend on
+# --------------------------------------------------------------------------
+
+
+def test_label_text_alone_does_not_make_a_note_row_label_only():
+    """The triple, not the text: a note quoting the label stays text-bearing."""
+    hint = expand_hint(
+        _row(
+            snippet="Matched media · pdf was the phrase in my inbox today.",
+            provenance={"source_type": "note"},
+        )
+    )
+
+    assert hint == {"expandable": False, "reason": REASON_TEXT_BEARING}
+
+
+def test_media_chunk_row_opening_with_the_label_text_is_not_label_only():
+    """A real media chunk carries a chunk_id, so the triple fails."""
+    hint = expand_hint(
+        _row(
+            source_id="12",
+            chunk_id="media_12_chunk_0",
+            snippet="Matched media · pdf, the report's own opening line.",
+            provenance={"source_type": "media"},
+        )
+    )
+
+    assert hint == {"expandable": False, "reason": REASON_TEXT_BEARING}
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        pytest.param(_row(provenance={}), id="no-source-type"),
+        pytest.param(_row(provenance={"source_type": "widget"}), id="unknown-type"),
+        pytest.param(_row(provenance=None), id="no-provenance"),
+        pytest.param(_row(source_id=""), id="no-source-id"),
+        pytest.param("not a row", id="not-a-mapping"),
+    ],
+)
+def test_unexpandable_rows_get_no_hint(row):
+    """No hint at all beats a hint the agent cannot act on."""
+    assert expand_hint(row) is None
+
+
+def test_snippet_cap_is_caller_supplied_so_it_cannot_drift():
+    snippet = "x" * 300
+
+    assert expand_hint(_row(snippet=snippet))["reason"] == REASON_TEXT_BEARING
+    assert (
+        expand_hint(_row(snippet=snippet), snippet_cap=200)["reason"]
+        == REASON_TRUNCATED_SNIPPET
+    )
+
+
+def test_ellipsis_terminated_snippet_is_truncated():
+    hint = expand_hint(_row(snippet="The report concludes that the region…"))
+
+    assert hint == {"expandable": True, "reason": REASON_TRUNCATED_SNIPPET}
+
+
+def test_hint_carries_no_identity_or_provenance():
+    hint = expand_hint(
+        _row(
+            source_id="secret-id",
+            snippet="Matched media · pdf",
+            chunk_id="",
+            provenance={"source_type": "media", "note_id": "secret-note"},
+        )
+    )
+
+    assert set(hint) == {"expandable", "reason"}
+
+
+def test_helper_does_not_mutate_the_row():
+    row = _row(snippet="Matched media · pdf", provenance={"source_type": "media"})
+    before = {"snippet": row["snippet"], "provenance": dict(row["provenance"])}
+
+    expand_hint(row)
+
+    assert row["snippet"] == before["snippet"]
+    assert dict(row["provenance"]) == before["provenance"]
+
+
+# --------------------------------------------------------------------------
+# The other half of the wired policy: the tool's own description (Phase T)
+# --------------------------------------------------------------------------
+
+
+def test_tool_description_states_the_policy_verbatim():
+    """The hint says WHICH row; the description says WHAT TO DO about it."""
+    from tldw_chatbook.Tools.document_expansion_tool import ExpandDocumentTool
+
+    assert (
+        "Expand a retrieval hit into its document. Use when a high-ranked "
+        "hit is label-only (media/conversation rows) or its snippet is "
+        "truncated and the answer needs the content. Re-query instead if "
+        "the hit itself looks irrelevant. Never expand the same source "
+        "twice — reuse the earlier result."
+    ) in " ".join(ExpandDocumentTool().description.split())

--- a/Tests/Library/test_library_expand_policy.py
+++ b/Tests/Library/test_library_expand_policy.py
@@ -203,3 +203,27 @@ def test_tool_description_states_the_policy_verbatim():
         "the hit itself looks irrelevant. Never expand the same source "
         "twice — reuse the earlier result."
     ) in " ".join(ExpandDocumentTool().description.split())
+
+
+def test_description_carries_the_two_branches_no_code_enforces():
+    """The spec named FOUR policy branches; the helper implements two.
+
+    "budget exhausted -> no" and "repeat expansion of the same source -> no"
+    need per-conversation agent-loop state (what has already been expanded,
+    what context budget is left) that a stateless per-call tool does not
+    have. They therefore ship as INSTRUCTION in the description and nothing
+    enforces or measures them -- disclosed in TASK-16174's AC#3 rather than
+    silently narrowed. This test is the only thing keeping them from
+    evaporating entirely, so it pins both sentences verbatim.
+    """
+    from tldw_chatbook.Tools.document_expansion_tool import ExpandDocumentTool
+
+    description = " ".join(ExpandDocumentTool().description.split())
+
+    assert (
+        "Never expand the same source twice — reuse the earlier result."
+    ) in description
+    assert (
+        "Stop expanding once your remaining context budget is short — a "
+        "window you cannot afford to read is spent for nothing."
+    ) in description

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -1513,16 +1513,29 @@ no retrieval behaviour.
   (`tldw_chatbook/Tools/document_expansion_tool.py`), a gateable built-in
   behind `[tools] expand_document_enabled` (OFF by default) and
   `risk_tags=("reads",)`, which floors it to *ask*. It takes exactly what
-  a row carries — `source_type` + `source_id`, optional
-  `chunk_id`/`chunk_start`/`offset` — and returns a budgeted window of
-  the note / media / conversation / prompt behind the hit.
+  a row carries — `source_type` + `source_id` required, plus optional
+  `chunk_start` (the window anchor) and `offset` (continuation) — and
+  returns a budgeted window of the note / media / conversation / prompt
+  behind the hit. `chunk_id` is NOT a parameter: it is an index
+  (`f"{doc_id}_chunk_{i}"`), nothing in the tool reads it, and the final
+  review found it shipped as agent-facing schema wired to nothing — the
+  fix wave retired it (a pasted row still works: it rides the
+  `**_provenance` swallow).
 - **Phase P — the policy, wired.** `Library/library_expand_policy.py`
   computes a per-row `{expandable, reason}` verdict, and
   `Agents/library_rag_tool_provider._project_row` attaches it *plus* the
   `source_type`/`source_id` the tool requires, under exactly the hint's
   own precondition. The agent is told which rows are labels rather than
   left to infer it, and is given an identity it can act on rather than
-  one it must guess.
+  one it must guess. A row also carries `chunk_id` when it has one and
+  `chunk_start` **when its provenance carries a usable anchor** (fix wave,
+  after the final review): a head anchor (`0`) or an unparseable one is
+  dropped, because `expand_document` centres its window only for
+  `anchor > 0` and a key that changes nothing is bytes spent for no
+  behaviour. Cost re-measured by T3b's strip-and-reserialize method on a
+  ten-row payload with five anchored rows: **+19.0 B per anchored row,
+  +95 B total (9.5 B/row), 11.7 % of the 32 KiB ceiling**; an unanchored
+  payload pays nothing.
 
 **Phase E — the oracle run.** Eight fixed questions over this corpus,
 each naming one media or conversation document and carrying a fact-oracle

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -1486,3 +1486,88 @@ describes the engine path and does not transfer to the pipeline path.
    scoring anything — re-stamp deliberately (see above), with the new
    fixture content named as the reason in the PR, not silently absorbed
    into an unrelated change's re-stamp.
+
+## This corpus as an ANSWER-level instrument (TASK-16174, 2026-08-15)
+
+Everything above measures **retrieval**: whether the right document
+arrives, scored rank-wise at the document level. TASK-16174 needed a
+different question — *what happens after it arrives?* — and reused this
+corpus for it, without touching a fixture, a golden query, or a baseline.
+The gated suite read **`[rag-eval baselines] PASSED: No regression. 105
+metric(s) within 0.05 of baseline.`** with all 105 cells at `(+0.000)`
+before and after the arc; that is the proof the answer-level work changed
+no retrieval behaviour.
+
+**What the arc shipped.**
+
+- **Phase K — the knobs retired.** `SearchConfig.include_parent_docs`,
+  `parent_size_threshold` and `parent_inclusion_strategy` were deleted,
+  along with nine writes across three shipped RAG profiles. A grep had
+  proved zero reads: they were a user-switchable surface wired to nothing.
+  `RAGConfig.from_dict` now filters unknown `[search]` keys with a logged
+  notice, so a saved config still carrying them loads instead of raising
+  `TypeError`. (`Docs/Development/CHUNKING-*.md` carried the false claim
+  that this feature was implemented; those documents now carry a
+  correction.)
+- **Phase T — the tool.** `expand_document`
+  (`tldw_chatbook/Tools/document_expansion_tool.py`), a gateable built-in
+  behind `[tools] expand_document_enabled` (OFF by default) and
+  `risk_tags=("reads",)`, which floors it to *ask*. It takes exactly what
+  a row carries — `source_type` + `source_id`, optional
+  `chunk_id`/`chunk_start`/`offset` — and returns a budgeted window of
+  the note / media / conversation / prompt behind the hit.
+- **Phase P — the policy, wired.** `Library/library_expand_policy.py`
+  computes a per-row `{expandable, reason}` verdict, and
+  `Agents/library_rag_tool_provider._project_row` attaches it *plus* the
+  `source_type`/`source_id` the tool requires, under exactly the hint's
+  own precondition. The agent is told which rows are labels rather than
+  left to infer it, and is given an identity it can act on rather than
+  one it must guess.
+
+**Phase E — the oracle run.** Eight fixed questions over this corpus,
+each naming one media or conversation document and carrying a fact-oracle
+regex grep-verified to appear only in that document's **body** — never in
+a title (the agent sees titles), never in another document, never in the
+question. The real agent loop (`AgentService` → `chat_api_call` →
+`api.anthropic.com`, `claude-haiku-4-5`, temperature 0) answered each
+question twice: once in the shipped default posture (gate off) and once
+with the gate on. Scoring is mechanical oracle inclusion in the final
+answer — **no LLM grader**. The route is `plain`
+(`default_search_mode = "plain"`), which is what emits the label-only
+`Matched media · document` / `Matched conversation · N messages` rows the
+tool exists for; under `hybrid` there is nothing label-only to expand.
+
+| question | target (label-only row) | oracle | tool-OFF | tool-ON | ON tool calls |
+|---|---|---|---|---|---|
+| `q1-quillon-access` | `media-quillon-antenna` (media) | `/rescue certification/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q2-pellucid-lag` | `media-pellucid-gauge` (media) | `/lowest decade/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q3-ashgrove-seal` | `conv-ashgrove-pump` (conversation) | `/shimming/` | miss | HIT | search_library_rag, expand_document |
+| `q4-obsidian-bearing` | `media-obsidian-lathe` (media) | `/brinelling/` | miss | HIT | search_library_rag, expand_document |
+| `q5-dunnock-cooling` | `conv-dunnock-row-cooling` (conversation) | `/blown sand/` | miss | HIT | search_library_rag, search_library_rag, expand_document |
+| `q6-gatehouse-ups` | `conv-gatehouse-power` (conversation) | `/(?:ninety\|90)\s*minutes/` | miss | miss | search_library_rag, search_library_rag |
+| `q7-filling-head-mtbf` | `media-filling-head-reliability` (media) | `/(?:nine hundred\|900)\s+(?:running\s+)?hours/` | miss | HIT | search_library_rag, search_library_rag, search_library_rag, expand_document |
+| `q8-larkspur-lubrication` | `media-larkspur-turbine` (media) | `/starved a bearing/` | miss | HIT | search_library_rag, expand_document |
+| **TOTAL** | | | **0/8** | **7/8** | |
+
+Total spend $0.177 (plus $0.022 for a one-question smoke run). The single
+tool-ON miss is a **retrieval** failure present in both arms — both of
+`q6`'s searches returned `status: "empty"`, so there was never a row to
+expand (the four-seam keyword path ANDs every query token, and the model's
+own phrasings over-constrained; the document is reachable at rank 1 for
+`gate house UPS`). Conditioned on the target row actually being returned,
+the tool-ON arm answered **7 of 7**. Four tool-OFF questions retrieved the
+label-only row and still scored zero, saying so unprompted: *"I can only
+see that it's a media document and cannot access its full contents through
+the search results."*
+
+Method, isolation proof, per-question attribution, disclosed limits and
+the full artifact:
+`Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/` (`questions.toml`,
+`oracle_run.py`, `report.md`, `run-artifacts.json`). The run is a
+**script, never a test** — the suite is network-blocked by default, and
+`oracle_run.py --dry-run` reproduces everything except the model calls.
+
+**If you extend this instrument**, keep two properties or it stops
+measuring anything: an oracle must never appear in a title (the agent sees
+titles), and the route must stay `plain` unless you are deliberately
+measuring a different regime.

--- a/Tests/RAG_Search/test_search_config_compat.py
+++ b/Tests/RAG_Search/test_search_config_compat.py
@@ -1,0 +1,104 @@
+"""Compat tests for the TASK-16174 Phase K retirement of the parent-inclusion knobs.
+
+`include_parent_docs` / `parent_size_threshold` / `parent_inclusion_strategy`
+were shipped, user-switchable and wired to nothing (spec:
+`Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md`). Retiring a
+dataclass field is not free: `RAGConfig.from_dict` builds `SearchConfig(**search_data)`
+straight from a user-editable dict, so a saved TOML that still carries a retired key
+would raise `TypeError` on load. These tests pin the retirement AND the survival of
+such a saved config.
+
+Loguru does not feed pytest's `caplog` on its own; the sink installed here is the
+repo's own `_forward_loguru_to_standard` bridge (precedent:
+`Tests/test_persistent_diagnostic_boundary.py:97`).
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.Logging_Config import _forward_loguru_to_standard
+from tldw_chatbook.RAG_Search.simplified.config import RAGConfig
+
+
+@pytest.fixture()
+def loguru_caplog(caplog):
+    """Make loguru warnings visible to pytest's `caplog`."""
+    sink_id = loguru_logger.add(_forward_loguru_to_standard, level="DEBUG")
+    caplog.set_level(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+def test_saved_config_with_retired_parent_keys_loads(loguru_caplog):
+    """A saved config still carrying the three retired keys loads, warns, drops them."""
+    data = {
+        "search": {
+            "include_parent_docs": True,
+            "parent_size_threshold": 5000,
+            "parent_inclusion_strategy": "size_based",
+            "default_top_k": 7,
+        }
+    }
+    cfg = RAGConfig.from_dict(data)  # must NOT raise TypeError
+    assert cfg.search.default_top_k == 7
+    assert not hasattr(cfg.search, "include_parent_docs")
+    assert not hasattr(cfg.search, "parent_size_threshold")
+    assert not hasattr(cfg.search, "parent_inclusion_strategy")
+    messages = [r.message for r in loguru_caplog.records]
+    assert any("include_parent_docs" in m for m in messages), messages
+    assert any("parent_size_threshold" in m for m in messages), messages
+    assert any("parent_inclusion_strategy" in m for m in messages), messages
+
+
+def test_unknown_search_key_is_dropped_with_notice(loguru_caplog):
+    """Any unknown search key degrades to an ignored key with a logged notice."""
+    cfg = RAGConfig.from_dict({"search": {"never_a_field": 1}})
+    assert not hasattr(cfg.search, "never_a_field")
+    assert any("never_a_field" in r.message for r in loguru_caplog.records)
+
+
+def test_no_profile_sets_parent_inclusion():
+    """No shipped profile switches on the retired parent-inclusion surface."""
+    import tldw_chatbook.RAG_Search.config_profiles as m
+
+    src = inspect.getsource(m)
+    assert "include_parent_docs" not in src
+    assert "parent_size_threshold" not in src
+    assert "parent_inclusion_strategy" not in src
+
+
+def test_saved_profile_json_with_retired_keys_still_loads():
+    """The real-world compat path: a user's saved custom profile JSON.
+
+    Profiles round-trip through `ProfileConfig.to_dict()` -> disk ->
+    `ProfileConfig.from_dict()`, which hands `rag_config` to `RAGConfig.from_dict`.
+    A profile saved before the retirement carries the three keys inside
+    `rag_config["search"]`; it must load rather than take profile loading down.
+    """
+    from tldw_chatbook.RAG_Search.config_profiles import ProfileConfig
+
+    profile = ProfileConfig.from_dict(
+        {
+            "id": "legacy_custom",
+            "name": "Legacy Custom",
+            "description": "Saved before TASK-16174 retired the parent knobs",
+            "profile_type": "custom",
+            "rag_config": {
+                "search": {
+                    "include_parent_docs": True,
+                    "parent_size_threshold": 8000,
+                    "parent_inclusion_strategy": "size_based",
+                    "default_top_k": 12,
+                }
+            },
+        }
+    )
+    assert profile.rag_config.search.default_top_k == 12
+    assert not hasattr(profile.rag_config.search, "include_parent_docs")

--- a/Tests/Tools/test_document_expansion_tool.py
+++ b/Tests/Tools/test_document_expansion_tool.py
@@ -27,6 +27,7 @@ PROMPT_DETAILS = "Use for structured extraction."
 PROMPT_SYSTEM = "You are a careful extraction assistant."
 HEAD_MARKER = "HEADSTART-ONLY-TOKEN"
 DEEP_MARKER = "DEEPBODY-ONLY-TOKEN"
+TAIL_MARKER = "TAILMESSAGE-ONLY-TOKEN"
 
 
 def _long_body() -> str:
@@ -227,12 +228,14 @@ async def test_over_budget_returns_window_and_next_offset(dbs):
     assert result["next_offset"] == 1000
 
 
-async def test_chunk_centred_window_when_chunk_id_known(dbs):
-    """A semantic row carries chunk lineage; the window follows it.
+async def test_chunk_start_centres_the_window(dbs):
+    """A semantic row carries chunk lineage; the window follows `chunk_start`.
 
     The row's `provenance` carries `chunk_start` (written by the indexer at
-    `rag_service.py`'s chunk-metadata build) alongside `chunk_id`. The agent
-    pastes them verbatim and gets the matched region, NOT the document head.
+    `rag_service.py`'s chunk-metadata build). The agent pastes it verbatim and
+    gets the matched region, NOT the document head. `chunk_id` is deliberately
+    absent from this call: it is an INDEX, it anchors nothing, and the fix
+    wave retired it from the schema for exactly that reason.
     """
     body = _long_body()
     note_id = _seed_note(dbs, body=body)
@@ -241,7 +244,6 @@ async def test_chunk_centred_window_when_chunk_id_known(dbs):
     result = await _tool().execute(
         source_type="note",
         source_id=note_id,
-        chunk_id=f"note_{note_id}_chunk_9",
         chunk_start=anchor,
         max_chars=1000,
     )
@@ -275,6 +277,160 @@ async def test_offset_continuation_walks_the_document(dbs):
     assert second["text"] == body[1000:2000]
     assert second["text"] != first["text"]
     assert second["next_offset"] == 2000
+
+
+async def test_chunk_id_is_accepted_but_is_not_agent_facing_surface(dbs):
+    """`chunk_id` is retired from the schema: nothing in `execute` reads it.
+
+    An agent pasting a row's whole provenance still works -- `chunk_id` rides
+    the `**_provenance` swallow -- and the window it gets is the document
+    HEAD, which is the proof the index never anchored anything. Shipping a
+    knob wired to nothing is the exact surface this arc's Phase K retired.
+    """
+    tool = _tool()
+    assert "chunk_id" not in tool.parameters["properties"]
+    assert "chunk_id" not in tool.parameters["required"]
+
+    body = _long_body()
+    note_id = _seed_note(dbs, body=body)
+
+    result = await tool.execute(
+        source_type="note",
+        source_id=note_id,
+        chunk_id=f"note_{note_id}_chunk_9",
+        chunk_index=9,
+        media_type="document",
+        max_chars=1000,
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["window"] == {"start": 0, "end": 1000}
+    assert HEAD_MARKER in result["text"]
+    assert DEEP_MARKER not in result["text"]
+
+
+def test_tool_description_names_chunk_start_as_the_window_anchor():
+    """The retirement must reach the prose too: the description tells the
+    agent to pass `chunk_start` -- the field the code actually consumes --
+    and never mentions the parameter that was removed."""
+    description = " ".join(_tool().description.split())
+
+    assert (
+        "pass the row's chunk_start to centre that window on the matched "
+        "chunk instead of the document head"
+    ) in description
+    assert "chunk_id" not in description
+
+
+# --- the budget promise -----------------------------------------------------
+
+
+async def test_absurd_budget_is_capped_at_the_hard_max(dbs):
+    """"the tool never returns more than the budget regardless of what is
+    asked" (spec) -- `HARD_MAX_CHARS` is that promise, and it was untested."""
+    from tldw_chatbook.Tools.document_expansion_tool import HARD_MAX_CHARS
+
+    body = "z" * (HARD_MAX_CHARS + 5000)
+    note_id = _seed_note(dbs, body=body)
+
+    result = await _tool().execute(
+        source_type="note", source_id=note_id, max_chars=10**9
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert len(result["text"]) == HARD_MAX_CHARS
+    assert result["window"] == {"start": 0, "end": HARD_MAX_CHARS}
+    assert result["total_size"] == len(body)
+    assert result["truncated"] is True
+    assert result["next_offset"] == HARD_MAX_CHARS
+
+
+@pytest.mark.parametrize("budget", [0, -5, "x", None])
+async def test_useless_budget_falls_back_to_the_default(dbs, budget):
+    """A non-positive or unparseable budget is floored to the default rather
+    than returning zero characters (or raising) -- the other half of
+    `_resolve_budget`, likewise untested until the fix wave."""
+    from tldw_chatbook.Tools.document_expansion_tool import DEFAULT_MAX_CHARS
+
+    body = "z" * (DEFAULT_MAX_CHARS + 2000)
+    note_id = _seed_note(dbs, body=body)
+
+    result = await _tool().execute(
+        source_type="note", source_id=note_id, max_chars=budget
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert len(result["text"]) == DEFAULT_MAX_CHARS
+    assert result["window"] == {"start": 0, "end": DEFAULT_MAX_CHARS}
+    assert result["next_offset"] == DEFAULT_MAX_CHARS
+
+
+# --- the conversation message cap is a PARTIAL read, and says so ------------
+
+
+async def test_conversation_over_the_message_cap_reports_itself_truncated(dbs):
+    """A >500-message conversation must not be reported as a complete read.
+
+    `MAX_TRANSCRIPT_MESSAGES` bounds the DB work, so `total_size` describes
+    only the prefix that was read. Returning `truncated: False` and
+    `next_offset: None` there asserts a completeness the payload does not
+    have -- and does it invisibly, since it looks exactly like a successful
+    whole-document read.
+    """
+    from tldw_chatbook.Tools.document_expansion_tool import MAX_TRANSCRIPT_MESSAGES
+
+    conversation_id = dbs.chacha.add_conversation({"title": "Very long chat"})
+    assert conversation_id, "precondition: the conversation writer returned an id"
+    for index in range(MAX_TRANSCRIPT_MESSAGES + 1):
+        content = (
+            f"{TAIL_MARKER} last"
+            if index == MAX_TRANSCRIPT_MESSAGES
+            else f"message {index}"
+        )
+        dbs.chacha.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "user",
+                "content": content,
+                "timestamp": (
+                    f"2026-01-01T{index // 3600:02d}:"
+                    f"{(index // 60) % 60:02d}:{index % 60:02d}Z"
+                ),
+            }
+        )
+
+    result = await _tool().execute(
+        source_type="conversation",
+        source_id=str(conversation_id),
+        max_chars=32000,
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert TAIL_MARKER not in result["text"], "the 501st message was never read"
+    assert result["window"] == {"start": 0, "end": result["total_size"]}
+    assert result["truncated"] is True, "a partial read must say it is partial"
+    assert result["next_offset"] is None, "character offsets cannot reach message 501"
+    note = result.get("note", "")
+    assert str(MAX_TRANSCRIPT_MESSAGES) in note and "message" in note.lower(), (
+        "the payload says WHICH boundary it hit, not merely that it hit one"
+    )
+
+
+async def test_a_short_conversation_carries_no_truncation_note(dbs):
+    """The note is emitted on exactly the partial reads -- a two-message
+    transcript is complete and says nothing."""
+    conversation_id = _seed_conversation(dbs)
+
+    result = await _tool().execute(
+        source_type="conversation", source_id=conversation_id
+    )
+
+    assert result["truncated"] is False
+    assert "note" not in result
 
 
 # --- misses and identity ----------------------------------------------------

--- a/Tests/Tools/test_document_expansion_tool.py
+++ b/Tests/Tools/test_document_expansion_tool.py
@@ -1,0 +1,413 @@
+"""TASK-16174 Phase T: the gated `expand_document` tool's contract.
+
+Since TASK-16071's rank-fair merge, 54% of the rows a top-M consumer is fed
+are LABEL-ONLY (`Matched media · pdf`, `Matched conversation · 3 messages`;
+`Library/library_local_rag_search_service.py`'s `_media_row`/`_conversation_row`,
+both with `chunk_id: ""`). An agent could retrieve them and not see behind
+them. These tests pin the tool that does, per source type, against REAL
+databases seeded through the production writer APIs -- the same four writers
+the RAG eval harness uses (`Tests/RAG_Eval/harness/ingest.py`), so row shapes
+and id assignment are production's and not a fixture's guess at them.
+
+The two label-only branches (media, conversation) are first-class cases here,
+not afterthoughts: AC#4 is "the contract works from exactly what those rows
+carry" -- `source_type` + `source_id`, empty `chunk_id`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+CLIENT_ID = "expand-document-tests"
+NOTE_BODY = "Tides are driven by the moon's gravity, not by wind."
+MEDIA_BODY = "The Fresnel lens focuses a beam without a solid glass block."
+PROMPT_DETAILS = "Use for structured extraction."
+PROMPT_SYSTEM = "You are a careful extraction assistant."
+HEAD_MARKER = "HEADSTART-ONLY-TOKEN"
+DEEP_MARKER = "DEEPBODY-ONLY-TOKEN"
+
+
+def _long_body() -> str:
+    """A body whose head and deep region are separately identifiable."""
+    return HEAD_MARKER + ("x" * 3000) + DEEP_MARKER + ("y" * 3000)
+
+
+@pytest.fixture
+def dbs(tmp_path, monkeypatch):
+    """Real ChaChaNotes/Media/Prompts databases, wired in as the tool's handles.
+
+    The tool resolves its handles through `config.get_*_db_lazy()` with
+    function-local imports (the `note_management_tools` precedent), so
+    patching the config module's attributes is the seam that reaches it.
+    """
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+    from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+    import tldw_chatbook.config as config_module
+
+    chacha = CharactersRAGDB(tmp_path / "chacha.db", client_id=CLIENT_ID)
+    media = MediaDatabase(tmp_path / "media.db", client_id=CLIENT_ID)
+    prompts = PromptsDatabase(tmp_path / "prompts.db", client_id=CLIENT_ID)
+
+    monkeypatch.setattr(config_module, "get_chachanotes_db_lazy", lambda: chacha)
+    monkeypatch.setattr(config_module, "get_media_db_lazy", lambda: media)
+    monkeypatch.setattr(config_module, "get_prompts_db_lazy", lambda: prompts)
+
+    yield SimpleNamespace(chacha=chacha, media=media, prompts=prompts)
+
+    for db in (prompts, media, chacha):
+        try:
+            db.close_connection()
+        except Exception:  # noqa: BLE001 -- teardown must not mask a failure
+            pass
+
+
+def _tool():
+    from tldw_chatbook.Tools.document_expansion_tool import ExpandDocumentTool
+
+    return ExpandDocumentTool()
+
+
+def _seed_note(dbs, body: str = NOTE_BODY, title: str = "Tide note") -> str:
+    note_id = dbs.chacha.add_note(title=title, content=body)
+    assert note_id, "precondition: the note writer returned an id"
+    return str(note_id)
+
+
+def _seed_media(dbs, body: str = MEDIA_BODY, title: str = "Lighthouse optics") -> str:
+    media_id, _uuid, message = dbs.media.add_media_with_keywords(
+        title=title, media_type="document", content=body
+    )
+    assert media_id is not None, f"precondition: media write failed ({message})"
+    return str(media_id)
+
+
+def _seed_conversation(dbs, title: str = "Optics chat") -> str:
+    conversation_id = dbs.chacha.add_conversation({"title": title})
+    assert conversation_id, "precondition: the conversation writer returned an id"
+    for sender, content in (("user", "Why does the beam carry?"), ("assistant", MEDIA_BODY)):
+        dbs.chacha.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": sender,
+                "content": content,
+                "timestamp": "2026-01-01T00:00:00Z",
+            }
+        )
+    return str(conversation_id)
+
+
+def _seed_prompt(dbs, name: str = "Extraction prompt") -> str:
+    prompt_id, _uuid, message = dbs.prompts.add_prompt(
+        name=name,
+        author=None,
+        details=PROMPT_DETAILS,
+        system_prompt=PROMPT_SYSTEM,
+    )
+    assert prompt_id is not None, f"precondition: prompt write failed ({message})"
+    return str(prompt_id)
+
+
+_SHAPE_KEYS = {
+    "status",
+    "source_type",
+    "source_id",
+    "title",
+    "text",
+    "total_size",
+    "window",
+    "truncated",
+    "next_offset",
+}
+
+
+def _assert_shape(result: dict) -> None:
+    """Every branch returns the SAME keys -- Task 3 consumes this shape."""
+    assert _SHAPE_KEYS <= set(result), f"missing keys: {_SHAPE_KEYS - set(result)}"
+    assert set(result["window"]) == {"start", "end"}
+
+
+# --- per-source-type contract ----------------------------------------------
+
+
+async def test_note_expands_to_full_body(dbs):
+    note_id = _seed_note(dbs)
+
+    result = await _tool().execute(source_type="note", source_id=note_id)
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["source_type"] == "note"
+    assert result["source_id"] == note_id
+    assert result["title"] == "Tide note"
+    assert result["text"] == NOTE_BODY
+    assert result["total_size"] == len(NOTE_BODY)
+    assert result["window"] == {"start": 0, "end": len(NOTE_BODY)}
+    assert result["truncated"] is False
+    assert result["next_offset"] is None
+
+
+async def test_media_label_only_row_expands(dbs):
+    """AC#4: a media row ships `source_type` + `source_id` and `chunk_id: ""`.
+
+    That is the ENTIRE input the tool gets for 54% of merged rows, so the
+    call is made with exactly those fields and nothing else.
+    """
+    media_id = _seed_media(dbs)
+    stored = dbs.media.get_media_by_id(int(media_id))
+
+    result = await _tool().execute(
+        source_type="media", source_id=media_id, chunk_id=""
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["source_type"] == "media"
+    assert result["source_id"] == media_id
+    assert result["title"] == "Lighthouse optics"
+    assert result["text"] == stored["content"]
+    assert MEDIA_BODY in result["text"]
+    assert result["truncated"] is False
+
+
+async def test_conversation_returns_role_prefixed_transcript(dbs):
+    """Mirrors `ingestion_indexing.conversation_document`'s `f"{sender}: {content}"`
+    rendering, so what the agent reads matches what was indexed."""
+    conversation_id = _seed_conversation(dbs)
+
+    result = await _tool().execute(
+        source_type="conversation", source_id=conversation_id, chunk_id=""
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["source_type"] == "conversation"
+    assert result["title"] == "Optics chat"
+    assert result["text"] == (
+        f"user: Why does the beam carry?\nassistant: {MEDIA_BODY}"
+    )
+    assert result["truncated"] is False
+
+
+async def test_prompt_expands(dbs):
+    """The body is the non-empty `PROMPT_DOCUMENT_COLUMNS` joined -- the same
+    rendering the prompts sub-leg indexes (`rag_service._prompt_document_text`)."""
+    prompt_id = _seed_prompt(dbs)
+
+    result = await _tool().execute(source_type="prompt", source_id=prompt_id)
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["source_type"] == "prompt"
+    assert result["title"] == "Extraction prompt"
+    assert result["text"] == f"{PROMPT_DETAILS}\n\n{PROMPT_SYSTEM}"
+    assert result["truncated"] is False
+
+
+# --- budget, windowing, continuation ---------------------------------------
+
+
+async def test_over_budget_returns_window_and_next_offset(dbs):
+    body = _long_body()
+    note_id = _seed_note(dbs, body=body)
+
+    result = await _tool().execute(
+        source_type="note", source_id=note_id, max_chars=1000
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert result["total_size"] == len(body)
+    assert result["window"] == {"start": 0, "end": 1000}
+    assert result["text"] == body[:1000]
+    assert len(result["text"]) == 1000
+    assert result["truncated"] is True
+    assert result["next_offset"] == 1000
+
+
+async def test_chunk_centred_window_when_chunk_id_known(dbs):
+    """A semantic row carries chunk lineage; the window follows it.
+
+    The row's `provenance` carries `chunk_start` (written by the indexer at
+    `rag_service.py`'s chunk-metadata build) alongside `chunk_id`. The agent
+    pastes them verbatim and gets the matched region, NOT the document head.
+    """
+    body = _long_body()
+    note_id = _seed_note(dbs, body=body)
+    anchor = body.index(DEEP_MARKER)
+
+    result = await _tool().execute(
+        source_type="note",
+        source_id=note_id,
+        chunk_id=f"note_{note_id}_chunk_9",
+        chunk_start=anchor,
+        max_chars=1000,
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "ok"
+    assert DEEP_MARKER in result["text"]
+    assert HEAD_MARKER not in result["text"]
+    assert result["window"]["start"] > 0
+    assert result["window"]["start"] <= anchor < result["window"]["end"]
+    assert result["truncated"] is True
+
+
+async def test_offset_continuation_walks_the_document(dbs):
+    """Navigation within one document without re-querying."""
+    body = _long_body()
+    note_id = _seed_note(dbs, body=body)
+    tool = _tool()
+
+    first = await tool.execute(source_type="note", source_id=note_id, max_chars=1000)
+    second = await tool.execute(
+        source_type="note",
+        source_id=note_id,
+        offset=first["next_offset"],
+        max_chars=1000,
+    )
+
+    _assert_shape(second)
+    assert second["status"] == "ok"
+    assert second["window"] == {"start": 1000, "end": 2000}
+    assert second["text"] == body[1000:2000]
+    assert second["text"] != first["text"]
+    assert second["next_offset"] == 2000
+
+
+# --- misses and identity ----------------------------------------------------
+
+
+async def test_unknown_id_is_not_found(dbs):
+    result = await _tool().execute(
+        source_type="note", source_id="00000000-0000-0000-0000-000000000000"
+    )
+
+    _assert_shape(result)
+    assert result["status"] == "not_found"
+    assert result["text"] == ""
+    assert result["total_size"] == 0
+    assert result["truncated"] is False
+    assert result["next_offset"] is None
+    assert "error" not in result
+
+
+async def test_semantic_identity_fallbacks(dbs):
+    """A semantic row's `source_id` can be a CHROMA POINT ID.
+
+    `_semantic_row` builds `source_id` from metadata `source_id` ||
+    `document_id` || the point id, so the real document identity may only be
+    in the provenance extras. `doc_id` there is the indexer's prefixed
+    document id (`f"note_{id}"`, `ingestion_indexing.note_document`), which
+    must resolve as well as a bare `note_id` does.
+    """
+    note_id = _seed_note(dbs)
+    tool = _tool()
+
+    via_note_id = await tool.execute(
+        source_type="note",
+        source_id="a1b2c3d4-chroma-point-id",
+        note_id=note_id,
+    )
+    assert via_note_id["status"] == "ok"
+    assert via_note_id["text"] == NOTE_BODY
+    assert via_note_id["source_id"] == note_id, "the RESOLVED identity is reported"
+
+    via_doc_id = await tool.execute(
+        source_type="note",
+        source_id="a1b2c3d4-chroma-point-id",
+        doc_id=f"note_{note_id}",
+    )
+    assert via_doc_id["status"] == "ok"
+    assert via_doc_id["text"] == NOTE_BODY
+    assert via_doc_id["source_id"] == note_id
+
+    media_id = _seed_media(dbs)
+    via_media_id = await tool.execute(
+        source_type="media",
+        source_id="a1b2c3d4-chroma-point-id",
+        media_id=media_id,
+    )
+    assert via_media_id["status"] == "ok"
+    assert MEDIA_BODY in via_media_id["text"]
+
+
+# --- catalog: gated off by default, risk-floored to ask ---------------------
+
+
+@pytest.fixture
+def tools_config(monkeypatch):
+    """`[tools]` gate reads, deterministic and independent of config.toml.
+
+    Same seam `Tests/Agents/test_gateable_builtin_tools.py` patches: both
+    `BuiltinToolProvider.__init__` and `all_tool_gates()` reach
+    `tldw_chatbook.config.get_cli_setting` by function-local import.
+    """
+    values: dict = {}
+    import tldw_chatbook.config as config_module
+
+    def fake(section, key=None, default=None):
+        if section != "tools" or not isinstance(key, str):
+            return default
+        return values.get(key, default)
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake)
+    return values
+
+
+def test_tool_is_gated_off_by_default(tools_config):
+    """Registered in the ONE table, absent until its gate is switched on.
+
+    The Settings-side switch is DERIVED from `_GATEABLE_BUILTINS` -- the MCP
+    hub's gate affordance enumerates it through `all_tool_gates()` -- so
+    asserting the row exists there with `enabled=False` is asserting the
+    switch exists and starts off.
+    """
+    from tldw_chatbook.Agents.builtin_tool_gate import all_tool_gates
+    from tldw_chatbook.Agents.tool_catalog import (
+        BuiltinToolProvider,
+        gateable_builtin_tools,
+    )
+
+    entry = next(
+        e for e in gateable_builtin_tools() if e.tool_name == "expand_document"
+    )
+    assert entry.gate_key == "expand_document_enabled"
+    assert entry.module_name == "document_expansion_tool"
+    assert entry.factory_name == "ExpandDocumentTool"
+
+    off_names = {e.name for e in BuiltinToolProvider().list_catalog()}
+    assert "expand_document" not in off_names
+
+    gate = next(g for g in all_tool_gates() if g.tool_name == "expand_document")
+    assert (gate.section, gate.key, gate.group) == (
+        "tools",
+        "expand_document_enabled",
+        "builtin",
+    )
+    assert gate.enabled is False
+    assert gate.description, "the switch renders the tool's own description"
+
+    tools_config["expand_document_enabled"] = True
+    on_names = {e.name for e in BuiltinToolProvider().list_catalog()}
+    assert "expand_document" in on_names
+
+
+def test_tool_carries_risk_tags():
+    """It reads the user's notes, media, conversations and prompts, so an
+    inherited `allow` must be FLOORED to `ask` (a per-call approval card)."""
+    from tldw_chatbook.Agents.builtin_tool_gate import tool_ref
+    from tldw_chatbook.MCP.permission_store import (
+        BUILTIN_HIGH_RISK_TAGS,
+        resolve_builtin_state,
+    )
+
+    tool = _tool()
+    assert tool.risk_tags == ("reads",)
+    assert set(tool.risk_tags) <= BUILTIN_HIGH_RISK_TAGS
+
+    state = resolve_builtin_state({}, tool_ref(tool))
+    assert state.state == "ask"
+    assert state.risk_floored is True

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -3100,7 +3100,12 @@ async def test_empty_diagnosis_no_servers_shows_add_server_and_button_opens_form
 async def test_empty_diagnosis_names_the_gate_off_count_when_gates_are_off():
     """task-3240 SECONDARY breadcrumb: `_empty_tools_diagnosis()` appends
     "N tool gate(s) are off ..." whenever `all_tool_gates()` finds any --
-    TASK-14807 defaults the local master gate on, leaving 8 gates off."""
+    TASK-14807 defaults the local master gate on, leaving every other gate
+    off. N is DERIVED (TASK-16174): a new gateable built-in changes the
+    count, and this test is about the breadcrumb, not the arity."""
+    from tldw_chatbook.Agents.tool_catalog import _GATEABLE_BUILTINS
+
+    off_count = len(_GATEABLE_BUILTINS) + 1  # + web_deep_search, - the master
     app = NoServersApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -3109,7 +3114,7 @@ async def test_empty_diagnosis_names_the_gate_off_count_when_gates_are_off():
         await pilot.pause()
         canvas = app.query_one(MCPToolsMode)
         message = str(canvas.query_one("#mcp-tools-empty-message", Static).renderable)
-        assert "8 tool gate(s) are off" in message
+        assert f"{off_count} tool gate(s) are off" in message
         assert "Tools mode" in message
 
 

--- a/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
+++ b/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
@@ -211,7 +211,7 @@ Task 3b pre-registered two ways expansion could misfire. **Neither
 manifested in this run, and neither is refuted by it** — the `plain`
 route emits no chunked rows and real database ids, so it cannot exercise
 either. They remain the first things to check if the tool is measured on a
-semantic/hybrid route, and are carried by a follow-up task:
+semantic/hybrid route, and are carried by **TASK-16588**:
 
 1. `chunk_start` is absent from the projected payload, so a chunked row
    would expand from the document HEAD rather than around the match.

--- a/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
+++ b/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
@@ -148,7 +148,7 @@ method, isolation proof, per-question attribution and disclosed limits:
   `Agents/library_rag_tool_provider._project_row` attaches it. The
   decision rule also sits in the tool's own `description`, pinned verbatim
   by `test_tool_description_states_the_policy_verbatim`. 17 policy tests +
-  42 provider tests cover each branch, the sealing loop's byte budget, and
+  47 provider tests cover each branch, the sealing loop's byte budget, and
   hostile rows.
 
   **DISCLOSURE (added by the fix wave, final review finding 2): "each

--- a/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
+++ b/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
@@ -130,23 +130,48 @@ method, isolation proof, per-question attribution and disclosed limits:
   from the same table (`builtin_tool_gate.all_tool_gates`), so it appeared
   with zero UI wiring.
 - **#2 — an actionable contract.** `execute(source_type, source_id,
-  chunk_id="", chunk_start=None, offset=0, max_chars=None, note_id=…,
-  media_id=…, doc_id=…, **provenance)` returning the SAME keys on every
-  branch — `status | source_type | source_id | title | text | total_size |
+  offset=0, max_chars=None, chunk_start=None, note_id=…, media_id=…,
+  doc_id=…, **provenance)` returning the SAME keys on every branch —
+  `status | source_type | source_id | title | text | total_size |
   window{start,end} | truncated | next_offset` — for note / media /
   conversation / prompt and for `not_found` / `unsupported` / `error`. Over
   budget it returns a window (chunk-centred when `chunk_start` is known,
   else the head) plus `next_offset`, so a long document is navigable
-  without re-querying. Eleven contract tests, RED-first.
+  without re-querying. Eleven contract tests, RED-first, plus seven added
+  by the fix wave below (the retired `chunk_id` parameter, the
+  `HARD_MAX_CHARS` cap and its `<= 0` floor, and the >500-message
+  conversation, which used to be reported as a complete read).
 - **#3 — a testable policy, in the payload the agent actually reads.**
   `Library/library_expand_policy.expand_hint` is pure and returns
   `{expandable, reason}` ∈ `label_only` / `truncated_snippet` /
   `text_bearing`, or `None` for a row with nothing to expand;
   `Agents/library_rag_tool_provider._project_row` attaches it. The
   decision rule also sits in the tool's own `description`, pinned verbatim
-  by `test_tool_description_states_the_policy_verbatim`. 16 policy tests +
-  39 provider tests cover each branch, the sealing loop's byte budget, and
+  by `test_tool_description_states_the_policy_verbatim`. 17 policy tests +
+  42 provider tests cover each branch, the sealing loop's byte budget, and
   hostile rows.
+
+  **DISCLOSURE (added by the fix wave, final review finding 2): "each
+  branch" means each branch THE HELPER HAS — and the helper has two of the
+  spec's four.** The spec
+  (`Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md`)
+  named four: label-only → expand; text-bearing → no; **budget exhausted →
+  no**; **repeat expansion of the same source → no**. The shipped
+  `expand_hint` has three reasons (`label_only` / `truncated_snippet` /
+  `text_bearing`) and no concept of budget or repetition. Those two branches
+  ship as INSTRUCTION in the tool's description and nothing enforces them,
+  measures them, or could: both are properties of a CONVERSATION, not of a
+  row — "have I already expanded this source?" and "what context budget is
+  left?" require per-run agent-loop state that a stateless per-call tool and
+  a pure per-row helper both lack, and adding that state (a per-run
+  expansion ledger in `AgentService`) is a different piece of work from this
+  arc. The plan dropped them silently; this bullet is the correction. Both
+  sentences are now pinned verbatim by
+  `test_description_carries_the_two_branches_no_code_enforces`
+  (`Tests/Library/test_library_expand_policy.py`) so they cannot quietly
+  evaporate, and the "budget exhausted" sentence was ADDED to the
+  description by the fix wave — before it, that branch existed nowhere at
+  all.
 - **#4 — the label-only problem addressed, not scoped out.** Media and
   conversation rows are the tool's first-class acceptance cases, not
   afterthoughts: the contract works from exactly what such a row carries
@@ -187,7 +212,14 @@ method, isolation proof, per-question attribution and disclosed limits:
   consumer is a default is exactly the dead surface Phase K just retired.
 - **`chunk_id` is an INDEX, not an offset** (`f"{doc_id}_chunk_{i}"`), so
   the window anchor is `chunk_start` — a real chunk-metadata key. No
-  index→offset guessing path exists, deliberately.
+  index→offset guessing path exists, deliberately. **The fix wave finished
+  the job**: `chunk_id` was still standing in the tool's JSON schema and
+  signature while nothing in `execute` read it — a dead agent-facing knob
+  inside the arc whose thesis is that such knobs must not ship (finding 1).
+  It is retired from the schema (a pasted row still works: it rides the
+  `**_provenance` swallow) and `chunk_start` is now EMITTED by
+  `_project_row`, so the seam is wired at both ends instead of offering the
+  one field the tool discards and withholding the one it consumes.
 - **Identity rides the hint's own precondition** (Task 3b). A row with
   nothing to expand carries neither hint nor identity, so verdict and
   identity cannot drift apart and no raw id leaks on an unsupported row.
@@ -213,8 +245,17 @@ route emits no chunked rows and real database ids, so it cannot exercise
 either. They remain the first things to check if the tool is measured on a
 semantic/hybrid route, and are carried by **TASK-16588**:
 
-1. `chunk_start` is absent from the projected payload, so a chunked row
-   would expand from the document HEAD rather than around the match.
+1. ~~`chunk_start` is absent from the projected payload, so a chunked row
+   would expand from the document HEAD rather than around the match.~~
+   **CAUSE FIXED by the fix wave** (it was the other half of finding 1's
+   wire-or-retire): `_project_row` now emits `chunk_start` whenever a row's
+   provenance carries a usable anchor (`> 0`; a head anchor or an
+   unparseable value is dropped, since the tool centres only for
+   `anchor > 0`). Cost re-measured by Task 3b's strip-and-reserialize
+   method: **+19.0 B per anchored row**, +95 B on a ten-row payload with
+   five anchored rows (11.7 % of the 32 KiB ceiling; an unanchored payload
+   pays nothing). Still UNMEASURED on a route that can produce a chunked
+   row — TASK-16588 AC#3 stands.
 2. A semantic `source_id` can be a vector-store point id whose
    `note_id`/`doc_id` fallbacks are likewise absent from the payload, so a
    declared-expandable row could return `not_found`.
@@ -257,5 +298,122 @@ implemented; each now carries a correction).
   optional-dependency guards).
 - Collection sweep over every test file this branch touched vs merge-base
   `8727a2861`: 6 files, 348 tests collected, 0 errors.
-- Ruff clean on every touched file.
+- Ruff (the repo's 0.15.22, whole-file) clean on every file this arc
+  touched **with one exception, which is dev's and not this arc's**:
+  `tldw_chatbook/RAG_Search/simplified/config.py` reports `F401
+  load_cli_config_and_ensure_existence imported but unused` at `:18`. The
+  same finding exists at the merge-base `8727a2861`, so the arc neither
+  introduced nor removed it — the earlier unqualified "clean on every
+  touched file" was falsifiable in one command (final review finding 10).
+
+---
+
+## Fix wave — the final review's findings (2026-08-15)
+
+The whole-branch adversarial review returned **SHIP-WITH-FIXES**: every
+recomputable number in this file, the QA report and the README arc section
+reproduced exactly (the gate's 105 cells, the arm-level spend, the sealed
+payload byte costs, and the 0/8 → 7/8 score re-derived from the raw
+answers), and what held it back was three blockers plus a set of pin and
+claim-precision gaps. This wave closed them. Everything below is RED-first
+where it is a behaviour change and mutation-checked where it is a pin.
+
+**1 (blocker) — `chunk_id` was inert agent-facing surface, and the payload
+emitted exactly the field the tool ignores.** Applied this arc's own
+wire-or-retire doctrine to the seam, both ends:
+*retired* `chunk_id` from the tool's JSON schema, signature and docstring
+(nothing in `execute` ever read it; a pasted row still works because it
+rides the `**_provenance` swallow), and *wired* the anchor the tool does
+read — `_project_row` now emits `chunk_start` whenever a row's provenance
+carries a usable one. A head anchor (`0`), a negative, a bool or an
+unparseable value is dropped, because `_window_bounds` centres only for
+`anchor > 0` and a key that changes nothing is bytes spent in a sealed
+payload for no behaviour. Byte cost re-measured with Task 3b's
+strip-and-reserialize method: **+19.0 B per anchored row**, +95 B over a
+ten-row payload with five anchored rows (9.5 B/row, 11.7 % of the 32 KiB
+ceiling, headroom 28,943 B); a payload with no anchored row pays nothing.
+The description's window sentence now names `chunk_start`, and the
+misleading test name (`test_chunk_centred_window_when_chunk_id_known`,
+whose decorative `chunk_id` did nothing) is gone.
+
+**2 (blocker) — AC#3's coverage claim vs the spec's four branches.**
+Disclosed in the AC#3 bullet above rather than narrowed silently, with the
+reason: two of the four are conversation-level, not row-level, and need
+per-run agent-loop state neither a stateless tool nor a pure per-row helper
+has. Both sentences are now pinned verbatim, and the "budget exhausted"
+sentence had to be ADDED to the description first — before this wave that
+branch existed in neither code nor prose.
+
+**3 (blocker) — a >500-message conversation was truncated and reported as
+complete.** `total_size` is the length of the RENDERED text, so for a
+conversation past `MAX_TRANSCRIPT_MESSAGES` the payload described a prefix
+while saying `truncated: False`, `next_offset: None` — a partial read
+indistinguishable from a whole-document one. `_fetch_conversation` now
+reads one message past the cap purely to tell "exactly at the cap" from
+"over it", and a capped read comes back as a typed `_Document` carrying a
+`note`; `execute` reports `truncated: True` and attaches that note
+(`MESSAGE_CAP_NOTE`, which names the cap and says the window and
+`next_offset` describe the prefix). `next_offset` stays honest: character
+offsets genuinely cannot reach message 501, so it is `None` at the end of
+the prefix and the note is what explains why. Uniform-keys contract kept
+(`note`, like `error`, is a branch-specific ADDITION, never a removal).
+
+**4 — the budget promise is now pinned.** `HARD_MAX_CHARS` and the
+non-positive floor had no test at all: the review's mutation
+(`int(mc) if mc else DEFAULT_MAX_CHARS`) left the suite at 11/11 green.
+Two tests added; both mutation-verified (cap deleted → 1 red; `<= 0` guard
+deleted → 2 red).
+
+**8 — two report figures had no committed backing.** The smoke-run cost
+($0.0222, and therefore the $0.199 headline) and "166 of 172 indexed" were
+console output that was never persisted, and the console log cannot now be
+reconstructed. They are restated in the QA report as **console-observed,
+not archived**, with a note saying which figures ARE recomputable from
+`run-artifacts.json`.
+
+**10 — the "ruff clean" claim.** Restated in Verification above with the
+pre-existing `F401` named. Re-verified in both directions during this wave:
+identical finding at `HEAD` and at the merge-base `8727a2861`.
+
+**11 — docs drift.** `Docs/User_Guide/mcp.md`'s "Agent built-ins"
+enumeration gained the eighth gate (`expand_document`, with its ask-floor
+consequence stated) and a fresh "Verified against" stamp;
+`Tests/RAG_Eval/README.md`'s arc section no longer implies a row carries
+`chunk_start` unconditionally — it now says exactly when it does, and
+records the retirement of `chunk_id` as a parameter.
+
+**12 — a stale invariant comment.** `Tests/Agents/test_library_tool_provider.py`'s
+"Raw backing identities and provenance never leave the adapter" stayed
+green only because its fixture carries no provenance. Qualified to the
+precondition truth, pointing at `_project_row` and both sides' tests.
+
+**Not fixed here, filed as TASK-16688** (id swept against `origin/dev`,
+every remote branch and all 127 worktrees; max found 16588, +100 leapfrog,
+collision re-checked): findings **5** (the two source-type allowlists have
+nothing pinning them together), **6** (the policy allowlist is narrower
+than `_SEMANTIC_SOURCE_TYPE_MAP`'s canonicalization variants — also added
+to TASK-16588 as in-scope evidence for its route measurement), **13** (the
+`[console] direct_library_tools` consent-boundary relationship is recorded
+nowhere), **15** (the conversation fetch loads image BLOBs it never
+renders) and **16** (the live run never exercised the window/continuation
+half). Findings **7** (the report's "verbatim" vs the 400-char tool-result
+clip) and **9** (the absolute developer path in `oracle_run.py`) were left
+untouched by this wave's scope.
+
+### Fix-wave verification
+
+- RED first: 6 new tests failed before the change (`chunk_id` still in the
+  schema; the description missing both new sentences; the >500-message
+  conversation asserting `truncated is False`; `KeyError: 'chunk_start'`
+  ×2). Born-green pins were mutation-checked instead — 6 mutations, every
+  one red: budget cap, budget floor, cap-note→truncated, note never set,
+  `chunk_start` emitted unconditionally, `chunk_start` never emitted.
+- `Tests/Tools Tests/Agents` **2009 passed, 15 skipped**;
+  `Tests/Library` **1986 passed, 2 skipped** (skips are the pre-existing
+  optional-dependency and platform guards).
+- Gate, re-run after the payload addition:
+  `[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of
+  baseline.` — `Tests/RAG_Eval` **307 passed**. A payload addition after
+  retrieval cannot move retrieval, and did not.
+- Ruff clean on every file this wave touched.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
+++ b/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
@@ -3,10 +3,11 @@ id: TASK-16174
 title: >-
   Agentic document expansion: a gated chunk-to-document expand tool, the agent
   policy, and its evaluation question
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-14 02:40'
-updated_date: '2026-08-14 06:29'
+updated_date: '2026-08-15 21:57'
 labels:
   - rag
   - agents
@@ -61,6 +62,17 @@ Source (repo-reachable): `Tests/RAG_Eval/README.md`'s PRF section prose and its 
 - [ ] #6 The relationship to the re-ranking gap is recorded: whether the expansion loop presumes a working reranker (TASK-3502, cross_encoder unimplemented) or is independent of it
 - [ ] #7 The inert parent-inclusion config surface is resolved, not left standing: include_parent_docs / parent_size_threshold / parent_inclusion_strategy (config.py:559-561, set by three shipped profiles) are either WIRED to the expansion work or RETIRED from config and from those profiles. A user-switchable knob that silently does nothing must not survive alongside a new tool that does the same job
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Executing the four-task plan at Docs/superpowers/plans/2026-08-15-rag-agentic-expansion.md, bound by the design spec at Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md.
+
+1. Task 1 (Phase K, AC#7): retire include_parent_docs / parent_size_threshold / parent_inclusion_strategy from SearchConfig and the three profiles that set them; make RAGConfig.from_dict filter unknown search keys (warn + drop) so saved TOML survives the retirement. Gate: RAG_EVAL=1 pytest Tests/RAG_Eval/ reads 105/105 (+0.000).
+2. Task 2 (Phase T, AC#1/#2/#4): new gated builtin expand_document (ExpandDocumentTool, gate key expand_document_enabled, risk-tagged -> floored to ask) with per-type fetch, budget, chunk-centred window and offset continuation; label-only media/conversation rows are first-class cases.
+3. Task 3 (Phase P, AC#3): pure expand_hint helper wired into Agents/library_rag_tool_provider.py's _project_row so the policy is in the payload the agent actually sees, plus the policy sentence in the tool description.
+4. Task 4 (Phase E, AC#5/#6): author + RUN an answer-level oracle check (tool-OFF vs tool-ON, fact oracles that appear only in media/conversation bodies), record the table honestly, re-run the gate, close all seven ACs on evidence.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
+++ b/backlog/tasks/task-16174 - Agentic-document-expansion-a-gated-chunk-to-document-expand-tool-the-agent-policy-and-its-evaluation-question.md
@@ -3,11 +3,11 @@ id: TASK-16174
 title: >-
   Agentic document expansion: a gated chunk-to-document expand tool, the agent
   policy, and its evaluation question
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-14 02:40'
-updated_date: '2026-08-15 21:57'
+updated_date: '2026-08-15 23:40'
 labels:
   - rag
   - agents
@@ -54,13 +54,13 @@ Source (repo-reachable): `Tests/RAG_Eval/README.md`'s PRF section prose and its 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The catalog gains one gated document-expansion tool that, given a retrieval hit, returns the surrounding or whole document text under an explicit size budget, and it is OFF by default like every other gateable builtin
-- [ ] #2 The tool's contract is stated in terms the agent can act on: what identity it takes (the retrieval row's source identity), what it returns for each source type, and what it does when the document is larger than the budget
-- [ ] #3 An agent policy is written and testable: the conditions under which expansion is worth its tokens (e.g. a high-ranked hit whose chunk is truncated or label-only) versus re-querying, with at least one test exercising each branch
-- [ ] #4 Media and conversation seam rows' label-only problem is addressed or explicitly scoped out: today those rows carry no document text ('Matched media - {type}'), so an expansion tool is the only way an agent sees their content
-- [ ] #5 The evaluation question is answered with a decision, not an assumption: either an answer-level (P3 grader) measurement is defined and run for the expansion loop, or the task records why retrieval-level scoring is sufficient and what that leaves unmeasured
-- [ ] #6 The relationship to the re-ranking gap is recorded: whether the expansion loop presumes a working reranker (TASK-3502, cross_encoder unimplemented) or is independent of it
-- [ ] #7 The inert parent-inclusion config surface is resolved, not left standing: include_parent_docs / parent_size_threshold / parent_inclusion_strategy (config.py:559-561, set by three shipped profiles) are either WIRED to the expansion work or RETIRED from config and from those profiles. A user-switchable knob that silently does nothing must not survive alongside a new tool that does the same job
+- [x] #1 The catalog gains one gated document-expansion tool that, given a retrieval hit, returns the surrounding or whole document text under an explicit size budget, and it is OFF by default like every other gateable builtin
+- [x] #2 The tool's contract is stated in terms the agent can act on: what identity it takes (the retrieval row's source identity), what it returns for each source type, and what it does when the document is larger than the budget
+- [x] #3 An agent policy is written and testable: the conditions under which expansion is worth its tokens (e.g. a high-ranked hit whose chunk is truncated or label-only) versus re-querying, with at least one test exercising each branch
+- [x] #4 Media and conversation seam rows' label-only problem is addressed or explicitly scoped out: today those rows carry no document text ('Matched media - {type}'), so an expansion tool is the only way an agent sees their content
+- [x] #5 The evaluation question is answered with a decision, not an assumption: either an answer-level (P3 grader) measurement is defined and run for the expansion loop, or the task records why retrieval-level scoring is sufficient and what that leaves unmeasured
+- [x] #6 The relationship to the re-ranking gap is recorded: whether the expansion loop presumes a working reranker (TASK-3502, cross_encoder unimplemented) or is independent of it
+- [x] #7 The inert parent-inclusion config surface is resolved, not left standing: include_parent_docs / parent_size_threshold / parent_inclusion_strategy (config.py:559-561, set by three shipped profiles) are either WIRED to the expansion work or RETIRED from config and from those profiles. A user-switchable knob that silently does nothing must not survive alongside a new tool that does the same job
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -80,4 +80,182 @@ Executing the four-task plan at Docs/superpowers/plans/2026-08-15-rag-agentic-ex
 Linkage from TASK-16071 Task 2 (2026-08-14): AC#4's label-only premise is now MEASURED in both directions and has TRIPLED — 39/211 fed rows label-only (18%) under the pre-16071 concatenating merge, 113/211 (54%) under the rank-fair interleave, same corpus/k/M/fetch count, only the merge changed. Mechanism: media and conversation rows are precisely the rows carrying no document text, and a rank-fair rotation puts them into the top-M slots a full notes seam used to monopolise — the merge changes WHAT a top-M consumer sees, not just the order. At 54% the label-only case is dominant rather than a minority, which strengthens 'addressed' and weakens 'explicitly scoped out' as an AC#4 resolution, raises the expected call volume feeding the AC#3 policy budget, and supplies a measured per-row cost baseline (one read per fed row) for AC#3/#5. Figures are carried inline by `Tests/RAG_Eval/README.md`'s PRF section prose and its TASK-16071 arc section — cite those, not the arc's gitignored session notes.
 
 PRODUCTION SITE (final review 2026-08-14): the label-only cost is not probe-only. `Agents/library_rag_tool_provider.py` (`:216-219` mode="rag", `:250-252` cut to _MAX_TOP_K=10) is the DEFAULT Console Library retrieval tool; under a plain profile its 10-row window went from up-to-ten text-bearing note rows to a ~4/3/3 rotation whose media/conversation rows carry label snippets only. That is this task's strongest concrete case: an agent's evidence window is where the fetch belongs.
+---
+
+## Implementation Notes — arc complete (2026-08-15)
+
+Four phases, four commits, one follow-on: **K** (retire the inert knobs) →
+**T** (the gated tool) → **P** (the policy, wired into the payload, plus
+**3b** the identity that makes it actionable) → **E** (the answer-level
+oracle run + closure). The gated retrieval suite read
+`[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of
+baseline.` with **all 105 cells at (+0.000)** at both ends of the arc — no
+retrieval behaviour moved, by construction: the capability is a pull-based
+agent tool invoked *after* retrieval, never engine-side inclusion during it.
+
+**The headline, measured rather than assumed.** Eight fixed questions over
+the RAG-eval fixture corpus, each carrying a fact oracle grep-verified to
+appear only inside one media/conversation document's **body** (never a
+title — the agent sees titles — never another document, never the question
+text). The real agent loop (`AgentService` → `chat_api_call` →
+`api.anthropic.com`, `claude-haiku-4-5`, temperature 0) answered each
+question twice, tool-OFF then tool-ON, scored by mechanical oracle
+inclusion with **no LLM grader**:
+
+| | tool-OFF | tool-ON |
+|---|---|---|
+| oracle-fact inclusion | **0/8** | **7/8** |
+
+$0.177 for the run (+$0.022 smoke). The single ON miss is a **retrieval**
+failure present in both arms — both of `q6`'s searches returned
+`status: "empty"`, so there was never a row to expand — so conditioned on
+the target row being returned the ON arm answered **7 of 7**. Four OFF
+questions retrieved the label-only row and still scored zero, saying the
+mechanism out loud unprompted: *"I can only see that it's a media document
+and cannot access its full contents through the search results."* Full
+method, isolation proof, per-question attribution and disclosed limits:
+`Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md`.
+
+### The seven ACs, against evidence
+
+- **#1 — gated tool, OFF by default.** `ExpandDocumentTool`
+  (`tldw_chatbook/Tools/document_expansion_tool.py`) registered as one
+  `GateableTool` row in `Agents/tool_catalog.py`'s `_GATEABLE_BUILTINS`
+  behind `[tools] expand_document_enabled`. Pinned by
+  `test_tool_is_gated_off_by_default`, and demonstrated live: the OFF
+  arm's built-in catalog is `['calculator', 'get_current_datetime']` and
+  the ON arm's is `['calculator', 'expand_document',
+  'get_current_datetime']` — the tool appears because the gate flipped,
+  not because the harness added it. The Settings-side switch is derived
+  from the same table (`builtin_tool_gate.all_tool_gates`), so it appeared
+  with zero UI wiring.
+- **#2 — an actionable contract.** `execute(source_type, source_id,
+  chunk_id="", chunk_start=None, offset=0, max_chars=None, note_id=…,
+  media_id=…, doc_id=…, **provenance)` returning the SAME keys on every
+  branch — `status | source_type | source_id | title | text | total_size |
+  window{start,end} | truncated | next_offset` — for note / media /
+  conversation / prompt and for `not_found` / `unsupported` / `error`. Over
+  budget it returns a window (chunk-centred when `chunk_start` is known,
+  else the head) plus `next_offset`, so a long document is navigable
+  without re-querying. Eleven contract tests, RED-first.
+- **#3 — a testable policy, in the payload the agent actually reads.**
+  `Library/library_expand_policy.expand_hint` is pure and returns
+  `{expandable, reason}` ∈ `label_only` / `truncated_snippet` /
+  `text_bearing`, or `None` for a row with nothing to expand;
+  `Agents/library_rag_tool_provider._project_row` attaches it. The
+  decision rule also sits in the tool's own `description`, pinned verbatim
+  by `test_tool_description_states_the_policy_verbatim`. 16 policy tests +
+  39 provider tests cover each branch, the sealing loop's byte budget, and
+  hostile rows.
+- **#4 — the label-only problem addressed, not scoped out.** Media and
+  conversation rows are the tool's first-class acceptance cases, not
+  afterthoughts: the contract works from exactly what such a row carries
+  (`source_type` + `source_id`, empty `chunk_id`). Closed in the field —
+  every one of the 7 successful live expansions was a label-only row, and
+  the 54%-label-only window this task was filed against is now openable.
+- **#5 — the evaluation question answered with a run.** The oracle run
+  above, committed whole (`questions.toml`, `oracle_run.py`, `report.md`,
+  `run-artifacts.json`). Retrieval-level scoring was NOT sufficient and
+  the task does not claim it was. Disclosed limits: N=8, one corpus, one
+  model, one run per arm; oracle inclusion ≠ answer quality; one route.
+- **#6 — the recorded sentence on reranking.** *The expansion tool is
+  INDEPENDENT of reranking: it consumes final retrieval rows whatever
+  produced them, and presumes nothing about TASK-3502's unimplemented
+  `cross_encoder`.* It reads `source_type`/`source_id` off a row that any
+  ordering could have produced, so a reranker landing later changes which
+  rows are offered, never whether they can be opened. Carried in the
+  tool's module docstring so it cannot drift from the code.
+- **#7 — the inert surface retired, not left standing.**
+  `include_parent_docs` / `parent_size_threshold` /
+  `parent_inclusion_strategy` deleted from `SearchConfig` and from all
+  three shipped profiles (nine writes). Grep-verified zero occurrences in
+  `tldw_chatbook/` beyond comments recording the retirement, and only the
+  compat test in `Tests/`. `RAGConfig.from_dict` now filters unknown
+  `[search]` keys with a logged notice, so a user's saved TOML still
+  carrying them loads instead of raising `TypeError` — the compat hazard
+  verified at plan time.
+
+### Decisions and trade-offs
+
+- **Retire, not wire (AC#7).** Pre-registered before any code: the knobs
+  get wired only if the capability lands engine-side. It did not — the
+  capability is pull-based, budgeted, gated and per-hit — and engine-side
+  inclusion would move retrieval, which the 105/105 gate forbids. Wiring
+  them here was out of scope by construction.
+- **A module constant, not a new `[tools]` key, for the budget.**
+  `DEFAULT_MAX_CHARS = 8000` / `HARD_MAX_CHARS = 32000`. A knob whose only
+  consumer is a default is exactly the dead surface Phase K just retired.
+- **`chunk_id` is an INDEX, not an offset** (`f"{doc_id}_chunk_{i}"`), so
+  the window anchor is `chunk_start` — a real chunk-metadata key. No
+  index→offset guessing path exists, deliberately.
+- **Identity rides the hint's own precondition** (Task 3b). A row with
+  nothing to expand carries neither hint nor identity, so verdict and
+  identity cannot drift apart and no raw id leaks on an unsupported row.
+  Cost: +97.5 B/row cumulative over the pre-arc payload (2585 → 3560 B on
+  a normal 10-row payload, 1.22% of the 32 KiB ceiling). Identity is never
+  truncated by the sealing loop — a halved id is a wrong id, not a smaller
+  one.
+- **The friction is disclosed, not designed around.** `risk_tags =
+  ("reads",)` floors the tool to *ask*, so each call raises an approval
+  card until the user sets Allow. The live run recorded exactly **7
+  approval rounds in the ON arm and 0 in the OFF arm** — the gate is real,
+  and a user will feel it.
+- **The oracle run measures the `plain` route.** That is the route that
+  emits label-only rows; under `hybrid` the engine returns chunk text and
+  there is nothing label-only to expand. Pre-registered in
+  `questions.toml`, not chosen after seeing a number.
+
+### Two suspects checked and NOT closed
+
+Task 3b pre-registered two ways expansion could misfire. **Neither
+manifested in this run, and neither is refuted by it** — the `plain`
+route emits no chunked rows and real database ids, so it cannot exercise
+either. They remain the first things to check if the tool is measured on a
+semantic/hybrid route, and are carried by a follow-up task:
+
+1. `chunk_start` is absent from the projected payload, so a chunked row
+   would expand from the document HEAD rather than around the match.
+2. A semantic `source_id` can be a vector-store point id whose
+   `note_id`/`doc_id` fallbacks are likewise absent from the payload, so a
+   declared-expandable row could return `not_found`.
+
+### Files
+
+Added: `tldw_chatbook/Tools/document_expansion_tool.py`;
+`tldw_chatbook/Library/library_expand_policy.py`;
+`Tests/Tools/test_document_expansion_tool.py`;
+`Tests/Library/test_library_expand_policy.py`;
+`Tests/RAG_Search/test_search_config_compat.py`;
+`Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/` (`questions.toml`,
+`oracle_run.py`, `report.md`, `run-artifacts.json`).
+
+Modified: `tldw_chatbook/RAG_Search/simplified/config.py`;
+`tldw_chatbook/RAG_Search/config_profiles.py`;
+`tldw_chatbook/Agents/tool_catalog.py`;
+`tldw_chatbook/Agents/library_rag_tool_provider.py`;
+`tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py` (a `_TOOL_COPY` row —
+without it first-run setup ships a blank row for the new tool);
+`Tests/Agents/test_builtin_tool_gate.py`,
+`Tests/Agents/test_library_tool_provider.py`,
+`Tests/UI/test_mcp_workbench.py` (four hard-coded arity literals now
+derived from `len(_GATEABLE_BUILTINS)`);
+`tldw_chatbook/Agents/builtin_tool_gate.py` and
+`tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py` (docstrings that hard-coded
+"the 7 rows"/"all nine gates" — the counts are now derived, so the eighth
+built-in did not falsify them); `Tests/RAG_Eval/README.md`;
+`Docs/Development/CHUNKING-IMPLEMENTATION-COMPLETE.md`,
+`-SUMMARY.md`, `CHUNKING-IMPROVE-1.md` (each claimed this feature was
+implemented; each now carries a correction).
+
+### Verification
+
+- Gate: `[rag-eval baselines] PASSED: No regression. 105 metric(s) within
+  0.05 of baseline.`, 105/105 cells `(+0.000)`; `Tests/RAG_Eval` 307
+  passed.
+- Batteries: `Tests/Library Tests/Tools Tests/Agents Tests/RAG_Search` =
+  **4313 passed, 29 skipped, 0 failed** (skips are pre-existing
+  optional-dependency guards).
+- Collection sweep over every test file this branch touched vs merge-base
+  `8727a2861`: 6 files, 348 tests collected, 0 errors.
+- Ruff clean on every touched file.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16588 - Carry-expand_document-s-identity-to-the-semantic-hybrid-routes-chunk_start-and-the-provenance-id-fallbacks.md
+++ b/backlog/tasks/task-16588 - Carry-expand_document-s-identity-to-the-semantic-hybrid-routes-chunk_start-and-the-provenance-id-fallbacks.md
@@ -1,0 +1,70 @@
+---
+id: TASK-16588
+title: >-
+  Carry expand_document's identity to the semantic/hybrid routes:
+  chunk_start and the provenance id fallbacks
+status: To Do
+assignee: []
+created_date: '2026-08-15 23:55'
+labels:
+  - rag
+  - agents
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16174 shipped `expand_document` and wired a per-row policy plus the
+identity the tool requires into `Agents/library_rag_tool_provider.
+_project_row`. Its Phase E oracle run measured the tool end to end on the
+**`plain`** route (the Library's four-seam keyword path) and found
+tool-OFF 0/8 vs tool-ON 7/8
+(`Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/report.md`).
+
+That run **cannot exercise two known gaps**, because the `plain` route
+structurally avoids both: it emits no chunked rows and its `source_id` is
+always a real database id. Task 3b pre-registered them, and the run
+recorded them as **unrefuted rather than refuted** — every probe reported
+`chunked_rows = []`, every expansion returned `status: "ok"`, and no
+identity fallback was ever needed. Both remain live for the
+`semantic`/`hybrid` routes, which are what a user on a vector or fused
+profile actually gets.
+
+**(a) `chunk_start` is not in the projected payload.** The tool accepts it
+as the window anchor and `_semantic_row` already copies it into
+`provenance`, but Task 3b's scope stopped at `source_type`/`source_id`
+(+`chunk_id`). So a chunked row expands from `offset = 0` — the document
+HEAD — not around the matched chunk. On a long document that returns a
+budget's worth of the wrong text while reporting `status: "ok"`, which is
+the failure mode hardest to notice: it looks like a successful expansion.
+`chunk_id` cannot substitute — it is an INDEX (`f"{doc_id}_chunk_{i}"`),
+not a character offset, and no index→offset path exists by design.
+
+**(b) a semantic `source_id` can be a vector-store point id.**
+`_semantic_row` resolves `source_id` as `metadata["source_id"] ||
+metadata["document_id"] || the chroma point id`, so for some rows the
+point id is what surfaces and the real document identity lives only in the
+provenance extras (`note_id` / `doc_id`). The tool accepts those as
+identity fallbacks, but they are **not** in the payload — so such a row is
+declared `expandable` by the hint and can still come back `not_found`. A
+verdict the agent cannot act on is exactly what Task 3b existed to
+prevent, one route over.
+
+The fix for both is the same shape as Task 3b's: a payload ADDITION under
+the hint's own precondition, keeping `{expandable, reason}` and every
+existing key unchanged. The cost is bytes in a sealed payload
+(Task 3b measured +40.0 B/row for the identity keys; +97.5 B/row
+cumulative for the arc), so the byte budget must be re-measured, not
+assumed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A projected row that has a `chunk_start` in its provenance carries it in the payload, under exactly the same precondition as the existing identity keys, so a chunked hit expands around the match rather than from the document head
+- [ ] #2 A row whose `source_id` is a vector-store point id carries the provenance identity fallback(s) the tool accepts (`note_id` / `doc_id`), so a row the hint declares expandable can actually be fetched
+- [ ] #3 Both are measured on a route that can exercise them (`semantic` and/or `hybrid`), not only asserted in unit tests: a run records, per row, whether the returned window contains the matched chunk and whether any declared-expandable row returned `not_found`
+- [ ] #4 The sealed-payload byte cost is re-measured on a normal ten-row payload and stated (Task 3b's method: strip-and-reserialize), and the sealing loop's progress guarantee still holds with the added keys
+- [ ] #5 `expand_hint`'s pinned `{expandable, reason}` interface, the tool's contract, and row order/count are unchanged; `citations` and the `provenance` mapping still never leave the adapter
+- [ ] #6 The gated retrieval suite still reads "PASSED: No regression. 105 metric(s)" with every cell at (+0.000) — this is a payload addition, not a retrieval change
+<!-- AC:END -->

--- a/backlog/tasks/task-16588 - Carry-expand_document-s-identity-to-the-semantic-hybrid-routes-chunk_start-and-the-provenance-id-fallbacks.md
+++ b/backlog/tasks/task-16588 - Carry-expand_document-s-identity-to-the-semantic-hybrid-routes-chunk_start-and-the-provenance-id-fallbacks.md
@@ -68,3 +68,21 @@ assumed.
 - [ ] #5 `expand_hint`'s pinned `{expandable, reason}` interface, the tool's contract, and row order/count are unchanged; `citations` and the `provenance` mapping still never leave the adapter
 - [ ] #6 The gated retrieval suite still reads "PASSED: No regression. 105 metric(s)" with every cell at (+0.000) — this is a payload addition, not a retrieval change
 <!-- AC:END -->
+
+## Notes
+
+- **AC#1 shipped early, at the unit level only (TASK-16174 fix wave,
+  2026-08-15).** The final whole-branch review called the dead `chunk_id`
+  parameter a blocker, and the wire-or-retire fix for it was to retire
+  `chunk_id` from the tool schema AND emit `chunk_start` from `_project_row`
+  whenever a row's provenance carries a usable anchor (`> 0`). So the payload
+  addition exists and is pinned by tests; what is still open on AC#1 is the
+  route MEASUREMENT in AC#3 — no `semantic`/`hybrid` run has yet shown a
+  window that actually contains the matched chunk.
+- **In-scope evidence for AC#3 (final review finding 6):** rows whose raw
+  provenance `source_type` is a canonicalization VARIANT — `media_chunk`,
+  `chat`, or a plural spelling, all of which `_SEMANTIC_SOURCE_TYPE_MAP`
+  treats as live — get no hint and therefore no identity at all under the
+  policy's singular-only `EXPANDABLE_SOURCE_TYPES`, so the route measurement
+  should count them rather than only the point-id case (carried as its own
+  finding in TASK-16688).

--- a/backlog/tasks/task-16688 - Expansion-residue-allowlist-pins-canonicalization-variants-the-direct_library_tools-consent-boundary-and-two-unmeasured-halves.md
+++ b/backlog/tasks/task-16688 - Expansion-residue-allowlist-pins-canonicalization-variants-the-direct_library_tools-consent-boundary-and-two-unmeasured-halves.md
@@ -1,0 +1,91 @@
+---
+id: TASK-16688
+title: >-
+  Expansion residue: allowlist pins, canonicalization variants, the
+  direct_library_tools consent boundary, and two unmeasured halves
+status: To Do
+assignee: []
+created_date: '2026-08-15 20:20'
+labels:
+  - rag
+  - agents
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16174's final whole-branch review returned SHIP-WITH-FIXES. Its three
+blockers (a dead `chunk_id` parameter, the AC#3 four-branch narrowing, and a
+>500-message conversation reported as a complete read) plus the pin and docs
+findings were fixed in a bounded fix wave on
+`feat/rag-16174-agentic-expansion`. Five findings were deliberately NOT
+fixed there — each is either a correctness gap on a route that arc could not
+measure, or a recorded-decision gap — and this task carries them so they do
+not evaporate with the branch.
+
+**(1) Finding 5 — two source-type allowlists with nothing pinning them
+together.** `document_expansion_tool.SUPPORTED_SOURCE_TYPES` and
+`library_expand_policy.EXPANDABLE_SOURCE_TYPES` are independent literals
+with identical content today. Drift in either direction reproduces exactly
+the failure Task 3b existed to prevent: the policy hinting a row the tool
+answers `unsupported`, or withholding a hint for a seam the tool can open.
+Same shape, lower stakes: `document_expansion_tool.PROMPT_BODY_COLUMNS`
+mirrors `rag_service.PROMPT_DOCUMENT_COLUMNS` (identical today, including
+the `"\n\n"` join and the strip/skip-empty rule) with a documented reason
+for not importing it, and nothing pins that either.
+
+**(2) Finding 6 — the policy allowlist is narrower than the codebase's own
+canonicalization surface.** `_SEMANTIC_SOURCE_TYPE_MAP`
+(`Library/library_local_rag_search_service.py`, mirrored in
+`library_rag_state.py`) treats `media_chunk`, `chat` and the plural
+spellings as live raw provenance values. `EXPANDABLE_SOURCE_TYPES` accepts
+only the four singulars, so such a row gets **no hint and — by Task 3b's
+shared precondition — no identity**, silently, while the UI's own "open this
+row" path canonicalizes it fine and the tool would fetch it if handed
+`source_type="media"`. Today's local indexer stamps only singulars
+(`RAG_Search/ingestion_indexing.py`), which is why this is not urgent; it is
+a semantic/hybrid-route gap of exactly TASK-16588's family, and those rows
+are in-scope evidence for 16588's route measurement.
+
+**(3) Finding 13 — the consent-boundary relationship with `[console]
+direct_library_tools` is nowhere recorded.** The Library agent-tools spec
+makes that toggle the Console consent boundary: OFF, the agent gets bounded
+`search_library_rag` excerpts and no direct Library reads. `expand_document`
+returns whole documents by **raw** backing id regardless of that setting,
+under its own `[tools]` gate plus the per-call ask floor; ON, it duplicates
+the 18 direct get-tools while bypassing their opaque public-ID codec. Two
+mitigations are real and pinned (OFF by default; `risk_tags=("reads",)` →
+`ask`, 7 approval rounds observed live), and the raw id already left the
+adapter pre-arc as `result_id` — so the arc types an existing exposure
+rather than inventing one. What is new is a read-by-raw-id primitive over
+sequential media/prompt PKs once a user clicks "always allow". The task
+file's own Description warned against "a THIRD overlapping surface"; this
+overlap is discussed nowhere.
+
+**(4) Finding 15 — the conversation fetch loads image BLOBs it never uses.**
+`document_expansion_tool._fetch_conversation` takes
+`get_messages_for_conversation`'s default `include_image_data=True`, so up
+to 500 message images are read into memory to render text that uses only
+`sender`/`content`. One-word fix (`include_image_data=False`, the task-260
+precedent); left out of the fix wave because it is a performance change with
+no test asserting the read cost.
+
+**(5) Finding 16 — the live run never exercised the window/continuation
+half of the contract.** Every target document in the Phase E run is
+289–4,924 chars against `DEFAULT_MAX_CHARS = 8000`, so all 8 expansions
+recorded `expand_truncated: false` and every call returned a whole document.
+The measured claim is "expansion opens a label", not "expansion navigates a
+long document"; the latter is unit-tested only (including, since the fix
+wave, the `HARD_MAX_CHARS` cap and the >500-message conversation).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The tool's and the policy's source-type allowlists can no longer drift apart: one is derived from the other, or a test fails when they differ (finding 5); the same is done or explicitly declined, with a reason, for PROMPT_BODY_COLUMNS vs rag_service.PROMPT_DOCUMENT_COLUMNS
+- [ ] #2 A row whose raw provenance source_type is a canonicalization VARIANT (media_chunk, chat, or a plural spelling) either gets a hint and identity like its singular twin, or the deliberate exclusion is recorded with the reason and pinned by a test (finding 6)
+- [ ] #3 The relationship between expand_document's gate and [console] direct_library_tools is recorded in one place a reader will find (task trade-offs plus Docs/User_Guide/mcp.md): whether expansion defers to that toggle, and why the raw-id read is acceptable under the ask floor (finding 13)
+- [ ] #4 The conversation fetch no longer reads image BLOBs it does not render, or the cost is measured and the default is kept deliberately (finding 15)
+- [ ] #5 The window/continuation half of the contract is exercised outside unit tests at least once — a document larger than the budget, expanded and continued via next_offset — and the result recorded (finding 16)
+- [ ] #6 Any behaviour change here re-runs the gated retrieval suite and it still reads "PASSED: No regression. 105 metric(s)" with every cell at (+0.000)
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/builtin_tool_gate.py
+++ b/tldw_chatbook/Agents/builtin_tool_gate.py
@@ -530,7 +530,7 @@ class ToolGate:
             Critical prerequisite fixed the identical bug one layer down,
             in ``tool_catalog.py``'s registration read; this enumerator
             must never reintroduce it one layer up).
-        group: ``"builtin"`` (the 7 ``_GATEABLE_BUILTINS`` rows) or ``
+        group: ``"builtin"`` (the ``_GATEABLE_BUILTINS`` rows) or ``
             "local"`` (the local-workspace-tool group: its master switch
             plus ``web_deep_search``, which shares the group it masters).
     """
@@ -581,8 +581,8 @@ def all_tool_gates() -> list[ToolGate]:
     """Every ``[tools]``/``[console]`` registration gate, on or off.
 
     THE single source of truth for task-3240's MCP-hub gate affordance
-    (Servers mode's built-in-source detail pane): the 7
-    ``_GATEABLE_BUILTINS`` rows (group ``"builtin"``, registration order),
+    (Servers mode's built-in-source detail pane): every
+    ``_GATEABLE_BUILTINS`` row (group ``"builtin"``, registration order),
     then the local group (group ``"local"``) -- its master switch
     (``[console] local_tools_enabled``) listed FIRST, since it masters the
     gate listed right after it, then ``web_deep_search``'s own gate.
@@ -598,7 +598,8 @@ def all_tool_gates() -> list[ToolGate]:
     ``BuiltinToolProvider.__init__``'s own per-entry try/except).
 
     Returns:
-        Nine gates in the order described above.
+        Every gate in the order described above (the `_GATEABLE_BUILTINS`
+        rows, then the local group's two).
     """
     from ..config import coerce_bool_setting, get_cli_setting
     from .local_tool_provider import WEB_DEEP_SEARCH_GATE_KEY

--- a/tldw_chatbook/Agents/library_rag_tool_provider.py
+++ b/tldw_chatbook/Agents/library_rag_tool_provider.py
@@ -4,10 +4,12 @@ When the Console's direct-Library-tools setting is off, this provider exposes
 exactly one agent tool -- ``search_library_rag`` -- as the default Library
 retrieval method. It is a bounded adapter over the app-owned
 ``library_rag_search_service``: excerpts and rows are capped so the final JSON
-stays under the shared 32 KiB ceiling, raw backing identities and provenance
+stays under the shared 32 KiB ceiling, citations and the provenance mapping
 never leave the adapter, and unavailable/setup conditions map to
 ``index_unavailable`` -- the provider never falls back to direct lexical
-reads.
+reads. The one identity a row may carry is the ``source_type``/``source_id``
+(+ ``chunk_id``) pair ``expand_document`` requires, emitted only for rows that
+tool can actually fetch (TASK-16174); see ``_project_row``.
 
 Synchronous to satisfy the ``ToolProvider`` protocol; it runs on the agent
 worker thread, where bridging the async retrieval service with
@@ -17,6 +19,7 @@ worker thread, where bridging the async retrieval service with
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from typing import Any
 
 from loguru import logger
@@ -26,7 +29,10 @@ from tldw_chatbook.Agents.agent_models import (
     ToolResult,
     ToolSchema,
 )
-from tldw_chatbook.Library.library_expand_policy import expand_hint
+from tldw_chatbook.Library.library_expand_policy import (
+    EXPANDABLE_SOURCE_TYPES,
+    expand_hint,
+)
 from tldw_chatbook.Library.library_rag_service import (
     LibraryRagSearchRequest,
     run_library_rag_search,
@@ -92,6 +98,20 @@ _RAG_TOOL_SCHEMA: dict[str, Any] = {
 }
 
 _ARGUMENT_KEYS = frozenset(_RAG_TOOL_SCHEMA["properties"])
+
+
+def _expandable_source_type(provenance: Any) -> str:
+    """The row's normalized ``provenance.source_type``, or ``""`` when it is
+    not a seam ``expand_document`` supports.
+
+    Reads and normalizes the same key the same way ``library_expand_policy``
+    does, so the identity this adapter declares can never name a different
+    seam from the hint declared beside it.
+    """
+    if not isinstance(provenance, Mapping):
+        return ""
+    source_type = str(provenance.get("source_type") or "").strip().lower()
+    return source_type if source_type in EXPANDABLE_SOURCE_TYPES else ""
 
 
 def _error_result(error: LibraryToolError) -> ToolResult:
@@ -279,18 +299,33 @@ class LibraryRagToolProvider:
 
     @staticmethod
     def _project_row(row: Any) -> dict[str, Any]:
-        """Project one evidence row to agent-safe fields (never raw source
-        identities, chunk ids, citations, or provenance).
+        """Project one evidence row to agent-safe fields (never citations, and
+        never the provenance mapping itself).
 
-        The one provenance-DERIVED field is ``expand_hint`` (TASK-16174): a
-        verdict on whether following this row into its document would add
-        anything, computed by the pure
-        ``Library.library_expand_policy.expand_hint`` helper. It carries only
-        ``expandable``/``reason`` -- no identity, no provenance value -- and
-        is omitted entirely for rows nothing can expand, so the payload's
-        no-raw-identity contract is unchanged. Without it, 54% of the rows an
-        agent is fed are label-only snippets it has no way to recognize as
-        labels.
+        Two provenance-DERIVED additions exist, both TASK-16174 and both
+        emitted under exactly one precondition -- the row is something
+        ``expand_document`` can actually fetch:
+
+        - ``expand_hint``: the verdict on whether following this row into its
+          document would add anything, from the pure
+          ``Library.library_expand_policy.expand_hint`` helper
+          (``expandable``/``reason`` only). Without it, 54% of the rows an
+          agent is fed are label-only snippets it has no way to recognize as
+          labels.
+        - ``source_type``/``source_id`` (+ ``chunk_id`` when non-empty): the
+          identity ``expand_document`` REQUIRES. Task 3 shipped the hint
+          alone, which left the loop closable only by inference -- a
+          label-only row's ``result_id`` merely HAPPENS to equal its
+          ``source_id``, and the seam was readable only from label prose. A
+          policy the agent can act on only by guessing measures its guessing.
+
+        The precondition is the hint's own (``expand_hint`` returns ``None``
+        for an absent/unsupported seam or an empty ``source_id``), so identity
+        and verdict cannot drift apart: a row with nothing to expand still
+        carries neither, keeping task-1337's projection for every such row.
+        Identity is emitted VERBATIM and is deliberately absent from the
+        sealing loop's shrink order -- a halved id is a wrong id, not a
+        smaller one.
         """
         score = getattr(row, "score", None)
         snippet = str(getattr(row, "snippet", "") or "")
@@ -303,20 +338,29 @@ class LibraryRagToolProvider:
                 :_MAX_RUNTIME_BACKEND_CHARS
             ],
         }
+        source_id = str(getattr(row, "source_id", "") or "").strip()
+        chunk_id = str(getattr(row, "chunk_id", "") or "").strip()
+        provenance = getattr(row, "provenance", None)
         # Computed from the UNPROJECTED snippet against this adapter's own
         # cap, so a snippet the projection above cuts is reported as
         # truncated rather than read back as complete text.
         hint = expand_hint(
             {
-                "source_id": getattr(row, "source_id", ""),
-                "chunk_id": getattr(row, "chunk_id", ""),
+                "source_id": source_id,
+                "chunk_id": chunk_id,
                 "snippet": snippet,
-                "provenance": getattr(row, "provenance", None),
+                "provenance": provenance,
             },
             snippet_cap=_MAX_SNIPPET_CHARS,
         )
         if hint is not None:
             projected["expand_hint"] = hint
+            # The hint's non-None precondition IS the tool's precondition, so
+            # this identity is always one `expand_document` accepts.
+            projected["source_type"] = _expandable_source_type(provenance)
+            projected["source_id"] = source_id
+            if chunk_id:
+                projected["chunk_id"] = chunk_id
         return projected
 
 

--- a/tldw_chatbook/Agents/library_rag_tool_provider.py
+++ b/tldw_chatbook/Agents/library_rag_tool_provider.py
@@ -114,6 +114,27 @@ def _expandable_source_type(provenance: Any) -> str:
     return source_type if source_type in EXPANDABLE_SOURCE_TYPES else ""
 
 
+def _chunk_start(provenance: Any) -> int | None:
+    """The matched chunk's character start, when it is one the tool acts on.
+
+    ``expand_document``'s window is centred only for ``anchor > 0``
+    (``_window_bounds``), so a head anchor (``0``, what chunk 0 carries), a
+    negative, a boolean or anything unparseable is dropped rather than
+    emitted: a key that changes nothing is bytes spent in a SEALED payload
+    for no behaviour, which is the inert surface this arc removes elsewhere.
+    """
+    if not isinstance(provenance, Mapping):
+        return None
+    raw = provenance.get("chunk_start")
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 def _error_result(error: LibraryToolError) -> ToolResult:
     return ToolResult(ok=False, error=json_dumps_compact(error.to_payload()))
 
@@ -312,8 +333,13 @@ class LibraryRagToolProvider:
           (``expandable``/``reason`` only). Without it, 54% of the rows an
           agent is fed are label-only snippets it has no way to recognize as
           labels.
-        - ``source_type``/``source_id`` (+ ``chunk_id`` when non-empty): the
-          identity ``expand_document`` REQUIRES. Task 3 shipped the hint
+        - ``source_type``/``source_id`` (+ ``chunk_id`` when non-empty, and
+          ``chunk_start`` when the provenance carries a usable anchor): the
+          identity ``expand_document`` REQUIRES, plus the one field that
+          moves its window. ``chunk_id`` is an INDEX and the tool ignores it
+          (it is not even a parameter); ``chunk_start`` is what turns a
+          chunked hit's expansion from a document-HEAD window into one
+          around the match. Task 3 shipped the hint
           alone, which left the loop closable only by inference -- a
           label-only row's ``result_id`` merely HAPPENS to equal its
           ``source_id``, and the seam was readable only from label prose. A
@@ -361,6 +387,9 @@ class LibraryRagToolProvider:
             projected["source_id"] = source_id
             if chunk_id:
                 projected["chunk_id"] = chunk_id
+            chunk_start = _chunk_start(provenance)
+            if chunk_start is not None:
+                projected["chunk_start"] = chunk_start
         return projected
 
 

--- a/tldw_chatbook/Agents/library_rag_tool_provider.py
+++ b/tldw_chatbook/Agents/library_rag_tool_provider.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Agents.agent_models import (
     ToolResult,
     ToolSchema,
 )
+from tldw_chatbook.Library.library_expand_policy import expand_hint
 from tldw_chatbook.Library.library_rag_service import (
     LibraryRagSearchRequest,
     run_library_rag_search,
@@ -279,17 +280,44 @@ class LibraryRagToolProvider:
     @staticmethod
     def _project_row(row: Any) -> dict[str, Any]:
         """Project one evidence row to agent-safe fields (never raw source
-        identities, chunk ids, citations, or provenance)."""
+        identities, chunk ids, citations, or provenance).
+
+        The one provenance-DERIVED field is ``expand_hint`` (TASK-16174): a
+        verdict on whether following this row into its document would add
+        anything, computed by the pure
+        ``Library.library_expand_policy.expand_hint`` helper. It carries only
+        ``expandable``/``reason`` -- no identity, no provenance value -- and
+        is omitted entirely for rows nothing can expand, so the payload's
+        no-raw-identity contract is unchanged. Without it, 54% of the rows an
+        agent is fed are label-only snippets it has no way to recognize as
+        labels.
+        """
         score = getattr(row, "score", None)
-        return {
+        snippet = str(getattr(row, "snippet", "") or "")
+        projected = {
             "result_id": str(getattr(row, "result_id", "") or "")[:_MAX_RESULT_ID_CHARS],
             "title": str(getattr(row, "title", "") or "")[:_MAX_TITLE_CHARS],
-            "snippet": str(getattr(row, "snippet", "") or "")[:_MAX_SNIPPET_CHARS],
+            "snippet": snippet[:_MAX_SNIPPET_CHARS],
             "score": score if isinstance(score, (int, float)) else None,
             "runtime_backend": str(getattr(row, "runtime_backend", "") or "")[
                 :_MAX_RUNTIME_BACKEND_CHARS
             ],
         }
+        # Computed from the UNPROJECTED snippet against this adapter's own
+        # cap, so a snippet the projection above cuts is reported as
+        # truncated rather than read back as complete text.
+        hint = expand_hint(
+            {
+                "source_id": getattr(row, "source_id", ""),
+                "chunk_id": getattr(row, "chunk_id", ""),
+                "snippet": snippet,
+                "provenance": getattr(row, "provenance", None),
+            },
+            snippet_cap=_MAX_SNIPPET_CHARS,
+        )
+        if hint is not None:
+            projected["expand_hint"] = hint
+        return projected
 
 
 __all__ = [

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -513,6 +513,12 @@ _GATEABLE_BUILTINS: tuple[GateableTool, ...] = (
     GateableTool(
         "grep_files_enabled", "file_operation_tools", "GrepFiles", "grep_files"
     ),
+    GateableTool(
+        "expand_document_enabled",
+        "document_expansion_tool",
+        "ExpandDocumentTool",
+        "expand_document",
+    ),
 )
 
 

--- a/tldw_chatbook/Library/library_expand_policy.py
+++ b/tldw_chatbook/Library/library_expand_policy.py
@@ -1,0 +1,123 @@
+"""Per-row expansion policy for Library retrieval rows (TASK-16174, Phase P).
+
+Since TASK-16071's rank-fair merge, most of what a top-M consumer is fed is
+label-only: media rows say ``Matched media · {type}`` and conversation rows
+say ``Matched conversation · N messages``
+(``library_local_rag_search_service._media_row``/``_conversation_row``), both
+with an empty ``chunk_id``. Phase T shipped ``expand_document`` so an agent
+can see behind such a row; this module is the half that TELLS it which rows
+those are, instead of leaving it to infer them from prose.
+
+The helper is pure -- string and shape inspection only, no I/O, no DB, no
+config -- so the policy can be unit-tested per branch and reused by any
+payload builder. ``Agents/library_rag_tool_provider._project_row`` is its
+first consumer.
+
+**Label detection is a TRIPLE**, never the label text alone:
+``provenance.source_type`` is a label-bearing seam AND ``chunk_id`` is empty
+AND the snippet opens with that seam's label prefix. Any weaker rule
+misfires in both directions -- a note that quotes "Matched media · pdf"
+would be called a label, and a real media chunk whose text happens to open
+with those words would be too, hiding the content the agent already has.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+#: Seams ``expand_document`` (Phase T) can actually fetch. A row of any other
+#: type gets no hint: a hint the agent cannot act on is worse than silence.
+EXPANDABLE_SOURCE_TYPES: tuple[str, ...] = ("note", "media", "conversation", "prompt")
+
+#: Seams whose keyword rows are rendered as a LABEL rather than as content.
+#: The prefixes are the stable head of the 15700-era label contract; the
+#: separator and tail (`· pdf`, `· 7 messages`) are deliberately not matched.
+LABEL_SNIPPET_PREFIXES: dict[str, str] = {
+    "media": "Matched media",
+    "conversation": "Matched conversation",
+}
+
+#: Mirrors the Library RAG tool provider's snippet projection cap. Callers
+#: pass their own cap (`snippet_cap=`) so the two cannot drift silently; this
+#: default only serves callers that project at the same width.
+DEFAULT_SNIPPET_CAP = 1200
+
+#: Suffixes an upstream excerpt uses to say "there is more".
+TRUNCATION_MARKERS: tuple[str, ...] = ("…", "...")
+
+REASON_LABEL_ONLY = "label_only"
+REASON_TRUNCATED_SNIPPET = "truncated_snippet"
+REASON_TEXT_BEARING = "text_bearing"
+
+
+def _source_type(row: Mapping[str, Any]) -> str:
+    provenance = row.get("provenance")
+    if not isinstance(provenance, Mapping):
+        return ""
+    return str(provenance.get("source_type") or "").strip().lower()
+
+
+def _is_label_only(source_type: str, chunk_id: str, snippet: str) -> bool:
+    """The triple: label-bearing seam + no chunk + the seam's label prefix."""
+    prefix = LABEL_SNIPPET_PREFIXES.get(source_type)
+    if prefix is None or chunk_id:
+        return False
+    return snippet.lstrip().startswith(prefix)
+
+
+def _is_truncated(snippet: str, snippet_cap: int | None) -> bool:
+    if snippet.rstrip().endswith(TRUNCATION_MARKERS):
+        return True
+    return bool(snippet_cap) and len(snippet) > snippet_cap
+
+
+def expand_hint(
+    row: Mapping[str, Any],
+    *,
+    snippet_cap: int | None = DEFAULT_SNIPPET_CAP,
+) -> dict[str, Any] | None:
+    """Say whether following this row into its document would add anything.
+
+    Args:
+        row: A retrieval row in mapping form -- ``source_id``, ``chunk_id``,
+            ``snippet`` and ``provenance`` (whose ``source_type`` names the
+            seam). Any other keys are ignored; the row is never mutated.
+        snippet_cap: The width the caller projects snippets to, used to spot
+            a snippet the payload itself cut. ``None`` disables the
+            length test (the marker test still applies).
+
+    Returns:
+        ``{"expandable": bool, "reason": "label_only" | "truncated_snippet" |
+        "text_bearing"}``, or ``None`` when the row cannot be expanded at
+        all (unknown/absent ``source_type``, or no ``source_id`` to expand).
+        The hint carries no identity or provenance -- only the verdict.
+    """
+    if not isinstance(row, Mapping):
+        return None
+    source_type = _source_type(row)
+    if source_type not in EXPANDABLE_SOURCE_TYPES:
+        return None
+    if not str(row.get("source_id") or "").strip():
+        return None
+
+    snippet = str(row.get("snippet") or "")
+    chunk_id = str(row.get("chunk_id") or "").strip()
+
+    if _is_label_only(source_type, chunk_id, snippet):
+        return {"expandable": True, "reason": REASON_LABEL_ONLY}
+    if _is_truncated(snippet, snippet_cap):
+        return {"expandable": True, "reason": REASON_TRUNCATED_SNIPPET}
+    return {"expandable": False, "reason": REASON_TEXT_BEARING}
+
+
+__all__ = [
+    "DEFAULT_SNIPPET_CAP",
+    "EXPANDABLE_SOURCE_TYPES",
+    "LABEL_SNIPPET_PREFIXES",
+    "REASON_LABEL_ONLY",
+    "REASON_TEXT_BEARING",
+    "REASON_TRUNCATED_SNIPPET",
+    "TRUNCATION_MARKERS",
+    "expand_hint",
+]

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -307,9 +307,6 @@ class ConfigProfileManager:
         hybrid_enhanced_rag.search.default_search_mode = "hybrid"
         hybrid_enhanced_rag.search.default_top_k = 10
         hybrid_enhanced_rag.search.include_citations = True
-        hybrid_enhanced_rag.search.include_parent_docs = True
-        hybrid_enhanced_rag.search.parent_size_threshold = 5000
-        hybrid_enhanced_rag.search.parent_inclusion_strategy = "size_based"
 
         self._profiles["hybrid_enhanced"] = ProfileConfig(
             id="hybrid_enhanced",
@@ -344,9 +341,6 @@ class ConfigProfileManager:
         hybrid_full_rag.search.default_search_mode = "hybrid"
         hybrid_full_rag.search.default_top_k = 20
         hybrid_full_rag.search.include_citations = True
-        hybrid_full_rag.search.include_parent_docs = True
-        hybrid_full_rag.search.parent_size_threshold = 8000
-        hybrid_full_rag.search.parent_inclusion_strategy = "size_based"
         hybrid_full_rag.search.max_context_size = 32000
 
         # "cross_encoder" is not an implemented reranking strategy in
@@ -521,9 +515,6 @@ class ConfigProfileManager:
         research_rag.chunking.preserve_structure = True
         research_rag.search.include_citations = True
         research_rag.search.default_top_k = 15
-        research_rag.search.include_parent_docs = True
-        research_rag.search.parent_size_threshold = 10000  # Larger for research papers
-        research_rag.search.parent_inclusion_strategy = "size_based"
 
         research_rerank = RerankingConfig(
             strategy="listwise", top_k_to_rerank=10, include_reasoning=True

--- a/tldw_chatbook/RAG_Search/simplified/config.py
+++ b/tldw_chatbook/RAG_Search/simplified/config.py
@@ -6,7 +6,7 @@ integrating with the existing tldw_cli configuration system while providing
 sensible defaults and easy overrides.
 """
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, fields, asdict
 from typing import Optional, Dict, Any, List, Union
 from pathlib import Path
 import os
@@ -555,11 +555,22 @@ class SearchConfig:
     # `and_then_prefix` by owner ruling).
     fts_match_construction: str = "and_then_prefix"
 
-    # Parent document inclusion settings (RAG pipeline feature)
-    include_parent_docs: bool = False
-    parent_size_threshold: int = 5000  # Maximum parent doc size in characters
-    parent_inclusion_strategy: str = "size_based"  # "always", "size_based", "never"
-    max_context_size: int = 16000  # Maximum total context size in characters
+    # Maximum total context size in characters. LIVE: the Settings > Library >
+    # RAG defaults screen reads and writes it (settings_library_rag_defaults.py).
+    #
+    # RETIRED HERE (TASK-16174, Phase K): `include_parent_docs`,
+    # `parent_size_threshold` and `parent_inclusion_strategy` used to sit on this
+    # block. They were shipped, user-switchable, switched ON by three profiles --
+    # and read by NOTHING (grep-verified: 1 definition + 3 profile writes, 0
+    # reads). The decision rule was pre-registered in the arc's spec: wire them
+    # only if the capability lands engine-side. It did not -- expansion ships as a
+    # pull-based agent tool that runs AFTER retrieval, so wiring them would have
+    # changed what retrieval returns, which this arc's gate forbids. See
+    # Docs/superpowers/specs/2026-08-15-rag-agentic-expansion-design.md.
+    #
+    # Saved configs that still carry the retired keys keep loading: `from_dict`
+    # drops unknown search keys with a logged notice instead of raising TypeError.
+    max_context_size: int = 16000
 
 
 @dataclass
@@ -703,11 +714,35 @@ class RAGConfig:
                 pipeline_data["pipeline_config_file"]
             )
 
+        # `search_data` comes straight from a user-editable TOML/profile JSON, so
+        # an unknown key here is a hostile-dict problem, not a programming error:
+        # a plain `SearchConfig(**search_data)` raises TypeError and takes the
+        # whole config load down. That is exactly what a config saved BEFORE
+        # TASK-16174 retired `include_parent_docs` / `parent_size_threshold` /
+        # `parent_inclusion_strategy` would do. Drop unknown keys with a notice
+        # naming each one, so a retired or mistyped key degrades to "ignored and
+        # reported". (Same defensive posture as `rag_service.py`'s
+        # `_resolve_fts_match_construction`, for the same reason: this dict is
+        # user input.) Scope is deliberately the SEARCH section only -- the other
+        # sections have no retired fields and are out of this arc's scope.
+        known_search_fields = {f.name for f in fields(SearchConfig)}
+        known_search_data = {
+            key: value
+            for key, value in search_data.items()
+            if key in known_search_fields
+        }
+        for dropped in search_data:
+            if dropped not in known_search_fields:
+                logger.warning(
+                    f"Ignoring unknown RAG search config key '{dropped}' "
+                    "(retired or misspelled); it has no effect."
+                )
+
         return cls(
             embedding=EmbeddingConfig(**embedding_data),
             vector_store=VectorStoreConfig(**vector_store_data),
             chunking=ChunkingConfig(**chunking_data),
-            search=SearchConfig(**search_data),
+            search=SearchConfig(**known_search_data),
             query_expansion=QueryExpansionConfig(**query_expansion_data),
             pipeline=PipelineConfig(**pipeline_data),
         )

--- a/tldw_chatbook/Tools/document_expansion_tool.py
+++ b/tldw_chatbook/Tools/document_expansion_tool.py
@@ -16,9 +16,13 @@ produced them, and presumes nothing about TASK-3502's unimplemented
 `cross_encoder`.
 
 **The contract works from exactly what a row carries.** `source_type` +
-`source_id` is enough (that is all a label-only row has); `chunk_id` and
-`chunk_start` refine the window when the row is a semantic hit; `offset`
-walks a long document without re-querying.
+`source_id` is enough (that is all a label-only row has); `chunk_start`
+refines the window when the row is a semantic hit; `offset` walks a long
+document without re-querying. `chunk_id` is NOT a parameter: it is an INDEX
+(`f"{doc_id}_chunk_{i}"`), not a character offset, so it could never anchor
+a window -- it is swallowed by `**_provenance` so a pasted row still works,
+and shipping it as agent-facing schema would be the same dead knob this
+arc's Phase K retired one layer down.
 
 **Identity, and why the fallbacks exist.** A semantic row's `source_id` is
 `metadata["source_id"] || metadata["document_id"] || the chroma point id`
@@ -33,7 +37,7 @@ the indexer's PREFIXED document id (`f"note_{id}"`, `f"media_{id}"`,
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 from loguru import logger
 
@@ -60,6 +64,16 @@ SUPPORTED_SOURCE_TYPES: Tuple[str, ...] = ("note", "media", "conversation", "pro
 #: character budget then bounds what is returned.
 MAX_TRANSCRIPT_MESSAGES = 500
 
+#: Said out loud when a conversation is longer than that ceiling. Without
+#: it the payload's `total_size` -- the length of the RENDERED PREFIX -- is
+#: read as the whole document's size, and a partial read is indistinguishable
+#: from a complete one.
+MESSAGE_CAP_NOTE = (
+    f"Only the first {MAX_TRANSCRIPT_MESSAGES} messages of this conversation "
+    f"were read; total_size, the window and next_offset describe that prefix, "
+    f"not the whole conversation."
+)
+
 #: Mirrors `RAG_Search.simplified.rag_service.PROMPT_DOCUMENT_COLUMNS` (the
 #: three BODY columns the prompts sub-leg renders as a row's document, in
 #: that order) WITHOUT importing it: `rag_service` pulls in the embeddings/
@@ -71,6 +85,22 @@ PROMPT_BODY_COLUMNS: Tuple[str, ...] = ("details", "system_prompt", "user_prompt
 
 class ExpansionUnavailableError(RuntimeError):
     """A database this expansion needs could not be opened."""
+
+
+class _Document(NamedTuple):
+    """One fetched document, plus how completely it could be read.
+
+    `note` is empty for the ordinary case. It is non-empty only when the
+    FETCH itself was capped (today: a conversation longer than
+    `MAX_TRANSCRIPT_MESSAGES`), in which case `text` is a prefix of the real
+    document and `total_size` describes only that prefix -- so the payload
+    must report `truncated` even when the character window covers everything
+    that was read.
+    """
+
+    title: str
+    text: str
+    note: str = ""
 
 
 def _normalize_candidate(source_type: str, value: Any) -> list[str]:
@@ -135,17 +165,17 @@ def _require(db: Any, label: str) -> Any:
     return db
 
 
-def _fetch_note(note_id: str) -> Optional[Tuple[str, str]]:
+def _fetch_note(note_id: str) -> Optional[_Document]:
     from ..config import get_chachanotes_db_lazy
 
     db = _require(get_chachanotes_db_lazy(), "notes")
     row = db.get_note_by_id(note_id)
     if not row:
         return None
-    return str(row.get("title") or ""), str(row.get("content") or "")
+    return _Document(str(row.get("title") or ""), str(row.get("content") or ""))
 
 
-def _fetch_media(media_id: str) -> Optional[Tuple[str, str]]:
+def _fetch_media(media_id: str) -> Optional[_Document]:
     from ..config import get_media_db_lazy
 
     numeric = _as_int_id(media_id)
@@ -155,16 +185,21 @@ def _fetch_media(media_id: str) -> Optional[Tuple[str, str]]:
     row = db.get_media_by_id(numeric)
     if not row:
         return None
-    return str(row.get("title") or ""), str(row.get("content") or "")
+    return _Document(str(row.get("title") or ""), str(row.get("content") or ""))
 
 
-def _fetch_conversation(conversation_id: str) -> Optional[Tuple[str, str]]:
+def _fetch_conversation(conversation_id: str) -> Optional[_Document]:
     """Render a conversation as the role-prefixed transcript.
 
     `f"{sender}: {content}"`, joined by newlines -- byte-identical to
     `ingestion_indexing.conversation_document`, so what the agent reads
     back is the text that was chunked and indexed, not a second rendering
     that happens to differ.
+
+    Reads ONE message past `MAX_TRANSCRIPT_MESSAGES` purely to tell "exactly
+    at the cap" (a complete read) from "over it" (a partial one). A partial
+    read comes back carrying a note, because reporting it as complete would
+    be indistinguishable from a whole-document read.
     """
     from ..config import get_chachanotes_db_lazy
 
@@ -172,21 +207,26 @@ def _fetch_conversation(conversation_id: str) -> Optional[Tuple[str, str]]:
     conversation = db.get_conversation_by_id(conversation_id)
     if not conversation:
         return None
-    messages = db.get_messages_for_conversation(
-        conversation_id, limit=MAX_TRANSCRIPT_MESSAGES
+    messages = list(
+        db.get_messages_for_conversation(
+            conversation_id, limit=MAX_TRANSCRIPT_MESSAGES + 1
+        )
+        or ()
     )
+    capped = len(messages) > MAX_TRANSCRIPT_MESSAGES
     lines: list[str] = []
-    for message in messages or ():
+    for message in messages[:MAX_TRANSCRIPT_MESSAGES]:
         content = (message or {}).get("content")
         if not content or not str(content).strip():
             continue
         sender = message.get("sender") or message.get("role") or "unknown"
         lines.append(f"{sender}: {content}")
     title = conversation.get("title") or f"Conversation {conversation_id}"
-    return str(title), "\n".join(lines)
+    note = MESSAGE_CAP_NOTE if capped else ""
+    return _Document(str(title), "\n".join(lines), note)
 
 
-def _fetch_prompt(prompt_id: str) -> Optional[Tuple[str, str]]:
+def _fetch_prompt(prompt_id: str) -> Optional[_Document]:
     from ..config import get_prompts_db_lazy
 
     numeric = _as_int_id(prompt_id)
@@ -201,7 +241,7 @@ def _fetch_prompt(prompt_id: str) -> Optional[Tuple[str, str]]:
         for column in PROMPT_BODY_COLUMNS
         if row.get(column) and str(row[column]).strip()
     ]
-    return str(row.get("name") or ""), "\n\n".join(parts)
+    return _Document(str(row.get("name") or ""), "\n\n".join(parts))
 
 
 _FETCHERS = {
@@ -298,8 +338,12 @@ class ExpandDocumentTool(Tool):
             "snippet is truncated and the answer needs the content. "
             "Re-query instead if the hit itself looks irrelevant. Never "
             "expand the same source twice — reuse the earlier result. "
+            "Stop expanding once your remaining context budget is short — a "
+            "window you cannot afford to read is spent for nothing. "
             "Returns a bounded window of the document text plus total_size "
-            "and, when more remains, next_offset to continue from."
+            "and, when more remains, next_offset to continue from; pass the "
+            "row's chunk_start to centre that window on the matched chunk "
+            "instead of the document head."
         )
 
     @property
@@ -315,13 +359,6 @@ class ExpandDocumentTool(Tool):
                 "source_id": {
                     "type": "string",
                     "description": "The row's source_id.",
-                },
-                "chunk_id": {
-                    "type": "string",
-                    "description": (
-                        "The row's chunk_id, when it has one. Label-only "
-                        "media/conversation rows ship an empty string."
-                    ),
                 },
                 "chunk_start": {
                     "type": "integer",
@@ -377,7 +414,6 @@ class ExpandDocumentTool(Tool):
         self,
         source_type: str = "",
         source_id: str = "",
-        chunk_id: str = "",
         offset: int = 0,
         max_chars: Optional[int] = None,
         chunk_start: Optional[int] = None,
@@ -390,12 +426,14 @@ class ExpandDocumentTool(Tool):
 
         Extra keyword arguments are accepted and ignored so an agent can
         paste a row's whole `provenance` mapping without a TypeError
-        (`chunk_index`, `media_type`, `uuid`, ... all ride along there).
+        (`chunk_id`, `chunk_index`, `media_type`, `uuid`, ... all ride along
+        there). `chunk_id` is deliberately among them rather than a declared
+        parameter: it is an index, nothing here reads it, and a knob wired to
+        nothing must not ship as agent-facing surface.
 
         Args:
             source_type: One of `SUPPORTED_SOURCE_TYPES`.
             source_id: The row's `source_id`.
-            chunk_id: The row's `chunk_id`, or `""` for a label-only row.
             offset: Continuation offset from a previous call's
                 `next_offset`.
             max_chars: Character budget; defaults to `DEFAULT_MAX_CHARS`
@@ -413,7 +451,10 @@ class ExpandDocumentTool(Tool):
             `total_size`, `window` (`{"start", "end"}`), `truncated` and
             `next_offset` (`None` when the window reaches the end). An
             `"error"` status additionally carries an `error` key, which is
-            what makes the provider report the call as failed.
+            what makes the provider report the call as failed; a read the
+            SOURCE itself capped (a conversation past
+            `MAX_TRANSCRIPT_MESSAGES`) additionally carries a `note` saying
+            so, and is always reported `truncated`.
         """
         requested_type = str(source_type or "").strip().lower()
         requested_id = str(source_id or "").strip()
@@ -425,7 +466,7 @@ class ExpandDocumentTool(Tool):
         try:
             fetch = _FETCHERS[requested_type]
             resolved_id = ""
-            document: Optional[Tuple[str, str]] = None
+            document: Optional[_Document] = None
             for candidate in _candidate_ids(
                 requested_type, requested_id, note_id, media_id, doc_id
             ):
@@ -437,7 +478,7 @@ class ExpandDocumentTool(Tool):
             if document is None:
                 return _empty_result("not_found", requested_type, requested_id)
 
-            title, text = document
+            title, text, note = document
             total = len(text)
             budget = _resolve_budget(max_chars)
             start, end = _window_bounds(
@@ -446,7 +487,7 @@ class ExpandDocumentTool(Tool):
                 _as_int_id(str(chunk_start)) if chunk_start is not None else None,
                 budget,
             )
-            return {
+            result: Dict[str, Any] = {
                 "status": "ok",
                 "source_type": requested_type,
                 "source_id": resolved_id,
@@ -454,9 +495,15 @@ class ExpandDocumentTool(Tool):
                 "text": text[start:end],
                 "total_size": total,
                 "window": {"start": start, "end": end},
-                "truncated": start > 0 or end < total,
+                # A source-capped read is truncated even when the window
+                # covers every character that was read: `total` describes
+                # the prefix, not the document.
+                "truncated": bool(note) or start > 0 or end < total,
                 "next_offset": end if end < total else None,
             }
+            if note:
+                result["note"] = note
+            return result
         except Exception as exc:  # noqa: BLE001 -- a tool must not crash the loop
             logger.opt(exception=True).error(
                 f"expand_document failed for {requested_type}:{requested_id}: {exc}"

--- a/tldw_chatbook/Tools/document_expansion_tool.py
+++ b/tldw_chatbook/Tools/document_expansion_tool.py
@@ -1,0 +1,466 @@
+"""Agentic document expansion: follow a retrieval hit into its document.
+
+TASK-16174 Phase T. An agent could already RETRIEVE (the Console Library
+tool, `Agents/library_rag_tool_provider.py`) but could not FOLLOW a hit
+into the document behind it -- and since TASK-16071's rank-fair merge, 54%
+of the rows a top-M consumer is fed are LABEL-ONLY: media rows say
+"Matched media · {type}" and conversation rows "Matched conversation ·
+N messages" (`Library/library_local_rag_search_service.py`'s `_media_row`
+/`_conversation_row`), both with an empty `chunk_id`. The majority of what
+an agent saw was a label it could not see behind.
+
+This tool is the pull-based answer: budgeted, gated OFF by default, and
+risk-tagged so an inherited `allow` is floored to `ask`. It is deliberately
+INDEPENDENT of reranking (AC#6) -- it consumes final result rows whatever
+produced them, and presumes nothing about TASK-3502's unimplemented
+`cross_encoder`.
+
+**The contract works from exactly what a row carries.** `source_type` +
+`source_id` is enough (that is all a label-only row has); `chunk_id` and
+`chunk_start` refine the window when the row is a semantic hit; `offset`
+walks a long document without re-querying.
+
+**Identity, and why the fallbacks exist.** A semantic row's `source_id` is
+`metadata["source_id"] || metadata["document_id"] || the chroma point id`
+(`_semantic_row`), so for some rows the point id is what surfaces and the
+real document identity is only in the provenance extras. `note_id`,
+`media_id` and `doc_id` are therefore accepted as optional identity
+fallbacks -- an agent can paste a row's provenance verbatim. `doc_id` is
+the indexer's PREFIXED document id (`f"note_{id}"`, `f"media_{id}"`,
+`f"conversation_{id}"` -- see `RAG_Search/ingestion_indexing.py`), so a
+`<source_type>_` prefix is stripped as a second candidate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from loguru import logger
+
+from . import Tool
+
+#: Default character budget for one expansion. A module constant, not a new
+#: `[tools]` key: this arc's Phase K just RETIRED three config knobs that
+#: nothing read, and shipping another user-switchable surface with no
+#: consumer would repeat exactly that. A caller that wants a different
+#: window passes `max_chars`.
+DEFAULT_MAX_CHARS = 8000
+
+#: Ceiling the tool will never exceed regardless of what is asked -- the
+#: budget is a promise to the payload the agent is assembling, so an
+#: absurd `max_chars` is capped rather than honored.
+HARD_MAX_CHARS = 32000
+
+#: The four seams the Library retrieval rows can name (`provenance.
+#: source_type`). Anything else returns `status="unsupported"` rather than
+#: guessing.
+SUPPORTED_SOURCE_TYPES: Tuple[str, ...] = ("note", "media", "conversation", "prompt")
+
+#: Transcript ceiling for one conversation read. Bounds the DB work; the
+#: character budget then bounds what is returned.
+MAX_TRANSCRIPT_MESSAGES = 500
+
+#: Mirrors `RAG_Search.simplified.rag_service.PROMPT_DOCUMENT_COLUMNS` (the
+#: three BODY columns the prompts sub-leg renders as a row's document, in
+#: that order) WITHOUT importing it: `rag_service` pulls in the embeddings/
+#: vector stack, and this tool is constructed by the Settings-side gate
+#: enumerator (`builtin_tool_gate.all_tool_gates`) purely to read its
+#: description. A three-string tuple is not worth that import.
+PROMPT_BODY_COLUMNS: Tuple[str, ...] = ("details", "system_prompt", "user_prompt")
+
+
+class ExpansionUnavailableError(RuntimeError):
+    """A database this expansion needs could not be opened."""
+
+
+def _normalize_candidate(source_type: str, value: Any) -> list[str]:
+    """Turn one identity hint into the candidate ids it could mean.
+
+    Args:
+        source_type: The seam being expanded, used to strip the indexer's
+            document-id prefix.
+        value: A raw hint (`source_id`, `note_id`, `doc_id`, `media_id`).
+
+    Returns:
+        Zero, one or two candidate id strings, most literal first.
+    """
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    candidates = [text]
+    prefix = f"{source_type}_"
+    if text.startswith(prefix) and len(text) > len(prefix):
+        candidates.append(text[len(prefix) :])
+    return candidates
+
+
+def _candidate_ids(
+    source_type: str,
+    source_id: Any,
+    note_id: Any,
+    media_id: Any,
+    doc_id: Any,
+) -> list[str]:
+    """Every id worth trying, in resolution order, de-duplicated.
+
+    Explicit `source_id` first (it is right for keyword/label-only rows,
+    which are the majority case), then the provenance extras.
+    """
+    ordered: list[str] = []
+    for value in (source_id, note_id, media_id, doc_id):
+        for candidate in _normalize_candidate(source_type, value):
+            if candidate not in ordered:
+                ordered.append(candidate)
+    return ordered
+
+
+def _as_int_id(value: str) -> Optional[int]:
+    """Coerce an integer-keyed id, or None when it cannot be one.
+
+    Media and prompt ids are INTEGER primary keys and their readers raise
+    on a non-integer, so a chroma point id must be discarded here rather
+    than turned into an exception the agent has to read.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _require(db: Any, label: str) -> Any:
+    if db is None:
+        raise ExpansionUnavailableError(f"the {label} database is unavailable")
+    return db
+
+
+def _fetch_note(note_id: str) -> Optional[Tuple[str, str]]:
+    from ..config import get_chachanotes_db_lazy
+
+    db = _require(get_chachanotes_db_lazy(), "notes")
+    row = db.get_note_by_id(note_id)
+    if not row:
+        return None
+    return str(row.get("title") or ""), str(row.get("content") or "")
+
+
+def _fetch_media(media_id: str) -> Optional[Tuple[str, str]]:
+    from ..config import get_media_db_lazy
+
+    numeric = _as_int_id(media_id)
+    if numeric is None:
+        return None
+    db = _require(get_media_db_lazy(), "media")
+    row = db.get_media_by_id(numeric)
+    if not row:
+        return None
+    return str(row.get("title") or ""), str(row.get("content") or "")
+
+
+def _fetch_conversation(conversation_id: str) -> Optional[Tuple[str, str]]:
+    """Render a conversation as the role-prefixed transcript.
+
+    `f"{sender}: {content}"`, joined by newlines -- byte-identical to
+    `ingestion_indexing.conversation_document`, so what the agent reads
+    back is the text that was chunked and indexed, not a second rendering
+    that happens to differ.
+    """
+    from ..config import get_chachanotes_db_lazy
+
+    db = _require(get_chachanotes_db_lazy(), "conversations")
+    conversation = db.get_conversation_by_id(conversation_id)
+    if not conversation:
+        return None
+    messages = db.get_messages_for_conversation(
+        conversation_id, limit=MAX_TRANSCRIPT_MESSAGES
+    )
+    lines: list[str] = []
+    for message in messages or ():
+        content = (message or {}).get("content")
+        if not content or not str(content).strip():
+            continue
+        sender = message.get("sender") or message.get("role") or "unknown"
+        lines.append(f"{sender}: {content}")
+    title = conversation.get("title") or f"Conversation {conversation_id}"
+    return str(title), "\n".join(lines)
+
+
+def _fetch_prompt(prompt_id: str) -> Optional[Tuple[str, str]]:
+    from ..config import get_prompts_db_lazy
+
+    numeric = _as_int_id(prompt_id)
+    if numeric is None:
+        return None
+    db = _require(get_prompts_db_lazy(), "prompts")
+    row = db.get_prompt_by_id(numeric)
+    if not row:
+        return None
+    parts = [
+        str(row[column]).strip()
+        for column in PROMPT_BODY_COLUMNS
+        if row.get(column) and str(row[column]).strip()
+    ]
+    return str(row.get("name") or ""), "\n\n".join(parts)
+
+
+_FETCHERS = {
+    "note": _fetch_note,
+    "media": _fetch_media,
+    "conversation": _fetch_conversation,
+    "prompt": _fetch_prompt,
+}
+
+
+def _resolve_budget(max_chars: Any) -> int:
+    """Resolve the character budget, capped and never zero or negative."""
+    if max_chars is None:
+        return DEFAULT_MAX_CHARS
+    try:
+        value = int(max_chars)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_CHARS
+    if value <= 0:
+        return DEFAULT_MAX_CHARS
+    return min(value, HARD_MAX_CHARS)
+
+
+def _window_bounds(
+    total: int, offset: int, anchor: Optional[int], budget: int
+) -> Tuple[int, int]:
+    """Pick the half-open character window to return.
+
+    Three cases, in priority order:
+
+    1. **Continuation** (`offset > 0`): start EXACTLY at `offset`. A
+       continuation that silently slid backwards would re-serve text the
+       agent already paid for and never terminate the walk.
+    2. **Chunk-centred** (`anchor` known): centre the budget on the matched
+       chunk's character start, then pull back if the document ends first
+       so a late chunk still returns a full budget rather than a sliver.
+    3. **Head**: the first `budget` characters -- what a label-only row,
+       which carries no chunk lineage at all, gets.
+
+    Args:
+        total: Length of the whole document text.
+        offset: Caller's continuation offset (clamped at 0 and `total`).
+        anchor: The matched chunk's character start, when known.
+        budget: Resolved character budget.
+
+    Returns:
+        A `(start, end)` pair with `0 <= start <= end <= total`.
+    """
+    if total <= 0:
+        return 0, 0
+    if offset > 0:
+        start = min(offset, total)
+        return start, min(start + budget, total)
+    if anchor is not None and anchor > 0:
+        start = max(0, min(anchor, total) - budget // 2)
+        end = min(start + budget, total)
+        if end - start < budget:
+            start = max(0, end - budget)
+        return start, end
+    return 0, min(budget, total)
+
+
+def _empty_result(status: str, source_type: str, source_id: str) -> Dict[str, Any]:
+    """The full return shape for a branch that produced no text.
+
+    Every branch returns the SAME keys -- a consumer (the policy hints in
+    Phase P, an agent's own parsing) must not have to special-case a miss.
+    """
+    return {
+        "status": status,
+        "source_type": source_type,
+        "source_id": source_id,
+        "title": "",
+        "text": "",
+        "total_size": 0,
+        "window": {"start": 0, "end": 0},
+        "truncated": False,
+        "next_offset": None,
+    }
+
+
+class ExpandDocumentTool(Tool):
+    """Expand one retrieval hit into a bounded window of its document."""
+
+    @property
+    def name(self) -> str:
+        return "expand_document"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Expand a retrieval hit into its document. Use when a "
+            "high-ranked hit is label-only (media/conversation rows) or its "
+            "snippet is truncated and the answer needs the content. "
+            "Re-query instead if the hit itself looks irrelevant. Never "
+            "expand the same source twice — reuse the earlier result. "
+            "Returns a bounded window of the document text plus total_size "
+            "and, when more remains, next_offset to continue from."
+        )
+
+    @property
+    def parameters(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "source_type": {
+                    "type": "string",
+                    "enum": list(SUPPORTED_SOURCE_TYPES),
+                    "description": "The row's provenance.source_type.",
+                },
+                "source_id": {
+                    "type": "string",
+                    "description": "The row's source_id.",
+                },
+                "chunk_id": {
+                    "type": "string",
+                    "description": (
+                        "The row's chunk_id, when it has one. Label-only "
+                        "media/conversation rows ship an empty string."
+                    ),
+                },
+                "chunk_start": {
+                    "type": "integer",
+                    "description": (
+                        "The matched chunk's character start, from the row's "
+                        "provenance. Given, the window is centred on the "
+                        "match instead of starting at the document head."
+                    ),
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": (
+                        "Continue from this character offset -- pass the "
+                        "next_offset of the previous call to walk a long "
+                        "document without re-querying."
+                    ),
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": (
+                        f"Character budget for this call (default "
+                        f"{DEFAULT_MAX_CHARS}, hard cap {HARD_MAX_CHARS})."
+                    ),
+                },
+                "note_id": {
+                    "type": "string",
+                    "description": (
+                        "Identity fallback from the row's provenance, used "
+                        "when source_id is a vector-store point id."
+                    ),
+                },
+                "media_id": {
+                    "type": "string",
+                    "description": "Identity fallback from the row's provenance.",
+                },
+                "doc_id": {
+                    "type": "string",
+                    "description": (
+                        "Identity fallback from the row's provenance "
+                        "(the indexer's prefixed document id)."
+                    ),
+                },
+            },
+            "required": ["source_type", "source_id"],
+        }
+
+    @property
+    def risk_tags(self) -> tuple[str, ...]:
+        """Reads the user's notes, media, conversations and prompts."""
+        return ("reads",)
+
+    async def execute(
+        self,
+        source_type: str = "",
+        source_id: str = "",
+        chunk_id: str = "",
+        offset: int = 0,
+        max_chars: Optional[int] = None,
+        chunk_start: Optional[int] = None,
+        note_id: Optional[Any] = None,
+        media_id: Optional[Any] = None,
+        doc_id: Optional[Any] = None,
+        **_provenance: Any,
+    ) -> Dict[str, Any]:
+        """Return a bounded window of the document behind one retrieval hit.
+
+        Extra keyword arguments are accepted and ignored so an agent can
+        paste a row's whole `provenance` mapping without a TypeError
+        (`chunk_index`, `media_type`, `uuid`, ... all ride along there).
+
+        Args:
+            source_type: One of `SUPPORTED_SOURCE_TYPES`.
+            source_id: The row's `source_id`.
+            chunk_id: The row's `chunk_id`, or `""` for a label-only row.
+            offset: Continuation offset from a previous call's
+                `next_offset`.
+            max_chars: Character budget; defaults to `DEFAULT_MAX_CHARS`
+                and is capped at `HARD_MAX_CHARS`.
+            chunk_start: The matched chunk's character start, when the
+                row's provenance carries it.
+            note_id: Identity fallback for a note row.
+            media_id: Identity fallback for a media row.
+            doc_id: Identity fallback carrying the indexer's prefixed
+                document id.
+
+        Returns:
+            `status` (`"ok"`/`"not_found"`/`"unsupported"`/`"error"`),
+            `source_type`, `source_id` (the RESOLVED id), `title`, `text`,
+            `total_size`, `window` (`{"start", "end"}`), `truncated` and
+            `next_offset` (`None` when the window reaches the end). An
+            `"error"` status additionally carries an `error` key, which is
+            what makes the provider report the call as failed.
+        """
+        requested_type = str(source_type or "").strip().lower()
+        requested_id = str(source_id or "").strip()
+
+        if requested_type not in SUPPORTED_SOURCE_TYPES:
+            logger.debug(f"expand_document: unsupported source_type {requested_type!r}")
+            return _empty_result("unsupported", requested_type, requested_id)
+
+        try:
+            fetch = _FETCHERS[requested_type]
+            resolved_id = ""
+            document: Optional[Tuple[str, str]] = None
+            for candidate in _candidate_ids(
+                requested_type, requested_id, note_id, media_id, doc_id
+            ):
+                document = fetch(candidate)
+                if document is not None:
+                    resolved_id = candidate
+                    break
+
+            if document is None:
+                return _empty_result("not_found", requested_type, requested_id)
+
+            title, text = document
+            total = len(text)
+            budget = _resolve_budget(max_chars)
+            start, end = _window_bounds(
+                total,
+                max(0, _as_int_id(str(offset)) or 0),
+                _as_int_id(str(chunk_start)) if chunk_start is not None else None,
+                budget,
+            )
+            return {
+                "status": "ok",
+                "source_type": requested_type,
+                "source_id": resolved_id,
+                "title": title,
+                "text": text[start:end],
+                "total_size": total,
+                "window": {"start": start, "end": end},
+                "truncated": start > 0 or end < total,
+                "next_offset": end if end < total else None,
+            }
+        except Exception as exc:  # noqa: BLE001 -- a tool must not crash the loop
+            logger.opt(exception=True).error(
+                f"expand_document failed for {requested_type}:{requested_id}: {exc}"
+            )
+            failure = _empty_result("error", requested_type, requested_id)
+            failure["error"] = f"Could not expand {requested_type} {requested_id}: {exc}"
+            return failure

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -1236,7 +1236,7 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
         Builtin-source snapshots only, same gate as `_builtin_toggle_
         widgets()` -- spec review finding 5 (branch (b)): `_collect_
         snapshots()` never produces a `local:__local__` row, so this is the
-        only reachable place for ALL nine gates. Rendered under two
+        only reachable place for ALL of them. Rendered under two
         subheadings ("Agent built-ins" / "Local workspace, web, and Watchlists tools") so the
         accepted UX trade-off stays visible rather than papered over: this
         pane is badged as the built-in MCP SERVER, but these checkboxes

--- a/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
+++ b/tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py
@@ -6079,6 +6079,10 @@ class ToolsStep(SetupStep):
         "update_note": ("Update note", "⚠ Edits your existing notes."),
         "glob_files": ("Find files", "Match file names by pattern (like *.md)."),
         "grep_files": ("Search in files", "Search inside files for text."),
+        "expand_document": (
+            "Expand document",
+            "Read the whole document behind a search result.",
+        ),
     }
 
     def gate_key_for(self, switch: Switch) -> str:


### PR DESCRIPTION
## What this is

The RAG programme's eleventh arc: the capability the owner asked for on 2026-08-14 — *BM25+vector → re-rank → an agent that follows retrieved chunks into whole documents* — built as one gated tool plus a wired policy, with the evaluation question answered by a run rather than an assumption. 13 commits, SDD (4 planned tasks + an added 3b + a final whole-branch review + one fix wave, re-review verdict FIXES-VERIFIED).

## Why it matters (measured)

Since TASK-16071's rank-fair merge, **54% of the rows a top-M consumer is fed are label-only** (`Matched media · pdf` — no document text). The answer-level oracle run makes the cost concrete:

| | tool-OFF | tool-ON |
|---|---|---|
| oracle facts reached (8 questions, facts existing ONLY in media/conversation bodies) | **0/8** | **7/8** |

The single ON miss is a retrieval failure present in both arms (q6's searches returned empty); conditioned on the row being returned, tool-ON is 7/7. Four OFF questions *had* the label-only row and still scored zero — the model said unprompted it could not see behind the label. Real `AgentService` → `api.anthropic.com` (claude-haiku, temp 0), mechanical fact-inclusion scoring, no LLM grader, **$0.20 total spend**, artifacts committed (`Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/`). Disclosed limits: N=8, one corpus, one model, one route; the ON arm ran an extra search on 3 questions.

## What ships

- **Phase K — the inert knobs retire (AC#7).** `include_parent_docs`/`parent_size_threshold`/`parent_inclusion_strategy` (set by three shipped profiles, read by nothing — grep-proven) leave config and profiles; saved configs carrying them now load with a warning instead of the `TypeError` they would have hit (`from_dict` filters unknown search keys). The live neighbours (`max_context_size`, `ChunkingConfig.enable_parent_retrieval`) were verified live and untouched.
- **Phase T — `expand_document` (AC#1/#2/#4).** A gateable builtin, OFF by default, risk-floored to `ask` (proven through the real resolver). Contract works from exactly what rows carry — including the label-only media/conversation rows (empty `chunk_id`) and prefixed `doc_id` identities; over-budget documents return a `chunk_start`-centred window with a continuation offset; conversations over the 500-message fetch cap now say so honestly (`truncated: true` + note).
- **Phase P — the policy, wired (AC#3).** A pure `expand_hint` helper (label detection by the provenance-triple, never label prose) rides every Library retrieval payload row, and the rows carry the `source_type`/`source_id`/`chunk_start` identity the tool requires — under the hint's own precondition, so verdict and actionability cannot drift. Payload cost: ~+100 B/row all-in against a 32 KiB ceiling, sealing-loop survival tested. Two spec branches ("budget exhausted", "never re-expand") ship as pinned description guidance, unenforced — disclosed in the task file with the reason.
- **Phase E — the decision (AC#5/#6).** Answer-level measurement defined AND run (table above); independence from the unimplemented reranker recorded.

## Discipline

- Gate: `RAG_EVAL=1` suite reads verbatim `PASSED: No regression. 105 metric(s) within 0.05 of baseline` — all cells (+0.000). Retrieval behaviour provably unchanged.
- Batteries: 4,313 → 3,995+84 after fixes, 0 failed; collection sweep vs merge-base clean; ruff clean on touched files (one pre-existing F401 at merge-base named, not silently fixed).
- Final whole-branch review (18 findings, 3 blocking) + one fix wave + scoped re-review (FIXES-VERIFIED). The blockers were: a dead `chunk_id` tool parameter (retired; `chunk_start` wired into the payload instead — the arc's own doctrine applied to itself), the undisclosed policy-branch narrowing (disclosed + pinned; the review found "budget exhausted" existed in neither code nor prose), and the >500-message truncation lie (fixed RED-first, boundary tested both sides).
- Follow-ups filed with swept IDs: **TASK-16588** (measure expansion on a route that can produce chunked/semantic rows — the plain route structurally cannot, so Task 3b's suspects are unrefuted, not refuted) and **TASK-16688** (review findings 5/6/13/15/16: twin-literal pins, canonicalization-variant rows, the direct-tools consent-boundary relationship, the unused image-BLOB load, the untested continuation half).
- New traps recorded in the ledger for the lessons pass: adding a `_GATEABLE_BUILTINS` row breaks four hard-coded arity literals outside the obvious battery and needs a `_TOOL_COPY` wizard entry, or first-run setup ships a blank row; `search_run_log`/`run_log_slice` are offered regardless of `allowed_tools` (appended after the allow filter) — a confound for any arm-isolation experiment.

Refs TASK-16174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gated `expand_document` tool and wires an expansion policy into Library retrieval payloads so the agent can follow label-only hits into their documents. Removes the unused parent-inclusion knobs from search config while keeping retrieval behavior unchanged; evaluation improved answers from 0/8 to 7/8 on facts present only in document bodies (TASK-16174).

- The tool is OFF by default, registered via `_GATEABLE_BUILTINS`, risk-tagged “reads” with an ask floor; independent of any reranker.
- Retrieval payloads now carry `expand_hint` plus `source_type`/`source_id`, and optional `chunk_start`; `chunk_id` is removed from the contract. Hints are derived only; no provenance map leaks.
- The policy detects label-only rows via a provenance triple (type + empty `chunk_id` + label prefix). It reports budgeted windows and honest transcript truncation; continuation guidance lives in the description.
- `RAG_EVAL=1` shows no retrieval regression (105/105 unchanged). UI gate counts derive from `_GATEABLE_BUILTINS`; First-Run wizard and MCP Servers mode list the new gate. Docs correct prior claims that parent-inclusion was implemented.

**Rollout and migration**
- No behavior change until you enable the `expand_document` gate.
- `include_parent_docs`, `parent_size_threshold`, and `parent_inclusion_strategy` are removed; `RAGConfig.from_dict` now drops unknown `[search]` keys with a warning. Remove these keys from custom profiles or saved configs.
- Follow-ups: TASK-16588 (carry identity to hybrid/semantic routes) and TASK-16688 (policy/allowlist and measurement gaps).

<sup>Written for commit 2a26cc66708ddda3ffe3d23a1a2b2ed78552da6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

