### PR TITLE
fix(research): address Qodo review of the deep-research stack

### DIFF
--- a/Tests/Chat/test_usage_recorder.py
+++ b/Tests/Chat/test_usage_recorder.py
@@ -319,3 +319,32 @@ def test_estimate_ignores_non_text_multimodal_content():
 
     # Base64 payloads must not explode the estimate: only the text part counts.
     assert recorder.prompt_tokens() < 100
+
+
+def test_partial_provider_usage_is_not_marked_exact(monkeypatch):
+    # Only the prompt side reported: the exchange must not count as exact.
+    payload = {
+        "choices": [{"message": {"role": "assistant", "content": "answer"}}],
+        "usage": {"prompt_tokens": 11},  # completion_tokens absent
+    }
+    monkeypatch.setitem(
+        Chat_Functions.API_CALL_HANDLERS, "llama_cpp", _fake_handler(payload)
+    )
+
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": "prompt text"}],
+            api_key=None, temp=0.5, system_message=None, streaming=False,
+            minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert recorder.prompt_tokens() == 11
+    assert recorder.exact_tokens() == 0  # partial report: never exact
+
+
+def test_fully_reported_usage_is_exact():
+    recorder = UsageTokenRecorder()
+    recorder.record_usage(prompt_tokens=5, completion_tokens=7)
+    assert recorder.exact_tokens() == 12
+    assert recorder.total_tokens() == 12

--- a/Tests/Chat/test_usage_recorder.py
+++ b/Tests/Chat/test_usage_recorder.py
@@ -276,3 +276,46 @@ def test_chat_api_call_mixed_usage_keys_prefer_openai_names(monkeypatch):
         )
 
     assert (recorder.prompt_tokens(), recorder.completion_tokens()) == (8, 9)
+
+
+# --- Qodo remediation (task-16789) ------------------------------------------------
+
+def test_estimate_includes_system_message():
+    handler = _fake_handler("answer")
+    Chat_Functions.API_CALL_HANDLERS["llama_cpp"] = handler
+    with usage_scope() as with_system:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": "tiny"}],
+            api_key=None, temp=0.5, system_message="A LONG SYSTEM PROMPT " * 10,
+            streaming=False, minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+    Chat_Functions.API_CALL_HANDLERS["llama_cpp"] = _fake_handler("answer")
+    with usage_scope() as without_system:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": "tiny"}],
+            api_key=None, temp=0.5, system_message=None,
+            streaming=False, minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    assert with_system.prompt_tokens() > without_system.prompt_tokens()
+
+
+def test_estimate_ignores_non_text_multimodal_content():
+    huge_b64 = "data:image/png;base64," + "A" * 100_000
+    handler = _fake_handler("answer")
+    Chat_Functions.API_CALL_HANDLERS["llama_cpp"] = handler
+    with usage_scope() as recorder:
+        chat_api_call(
+            api_endpoint="llama_cpp",
+            messages_payload=[{"role": "user", "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": huge_b64}},
+            ]}],
+            api_key=None, temp=0.5, system_message=None,
+            streaming=False, minp=None, maxp=None, model=None, topk=None, topp=None,
+        )
+
+    # Base64 payloads must not explode the estimate: only the text part counts.
+    assert recorder.prompt_tokens() < 100

--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -347,3 +347,28 @@ def test_arxiv_single_word_queries_stay_unquoted(monkeypatch):
     search_arxiv(query="transformers", client=client)
 
     assert client.request.calls[0]["params"]["search_query"] == "all:transformers"
+
+
+def test_search_papers_runs_providers_concurrently(monkeypatch):
+    import threading
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    arxiv_started = threading.Event()
+    s2_release = threading.Event()
+
+    def blocking_arxiv(**kwargs):
+        arxiv_started.set()
+        assert s2_release.wait(timeout=5), "serial execution would deadlock here"
+        return {"items": []}
+
+    def releasing_s2(**kwargs):
+        s2_release.set()  # proves S2 ran WHILE arxiv was in flight
+        return {"items": []}
+
+    monkeypatch.setattr(ap, "search_arxiv", blocking_arxiv)
+    monkeypatch.setattr(ap, "search_semantic_scholar", releasing_s2)
+
+    papers = ap.search_papers_sync_for_test() if hasattr(ap, "search_papers_sync_for_test") else None
+    import asyncio
+    papers = asyncio.run(ap.search_papers("query"))
+    assert papers == []

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -652,7 +652,8 @@ def test_engine_settles_recorded_usage_into_ledger():
     assert final["status"] == "completed"
     ledger = _artifact_content(service.get_bundle(run["id"]), "budget_ledger.json")
     assert ledger["tokens_settled"] == 40
-    assert ledger["tokens_estimated"] is True
+    # record_usage counts are provider-exact (task-16789): not estimates.
+    assert ledger["tokens_estimated"] is False
 
 
 def test_engine_enforces_max_tokens_between_llm_calls():

--- a/Tests/Research/test_local_research_service.py
+++ b/Tests/Research/test_local_research_service.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 
 from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
@@ -259,3 +261,68 @@ def test_approve_requires_pending_checkpoint(tmp_path):
 
     with pytest.raises(ValueError, match="not pending"):
         service.patch_and_approve_checkpoint(run["id"], checkpoint["id"])
+
+
+# --- external-DB transaction (task-16789) ------------------------------------------
+
+class FakeExternalResearchDB:
+    """Minimal external-DB double: transaction() yields a real sqlite conn
+    (delete_run's precedent interface)."""
+
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.row_factory = sqlite3.Row
+        self.conn.executescript(
+            """
+            CREATE TABLE research_runs (
+                id TEXT PRIMARY KEY, session_id TEXT, query TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'running',
+                phase TEXT NOT NULL DEFAULT 'local_planning',
+                control_state TEXT NOT NULL DEFAULT 'running',
+                progress_percent REAL, progress_message TEXT,
+                source_policy TEXT NOT NULL DEFAULT 'balanced',
+                autonomy_mode TEXT NOT NULL DEFAULT 'checkpointed',
+                limits_json TEXT NOT NULL DEFAULT '{}',
+                provider_overrides_json TEXT NOT NULL DEFAULT '{}',
+                chat_handoff_json TEXT NOT NULL DEFAULT '{}',
+                follow_up_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+                deleted INTEGER NOT NULL DEFAULT 0,
+                client_id TEXT NOT NULL DEFAULT 'local',
+                version INTEGER NOT NULL DEFAULT 1
+            );
+            """
+        )
+
+    def transaction(self):
+        return self.conn
+
+    def get_run(self, run_id):
+        row = self.conn.execute(
+            "SELECT * FROM research_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def close(self):
+        self.conn.close()
+
+
+def test_update_run_progress_external_db_wraps_in_transaction():
+    external = FakeExternalResearchDB()
+    now = "2026-08-16T00:00:00Z"
+    external.conn.execute(
+        "INSERT INTO research_runs (id, query, created_at, updated_at) "
+        "VALUES ('ext-run', 'External question', ?, ?)",
+        (now, now),
+    )
+    service = LocalResearchService(external)  # db object -> external mode
+
+    updated = service.update_run_progress(
+        "ext-run", phase="collecting", progress_percent=45.0,
+        event="progress", data={"phase": "collecting"},
+    )
+
+    assert updated["phase"] == "collecting"
+    assert updated["progress_percent"] == 45.0
+    assert updated["version"] == 2
+    external.close()

--- a/Tests/Research/test_research_budget.py
+++ b/Tests/Research/test_research_budget.py
@@ -100,6 +100,7 @@ def test_snapshot_is_persistable_and_reports_all_axes():
     ledger.reserve_searches(1)
     ledger.settle_searches(2)
     ledger.settle_docs(3)
+    ledger.settle_tokens(5)  # estimate-settled: flag must be True here
 
     snap = ledger.snapshot()
 
@@ -114,7 +115,7 @@ def test_snapshot_is_persistable_and_reports_all_axes():
         "searches_overshoot": 1,
         "docs_used": 3,
         "tokens_reserved": 0,
-        "tokens_settled": 0,
+        "tokens_settled": 5,
         "tokens_estimated": True,
         "runtime_elapsed_s": snap["runtime_elapsed_s"],  # float, asserted below
     }
@@ -158,3 +159,30 @@ def test_snapshot_marks_tokens_as_estimates():
 
     assert ledger.snapshot()["tokens_estimated"] is True
     assert ledger.snapshot()["tokens_settled"] == 20
+
+
+# --- Qodo remediation (task-16789) ------------------------------------------------
+
+def test_allot_docs_zero_batch_returns_zero_even_with_exhausted_budget():
+    ledger = BudgetLedger.from_limits({"max_fetched_docs": 0})
+
+    assert ledger.allot_docs(0) == 0  # nothing to process: no budget failure
+
+
+def test_tokens_estimated_reflects_exactness_of_settled_usage():
+    ledger = BudgetLedger.from_limits({"max_tokens": 1000})
+    ledger.settle_tokens(10, exact=True)
+    assert ledger.snapshot()["tokens_estimated"] is False
+
+    ledger.settle_tokens(10)  # estimate-settled
+    assert ledger.snapshot()["tokens_estimated"] is True
+
+
+def test_release_searches_returns_unused_reservations():
+    ledger = BudgetLedger.from_limits({"max_searches": 3})
+
+    ledger.reserve_searches(3)
+    ledger.release_searches(2)  # fan-out stopped early: 2 never executed
+    ledger.settle_searches(1)
+
+    assert ledger.remaining_searches() == 2

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -706,3 +706,17 @@ async def test_auto_refresh_skips_terminal_and_non_local():
     window.current_source = "server"  # server source: not our engine
     await window._auto_refresh_selected_run()
     assert calls["n"] == 0
+
+
+# --- Qodo remediation (task-16789) ------------------------------------------------
+
+def test_academic_lane_default_parses_string_booleans(monkeypatch):
+    from tldw_chatbook.UI.Research_Window import _parse_config_bool
+
+    for raw, expected in [
+        ("false", False), ("False", False), ("0", False), ("no", False),
+        ("off", False), ("", False),
+        ("true", True), ("True", True), ("1", True), ("yes", True), ("on", True),
+        (True, True), (False, False),
+    ]:
+        assert _parse_config_bool(raw) is expected, f"{raw!r} should parse {expected}"

--- a/Tests/Web_Scraping/test_deep_search_citations.py
+++ b/Tests/Web_Scraping/test_deep_search_citations.py
@@ -342,3 +342,10 @@ def test_verify_claims_carry_per_sentence_quote_verdicts():
 def test_verify_claims_skip_uncited_sentences():
     out = verify_citations("Cited[1]. Uncited sentence.", _EVIDENCE)
     assert [c["text"] for c in out["claims"]] == ["Cited[1]."]
+
+
+# --- Qodo remediation (task-16789) ------------------------------------------------
+
+def test_unknown_marker_sentence_is_not_counted_uncited():
+    out = verify_citations("Cited sentence[1]. Unknown citation attempt[99].", _EVIDENCE)
+    assert out["uncited_sentences"] == 0  # both sentences ATTEMPTED citations

--- a/backlog/tasks/task-16789 - Address-Qodo-review-of-the-deep-research-stack.md
+++ b/backlog/tasks/task-16789 - Address-Qodo-review-of-the-deep-research-stack.md
@@ -1,0 +1,33 @@
+---
+id: TASK-16789
+title: Address Qodo review of the deep-research stack
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 04:39'
+updated_date: '2026-08-16 04:47'
+labels:
+  - research
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Qodo reviewed the merged deep-research stack (PRs 1707/1708/1670) and filed 8 bugs and 4 rule violations across them: zero-doc batch raises, estimate path omitting system_message and over-counting multimodal payloads, worker-side _set_status mutation, unknown-citation sentences counted uncited, search reservations never released when fan-out stops early, serial paper search, truthy-string config cast for the academic toggle, tokens_estimated always true, plus docstring/import-order/transaction-compliance findings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 allot_docs(0) returns 0 even with an exhausted budget,Estimated prompt tokens include the system message and do not explode on list-shaped (multimodal) message content,Status updates from the engine worker dispatch through the UI message pump rather than mutating widgets directly,uncited_sentences is computed on the original answer so unknown-marker sentences are not miscounted as uncited,Unused search reservations are released when the pipeline stops fan-out early so budgets reflect executed searches,Paper search runs both providers concurrently with per-provider degradation preserved,String config values parse as booleans correctly for the academic toggle default,tokens_estimated reflects whether settled usage was exact or estimated,update_run_progress external-DB branch follows the service transaction pattern,Docstring and import-order findings fixed,Tests cover each behavioral fix
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- **Bugs fixed**: (1) `allot_docs(0)` returns 0 on an exhausted budget (nothing to process consumes nothing). (2) Estimated prompt tokens now include `system_message` via `_estimate_prompt_text`, which also takes only text parts of list-shaped multimodal content so base64 payloads cannot explode estimates. (3) Engine-worker status errors dispatch via `call_later` (UI message pump) instead of direct widget mutation. (4) `uncited_sentences` computed on the ORIGINAL answer, so unknown-marker sentences (`[n?]` in the annotated form) are no longer miscounted as uncited. (5) `_collect_round` settles EXECUTED searches (parsing the pipeline's "searched N of M queries" early-stop warning) and `release_searches()` returns unused reservations, so early fan-out stops no longer exhaust `max_searches` prematurely. (6) `search_papers` runs both providers via `asyncio.gather` (per-provider degradation preserved inside each lane). (7) `_parse_config_bool` handles string config values for the academic toggle ("false"/"0"/"no"/"off" are False). (8) `tokens_estimated` reflects reality: `UsageTokenRecorder` splits exact (`record_usage`) vs estimated (`record_exchange`) counts, the engine settles with `exact=`, and the snapshot flag is true only when settled usage includes estimates.
+- **Rules fixed**: `update_run_progress`'s external-DB branch now follows delete_run's `transaction()` + raw-statement precedent (with version bump, fake-external-DB test); Google-style docstrings added to `match_quote_in_sources`, `execute_run`, `record_usage`, `resolve_semantic_scholar_api_key`, and ResearchScreen's `compose_content`/`save_state`/`restore_state`; the WebSearch_APIs import block re-sorted (ruff isort).
+- Two behavioral pins updated to the corrected semantics (record_usage counts are exact -> `tokens_estimated` False; snapshot test settles estimate tokens so its flag stays True).
+- Verified TDD: 9 new tests (zero-doc allot, exactness flag, reservation release, unknown-marker uncited, system-message estimate, multimodal cap, string-bool parse, provider concurrency via deadlock-proof events, external-DB transaction) all written first and watched failing; full remediation sweep 303 passed; ruff clean.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -1013,8 +1013,8 @@ def chat_api_call(
                             usage_prompt is not None or usage_completion is not None
                         ):
                             recorder.record_usage(
-                                prompt_tokens=usage_prompt or 0,
-                                completion_tokens=usage_completion or 0,
+                                prompt_tokens=usage_prompt,
+                                completion_tokens=usage_completion,
                             )
                         elif recorder is not None:
                             recorder.record_exchange(

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -1018,10 +1018,8 @@ def chat_api_call(
                             )
                         elif recorder is not None:
                             recorder.record_exchange(
-                                prompt_text="\n".join(
-                                    str(message.get("content") or "")
-                                    for message in (messages_payload or [])
-                                    if isinstance(message, dict)
+                                prompt_text=_estimate_prompt_text(
+                                    messages_payload, system_message
                                 ),
                                 completion_text=content,
                             )
@@ -1042,10 +1040,8 @@ def chat_api_call(
                 recorder = active_recorder()
                 if recorder is not None:
                     recorder.record_exchange(
-                        prompt_text="\n".join(
-                            str(message.get("content") or "")
-                            for message in (messages_payload or [])
-                            if isinstance(message, dict)
+                        prompt_text=_estimate_prompt_text(
+                            messages_payload, system_message
                         ),
                         completion_text=response,
                     )
@@ -1192,6 +1188,31 @@ def chat_api_call(
             ),
             status_code=500,
         )
+
+
+def _estimate_prompt_text(
+    messages_payload: Any, system_message: Optional[str]
+) -> str:
+    """Text used for ESTIMATED prompt tokens (task-16789): the system
+    message is part of the prompt and must count; multimodal content lists
+    contribute only their text parts so base64 image payloads cannot
+    explode the estimate."""
+    parts: list = []
+    if system_message:
+        parts.append(str(system_message))
+    for message in messages_payload or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            parts.extend(
+                str(item.get("text") or "")
+                for item in content
+                if isinstance(item, dict) and item.get("type") == "text"
+            )
+    return "\n".join(part for part in parts if part)
 
 
 def chat_reply_text(response: Any) -> str:

--- a/tldw_chatbook/Chat/usage_recorder.py
+++ b/tldw_chatbook/Chat/usage_recorder.py
@@ -49,19 +49,34 @@ class UsageTokenRecorder:
         self._completion_tokens = 0
         self._exact_tokens = 0
 
-    def record_usage(self, *, prompt_tokens: int, completion_tokens: int) -> None:
+    def record_usage(
+        self,
+        *,
+        prompt_tokens: int | None,
+        completion_tokens: int | None,
+    ) -> None:
         """Record exact, provider-reported counts.
 
         Args:
-            prompt_tokens: Exact prompt tokens reported by the provider.
+            prompt_tokens: Exact prompt tokens reported by the provider;
+                ``None`` when the provider did not report that side (the
+                missing side stays uncounted rather than zero-filled, so
+                partial reports never masquerade as exact totals).
             completion_tokens: Exact completion tokens reported by the
-                provider.
+                provider; ``None`` when unreported.
         """
-        self._prompt_tokens += max(0, int(prompt_tokens))
-        self._completion_tokens += max(0, int(completion_tokens))
-        self._exact_tokens += max(0, int(prompt_tokens)) + max(
-            0, int(completion_tokens)
-        )
+        # A PARTIAL report (one side unreported) is not exact: the settled
+        # total is incomplete, so it must not flip the ledger's
+        # tokens_estimated flag (task-16789 follow-up).
+        both_reported = prompt_tokens is not None and completion_tokens is not None
+        if prompt_tokens is not None:
+            self._prompt_tokens += max(0, int(prompt_tokens))
+        if completion_tokens is not None:
+            self._completion_tokens += max(0, int(completion_tokens))
+        if both_reported:
+            self._exact_tokens += max(0, int(prompt_tokens)) + max(
+                0, int(completion_tokens)
+            )
 
     def record_exchange(self, *, prompt_text: str, completion_text: str) -> None:
         """Record one non-streaming exchange by estimating both sides."""
@@ -81,7 +96,11 @@ class UsageTokenRecorder:
 
     def exact_tokens(self) -> int:
         """Settled tokens that came from provider-reported usage (not
-        estimates) -- drives the ledger's tokens_estimated flag."""
+        estimates) -- drives the ledger's tokens_estimated flag.
+
+        Returns:
+            The token count settled through ``record_usage`` so far.
+        """
         return self._exact_tokens
 
 

--- a/tldw_chatbook/Chat/usage_recorder.py
+++ b/tldw_chatbook/Chat/usage_recorder.py
@@ -47,12 +47,21 @@ class UsageTokenRecorder:
     def __init__(self) -> None:
         self._prompt_tokens = 0
         self._completion_tokens = 0
+        self._exact_tokens = 0
 
     def record_usage(self, *, prompt_tokens: int, completion_tokens: int) -> None:
-        """Record exact counts (the real-usage path for future provider
-        plumbing)."""
+        """Record exact, provider-reported counts.
+
+        Args:
+            prompt_tokens: Exact prompt tokens reported by the provider.
+            completion_tokens: Exact completion tokens reported by the
+                provider.
+        """
         self._prompt_tokens += max(0, int(prompt_tokens))
         self._completion_tokens += max(0, int(completion_tokens))
+        self._exact_tokens += max(0, int(prompt_tokens)) + max(
+            0, int(completion_tokens)
+        )
 
     def record_exchange(self, *, prompt_text: str, completion_text: str) -> None:
         """Record one non-streaming exchange by estimating both sides."""
@@ -69,6 +78,11 @@ class UsageTokenRecorder:
 
     def total_tokens(self) -> int:
         return self._prompt_tokens + self._completion_tokens
+
+    def exact_tokens(self) -> int:
+        """Settled tokens that came from provider-reported usage (not
+        estimates) -- drives the ledger's tokens_estimated flag."""
+        return self._exact_tokens
 
 
 def active_recorder() -> Optional[UsageTokenRecorder]:

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -122,6 +122,29 @@ VALID_TABLES = {
 
 # Define valid columns for each table (for most commonly used tables)
 VALID_COLUMNS = {
+    # Research interop DB (task-16789: registered so engine-controlled
+    # UPDATE columns can be schema-validated rather than trusted)
+    "research_runs": {
+        "id",
+        "session_id",
+        "query",
+        "status",
+        "phase",
+        "control_state",
+        "progress_percent",
+        "progress_message",
+        "source_policy",
+        "autonomy_mode",
+        "limits_json",
+        "provider_overrides_json",
+        "chat_handoff_json",
+        "follow_up_json",
+        "created_at",
+        "updated_at",
+        "deleted",
+        "client_id",
+        "version",
+    },
     # ChaChaNotes DB
     "character_cards": {
         "id",

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -234,8 +234,12 @@ def search_arxiv(
 
 
 def resolve_semantic_scholar_api_key() -> str | None:
-    """Env var wins, then the ``[API] semantic_scholar_api_key`` config slot
-    (house precedence: env -> config.toml)."""
+    """Resolve the Semantic Scholar API key (house precedence).
+
+    Returns:
+        The key from the ``SEMANTIC_SCHOLAR_API_KEY`` env var when set, else
+        the ``[API] semantic_scholar_api_key`` config slot, else ``None``.
+    """
     env_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
     if env_key:
         return env_key
@@ -445,6 +449,7 @@ async def search_papers(
     nothing while the other still returns; only total failure raises (the
     engine lane turns that into a warning, never a run failure).
     """
+    import asyncio
     from asyncio import to_thread
 
     failures: list[str] = []
@@ -463,28 +468,39 @@ async def search_papers(
                 seen_dois.add(doi)
             papers.append(item)
 
-    try:
-        arxiv_out = await to_thread(
-            search_arxiv, query=topic_query, results_per_page=results_per_page
-        )
-        _collect(arxiv_out.get("items") or [])
-    except AcademicProviderError as exc:
-        failures.append(f"arxiv: {exc}")
-        logger.warning(f"search_papers arxiv lane failed: {exc}")
+    async def _arxiv_lane() -> Any:
+        try:
+            return await to_thread(
+                search_arxiv, query=topic_query, results_per_page=results_per_page
+            )
+        except AcademicProviderError as exc:
+            failures.append(f"arxiv: {exc}")
+            logger.warning(f"search_papers arxiv lane failed: {exc}")
+            return None
 
-    try:
-        s2_out = await to_thread(
-            search_semantic_scholar,
-            query=topic_query,
-            results_per_page=results_per_page,
-            api_key=semantic_scholar_api_key
-            if semantic_scholar_api_key is not None
-            else resolve_semantic_scholar_api_key(),
-        )
+    async def _s2_lane() -> Any:
+        try:
+            return await to_thread(
+                search_semantic_scholar,
+                query=topic_query,
+                results_per_page=results_per_page,
+                api_key=semantic_scholar_api_key
+                if semantic_scholar_api_key is not None
+                else resolve_semantic_scholar_api_key(),
+            )
+        except AcademicProviderError as exc:
+            failures.append(f"semantic_scholar: {exc}")
+            logger.warning(f"search_papers semantic scholar lane failed: {exc}")
+            return None
+
+    # task-16789: both providers run CONCURRENTLY (serial execution added
+    # avoidable latency, especially under timeouts/retries); per-provider
+    # degradation is preserved inside each lane.
+    arxiv_out, s2_out = await asyncio.gather(_arxiv_lane(), _s2_lane())
+    if arxiv_out is not None:
+        _collect(arxiv_out.get("items") or [])
+    if s2_out is not None:
         _collect(s2_out.get("items") or [])
-    except AcademicProviderError as exc:
-        failures.append(f"semantic_scholar: {exc}")
-        logger.warning(f"search_papers semantic scholar lane failed: {exc}")
 
     if not papers and failures:
         raise AcademicProviderError(

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import re
 from typing import Any, Awaitable, Callable
 
 from loguru import logger
@@ -181,7 +182,13 @@ class LocalResearchEngine:
         with usage_scope() as recorder:
             result = await self._maybe_await(make_call())
         if ledger is not None:
-            ledger.settle_tokens(recorder.total_tokens())
+            # Exact when every settled token came from provider-reported
+            # usage rather than the estimate path (task-16789).
+            ledger.settle_tokens(
+                recorder.total_tokens(),
+                exact=recorder.total_tokens() > 0
+                and recorder.exact_tokens() == recorder.total_tokens(),
+            )
         return result
 
     def _get_run(self, run_id: str) -> dict[str, Any]:
@@ -241,8 +248,16 @@ class LocalResearchEngine:
     async def execute_run(self, run_id: str) -> dict[str, Any]:
         """Run the full phase machine for ``run_id`` to a terminal state.
 
-        Returns the final run record. Raises ``ValueError`` for a missing or
-        already-terminal run (execution must not resurrect state).
+        Args:
+            run_id: The run to execute.
+
+        Returns:
+            The final run record (terminal, paused, awaiting review, or the
+            pre-pause record for control stops).
+
+        Raises:
+            ValueError: If the run does not exist or is already terminal
+                (execution must not resurrect state).
         """
         run = self._get_run(run_id)
         status = str(run.get("status") or "")
@@ -304,6 +319,7 @@ class LocalResearchEngine:
                     0.0, ledger.max_runtime_seconds - ledger.elapsed_seconds()
                 )
             remaining = ledger.remaining_searches()
+            reserved_for_call = 0
             if remaining is not None:
                 cap = min(
                     int(params.get("search_default_max_queries", 5) or 5),
@@ -311,6 +327,7 @@ class LocalResearchEngine:
                 )
                 params["search_default_max_queries"] = cap
                 ledger.reserve_searches(cap)
+                reserved_for_call = cap
             outcome = await self._llm_bounded_call(lambda: self.search_fn(query, params))
             if isinstance(outcome, tuple) and len(outcome) == 2:
                 wsr, sqd = outcome
@@ -322,7 +339,20 @@ class LocalResearchEngine:
             sub_questions.extend(call_sub_questions)
             collected.extend(r for r in (wsr or {}).get("results") or [] if isinstance(r, dict))
             warnings.extend(w for w in (wsr or {}).get("warnings") or [])
-            ledger.settle_searches(1 + len(call_sub_questions))
+            # task-16789: settle EXECUTED searches, not the reserved cap --
+            # the pipeline can stop its fan-out early (phase-1 deadline), and
+            # reservations for never-executed searches must be released or
+            # the budget exhausts prematurely. The pipeline's own warning
+            # reports the executed count when it stopped early.
+            executed_searches = 1 + len(call_sub_questions)
+            for warning in (wsr or {}).get("warnings") or []:
+                stopped = re.search(r"searched (\d+) of (\d+) queries", str(warning))
+                if stopped:
+                    executed_searches = int(stopped.group(1))
+                    break
+            ledger.settle_searches(executed_searches)
+            if reserved_for_call > executed_searches:
+                ledger.release_searches(reserved_for_call - executed_searches)
         return collected, sub_questions, warnings
 
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -843,6 +843,9 @@ class LocalResearchService:
         notifications because it never sets a terminal status.
         """
         if self._uses_external_db:
+            # delete_run's precedent (task-16789): raw statement inside the
+            # db's own transaction() context, per the standardized
+            # transaction-handling rule.
             fields: dict[str, Any] = {}
             if phase is not None:
                 fields["phase"] = phase
@@ -854,7 +857,16 @@ class LocalResearchService:
                 fields["status"] = status
             if control_state is not None:
                 fields["control_state"] = control_state
-            return self._as_local_run(self.db.update_run_state(run_id, **fields))
+            if not fields:
+                return self._as_local_run(self.db.get_run(run_id))
+            assignments = ", ".join(f"{key} = ?" for key in fields)
+            with self.db.transaction() as conn:
+                conn.execute(
+                    f"UPDATE research_runs SET {assignments}, "
+                    "updated_at = ?, version = version + 1 WHERE id = ?",
+                    (*fields.values(), self._now(), run_id),
+                )
+            return self._as_local_run(self.db.get_run(run_id))
         fields = {
             key: value
             for key, value in (

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -677,6 +677,16 @@ class LocalResearchService:
             fields["progress_message"] = error_msg
         return self._update_run_state(run_id, "failed", **fields)
 
+    # Hardcoded assignment fragments for update_run_progress's external-DB
+    # branch (task-16789): the ONLY source of SQL text for those columns.
+    _RUN_PROGRESS_FIELD_SQL = {
+        "phase": "phase = ?",
+        "progress_percent": "progress_percent = ?",
+        "progress_message": "progress_message = ?",
+        "status": "status = ?",
+        "control_state": "control_state = ?",
+    }
+
     # Patch keys allowed per checkpoint type (task-16482; server
     # checkpoint_service parity, scoped to the local engine's phases).
     _CHECKPOINT_PATCH_KEYS = {
@@ -859,20 +869,23 @@ class LocalResearchService:
                 fields["control_state"] = control_state
             if not fields:
                 return self._as_local_run(self.db.get_run(run_id))
-            # Column names are engine-controlled, but the house rule is
-            # explicit: SQL identifiers are validated, not trusted (even
-            # hardcoded ones -- cheap insurance against future field
-            # additions drifting past the whitelist).
-            from ..DB.sql_validation import validate_column_name
-
-            for key in fields:
-                if not validate_column_name(key, "research_runs"):
-                    raise ValueError(f"invalid research_runs column: {key!r}")
-            assignments = ", ".join(f"{key} = ?" for key in fields)
+            # SQL is never built from variable text: each field maps to a
+            # HARDCODED literal assignment fragment, field names only select
+            # among the literals, and every value stays parameterized
+            # (house rule: no SQL via string interpolation of identifiers).
+            try:
+                assignments = ", ".join(
+                    self._RUN_PROGRESS_FIELD_SQL[key] for key in fields
+                )
+            except KeyError as exc:
+                raise ValueError(
+                    f"unsupported run-progress column: {exc.args[0]!r}"
+                ) from exc
             with self.db.transaction() as conn:
                 conn.execute(
-                    f"UPDATE research_runs SET {assignments}, "
-                    "updated_at = ?, version = version + 1 WHERE id = ?",
+                    "UPDATE research_runs SET "
+                    + assignments
+                    + ", updated_at = ?, version = version + 1 WHERE id = ?",
                     (*fields.values(), self._now(), run_id),
                 )
             return self._as_local_run(self.db.get_run(run_id))

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -859,6 +859,15 @@ class LocalResearchService:
                 fields["control_state"] = control_state
             if not fields:
                 return self._as_local_run(self.db.get_run(run_id))
+            # Column names are engine-controlled, but the house rule is
+            # explicit: SQL identifiers are validated, not trusted (even
+            # hardcoded ones -- cheap insurance against future field
+            # additions drifting past the whitelist).
+            from ..DB.sql_validation import validate_column_name
+
+            for key in fields:
+                if not validate_column_name(key, "research_runs"):
+                    raise ValueError(f"invalid research_runs column: {key!r}")
             assignments = ", ".join(f"{key} = ?" for key in fields)
             with self.db.transaction() as conn:
                 conn.execute(

--- a/tldw_chatbook/Research_Interop/research_budget.py
+++ b/tldw_chatbook/Research_Interop/research_budget.py
@@ -70,6 +70,7 @@ class BudgetLedger:
         self.docs_used = 0
         self.tokens_reserved = 0
         self.tokens_settled = 0
+        self.tokens_settled_exact = 0
         self._start_monotonic = time.monotonic()
 
     @classmethod
@@ -96,6 +97,12 @@ class BudgetLedger:
             )
         self.searches_reserved += max(0, int(count))
 
+    def release_searches(self, count: int) -> None:
+        """Return unused reservations (task-16789): when the pipeline stops
+        its fan-out early (e.g. the phase-1 deadline), reserved-but-never-
+        executed searches must not keep counting against the budget."""
+        self.searches_reserved -= min(max(0, int(count)), self.searches_reserved)
+
     def settle_searches(self, count: int) -> None:
         count = max(0, int(count))
         # Overshoot is measured against RESERVATIONS (mole semantics:
@@ -116,15 +123,20 @@ class BudgetLedger:
     def allot_docs(self, count: int) -> int:
         """Cap a batch of fetched docs at the remaining budget (the cap
         happens BEFORE the docs are processed onward); a zero remaining
-        budget is an exhaustion error, not a silent empty batch."""
+        budget is an exhaustion error, not a silent empty batch -- unless
+        the batch itself is empty, which consumes no budget (task-16789:
+        ``allot_docs(0)`` must return 0 even on an exhausted budget)."""
+        count = int(count)
+        if count <= 0:
+            return 0
         remaining = self.remaining_docs()
         if remaining is not None:
             if remaining == 0:
                 raise ResearchLimitExceeded(
                     "max_fetched_docs", "fetched-doc budget is exhausted"
                 )
-            return min(int(count), remaining)
-        return int(count)
+            return min(count, remaining)
+        return count
 
     def settle_docs(self, count: int) -> None:
         self.docs_used += max(0, int(count))
@@ -143,8 +155,14 @@ class BudgetLedger:
             )
         self.tokens_reserved += max(0, int(count))
 
-    def settle_tokens(self, count: int) -> None:
-        self.tokens_settled += max(0, int(count))
+    def settle_tokens(self, count: int, *, exact: bool = False) -> None:
+        """Record settled token usage; ``exact`` marks whether the counts
+        came from provider-reported usage rather than estimates
+        (task-16789: the snapshot flag must reflect reality)."""
+        count = max(0, int(count))
+        self.tokens_settled += count
+        if exact:
+            self.tokens_settled_exact += count
 
     def check_tokens(self) -> None:
         """Raise when settled token usage has reached the budget (checked
@@ -189,8 +207,8 @@ class BudgetLedger:
             "docs_used": self.docs_used,
             "tokens_reserved": self.tokens_reserved,
             "tokens_settled": self.tokens_settled,
-            # Estimates from the chat_api_call seam until providers expose
-            # real usage (task-16329); the flag keeps the numbers honest.
-            "tokens_estimated": True,
+            # True when any settled usage was estimated rather than
+            # provider-reported (task-16789).
+            "tokens_estimated": self.tokens_settled_exact < self.tokens_settled,
             "runtime_elapsed_s": round(self.elapsed_seconds(), 3),
         }

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -53,6 +53,17 @@ def _parse_limits_text(text: str | None) -> tuple[dict[str, float], list[str]]:
     return limits, warnings
 
 
+def _parse_config_bool(value: Any) -> bool:
+    """Parse a config bool that may arrive as an actual bool or a string
+    (task-16789: ``bool("false")`` is True -- truthy strings must not
+    enable the network-costing lane)."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value or "").strip().lower() in {"true", "1", "yes", "on"}
+
+
 def _academic_lane_default() -> bool:
     """Config default for the academic lane toggle: [SearchSettings]
     research_academic_lane (default False). Failures default OFF -- the
@@ -60,7 +71,9 @@ def _academic_lane_default() -> bool:
     try:
         from tldw_chatbook.config import get_cli_setting
 
-        return bool(get_cli_setting("SearchSettings", "research_academic_lane", False))
+        return _parse_config_bool(
+            get_cli_setting("SearchSettings", "research_academic_lane", False)
+        )
     except Exception:
         return False
 
@@ -326,7 +339,13 @@ class ResearchWindow(Vertical):
             try:
                 await engine.execute_run(run_id)
             except Exception as exc:  # noqa: BLE001 - worker must not crash the app
-                self._set_status(f"Local research engine error: {exc}")
+                # task-16789: dispatch through the UI message pump rather
+                # than mutating widgets from worker context (async workers
+                # run on the loop, but deferring is correct for either).
+                try:
+                    self.call_later(self._set_status, f"Local research engine error: {exc}")
+                except Exception:
+                    self._set_status(f"Local research engine error: {exc}")
 
         if self.is_mounted:
             self.run_worker(

--- a/tldw_chatbook/UI/Screens/research_screen.py
+++ b/tldw_chatbook/UI/Screens/research_screen.py
@@ -23,6 +23,8 @@ class ResearchScreen(BaseAppScreen):
         self._pending_restore_state: Dict[str, Any] | None = None
 
     def compose_content(self) -> ComposeResult:
+        """Compose the screen's content: the ResearchWindow plus any pending
+        state restoration."""
         self.research_window = ResearchWindow(
             self.app_instance,
             id="research-window",
@@ -34,6 +36,12 @@ class ResearchScreen(BaseAppScreen):
         yield self.research_window
 
     def save_state(self) -> Dict[str, Any]:
+        """Persist the hosted window's state for navigation restore.
+
+        Returns:
+            The window's save-state dict, or the pending restore state when
+            the window has not been composed yet.
+        """
         try:
             window = self.query_one("#research-window", ResearchWindow)
         except Exception:
@@ -43,6 +51,12 @@ class ResearchScreen(BaseAppScreen):
         return window.save_state()
 
     def restore_state(self, state: Dict[str, Any]) -> None:
+        """Restore the hosted window's state after navigation.
+
+        Args:
+            state: The state dict previously returned by ``save_state``;
+                deferred until compose when the window is not mounted yet.
+        """
         try:
             window = self.query_one("#research-window", ResearchWindow)
         except Exception:

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -41,13 +41,14 @@ import asyncio
 import base64
 import concurrent.futures
 import json
-from html import unescape
 import random
 import re
 import threading
 import time
-from typing import Optional, Dict, Any, List, Union, Callable, TypedDict, NotRequired
-from urllib.parse import urlparse, urlencode, unquote
+from functools import wraps
+from html import unescape
+from typing import Any, Callable, Dict, List, NotRequired, Optional, TypedDict, Union
+from urllib.parse import unquote, urlencode, urlparse
 
 #
 # 3rd-Party Imports
@@ -55,7 +56,6 @@ import requests
 from requests import RequestException
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
-from functools import wraps
 
 # Handle optional lxml dependency
 try:
@@ -70,12 +70,6 @@ except ImportError:
 
 #
 # Local Imports
-from tldw_chatbook.Web_Scraping.Article_Extractor_Lib import scrape_article
-from tldw_chatbook.Web_Scraping import deep_search_citations
-from tldw_chatbook.Chat.Chat_Functions import chat_api_call, chat_reply_text
-from tldw_chatbook.Internal_Prompts import render_internal_prompt
-from tldw_chatbook.Utils.egress import is_public_http_url
-
 # `analyze` (LLM_Calls.Summarization_General_Lib) pulls in the summarization
 # stack (nltk/scipy/sklearn/pandas via Chunking/Chunk_Lib). It is imported
 # lazily inside search_result_relevance(), only when actually summarizing a
@@ -83,8 +77,14 @@ from tldw_chatbook.Utils.egress import is_public_http_url
 # load it (this module sits on the app.py -> Tools -> WebSearch_APIs boot
 # path via the tool-executor registry).
 from loguru import logger
-from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call, chat_reply_text
 from tldw_chatbook.config import load_settings
+from tldw_chatbook.Internal_Prompts import render_internal_prompt
+from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
+from tldw_chatbook.Utils.egress import is_public_http_url
+from tldw_chatbook.Web_Scraping import deep_search_citations
+from tldw_chatbook.Web_Scraping.Article_Extractor_Lib import scrape_article
 
 # Handle optional defusedxml (Yandex XML parsing)
 try:
@@ -1315,7 +1315,9 @@ async def search_result_relevance(
                         # lazily here (chatbook precedent, see module docstring)
                         # so a plain import of this module doesn't eagerly pull in
                         # the summarization stack.
-                        from tldw_chatbook.LLM_Calls.Summarization_General_Lib import analyze
+                        from tldw_chatbook.LLM_Calls.Summarization_General_Lib import (
+                            analyze,
+                        )
 
                         logger.info(f"Summarizing relevant result: ID={result_id}")
 
@@ -1706,7 +1708,9 @@ def aggregate_results(
         # is explicitly told to preserve "[n]" citation markers verbatim so
         # the citation-integrity fix (adaptation 4) survives this reduce step.
         # `analyze` is imported lazily (chatbook precedent, see module docstring).
-        from tldw_chatbook.LLM_Calls.Summarization_General_Lib import analyze as _analyze
+        from tldw_chatbook.LLM_Calls.Summarization_General_Lib import (
+            analyze as _analyze,
+        )
 
         summarized_chunks: List[str] = []
         for info in chunk_infos:

--- a/tldw_chatbook/Web_Scraping/deep_search_citations.py
+++ b/tldw_chatbook/Web_Scraping/deep_search_citations.py
@@ -93,8 +93,15 @@ def match_quote_in_sources(quote: str, source_texts: Sequence[str]) -> Dict[str,
     """Match one quoted span against source texts with the verbatim-first
     ladder: exact substring, then normalized containment, then bounded fuzzy.
 
-    Returns ``{"matched": bool, "level": "exact"|"normalized"|"fuzzy"|None,
-    "source_index": int|None}`` (index into ``source_texts``, 0-based).
+    Args:
+        quote: The quoted span from the answer text.
+        source_texts: Candidate source texts (raw scrapes first, then LLM
+            summaries), searched in order.
+
+    Returns:
+        Dict with ``matched`` (bool), ``level`` (``"exact"``,
+        ``"normalized"``, ``"fuzzy"``, or ``None`` when unmatched), and
+        ``source_index`` (0-based index into ``source_texts``, or ``None``).
     """
     quote = (quote or "").strip()
     if not quote:
@@ -185,8 +192,16 @@ def verify_citations(
         if match_quote_in_sources(span, source_texts)["matched"]:
             quotes_verified += 1
 
-    sentences = [s for s in _SENTENCE_SPLIT_RE.split(annotated) if s.strip()]
-    uncited_sentences = sum(1 for s in sentences if not CITATION_MARKER_RE.search(s))
+    # Uncited counting runs on the ORIGINAL answer (task-16789): the
+    # annotated form rewrites unknown markers to "[n?]", which the numeric
+    # marker regex cannot see -- those sentences ATTEMPTED citations and
+    # must not be miscounted as uncited.
+    original_sentences = [
+        s for s in _SENTENCE_SPLIT_RE.split(answer_text) if s.strip()
+    ]
+    uncited_sentences = sum(
+        1 for s in original_sentences if not CITATION_MARKER_RE.search(s)
+    )
 
     # Per-claim detail (task-16325): every sentence carrying at least one
     # citation marker becomes a claim record -- resolved source ids, unknown


### PR DESCRIPTION
## Summary

Remediation for Qodo's code review of the merged deep-research stack (PRs #1707 / #1708 / #1670): all 8 bugs and 4 rule violations, each with a regression test written first.

### Bugs
1. **Zero-doc batch raises** — `allot_docs(0)` on an exhausted budget returned an error; empty batches now consume nothing.
2. **Prompt estimate under/over-count** — estimated tokens now include `system_message`, and multimodal list content contributes text parts only (base64 image payloads can no longer explode `max_tokens` estimates).
3. **Worker-side widget mutation** — engine-worker status errors dispatch through `call_later` (UI message pump) per the thread-safety rule.
4. **Unknown citations counted uncited** — `uncited_sentences` is computed on the original answer, so `[n?]`-flagged sentences count as attempted citations, not uncited.
5. **Search budget overcharge** — early fan-out stops (phase-1 deadline) now settle the EXECUTED search count (parsed from the pipeline's own warning) and release unused reservations.
6. **Serial paper search** — arXiv + Semantic Scholar run concurrently via `gather`; per-provider degradation preserved (deadlock-proof regression test).
7. **Config bool cast trap** — `bool("false")` no longer enables the academic lane; string values parse properly.
8. **`tokens_estimated` always true** — the recorder splits exact (provider-reported) vs estimated counts; the ledger flag now reflects settled reality.

### Rule violations
- `update_run_progress` external-DB branch follows `delete_run`'s `transaction()` + raw-statement precedent (version bump, fake-DB test).
- Google-style docstrings on the flagged public callables (`match_quote_in_sources`, `execute_run`, `record_usage`, `resolve_semantic_scholar_api_key`, ResearchScreen methods).
- WebSearch_APIs import block re-sorted (ruff isort).

## Test evidence
9 new TDD tests; full remediation sweep 303 passed across Research, Research_Interop, Web_Scraping, Tools, usage-recorder, window, and scorer suites; ruff clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses Qodo’s review of the deep-research stack (task-16789) by fixing eight bugs, resolving four rule violations, and tightening follow-ups: partial provider usage no longer counts as exact, and external-DB progress updates use hardcoded SQL fragments inside a transaction. This aligns token accounting, search budgeting, citations, provider concurrency, UI thread safety, and config parsing.

- Old vs new behavior: `allot_docs(0)` on an exhausted budget raised; now returns 0 and consumes nothing. Prompt token estimates ignored `system_message` and counted base64 multimodal payloads; now include `system_message` and only text parts. Worker mutated UI widgets directly on errors; now dispatches via `call_later`. Unknown citation markers were counted uncited; now count uncited on the original answer so “[n?]” are attempted citations. Search budgeting settled the reserved cap and kept unused reservations; now settles executed searches (parsed from pipeline warnings) and releases unused reservations. Paper search ran arXiv then Semantic Scholar serially; now runs both concurrently while preserving per-provider degradation. String booleans enabled the academic lane; now parse correctly. `tokens_estimated` was always true; now the recorder splits exact vs estimated and the engine settles with `exact=` only when both prompt and completion are provider-reported.

**Review and rollout**
- Tests pin each fix; suite passes.
- Integrator actions:
  - External DB adapters must expose `transaction()`. `update_run_progress` performs a parameterized raw `UPDATE` using hardcoded column assignment fragments inside the adapter’s transaction and increments `version`.
  - If you consume `snapshot()["tokens_estimated"]`, handle True/False dynamically; partial provider reports keep it True until both sides are reported exactly.

<sup>Written for commit 3e7450bc52fc3bbaa6f40d870a97bad07b0d482a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

