### PR TITLE
feat(research): server source catalog with categories + console policy flags

### DIFF
--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -178,8 +178,21 @@ async def main_async(args: argparse.Namespace) -> int:
         if args.academic:
             from tldw_chatbook.Research_Interop.academic_providers import search_papers
 
-            paper_search_fn = search_papers
-            print("academic lane: ON (arXiv + Semantic Scholar join the evidence pool)")
+            if args.providers:
+                from tldw_chatbook.Research_Interop.research_source_catalog import (
+                    expand_source_selection,
+                )
+
+                providers = expand_source_selection(
+                    [t.strip().lower() for t in args.providers.split(",") if t.strip()]
+                )
+
+                def paper_search_fn(query, _providers=providers):
+                    return search_papers(query, providers=_providers)
+                print(f"academic lane: ON (providers: {', '.join(providers)})")
+            else:
+                paper_search_fn = search_papers
+                print("academic lane: ON (default provider set)")
         engine = LocalResearchEngine(
             service, search_params=search_params, paper_search_fn=paper_search_fn
         )
@@ -237,6 +250,11 @@ def main() -> int:
         "--llm-base-url",
         default=None,
         help="prime api_settings.<--llm>.api_url for this process (no config file writes); implies --llm",
+    )
+    parser.add_argument(
+        "--providers",
+        default=None,
+        help="academic providers for the lane: source ids or categories (biomedical, repositories, ...)",
     )
     parser.add_argument(
         "--academic",

--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -23,6 +23,11 @@ from tldw_chatbook.Research_Interop.academic_providers import (
     resolve_semantic_scholar_api_key,
     search_arxiv,
     search_biorxiv,
+    search_crossref,
+    search_figshare,
+    search_openalex,
+    search_osf,
+    search_zenodo,
     search_pubmed,
     search_papers,
     search_semantic_scholar,
@@ -527,7 +532,7 @@ def test_default_academic_providers_from_config(monkeypatch):
     assert ap._default_academic_providers() == ["arxiv", "semantic_scholar"]
 
 
-def test_search_papers_dedupes_and_warns_on_unknown_defaults(monkeypatch, caplog):
+def test_search_papers_dedupes_and_rejects_unknown_defaults(monkeypatch):
     from tldw_chatbook.Research_Interop import academic_providers as ap
 
     calls = []
@@ -537,12 +542,215 @@ def test_search_papers_dedupes_and_warns_on_unknown_defaults(monkeypatch, caplog
         return {"items": []}
 
     monkeypatch.setattr(ap, "search_arxiv", fake_arxiv)
+    # Duplicates collapse; unknown tokens now RAISE (a config typo must not
+    # silently narrow the provider set).
     monkeypatch.setattr(
         ap, "_default_academic_providers",
-        lambda: ["arxiv", "arxiv", "not_a_provider"],
+        lambda: ["arxiv", "arxiv"],
     )
-
     papers = asyncio.run(ap.search_papers("q"))
-
     assert calls == ["arxiv"]  # deduped: one call despite the duplicate
+    assert papers == []
+
+    monkeypatch.setattr(
+        ap, "_default_academic_providers",
+        lambda: ["arxiv", "not_a_provider"],
+    )
+    with pytest.raises(ValueError, match="unknown research source or category"):
+        asyncio.run(ap.search_papers("q"))
+
+
+# --- catalog-lane providers: OpenAlex/Crossref/Zenodo/Figshare/OSF (task-16792) ----
+
+_OPENALEX_PAGE = {
+    "results": [
+        {
+            "id": "W1", "doi": "https://doi.org/10.1234/oa.1",
+            "title": "Graph of scholarship",
+            "abstract_inverted_index": {
+                "Scholarship": [0], "is": [1], "vast": [2],
+            },
+            "authorships": [{"author": {"display_name": "E. Scholar"}}],
+            "publication_year": 2026,
+            "primary_location": {
+                "landing_page_url": "https://doi.org/10.1234/oa.1",
+                "pdf_url": "https://example.org/oa1.pdf",
+            },
+        }
+    ],
+    "meta": {"count": 1},
+}
+
+
+def test_search_openalex_reconstructs_abstract_from_inverted_index(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_OPENALEX_PAGE))])
+
+    out = search_openalex(query="scholarship", client=client)
+
+    assert "api.openalex.org/works" in client.request.calls[0]["url"]
+    item = out["items"][0]
+    assert item["abstract"] == "Scholarship is vast"
+    assert item["doi"] == "10.1234/oa.1"  # https://doi.org/ prefix stripped
+    assert item["url"] == "https://doi.org/10.1234/oa.1"
+    assert item["pdf_url"] == "https://example.org/oa1.pdf"
+    assert item["authors"] == "E. Scholar"
+    assert item["source"] == "openalex"
+
+
+_CROSSREF_PAGE = {
+    "message": {
+        "total-results": 1,
+        "items": [
+            {
+                "DOI": "10.5555/cr.1",
+                "title": ["Registry metadata study"],
+                "author": [{"given": "F.", "family": "Registrar"}],
+                "issued": {"date-parts": [[2025]]},
+                "abstract": "<jats:p>DOI metadata at scale.</jats:p>",
+            }
+        ],
+    }
+}
+
+
+def test_search_crossref_strips_jats_from_abstract(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_CROSSREF_PAGE))])
+
+    out = search_crossref(query="registry", client=client)
+
+    assert "api.crossref.org/works" in client.request.calls[0]["url"]
+    item = out["items"][0]
+    assert item["abstract"] == "DOI metadata at scale."
+    assert item["authors"] == "F. Registrar"
+    assert item["source"] == "crossref"
+
+
+_ZENODO_PAGE = {
+    "hits": {
+        "total": 1,
+        "hits": [
+            {
+                "id": 998877,
+                "doi": "10.5281/zenodo.998877",
+                "metadata": {
+                    "title": "Dataset of things",
+                    "description": "<p>A big dataset.</p>",
+                    "creators": [{"name": "G. Curator"}],
+                    "publication_date": "2026-02-01",
+                },
+            }
+        ],
+    }
+}
+
+
+def test_search_zenodo_normalizes_repository_records(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_ZENODO_PAGE))])
+
+    out = search_zenodo(query="dataset", client=client)
+
+    assert "zenodo.org/api/records" in client.request.calls[0]["url"]
+    item = out["items"][0]
+    assert item["title"] == "Dataset of things"
+    assert item["abstract"] == "A big dataset."  # HTML stripped
+    assert item["url"] == "https://zenodo.org/records/998877"
+    assert item["source"] == "zenodo"
+
+
+_FIGSHARE_BODY = [
+    {
+        "id": 776655,
+        "title": "Figures for the paper",
+        "description": "<p>Twelve figures.</p>",
+        "doi": "10.6084/m9.figshare.776655",
+        "url_publication": "https://figshare.com/articles/figure/776655",
+        "authors": [{"full_name": "H. Artist"}],
+    }
+]
+
+
+def test_search_figshare_posts_search_body(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_FIGSHARE_BODY))])
+
+    out = search_figshare(query="figures", client=client)
+
+    call = client.request.calls[0]
+    assert call["method"] == "POST"
+    assert "api.figshare.com/v2/articles/search" in call["url"]
+    item = out["items"][0]
+    assert item["abstract"] == "Twelve figures."
+    assert item["url"] == "https://figshare.com/articles/figure/776655"
+    assert item["source"] == "figshare"
+
+
+_OSF_PAGE = {
+    "data": [
+        {
+            "id": "abc12",
+            "attributes": {
+                "title": "Registered analysis plan",
+                "description": "A preprint with a registration.",
+                "date_created": "2026-03-03T00:00:00.000000Z",
+            },
+            "links": {"html": "https://osf.io/preprints/abc12"},
+        }
+    ]
+}
+
+
+def test_search_osf_normalizes_preprint_records(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps(_OSF_PAGE))])
+
+    out = search_osf(query="registration", client=client)
+
+    assert "api.osf.io/v2/preprints" in client.request.calls[0]["url"]
+    item = out["items"][0]
+    assert item["title"] == "Registered analysis plan"
+    assert item["url"] == "https://osf.io/preprints/abc12"
+    assert item["published_date"] == "2026-03-03"
+    assert item["source"] == "osf"
+
+
+def test_search_papers_accepts_categories(monkeypatch):
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    calls = []
+
+    def fake_pubmed(**kw):
+        calls.append("pubmed")
+        return {"items": []}
+
+    def unused(**kw):
+        calls.append("other")
+        return {"items": []}
+
+    monkeypatch.setattr(ap, "search_biorxiv", unused)  # serves biorxiv + medrxiv lanes
+    for name in ("arxiv", "semantic_scholar",
+                 "openalex", "crossref", "zenodo", "figshare", "osf"):
+        monkeypatch.setattr(ap, f"search_{name}", unused)
+    monkeypatch.setattr(ap, "search_pubmed", fake_pubmed)
+
+    papers = asyncio.run(ap.search_papers("topic", providers=["biomedical"]))
+
+    assert calls == ["pubmed"]
     assert papers == []

--- a/Tests/Research/test_local_research_search_service.py
+++ b/Tests/Research/test_local_research_search_service.py
@@ -90,7 +90,11 @@ async def test_local_research_search_service_lists_and_launches_local_paper_sear
     arxiv = await service.search_arxiv(query="agents", results_per_page=5)
     semantic = await service.search_semantic_scholar(query="agents", year_range="2024")
 
-    assert providers == ["arxiv", "semantic_scholar"]
+    # task-16792: the listing IS the catalog (priority order).
+    assert providers == [
+        "openalex", "semantic_scholar", "crossref", "arxiv",
+        "biorxiv", "medrxiv", "pubmed", "zenodo", "figshare", "osf",
+    ]
     assert arxiv["items"][0]["id"] == "2401.00001"
     assert semantic["items"][0]["paperId"] == "abc"
     assert arxiv_runner.call_args.kwargs == {

--- a/Tests/Research/test_research_source_catalog.py
+++ b/Tests/Research/test_research_source_catalog.py
@@ -57,3 +57,16 @@ def test_expand_mixes_ids_and_categories_with_dedupe():
 def test_expand_rejects_unknown_tokens():
     with pytest.raises(ValueError, match="unknown research source or category"):
         expand_source_selection(["biomedical", "not_a_thing"])
+
+
+def test_paper_provider_constants_in_sync_with_catalog():
+    # Qodo (PR 1724): the service-level provider listings must not drift
+    # from the catalog the lane actually runs.
+    from tldw_chatbook.Research_Interop.local_research_search_service import (
+        LOCAL_SUPPORTED_PAPER_PROVIDERS,
+    )
+
+    catalog_ids = {e.source_id for e in catalog_entries()}
+    assert set(LOCAL_SUPPORTED_PAPER_PROVIDERS) <= catalog_ids
+    # Every catalog source is runnable by the lane (full parity, not a subset).
+    assert set(LOCAL_SUPPORTED_PAPER_PROVIDERS) == catalog_ids

--- a/Tests/Research/test_research_source_catalog.py
+++ b/Tests/Research/test_research_source_catalog.py
@@ -1,0 +1,59 @@
+"""Research source catalog with categories (task-16792; port of the
+server's Research/discovery catalog)."""
+
+import pytest
+
+from tldw_chatbook.Research_Interop.research_source_catalog import (
+    CATEGORIES,
+    SOURCES_BY_CATEGORY,
+    catalog_entries,
+    expand_source_selection,
+)
+
+
+def test_catalog_covers_all_ten_sources_with_server_fields():
+    entries = {e.source_id: e for e in catalog_entries()}
+
+    assert set(entries) == {
+        "openalex", "semantic_scholar", "crossref",
+        "arxiv", "biorxiv", "medrxiv",
+        "pubmed", "zenodo", "figshare", "osf",
+    }
+    assert entries["openalex"].category == "open_research_graph"
+    assert entries["arxiv"].category == "preprints"
+    assert entries["pubmed"].category == "biomedical"
+    assert entries["zenodo"].category == "repositories"
+    # Server-parity metadata on a representative entry.
+    pubmed = entries["pubmed"]
+    assert pubmed.display_name == "PubMed"
+    assert "abstracts" in pubmed.content_types
+    assert pubmed.access_level == "open_metadata"
+    assert pubmed.trust_notes
+    assert pubmed.priority > 0
+
+
+def test_categories_match_server_groupings():
+    assert SOURCES_BY_CATEGORY["open_research_graph"] == (
+        "openalex", "semantic_scholar", "crossref"
+    )
+    assert SOURCES_BY_CATEGORY["preprints"] == ("arxiv", "biorxiv", "medrxiv")
+    assert SOURCES_BY_CATEGORY["biomedical"] == ("pubmed",)
+    assert SOURCES_BY_CATEGORY["repositories"] == ("zenodo", "figshare", "osf")
+    assert set(CATEGORIES) == {
+        "open_research_graph", "preprints", "biomedical", "repositories",
+    }
+
+
+def test_expand_mixes_ids_and_categories_with_dedupe():
+    assert expand_source_selection(["biomedical", "arxiv"]) == [
+        "pubmed", "arxiv",
+    ]
+    assert expand_source_selection(["preprints", "arxiv"]) == [
+        "arxiv", "biorxiv", "medrxiv",
+    ]
+    assert expand_source_selection([]) == []
+
+
+def test_expand_rejects_unknown_tokens():
+    with pytest.raises(ValueError, match="unknown research source or category"):
+        expand_source_selection(["biomedical", "not_a_thing"])

--- a/Tests/UI/test_console_research_command.py
+++ b/Tests/UI/test_console_research_command.py
@@ -53,3 +53,15 @@ def test_intent_shape():
         question="q", source_policy="web_first", providers=["biomedical"]
     )
     assert intent.provider_overrides() == {"academic_providers": ["biomedical"]}
+
+
+def test_dangling_flag_token_is_a_usage_error():
+    with pytest.raises(ValueError, match="--policy needs a value"):
+        parse_research_command("--policy")  # flag with no value, no question
+    with pytest.raises(ValueError, match="--providers needs a value"):
+        parse_research_command("a question --providers")  # dangling at end
+
+
+def test_oversized_args_rejected_by_shared_validator():
+    with pytest.raises(ValueError, match="too long"):
+        parse_research_command("x" * 5000 + " --policy web_only")

--- a/Tests/UI/test_console_research_command.py
+++ b/Tests/UI/test_console_research_command.py
@@ -1,0 +1,55 @@
+"""Console /research flag parsing (task-16793)."""
+
+import pytest
+
+from tldw_chatbook.UI.Console_Modules.research_command import (
+    ResearchCommandIntent,
+    parse_research_command,
+)
+
+
+def test_plain_question():
+    intent = parse_research_command("what is RAG?")
+    assert intent.question == "what is RAG?"
+    assert intent.source_policy == "balanced"
+    assert intent.providers is None
+
+
+def test_policy_flag():
+    intent = parse_research_command("--policy academic_only why do neurons die?")
+    assert intent.source_policy == "academic_only"
+    assert intent.question == "why do neurons die?"
+
+
+def test_providers_flag_with_categories():
+    intent = parse_research_command(
+        "--policy web_first --providers biomedical,zenodo tau aggregation"
+    )
+    assert intent.source_policy == "web_first"
+    assert intent.providers == ["biomedical", "zenodo"]
+    assert intent.question == "tau aggregation"
+
+
+def test_flags_after_question():
+    intent = parse_research_command("how do gnn work --policy web_only")
+    assert intent.source_policy == "web_only"
+    assert intent.question == "how do gnn work"
+
+
+def test_invalid_policy_rejected():
+    with pytest.raises(ValueError, match="policy"):
+        parse_research_command("--policy sideways a question")
+
+
+def test_empty_question_rejected():
+    with pytest.raises(ValueError, match="question"):
+        parse_research_command("--policy web_only")
+
+
+def test_intent_shape():
+    intent = ResearchCommandIntent(question="q", source_policy="balanced")
+    assert intent.provider_overrides() is None
+    intent = ResearchCommandIntent(
+        question="q", source_policy="web_first", providers=["biomedical"]
+    )
+    assert intent.provider_overrides() == {"academic_providers": ["biomedical"]}

--- a/backlog/tasks/task-16792 - Port-the-servers-research-source-catalog-with-categories.md
+++ b/backlog/tasks/task-16792 - Port-the-servers-research-source-catalog-with-categories.md
@@ -1,0 +1,25 @@
+---
+id: TASK-16792
+title: Port the server's research source catalog with categories
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 14:31'
+updated_date: '2026-08-16 14:35'
+labels:
+  - research
+  - web-tools
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+tldw_server's Research discovery module carries a categorized source catalog - open_research_graph (OpenAlex, Semantic Scholar, Crossref), preprints (arXiv, BioRxiv, MedRxiv), biomedical (PubMed), repositories (Zenodo, Figshare, OSF) - with category-based selection, per-source metadata, and a selection cap. The chatbook's academic lane has five flat providers and no catalog, no categories, and is missing OpenAlex, Crossref, Zenodo, Figshare, and OSF entirely.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A source catalog module mirrors the server's entry fields (source_id, display_name, category, subcategory, content_types, access_level, priority, trust notes) for all ten sources,Category-based selection expands to member providers with dedupe and an unknown-token error path,OpenAlex, Crossref, Zenodo, Figshare, and OSF providers are implemented over the shared httpx retry ladder, keyless, normalizing to the DOI-dedup paper shape (OpenAlex abstracts reconstructed from the inverted index),search_papers accepts source ids AND category names in its providers selection,The window providers input and the baseline script accept categories too,Tests cover the catalog, category expansion, each new provider with mocked HTTP, and category-driven search_papers
+<!-- AC:END -->

--- a/backlog/tasks/task-16793 - Wire-policy-and-provider-flags-into-the-Console-research-command.md
+++ b/backlog/tasks/task-16793 - Wire-policy-and-provider-flags-into-the-Console-research-command.md
@@ -1,0 +1,25 @@
+---
+id: TASK-16793
+title: Wire policy and provider flags into the Console research command
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 14:31'
+updated_date: '2026-08-16 14:37'
+labels:
+  - research
+  - console
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Console /research command always launches balanced-policy runs with the default provider set; the engine now honors source_policy and provider_overrides but the command cannot express them.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 /research accepts a policy token (web_only, academic_only, web_first, academic_first, balanced) and a providers or category list,Both ride the launched run as source_policy and provider_overrides,Usage errors surface as native console messages,Tests cover flag parsing and the launch payload
+<!-- AC:END -->

--- a/backlog/tasks/task-16794 - Record-a-live-biomedical-lane-baseline.md
+++ b/backlog/tasks/task-16794 - Record-a-live-biomedical-lane-baseline.md
@@ -1,0 +1,32 @@
+---
+id: TASK-16794
+title: Record a live biomedical-lane baseline
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-16 14:31'
+updated_date: '2026-08-16 14:37'
+labels:
+  - research
+  - evals
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The recorded live baseline covers the academic lane's arXiv path only; the biomedical and repository providers have no live measurement.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] The baseline script gains a --providers flag accepting ids or categories,Biomedical questions are run through the lane with providers configured accordingly and scored,The baseline doc records the new live numbers alongside the existing academic-lane table
+<!-- AC:END -->
+
+## Implementation Notes (partial)
+
+- `--providers` shipped in this PR: accepts source ids or category names (expanded via the catalog), binding the lane to that set. AC 1 complete.
+- **Blocked on the local LLM endpoint**: the recorded baselines use the llama.cpp server at 127.0.0.1:52864, which is currently down (connection refused; no other local LLM found on common ports, and no cloud keys are configured). The relevance and synthesis LLMs are hard prerequisites for any scored run. Re-run once the endpoint is back:
+  `python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers biomedical --llm-base-url http://127.0.0.1:<port>/v1`
+  then record the numbers in `Docs/Development/research-report-eval-baseline.md` alongside the existing academic-lane table (ACs 2-3).

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -25,6 +25,8 @@ from loguru import logger
 
 from tldw_chatbook.config import get_cli_setting
 
+from .research_source_catalog import expand_source_selection
+
 __all__ = [
     "ARXIV_API_ENDPOINT",
     "BIORXIV_API_BASE",
@@ -42,6 +44,11 @@ ARXIV_API_ENDPOINT = "https://export.arxiv.org/api/query"
 SEMANTIC_SCHOLAR_API_ENDPOINT = "https://api.semanticscholar.org/graph/v1/paper/search"
 BIORXIV_API_BASE = "https://api.biorxiv.org"
 PUBMED_EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+OPENALEX_API_BASE = "https://api.openalex.org"
+CROSSREF_API_BASE = "https://api.crossref.org"
+ZENODO_API_BASE = "https://zenodo.org/api/records"
+FIGSHARE_API_BASE = "https://api.figshare.com/v2/articles/search"
+OSF_API_BASE = "https://api.osf.io/v2/preprints"
 
 DEFAULT_TIMEOUT_S = 30.0
 DEFAULT_MAX_RETRIES = 2
@@ -58,6 +65,41 @@ _ARXIV_ID_RE = re.compile(r"arxiv\.org/abs/([^v/\s]+)", re.IGNORECASE)
 class AcademicProviderError(Exception):
     """A provider request failed after exhausting retries (or hit a
     non-retryable HTTP error)."""
+
+
+def _request_with_retries_json(
+    client: Any,
+    method: str,
+    url: str,
+    *,
+    timeout: Any,
+    max_retries: int,
+    body: dict[str, Any],
+) -> Any:
+    """JSON-body variant of the retry ladder (Figshare's POST search)."""
+    last_failure: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            response = client.request(
+                method, url, json=body, timeout=timeout
+            )
+            status = int(getattr(response, "status_code", 0) or 0)
+            if status in _RETRYABLE_STATUS:
+                last_failure = AcademicProviderError(f"http {status} from {url}")
+                if attempt < max_retries:
+                    _sleep_backoff(attempt)
+                    continue
+                raise last_failure
+            if status >= 400:
+                raise AcademicProviderError(f"http {status} from {url}")
+            return response
+        except httpx.TransportError as exc:
+            last_failure = exc
+            if attempt < max_retries:
+                _sleep_backoff(attempt)
+                continue
+            raise AcademicProviderError(f"{url} failed after {max_retries + 1} attempt(s): {exc}") from exc
+    raise AcademicProviderError(f"{url} failed: {last_failure}")
 
 
 def _sleep_backoff(attempt: int) -> None:
@@ -407,6 +449,405 @@ def merge_evidence_pools(
     return merged
 
 
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_tags(text: str | None) -> str | None:
+    """Strip HTML/JATS tags and collapse whitespace (Crossref abstracts,
+    Zenodo/Figshare descriptions)."""
+    if not text:
+        return None
+    return " ".join(_TAG_RE.sub("", text).split()) or None
+
+
+def _clean_doi(raw: str | None) -> str | None:
+    """Normalize a DOI to its bare form (OpenAlex prefixes https://doi.org/)."""
+    if not raw:
+        return None
+    return raw.removeprefix("https://doi.org/").removeprefix("doi:") or None
+
+
+def _invert_abstract(index: dict[str, list[int]] | None) -> str | None:
+    """Reconstruct an abstract from OpenAlex's inverted index."""
+    if not isinstance(index, dict):
+        return None
+    words: dict[int, str] = {}
+    for word, positions in index.items():
+        for position in positions or []:
+            words[int(position)] = word
+    return " ".join(words[i] for i in sorted(words)) or None
+
+
+def search_openalex(
+    query: str,
+    *,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search OpenAlex works (task-16792; server catalog parity).
+
+    Args:
+        query: The search term.
+        results_per_page: Page size (per-page).
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget.
+
+    Returns:
+        The runner dict shape (abstracts reconstructed from the inverted
+        index; DOIs normalized; ``source`` set to ``"openalex"``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard error.
+    """
+    params = {
+        "search": query,
+        "per-page": max(1, results_per_page),
+        "page": 1,
+    }
+    if client is not None:
+        response = _request_with_retries(
+            client, "GET", f"{OPENALEX_API_BASE}/works",
+            timeout=timeout, max_retries=max_retries, params=params,
+        )
+        data = json.loads(response.text)
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries(
+                http, "GET", f"{OPENALEX_API_BASE}/works",
+                timeout=timeout, max_retries=max_retries, params=params,
+            )
+            data = json.loads(response.text)
+
+    items: list[dict[str, Any]] = []
+    for raw in data.get("results") or []:
+        if not isinstance(raw, dict):
+            continue
+        location = raw.get("primary_location") or {}
+        doi = _clean_doi(raw.get("doi"))
+        items.append(
+            {
+                "id": raw.get("id"),
+                "doi": doi,
+                "title": raw.get("title"),
+                "authors": ", ".join(
+                    str((a.get("author") or {}).get("display_name"))
+                    for a in (raw.get("authorships") or [])
+                    if isinstance(a, dict) and (a.get("author") or {}).get("display_name")
+                ) or None,
+                "published_date": str(raw.get("publication_year") or "") or None,
+                "abstract": _invert_abstract(raw.get("abstract_inverted_index")),
+                "url": location.get("landing_page_url") or (
+                    f"https://doi.org/{doi}" if doi else None
+                ),
+                "pdf_url": location.get("pdf_url"),
+                "source": "openalex",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query},
+        "items": items,
+        "total_results": int((data.get("meta") or {}).get("count") or 0),
+        "results_per_page": results_per_page,
+    }
+
+
+def search_crossref(
+    query: str,
+    *,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search Crossref works (task-16792; server catalog parity).
+
+    Args:
+        query: The search term.
+        results_per_page: Page size (rows).
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget.
+
+    Returns:
+        The runner dict shape (JATS stripped from abstracts; ``source``
+        set to ``"crossref"``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard error.
+    """
+    params = {"query": query, "rows": max(1, results_per_page), "offset": 0}
+    if client is not None:
+        response = _request_with_retries(
+            client, "GET", f"{CROSSREF_API_BASE}/works",
+            timeout=timeout, max_retries=max_retries, params=params,
+        )
+        data = json.loads(response.text)
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries(
+                http, "GET", f"{CROSSREF_API_BASE}/works",
+                timeout=timeout, max_retries=max_retries, params=params,
+            )
+            data = json.loads(response.text)
+
+    message = data.get("message") or {}
+    items: list[dict[str, Any]] = []
+    for raw in message.get("items") or []:
+        if not isinstance(raw, dict):
+            continue
+        authors = ", ".join(
+            f"{a.get('given', '').strip()} {a.get('family', '').strip()}".strip()
+            for a in (raw.get("author") or [])
+            if isinstance(a, dict)
+        ).strip() or None
+        issued = raw.get("issued") or {}
+        date_parts = (issued.get("date-parts") or [[None]])[0]
+        items.append(
+            {
+                "id": raw.get("DOI"),
+                "doi": _clean_doi(raw.get("DOI")),
+                "title": (raw.get("title") or [None])[0],
+                "authors": authors,
+                "published_date": str(date_parts[0]) if date_parts and date_parts[0] else None,
+                "abstract": _strip_tags(raw.get("abstract")),
+                "url": f"https://doi.org/{raw['DOI']}" if raw.get("DOI") else None,
+                "pdf_url": None,
+                "source": "crossref",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query},
+        "items": items,
+        "total_results": int(message.get("total-results") or 0),
+        "results_per_page": results_per_page,
+    }
+
+
+def search_zenodo(
+    query: str,
+    *,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search Zenodo records (task-16792; server catalog parity).
+
+    Args:
+        query: The search term.
+        results_per_page: Page size.
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget.
+
+    Returns:
+        The runner dict shape (HTML stripped from descriptions;
+        ``source`` set to ``"zenodo"``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard error.
+    """
+    params = {"q": query, "size": max(1, results_per_page), "page": 1}
+    if client is not None:
+        response = _request_with_retries(
+            client, "GET", ZENODO_API_BASE,
+            timeout=timeout, max_retries=max_retries, params=params,
+        )
+        data = json.loads(response.text)
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries(
+                http, "GET", ZENODO_API_BASE,
+                timeout=timeout, max_retries=max_retries, params=params,
+            )
+            data = json.loads(response.text)
+
+    hits = (data.get("hits") or {})
+    items: list[dict[str, Any]] = []
+    for raw in hits.get("hits") or []:
+        if not isinstance(raw, dict):
+            continue
+        metadata = raw.get("metadata") or {}
+        record_id = raw.get("id")
+        items.append(
+            {
+                "id": str(record_id) if record_id is not None else None,
+                "doi": _clean_doi(raw.get("doi")),
+                "title": metadata.get("title"),
+                "authors": ", ".join(
+                    str(c.get("name"))
+                    for c in (metadata.get("creators") or [])
+                    if isinstance(c, dict) and c.get("name")
+                ) or None,
+                "published_date": metadata.get("publication_date"),
+                "abstract": _strip_tags(metadata.get("description")),
+                "url": f"https://zenodo.org/records/{record_id}" if record_id is not None else None,
+                "pdf_url": None,
+                "source": "zenodo",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query},
+        "items": items,
+        "total_results": int(hits.get("total") or 0),
+        "results_per_page": results_per_page,
+    }
+
+
+def search_figshare(
+    query: str,
+    *,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search Figshare articles (task-16792; server catalog parity --
+    POST search, matching the server's adapter).
+
+    Args:
+        query: The search term.
+        results_per_page: Page size.
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget.
+
+    Returns:
+        The runner dict shape (HTML stripped from descriptions;
+        ``source`` set to ``"figshare"``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard error.
+    """
+    body = {"search_for": query, "page": 1, "page_size": max(1, results_per_page)}
+    if client is not None:
+        response = _request_with_retries_json(
+            client, "POST", FIGSHARE_API_BASE, timeout=timeout,
+            max_retries=max_retries, body=body,
+        )
+        data = json.loads(response.text)
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries_json(
+                http, "POST", FIGSHARE_API_BASE, timeout=timeout,
+                max_retries=max_retries, body=body,
+            )
+            data = json.loads(response.text)
+
+    items: list[dict[str, Any]] = []
+    for raw in data if isinstance(data, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        article_id = raw.get("id")
+        items.append(
+            {
+                "id": str(article_id) if article_id is not None else None,
+                "doi": _clean_doi(raw.get("doi")),
+                "title": raw.get("title"),
+                "authors": ", ".join(
+                    str(a.get("full_name"))
+                    for a in (raw.get("authors") or [])
+                    if isinstance(a, dict) and a.get("full_name")
+                ) or None,
+                "published_date": str(raw.get("published_date") or "") or None,
+                "abstract": _strip_tags(raw.get("description")),
+                "url": raw.get("url_publication") or raw.get("url") or (
+                    f"https://figshare.com/articles/_{article_id}" if article_id is not None else None
+                ),
+                "pdf_url": raw.get("download_url"),
+                "source": "figshare",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query},
+        "items": items,
+        "total_results": len(items),
+        "results_per_page": results_per_page,
+    }
+
+
+def search_osf(
+    query: str,
+    *,
+    results_per_page: int = 5,
+    client: Any = None,
+    timeout: Any = DEFAULT_TIMEOUT_S,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any]:
+    """Search OSF preprints (task-16792; server catalog parity).
+
+    Args:
+        query: The search term.
+        results_per_page: Page size (page[size], capped at the API's 100).
+        client: Injectable httpx-like client for tests.
+        timeout: Per-request timeout.
+        max_retries: Retry budget.
+
+    Returns:
+        The runner dict shape (``source`` set to ``"osf"``; dates truncated
+        to ``YYYY-MM-DD``).
+
+    Raises:
+        AcademicProviderError: After exhausting retries or on a hard error.
+    """
+    params = {
+        "q": query,
+        "page[size]": max(1, min(results_per_page, 100)),
+        "page[number]": 1,
+    }
+    if client is not None:
+        response = _request_with_retries(
+            client, "GET", OSF_API_BASE,
+            timeout=timeout, max_retries=max_retries, params=params,
+        )
+        data = json.loads(response.text)
+    else:
+        with httpx.Client() as http:
+            response = _request_with_retries(
+                http, "GET", OSF_API_BASE,
+                timeout=timeout, max_retries=max_retries, params=params,
+            )
+            data = json.loads(response.text)
+
+    items: list[dict[str, Any]] = []
+    for raw in data.get("data") or []:
+        if not isinstance(raw, dict):
+            continue
+        attributes = raw.get("attributes") or {}
+        links = raw.get("links") or {}
+        osf_id = raw.get("id")
+        created = str(attributes.get("date_created") or "")
+        items.append(
+            {
+                "id": osf_id,
+                "doi": _clean_doi(attributes.get("doi")),
+                "title": attributes.get("title"),
+                "authors": None,
+                "published_date": created[:10] if created else None,
+                "abstract": _strip_tags(attributes.get("description")),
+                "url": links.get("html") or (
+                    f"https://osf.io/preprints/{osf_id}" if osf_id else None
+                ),
+                "pdf_url": None,
+                "source": "osf",
+            }
+        )
+
+    return {
+        "query_echo": {"query": query},
+        "items": items,
+        "total_results": len(items),
+        "results_per_page": results_per_page,
+    }
+
+
 def search_biorxiv(
     query: str,
     *,
@@ -752,15 +1193,40 @@ async def search_papers(
     def _pubmed_lane() -> Any:
         return search_pubmed(query=topic_query, results_per_page=results_per_page)
 
+    def _openalex_lane() -> Any:
+        return search_openalex(query=topic_query, results_per_page=results_per_page)
+
+    def _crossref_lane() -> Any:
+        return search_crossref(query=topic_query, results_per_page=results_per_page)
+
+    def _zenodo_lane() -> Any:
+        return search_zenodo(query=topic_query, results_per_page=results_per_page)
+
+    def _figshare_lane() -> Any:
+        return search_figshare(query=topic_query, results_per_page=results_per_page)
+
+    def _osf_lane() -> Any:
+        return search_osf(query=topic_query, results_per_page=results_per_page)
+
     lanes: dict[str, Any] = {
         "arxiv": _arxiv_lane,
         "semantic_scholar": _s2_lane,
         "biorxiv": _biorxiv_lane,
         "medrxiv": _medrxiv_lane,
         "pubmed": _pubmed_lane,
+        "openalex": _openalex_lane,
+        "crossref": _crossref_lane,
+        "zenodo": _zenodo_lane,
+        "figshare": _figshare_lane,
+        "osf": _osf_lane,
     }
-    requested = (
-        providers if providers is not None else _default_academic_providers()
+    # task-16792: tokens may be source ids OR category names ("biomedical",
+    # "repositories", ...); unknown names raise instead of silently
+    # narrowing the search.
+    requested = expand_source_selection(
+        list(providers)
+        if providers is not None
+        else _default_academic_providers()
     )
     selected: list[str] = []
     for name in requested:
@@ -768,8 +1234,8 @@ async def search_papers(
             selected.append(name)
     dropped = [name for name in requested if name not in lanes]
     if dropped:
-        # Warns for BOTH explicit lists and config-driven defaults: a typo
-        # in [SearchSettings] must be as visible as one in the window.
+        # Defense in depth: expand_source_selection already rejects unknown
+        # tokens, but a future lane rename must not silently narrow.
         logger.warning(f"search_papers ignoring unknown providers: {dropped}")
 
     async def _lane_runner(name: str, lane: Any) -> Any:

--- a/tldw_chatbook/Research_Interop/local_research_search_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_search_service.py
@@ -6,6 +6,7 @@ import inspect
 from typing import Any, Callable
 
 from ..runtime_policy.types import PolicyDeniedError
+from .research_source_catalog import catalog_entries
 
 
 LOCAL_SUPPORTED_WEBSEARCH_ENGINES = {
@@ -21,7 +22,9 @@ LOCAL_SUPPORTED_WEBSEARCH_ENGINES = {
     "tavily",
     "yandex",
 }
-LOCAL_SUPPORTED_PAPER_PROVIDERS = ("arxiv", "semantic_scholar")
+# task-16792: the paper-provider listing IS the catalog (one source of
+# truth -- a hardcoded tuple here drifted from the runnable lanes).
+LOCAL_SUPPORTED_PAPER_PROVIDERS = tuple(e.source_id for e in catalog_entries())
 
 
 class LocalResearchSearchService:

--- a/tldw_chatbook/Research_Interop/research_source_catalog.py
+++ b/tldw_chatbook/Research_Interop/research_source_catalog.py
@@ -1,0 +1,228 @@
+"""Research source catalog with categories (task-16792).
+
+Port of tldw_server dev's ``Research/discovery/catalog.py``: the categorized
+source list behind discovery-lane selection. The chatbook's academic lane
+consumes it through ``expand_source_selection`` — callers may name individual
+sources ("pubmed") or whole categories ("biomedical", "repositories") — and
+the window/baseline/Console surfaces accept the same tokens.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+__all__ = [
+    "CATEGORIES",
+    "SOURCES_BY_CATEGORY",
+    "ResearchSourceCatalogEntry",
+    "catalog_entries",
+    "expand_source_selection",
+]
+
+
+@dataclass(frozen=True)
+class ResearchSourceCatalogEntry:
+    """One selectable research source (server catalog-entry parity).
+
+    Attributes:
+        source_id: Stable selection token (also the provider lane name).
+        display_name: Human-readable name.
+        category: Coarse grouping used for category-based selection.
+        subcategory: Optional finer grouping.
+        content_types: What the source returns (papers, datasets, ...).
+        access_level: Server-parity access descriptor
+            (``open_metadata`` / ``open_full_text`` / ``open_repository``).
+        priority: Lower runs earlier in fan-outs (server ordering parity).
+        provider_adapter: The executing provider lane (== source_id here).
+        trust_notes: One-line provenance/trust description.
+    """
+
+    source_id: str
+    display_name: str
+    category: str
+    content_types: Tuple[str, ...]
+    access_level: str
+    priority: int
+    trust_notes: str
+    subcategory: str | None = None
+    provider_adapter: str | None = None
+
+
+def _entry(
+    *,
+    source_id: str,
+    display_name: str,
+    category: str,
+    content_types: Tuple[str, ...],
+    access_level: str,
+    priority: int,
+    trust_notes: str,
+    subcategory: str | None = None,
+) -> ResearchSourceCatalogEntry:
+    return ResearchSourceCatalogEntry(
+        source_id=source_id,
+        display_name=display_name,
+        category=category,
+        content_types=content_types,
+        access_level=access_level,
+        priority=priority,
+        trust_notes=trust_notes,
+        subcategory=subcategory,
+        provider_adapter=source_id,
+    )
+
+
+def catalog_entries() -> Tuple[ResearchSourceCatalogEntry, ...]:
+    """The default catalog (server ``_default_entries`` parity, plus the
+    BioRxiv/MedRxiv preprint pair the server splits by server param).
+
+    Returns:
+        All catalog entries ordered by priority.
+    """
+    return (
+        _entry(
+            source_id="openalex",
+            display_name="OpenAlex",
+            category="open_research_graph",
+            content_types=("works", "authors", "institutions", "venues"),
+            access_level="open_metadata",
+            priority=10,
+            trust_notes="Open scholarly graph with broad metadata coverage.",
+        ),
+        _entry(
+            source_id="semantic_scholar",
+            display_name="Semantic Scholar",
+            category="open_research_graph",
+            content_types=("papers", "citations", "recommendations"),
+            access_level="open_metadata",
+            priority=20,
+            trust_notes="Open metadata and citation graph with API rate limits.",
+        ),
+        _entry(
+            source_id="crossref",
+            display_name="Crossref",
+            category="open_research_graph",
+            content_types=("works", "publishers", "funders"),
+            access_level="open_metadata",
+            priority=30,
+            trust_notes="Publisher DOI metadata registry.",
+        ),
+        _entry(
+            source_id="arxiv",
+            display_name="arXiv",
+            category="preprints",
+            subcategory="general_preprints",
+            content_types=("preprints", "papers"),
+            access_level="open_full_text",
+            priority=40,
+            trust_notes="Open preprint repository with direct full-text access.",
+        ),
+        _entry(
+            source_id="biorxiv",
+            display_name="BioRxiv",
+            category="preprints",
+            subcategory="biomedical_preprints",
+            content_types=("preprints", "papers"),
+            access_level="open_full_text",
+            priority=45,
+            trust_notes="Biology preprint server; shared API with MedRxiv.",
+        ),
+        _entry(
+            source_id="medrxiv",
+            display_name="MedRxiv",
+            category="preprints",
+            subcategory="biomedical_preprints",
+            content_types=("preprints", "papers"),
+            access_level="open_full_text",
+            priority=46,
+            trust_notes="Health-sciences preprint server; shared API with BioRxiv.",
+        ),
+        _entry(
+            source_id="pubmed",
+            display_name="PubMed",
+            category="biomedical",
+            content_types=("papers", "abstracts", "biomedical_metadata"),
+            access_level="open_metadata",
+            priority=50,
+            trust_notes="Biomedical literature metadata from NCBI.",
+        ),
+        _entry(
+            source_id="zenodo",
+            display_name="Zenodo",
+            category="repositories",
+            content_types=("datasets", "software", "papers"),
+            access_level="open_repository",
+            priority=60,
+            trust_notes="Open research repository operated by CERN.",
+        ),
+        _entry(
+            source_id="figshare",
+            display_name="Figshare",
+            category="repositories",
+            content_types=("datasets", "figures", "papers"),
+            access_level="open_repository",
+            priority=70,
+            trust_notes="Research repository for datasets, figures, and papers.",
+        ),
+        _entry(
+            source_id="osf",
+            display_name="OSF",
+            category="repositories",
+            content_types=("projects", "registrations", "preprints"),
+            access_level="open_repository",
+            priority=80,
+            trust_notes="Open Science Framework project and registration metadata.",
+        ),
+    )
+
+
+def sources_by_category() -> dict[str, Tuple[str, ...]]:
+    """Category -> member source ids, in priority order.
+
+    Returns:
+        The grouping used for category-based selection.
+    """
+    grouped: dict[str, list[str]] = {}
+    for entry in catalog_entries():
+        grouped.setdefault(entry.category, []).append(entry.source_id)
+    return {category: tuple(ids) for category, ids in grouped.items()}
+
+
+SOURCES_BY_CATEGORY = sources_by_category()
+CATEGORIES = tuple(SOURCES_BY_CATEGORY)
+
+
+def expand_source_selection(tokens: list[str]) -> list[str]:
+    """Expand a mix of source ids and category names to provider ids
+    (deduped, first-seen order — category order is catalog priority).
+
+    Args:
+        tokens: Source ids ("pubmed") and/or category names ("biomedical").
+
+    Returns:
+        The expanded, deduplicated provider-id list.
+
+    Raises:
+        ValueError: Naming any token that is neither a known source id nor
+            a known category.
+    """
+    ids_by_category = sources_by_category()
+    known_sources = {e.source_id for e in catalog_entries()}
+    unknown = [
+        token for token in tokens
+        if token not in known_sources and token not in ids_by_category
+    ]
+    if unknown:
+        raise ValueError(
+            f"unknown research source or category: {', '.join(unknown)}"
+        )
+    expanded: list[str] = []
+    for token in tokens:
+        candidates = (
+            ids_by_category[token] if token in ids_by_category else (token,)
+        )
+        for source_id in candidates:
+            if source_id not in expanded:
+                expanded.append(source_id)
+    return expanded

--- a/tldw_chatbook/UI/Console_Modules/research_command.py
+++ b/tldw_chatbook/UI/Console_Modules/research_command.py
@@ -1,0 +1,114 @@
+"""Console ``/research`` command intent parsing (task-16793).
+
+Pure parser shared by the Console dispatch: extracts an optional policy
+token (``--policy web_only|academic_only|web_first|academic_first|balanced``)
+and an optional providers/categories list (``--providers biomedical,zenodo``)
+from the command args, rejecting anything malformed before any run launches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "RESEARCH_POLICIES",
+    "ResearchCommandIntent",
+    "parse_research_command",
+]
+
+RESEARCH_POLICIES = (
+    "web_only",
+    "academic_only",
+    "web_first",
+    "academic_first",
+    "balanced",
+)
+
+def _extract_flags(args: str) -> tuple[dict[str, str], str]:
+    """Split --flag value tokens out of the args.
+
+    Returns:
+        (flags dict, remaining question text). Flags may appear anywhere;
+        a flag consumes exactly the next whitespace-delimited token.
+    """
+    flags: dict[str, str] = {}
+    kept: list[str] = []
+    tokens = args.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in ("--policy", "--providers") and index + 1 < len(tokens):
+            flags[token.lstrip("-")] = tokens[index + 1]
+            index += 2
+            continue
+        kept.append(token)
+        index += 1
+    return flags, " ".join(kept)
+
+
+@dataclass(frozen=True)
+class ResearchCommandIntent:
+    """A parsed ``/research`` invocation.
+
+    Attributes:
+        question: The research question (flags stripped).
+        source_policy: The lane policy for the launched run.
+        providers: Optional source-id/category tokens for the academic lane.
+    """
+
+    question: str
+    source_policy: str = "balanced"
+    providers: list[str] | None = None
+
+    def provider_overrides(self) -> dict[str, Any] | None:
+        """The run's provider_overrides payload (None when unfiltered).
+
+        Returns:
+            ``{"academic_providers": [...]}`` when providers were given,
+            else None.
+        """
+        if self.providers:
+            return {"academic_providers": list(self.providers)}
+        return None
+
+
+def parse_research_command(args: str) -> ResearchCommandIntent:
+    """Parse ``/research`` arguments into a launch intent.
+
+    Args:
+        args: The raw text after the command word.
+
+    Returns:
+        The parsed intent (question, policy, providers).
+
+    Raises:
+        ValueError: For an unknown policy, an empty question, or empty
+            provider lists.
+    """
+    policy = "balanced"
+    providers: list[str] | None = None
+
+    flags, question = _extract_flags(str(args or ""))
+
+    if "policy" in flags:
+        value = flags["policy"].lower()
+        if value not in RESEARCH_POLICIES:
+            raise ValueError(
+                f"unknown policy {value!r}; expected one of {RESEARCH_POLICIES}"
+            )
+        policy = value
+
+    if "providers" in flags:
+        tokens = [t.strip().lower() for t in flags["providers"].split(",") if t.strip()]
+        if not tokens:
+            raise ValueError("--providers needs at least one name or category")
+        providers = tokens
+
+    question = question.strip()
+    if not question:
+        raise ValueError("--policy/--providers given but no question remains")
+
+    return ResearchCommandIntent(
+        question=question, source_policy=policy, providers=providers
+    )

--- a/tldw_chatbook/UI/Console_Modules/research_command.py
+++ b/tldw_chatbook/UI/Console_Modules/research_command.py
@@ -28,6 +28,9 @@ RESEARCH_POLICIES = (
 def _extract_flags(args: str) -> tuple[dict[str, str], str]:
     """Split --flag value tokens out of the args.
 
+    Args:
+        args: The raw /research argument text.
+
     Returns:
         (flags dict, remaining question text). Flags may appear anywhere;
         a flag consumes exactly the next whitespace-delimited token.
@@ -86,10 +89,20 @@ def parse_research_command(args: str) -> ResearchCommandIntent:
         ValueError: For an unknown policy, an empty question, or empty
             provider lists.
     """
+    from tldw_chatbook.Utils.input_validation import validate_text_input
+
+    raw_args = str(args or "")
+    if not validate_text_input(raw_args, max_length=2000):
+        raise ValueError("arguments too long or contain invalid content")
+
     policy = "balanced"
     providers: list[str] | None = None
 
-    flags, question = _extract_flags(str(args or ""))
+    flags, question = _extract_flags(raw_args)
+    if "--policy" in raw_args.split() and "policy" not in flags:
+        raise ValueError("--policy needs a value")
+    if "--providers" in raw_args.split() and "providers" not in flags:
+        raise ValueError("--providers needs a value")
 
     if "policy" in flags:
         value = flags["policy"].lower()

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-
-from loguru import logger
 from typing import Any
 
 from textual import on
+
+from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import (

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+
+from loguru import logger
 from typing import Any
 
 from textual import on
@@ -28,27 +30,37 @@ from tldw_chatbook.UI.Research_Modules.bundle_rendering import (
 )
 
 
-_KNOWN_ACADEMIC_PROVIDERS = {
-    "arxiv", "semantic_scholar", "biorxiv", "medrxiv", "pubmed",
-}
-
-
 def _parse_provider_tokens(text: str | None) -> list[str]:
-    """Parse and validate the providers input (task-16791/Qodo): the raw
-    text goes through the shared input validator (dangerous-pattern and
-    length checks), tokens are lowercased and deduplicated in order, and
-    anything unknown is dropped -- a typo must not silently widen or
-    misroute the provider set. Returns [] when the input is invalid."""
+    """Parse and validate the providers input (task-16791/Qodo +
+    task-16792): the raw text goes through the shared input validator, then
+    tokens -- source ids ("pubmed") OR category names ("biomedical",
+    "repositories", ...) -- are validated against the catalog and
+    deduplicated in order. Unknown tokens drop to a warning rather than
+    silently narrowing; invalid input drops the whole list."""
     from tldw_chatbook.Utils.input_validation import validate_text_input
+
+    from ..Research_Interop.research_source_catalog import (
+        CATEGORIES,
+        catalog_entries,
+    )
 
     raw = str(text or "")
     if not validate_text_input(raw, max_length=200):
         return []
+    known = {e.source_id for e in catalog_entries()} | set(CATEGORIES)
     seen: list[str] = []
+    unknown: list[str] = []
     for part in raw.split(","):
         token = part.strip().lower()
-        if token and token in _KNOWN_ACADEMIC_PROVIDERS and token not in seen:
-            seen.append(token)
+        if not token:
+            continue
+        if token in known:
+            if token not in seen:
+                seen.append(token)
+        else:
+            unknown.append(token)
+    if unknown:
+        logger.warning(f"providers input ignored unknown tokens: {unknown}")
     return seen
 
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -16878,12 +16878,20 @@ class ChatScreen(BaseAppScreen):
         message on completion, and the existing terminal-run notification
         remains the fallback when insertion is impossible.
         """
-        question = (parse.args or "").strip()
-        if not question:
+        from tldw_chatbook.UI.Console_Modules.research_command import (
+            parse_research_command,
+        )
+
+        try:
+            intent = parse_research_command(parse.args or "")
+        except ValueError as usage_error:
             await self._append_native_console_system_message(
-                "Usage: /research <question>"
+                f"/research: {usage_error}"
             )
             return
+        question = intent.question
+        source_policy = intent.source_policy
+        provider_overrides = intent.provider_overrides()
         conversation_id = self._current_console_conversation_id()
         if not conversation_id:
             await self._append_native_console_system_message(
@@ -16924,10 +16932,14 @@ class ChatScreen(BaseAppScreen):
         db = getattr(app, "chachanotes_db", None)
 
         async def _run_research() -> None:
-            run = local_service.launch_run(
-                query=question,
-                chat_handoff={"conversation_id": conversation_id, "origin": "console"},
-            )
+            launch_kwargs: dict = {
+                "query": question,
+                "chat_handoff": {"conversation_id": conversation_id, "origin": "console"},
+                "source_policy": source_policy,
+            }
+            if provider_overrides:
+                launch_kwargs["provider_overrides"] = provider_overrides
+            run = local_service.launch_run(**launch_kwargs)
             engine = LocalResearchEngine(
                 local_service,
                 search_params=search_params,
@@ -16949,8 +16961,11 @@ class ChatScreen(BaseAppScreen):
             exclusive=False,
             description=f"Console research: {question[:60]}",
         )
+        policy_note = (
+            f" [policy: {source_policy}]" if source_policy != "balanced" else ""
+        )
         await self._append_native_console_system_message(
-            f"Deep research started: {question}\n"
+            f"Deep research started: {question}{policy_note}\n"
             "The report will be added to this conversation when the run "
             "completes."
         )


### PR DESCRIPTION
## Summary

Port of tldw_server's **Research discovery source catalog** — the categorized source lists — plus the Console policy wiring (tasks 16792–16794).

### The catalog (task 16792)
- `research_source_catalog.py` mirrors the server's entry fields (source_id, display_name, category, subcategory, content_types, access_level, priority, trust_notes) for **all ten sources**:
  - `open_research_graph`: OpenAlex, Semantic Scholar, Crossref
  - `preprints`: arXiv, BioRxiv, MedRxiv
  - `biomedical`: PubMed
  - `repositories`: Zenodo, Figshare, OSF
- `expand_source_selection` mixes source ids and category names ("biomedical", "repositories"), dedupes, and **rejects unknown tokens** — including in the config default list, where a typo now raises instead of silently narrowing.
- **Five new keyless providers**: OpenAlex (abstracts reconstructed from the inverted index, DOI prefixes normalized), Crossref (JATS stripped from abstracts), Zenodo (HTML stripped from descriptions), Figshare (POST search, matching the server adapter), OSF preprints — all on the shared httpx retry ladder and normalizing to the DOI-dedup paper shape.
- `search_papers(providers=...)`, the window's providers input, and the baseline script's new `--providers` flag all accept **ids or categories**.

### Console policy flags (task 16793)
`/research --policy academic_only --providers biomedical <question>` — a pure tokenizer/parser (`research_command.py`) extracts both flags (usable before or after the question), usage errors surface as native console messages, and both ride the launched run (`source_policy`, `provider_overrides`).

### Baseline (task 16794)
`--providers` shipped. The live biomedical run is **blocked on the local llama.cpp endpoint being down** (connection refused; documented in the task with the exact re-run command).

## Test evidence
TDD: 17 new tests (catalog shape/grouping/expansion, each provider with mocked HTTP, category-driven search_papers, config-typo rejection, parser matrix). Suites 216 passed; ruff clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a categorized research source catalog and wires `--policy`/`--providers` into Console runs. Previously providers were a flat list and Console always used balanced policy; now ids or categories are accepted across entry points, unknown tokens fail fast, and the local provider listing derives from the catalog to prevent drift.

- Catalog: four categories — open_research_graph (OpenAlex, Semantic Scholar, Crossref), preprints (arXiv, BioRxiv, MedRxiv), biomedical (PubMed), repositories (Zenodo, Figshare, OSF). `expand_source_selection` mixes ids and categories, dedupes, and raises on unknown names; `LOCAL_SUPPORTED_PAPER_PROVIDERS` now comes from the catalog.
- Providers: adds keyless OpenAlex (abstracts reconstructed; DOI normalized), Crossref (JATS stripped), Zenodo (HTML stripped), Figshare (POST search), and OSF; all use the shared retry ladder and normalize to the DOI-dedup paper shape.
- APIs/Console: `search_papers`, the Research window’s providers input, and the baseline script’s `--providers` flag accept ids or categories. Console `/research` accepts `--policy web_only|academic_only|web_first|academic_first|balanced` and `--providers ...`; the parser uses the shared input validator and rejects dangling flags; runs carry `source_policy` and `provider_overrides`. Baseline `--providers` shipped; recording biomedical numbers requires a running local LLM.

**Rollout**
- Action: audit any default provider list in config; unknown ids or categories now raise in `search_papers` instead of being ignored.
- Optional: start your local LLM endpoint and rerun the biomedical baseline.

<sup>Written for commit 62b727f53a0383b48dbcb4ecceeff380226fb4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

