### PR TITLE
feat(console): let human approval prompts wait indefinitely (ADR-067)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -88,6 +88,13 @@ appears above the transcript:
   "path outside allowed folders; will fail even if approved" — means the file
   path will be rejected regardless of your decision.
 
+An armed approval card does not expire — the run waits for your decision
+however long you take. Stopping the run or closing the session withdraws a
+pending card; nothing else does. If you'd rather have undecided calls
+auto-denied on a clock, set `[mcp] approval_timeout_seconds` in
+`config.toml` (seconds; `0`, the default, waits indefinitely — the skill
+install and run-script confirm cards follow the same rule).
+
 **Always allow** (MCP tools only) is remembered per tool, tied to the tool's
 current definition — if the server later changes the tool, the approval card
 comes back with a "(definition changed)" badge. Review or change a remembered

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -1973,3 +1973,90 @@ def test_no_definitions_spawn_unchanged(db):
         api_endpoint="llama_cpp",
     )
     assert '"agent"' not in json.dumps(chat.calls[0], default=str)
+
+
+# -- ADR-067: pausable per-call deadline ---------------------------------
+#
+# A blocking human prompt (approval card / skill confirm) can wait inside
+# the callable handed to _call_with_timeout. The pre-ADR invariant
+# (approval timeout 120s < max_tool_call_seconds 300s) bounded the
+# abandoned-thread double-execution hazard by keeping the approval wait
+# strictly under the wrapper's ceiling. Indefinite human waits replace
+# that with a pausable clock: while a decision is pending for the run,
+# the deadline re-arms each poll slice, so wall-clock counts only actual
+# tool execution.
+
+
+def test_call_with_timeout_pauses_deadline_while_predicate_holds():
+    """While ``pauses_deadline`` polls True the deadline re-arms, so time
+    spent waiting on a human decision inside ``fn`` does not consume the
+    tool's execution budget. The 0.3s ceiling would abandon this 1.0s
+    call without the pause."""
+    def fn():
+        time.sleep(1.0)
+        return ToolResult(ok=True, content="worth the wait")
+
+    pause_until = time.monotonic() + 1.2
+    out = _call_with_timeout(
+        fn,
+        0.3,
+        "paused_tool",
+        pauses_deadline=lambda: time.monotonic() < pause_until,
+    )
+    assert out.ok is True and out.content == "worth the wait"
+
+
+def test_call_with_timeout_deadline_resumes_after_pause_ends():
+    """The pause re-arms the deadline, it does not remove it: once the
+    predicate goes False the armed deadline applies again, so a call that
+    keeps hanging AFTER its human decision still trips the ceiling
+    promptly instead of riding a frozen clock forever."""
+    def fn():
+        time.sleep(3.0)
+        return ToolResult(ok=True, content="too late")
+
+    pause_until = time.monotonic() + 0.7
+    t0 = time.monotonic()
+    out = _call_with_timeout(
+        fn,
+        0.3,
+        "resumed_tool",
+        pauses_deadline=lambda: time.monotonic() < pause_until,
+    )
+    elapsed = time.monotonic() - t0
+    assert out.ok is False and "timed out" in out.error
+    assert elapsed < 2.0
+
+
+def test_make_invoke_tool_pauses_deadline_during_human_input_wait(db, monkeypatch):
+    """The ADR-067 production wiring: ``_make_invoke_tool`` feeds
+    ``human_input_wait_active(run_id)`` into the wrapper, so a registry
+    tool blocked on a human decision (marked from ANY thread via
+    ``use_human_input_wait``) outlives max_tool_call_seconds."""
+    def chat(**kwargs):  # pragma: no cover - unused by this test
+        return {"choices": [{"message": {"content": "unused"}}]}
+
+    service = _service_with_chat(db, chat)
+
+    def slow_invoke_by_name(name, args):
+        time.sleep(1.0)
+        return ToolResult(ok=True, content="approved then ran")
+
+    monkeypatch.setattr(service.registry, "invoke_by_name", slow_invoke_by_name)
+    cfg = AgentConfig(
+        model="test-model",
+        system_prompt="s",
+        allowed_tools=("calculator",),
+        budget=RunBudget(max_tool_call_seconds=0.3),
+    )
+    invoke_tool = service._make_invoke_tool(
+        cfg, disclosed_names={"calculator"}, run_id="run-pause-1"
+    )
+    from tldw_chatbook.Agents.agent_models import ToolCall
+    from tldw_chatbook.Agents.human_input_wait import use_human_input_wait
+
+    with use_human_input_wait("run-pause-1"):
+        result = invoke_tool(ToolCall(name="calculator", args={"expression": "2+2"}))
+
+    assert result.ok is True
+    assert result.content == "approved then ran"

--- a/Tests/Agents/test_human_input_wait.py
+++ b/Tests/Agents/test_human_input_wait.py
@@ -56,6 +56,10 @@ def test_wait_is_visible_across_threads():
         thread.start()
         assert observed.wait(timeout=5.0), "observer never ran"
         thread.join(timeout=5.0)
+        # A join(timeout=...) that returns says nothing about termination,
+        # and a leaked non-daemon thread hangs interpreter shutdown (the
+        # exact failure mode in the TASK-16789 lesson).
+        assert not thread.is_alive(), "observer thread did not terminate"
 
     assert seen == [True]
     assert human_input_wait_active("run-1") is False

--- a/Tests/Agents/test_human_input_wait.py
+++ b/Tests/Agents/test_human_input_wait.py
@@ -1,0 +1,93 @@
+"""ADR-067: the run-keyed human-input wait registry.
+
+A blocking human prompt (tool approval card, skill install confirm, skill
+script confirm) marks its run while a decision is pending so
+``AgentService._call_with_timeout`` can pause the per-call wall clock:
+machine budget must not tick while a human is being waited on. Mirrors
+``run_context``'s dependency-light, stdlib-only discipline.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from tldw_chatbook.Agents.human_input_wait import (
+    human_input_wait_active,
+    use_human_input_wait,
+)
+
+
+def test_not_active_without_a_wait():
+    assert human_input_wait_active("run-1") is False
+
+
+def test_active_inside_context_and_cleared_after():
+    with use_human_input_wait("run-1"):
+        assert human_input_wait_active("run-1") is True
+    assert human_input_wait_active("run-1") is False
+
+
+def test_cleared_when_wait_ends_via_exception():
+    """A round torn down mid-wait (cancel path) must drop its mark too --
+    a leaked mark would freeze the per-call clock for that run's next
+    tool call forever."""
+    try:
+        with use_human_input_wait("run-1"):
+            raise RuntimeError("round torn down mid-wait")
+    except RuntimeError:
+        pass
+    assert human_input_wait_active("run-1") is False
+
+
+def test_wait_is_visible_across_threads():
+    """The mark is SET on the round's worker thread and POLLED on the
+    wrapper's thread, so the registry must be thread-safe process state --
+    a ContextVar set on the worker would be invisible where the deadline
+    is checked (the trap ``run_context`` documents for its own bindings)."""
+    seen: list[bool] = []
+    observed = threading.Event()
+
+    def observer() -> None:
+        seen.append(human_input_wait_active("run-1"))
+        observed.set()
+
+    with use_human_input_wait("run-1"):
+        thread = threading.Thread(target=observer)
+        thread.start()
+        assert observed.wait(timeout=5.0), "observer never ran"
+        thread.join(timeout=5.0)
+
+    assert seen == [True]
+    assert human_input_wait_active("run-1") is False
+
+
+def test_waits_for_different_runs_are_independent():
+    """Concurrent runs are the norm (fleet children share one session);
+    one run's pending decision must not pause a sibling's clock."""
+    with use_human_input_wait("run-1"):
+        assert human_input_wait_active("run-2") is False
+        with use_human_input_wait("run-2"):
+            assert human_input_wait_active("run-2") is True
+        assert human_input_wait_active("run-2") is False
+        assert human_input_wait_active("run-1") is True
+    assert human_input_wait_active("run-1") is False
+
+
+def test_concurrent_same_run_waits_refcount():
+    """Two rounds for ONE run may overlap (batch review hook + single-call
+    fallback approval); the run stays marked until BOTH end."""
+    with use_human_input_wait("run-1"):
+        with use_human_input_wait("run-1"):
+            assert human_input_wait_active("run-1") is True
+        assert human_input_wait_active("run-1") is True
+    assert human_input_wait_active("run-1") is False
+
+
+def test_falsy_run_id_is_normalized():
+    """``""`` is the no-run key (a round armed outside any agent run, e.g.
+    the MCP workbench Test Tool); it marks and clears like any other,
+    never crashes, and ``None`` reads the same slot."""
+    with use_human_input_wait(None):
+        assert human_input_wait_active("") is True
+        assert human_input_wait_active(None) is True
+    assert human_input_wait_active("") is False

--- a/Tests/Chat/test_console_skill_script_confirm.py
+++ b/Tests/Chat/test_console_skill_script_confirm.py
@@ -84,7 +84,14 @@ def make_controller() -> Callable[[], ConsoleChatController]:
     inspect what was actually marshaled to the UI (e.g. that it carries
     ``timeout_seconds``/``request_id``) read that list instead of the
     payloads being silently discarded.
+
+    Teardown fails every controller's armed rounds closed: ADR-067 made
+    the confirm timeout default to no-deadline, so a test that ends (or
+    FAILS mid-assert) with a round armed would leave its non-daemon worker
+    thread waiting forever and hang interpreter shutdown. Flipping
+    ``_shutdown_requested`` resolves each such round at its next 1s poll.
     """
+    made: list[ConsoleChatController] = []
 
     def _make() -> ConsoleChatController:
         store = ConsoleChatStore()
@@ -94,9 +101,13 @@ def make_controller() -> Callable[[], ConsoleChatController]:
         controller.set_pending_skill_script = (
             controller.pending_skill_script_payloads.append
         )
+        made.append(controller)
         return controller
 
-    return _make
+    yield _make
+
+    for controller in made:
+        controller._shutdown_requested.set()
 
 
 # -- bridge closure fixtures ------------------------------------------------
@@ -591,8 +602,14 @@ def test_confirm_payload_carries_timeout_and_request_id(make_controller):
     """The payload actually marshaled to the UI sink must carry both the
     timeout and a per-round request id (not just the caller's own keys) --
     a card built from an under-described payload is a security defect,
-    since that payload is exactly what the human approves on."""
+    since that payload is exactly what the human approves on.
+
+    ADR-067: the timeout is exercised through a POSITIVE seam value -- the
+    shipped default is now 0 (= no deadline), and the payload must carry
+    whatever was resolved, but this test's subject is the round trip of a
+    real deadline onto the card."""
     controller = make_controller()
+    controller.skill_script_confirm_timeout_seconds = lambda: 45.0
     result = {}
 
     def worker():
@@ -607,8 +624,7 @@ def test_confirm_payload_carries_timeout_and_request_id(make_controller):
     assert shown is not None
     assert shown["skill_name"] == "demo"
     assert shown["script_path"] == "scripts/hello.py"
-    assert isinstance(shown["timeout_seconds"], float)
-    assert shown["timeout_seconds"] > 0
+    assert shown["timeout_seconds"] == 45.0
     assert shown["request_id"] == controller.pending_skill_script_ids()[0]
     assert shown["request_id"]  # non-empty
     controller.resolve_pending_skill_script(True, False, request_id=shown["request_id"])
@@ -1149,3 +1165,29 @@ def test_a_late_allow_after_a_revoke_cannot_run_the_script(tmp_path, monkeypatch
     result = outcome["result"]
     assert result.ok is False
     assert "declined" in result.error
+
+
+def test_confirm_zero_timeout_keeps_round_armed_for_late_decision(make_controller):
+    """ADR-067: timeout 0 = no deadline -- mirrors the install-confirm
+    sibling; the round survives the first 1s poll that the pre-ADR
+    `deadline = now + 0` tripped, and resolves on the decision."""
+    controller = make_controller()
+    controller.skill_script_confirm_timeout_seconds = lambda: 0.0
+
+    def _allow_late() -> None:
+        time.sleep(1.6)
+        payload = controller.pending_skill_script_payloads[0]
+        controller.resolve_pending_skill_script(
+            True, False, request_id=payload["request_id"]
+        )
+
+    decider = threading.Thread(target=_allow_late)
+    decider.start()
+    started = time.monotonic()
+    decision = controller.request_skill_script_confirm({"skill_name": "demo"})
+    elapsed = time.monotonic() - started
+    decider.join()
+
+    assert decision == {"allow": True, "remember": False}
+    assert elapsed >= 1.5
+    assert controller.pending_skill_script_payloads[0]["timeout_seconds"] == 0.0

--- a/Tests/UI/test_chat_approval_card.py
+++ b/Tests/UI/test_chat_approval_card.py
@@ -309,3 +309,14 @@ def test_distinct_calls_get_their_own_row_and_verdict():
         "splitting them would offer a decision that cannot be honoured"
     )
     assert fence_rows[0]["count"] == 2
+
+
+def test_format_approval_deadline_hides_copy_when_no_deadline_armed():
+    """ADR-067: 0/None deadline (the new shipped default) renders NO
+    countdown copy. Pins the TASK-1844 behavior now that 0 is the norm."""
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import (
+        format_approval_deadline,
+    )
+
+    assert format_approval_deadline(0) == ""
+    assert format_approval_deadline(None) == ""

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1578,6 +1578,12 @@ def test_request_mcp_approvals_other_sessions_cancel_event_does_not_deny_this_ro
     controller, store = _build_controller()
     session_a = store.create_session(title="A").id
     session_b = store.create_session(title="B").id
+    # ADR-067: an app-less controller now fails closed before arming (see
+    # `request_mcp_approvals`' no-app guard), so wire the usual fake
+    # bridge -- this test's subject is cross-session cancel isolation, not
+    # the no-app path.
+    controller.app = _FakeApp()
+    controller.set_pending_approval = lambda payload: None
     # A short deadline: if A's cancel event wrongly denied this round, the
     # cancellation branch would fire first (`_record_cancelled_approval_
     # decisions` aside) -- observing "timeout" instead of "deny" proves the
@@ -3115,3 +3121,127 @@ def test_shutdown_still_denies_a_survivors_round():
 
     assert not worker.is_alive(), "teardown left a survivor's round parked"
     assert results[RUN_SURVIVOR] == {"mcp__srv__write": "deny"}
+
+
+# -- ADR-067: no-deadline approval rounds --------------------------------
+#
+# The shipped default is now 0 = "no auto-deny": a round stays armed until
+# the user answers or the run is stopped. A positive timeout still denies
+# undecided calls (the existing expiry tests above, via seam values like
+# 0.05, pin that). The pre-ADR code computed `deadline = now + 0` for a
+# zero timeout and stamped "timeout" at the first 1s poll -- every test
+# below asserts the round survives past that point.
+
+
+def test_request_mcp_approvals_zero_timeout_keeps_round_armed_for_late_decision():
+    """Timeout 0 means NO deadline: the round survives the first 1s poll
+    and resolves only on the user's decision."""
+    controller, _ = _build_controller()
+    received: list[dict | None] = []
+    controller.app = _FakeApp()
+    controller.set_pending_approval = received.append
+    controller.mcp_approval_timeout_seconds = lambda: 0.0
+
+    def _decide_late() -> None:
+        time.sleep(1.6)  # beyond the first poll where the old code bailed
+        assert received and received[0] is not None
+        controller.resolve_pending_approval(
+            {"mcp__srv__tool": "approve_once"}, round_id=received[0]["round_id"]
+        )
+
+    decider = threading.Thread(target=_decide_late)
+    decider.start()
+    started = time.monotonic()
+    decisions = controller.request_mcp_approvals([_pending()])
+    elapsed = time.monotonic() - started
+    decider.join()
+
+    assert decisions == {"mcp__srv__tool": "approve_once"}
+    # The round was still armed past the old first-poll bail point.
+    assert elapsed >= 1.5
+    # The card was told no deadline exists (countdown copy hidden).
+    assert received[0]["timeout_seconds"] == 0.0
+    assert received[-1] is None
+
+
+def test_request_mcp_approvals_marks_human_input_wait_while_round_armed():
+    """While a round waits, its OWNING run is marked in the human-input
+    wait registry so `_call_with_timeout` pauses the per-call clock --
+    keyed by the round's `use_run_id` binding, cleared when it resolves."""
+    from tldw_chatbook.Agents.human_input_wait import human_input_wait_active
+
+    controller, _ = _build_controller()
+    received: list[dict | None] = []
+    controller.app = _FakeApp()
+    controller.set_pending_approval = received.append
+    controller.mcp_approval_timeout_seconds = lambda: 30.0
+
+    result: dict[str, object] = {}
+
+    def _run_round() -> None:
+        with use_run_id("run-approval-wait"):
+            result["decisions"] = controller.request_mcp_approvals([_pending()])
+
+    def _sample_then_decide() -> None:
+        # Wait for the round to arm, sample the mark from THIS thread (the
+        # wrapper's vantage point -- the mark must be process state, not
+        # worker-thread-local), then resolve the round.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not received:
+            time.sleep(0.01)
+        assert received, "round never armed"
+        result["marked_while_armed"] = human_input_wait_active("run-approval-wait")
+        controller.resolve_pending_approval(
+            {"mcp__srv__tool": "deny"}, round_id=received[0]["round_id"]
+        )
+
+    worker = threading.Thread(target=_run_round)
+    decider = threading.Thread(target=_sample_then_decide)
+    worker.start()
+    decider.start()
+    worker.join(timeout=10.0)
+    decider.join(timeout=10.0)
+
+    assert result["decisions"] == {"mcp__srv__tool": "deny"}
+    assert result["marked_while_armed"] is True
+    assert human_input_wait_active("run-approval-wait") is False
+
+
+def test_request_mcp_approvals_without_ui_fails_closed_immediately():
+    """With no UI bridge wired nothing can EVER resolve the round, and the
+    no-deadline default means the poll loop would never end -- so the
+    bridge must fail closed on the spot, mirroring the skill confirms'
+    own no-app guards."""
+    controller, _ = _build_controller()
+    assert controller.app is None
+    controller.mcp_approval_timeout_seconds = lambda: 0.05
+
+    started = time.monotonic()
+    decisions = controller.request_mcp_approvals([_pending()])
+    elapsed = time.monotonic() - started
+
+    assert decisions == {"mcp__srv__tool": "deny"}
+    assert elapsed < 2.5
+
+
+def test_mcp_approval_timeout_default_is_no_deadline(monkeypatch):
+    """ADR-067: the shipped default flips 120 -> 0 (armed until answered);
+    auto-deny is opt-in via [mcp] approval_timeout_seconds."""
+    import tldw_chatbook.Chat.console_chat_controller as cc_module
+
+    controller, _ = _build_controller()
+    assert controller.mcp_approval_timeout_seconds is None  # no seam wired
+    monkeypatch.setattr(
+        cc_module, "get_cli_setting", lambda section, key, default: default
+    )
+    assert controller._resolve_mcp_approval_timeout_seconds() == 0.0
+
+
+def test_human_prompt_defaults_pin_no_deadline():
+    """ADR-067 contract pin: every blocking human prompt defaults to 0
+    (wait indefinitely). Flip any of these and this test must fail."""
+    import tldw_chatbook.Chat.console_chat_controller as cc_module
+
+    assert cc_module._DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS == 0.0
+    assert cc_module._DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS == 0.0
+    assert cc_module._DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS == 0.0

--- a/Tests/UI/test_console_skill_install_confirm.py
+++ b/Tests/UI/test_console_skill_install_confirm.py
@@ -549,3 +549,32 @@ async def test_restored_pending_install_never_mounts_an_actionable_card_through_
             == "Restored summary text should survive"
         )
         assert "Restored summary text should survive" in _visible_text(console)
+
+
+def test_confirm_zero_timeout_keeps_round_armed_for_late_decision():
+    """ADR-067: timeout 0 = no deadline. The pre-ADR code armed
+    `deadline = now + 0` and denied at the first 1s poll; the round must
+    now stay armed and resolve on the user's decision."""
+    controller, _ = _controller()
+    received: list[dict | None] = []
+    controller.app = _FakeApp()
+    controller.set_pending_skill_install = received.append
+    controller.skill_install_confirm_timeout_seconds = lambda: 0.0
+
+    def _allow_late() -> None:
+        time.sleep(1.6)
+        controller.resolve_pending_skill_install(
+            True, request_id=received[0]["request_id"]
+        )
+
+    decider = threading.Thread(target=_allow_late)
+    decider.start()
+    started = time.monotonic()
+    allowed = controller.request_skill_install_confirm("https://x/y")
+    elapsed = time.monotonic() - started
+    decider.join()
+
+    assert allowed is True
+    assert elapsed >= 1.5
+    # Card was told no deadline exists.
+    assert received[0]["timeout_seconds"] == 0.0

--- a/backlog/decisions/067-indefinite-human-approval-waits.md
+++ b/backlog/decisions/067-indefinite-human-approval-waits.md
@@ -1,0 +1,73 @@
+# ADR-067: Indefinite human approval waits with a pausable per-call clock
+
+Status: Accepted
+Date: 2026-08-15
+Related Task: [TASK-16320](../tasks/task-16320%20-%20Console-approval-prompts-wait-indefinitely-by-default.md)
+Supersedes: the `approval_timeout < max_tool_call_seconds` invariant as stated in
+`_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`'s comment (Chat/console_chat_controller.py)
+and `RunBudget.max_tool_call_seconds`'s comment (Agents/agent_models.py). Those
+comments are updated by the task; the historical specs/plans that mention 120s
+defaults remain reference-only.
+
+## Decision
+
+Blocking human prompts — the tool approval card, the skill install confirm, and
+the skill script confirm — no longer auto-deny by default. They stay armed until
+the user answers or the run is stopped/cancelled. The auto-deny ceiling remains
+available: a configured positive timeout still fails undecided calls closed
+(`"timeout"` verdicts), and `0` (the new default everywhere) means "no deadline".
+
+To make an unbounded human wait safe, the per-tool-call wall clock
+(`AgentService._call_with_timeout`, ceiling `RunBudget.max_tool_call_seconds`,
+300s at defaults) now **pauses while a human decision is pending for the run**.
+A new dependency-light registry, `Agents/human_input_wait.py`, exposes
+`use_human_input_wait(run_id)` (thread-safe, set/cleared around each wait loop)
+and `human_input_wait_active(run_id)`. `_make_invoke_tool` passes the predicate
+into `_call_with_timeout` as `pauses_deadline`; while it polls true, the wrapper
+re-arms its deadline so wall-clock time counts only actual tool *execution*.
+
+The superseded invariant (`approval_timeout < max_tool_call_seconds`) existed
+because the invoke-path approval wait runs inside the per-call wrapper: an
+approval timeout at or above the wrapper ceiling would let the wrapper fire
+first, report the call failed, abandon the waiting thread — and a late approval
+would then execute the tool for real (double execution). Pausing the clock
+removes the race at the root: the wrapper cannot expire while the human wait it
+is hosting is still live. Cancellation was already closed by
+`revoke_approval_rounds_for_run` and is unaffected; a genuinely hung tool still
+times out after `seconds` of execution time.
+
+`[mcp] approval_timeout_seconds` keeps its key and semantics for positive
+values; `<= 0` now means "wait indefinitely" (previously such values armed a
+deadline in the past, i.e. an immediate auto-deny). The card's countdown copy
+(`format_approval_deadline`) already renders nothing for 0/None.
+
+## Alternatives considered
+
+- **Just remove the 120s ceiling.** Rejected: reopens the documented
+  abandoned-thread double-execution window — the 300s wrapper would fire under
+  an infinite wait, and a late approval would act for real after the runtime
+  reported failure.
+- **Raise both ceilings (approval timeout and `max_tool_call_seconds`).** A
+  large finite pair still bounds "go to dinner" badly (hours-long dinners,
+  honest mistakes) and weakens the hung-tool guarantee for every tool. Rejected.
+- **Move the approval wait outside `_call_with_timeout`.** Architectural
+  rework of the provider/gate seams (task-327 put the fallback approval inside
+  `invoke` deliberately). The pause achieves the same effect additively.
+- **Keep 120s as the default, opt-in to indefinite via config.** Rejected by
+  the product decision this ADR records: prompts should not expire on users
+  who step away; auto-deny stays available for those who want it.
+
+## Consequences
+
+- A pending approval no longer expires; a session can sit in NEEDS_APPROVAL
+  indefinitely and revive when the user returns. Stopping the run, switching
+  conversations away and back, and teardown still deny/clear promptly (those
+  paths resolve the round, they do not wait).
+- Per-call wall-clock is now "execution time, excluding human-decision waits".
+  A tool that arms a human wait and then hangs *after* the decision still dies
+  at the full ceiling (the deadline re-arms while paused, it does not vanish).
+- `UnifiedMCPControlPlaneService.approval_timeout_seconds` (no product callers;
+  the controller reads the config key directly) still returns 120.0 as its own
+  default; if a consumer ever appears it must adopt the same `<= 0` semantics.
+- Tests that rely on auto-deny inject positive seam values (e.g. 0.05) and are
+  unaffected by the default flip.

--- a/backlog/decisions/067-indefinite-human-approval-waits.md
+++ b/backlog/decisions/067-indefinite-human-approval-waits.md
@@ -2,7 +2,7 @@
 
 Status: Accepted
 Date: 2026-08-15
-Related Task: [TASK-16320](../tasks/task-16320%20-%20Console-approval-prompts-wait-indefinitely-by-default.md)
+Related Task: [TASK-16789](../tasks/task-16789%20-%20Console-approval-prompts-wait-indefinitely-by-default.md)
 Supersedes: the `approval_timeout < max_tool_call_seconds` invariant as stated in
 `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`'s comment (Chat/console_chat_controller.py)
 and `RunBudget.max_tool_call_seconds`'s comment (Agents/agent_models.py). Those

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1843,9 +1843,6 @@ disjoint bug classes; you need both.
 
 ---
 
-
----
-
 ## An app-importing pytest probe outside `Tests/` bypasses the suite's own config isolation
 
 **TASK-3894 (P1 eval harness) Task 4, 2026-08-09.** Capturing real chunk-count numbers
@@ -4455,3 +4452,29 @@ reseed) to the swap -- bracket the exact call under test, not the settle;
 belonged to a different mechanism. The residual's fix-shaped hypothesis is a
 hypothesis; A/B the mechanism (here: neuter the proposed fix on the same
 HEAD) before writing the Implementation Notes around it.
+
+---
+
+---
+
+## An unbounded wait default turns leaked test rounds into post-suite interpreter hangs
+
+**TASK-16320, 2026-08-15.** After flipping the human-prompt timeouts to a
+no-deadline default (ADR-067), `Tests/Chat/test_console_skill_script_confirm.py`
+printed "1 failed, 28 passed in 7.49s" — and then the pytest process sat at 0%
+CPU for 20+ minutes producing no output (the `| tail` wrapper hid everything
+until exit). `sample <pid>` showed the main thread in
+`wait_for_thread_shutdown`: the run was over, and the interpreter was waiting
+for a non-daemon worker thread. The failing test's assert had skipped its
+`resolve_pending_skill_script(...)` cleanup, leaving the confirm round armed;
+with the old 120s default that leaked worker self-resolved at process exit in
+≤120s (invisible), with no deadline its 1s poll loop never exits at all.
+
+**What to do.** When a wait loop's default becomes unbounded, every fixture
+that can arm a round must fail it closed on teardown — the file's
+`make_controller` now sets `_shutdown_requested` after each test, which
+resolves any still-armed round at its next poll. Diagnosis signature to
+recognize next time: pytest's own timing says the suite finished but the
+process idles at 0% CPU; macOS `sample` shows `wait_for_thread_shutdown`;
+`kill -ABRT` (with `PYTHONFAULTHANDLER=1`) dumps the stuck thread stacks into
+stderr.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4459,7 +4459,7 @@ HEAD) before writing the Implementation Notes around it.
 
 ## An unbounded wait default turns leaked test rounds into post-suite interpreter hangs
 
-**TASK-16320, 2026-08-15.** After flipping the human-prompt timeouts to a
+**TASK-16789, 2026-08-15.** After flipping the human-prompt timeouts to a
 no-deadline default (ADR-067), `Tests/Chat/test_console_skill_script_confirm.py`
 printed "1 failed, 28 passed in 7.49s" — and then the pytest process sat at 0%
 CPU for 20+ minutes producing no output (the `| tail` wrapper hid everything

--- a/backlog/tasks/task-16320 - Console-approval-prompts-wait-indefinitely-by-default.md
+++ b/backlog/tasks/task-16320 - Console-approval-prompts-wait-indefinitely-by-default.md
@@ -1,0 +1,109 @@
+---
+id: TASK-16320
+title: Console approval prompts wait indefinitely by default
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 21:46'
+updated_date: '2026-08-16 02:51'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Blocking human prompts (tool approval card, skill install confirm, skill script confirm) currently auto-deny after 120s. A user who steps away loses the run. Prompts should stay armed until the user answers or the run is stopped, without reopening the abandoned-thread double-execution hazard that the 120s ceiling exists to prevent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tool approval card does not auto-deny when `[mcp] approval_timeout_seconds` is unset (new default 0 = no deadline); it resolves only on user decision or run cancellation
+- [x] #2 Approval wait no longer consumes the per-call tool timeout: `_call_with_timeout` pauses its deadline while a human decision is pending for the run; a genuinely hung tool still times out and cancellation still works
+- [x] #3 Skill install confirm and skill script confirm prompts also wait indefinitely by default (defaults flip 120 -> 0)
+- [x] #4 A configured positive timeout still auto-denies (existing seam values and existing timeout tests keep working)
+- [x] #5 Approval card shows no countdown copy when no deadline is armed
+- [x] #6 Tests cover wrapper deadline pause, no-deadline rounds for all three prompts, and default resolution
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Approach: a human prompt now waits indefinitely by default, made safe by
+pausing — not removing — the per-call tool ceiling. `Agents/human_input_wait.py`
+is a new stdlib-only, lock-guarded, refcounted registry keyed by run id
+(deliberately NOT a ContextVar: the mark is set on the round's worker thread
+and polled on the wrapper's thread). `AgentService._call_with_timeout` gained
+an optional `pauses_deadline` predicate; while it polls true the deadline
+re-arms each 0.5s slice, so the ceiling counts tool execution time, not human
+deliberation — a hung tool still dies on schedule, Stop still cancels within
+one slice, and the wait cannot lose the abandoned-thread double-execution race
+the old `approval_timeout < max_tool_call_seconds` invariant existed to bound.
+`_make_invoke_tool` wires `pauses_deadline=human_input_wait_active(run_id)`.
+
+Controller: `_DEFAULT_{MCP_APPROVAL,SKILL_INSTALL_CONFIRM,SKILL_SCRIPT_
+CONFIRM}_TIMEOUT_SECONDS` flip 120 -> 0; each of the three wait loops treats a
+resolved timeout <= 0 as "no deadline armed" (nullable `deadline`), wraps its
+wait in `use_human_input_wait(owning_run_id)`, and carries the 0 through to
+the card payload (the card already renders no countdown for 0). New no-app
+guard in `request_mcp_approvals`: an app-less controller can never surface or
+resolve a round, so it fails every call closed to "deny" immediately instead
+of arming an unresolvable round (mirrors the skill confirms' existing guards;
+a wired app with a missing card seam is intentionally NOT guarded — the round
+stays resolvable and `_marshal_pending_approval` no-ops).
+
+Decisions: `[mcp] approval_timeout_seconds` keeps its key; positive values
+keep the old auto-deny semantics, 0 (new default) waits indefinitely —
+confirmed with the user as the desired default, along with covering both
+skill confirm prompts, not just the approval card. ADR-067
+(`backlog/decisions/067-indefinite-human-approval-waits.md`) records the
+superseded invariant; the `max_tool_call_seconds` docstring and the
+controller constants were rewritten to cite it. The unconsumed
+`UnifiedMCPControlPlaneService.approval_timeout_seconds` (no product callers)
+keeps its own 120.0 default — noted in the ADR for any future consumer.
+
+Tests (TDD — each watched fail first): registry semantics incl. cross-thread
+visibility and same-run refcounting (`Tests/Agents/test_human_input_wait.py`);
+wrapper pause/resume + `_make_invoke_tool` wiring
+(`Tests/Agents/test_agent_service.py`); zero-timeout rounds surviving past the
+old first-poll bail for all three prompts, run-keyed human-wait marking,
+no-app fail-closed, and the 0.0 default resolution + constants pin
+(`test_console_mcp_approval.py`, `test_console_skill_install_confirm.py`,
+`test_console_skill_script_confirm.py`); countdown-copy-hidden pin
+(`test_chat_approval_card.py`).
+
+Verification: Tests/Agents (1428 passed), test_console_mcp_approval (74),
+skill install/script confirm suites (17/10/29/5), agent_swap + fleet_wake +
+diff_channel + probe --run-slow (60+4), parallel_runs + agent_bridge +
+skill_remote_fetch (270), chat_approval_card — all green; mypy adds no new
+errors (30 pre-existing in agent_service/console_chat_controller, identical
+on HEAD).
+
+Incidental test fixes required by the flip: the script-confirm payload test
+now round-trips a positive seam value (45.0) instead of pinning `> 0`; the
+cross-session-cancel approval test wires the fake app (an app-less controller
+now fails closed before arming, which is that path's own new test);
+`make_controller` gained a teardown that fails armed rounds closed so a
+failing test can no longer hang interpreter shutdown (lesson recorded in
+`backlog/docs/lessons-testing-evidence.md`).
+
+Files: tldw_chatbook/Agents/human_input_wait.py (new),
+Agents/agent_service.py, Agents/agent_models.py (comment only),
+Chat/console_chat_controller.py, config.py (template comment);
+Docs/User_Guide/console/agent-runs-and-tools.md;
+Tests/Agents/test_human_input_wait.py (new), Tests/Agents/test_agent_service.py,
+Tests/UI/test_console_mcp_approval.py, Tests/UI/test_chat_approval_card.py,
+Tests/UI/test_console_skill_install_confirm.py,
+Tests/Chat/test_console_skill_script_confirm.py;
+backlog/decisions/067-indefinite-human-approval-waits.md.
+<!-- SECTION:NOTES:END -->
+
+## Implementation Plan (the how)
+
+1. ADR-067: record the new invariant (human-decision waits pause the per-call clock; timeout <= 0 disables auto-deny)
+2. TDD: failing tests for `_call_with_timeout` deadline pause, `human_input_wait` registry, no-deadline approval/confirm rounds, default resolution
+3. Implement `Agents/human_input_wait.py` (thread-safe run-id-keyed registry)
+4. Add `pauses_deadline` to `_call_with_timeout`; wire from `_make_invoke_tool` via `human_input_wait_active(run_id)`
+5. Controller: treat resolved timeout <= 0 as no deadline in `request_mcp_approvals` + both skill confirms; flip the three defaults to 0; wrap waits in `use_human_input_wait(owning_run_id)`
+6. Update docs/config example; run suites; task hygiene

--- a/backlog/tasks/task-16789 - Console-approval-prompts-wait-indefinitely-by-default.md
+++ b/backlog/tasks/task-16789 - Console-approval-prompts-wait-indefinitely-by-default.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-16320
+id: TASK-16789
 title: Console approval prompts wait indefinitely by default
 status: Done
 assignee:

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -273,29 +273,25 @@ class RunBudget:
     # 0 = unlimited (default), keeping existing runs byte-identical. This is a
     # SPEND ceiling (the growing prompt is re-sent each call), not a window size.
     max_total_tokens: int = 0
-    # task-327: per-tool-call wall-clock ceiling. A single custom/blocking
-    # tool provider must not be able to wedge a cooperative-cancel run
-    # forever. 0 = unlimited (opt-out). Enforced in agent_service's impure
-    # seam (the pure runtime stays timeout-free). MCP tools DO flow through
-    # this same wrapper (MCPToolProvider is registered into the same
-    # per-run ToolCatalogRegistry as builtins), so the default is set
-    # deliberately above MCP's own worst case rather than independent of
-    # it: an "ask"-gated call can wait up to ~121s for human approval
-    # (`_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS = 120.0` in
-    # `Chat/console_chat_controller.py`, polled every
-    # `_MCP_APPROVAL_POLL_SECONDS = 1.0`) and then up to 65s to execute
-    # (`_tool_call_timeout() = 60.0` in
+    # task-327: per-tool-call EXECUTION-time ceiling. A single
+    # custom/blocking tool provider must not be able to wedge a
+    # cooperative-cancel run forever. 0 = unlimited (opt-out). Enforced in
+    # agent_service's impure seam (the pure runtime stays timeout-free).
+    # MCP tools DO flow through this same wrapper (MCPToolProvider is
+    # registered into the same per-run ToolCatalogRegistry as builtins),
+    # so the default sits above MCP's own execution worst case: up to 65s
+    # to execute (`_tool_call_timeout() = 60.0` in
     # `MCP/unified_control_plane_service.py` plus
-    # `_RESULT_WAIT_SLACK_SECONDS = 5.0` in `Agents/mcp_tool_provider.py`)
-    # -- ~186s end to end AT MCP'S DEFAULT CONFIG. Both cited MCP bounds are
-    # user-tunable (`[mcp] tool_call_timeout_seconds`, and the approval
-    # timeout resolved from config in `console_chat_controller`), so this
-    # invariant only holds while MCP itself stays at its shipped defaults --
-    # a user who raises either MCP-side bound can still reopen the
-    # double-execution window this default is meant to avoid. Lowering this
-    # below that risks the wrapper reporting "timed out" for a call that
-    # later really executes on its abandoned thread (see
-    # `_call_with_timeout`'s docstring).
+    # `_RESULT_WAIT_SLACK_SECONDS = 5.0` in `Agents/mcp_tool_provider.py`).
+    # ADR-067: time spent waiting on a HUMAN decision no longer counts --
+    # the wrapper's deadline pauses while `Agents.human_input_wait` marks
+    # the run (approval card / skill confirms; their default is no
+    # auto-deny at all), superseding the old requirement that the approval
+    # timeout stay strictly below this ceiling. `[mcp]
+    # tool_call_timeout_seconds` is still user-tunable: raising it past
+    # this default can still reopen the double-execution window (the
+    # wrapper reporting "timed out" for a call that later really executes
+    # on its abandoned thread -- see `_call_with_timeout`'s docstring).
     max_tool_call_seconds: float = 300.0
 
 

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -70,6 +70,7 @@ from tldw_chatbook.Chat.provider_continuation import (
 )
 from .agent_runtime import LoopDeps, render_tool_protocol, run_agent_loop
 from .fleet_coordinator import FleetCoordinator, FleetHandle
+from .human_input_wait import human_input_wait_active
 from .native_tools import (
     ensure_tool_call_ids,
     parse_native_tool_calls,
@@ -503,8 +504,9 @@ def _call_with_timeout(
     seconds: float,
     tool_name: str,
     should_cancel: Callable[[], bool] = lambda: False,
+    pauses_deadline: Callable[[], bool] = lambda: False,
 ) -> ToolResult:
-    """Run ``fn`` on a daemon thread, bounded by ``seconds`` wall-clock.
+    """Run ``fn`` on a daemon thread, bounded by ``seconds`` of EXECUTION time.
 
     Always returns a ToolResult: ``fn``'s value on success, ``ok=False`` with
     the message on a raised exception, or an ``ok=False`` timeout/cancelled
@@ -532,6 +534,20 @@ def _call_with_timeout(
     abandoned worker left to finish/die on its own), just with a "cancelled"
     message instead of "timed out" -- the abandon-on-timeout semantics and
     the overall ``seconds`` ceiling are both preserved unchanged.
+
+    ADR-067: while ``pauses_deadline`` polls True the deadline RE-ARMS each
+    slice, so elapsed human-deliberation time does not consume the budget --
+    the ceiling counts actual tool execution, not wall-clock spent waiting
+    on a person. This is what lets a blocking human prompt (approval card,
+    skill confirm -- marked via ``Agents.human_input_wait`` keyed by the
+    run id) wait indefinitely without reopening the pre-ADR hazard that the
+    old ``approval_timeout < max_tool_call_seconds`` invariant existed to
+    bound: the wrapper firing under a still-live approval wait, reporting
+    failure, and a late approval then executing the tool for real on the
+    abandoned thread. The pause is not a removal: once the predicate goes
+    False the re-armed deadline applies again, so a tool that keeps hanging
+    after its human decision still trips the ceiling promptly, and
+    cancellation is checked every slice regardless.
     """
     box: dict = {}
 
@@ -548,6 +564,8 @@ def _call_with_timeout(
         worker.join(min(_CANCEL_POLL_SECONDS, max(deadline - time.monotonic(), 0)))
         if worker.is_alive() and should_cancel():
             return ToolResult(ok=False, error=f"tool call cancelled: {tool_name}")
+        if worker.is_alive() and pauses_deadline():
+            deadline = time.monotonic() + seconds
     if worker.is_alive():
         return ToolResult(
             ok=False, error=f"tool call timed out after {seconds:g}s: {tool_name}"
@@ -1038,6 +1056,10 @@ class AgentService:
                     timeout,
                     call.name,
                     should_cancel,
+                    # ADR-067: pause the per-call clock while a human
+                    # decision is pending for THIS run, so an approval/
+                    # confirm wait inside the invoke outlives the ceiling.
+                    pauses_deadline=lambda: human_input_wait_active(run_id),
                 )
             return _invoke()
 

--- a/tldw_chatbook/Agents/human_input_wait.py
+++ b/tldw_chatbook/Agents/human_input_wait.py
@@ -42,13 +42,14 @@ _WAIT_REFCOUNTS: dict[str, int] = {}
 
 
 @contextmanager
-def use_human_input_wait(run_id: str) -> Iterator[None]:
+def use_human_input_wait(run_id: str | None) -> Iterator[None]:
     """Mark ``run_id`` as waiting on a human decision for the block.
 
     Args:
-        run_id: The run whose per-call clock should pause. A falsy value
-            normalizes to ``""`` (the no-run key a round armed outside any
-            agent run carries -- same convention as ``run_context``).
+        run_id: The run whose per-call clock should pause. ``None`` or an
+            empty string normalizes to ``""`` (the no-run key a round
+            armed outside any agent run carries -- same convention as
+            ``run_context``).
 
     Yields:
         None. The mark is refcounted and drops on exit, including on an
@@ -69,12 +70,13 @@ def use_human_input_wait(run_id: str) -> Iterator[None]:
                 _WAIT_REFCOUNTS.pop(key, None)
 
 
-def human_input_wait_active(run_id: str) -> bool:
+def human_input_wait_active(run_id: str | None) -> bool:
     """Whether a human decision is pending for ``run_id`` right now.
 
     Args:
-        run_id: The run to check. A falsy value checks the ``""`` slot,
-            mirroring ``use_human_input_wait``'s normalization.
+        run_id: The run to check. ``None`` or an empty string checks the
+            ``""`` slot, mirroring ``use_human_input_wait``'s
+            normalization.
 
     Returns:
         True while at least one wait holds the mark. Never raises.

--- a/tldw_chatbook/Agents/human_input_wait.py
+++ b/tldw_chatbook/Agents/human_input_wait.py
@@ -1,0 +1,83 @@
+"""Run-scoped marks for waits on a HUMAN decision (ADR-067).
+
+Three blocking prompts arm a card and then poll for the user's answer:
+the tool approval round (``ConsoleChatController.request_mcp_approvals``),
+the skill install confirm, and the skill script confirm. The approval
+round -- and any other wait dispatched inside a tool call -- blocks on a
+thread hosted by ``AgentService._call_with_timeout``, whose wall-clock
+deadline exists so a single wedged tool cannot hang a cooperative-cancel
+run forever.
+
+Waiting for a dinner-and-back human is not a wedged tool. While a mark
+is held for a run, that run's per-call deadline PAUSES (re-arms each poll
+slice, see ``_call_with_timeout``'s ``pauses_deadline``): the budget
+counts machine time -- actual tool execution -- not human deliberation.
+
+Why process state and not another ContextVar (contrast
+``run_context``): the mark is SET on the round's worker/daemon thread and
+POLLED on the wrapper's calling thread. A ContextVar set on the worker is
+invisible where the deadline is checked -- the exact trap ``run_context``
+documents for its own bindings. The run id itself still travels via
+``run_context`` (the round captures ``current_run_id()`` at arm time);
+only the mark crosses threads here.
+
+Refcounted per run: a run may legitimately hold TWO overlapping waits
+(a batch review-hook round plus a single-call fallback approval), so the
+mark must survive until the last one clears. Stdlib only, no project
+imports: this is consumed by ``agent_service`` and ``Chat``, and stays
+dependency-light like ``run_context``.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+#: Guards ``_WAIT_REFCOUNTS``: the set/clear run on the round's thread,
+#: the active-check runs on the wrapper's poll thread.
+_WAIT_LOCK = threading.Lock()
+#: run_id -> number of overlapping waits currently held for that run.
+_WAIT_REFCOUNTS: dict[str, int] = {}
+
+
+@contextmanager
+def use_human_input_wait(run_id: str) -> Iterator[None]:
+    """Mark ``run_id`` as waiting on a human decision for the block.
+
+    Args:
+        run_id: The run whose per-call clock should pause. A falsy value
+            normalizes to ``""`` (the no-run key a round armed outside any
+            agent run carries -- same convention as ``run_context``).
+
+    Yields:
+        None. The mark is refcounted and drops on exit, including on an
+        exception (a round torn down mid-wait must not leak a frozen
+        clock for the run's next tool call).
+    """
+    key = run_id or ""
+    with _WAIT_LOCK:
+        _WAIT_REFCOUNTS[key] = _WAIT_REFCOUNTS.get(key, 0) + 1
+    try:
+        yield
+    finally:
+        with _WAIT_LOCK:
+            remaining = _WAIT_REFCOUNTS.get(key, 0) - 1
+            if remaining > 0:
+                _WAIT_REFCOUNTS[key] = remaining
+            else:
+                _WAIT_REFCOUNTS.pop(key, None)
+
+
+def human_input_wait_active(run_id: str) -> bool:
+    """Whether a human decision is pending for ``run_id`` right now.
+
+    Args:
+        run_id: The run to check. A falsy value checks the ``""`` slot,
+            mirroring ``use_human_input_wait``'s normalization.
+
+    Returns:
+        True while at least one wait holds the mark. Never raises.
+    """
+    with _WAIT_LOCK:
+        return (_WAIT_REFCOUNTS.get(run_id or "", 0) > 0)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -173,6 +173,7 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     LOCAL_TOOLS_DEFAULT_ENABLED,
     build_builtin_gate,
 )
+from tldw_chatbook.Agents.human_input_wait import use_human_input_wait
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall, MCPToolProvider
 from tldw_chatbook.Agents.run_context import current_run_id
@@ -241,37 +242,38 @@ CONSOLE_MCP_BUILTIN_RAW_NAME_EXCLUSIONS: frozenset = frozenset(
 )
 
 
-#: Fallback used when no `mcp_approval_timeout_seconds` seam is injected --
-#: mirrors `UnifiedMCPControlPlaneService.approval_timeout_seconds`'s own
-#: default (task-201/T2), read directly here since the controller has no
-#: dependency on that service (T6 wires the service into `MCPToolProvider`,
-#: not into this controller).
+#: ADR-067: 0 -- the default for all three human-prompt timeouts below --
+#: means "no deadline": the round stays armed until the user answers or the
+#: run is stopped/cancelled. A positive value still fails undecided calls
+#: closed to ``"timeout"``. A human prompt is not a wedged tool; making the
+#: user race a clock to keep their run was the defect, auto-deny is opt-in.
 #:
-#: task-545/T6: built-in tool approvals reuse this SAME timeout (routed
-#: through `request_mcp_approvals`/`build_tool_review_hook`), so this value
-#: must stay strictly BELOW `RunBudget.max_tool_call_seconds` (300s at
-#: defaults, `Agents/agent_models.py`) -- never equal, never above. The
-#: approval wait happens INSIDE `agent_service._call_with_timeout`'s own
-#: per-call wrapper (task-327): if the approval timeout were >= the
-#: tool-call ceiling, `_call_with_timeout` would fire first, tell the agent
-#: the call failed/timed out, and the underlying `invoke()` call would
-#: still be running on the (by then abandoned) worker thread -- so a late
-#: approval from the user would execute the tool for real after the
-#: runtime already moved on and reported failure. Any future change to
-#: either constant must preserve `approval_timeout < max_tool_call_seconds`.
-_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS = 120.0
+#: The PRE-ADR default was 120.0, kept strictly below
+#: ``RunBudget.max_tool_call_seconds`` (300s at defaults,
+#: ``Agents/agent_models.py``) because the invoke-path approval wait runs
+#: INSIDE ``agent_service._call_with_timeout``'s per-call wrapper: an
+#: approval timeout at/above the wrapper ceiling would let the wrapper fire
+#: first, report the call failed, and a late approval would then execute
+#: the tool for real on the abandoned thread. That invariant is SUPERSEDED:
+#: the wrapper's deadline now PAUSES while a human decision is pending for
+#: the run (``Agents/human_input_wait`` marks the wait;
+#: ``_call_with_timeout``'s ``pauses_deadline`` re-arms the ceiling each
+#: poll slice), so wall-clock counts tool execution, not human deliberation
+#: -- an indefinite wait can no longer lose that race. Cancellation was
+#: already closed by ``revoke_approval_rounds_for_run`` and is unaffected.
+_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS = 0.0
 #: Poll granularity for `request_mcp_approvals`'s wait loop (binding, from
 #: the Phase-5 plan) -- also the worst-case slack added on top of a
 #: configured timeout/cancellation before this method observes it.
 _MCP_APPROVAL_POLL_SECONDS = 1.0
-#: Fallback used when no `skill_install_confirm_timeout_seconds` seam is
-#: injected -- mirrors `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`'s role for
-#: `request_skill_install_confirm`'s own wait loop.
-_DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS = 120.0
-#: Fallback used when no `skill_script_confirm_timeout_seconds` seam is
-#: injected -- mirrors `_DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS`'s
-#: role for `request_skill_script_confirm`'s own wait loop.
-_DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS = 120.0
+#: Same ADR-067 contract as `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`, for
+#: `request_skill_install_confirm`'s own wait loop (fallback used when no
+#: `skill_install_confirm_timeout_seconds` seam is injected).
+_DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS = 0.0
+#: Same ADR-067 contract as `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`, for
+#: `request_skill_script_confirm`'s own wait loop (fallback used when no
+#: `skill_script_confirm_timeout_seconds` seam is injected).
+_DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS = 0.0
 #: TASK-1050: synthetic round id `set_run_pending_approval`'s deprecated
 #: boolean shim registers under, internally, so its add/discard composes
 #: safely with the round-keyed `_pending_approvals` accounting (see that
@@ -1592,7 +1594,9 @@ class ConsoleChatController:
         #: Optional override for how long ``request_mcp_approvals`` waits
         #: for a human decision before failing every undecided call to
         #: ``"timeout"``. Defaults to reading ``[mcp] approval_timeout_
-        #: seconds`` (T2's ``approval_timeout_seconds``) when unset.
+        #: seconds`` (T2's ``approval_timeout_seconds``) when unset --
+        #: ADR-067: that default is 0 = no deadline (wait indefinitely);
+        #: a positive value re-arms the auto-deny clock.
         self.mcp_approval_timeout_seconds: Callable[[], float] | None = None
         #: Task 9 (Fix round 1): each batch-approval round's release signal
         #: + shared decisions holder + owning session id, keyed by a
@@ -3921,19 +3925,24 @@ class ConsoleChatController:
         later, and ``park_pending_approval`` fires the fleet badge +
         one-shot toast instead of touching the mounted-card slot). Either
         way it then polls ``event.wait(1.0)`` re-checking this run's OWN
-        cancel signal (``_is_session_cancelled``) and a deadline every
-        second until one of three things happens: the user submits a
-        decision (``resolve_pending_approval``, called from the UI thread
-        once the card's own stamped ``round_id`` is delivered back, sets
-        the Event -- Fix round 1: NOT "whichever round belongs to the
-        active session", see ``resolve_pending_approval``'s own docstring
-        for why that was a real cross-session misattribution hazard), the
-        run is cancelled/torn down (``_is_session_cancelled`` -- F5 fix,
-        Qodo wave: this round's OWN cancel event, or real process teardown
-        via ``_shutdown_requested``, never any OTHER session's bare Stop --
-        see that method's own docstring), or the configured approval
-        timeout elapses. Whichever unique ``llm_name`` never received an
-        explicit decision by then fails closed to ``"deny"``
+        cancel signal (``_is_session_cancelled``) and -- only when a
+        POSITIVE timeout is configured (ADR-067: the default is 0 = none)
+        -- a deadline, every second until one of three things happens: the
+        user submits a decision (``resolve_pending_approval``, called from
+        the UI thread once the card's own stamped ``round_id`` is delivered
+        back, sets the Event -- Fix round 1: NOT "whichever round belongs
+        to the active session", see ``resolve_pending_approval``'s own
+        docstring for why that was a real cross-session misattribution
+        hazard), the run is cancelled/torn down (``_is_session_cancelled``
+        -- F5 fix, Qodo wave: this round's OWN cancel event, or real
+        process teardown via ``_shutdown_requested``, never any OTHER
+        session's bare Stop -- see that method's own docstring), or the
+        configured approval timeout elapses. With no deadline armed the
+        round simply waits for one of the first two, however long the
+        human takes -- the wait is marked in ``Agents.human_input_wait``
+        so a per-call wrapper hosting it pauses its ceiling. Whichever
+        unique ``llm_name`` never received an explicit decision by then
+        fails closed to ``"deny"``
         (cancellation) or ``"timeout"`` (deadline) -- see
         ``MCPToolProvider._apply_verdict`` for how each decision string is
         consumed. The mounted card (if any) is always cleared afterwards
@@ -3966,6 +3975,15 @@ class ConsoleChatController:
                 call_by_name[call.llm_name] = call
         if not unique_names:
             return {}
+        if self.app is None:
+            # ADR-067: with no app bridge nothing can ever surface or
+            # resolve this round, and the no-deadline default means the
+            # loop below would never end -- fail closed on the spot,
+            # mirroring both skill confirms' own no-app guards. (A wired
+            # app with a missing card seam is NOT this case: the round
+            # stays resolvable via `resolve_pending_approval`/cancel, and
+            # `_marshal_pending_approval` already no-ops its missing seam.)
+            return {name: "deny" for name in unique_names}
 
         event = threading.Event()
         decisions: dict[str, str] = {}
@@ -4035,7 +4053,13 @@ class ConsoleChatController:
             self._pending_approval_rounds[round_id] = round_state
 
         timeout_seconds = self._resolve_mcp_approval_timeout_seconds()
-        deadline = time.monotonic() + timeout_seconds
+        # ADR-067: <= 0 arms NO deadline -- the round waits for a decision
+        # or this run's cancellation, however long the human takes (the
+        # card renders no countdown copy for 0; see
+        # `format_approval_deadline`).
+        deadline = (
+            time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+        )
         payload = {
             "round_id": round_id,
             "session_id": owning_session_id,
@@ -4104,38 +4128,43 @@ class ConsoleChatController:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
             else:
                 self._marshal_pending_approval(payload)
-            while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._is_session_cancelled(
-                    session_id,
-                    cancel_event=round_cancel_event,
-                    visit_event=visit_cancel_event,
-                ):
-                    # Finding I3: a stop/unmount that resolves THIS round
-                    # denies every still-undecided call, but
-                    # `run_agent_loop`'s own `should_cancel()` check fires
-                    # for every call in this turn's batch BEFORE any of
-                    # them reaches `invoke()` -- so the "deny" verdict
-                    # stamped below is never consumed there and would
-                    # otherwise leave no audit record at all (contrast
-                    # with the timeout branch, whose calls DO still reach
-                    # `invoke()`'s own gate and get logged there, since a
-                    # timeout is not itself a cancellation). Log directly
-                    # here, best-effort, for exactly the names this branch
-                    # is about to fail closed.
-                    cancelled_names = [
-                        name for name in unique_names if name not in decisions
-                    ]
-                    for name in unique_names:
-                        decisions.setdefault(name, "deny")
-                    self._record_cancelled_approval_decisions(
-                        cancelled_names,
-                        call_by_name,
-                    )
-                    break
-                if time.monotonic() >= deadline:
-                    for name in unique_names:
-                        decisions.setdefault(name, "timeout")
-                    break
+            # ADR-067: mark this run as waiting on a human decision for the
+            # duration of the wait, so a per-call wrapper hosting this round
+            # (the invoke-path fallback approval) pauses its deadline -- an
+            # indefinite wait must not trip `max_tool_call_seconds`.
+            with use_human_input_wait(owning_run_id):
+                while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
+                    if self._is_session_cancelled(
+                        session_id,
+                        cancel_event=round_cancel_event,
+                        visit_event=visit_cancel_event,
+                    ):
+                        # Finding I3: a stop/unmount that resolves THIS round
+                        # denies every still-undecided call, but
+                        # `run_agent_loop`'s own `should_cancel()` check fires
+                        # for every call in this turn's batch BEFORE any of
+                        # them reaches `invoke()` -- so the "deny" verdict
+                        # stamped below is never consumed there and would
+                        # otherwise leave no audit record at all (contrast
+                        # with the timeout branch, whose calls DO still reach
+                        # `invoke()`'s own gate and get logged there, since a
+                        # timeout is not itself a cancellation). Log directly
+                        # here, best-effort, for exactly the names this branch
+                        # is about to fail closed.
+                        cancelled_names = [
+                            name for name in unique_names if name not in decisions
+                        ]
+                        for name in unique_names:
+                            decisions.setdefault(name, "deny")
+                        self._record_cancelled_approval_decisions(
+                            cancelled_names,
+                            call_by_name,
+                        )
+                        break
+                    if deadline is not None and time.monotonic() >= deadline:
+                        for name in unique_names:
+                            decisions.setdefault(name, "timeout")
+                        break
             # PR2a Task 7: a revoked round answers "deny" for every name,
             # unconditionally -- it does not consult `decisions` at all.
             # The run this round belongs to has been cancelled or
@@ -5106,6 +5135,11 @@ class ConsoleChatController:
         # the same reason the run's cancel event is -- see
         # `_bind_visit_cancel_signal`.
         visit_cancel_event = self._bind_visit_cancel_signal()
+        # ADR-067: same run stamp as `request_mcp_approvals` -- keys the
+        # human-input wait mark below (the install confirm is primary-agent
+        # only and in-loop, so no wrapper hosts it today, but the mark
+        # keeps every human wait on one contract).
+        owning_run_id = current_run_id()
         with self._pending_skill_install_lock:
             self._pending_skill_install_rounds[request_id] = {
                 "event": event,
@@ -5118,7 +5152,11 @@ class ConsoleChatController:
             if self.skill_install_confirm_timeout_seconds is not None
             else _DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS
         )
-        deadline = time.monotonic() + timeout_seconds
+        # ADR-067: <= 0 arms NO deadline (the default) -- the round waits
+        # for a decision or the owning run's cancellation.
+        deadline = (
+            time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+        )
         payload = {
             "url": url,
             "timeout_seconds": timeout_seconds,
@@ -5152,15 +5190,18 @@ class ConsoleChatController:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
             else:
                 self._marshal_pending_skill_install(payload)
-            while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._is_session_cancelled(
-                    session_id,
-                    cancel_event=round_cancel_event,
-                    visit_event=visit_cancel_event,
-                ):
-                    break
-                if time.monotonic() >= deadline:
-                    break
+            # ADR-067: mark the owning run as waiting on a human decision
+            # (see `request_mcp_approvals`' identical wrap for the why).
+            with use_human_input_wait(owning_run_id):
+                while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
+                    if self._is_session_cancelled(
+                        session_id,
+                        cancel_event=round_cancel_event,
+                        visit_event=visit_cancel_event,
+                    ):
+                        break
+                    if deadline is not None and time.monotonic() >= deadline:
+                        break
             return bool(decision.get("allow", False))
         finally:
             with self._pending_skill_install_lock:
@@ -5434,7 +5475,11 @@ class ConsoleChatController:
             if self.skill_script_confirm_timeout_seconds is not None
             else _DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS
         )
-        deadline = time.monotonic() + timeout_seconds
+        # ADR-067: <= 0 arms NO deadline (the default) -- the round waits
+        # for a decision or the owning run's cancellation.
+        deadline = (
+            time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+        )
         card_payload = dict(payload)
         card_payload["timeout_seconds"] = timeout_seconds
         card_payload["request_id"] = request_id
@@ -5455,15 +5500,20 @@ class ConsoleChatController:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
             else:
                 self._marshal_pending_skill_script(card_payload)
-            while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
-                if self._is_session_cancelled(
-                    session_id,
-                    cancel_event=round_cancel_event,
-                    visit_event=visit_cancel_event,
-                ):
-                    break
-                if time.monotonic() >= deadline:
-                    break
+            # ADR-067: mark the owning run as waiting on a human decision
+            # (see `request_mcp_approvals`' identical wrap for the why).
+            with use_human_input_wait(
+                str(script_round_state.get("run_id") or "")
+            ):
+                while not event.wait(_MCP_APPROVAL_POLL_SECONDS):
+                    if self._is_session_cancelled(
+                        session_id,
+                        cancel_event=round_cancel_event,
+                        visit_event=visit_cancel_event,
+                    ):
+                        break
+                    if deadline is not None and time.monotonic() >= deadline:
+                        break
             # PR2a Task 7 (review M1): a revoked round denies
             # unconditionally, without consulting `decision` at all --
             # `resolve_pending_skill_script` writes into that shared box

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -4176,6 +4176,7 @@ expose_prompts = true  # Expose prompt templates
 require_auth = false  # Require authentication (not implemented yet)
 rate_limit = 100  # Max requests per minute per client
 max_concurrent_requests = 10  # Max concurrent requests
+# approval_timeout_seconds = 0  # Console approval-card auto-deny ceiling: 0 (default) waits indefinitely; e.g. 120 auto-denies undecided calls after 120s
 
 # expose_local_tools = false   # expose workspace, web, and Watchlists agent tools (fs_*/git_*/web_*/watchlists_*) to external MCP clients; each tool remains permission-gated
 


### PR DESCRIPTION
## What

Console permission prompts no longer expire: the tool approval card, the skill install confirm, and the run-script confirm stay armed until the user answers or the run is stopped — dinner-safe by default. Auto-deny is opt-in via `[mcp] approval_timeout_seconds` (any positive value, e.g. `120` restores the old behavior); the card's countdown copy only appears when a deadline is actually configured.

## Why it isn't just a deleted constant

The 120s auto-deny existed to stay strictly below the per-tool-call ceiling (`RunBudget.max_tool_call_seconds`, 300s) because the invoke-path approval wait runs *inside* `_call_with_timeout`: an infinite wait would be abandoned at 300s, the run would report failure, and a late approval would execute the tool for real on the abandoned thread (double execution). This PR supersedes that invariant by pausing the clock instead of removing it:

- **`Agents/human_input_wait.py` (new)** — stdlib-only, lock-guarded, refcounted registry keyed by run id. Deliberately not a ContextVar: the mark is set on the round's worker thread and polled on the wrapper's thread.
- **`_call_with_timeout`** — new optional `pauses_deadline` predicate; while a human decision is pending for the run, the deadline re-arms each poll slice. The ceiling now counts tool *execution* time: a genuinely hung tool still dies on schedule and Stop still cancels within one slice.
- **Controller** — the three wait loops treat a resolved timeout `<= 0` (the new default) as "no deadline armed", wrap their wait in `use_human_input_wait(owning_run_id)`, and carry 0 through to the card payload. `request_mcp_approvals` gains a no-app fail-closed guard (an app-less controller can never surface or resolve a round).

ADR-067 records the superseded invariant; the `max_tool_call_seconds` docstring and controller constants were rewritten to cite it.

## Testing

TDD throughout — each new test was written first and watched fail. On dev + this change:

- `Tests/Agents/`: 1423 passed (5 pre-existing `test_session_todo_store` failures, verified identical on pristine dev)
- Approval + all four skill-confirm suites + card suites: 153 passed
- agent swap / fleet wake safety / diff channel: 57 passed
- mypy: no new errors (30 pre-existing in the touched files, identical on the base)

Two incidental test repairs the default flip required: the script-confirm payload test round-trips a configured positive timeout instead of pinning `> 0`, and `make_controller` now fails armed rounds closed on teardown so a failing test cannot hang interpreter shutdown (lesson recorded in `backlog/docs/lessons-testing-evidence.md`).

Task: backlog/tasks/task-16789 · ADR: backlog/decisions/067-indefinite-human-approval-waits.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Console approval prompts wait indefinitely by default; previously they auto-denied after 120s. We pause the per-call tool deadline during human waits so only execution time counts; hung tools still time out, Stop cancels promptly, and approval requests without a UI bridge fail closed immediately. Aligns with ADR-067 and satisfies TASK-16789.

- Adds `tldw_chatbook/Agents/human_input_wait.py` with `use_human_input_wait(run_id)` and `human_input_wait_active(run_id)` (run-scoped, thread-safe, refcounted; visible across threads; falsy ids normalize to "").
- `_call_with_timeout` adds `pauses_deadline`; `_make_invoke_tool` wires it to the run’s human-wait mark.
- Controller defaults flip to 0: `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS`, `_DEFAULT_SKILL_INSTALL_CONFIRM_TIMEOUT_SECONDS`, `_DEFAULT_SKILL_SCRIPT_CONFIRM_TIMEOUT_SECONDS`. Wait loops treat `<= 0` as no deadline, wrap in `use_human_input_wait`, and pass the timeout through to cards; countdown copy hides when no deadline.
- `request_mcp_approvals` denies immediately when no app bridge is present. Docs and tests updated.

**Migration**
- Set `[mcp] approval_timeout_seconds` to a positive value to restore auto-deny.
- Treat `<= 0` as “no deadline” everywhere approval timeouts are read (including `UnifiedMCPControlPlaneService.approval_timeout_seconds` if consumed).
- Update tests that expect expiration to pass a positive timeout.
- Ensure a UI bridge is wired for approvals; otherwise `request_mcp_approvals` denies immediately.

<sup>Written for commit 83586c1825d76197b837a949c7bae0f480528409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

