### PR TITLE
perf(watchlists): drop the pre-mount seeding recomposes; batch the section swap as a contract (TASK-15778)

### DIFF
--- a/Tests/Watchlists/test_watchlists_cold_read_swap.py
+++ b/Tests/Watchlists/test_watchlists_cold_read_swap.py
@@ -1,0 +1,411 @@
+"""Batched section swap + recompose-free pane seeding (task-15778).
+
+Two related residuals from task-15461's Implementation Notes:
+
+1. **The section swap's DOM work runs under one `App.batch_update`.** The
+   cold Read switch is the one section move that mounts the CONTENT region
+   back, and the swap performs it as discrete awaited remove/mount cycles.
+   Measured at HEAD the screen never actually painted mid-swap even before
+   this task -- the whole sequence runs inside `_drain_surface_refresh`'s
+   single `call_next` callback, so the pump never idles and the paused
+   update timer never fires (task-15461's own `run_worker` -> `call_next`
+   move bought that silently). The batch makes the one-pass property an
+   explicit contract instead of a scheduling accident: it survives a future
+   factory that awaits, or the drain moving off a single callback.
+
+2. **`_build_detail_pane`/`_build_content_pane` seed `recompose=True`
+   reactives with `set_reactive`.** A plain assignment on the freshly
+   constructed, unmounted pane queues `refresh(recompose=True)` the moment
+   the seeded value differs from the class default (`[] != [row]`), which
+   tears the pane straight back down just after it mounts -- one full extra
+   pane rebuild per data-carrying region build (measured: sources 1->0,
+   rules 1->0, overview 1->0, artifacts 2->1 recomposes per switch; the
+   remaining artifacts 1 is the briefings loader landing post-mount, a real
+   data arrival). The conversion is per-reactive, not blanket:
+   non-recompose reactives keep their plain assignments so load-bearing
+   watcher side effects survive -- `RunsPane.selected_run` must keep
+   clearing the stale detail (hence detail-after-selection order) and must
+   keep starting the status poll for a still-running run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.Watchlists.test_watchlists_scoped_rebuilds import (
+    _RebuildCounter,
+    _open,
+    _seed,
+    _seed_alert_rule,
+    _settle,
+)
+from tldw_chatbook.UI.Screens.watchlists_collections_screen import (
+    WatchlistsCollectionsScreen,
+)
+from tldw_chatbook.UI.Watchlists_Modules.artifacts_pane import ArtifactsPane
+from tldw_chatbook.UI.Watchlists_Modules.content_pane import ContentPane
+from tldw_chatbook.UI.Watchlists_Modules.notifications_pane import NotificationsPane
+from tldw_chatbook.UI.Watchlists_Modules.overview_pane import OverviewPane
+from tldw_chatbook.UI.Watchlists_Modules.region_layout import Region, RegionLayout
+from tldw_chatbook.UI.Watchlists_Modules.rules_pane import RulesPane
+from tldw_chatbook.UI.Watchlists_Modules.runs_pane import RunsPane
+from tldw_chatbook.UI.Watchlists_Modules.sources_pane import SourcesPane
+from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
+    WatchlistsWorkbench,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_LOAD_REGION_LAYOUT_TARGET = (
+    "tldw_chatbook.UI.Screens.watchlists_collections_screen.load_region_layout"
+)
+
+
+# ---------------------------------------------------------------------------
+# AC#1 -- the cold Read swap's DOM work runs inside one batch_update
+# ---------------------------------------------------------------------------
+
+
+class _BatchObserver:
+    """Records `app._batch_count > 0` at entry to each swap DOM-work method.
+
+    Call-through wrappers on the three methods `apply_section_view` drives:
+    the region sync (which mounts CONTENT back on a cold Read switch), the
+    section pane rebuild and the header rebuild. Only entries made while
+    `apply_section_view` itself is on the stack are recorded -- the drainer
+    can legitimately run e.g. a rail `refresh_region_content` outside the
+    swap (and outside the batch) in the same settle window, and that is not
+    what the AC is about. Asserting on the batch counter at entry is
+    deterministic -- unlike counting layout passes, it cannot be masked by
+    the pump happening never to idle mid-swap (which is exactly what HEAD
+    measured; see the module docstring).
+    """
+
+    _METHODS = ("_sync_regions", "refresh_region_content", "refresh_header_content")
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, bool]] = []
+        self._in_swap = False
+        self._originals = {
+            name: getattr(WatchlistsWorkbench, name) for name in self._METHODS
+        }
+        self._original_apply = WatchlistsWorkbench.apply_section_view
+
+    def __enter__(self) -> "_BatchObserver":
+        observer = self
+        original_apply = self._original_apply
+
+        async def _bracketed_apply(widget_self, **kwargs):
+            observer._in_swap = True
+            try:
+                return await original_apply(widget_self, **kwargs)
+            finally:
+                observer._in_swap = False
+
+        def _wrap(name, original):
+            async def _observing(widget_self, *args, **kwargs):
+                if observer._in_swap:
+                    observer.entries.append((name, widget_self.app._batch_count > 0))
+                return await original(widget_self, *args, **kwargs)
+
+            return _observing
+
+        WatchlistsWorkbench.apply_section_view = _bracketed_apply
+        for name, original in self._originals.items():
+            setattr(WatchlistsWorkbench, name, _wrap(name, original))
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        WatchlistsWorkbench.apply_section_view = self._original_apply
+        for name, original in self._originals.items():
+            setattr(WatchlistsWorkbench, name, original)
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        # The shipped first-run default and a deliberately customised
+        # layout: the batch must hold in both config states, not just the
+        # default the fixture happens to produce.
+        RegionLayout(collapsed=frozenset({Region.RIGHT_RAIL})),
+        RegionLayout(collapsed=frozenset({Region.LEFT_RAIL})),
+    ],
+    ids=["first-run-default", "user-customised"],
+)
+async def test_the_cold_read_swap_runs_inside_one_batch_update(monkeypatch, layout):
+    """Every piece of the swap's DOM work must see an open batch.
+
+    Born red against the pre-task code: without the `batch_update` in
+    `apply_section_view`, every entry records `_batch_count == 0`.
+    """
+    monkeypatch.setattr(_LOAD_REGION_LAYOUT_TARGET, lambda: layout)
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=3)
+    async with _open(app, watchlist_id, section="sources") as (screen, pilot, host):
+        await _settle(pilot, host)
+        assert not screen.query("#wl-region-content"), (
+            "precondition: CONTENT must be unmounted off Read, or the switch "
+            "below is not the cold one"
+        )
+        with _BatchObserver() as observed:
+            screen.active_section = "items"
+            await _settle(pilot, host)
+
+        assert screen.query("#wl-region-content"), "CONTENT must be back on Read"
+        surfaces = {name for name, _ in observed.entries}
+        assert {"_sync_regions", "refresh_region_content"} <= surfaces, (
+            f"the swap must actually have exercised its DOM work: {observed.entries}"
+        )
+        unbatched = [name for name, batched in observed.entries if not batched]
+        assert unbatched == [], (
+            "every DOM-work entry of the section swap must run inside "
+            f"App.batch_update; these ran outside it: {unbatched}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC#2 + AC#3 + content-pane AC -- pre-mount seeding queues no recompose,
+# per pane branch
+# ---------------------------------------------------------------------------
+
+
+def _unmounted_screen(app) -> WatchlistsCollectionsScreen:
+    return WatchlistsCollectionsScreen(app)
+
+
+def _pane_of(built, pane_type):
+    for child in built._pending_children:
+        if isinstance(child, pane_type):
+            return child
+    raise AssertionError(f"no {pane_type.__name__} among {built._pending_children!r}")
+
+
+_RULE_ROW = {
+    "id": "r1",
+    "name": "Rule One",
+    "condition_type": "no_items",
+    "severity": "warning",
+    "enabled": True,
+}
+
+
+def _primed_screen(app, section: str) -> WatchlistsCollectionsScreen:
+    """An unmounted screen whose state gives `section`'s pane NON-default
+    seeds, so a plain-assignment seeding would queue the extra recompose."""
+    screen = _unmounted_screen(app)
+    screen.active_section = section
+    if section == "overview":
+        screen.set_reactive(
+            WatchlistsCollectionsScreen.overview_data,
+            {"sources": 1, "items": 2, "runs": 0},
+        )
+        screen._tree_watchlists = [{"id": 1, "name": "One"}]
+    elif section == "sources":
+        screen._loaded_sources = [
+            {"id": "s1", "name": "AI News", "type": "rss", "source": "https://x/f"}
+        ]
+    elif section == "runs":
+        run = {"id": "run-1", "status": "complete", "source_name": "AI News"}
+        screen._loaded_runs = [run]
+        # App order: the selection watcher clears the detail mirrors, the
+        # loader then fills them.
+        screen.selected_run = run
+        screen._run_detail_items = [{"title": "Story", "status": "kept"}]
+        screen._run_detail_logs = "log line"
+        screen._run_detail_items_note = "1 item"
+    elif section == "rules":
+        screen._loaded_rules = [_RULE_ROW]
+    elif section == "rules-editing":
+        screen.active_section = "rules"
+        screen._loaded_rules = [_RULE_ROW]
+        screen._rule_form_open = True
+        screen._rule_form_editing = _RULE_ROW
+    elif section == "notifications":
+        row = {"id": 7, "title": "Alert", "severity": "warning"}
+        screen._loaded_notifications = [row]
+        screen.set_reactive(WatchlistsCollectionsScreen.selected_notification, row)
+    elif section == "artifacts":
+        briefing = {"id": 3, "status": "complete", "title": "Briefing"}
+        screen._loaded_briefings = [briefing]
+        screen._selected_briefing = briefing
+        screen._loaded_scripts = [{"id": 5, "briefing_id": 3}]
+    elif section == "items":
+        # Primed through the SYNC-watcher reactives rather than `items`
+        # rows: `watch_items` is async, and on a pane this probe never
+        # mounts the queued coroutine would simply be garbage-collected
+        # un-awaited (a test artifact, not a product path -- production
+        # always mounts the built pane). The mounted warm-revisit test
+        # below bounces through Read with real rows.
+        screen._items_search_query = "story"
+        screen._selected_content_item = {"id": "i1", "title": "Story 1"}
+    return screen
+
+
+_PANE_BY_SECTION = {
+    "overview": OverviewPane,
+    "sources": SourcesPane,
+    "runs": RunsPane,
+    "rules": RulesPane,
+    "rules-editing": RulesPane,
+    "notifications": NotificationsPane,
+    "artifacts": ArtifactsPane,
+    "items": None,  # ArticleListPane: no recompose reactives -- guard only
+}
+
+
+@pytest.mark.parametrize("section", list(_PANE_BY_SECTION))
+async def test_detail_pane_seeding_queues_no_recompose(section):
+    """A freshly built, data-seeded pane must not be scheduled for an
+    immediate rebuild.
+
+    `refresh(recompose=True)` marks `_recompose_required` on the unmounted
+    pane and queues `_check_recompose`, which fires just after the mount and
+    tears the pane straight back down. Born red for every data-carrying
+    branch against the pre-task plain-assignment seeding (`items` is the
+    audited exception -- `ArticleListPane` has no `recompose=True` reactives
+    at all, so that branch is a regression guard, not a born-red pin).
+    """
+    app = _build_test_app()
+    screen = _primed_screen(app, section)
+
+    built = screen._build_detail_pane()
+
+    flagged = [
+        f"{type(child).__name__}#{child.id or '-'}"
+        for child in built._pending_children
+        if child._recompose_required
+    ]
+    assert flagged == [], (
+        "pre-mount seeding must not queue a recompose on the freshly built "
+        f"pane; flagged: {flagged}"
+    )
+    pane_type = _PANE_BY_SECTION[section]
+    if pane_type is not None:
+        _pane_of(built, pane_type)  # the seeded pane really is in there
+
+
+async def test_rules_editing_seed_still_prefills_the_form_state():
+    """`edit_rule`'s pre-mount route must seed the same reactives the
+    mounted route assigns -- `compose()` reads them to pre-fill the form."""
+    app = _build_test_app()
+    screen = _primed_screen(app, "rules-editing")
+
+    pane = _pane_of(screen._build_detail_pane(), RulesPane)
+
+    assert pane.show_rule_form is True
+    assert pane.selected_rule == _RULE_ROW
+    assert pane._editing_rule_id == "r1"
+    assert pane._recompose_required is False
+
+
+async def test_content_pane_item_seeding_queues_no_recompose():
+    """`_build_content_pane` (the CONTENT region the cold Read swap mounts
+    back): `item` is `recompose=True`, so a plain assignment re-rendered the
+    whole article a second time immediately after the swap whenever an item
+    was selected. Born red against the pre-task code."""
+    app = _build_test_app()
+    screen = _unmounted_screen(app)
+    screen._selected_content_item = {
+        "id": "i1",
+        "title": "Story 1",
+        "content": "body",
+    }
+
+    pane = screen._build_content_pane()
+
+    assert isinstance(pane, ContentPane)
+    assert pane.item == screen._selected_content_item, "the reader still seeds"
+    assert pane._recompose_required is False, (
+        "seeding `item` must not schedule an immediate second render of the article"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC#2 -- RunsPane's load-bearing seeding order and watcher side effects
+# ---------------------------------------------------------------------------
+
+
+async def test_runs_pane_seeding_keeps_the_detail_set_after_the_selection():
+    """`selected_run`'s watcher clears the detail (a run's items must never
+    outlive the run they belong to), so `_build_detail_pane` must keep
+    setting the detail AFTER the selection. Reordering the seeding -- or
+    silencing the watcher's clear without re-seeding -- reds this."""
+    app = _build_test_app()
+    screen = _primed_screen(app, "runs")
+
+    pane = _pane_of(screen._build_detail_pane(), RunsPane)
+
+    assert pane.selected_run == screen.selected_run
+    assert pane.run_items == [{"title": "Story", "status": "kept"}], (
+        "the detail must survive the selection watcher's clear -- it is "
+        "seeded after `selected_run` on purpose"
+    )
+    assert pane.run_logs == "log line"
+    assert pane.run_items_note == "1 item"
+
+
+async def test_runs_pane_seeding_still_starts_the_poll_for_a_running_run():
+    """`watch_selected_run` starts the status poll when the seeded run is
+    still running -- the reason `selected_run` stays a PLAIN assignment in
+    `_build_detail_pane` (task-15778's per-reactive audit). A blind
+    `set_reactive` conversion would silently freeze a mid-flight run's
+    status on every region rebuild; this pins the watcher route."""
+    polled: list[dict] = []
+
+    original = RunsPane._start_run_poll
+    RunsPane._start_run_poll = lambda self, run: polled.append(run)
+    try:
+        app = _build_test_app()
+        screen = _unmounted_screen(app)
+        screen.active_section = "runs"
+        running = {"id": "run-9", "status": "running", "source_name": "AI News"}
+        screen._loaded_runs = [running]
+        screen.selected_run = running
+
+        pane = _pane_of(screen._build_detail_pane(), RunsPane)
+    finally:
+        RunsPane._start_run_poll = original
+
+    assert pane.selected_run == running
+    assert polled == [running], (
+        "the pane's `watch_selected_run` must fire during seeding and start "
+        "the poll for a still-running run -- a region rebuild mid-run "
+        f"depends on it; got {polled!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a mounted, warm revisit costs zero pane recomposes
+# ---------------------------------------------------------------------------
+
+
+async def test_warm_revisits_cost_zero_pane_recomposes():
+    """Mounted proof of the seeding fix: revisiting a section whose rows are
+    already on screen state builds the pane once, carrying the rows, and
+    recomposes it zero times. Pre-task this was exactly 1 per data-carrying
+    revisit -- the pre-mount seeding recompose."""
+    app = _build_test_app()
+    watchlist_id = _seed(app, items=2, briefings=1)
+    await _seed_alert_rule(app)
+    async with _open(app, watchlist_id, section="items") as (screen, pilot, host):
+        await _settle(pilot, host)
+        # First visits load each section's rows onto screen state.
+        for section in ("rules", "artifacts", "sources"):
+            screen.active_section = section
+            await _settle(pilot, host)
+
+        for section, pane_key in (
+            ("rules", "RulesPane#watchlists-rules-pane"),
+            ("artifacts", "ArtifactsPane#watchlists-artifacts-pane"),
+            ("sources", "SourcesPane#watchlists-sources-pane"),
+        ):
+            screen.active_section = "items"
+            await _settle(pilot, host)
+            with _RebuildCounter() as counted:
+                screen.active_section = section
+                await _settle(pilot, host)
+            assert counted.recomposes[pane_key] == 0, (
+                f"warm {section} revisit must not rebuild the freshly built "
+                f"pane: {counted.report()}"
+            )

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from collections import Counter
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 import pytest
 from textual.widget import Widget
@@ -259,21 +258,20 @@ async def test_a_section_switch_builds_the_sections_pane_exactly_once():
 
     * The **region** is built exactly once per switch -- that is `builds`.
     * The **pane** rebuilds at most once, and the one is not a data-arrival
-      duplicate: `_build_detail_pane` seeds `rules_pane.rules` on a
-      freshly-constructed pane whose class default is `[]`, so Textual queues
-      a recompose (`[] != [row]`) that fires just after the pane mounts.
-      Traced to `_build_detail_pane` directly, and it is pre-existing and
-      unchanged by this task -- the whole-screen recompose called the same
-      factory and paid the same cost. It is invisible on an empty fixture,
-      which is exactly why it went unnoticed until a row was seeded.
-      (Removing it means seeding the panes with `set_reactive`, which is not
-      safe to do blind: `RunsPane`'s seeding order is load-bearing -- setting
-      `selected_run` clears the detail, so the detail must be set after it.
-      Recorded as a residual, deliberately not attempted here.)
+      duplicate. `_build_detail_pane` used to seed `rules_pane.rules` by
+      plain assignment on a freshly-constructed pane whose class default is
+      `[]`, so Textual queued a recompose (`[] != [row]`) that fired just
+      after the pane mounted -- the residual this task recorded, closed by
+      task-15778 (the factories now seed `recompose=True` reactives with
+      `set_reactive`, per-reactive, keeping `RunsPane`'s load-bearing
+      `selected_run` watcher on the plain path). What `<= 1` still allows on
+      a COLD visit is the genuine data arrival: the loader can land after
+      the mount and push `[] -> [row]`, which is one honest rebuild.
 
     The claim this test therefore pins is the one AC#1 makes: **one scoped
     region build, and no SECOND rebuild from the loader landing** -- verified
-    on a warm revisit, where the rows are already on screen state.
+    on a warm revisit, where the rows are already on screen state (and where,
+    since task-15778, the count is exactly zero).
     """
     app = _build_test_app()
     watchlist_id = _seed(app)
@@ -323,9 +321,10 @@ async def test_a_section_switch_builds_the_sections_pane_exactly_once():
             await _settle(pilot, host)
 
         assert builds == ["sources", "rules"], builds
-        assert warm.recomposes["RulesPane#watchlists-rules-pane"] <= 1, (
-            "a warm revisit must cost at most the pre-mount seeding rebuild "
-            f"named in this test's docstring: {warm.report()}"
+        assert warm.recomposes["RulesPane#watchlists-rules-pane"] == 0, (
+            "a warm revisit must not rebuild the freshly built pane at all "
+            "-- the pre-mount seeding recompose this used to tolerate was "
+            f"removed by task-15778: {warm.report()}"
         )
         assert warm.recomposes["WatchlistsCollectionsScreen#-"] == 0, warm.report()
         assert (

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4433,3 +4433,25 @@ probe characterizing what the code does deterministically under the flake's stim
 -- the flake may be the tail of a bug whose body is fully reproducible; (2) a
 repetition budget that finds nothing (34/34 clean here) is not evidence the race is
 gone -- the gated one-run interleave was both stronger and cheaper.
+
+## Re-verify a residual's CAUSAL hypothesis before building the fix around it (task-15778, 2026-08-15)
+
+Task-15461's Implementation Notes recorded a residual with a cause attached:
+the cold Read tab's wall-clock regressed "because the scoped path does the
+CONTENT remount as its own discrete remove/mount pair rather than inside one
+batched recompose -- Textual's `batch()` is the obvious next move." Task-15778
+was filed around that hypothesis. A neutered-batch A/B on the same HEAD
+refuted it: **zero** in-swap layout passes and zero compositor refreshes with
+AND without `App.batch_update`, because the entire swap already runs inside
+`_drain_surface_refresh`'s single `call_next` callback -- a paint-atomicity
+that 15461's own `run_worker` -> `call_next` move had bought silently, one
+task before it filed the residual blaming its absence. The batch shipped
+anyway, but as an explicit contract (survives a future awaiting factory or a
+drain restructure), documented as such -- not as the measured win the task
+title promised. Two probe traps that nearly hid this: (1) counting layout
+passes over the whole settle window attributed 3 post-swap passes (loader,
+reseed) to the swap -- bracket the exact call under test, not the settle;
+(2) the first probe "confirmed" the premise with numbers that were real but
+belonged to a different mechanism. The residual's fix-shaped hypothesis is a
+hypothesis; A/B the mechanism (here: neuter the proposed fix on the same
+HEAD) before writing the Implementation Notes around it.

--- a/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
+++ b/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15778
 title: 'Watchlists: batch the cold Read-tab region swap and drop the pre-mount seeding recompose'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-13 12:31'
@@ -39,22 +39,24 @@ rebuilds.
 
 ## Acceptance Criteria
 
-- [ ] The cold `section: Read` switch's CONTENT-region remount is batched
+- [x] The cold `section: Read` switch's CONTENT-region remount is batched
       (e.g. via Textual's `batch()`) into the same pass as its other DOM
       work, and the wall-clock regression measured in task-15461 is closed
-      (before/after recorded)
-- [ ] `_build_detail_pane`'s pre-mount seeding uses `set_reactive` (or an
+      (before/after recorded — with an honest refutation: the audited
+      mechanism behind the regression never existed at this HEAD; see
+      Implementation Notes)
+- [x] `_build_detail_pane`'s pre-mount seeding uses `set_reactive` (or an
       equivalent that avoids the extra recompose) without breaking any
       pane's load-bearing seeding order — `RunsPane`'s `selected_run`-before-
       detail ordering explicitly verified by test
-- [ ] Every other pane that uses `_build_detail_pane` is checked for its own
+- [x] Every other pane that uses `_build_detail_pane` is checked for its own
       seeding-order dependencies before the change lands, not just
       `RunsPane`
-- [ ] `_build_content_pane`'s `item` seeding (the CONTENT region built by the
+- [x] `_build_content_pane`'s `item` seeding (the CONTENT region built by the
       same cold Read-tab swap; `item` is `recompose=True` and pays the same
       extra recompose whenever an item is selected) gets the identical
       treatment, with its own seeding-order/watcher audit
-- [ ] `Tests/Watchlists/test_watchlists_scoped_rebuilds.py` and the sources/
+- [x] `Tests/Watchlists/test_watchlists_scoped_rebuilds.py` and the sources/
       rules pane suites stay green
 
 ## Implementation Plan
@@ -97,3 +99,84 @@ rebuilds.
 6. Run the Watchlists suites (scoped_rebuilds, cold_open_layout, workbench,
    sources/rules/runs/artifacts/items pane suites, destination shell), ruff
    check + format on touched files, commit.
+
+## Implementation Notes
+
+**Premise re-verification at HEAD `41a2f8a00`** (includes 15775's
+seed-before-compose and 15776's row collapse — neither touched these two
+residuals):
+
+| premise | state at HEAD | evidence |
+|---|---|---|
+| swap unbatched | still true — no `batch_update`/`batch()` anywhere in the swap path | grep + probe |
+| pre-mount seeding recompose | still true | instrumented section sweep: SourcesPane 1, RulesPane 1, OverviewPane 1, ArtifactsPane 2 recomposes per data-carrying switch; ContentPane 1 on a cold Read switch with a selected item |
+| "the regression is BECAUSE the swap is unbatched" | **refuted** | 0 in-swap layout passes and 0 compositor refreshes measured on a cold Read switch, batch NEUTERED (A/B on the same HEAD) — the whole swap runs inside `_drain_surface_refresh`'s single `call_next` callback (15461's own `run_worker`→`call_next` move), so the pump never idles mid-swap and the paused update timer never fires |
+
+**Fix 1 — batch (AC#1).** `WatchlistsWorkbench.apply_section_view` now runs
+its DOM work (region sync, section-pane rebuild, header rebuild) inside
+`App.batch_update()`. Given the refutation above this is a contract, not a
+measured win: it makes the one-pass property structural (survives a future
+factory that awaits, or the drain moving off a single callback) instead of
+an accident of the drain's scheduling. Wall clock recorded, honest: cold
+Read swap window 32–37 ms pre vs 37–39 ms post (noise); dispatch→settled
+113–270 ms both arms, indistinguishable on a busy machine. The 15461-era
+75→110 ms number does not reproduce as a batching problem at this HEAD.
+
+**Fix 2 — seeding (AC#2/#3/#4).** `_build_detail_pane` and
+`_build_content_pane` seed `recompose=True` reactives with `set_reactive`,
+per-reactive after a per-pane watcher audit — NOT blanket:
+
+* Converted (all pre-mount watchers `is_mounted`-gated no-ops, verified by
+  reading each): OverviewPane `data`/`watchlist_count`; SourcesPane
+  `sources`/`show_create_form`/`create_draft_source_type`; RunsPane `runs`;
+  RulesPane `rules`/`show_rule_form` (+ `edit_rule` gained a pre-mount
+  `set_reactive` route, same body, `is_mounted`-switched); NotificationsPane
+  `notifications`/`selected_notification`; ArtifactsPane — all 20 seeded
+  reactives; ContentPane `item` (no watcher at all).
+* Deliberately left plain: every non-recompose reactive. RunsPane's
+  `selected_run` is the load-bearing case — its watcher clears the stale
+  detail (hence the detail-after-selection order, pinned by test) AND
+  starts the status poll for a still-running run (pinned by test; a blind
+  `set_reactive` would freeze a mid-flight run's status on every region
+  rebuild). ArticleListPane audited: zero `recompose=True` reactives,
+  nothing to convert (documented in the branch).
+
+**Measured before/after** (isolated per-test config, seeded fixture,
+`_RebuildCounter` on `Widget.recompose`/`mount`; ms noisy on a busy
+machine, counts deterministic):
+
+| interaction | pane recomposes | mounts | ms (dispatch→settled) |
+|---|---|---|---|
+| cold Read, item selected | ContentPane 1 → 0 | 81 → 69 | ~126–220 → ~132–148 (noise) |
+| switch → sources | 1 → 0 | — | — |
+| switch → rules (loader pre-landed) | 1 → 0 | — | — |
+| switch → overview | 1 → 0 | — | — |
+| switch → artifacts | 2 → 1 (the 1 = briefings loader landing post-mount, honest data arrival) | — | — |
+| switch → runs / items | 0 → 0 (runs list empty; ArticleListPane has no recompose reactives) | — | — |
+
+**Born-red.** All new pins in
+`Tests/Watchlists/test_watchlists_cold_read_swap.py` were run against the
+pre-fix production files (file-swap from git, tests kept): 13 red — the
+batch pin (both config states: first-run default AND a user-customised
+layout), every data-carrying `_recompose_required` seeding pin, the
+edit-form prefill pin, the ContentPane pin, the warm-revisit end-to-end
+pin, and the tightened scoped_rebuilds warm assertion (`<= 1` → `== 0`).
+The 3 that stayed green are the designed behaviour-preservation pins:
+`[items]` (never had the defect), the RunsPane ordering pin and the
+RunsPane poll pin — each of those was then redded by its targeted mutation
+(detail-before-selection reorder; blind `set_reactive` on `selected_run`),
+Edit-based restores, tree verified clean after.
+
+**Tests.** `Tests/Watchlists/` full directory: 688 passed. Watchlists UI
+suites (`test_watchlists_content_pane.py`, `test_watchlists_rail_counts_
+and_scope.py`, `test_watchlists_destination_shell.py`): 163 passed. ruff
+check clean on all touched files; the new test file ruff-formatted (the
+four touched production files were already unformatted at HEAD, so no
+whole-file reformat churn).
+
+**Files.** `tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py`,
+`tldw_chatbook/UI/Screens/watchlists_collections_screen.py`,
+`tldw_chatbook/UI/Watchlists_Modules/rules_pane.py`,
+`tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py` (comment only),
+`Tests/Watchlists/test_watchlists_cold_read_swap.py` (new),
+`Tests/Watchlists/test_watchlists_scoped_rebuilds.py`.

--- a/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
+++ b/backlog/tasks/task-15778 - Watchlists-batch-the-cold-Read-tab-region-swap-and-drop-the-pre-mount-seeding-recompose.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15778
 title: 'Watchlists: batch the cold Read-tab region swap and drop the pre-mount seeding recompose'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - perf
@@ -49,5 +50,50 @@ rebuilds.
 - [ ] Every other pane that uses `_build_detail_pane` is checked for its own
       seeding-order dependencies before the change lands, not just
       `RunsPane`
+- [ ] `_build_content_pane`'s `item` seeding (the CONTENT region built by the
+      same cold Read-tab swap; `item` is `recompose=True` and pays the same
+      extra recompose whenever an item is selected) gets the identical
+      treatment, with its own seeding-order/watcher audit
 - [ ] `Tests/Watchlists/test_watchlists_scoped_rebuilds.py` and the sources/
       rules pane suites stay green
+
+## Implementation Plan
+
+1. Re-verify both premises at HEAD (`41a2f8a00`, which includes task-15775's
+   seed-before-compose and task-15776's row collapse): confirm neither
+   residual was already fixed — (a) no `batch_update`/`batch()` anywhere in
+   the workbench's swap path, so the cold Read switch still pays one
+   layout/paint pass per remove/mount cycle; (b) `_build_detail_pane` still
+   seeds recompose=True reactives by plain assignment, so a seeded row still
+   queues one extra pane recompose per region build. Evidence via an
+   instrumented probe (isolated HOME/XDG config, seeded fixture): layout-pass
+   count + wall clock for the cold Read switch, and per-pane recompose counts
+   per section switch.
+2. AC#1: wrap `WatchlistsWorkbench.apply_section_view`'s mounted-path DOM
+   work in `self.app.batch_update()` so the CONTENT mount, the ITEMS region
+   rebuild and the header rebuild are reconciled in ONE layout/paint pass
+   instead of one per remove/mount cycle. Focus restoration
+   (`_restore_focus_after_swap`) and the persisted-layout contract are
+   untouched — the batch only defers repaints, it does not reorder the DOM
+   work.
+3. AC#2/#3: audit every pane branch in `_build_detail_pane` for
+   recompose=True reactives and watcher side effects, then convert exactly
+   the recompose=True seeding assignments to `set_reactive` (their pre-mount
+   watchers are all `is_mounted`-gated no-ops — verified per pane). Keep the
+   non-recompose assignments as plain assignments so their load-bearing
+   watcher side effects survive: `RunsPane.selected_run` must keep firing
+   `watch_selected_run` (clears the detail — hence detail-after-selection
+   order — and starts the run poll for a mid-flight run). `RulesPane.
+   edit_rule` gets a pre-mount `set_reactive` path for `show_rule_form`.
+4. Born-red tests (new file `Tests/Watchlists/test_watchlists_cold_read_swap.py`,
+   reusing the 15775 `_SwapCounter`/15461 `_RebuildCounter` patterns):
+   batch-active-during-swap pin (deterministic, red pre-fix), zero-pane-
+   recompose-per-switch pins for the seeded panes (red pre-fix at 1),
+   `RunsPane` ordering + poll-side-effect pins (red under a wrong-order or
+   set_reactive-blind mutation), and the cold Read switch verified under
+   both the first-run default layout and a user-customized layout.
+5. Before/after swap-count + layout-pass + timing measurements on a cold
+   Read-tab open, recorded in Implementation Notes.
+6. Run the Watchlists suites (scoped_rebuilds, cold_open_layout, workbench,
+   sources/rules/runs/artifacts/items pane suites, destination shell), ruff
+   check + format on touched files, commit.

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -2085,6 +2085,22 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
 
         Called fresh on every region rebuild — see the factory note on
         `WatchlistsWorkbench.__init__`.
+
+        Seeding discipline (task-15778): every `recompose=True` reactive is
+        seeded with `set_reactive`, never plain assignment. A plain
+        assignment on the freshly constructed, not-yet-mounted pane runs
+        `refresh(recompose=True)` the instant the seeded value differs from
+        the class default (`[] != [row]`), which queues a `_check_recompose`
+        that fires just after the pane mounts — one full extra pane rebuild
+        per region build, measured on every data-carrying section switch
+        (task-15461's residual 4). `compose()` reads the same reactives, so
+        `set_reactive` renders identically without the queued rebuild. The
+        panes' pre-mount watchers were audited per-branch before this
+        change: every watcher on a converted reactive is an
+        `is_mounted`-gated no-op pre-mount, so nothing is lost by skipping
+        it. NON-recompose reactives deliberately stay plain assignments —
+        `RunsPane.selected_run`'s watcher side effects are load-bearing
+        (see that branch).
         """
         detail_title = self._SECTION_DETAIL_TITLE.get(self.active_section, "Detail")
         children: list[Widget] = [
@@ -2096,11 +2112,13 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         ]
         if self.active_section == "overview":
             overview = OverviewPane(id="watchlists-overview-pane")
-            overview.data = self.overview_data
+            overview.set_reactive(OverviewPane.data, self.overview_data)
             # TASK-998: lets the first-run panel distinguish "no watchlists at
             # all" from "a watchlist with no sources in it" -- `overview_data`
             # counts sources, items and runs, never watchlists.
-            overview.watchlist_count = len(self._tree_watchlists)
+            overview.set_reactive(
+                OverviewPane.watchlist_count, len(self._tree_watchlists)
+            )
             children.append(overview)
         elif self.active_section == "sources":
             sources_pane = SourcesPane(id="watchlists-sources-pane")
@@ -2111,7 +2129,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # Scoped (TASK-2304 AC#2): a rebuild must not quietly re-widen
             # the table back to every source while the header still names one
             # watchlist.
-            sources_pane.sources = self.scoped_loaded_sources()
+            sources_pane.set_reactive(
+                SourcesPane.sources, self.scoped_loaded_sources()
+            )
             sources_pane.selected_source = self.selected_source
             # TASK-2309: re-seed from screen state for the identical
             # rebuild-survival reason as `selected_source` on the line
@@ -2133,12 +2153,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 else sources_pane.default_destination
             )
             if self._source_create_draft_type is not None:
-                sources_pane.create_draft_source_type = self._source_create_draft_type
+                sources_pane.set_reactive(
+                    SourcesPane.create_draft_source_type,
+                    self._source_create_draft_type,
+                )
             # Seed the create-form draft so it survives this pane being
             # reconstructed (see the note on `_source_create_draft` in
             # __init__ and CreateFormDraftChanged/CreateFormVisibilityChanged
-            # in sources_pane.py).
-            sources_pane.show_create_form = self._source_create_form_open
+            # in sources_pane.py). `set_reactive` (task-15778):
+            # `watch_show_create_form` is entirely `is_mounted`-gated, so the
+            # plain assignment bought nothing pre-mount but the extra
+            # recompose.
+            sources_pane.set_reactive(
+                SourcesPane.show_create_form, self._source_create_form_open
+            )
             sources_pane.create_draft_name = self._source_create_draft["name"]
             sources_pane.create_draft_url = self._source_create_draft["url"]
             sources_pane.create_draft_tags = self._source_create_draft["tags"]
@@ -2149,7 +2177,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             children.append(sources_pane)
         elif self.active_section == "runs":
             runs_pane = RunsPane(id="watchlists-runs-pane")
-            runs_pane.runs = self._loaded_runs
+            # `runs` is the pane's only `recompose=True` reactive, so it is
+            # the only one converted to `set_reactive` (task-15778). The
+            # four below stay PLAIN assignments on purpose:
+            # `watch_selected_run` is load-bearing even pre-mount -- it
+            # starts the status poll when the seeded run is still running
+            # (without it, a region rebuild mid-run would freeze the run's
+            # status until a manual refresh) -- and none of the four is
+            # `recompose=True`, so none of them costs the extra rebuild this
+            # task removes.
+            runs_pane.set_reactive(RunsPane.runs, self._loaded_runs)
             runs_pane.selected_run = self.selected_run
             # After `selected_run`, never before: setting the selection clears
             # the pane's detail (a run's items must never outlive the run they
@@ -2161,6 +2198,11 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         elif self.active_section == "items":
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
+            # Audited for task-15778 and deliberately left as plain
+            # assignments: `ArticleListPane` has NO `recompose=True`
+            # reactives at all (its watchers patch the mounted list in
+            # place), so this branch never paid the pre-mount seeding
+            # recompose and there is nothing to convert.
             items_pane = ArticleListPane(id="watchlists-items-pane")
             items_pane.items = self._loaded_items
             # Seed the filter, the search box and the selection too
@@ -2189,51 +2231,80 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # Seed the last-loaded rows (Finding 2, fix round 2) — see the
             # note on `sources_pane.sources` above; same rebuild, same gap.
             rules_pane = RulesPane(id="watchlists-rules-pane")
-            rules_pane.rules = self._loaded_rules
+            rules_pane.set_reactive(RulesPane.rules, self._loaded_rules)
             # Seed the edit-form state so an in-progress rule edit survives
             # this pane being reconstructed (Finding 4, fix round 2) — the
             # same treatment the Sources create-form draft already gets
             # above; see `_rule_form_open`/`_rule_form_editing` in __init__
-            # and RuleFormVisibilityChanged in rules_pane.py.
+            # and RuleFormVisibilityChanged in rules_pane.py. `edit_rule`
+            # itself takes the `set_reactive` route on an unmounted pane
+            # (task-15778) — see its own comment.
             if self._rule_form_open:
                 if self._rule_form_editing is not None:
                     rules_pane.edit_rule(self._rule_form_editing)
                 else:
-                    rules_pane.show_rule_form = True
+                    rules_pane.set_reactive(RulesPane.show_rule_form, True)
             children.append(rules_pane)
         elif self.active_section == "notifications":
             notifications_pane = NotificationsPane(id="watchlists-notifications-pane")
-            notifications_pane.notifications = self._loaded_notifications
-            notifications_pane.selected_notification = self.selected_notification
+            notifications_pane.set_reactive(
+                NotificationsPane.notifications, self._loaded_notifications
+            )
+            notifications_pane.set_reactive(
+                NotificationsPane.selected_notification,
+                self.selected_notification,
+            )
             children.append(notifications_pane)
         elif self.active_section == "artifacts":
             # Seeded from screen state for the same reason every sibling
             # above is -- this is a factory the workbench calls on every
             # region rebuild, so a fresh pane's reactives start at their
-            # class defaults.
+            # class defaults. Every reactive this branch seeds is
+            # `recompose=True`, so every one goes through `set_reactive`
+            # (task-15778; the pane's two seeded-reactive watchers,
+            # `watch_selected_briefing`/`watch_selected_script`, are both
+            # pre-mount no-ops -- the former even guards specifically
+            # against wiping this very seeding).
             artifacts_pane = ArtifactsPane(id="watchlists-artifacts-pane")
-            artifacts_pane.briefings = self._loaded_briefings
-            artifacts_pane.selected_briefing = self._selected_briefing
-            artifacts_pane.scope_label = self._briefing_scope_label()
-            artifacts_pane.can_generate = self._can_generate_briefing()
-            artifacts_pane.default_provider_display = self._briefing_provider_display()
-            artifacts_pane.selection_mode = self._briefing_selection_mode
-            artifacts_pane.presets = self._loaded_briefing_presets
-            artifacts_pane.default_preset_id = self._briefing_default_preset_id
-            artifacts_pane.briefing_cadence_seconds = self._briefing_cadence_seconds
-            artifacts_pane.briefing_schedules_enabled = (
-                self._briefing_schedules_enabled()
+            seed = artifacts_pane.set_reactive
+            seed(ArtifactsPane.briefings, self._loaded_briefings)
+            seed(ArtifactsPane.selected_briefing, self._selected_briefing)
+            seed(ArtifactsPane.scope_label, self._briefing_scope_label())
+            seed(ArtifactsPane.can_generate, self._can_generate_briefing())
+            seed(
+                ArtifactsPane.default_provider_display,
+                self._briefing_provider_display(),
             )
-            artifacts_pane.scripts = self._loaded_scripts
-            artifacts_pane.selected_script = self._selected_script
-            artifacts_pane.script_audio = self._loaded_script_audio
-            artifacts_pane.scripts_with_audio = self._scripts_with_audio
-            artifacts_pane.citations = self._loaded_citations
-            artifacts_pane.has_audio_episodes = self._watchlist_has_audio_episodes
-            artifacts_pane.chachanotes_available = self._chachanotes_db() is not None
-            artifacts_pane.can_serve_feed = self._last_feed_export_directory is not None
-            artifacts_pane.feed_server_running = self._feed_server.is_running
-            artifacts_pane.feed_server_url = self._feed_server.url
+            seed(ArtifactsPane.selection_mode, self._briefing_selection_mode)
+            seed(ArtifactsPane.presets, self._loaded_briefing_presets)
+            seed(ArtifactsPane.default_preset_id, self._briefing_default_preset_id)
+            seed(
+                ArtifactsPane.briefing_cadence_seconds,
+                self._briefing_cadence_seconds,
+            )
+            seed(
+                ArtifactsPane.briefing_schedules_enabled,
+                self._briefing_schedules_enabled(),
+            )
+            seed(ArtifactsPane.scripts, self._loaded_scripts)
+            seed(ArtifactsPane.selected_script, self._selected_script)
+            seed(ArtifactsPane.script_audio, self._loaded_script_audio)
+            seed(ArtifactsPane.scripts_with_audio, self._scripts_with_audio)
+            seed(ArtifactsPane.citations, self._loaded_citations)
+            seed(
+                ArtifactsPane.has_audio_episodes,
+                self._watchlist_has_audio_episodes,
+            )
+            seed(
+                ArtifactsPane.chachanotes_available,
+                self._chachanotes_db() is not None,
+            )
+            seed(
+                ArtifactsPane.can_serve_feed,
+                self._last_feed_export_directory is not None,
+            )
+            seed(ArtifactsPane.feed_server_running, self._feed_server.is_running)
+            seed(ArtifactsPane.feed_server_url, self._feed_server.url)
             children.append(artifacts_pane)
         return Vertical(
             *children,
@@ -2299,7 +2370,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         would go stale the instant the layout that produced it changes.
         """
         pane = ContentPane(id="watchlists-content-pane")
-        pane.item = self._selected_content_item
+        # `set_reactive`: `item` is the pane's one `recompose=True` reactive
+        # and has no watcher, so a plain assignment here bought nothing but
+        # the queued extra recompose whenever an item was selected — a full
+        # second render of the article, inside the very swap task-15778
+        # batches. `expanded`/`position` below are non-recompose reactives
+        # whose watchers patch in place and stay plain, same audit as
+        # `_build_detail_pane`'s.
+        pane.set_reactive(ContentPane.item, self._selected_content_item)
         pane.expanded = self.region_layout.solo_region == Region.CONTENT
         # TASK-3072 plan task 9: re-seed the footer the same way `item` is
         # re-seeded just above, so a region rebuild re-renders the same

--- a/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/artifacts_pane.py
@@ -1546,10 +1546,12 @@ class ArtifactsPane(RecomposeCaptureGuard, Vertical):
 
     def watch_selected_briefing(self, briefing: dict[str, Any] | None) -> None:
         if not self.is_mounted:
-            # Pre-mount seeding (`WatchlistsCollectionsScreen.
-            # _build_detail_pane` sets `selected_briefing` and then the
-            # script/citation state, in that order). Clearing here would wipe
-            # the seeding that follows, and there is no screen to tell.
+            # Defense in depth for pre-mount seeding. Since task-15778
+            # `WatchlistsCollectionsScreen._build_detail_pane` seeds every
+            # reactive with `set_reactive`, so this watcher no longer fires
+            # there at all — but a future plain assignment on an unmounted
+            # pane must still not wipe the script/citation seeding that
+            # follows it, and there is no screen to tell either way.
             return
         self._clear_selection_derived_state()
         self.post_message(BriefingSelected(briefing))

--- a/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/rules_pane.py
@@ -331,7 +331,26 @@ class RulesPane(RecomposeCaptureGuard, Vertical):
         self._editing_rule_id = None
 
     def edit_rule(self, rule: dict[str, Any]) -> None:
-        """Open the rule form pre-filled for editing."""
+        """Open the rule form pre-filled for editing.
+
+        Two routes on purpose (task-15778). Mounted (the interactive
+        `EditRuleRequested` path), the plain assignments are the point:
+        `show_rule_form`'s recompose renders the form and
+        `watch_selected_rule` tells the screen. Unmounted (the
+        `_build_detail_pane` factory re-seeding an in-progress edit across
+        a region rebuild), both watchers are `is_mounted`-gated no-ops and
+        `compose()` reads the same reactives, so the plain assignments
+        bought nothing there but a queued `_check_recompose` that tore the
+        freshly mounted pane straight back down -- the pre-mount seeding
+        recompose that task removes.
+
+        Args:
+            rule: The rule row to pre-fill the form with.
+        """
         self._editing_rule_id = str(rule.get("id") or "")
-        self.selected_rule = rule
-        self.show_rule_form = True
+        if self.is_mounted:
+            self.selected_rule = rule
+            self.show_rule_form = True
+            return
+        self.set_reactive(RulesPane.selected_rule, rule)
+        self.set_reactive(RulesPane.show_rule_form, True)

--- a/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/watchlists_workbench.py
@@ -383,18 +383,39 @@ class WatchlistsWorkbench(Horizontal):
         # moved, so the two changes would be applied in the wrong order and
         # the layout half would be done twice.
         self.set_reactive(WatchlistsWorkbench.region_layout, layout)
-        await self._sync_regions(previous_layout)
-        for region in rebuild_regions:
-            if region in self._hidden:
-                continue
-            # A region the sync above just swapped is already built from the
-            # current factory; rebuilding it again would be the second of the
-            # two rebuilds this task exists to remove.
-            if self._region_form_changed(previous_layout, previous_hidden, region):
-                continue
-            await self.refresh_region_content(region)
-        if rebuild_header:
-            await self.refresh_header_content()
+        # One layout/paint pass for the whole section move (task-15778),
+        # as an explicit contract rather than a scheduling accident. The
+        # region sync, the section pane rebuild and the header rebuild
+        # below are each an awaited remove/mount cycle, and every await
+        # between them is in principle a window for the screen's update
+        # timer to paint a half-moved workbench. Measured at HEAD it never
+        # actually does -- the whole sequence runs inside the screen's one
+        # `_drain_surface_refresh` `call_next` callback (task-15461's own
+        # move off `run_worker`), so the pump never goes idle mid-swap and
+        # the paused update timer never resumes: 0 in-swap layout passes
+        # and 0 compositor refreshes with and without this batch, on a
+        # cold Read switch. `batch_update` makes that one-pass property
+        # structural: it survives a future factory that awaits, or the
+        # drain moving off a single callback, instead of depending on
+        # them never happening. It defers repaints only -- it does not
+        # reorder or coalesce the DOM work itself, so the raising-factory
+        # guarantees inside `refresh_region_content`/`_swap_region_widget`
+        # are unchanged.
+        with self.app.batch_update():
+            await self._sync_regions(previous_layout)
+            for region in rebuild_regions:
+                if region in self._hidden:
+                    continue
+                # A region the sync above just swapped is already built from
+                # the current factory; rebuilding it again would be the
+                # second of the two rebuilds this task exists to remove.
+                if self._region_form_changed(
+                    previous_layout, previous_hidden, region
+                ):
+                    continue
+                await self.refresh_region_content(region)
+            if rebuild_header:
+                await self.refresh_header_content()
 
     def _region_form_changed(
         self,


### PR DESCRIPTION
## Summary

Two halves, one honest and one refuted-and-reframed:

**The refutation**: the filed premise — "cold-Read wall clock regressed because the section swap is unbatched" — does not reproduce. A neutered-batch A/B shows 0 in-swap layout passes and 0 compositor refreshes in BOTH arms: task-15461's own `run_worker`→`call_next` change had already made the swap paint-atomic one task before the residual was filed blaming its absence. The review reproduced this with an independently-written probe after reading Textual's `_on_timer_update` gating. `apply_section_view` still gains `App.batch_update()` — shipped as an explicit one-pass CONTRACT that survives future restructuring, documented as unmeasured, not sold as a win. Lessons entry: re-verify a residual's causal hypothesis before implementing its cure.

**The real fix**: pane builders seeded `recompose=True` reactives post-construction, so every section switch paid an immediate rebuild of the just-composed pane. Now seeded via `set_reactive` per a per-pane watcher audit (Artifacts all 20, Sources 3, Overview 2, Rules 2 + the pre-mount edit route, Notifications 2, Runs' `runs` only — `selected_run` stays plain because its watcher is load-bearing: detail ordering + the mid-flight run poll, which the review verified starts unconditionally). Cold-Read: ContentPane recomposes 1→0, mounts 81→69; per-switch recomposes to 0 across panes (Artifacts' remaining 1 is honest post-mount data arrival).

Born-red 13/16 on file-swap + each green-by-design pin redded under its targeted mutation (review spot-checked both kinds); both-config-state batch pin; `Tests/Watchlists/` 688 + UI suites 163 green (review-reproduced exactly).

Review: independent pass → MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches the watchlists section swap and removes the pre‑mount seeding recompose to cut redundant pane rebuilds without changing watcher behavior. Previously, the cold Read swap ran as discrete DOM updates and panes seeded `recompose=True` reactives by plain assignment (triggering an immediate rebuild); now the swap runs inside `App.batch_update` and seeding uses `set_reactive`, yielding 1→0 recomposes per switch (Artifacts 2→1; remaining 1 is real post‑mount data).

- Pane seeding: Overview/Sources/Rules/Notifications convert seeded `recompose=True` reactives to `set_reactive`; Artifacts converts all seeded reactives; Content seeds `item` via `set_reactive`; Article list unchanged (no `recompose=True` reactives).
- Runs pane: keeps non‑`recompose` seeds as plain assignments so `watch_selected_run` still clears detail and starts the poll; preserves detail‑after‑selection order.
- Section swap: `WatchlistsWorkbench.apply_section_view` wraps region sync, pane rebuilds, and header rebuild in `self.app.batch_update()` as a one‑pass contract; behavior matches prior head and is future‑proofed.
- Tests: adds `Tests/Watchlists/test_watchlists_cold_read_swap.py` (batching + zero‑recompose seeding + Runs watcher/order pins) and tightens `test_watchlists_scoped_rebuilds.py` warm revisit to `== 0`; all Watchlists suites green.

Links to TASK-15778:
- ACs met: batched cold Read swap; `set_reactive` pre‑mount seeding (detail and content panes); per‑pane watcher/ordering audit (Runs preserved).

<sup>Written for commit 21455df1d354fd4979a47e67549c08424cfa80f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

