### PR TITLE
feat(research): biomedical providers, source policy, provider overrides

### DIFF
--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -8,6 +8,7 @@ retry, and merge logic run real.
 """
 
 import asyncio
+import json
 from unittest.mock import MagicMock
 
 import httpx
@@ -21,6 +22,8 @@ from tldw_chatbook.Research_Interop.academic_providers import (
     papers_to_evidence,
     resolve_semantic_scholar_api_key,
     search_arxiv,
+    search_biorxiv,
+    search_pubmed,
     search_papers,
     search_semantic_scholar,
 )
@@ -372,3 +375,153 @@ def test_search_papers_runs_providers_concurrently(monkeypatch):
     import asyncio
     papers = asyncio.run(ap.search_papers("query"))
     assert papers == []
+
+
+# --- BioRxiv / MedRxiv / PubMed providers (task-16790) -----------------------------
+
+_BIORXIV_PAGE = {
+    "messages": [{"count": 2, "total": 2}],
+    "collection": [
+        {"doi": "10.1101/2026.01.01.000001", "title": "Protein folding advances",
+         "authors": "A. Author; B. Author", "category": "bioinformatics",
+         "date": "2026-01-02", "abstract": "We study folding dynamics.",
+         "server": "biorxiv", "version": 1},
+        {"doi": "10.1101/2026.01.01.000002", "title": "Unrelated climate paper",
+         "authors": "C. Author", "date": "2026-01-03", "abstract": "Ice cores.",
+         "server": "biorxiv", "version": 1},
+    ],
+}
+
+
+def test_search_biorxiv_filters_and_normalizes(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_BIORXIV_PAGE))])
+
+    out = search_biorxiv(query="protein folding", client=client)
+
+    call = client.request.calls[0]
+    assert "api.biorxiv.org/details/biorxiv/" in call["url"]
+    item = out["items"][0]
+    assert item["title"] == "Protein folding advances"
+    assert item["doi"] == "10.1101/2026.01.01.000001"
+    assert item["source"] == "biorxiv"
+    assert item["url"] == "https://www.biorxiv.org/content/10.1101/2026.01.01.000001v1"
+    assert item["pdf_url"].endswith(".full.pdf")
+    # Client-side query filter drops the unrelated paper.
+    assert len(out["items"]) == 1
+
+
+def test_search_biorxiv_medrxiv_switch(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_BIORXIV_PAGE))])
+
+    search_biorxiv(query="folding", server="medrxiv", client=client)
+
+    assert "/details/medrxiv/" in client.request.calls[0]["url"]
+
+
+_ESEARCH = {"esearchresult": {"idlist": ["39123456", "39123457"], "count": "2"}}
+_ESUMMARY = {
+    "result": {
+        "uids": ["39123456"],
+        "39123456": {
+            "title": "CRISPR base editing efficiency",
+            "fulljournalname": "Nature Biotech",
+            "pubdate": "2026 Jan",
+            "authors": [{"name": "D. Researcher"}],
+            "articleids": [
+                {"idtype": "doi", "value": "10.1038/nbt.2026.01"},
+                {"idtype": "pmc", "value": "PMC9999888"},
+            ],
+        },
+    }
+}
+
+
+def test_search_pubmed_two_step_esearch_then_esummary(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning(
+        [_response(text=json.dumps(_ESEARCH)), _response(text=json.dumps(_ESUMMARY))]
+    )
+
+    out = search_pubmed(query="CRISPR base editing", client=client)
+
+    first, second = client.request.calls
+    assert "esearch.fcgi" in first["url"]
+    assert "CRISPR" in first["params"]["term"]
+    assert "esummary.fcgi" in second["url"]
+    assert second["params"]["id"] == "39123456,39123457"
+    item = out["items"][0]
+    assert item["doi"] == "10.1038/nbt.2026.01"
+    assert item["url"] == "https://pubmed.ncbi.nlm.nih.gov/39123456/"
+    assert item["pdf_url"] == "https://pmc.ncbi.nlm.nih.gov/9999888/pdf"
+    assert item["source"] == "pubmed"
+    assert item["authors"] == "D. Researcher"
+
+
+def test_search_pubmed_empty_idlist(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning(
+        [_response(text=json.dumps({"esearchresult": {"idlist": [], "count": "0"}}))]
+    )
+
+    out = search_pubmed(query="nothing", client=client)
+
+    assert out["items"] == [] and out["total_results"] == 0
+
+
+def test_search_papers_provider_set_filtering(monkeypatch):
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    calls = []
+
+    def fake_arxiv(**kw):
+        calls.append("arxiv")
+        return {"items": [{"title": "A", "abstract": "a", "doi": "10.1/a",
+                           "url": "https://doi.org/10.1/a", "source": "arxiv"}]}
+
+    def fake_pubmed(**kw):
+        calls.append("pubmed")
+        return {"items": [{"title": "P", "abstract": "p", "doi": "10.2/p",
+                           "url": "https://pubmed.ncbi.nlm.nih.gov/1/",
+                           "source": "pubmed"}]}
+
+    def unused_s2(**kw):
+        calls.append("semantic_scholar")
+        return {"items": []}
+
+    monkeypatch.setattr(ap, "search_arxiv", fake_arxiv)
+    monkeypatch.setattr(ap, "search_semantic_scholar", unused_s2)
+    monkeypatch.setattr(ap, "search_pubmed", fake_pubmed)
+
+    papers = asyncio.run(ap.search_papers("topic", providers=["arxiv", "pubmed"]))
+
+    assert sorted(calls) == ["arxiv", "pubmed"]
+    assert {p["source"] for p in papers} == {"arxiv", "pubmed"}
+
+
+def test_default_academic_providers_from_config(monkeypatch):
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    monkeypatch.setattr(
+        ap, "get_cli_setting",
+        lambda section, key, default=None: "arxiv, pubmed, biorxiv",
+    )
+    assert ap._default_academic_providers() == ["arxiv", "pubmed", "biorxiv"]
+
+    monkeypatch.setattr(
+        ap, "get_cli_setting", lambda section, key, default=None: default
+    )
+    assert ap._default_academic_providers() == ["arxiv", "semantic_scholar"]

--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -525,3 +525,24 @@ def test_default_academic_providers_from_config(monkeypatch):
         ap, "get_cli_setting", lambda section, key, default=None: default
     )
     assert ap._default_academic_providers() == ["arxiv", "semantic_scholar"]
+
+
+def test_search_papers_dedupes_and_warns_on_unknown_defaults(monkeypatch, caplog):
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    calls = []
+
+    def fake_arxiv(**kw):
+        calls.append("arxiv")
+        return {"items": []}
+
+    monkeypatch.setattr(ap, "search_arxiv", fake_arxiv)
+    monkeypatch.setattr(
+        ap, "_default_academic_providers",
+        lambda: ["arxiv", "arxiv", "not_a_provider"],
+    )
+
+    papers = asyncio.run(ap.search_papers("q"))
+
+    assert calls == ["arxiv"]  # deduped: one call despite the duplicate
+    assert papers == []

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -921,3 +921,94 @@ def test_approved_sources_checkpoint_with_empty_patch_still_passes():
     final = asyncio.run(engine.execute_run(run["id"]))
 
     assert final["status"] == "completed"
+
+
+# --- source policy + provider overrides (task-16791) -------------------------------
+
+def _policy_pipeline(state):
+    def search_fn(q, params):
+        state["web"] = state.get("web", 0) + 1
+        state["last_params"] = dict(params)
+        return ({"results": [{"title": "Web", "url": "https://web.example/"}],
+                 "warnings": []},
+                {"sub_questions": [], "main_goal": q})
+
+    async def paper_fn(query, **kwargs):
+        state.setdefault("papers", []).append(kwargs.get("providers"))
+        return [{"title": "Paper", "abstract": "p", "doi": "10.9/z",
+                 "url": "https://doi.org/10.9/z", "source": "pubmed"}]
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        state["merged"] = list(wsr.get("results") or [])
+        return {
+            "final_answer": {"text": "R[1].", "confidence": 0.5, "chunks": [],
+                             "evidence": [{"id": 1, "url": "https://web.example/",
+                                           "title": "Web", "content": "c",
+                                           "original_content": "o", "reasoning": "r",
+                                           "chunk_index": 1}]},
+            "relevant_results": {"1": {}},
+            "web_search_results_dict": wsr,
+        }
+
+    return search_fn, analyze_fn, paper_fn
+
+
+def _run_policy_engine(service, question, *, policy=None, overrides=None):
+    state: dict = {}
+    search_fn, analyze_fn, paper_fn = _policy_pipeline(state)
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn,
+        paper_search_fn=paper_fn,
+    )
+    kwargs = {"query": question, "autonomy_mode": "autonomous"}
+    if policy:
+        kwargs["source_policy"] = policy
+    if overrides:
+        kwargs["provider_overrides"] = overrides
+    run = service.launch_run(**kwargs)
+    return run, engine, state
+
+
+def test_policy_web_only_skips_academic_lane():
+    service = _make_service()
+    run, engine, state = _run_policy_engine(service, "Q", policy="web_only")
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    assert state["web"] >= 1
+    assert "papers" not in state
+    assert all(r.get("url") == "https://web.example/" for r in state["merged"])
+
+
+def test_policy_academic_only_skips_web_engine():
+    service = _make_service()
+    run, engine, state = _run_policy_engine(service, "Q", policy="academic_only")
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    assert "web" not in state  # zero web-engine spend
+    assert state["papers"]  # academic lane ran
+    assert [r.get("url") for r in state["merged"]] == ["https://doi.org/10.9/z"]
+
+
+def test_policy_academic_first_orders_papers_before_web():
+    service = _make_service()
+    run, engine, state = _run_policy_engine(service, "Q", policy="academic_first")
+    asyncio.run(engine.execute_run(run["id"]))
+
+    urls = [r.get("url") for r in state["merged"]]
+    assert urls.index("https://doi.org/10.9/z") < urls.index("https://web.example/")
+
+
+def test_provider_overrides_reach_params_and_papers():
+    service = _make_service()
+    run, engine, state = _run_policy_engine(
+        service, "Q",
+        overrides={"engine": "duckduckgo", "result_count": 3,
+                   "academic_providers": ["pubmed"]},
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert state["last_params"]["engine"] == "duckduckgo"
+    assert state["last_params"]["result_count"] == 3
+    assert state["papers"] == [["pubmed"]]

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -759,3 +759,33 @@ def test_window_policy_persists_in_state():
     window2.restore_state(state)
     assert window2.source_policy == "web_first"
     assert window2.providers_text == "pubmed"
+
+
+# --- Qodo remediation on PR 1722 ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_run_reads_limits_and_providers_from_inputs(monkeypatch):
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    monkeypatch.setattr(window, "_start_local_engine", lambda run_id: None)
+
+    # Simulate what compose() + typing produces: the widgets' values must
+    # reach the payload even when only the attributes were never set.
+    window.limits_text = "max_searches=3"
+    window.providers_text = "pubmed, arxiv, typo_lane"
+    await window.create_run({"query": "Inputs question"})
+
+    create_call = [c for c in service.calls if c[0] == "create_run"][0]
+    payload = create_call[2]
+    assert payload["provider_overrides"]["academic_providers"] == ["pubmed", "arxiv"]
+    assert payload["limits_json"] == {"max_searches": 3}
+
+
+def test_parse_provider_tokens_validates_and_dedupes():
+    from tldw_chatbook.UI.Research_Window import _parse_provider_tokens
+
+    assert _parse_provider_tokens("pubmed, arxiv, pubmed") == ["pubmed", "arxiv"]
+    assert _parse_provider_tokens("  ARXIV ,, biorxiv ") == ["arxiv", "biorxiv"]
+    # Dangerous input fails validation -> empty list (caller warns).
+    assert _parse_provider_tokens("pubmed, <script>x") == []

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -372,10 +372,14 @@ def test_window_academic_toggle_defaults_off_and_persists_in_state():
     window = ResearchWindow(app_instance=app)
 
     assert window.academic_enabled is False
-    assert window.save_state() == {"source": "local", "academic": False, "limits": ""}
+    assert window.save_state() == {"source": "local", "academic": False,
+                                   "limits": "", "policy": "balanced",
+                                   "providers": ""}
 
     window.academic_enabled = True
-    assert window.save_state() == {"source": "local", "academic": True, "limits": ""}
+    assert window.save_state() == {"source": "local", "academic": True,
+                                   "limits": "", "policy": "balanced",
+                                   "providers": ""}
 
 
 def test_window_academic_toggle_restores_from_state():
@@ -720,3 +724,38 @@ def test_academic_lane_default_parses_string_booleans(monkeypatch):
         (True, True), (False, False),
     ]:
         assert _parse_config_bool(raw) is expected, f"{raw!r} should parse {expected}"
+
+
+# --- source policy + providers in the window (task-16791) -------------------------
+
+@pytest.mark.asyncio
+async def test_window_policy_and_providers_sent_on_create(monkeypatch):
+    service = FakeResearchScopeService()
+    app = SimpleNamespace(research_scope_service=service, local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    monkeypatch.setattr(window, "_start_local_engine", lambda run_id: None)
+
+    window.source_policy = "academic_only"
+    window.providers_text = "arxiv, pubmed"
+    await window.create_run({"query": "Policy question"})
+
+    create_call = [c for c in service.calls if c[0] == "create_run"][0]
+    payload = create_call[2]
+    assert payload["source_policy"] == "academic_only"
+    assert payload["provider_overrides"] == {"academic_providers": ["arxiv", "pubmed"]}
+
+
+def test_window_policy_persists_in_state():
+    app = SimpleNamespace(research_scope_service=FakeResearchScopeService(),
+                          local_research_service=None)
+    window = ResearchWindow(app_instance=app)
+    window.source_policy = "web_first"
+    window.providers_text = "pubmed"
+    state = window.save_state()
+    assert state["policy"] == "web_first"
+    assert state["providers"] == "pubmed"
+
+    window2 = ResearchWindow(app_instance=app)
+    window2.restore_state(state)
+    assert window2.source_policy == "web_first"
+    assert window2.providers_text == "pubmed"

--- a/backlog/tasks/task-16790 - Add-BioRxiv-MedRxiv-and-PubMed-academic-providers.md
+++ b/backlog/tasks/task-16790 - Add-BioRxiv-MedRxiv-and-PubMed-academic-providers.md
@@ -1,0 +1,31 @@
+---
+id: TASK-16790
+title: 'Add BioRxiv, MedRxiv, and PubMed academic providers'
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 13:21'
+updated_date: '2026-08-16 13:24'
+labels:
+  - research
+  - web-tools
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The academic lane covers arXiv and Semantic Scholar only; tldw_server's pipeline also searches BioRxiv/MedRxiv (shared details API) and PubMed (ESearch+ESummary), so biomedical questions have no local coverage. Port both providers and make the provider set configurable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] search_biorxiv queries the details API with a default 30-day window, client-side query filtering, and MedRxiv via the server parameter,search_pubmed does the ESearch then ESummary two-step and normalizes items (DOI from articleids, PMC PDF links when present),Both providers use the shared httpx retry ladder and constants-driven endpoints and normalize to the established paper shape for DOI dedup,search_papers fans out across a configurable provider set (config [SearchSettings] research_academic_providers, default arxiv+semantic_scholar) with the providers parameter filtering lanes and per-provider degradation preserved,Tests with mocked HTTP cover both providers, filtering, the medrxiv switch, and provider-set configuration
+<!-- AC:END -->
+
+## Implementation Notes
+
+- `search_biorxiv` (port of the server's Third_Party/BioRxiv.py, simplified to the lane's needs): details API over a default 30-day window (server's default), client-side case-insensitive query filtering over title/abstract, MedRxiv via the `server` parameter (shared API, matching the server's MedRxiv aliasing), canonical content/PDF URLs from DOI+version. `search_pubmed` (port of Third_Party/PubMed.py): ESearch→ESummary two-step with relevance sort, DOI/PMCID extraction from articleids, PMC PDF links when present. Both ride the shared `_request_with_retries` ladder (timeouts, capped backoff, 429/5xx retries, 4xx fail-fast), constants-driven endpoints, injectable clients, and normalize to the established paper shape for DOI dedup.
+- `search_papers` became a registry fan-out: lanes for arxiv/semantic_scholar/biorxiv/medrxiv/pubmed, all selected providers concurrent via gather, per-provider degradation preserved, unknown provider names warn and drop. `providers=` filters the set per call; the default set comes from `_default_academic_providers()` (`[SearchSettings] research_academic_providers`, comma list, default arxiv+semantic_scholar).
+- The existing concurrency/degradation tests still pass unchanged; 6 new provider tests (mocked httpx) cover both providers, medrxiv switch, provider-set filtering, and config defaults.

--- a/backlog/tasks/task-16791 - Enforce-source-policy-and-provider-overrides-in-the-engine.md
+++ b/backlog/tasks/task-16791 - Enforce-source-policy-and-provider-overrides-in-the-engine.md
@@ -1,0 +1,33 @@
+---
+id: TASK-16791
+title: Enforce source policy and provider overrides in the engine
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 13:21'
+updated_date: '2026-08-16 13:31'
+labels:
+  - research
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Runs record source_policy (balanced default) and provider_overrides_json but the engine ignores both: lanes run based on construction flags, not the run's own routing. Give runs server-parity lane routing and per-run overrides, exposed in the Research window.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 source_policy web_only skips the academic lane and academic_only skips the web engine entirely (no search spend),academic_first and web_first control evidence merge order (docs-budget truncation follows the preferred lane),provider_overrides from the run merge over engine params (engine, result_count) and filter academic providers per run,The Research window gains a policy selector and a providers input, persisted in state and sent on run creation,Tests cover lane gating, merge ordering, override application, and the window payload wiring
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Engine: `execute_run` normalizes the run's `source_policy` (web_only / academic_only / web_first / academic_first / balanced, default balanced) and merges `provider_overrides` over construction params (`engine`, `result_count`), stashing both for the phase machine (cleared in the finally). `_collect_round` gates the web loop (`academic_only` spends nothing on the web engine); the paper lane gates on `web_only`; merge order follows the preferred lane (`academic_first` puts papers first, which is what docs-budget truncation keeps). `academic_providers` overrides reach the paper callable as a `providers=` kwarg (plain call fallback for callables without it).
+- Window: policy Select (five options) + providers Input in the create row; `source_policy` always rides the create payload, `provider_overrides.academic_providers` when providers are listed; both persist via save/restore state.
+- Gotcha found while wiring: the paper lane's TypeError fallback originally swallowed a NameError (bare `academic_providers` in `_execute_phases`), silently skipping the lane -- fixed by reading the stashed value; the lane-failure catch now only sees genuine provider errors.
+- Verified TDD: 4 engine tests (web_only skip, academic_only zero web spend, academic_first ordering, overrides reaching params and papers) + 2 window tests (payload wiring, state persistence); suites 227 passed; ruff clean.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -463,16 +463,17 @@ def search_biorxiv(
         f, t = start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")
 
     url = f"{BIORXIV_API_BASE}/details/{server_norm}/{f}/{t}/0"
-    owned_client = client is None
-    http = client or httpx.Client()
-    try:
+    if client is not None:
         response = _request_with_retries(
-            http, "GET", url, timeout=timeout, max_retries=max_retries
+            client, "GET", url, timeout=timeout, max_retries=max_retries
         )
         data = json.loads(response.text)
-    finally:
-        if owned_client:
-            http.close()
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries(
+                http, "GET", url, timeout=timeout, max_retries=max_retries
+            )
+            data = json.loads(response.text)
 
     total = 0
     messages = data.get("messages") or []
@@ -568,29 +569,31 @@ def search_pubmed(
         ty = int(to_year or from_year)
         esearch_params.update({"datetype": "pdat", "mindate": str(fy), "maxdate": str(ty)})
 
-    owned_client = client is None
-    http = client or httpx.Client()
-    try:
+    def _run(http: Any) -> tuple[list[str], int, dict[str, Any]]:
         esearch = _request_with_retries(
             http, "GET", f"{PUBMED_EUTILS_BASE}/esearch.fcgi",
             timeout=timeout, max_retries=max_retries, params=esearch_params,
         )
         esr = json.loads(esearch.text).get("esearchresult") or {}
-        idlist = [str(i) for i in (esr.get("idlist") or [])]
-        total = int(esr.get("count") or 0)
-        if not idlist:
-            return {"query_echo": {"query": query}, "items": [],
-                    "total_results": total, "results_per_page": results_per_page}
-
+        ids = [str(i) for i in (esr.get("idlist") or [])]
+        count = int(esr.get("count") or 0)
+        if not ids:
+            return ids, count, {}
         esummary = _request_with_retries(
             http, "GET", f"{PUBMED_EUTILS_BASE}/esummary.fcgi",
             timeout=timeout, max_retries=max_retries,
-            params={"db": "pubmed", "id": ",".join(idlist), "retmode": "json"},
+            params={"db": "pubmed", "id": ",".join(ids), "retmode": "json"},
         )
-        result = json.loads(esummary.text).get("result") or {}
-    finally:
-        if owned_client:
-            http.close()
+        return ids, count, json.loads(esummary.text).get("result") or {}
+
+    if client is not None:
+        idlist, total, result = _run(client)
+    else:
+        with httpx.Client() as http:
+            idlist, total, result = _run(http)
+    if not idlist:
+        return {"query_echo": {"query": query}, "items": [],
+                "total_results": total, "results_per_page": results_per_page}
 
     items: list[dict[str, Any]] = []
     for uid in result.get("uids") or idlist:
@@ -756,15 +759,17 @@ async def search_papers(
         "medrxiv": _medrxiv_lane,
         "pubmed": _pubmed_lane,
     }
-    selected = [
-        name for name in (providers if providers is not None else _default_academic_providers())
-        if name in lanes
-    ]
-    dropped = [
-        name for name in (providers or [])
-        if name not in lanes
-    ]
+    requested = (
+        providers if providers is not None else _default_academic_providers()
+    )
+    selected: list[str] = []
+    for name in requested:
+        if name in lanes and name not in selected:  # order-preserving dedupe
+            selected.append(name)
+    dropped = [name for name in requested if name not in lanes]
     if dropped:
+        # Warns for BOTH explicit lists and config-driven defaults: a typo
+        # in [SearchSettings] must be as visible as one in the window.
         logger.warning(f"search_papers ignoring unknown providers: {dropped}")
 
     async def _lane_runner(name: str, lane: Any) -> Any:

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -10,6 +10,8 @@ pool with web results (``merge_evidence_pools``).
 
 from __future__ import annotations
 
+import datetime
+import json
 import math
 import os
 import random
@@ -25,6 +27,8 @@ from tldw_chatbook.config import get_cli_setting
 
 __all__ = [
     "ARXIV_API_ENDPOINT",
+    "BIORXIV_API_BASE",
+    "PUBMED_EUTILS_BASE",
     "SEMANTIC_SCHOLAR_API_ENDPOINT",
     "AcademicProviderError",
     "merge_evidence_pools",
@@ -36,6 +40,8 @@ __all__ = [
 
 ARXIV_API_ENDPOINT = "https://export.arxiv.org/api/query"
 SEMANTIC_SCHOLAR_API_ENDPOINT = "https://api.semanticscholar.org/graph/v1/paper/search"
+BIORXIV_API_BASE = "https://api.biorxiv.org"
+PUBMED_EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
 DEFAULT_TIMEOUT_S = 30.0
 DEFAULT_MAX_RETRIES = 2
@@ -401,6 +407,236 @@ def merge_evidence_pools(
     return merged
 
 
+def search_biorxiv(
+    query: str,
+    *,
+    server: str = "biorxiv",
+    from_date: str | None = None,
+    to_date: str | None = None,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search BioRxiv/MedRxiv preprints (task-16790; port of the server's
+    Third_Party/BioRxiv.py details flow, simplified to the lane's needs).
+
+    The details API lists by date range (default: last 30 days, matching the
+    server), so the query filters client-side over title/abstract.
+
+    Args:
+        query: Topic query; matched case-insensitively against titles and
+            abstracts.
+        server: ``"biorxiv"`` or ``"medrxiv"`` (shared API, per the server's
+            MedRxiv aliasing).
+        from_date: Optional ``YYYY-MM-DD`` range start.
+        to_date: Optional ``YYYY-MM-DD`` range end.
+        results_per_page: Maximum items returned after filtering.
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget for retryable failures.
+
+    Returns:
+        The runner dict shape (``items`` normalized to the shared paper
+        shape with ``source`` set to the server name).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard HTTP
+            error.
+    """
+    server_norm = server.lower().strip() if server else "biorxiv"
+    if server_norm not in {"biorxiv", "medrxiv"}:
+        server_norm = "biorxiv"
+
+    def _validate_date(d: str | None) -> str | None:
+        try:
+            datetime.date.fromisoformat(str(d or ""))
+            return str(d)
+        except ValueError:
+            return None
+
+    f = _validate_date(from_date)
+    t = _validate_date(to_date)
+    if not (f and t):
+        end = datetime.datetime.now(datetime.timezone.utc).date()
+        start = end - datetime.timedelta(days=30)
+        f, t = start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")
+
+    url = f"{BIORXIV_API_BASE}/details/{server_norm}/{f}/{t}/0"
+    owned_client = client is None
+    http = client or httpx.Client()
+    try:
+        response = _request_with_retries(
+            http, "GET", url, timeout=timeout, max_retries=max_retries
+        )
+        data = json.loads(response.text)
+    finally:
+        if owned_client:
+            http.close()
+
+    total = 0
+    messages = data.get("messages") or []
+    if messages and isinstance(messages[0], dict):
+        try:
+            total = int(messages[0].get("total") or messages[0].get("count") or 0)
+        except (TypeError, ValueError):
+            total = 0
+
+    needle = " ".join(query.casefold().split())
+    items: list[dict[str, Any]] = []
+    for raw in data.get("collection") or []:
+        if not isinstance(raw, dict):
+            continue
+        title = str(raw.get("title") or "")
+        abstract = str(raw.get("abstract") or "")
+        if needle and needle not in title.casefold() and needle not in abstract.casefold():
+            continue
+        doi = str(raw.get("doi") or "")
+        version = raw.get("version")
+        v_suffix = f"v{version}" if str(version or "").isdigit() else ""
+        base_host = "biorxiv.org" if server_norm == "biorxiv" else "medrxiv.org"
+        content_url = f"https://www.{base_host}/content/{doi}{v_suffix}" if doi else None
+        items.append(
+            {
+                "id": doi or None,
+                "doi": doi or None,
+                "title": title or None,
+                "authors": raw.get("authors"),
+                "published_date": raw.get("date"),
+                "abstract": abstract or None,
+                "url": content_url,
+                "pdf_url": f"{content_url}.full.pdf" if content_url else None,
+                "source": server_norm,
+            }
+        )
+        if len(items) >= results_per_page:
+            break
+
+    return {
+        "query_echo": {"query": query, "server": server_norm,
+                       "from_date": f, "to_date": t},
+        "items": items,
+        "total_results": total,
+        "results_per_page": results_per_page,
+    }
+
+
+def search_pubmed(
+    query: str,
+    *,
+    from_year: int | None = None,
+    to_year: int | None = None,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search PubMed via ESearch + ESummary (task-16790; port of the
+    server's Third_Party/PubMed.py two-step).
+
+    Args:
+        query: The search term (relevance-sorted).
+        from_year: Optional publication-year lower bound.
+        to_year: Optional publication-year upper bound.
+        results_per_page: Page size (retmax, clamped to the API's 200).
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget per request.
+
+    Returns:
+        The runner dict shape (``items`` normalized to the shared paper
+        shape with ``source`` set to ``"pubmed"``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard HTTP
+            error.
+    """
+    if not query.strip():
+        return {"query_echo": {"query": query}, "items": [], "total_results": 0,
+                "results_per_page": results_per_page}
+
+    esearch_params: dict[str, Any] = {
+        "db": "pubmed",
+        "term": query.strip(),
+        "retmode": "json",
+        "retstart": "0",
+        "retmax": str(max(1, min(results_per_page, 200))),
+        "sort": "relevance",
+    }
+    if from_year or to_year:
+        fy = int(from_year or to_year)
+        ty = int(to_year or from_year)
+        esearch_params.update({"datetype": "pdat", "mindate": str(fy), "maxdate": str(ty)})
+
+    owned_client = client is None
+    http = client or httpx.Client()
+    try:
+        esearch = _request_with_retries(
+            http, "GET", f"{PUBMED_EUTILS_BASE}/esearch.fcgi",
+            timeout=timeout, max_retries=max_retries, params=esearch_params,
+        )
+        esr = json.loads(esearch.text).get("esearchresult") or {}
+        idlist = [str(i) for i in (esr.get("idlist") or [])]
+        total = int(esr.get("count") or 0)
+        if not idlist:
+            return {"query_echo": {"query": query}, "items": [],
+                    "total_results": total, "results_per_page": results_per_page}
+
+        esummary = _request_with_retries(
+            http, "GET", f"{PUBMED_EUTILS_BASE}/esummary.fcgi",
+            timeout=timeout, max_retries=max_retries,
+            params={"db": "pubmed", "id": ",".join(idlist), "retmode": "json"},
+        )
+        result = json.loads(esummary.text).get("result") or {}
+    finally:
+        if owned_client:
+            http.close()
+
+    items: list[dict[str, Any]] = []
+    for uid in result.get("uids") or idlist:
+        raw = result.get(str(uid))
+        if not isinstance(raw, dict):
+            continue
+        doi = None
+        pmcid = None
+        for it in raw.get("articleids") or []:
+            idtype = (it.get("idtype") or "").lower()
+            value = it.get("value")
+            if not value:
+                continue
+            if idtype == "doi":
+                doi = value
+            elif idtype == "pmc":
+                pmcid = value.replace("PMC", "") if value.startswith("PMC") else value
+        authors = ", ".join(
+            str(a.get("name"))
+            for a in (raw.get("authors") or [])
+            if isinstance(a, dict) and a.get("name")
+        ) or None
+        items.append(
+            {
+                "id": str(uid),
+                "pmid": str(uid),
+                "doi": doi,
+                "title": raw.get("title"),
+                "authors": authors,
+                "journal": raw.get("fulljournalname") or raw.get("source"),
+                "published_date": raw.get("pubdate") or raw.get("epubdate"),
+                "abstract": raw.get("abstract"),
+                "url": f"https://pubmed.ncbi.nlm.nih.gov/{uid}/",
+                "pdf_url": f"https://pmc.ncbi.nlm.nih.gov/{pmcid}/pdf" if pmcid else None,
+                "source": "pubmed",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query, "from_year": from_year, "to_year": to_year},
+        "items": items,
+        "total_results": total,
+        "results_per_page": results_per_page,
+    }
+
+
 _QUESTION_PREFIXES = (
     "what is",
     "what are",
@@ -435,9 +671,31 @@ def _paper_query(question: str) -> str:
     return query
 
 
+def _default_academic_providers() -> list[str]:
+    """Config-driven provider set for the academic lane (task-16790):
+    ``[SearchSettings] research_academic_providers`` as a comma list;
+    default arXiv + Semantic Scholar. Unknown names are filtered at use
+    time by the lane registry, so a typo costs nothing but a warning.
+
+    Returns:
+        The configured provider names, lowercased and deduplicated.
+    """
+    raw = get_cli_setting(
+        "SearchSettings", "research_academic_providers",
+        "arxiv,semantic_scholar",
+    )
+    names: list[str] = []
+    for part in str(raw or "").split(","):
+        name = part.strip().lower()
+        if name and name not in names:
+            names.append(name)
+    return names or ["arxiv", "semantic_scholar"]
+
+
 async def search_papers(
     query: str,
     *,
+    providers: list[str] | None = None,
     results_per_page: int = 5,
     semantic_scholar_api_key: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -468,39 +726,63 @@ async def search_papers(
                 seen_dois.add(doi)
             papers.append(item)
 
-    async def _arxiv_lane() -> Any:
+    def _arxiv_lane() -> Any:
+        return search_arxiv(query=topic_query, results_per_page=results_per_page)
+
+    def _s2_lane() -> Any:
+        return search_semantic_scholar(
+            query=topic_query,
+            results_per_page=results_per_page,
+            api_key=semantic_scholar_api_key
+            if semantic_scholar_api_key is not None
+            else resolve_semantic_scholar_api_key(),
+        )
+
+    def _biorxiv_lane() -> Any:
+        return search_biorxiv(query=topic_query, results_per_page=results_per_page)
+
+    def _medrxiv_lane() -> Any:
+        return search_biorxiv(
+            query=topic_query, server="medrxiv", results_per_page=results_per_page
+        )
+
+    def _pubmed_lane() -> Any:
+        return search_pubmed(query=topic_query, results_per_page=results_per_page)
+
+    lanes: dict[str, Any] = {
+        "arxiv": _arxiv_lane,
+        "semantic_scholar": _s2_lane,
+        "biorxiv": _biorxiv_lane,
+        "medrxiv": _medrxiv_lane,
+        "pubmed": _pubmed_lane,
+    }
+    selected = [
+        name for name in (providers if providers is not None else _default_academic_providers())
+        if name in lanes
+    ]
+    dropped = [
+        name for name in (providers or [])
+        if name not in lanes
+    ]
+    if dropped:
+        logger.warning(f"search_papers ignoring unknown providers: {dropped}")
+
+    async def _lane_runner(name: str, lane: Any) -> Any:
         try:
-            return await to_thread(
-                search_arxiv, query=topic_query, results_per_page=results_per_page
-            )
+            return await to_thread(lane)
         except AcademicProviderError as exc:
-            failures.append(f"arxiv: {exc}")
-            logger.warning(f"search_papers arxiv lane failed: {exc}")
+            failures.append(f"{name}: {exc}")
+            logger.warning(f"search_papers {name} lane failed: {exc}")
             return None
 
-    async def _s2_lane() -> Any:
-        try:
-            return await to_thread(
-                search_semantic_scholar,
-                query=topic_query,
-                results_per_page=results_per_page,
-                api_key=semantic_scholar_api_key
-                if semantic_scholar_api_key is not None
-                else resolve_semantic_scholar_api_key(),
-            )
-        except AcademicProviderError as exc:
-            failures.append(f"semantic_scholar: {exc}")
-            logger.warning(f"search_papers semantic scholar lane failed: {exc}")
-            return None
-
-    # task-16789: both providers run CONCURRENTLY (serial execution added
-    # avoidable latency, especially under timeouts/retries); per-provider
-    # degradation is preserved inside each lane.
-    arxiv_out, s2_out = await asyncio.gather(_arxiv_lane(), _s2_lane())
-    if arxiv_out is not None:
-        _collect(arxiv_out.get("items") or [])
-    if s2_out is not None:
-        _collect(s2_out.get("items") or [])
+    # task-16789: all selected providers run CONCURRENTLY (serial execution
+    # added avoidable latency); per-provider degradation lives in each lane.
+    outcomes = await asyncio.gather(
+        *(_lane_runner(name, lanes[name]) for name in selected)
+    )
+    for outcome in outcomes:
+        if outcome is not None:
+            _collect(outcome.get("items") or [])
 
     if not papers and failures:
         raise AcademicProviderError(

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -229,6 +229,26 @@ class LocalResearchEngine:
             "web_only", "academic_only", "web_first", "academic_first", "balanced",
         } else "balanced"
 
+    def _paper_fn_accepts_providers(self) -> bool:
+        """Whether the injected paper callable takes a ``providers`` kwarg
+        (Qodo PR 1722: decided by signature inspection UP FRONT -- a broad
+        except-TypeError retry masked real TypeErrors raised from inside
+        provider implementations)."""
+        cached = getattr(self, "_paper_fn_accepts_providers_cache", None)
+        if cached is not None:
+            return cached
+        try:
+            parameters = inspect.signature(self.paper_search_fn).parameters
+            accepts = any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                or param.name == "providers"
+                for param in parameters.values()
+            )
+        except (TypeError, ValueError):
+            accepts = False
+        self._paper_fn_accepts_providers_cache = accepts
+        return accepts
+
     def _is_checkpointed(self, run: dict[str, Any]) -> bool:
         return str(run.get("autonomy_mode") or "") == "checkpointed"
 
@@ -503,21 +523,15 @@ class LocalResearchEngine:
                 # rounds (task-16326). A provider error is a warning, not a
                 # run failure -- the other lane already collected.
                 providers_filter = self._active_academic_providers
+                accepts_providers = self._paper_fn_accepts_providers()
                 for query in round_queries:
                     try:
-                        if providers_filter is not None:
+                        if providers_filter is not None and accepts_providers:
                             papers = await self._maybe_await(
                                 self.paper_search_fn(query, providers=providers_filter)
                             )
                         else:
                             papers = await self._maybe_await(self.paper_search_fn(query))
-                    except TypeError:
-                        # Callable without a providers kwarg: call it plain.
-                        try:
-                            papers = await self._maybe_await(self.paper_search_fn(query))
-                        except Exception as exc:  # noqa: BLE001 - lane degrades
-                            merged_warnings.append(f"academic search failed: {exc}")
-                            continue
                     except Exception as exc:  # noqa: BLE001 - lane degrades
                         merged_warnings.append(f"academic search failed: {exc}")
                         continue

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -219,6 +219,16 @@ class LocalResearchEngine:
             raise _RunCancelled(run)
         return run
 
+    @staticmethod
+    def _normalize_source_policy(raw: Any) -> str:
+        """Normalize a run's source_policy (task-16791) to one of
+        web_only / academic_only / web_first / academic_first / balanced
+        (default balanced: both lanes, web evidence first)."""
+        value = str(raw or "").strip().lower()
+        return value if value in {
+            "web_only", "academic_only", "web_first", "academic_first", "balanced",
+        } else "balanced"
+
     def _is_checkpointed(self, run: dict[str, Any]) -> bool:
         return str(run.get("autonomy_mode") or "") == "checkpointed"
 
@@ -273,6 +283,25 @@ class LocalResearchEngine:
             limits = {**limits, **plan_patch_limits}
         ledger = BudgetLedger.from_limits(limits)
         self._active_ledger = ledger
+        # task-16791: per-run routing/overrides (server parity). The run's
+        # provider_overrides merge OVER the engine's construction params.
+        policy = self._normalize_source_policy(run.get("source_policy"))
+        overrides = (
+            run.get("provider_overrides")
+            if isinstance(run.get("provider_overrides"), dict)
+            else {}
+        )
+        run_params = dict(self.search_params)
+        if "engine" in overrides:
+            run_params["engine"] = overrides["engine"]
+        if "result_count" in overrides:
+            try:
+                run_params["result_count"] = max(1, int(overrides["result_count"]))
+            except (TypeError, ValueError):
+                pass
+        self._active_run_params = run_params
+        self._active_policy = policy
+        self._active_academic_providers = overrides.get("academic_providers")
 
         try:
             return await self._execute_phases(run, ledger)
@@ -299,20 +328,30 @@ class LocalResearchEngine:
             return self.service.fail_run(run_id, error_msg=str(exc))
         finally:
             self._active_ledger = None
+            self._active_run_params = None
+            self._active_policy = None
+            self._active_academic_providers = None
 
     async def _collect_round(
         self,
         queries: list[str],
         base_params: dict[str, Any],
         ledger: BudgetLedger,
+        *,
+        source_policy: str = "balanced",
+        academic_providers: list | None = None,
     ) -> tuple[list[dict[str, Any]], list[str], list[str]]:
         """Run one collection round: one search call per query, each with the
         fan-out cap clamped to the remaining search budget BEFORE it can
-        spend (task-16323), settling the actual query count after."""
+        spend (task-16323), settling the actual query count after.
+        task-16791: source_policy gates the lanes (academic_only spends
+        nothing on the web engine; web_only skips the paper lane) and sets
+        the evidence merge order (academic_first puts papers first, which
+        is what the docs-budget truncation keeps)."""
         collected: list[dict[str, Any]] = []
         sub_questions: list[str] = []
         warnings: list[str] = []
-        for query in queries:
+        for query in queries if source_policy != "academic_only" else []:
             params = dict(base_params)
             if ledger.max_runtime_seconds is not None:
                 params["phase1_time_budget_s"] = max(
@@ -337,7 +376,9 @@ class LocalResearchEngine:
                 sqd = shaped.get("sub_query_dict") or {}
             call_sub_questions = list((sqd or {}).get("sub_questions") or [])
             sub_questions.extend(call_sub_questions)
-            collected.extend(r for r in (wsr or {}).get("results") or [] if isinstance(r, dict))
+            collected.extend(
+                r for r in (wsr or {}).get("results") or [] if isinstance(r, dict)
+            )
             warnings.extend(w for w in (wsr or {}).get("warnings") or [])
             # task-16789: settle EXECUTED searches, not the reserved cap --
             # the pipeline can stop its fan-out early (phase-1 deadline), and
@@ -444,18 +485,39 @@ class LocalResearchEngine:
             self._check_control(run_id, "collecting")
             ledger.check_runtime()
             round_results, round_sub_questions, round_warnings = await self._collect_round(
-                round_queries, search_params, ledger
+                round_queries,
+                self._active_run_params or search_params,
+                ledger,
+                source_policy=self._active_policy or "balanced",
+                academic_providers=self._active_academic_providers,
             )
             all_sub_questions.extend(round_sub_questions)
             merged_warnings.extend(round_warnings)
-            if self.paper_search_fn is not None:
+            paper_results: list[dict[str, Any]] = []
+            if (
+                self.paper_search_fn is not None
+                and (self._active_policy or "balanced") != "web_only"
+            ):
                 # Academic lane: papers for this round's queries join the
                 # same evidence pool, deduped by DOI across providers and
                 # rounds (task-16326). A provider error is a warning, not a
-                # run failure -- the web lane already collected.
+                # run failure -- the other lane already collected.
+                providers_filter = self._active_academic_providers
                 for query in round_queries:
                     try:
-                        papers = await self._maybe_await(self.paper_search_fn(query))
+                        if providers_filter is not None:
+                            papers = await self._maybe_await(
+                                self.paper_search_fn(query, providers=providers_filter)
+                            )
+                        else:
+                            papers = await self._maybe_await(self.paper_search_fn(query))
+                    except TypeError:
+                        # Callable without a providers kwarg: call it plain.
+                        try:
+                            papers = await self._maybe_await(self.paper_search_fn(query))
+                        except Exception as exc:  # noqa: BLE001 - lane degrades
+                            merged_warnings.append(f"academic search failed: {exc}")
+                            continue
                     except Exception as exc:  # noqa: BLE001 - lane degrades
                         merged_warnings.append(f"academic search failed: {exc}")
                         continue
@@ -465,7 +527,13 @@ class LocalResearchEngine:
                             if doi in seen_dois:
                                 continue
                             seen_dois.add(doi)
-                        round_results.append(paper)
+                        paper_results.append(paper)
+            # task-16791: merge order follows the policy's preferred lane.
+            round_results = (
+                paper_results + round_results
+                if (self._active_policy or "balanced") == "academic_first"
+                else round_results + paper_results
+            )
             for result in round_results:
                 url = str(result.get("url") or "")
                 if url and url in seen_urls:

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -28,6 +28,30 @@ from tldw_chatbook.UI.Research_Modules.bundle_rendering import (
 )
 
 
+_KNOWN_ACADEMIC_PROVIDERS = {
+    "arxiv", "semantic_scholar", "biorxiv", "medrxiv", "pubmed",
+}
+
+
+def _parse_provider_tokens(text: str | None) -> list[str]:
+    """Parse and validate the providers input (task-16791/Qodo): the raw
+    text goes through the shared input validator (dangerous-pattern and
+    length checks), tokens are lowercased and deduplicated in order, and
+    anything unknown is dropped -- a typo must not silently widen or
+    misroute the provider set. Returns [] when the input is invalid."""
+    from tldw_chatbook.Utils.input_validation import validate_text_input
+
+    raw = str(text or "")
+    if not validate_text_input(raw, max_length=200):
+        return []
+    seen: list[str] = []
+    for part in raw.split(","):
+        token = part.strip().lower()
+        if token and token in _KNOWN_ACADEMIC_PROVIDERS and token not in seen:
+            seen.append(token)
+    return seen
+
+
 def _parse_limits_text(text: str | None) -> tuple[dict[str, float], list[str]]:
     """Parse a limits input like "max_searches=5, max_runtime_seconds=120"
     into a limits_json dict (task-16334). Invalid pairs are excluded and
@@ -282,6 +306,14 @@ class ResearchWindow(Vertical):
         self._set_status(f"Follow-up {result.get('status')}.")
         return result
 
+    @on(Input.Changed, "#research-limits-input")
+    def _on_limits_input_changed(self, event: Input.Changed) -> None:
+        self.limits_text = event.value
+
+    @on(Input.Changed, "#research-providers-input")
+    def _on_providers_input_changed(self, event: Input.Changed) -> None:
+        self.providers_text = event.value
+
     @on(Select.Changed, "#research-policy-select")
     def _on_policy_changed(self, event: Select.Changed) -> None:
         self.source_policy = str(event.value or "balanced")
@@ -319,6 +351,18 @@ class ResearchWindow(Vertical):
         return self.runs
 
     async def create_run(self, payload: dict[str, Any]) -> Any:
+        # Qodo (PR 1722): read the inputs live -- restore_state seeds the
+        # attributes, but typing in the widgets must reach the payload.
+        try:
+            self.limits_text = self.query_one("#research-limits-input", Input).value
+        except Exception:
+            pass
+        try:
+            self.providers_text = self.query_one(
+                "#research-providers-input", Input
+            ).value
+        except Exception:
+            pass
         limits, warnings = _parse_limits_text(self.limits_text)
         if warnings:
             self._set_status("Limits: " + "; ".join(warnings))
@@ -326,11 +370,9 @@ class ResearchWindow(Vertical):
             payload = {**payload, "limits_json": limits}
         # task-16791: lane routing + provider selection ride the run record.
         payload = {**payload, "source_policy": self.source_policy}
-        providers = [
-            part.strip().lower()
-            for part in self.providers_text.split(",")
-            if part.strip()
-        ]
+        providers = _parse_provider_tokens(self.providers_text)
+        if self.providers_text.strip() and not providers:
+            self._set_status("Providers input invalid or all-unknown; ignored.")
         if providers:
             payload = {**payload, "provider_overrides": {
                 "academic_providers": providers,

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -98,6 +98,9 @@ class ResearchWindow(Vertical):
         # and the rendered follow-up answer.
         self.limits_text = ""
         self.followup_answer_text = ""
+        # task-16791: per-run lane routing + academic provider selection.
+        self.source_policy = "balanced"
+        self.providers_text = ""
         self.controller = ResearchController(
             getattr(app_instance, "research_scope_service", None)
         )
@@ -122,6 +125,18 @@ class ResearchWindow(Vertical):
             yield Input(
                 placeholder="Limits: max_searches=5, max_runtime_seconds=120",
                 id="research-limits-input",
+            )
+            yield Select(
+                [("Balanced", "balanced"), ("Web only", "web_only"),
+                 ("Academic only", "academic_only"), ("Web first", "web_first"),
+                 ("Academic first", "academic_first")],
+                value=self.source_policy,
+                allow_blank=False,
+                id="research-policy-select",
+            )
+            yield Input(
+                placeholder="Providers: arxiv, pubmed",
+                id="research-providers-input",
             )
             yield Button("Create Run", id="research-create-run", variant="primary")
         yield Static(self.status_message, id="research-status")
@@ -166,6 +181,8 @@ class ResearchWindow(Vertical):
             "source": self.current_source,
             "academic": self.academic_enabled,
             "limits": self.limits_text,
+            "policy": self.source_policy,
+            "providers": self.providers_text,
         }
 
     def restore_state(self, state: dict[str, Any]) -> None:
@@ -173,6 +190,13 @@ class ResearchWindow(Vertical):
         self.current_source = source if source in {"local", "server"} else "local"
         self.academic_enabled = bool((state or {}).get("academic"))
         self.limits_text = str((state or {}).get("limits") or "")
+        policy = str((state or {}).get("policy") or "balanced")
+        self.source_policy = (
+            policy if policy in {
+                "balanced", "web_only", "academic_only", "web_first", "academic_first",
+            } else "balanced"
+        )
+        self.providers_text = str((state or {}).get("providers") or "")
         self._sync_academic_toggle()
         try:
             self.query_one("#research-limits-input", Input).value = self.limits_text
@@ -258,6 +282,11 @@ class ResearchWindow(Vertical):
         self._set_status(f"Follow-up {result.get('status')}.")
         return result
 
+    @on(Select.Changed, "#research-policy-select")
+    def _on_policy_changed(self, event: Select.Changed) -> None:
+        self.source_policy = str(event.value or "balanced")
+        self._set_status(f"Source policy: {self.source_policy}")
+
     @on(Checkbox.Changed, "#research-academic-toggle")
     def _on_academic_toggle_changed(self, event: Checkbox.Changed) -> None:
         self.academic_enabled = bool(event.value)
@@ -295,6 +324,17 @@ class ResearchWindow(Vertical):
             self._set_status("Limits: " + "; ".join(warnings))
         if limits:
             payload = {**payload, "limits_json": limits}
+        # task-16791: lane routing + provider selection ride the run record.
+        payload = {**payload, "source_policy": self.source_policy}
+        providers = [
+            part.strip().lower()
+            for part in self.providers_text.split(",")
+            if part.strip()
+        ]
+        if providers:
+            payload = {**payload, "provider_overrides": {
+                "academic_providers": providers,
+            }}
         created = await self.controller.create_run(self.current_source, payload)
         if self.current_source == "local":
             created_id = (


### PR DESCRIPTION
## Summary

Server-pipeline parity for the deep-research engine's backend sources and settings (tasks 16790–16791), ported from tldw_server dev's Third_Party adapters and Research broker semantics.

### More sources (task 16790)
- **`search_biorxiv`** — BioRxiv/MedRxiv preprints via the shared details API (default 30-day window matching the server, client-side query filtering, MedRxiv through the `server` parameter, canonical content/PDF URLs).
- **`search_pubmed`** — ESearch → ESummary two-step with relevance sort, DOI/PMCID extraction, PMC PDF links.
- Both ride the existing httpx retry ladder (timeouts, capped backoff, 429/5xx retries) and normalize to the established paper shape, so DOI-level dedup applies across all five providers.
- `search_papers` is now a registry fan-out — arxiv, semantic_scholar, biorxiv, medrxiv, pubmed run concurrently with per-provider degradation; `providers=` filters per call; the default set is configurable via `[SearchSettings] research_academic_providers`.

### Run-level settings (task 16791)
- **`source_policy` enforcement**: `academic_only` spends nothing on the web engine; `web_only` skips the paper lane; `web_first`/`academic_first` set evidence merge order (which the docs-budget truncation keeps); `balanced` default.
- **`provider_overrides`**: the run's overrides merge over engine params (`engine`, `result_count`) and filter academic providers per run.
- Research window: policy selector + providers input in the create row, persisted in state.

## Test evidence
TDD: 12 new tests (providers with mocked HTTP, medrxiv switch, provider-set filtering, config defaults, lane gating, zero web spend, merge ordering, override application, window payload + persistence). Suites 227 passed; ruff clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BioRxiv/MedRxiv and PubMed providers and enforces per‑run `source_policy` and `provider_overrides` in the local research engine. Previously the engine searched only arXiv and Semantic Scholar and ignored run routing; now it fans out across five providers with configurable defaults, gates lanes by policy, and hardens provider selection and UI wiring to prevent misrouting.

- Adds `search_biorxiv` (shared details API, default 30‑day window, client‑side query filter, MedRxiv via `server`) and `search_pubmed` (ESearch→ESummary, DOI/PMCID extraction, PMC PDFs). Both use the existing httpx retry ladder, manage clients via context managers, and normalize to the paper shape so DOI‑level dedup works across all five providers.
- `search_papers` becomes a registry fan‑out over arxiv/semantic_scholar/biorxiv/medrxiv/pubmed, runs lanes concurrently, and accepts `providers=` per call. Defaults come from `[SearchSettings] research_academic_providers`. The provider list is order‑preserving deduped and logs warnings for unknown names in explicit lists and in config defaults.
- The engine honors `source_policy`: `web_only` skips the paper lane; `academic_only` skips the web engine; `web_first`/`academic_first` set evidence merge order. `provider_overrides` merge over engine params (`engine`, `result_count`) and filter academic providers via `academic_providers`. The provider filter is passed only when the paper function supports `providers` (signature inspection), avoiding masked TypeErrors.
- The Research window adds a policy selector and providers input, persists both in state, and now reads widget values at create time. Provider tokens go through shared input validation and a known‑provider whitelist; invalid or all‑unknown input is ignored with a status message. Fixes limits input not being read previously. Tests cover provider behavior, defaults and warnings, lane gating, merge ordering, overrides, and window wiring.

<sup>Written for commit 62cac46cb18684b677ab2da14b3eaf134e231dec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

