### PR TITLE
fix(console): repair the dev-red switcher pair and unmount-repair row (task-16792)

### DIFF
--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -5403,10 +5403,28 @@ async def test_mounted_console_cancel_latest_waiter_keeps_durable_c() -> None:
 
 @pytest.mark.asyncio
 async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume():
-    class RecordingPersistence:
+    class HungFirstWritePersistence:
+        """One shared-store double: the FIRST system-prompt write blocks.
+
+        task-16792 fixture correction: the Console runtime/store became
+        app-owned (task-15860), so two co-mounted ChatScreens share ONE
+        store -- the original per-screen persistence pair aliased to a
+        single store and the repair write bound to the hung double
+        (stack-verified 2026-08-16). One double now serves both roles:
+        the hung screen's refresh write blocks until released; every
+        later write (the app-level repair force-persist) records. The
+        contract under test is unchanged: unmount bounds a stuck writer,
+        and the repair persists the latest identity even while the
+        original write is still blocked.
+        """
+
         def __init__(self) -> None:
             self.durable_system = "Speak with Alpha."
             self.durable_greeting = "Hello Alpha."
+            self.started = threading.Event()
+            self.release = threading.Event()
+            self.finished = threading.Event()
+            self.first_system_write_seen = False
 
         def create_message(self, **kwargs):
             self.durable_greeting = kwargs["content"]
@@ -5416,6 +5434,15 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
             return True
 
         def update_conversation_system_prompt(self, **kwargs):
+            first_write = not self.first_system_write_seen
+            self.first_system_write_seen = True
+            if first_write:
+                self.started.set()
+                try:
+                    assert self.release.wait(10)
+                    return True
+                finally:
+                    self.finished.set()
             self.durable_system = kwargs["system_prompt"]
             return True
 
@@ -5423,39 +5450,17 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
             self.durable_greeting = kwargs["content"]
             return True
 
-    class HungPersistence(RecordingPersistence):
-        def __init__(self) -> None:
-            super().__init__()
-            self.started = threading.Event()
-            self.release = threading.Event()
-            self.finished = threading.Event()
-
-        def create_message(self, **kwargs):
-            self.durable_greeting = kwargs["content"]
-            return "msg-hung"
-
-        def update_conversation_system_prompt(self, **kwargs):
-            self.started.set()
-            try:
-                assert self.release.wait(10)
-                return super().update_conversation_system_prompt(**kwargs)
-            finally:
-                self.finished.set()
-
     app = _build_test_app()
     app.app_config["chat_defaults"] = {"user_display_name": "Alpha"}
-    app.app_config.setdefault("console", {})[
-        "roleplay_refresh_teardown_timeout_seconds"
-    ] = 0.05
+    app.app_config.setdefault("console", {})["roleplay_refresh_teardown_timeout_seconds"] = 0.05
     host = ConsoleHarness(app)
-    repair_persistence = RecordingPersistence()
-    hung_persistence = HungPersistence()
+    hung_persistence = HungFirstWritePersistence()
 
     async with host.run_test(size=(160, 48)) as pilot:
         resumed = host.screen_stack[-1]
         await _wait_for_selector(resumed, pilot, "#console-settings-summary")
         resumed_store = resumed._ensure_console_chat_store()
-        resumed_store.persistence = repair_persistence
+        resumed_store.persistence = hung_persistence
         resumed_session = resumed_store.ensure_session()
         resumed_session.settings = ConsoleSessionSettings(
             provider="llama_cpp", system_prompt="Speak with Alpha."
@@ -5474,7 +5479,6 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
         await host.push_screen(hung)
         await _wait_for_selector(hung, pilot, "#console-settings-summary")
         hung_store = hung._ensure_console_chat_store()
-        hung_store.persistence = hung_persistence
         hung_session = hung_store.ensure_session()
         hung_session.settings = ConsoleSessionSettings(
             provider="llama_cpp", system_prompt="Speak with Alpha."
@@ -5518,15 +5522,15 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
                         0,
                     )
                     == 1
-                    and repair_persistence.durable_system == "Speak with Cecelia."
-                    and repair_persistence.durable_greeting == "Hello Cecelia."
+                    and hung_persistence.durable_system == "Speak with Cecelia."
+                    and hung_persistence.durable_greeting == "Hello Cecelia."
                 ):
                     break
                 await pilot.pause(0.01)
             assert app._console_roleplay_repair_consumed_generation == 1
             assert host.screen_stack[-1] is resumed
-            assert repair_persistence.durable_system == "Speak with Cecelia."
-            assert repair_persistence.durable_greeting == "Hello Cecelia."
+            assert hung_persistence.durable_system == "Speak with Cecelia."
+            assert hung_persistence.durable_greeting == "Hello Cecelia."
 
             del hung, hung_store, hung_session
             for _ in range(50):

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -5440,6 +5440,11 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
                 self.started.set()
                 try:
                     assert self.release.wait(10)
+                    # The released write still applies its side effect, as
+                    # the original HungPersistence did via super() -- a
+                    # completed write must persist what it carried (Qodo
+                    # review, PR #1726).
+                    self.durable_system = kwargs["system_prompt"]
                     return True
                 finally:
                     self.finished.set()

--- a/backlog/tasks/task-16792 - Three-more-dev-red-rows-switcher-pair-and-unmount-repair.md
+++ b/backlog/tasks/task-16792 - Three-more-dev-red-rows-switcher-pair-and-unmount-repair.md
@@ -1,0 +1,95 @@
+---
+id: TASK-16792
+title: Three more dev-red rows switcher pair and unmount repair
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-16 14:55'
+labels:
+  - test-health
+dependencies: []
+---
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found 2026-08-16 while closing PR #1720 (companion to TASK-16480's six, of
+which none overlap): three more tests are red on untouched dev (verified on
+dev tip 8f1671f3a and attributed commit-by-commit).
+
+- `Tests/UI/test_console_native_chat_flow.py::test_ctrl_k_opens_session_switcher_and_activates_native_session`
+- `Tests/UI/test_console_native_chat_flow.py::test_switcher_rename_choice_chains_to_rename_modal`
+- `Tests/UI/test_console_session_settings.py::test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume`
+
+Attribution (bisect/parent-check evidence, 2026-08-16):
+
+1+2. ONE root cause: `ChatScreen.action_open_console_session_switcher`
+raises `AttributeError: 'ChatScreen' object has no attribute
+'_current_console_conversation_id'` (`tldw_chatbook/UI/Screens/chat_screen.py:3003`)
+-- the method exists only on the session controller
+(`UI/Console_Modules/session.py:1999`). Introduced by 520b1ec12 (browser
+consolidation, PR #1661): its diff adds the unqualified call while removing
+the correct `self._session._current_console_conversation_id()` forms.
+Verified: test passes at 520b1ec12^, fails at 520b1ec12. The rename-chain
+test fails downstream of the same error (the switcher modal never opens).
+USER-FACING IMPACT: Ctrl+K switcher is dead, and the same missing-method
+call in the `/research` handler (`chat_screen.py:16887`, from e1f3a4424,
+deep-research PR #1670 lineage) breaks `/research <question>` at runtime.
+
+3. First bad commit 0a79c4d1c ("wip(console): runtime lifetime + teardown
+split -- CHECKPOINT, 4 tests red", task-15860 arc, merged via PR #1680).
+Observable split on dev tip: the unmount-time repair SCHEDULING still works
+(`app._console_roleplay_repair_generation == 1` asserted and passes) but the
+resume-side CONSUMPTION never happens
+(`_console_roleplay_repair_consumed_generation` never set; the durable
+roleplay writes never flip to "Cecelia"). The checkpoint's own message says
+NOT reviewed / NOT complete; this red rode through the merge unreconciled.
+
+ADR required: no
+ADR path: N/A
+Reason: test-health attribution and repair of existing behavior; no new
+architectural decision.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan (the how)
+
+1. Red tests are the three dev-red rows themselves (verified red on dev tip 8f1671f3a)
+2. Tests 1+2: add the missing ChatScreen delegation seam `_current_console_conversation_id` -> `self._session._current_console_conversation_id()` (one-line delegator, matching the screen's existing controller-delegation pattern); this fixes the switcher pair AND the `/research` call site at once
+3. Test 3: trace the resume-side repair consumption drop in the task-15860 teardown split (instrument `_consume_pending_console_roleplay_repair` and the unmount ordering), fix at the dispatch point, do not loosen the test
+4. Run the three red tests + their whole suites (native chat flow, console session settings) + lint
+5. Task closeout, PR
+
+ADR required: no
+ADR path: N/A
+Reason: restoring pre-existing behavior across a refactor seam; no new decision
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fix restores a `ChatScreen` delegation seam for `_current_console_conversation_id` (or corrects the two call sites to `self._session._current_console_conversation_id()`); Ctrl+K switcher and rename-chain tests pass on dev
+- [x] #2 `/research <question>` no longer raises the missing-method AttributeError (its call site shares the fix; covered by a test or the existing research suites)
+- [x] #3 The unmount-timeout test's repair chain consumes on resume again (`_console_roleplay_repair_consumed_generation` set, durable roleplay writes updated); traced to the specific teardown/lifetime change that dropped the dispatch and fixed there rather than by loosening the test
+- [x] #4 The three modules' relevant suites pass whole on dev
+- [x] #5 Findings recorded against TASK-16480's inventory so the dev-red ledger stays one place
+<!-- AC:END -->
+
+## Implementation Notes
+
+- Tests 1+2 (switcher pair): added the missing one-line delegation seam
+  `ChatScreen._current_console_conversation_id` -> session controller
+  (`UI/Screens/chat_screen.py`). Fixes Ctrl+K (broken by 520b1ec12/PR #1661)
+  and `/research <question>` (broken by e1f3a4424/PR #1670 lineage) with one
+  seam; both switcher tests green, research command test green.
+- Test 3 (unmount repair): traced to a stale fixture, not a product break.
+  task-15860 made the Console runtime/store app-owned, so the test's two
+  co-mounted ChatScreens share ONE store; the per-screen persistence pair
+  aliased and the repair write bound to the hung double (stack dump: writer
+  blocked in HungPersistence via persist_roleplay_projection_plan). Reworked
+  the fixture to one shared double whose FIRST system write hangs and later
+  writes record -- every original assertion preserved (teardown bound,
+  repair generation/consumed, durable identity flip, gc collectibility,
+  clean loop). Whole suites: 501 passed (was 498+3 red), decomposition 141.
+- Modified files: `tldw_chatbook/UI/Screens/chat_screen.py`,
+  `Tests/UI/test_console_session_settings.py`, TASK-16480 ledger note.
+- Deviation from plan: AC #3 anticipated a product-side dispatch fix; the
+  stack-level trace showed the dispatch/repair machinery works as designed
+  once the fixture matches the app-owned store. Documented rather than
+  forcing a product change.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9969,6 +9969,18 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         await self._open_console_retrieval_scope_picker()
 
+    def _current_console_conversation_id(self) -> Optional[str]:
+        """Return the active native Console session's persisted conversation id.
+
+        One-line delegation to the session controller (task-16792): the
+        browser consolidation (520b1ec12) and the ``/research`` delivery
+        (e1f3a4424) both call this name on the screen, but the method only
+        existed on ``ConsoleSessionController`` -- every Ctrl+K switcher
+        open and ``/research <question>`` dispatch raised ``AttributeError``
+        until this seam existed.
+        """
+        return self._session._current_console_conversation_id()
+
     def _current_console_rail_conversation_id(self) -> Optional[str]:
         """Return the conversation scope used only for Console rail persistence."""
         native_session = self._session._active_native_console_session()


### PR DESCRIPTION
## Summary

Closes the three remaining dev-red tests found on the PR #1720 run, each attributed to its causing commit (TASK-16792, companion to TASK-16480's dev-red ledger — note added there).

- **Ctrl+K switcher + rename chain (one bug, user-facing):** `action_open_console_session_switcher` called `self._current_console_conversation_id()`, a method that exists only on the session controller — every Ctrl+K raised `AttributeError` and the rename chain failed downstream. Introduced by 520b1ec12 (browser consolidation, PR #1661); verified passes at its parent, fails at it. The same missing-method call sat in the `/research` handler (e1f3a4424, deep-research delivery), so `/research <question>` was also dead at runtime. Fixed with the missing one-line delegation seam on `ChatScreen` — one seam fixes both call sites.
- **Unmount-times-out-hung-refresh test:** bisected to 0a79c4d1c (task-15860 runtime lifetime + teardown split checkpoint, merged via PR #1680). Stack-level trace of the stuck repair writer showed this is a **stale fixture, not a product break**: the runtime/store became app-owned, so the test's two co-mounted ChatScreens share ONE store — its per-screen persistence pair aliased to a single store and the "repair" write bound to the hung double. Reworked the fixture to one shared persistence whose first system write hangs and later writes record, preserving every original assertion (teardown bound, repair generation + consumed, durable identity flip, retired-screen collectibility, clean loop). Per TASK-16480's discipline this is a documented fixture correction under the deliberate ownership change, not an absorbed expectation.

## Test plan

- [x] The three previously-red tests pass
- [x] Whole suites on this branch: `test_console_native_chat_flow.py` + `test_console_session_settings.py` **501 passed, 0 failed** (dev: 498 passed / 3 failed)
- [x] `test_console_internals_decomposition.py` 141 passed; research command test passed
- [x] ruff clean on changed files (the one `inspect` finding pre-exists on dev)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Console session switcher and `/research` by re-adding the missing screen-to-session delegation, and updates the unmount-repair test to match the app-owned Console store. Previously Ctrl+K and `/research` raised AttributeError; now both flows work, and a released hung write applies its side effect.

- Reintroduces `ChatScreen._current_console_conversation_id` as a one-line delegate to the session controller, fixing the Ctrl+K switcher and the `/research` dispatcher.
- Reworks the unmount-timeout fixture to one shared persistence that blocks on the first system-prompt write and records subsequent writes; the released hung write persists its carried changes.
- No migration required; behavior returns to pre-regression. Connects to Linear TASK-16792 and aligns with TASK-16480’s dev-red ledger.
- Suites now pass: native-chat-flow + session-settings 501 passed; decomposition 141 passed; research command test passed.

<sup>Written for commit f6ea75adf5a7637b20184e058c2708a33f1c8c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

