### PR TITLE
fix(console): provider/endpoint persistence + provider-state hygiene (tasks 16473-16476)

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -2346,7 +2346,15 @@ async def test_console_native_missing_key_blocks_before_clearing_generic_draft()
         composer.load_draft("preserve this")
 
         console.query_one("#console-send-message", Button).press()
-        await _wait_for_text(console, pilot, "missing API key")
+        # task-16474: this used to wait for "missing API key", a string that
+        # only existed inside the COLLAPSED inspector rail's row Statics --
+        # rows the rail-collapse cascade stamps display=False on, so their
+        # scrape-visibility depended on whether an ambient post-mount sync
+        # happened to restore them (the compact-bar mount burst used to
+        # provide that extra cycle). The composer's own blocked copy is the
+        # deterministic, user-facing statement of the same missing-key
+        # block, so that is what the contract pins now.
+        await _wait_for_text(console, pilot, "add an API key to continue")
 
         assert composer.draft_text() == "preserve this"
 

--- a/Tests/UI/test_console_provider_persistence_regressions.py
+++ b/Tests/UI/test_console_provider_persistence_regressions.py
@@ -1,0 +1,370 @@
+"""Red regression tests for the Console provider/endpoint persistence defects.
+
+Filed from the 2026-08-15 user report (llama.cpp custom endpoint lost on every
+boot; Provider chip flipping to a provider the user never chose). Each test
+pins the DESIRED behavior and is expected to fail until its task lands:
+
+- TASK-16473: applying Console settings with a session-scoped provider
+  endpoint that nothing persisted backs must warn that it will not survive a
+  restart (``test_console_settings_apply_warns_when_llamacpp_endpoint_not_persisted``).
+- TASK-16474: programmatic compact-bar population (mount and sidebar
+  reverse-sync) must never write the provider/model mirrors
+  (``test_compact_provider_mirror_untouched_by_mount_population``) and the
+  bar must not preselect an arbitrary first provider when
+  ``chat_defaults.provider`` is missing
+  (``test_compact_bar_selects_no_arbitrary_first_provider``).
+- TASK-16475: a stale-default refresh that swaps the session provider must be
+  visible to the user (``test_stale_default_refresh_swap_is_visible``).
+- TASK-16476: adopting a detected local server must not overwrite a
+  configured endpoint (``test_detected_server_adoption_keeps_configured_endpoint``).
+"""
+
+from dataclasses import replace
+
+import pytest
+
+import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+import tldw_chatbook.Widgets.compact_model_bar as compact_model_bar_module
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    unsaved_console_endpoint_warning,
+)
+from tldw_chatbook.Chat.local_server_discovery import DiscoveredLocalServer
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+
+def test_unsaved_console_endpoint_warning_cases():
+    """TASK-16473 pure helper: which session endpoints are restart-backed.
+
+    The four AC cases plus the env/override backing and the no-endpoint
+    provider, against the real restart fallback chain.
+    """
+    empty_config = {"chat_defaults": {}, "api_settings": {"llama_cpp": {}}}
+    configured_config = {
+        "chat_defaults": {},
+        "api_settings": {"llama_cpp": {"api_url": "http://127.0.0.1:8080"}},
+    }
+    override_config = {
+        "chat_defaults": {},
+        "api_settings": {"llama_cpp": {}},
+        "console": {"llama_cpp_base_url_override": "http://192.168.1.50:8080"},
+    }
+
+    def session(url):
+        return ConsoleSessionSettings(provider="llama_cpp", model="m", base_url=url)
+
+    # Custom endpoint, nothing persisted: the trap itself.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://192.168.1.50:8080"), app_config=empty_config
+        )
+        is not None
+    )
+    # Custom endpoint differing from the configured one.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://127.0.0.1:9099"), app_config=configured_config
+        )
+        is not None
+    )
+    # Endpoint matching the configured one: backed, no warning.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://127.0.0.1:8080"), app_config=configured_config
+        )
+        is None
+    )
+    # Default endpoint with nothing persisted: the boot fallback reproduces
+    # it, so there is nothing to warn about.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://127.0.0.1:9099"), app_config=empty_config
+        )
+        is None
+    )
+    # Console override backing the session endpoint.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://192.168.1.50:8080"), app_config=override_config
+        )
+        is None
+    )
+    # Env override backing the session endpoint.
+    assert (
+        unsaved_console_endpoint_warning(
+            session("http://192.168.1.50:8080"),
+            app_config=empty_config,
+            environ={"TLDW_CONSOLE_LLAMA_CPP_BASE_URL": "http://192.168.1.50:8080"},
+        )
+        is None
+    )
+    # Provider without an endpoint: nothing to lose.
+    assert (
+        unsaved_console_endpoint_warning(
+            ConsoleSessionSettings(provider="openai", model="gpt-4o"),
+            app_config={"api_settings": {"openai": {"api_key": "sk-x"}}},
+        )
+        is None
+    )
+    # The warning copy names the consequence and the persist action.
+    warning = unsaved_console_endpoint_warning(
+        session("http://192.168.1.50:8080"), app_config=empty_config
+    )
+    assert "restart" in warning and "Save as default" in warning
+
+
+def _capture_notifies(app, monkeypatch) -> list[tuple[str, dict]]:
+    """Capture ``(message, kwargs)`` for every ``app.notify`` call."""
+    captured: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        app, "notify", lambda message, **kwargs: captured.append((str(message), kwargs))
+    )
+    return captured
+
+
+def _discard_worker(work=None, *args, **kwargs):
+    """Stand in for ``run_worker`` on an unmounted screen.
+
+    The real seam receives an already-created coroutine; close it so the
+    discarded coroutine never warns.
+    """
+    close = getattr(work, "close", None)
+    if callable(close):
+        close()
+
+
+def test_console_settings_apply_warns_when_llamacpp_endpoint_not_persisted(
+    monkeypatch,
+):
+    """TASK-16473: a session-only llama.cpp endpoint must not save silently.
+
+    The user's report: they enter their custom llama.cpp IP:Port in Console
+    settings, press Save, and re-enter it on every boot. The apply path is
+    session-scoped by design; the defect is that nothing tells the user their
+    endpoint has no persisted backing. Desired: a warning notification on the
+    apply, naming the endpoint consequence.
+    """
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": "m"}
+    app.app_config["api_settings"] = {"llama_cpp": {}}
+    console = ChatScreen(app)
+    store = console._ensure_console_chat_store()
+    store.ensure_session()
+
+    notifies = _capture_notifies(app, monkeypatch)
+    monkeypatch.setattr(console, "_sync_console_identity_surfaces", lambda: None)
+    monkeypatch.setattr(console, "run_worker", _discard_worker)
+
+    current = console._session._ensure_active_console_session_settings()
+    session_only = replace(
+        current,
+        provider="llama_cpp",
+        model="m",
+        base_url="http://192.168.1.50:8080",
+        source="user",
+    )
+    console._apply_console_settings_result(session_only)
+
+    endpoint_warnings = [
+        message
+        for message, kwargs in notifies
+        if kwargs.get("severity") == "warning" and "endpoint" in message.lower()
+    ]
+    assert endpoint_warnings, (
+        "Applying a llama.cpp endpoint with no persisted backing must warn "
+        f"that it will not survive a restart; notifies seen: {notifies}"
+    )
+    warning = endpoint_warnings[0].lower()
+    assert "restart" in warning or "survive" in warning or "save as default" in warning
+
+
+@pytest.mark.asyncio
+async def test_compact_provider_mirror_untouched_by_mount_population(monkeypatch):
+    """TASK-16474: mount/population must not write the provider mirror.
+
+    ``_console_control_provider`` outranks ``chat_defaults.provider`` when
+    fresh session defaults are derived, so an ambient Select.Changed from the
+    compact bar's mount population silently decides the provider of the next
+    session. Desired: with zero user interaction the mirror stays unset.
+
+    Note the bar in ``ConsoleControlBar`` is LIVE UI despite its
+    ``console-hidden-control`` class (a visible-text diff at 160x48 on
+    2026-08-15 showed it rendering in the header), so the fix is event
+    suppression, not removal.
+    """
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": "m1"}
+    monkeypatch.setattr(
+        compact_model_bar_module,
+        "get_cli_providers_and_models",
+        lambda: {"llama_cpp": ["m1"]},
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-compact-model-bar")
+        await pilot.pause(0.05)
+
+        assert console._console_control_provider is None, (
+            "Compact-bar mount/population wrote the provider mirror "
+            f"({console._console_control_provider!r}); only a user selection "
+            "may set it."
+        )
+        assert console._console_control_model is None, (
+            "Compact-bar mount/population wrote the model mirror "
+            f"({console._console_control_model!r}); only a user selection "
+            "may set it."
+        )
+
+        # Programmatic reverse-sync (the sidebar->bar seam) is population
+        # too: it must refresh the bar's displayed values without claiming
+        # them as user selections.
+        console._sync_compact_shell_controls(provider="llama_cpp", model="m1")
+        await pilot.pause(0.05)
+        assert console._console_control_provider is None, (
+            "sync_from_sidebar wrote the provider mirror "
+            f"({console._console_control_provider!r}); programmatic "
+            "population must not."
+        )
+        assert console._console_control_model is None, (
+            "sync_from_sidebar wrote the model mirror "
+            f"({console._console_control_model!r}); programmatic "
+            "population must not."
+        )
+
+
+@pytest.mark.asyncio
+async def test_compact_bar_selects_no_arbitrary_first_provider(monkeypatch):
+    """TASK-16474: no arbitrary first-[providers]-key fallback in the bar.
+
+    With ``chat_defaults.provider`` missing, the bar used to preselect the
+    first ``[providers]`` key in file order -- a provider nobody chose. The
+    select must stay on its prompt until the user picks one.
+    """
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {}
+    monkeypatch.setattr(
+        compact_model_bar_module,
+        "get_cli_providers_and_models",
+        lambda: {"alpha": ["a1"], "beta": ["b1"]},
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(140, 42)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-compact-model-bar")
+        await pilot.pause(0.05)
+
+        from textual.widgets import Select as TextualSelect
+
+        provider_select = console.query_one("#compact-api-provider", TextualSelect)
+        assert provider_select.value in (
+            None,
+            TextualSelect.BLANK,
+            TextualSelect.NULL,
+        ), (
+            "Compact bar preselected an arbitrary provider "
+            f"({provider_select.value!r}) with no chat_defaults.provider."
+        )
+
+
+def test_stale_default_refresh_swap_is_visible(monkeypatch):
+    """TASK-16475: a stale-default refresh that changes provider must notify.
+
+    Setup mirrors ``test_console_stale_default_refresh_respects_user_marked_
+    settings``: an untouched blocked openai session converges on the
+    llama.cpp chat defaults. The swap itself is task-177 behavior and stays;
+    the defect is that it is invisible. Desired: a warning names the provider
+    change.
+    """
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": "local-model"}
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": "http://127.0.0.1:9099", "model": "local-model"},
+        "openai": {"api_key": ""},
+    }
+    notifies = _capture_notifies(app, monkeypatch)
+    console = ChatScreen(app)
+    store = console._ensure_console_chat_store()
+
+    stale_derived = ConsoleSessionSettings(provider="openai", model="gpt-4o")
+    store.create_session(
+        settings=stale_derived,
+        canonical_settings_baseline=stale_derived,
+    )
+
+    refreshed = console._session._ensure_active_console_session_settings()
+    # Sanity guard against a vacuous pass: the swap itself must still happen
+    # (task-177 convergence), so the notice requirement is exercised for real.
+    assert refreshed.provider == "llama_cpp"
+
+    swap_notices = [
+        message
+        for message, kwargs in notifies
+        if kwargs.get("severity") == "warning" and "provider" in message.lower()
+    ]
+    assert swap_notices, (
+        "The stale-default refresh replaced the session provider "
+        f"(openai -> llama_cpp) without any user-visible notice; "
+        f"notifies seen: {notifies}"
+    )
+    notice = swap_notices[0].lower()
+    assert "openai" in notice and "llama_cpp" in notice
+
+
+def test_detected_server_adoption_keeps_configured_endpoint(monkeypatch):
+    """TASK-16476: adoption must not clobber a configured endpoint.
+
+    The user's llama.cpp endpoint is persisted at
+    ``api_settings.llama_cpp.api_url``. Adopting a detected loopback server at
+    a different port must keep the configured endpoint in config (fill only
+    when absent) while still applying the detected endpoint to the session so
+    the adoption remains effective immediately.
+    """
+    configured_endpoint = "http://127.0.0.1:8080"
+    detected_endpoint = "http://127.0.0.1:9099"
+    app = _build_test_app()
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": configured_endpoint, "model": "user-model"}
+    }
+    console = ChatScreen(app)
+    store = console._ensure_console_chat_store()
+    store.ensure_session()
+
+    captured_sections: dict = {}
+
+    def fake_save(section_values):
+        captured_sections.update(section_values)
+        return True
+
+    monkeypatch.setattr(
+        chat_screen_module, "save_settings_to_cli_config", fake_save
+    )
+    monkeypatch.setattr(console, "_sync_console_transcript_guidance", lambda: None)
+    monkeypatch.setattr(console, "run_worker", _discard_worker)
+    console._session._sync_chat_core_state_fn = lambda: None
+    console._session._sync_settings_summary_fn = lambda: None
+
+    console._console_detected_local_server = DiscoveredLocalServer(
+        provider_key="llama_cpp",
+        base_url=detected_endpoint,
+        model_ids=("detected-model",),
+    )
+    console._apply_detected_local_server()
+
+    provider_write = captured_sections.get("api_settings.llama_cpp", {})
+    assert provider_write.get("api_url") != detected_endpoint, (
+        "Adoption overwrote the configured llama.cpp endpoint "
+        f"({configured_endpoint}) with the detected one ({detected_endpoint})."
+    )
+    active_settings = store.session_settings(store.active_session_id)
+    assert active_settings.base_url == detected_endpoint, (
+        "Adoption must apply the detected endpoint to the active session so "
+        "'Use detected ...' stays effective without the config write; got "
+        f"{active_settings.base_url!r}."
+    )

--- a/Tests/UI/test_console_provider_persistence_regressions.py
+++ b/Tests/UI/test_console_provider_persistence_regressions.py
@@ -106,7 +106,7 @@ def test_unsaved_console_endpoint_warning_cases():
     assert (
         unsaved_console_endpoint_warning(
             ConsoleSessionSettings(provider="openai", model="gpt-4o"),
-            app_config={"api_settings": {"openai": {"api_key": "sk-x"}}},
+            app_config={"api_settings": {"openai": {"api_key": DUMMY_OPENAI_API_KEY}}},
         )
         is None
     )
@@ -115,6 +115,11 @@ def test_unsaved_console_endpoint_warning_cases():
         session("http://192.168.1.50:8080"), app_config=empty_config
     )
     assert "restart" in warning and "Save as default" in warning
+
+
+# Matches the repo-wide dummy convention (self-describing, not
+# token-shaped) so key-scanner rules stay quiet.
+DUMMY_OPENAI_API_KEY = "DUMMY_OPENAI_API_KEY"
 
 
 def _capture_notifies(app, monkeypatch) -> list[tuple[str, dict]]:
@@ -367,4 +372,54 @@ def test_detected_server_adoption_keeps_configured_endpoint(monkeypatch):
         "Adoption must apply the detected endpoint to the active session so "
         "'Use detected ...' stays effective without the config write; got "
         f"{active_settings.base_url!r}."
+    )
+
+
+def test_detected_server_adoption_treats_trailing_slash_as_same_endpoint(
+    monkeypatch,
+):
+    """TASK-16476 / Qodo review (PR #1720): identity, not raw-string, compare.
+
+    A configured endpoint differing from the detected one only by a trailing
+    slash is the same server: adoption must not warn about "keeping" it and
+    the canonicalizing ``api_url`` write still happens.
+    """
+    detected_endpoint = "http://127.0.0.1:8080"
+    app = _build_test_app()
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": "http://127.0.0.1:8080/", "model": "user-model"}
+    }
+    console = ChatScreen(app)
+    store = console._ensure_console_chat_store()
+    store.ensure_session()
+
+    notifies = _capture_notifies(app, monkeypatch)
+    captured_sections: dict = {}
+
+    def fake_save(section_values):
+        captured_sections.update(section_values)
+        return True
+
+    monkeypatch.setattr(
+        chat_screen_module, "save_settings_to_cli_config", fake_save
+    )
+    monkeypatch.setattr(console, "_sync_console_transcript_guidance", lambda: None)
+    monkeypatch.setattr(console, "run_worker", _discard_worker)
+    console._session._sync_chat_core_state_fn = lambda: None
+    console._session._sync_settings_summary_fn = lambda: None
+
+    console._console_detected_local_server = DiscoveredLocalServer(
+        provider_key="llama_cpp",
+        base_url=detected_endpoint,
+        model_ids=("detected-model",),
+    )
+    console._apply_detected_local_server()
+
+    assert not [message for message, _kwargs in notifies if "Keeping" in message], (
+        f"Same-server endpoints (trailing slash) must not warn; saw: {notifies}"
+    )
+    provider_write = captured_sections.get("api_settings.llama_cpp", {})
+    assert provider_write.get("api_url") == detected_endpoint, (
+        "Same-server adoption should still write the canonical api_url; got "
+        f"{provider_write.get('api_url')!r}."
     )

--- a/backlog/tasks/task-16473 - Console-warn-when-a-saved-provider-endpoint-will-not-survive-restart.md
+++ b/backlog/tasks/task-16473 - Console-warn-when-a-saved-provider-endpoint-will-not-survive-restart.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16473
+title: Console warn when a saved provider endpoint will not survive restart
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 15:10'
+labels: []
+dependencies: []
+---
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User report (2026-08-15): a llama.cpp user re-enters their custom IP:Port on every boot. Root cause: the Console settings modal's "Save" (and the Alt+M popover's apply) write session settings only, and Console session settings are per-process in-memory state (`ConsoleChatStore`, `ScreenStateStore`), so on the next boot the endpoint re-derives from env / `[console] llama_cpp_base_url_override` / `[api_settings.<provider>]` and falls back to the default (`http://127.0.0.1:9099`). For llama.cpp the trap is invisible: `build_console_settings_readiness` skips the "Endpoint not saved" comparison for the direct llama path, so a session carrying an unsaved custom endpoint still reports "Ready" and nothing nudges the user toward "Save as default" (`Chat/console_session_settings.py`, the `uses_direct_llama_path` guard in `build_console_settings_readiness`; apply path `UI/Screens/chat_screen.py::_apply_console_settings_result`; session-scoped save `Widgets/Console/console_settings_modal.py` `_save`).
+
+ADR required: no — bug fix adding a warning at an existing UI seam; no storage, sync, or boundary decision changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan (the how)
+
+1. Pure helper `llamacpp_endpoint_unsaved_notice`-style decision in `Chat/console_session_settings.py` reusing `_endpoint_differs_for_provider`/`first_configured_endpoint` vocabulary: returns warning copy when the session endpoint differs from everything persisted, None otherwise
+2. Red test exists (`test_console_settings_apply_warns_when_llamacpp_endpoint_not_persisted`); add pure-helper unit tests for the four AC cases
+3. Fire the warning from `_apply_console_settings_result` after a successful session-scoped replace (one warning per apply)
+4. Run the Console settings modal + session settings suites
+
+ADR required: no
+ADR path: N/A
+Reason: warning at an existing UI seam; no storage/sync/boundary change
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Applying Console settings whose provider endpoint differs from everything persisted for that provider (no matching `[api_settings]` endpoint key, no `[console] llama_cpp_base_url_override`, no env override) surfaces a warning that names the consequence (endpoint is session-only and will not survive a restart) and the persist action ("Save as default")
+- [x] #2 No warning when the session endpoint matches persisted config, and no warning for providers that use no endpoint
+- [x] #3 The differs-from-persisted decision is a pure, unit-tested helper (reusing the `_endpoint_differs_for_provider` / `first_configured_endpoint` vocabulary), covering: custom endpoint with no config, custom endpoint differing from configured, endpoint matching config, llama.cpp default-endpoint-no-config
+- [x] #4 Regression test `test_console_settings_apply_warns_when_llamacpp_endpoint_not_persisted` (added red in `Tests/UI/test_console_provider_persistence_regressions.py`) passes, and the existing Console settings-modal suite stays green
+- [x] #5 Warning fires on the modal "Save" apply path and does not spam: one warning per apply that actually carries an unsaved differing endpoint
+<!-- AC:END -->
+## Implementation Notes
+
+- Added pure helpers in `Chat/console_session_settings.py`: `console_session_endpoint_survives_restart` (compares the session endpoint against the real restart fallback chain: env -> `[console] llama_cpp_base_url_override` -> configured endpoint -> default) and `unsaved_console_endpoint_warning` (copy naming the restart consequence and "Save as default").
+- `_apply_console_settings_result` (`UI/Screens/chat_screen.py`) now fires that warning after the success toast when the applied endpoint has no persisted backing; one warning per apply, none when backed or provider uses no endpoint.
+- Modified files: `Chat/console_session_settings.py`, `UI/Screens/chat_screen.py`, `Tests/UI/test_console_provider_persistence_regressions.py` (apply-path regression test + 7-case helper unit test, both verified red on dev baseline).

--- a/backlog/tasks/task-16474 - Console-ambient-compact-bar-population-must-not-drive-the-provider-mirror.md
+++ b/backlog/tasks/task-16474 - Console-ambient-compact-bar-population-must-not-drive-the-provider-mirror.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16474
+title: Console ambient compact bar population must not drive the provider mirror
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 15:10'
+labels: []
+dependencies: []
+---
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User report (2026-08-15): the Console Provider status chip "changes to a seemingly random one". `_console_control_provider` is the in-memory mirror that OUTRANKS `chat_defaults.provider` when fresh session defaults are derived (`UI/Screens/provider_model_resolution.py`, console_provider before chat_defaults), and `on_console_compact_provider_changed` (`UI/Screens/chat_screen.py`, `#compact-api-provider` Select.Changed) cannot distinguish a user change from programmatic population. The mount/population burst therefore set the mirror at every (re)compose — so a mirror the user set by applying settings was silently reverted to the `chat_defaults`-derived value whenever the bar remounted, and the next new session or stale-default refresh derived the wrong provider. `CompactModelBar` also computed `available_providers[0]` (first `[providers]` key in file order) as a fallback default (`Widgets/compact_model_bar.py` compose/on_mount).
+
+Implementation correction (2026-08-15, this task's own red-test run): the bar inside `ConsoleControlBar` is LIVE UI, not dead — despite the `console-hidden-control` class it renders in the expanded header (a visible-text diff at 160x48 showed "OpenAI ▼ gpt-5.6-terra ▼ Temp:" and removing it broke `test_console_native_missing_key_blocks_before_clearing_generic_draft` plus the header layout). The fix is event suppression on programmatic population, NOT bar removal.
+
+ADR required: no — restoring the documented mirror contract ("Mirror native compact provider changes", i.e. user changes); no interface or boundary change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan (the how)
+
+1. Suppress Select.Changed during programmatic population in `CompactModelBar`: wrap the on_mount value sets, the sync_from_sidebar value/option sets, with `prevent(Select.Changed)` (red test: `test_compact_provider_mirror_untouched_by_mount_population`, which also exercises the sidebar reverse-sync)
+2. Drop the `available_providers[0]` arbitrary default in compose/on_mount; leave the provider select on its prompt when chat_defaults.provider is missing/unresolvable (red test: `test_compact_bar_selects_no_arbitrary_first_provider`)
+3. Keep the bar mounted in `ConsoleControlBar` (live UI — see the description correction)
+4. Run the Console suites (session settings, internals decomposition, native chat flow)
+
+ADR required: no
+ADR path: N/A
+Reason: restores the documented mirror contract (user changes only); the bar and its placement are unchanged
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 After Console mount with zero user interaction, `_console_control_provider` / `_console_control_model` remain unset; only a genuine user selection on a visible control writes them, and a later programmatic repopulation/recompose (mount burst, sidebar reverse-sync) never writes or reverts them
+- [x] #2 The compact bar stays mounted and functional (it is live UI in the expanded header); its programmatic population simply no longer emits user-intent Select.Changed events
+- [x] #3 When `chat_defaults.provider` is missing or unresolvable, the compact bar never surfaces an arbitrary first `[providers]` key as if selected (provider select shows its prompt / stays blank until the user chooses)
+- [x] #4 Regression tests added red in `Tests/UI/test_console_provider_persistence_regressions.py` pass: `test_compact_provider_mirror_untouched_by_mount_population`, `test_compact_bar_selects_no_arbitrary_first_provider`
+- [x] #5 The Console suites (`Tests/UI/test_console_session_settings.py`, `test_console_internals_decomposition.py`, `test_console_native_chat_flow.py`) stay green (modulo pre-existing dev reds: the unmount-timeout and ctrl-k switcher tests); in particular the task-177 refresh journey still derives from `chat_defaults` when no user selection exists
+<!-- AC:END -->
+## Implementation Notes
+
+- `CompactModelBar` (`Widgets/compact_model_bar.py`): all programmatic population (on_mount value sets, sync_from_sidebar value/option sets) wrapped in `prevent(Select.Changed)`; provider select `allow_blank=False -> True` because Textual's Select force-picks `options[0]` at mount/set_options when blank is disallowed (that internal auto-pick fires Changed outside any suppression and was the actual ambient mirror writer); blank-sentinel guard added to `handle_compact_provider_change`; the arbitrary `available_providers[0]` fallback removed; on_mount requests one coalesced control-bar sync to keep the rail/inspector refresh cadence the ambient events used to provide.
+- `_sync_compact_shell_controls` (`UI/Screens/chat_screen.py`) no longer assigns the mirrors directly (test-only seam; programmatic sync is population).
+- COURSE CORRECTION: the original plan removed the CompactModelBar from `ConsoleControlBar` as "dead UI" -- wrong. It renders live in the expanded header (visible-text diff at 160x48); removing it broke the header layout and `test_console_native_missing_key_blocks_before_clearing_generic_draft`. The bar stays; suppression is the fix. That test was also re-pinned: it scraped "missing API key" from COLLAPSED inspector rows whose display stamps depend on rail-cascade timing (pre-existing race); it now waits on the composer's deterministic "add an API key to continue" copy, same contract.
+- Modified files: `Widgets/compact_model_bar.py`, `UI/Screens/chat_screen.py`, `Tests/UI/test_console_provider_persistence_regressions.py`, `Tests/UI/test_console_native_chat_flow.py` (test re-pin). Both regression tests verified red on dev state, green after.

--- a/backlog/tasks/task-16475 - Console-surface-stale-default-provider-swaps-to-the-user.md
+++ b/backlog/tasks/task-16475 - Console-surface-stale-default-provider-swaps-to-the-user.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16475
+title: Console surface stale-default provider swaps to the user
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 15:10'
+labels: []
+dependencies: []
+---
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User report (2026-08-15): the Provider chip flips to a provider the user never chose. `_maybe_refresh_stale_default_console_settings` (`UI/Console_Modules/session.py`, from task-177) replaces an untouched blocked session's settings with re-derived defaults whenever the fresh defaults are send-capable — including when they name a DIFFERENT provider than the session had. The swap itself is task-177's intended convergence (a Settings fix must reach never-used blocked sessions without a restart) and is protected by `test_console_stale_default_refresh_respects_user_marked_settings`; what is missing is any signal. From the user's seat the Provider chip silently changes identity, which reads as "random". This task makes the swap observable; it must NOT block or narrow the task-177 convergence (provider-equality gating is explicitly out of scope unless separately decided).
+
+ADR required: no — observability addition on an existing behavior; the refresh policy itself is unchanged (task-177 lineage).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan (the how)
+
+1. In `_maybe_refresh_stale_default_console_settings`, when the replacing defaults change the provider key, emit a one-time warning notify (previous -> new provider, pointing at Settings/chat_defaults) plus a log record with both keys
+2. Red test exists (`test_stale_default_refresh_swap_is_visible`); equality gates already prevent repeat notices
+3. Keep task-177 convergence untouched (same-provider refresh stays silent; user-marked sessions untouched)
+4. Run the task-177 tests + session settings suite
+
+ADR required: no
+ADR path: N/A
+Reason: observability only; refresh policy unchanged (task-177 lineage)
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 When the stale-default refresh replaces a session's settings with defaults whose provider (`provider_config_key`) differs from the session's previous provider, the Console surfaces a one-time notice naming the change (previous provider -> new provider) and pointing at Settings/`chat_defaults` as the source of the new default
+- [x] #2 Same-provider refreshes (credential/endpoint/model converging after a Settings fix) produce no notice; user-marked sessions are never refreshed (existing behavior, stays covered)
+- [x] #3 The notice fires once per actual replacement (the ensure path runs on many sync ticks; equality gates must keep repeat notices away)
+- [x] #4 Regression test `test_stale_default_refresh_swap_is_visible` (added red in `Tests/UI/test_console_provider_persistence_regressions.py`) passes; the task-177 tests in `Tests/UI/test_console_session_settings.py` stay green
+- [x] #5 The notice is a warning-severity notification (or transcript-level notice) and is also logged with both provider keys for diagnostics
+<!-- AC:END -->
+## Implementation Notes
+
+- `_maybe_refresh_stale_default_console_settings` (`UI/Console_Modules/session.py`) now detects when the replacing defaults change the provider key and calls `_notify_stale_default_provider_swap`: one warning-severity notify ("Console provider changed X -> Y: this unused session now follows your saved defaults (Settings > Providers & Models).") plus an info log with both keys. Best-effort -- notification failure never breaks the ensure path.
+- task-177 convergence untouched: same-provider refresh stays silent, user-marked sessions never refreshed (both existing tests still green).
+- Modified files: `UI/Console_Modules/session.py`, `Tests/UI/test_console_provider_persistence_regressions.py` (regression test with a sanity assert that the swap itself still happens).

--- a/backlog/tasks/task-16476 - Console-server-adoption-must-not-clobber-a-configured-endpoint.md
+++ b/backlog/tasks/task-16476 - Console-server-adoption-must-not-clobber-a-configured-endpoint.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16476
+title: Console server adoption must not clobber a configured endpoint
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-15 15:10'
+labels: []
+dependencies: []
+---
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User report follow-up (2026-08-15, llama.cpp endpoint/config drift): `_apply_detected_local_server` (`UI/Screens/chat_screen.py`) persists `api_settings.<provider>.api_url` and `chat_defaults.provider`/`model` when the user adopts a discovered loopback server from the setup card. When the provider already has a DIFFERENT user-configured endpoint, adoption silently overwrites it — e.g. a user's `http://127.0.0.1:8080` replaced by the discovery default (note the defaults disagree: discovery probes `http://127.0.0.1:8080` first while the endpoint fallback default is `http://127.0.0.1:9099`, `Chat/local_server_discovery.py` vs `Chat/console_session_settings.py`). Discovery is loopback-only, so it can never see a LAN llama.cpp box; the persisted endpoint is the only record of it. Adoption also drops the detected endpoint from the session itself for llama.cpp (`base_url=None` after the provider-key check), so the config write is currently the only thing that makes "Use detected ..." effective at all — the fix must keep adoption effective for the session while protecting the persisted endpoint.
+
+ADR required: no — preserving user-authored config at an existing write seam; the adoption contract's provider/model writes are unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan (the how)
+
+1. In `_apply_detected_local_server`: skip the `api_url` config write when the target provider already has a different non-empty persisted endpoint (fill only when absent), notify which endpoint was kept
+2. Apply the detected base_url to the adopted session settings (replace the llama.cpp base_url=None drop with the detected URL) so adoption stays effective without the config write
+3. Keep chat_defaults.provider/model writes unchanged
+4. Red test exists (`test_detected_server_adoption_keeps_configured_endpoint`); run setup-card/discovery suites
+
+ADR required: no
+ADR path: N/A
+Reason: preserving user-authored config at an existing write seam; adoption contract otherwise unchanged
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Adopting a detected server never silently overwrites an existing non-empty persisted endpoint for the target provider with a different value; the config write either omits the endpoint key or keeps the configured value (fills only when absent)
+- [x] #2 Adoption still applies the detected endpoint to the active session for immediate use (session settings carry the detected base URL as a user-source selection), so "Use detected ..." remains effective without the config write
+- [x] #3 `chat_defaults.provider`/`model` writes are unchanged (the affordance's stated contract: "Sets provider to X at host:port")
+- [x] #4 When adoption skips the endpoint write because a different endpoint is configured, the user is told (one-line notice naming the kept configured endpoint)
+- [x] #5 Regression test `test_detected_server_adoption_keeps_configured_endpoint` (added red in `Tests/UI/test_console_provider_persistence_regressions.py`) passes; existing setup-card/discovery suites stay green
+- [x] #6 Persist-failure path unchanged: session-only apply with the existing "could not persist" warning
+<!-- AC:END -->
+## Implementation Notes
+
+- `_apply_detected_local_server` (`UI/Screens/chat_screen.py`): the `api_url` config write now fills only when the provider has no configured endpoint; an existing DIFFERENT endpoint is kept and a warning notify names the kept endpoint. The detected base URL is applied to the adopted session settings (replacing the old llama.cpp `base_url=None` drop) so "Use detected ..." stays effective without the config write. `chat_defaults.provider`/`model` writes unchanged; persist-failure path unchanged.
+- Modified files: `UI/Screens/chat_screen.py` (+ `safe_endpoint_display` import), `Tests/UI/test_console_provider_persistence_regressions.py` (regression test: configured 8080 kept, session base_url = detected 9099).

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -1003,6 +1003,16 @@ def _console_endpoint_restart_fallback(
     resolves env override -> ``[console] llama_cpp_base_url_override`` -> the
     provider's configured endpoint -> the built-in default; other URL-based
     providers resolve only their configured endpoint.
+
+    Args:
+        provider_key: Normalized provider readiness key.
+        provider_settings: The provider's persisted ``api_settings`` section.
+        app_config: Application configuration mapping.
+        environ: Environment override source; ``None`` reads ``os.environ``.
+
+    Returns:
+        The restart fallback endpoint, or ``None`` for URL-based providers
+        with nothing configured.
     """
     if provider_key in {"llama_cpp", "local_llamacpp"}:
         env = environ if environ is not None else os.environ
@@ -1030,6 +1040,15 @@ def console_session_endpoint_survives_restart(
     value (so re-deriving defaults next boot reproduces it). ``False`` means
     the endpoint lives only in this session and is silently lost on restart
     -- the task-16473 persistence trap.
+
+    Args:
+        settings: Console session settings carrying the endpoint to check.
+        app_config: Application configuration mapping.
+        environ: Environment override source; ``None`` reads ``os.environ``.
+
+    Returns:
+        Whether re-deriving defaults on the next boot would reproduce the
+        session's endpoint.
     """
     provider_key = provider_config_key(settings.provider)
     provider_settings = _provider_settings(app_config, provider_key)
@@ -1066,6 +1085,15 @@ def unsaved_console_endpoint_warning(
     endpoints (the direct llama path skips the endpoint-saved check), so
     nothing else tells the user their endpoint evaporates on restart. This is
     the warning that apply surfaces.
+
+    Args:
+        settings: Console session settings carrying the endpoint to describe.
+        app_config: Application configuration mapping.
+        environ: Environment override source; ``None`` reads ``os.environ``.
+
+    Returns:
+        User-facing warning copy, or ``None`` when the endpoint is backed for
+        the next boot.
     """
     if console_session_endpoint_survives_restart(
         settings, app_config=app_config, environ=environ

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
 from urllib.parse import urlparse, urlunparse
@@ -987,6 +988,94 @@ def _endpoint_differs_for_provider(
         )
         return selected != configured
     return generic_endpoint_differs(base_url, provider_settings)
+
+
+def _console_endpoint_restart_fallback(
+    provider_key: str,
+    provider_settings: Mapping[str, object],
+    app_config: Mapping[str, object],
+    environ: Mapping[str, str] | None,
+) -> str | None:
+    """Return the endpoint the next boot would derive for this provider.
+
+    Mirrors the selection fallback chain in
+    ``ChatScreen._build_console_provider_selection_uncached``: llama.cpp
+    resolves env override -> ``[console] llama_cpp_base_url_override`` -> the
+    provider's configured endpoint -> the built-in default; other URL-based
+    providers resolve only their configured endpoint.
+    """
+    if provider_key in {"llama_cpp", "local_llamacpp"}:
+        env = environ if environ is not None else os.environ
+        console_config = _mapping_value(app_config, "console")
+        fallback = (
+            env.get("TLDW_CONSOLE_LLAMA_CPP_BASE_URL")
+            or _string_value(console_config.get("llama_cpp_base_url_override"))
+            or first_configured_endpoint(provider_settings)
+            or DEFAULT_LLAMACPP_BASE_URL
+        )
+        return normalize_llamacpp_base_url(fallback)
+    return first_configured_endpoint(provider_settings)
+
+
+def console_session_endpoint_survives_restart(
+    settings: ConsoleSessionSettings,
+    *,
+    app_config: Mapping[str, object],
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether the session endpoint is backed for the next boot.
+
+    ``True`` when the provider uses no endpoint, the session carries no
+    endpoint, or the session endpoint equals the restart fallback chain's
+    value (so re-deriving defaults next boot reproduces it). ``False`` means
+    the endpoint lives only in this session and is silently lost on restart
+    -- the task-16473 persistence trap.
+    """
+    provider_key = provider_config_key(settings.provider)
+    provider_settings = _provider_settings(app_config, provider_key)
+    base_url = _string_value(settings.base_url)
+    if not base_url or not _is_url_based_provider(provider_key, provider_settings):
+        return True
+    fallback = _console_endpoint_restart_fallback(
+        provider_key, provider_settings, app_config, environ
+    )
+    if provider_key in {"llama_cpp", "local_llamacpp"}:
+        selected = normalize_generic_endpoint_for_compare(
+            normalize_llamacpp_base_url(base_url)
+        )
+        resolved = normalize_generic_endpoint_for_compare(
+            normalize_llamacpp_base_url(fallback or DEFAULT_LLAMACPP_BASE_URL)
+        )
+        return selected == resolved
+    if not fallback:
+        return False
+    return normalize_generic_endpoint_for_compare(
+        base_url
+    ) == normalize_generic_endpoint_for_compare(fallback)
+
+
+def unsaved_console_endpoint_warning(
+    settings: ConsoleSessionSettings,
+    *,
+    app_config: Mapping[str, object],
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Build the session-only endpoint warning copy, or ``None`` when backed.
+
+    task-16473: llama.cpp readiness reports "Ready" for session-scoped
+    endpoints (the direct llama path skips the endpoint-saved check), so
+    nothing else tells the user their endpoint evaporates on restart. This is
+    the warning that apply surfaces.
+    """
+    if console_session_endpoint_survives_restart(
+        settings, app_config=app_config, environ=environ
+    ):
+        return None
+    display = safe_endpoint_display(settings.base_url) or "the current endpoint"
+    return (
+        f"Endpoint {display} is saved for this session only and will not "
+        "survive a restart. Use Save as default (or Settings) to keep it."
+    )
 
 
 def _valid_base_url(provider_key: str, base_url: str) -> bool:

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -1298,13 +1298,49 @@ class ConsoleSessionController:
         )
         if not fresh_readiness.native_send_supported:
             return settings
+        previous_provider_key = provider_config_key(settings.provider)
+        next_provider_key = provider_config_key(fresh_defaults.provider)
         store.replace_session_settings(
             session.id,
             fresh_defaults,
             mark_user_work=False,
             canonical_settings_baseline=fresh_defaults,
         )
+        if previous_provider_key and next_provider_key != previous_provider_key:
+            # task-16475: the convergence itself is task-177 behavior, but a
+            # session whose provider identity changes under it must not do so
+            # silently -- from the user's seat the Provider chip just flipped
+            # to a provider they never chose.
+            self._notify_stale_default_provider_swap(
+                previous_provider_key,
+                next_provider_key or str(fresh_defaults.provider),
+            )
         return fresh_defaults
+
+    def _notify_stale_default_provider_swap(
+        self,
+        previous_provider_key: str,
+        next_provider_key: str,
+    ) -> None:
+        """Announce one stale-default refresh that changed the provider.
+
+        Best-effort: the refresh runs deep inside ensure/sync paths, so a
+        notification failure must never break them.
+        """
+        copy = (
+            f"Console provider changed {previous_provider_key} -> "
+            f"{next_provider_key}: this unused session now follows your saved "
+            "defaults (Settings > Providers & Models)."
+        )
+        logger.info(
+            "Stale-default refresh swapped session provider ({} -> {})",
+            previous_provider_key,
+            next_provider_key,
+        )
+        try:
+            self.app_instance.notify(copy, severity="warning")
+        except Exception:  # noqa: BLE001 -- display-only signal
+            logger.debug("Provider-swap notice could not be shown", exc_info=True)
 
     def _replace_active_console_session_settings(
         self,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -242,6 +242,7 @@ from ...Chat.console_provider_gateway import (
 )
 from ...Chat.console_provider_endpoints import (
     first_configured_endpoint,
+    normalize_generic_endpoint_for_compare,
     safe_endpoint_display,
 )
 
@@ -12859,17 +12860,25 @@ class ChatScreen(BaseAppScreen):
             return
         model_id = server.model_ids[0] if server.model_ids else None
         app_config = self._provider_readiness_app_config()
+        provider_key = provider_config_key(server.provider_key)
         provider_settings = self._config_section(
             self._config_section(app_config, "api_settings"),
-            provider_config_key(server.provider_key),
+            provider_key,
         )
         configured_endpoint = first_configured_endpoint(provider_settings)
         provider_values: dict[str, object] = {}
-        if configured_endpoint and configured_endpoint != server.base_url:
+        # Qodo review (PR #1720): compare connection identities, not raw
+        # strings -- a configured endpoint differing only by a trailing
+        # slash (or a llama.cpp endpoint-path suffix) is the SAME server and
+        # must not warn or skip the canonicalizing write. Same vocabulary
+        # ``_endpoint_differs_for_provider`` uses.
+        if configured_endpoint and self._adoption_endpoints_differ(
+            provider_key, configured_endpoint, server.base_url
+        ):
             self.app_instance.notify(
                 "Keeping the saved endpoint "
                 f"{safe_endpoint_display(configured_endpoint) or configured_endpoint} "
-                f"for {provider_config_key(server.provider_key)}; using the detected "
+                f"for {provider_key}; using the detected "
                 "server for this session only.",
                 severity="warning",
             )
@@ -12912,6 +12921,41 @@ class ChatScreen(BaseAppScreen):
         self.run_worker(
             self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
         )
+
+    @staticmethod
+    def _adoption_endpoints_differ(
+        provider_key: str,
+        configured_endpoint: str,
+        detected_endpoint: str,
+    ) -> bool:
+        """Return whether adoption endpoints differ by connection identity.
+
+        Qodo review (PR #1720): raw string inequality treats a trailing
+        slash (or a llama.cpp endpoint-path suffix) as a different server,
+        warning and skipping the write for what is the same connection. Uses
+        the same normalization vocabulary as
+        ``_endpoint_differs_for_provider``.
+
+        Args:
+            provider_key: Normalized provider readiness key.
+            configured_endpoint: Persisted endpoint for the provider.
+            detected_endpoint: Discovered server base URL.
+
+        Returns:
+            ``True`` only when the two endpoints normalize to different
+            connection identities.
+        """
+        if provider_key in {"llama_cpp", "local_llamacpp"}:
+            configured = normalize_generic_endpoint_for_compare(
+                normalize_llamacpp_base_url(configured_endpoint)
+            )
+            detected = normalize_generic_endpoint_for_compare(
+                normalize_llamacpp_base_url(detected_endpoint)
+            )
+            return configured != detected
+        return normalize_generic_endpoint_for_compare(
+            configured_endpoint
+        ) != normalize_generic_endpoint_for_compare(detected_endpoint)
 
     def _console_setup_modal_blocking(self) -> bool:
         """Return True when the first-run setup modal is covering the workbench."""

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -227,6 +227,7 @@ from ...Chat.console_session_settings import (
     build_default_console_session_settings,
     build_console_settings_readiness,
     build_console_settings_summary_state,
+    unsaved_console_endpoint_warning,
 )
 from ...Chat.console_chat_store import (
     MAX_PENDING_ATTACHMENTS,
@@ -239,7 +240,10 @@ from ...Chat.console_provider_gateway import (
     DEFAULT_LLAMACPP_BASE_URL,
     normalize_llamacpp_base_url,
 )
-from ...Chat.console_provider_endpoints import first_configured_endpoint
+from ...Chat.console_provider_endpoints import (
+    first_configured_endpoint,
+    safe_endpoint_display,
+)
 
 from ...Chat.console_voice_input import (
     acoustic_barge_in_enabled,
@@ -2335,6 +2339,16 @@ class ChatScreen(BaseAppScreen):
                 group="console-sync",
             )
         self.app_instance.notify("Console settings saved.", severity="success")
+        # task-16473: a session endpoint with no persisted backing works for
+        # this run (llama.cpp readiness even reports "Ready") and then
+        # silently evaporates on restart -- the exact trap behind the
+        # "re-enter my llama.cpp IP:Port every boot" report.
+        endpoint_warning = unsaved_console_endpoint_warning(
+            settings,
+            app_config=self._provider_readiness_app_config(),
+        )
+        if endpoint_warning:
+            self.app_instance.notify(endpoint_warning, severity="warning")
 
     async def _refresh_console_roleplay_projections(
         self,
@@ -12832,25 +12846,54 @@ class ChatScreen(BaseAppScreen):
         choice (mirroring the settings-modal apply path) and re-evaluates the
         setup card from the fresh on-disk config (task-177 mechanics; no
         boot-time snapshots).
+
+        task-16476: a provider that already has a DIFFERENT user-configured
+        endpoint keeps it -- the endpoint write fills only when absent, and
+        the detected endpoint is applied to the session instead, so "Use
+        detected ..." stays effective without clobbering persisted config
+        (discovery is loopback-only and can never see the LAN server the
+        configured endpoint may point at).
         """
         server = self._console_detected_local_server
         if server is None:
             return
         model_id = server.model_ids[0] if server.model_ids else None
-        provider_values: dict[str, object] = {"api_url": server.base_url}
+        app_config = self._provider_readiness_app_config()
+        provider_settings = self._config_section(
+            self._config_section(app_config, "api_settings"),
+            provider_config_key(server.provider_key),
+        )
+        configured_endpoint = first_configured_endpoint(provider_settings)
+        provider_values: dict[str, object] = {}
+        if configured_endpoint and configured_endpoint != server.base_url:
+            self.app_instance.notify(
+                "Keeping the saved endpoint "
+                f"{safe_endpoint_display(configured_endpoint) or configured_endpoint} "
+                f"for {provider_config_key(server.provider_key)}; using the detected "
+                "server for this session only.",
+                severity="warning",
+            )
+        else:
+            provider_values["api_url"] = server.base_url
         chat_defaults: dict[str, object] = {"provider": server.provider_key}
         if model_id:
             provider_values["model"] = model_id
             chat_defaults["model"] = model_id
-        try:
-            saved = save_settings_to_cli_config(
-                {
-                    f"api_settings.{server.provider_key}": provider_values,
-                    "chat_defaults": chat_defaults,
-                }
-            )
-        except Exception:
-            saved = False
+        if provider_values:
+            try:
+                saved = save_settings_to_cli_config(
+                    {
+                        f"api_settings.{server.provider_key}": provider_values,
+                        "chat_defaults": chat_defaults,
+                    }
+                )
+            except Exception:
+                saved = False
+        else:
+            try:
+                saved = save_settings_to_cli_config({"chat_defaults": chat_defaults})
+            except Exception:
+                saved = False
         if not saved:
             logger.warning(
                 "Could not persist detected local server defaults to config; "
@@ -12861,8 +12904,7 @@ class ChatScreen(BaseAppScreen):
             server.provider_key,
             model_id,
         )
-        if provider_config_key(settings.provider) in {"llama_cpp", "local_llamacpp"}:
-            settings = replace(settings, base_url=None)
+        settings = replace(settings, base_url=server.base_url)
         self._session._replace_active_console_session_settings(
             replace(settings, source="user")
         )
@@ -19207,14 +19249,21 @@ class ChatScreen(BaseAppScreen):
         model: Optional[str] = None,
         temperature: Optional[str] = None,
     ) -> None:
-        """Push sidebar control values back into the compact shell bar."""
+        """Push sidebar control values back into the compact shell bar.
+
+        task-16474: this programmatic sync no longer writes the
+        ``_console_control_provider``/``_console_control_model`` mirrors --
+        those track genuine user selections only (the mirrors outrank
+        ``chat_defaults`` when fresh session defaults are derived, so
+        ambient writes decided the provider of the next session). The bar's
+        displayed values and the session settings replacement below are
+        unchanged.
+        """
         updates: Dict[str, str] = {}
         if provider is not None:
             updates["provider"] = provider
-            self._console_control_provider = provider
         if model is not None:
             updates["model"] = model
-            self._console_control_model = model
         if temperature is not None:
             updates["temperature"] = temperature
 

--- a/tldw_chatbook/Widgets/compact_model_bar.py
+++ b/tldw_chatbook/Widgets/compact_model_bar.py
@@ -45,19 +45,26 @@ class CompactModelBar(Horizontal):
         defaults = config.get("chat_defaults", {})
         providers_models = get_cli_providers_and_models()
         available_providers = list(providers_models.keys())
+        # task-16474: no arbitrary first-provider fallback. When
+        # chat_defaults.provider is missing or unresolvable the select stays
+        # on its prompt until the user chooses -- the first [providers] key
+        # in file order is not a selection anyone made.
         default_provider = resolve_provider_name(
-            defaults.get(
-                "provider", available_providers[0] if available_providers else ""
-            ),
+            defaults.get("provider", ""),
             providers_models,
         )
 
-        # Provider select
+        # Provider select. allow_blank=True (task-16474): Textual's Select
+        # force-picks options[0] at mount and on set_options when blank is
+        # disallowed, which both fabricates a selection nobody made and fires
+        # a Changed event the provider mirror would treat as user intent.
+        # Blank now means "nothing chosen" and the screen handler already
+        # ignores empty values.
         provider_options = [(p, p) for p in available_providers]
         yield Select(
             options=provider_options,
             prompt="Provider",
-            allow_blank=False,
+            allow_blank=True,
             id="compact-api-provider",
         )
 
@@ -89,22 +96,28 @@ class CompactModelBar(Horizontal):
         )
 
     def on_mount(self) -> None:
-        """Set default values after widgets are mounted."""
+        """Set default values after widgets are mounted.
+
+        task-16474: population is programmatic, so every value set here is
+        wrapped in ``prevent(Select.Changed)`` -- the screen's provider/model
+        mirrors must only track genuine user selections, never the mount
+        burst (which used to write them on every recompose and silently
+        revert values the user had applied).
+        """
         config = self.app_instance.app_config
         defaults = config.get("chat_defaults", {})
         providers_models = get_cli_providers_and_models()
         available_providers = list(providers_models.keys())
         default_provider = resolve_provider_name(
-            defaults.get(
-                "provider", available_providers[0] if available_providers else ""
-            ),
+            defaults.get("provider", ""),
             providers_models,
         )
         # Set provider
         try:
             provider_select = self.query_one("#compact-api-provider", Select)
             if default_provider in available_providers:
-                provider_select.value = default_provider
+                with provider_select.prevent(Select.Changed):
+                    provider_select.value = default_provider
         except NoMatches:
             pass
         # Set model
@@ -113,15 +126,35 @@ class CompactModelBar(Horizontal):
         try:
             model_select = self.query_one("#compact-api-model", Select)
             if default_model in initial_models:
-                model_select.value = default_model
+                with model_select.prevent(Select.Changed):
+                    model_select.value = default_model
             elif initial_models:
-                model_select.value = initial_models[0]
+                with model_select.prevent(Select.Changed):
+                    model_select.value = initial_models[0]
         except NoMatches:
             pass
+        # The suppressed population events used to reach the screen's
+        # Select.Changed handler, whose coalesced control-bar sync kept the
+        # rail/inspector fresh after the bar (re)mounted. Population no
+        # longer carries user intent, so request that same sync explicitly
+        # instead of resurrecting the ambient events (task-16474).
+        screen = self.screen
+        request_sync = getattr(screen, "_request_console_control_bar_sync", None)
+        if callable(request_sync):
+            request_sync()
 
     @on(Select.Changed, "#compact-api-provider")
     async def handle_compact_provider_change(self, event: Select.Changed) -> None:
         """Handle provider change in compact bar and sync to sidebar."""
+        # task-16474: the provider select allows blank ("nothing chosen");
+        # a blank change carries no provider to sync. Covers Textual's
+        # BLANK and NULL sentinels the same way the screen's handler does.
+        if (
+            event.value is None
+            or event.value == Select.BLANK
+            or str(event.value).startswith("Select.")
+        ):
+            return
         new_provider = str(event.value)
         logger.info(f"Compact bar: provider changed to {new_provider}")
 
@@ -198,10 +231,12 @@ class CompactModelBar(Horizontal):
             if provider is not None:
                 compact_provider = self.query_one("#compact-api-provider", Select)
                 if compact_provider.value != provider:
-                    compact_provider.value = provider
+                    with compact_provider.prevent(Select.Changed):
+                        compact_provider.value = provider
                 available_models = providers_models.get(provider, [])
                 compact_model = self.query_one("#compact-api-model", Select)
-                compact_model.set_options([(m, m) for m in available_models])
+                with compact_model.prevent(Select.Changed):
+                    compact_model.set_options([(m, m) for m in available_models])
             if model is not None:
                 if compact_model is None:
                     compact_model = self.query_one("#compact-api-model", Select)
@@ -224,13 +259,16 @@ class CompactModelBar(Horizontal):
                     )
                 if model not in available_models:
                     available_models = [*available_models, model]
-                    compact_model.set_options([(m, m) for m in available_models])
+                    with compact_model.prevent(Select.Changed):
+                        compact_model.set_options([(m, m) for m in available_models])
                 if compact_model.value != model:
-                    compact_model.value = model
+                    with compact_model.prevent(Select.Changed):
+                        compact_model.value = model
             if temperature is not None:
                 compact_temp = self.query_one("#compact-temperature", Input)
                 if compact_temp.value != temperature:
-                    compact_temp.value = temperature
+                    with compact_temp.prevent(Input.Changed):
+                        compact_temp.value = temperature
         except NoMatches:
             pass
 


### PR DESCRIPTION
## Summary

From the 2026-08-15 user report: a llama.cpp user re-entered their custom IP:Port on every boot and saw the Console Provider chip flip to providers they never chose. Investigation traced both symptoms to session-scoped provider state plus ambient writes to config-derived defaults; four backlog tasks (16473-16476) were filed with red regression tests, then fixed here.

- **16473 — endpoint persistence warning**: new pure helpers in `Chat/console_session_settings.py` (`console_session_endpoint_survives_restart` / `unsaved_console_endpoint_warning`) compare the session endpoint against the real restart fallback chain (env `TLDW_CONSOLE_LLAMA_CPP_BASE_URL` -> `[console] llama_cpp_base_url_override` -> `[api_settings.<provider>]` endpoint -> built-in default). `_apply_console_settings_result` now warns "will not survive a restart — use Save as default" when the applied endpoint has no persisted backing (llama.cpp readiness reports Ready for such endpoints, so nothing else nudged persistence).
- **16474 — provider mirror hygiene**: programmatic population in `CompactModelBar` no longer writes the `_console_control_provider`/`_console_control_model` mirrors (the mirror outranks `chat_defaults.provider` when fresh session defaults are derived). `prevent(Select.Changed)` wraps all programmatic sets; the provider select moves to `allow_blank=True` because Textual's Select force-picks `options[0]` at mount when blank is disallowed — that internal auto-pick was the actual ambient writer. The arbitrary first-`[providers]`-key fallback is removed. The bar itself stays: it is live header UI despite the `console-hidden-control` class (visible-text diff evidence recorded in the task).
- **16475 — visible provider swaps**: `_maybe_refresh_stale_default_console_settings` now emits a one-time warning + log when the refresh changes a session's provider. task-177 convergence unchanged (same-provider refreshes stay silent; user-marked sessions untouched — both existing tests green).
- **16476 — adoption clobber guard**: `_apply_detected_local_server` fills `api_url` only when absent, keeps a differing configured endpoint (with a notice naming it), and applies the detected endpoint to the session so "Use detected ..." stays effective without the config write.

## Test plan

- [x] `Tests/UI/test_console_provider_persistence_regressions.py` — 6 regression tests, each verified **red on pristine dev** (stash-compare) and green on this branch
- [x] Affected suites on the committed tree: decomposition + regressions 146 passed; native-chat-flow + UI session-settings 498 passed (3 failures independently reproduced on pristine dev: unmount-timeout, ctrl-k switcher, rename chain — pre-existing, untouched by this branch); pure Chat settings + first-run wizard 496 passed; shell bar 16 passed; setup-card/discovery 11 passed
- [x] ruff clean on all changed files (one unused-import finding pre-exists on dev)

## Notes for reviewers

- `test_console_native_missing_key_blocks_before_clearing_generic_draft` was re-pinned: it scraped "missing API key" from COLLAPSED inspector rows whose DOM display depends on a pre-existing rail-cascade race; it now waits on the composer's deterministic "add an API key to continue" copy — same contract (blocked send keeps the draft and names the missing-key reason).
- Backlog tasks 16473-16476 are marked Done in this PR (ACs checked, Implementation Notes recorded).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console provider/endpoint persistence and provider-state hygiene. Old: custom `llama.cpp` endpoints were session-only and vanished on restart, and ambient compact-bar events could flip the Provider; New: Console warns when an endpoint won’t persist, suppresses programmatic Select changes and arbitrary first-provider defaults, surfaces provider swaps on stale-default refresh, and keeps configured endpoints when adopting detected servers while applying the detected endpoint to the active session. Adoption now compares endpoints by connection identity (treats trailing slashes as the same server).

- Warn on unsaved endpoints (16473): `_apply_console_settings_result` calls `unsaved_console_endpoint_warning` (via `console_session_endpoint_survives_restart`) to notify when a `llama.cpp` endpoint has no persisted backing.
- Compact bar hygiene (16474): `compact_model_bar` wraps programmatic sets with `prevent(Select.Changed)`, sets `allow_blank=True`, removes the first-provider fallback; `_sync_compact_shell_controls` no longer writes provider/model mirrors.
- Stale-default visibility (16475): `_maybe_refresh_stale_default_console_settings` emits a one-time warning + log when the refresh changes the session’s provider.
- Detected server adoption (16476): `_apply_detected_local_server` fills `api_url` only when absent, warns when keeping a different configured endpoint, and applies the detected endpoint to the active session; endpoint comparison uses identity normalization (trailing-slash-only differences don’t warn or skip canonical writes). Added a regression test for this case.
- Tests: added `Tests/UI/test_console_provider_persistence_regressions.py` (6 regressions + trailing-slash case) and re-pinned one expectation in `test_console_native_chat_flow.py`; suites pass on this branch, pre-existing dev reds unchanged. Qodo review: replaced token-shaped test literal with `DUMMY_OPENAI_API_KEY` and added Args/Returns docstrings to new helpers. No migration required.

<sup>Written for commit d0d88eecb32c1bec40c49cc9fc1cd7a8bb6e2aaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

