### PR TITLE
docs(agents): ask before full test sweeps, default to targeted runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,8 @@ Key sections:
 
 ### Testing
 
-- Run full suite before PRs
+- **Ask before full sweeps**: before running the full test suite, ask whether a full sweep is wanted. Unless the user opts in, verify with targeted runs only — the tests touching the modified files/functionality
+- Run the full suite only when the user asks for it (e.g. pre-PR/pre-merge verification they explicitly request)
 - Use real SQLite in-memory for DB tests
 - Property-based testing with Hypothesis
 - Markers: unit, integration, optional, asyncio


### PR DESCRIPTION
## Summary

Codifies the verification policy for agents working in this repo:

- **Ask before full sweeps** — before running the full test suite, ask whether a full sweep is wanted. Unless the user opts in, verify with targeted runs only: the tests touching the modified files/functionality.
- Full-suite runs are reserved for explicitly requested pre-PR/pre-merge verification.

Docs-only change to `AGENTS.md` (Testing section); no code touched.

## Context

Established during PR #1721, where the full-suite sweep was repeatedly the most expensive part of verification while targeted runs already covered every modified surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the agent testing policy: agents must ask before running the full test suite and default to targeted runs. Previously agents ran the full suite before PRs; now the full suite runs only on explicit request to reduce time and compute cost.

- Docs-only change in `AGENTS.md` (Testing section); no code or CI changes.
- Agents must ask before starting a full test suite run; otherwise run only tests touching modified files.
- Use the full test suite on explicit request for pre-PR or pre-merge verification.
- No migration required; update any agent runbooks or automation to honor the ask-first default.

<sup>Written for commit 2bb4521f4ad292613cde3cdd7677ed78c8c90ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

