### PR TITLE
docs(research): record the biomedical-lane live baseline

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -84,6 +84,31 @@ model can exhaust the default 4096 `max_tokens` on reasoning alone and
 return an empty completion -- the baseline script now primes 16384 for
 local endpoints.
 
+## Biomedical-lane live baseline (2026-08-16, task-16794)
+
+Same runner, `--providers biomedical` (PubMed lane) over the default
+question set — local llama.cpp Qwen3.8-27B at `127.0.0.1:9191`, duckduckgo
+web lane, bounded as above:
+
+Command:
+`python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers biomedical --llm-base-url http://127.0.0.1:9191/v1`
+
+| Metric | Academic lane (n=3) | Biomedical lane (n=3) |
+|---|---|---|
+| `citation_accuracy` | 1.00 (49/49 markers) | **1.00 (36/36 markers)** |
+| `claim_support_rate` | 1.00 | 1.00 |
+| `gate_pass_rate` | 0.93 | **0.93** |
+| `cited_sentence_ratio` | 0.63 | 0.51 |
+| `quote_grounding` | 0.67 | 0.00 (no quotes emitted) |
+
+Citation integrity holds on the biomedical lane: every marker resolved
+across all three runs. The noted failure mode from the academic-lane runs
+repeats (thinking model + question-shaped topics): one run's evidence mix
+drove cited_sentence_ratio down, and no quotes were emitted (quote
+grounding untested, not failing). En route the script gained the
+`autonomy_mode="autonomous"` fix — checkpointed (the service default since
+task-16482) would park every run at plan review and produce no report.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -133,7 +133,10 @@ async def _run_question(engine, service, question: str) -> dict | None:
     """Execute one bounded research run; return its verification payload (or
     None with the failure printed -- one failed question must not sink the
     baseline)."""
-    run = service.launch_run(query=question)
+    # Autonomous mode: the baseline measures the PIPELINE, not the
+    # checkpoint UX -- checkpointed runs (the service default since
+    # task-16482) park at plan review and never produce a report.
+    run = service.launch_run(query=question, autonomy_mode="autonomous")
     final = await engine.execute_run(run["id"])
     if final.get("status") != "completed":
         print(f"  [run failed: {final.get('status')} — {final.get('progress_message')}]")

--- a/backlog/tasks/task-16794 - Record-a-live-biomedical-lane-baseline.md
+++ b/backlog/tasks/task-16794 - Record-a-live-biomedical-lane-baseline.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-16794
 title: Record a live biomedical-lane baseline
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-16 14:31'
-updated_date: '2026-08-16 14:37'
+updated_date: '2026-08-16 15:45'
 labels:
   - research
   - evals
@@ -21,12 +21,21 @@ The recorded live baseline covers the academic lane's arXiv path only; the biome
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] The baseline script gains a --providers flag accepting ids or categories,Biomedical questions are run through the lane with providers configured accordingly and scored,The baseline doc records the new live numbers alongside the existing academic-lane table
+- [x] #1 The baseline script gains a --providers flag accepting ids or categories,Biomedical questions are run through the lane with providers configured accordingly and scored,The baseline doc records the new live numbers alongside the existing academic-lane table
 <!-- AC:END -->
+
+
 
 ## Implementation Notes (partial)
 
 - `--providers` shipped in this PR: accepts source ids or category names (expanded via the catalog), binding the lane to that set. AC 1 complete.
-- **Blocked on the local LLM endpoint**: the recorded baselines use the llama.cpp server at 127.0.0.1:52864, which is currently down (connection refused; no other local LLM found on common ports, and no cloud keys are configured). The relevance and synthesis LLMs are hard prerequisites for any scored run. Re-run once the endpoint is back:
+- **RESOLVED (endpoint on :9191)**; the original blocker note follows:
+- ~~Blocked on the local LLM endpoint~~: the recorded baselines use the llama.cpp server at 127.0.0.1:52864, which is currently down (connection refused; no other local LLM found on common ports, and no cloud keys are configured). The relevance and synthesis LLMs are hard prerequisites for any scored run. Re-run once the endpoint is back:
   `python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers biomedical --llm-base-url http://127.0.0.1:<port>/v1`
   then record the numbers in `Docs/Development/research-report-eval-baseline.md` alongside the existing academic-lane table (ACs 2-3).
+
+## Implementation Notes (completion)
+
+- Live run (2026-08-16, PubMed lane via `--providers biomedical`, local Qwen3.8-27B on :9191): citation_accuracy **1.00 (36/36 markers)**, claim_support 1.00, gate_pass 0.93, cited_sentence_ratio 0.51 — all three questions scored. Comparison table against the academic lane added to the baseline doc.
+- Real bug found and fixed by the live run: the script launched runs with the service-default `checkpointed` autonomy, so every run parked at plan review and produced no report — it now launches `autonomous` (the baseline measures the pipeline, not the checkpoint UX).
+- quote_grounding 0.00 on this run set: the model emitted no quoted spans (untested, not failing) — same pattern as the pre-hardening academic runs.


### PR DESCRIPTION
## Summary

Closes task-16794: the live measurement of the biomedical (PubMed) academic lane, plus a real script fix the run exposed.

### Recorded numbers (task-16794)

`--providers biomedical`, local Qwen3.8-27B, duckduckgo web lane, bounded — **all three questions scored**:

| Metric | Academic lane (n=3) | Biomedical lane (n=3) |
|---|---|---|
| citation_accuracy | 1.00 (49/49) | **1.00 (36/36 markers)** |
| claim_support_rate | 1.00 | 1.00 |
| gate_pass_rate | 0.93 | 0.93 |
| cited_sentence_ratio | 0.63 | 0.51 |
| quote_grounding | 0.67 | 0.00 (no quotes emitted — untested, not failing) |

Citation integrity holds on the new lane. Comparison table added to `Docs/Development/research-report-eval-baseline.md`.

### Bug fix found by the live run

The script launched runs with the service-default `checkpointed` autonomy, so every run parked at plan review and produced no report. It now launches `autonomous` — the baseline measures the pipeline, not the checkpoint UX.

## Test evidence
Docs + a two-line script fix; the recorded run is itself the verification (3/3 scored, exits 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records a live baseline for the biomedical (PubMed) research lane and adds a comparison to the academic lane. Forces the baseline runner to use autonomous mode so runs complete and produce reports; previously it inherited checkpointed mode and parked at plan review.

**Reviewer notes**
- Docs: Adds “Biomedical-lane live baseline” to `Docs/Development/research-report-eval-baseline.md` with the exact command and a comparison table; key results: citation_accuracy 1.00 (36/36), claim_support_rate 1.00, gate_pass_rate 0.93.
- Script: `Helper_Scripts/Benchmarks/record_research_baseline.py` now calls `service.launch_run(..., autonomy_mode="autonomous")` to measure the pipeline rather than the checkpoint UX.
- Verification: Recorded run scored 3/3 and exited 0; updates task-16794 to Done.

<sup>Written for commit 456a86cf31654fa5db56c0e8418c0a85e4506d2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

