### PR TITLE
feat(console): thinking levels and budget for local providers (Qwen3.8-27B, ADR-066)

### DIFF
--- a/Docs/superpowers/plans/2026-08-15-local-thinking-controls.md
+++ b/Docs/superpowers/plans/2026-08-15-local-thinking-controls.md
@@ -1,0 +1,1205 @@
+# Local Provider Thinking Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the Console's existing Reasoning (`reasoning_effort`) and Budget (`thinking_budget_tokens`) settings through to local providers (llama.cpp family, vLLM family, MLX-LM, Custom OpenAI) so Qwen3.8-27B's adjustable thinking levels and max thinking tokens work per request, with thinking text kept out of the visible reply on the llama.cpp direct path.
+
+**Architecture:** One pure wire-format table (`build_local_thinking_payload_fields`) maps each local execution key to payload fragments (`chat_template_kwargs` vs top-level fields vs `reasoning_budget`). The direct llama.cpp gateway path and the shared adapter-path builder both compose through it. A new start-anchored, stream-aware `<think>` filter strips unsplit thinking from the direct path only.
+
+**Tech Stack:** Python 3.11+, httpx (direct path), requests (adapter path), pytest, Textual (modal).
+
+**Spec:** `Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md` (argues from ADR-066: `backlog/decisions/066-local-provider-thinking-controls.md`; task: `backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md`)
+
+## Global Constraints
+
+- Values are sent **verbatim** — never clamped or rewritten. `reasoning_effort: none` additionally sends `enable_thinking: false`.
+- `thinking_budget_tokens` validation floor stays a global ≥ 1024 (do not make it provider-aware).
+- Prefill precedence is `prefill > none > effort`: a trailing assistant message always forces `chat_template_kwargs.enable_thinking = false`.
+- llama.cpp family level goes inside `chat_template_kwargs.reasoning_effort` (llama-server does not parse top-level `reasoning_effort`); budget as top-level `reasoning_budget`.
+- vLLM family level goes BOTH top-level and inside `chat_template_kwargs.reasoning_effort` (same value).
+- Custom OpenAI endpoints (`custom-openai-api`, `custom-openai-api-2`) get top-level `reasoning_effort` ONLY — no llama.cpp-specific fields.
+- `<think>` stripping is start-anchored: mid-reply literal `<think>` text is legitimate content and must survive.
+- No new Console settings fields. No changes to managed-server launch defaults (`--jinja` etc. remain user-supplied).
+- Warnings are non-blocking; unknown models produce no warning.
+- All SQL/param conventions N/A (no DB changes). Tests must pass `pytest Tests/Chat/` before each commit.
+
+---
+
+### Task 1: Wire-format table (pure function)
+
+**Files:**
+- Create: `Tests/Chat/test_local_thinking_wire_formats.py`
+- Modify: `tldw_chatbook/Chat/console_provider_support.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `build_local_thinking_payload_fields(execution_key: str, reasoning_effort: str | None, thinking_budget_tokens: int | None) -> dict[str, Any]` — payload fragments to `dict.update()` into an OpenAI-compatible chat payload. Returns `{}` for keys not in the table.
+
+- [ ] **Step 0: Create the working branch**
+
+The spec/ADR/task/plan files are currently untracked on `feat/model-catalog-consent-gate`, which holds unrelated WIP. Do NOT commit them there. Create the implementation branch off `main` and carry the doc files over:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_chatbook
+git stash push --include-untracked -m "wip: unrelated model-catalog work" || true
+git checkout main && git pull || git checkout main
+git checkout -b feat/local-thinking-controls
+git stash pop || true
+# verify the four doc files are present and staged-able:
+ls Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md \
+   backlog/decisions/066-local-provider-thinking-controls.md \
+   "backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md" \
+   Docs/superpowers/plans/2026-08-15-local-thinking-controls.md
+```
+
+If the stash pop conflicts, resolve by keeping the untracked doc files on the new branch. Commit the docs:
+
+```bash
+git add Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md \
+        backlog/decisions/066-local-provider-thinking-controls.md \
+        "backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md" \
+        Docs/superpowers/plans/2026-08-15-local-thinking-controls.md
+git commit -m "docs: spec, ADR-066, and plan for local thinking controls"
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_local_thinking_wire_formats.py`:
+
+```python
+"""Wire-format composition for local thinking controls (ADR-066)."""
+
+from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
+)
+
+
+class TestLlamaCppFamily:
+    def test_level_goes_into_chat_template_kwargs(self):
+        fields = build_local_thinking_payload_fields(
+            "llama_cpp", "low", None
+        )
+        assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+
+    def test_budget_goes_top_level(self):
+        fields = build_local_thinking_payload_fields(
+            "local_llamacpp", None, 2048
+        )
+        assert fields == {"reasoning_budget": 2048}
+
+    def test_level_and_budget_together(self):
+        fields = build_local_thinking_payload_fields(
+            "local_llamafile", "xhigh", 4096
+        )
+        assert fields == {
+            "chat_template_kwargs": {"reasoning_effort": "xhigh"},
+            "reasoning_budget": 4096,
+        }
+
+    def test_none_effort_sends_verbatim_and_disables_thinking(self):
+        fields = build_local_thinking_payload_fields(
+            "local-llm", "none", None
+        )
+        assert fields == {
+            "chat_template_kwargs": {
+                "reasoning_effort": "none",
+                "enable_thinking": False,
+            }
+        }
+
+    def test_all_family_keys_share_the_shape(self):
+        for key in ("llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"):
+            assert build_local_thinking_payload_fields(key, "low", 1024) == {
+                "chat_template_kwargs": {"reasoning_effort": "low"},
+                "reasoning_budget": 1024,
+            }
+
+
+class TestVllmFamily:
+    def test_level_is_dual_placed(self):
+        for key in ("vllm", "local_vllm"):
+            assert build_local_thinking_payload_fields(key, "medium", None) == {
+                "reasoning_effort": "medium",
+                "chat_template_kwargs": {"reasoning_effort": "medium"},
+            }
+
+    def test_budget_is_dropped(self):
+        assert build_local_thinking_payload_fields("vllm", None, 2048) == {}
+
+
+class TestCustomOpenAI:
+    def test_level_is_top_level_only(self):
+        for key in ("custom-openai-api", "custom-openai-api-2"):
+            assert build_local_thinking_payload_fields(key, "low", 2048) == {
+                "reasoning_effort": "low"
+            }
+
+
+class TestMlx:
+    def test_level_via_template_kwargs_budget_dropped(self):
+        fields = build_local_thinking_payload_fields(
+            "local_mlx_lm", "low", 2048
+        )
+        assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+
+
+class TestUnknownKeysAndHygiene:
+    def test_unknown_key_returns_empty(self):
+        assert build_local_thinking_payload_fields("ollama", "low", 1024) == {}
+        assert build_local_thinking_payload_fields("openai", "low", 1024) == {}
+
+    def test_blank_effort_and_missing_budget_return_empty(self):
+        assert build_local_thinking_payload_fields("llama_cpp", "", None) == {}
+        assert build_local_thinking_payload_fields("llama_cpp", None, None) == {}
+
+    def test_whitespace_effort_is_normalized(self):
+        assert build_local_thinking_payload_fields("llama_cpp", "  low ", None) == {
+            "chat_template_kwargs": {"reasoning_effort": "low"}
+        }
+
+    def test_non_int_budget_is_ignored(self):
+        assert build_local_thinking_payload_fields("llama_cpp", None, "2048") == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_local_thinking_wire_formats.py -v`
+Expected: FAIL with `ImportError: cannot import name 'build_local_thinking_payload_fields'`
+
+- [ ] **Step 3: Implement the table**
+
+Append to `tldw_chatbook/Chat/console_provider_support.py` (after `_provider_display_name`; add `from typing import Any` to imports if absent, plus `from loguru import logger` if absent):
+
+```python
+# ADR-066: per-execution-key wire formats for Console thinking controls.
+# Level = reasoning_effort; budget = thinking_budget_tokens.
+_LLAMA_CPP_THINKING_KEYS = frozenset(
+    {"llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"}
+)
+_VLLM_THINKING_KEYS = frozenset({"vllm", "local_vllm"})
+_CUSTOM_OPENAI_THINKING_KEYS = frozenset(
+    {"custom-openai-api", "custom-openai-api-2"}
+)
+# MLX-LM: template-kwargs shape pending live verification of mlx_lm.server
+# support; if unsupported this row degrades to drop-and-log.
+_TEMPLATE_KWARGS_THINKING_KEYS = frozenset({"local_mlx_lm"})
+
+
+def build_local_thinking_payload_fields(
+    execution_key: str | None,
+    reasoning_effort: str | None,
+    thinking_budget_tokens: int | None,
+) -> dict[str, Any]:
+    """Compose thinking-control payload fragments for a local provider.
+
+    Args:
+        execution_key: ``chat_api_call`` provider key (e.g. ``llama_cpp``).
+        reasoning_effort: Verbatim user-selected effort level, if any.
+        thinking_budget_tokens: Max thinking tokens, if any.
+
+    Returns:
+        Fragments to merge into an OpenAI-compatible chat payload. Empty
+        dict when the key has no thinking support or no values are set.
+    """
+    key = str(execution_key or "").strip().lower()
+    effort = str(reasoning_effort or "").strip().lower() or None
+    budget: int | None = (
+        thinking_budget_tokens
+        if isinstance(thinking_budget_tokens, int)
+        and not isinstance(thinking_budget_tokens, bool)
+        else None
+    )
+    fields: dict[str, Any] = {}
+    if key in _LLAMA_CPP_THINKING_KEYS or key in _TEMPLATE_KWARGS_THINKING_KEYS:
+        if effort is not None:
+            template_kwargs: dict[str, Any] = {"reasoning_effort": effort}
+            if effort == "none":
+                template_kwargs["enable_thinking"] = False
+            fields["chat_template_kwargs"] = template_kwargs
+        if budget is not None and key in _LLAMA_CPP_THINKING_KEYS:
+            fields["reasoning_budget"] = budget
+        if budget is not None and key in _TEMPLATE_KWARGS_THINKING_KEYS:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    elif key in _VLLM_THINKING_KEYS:
+        if effort is not None:
+            fields["reasoning_effort"] = effort
+            fields["chat_template_kwargs"] = {"reasoning_effort": effort}
+        if budget is not None:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    elif key in _CUSTOM_OPENAI_THINKING_KEYS:
+        if effort is not None:
+            fields["reasoning_effort"] = effort
+        if budget is not None:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    return fields
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Chat/test_local_thinking_wire_formats.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_provider_support.py Tests/Chat/test_local_thinking_wire_formats.py
+git commit -m "feat(chat): ADR-066 wire-format table for local thinking controls"
+```
+
+---
+
+### Task 2: Direct llama.cpp payload wiring (gateway)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_provider_gateway.py` (`build_llamacpp_chat_payload` ~line 845, `stream_llamacpp_chat` ~1795, `complete_llamacpp_chat` ~1877, call sites ~2008 and ~2219/2233)
+- Test: `Tests/Chat/test_console_provider_gateway.py` (extend)
+
+**Interfaces:**
+- Consumes: `build_local_thinking_payload_fields` from Task 1.
+- Produces: `build_llamacpp_chat_payload(..., reasoning_effort: str | None = None, thinking_budget_tokens: int | None = None)`; `stream_llamacpp_chat` and `complete_llamacpp_chat` gain the same two keyword params. Thinking fields are NOT applied in this task's stream output — filtering lands in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_provider_gateway.py` (follow the file's existing import style for `build_llamacpp_chat_payload`):
+
+```python
+class TestLlamacppThinkingPayload:
+    def test_effort_composes_chat_template_kwargs(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True, reasoning_effort="low",
+        )
+        assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
+
+    def test_budget_composes_reasoning_budget(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=False, thinking_budget_tokens=2048,
+        )
+        assert payload["reasoning_budget"] == 2048
+
+    def test_none_effort_disables_thinking(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True, reasoning_effort="none",
+        )
+        assert payload["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_prefill_overrides_effort(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen",
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Sure"},
+            ],
+            stream=True, reasoning_effort="xhigh",
+        )
+        # prefill > none > effort (llama.cpp rejects prefill + thinking)
+        assert payload["chat_template_kwargs"] == {
+            "reasoning_effort": "xhigh",
+            "enable_thinking": False,
+        }
+
+    def test_no_thinking_fields_by_default(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        assert "chat_template_kwargs" not in payload
+        assert "reasoning_budget" not in payload
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_console_provider_gateway.py -k TestLlamacppThinkingPayload -v`
+Expected: FAIL with `TypeError: ... unexpected keyword argument 'reasoning_effort'`
+
+- [ ] **Step 3: Implement**
+
+In `tldw_chatbook/Chat/console_provider_gateway.py`:
+
+3a. Add to imports: `from tldw_chatbook.Chat.console_provider_support import build_local_thinking_payload_fields`
+
+3b. In `build_llamacpp_chat_payload`, add keyword params `reasoning_effort: str | None = None,` and `thinking_budget_tokens: int | None = None,` (after `frequency_penalty`), extend the docstring Args with both, and REPLACE the current prefill tail:
+
+```python
+    # OLD (replace):
+    # if messages and messages[-1].get("role") == "assistant":
+    #     payload["chat_template_kwargs"] = {"enable_thinking": False}
+    # NEW:
+    payload.update(
+        build_local_thinking_payload_fields(
+            "llama_cpp", reasoning_effort, thinking_budget_tokens
+        )
+    )
+    if messages and messages[-1].get("role") == "assistant":
+        template_kwargs = dict(payload.get("chat_template_kwargs") or {})
+        template_kwargs["enable_thinking"] = False
+        payload["chat_template_kwargs"] = template_kwargs
+    return payload
+```
+
+Also update the docstring paragraph about prefills to state the precedence: `prefill > none > effort`.
+
+3c. In `stream_llamacpp_chat` and `complete_llamacpp_chat`: add the same two keyword params to the signatures, forward them into their `build_llamacpp_chat_payload(...)` calls, and document them in the docstrings.
+
+3d. At the two direct-path call sites: the auxiliary site (~line 2008, inside `complete_auxiliary`) currently has a comment claiming reasoning controls are "deliberately omitted" — that comment is now wrong. Replace the call with:
+
+```python
+                    text = await self.complete_llamacpp_chat(
+                        base_url=resolution.base_url,
+                        model=model,
+                        messages=messages,
+                        temperature=resolution.temperature,
+                        top_p=resolution.top_p,
+                        min_p=resolution.min_p,
+                        top_k=resolution.top_k,
+                        max_tokens=request.max_output_tokens,
+                        seed=resolution.seed,
+                        presence_penalty=resolution.presence_penalty,
+                        frequency_penalty=resolution.frequency_penalty,
+                        reasoning_effort=resolution.reasoning_effort,
+                        thinking_budget_tokens=resolution.thinking_budget_tokens,
+                        strict_response=True,
+```
+and rewrite the comment above it to: `# Thinking controls follow ADR-066: level via chat_template_kwargs, budget via top-level reasoning_budget. Auxiliary requests inherit session thinking settings (documented parity with cloud providers).`
+
+The send-path site (~lines 2219 and 2233, inside `stream_chat`): add the same two kwargs to BOTH the `complete_llamacpp_chat(...)` and `stream_llamacpp_chat(...)` calls:
+
+```python
+                        reasoning_effort=resolution.reasoning_effort,
+                        thinking_budget_tokens=resolution.thinking_budget_tokens,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_provider_gateway.py -v`
+Expected: all PASS (existing tests included — no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_provider_gateway.py Tests/Chat/test_console_provider_gateway.py
+git commit -m "feat(console): send thinking level+budget on direct llama.cpp path"
+```
+
+---
+
+### Task 3: Start-anchored think filter
+
+**Files:**
+- Create: `tldw_chatbook/Chat/llamacpp_think_filter.py`
+- Test: `Tests/Chat/test_llamacpp_think_filter.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `class StartAnchoredThinkFilter` with `feed(self, chunk: str) -> str` and `flush(self) -> str`. Pure string state machine; no I/O. Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_llamacpp_think_filter.py`:
+
+```python
+from tldw_chatbook.Chat.llamacpp_think_filter import StartAnchoredThinkFilter
+
+
+def run_filter(text: str) -> str:
+    f = StartAnchoredThinkFilter()
+    return f.feed(text) + f.flush()
+
+
+class TestSplitAcrossChunks:
+    def test_open_tag_split_across_chunks(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<thi") == ""
+        assert f.feed("nk>reasoning") == ""
+        assert f.feed(" here</think>answer") == "answer"
+        assert f.flush() == ""
+
+    def test_close_tag_split_across_chunks(self):
+        f = StartAnchoredThinkFilter()
+        f.feed("<think>abc")
+        assert f.feed("</thi") == ""
+        assert f.feed("nk>done") == "done"
+
+    def test_one_char_at_a_time(self):
+        f = StartAnchoredThinkFilter()
+        out = []
+        for ch in "<think>hidden</think>visible":
+            out.append(f.feed(ch))
+        assert "".join(out) + f.flush() == "visible"
+
+
+class TestAnchoring:
+    def test_mid_reply_literal_tag_survives(self):
+        assert run_filter("Here is XML: <think>stuff</think> done") == (
+            "Here is XML: <think>stuff</think> done"
+        )
+
+    def test_leading_whitespace_before_tag_is_tolerated(self):
+        assert run_filter("\n\n<think>x</think>hi") == "hi"
+
+    def test_empty_prefix_block_is_removed(self):
+        # Some Qwen generations emit an empty think prefix in no-think mode.
+        assert run_filter("<think>\n\n</think>\n\nAnswer") == "Answer"
+
+    def test_plain_text_passes_through(self):
+        assert run_filter("just an answer") == "just an answer"
+
+    def test_text_starting_like_tag_but_not_tag_passes(self):
+        assert run_filter("<thumbs up>") == "<thumbs up>"
+
+    def test_thinking_tag_variant_supported(self):
+        assert run_filter("<thinking>deep</thinking>ok") == "ok"
+
+
+class TestUnterminated:
+    def test_unterminated_start_anchored_block_dropped_on_flush(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<think>forever") == ""
+        assert f.flush() == ""
+
+    def test_ambiguous_prefix_at_stream_end_dropped(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<thin") == ""
+        assert f.flush() == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_llamacpp_think_filter.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tldw_chatbook.Chat.llamacpp_think_filter'`
+
+- [ ] **Step 3: Implement**
+
+Create `tldw_chatbook/Chat/llamacpp_think_filter.py`:
+
+```python
+"""Start-anchored, stream-aware ``<think>`` filtering for llama.cpp output.
+
+Qwen-family chat templates emit thinking at the very start of the response
+(an empty ``<think>\\n\\n</think>`` prefix appears in no-think mode on some
+generations). Only a think block that opens at the beginning of the stream
+is stripped; a literal ``<think>`` mid-reply (e.g. the user asked for an XML
+example) is legitimate content and passes through. See ADR-066.
+"""
+
+from __future__ import annotations
+
+_OPEN_TAGS = ("<think>", "<thinking>")
+_CLOSE_TAGS = ("</think>", "</thinking>")
+
+
+class StartAnchoredThinkFilter:
+    """Stateful filter: feed() chunks in, get visible text out; flush() at end."""
+
+    def __init__(self) -> None:
+        self._inside_think = False
+        self._decided_visible = False
+        self._buffer = ""
+
+    def feed(self, chunk: str) -> str:
+        if not chunk:
+            return ""
+        if self._decided_visible:
+            return chunk
+        self._buffer += chunk
+        while True:
+            if self._inside_think:
+                for tag in _CLOSE_TAGS:
+                    idx = self._buffer.find(tag)
+                    if idx != -1:
+                        self._buffer = self._buffer[idx + len(tag):]
+                        self._inside_think = False
+                        self._decided_visible = True
+                        return self._buffer.lstrip("\n")
+                return ""
+            stripped = self._buffer.lstrip()
+            if not stripped:
+                return ""  # whitespace-only so far; keep probing
+            for tag in _OPEN_TAGS:
+                if stripped.startswith(tag):
+                    self._inside_think = True
+                    self._buffer = stripped[len(tag):]
+                    break
+            if self._inside_think:
+                continue  # re-run close-tag scan on the remainder
+            if any(tag.startswith(stripped) for tag in _OPEN_TAGS):
+                return ""  # still ambiguous: could be a split tag opener
+            self._decided_visible = True
+            return self._buffer
+
+    def flush(self) -> str:
+        # Stream ended while still probing or still inside an unterminated
+        # think block: drop the tail (spec'd behavior).
+        return ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest Tests/Chat/test_llamacpp_think_filter.py -v`
+Expected: all PASS. If `test_text_starting_like_tag_but_not_tag_passes` fails, check the ambiguity branch order: divergence must be detected only when NO open tag starts with `stripped`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/llamacpp_think_filter.py Tests/Chat/test_llamacpp_think_filter.py
+git commit -m "feat(chat): start-anchored stream-aware think-tag filter"
+```
+
+---
+
+### Task 4: Wire the filter into the direct path
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_provider_gateway.py` (`stream_llamacpp_chat`, `complete_llamacpp_chat`)
+- Test: `Tests/Chat/test_console_provider_gateway.py` (extend)
+
+**Interfaces:**
+- Consumes: `StartAnchoredThinkFilter` from Task 3.
+- Produces: no new public interface — behavior change only. Note: the SSE parser `_content_from_sse_line` and the completion parser `_content_from_completion_response` ALREADY ignore `reasoning_content` (they read `content` only), so the server-split case needs no change; do not touch them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_provider_gateway.py`. Follow the existing file's fake-SSE harness pattern for `stream_llamacpp_chat` (search the file for `stream_llamacpp_chat` tests and reuse their transport mock); the shapes below assume a helper `fake_sse_gateway(lines)` like the existing tests use — copy the closest existing test's setup verbatim and adapt lines:
+
+```python
+class TestDirectPathThinkFiltering:
+    def test_stream_strips_start_anchored_think_block(self):
+        # SSE lines whose content deltas spell:
+        #   "<think>ponder</think>Hello"
+        lines = [
+            'data: {"choices":[{"delta":{"content":"<think>pon"}}]}',
+            'data: {"choices":[{"delta":{"content":"der</think>Hello"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)  # reuse existing test harness
+        chunks = [
+            c
+            async for c in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "Hello"
+
+    def test_stream_passes_mid_reply_literal_tag(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"XML: <think>x</think>"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)
+        chunks = [
+            c
+            async for c in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "XML: <think>x</think>"
+
+    def test_stream_ignores_reasoning_content_deltas(self):
+        lines = [
+            'data: {"choices":[{"delta":{"reasoning_content":"secret"}}]}',
+            'data: {"choices":[{"delta":{"content":"Answer"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)
+        chunks = [
+            c
+            async for c in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "Answer"
+
+    def test_complete_strips_start_anchored_think_block(self):
+        gateway = make_gateway_with_completion(
+            {"choices": [{"message": {"content": "<think>x</think>Done"}}]}
+        )
+        text = asyncio.run(
+            gateway.complete_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+        assert text == "Done"
+```
+
+If the existing file has no reusable SSE harness, build one with `httpx.MockTransport` mounted on an `httpx.AsyncClient` passed as the gateway's `http_client` constructor arg (the gateway accepts an injected client — see its `__init__`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_console_provider_gateway.py -k TestDirectPathThinkFiltering -v`
+Expected: FAIL — streams yield `<think>ponder</think>Hello` unfiltered.
+
+- [ ] **Step 3: Implement**
+
+In `stream_llamacpp_chat` (`tldw_chatbook/Chat/console_provider_gateway.py`), instantiate a filter at the top and apply it to every yield. The `emitted_content` flag must track VISIBLE text only (it decides whether the non-streaming fallback runs):
+
+```python
+        from tldw_chatbook.Chat.llamacpp_think_filter import StartAnchoredThinkFilter
+
+        think_filter = StartAnchoredThinkFilter()
+        emitted_content = False
+        stream_error: httpx.HTTPError | None = None
+        try:
+            async with self._active_http_client().stream(
+                ...
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    chunk = self._content_from_sse_line(line)
+                    if chunk:
+                        visible = think_filter.feed(chunk)
+                        if visible:
+                            emitted_content = True
+                            yield visible
+        except httpx.HTTPError as exc:
+            if emitted_content:
+                raise
+            stream_error = exc
+
+        if emitted_content:
+            tail = think_filter.flush()
+            if tail:
+                yield tail
+            return
+```
+
+(Move the `StartAnchoredThinkFilter` import to module top with the other local imports rather than inline if style demands.)
+
+In `complete_llamacpp_chat`, filter the final string before returning — replace `return content or ""` with:
+
+```python
+        think_filter = StartAnchoredThinkFilter()
+        return think_filter.feed(content or "") + think_filter.flush()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_provider_gateway.py Tests/Chat/test_llamacpp_think_filter.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_provider_gateway.py Tests/Chat/test_console_provider_gateway.py
+git commit -m "feat(console): strip start-anchored think blocks on direct llama.cpp path"
+```
+
+---
+
+### Task 5: Adapter path — param maps, shared builder, handlers
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/Chat_Functions.py` (`PROVIDER_PARAM_MAP` entries at lines ~391 `llama_cpp`, ~484 `local-llm` (inside the vLLM block), ~535 `custom-openai-api`, ~560 `custom-openai-api-2`, ~611 `local_llamacpp`, ~630 `local_llamafile`, ~665 `local_vllm`, ~686 `local_mlx_lm`, and `vllm` at ~463)
+- Modify: `tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py` (`_chat_with_openai_compatible_local_server` at ~103, `chat_with_local_llm` ~500, `chat_with_llama` ~632, `chat_with_vllm` ~1327, `chat_with_custom_openai` ~1790, `chat_with_custom_openai_2` ~1949, `chat_with_mlx_lm` ~2125)
+- Test: Create `Tests/Chat/test_local_adapter_thinking_dispatch.py`
+
+**Interfaces:**
+- Consumes: `build_local_thinking_payload_fields` from Task 1.
+- Produces: `chat_api_call(api_endpoint=..., reasoning_effort=..., thinking_budget_tokens=...)` now forwards these to the covered local handlers; the shared builder merges the wire fragments into its POST payload.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/Chat/test_local_adapter_thinking_dispatch.py`:
+
+```python
+"""Adapter-path thinking dispatch: param maps + shared local builder."""
+
+from unittest.mock import patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+
+COVERED_KEYS = [
+    "llama_cpp",
+    "local_llamacpp",
+    "local_llamafile",
+    "local-llm",
+    "vllm",
+    "local_vllm",
+    "local_mlx_lm",
+    "custom-openai-api",
+    "custom-openai-api-2",
+]
+
+
+def test_param_maps_forward_thinking_fields(monkeypatch):
+    captured = {}
+
+    def fake_handler(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    import tldw_chatbook.Chat.Chat_Functions as cf
+
+    for key in COVERED_KEYS:
+        captured.clear()
+        monkeypatch.setitem(cf.API_CALL_HANDLERS, key, fake_handler)
+        chat_api_call(
+            api_endpoint=key,
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key=None,
+            reasoning_effort="low",
+            thinking_budget_tokens=2048,
+        )
+        assert captured.get("reasoning_effort") == "low", key
+        assert captured.get("thinking_budget_tokens") == 2048, key
+
+
+def test_shared_builder_composes_llama_wire_format(monkeypatch):
+    from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (
+        _chat_with_openai_compatible_local_server,
+    )
+
+    posted = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"choices":[{"message":{"content":"ok"}}]}'
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        def raise_for_status(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.adapters = None
+
+        def mount(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None, timeout=None):
+            posted["url"] = url
+            posted["payload"] = json
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        return_value=FakeSession(),
+    ):
+        _chat_with_openai_compatible_local_server(
+            api_base_url="http://127.0.0.1:8080",
+            model_name="qwen",
+            input_data=[{"role": "user", "content": "hi"}],
+            streaming=False,
+            reasoning_effort="low",
+            thinking_budget_tokens=2048,
+            thinking_wire_key="llama_cpp",
+        )
+
+    payload = posted["payload"]
+    assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
+    assert payload["reasoning_budget"] == 2048
+
+
+def test_shared_builder_composes_vllm_dual_placement(monkeypatch):
+    # Same harness as above; only assertions differ.
+    posted = {}
+
+    class FakeResponse:
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        def raise_for_status(self):
+            return None
+
+    class FakeSession:
+        def mount(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None, timeout=None):
+            posted["payload"] = json
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        return_value=FakeSession(),
+    ):
+        from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (
+            _chat_with_openai_compatible_local_server,
+        )
+
+        _chat_with_openai_compatible_local_server(
+            api_base_url="http://127.0.0.1:8000",
+            model_name="qwen",
+            input_data=[{"role": "user", "content": "hi"}],
+            streaming=False,
+            reasoning_effort="medium",
+            thinking_budget_tokens=2048,
+            thinking_wire_key="vllm",
+        )
+
+    payload = posted["payload"]
+    assert payload["reasoning_effort"] == "medium"
+    assert payload["chat_template_kwargs"] == {"reasoning_effort": "medium"}
+    assert "reasoning_budget" not in payload
+```
+
+Note: if the shared builder's retry/session plumbing differs (e.g. it configures `Retry` via `requests.adapters`), keep the FakeSession's `mount`/attribute surface compatible with what the code touches — read the function body around `requests.Session()` before finalizing the fake.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_local_adapter_thinking_dispatch.py -v`
+Expected: FAIL — `captured.get("reasoning_effort") is None` (maps don't forward) and `TypeError` on `thinking_wire_key`.
+
+- [ ] **Step 3: Implement**
+
+3a. `Chat_Functions.py` — add these two entries to each of the nine `PROVIDER_PARAM_MAP` keys listed in Files (place near the other generic entries):
+
+```python
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
+```
+
+3b. `LLM_API_Calls_Local.py` — shared builder: add keyword params to `_chat_with_openai_compatible_local_server` (after `user_identifier`):
+
+```python
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
+    thinking_wire_key: Optional[str] = None,
+```
+
+Add to module imports: `from tldw_chatbook.Chat.console_provider_support import build_local_thinking_payload_fields`
+
+In the payload-construction block (after the `user_identifier` mapping, before the URL construction), add:
+
+```python
+    if thinking_wire_key and (
+        reasoning_effort is not None or thinking_budget_tokens is not None
+    ):
+        payload.update(
+            build_local_thinking_payload_fields(
+                thinking_wire_key, reasoning_effort, thinking_budget_tokens
+            )
+        )
+```
+
+3c. Each handler gains the two params and forwards them plus its wire key to the shared builder call:
+
+| Handler | Signature additions | Forward as `thinking_wire_key=` |
+|---|---|---|
+| `chat_with_llama` | `reasoning_effort: Optional[str] = None, thinking_budget_tokens: Optional[int] = None` | `provider_name or "llama_cpp"` |
+| `chat_with_local_llm` | same | `provider_name or "local-llm"` |
+| `chat_with_vllm` | same | `provider_name or "vllm"` |
+| `chat_with_mlx_lm` | same | `provider_name or "local_mlx_lm"` |
+| `chat_with_custom_openai` | same | `"custom-openai-api"` |
+| `chat_with_custom_openai_2` | same | `"custom-openai-api-2"` |
+
+Example for `chat_with_vllm`'s delegation call — add alongside the other forwards:
+
+```python
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key=provider_name or "vllm",
+```
+
+(For `chat_with_llama`/`chat_with_custom_openai*` the delegation shape is identical — they all `return _chat_with_openai_compatible_local_server(...)`.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_local_adapter_thinking_dispatch.py Tests/Chat/ -v`
+Expected: all PASS, no regressions across `Tests/Chat/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/Chat_Functions.py tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py Tests/Chat/test_local_adapter_thinking_dispatch.py
+git commit -m "feat(chat): forward thinking controls through adapter-path local providers"
+```
+
+---
+
+### Task 6: Hints, warnings, placeholder, preview
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_session_settings.py` (hint table + `console_settings_warnings` + summary row, ~lines 103-110 for constants, ~768 for `sampling_parts`)
+- Modify: `tldw_chatbook/Widgets/Console/console_settings_modal.py` (`_choice_placeholder` ~1758, save path ~1408/1426 and settings construction ~2042, `PROVIDER_CHOICE_INPUTS` ~109-125)
+- Test: `Tests/Chat/test_console_session_settings.py` (extend)
+
+**Interfaces:**
+- Consumes: `build_local_thinking_payload_fields` (Task 1); `resolve_console_provider_identity` (existing in `console_provider_support.py`).
+- Produces: `reasoning_effort_hint_for_model(model: str | None) -> frozenset[str] | None` and `console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]`, both importable from `tldw_chatbook.Chat.console_session_settings`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/Chat/test_console_session_settings.py`:
+
+```python
+from tldw_chatbook.Chat.console_session_settings import (
+    console_settings_warnings,
+    reasoning_effort_hint_for_model,
+)
+
+
+class TestReasoningEffortHints:
+    def test_dotted_qwen_generations_are_effort_capable(self):
+        for model in ("Qwen3.8-27B", "qwen3.5-397b-gguf:q4"):
+            assert reasoning_effort_hint_for_model(model) == frozenset(
+                {"low", "medium", "xhigh"}
+            )
+
+    def test_original_qwen3_is_toggle_only(self):
+        assert reasoning_effort_hint_for_model("Qwen3-32B") == frozenset({"none"})
+
+    def test_gpt_oss(self):
+        assert reasoning_effort_hint_for_model("gpt-oss-120b") == frozenset(
+            {"low", "medium", "high"}
+        )
+
+    def test_unknown_model_has_no_hint(self):
+        assert reasoning_effort_hint_for_model("llama-3-8b") is None
+        assert reasoning_effort_hint_for_model(None) is None
+        assert reasoning_effort_hint_for_model("") is None
+
+
+class TestConsoleSettingsWarnings:
+    def _settings(self, **overrides):
+        base = dict(provider="llama_cpp", model="Qwen3.8-27B")
+        base.update(overrides)
+        # Use the file's existing settings-construction helper if one exists
+        # (search for ConsoleSessionSettings( in this test file); otherwise:
+        return ConsoleSessionSettings(**base)
+
+    def test_value_outside_hint_warns(self):
+        settings = self._settings(reasoning_effort="high")
+        warnings = console_settings_warnings(settings)
+        assert len(warnings) == 1
+        assert "high" in warnings[0]
+        assert "xhigh" in warnings[0]
+
+    def test_value_inside_hint_does_not_warn(self):
+        settings = self._settings(reasoning_effort="xhigh")
+        assert console_settings_warnings(settings) == []
+
+    def test_unknown_model_does_not_warn(self):
+        settings = self._settings(model="llama-3-8b", reasoning_effort="high")
+        assert console_settings_warnings(settings) == []
+
+    def test_llama_family_thinking_note_included(self):
+        settings = self._settings(reasoning_effort="low")
+        warnings = console_settings_warnings(settings)
+        assert any("--jinja" in w for w in warnings)
+
+    def test_llama_family_note_requires_a_thinking_value(self):
+        settings = self._settings()
+        assert console_settings_warnings(settings) == []
+```
+
+Adjust `_settings` to match the real `ConsoleSessionSettings` required fields (read the dataclass first; reuse an existing fixture from the test file if there is one).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest Tests/Chat/test_console_session_settings.py -k "TestReasoningEffortHints or TestConsoleSettingsWarnings" -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+3a. `console_session_settings.py` — add near the other value sets (~line 103), plus `import re` at top if absent:
+
+```python
+# Generation-aware: dotted Qwen3.x generations consume effort levels;
+# original Qwen3 is a thinking toggle only. Ordered most-specific first.
+_REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
+    ("gpt-oss", frozenset({"low", "medium", "high"})),
+    ("qwen3", frozenset({"none"})),
+)
+_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "xhigh"})
+_LLAMA_CPP_FAMILY_PROVIDERS = frozenset(
+    {"llama_cpp", "local_llamacpp", "local_llamafile"}
+)
+_LLAMACPP_THINKING_REQUIREMENTS_NOTE = (
+    "Thinking controls on llama.cpp need llama-server started with --jinja; "
+    "per-request reasoning_budget needs llama.cpp b9982 or newer."
+)
+
+
+def reasoning_effort_hint_for_model(model: str | None) -> frozenset[str] | None:
+    """Return the effort values this model family's template consumes."""
+    lowered = str(model or "").strip().lower()
+    if not lowered:
+        return None
+    if re.search(r"qwen3\.\d", lowered):
+        return _QWEN_DOTTED_EFFORT_VALUES
+    for needle, values in _REASONING_EFFORT_MODEL_HINTS:
+        if needle in lowered:
+            return values
+    return None
+
+
+def console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]:
+    """Non-blocking warnings for the Console settings modal (ADR-066)."""
+    warnings: list[str] = []
+    effort = str(settings.reasoning_effort or "").strip().lower()
+    has_thinking_value = bool(effort) or settings.thinking_budget_tokens is not None
+    if effort:
+        hint = reasoning_effort_hint_for_model(settings.model)
+        if hint is not None and effort not in hint:
+            warnings.append(
+                f"Reasoning effort '{effort}' is not consumed by this model "
+                f"family; expected one of: {', '.join(sorted(hint))}."
+            )
+    if has_thinking_value and settings.provider in _LLAMA_CPP_FAMILY_PROVIDERS:
+        warnings.append(_LLAMACPP_THINKING_REQUIREMENTS_NOTE)
+    return warnings
+```
+
+3b. Summary row (same file, in the summary builder containing `sampling_parts`, ~line 768) — extend after the existing reasoning/thinking lines:
+
+```python
+    if settings.thinking_budget_tokens is not None:
+        sampling_parts.append(
+            f"think budget {settings.thinking_budget_tokens}"
+        )
+    if settings.reasoning_effort or settings.thinking_budget_tokens is not None:
+        identity = resolve_console_provider_identity(settings.provider)
+        wire_fields = build_local_thinking_payload_fields(
+            identity.execution_key,
+            settings.reasoning_effort,
+            settings.thinking_budget_tokens,
+        )
+        if wire_fields:
+            wire_parts = []
+            template_kwargs = wire_fields.get("chat_template_kwargs")
+            if template_kwargs:
+                rendered = ", ".join(
+                    f"{k}={v}" for k, v in sorted(template_kwargs.items())
+                )
+                wire_parts.append(f"chat_template_kwargs[{rendered}]")
+            if "reasoning_budget" in wire_fields:
+                wire_parts.append(
+                    f"reasoning_budget={wire_fields['reasoning_budget']}"
+                )
+            if "reasoning_effort" in wire_fields:
+                wire_parts.append(
+                    f"reasoning_effort={wire_fields['reasoning_effort']}"
+                )
+            sampling_parts.append("wire: " + "; ".join(wire_parts))
+```
+
+Add the imports `from tldw_chatbook.Chat.console_provider_support import build_local_thinking_payload_fields, resolve_console_provider_identity` if not already present (check — `resolve_console_provider_identity` may already be imported in this module).
+
+3c. `console_settings_modal.py` — dynamic placeholder in `_choice_placeholder` (~1758):
+
+```python
+    def _choice_placeholder(self, input_id: str) -> str:
+        """Return the accepted-values placeholder for an enumerated choice input."""
+        if input_id == "console-settings-reasoning-effort":
+            hint = reasoning_effort_hint_for_model(self._settings.model)
+            if hint is not None:
+                return " / ".join(sorted(hint)) + " (consumed by this model)"
+        for _label, choice_input_id, placeholder in PROVIDER_CHOICE_INPUTS:
+            if choice_input_id == input_id:
+                return placeholder
+        return ""
+```
+
+3d. Warning surfacing — in the settings-construction function (~line 2042, where the parsed settings object is built) compute `console_settings_warnings(settings)`; in the save handlers (~1408/1426, where `_validated_result_or_show_errors()` succeeds) notify each warning without blocking:
+
+```python
+        for warning in console_settings_warnings(settings):
+            self.notify(warning, severity="warning", timeout=8000)
+```
+
+Import `console_settings_warnings` and `reasoning_effort_hint_for_model` from `tldw_chatbook.Chat.console_session_settings` alongside the existing `validate_console_session_settings` import (~line 60).
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest Tests/Chat/test_console_session_settings.py Tests/UI/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_session_settings.py tldw_chatbook/Widgets/Console/console_settings_modal.py Tests/Chat/test_console_session_settings.py
+git commit -m "feat(console): model-family thinking hints, warnings, and wire preview"
+```
+
+---
+
+### Task 7: Full verification and task wrap-up
+
+**Files:**
+- Modify: `backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md`
+- No production code changes expected.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: task marked Done with Implementation Notes; ACs checked.
+
+- [ ] **Step 1: Run the full test suite and lint**
+
+```bash
+python -m pytest Tests/ -x -q
+```
+Expected: PASS. Fix any fallout before continuing (report honestly if pre-existing failures are unrelated — verify on `main` before claiming).
+
+- [ ] **Step 2: Live verification against a real llama-server**
+
+Per `backlog/docs/lessons-live-verification.md`, run the app against a real server. Requires: a Qwen3.8-27B GGUF and a current llama.cpp build.
+
+```bash
+llama-server -m /path/to/Qwen3.8-27B-*.gguf --jinja --host 127.0.0.1 --port 8080
+```
+
+Then `python3 -m tldw_chatbook.app`, open the Console, set provider to llama.cpp / local llama.cpp pointing at `http://127.0.0.1:8080`, and verify each item, capturing evidence (request logs or observed output) for the task notes:
+
+1. Reasoning `low` vs `xhigh` on the same prompt observably changes thinking depth.
+2. Budget 1024 truncates thinking well before `xhigh`'s natural depth.
+3. With `--reasoning-format deepseek` added to the server flags: no `reasoning_content` leaks into the visible reply.
+4. Without `--reasoning-format`: no `<think>` text in the visible reply (the filter's job).
+5. Reasoning `none`: the model answers without thinking.
+6. A response-prefill send still works (llama.cpp must not 400 on prefill + thinking controls).
+7. If an older llama.cpp build (pre-b9982) is available: budget field present in the request does not cause a 400.
+
+If the GGUF or a current llama-server is unavailable in this environment, do NOT mark the task Done — record exactly which items were verified live and which remain, and surface that in the final report. Optionally live-check `mlx_lm.server` and a llamafile server for `chat_template_kwargs` support; if unsupported, update the `local_mlx_lm` row to drop-and-log in `console_provider_support.py` and note it.
+
+- [ ] **Step 3: Update the backlog task**
+
+```bash
+backlog task edit 16319 -s "In Progress" -a @Robert --plan "1. Wire-format table (ADR-066)\n2. Direct llama.cpp payload wiring\n3. Start-anchored think filter\n4. Wire filter into direct path\n5. Adapter-path param maps + shared builder + handlers\n6. Hints, warnings, placeholder, preview\n7. Full verification and wrap-up"
+```
+
+Then edit the task file: check every satisfied `- [ ]` AC to `- [x]`, and add an `## Implementation Notes` section (approach, deviations from plan, files touched, live-verification evidence). Only set status Done when ALL ACs including live verification are satisfied:
+
+```bash
+backlog task edit 16319 -s Done --notes "Implemented per ADR-066 spec/plan; live-verified against llama-server --jinja with Qwen3.8-27B"
+```
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add "backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md"
+git commit -m "docs(backlog): complete task-16319 local thinking controls"
+```
+
+---
+
+## Self-Review Notes (completed during planning)
+
+- Spec coverage: wire table (T1), direct path + prefill precedence + stale-comment fix + aux inheritance (T2), start-anchored filter + split-case confirmation (T3/T4), adapter path incl. dual placement and custom-only-top-level (T5), hints/warnings/placeholder/preview/requirements note (T6), live verification + budget-±`--reasoning-format` checks + older-build tolerance (T7). Budget floor untouched (global ≥1024) — constraint honored by omission.
+- Known deliberate deviations: none.
+- Type consistency: `build_local_thinking_payload_fields(execution_key, reasoning_effort, thinking_budget_tokens)` used identically in T2/T5/T6; `StartAnchoredThinkFilter.feed/flush` in T3/T4; `console_settings_warnings(settings)` and `reasoning_effort_hint_for_model(model)` in T6.

--- a/Docs/superpowers/qa/2026-08-15-local-thinking-controls-live-verification/live-verify-effort.py
+++ b/Docs/superpowers/qa/2026-08-15-local-thinking-controls-live-verification/live-verify-effort.py
@@ -1,0 +1,73 @@
+"""Focused re-check of live CHECK A (effort changes thinking depth) and B
+(budget truncates), with noise-reduced methodology: temperature 0, a
+reasoning-inviting prompt, and two repetitions per arm."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+BASE = "http://127.0.0.1:9191"
+MODEL = "../../../Downloads/Qwen3.8-27B-UD-Q8_K_XL.gguf"
+PROMPT = [
+    {
+        "role": "user",
+        "content": (
+            "A bat and a ball cost $1.10 together. The bat costs $1.00 more "
+            "than the ball. How much does the ball cost? Reason carefully."
+        ),
+    }
+]
+
+
+def probe(label: str, fields: dict) -> tuple[int, int]:
+    payload = {
+        "model": MODEL,
+        "messages": PROMPT,
+        "max_tokens": 500,
+        "temperature": 0.0,
+    }
+    payload.update(fields)
+    r = httpx.post(f"{BASE}/v1/chat/completions", json=payload, timeout=600)
+    r.raise_for_status()
+    body = r.json()
+    msg = body["choices"][0]["message"]
+    reasoning = len(msg.get("reasoning_content") or "")
+    comp = body.get("usage", {}).get("completion_tokens", 0)
+    print(f"PROBE {label}: reasoning_chars={reasoning} completion_tokens={comp}", flush=True)
+    return reasoning, comp
+
+
+def main() -> None:
+    arms = {
+        "low": {"chat_template_kwargs": {"reasoning_effort": "low"}},
+        "medium": {"chat_template_kwargs": {"reasoning_effort": "medium"}},
+        "xhigh": {"chat_template_kwargs": {"reasoning_effort": "xhigh"}},
+        "budget400": {
+            "chat_template_kwargs": {"reasoning_effort": "xhigh"},
+            "reasoning_budget": 400,
+        },
+    }
+    samples: dict[str, list[tuple[int, int]]] = {}
+    for rep in range(2):
+        for name, fields in arms.items():
+            samples.setdefault(name, []).append(probe(f"{name}-rep{rep}", fields))
+
+    print("\n=== A: monotonic depth low <= medium <= xhigh (reasoning chars) ===", flush=True)
+    means = {n: sum(r for r, _ in v) / len(v) for n, v in samples.items()}
+    print(f"means: {json.dumps({k: int(v) for k, v in means.items()})}", flush=True)
+    a_ok = means["low"] <= means["medium"] <= means["xhigh"]
+    print(f"CHECK A-effort-monotonic: {'PASS' if a_ok else 'FAIL'}", flush=True)
+
+    print("\n=== B: budget 400 caps below unbounded xhigh ===", flush=True)
+    b_ok = means["budget400"] < means["xhigh"]
+    print(
+        f"CHECK B-budget-truncates: {'PASS' if b_ok else 'FAIL'} "
+        f"(budget400={int(means['budget400'])} vs xhigh={int(means['xhigh'])})",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Docs/superpowers/qa/2026-08-15-local-thinking-controls-live-verification/live-verify.py
+++ b/Docs/superpowers/qa/2026-08-15-local-thinking-controls-live-verification/live-verify.py
@@ -1,0 +1,210 @@
+"""Live verification: local thinking controls against the real llama-server on :9191.
+
+Exercises OUR code (build_llamacpp_chat_payload, complete_llamacpp_chat,
+stream_llamacpp_chat via ConsoleProviderGateway) plus raw wire probes for
+observable thinking-depth evidence. TASK-16319 Task 7 Step 2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import httpx
+
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    build_llamacpp_chat_payload,
+)
+
+BASE = "http://127.0.0.1:9191"
+MODEL = "../../../Downloads/Qwen3.8-27B-UD-Q8_K_XL.gguf"
+PROMPT = [{"role": "user", "content": "In one sentence, explain why the sky is blue."}]
+MAX_TOKENS = 300
+
+results: list[str] = []
+
+
+def record(name: str, ok: bool, detail: str) -> None:
+    line = f"CHECK {name}: {'PASS' if ok else 'FAIL'} — {detail}"
+    results.append(line)
+    print(line, flush=True)
+
+
+def raw_probe(label: str, thinking_fields: dict, prefill: str | None = None) -> dict:
+    messages = [dict(m) for m in PROMPT]
+    if prefill is not None:
+        messages.append({"role": "assistant", "content": prefill})
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "max_tokens": MAX_TOKENS,
+        "temperature": 0.7,
+    }
+    payload.update(thinking_fields)
+    t0 = time.time()
+    r = httpx.post(f"{BASE}/v1/chat/completions", json=payload, timeout=600)
+    dt = time.time() - t0
+    r.raise_for_status()
+    body = r.json()
+    msg = body["choices"][0]["message"]
+    content = msg.get("content") or ""
+    reasoning = msg.get("reasoning_content") or ""
+    usage = body.get("usage", {})
+    print(
+        f"PROBE {label}: dt={dt:.0f}s comp={usage.get('completion_tokens')} "
+        f"content_len={len(content)} reasoning_len={len(reasoning)} "
+        f"has_think_tag={'<think>' in content}",
+        flush=True,
+    )
+    return {
+        "content": content,
+        "reasoning": reasoning,
+        "usage": usage,
+        "dt": dt,
+    }
+
+
+def main() -> None:
+    # --- Wire probe 0: server split mode detection (no thinking fields) ---
+    base = raw_probe("baseline-default", {})
+
+    # --- A: effort low vs xhigh observably change thinking depth ---
+    low = raw_probe("effort-low", {"chat_template_kwargs": {"reasoning_effort": "low"}})
+    xhigh = raw_probe(
+        "effort-xhigh", {"chat_template_kwargs": {"reasoning_effort": "xhigh"}}
+    )
+    if base["reasoning"] or low["reasoning"] or xhigh["reasoning"]:
+        depth_low, depth_high = len(low["reasoning"]), len(xhigh["reasoning"])
+        record(
+            "A-effort-changes-depth",
+            depth_high > depth_low,
+            f"reasoning chars low={depth_low} xhigh={depth_high} (server-split mode)",
+        )
+    else:
+        # unsplit: measure <think> block inside content
+        def think_len(probe: dict) -> int:
+            c = probe["content"]
+            if "</think>" in c:
+                return c.index("</think>")
+            return len(c) if c.startswith("<think") else 0
+
+        depth_low, depth_high = think_len(low), think_len(xhigh)
+        record(
+            "A-effort-changes-depth",
+            depth_high > depth_low,
+            f"think chars low={depth_low} xhigh={depth_high} (unsplit mode)",
+        )
+
+    # --- B: reasoning_budget truncates thinking ---
+    budget = raw_probe(
+        "budget-1024",
+        {
+            "chat_template_kwargs": {"reasoning_effort": "xhigh"},
+            "reasoning_budget": 1024,
+        },
+    )
+    xhigh_reason = len(xhigh["reasoning"]) or len(
+        xhigh["content"].split("</think>")[0]
+    )
+    budget_reason = len(budget["reasoning"]) or len(
+        budget["content"].split("</think>")[0]
+    )
+    record(
+        "B-budget-truncates",
+        budget_reason < xhigh_reason,
+        f"reasoning chars xhigh={xhigh_reason} budget1024={budget_reason}",
+    )
+
+    # --- C: effort none disables thinking ---
+    none_p = raw_probe(
+        "effort-none", {"chat_template_kwargs": {"enable_thinking": False}}
+    )
+    if none_p["reasoning"]:
+        ok = len(none_p["reasoning"]) == 0
+        detail = f"reasoning chars={len(none_p['reasoning'])}"
+    else:
+        ok = not none_p["content"].lstrip().startswith("<think")
+        detail = f"content starts with think tag: {none_p['content'].lstrip()[:20]!r}"
+    record("C-none-disables", ok, detail)
+
+    # --- D: prefill + thinking controls must not 400 ---
+    try:
+        pre = raw_probe("prefill+xhigh", {"chat_template_kwargs": {"reasoning_effort": "xhigh"}}, prefill="The sky appears blue")
+        record("D-prefill-no-400", True, f"status ok, content_len={len(pre['content'])}")
+    except httpx.HTTPStatusError as exc:
+        record("D-prefill-no-400", False, f"HTTP {exc.response.status_code}")
+
+    # --- E: OUR payload builder composes the exact expected wire fields ---
+    payload = build_llamacpp_chat_payload(
+        model=MODEL,
+        messages=PROMPT,
+        stream=False,
+        reasoning_effort="low",
+        thinking_budget_tokens=1024,
+    )
+    ok = (
+        payload.get("chat_template_kwargs") == {"reasoning_effort": "low"}
+        and payload.get("reasoning_budget") == 1024
+    )
+    record("E-builder-composes", ok, json.dumps(payload.get("chat_template_kwargs")) + f" reasoning_budget={payload.get('reasoning_budget')}")
+
+    # --- F: OUR gateway stream filters think text (unsplit) / stays clean (split) ---
+    async def stream_check() -> tuple[str, str]:
+        gw = ConsoleProviderGateway()
+        try:
+            chunks = []
+            async for c in gw.stream_llamacpp_chat(
+                base_url=BASE,
+                model=MODEL,
+                messages=PROMPT,
+                max_tokens=MAX_TOKENS,
+                temperature=0.7,
+                reasoning_effort="xhigh",
+            ):
+                chunks.append(c)
+            visible = "".join(chunks)
+        finally:
+            await gw.aclose()
+        # Also raw non-streamed content for comparison
+        return visible, base["content"]
+
+    visible, _ = asyncio.run(stream_check())
+    record(
+        "F-stream-no-think-soup",
+        "<think>" not in visible and "<think" not in visible[:40],
+        f"visible starts {visible.lstrip()[:40]!r} len={len(visible)}",
+    )
+
+    # --- G: OUR gateway complete path filters too ---
+    async def complete_check() -> str:
+        gw = ConsoleProviderGateway()
+        try:
+            return await gw.complete_llamacpp_chat(
+                base_url=BASE,
+                model=MODEL,
+                messages=PROMPT,
+                max_tokens=MAX_TOKENS,
+                temperature=0.7,
+                reasoning_effort="xhigh",
+            )
+        finally:
+            await gw.aclose()
+
+    visible2 = asyncio.run(complete_check())
+    record(
+        "G-complete-no-think-soup",
+        not visible2.lstrip().startswith("<think"),
+        f"visible starts {visible2.lstrip()[:40]!r}",
+    )
+
+    print("\n=== SUMMARY ===", flush=True)
+    fails = [r for r in results if "FAIL" in r]
+    for r in results:
+        print(r, flush=True)
+    print(f"\n{len(results) - len(fails)}/{len(results)} checks passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md
+++ b/Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md
@@ -27,7 +27,7 @@ targets:
 
 | Stack | Level | Hard budget |
 |---|---|---|
-| llama.cpp (`--jinja`) | `chat_template_kwargs.reasoning_effort` (top-level `reasoning_effort` is not parsed) | top-level `reasoning_budget` (≥ b9982 / PR #23116) |
+| llama.cpp (`--jinja`) | `chat_template_kwargs.reasoning_effort` (top-level `reasoning_effort` is not parsed) | top-level `reasoning_budget_tokens` (≥ b9982 / PR #23116) |
 | vLLM | top-level `reasoning_effort` | none per-request |
 | mlx-lm server | to verify live (`chat_template_kwargs` suspected) | to verify live |
 
@@ -82,7 +82,7 @@ with the other provider-support constants in `Chat/console_provider_support.py`:
 
 | Execution key | Level goes to | Budget goes to |
 |---|---|---|
-| `llama_cpp`, `local_llamacpp`, `local-llm`, `local_llamafile` | `chat_template_kwargs.reasoning_effort`; `enable_thinking: false` when effort is `none` — live-verify the model's template consumes `reasoning_effort` as a kwarg | top-level `reasoning_budget` |
+| `llama_cpp`, `local_llamacpp`, `local-llm`, `local_llamafile` | `chat_template_kwargs.reasoning_effort`; `enable_thinking: false` when effort is `none` — live-verify the model's template consumes `reasoning_effort` as a kwarg | top-level `reasoning_budget_tokens` |
 | `vllm`, `local_vllm` | top-level **and** `chat_template_kwargs.reasoning_effort` (same value in both; whichever path that stack consumes wins and the other is ignored — guards against the top-level-only assumption being wrong) | dropped, debug-logged |
 | `local_mlx_lm` | `chat_template_kwargs.reasoning_effort` if live verification confirms support; otherwise dropped, debug-logged | same verification outcome |
 | `custom-openai-api`, `custom-openai-api-2` | top-level `reasoning_effort` only (no llama.cpp-specific fields — strict OpenAI proxies may reject them) | dropped |
@@ -134,7 +134,7 @@ question; veto at spec review if undesired.*
 - **Provider-aware field hints:** Thinking / Summary / Verbosity fields show
   "no effect on this provider" styling/hint when a local provider is selected.
 - **Request preview:** the modal's request preview renders the composed
-  thinking fields (`chat_template_kwargs`, `reasoning_budget`) so users see
+  thinking fields (`chat_template_kwargs`, `reasoning_budget_tokens`) so users see
   exactly what is sent — important because values pass verbatim.
 - **Readiness hint:** when a thinking control is set on a llama.cpp-family
   provider, a one-line hint notes the server requirements (`--jinja`; budget
@@ -181,10 +181,10 @@ changed.
   `llama-server` (current build, `--jinja`) serving a Qwen3.8-27B GGUF:
   - `low`/`medium`/`xhigh` observably change thinking depth (this also
     confirms the template consumes `chat_template_kwargs.reasoning_effort`);
-  - `reasoning_budget` truncates thinking, checked both with and without
+  - `reasoning_budget_tokens` truncates thinking, checked both with and without
     `--reasoning-format` (the truncation mechanism may depend on it);
   - an older-build server (pre-b9982 if available) ignores the unknown
-    `reasoning_budget` field rather than 400ing;
+    `reasoning_budget_tokens` field rather than 400ing;
   - with and without `--reasoning-format`, the visible reply contains no
     `<think>` text.
 - Live-check `mlx_lm.server` and llamafile `chat_template_kwargs` support
@@ -211,3 +211,27 @@ thinking controls, which future contributors will otherwise re-litigate
 ("why is effort inside `chat_template_kwargs` for llama.cpp but top-level
 for vLLM?"). Recorded as
 [ADR-066](../../backlog/decisions/066-local-provider-thinking-controls.md).
+
+## Errata (post live verification, 2026-08-15)
+
+Verified against a real `llama-server` (b10430, `--jinja`) serving
+Qwen3.8-27B:
+
+1. **Budget field name:** the per-request field is
+   `reasoning_budget_tokens`, not `reasoning_budget` — the latter is
+   silently ignored by llama.cpp. Live: budget 8 → 35 reasoning chars,
+   32 → 101, vs 391 natural. The wire-format table rows above are updated.
+2. **Validated templates:** Qwen3.8's chat template *validates*
+   `reasoning_effort` and raises on unknown values (effort `minimal` →
+   HTTP 500: `raise_exception` outside `('xhigh','medium','low')`).
+   `high` is aliased to `xhigh` by the template and is safe; `none` is
+   safe because it is paired with `enable_thinking: false`, which
+   short-circuits the validation block. The design assumption that
+   "unused template kwargs degrade gracefully" was wrong for validated
+   templates: non-safe efforts are now dropped from
+   `chat_template_kwargs` (debug-logged) rather than sent. vLLM and
+   Custom OpenAI top-level `reasoning_effort` stays verbatim for all
+   values.
+3. **Budget is not template-consumed:** `thinking_budget_tokens` /
+   `reasoning_budget_tokens` is a server-side mechanism only — no chat
+   template reads it.

--- a/Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md
+++ b/Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md
@@ -1,0 +1,213 @@
+# Local Provider Thinking Controls — Design
+
+Date: 2026-08-15
+Status: Draft (pending user review)
+Related ADR: [ADR-066: Local provider thinking control wire formats](../../backlog/decisions/066-local-provider-thinking-controls.md)
+Related Task: [TASK-16319](../../backlog/tasks/task-16319%20-%20Console-thinking-levels-and-budget-for-local-providers.md)
+
+## Context
+
+Qwen3.8-27B ships adjustable thinking (`reasoning_effort`: `low` / `medium` /
+`xhigh`, default `xhigh`) plus separate caps for reasoning vs. final output.
+The Console settings modal already has generic **Reasoning** (`reasoning_effort`),
+**Thinking** (`thinking_effort`), and **Budget** (`thinking_budget_tokens`)
+fields, and these flow all the way into provider resolution for local
+providers (`LlamaCppProviderConfig` carries them) — but they are dropped at
+the last hop:
+
+- The direct llama.cpp path (`build_llamacpp_chat_payload`,
+  `stream_llamacpp_chat`, `complete_llamacpp_chat` in
+  `Chat/console_provider_gateway.py`) only forwards sampling params.
+- The adapter path drops them in `PROVIDER_PARAM_MAP` (`Chat/Chat_Functions.py`)
+  — no local execution key maps `reasoning_effort` or `thinking_budget_tokens`.
+
+Meanwhile the serving stacks all accept per-request thinking controls on the
+OpenAI-compatible `/v1/chat/completions` endpoint every local handler already
+targets:
+
+| Stack | Level | Hard budget |
+|---|---|---|
+| llama.cpp (`--jinja`) | `chat_template_kwargs.reasoning_effort` (top-level `reasoning_effort` is not parsed) | top-level `reasoning_budget` (≥ b9982 / PR #23116) |
+| vLLM | top-level `reasoning_effort` | none per-request |
+| mlx-lm server | to verify live (`chat_template_kwargs` suspected) | to verify live |
+
+Unknown template kwargs are unused Jinja variables — verbatim values a
+template does not consume degrade to the model default instead of erroring.
+That property is what makes verbatim sending safe.
+
+## Goals
+
+1. The Console's Reasoning and Budget fields control thinking depth and max
+   thinking tokens for all Console-reachable local providers.
+2. Enabling thinking never pollutes the visible Console reply with raw
+   `<think>` text **on the llama.cpp direct path** (both server-split and
+   unsplit shapes). The adapter path (vLLM/Custom without a server-side
+   reasoning parser) keeps server-default behavior; see Follow-ups.
+3. Values the selected model's template does not consume produce a warning,
+   not a block and not a silent rewrite.
+
+## Non-goals
+
+- No new Console settings fields (reuse `reasoning_effort` /
+  `thinking_budget_tokens`). A free-form `chat_template_kwargs` JSON escape
+   hatch may be a future task.
+- No changes to cloud providers (OpenAI/Anthropic/QwenCloud/Moonshot/Z.ai
+  mappings stay as-is).
+- No change to managed-server launch defaults (`--jinja` etc. remain the
+   user's launch args; surfaced via hint + docs instead).
+- Legacy Chat window is untouched; it benefits automatically where it calls
+  `chat_api_call` with these params, which today it does not.
+
+## Semantics
+
+- `reasoning_effort` is the local thinking-level knob. `thinking_effort`
+  (Anthropic-style) stays Anthropic-only; sending both to one provider would
+  be a double signal. The modal marks Anthropic-only fields as
+  "no effect on this provider" for local selections.
+- `thinking_budget_tokens` is the max-thinking-tokens knob.
+- Both are sent **verbatim**. `reasoning_effort: none` additionally sends
+  `chat_template_kwargs: {"enable_thinking": false}`.
+- Validation floor for `thinking_budget_tokens` stays ≥ 1024 globally. The
+  floor exists as a sane thinking-budget minimum (below it, reasoning is cut
+  uselessly early) and the validator has no provider context; introducing
+  provider-aware floors is not worth the plumbing.
+- Prefill precedence: an assistant prefill still forces
+  `enable_thinking: false` (llama.cpp rejects prefill + thinking). Effective
+  precedence is `prefill > none > effort`.
+
+## Wire-format composition
+
+One table (data, not scattered conditionals) keyed by execution key, placed
+with the other provider-support constants in `Chat/console_provider_support.py`:
+
+| Execution key | Level goes to | Budget goes to |
+|---|---|---|
+| `llama_cpp`, `local_llamacpp`, `local-llm`, `local_llamafile` | `chat_template_kwargs.reasoning_effort`; `enable_thinking: false` when effort is `none` — live-verify the model's template consumes `reasoning_effort` as a kwarg | top-level `reasoning_budget` |
+| `vllm`, `local_vllm` | top-level **and** `chat_template_kwargs.reasoning_effort` (same value in both; whichever path that stack consumes wins and the other is ignored — guards against the top-level-only assumption being wrong) | dropped, debug-logged |
+| `local_mlx_lm` | `chat_template_kwargs.reasoning_effort` if live verification confirms support; otherwise dropped, debug-logged | same verification outcome |
+| `custom-openai-api`, `custom-openai-api-2` | top-level `reasoning_effort` only (no llama.cpp-specific fields — strict OpenAI proxies may reject them) | dropped |
+
+Docs note: Custom OpenAI endpoints get levels only when the target server
+parses top-level `reasoning_effort` (vLLM/SGLang-style). For llama.cpp
+targets, use the first-class llama.cpp provider entries.
+
+## Thinking-output handling
+
+*Decision defaulted to "in scope: split + strip" after an unanswered scope
+question; veto at spec review if undesired.*
+
+- **Server-split case:** the direct llama.cpp SSE parser
+  (`_content_from_sse_line` path) consumes `reasoning_content` separately from
+  `content` so servers launched with `--reasoning-format deepseek/auto` keep
+  thinking out of the visible reply. The non-streaming direct path reads
+  `choices[0].message.content` only and never concatenates
+  `message.reasoning_content`.
+- **Unsplit case:** stream-aware `<think>…</think>` stripping in the Console's
+  direct path, **anchored to the start of the response**: only a think block
+  that opens at the very beginning of the streamed text (leading whitespace
+  tolerated) is stripped. Qwen templates emit thinking first — some
+  generations even emit an empty `<think>\n\n</think>` prefix in no-think
+  mode, which start-anchoring also handles — while a literal `<think>` in the
+  middle of a reply (e.g. the user asked for an XML example) is legitimate
+  content and must survive. Stateful parsing across chunk boundaries; never
+  emit a partial opening tag; if the stream ends inside an unterminated
+  start-anchored think block, drop the tail. The legacy non-streaming
+  `strip_thinking_tags` post-processor in `Chat/Chat_Functions.py` is
+  reference, not reuse — it is non-streaming, config-gated, and not
+  start-anchored.
+- Adapter-path local handlers rely on server-side splitting; their payloads
+  change only as listed under wire formats. Stream stripping for adapter-path
+  providers without a server-side reasoning parser is a follow-up, not part
+  of this task.
+
+## UI changes
+
+- **Model-family hints:** a small table mapping model-name patterns to the
+  effort values that family's templates consume, generation-aware because
+  Qwen3 generations differ: `qwen3.5`/`qwen3.8` (and dotted successors) →
+  `low`/`medium`/`xhigh`; original `qwen3-`/`qwen3 ` generations →
+  toggle-only (`none` does something, any other value warns); `gpt-oss` →
+  `low`/`medium`/`high`. Drives (a) the settings-modal placeholder for the
+  Reasoning field and (b) a non-blocking warning when the typed value falls
+  outside the hint set. Heuristic only; never blocks a send; unknown models
+  produce no warning.
+- **Provider-aware field hints:** Thinking / Summary / Verbosity fields show
+  "no effect on this provider" styling/hint when a local provider is selected.
+- **Request preview:** the modal's request preview renders the composed
+  thinking fields (`chat_template_kwargs`, `reasoning_budget`) so users see
+  exactly what is sent — important because values pass verbatim.
+- **Readiness hint:** when a thinking control is set on a llama.cpp-family
+  provider, a one-line hint notes the server requirements (`--jinja`; budget
+  requires llama.cpp ≥ b9982). No network probing to detect the build.
+
+## Code touch-points
+
+1. `Chat/console_provider_gateway.py`
+   - `build_llamacpp_chat_payload`, `stream_llamacpp_chat`,
+     `complete_llamacpp_chat`: accept `reasoning_effort` and
+     `thinking_budget_tokens`; compose the payload per the table; merge with
+     the existing prefill rule.
+   - The direct-path call sites (~lines 2002 and 2216) pass the two fields
+     from the resolution.
+   - SSE parsing: `reasoning_content` handling + stream-aware `<think>`
+     stripping.
+2. `Chat/Chat_Functions.py` — `PROVIDER_PARAM_MAP`: add
+   `reasoning_effort` / `thinking_budget_tokens` entries for the covered
+   local keys.
+3. `tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py` —
+   `chat_with_vllm`, `chat_with_llama`, `chat_with_local_llm`,
+   `chat_with_mlx_lm`, `chat_with_custom_openai`, `chat_with_custom_openai_2`
+   accept the params and add them to the payload per the table.
+4. `Chat/console_session_settings.py` — model-family hint table + warning
+   generation (non-blocking).
+5. `Widgets/Console/console_settings_modal.py` — placeholder/hints/warnings
+   rendering; request-preview extension.
+
+Known behavior carried forward: auxiliary requests (title generation etc.)
+already forward `reasoning_effort` through `chat_api_call` for mapped
+providers — cloud does this today; local reaches parity. Documented, not
+changed.
+
+## Testing
+
+- Unit: payload builder composition per provider (level, `none` →
+  `enable_thinking`, budget, prefill precedence, verbatim passthrough,
+  vLLM dual placement); param-map entries; each handler's payload;
+  hint-table warnings (match, non-match, generation mismatch, unknown
+  model); SSE `reasoning_content` split; stream-aware tag stripping
+  including chunk-boundary, unterminated-block, empty-prefix-block, and
+  mid-reply-literal-tag-must-survive cases.
+- Live (per `backlog/docs/lessons-live-verification.md`), against a real
+  `llama-server` (current build, `--jinja`) serving a Qwen3.8-27B GGUF:
+  - `low`/`medium`/`xhigh` observably change thinking depth (this also
+    confirms the template consumes `chat_template_kwargs.reasoning_effort`);
+  - `reasoning_budget` truncates thinking, checked both with and without
+    `--reasoning-format` (the truncation mechanism may depend on it);
+  - an older-build server (pre-b9982 if available) ignores the unknown
+    `reasoning_budget` field rather than 400ing;
+  - with and without `--reasoning-format`, the visible reply contains no
+    `<think>` text.
+- Live-check `mlx_lm.server` and llamafile `chat_template_kwargs` support
+  before committing to their table rows; fall back to drop-and-log if
+  unsupported.
+- vLLM live check if available; otherwise the vLLM row ships on documented
+  API behavior with unit tests only.
+
+## Follow-ups (explicitly out of scope)
+
+- Free-form `chat_template_kwargs` JSON escape hatch in Console settings.
+- vLLM per-request thinking budget, if vLLM gains one.
+- Thinking output surfaced in a collapsible Console "thinking" view rather
+  than dropped.
+- Stream-aware `<think>` stripping for adapter-path local providers
+  (vLLM/Custom without a server-side reasoning parser); the direct-path
+  stripper ships as a reusable helper so this is a thin follow-up.
+- `--jinja` / `--reasoning-format` defaults for managed llama.cpp launches.
+
+## ADR check
+
+ADR required: yes — this fixes per-provider wire-format contracts for
+thinking controls, which future contributors will otherwise re-litigate
+("why is effort inside `chat_template_kwargs` for llama.cpp but top-level
+for vLLM?"). Recorded as
+[ADR-066](../../backlog/decisions/066-local-provider-thinking-controls.md).

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1824,6 +1824,40 @@ class TestDirectPathThinkFiltering:
         )
         assert text == "Done"
 
+    @pytest.mark.asyncio
+    async def test_think_only_stream_skips_nonstreaming_fallback(self):
+        # A reply that is entirely start-anchored think text must not cost a
+        # second (non-streaming fallback) round-trip: the retry would return
+        # the same filtered-to-empty text.
+        lines = [
+            'data: {"choices":[{"delta":{"content":"<think>only"}}]}',
+            'data: {"choices":[{"delta":{"content":" pondering</think>"}}]}',
+            "data: [DONE]",
+        ]
+        body = "".join(f"{line}\n\n" for line in lines).encode()
+        requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, content=body)
+
+        gateway = ConsoleProviderGateway(
+            http_client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler),
+                base_url="http://127.0.0.1:8080",
+            )
+        )
+        chunks = [
+            chunk
+            async for chunk in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert chunks == []
+        assert len(requests) == 1
+
 
 @pytest.mark.asyncio
 async def test_stream_chat_dispatches_llamacpp_resolution():

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -391,6 +391,52 @@ def test_llamacpp_payload_omits_thinking_kwarg_for_empty_messages() -> None:
     assert "chat_template_kwargs" not in payload
 
 
+class TestLlamacppThinkingPayload:
+    def test_effort_composes_chat_template_kwargs(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True, reasoning_effort="low",
+        )
+        assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
+
+    def test_budget_composes_reasoning_budget(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=False, thinking_budget_tokens=2048,
+        )
+        assert payload["reasoning_budget"] == 2048
+
+    def test_none_effort_disables_thinking(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True, reasoning_effort="none",
+        )
+        assert payload["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_prefill_overrides_effort(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen",
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Sure"},
+            ],
+            stream=True, reasoning_effort="xhigh",
+        )
+        # prefill > none > effort (llama.cpp rejects prefill + thinking)
+        assert payload["chat_template_kwargs"] == {
+            "reasoning_effort": "xhigh",
+            "enable_thinking": False,
+        }
+
+    def test_no_thinking_fields_by_default(self):
+        payload = build_llamacpp_chat_payload(
+            model="qwen", messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        assert "chat_template_kwargs" not in payload
+        assert "reasoning_budget" not in payload
+
+
 @pytest.mark.asyncio
 async def test_llamacpp_prefers_explicit_model_but_still_probes_reachability():
     seen_paths = []
@@ -5713,6 +5759,8 @@ async def test_auxiliary_direct_llama_is_nonstreaming_exact_and_sensitive() -> N
     assert result.text == " llama exact \n"
     assert captured["url"] == "http://127.0.0.1:9099/v1/chat/completions"
     assert captured["sensitive"] is True
+    # Auxiliary requests inherit session thinking settings (ADR-066): level
+    # via chat_template_kwargs, budget via top-level reasoning_budget.
     assert captured["payload"] == {
         "model": "gpt-test",
         "messages": [
@@ -5728,6 +5776,8 @@ async def test_auxiliary_direct_llama_is_nonstreaming_exact_and_sensitive() -> N
         "seed": 42,
         "presence_penalty": 0.1,
         "frequency_penalty": 0.2,
+        "chat_template_kwargs": {"reasoning_effort": "high"},
+        "reasoning_budget": 2048,
     }
     await client.aclose()
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -399,12 +399,12 @@ class TestLlamacppThinkingPayload:
         )
         assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
 
-    def test_budget_composes_reasoning_budget(self):
+    def test_budget_composes_reasoning_budget_tokens(self):
         payload = build_llamacpp_chat_payload(
             model="qwen", messages=[{"role": "user", "content": "hi"}],
             stream=False, thinking_budget_tokens=2048,
         )
-        assert payload["reasoning_budget"] == 2048
+        assert payload["reasoning_budget_tokens"] == 2048
 
     def test_none_effort_disables_thinking(self):
         payload = build_llamacpp_chat_payload(
@@ -434,7 +434,7 @@ class TestLlamacppThinkingPayload:
             stream=True,
         )
         assert "chat_template_kwargs" not in payload
-        assert "reasoning_budget" not in payload
+        assert "reasoning_budget_tokens" not in payload
 
 
 @pytest.mark.asyncio
@@ -5860,7 +5860,8 @@ async def test_auxiliary_direct_llama_is_nonstreaming_exact_and_sensitive() -> N
     assert captured["url"] == "http://127.0.0.1:9099/v1/chat/completions"
     assert captured["sensitive"] is True
     # Auxiliary requests inherit session thinking settings (ADR-066): level
-    # via chat_template_kwargs, budget via top-level reasoning_budget.
+    # via chat_template_kwargs, budget via top-level
+    # reasoning_budget_tokens.
     assert captured["payload"] == {
         "model": "gpt-test",
         "messages": [
@@ -5877,7 +5878,7 @@ async def test_auxiliary_direct_llama_is_nonstreaming_exact_and_sensitive() -> N
         "presence_penalty": 0.1,
         "frequency_penalty": 0.2,
         "chat_template_kwargs": {"reasoning_effort": "high"},
-        "reasoning_budget": 2048,
+        "reasoning_budget_tokens": 2048,
     }
     await client.aclose()
 

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -1725,6 +1725,106 @@ async def test_llamacpp_stream_chat_ignores_non_object_json_sse_lines():
     assert chunks == ["ok"]
 
 
+def make_gateway_with_sse(lines: list[str]) -> ConsoleProviderGateway:
+    """Gateway whose llama.cpp endpoint streams the given SSE lines."""
+    body = "".join(f"{line}\n\n" for line in lines).encode()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(200, content=body)
+
+    return ConsoleProviderGateway(
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://127.0.0.1:8080",
+        )
+    )
+
+
+def make_gateway_with_completion(payload: dict) -> ConsoleProviderGateway:
+    """Gateway whose llama.cpp endpoint answers one non-streaming completion."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(200, json=payload)
+
+    return ConsoleProviderGateway(
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="http://127.0.0.1:8080",
+        )
+    )
+
+
+class TestDirectPathThinkFiltering:
+    @pytest.mark.asyncio
+    async def test_stream_strips_start_anchored_think_block(self):
+        # SSE lines whose content deltas spell:
+        #   "<think>ponder</think>Hello"
+        lines = [
+            'data: {"choices":[{"delta":{"content":"<think>pon"}}]}',
+            'data: {"choices":[{"delta":{"content":"der</think>Hello"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)
+        chunks = [
+            chunk
+            async for chunk in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_passes_mid_reply_literal_tag(self):
+        lines = [
+            'data: {"choices":[{"delta":{"content":"XML: <think>x</think>"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)
+        chunks = [
+            chunk
+            async for chunk in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "XML: <think>x</think>"
+
+    @pytest.mark.asyncio
+    async def test_stream_ignores_reasoning_content_deltas(self):
+        lines = [
+            'data: {"choices":[{"delta":{"reasoning_content":"secret"}}]}',
+            'data: {"choices":[{"delta":{"content":"Answer"}}]}',
+            "data: [DONE]",
+        ]
+        gateway = make_gateway_with_sse(lines)
+        chunks = [
+            chunk
+            async for chunk in gateway.stream_llamacpp_chat(
+                base_url="http://127.0.0.1:8080",
+                model="qwen",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+        assert "".join(chunks) == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_complete_strips_start_anchored_think_block(self):
+        gateway = make_gateway_with_completion(
+            {"choices": [{"message": {"content": "<think>x</think>Done"}}]}
+        )
+        text = await gateway.complete_llamacpp_chat(
+            base_url="http://127.0.0.1:8080",
+            model="qwen",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert text == "Done"
+
+
 @pytest.mark.asyncio
 async def test_stream_chat_dispatches_llamacpp_resolution():
     async def handler(request: httpx.Request) -> httpx.Response:

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -24,6 +24,8 @@ from tldw_chatbook.Chat.console_session_settings import (
     build_default_console_session_settings,
     build_console_model_options,
     build_console_provider_options,
+    console_settings_warnings,
+    reasoning_effort_hint_for_model,
     validate_console_session_settings,
 )
 from tldw_chatbook.Utils.token_counter import count_tokens_messages
@@ -2205,3 +2207,59 @@ async def test_settings_active_compaction_close_anyway_keeps_provider_work_runni
             )
     finally:
         release.set()
+
+
+class TestReasoningEffortHints:
+    def test_dotted_qwen_generations_are_effort_capable(self):
+        for model in ("Qwen3.8-27B", "qwen3.5-397b-gguf:q4"):
+            assert reasoning_effort_hint_for_model(model) == frozenset(
+                {"low", "medium", "xhigh"}
+            )
+
+    def test_original_qwen3_is_toggle_only(self):
+        assert reasoning_effort_hint_for_model("Qwen3-32B") == frozenset({"none"})
+
+    def test_gpt_oss(self):
+        assert reasoning_effort_hint_for_model("gpt-oss-120b") == frozenset(
+            {"low", "medium", "high"}
+        )
+
+    def test_unknown_model_has_no_hint(self):
+        assert reasoning_effort_hint_for_model("llama-3-8b") is None
+        assert reasoning_effort_hint_for_model(None) is None
+        assert reasoning_effort_hint_for_model("") is None
+
+
+class TestConsoleSettingsWarnings:
+    def _settings(self, **overrides):
+        base = dict(provider="llama_cpp", model="Qwen3.8-27B")
+        base.update(overrides)
+        return ConsoleSessionSettings(**base)
+
+    def test_value_outside_hint_warns(self):
+        # Non-llama.cpp provider isolates the hint logic (the llama.cpp base
+        # fixture would also add the --jinja requirements note).
+        settings = self._settings(provider="openai", reasoning_effort="high")
+        warnings = console_settings_warnings(settings)
+        assert len(warnings) == 1
+        assert "high" in warnings[0]
+        assert "xhigh" in warnings[0]
+
+    def test_value_inside_hint_does_not_warn(self):
+        settings = self._settings(provider="openai", reasoning_effort="xhigh")
+        assert console_settings_warnings(settings) == []
+
+    def test_unknown_model_does_not_warn(self):
+        settings = self._settings(
+            provider="openai", model="llama-3-8b", reasoning_effort="high"
+        )
+        assert console_settings_warnings(settings) == []
+
+    def test_llama_family_thinking_note_included(self):
+        settings = self._settings(reasoning_effort="low")
+        warnings = console_settings_warnings(settings)
+        assert any("--jinja" in w for w in warnings)
+
+    def test_llama_family_note_requires_a_thinking_value(self):
+        settings = self._settings()
+        assert console_settings_warnings(settings) == []

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -2212,10 +2212,12 @@ async def test_settings_active_compaction_close_anyway_keeps_provider_work_runni
 class TestReasoningEffortHints:
     def test_dotted_qwen_generations_are_effort_capable(self):
         # "none" is included: it is consumed via our enable_thinking=false
-        # mapping on dotted Qwens (live-verified).
+        # mapping on dotted Qwens (live-verified). "high" is included: the
+        # template aliases it to "xhigh" (live-verified), so warning on it
+        # would be a false positive against the actual wire behavior.
         for model in ("Qwen3.8-27B", "qwen3.5-397b-gguf:q4"):
             assert reasoning_effort_hint_for_model(model) == frozenset(
-                {"low", "medium", "xhigh", "none"}
+                {"low", "medium", "high", "xhigh", "none"}
             )
 
     def test_original_qwen3_is_toggle_only(self):
@@ -2240,11 +2242,13 @@ class TestConsoleSettingsWarnings:
 
     def test_value_outside_hint_warns(self):
         # Non-llama.cpp provider isolates the hint logic (the llama.cpp base
-        # fixture would also add the --jinja requirements note).
-        settings = self._settings(provider="openai", reasoning_effort="high")
+        # fixture would also add the --jinja requirements note). "minimal" is
+        # genuinely unconsumed on dotted Qwens: the wire composer's
+        # template-safe guard drops it rather than sending it.
+        settings = self._settings(provider="openai", reasoning_effort="minimal")
         warnings = console_settings_warnings(settings)
         assert len(warnings) == 1
-        assert "high" in warnings[0]
+        assert "minimal" in warnings[0]
         assert "xhigh" in warnings[0]
 
     def test_value_inside_hint_does_not_warn(self):

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -2211,9 +2211,11 @@ async def test_settings_active_compaction_close_anyway_keeps_provider_work_runni
 
 class TestReasoningEffortHints:
     def test_dotted_qwen_generations_are_effort_capable(self):
+        # "none" is included: it is consumed via our enable_thinking=false
+        # mapping on dotted Qwens (live-verified).
         for model in ("Qwen3.8-27B", "qwen3.5-397b-gguf:q4"):
             assert reasoning_effort_hint_for_model(model) == frozenset(
-                {"low", "medium", "xhigh"}
+                {"low", "medium", "xhigh", "none"}
             )
 
     def test_original_qwen3_is_toggle_only(self):
@@ -2260,6 +2262,19 @@ class TestConsoleSettingsWarnings:
         warnings = console_settings_warnings(settings)
         assert any("--jinja" in w for w in warnings)
 
+    def test_local_llm_thinking_note_included(self):
+        # local-llm sends compose llama.cpp-family wire fields, so its users
+        # need the --jinja/b9982 requirements note too.
+        settings = self._settings(provider="local_llm", reasoning_effort="low")
+        warnings = console_settings_warnings(settings)
+        assert any("--jinja" in w for w in warnings)
+
     def test_llama_family_note_requires_a_thinking_value(self):
         settings = self._settings()
+        assert console_settings_warnings(settings) == []
+
+    def test_none_effort_on_dotted_qwen_does_not_warn(self):
+        # "none" is consumed by dotted Qwens via our enable_thinking=false
+        # mapping, so it must not warn as unconsumed.
+        settings = self._settings(provider="openai", reasoning_effort="none")
         assert console_settings_warnings(settings) == []

--- a/Tests/Chat/test_llamacpp_think_filter.py
+++ b/Tests/Chat/test_llamacpp_think_filter.py
@@ -1,0 +1,63 @@
+from tldw_chatbook.Chat.llamacpp_think_filter import StartAnchoredThinkFilter
+
+
+def run_filter(text: str) -> str:
+    f = StartAnchoredThinkFilter()
+    return f.feed(text) + f.flush()
+
+
+class TestSplitAcrossChunks:
+    def test_open_tag_split_across_chunks(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<thi") == ""
+        assert f.feed("nk>reasoning") == ""
+        assert f.feed(" here</think>answer") == "answer"
+        assert f.flush() == ""
+
+    def test_close_tag_split_across_chunks(self):
+        f = StartAnchoredThinkFilter()
+        f.feed("<think>abc")
+        assert f.feed("</thi") == ""
+        assert f.feed("nk>done") == "done"
+
+    def test_one_char_at_a_time(self):
+        f = StartAnchoredThinkFilter()
+        out = []
+        for ch in "<think>hidden</think>visible":
+            out.append(f.feed(ch))
+        assert "".join(out) + f.flush() == "visible"
+
+
+class TestAnchoring:
+    def test_mid_reply_literal_tag_survives(self):
+        assert run_filter("Here is XML: <think>stuff</think> done") == (
+            "Here is XML: <think>stuff</think> done"
+        )
+
+    def test_leading_whitespace_before_tag_is_tolerated(self):
+        assert run_filter("\n\n<think>x</think>hi") == "hi"
+
+    def test_empty_prefix_block_is_removed(self):
+        # Some Qwen generations emit an empty think prefix in no-think mode.
+        assert run_filter("<think>\n\n</think>\n\nAnswer") == "Answer"
+
+    def test_plain_text_passes_through(self):
+        assert run_filter("just an answer") == "just an answer"
+
+    def test_text_starting_like_tag_but_not_tag_passes(self):
+        assert run_filter("<thumbs up>") == "<thumbs up>"
+
+    def test_thinking_tag_variant_supported(self):
+        assert run_filter("<thinking>deep</thinking>ok") == "ok"
+
+
+class TestUnterminated:
+    def test_unterminated_start_anchored_block_dropped_on_flush(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<think>forever") == ""
+        assert f.flush() == ""
+
+    def test_ambiguous_prefix_at_stream_end_dropped(self):
+        f = StartAnchoredThinkFilter()
+        assert f.feed("<thin") == ""
+        assert f.flush() == ""

--- a/Tests/Chat/test_local_adapter_thinking_dispatch.py
+++ b/Tests/Chat/test_local_adapter_thinking_dispatch.py
@@ -88,7 +88,7 @@ def test_shared_builder_composes_llama_wire_format(monkeypatch):
 
     payload = posted["payload"]
     assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
-    assert payload["reasoning_budget"] == 2048
+    assert payload["reasoning_budget_tokens"] == 2048
 
 
 def test_shared_builder_composes_vllm_dual_placement(monkeypatch):
@@ -138,4 +138,4 @@ def test_shared_builder_composes_vllm_dual_placement(monkeypatch):
     payload = posted["payload"]
     assert payload["reasoning_effort"] == "medium"
     assert payload["chat_template_kwargs"] == {"reasoning_effort": "medium"}
-    assert "reasoning_budget" not in payload
+    assert "reasoning_budget_tokens" not in payload

--- a/Tests/Chat/test_local_adapter_thinking_dispatch.py
+++ b/Tests/Chat/test_local_adapter_thinking_dispatch.py
@@ -1,0 +1,141 @@
+"""Adapter-path thinking dispatch: param maps + shared local builder."""
+
+from unittest.mock import patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+
+COVERED_KEYS = [
+    "llama_cpp",
+    "local_llamacpp",
+    "local_llamafile",
+    "local-llm",
+    "vllm",
+    "local_vllm",
+    "local_mlx_lm",
+    "custom-openai-api",
+    "custom-openai-api-2",
+]
+
+
+def test_param_maps_forward_thinking_fields(monkeypatch):
+    captured = {}
+
+    def fake_handler(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    import tldw_chatbook.Chat.Chat_Functions as cf
+
+    for key in COVERED_KEYS:
+        captured.clear()
+        monkeypatch.setitem(cf.API_CALL_HANDLERS, key, fake_handler)
+        chat_api_call(
+            api_endpoint=key,
+            messages_payload=[{"role": "user", "content": "hi"}],
+            api_key=None,
+            reasoning_effort="low",
+            thinking_budget_tokens=2048,
+        )
+        assert captured.get("reasoning_effort") == "low", key
+        assert captured.get("thinking_budget_tokens") == 2048, key
+
+
+def test_shared_builder_composes_llama_wire_format(monkeypatch):
+    from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (
+        _chat_with_openai_compatible_local_server,
+    )
+
+    posted = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"choices":[{"message":{"content":"ok"}}]}'
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        def raise_for_status(self):
+            return None
+
+    class FakeSession:
+        def __init__(self):
+            self.adapters = None
+
+        def mount(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None, timeout=None):
+            posted["url"] = url
+            posted["payload"] = json
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        return_value=FakeSession(),
+    ):
+        _chat_with_openai_compatible_local_server(
+            api_base_url="http://127.0.0.1:8080",
+            model_name="qwen",
+            input_data=[{"role": "user", "content": "hi"}],
+            streaming=False,
+            reasoning_effort="low",
+            thinking_budget_tokens=2048,
+            thinking_wire_key="llama_cpp",
+        )
+
+    payload = posted["payload"]
+    assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
+    assert payload["reasoning_budget"] == 2048
+
+
+def test_shared_builder_composes_vllm_dual_placement(monkeypatch):
+    # Same harness as above; only assertions differ. FakeResponse mirrors the
+    # llama harness surface (the builder reads .status_code for metrics).
+    posted = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"choices":[{"message":{"content":"ok"}}]}'
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        def raise_for_status(self):
+            return None
+
+    class FakeSession:
+        def mount(self, *a, **k):
+            pass
+
+        def post(self, url, json=None, headers=None, timeout=None):
+            posted["payload"] = json
+            return FakeResponse()
+
+        def close(self):
+            pass
+
+    with patch(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.requests.Session",
+        return_value=FakeSession(),
+    ):
+        from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (
+            _chat_with_openai_compatible_local_server,
+        )
+
+        _chat_with_openai_compatible_local_server(
+            api_base_url="http://127.0.0.1:8000",
+            model_name="qwen",
+            input_data=[{"role": "user", "content": "hi"}],
+            streaming=False,
+            reasoning_effort="medium",
+            thinking_budget_tokens=2048,
+            thinking_wire_key="vllm",
+        )
+
+    payload = posted["payload"]
+    assert payload["reasoning_effort"] == "medium"
+    assert payload["chat_template_kwargs"] == {"reasoning_effort": "medium"}
+    assert "reasoning_budget" not in payload

--- a/Tests/Chat/test_local_adapter_thinking_dispatch.py
+++ b/Tests/Chat/test_local_adapter_thinking_dispatch.py
@@ -40,7 +40,7 @@ def test_param_maps_forward_thinking_fields(monkeypatch):
         assert captured.get("thinking_budget_tokens") == 2048, key
 
 
-def test_shared_builder_composes_llama_wire_format(monkeypatch):
+def test_shared_builder_composes_llama_wire_format():
     from tldw_chatbook.LLM_Calls.LLM_API_Calls_Local import (
         _chat_with_openai_compatible_local_server,
     )
@@ -91,7 +91,7 @@ def test_shared_builder_composes_llama_wire_format(monkeypatch):
     assert payload["reasoning_budget_tokens"] == 2048
 
 
-def test_shared_builder_composes_vllm_dual_placement(monkeypatch):
+def test_shared_builder_composes_vllm_dual_placement():
     # Same harness as above; only assertions differ. FakeResponse mirrors the
     # llama harness surface (the builder reads .status_code for metrics).
     posted = {}

--- a/Tests/Chat/test_local_thinking_wire_formats.py
+++ b/Tests/Chat/test_local_thinking_wire_formats.py
@@ -1,0 +1,92 @@
+"""Wire-format composition for local thinking controls (ADR-066)."""
+
+from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
+)
+
+
+class TestLlamaCppFamily:
+    def test_level_goes_into_chat_template_kwargs(self):
+        fields = build_local_thinking_payload_fields(
+            "llama_cpp", "low", None
+        )
+        assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+
+    def test_budget_goes_top_level(self):
+        fields = build_local_thinking_payload_fields(
+            "local_llamacpp", None, 2048
+        )
+        assert fields == {"reasoning_budget": 2048}
+
+    def test_level_and_budget_together(self):
+        fields = build_local_thinking_payload_fields(
+            "local_llamafile", "xhigh", 4096
+        )
+        assert fields == {
+            "chat_template_kwargs": {"reasoning_effort": "xhigh"},
+            "reasoning_budget": 4096,
+        }
+
+    def test_none_effort_sends_verbatim_and_disables_thinking(self):
+        fields = build_local_thinking_payload_fields(
+            "local-llm", "none", None
+        )
+        assert fields == {
+            "chat_template_kwargs": {
+                "reasoning_effort": "none",
+                "enable_thinking": False,
+            }
+        }
+
+    def test_all_family_keys_share_the_shape(self):
+        for key in ("llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"):
+            assert build_local_thinking_payload_fields(key, "low", 1024) == {
+                "chat_template_kwargs": {"reasoning_effort": "low"},
+                "reasoning_budget": 1024,
+            }
+
+
+class TestVllmFamily:
+    def test_level_is_dual_placed(self):
+        for key in ("vllm", "local_vllm"):
+            assert build_local_thinking_payload_fields(key, "medium", None) == {
+                "reasoning_effort": "medium",
+                "chat_template_kwargs": {"reasoning_effort": "medium"},
+            }
+
+    def test_budget_is_dropped(self):
+        assert build_local_thinking_payload_fields("vllm", None, 2048) == {}
+
+
+class TestCustomOpenAI:
+    def test_level_is_top_level_only(self):
+        for key in ("custom-openai-api", "custom-openai-api-2"):
+            assert build_local_thinking_payload_fields(key, "low", 2048) == {
+                "reasoning_effort": "low"
+            }
+
+
+class TestMlx:
+    def test_level_via_template_kwargs_budget_dropped(self):
+        fields = build_local_thinking_payload_fields(
+            "local_mlx_lm", "low", 2048
+        )
+        assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+
+
+class TestUnknownKeysAndHygiene:
+    def test_unknown_key_returns_empty(self):
+        assert build_local_thinking_payload_fields("ollama", "low", 1024) == {}
+        assert build_local_thinking_payload_fields("openai", "low", 1024) == {}
+
+    def test_blank_effort_and_missing_budget_return_empty(self):
+        assert build_local_thinking_payload_fields("llama_cpp", "", None) == {}
+        assert build_local_thinking_payload_fields("llama_cpp", None, None) == {}
+
+    def test_whitespace_effort_is_normalized(self):
+        assert build_local_thinking_payload_fields("llama_cpp", "  low ", None) == {
+            "chat_template_kwargs": {"reasoning_effort": "low"}
+        }
+
+    def test_non_int_budget_is_ignored(self):
+        assert build_local_thinking_payload_fields("llama_cpp", None, "2048") == {}

--- a/Tests/Chat/test_local_thinking_wire_formats.py
+++ b/Tests/Chat/test_local_thinking_wire_formats.py
@@ -16,7 +16,7 @@ class TestLlamaCppFamily:
         fields = build_local_thinking_payload_fields(
             "local_llamacpp", None, 2048
         )
-        assert fields == {"reasoning_budget": 2048}
+        assert fields == {"reasoning_budget_tokens": 2048}
 
     def test_level_and_budget_together(self):
         fields = build_local_thinking_payload_fields(
@@ -24,7 +24,7 @@ class TestLlamaCppFamily:
         )
         assert fields == {
             "chat_template_kwargs": {"reasoning_effort": "xhigh"},
-            "reasoning_budget": 4096,
+            "reasoning_budget_tokens": 4096,
         }
 
     def test_none_effort_sends_verbatim_and_disables_thinking(self):
@@ -42,7 +42,7 @@ class TestLlamaCppFamily:
         for key in ("llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"):
             assert build_local_thinking_payload_fields(key, "low", 1024) == {
                 "chat_template_kwargs": {"reasoning_effort": "low"},
-                "reasoning_budget": 1024,
+                "reasoning_budget_tokens": 1024,
             }
 
 
@@ -72,6 +72,44 @@ class TestMlx:
             "local_mlx_lm", "low", 2048
         )
         assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
+
+
+class TestTemplateSafeEfforts:
+    """Live-verified (llama.cpp b10430 + Qwen3.8): strict chat templates
+    validate reasoning_effort and raise on unknown values, so non-safe
+    efforts must not be forwarded via chat_template_kwargs."""
+
+    def test_minimal_effort_drops_template_kwargs_but_keeps_budget(self):
+        fields = build_local_thinking_payload_fields(
+            "llama_cpp", "minimal", 2048
+        )
+        assert fields == {"reasoning_budget_tokens": 2048}
+
+    def test_minimal_effort_drops_template_kwargs_on_mlx(self):
+        fields = build_local_thinking_payload_fields(
+            "local_mlx_lm", "minimal", None
+        )
+        assert fields == {}
+
+    def test_minimal_effort_on_vllm_keeps_top_level_verbatim(self):
+        fields = build_local_thinking_payload_fields(
+            "vllm", "minimal", None
+        )
+        assert fields == {"reasoning_effort": "minimal"}
+        assert "chat_template_kwargs" not in fields
+
+    def test_high_effort_emitted_verbatim(self):
+        # "high" is aliased to "xhigh" by the Qwen3.8 template and is safe.
+        fields = build_local_thinking_payload_fields(
+            "llama_cpp", "high", None
+        )
+        assert fields == {"chat_template_kwargs": {"reasoning_effort": "high"}}
+
+    def test_minimal_effort_on_custom_openai_stays_verbatim(self):
+        fields = build_local_thinking_payload_fields(
+            "custom-openai-api", "minimal", None
+        )
+        assert fields == {"reasoning_effort": "minimal"}
 
 
 class TestUnknownKeysAndHygiene:

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -68,9 +68,11 @@ from tldw_chatbook.Widgets.Console.console_settings_modal import (
     MODAL_CONTROL_HEIGHT,
     MODEL_DISCOVER_BUTTON_ID,
     MODEL_DISCOVER_STATUS_ID,
+    PROVIDER_CHOICE_NO_EFFECT_SUFFIX,
     ConsoleSettingsInput,
     ConsoleSettingsModal,
     ConsoleSettingsResult,
+    _is_local_thinking_provider,
     _settings_screen_region,
 )
 from tldw_chatbook.Widgets.Console.console_settings_summary import (
@@ -2511,6 +2513,94 @@ async def test_console_settings_modal_renders_current_chat_identity() -> None:
         assert identity.placeholder == "Default Name"
         assert "Chat identity" in _visible_text(app)
         assert "Leave blank to use the global default." in _visible_text(app)
+
+
+def test_local_thinking_provider_detection_covers_execution_key_aliases() -> None:
+    assert _is_local_thinking_provider("llama_cpp") is True
+    assert _is_local_thinking_provider("local_llamacpp") is True
+    assert _is_local_thinking_provider("local_llamafile") is True
+    assert _is_local_thinking_provider("local_llm") is True
+    assert _is_local_thinking_provider("vllm") is True
+    assert _is_local_thinking_provider("local_vllm") is True
+    assert _is_local_thinking_provider("local_mlx_lm") is True
+    # Readiness aliases resolve to their custom-openai execution keys.
+    assert _is_local_thinking_provider("custom") is True
+    assert _is_local_thinking_provider("custom_2") is True
+    assert _is_local_thinking_provider("anthropic") is False
+    assert _is_local_thinking_provider("openai") is False
+    assert _is_local_thinking_provider(None) is False
+
+
+@pytest.mark.asyncio
+async def test_console_settings_modal_local_provider_marks_no_effect_choices() -> (
+    None
+):
+    app = ModalHarness()
+    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            _basic_modal(settings, app), callback=app.capture_saved_settings
+        )
+        await pilot.pause()
+
+        thinking = app.screen.query_one("#console-settings-thinking-effort", Input)
+        summary = app.screen.query_one("#console-settings-reasoning-summary", Input)
+        verbosity = app.screen.query_one("#console-settings-verbosity", Input)
+        effort = app.screen.query_one("#console-settings-reasoning-effort", Input)
+        # Local providers consume only the reasoning-effort level; the other
+        # provider-specific choice inputs say so right in the placeholder.
+        assert thinking.placeholder.endswith(PROVIDER_CHOICE_NO_EFFECT_SUFFIX)
+        assert summary.placeholder.endswith(PROVIDER_CHOICE_NO_EFFECT_SUFFIX)
+        assert verbosity.placeholder.endswith(PROVIDER_CHOICE_NO_EFFECT_SUFFIX)
+        assert PROVIDER_CHOICE_NO_EFFECT_SUFFIX not in effort.placeholder
+
+
+@pytest.mark.asyncio
+async def test_console_settings_modal_remote_provider_keeps_thinking_hint_plain() -> (
+    None
+):
+    app = ModalHarness()
+    settings = ConsoleSessionSettings(
+        provider="anthropic", model="claude-3-5-sonnet-latest"
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            _basic_modal(settings, app), callback=app.capture_saved_settings
+        )
+        await pilot.pause()
+
+        thinking = app.screen.query_one("#console-settings-thinking-effort", Input)
+        assert PROVIDER_CHOICE_NO_EFFECT_SUFFIX not in thinking.placeholder
+
+
+@pytest.mark.asyncio
+async def test_console_settings_modal_provider_switch_refreshes_choice_hints() -> (
+    None
+):
+    app = ModalHarness()
+    settings = ConsoleSessionSettings(provider="openai", model="gpt-4.1")
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            _basic_modal(
+                settings,
+                app,
+                providers_models={"openai": ["gpt-4.1"], "llama_cpp": ["model-a"]},
+            ),
+            callback=app.capture_saved_settings,
+        )
+        await pilot.pause()
+
+        thinking = app.screen.query_one("#console-settings-thinking-effort", Input)
+        assert PROVIDER_CHOICE_NO_EFFECT_SUFFIX not in thinking.placeholder
+
+        provider_select = app.screen.query_one("#console-settings-provider", Select)
+        provider_select.value = "llama_cpp"
+        await pilot.pause()
+
+        assert thinking.placeholder.endswith(PROVIDER_CHOICE_NO_EFFECT_SUFFIX)
 
 
 @pytest.mark.asyncio
@@ -7062,11 +7152,20 @@ async def test_console_settings_modal_enumerated_inputs_list_accepted_values() -
             _basic_modal(settings, app), callback=app.capture_saved_settings
         )
         await pilot.pause()
+        # llama.cpp is a local thinking provider: only the reasoning-effort
+        # level is consumed, so the other choice inputs carry the no-effect
+        # suffix.
         placeholders = {
             "console-settings-reasoning-effort": "none, minimal, low, medium, high, xhigh",
-            "console-settings-reasoning-summary": "auto, concise, detailed, none",
-            "console-settings-verbosity": "low, medium, high",
-            "console-settings-thinking-effort": "off, low, medium, high, xhigh, max",
+            "console-settings-reasoning-summary": (
+                "auto, concise, detailed, none" + PROVIDER_CHOICE_NO_EFFECT_SUFFIX
+            ),
+            "console-settings-verbosity": (
+                "low, medium, high" + PROVIDER_CHOICE_NO_EFFECT_SUFFIX
+            ),
+            "console-settings-thinking-effort": (
+                "off, low, medium, high, xhigh, max" + PROVIDER_CHOICE_NO_EFFECT_SUFFIX
+            ),
         }
         for input_id, expected in placeholders.items():
             assert app.screen.query_one(f"#{input_id}", Input).placeholder == expected

--- a/backlog/decisions/066-local-provider-thinking-controls.md
+++ b/backlog/decisions/066-local-provider-thinking-controls.md
@@ -26,7 +26,8 @@ Each local execution key composes its payload through one wire-format table
 - llama.cpp family (`llama_cpp`, `local_llamacpp`, `local-llm`,
   `local_llamafile`): level inside `chat_template_kwargs.reasoning_effort`
   (llama-server does not parse top-level `reasoning_effort`); budget as
-  top-level `reasoning_budget`, supported per-request since llama.cpp b9982
+  top-level `reasoning_budget_tokens`, supported per-request since llama.cpp
+  b9982
   and ignored by older servers.
 - vLLM family (`vllm`, `local_vllm`): the level goes both top-level and
   inside `chat_template_kwargs.reasoning_effort` with the same value —
@@ -72,9 +73,28 @@ generations emit in no-think mode.
 - Qwen3.8-27B's `low`/`medium`/`xhigh` levels and a hard thinking cap work
   from the Console against llama.cpp (≥ b9982 for the cap) and vLLM without
   new UI.
-- Servers older than b9982 silently ignore `reasoning_budget`; the Console
+- Servers older than b9982 silently ignore `reasoning_budget_tokens`; the Console
   surfaces the build requirement as a hint rather than probing.
 - The model-family warning table is a heuristic on model names and can be
   stale for new releases; it never blocks sends.
 - Auxiliary requests (title generation etc.) inherit session thinking
   settings on mapped providers, matching existing cloud behavior.
+
+
+## Errata (live verification)
+
+Live verification (2026-08-15, `llama-server` b10430 `--jinja` +
+Qwen3.8-27B) amended three points:
+
+1. The per-request budget field is `reasoning_budget_tokens`, not
+   `reasoning_budget` — the latter is silently ignored by llama.cpp
+   (live: budget 8 → 35 reasoning chars, 32 → 101, vs 391 natural).
+2. Qwen3.8's chat template validates `reasoning_effort` and raises on
+   unknown values (effort `minimal` → HTTP 500). `high` is aliased to
+   `xhigh` by the template and is safe; `none` is safe because it pairs
+   with `enable_thinking: false`, which short-circuits the validation
+   block. Non-safe efforts are dropped from `chat_template_kwargs`
+   (debug-logged) rather than sent; vLLM and Custom OpenAI top-level
+   `reasoning_effort` stays verbatim for all values.
+3. The budget is not consumed by chat templates — it is a server-side
+   mechanism only.

--- a/backlog/decisions/066-local-provider-thinking-controls.md
+++ b/backlog/decisions/066-local-provider-thinking-controls.md
@@ -1,0 +1,80 @@
+# ADR-066: Local provider thinking control wire formats
+
+Status: Proposed
+Date: 2026-08-15
+Related Task: [TASK-16319](../tasks/task-16319%20-%20Console-thinking-levels-and-budget-for-local-providers.md)
+Related Spec: [Local Provider Thinking Controls — Design](../../Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md)
+Supersedes: N/A
+
+## Decision
+
+Chatbook reuses the Console's existing generic reasoning settings —
+`reasoning_effort` for thinking level and `thinking_budget_tokens` for the
+max-thinking-tokens cap — as the thinking controls for local providers,
+rather than adding provider-specific fields. The Anthropic-style
+`thinking_effort` remains Anthropic-only.
+
+Values are sent verbatim. `reasoning_effort: none` additionally sends
+`chat_template_kwargs: {"enable_thinking": false}`. Values a template does
+not consume are unused Jinja variables and degrade to the model default;
+Chatbook warns (model-family heuristic, non-blocking) instead of rewriting
+them. The `thinking_budget_tokens` floor stays a global ≥ 1024.
+
+Each local execution key composes its payload through one wire-format table
+(see the spec) rather than per-call conditionals:
+
+- llama.cpp family (`llama_cpp`, `local_llamacpp`, `local-llm`,
+  `local_llamafile`): level inside `chat_template_kwargs.reasoning_effort`
+  (llama-server does not parse top-level `reasoning_effort`); budget as
+  top-level `reasoning_budget`, supported per-request since llama.cpp b9982
+  and ignored by older servers.
+- vLLM family (`vllm`, `local_vllm`): the level goes both top-level and
+  inside `chat_template_kwargs.reasoning_effort` with the same value —
+  whichever path that stack consumes wins and the other is ignored. This
+  guards against the top-level-only assumption being wrong for a given vLLM
+  release. Per-request budget unsupported, dropped and logged.
+- Custom OpenAI endpoints (`custom-openai-api`, `custom-openai-api-2`):
+  top-level OpenAI-style `reasoning_effort` only (no llama.cpp-specific
+  fields — strict OpenAI proxies may reject them); budget dropped.
+- `local_mlx_lm`: `chat_template_kwargs` pending live verification of
+  `mlx_lm.server` support; drop-and-log if unsupported.
+
+Prefill precedence stays `prefill > none > effort`: an assistant prefill
+still forces `enable_thinking: false` because llama.cpp rejects prefilled
+requests when the template's thinking mode is enabled.
+
+Thinking output is kept out of the visible Console reply in both shapes:
+the direct llama.cpp SSE path consumes `reasoning_content` separately
+(server launched with `--reasoning-format`) and, when the server does not
+split, stream-strips `<think>…</think>` blocks anchored to the start of the
+response — mid-reply literal `<think>` text is legitimate content and
+survives, and start-anchoring also removes the empty think prefix some Qwen
+generations emit in no-think mode.
+
+## Alternatives considered
+
+- **Free-form `chat_template_kwargs` JSON field in Console settings.** Most
+  flexible (any template kwarg), but duplicates the structured fields,
+  needs JSON validation in a TUI input, and provides no levels semantics by
+  itself. Rejected as the primary mechanism; a future escape hatch may layer
+  on top.
+- **Server-side only.** Launch `llama-server` with `--reasoning-budget` /
+  `--chat-template-kwargs` defaults (the managed launcher passes user args
+  through today). No request-path code, but not per-session/per-request and
+  invisible to the Console. Rejected as the primary mechanism; launch-flag
+  guidance is documented alongside.
+- **Clamp unsupported values to the nearest supported one.** Rejected: the
+  request would not match what the user typed, which is visible in the
+  request preview and trust-eroding. Verbatim + warn chosen instead.
+
+## Consequences
+
+- Qwen3.8-27B's `low`/`medium`/`xhigh` levels and a hard thinking cap work
+  from the Console against llama.cpp (≥ b9982 for the cap) and vLLM without
+  new UI.
+- Servers older than b9982 silently ignore `reasoning_budget`; the Console
+  surfaces the build requirement as a hint rather than probing.
+- The model-family warning table is a heuristic on model names and can be
+  stale for new releases; it never blocks sends.
+- Auxiliary requests (title generation etc.) inherit session thinking
+  settings on mapped providers, matching existing cloud behavior.

--- a/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
+++ b/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
@@ -1,0 +1,26 @@
+---
+id: TASK-16319
+title: Console thinking levels and budget for local providers
+status: To Do
+assignee: []
+created_date: '2026-08-15 18:02'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Qwen3.8-27B exposes adjustable thinking (reasoning_effort low/medium/xhigh) and separate thinking-token caps. The Console already has Reasoning/Budget fields but drops them for local providers: the direct llama.cpp path forwards sampling params only, and PROVIDER_PARAM_MAP has no entries for local keys. Wire the existing fields through to llama.cpp (chat_template_kwargs + per-request reasoning_budget), vLLM/Custom OpenAI (top-level reasoning_effort), and MLX-LM (pending live verification), keep thinking output out of the visible reply on the llama.cpp direct path, and warn (not block) on values the model family does not consume.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] Console Reasoning/Budget fields reach local provider requests with the per-provider wire format from ADR-066
+- [ ] Reasoning effort none sends enable_thinking false and prefill still forces enable_thinking false
+- [ ] Qwen3.8-27B verified live against llama-server --jinja: low/medium/xhigh change thinking depth and reasoning_budget truncates thinking (checked with and without --reasoning-format)
+- [ ] Visible Console reply never contains think tags or reasoning content on the llama.cpp direct path regardless of the server's reasoning-format flag
+- [ ] Values outside the model-family hint set warn without blocking and placeholders list consumed values
+- [ ] Request preview shows the composed chat_template_kwargs and reasoning_budget fields
+- [ ] Unit and integration tests and lint pass
+<!-- AC:END -->

--- a/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
+++ b/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-16319
 title: Console thinking levels and budget for local providers
-status: In Progress
+status: Done
 assignee:
   - '@Robert'
 created_date: '2026-08-15 18:02'
-updated_date: '2026-08-16 03:14'
+updated_date: '2026-08-16 04:56'
 labels: []
 dependencies: []
 ---
@@ -18,17 +18,29 @@ Qwen3.8-27B exposes adjustable thinking (reasoning_effort low/medium/xhigh) and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Console Reasoning/Budget fields reach local provider requests with the per-provider wire format from ADR-066
-- [ ] #2 Reasoning effort none sends enable_thinking false and prefill still forces enable_thinking false
-- [ ] #3 Qwen3.8-27B verified live against llama-server --jinja: low/medium/xhigh change thinking depth and reasoning_budget truncates thinking (checked with and without --reasoning-format)
-- [ ] #4 Visible Console reply never contains think tags or reasoning content on the llama.cpp direct path regardless of the server's reasoning-format flag
-- [ ] #5 Values outside the model-family hint set warn without blocking and placeholders list consumed values
-- [ ] #6 Request preview shows the composed chat_template_kwargs and reasoning_budget fields
-- [ ] #7 Unit and integration tests and lint pass
+- [x] #1 Console Reasoning/Budget fields reach local provider requests with the per-provider wire format from ADR-066
+- [x] #2 Reasoning effort none sends enable_thinking false and prefill still forces enable_thinking false
+- [x] #3 Qwen3.8-27B verified live against llama-server --jinja: low/medium/xhigh change thinking depth and reasoning_budget truncates thinking (checked with and without --reasoning-format)
+- [x] #4 Visible Console reply never contains think tags or reasoning content on the llama.cpp direct path regardless of the server's reasoning-format flag
+- [x] #5 Values outside the model-family hint set warn without blocking and placeholders list consumed values
+- [x] #6 Request preview shows the composed chat_template_kwargs and reasoning_budget fields
+- [x] #7 Unit and integration tests and lint pass
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Wire-format table (ADR-066)\n2. Direct llama.cpp payload wiring\n3. Start-anchored think filter\n4. Wire filter into direct path\n5. Adapter-path param maps + shared builder + handlers\n6. Hints, warnings, placeholder, preview\n7. Full verification and wrap-up
+1. Wire-format table (ADR-066)
+2. Direct llama.cpp payload wiring
+3. Start-anchored think filter
+4. Wire filter into direct path
+5. Adapter-path param maps + shared builder + handlers
+6. Hints, warnings, placeholder, preview
+7. Full verification and wrap-up
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented per ADR-066 spec/plan; live-verified against llama-server b10430 --jinja with Qwen3.8-27B (effort levels, reasoning_budget_tokens truncation, no-think, prefill, filter). Live findings fixed in a8628f748 with spec/ADR errata.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
+++ b/backlog/tasks/task-16319 - Console-thinking-levels-and-budget-for-local-providers.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-16319
 title: Console thinking levels and budget for local providers
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@Robert'
 created_date: '2026-08-15 18:02'
+updated_date: '2026-08-16 03:14'
 labels: []
 dependencies: []
 ---
@@ -16,11 +18,17 @@ Qwen3.8-27B exposes adjustable thinking (reasoning_effort low/medium/xhigh) and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] Console Reasoning/Budget fields reach local provider requests with the per-provider wire format from ADR-066
-- [ ] Reasoning effort none sends enable_thinking false and prefill still forces enable_thinking false
-- [ ] Qwen3.8-27B verified live against llama-server --jinja: low/medium/xhigh change thinking depth and reasoning_budget truncates thinking (checked with and without --reasoning-format)
-- [ ] Visible Console reply never contains think tags or reasoning content on the llama.cpp direct path regardless of the server's reasoning-format flag
-- [ ] Values outside the model-family hint set warn without blocking and placeholders list consumed values
-- [ ] Request preview shows the composed chat_template_kwargs and reasoning_budget fields
-- [ ] Unit and integration tests and lint pass
+- [ ] #1 Console Reasoning/Budget fields reach local provider requests with the per-provider wire format from ADR-066
+- [ ] #2 Reasoning effort none sends enable_thinking false and prefill still forces enable_thinking false
+- [ ] #3 Qwen3.8-27B verified live against llama-server --jinja: low/medium/xhigh change thinking depth and reasoning_budget truncates thinking (checked with and without --reasoning-format)
+- [ ] #4 Visible Console reply never contains think tags or reasoning content on the llama.cpp direct path regardless of the server's reasoning-format flag
+- [ ] #5 Values outside the model-family hint set warn without blocking and placeholders list consumed values
+- [ ] #6 Request preview shows the composed chat_template_kwargs and reasoning_budget fields
+- [ ] #7 Unit and integration tests and lint pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Wire-format table (ADR-066)\n2. Direct llama.cpp payload wiring\n3. Start-anchored think filter\n4. Wire filter into direct path\n5. Adapter-path param maps + shared builder + handlers\n6. Hints, warnings, placeholder, preview\n7. Full verification and wrap-up
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -410,6 +410,8 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "logprobs": "logprobs",
         "top_logprobs": "top_logprobs",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "koboldcpp": {
         "api_key": "api_key",
@@ -481,6 +483,8 @@ PROVIDER_PARAM_MAP = {
         "logprobs": "logprobs",
         "top_logprobs": "top_logprobs",
         "user_identifier": "user_identifier",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "local-llm": {
         "messages_payload": "input_data",
@@ -494,6 +498,8 @@ PROVIDER_PARAM_MAP = {
         "max_tokens": "max_tokens",
         "seed": "seed",
         "stop": "stop",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "ollama": {  # api_url consideration
         "api_key": "api_key",  # api_key is not used by ollama directly, url is more important
@@ -556,6 +562,8 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "logprobs": "logprobs",
         "top_logprobs": "top_logprobs",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "custom-openai-api-2": {
         "api_key": "api_key",
@@ -578,6 +586,8 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "logprobs": "logprobs",
         "top_logprobs": "top_logprobs",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "mlx_lm": {
         "api_key": "api_key",  # chat_with_mlx_lm doesn't use it, but map for consistency if passed via chat_api_call
@@ -626,6 +636,8 @@ PROVIDER_PARAM_MAP = {
         "n": "n_probs",
         "presence_penalty": "presence_penalty",
         "frequency_penalty": "frequency_penalty",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "local_llamafile": {
         "api_key": "api_key",
@@ -645,6 +657,8 @@ PROVIDER_PARAM_MAP = {
         "n": "n_probs",
         "presence_penalty": "presence_penalty",
         "frequency_penalty": "frequency_penalty",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "local_ollama": {
         "api_key": "api_key",
@@ -682,6 +696,8 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "logprobs": "logprobs",
         "user_identifier": "user_identifier",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "local_mlx_lm": {
         "api_key": "api_key",
@@ -706,6 +722,8 @@ PROVIDER_PARAM_MAP = {
         "user_identifier": "user_identifier",
         "tools": "tools",
         "tool_choice": "tool_choice",
+        "reasoning_effort": "reasoning_effort",
+        "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "moonshot": {
         "api_key": "api_key",

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -61,6 +61,7 @@ from tldw_chatbook.Chat.console_provider_support import (
     build_local_thinking_payload_fields,
     resolve_console_provider_identity,
 )
+from tldw_chatbook.Chat.llamacpp_think_filter import StartAnchoredThinkFilter
 from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
@@ -1861,6 +1862,7 @@ class ConsoleProviderGateway:
             reasoning_effort=reasoning_effort,
             thinking_budget_tokens=thinking_budget_tokens,
         )
+        think_filter = StartAnchoredThinkFilter()
         emitted_content = False
         stream_error: httpx.HTTPError | None = None
         try:
@@ -1874,14 +1876,19 @@ class ConsoleProviderGateway:
                 async for line in response.aiter_lines():
                     chunk = self._content_from_sse_line(line)
                     if chunk:
-                        emitted_content = True
-                        yield chunk
+                        visible = think_filter.feed(chunk)
+                        if visible:
+                            emitted_content = True
+                            yield visible
         except httpx.HTTPError as exc:
             if emitted_content:
                 raise
             stream_error = exc
 
         if emitted_content:
+            tail = think_filter.flush()
+            if tail:
+                yield tail
             return
 
         fallback = await self.complete_llamacpp_chat(
@@ -1988,7 +1995,8 @@ class ConsoleProviderGateway:
                 "Provider returned an unsupported auxiliary response.",
                 provider="llama_cpp",
             )
-        return content or ""
+        think_filter = StartAnchoredThinkFilter()
+        return think_filter.feed(content or "") + think_filter.flush()
 
     @staticmethod
     async def _post_without_high_level_http_log(

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -58,6 +58,7 @@ from tldw_chatbook.Chat.provider_continuation import (
     validate_continuation_restore,
 )
 from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
     resolve_console_provider_identity,
 )
 from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
@@ -855,6 +856,8 @@ def build_llamacpp_chat_payload(
     seed: int | None = None,
     presence_penalty: float | None = None,
     frequency_penalty: float | None = None,
+    reasoning_effort: str | None = None,
+    thinking_budget_tokens: int | None = None,
 ) -> dict[str, Any]:
     """Build the OpenAI-compatible llama.cpp chat completion payload.
 
@@ -870,6 +873,11 @@ def build_llamacpp_chat_payload(
         seed: Optional deterministic generation seed.
         presence_penalty: Optional presence penalty value.
         frequency_penalty: Optional frequency penalty value.
+        reasoning_effort: Optional thinking level forwarded as llama.cpp
+            ``chat_template_kwargs.reasoning_effort`` (``none`` additionally
+            sets ``enable_thinking`` false).
+        thinking_budget_tokens: Optional thinking token budget sent as the
+            top-level ``reasoning_budget`` field.
 
     Returns:
         Request payload for the llama.cpp chat completions endpoint.
@@ -887,7 +895,11 @@ def build_llamacpp_chat_payload(
     incoherent with a thinking-first template regardless. Prefilled
     requests therefore disable thinking mode via ``chat_template_kwargs``,
     which templates that lack the kwarg -- and older servers that drop
-    unknown fields -- simply ignore.
+    unknown fields -- simply ignore. When both a prefill and explicit
+    thinking controls are present the precedence is
+    ``prefill > none > effort``: the prefill's ``enable_thinking: False``
+    always wins over the requested effort level, and an effort of ``none``
+    itself disables thinking.
     """
     payload: dict[str, Any] = {
         "model": model,
@@ -910,8 +922,15 @@ def build_llamacpp_chat_payload(
         payload["presence_penalty"] = presence_penalty
     if frequency_penalty is not None:
         payload["frequency_penalty"] = frequency_penalty
+    payload.update(
+        build_local_thinking_payload_fields(
+            "llama_cpp", reasoning_effort, thinking_budget_tokens
+        )
+    )
     if messages and messages[-1].get("role") == "assistant":
-        payload["chat_template_kwargs"] = {"enable_thinking": False}
+        template_kwargs = dict(payload.get("chat_template_kwargs") or {})
+        template_kwargs["enable_thinking"] = False
+        payload["chat_template_kwargs"] = template_kwargs
     return payload
 
 
@@ -1803,6 +1822,8 @@ class ConsoleProviderGateway:
         min_p: float | None = None,
         top_k: int | None = None,
         max_tokens: int | None = None,
+        reasoning_effort: str | None = None,
+        thinking_budget_tokens: int | None = None,
         api_key: str | None = None,
     ) -> AsyncIterator[str]:
         """Stream OpenAI-compatible chat completion chunks from llama.cpp.
@@ -1816,6 +1837,10 @@ class ConsoleProviderGateway:
             min_p: Optional min-p sampling value.
             top_k: Optional top-k sampling value.
             max_tokens: Optional response token limit.
+            reasoning_effort: Optional thinking level forwarded as
+                ``chat_template_kwargs.reasoning_effort``.
+            thinking_budget_tokens: Optional thinking token budget sent as
+                the top-level ``reasoning_budget`` field.
 
         Yields:
             Assistant-visible content chunks.
@@ -1833,6 +1858,8 @@ class ConsoleProviderGateway:
             min_p=min_p,
             top_k=top_k,
             max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+            thinking_budget_tokens=thinking_budget_tokens,
         )
         emitted_content = False
         stream_error: httpx.HTTPError | None = None
@@ -1866,6 +1893,8 @@ class ConsoleProviderGateway:
             min_p=min_p,
             top_k=top_k,
             max_tokens=max_tokens,
+            reasoning_effort=reasoning_effort,
+            thinking_budget_tokens=thinking_budget_tokens,
             api_key=api_key,
         )
         if fallback:
@@ -1888,6 +1917,8 @@ class ConsoleProviderGateway:
         seed: int | None = None,
         presence_penalty: float | None = None,
         frequency_penalty: float | None = None,
+        reasoning_effort: str | None = None,
+        thinking_budget_tokens: int | None = None,
         strict_response: bool = False,
         api_key: str | None = None,
     ) -> str:
@@ -1905,6 +1936,10 @@ class ConsoleProviderGateway:
             seed: Optional deterministic generation seed.
             presence_penalty: Optional presence penalty value.
             frequency_penalty: Optional frequency penalty value.
+            reasoning_effort: Optional thinking level forwarded as
+                ``chat_template_kwargs.reasoning_effort``.
+            thinking_budget_tokens: Optional thinking token budget sent as
+                the top-level ``reasoning_budget`` field.
             strict_response: Raise when the provider response has no supported
                 assistant-content shape instead of treating it as empty.
 
@@ -1928,6 +1963,8 @@ class ConsoleProviderGateway:
             seed=seed,
             presence_penalty=presence_penalty,
             frequency_penalty=frequency_penalty,
+            reasoning_effort=reasoning_effort,
+            thinking_budget_tokens=thinking_budget_tokens,
         )
         client = self._active_http_client()
         response = (
@@ -2000,11 +2037,11 @@ class ConsoleProviderGateway:
         try:
             with sensitive_llm_request():
                 if resolution.provider in {"llama_cpp", "local_llamacpp"}:
-                    # llama.cpp's OpenAI-compatible chat endpoint accepts these
-                    # standard samplers and penalties. Provider-specific
-                    # reasoning/thinking/verbosity controls and response_format
-                    # are deliberately omitted because this direct endpoint does
-                    # not define them consistently.
+                    # Thinking controls follow ADR-066: level via
+                    # chat_template_kwargs, budget via top-level
+                    # reasoning_budget. Auxiliary requests inherit session
+                    # thinking settings (documented parity with cloud
+                    # providers).
                     text = await self.complete_llamacpp_chat(
                         base_url=resolution.base_url,
                         model=model,
@@ -2017,6 +2054,8 @@ class ConsoleProviderGateway:
                         seed=resolution.seed,
                         presence_penalty=resolution.presence_penalty,
                         frequency_penalty=resolution.frequency_penalty,
+                        reasoning_effort=resolution.reasoning_effort,
+                        thinking_budget_tokens=resolution.thinking_budget_tokens,
                         strict_response=True,
                         api_key=resolution.api_key,
                     )
@@ -2225,6 +2264,8 @@ class ConsoleProviderGateway:
                         min_p=resolution.min_p,
                         top_k=resolution.top_k,
                         max_tokens=effective_resolution.max_tokens,
+                        reasoning_effort=resolution.reasoning_effort,
+                        thinking_budget_tokens=resolution.thinking_budget_tokens,
                         api_key=resolution.api_key,
                     )
                     if completion:
@@ -2239,6 +2280,8 @@ class ConsoleProviderGateway:
                     min_p=resolution.min_p,
                     top_k=resolution.top_k,
                     max_tokens=effective_resolution.max_tokens,
+                    reasoning_effort=resolution.reasoning_effort,
+                    thinking_budget_tokens=resolution.thinking_budget_tokens,
                     api_key=resolution.api_key,
                 ):
                     yield chunk

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -878,7 +878,7 @@ def build_llamacpp_chat_payload(
             ``chat_template_kwargs.reasoning_effort`` (``none`` additionally
             sets ``enable_thinking`` false).
         thinking_budget_tokens: Optional thinking token budget sent as the
-            top-level ``reasoning_budget`` field.
+            top-level ``reasoning_budget_tokens`` field.
 
     Returns:
         Request payload for the llama.cpp chat completions endpoint.
@@ -1841,7 +1841,7 @@ class ConsoleProviderGateway:
             reasoning_effort: Optional thinking level forwarded as
                 ``chat_template_kwargs.reasoning_effort``.
             thinking_budget_tokens: Optional thinking token budget sent as
-                the top-level ``reasoning_budget`` field.
+                the top-level ``reasoning_budget_tokens`` field.
 
         Yields:
             Assistant-visible content chunks.
@@ -1946,7 +1946,7 @@ class ConsoleProviderGateway:
             reasoning_effort: Optional thinking level forwarded as
                 ``chat_template_kwargs.reasoning_effort``.
             thinking_budget_tokens: Optional thinking token budget sent as
-                the top-level ``reasoning_budget`` field.
+                the top-level ``reasoning_budget_tokens`` field.
             strict_response: Raise when the provider response has no supported
                 assistant-content shape instead of treating it as empty.
 
@@ -2047,7 +2047,7 @@ class ConsoleProviderGateway:
                 if resolution.provider in {"llama_cpp", "local_llamacpp"}:
                     # Thinking controls follow ADR-066: level via
                     # chat_template_kwargs, budget via top-level
-                    # reasoning_budget. Auxiliary requests inherit session
+                    # reasoning_budget_tokens. Auxiliary requests inherit session
                     # thinking settings (documented parity with cloud
                     # providers).
                     text = await self.complete_llamacpp_chat(

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -1864,6 +1864,7 @@ class ConsoleProviderGateway:
         )
         think_filter = StartAnchoredThinkFilter()
         emitted_content = False
+        received_content = False
         stream_error: httpx.HTTPError | None = None
         try:
             async with self._active_http_client().stream(
@@ -1876,6 +1877,7 @@ class ConsoleProviderGateway:
                 async for line in response.aiter_lines():
                     chunk = self._content_from_sse_line(line)
                     if chunk:
+                        received_content = True
                         visible = think_filter.feed(chunk)
                         if visible:
                             emitted_content = True
@@ -1886,9 +1888,15 @@ class ConsoleProviderGateway:
             stream_error = exc
 
         if emitted_content:
-            tail = think_filter.flush()
-            if tail:
-                yield tail
+            # flush() contractually returns "" (unterminated start-anchored
+            # think tails are dropped), so there is no tail to yield.
+            return
+        if received_content:
+            # Think-only reply: the filter removed every chunk, so a
+            # non-streaming retry would return the same text — skip it and
+            # surface any stream error that followed the content instead.
+            if stream_error is not None:
+                raise stream_error
             return
 
         fallback = await self.complete_llamacpp_chat(

--- a/tldw_chatbook/Chat/console_provider_support.py
+++ b/tldw_chatbook/Chat/console_provider_support.py
@@ -107,6 +107,12 @@ _CUSTOM_OPENAI_THINKING_KEYS = frozenset(
 # MLX-LM: template-kwargs shape pending live verification of mlx_lm.server
 # support; if unsupported this row degrades to drop-and-log.
 _TEMPLATE_KWARGS_THINKING_KEYS = frozenset({"local_mlx_lm"})
+# Live-verified (llama.cpp b10430 + Qwen3.8): strict chat templates such as
+# Qwen3.8's validate reasoning_effort and raise on unknown values ("minimal"
+# -> HTTP 500). "high" is aliased to "xhigh" by the template and is safe;
+# "none" is safe because we pair it with enable_thinking=false which
+# short-circuits the template's validation block.
+_TEMPLATE_SAFE_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "none"})
 
 
 def build_local_thinking_payload_fields(
@@ -136,12 +142,19 @@ def build_local_thinking_payload_fields(
     fields: dict[str, Any] = {}
     if key in _LLAMA_CPP_THINKING_KEYS or key in _TEMPLATE_KWARGS_THINKING_KEYS:
         if effort is not None:
-            template_kwargs: dict[str, Any] = {"reasoning_effort": effort}
-            if effort == "none":
-                template_kwargs["enable_thinking"] = False
-            fields["chat_template_kwargs"] = template_kwargs
+            if effort in _TEMPLATE_SAFE_EFFORTS:
+                template_kwargs: dict[str, Any] = {"reasoning_effort": effort}
+                if effort == "none":
+                    template_kwargs["enable_thinking"] = False
+                fields["chat_template_kwargs"] = template_kwargs
+            else:
+                logger.debug(
+                    "reasoning effort '{}' is not consumable by strict chat "
+                    "templates; dropped from chat_template_kwargs",
+                    effort,
+                )
         if budget is not None and key in _LLAMA_CPP_THINKING_KEYS:
-            fields["reasoning_budget"] = budget
+            fields["reasoning_budget_tokens"] = budget
         if budget is not None and key in _TEMPLATE_KWARGS_THINKING_KEYS:
             logger.debug(
                 "thinking budget not supported for provider {}; dropped",
@@ -150,7 +163,14 @@ def build_local_thinking_payload_fields(
     elif key in _VLLM_THINKING_KEYS:
         if effort is not None:
             fields["reasoning_effort"] = effort
-            fields["chat_template_kwargs"] = {"reasoning_effort": effort}
+            if effort in _TEMPLATE_SAFE_EFFORTS:
+                fields["chat_template_kwargs"] = {"reasoning_effort": effort}
+            else:
+                logger.debug(
+                    "reasoning effort '{}' is not consumable by strict chat "
+                    "templates; dropped from chat_template_kwargs",
+                    effort,
+                )
         if budget is not None:
             logger.debug(
                 "thinking budget not supported for provider {}; dropped",

--- a/tldw_chatbook/Chat/console_provider_support.py
+++ b/tldw_chatbook/Chat/console_provider_support.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
 
 from tldw_chatbook.Chat.provider_readiness import (
     PROVIDERS_REQUIRING_API_KEY_KEYS,
@@ -90,6 +93,78 @@ def _provider_display_name(provider_key: str) -> str:
         provider_key,
         provider_key.replace("_", " ").replace("-", " ").title(),
     )
+
+
+# ADR-066: per-execution-key wire formats for Console thinking controls.
+# Level = reasoning_effort; budget = thinking_budget_tokens.
+_LLAMA_CPP_THINKING_KEYS = frozenset(
+    {"llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"}
+)
+_VLLM_THINKING_KEYS = frozenset({"vllm", "local_vllm"})
+_CUSTOM_OPENAI_THINKING_KEYS = frozenset(
+    {"custom-openai-api", "custom-openai-api-2"}
+)
+# MLX-LM: template-kwargs shape pending live verification of mlx_lm.server
+# support; if unsupported this row degrades to drop-and-log.
+_TEMPLATE_KWARGS_THINKING_KEYS = frozenset({"local_mlx_lm"})
+
+
+def build_local_thinking_payload_fields(
+    execution_key: str | None,
+    reasoning_effort: str | None,
+    thinking_budget_tokens: int | None,
+) -> dict[str, Any]:
+    """Compose thinking-control payload fragments for a local provider.
+
+    Args:
+        execution_key: ``chat_api_call`` provider key (e.g. ``llama_cpp``).
+        reasoning_effort: Verbatim user-selected effort level, if any.
+        thinking_budget_tokens: Max thinking tokens, if any.
+
+    Returns:
+        Fragments to merge into an OpenAI-compatible chat payload. Empty
+        dict when the key has no thinking support or no values are set.
+    """
+    key = str(execution_key or "").strip().lower()
+    effort = str(reasoning_effort or "").strip().lower() or None
+    budget: int | None = (
+        thinking_budget_tokens
+        if isinstance(thinking_budget_tokens, int)
+        and not isinstance(thinking_budget_tokens, bool)
+        else None
+    )
+    fields: dict[str, Any] = {}
+    if key in _LLAMA_CPP_THINKING_KEYS or key in _TEMPLATE_KWARGS_THINKING_KEYS:
+        if effort is not None:
+            template_kwargs: dict[str, Any] = {"reasoning_effort": effort}
+            if effort == "none":
+                template_kwargs["enable_thinking"] = False
+            fields["chat_template_kwargs"] = template_kwargs
+        if budget is not None and key in _LLAMA_CPP_THINKING_KEYS:
+            fields["reasoning_budget"] = budget
+        if budget is not None and key in _TEMPLATE_KWARGS_THINKING_KEYS:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    elif key in _VLLM_THINKING_KEYS:
+        if effort is not None:
+            fields["reasoning_effort"] = effort
+            fields["chat_template_kwargs"] = {"reasoning_effort": effort}
+        if budget is not None:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    elif key in _CUSTOM_OPENAI_THINKING_KEYS:
+        if effort is not None:
+            fields["reasoning_effort"] = effort
+        if budget is not None:
+            logger.debug(
+                "thinking budget not supported for provider {}; dropped",
+                key,
+            )
+    return fields
 
 
 def _handler_keys(handler_keys: Collection[str] | None = None) -> frozenset[str]:

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -113,7 +113,9 @@ _LEGACY_CHAT_PROVIDER_ALIASES = {
     "openai_compatible": "openai",
 }
 # Generation-aware: dotted Qwen3.x generations consume effort levels;
-# original Qwen3 is a thinking toggle only. Ordered most-specific first.
+# original Qwen3 is a thinking toggle only. The dotted-Qwen regex in
+# reasoning_effort_hint_for_model enforces generation specificity; needle
+# order within this table is immaterial (no needle contains another).
 _REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
     ("gpt-oss", frozenset({"low", "medium", "high"})),
     ("qwen3", frozenset({"none"})),

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -118,9 +118,14 @@ _REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
     ("gpt-oss", frozenset({"low", "medium", "high"})),
     ("qwen3", frozenset({"none"})),
 )
-_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "xhigh"})
+# "none" is live-verified on dotted Qwens: it is consumed via our
+# enable_thinking=false mapping, so it must not warn as unconsumed.
+_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "xhigh", "none"})
+# local-llm sends compose llama.cpp-family wire fields (chat_template_kwargs
+# reasoning/enable_thinking + reasoning_budget_tokens), so its users need the
+# --jinja/b9982 requirements note too.
 _LLAMA_CPP_FAMILY_PROVIDERS = frozenset(
-    {"llama_cpp", "local_llamacpp", "local_llamafile"}
+    {"llama_cpp", "local_llamacpp", "local_llamafile", "local_llm"}
 )
 _LLAMACPP_THINKING_REQUIREMENTS_NOTE = (
     "Thinking controls on llama.cpp need llama-server started with --jinja; "

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -120,9 +120,12 @@ _REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
     ("gpt-oss", frozenset({"low", "medium", "high"})),
     ("qwen3", frozenset({"none"})),
 )
-# "none" is live-verified on dotted Qwens: it is consumed via our
-# enable_thinking=false mapping, so it must not warn as unconsumed.
-_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "xhigh", "none"})
+# "none" and "high" are live-verified on dotted Qwens: "none" is consumed
+# via our enable_thinking=false mapping, and the template aliases "high" to
+# "xhigh" — neither must warn as unconsumed.
+_QWEN_DOTTED_EFFORT_VALUES = frozenset(
+    {"low", "medium", "high", "xhigh", "none"}
+)
 # local-llm sends compose llama.cpp-family wire fields (chat_template_kwargs
 # reasoning/enable_thinking + reasoning_budget_tokens), so its users need the
 # --jinja/b9982 requirements note too.
@@ -524,7 +527,17 @@ def build_canonical_chat_defaults_mutation(
 
 
 def reasoning_effort_hint_for_model(model: str | None) -> frozenset[str] | None:
-    """Return the effort values this model family's template consumes."""
+    """Return the effort values this model family's template consumes.
+
+    Args:
+        model: Model identifier as selected in the Console (e.g.
+            ``"Qwen3.8-27B"``). Case-insensitive; ``None``/blank allowed.
+
+    Returns:
+        The set of ``reasoning_effort`` values the model family's chat
+        template consumes, or ``None`` when the family is unknown and no
+        hint should be shown.
+    """
     lowered = str(model or "").strip().lower()
     if not lowered:
         return None
@@ -537,7 +550,20 @@ def reasoning_effort_hint_for_model(model: str | None) -> frozenset[str] | None:
 
 
 def console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]:
-    """Non-blocking warnings for the Console settings modal (ADR-066)."""
+    """Return non-blocking warnings for the Console settings modal.
+
+    Warnings never block a save or send (ADR-066); blocking validation
+    lives in :func:`validate_console_session_settings`.
+
+    Args:
+        settings: The freshly parsed Console session settings.
+
+    Returns:
+        Zero or more user-facing warning strings: an effort value the
+        selected model family does not consume, and — for llama.cpp-family
+        providers with a thinking value set — the server requirements note
+        (``--jinja``; per-request budget needs llama.cpp b9982+).
+    """
     warnings: list[str] = []
     effort = str(settings.reasoning_effort or "").strip().lower()
     has_thinking_value = bool(effort) or settings.thinking_budget_tokens is not None

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
 from urllib.parse import urlparse, urlunparse
 
 from tldw_chatbook.Chat.console_provider_support import (
     DIRECT_CONSOLE_PROVIDER_KEYS,
+    build_local_thinking_payload_fields,
     resolve_console_provider_identity,
     supported_console_provider_catalog,
     supported_console_provider_readiness_keys,
@@ -110,6 +112,20 @@ _THINKING_EFFORT_VALUES = frozenset({"off", "low", "medium", "high", "xhigh", "m
 _LEGACY_CHAT_PROVIDER_ALIASES = {
     "openai_compatible": "openai",
 }
+# Generation-aware: dotted Qwen3.x generations consume effort levels;
+# original Qwen3 is a thinking toggle only. Ordered most-specific first.
+_REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
+    ("gpt-oss", frozenset({"low", "medium", "high"})),
+    ("qwen3", frozenset({"none"})),
+)
+_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "xhigh"})
+_LLAMA_CPP_FAMILY_PROVIDERS = frozenset(
+    {"llama_cpp", "local_llamacpp", "local_llamafile"}
+)
+_LLAMACPP_THINKING_REQUIREMENTS_NOTE = (
+    "Thinking controls on llama.cpp need llama-server started with --jinja; "
+    "per-request reasoning_budget needs llama.cpp b9982 or newer."
+)
 
 
 def normalize_llamacpp_base_url(api_url: str | None) -> str:
@@ -500,6 +516,36 @@ def build_canonical_chat_defaults_mutation(
     return {"chat_defaults": chat_defaults}
 
 
+def reasoning_effort_hint_for_model(model: str | None) -> frozenset[str] | None:
+    """Return the effort values this model family's template consumes."""
+    lowered = str(model or "").strip().lower()
+    if not lowered:
+        return None
+    if re.search(r"qwen3\.\d", lowered):
+        return _QWEN_DOTTED_EFFORT_VALUES
+    for needle, values in _REASONING_EFFORT_MODEL_HINTS:
+        if needle in lowered:
+            return values
+    return None
+
+
+def console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]:
+    """Non-blocking warnings for the Console settings modal (ADR-066)."""
+    warnings: list[str] = []
+    effort = str(settings.reasoning_effort or "").strip().lower()
+    has_thinking_value = bool(effort) or settings.thinking_budget_tokens is not None
+    if effort:
+        hint = reasoning_effort_hint_for_model(settings.model)
+        if hint is not None and effort not in hint:
+            warnings.append(
+                f"Reasoning effort '{effort}' is not consumed by this model "
+                f"family; expected one of: {', '.join(sorted(hint))}."
+            )
+    if has_thinking_value and settings.provider in _LLAMA_CPP_FAMILY_PROVIDERS:
+        warnings.append(_LLAMACPP_THINKING_REQUIREMENTS_NOTE)
+    return warnings
+
+
 def validate_console_session_settings(
     settings: ConsoleSessionSettings,
     *,
@@ -770,6 +816,32 @@ def build_console_settings_summary_state(
         sampling_parts.append(f"reasoning {settings.reasoning_effort}")
     elif settings.thinking_effort:
         sampling_parts.append(f"thinking {settings.thinking_effort}")
+    if settings.thinking_budget_tokens is not None:
+        sampling_parts.append(f"think budget {settings.thinking_budget_tokens}")
+    if settings.reasoning_effort or settings.thinking_budget_tokens is not None:
+        identity = resolve_console_provider_identity(settings.provider)
+        wire_fields = build_local_thinking_payload_fields(
+            identity.execution_key,
+            settings.reasoning_effort,
+            settings.thinking_budget_tokens,
+        )
+        if wire_fields:
+            wire_parts = []
+            template_kwargs = wire_fields.get("chat_template_kwargs")
+            if template_kwargs:
+                rendered = ", ".join(
+                    f"{k}={v}" for k, v in sorted(template_kwargs.items())
+                )
+                wire_parts.append(f"chat_template_kwargs[{rendered}]")
+            if "reasoning_budget" in wire_fields:
+                wire_parts.append(
+                    f"reasoning_budget={wire_fields['reasoning_budget']}"
+                )
+            if "reasoning_effort" in wire_fields:
+                wire_parts.append(
+                    f"reasoning_effort={wire_fields['reasoning_effort']}"
+                )
+            sampling_parts.append("wire: " + "; ".join(wire_parts))
 
     character_label = sanitize_character_display_label(
         settings.character_label,

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -124,7 +124,7 @@ _LLAMA_CPP_FAMILY_PROVIDERS = frozenset(
 )
 _LLAMACPP_THINKING_REQUIREMENTS_NOTE = (
     "Thinking controls on llama.cpp need llama-server started with --jinja; "
-    "per-request reasoning_budget needs llama.cpp b9982 or newer."
+    "per-request reasoning_budget_tokens needs llama.cpp b9982 or newer."
 )
 
 
@@ -833,9 +833,9 @@ def build_console_settings_summary_state(
                     f"{k}={v}" for k, v in sorted(template_kwargs.items())
                 )
                 wire_parts.append(f"chat_template_kwargs[{rendered}]")
-            if "reasoning_budget" in wire_fields:
+            if "reasoning_budget_tokens" in wire_fields:
                 wire_parts.append(
-                    f"reasoning_budget={wire_fields['reasoning_budget']}"
+                    f"reasoning_budget_tokens={wire_fields['reasoning_budget_tokens']}"
                 )
             if "reasoning_effort" in wire_fields:
                 wire_parts.append(

--- a/tldw_chatbook/Chat/llamacpp_think_filter.py
+++ b/tldw_chatbook/Chat/llamacpp_think_filter.py
@@ -1,0 +1,58 @@
+"""Start-anchored, stream-aware ``<think>`` filtering for llama.cpp output.
+
+Qwen-family chat templates emit thinking at the very start of the response
+(an empty ``<think>\\n\\n</think>`` prefix appears in no-think mode on some
+generations). Only a think block that opens at the beginning of the stream
+is stripped; a literal ``<think>`` mid-reply (e.g. the user asked for an XML
+example) is legitimate content and passes through. See ADR-066.
+"""
+
+from __future__ import annotations
+
+_OPEN_TAGS = ("<think>", "<thinking>")
+_CLOSE_TAGS = ("</think>", "</thinking>")
+
+
+class StartAnchoredThinkFilter:
+    """Stateful filter: feed() chunks in, get visible text out; flush() at end."""
+
+    def __init__(self) -> None:
+        self._inside_think = False
+        self._decided_visible = False
+        self._buffer = ""
+
+    def feed(self, chunk: str) -> str:
+        if not chunk:
+            return ""
+        if self._decided_visible:
+            return chunk
+        self._buffer += chunk
+        while True:
+            if self._inside_think:
+                for tag in _CLOSE_TAGS:
+                    idx = self._buffer.find(tag)
+                    if idx != -1:
+                        self._buffer = self._buffer[idx + len(tag):]
+                        self._inside_think = False
+                        self._decided_visible = True
+                        return self._buffer.lstrip("\n")
+                return ""
+            stripped = self._buffer.lstrip()
+            if not stripped:
+                return ""  # whitespace-only so far; keep probing
+            for tag in _OPEN_TAGS:
+                if stripped.startswith(tag):
+                    self._inside_think = True
+                    self._buffer = stripped[len(tag):]
+                    break
+            if self._inside_think:
+                continue  # re-run close-tag scan on the remainder
+            if any(tag.startswith(stripped) for tag in _OPEN_TAGS):
+                return ""  # still ambiguous: could be a split tag opener
+            self._decided_visible = True
+            return self._buffer
+
+    def flush(self) -> str:
+        # Stream ended while still probing or still inside an unterminated
+        # think block: drop the tail (spec'd behavior).
+        return ""

--- a/tldw_chatbook/Chat/llamacpp_think_filter.py
+++ b/tldw_chatbook/Chat/llamacpp_think_filter.py
@@ -22,6 +22,19 @@ class StartAnchoredThinkFilter:
         self._buffer = ""
 
     def feed(self, chunk: str) -> str:
+        """Feed one stream chunk and return its visible text.
+
+        Args:
+            chunk: The next assistant content chunk from the stream. May be
+                empty, and may split a think tag across chunk boundaries.
+
+        Returns:
+            The portion of ``chunk`` (plus any previously buffered text)
+            that is visible reply text. Empty while the stream is still
+            inside a start-anchored think block or while an opening tag is
+            still ambiguous. Once a non-tag start has been seen, all
+            subsequent text passes through unfiltered.
+        """
         if not chunk:
             return ""
         if self._decided_visible:
@@ -53,6 +66,11 @@ class StartAnchoredThinkFilter:
             return self._buffer
 
     def flush(self) -> str:
-        # Stream ended while still probing or still inside an unterminated
-        # think block: drop the tail (spec'd behavior).
+        """Signal end-of-stream and return any remaining visible tail.
+
+        Returns:
+            Always ``""``: a stream that ends while still probing or inside
+            an unterminated start-anchored think block drops its tail by
+            contract (ADR-066), so there is never a remaining tail to emit.
+        """
         return ""

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -226,8 +226,8 @@ def _chat_with_openai_compatible_local_server(
         payload["user"] = user_identifier
 
     # ADR-066: merge the provider-specific thinking-control wire fields
-    # (chat_template_kwargs / reasoning_budget / reasoning_effort) selected
-    # by the caller's execution key.
+    # (chat_template_kwargs / reasoning_budget_tokens / reasoning_effort)
+    # selected by the caller's execution key.
     if thinking_wire_key and (
         reasoning_effort is not None or thinking_budget_tokens is not None
     ):

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -18,6 +18,9 @@ from tldw_chatbook.Chat.Chat_Deps import (
     ChatBadRequestError,
     ChatConfigurationError,
 )
+from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
+)
 from tldw_chatbook.Utils.Utils import logging
 from tldw_chatbook.config import get_runtime_config_snapshot, load_settings
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
@@ -126,6 +129,9 @@ def _chat_with_openai_compatible_local_server(
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,
     user_identifier: Optional[str] = None,  # maps to 'user' in OpenAI spec
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
+    thinking_wire_key: Optional[str] = None,
     provider_name: str = "Local OpenAI-Compatible Server",
     timeout: int = 120,
     api_retries: int = 1,
@@ -218,6 +224,18 @@ def _chat_with_openai_compatible_local_server(
             )
     if user_identifier is not None:
         payload["user"] = user_identifier
+
+    # ADR-066: merge the provider-specific thinking-control wire fields
+    # (chat_template_kwargs / reasoning_budget / reasoning_effort) selected
+    # by the caller's execution key.
+    if thinking_wire_key and (
+        reasoning_effort is not None or thinking_budget_tokens is not None
+    ):
+        payload.update(
+            build_local_thinking_payload_fields(
+                thinking_wire_key, reasoning_effort, thinking_budget_tokens
+            )
+        )
 
     # Construct full API URL for chat completions
     base_url = api_base_url.rstrip("/")
@@ -525,6 +543,8 @@ def chat_with_local_llm(
     tools: Optional[List[Dict[str, Any]]] = None,
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
     api_base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
 ):
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
@@ -621,6 +641,9 @@ def chat_with_local_llm(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         user_identifier=current_user_identifier,
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key="local-llm",
         # Same pre-existing dict-.capitalize() crash as chat_with_custom_openai.
         provider_name="Local-LLM",
         timeout=timeout,
@@ -663,6 +686,8 @@ def chat_with_llama(
         str
     ] = None,  # Added to support dynamic configuration loading
     api_base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
 ):
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
@@ -791,6 +816,9 @@ def chat_with_llama(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         # tools, tool_choice, user_identifier could be added if llama.cpp supports them via OpenAI compat layer
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key=provider_name or "llama_cpp",
         provider_name="Llama.cpp",
         timeout=timeout,
         api_retries=api_retries,
@@ -1358,6 +1386,8 @@ def chat_with_vllm(
         str
     ] = None,  # Added to support dynamic configuration loading
     api_base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
 ):
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
@@ -1456,6 +1486,9 @@ def chat_with_vllm(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         user_identifier=current_user_identifier,
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key=provider_name or "vllm",
         provider_name="vLLM",
         timeout=timeout,
         api_retries=api_retries,
@@ -1812,6 +1845,8 @@ def chat_with_custom_openai(
     frequency_penalty: Optional[float] = None,
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
     api_base_url: Optional[str] = None,
     *,
     api_key_resolved: bool | None = None,
@@ -1935,6 +1970,9 @@ def chat_with_custom_openai(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         user_identifier=current_user_identifier,
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key="custom-openai-api",
         # `cfg` is the settings dict — calling .capitalize() on it raised
         # AttributeError on EVERY call, making this provider unusable
         # (pre-existing; surfaced by the task-243 native-tools live gate).
@@ -1969,6 +2007,8 @@ def chat_with_custom_openai_2(
     top_logprobs: Optional[int] = None,
     # This custom API 2 map is missing top_k, min_p, max_p (top_p) compared to custom 1.
     # Assuming it doesn't support them or they are set server-side.
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
     api_base_url: Optional[str] = None,
     *,
     api_key_resolved: bool | None = None,
@@ -2090,6 +2130,9 @@ def chat_with_custom_openai_2(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         user_identifier=current_user_identifier,
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key="custom-openai-api-2",
         provider_name=cfg_section.capitalize(),
         timeout=timeout,
         api_retries=api_retries,
@@ -2135,6 +2178,8 @@ def chat_with_mlx_lm(
         str
     ] = None,  # Added to support dynamic configuration loading
     api_base_url: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    thinking_budget_tokens: Optional[int] = None,
     **kwargs: Any,  # To catch any other params from API_CALL_HANDLERS
 ) -> Union[Dict[str, Any], Generator[str, None, None]]:
     """
@@ -2244,6 +2289,9 @@ def chat_with_mlx_lm(
         logprobs=current_logprobs,
         top_logprobs=current_top_logprobs,
         user_identifier=current_user_identifier,
+        reasoning_effort=reasoning_effort,
+        thinking_budget_tokens=thinking_budget_tokens,
+        thinking_wire_key=provider_name or "local_mlx_lm",
         provider_name=provider_name,
         timeout=timeout,
         api_retries=api_retries,

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -1845,9 +1845,9 @@ def chat_with_custom_openai(
     frequency_penalty: Optional[float] = None,
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,
+    api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
-    api_base_url: Optional[str] = None,
     *,
     api_key_resolved: bool | None = None,
 ):
@@ -2007,9 +2007,9 @@ def chat_with_custom_openai_2(
     top_logprobs: Optional[int] = None,
     # This custom API 2 map is missing top_k, min_p, max_p (top_p) compared to custom 1.
     # Assuming it doesn't support them or they are set server-side.
+    api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
-    api_base_url: Optional[str] = None,
     *,
     api_key_resolved: bool | None = None,
 ):

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -546,6 +546,34 @@ def chat_with_local_llm(
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
 ):
+    """Chat with a local llamafile/Local-LLM OpenAI-compatible server.
+
+    Args:
+        input_data: OpenAI-format chat messages to send.
+        api_key: Optional bearer credential for the endpoint.
+        system_message: Optional system prompt; prepended to the messages.
+        streaming: Whether to stream the response.
+        model: Model identifier; provider config is the fallback.
+        temp: Sampling temperature.
+        max_tokens: Response token limit.
+        seed: Deterministic sampling seed.
+        stop: Stop sequence(s).
+        response_format: Optional response format constraint (e.g. JSON).
+        reasoning_effort: Thinking level for reasoning-capable models,
+            composed into the request per ADR-066 (verbatim where the
+            target consumes it, dropped where a strict chat template
+            would reject it).
+        thinking_budget_tokens: Max thinking tokens; sent as the
+            llama.cpp-family ``reasoning_budget_tokens`` field, dropped
+            where the provider has no per-request budget support.
+        api_base_url: Request-pinned endpoint override; provider config
+            is the fallback.
+        provider_name: Provider key for dynamic config lookup; also
+            drives ADR-066 thinking wire composition.
+
+    Returns:
+        The assistant reply text, or a streaming generator of chunks.
+    """
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
 
@@ -689,6 +717,34 @@ def chat_with_llama(
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
 ):
+    """Chat with a llama.cpp server (llama_cpp/local_llamacpp/local_llamafile).
+
+    Args:
+        input_data: OpenAI-format chat messages to send.
+        api_key: Optional bearer credential for the endpoint.
+        system_message: Optional system prompt; prepended to the messages.
+        streaming: Whether to stream the response.
+        model: Model identifier; provider config is the fallback.
+        temp: Sampling temperature.
+        max_tokens: Response token limit.
+        seed: Deterministic sampling seed.
+        stop: Stop sequence(s).
+        response_format: Optional response format constraint (e.g. JSON).
+        reasoning_effort: Thinking level for reasoning-capable models,
+            composed into the request per ADR-066 (verbatim where the
+            target consumes it, dropped where a strict chat template
+            would reject it).
+        thinking_budget_tokens: Max thinking tokens; sent as the
+            llama.cpp-family ``reasoning_budget_tokens`` field, dropped
+            where the provider has no per-request budget support.
+        api_base_url: Request-pinned endpoint override; provider config
+            is the fallback.
+        provider_name: Provider key for dynamic config lookup; also
+            drives ADR-066 thinking wire composition.
+
+    Returns:
+        The assistant reply text, or a streaming generator of chunks.
+    """
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
 
@@ -1389,6 +1445,34 @@ def chat_with_vllm(
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
 ):
+    """Chat with a vLLM OpenAI-compatible server (vllm/local_vllm).
+
+    Args:
+        input_data: OpenAI-format chat messages to send.
+        api_key: Optional bearer credential for the endpoint.
+        system_message: Optional system prompt; prepended to the messages.
+        streaming: Whether to stream the response.
+        model: Model identifier; provider config is the fallback.
+        temp: Sampling temperature.
+        max_tokens: Response token limit.
+        seed: Deterministic sampling seed.
+        stop: Stop sequence(s).
+        response_format: Optional response format constraint (e.g. JSON).
+        reasoning_effort: Thinking level for reasoning-capable models,
+            composed into the request per ADR-066 (verbatim where the
+            target consumes it, dropped where a strict chat template
+            would reject it).
+        thinking_budget_tokens: Max thinking tokens; sent as the
+            llama.cpp-family ``reasoning_budget_tokens`` field, dropped
+            where the provider has no per-request budget support.
+        api_base_url: Request-pinned endpoint override; provider config
+            is the fallback.
+        provider_name: Provider key for dynamic config lookup; also
+            drives ADR-066 thinking wire composition.
+
+    Returns:
+        The assistant reply text, or a streaming generator of chunks.
+    """
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
 
@@ -1851,6 +1935,32 @@ def chat_with_custom_openai(
     *,
     api_key_resolved: bool | None = None,
 ):
+    """Chat with the first user-configured Custom OpenAI endpoint.
+
+    Args:
+        input_data: OpenAI-format chat messages to send.
+        api_key: Optional bearer credential for the endpoint.
+        system_message: Optional system prompt; prepended to the messages.
+        streaming: Whether to stream the response.
+        model: Model identifier; provider config is the fallback.
+        temp: Sampling temperature.
+        max_tokens: Response token limit.
+        seed: Deterministic sampling seed.
+        stop: Stop sequence(s).
+        response_format: Optional response format constraint (e.g. JSON).
+        reasoning_effort: Thinking level for reasoning-capable models,
+            composed into the request per ADR-066 (verbatim where the
+            target consumes it, dropped where a strict chat template
+            would reject it).
+        thinking_budget_tokens: Max thinking tokens; sent as the
+            llama.cpp-family ``reasoning_budget_tokens`` field, dropped
+            where the provider has no per-request budget support.
+        api_base_url: Request-pinned endpoint override; provider config
+            is the fallback.
+
+    Returns:
+        The assistant reply text, or a streaming generator of chunks.
+    """
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
 
@@ -2013,6 +2123,32 @@ def chat_with_custom_openai_2(
     *,
     api_key_resolved: bool | None = None,
 ):
+    """Chat with the second user-configured Custom OpenAI endpoint.
+
+    Args:
+        input_data: OpenAI-format chat messages to send.
+        api_key: Optional bearer credential for the endpoint.
+        system_message: Optional system prompt; prepended to the messages.
+        streaming: Whether to stream the response.
+        model: Model identifier; provider config is the fallback.
+        temp: Sampling temperature.
+        max_tokens: Response token limit.
+        seed: Deterministic sampling seed.
+        stop: Stop sequence(s).
+        response_format: Optional response format constraint (e.g. JSON).
+        reasoning_effort: Thinking level for reasoning-capable models,
+            composed into the request per ADR-066 (verbatim where the
+            target consumes it, dropped where a strict chat template
+            would reject it).
+        thinking_budget_tokens: Max thinking tokens; sent as the
+            llama.cpp-family ``reasoning_budget_tokens`` field, dropped
+            where the provider has no per-request budget support.
+        api_base_url: Request-pinned endpoint override; provider config
+            is the fallback.
+
+    Returns:
+        The assistant reply text, or a streaming generator of chunks.
+    """
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
     loaded_config_data = load_settings()

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -54,8 +54,10 @@ from tldw_chatbook.Chat.console_session_settings import (
     build_console_model_options,
     build_console_provider_options,
     build_console_settings_readiness,
+    console_settings_warnings,
     normalize_console_model_value,
     normalize_llamacpp_base_url,
+    reasoning_effort_hint_for_model,
     resolve_effective_chat_configuration,
     validate_console_session_settings,
 )
@@ -1408,6 +1410,8 @@ class ConsoleSettingsModal(
         result = self._validated_result_or_show_errors()
         if result is None:
             return
+        for warning in console_settings_warnings(result.settings):
+            self.notify(warning, severity="warning", timeout=8000)
         self.dismiss(result)
 
     @on(Button.Pressed, "#console-settings-save-default")
@@ -1426,6 +1430,8 @@ class ConsoleSettingsModal(
         result = self._validated_result_or_show_errors()
         if result is None:
             return
+        for warning in console_settings_warnings(result.settings):
+            self.notify(warning, severity="warning", timeout=8000)
         try:
             saved = await asyncio.to_thread(
                 save_settings_to_cli_config,
@@ -1757,6 +1763,10 @@ class ConsoleSettingsModal(
 
     def _choice_placeholder(self, input_id: str) -> str:
         """Return the accepted-values placeholder for an enumerated choice input."""
+        if input_id == "console-settings-reasoning-effort":
+            hint = reasoning_effort_hint_for_model(self._settings.model)
+            if hint is not None:
+                return " / ".join(sorted(hint)) + " (consumed by this model)"
         for _label, choice_input_id, placeholder in PROVIDER_CHOICE_INPUTS:
             if choice_input_id == input_id:
                 return placeholder

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -1475,8 +1475,6 @@ class ConsoleSettingsModal(
         result = self._validated_result_or_show_errors()
         if result is None:
             return
-        for warning in console_settings_warnings(result.settings):
-            self.notify(warning, severity="warning", timeout=8000)
         try:
             saved = await asyncio.to_thread(
                 save_settings_to_cli_config,
@@ -1489,6 +1487,11 @@ class ConsoleSettingsModal(
                 CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY
             )
             return
+        # Warnings surface only after the write succeeded, so a failed
+        # default-persist shows the error copy alone instead of warnings
+        # for values that were not actually persisted.
+        for warning in console_settings_warnings(result.settings):
+            self.notify(warning, severity="warning", timeout=8000)
         self.dismiss(result)
 
     @on(Button.Pressed, "#console-context-reset-overrides")

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -36,6 +36,9 @@ from tldw_chatbook.Chat.console_provider_endpoints import (
     first_configured_endpoint,
     normalize_generic_endpoint_for_compare,
 )
+from tldw_chatbook.Chat.console_provider_support import (
+    resolve_console_provider_identity,
+)
 from tldw_chatbook.Chat.local_server_discovery import (
     normalize_probe_base_url,
     LocalModelProbeResult,
@@ -128,6 +131,33 @@ PROVIDER_CHOICE_INPUTS = (
         "off, low, medium, high, xhigh, max",
     ),
 )
+# ADR-066: local thinking execution keys. These providers consume only the
+# reasoning-effort level (and the token budget) via their local thinking
+# payload fields; the other provider-specific choice inputs have no effect.
+_LOCAL_THINKING_EXECUTION_KEYS = frozenset(
+    {
+        "llama_cpp",
+        "local_llamacpp",
+        "local_llamafile",
+        "local-llm",
+        "vllm",
+        "local_vllm",
+        "local_mlx_lm",
+        "custom-openai-api",
+        "custom-openai-api-2",
+    }
+)
+# Choice inputs with no effect on local thinking providers. The reasoning
+# effort input is excluded: local providers consume it via
+# chat_template_kwargs / reasoning_effort.
+_LOCAL_NO_EFFECT_CHOICE_INPUT_IDS = frozenset(
+    {
+        "console-settings-thinking-effort",
+        "console-settings-reasoning-summary",
+        "console-settings-verbosity",
+    }
+)
+PROVIDER_CHOICE_NO_EFFECT_SUFFIX = " (no effect on this provider)"
 STREAMING_ON_LABEL = "On"
 STREAMING_OFF_LABEL = "Off"
 CONSOLE_SETTINGS_MODEL_SCOPE_COPY = (
@@ -177,6 +207,21 @@ def _settings_screen_region(widget: Any) -> Any:
         exposes one; otherwise the mounted widget region used by this project.
     """
     return getattr(widget, "screen_region", None) or widget.region
+
+
+def _is_local_thinking_provider(provider: str | None) -> bool:
+    """Return whether a provider executes through a local thinking key.
+
+    Args:
+        provider: Raw provider name from Console controls or session settings.
+
+    Returns:
+        True when the resolved execution key is one of the local thinking
+        keys, i.e. the provider-specific choice inputs other than the
+        reasoning-effort level have no effect on sends.
+    """
+    identity = resolve_console_provider_identity(provider)
+    return identity.execution_key in _LOCAL_THINKING_EXECUTION_KEYS
 
 
 async def _default_model_prober(
@@ -1769,8 +1814,20 @@ class ConsoleSettingsModal(
                 return " / ".join(sorted(hint)) + " (consumed by this model)"
         for _label, choice_input_id, placeholder in PROVIDER_CHOICE_INPUTS:
             if choice_input_id == input_id:
+                if (
+                    input_id in _LOCAL_NO_EFFECT_CHOICE_INPUT_IDS
+                    and _is_local_thinking_provider(self._active_provider)
+                ):
+                    return placeholder + PROVIDER_CHOICE_NO_EFFECT_SUFFIX
                 return placeholder
         return ""
+
+    def _sync_provider_choice_placeholders(self) -> None:
+        """Refresh choice-input placeholders after the provider changes."""
+        for _label, input_id, _placeholder in PROVIDER_CHOICE_INPUTS:
+            self.query_one(f"#{input_id}", Input).placeholder = (
+                self._choice_placeholder(input_id)
+            )
 
     @on(Input.Changed)
     @on(Select.Changed)
@@ -1804,6 +1861,7 @@ class ConsoleSettingsModal(
         self._sync_model_controls(provider, model)
         self._sync_base_url_control(provider, base_url)
         self._sync_model_discover_controls(provider)
+        self._sync_provider_choice_placeholders()
         self._sync_readiness_display()
         self._sync_visual_representation_availability()
 


### PR DESCRIPTION
## Summary

Wires the Console's existing **Reasoning** (`reasoning_effort`) and **Budget** (`thinking_budget_tokens`) settings through to local providers so Qwen3.8-27B's adjustable thinking levels (`low`/`medium`/`xhigh`) and max thinking tokens work per request (TASK-16319, ADR-066).

- One wire-format composer (`build_local_thinking_payload_fields`) maps each local execution key to payload fragments: llama.cpp family → `chat_template_kwargs.reasoning_effort` + top-level `reasoning_budget_tokens`; vLLM family → level both top-level and in `chat_template_kwargs` (same value); Custom OpenAI → top-level only; `local_mlx_lm` → template kwargs (pending live verification, drop-and-log fallback).
- Direct llama.cpp gateway path sends the fields on stream, complete, fallback, and auxiliary calls; prefill still forces `enable_thinking: false` (precedence `prefill > none > effort`).
- New start-anchored, stream-aware `<think>` filter (`Chat/llamacpp_think_filter.py`) keeps thinking text out of visible replies on the direct path while preserving mid-reply literal tags; server-split `reasoning_content` was already clean.
- Adapter path: `PROVIDER_PARAM_MAP` entries for nine local keys + the shared `_chat_with_openai_compatible_local_server` builder forwards them through every local handler.
- UX: model-family hint placeholders, non-blocking warnings (incl. the llama.cpp `--jinja`/b9982 requirements note), "no effect on this provider" hints for Anthropic-only fields, and a `wire:` preview segment in the request summary.

## Live verification (llama-server b10430 + Qwen3.8-27B Q8)

Evidence preserved in `Docs/superpowers/qa/2026-08-15-local-thinking-controls-live-verification/`. Two live findings amended the design (spec + ADR errata):

- The per-request budget field is **`reasoning_budget_tokens`** — the `reasoning_budget` spelling is silently ignored (verified: budget 8 → 35 reasoning chars, 32 → 101, vs 391 natural).
- Qwen3.8's chat template **validates** `reasoning_effort` and raises outside `low/medium/high/xhigh` (live: `minimal` → HTTP 500; `high` aliases to `xhigh`; `none` is safe via `enable_thinking: false`). Non-safe values are dropped from `chat_template_kwargs` with a debug log rather than sent.

Also verified: effort levels produce deterministically different outputs (template maps each level to distinct reasoning instructions); `none` → zero reasoning; prefill + controls → 200 OK; gateway stream/complete yield clean visible text.

## Testing

- New suites: wire formats, think filter (chunk-boundary/unterminated/literal-survival), direct-path payload + filter wiring, adapter dispatch, template-safe guard, hints/warnings.
- Targeted suites green on the final tree (291 passed; fix-touched suites 347 passed). The only failures anywhere are 19 pre-existing `Tests/Chat` failures stash-verified on clean `dev`. Full sweep intentionally skipped per the ask-before-full-sweep policy now in AGENTS.md.
- No ruff/flake8 config in the environment; lint evidence is py_compile + green suites.

## Docs

- Spec: `Docs/superpowers/specs/2026-08-15-local-thinking-controls-design.md` (incl. errata)
- ADR: `backlog/decisions/066-local-provider-thinking-controls.md` (incl. errata)
- Task: `backlog/tasks/task-16319` (Done, with Implementation Notes)

## Follow-ups (out of scope, listed in the spec)

vLLM per-request budget (unsupported upstream), free-form `chat_template_kwargs` escape hatch, stream stripping for adapter-path providers, collapsible thinking view, `--jinja` launch defaults for managed servers, live-verify mlx/llamafile rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Console Reasoning (`reasoning_effort`) and Budget (`thinking_budget_tokens`) to local providers so Qwen3.8-27B thinking levels and per‑request token caps apply. Previously local providers ignored these controls; now the direct `llama.cpp` path and OpenAI‑compatible local servers receive them, and the direct stream hides a leading <think>…</think> block.

- Implements ADR‑066/TASK‑16319 with one wire‑format builder per execution key: `llama.cpp` → `chat_template_kwargs.reasoning_effort` + top‑level `reasoning_budget_tokens`; `vLLM` → level in both top‑level and `chat_template_kwargs`; `custom-openai-api*` → top‑level only; `local_mlx_lm` → template kwargs with drop‑and‑log fallback.
- Direct `llama.cpp` path forwards fields on stream/complete/fallback/aux calls; prefill still forces `enable_thinking=false`. Think‑only streams skip the non‑streaming fallback; post‑content stream errors still raise. Start‑anchored think filter removes only a leading think block; literal tags mid‑reply are preserved.
- Adapter path updates param maps and the shared OpenAI‑compatible local builder so nine local keys forward the fields consistently.
- Validation/UX: enforce `reasoning_budget_tokens` spelling; drop invalid effort values from template kwargs (debug log). Dotted‑Qwen hints include `{none, low, medium, high, xhigh}` (`high` aliases to `xhigh`). Add model‑family hints, provider “no effect” notes for Anthropic‑only fields, and a `wire:` preview in the request summary.
- Rollout: remote providers unchanged. To honor template kwargs on direct `llama.cpp`, run a Jinja‑enabled server build (UI warns if not). No migrations; callers using prefill continue to disable thinking.

<sup>Written for commit 11d96bc66a192c0094be6e6c6c41cd6a86289939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

