### PR TITLE
fix(console): two-sided transcript windowing — unbounded reveal and the scroll-back ceiling (TASK-15777)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -160,16 +160,18 @@ under you, keeping the same message in view; the jump-to-latest pill or a new
 send takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
 context sent to the model always use the full history.
 
-Scroll-back is unlimited: the view slides rather than grows. Once the mounted
-stretch reaches `prune_low_watermark` (12,000 rows by default), scrolling
-further back keeps loading older history while the newest end of the stretch
-is set aside the same way — so all of a very long session is reachable by
-scrolling, at a roughly constant memory cost. Scrolling back down (or a jump
-to an old message — selecting one far outside the stretch lands you on a
-fresh window around it instead of loading everything in between) walks
-forward the same way, and the jump-to-latest pill or a new send always
-returns you straight to a fresh view of the tail. Tune it under
-`[chat_defaults]` in `config.toml`:
+Scroll-back no longer stops at the watermarks: the view slides rather than
+grows. Once the mounted stretch reaches `prune_low_watermark` (12,000 rows by
+default), scrolling further back keeps loading older history while the newest
+end of the stretch is set aside the same way — so a very long session stays
+reachable by scrolling, at a roughly constant memory cost. One deliberate
+exception: a selected message is never set aside, so a selection pinned at
+the newest end of the stretch pauses the sliding until you clear it (Esc).
+Scrolling back down (or a jump to an old message — selecting one far outside
+the stretch lands you on a fresh window around it instead of loading
+everything in between) walks forward the same way, and the jump-to-latest
+pill or a new send always returns you straight to a fresh view of the tail.
+Tune it under `[chat_defaults]` in `config.toml`:
 
 - `transcript_window_lines` (144) and `transcript_scrollback_lines` (96) are
   **floors**, not the budget. The window actually used is the larger of the

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -158,11 +158,18 @@ opens in about a second instead of tens of seconds. Scroll to the top of what is
 shown (wheel, Page Up, or the scrollbar) and the previous chunk is prepended
 under you, keeping the same message in view; the jump-to-latest pill or a new
 send takes you back to the tail. Nothing is deleted: exports, `/rewind`, and the
-context sent to the model always use the full history. Very long sessions still
-stop growing the view at the height watermarks, and once the mounted view
-reaches `prune_low_watermark` (12,000 rows by default) scrolling further back
-stops loading more — the alternative is the view churning rows in and out
-indefinitely. Tune it under `[chat_defaults]` in `config.toml`:
+context sent to the model always use the full history.
+
+Scroll-back is unlimited: the view slides rather than grows. Once the mounted
+stretch reaches `prune_low_watermark` (12,000 rows by default), scrolling
+further back keeps loading older history while the newest end of the stretch
+is set aside the same way — so all of a very long session is reachable by
+scrolling, at a roughly constant memory cost. Scrolling back down (or a jump
+to an old message — selecting one far outside the stretch lands you on a
+fresh window around it instead of loading everything in between) walks
+forward the same way, and the jump-to-latest pill or a new send always
+returns you straight to a fresh view of the tail. Tune it under
+`[chat_defaults]` in `config.toml`:
 
 - `transcript_window_lines` (144) and `transcript_scrollback_lines` (96) are
   **floors**, not the budget. The window actually used is the larger of the
@@ -171,7 +178,10 @@ indefinitely. Tune it under `[chat_defaults]` in `config.toml`:
   above `height × 6` to widen the window, or set `transcript_window_lines` to
   `0` to mount the whole history at load, as before.
 - `prune_low_watermark` / `prune_high_watermark` bound the mounted view itself
-  and keep working with the window disabled.
+  and keep working with the window disabled. With the window disabled (or with
+  watermarks set too small to hold a scroll-back step), sliding is off too:
+  history the watermarks pruned is then reachable only via export or a jump,
+  as before TASK-15777.
 
 ### Composer
 
@@ -395,4 +405,7 @@ on the Get started card, and the same handoff on a configured Console
 still lands on the unchanged staged-evidence strip). "Long conversations"
 verified against the TASK-15455 windowing (PR #1538) plus its reconciliation
 delta — shipped tests and an isolated 500-message load probe; not re-checked
-live.*
+live. "Long conversations" sliding scroll-back and bounded far jumps
+verified against TASK-15777 — shipped tests plus isolated 400/500-message
+mounted probes (scroll-back walked m360→m0 at a constant 101 mounted rows;
+a far jump mounted 5 rows instead of 490); not re-checked live.*

--- a/Tests/UI/test_console_transcript_two_sided_window.py
+++ b/Tests/UI/test_console_transcript_two_sided_window.py
@@ -436,11 +436,21 @@ async def test_kill_switch_keeps_the_one_sided_ceiling_and_full_reveals():
 async def test_end_key_from_deep_scrollback_shows_pill_and_mounts_the_reply():
     """`End` must never produce follow-state over a hidden tail (review A).
 
-    Born red: `Widget.scroll_end()` (the End key) clears `_anchor_released`
-    without calling `anchor()`, so the transcript reported tail-follow while
-    the newest rows stayed hidden — a streamed reply never mounted and the
-    jump pill (whose visibility is gated on NOT following) was suppressed at
-    exactly the moment it was the only recovery.
+    Born red round 1: `Widget.scroll_end()` (the End key) clears
+    `_anchor_released` without calling `anchor()`, so the transcript
+    reported tail-follow while the newest rows stayed hidden — a streamed
+    reply never mounted and the jump pill (whose visibility is gated on NOT
+    following) was suppressed at exactly the moment it was the only
+    recovery.
+
+    Born red AGAIN round 2, at `1e0af17a5`, once frames pass between End
+    and the first ingest (the round-1 shape had zero and passed on timing
+    luck): the drain crosses the high watermark, the prune fires, and —
+    because the belt predicate makes `following` False while a tail is
+    hidden — its restore took the not-following branch, whose PUBLIC
+    `scroll_to` fabricated an anchor release, disarming both convergence
+    braces. The drain then stalled mid-history forever (reviewer: settle 5,
+    20 and 100 frames all failed; only 0 passed).
     """
     app = TwoSidedHarness()
     history = _messages(400)
@@ -470,6 +480,22 @@ async def test_end_key_from_deep_scrollback_shows_pill_and_mounts_the_reply():
             "a run — its suppression was the trap in review finding A"
         )
 
+        # The round-2 shape: let frames pass so the drain crosses the high
+        # mark and the prune fires BEFORE any ingest arrives. The drain must
+        # keep converging through the prune — an End press alone, no ticks,
+        # must reach the true tail.
+        await _settle(pilot, times=5)
+        assert await _wait_for(
+            pilot,
+            lambda: not transcript._hidden_tail_ids,
+            attempts=120,
+        ), (
+            "the End drain stalled mid-history: "
+            f"{len(transcript._hidden_tail_ids)} messages still hidden at "
+            f"last={_mounted_message_ids(transcript)[-1]}"
+        )
+        assert _mounted_message_ids(transcript)[-1] == "m399"
+
         # An in-flight reply (no new USER message, so no send-yank branch).
         live = ConsoleChatMessage(
             id="live-reply",
@@ -477,7 +503,7 @@ async def test_end_key_from_deep_scrollback_shows_pill_and_mounts_the_reply():
             content="streamed so far",
             status="streaming",
         )
-        for _ in range(8):
+        for _ in range(3):
             transcript.set_messages([*history, live])
             await transcript.refresh_messages()
             await _settle(pilot, times=3)
@@ -603,7 +629,9 @@ async def test_kill_switch_flip_with_a_hidden_tail_mounts_everything():
         await transcript.refresh_messages()
         await _settle(pilot)
         assert len(_mounted_message_ids(transcript)) == 400, (
-            "with windowing AND pruning off, everything mounts"
+            "with windowing and pruning off AND the pruned prefix cleared "
+            "(as a restart would clear it), everything mounts — a previously "
+            "pruned prefix itself stays sticky by the 15455/15458 contract"
         )
 
 

--- a/Tests/UI/test_console_transcript_two_sided_window.py
+++ b/Tests/UI/test_console_transcript_two_sided_window.py
@@ -291,6 +291,13 @@ async def test_jump_to_latest_from_deep_scrollback_restores_a_bounded_tail():
         )
         assert "m399" not in _mounted_message_ids(transcript)
 
+        # Review F: pin the pill itself — its visibility while a tail is
+        # hidden during a run is the recovery affordance (see the End-key
+        # pin for the suppression this would have caught).
+        transcript.sync_jump_indicator("streaming")
+        pill = transcript.query_one("#console-transcript-jump-pill")
+        assert pill.display, "the pill must be offered while a tail is hidden"
+
         transcript.jump_to_latest()
         assert await _wait_for(
             pilot, lambda: "m399" in _mounted_message_ids(transcript)
@@ -417,3 +424,250 @@ async def test_kill_switch_keeps_the_one_sided_ceiling_and_full_reveals():
         assert _mounted_message_ids(transcript)[-1] == "m399", (
             "with windowing disabled the tail must never be trimmed"
         )
+
+
+# ---------------------------------------------------------------------------
+# Review round (TASK-15777 FIX-FIRST verdict): ghost tail-follow, the
+# measured/estimated trim skew, the kill-switch flip, and trim protections.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_key_from_deep_scrollback_shows_pill_and_mounts_the_reply():
+    """`End` must never produce follow-state over a hidden tail (review A).
+
+    Born red: `Widget.scroll_end()` (the End key) clears `_anchor_released`
+    without calling `anchor()`, so the transcript reported tail-follow while
+    the newest rows stayed hidden — a streamed reply never mounted and the
+    jump pill (whose visibility is gated on NOT following) was suppressed at
+    exactly the moment it was the only recovery.
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        assert transcript._hidden_tail_ids, "precondition: a tail must be hidden"
+
+        # The End key path: re-engages Textual's anchor WITHOUT anchor().
+        transcript.scroll_end(animate=False)
+        transcript.sync_jump_indicator("streaming")
+        pill = transcript.query_one("#console-transcript-jump-pill")
+        assert not transcript._is_following_tail(), (
+            "a hidden tail means the reader is NOT at the newest content, "
+            "whatever Textual's anchor flag says"
+        )
+        assert pill.display, (
+            "the jump pill must be offered whenever a tail is hidden during "
+            "a run — its suppression was the trap in review finding A"
+        )
+
+        # An in-flight reply (no new USER message, so no send-yank branch).
+        live = ConsoleChatMessage(
+            id="live-reply",
+            role=ConsoleMessageRole.ASSISTANT,
+            content="streamed so far",
+            status="streaming",
+        )
+        for _ in range(8):
+            transcript.set_messages([*history, live])
+            await transcript.refresh_messages()
+            await _settle(pilot, times=3)
+
+        assert "live-reply" in _mounted_message_ids(transcript), (
+            "a reader whose anchor re-engaged at the slice bottom must "
+            "converge to the true tail and see the streamed reply"
+        )
+        assert not transcript._hidden_tail_ids
+        assert transcript._is_following_tail()
+
+
+@pytest.mark.asyncio
+async def test_short_message_scrollback_reaches_m0_without_prune_chasing():
+    """The trim must bound MEASURED height, not estimated (review B).
+
+    Born red: the trim walked estimated lines while the prune fires on
+    measured height. Short one-line messages measure ~1.35x their estimate
+    in this harness; with a high/low budget of 760/600 = 1.27 the estimated
+    trim never fired, the prune removed exactly what every hydration added
+    (a permanent 2-cycle), and m0 was never reached.
+    """
+    app = TwoSidedHarness(low=600, high=760)
+    history = [
+        ConsoleChatMessage(
+            id=f"m{index}",
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="ok",
+        )
+        for index in range(600)
+    ]
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        prune_batches: list[int] = []
+        original_prunable = transcript._compute_prunable_prefix
+
+        def _counting_prunable(*args, **kwargs):
+            prune_ids, height = original_prunable(*args, **kwargs)
+            if prune_ids:
+                prune_batches.append(len(prune_ids))
+            return prune_ids, height
+
+        transcript._compute_prunable_prefix = _counting_prunable  # type: ignore[method-assign]
+        try:
+            reached = await _scroll_back_until(
+                pilot,
+                transcript,
+                lambda: "m0" in _mounted_message_ids(transcript),
+                rounds=80,
+            )
+        finally:
+            transcript._compute_prunable_prefix = original_prunable  # type: ignore[method-assign]
+
+        assert reached, (
+            "short-message scroll-back never reached m0: stuck at "
+            f"{_mounted_message_ids(transcript)[:1]} after "
+            f"{len(prune_batches)} prune batches"
+        )
+        assert len(prune_batches) <= 8, (
+            "the prune must not chase hydration (the review's 2-cycle logged "
+            f"~98 prune events); saw {len(prune_batches)}"
+        )
+        assert transcript.virtual_size.height <= 760 + 40, (
+            "the mounted view must stay near the watermarks"
+        )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_flip_with_a_hidden_tail_mounts_everything():
+    """Flipping the kill switch mid-session must clear the hidden tail (review C).
+
+    Born red: `set_messages`' windowing-disabled branch carried the sticky
+    suffix forward, so `transcript_window_lines = 0` — the escape hatch that
+    exists to switch a windowing bug off without a release — left 299
+    messages hidden forever.
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        assert transcript._hidden_tail_ids, "precondition: a tail must be hidden"
+
+        app.app_config["chat_defaults"]["transcript_window_lines"] = 0
+        for _ in range(3):
+            transcript.set_messages(list(history))
+            await transcript.refresh_messages()
+            await _settle(pilot)
+
+        assert not transcript._hidden_tail_ids, (
+            "the kill switch must clear the hidden tail on the next ingest"
+        )
+        # The kill switch disables WINDOWING, not the watermarks: the tail
+        # must resurrect and the view must unfreeze, while the height
+        # watermarks may still bound the mounted prefix (the 15455 contract
+        # the existing kill-switch pins protect).
+        mounted = _mounted_message_ids(transcript)
+        assert mounted[-1] == "m399", (
+            "windowing off must remount the trimmed tail — the review's "
+            "frozen-view repro was exactly this row never coming back"
+        )
+
+        # Switching the watermarks off as well restores the whole history.
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 0
+        transcript._pruned_message_ids.clear()
+        transcript.set_messages(list(history))
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert len(_mounted_message_ids(transcript)) == 400, (
+            "with windowing AND pruning off, everything mounts"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tail_trim_never_hides_the_selected_message():
+    """The trim protects the selection exactly like the prune does (review D).
+
+    Born red: the trim protected only the focused row; a selected tail
+    message unmounted (action row included) during deep scroll-back while
+    `selected_message_id` still named it, and `j` then teleported to the
+    top of the visible window.
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_message("m398")
+        assert await _wait_for(
+            pilot, lambda: "m398" in _mounted_message_ids(transcript)
+        )
+
+        transcript.release_anchor()
+        for _ in range(30):
+            transcript.scroll_to(y=0, animate=False)
+            await _settle(pilot)
+
+        assert "m398" in _mounted_message_ids(transcript), (
+            "the selected message must never be trimmed out of the DOM"
+        )
+        assert len(_mounted_message_ids(transcript)) <= 300, (
+            "the prune must still bound the DOM while the selection blocks "
+            "the tail trim"
+        )
+
+
+@pytest.mark.asyncio
+async def test_far_jump_lands_with_the_target_as_the_first_mounted_row():
+    """A re-centered jump mounts the load-shaped window, nothing above (review E).
+
+    Born red: the transient empty layout during the re-center reconcile (and
+    the target-to-top placement) fired the top-boundary watcher, so one extra
+    upward chunk mounted — m10 of 500 landed as 34 rows starting at m0
+    instead of the intended window starting at m10.
+    """
+    app = TwoSidedHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_message("m10")
+        assert await _wait_for(
+            pilot, lambda: "m10" in _mounted_message_ids(transcript)
+        )
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert mounted[0] == "m10", (
+            f"the jump target must be the first mounted row, got {mounted[0]}"
+        )
+        assert len(mounted) <= 40

--- a/Tests/UI/test_console_transcript_two_sided_window.py
+++ b/Tests/UI/test_console_transcript_two_sided_window.py
@@ -1,0 +1,419 @@
+"""TASK-15777: two-sided Console transcript windowing.
+
+TASK-15455 shipped a ONE-sided window: a contiguous hidden prefix whose
+boundary every hydration and reveal path moves. That design left two
+residuals its own Implementation Notes recorded:
+
+1. *Scroll-back reachability ceiling* — once the mounted view reaches the LOW
+   prune watermark, boundary hydration is refused forever (the refusal was
+   the prune/hydration fixed-point loop-breaker), so older history can never
+   be scrolled to (probe: 400 messages at 600/900 marks froze at ``m248``).
+2. *Unbounded reveal on a far jump* — revealing a message near the start
+   mounts everything from it to the tail in one pass (probe: 490 rows for
+   ``m10`` of 500).
+
+This task adds a second contiguous hidden boundary — a hidden TAIL — so the
+mounted rows stay ONE contiguous slice (both boundaries are indices over the
+same message list; islands are impossible by construction, so the no-gap-seam
+property of the merged design is preserved). Two-sided behavior engages only
+when windowing is on, pruning is on, and the watermarks can hold at least a
+chunk plus a couple of viewports; degenerate configurations (the 45/70
+fixed-point fixtures) and the kill switch keep the one-sided behavior
+byte-for-byte, which is why the TASK-15455 suites pass unmodified.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+class TwoSidedHarness(App):
+    """Transcript host with sane, scaled watermarks (two-sided regime)."""
+
+    CSS = "ConsoleTranscript { height: 24; width: 100; }"
+
+    def __init__(
+        self,
+        *,
+        low: int = 600,
+        high: int = 900,
+        window_lines: int | None = None,
+    ) -> None:
+        super().__init__()
+        chat_defaults: dict[str, object] = {
+            "assistant_markdown": False,
+            "prune_low_watermark": low,
+            "prune_high_watermark": high,
+        }
+        if window_lines is not None:
+            chat_defaults["transcript_window_lines"] = window_lines
+        self.app_config = {"chat_defaults": chat_defaults}
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _messages(count: int, *, prefix: str = "m") -> list[ConsoleChatMessage]:
+    return [
+        ConsoleChatMessage(
+            id=f"{prefix}{index}",
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="\n".join(f"message {index} line {line}" for line in range(4)),
+        )
+        for index in range(count)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    return [row.message_id for row in transcript.query(".console-transcript-message")]
+
+
+def _is_contiguous(mounted: list[str], *, prefix: str = "m") -> bool:
+    indices = [int(message_id[len(prefix) :]) for message_id in mounted]
+    return indices == list(range(indices[0], indices[0] + len(indices)))
+
+
+async def _settle(pilot, *, times: int = 6) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 80) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+async def _scroll_back_until(
+    pilot,
+    transcript: ConsoleTranscript,
+    predicate,
+    *,
+    rounds: int = 80,
+    bound: int | None = None,
+) -> bool:
+    """Drive repeated top-boundary hits, optionally asserting a DOM bound."""
+    transcript.release_anchor()
+    for _ in range(rounds):
+        transcript.scroll_to(y=0, animate=False)
+        await _settle(pilot)
+        if bound is not None:
+            mounted = len(_mounted_message_ids(transcript))
+            assert mounted <= bound, (
+                f"scroll-back must keep the DOM bounded: {mounted} > {bound}"
+            )
+        if predicate():
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Symptom 2: the scroll-back reachability ceiling (born red on TASK-15455).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sustained_scrollback_reaches_the_oldest_message_and_stays_bounded():
+    """Scroll-back must reach m0 of 400 while the mounted DOM stays bounded.
+
+    Born red on the one-sided design: hydration froze at ``first=m248`` the
+    moment the mounted height crossed the low watermark (probe, 2026-08-15).
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        reached = await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+            bound=170,
+        )
+        assert reached, (
+            "sustained scroll-back never reached the oldest message: "
+            f"stuck at {_mounted_message_ids(transcript)[:1]}"
+        )
+        assert transcript.virtual_size.height <= 900, (
+            "the mounted view escaped the high watermark during scroll-back"
+        )
+        mounted = _mounted_message_ids(transcript)
+        assert _is_contiguous(mounted), "mounted rows must stay one contiguous slice"
+        assert len(transcript._messages) == 400, "the store keeps the full history"
+
+
+@pytest.mark.asyncio
+async def test_deep_scrollback_trims_the_tail_and_scrolling_down_recovers_it():
+    """The tail leaves the DOM during deep scroll-back and rehydrates downward.
+
+    Born red on the one-sided design: the tail row was ALWAYS mounted, which
+    is exactly why the DOM could not stay bounded once the ceiling moved.
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        assert "m399" not in _mounted_message_ids(transcript), (
+            "deep scroll-back must trim the tail out of the DOM"
+        )
+
+        # Scrolling down at the bottom boundary walks back toward the tail.
+        for _ in range(80):
+            transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            await _settle(pilot)
+            mounted = len(_mounted_message_ids(transcript))
+            assert mounted <= 260, (
+                f"the downward walk must keep the DOM bounded: {mounted}"
+            )
+            if "m399" in _mounted_message_ids(transcript):
+                break
+        assert "m399" in _mounted_message_ids(transcript), (
+            "scrolling down never recovered the trimmed tail"
+        )
+        assert _is_contiguous(_mounted_message_ids(transcript))
+
+
+# ---------------------------------------------------------------------------
+# Symptom 1: unbounded reveal on a far jump (born red on TASK-15455).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_far_jump_mounts_a_bounded_recentered_window():
+    """Selecting a message near the start mounts a window, not 490 rows.
+
+    Born red on the one-sided design: revealing ``m10`` of 500 mounted every
+    row from it to the tail in one pass (probe: 490 rows).
+    """
+    app = TwoSidedHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        assert "m10" not in _mounted_message_ids(transcript)
+
+        transcript.select_message("m10")
+        assert await _wait_for(
+            pilot, lambda: "m10" in _mounted_message_ids(transcript)
+        ), "selecting a windowed-out message never mounted it"
+        await _settle(pilot)
+
+        mounted = _mounted_message_ids(transcript)
+        assert len(mounted) <= 80, (
+            f"a far jump must mount a bounded window, got {len(mounted)} rows"
+        )
+        assert "m499" not in mounted, "the far window must not drag the tail along"
+        assert _is_contiguous(mounted), "the re-centered window must be contiguous"
+        assert transcript.selected_message_id == "m10"
+        assert transcript.query(".console-transcript-action-row"), (
+            "the revealed selection must show its action row"
+        )
+        assert not transcript._is_following_tail(), (
+            "a far jump detaches the reader from the tail"
+        )
+
+
+@pytest.mark.asyncio
+async def test_far_jump_then_scrolling_down_walks_back_to_the_tail():
+    """After a far jump the tail stays reachable by scrolling down."""
+    app = TwoSidedHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        transcript.select_message("m10")
+        assert await _wait_for(
+            pilot, lambda: "m10" in _mounted_message_ids(transcript)
+        )
+        await _settle(pilot)
+        assert "m499" not in _mounted_message_ids(transcript)
+
+        for _ in range(120):
+            transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            await _settle(pilot, times=4)
+            if "m499" in _mounted_message_ids(transcript):
+                break
+        assert "m499" in _mounted_message_ids(transcript), (
+            "the tail must be reachable by scrolling down after a far jump"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Interactions the 15455 notes named: tail-follow, streaming, the jump pill.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jump_to_latest_from_deep_scrollback_restores_a_bounded_tail():
+    """The jump pill lands on a fresh, bounded, tail-following window."""
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        assert "m399" not in _mounted_message_ids(transcript)
+
+        transcript.jump_to_latest()
+        assert await _wait_for(
+            pilot, lambda: "m399" in _mounted_message_ids(transcript)
+        ), "jump-to-latest never remounted the tail"
+        await _settle(pilot)
+        assert transcript._is_following_tail(), "the jump re-engages tail-follow"
+        assert transcript.scroll_y == transcript.max_scroll_y
+        assert len(_mounted_message_ids(transcript)) <= 170, (
+            "the jump must land on a bounded tail window"
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_tick_keeps_the_hidden_tail_sticky():
+    """A 0.2s-style ingest must not remount the trimmed tail under the reader."""
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        mounted_before = _mounted_message_ids(transcript)
+        assert "m399" not in mounted_before
+        reader_y = float(transcript.scroll_y)
+
+        live = ConsoleChatMessage(
+            id="live-reply",
+            role=ConsoleMessageRole.ASSISTANT,
+            content="streamed so far",
+            status="streaming",
+        )
+        for _ in range(3):
+            transcript.set_messages([*history, live])
+            await transcript.refresh_messages()
+            await _settle(pilot, times=3)
+
+        mounted_after = _mounted_message_ids(transcript)
+        assert "live-reply" not in mounted_after, (
+            "a streamed append while scrolled back must stay in the hidden tail"
+        )
+        assert mounted_after == mounted_before, (
+            "the tick must not churn the reader's mounted slice"
+        )
+        assert float(transcript.scroll_y) == pytest.approx(reader_y, abs=1.0), (
+            "the tick must not move the reader"
+        )
+
+
+@pytest.mark.asyncio
+async def test_new_user_send_from_deep_scrollback_rewindows_the_tail():
+    """A send yanks to a fresh tail window: suffix cleared, bounded, following."""
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        await _scroll_back_until(
+            pilot,
+            transcript,
+            lambda: "m0" in _mounted_message_ids(transcript),
+        )
+        assert "m399" not in _mounted_message_ids(transcript)
+
+        transcript.note_follow_intent()
+        sent = ConsoleChatMessage(
+            id="sent-user", role=ConsoleMessageRole.USER, content="a fresh send"
+        )
+        placeholder = ConsoleChatMessage(
+            id="pending-reply",
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+            status="streaming",
+        )
+        transcript.set_messages([*history, sent, placeholder])
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: "sent-user" in _mounted_message_ids(transcript)
+        ), "the send must land the reader on the tail"
+        await _settle(pilot)
+        assert transcript._is_following_tail(), "a send re-engages tail-follow"
+        assert len(_mounted_message_ids(transcript)) <= 170, (
+            "the send must re-window the tail, not remount the whole slice"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The gates: kill switch and degenerate watermarks keep one-sided behavior.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_keeps_the_one_sided_ceiling_and_full_reveals():
+    """`transcript_window_lines = 0` keeps the exact pre-task behavior."""
+    app = TwoSidedHarness(window_lines=0)
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        assert await _wait_for(
+            pilot, lambda: bool(transcript._pruned_message_ids)
+        ), "the watermarks must still prune with windowing disabled"
+        await _settle(pilot)
+
+        first_before = _mounted_message_ids(transcript)[0]
+        transcript.release_anchor()
+        for _ in range(6):
+            transcript.scroll_to(y=0, animate=False)
+            await _settle(pilot)
+        assert _mounted_message_ids(transcript)[0] == first_before, (
+            "with windowing disabled, the pruned prefix must stay unreachable "
+            "by scroll (the pre-task contract the kill switch restores)"
+        )
+        assert _mounted_message_ids(transcript)[-1] == "m399", (
+            "with windowing disabled the tail must never be trimmed"
+        )

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -528,6 +528,29 @@ ledger-creation time; by cleanup time it is too late.
 
 ---
 
+## A checkout-based baseline round silently discards uncommitted work on that file
+
+**TASK-15777, 2026-08-15.** To attribute test failures, the standard baseline
+round is: `git checkout <base> -- <file>` → run the failing tests → `git
+checkout HEAD -- <file>`. During the two-sided-windowing work this round was
+run twice; between the two runs an uncommitted improvement (the reveal-segment
+recenter criterion) had been made to that same file on top of the last WIP
+commit. The second round's `git checkout HEAD -- <file>` restored the WIP
+commit and silently discarded the improvement — no error, no prompt, working
+tree "clean". It was only caught because `git status --porcelain` in the same
+command's output listed fewer modified files than expected; the edit had to be
+re-applied from the conversation's diff and every suite re-run on the
+re-committed state.
+
+**What to do.** `git checkout ... -- <file>` is a mutation of the working
+tree, exactly like the `git checkout HEAD --` restore trap in
+`lessons-testing-evidence.md`. Before ANY checkout-based baseline round,
+commit the current state first — the round's restore step is then provably a
+no-op. If the file was touched after the last commit, the restore step
+destroys that delta unconditionally.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md`

--- a/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
+++ b/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
@@ -193,11 +193,15 @@ carries a pin that was run RED against the pre-fix HEAD `dc5224c0b` first
   Belt-and-braces fix: `_is_following_tail()` itself now returns False
   whenever a hidden tail exists (`_raw_anchor_engaged()` keeps the raw
   Textual state), the `_hydrate_tailward` self-chain also runs while the
-  raw anchor is engaged (converges to the true tail from an End press even
-  with no ticks), and `set_messages` heals raw-anchored-with-suffix by
-  re-windowing onto a fresh tail (covers the no-new-user-message reply that
-  never takes the send branch). Pin: End from deep scroll-back → pill
-  displayed + streamed reply mounts + suffix drains.
+  raw anchor is engaged, and `set_messages` heals raw-anchored-with-suffix
+  by re-windowing onto a fresh tail (covers the no-new-user-message reply
+  that never takes the send branch). Pin: End from deep scroll-back → pill
+  displayed + streamed reply mounts + suffix drains. **Round-2 correction:
+  this round's "converges even with no ticks" claim was FALSE at
+  `1e0af17a5`** — the round-1 pin passed only at zero intervening frames;
+  the round-2 review pinned the stall's causal chain and the round-2 fixes
+  below make the convergence claim actually true (and pinned at a 5-frame
+  settle).
 - **B (MEDIUM-HIGH, fixed point was ratio-contingent).** The trim walked
   ESTIMATED lines while the prune fires on MEASURED height; content with
   measured/estimated > high/low (short one-line messages ≈1.35-1.7x)
@@ -238,3 +242,66 @@ unmodified (`git diff` empty); adjacent console set (pruning, tail-follow,
 selection contract, jump pill, region, fence throttle, diff row, native
 transcript) 160 passed + the 3 speak-action failures already proven
 pre-existing on base; ruff clean.
+
+### Review round 2 (FIX-FIRST — one blocker: A's convergence)
+
+The round-2 review confirmed B, C, E, F decisively fixed and D acceptable,
+and pinned A's remaining stall causally: the belt predicate makes the
+prune's `following` capture False during an End-initiated drain, so its
+else-branch restore ran the PUBLIC `scroll_to` → `release_anchor()` —
+clearing the raw anchor both convergence braces test. Fixing that exposed
+a second, deeper entry the review had not needed to name:
+
+- **Prune restore made faithful, not merely non-releasing.** First fix
+  attempt (`_scroll_to(..., release_anchor=False)` alone) turned
+  `test_pruning_preserves_scroll_position_when_scrolled_up` red — which
+  revealed the old public release had been ACCIDENTALLY LOAD-BEARING: the
+  reconcile's layout shrink CLAMPS `scroll_y`, and a detached reader
+  sitting at the bottom gets silently re-attached by Textual's
+  `_check_anchor` at that clamp (traced: `W 33->31`, `CHECK re-engaged`,
+  then the compensation is pulled back to the bottom by the still-engaged
+  anchor). The public release had been undoing that. The restore now
+  captures `_raw_anchor_engaged()` at prune entry and restores THAT state:
+  a detached reader the clamp re-attached is re-released via a new
+  `_release_anchor_quietly()` (no user-intent stamp — TASK-336 ordering —
+  unlike the old accidental release, which stamped), BEFORE the
+  compensating internal `_scroll_to` so the anchor cannot fight it; an
+  entry-engaged anchor (the End drain) stays engaged so the chain
+  survives the prune. Why this branch over the reviewer's alternative
+  (`_raw_anchor_engaged()` at the `following =` capture): that would send
+  raw-anchored-with-suffix readers into the `anchor()`+`scroll_end`
+  branch, and `anchor()` reveals the tail window — a prune firing
+  mid-walk would teleport a reader whose anchor engaged incidentally at
+  the slice bottom, yanking them and dropping their mounted scroll-back.
+  The `following` choice of branch is right; only the side effect was
+  wrong.
+- **`scroll_end` override — the first chain link cannot be event-driven.**
+  Reproducing the reshaped pin exposed a second stall entry the round-2
+  probe's shape happened not to hit: with a pill display toggle between
+  End and the deferred scroll (exactly what the app's sync does), the
+  compositor's anchor path moves the widget to the bottom WITHOUT firing
+  the `scroll_y` watcher at all (instrumented: watcher provably live
+  through the up-walk, silent across the whole 32→580 jump — the reactive
+  never saw a change because the compositor had already moved it). Every
+  scroll-EVENT hook can therefore miss the drain's first link, so
+  `scroll_end()` itself (the End action) now schedules the first tailward
+  chunk; the self-chain carries on the raw ANCHOR STATE, needing no
+  events. `jump_to_latest` and the prune's following-branch reach
+  `scroll_end` with no suffix (no-op for them).
+- **Pin re-shaped** per the review: End → 5-frame settle → assert the
+  drain converges to the true tail with NO ticks → then ingest and assert
+  the reply mounts. Born red against `1e0af17a5` (stalled, 250 hidden);
+  the reviewer's `probe_a_timing.py` passes at 5/20/100 settle frames
+  (was: fail at all three, pass only at 0).
+- Non-blockers landed: debug log when the trim is blocked by a pinned
+  selection/focus (mirrors the prune's blocked-walk log); the phase-2
+  kill-switch assertion message no longer over-claims (it now names the
+  cleared-prefix precondition); `_measured_message_groups` documents the
+  latent margin-collapse divergence from the prune's cumulative walk
+  (exact today at zero row margins; conservative if margins appear).
+
+Round-2 verification: two-sided 13/13; protected 17/17, both files still
+byte-identical to base; pruning suite 8/8 (the detached-reader pin that
+caught the load-bearing release, back green with the faithful restore);
+adjacent set 160 passed + the 3 known pre-existing; `probe_a_timing.py`
+5/20/100 all pass; ruff clean.

--- a/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
+++ b/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-15777
 title: 'Console transcript: unbounded reveal on a far jump, and a scroll-back reachability ceiling'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-13 12:31'
@@ -41,17 +41,17 @@ reveal-then-restore ordering rather than re-deriving it from scratch.
 
 ## Acceptance Criteria
 
-- [ ] A design decision is made and documented for bounding the reveal cost
+- [x] A design decision is made and documented for bounding the reveal cost
       of a far jump (e.g. windowed reveal + progressive hydration toward the
       target, rather than mounting everything between the jump target and
       the tail in one pass)
-- [ ] A design decision is made and documented for two-sided windowing (or an
+- [x] A design decision is made and documented for two-sided windowing (or an
       explicit, justified decision not to pursue it), covering how it
       interacts with tail-follow, in-flight streaming, and the jump pill
-- [ ] Whichever lever(s) ship are covered by tests pinning: bounded mount
+- [x] Whichever lever(s) ship are covered by tests pinning: bounded mount
       count on a far jump, and (if two-sided windowing ships) that
       scroll-back remains reachable past the current low-watermark ceiling
-- [ ] `Tests/UI/test_console_transcript_window_reconcile.py` and
+- [x] `Tests/UI/test_console_transcript_window_reconcile.py` and
       `Tests/UI/test_console_transcript_windowing.py` stay green
 
 ## Implementation Plan
@@ -92,3 +92,86 @@ windowing — but gate it so every existing regime is byte-identical:
    scroll-back; both protected suites run in full, unmodified.
 7. Docs: `Docs/User_Guide/console.md` "Long conversations" + `config.py`
    comment lose the ceiling caveat.
+
+## Implementation Notes
+
+Both symptoms shipped fixed by ONE mechanism: a second contiguous hidden
+boundary (a hidden TAIL) alongside TASK-15455's hidden prefix — two-sided
+windowing — gated so every existing regime is behavior-identical.
+
+**Design decisions (the two ACs).**
+
+- *Two-sided windowing: SHIPPED*, scoped by a gate (`_two_sided_active`):
+  windowing enabled AND pruning enabled (`high_mark > 0`) AND sane marks
+  (`low >= chunk + 2*viewport`, `high - low >= chunk`). The two boundaries
+  are always indices over one message list, so mounted rows are one
+  contiguous slice by construction — islands are impossible and no gap-seam
+  row is needed (the failure mode 15455's reconciliation rejected came from
+  two independently mutated SETS, not two indices). Interactions, as the
+  filing demanded:
+  - *tail-follow*: an `anchor()` override funnels every "follow the newest"
+    path through `_reveal_tail_window()` — clear the suffix and re-window
+    onto a fresh bounded tail (clearing alone would remount everything
+    between the reader and the tail: the unbounded reveal again).
+  - *in-flight streaming*: the suffix is sticky across `set_messages`
+    ingests (remapped by surviving ids); ids appended while the reader is
+    deep in scroll-back join the suffix automatically, so the 0.2s sync tick
+    neither remounts the tail nor moves the reader (pinned).
+  - *jump pill / send*: both land on a fresh bounded tail window; the send
+    branch recomputes `window_start` explicitly because `_set_hidden_prefix`
+    at the end of `set_messages` would overwrite what `anchor()` set.
+- *Far-jump bound: SHIPPED as windowed reveal (re-center), not progressive
+  hydration toward the target.* When the newly revealed stretch between the
+  target and the current window exceeds the LOW watermark in estimated
+  lines, `reveal_message` mounts an initial-window-sized slice from the
+  target's turn (the same shape a session load produces) and hides the rest
+  in the suffix; the target row is scrolled to the top once mounted. Near
+  reveals (j/k over the boundary, nearby restores) keep the plain boundary
+  extension. *Alternatives considered*: progressive hydration toward the
+  target (bounds the latency spike but NOT the DOM — the selected target is
+  prune-protected at the top, so nothing ever trims); a hard row cap on the
+  reveal (arbitrary knob, still unbounded below it); islands + gap seam
+  (rejected by 15455 for reconciler complexity). The low watermark is the
+  principled budget: a jump may mount at most what the watermarks allow to
+  STAY mounted.
+
+**Fixed-point preservation** (the 15455 reconciliation headline): hydration
+is no longer refused at the low mark — instead each hydrated chunk is
+followed by an estimated-lines tail-trim back to
+`max(low, scroll_y + 2*viewports)` (never trimming a row group holding
+focus), which lands the height under `high` BEFORE the prune check runs, so
+the prune can never chase hydration. Where that argument cannot hold
+(degenerate marks like the 45/70 fixtures, where one chunk overshoots
+`high`), the gate keeps the 15455 refusal — the fixed-point tests pass
+unmodified. Downward: symmetric boundary hydration (wheel-down / PageDown /
+watch_scroll_y + a self-chaining check for the anchored-at-bottom case,
+where the anchor's auto-scroll happens while the in-flight latch swallows
+the boundary signal), with the existing prefix prune bounding that end.
+
+**Evidence.**
+- Probe on unmodified base `4ea8bf1c9` (400 msgs, 600/900 marks): scroll-back
+  grew 24→152 mounted rows then froze at `first=m248` forever — 248 messages
+  unreachable; far jump `m10` of 500 mounted 490 rows.
+- Born-red pins (both failed on base, verbatim):
+  `test_sustained_scrollback_reaches_the_oldest_message_and_stays_bounded`
+  and `test_far_jump_mounts_a_bounded_recentered_window` in the new
+  `Tests/UI/test_console_transcript_two_sided_window.py` (8 tests: the two
+  symptoms, tail-trim + downward recovery, post-jump tail walk, jump pill,
+  streaming-tick stickiness, send re-window, kill-switch inertness).
+- Probe after fix: mounted DOM constant at 101 rows / height 407 while the
+  window walks m360→m0 (reachability + bound); far jump at DEFAULT 12k/20k
+  marks with realistic 30-line messages mounts 5 rows (m10–m14) vs 490.
+- Suites: new 8/8; protected `window_reconcile` + `windowing` 17/17 GREEN
+  AND UNMODIFIED; adjacent transcript suites (native, pruning, tail-follow,
+  selection contract, jump pill, region, fence throttle, diff row, markdown,
+  composer collapse, citation sources, native chat flow) ~670 passed; the 9
+  failures observed are all PRE-EXISTING on base `4ea8bf1c9` (identical
+  lists re-run against the unmodified widget: 4 markdown-widget API-drift
+  reds, 3 speak-action reds, 2 session-switcher reds). ruff clean.
+
+**Files.** `tldw_chatbook/Widgets/Console/console_transcript.py`,
+`tldw_chatbook/config.py` (comment), `Docs/User_Guide/console.md`
+("Long conversations" + stamp),
+`Tests/UI/test_console_transcript_two_sided_window.py` (new),
+`backlog/docs/lessons-backlog-hygiene.md` (checkout-baseline trap), this
+task file.

--- a/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
+++ b/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-15777
 title: 'Console transcript: unbounded reveal on a far jump, and a scroll-back reachability ceiling'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-13 12:31'
 labels:
   - perf
@@ -52,3 +53,42 @@ reveal-then-restore ordering rather than re-deriving it from scratch.
       scroll-back remains reachable past the current low-watermark ceiling
 - [ ] `Tests/UI/test_console_transcript_window_reconcile.py` and
       `Tests/UI/test_console_transcript_windowing.py` stay green
+
+## Implementation Plan
+
+Design decision (both symptoms share one mechanism): add a second, contiguous
+hidden **suffix** boundary next to the existing hidden prefix — two-sided
+windowing — but gate it so every existing regime is byte-identical:
+
+1. **State.** `_hidden_tail_ids` (set) + `_hidden_tail_start` (index), always
+   derived together from one index over `_messages`, so mounted rows stay ONE
+   contiguous slice by construction (no islands, no gap seam — the failure
+   mode 15455 rejected came from two independently mutated sets).
+2. **Gate.** Two-sided behavior activates only when windowing is enabled
+   (kill switch respected), pruning is enabled (`high_mark > 0`), and the
+   watermarks are sane (`low >= chunk + 2*viewport` and `high - low >= chunk`).
+   Degenerate/tiny marks (the 45/70 fixed-point fixtures) keep today's
+   one-sided behavior INCLUDING the low-watermark hydration refusal — that
+   refusal is the fixed-point loop-breaker there and must survive.
+3. **Ceiling fix (symptom 2).** With the gate active, boundary hydration is no
+   longer refused at the low watermark; after each hydrated chunk the tail is
+   trimmed back into the hidden suffix (estimated-lines walk, keeping at least
+   `max(low_mark, scroll_y + 2*viewport)` mounted, never trimming a group
+   holding focus). Post-trim height < high, so the prune never fires and the
+   15455 fixed point is preserved by construction.
+4. **Downward reachability.** Symmetric hydration at the bottom boundary
+   (wheel-down / PageDown / watch_scroll_y) reveals the next suffix chunk;
+   the existing prefix prune bounds the other end. Jump pill re-windows the
+   tail; a new-user-send yank clears the suffix and re-windows the tail;
+   `set_messages` keeps the suffix sticky across streaming ticks (appended
+   ids join it) and remaps it by surviving ids.
+5. **Far-jump bound (symptom 1).** `reveal_message` re-centers the window on
+   the target (initial-window budget below the target's turn) when the
+   full reveal would exceed the low watermark in estimated lines; smaller
+   reveals keep today's extend-the-boundary behavior, so the pinned
+   contiguous-reveal tests stay green.
+6. **Evidence.** Mounted probe reproducing both symptoms on the unmodified
+   widget; born-red pins for both; DOM bound asserted after sustained
+   scroll-back; both protected suites run in full, unmodified.
+7. Docs: `Docs/User_Guide/console.md` "Long conversations" + `config.py`
+   comment lose the ceiling caveat.

--- a/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
+++ b/backlog/tasks/task-15777 - Console-transcript-unbounded-reveal-and-a-scroll-back-reachability-ceiling.md
@@ -175,3 +175,66 @@ the boundary signal), with the existing prefix prune bounding that end.
 `Tests/UI/test_console_transcript_two_sided_window.py` (new),
 `backlog/docs/lessons-backlog-hygiene.md` (checkout-baseline trap), this
 task file.
+
+### Review round (FIX-FIRST verdict — all findings addressed)
+
+An independent review (scratchpad `review15777.md`) confirmed the mechanism
+(slice-by-construction verified on every mutation path; born-red 7-of-8,
+stronger than claimed; both headline repros exact) and found three blockers
+plus two lower items, all reproduced. All fixed this round; every fix
+carries a pin that was run RED against the pre-fix HEAD `dc5224c0b` first
+(5/5 failed), then green:
+
+- **A (HIGH, ghost tail-follow).** `Widget.scroll_end()` (the End key) and
+  `_check_anchor()` clear `_anchor_released` without calling `anchor()`, so
+  the override was bypassable: follow-state over a hidden tail — streamed
+  replies piled invisibly into the suffix and the jump pill (gated on NOT
+  following) was suppressed exactly when it was the only recovery.
+  Belt-and-braces fix: `_is_following_tail()` itself now returns False
+  whenever a hidden tail exists (`_raw_anchor_engaged()` keeps the raw
+  Textual state), the `_hydrate_tailward` self-chain also runs while the
+  raw anchor is engaged (converges to the true tail from an End press even
+  with no ticks), and `set_messages` heals raw-anchored-with-suffix by
+  re-windowing onto a fresh tail (covers the no-new-user-message reply that
+  never takes the send branch). Pin: End from deep scroll-back → pill
+  displayed + streamed reply mounts + suffix drains.
+- **B (MEDIUM-HIGH, fixed point was ratio-contingent).** The trim walked
+  ESTIMATED lines while the prune fires on MEASURED height; content with
+  measured/estimated > high/low (short one-line messages ≈1.35-1.7x)
+  produced a permanent hydrate/prune 2-cycle that never reached m0
+  (review: 98 prune events). Fix: `_compute_tail_trim_start` now walks
+  measured `outer_size.height` with the prune's own margin-collapse math
+  (`_measured_message_groups`, mirroring `_compute_prunable_prefix`), so
+  the trim and the prune share units and the ordering argument is real.
+  Pin: 600 one-line messages at 600/760 marks (ratio 1.27 < measured 1.35)
+  reach m0 with ≤ 8 prune batches. `console.md`'s "unlimited" prose
+  softened to what is true (sliding, with the selection-pause exception).
+- **C (MEDIUM, kill-switch flip).** `set_messages`' windowing-disabled
+  branch now clears the hidden tail (it only carried the prefix contract
+  before), so `transcript_window_lines = 0` mid-session resurrects the
+  trimmed tail on the next ingest. Pin: flip with 299 hidden → tail row
+  remounts (watermarks still bound the view, per the 15455 contract); with
+  pruning also off, all 400 mount.
+- **D (LOW, selection).** The trim now protects the SELECTED message like
+  the prune does (stop-the-walk; contiguity forbids skipping). Trade-off
+  documented: a selection pinned at the mounted bottom pauses the sliding
+  (prune still bounds height) until cleared — same stance the prune already
+  takes. Streaming rows deliberately stay trimmable (hidden = zero cost;
+  pill/heal recover them). Pin: selected m398 survives 30 scroll-back
+  rounds mounted.
+- **E (LOW, far-jump overshoot).** The re-center's reconcile transits an
+  emptied arrangement and the placement parks the target near y=0 — both
+  fired the top-boundary watcher and hydrated one spurious chunk ABOVE the
+  target (34 rows from m0 instead of the window from m10). Fixed with a
+  one-shot `_suppress_boundary_hydration` latch set in
+  `_recenter_window_on`, released when the placement lands (or superseded).
+  Pin: the jump target is the first mounted row.
+- **F (NIT).** The jump-pill test now pins `pill.display` while a tail is
+  hidden (the missing assertion that would have caught A).
+
+Round verification: two-sided suite 13/13 (8 original + 5 review pins, all
+5 born red on `dc5224c0b`); protected suites 17/17 green and STILL
+unmodified (`git diff` empty); adjacent console set (pruning, tail-follow,
+selection contract, jump pill, region, fence throttle, diff row, native
+transcript) 160 passed + the 3 speak-action failures already proven
+pre-existing on base; ruff clean.

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2243,6 +2243,27 @@ class ConsoleTranscript(VerticalScroll):
                 self.call_later(self.refresh_messages)
         super().anchor(*args, **kwargs)
 
+    def scroll_end(self, *args, **kwargs) -> None:
+        """Jump to the bottom; with a hidden tail, plant the drain's first link.
+
+        Review A, round 2: ``Widget.scroll_end`` (the End key) re-engages
+        the raw anchor synchronously, but its actual scroll can be
+        superseded by the compositor's anchor path, which moves an anchored
+        widget WITHOUT firing the ``scroll_y`` watcher (measured: a pill
+        display toggle between End and the deferred scroll left
+        ``watch_scroll_y`` completely silent across the 32->580 jump). Every
+        scroll-EVENT hook (wheel, PageDown, the watcher) can therefore miss
+        this entry entirely, so the End action itself schedules the first
+        tailward chunk; from there the ``_hydrate_tailward`` self-chain
+        carries the drain on the raw ANCHOR STATE, which needs no scroll
+        events. Callers that already handled the window (``jump_to_latest``
+        via ``anchor()``, the prune's following-branch restore) reach here
+        with no hidden tail, making this a no-op for them.
+        """
+        super().scroll_end(*args, **kwargs)
+        if self._hidden_tail_ids:
+            self._schedule_tailward_hydration()
+
     def _schedule_scrollback_hydration(self) -> None:
         """Coalesce one lazy prepend after explicit detached upward scrolling.
 
@@ -2417,15 +2438,28 @@ class ConsoleTranscript(VerticalScroll):
             message.id: index for index, message in enumerate(self._messages)
         }
         trim_start_id: str | None = None
+        blocking_id: str | None = None
         # Never trim the topmost group: the window must stay non-empty.
         for message_id, group_height in reversed(groups[1:]):
             if message_id in protected_ids:
+                blocking_id = message_id
                 break
             if remaining - group_height <= keep_floor:
                 break
             remaining -= group_height
             trim_start_id = message_id
         if trim_start_id is None:
+            if blocking_id is not None and remaining > keep_floor:
+                # Mirror of the prune's blocked-walk log: without it a
+                # paused slide (selection or focus pinned at the mounted
+                # bottom) is indistinguishable from the trim simply having
+                # nothing to do.
+                logger.debug(
+                    "Console transcript tail trim blocked: mounted height "
+                    f"{remaining} over keep floor {keep_floor} but message "
+                    f"{blocking_id!r} (selected or focused) pins the newest "
+                    "end of the slice"
+                )
             return None
         return index_by_id.get(trim_start_id)
 
@@ -2436,6 +2470,19 @@ class ConsoleTranscript(VerticalScroll):
         size + collapsed vertical margins), scoped per message group. The
         walk ends at the first non-message child (trailing end-rule, empty
         panel, docked jump pill), exactly like the prune's walk.
+
+        Latent mirror divergence, deliberate and currently exact (review
+        round 2): the prune's walk carries ``group_height``/``group_margin``
+        cumulatively ACROSS group boundaries, so a group's first row
+        collapses against the previous group's trailing margin; this walk
+        resets both per group, skipping that inter-group collapse — a
+        per-boundary difference of ``min(prev_bottom, top)``. Today every
+        transcript row has zero vertical margin, so the sum matches the
+        measured virtual height exactly (probe: constant -3 delta = the
+        three non-message chrome rows, at any group count) and the sign is
+        conservative. If a row style ever gains a vertical margin, this
+        walk will overcount each boundary by that collapse amount — still
+        conservative (trims slightly less), but worth knowing.
         """
         key_by_widget_id = {
             id(widget): key for key, widget in self._row_widgets.items()
@@ -3048,9 +3095,27 @@ class ConsoleTranscript(VerticalScroll):
                 self.scroll_end(animate=False)
             else:
                 # Keep the same content in view: shift the offset up by the
-                # height actually removed (measured, not estimated).
+                # height actually removed (measured, not estimated). Use
+                # Textual's internal switch — this is a COMPENSATION, not a
+                # user gesture, exactly like the hydration restore above.
+                # The public scroll_to() calls release_anchor(), which (a)
+                # stamps _user_scroll_time as if the user had scrolled (a
+                # programmatic shift must never outrank a later send's
+                # follow intent — TASK-336 ordering), and (b) — review
+                # round 2's blocker — cleared the RAW anchor during an
+                # End-initiated tail drain: with a tail hidden the belt
+                # predicate makes `following` False, this branch ran, and
+                # the fabricated release disarmed both convergence braces
+                # (the _hydrate_tailward chain and the set_messages heal),
+                # stalling the drain mid-history forever. A genuinely
+                # detached reader's anchor is already released, so for them
+                # this is behavior-identical.
                 removed = total_height - self.virtual_size.height
-                self.scroll_to(y=max(0.0, anchor_y - removed), animate=False)
+                self._scroll_to(
+                    y=max(0.0, anchor_y - removed),
+                    animate=False,
+                    release_anchor=False,
+                )
 
         self.call_after_refresh(_restore_scroll)
 

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2011,6 +2011,17 @@ class ConsoleTranscript(VerticalScroll):
         # than waiting for the next 0.2s sync tick.
         self.sync_jump_indicator(self._last_run_status)
 
+    def _release_anchor_quietly(self) -> None:
+        """Release the raw anchor WITHOUT stamping user scroll intent.
+
+        For programmatic corrections (the prune restoring a detached reader
+        the shrink-clamp re-attached — TASK-15777 review round 2). The
+        public ``release_anchor`` records the release as a user gesture,
+        which would let a maintenance scroll outrank a later send's follow
+        intent (TASK-336 ordering).
+        """
+        super().release_anchor()
+
     @on(events.MouseScrollUp)
     def _hydrate_scrollback_on_boundary_wheel(
         self, _event: events.MouseScrollUp
@@ -3078,6 +3089,7 @@ class ConsoleTranscript(VerticalScroll):
             f"(estimated height {estimated_height})"
         )
         following = self._is_following_tail()
+        raw_anchor_at_entry = self._raw_anchor_engaged()
         anchor_y = self.scroll_y
         self._pruned_message_ids.update(prune_ids)
         logger.info(
@@ -3094,22 +3106,32 @@ class ConsoleTranscript(VerticalScroll):
                 self.anchor()
                 self.scroll_end(animate=False)
             else:
-                # Keep the same content in view: shift the offset up by the
-                # height actually removed (measured, not estimated). Use
-                # Textual's internal switch — this is a COMPENSATION, not a
-                # user gesture, exactly like the hydration restore above.
-                # The public scroll_to() calls release_anchor(), which (a)
-                # stamps _user_scroll_time as if the user had scrolled (a
-                # programmatic shift must never outrank a later send's
-                # follow intent — TASK-336 ordering), and (b) — review
-                # round 2's blocker — cleared the RAW anchor during an
-                # End-initiated tail drain: with a tail hidden the belt
-                # predicate makes `following` False, this branch ran, and
-                # the fabricated release disarmed both convergence braces
-                # (the _hydrate_tailward chain and the set_messages heal),
-                # stalling the drain mid-history forever. A genuinely
-                # detached reader's anchor is already released, so for them
-                # this is behavior-identical.
+                # Restore the reader's state FAITHFULLY, in two parts.
+                #
+                # Anchor state (review round 2's blocker): the shrink from
+                # the reconcile CLAMPS scroll_y to the new maximum, and if
+                # the reader happened to sit at the bottom, Textual's
+                # `_check_anchor` silently re-engages the raw anchor at
+                # that clamp — before this callback runs. The old public
+                # `scroll_to` released the anchor as a side effect, which
+                # accidentally undid that for detached readers but ALSO
+                # disarmed the End-drain's convergence braces (raw anchor
+                # engaged + hidden tail), stalling the drain mid-history
+                # forever. So: restore the anchor state captured at prune
+                # entry — quietly re-release a detached reader the clamp
+                # re-attached (no user-intent stamp: a programmatic shift
+                # must never outrank a later send's follow intent,
+                # TASK-336), and leave an entry-engaged anchor engaged so
+                # the drain keeps converging.
+                if not raw_anchor_at_entry and self._raw_anchor_engaged():
+                    self._release_anchor_quietly()
+                # Content: keep the same rows in view by shifting the
+                # offset up by the height actually removed (measured, not
+                # estimated), via Textual's internal switch — this is a
+                # COMPENSATION, not a user gesture, exactly like the
+                # hydration restore above. Ordering matters: release first,
+                # or the still-engaged anchor pulls the compensating scroll
+                # back to the bottom.
                 removed = total_height - self.virtual_size.height
                 self._scroll_to(
                     y=max(0.0, anchor_y - removed),

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -3043,13 +3043,15 @@ class ConsoleTranscript(VerticalScroll):
             transcript. Deliberately does NOT refresh: callers already own a
             refresh, and the restore path needs to sequence its own.
 
-        TASK-15777: a FAR reveal — one whose resulting window would exceed
-        the low watermark in estimated lines — re-centers the window on the
-        target instead of extending the boundary, mounting an
-        initial-window-sized slice from the target's turn (the same shape a
-        session load produces) with everything past it in the hidden tail.
-        Near reveals keep the plain boundary extension, so small-session
-        behavior is unchanged. Only meaningful under ``_two_sided_active``.
+        TASK-15777: a FAR reveal — one where the newly revealed stretch
+        between the target and the current window would exceed the low
+        watermark in estimated lines — re-centers the window on the target
+        instead of extending the boundary, mounting an initial-window-sized
+        slice from the target's turn (the same shape a session load produces)
+        with everything past it in the hidden tail. Near reveals (a j/k step
+        over the boundary, a nearby restore) keep the plain boundary
+        extension, so small-session behavior is unchanged. Only meaningful
+        under ``_two_sided_active``.
         """
         for index, message in enumerate(self._messages):
             if message.id != message_id:
@@ -3060,9 +3062,9 @@ class ConsoleTranscript(VerticalScroll):
                 return False
             if index < first_visible:
                 revealed_start = self._turn_aligned_start(self._messages, index)
-                revealed_end = tail_start
+                revealed_end = first_visible
             else:
-                revealed_start = first_visible
+                revealed_start = tail_start
                 revealed_end = index + 1
             if self._two_sided_active() and self._estimated_window_lines(
                 revealed_start, revealed_end

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1858,6 +1858,13 @@ class ConsoleTranscript(VerticalScroll):
         #: far jump the old scroll offset is meaningless, so the revealed
         #: target is scrolled to the top of the viewport once its row mounts.
         self._reveal_scroll_target: str | None = None
+        #: Review E: while the re-center's reconcile + placement are in
+        #: flight, the layout transits states (an emptied arrangement, the
+        #: target parked at y~0) that look exactly like top-boundary hits and
+        #: fired one spurious upward hydration — the jump landed with an
+        #: extra chunk mounted ABOVE the target. Latched in
+        #: ``_recenter_window_on``, released once the placement lands.
+        self._suppress_boundary_hydration = False
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -1914,9 +1921,28 @@ class ConsoleTranscript(VerticalScroll):
             return True
         return super().allow_vertical_scroll
 
-    def _is_following_tail(self) -> bool:
-        """Return True when the view is pinned to the newest content."""
+    def _raw_anchor_engaged(self) -> bool:
+        """Return Textual's anchor state: pinned to the bottom of the MOUNTED rows."""
         return bool(self.is_anchored and not getattr(self, "_anchor_released", False))
+
+    def _is_following_tail(self) -> bool:
+        """Return True when the view is pinned to the NEWEST content.
+
+        TASK-15777 (review A): Textual re-engages the anchor without calling
+        ``anchor()`` — ``Widget.scroll_end()`` (the End key) and
+        ``_check_anchor()`` both clear ``_anchor_released`` directly — so the
+        raw anchor state can be engaged while a hidden tail exists ("ghost
+        follow": pinned to the bottom of a stale slice, not the newest
+        content). Treating that state as following suppressed the jump pill
+        (whose visibility is gated on NOT following) exactly when it was the
+        only recovery, and let streamed replies accumulate unseen in the
+        hidden tail. The predicate is therefore the belt: whatever path
+        flips Textual's flag, a non-empty hidden tail means NOT following.
+        The braces are the convergence paths — the ``_hydrate_tailward``
+        chain and the ``set_messages`` ghost-follow heal — which drain or
+        drop the suffix so the raw state becomes true again.
+        """
+        return self._raw_anchor_engaged() and not self._hidden_tail_ids
 
     def sync_jump_indicator(self, run_status: str) -> None:
         """Show/hide the jump-to-latest pill for the current run + scroll state.
@@ -2159,8 +2185,13 @@ class ConsoleTranscript(VerticalScroll):
 
         The last condition is the fixed-point loop-breaker's replacement: with
         sane marks, post-hydration trimming returns the mounted height to
-        ~``low`` before the prune check runs, so the prune (which fires only
-        above ``high``) can never chase hydration. Degenerate marks (e.g. the
+        ~``low`` before the prune check runs — and the trim works in the
+        prune's own MEASURED units (review B: an estimated trim held only
+        while ``measured/estimated <= high/low``, and ordinary short
+        messages exceed that at tight ratios) — so the prune (which fires
+        only above ``high``) cannot chase hydration, except while a
+        protected group (selection, focus) blocks the trim, where scroll-back
+        stalls bounded rather than churning free. Degenerate marks (e.g. the
         45/70 test configuration, where a single chunk overshoots ``high``)
         keep the TASK-15455 refusal-at-low-watermark behavior instead — there
         the refusal IS the loop-breaker and must survive.
@@ -2187,6 +2218,9 @@ class ConsoleTranscript(VerticalScroll):
         rehydrates chunk-by-chunk if the reader scrolls up again.
         """
         self._set_hidden_tail(None)
+        # A jump-to-latest between a re-center and its placement supersedes
+        # the placement; do not leave upward hydration suppressed (review E).
+        self._suppress_boundary_hydration = False
         if self._windowing_enabled():
             self._set_hidden_prefix(
                 self._tail_window_start(
@@ -2236,6 +2270,7 @@ class ConsoleTranscript(VerticalScroll):
         if (
             self._scrollback_hydration_scheduled
             or self._hydrating_scrollback
+            or self._suppress_boundary_hydration
             or not self.is_mounted
             or self._is_following_tail()
             or self._first_visible_message_index() <= 0
@@ -2299,9 +2334,11 @@ class ConsoleTranscript(VerticalScroll):
                 # on the same content, trim the far end of the mounted slice
                 # into the hidden tail so sustained scroll-back keeps the DOM
                 # bounded instead of hitting the low-watermark ceiling. The
-                # trim lands the height back at ~low BEFORE the prune check
-                # runs (refresh_messages schedules it), so the prune (which
-                # fires only above high) never chases hydration.
+                # trim lands the MEASURED height back at ~low BEFORE the
+                # prune check runs (refresh_messages schedules it), so the
+                # prune (which fires only above the measured high mark)
+                # cannot chase hydration — measured, not estimated, is what
+                # makes that ordering an argument (review B).
                 trim_start = (
                     self._compute_tail_trim_start()
                     if self._two_sided_active()
@@ -2320,15 +2357,34 @@ class ConsoleTranscript(VerticalScroll):
     def _compute_tail_trim_start(self) -> int | None:
         """Return the message index where the hidden tail should start, if any.
 
-        Walks the mounted slice from its newest end in ESTIMATED lines,
-        keeping at least ``max(low_mark, scroll_y + 2 viewports)`` mounted —
-        the low watermark is the same budget every other mounted state is
-        allowed, and the viewport term guarantees the trim can never touch
-        content the reader is looking at (or about to reach). Estimates are
-        the same ones the window boundaries already use; the watermarks
-        remain the measured post-layout authority. A group whose row holds
-        keyboard focus stops the walk — removing a focused widget would
-        silently steal the user's keyboard context.
+        Walks the MOUNTED rows from the newest end in MEASURED heights (the
+        same ``outer_size.height`` + margin-collapse accounting the prune's
+        ``_compute_prunable_prefix`` uses), keeping at least
+        ``max(low_mark, scroll_y + 2 viewports)`` mounted — the low watermark
+        is the same budget every other mounted state is allowed, and the
+        viewport term guarantees the trim can never touch content the reader
+        is looking at (or about to reach).
+
+        Measuring is load-bearing, not a refinement (review B): the prune
+        fires on measured ``virtual_size.height``, so an ESTIMATED trim only
+        kept the prune away while ``measured/estimated <= high/low`` — and
+        ordinary short one-line messages measure ~1.35-1.7x their estimate,
+        which at tight watermark ratios produced a permanent 2-cycle where
+        the prune removed exactly what each hydration added and scroll-back
+        never progressed. Trimming in the prune's own units makes the fixed
+        point hold for any content shape.
+
+        Protections stop the walk (contiguity forbids skipping): the
+        SELECTED message (same contract as the prune — review D: trimming it
+        unmounted its action row and made ``j`` teleport) and a group whose
+        row holds keyboard focus (removing a focused widget silently steals
+        the user's keyboard context). While a protection blocks the trim,
+        the prune still bounds total height from the top; scroll-back past
+        a bottom-pinned selection stalls until the selection is cleared —
+        the same stance the prune already takes when a selection blocks its
+        walk. A streaming row is deliberately NOT protected here: hidden, it
+        costs nothing and updates nothing; the pill and the ghost-follow
+        heal bring it back.
 
         Returns:
             The new hidden-tail start index, or ``None`` when nothing should
@@ -2345,20 +2401,77 @@ class ConsoleTranscript(VerticalScroll):
             low_mark,
             int(self.scroll_y) + 2 * self._window_viewport_height(),
         )
-        window = self._messages[first:tail_start]
-        heights = [self._estimated_message_lines(message) for message in window]
-        total = sum(heights)
+        remaining = self.virtual_size.height
+        if remaining <= keep_floor:
+            return None
+        groups = self._measured_message_groups()
+        if len(groups) <= 1:
+            return None
+        protected_ids: set[str] = set()
+        if self.selected_message_id is not None:
+            protected_ids.add(self.selected_message_id)
         focused_id = self._focused_row_message_id()
-        end = tail_start
-        while end - first > 1:
-            group_height = heights[end - 1 - first]
-            if total - group_height <= keep_floor:
+        if focused_id is not None:
+            protected_ids.add(focused_id)
+        index_by_id = {
+            message.id: index for index, message in enumerate(self._messages)
+        }
+        trim_start_id: str | None = None
+        # Never trim the topmost group: the window must stay non-empty.
+        for message_id, group_height in reversed(groups[1:]):
+            if message_id in protected_ids:
                 break
-            if focused_id is not None and self._messages[end - 1].id == focused_id:
+            if remaining - group_height <= keep_floor:
                 break
-            total -= group_height
-            end -= 1
-        return end if end < tail_start else None
+            remaining -= group_height
+            trim_start_id = message_id
+        if trim_start_id is None:
+            return None
+        return index_by_id.get(trim_start_id)
+
+    def _measured_message_groups(self) -> list[tuple[str, int]]:
+        """Return measured ``(message_id, height)`` per mounted group, top-down.
+
+        The per-row accounting mirrors ``_compute_prunable_prefix`` (outer
+        size + collapsed vertical margins), scoped per message group. The
+        walk ends at the first non-message child (trailing end-rule, empty
+        panel, docked jump pill), exactly like the prune's walk.
+        """
+        key_by_widget_id = {
+            id(widget): key for key, widget in self._row_widgets.items()
+        }
+        message_ids = {message.id for message in self._messages}
+        groups: list[tuple[str, int]] = []
+        group_id: str | None = None
+        group_height = 0
+        group_margin = 0
+        for child in self.children:
+            key = key_by_widget_id.get(id(child))
+            row_message_id: str | None = None
+            if key is not None and ":" in key:
+                candidate = key.split(":", 1)[1]
+                if candidate in message_ids:
+                    row_message_id = candidate
+            if row_message_id is None:
+                break
+            if row_message_id != group_id:
+                if group_id is not None:
+                    groups.append((group_id, group_height))
+                group_id = row_message_id
+                group_height = 0
+                group_margin = 0
+            if not child.display:
+                continue
+            top, _, bottom, _ = child.styles.margin
+            group_height = (
+                (group_height - group_margin + max(group_margin, top))
+                + bottom
+                + child.outer_size.height
+            )
+            group_margin = bottom
+        if group_id is not None:
+            groups.append((group_id, group_height))
+        return groups
 
     def _focused_row_message_id(self) -> str | None:
         """Return the message id of the row group holding keyboard focus."""
@@ -2441,8 +2554,13 @@ class ConsoleTranscript(VerticalScroll):
         # ``scroll_y`` change to re-fire the watcher. Re-checking here keeps
         # the walk converging toward the true tail; a detached reader
         # mid-window is left alone (the reveal grew ``max_scroll_y`` past
-        # them, so they are no longer at the boundary).
-        if self._hidden_tail_ids and self._at_bottom_boundary():
+        # them, so they are no longer at the boundary). Review A: the raw
+        # anchor state is part of the condition because the anchor's
+        # auto-scroll can land a tick AFTER this re-check reads
+        # ``scroll_y`` — an anchored reader must converge regardless.
+        if self._hidden_tail_ids and (
+            self._at_bottom_boundary() or self._raw_anchor_engaged()
+        ):
             self._schedule_tailward_hydration()
 
     def set_presentation_context(
@@ -2593,6 +2711,17 @@ class ConsoleTranscript(VerticalScroll):
         self._set_hidden_tail(
             min(surviving_tail_indices) if surviving_tail_indices else None
         )
+        if self._hidden_tail_ids and self._raw_anchor_engaged():
+            # Ghost-follow heal (review A): Textual's anchor re-engaged
+            # WITHOUT anchor() (End key / _check_anchor), so the reader is
+            # pinned to the bottom of a stale slice while replies pile into
+            # the hidden tail — and a reply WITHOUT a new user message never
+            # takes the send branch below. Following means the newest content
+            # must mount: drop the suffix and re-window onto a fresh tail
+            # (``preserved_start = None`` routes the boundary computation
+            # below through the same fresh-tail path a session load uses).
+            self._set_hidden_tail(None)
+            preserved_start = None
         if not self._windowing_enabled():
             # TASK-15455 (reconciliation): `[chat_defaults]
             # transcript_window_lines = 0` mounts the whole history, the
@@ -2607,6 +2736,15 @@ class ConsoleTranscript(VerticalScroll):
             # sticky across ingests (`_pruned_message_ids &= message_ids`);
             # carrying the preserved boundary forward reproduces that, while a
             # fresh or disjoint ingest still starts at 0 = mount everything.
+            #
+            # Review C: the kill switch must clear the hidden TAIL too — the
+            # escape hatch exists so a windowing bug can be switched off
+            # without a release, and carrying the sticky suffix forward left
+            # the trimmed tail hidden forever after a mid-session flip. Safe
+            # against the 15458 per-tick churn: no tail-creating path runs
+            # with windowing off, so this clear is one-shot, and the
+            # watermark-pruned PREFIX stays sticky exactly as before.
+            self._set_hidden_tail(None)
             window_start = 0 if preserved_start is None else preserved_start
         elif preserved_start is None:
             window_start = self._tail_window_start(
@@ -2806,19 +2944,31 @@ class ConsoleTranscript(VerticalScroll):
                 self.call_after_refresh(
                     self._scroll_reveal_target_into_view, target_widget
                 )
+            else:
+                # No row to place: release the review-E latch here, since
+                # the placement callback that normally releases it will
+                # never run.
+                self._suppress_boundary_hydration = False
         self._schedule_prune_check()
 
     def _scroll_reveal_target_into_view(self, widget: Widget) -> None:
         """Scroll a just-revealed jump target to the top of the viewport."""
-        if not self.is_mounted or widget.parent is not self:
-            return
-        # Textual's internal switch: this is a programmatic placement, not a
-        # fresh user gesture (the jump already released the anchor).
-        self._scroll_to(
-            y=max(0.0, float(widget.virtual_region.y) - 1.0),
-            animate=False,
-            release_anchor=False,
-        )
+        try:
+            if not self.is_mounted or widget.parent is not self:
+                return
+            # Textual's internal switch: this is a programmatic placement,
+            # not a fresh user gesture (the jump already released the
+            # anchor).
+            self._scroll_to(
+                y=max(0.0, float(widget.virtual_region.y) - 1.0),
+                animate=False,
+                release_anchor=False,
+            )
+        finally:
+            # The placement has landed (the watcher for it ran synchronously
+            # inside the _scroll_to above); boundary hydration is the
+            # reader's again.
+            self._suppress_boundary_hydration = False
 
     def _schedule_prune_check(self) -> None:
         """Run one watermark pruning check after the pending refresh settles.
@@ -3107,6 +3257,11 @@ class ConsoleTranscript(VerticalScroll):
         self._set_hidden_tail(end if end < len(self._messages) else None)
         self.release_anchor()
         self._reveal_scroll_target = message_id
+        # Review E: the reconcile that realizes this window transits an
+        # emptied arrangement, and the placement parks the target near y=0 —
+        # both read as top-boundary hits and hydrated one spurious chunk
+        # ABOVE the jump target. Suppressed until the placement lands.
+        self._suppress_boundary_hydration = True
 
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1843,6 +1843,21 @@ class ConsoleTranscript(VerticalScroll):
         #: prefix, but only hydration removes ids from it.
         self._scrollback_hydration_scheduled = False
         self._hydrating_scrollback = False
+        #: TASK-15777: view-only hidden TAIL — the second window boundary.
+        #: Always a contiguous SUFFIX of ``_messages`` derived from one index
+        #: (``_hidden_tail_start``), so mounted rows stay one contiguous slice
+        #: by construction: two boundary indices over one list can never
+        #: produce islands, which is why no gap-seam row is needed (the
+        #: failure mode TASK-15455 rejected came from two independently
+        #: mutated sets). Empty in every one-sided regime — the kill switch,
+        #: disabled pruning, and degenerate watermarks never populate it.
+        self._hidden_tail_ids: set[str] = set()
+        self._hidden_tail_start: int | None = None
+        self._tailward_hydration_scheduled = False
+        #: One-shot id consumed by ``refresh_messages``: after a re-centered
+        #: far jump the old scroll offset is meaningless, so the revealed
+        #: target is scrolled to the top of the viewport once its row mounts.
+        self._reveal_scroll_target: str | None = None
 
     def on_mount(self) -> None:
         """Engage tail-follow: stay scrolled to the newest content.
@@ -1978,6 +1993,14 @@ class ConsoleTranscript(VerticalScroll):
         if self.scroll_y <= SCROLLBACK_HYDRATION_THRESHOLD:
             self._schedule_scrollback_hydration()
 
+    @on(events.MouseScrollDown)
+    def _hydrate_tailward_on_boundary_wheel(
+        self, _event: events.MouseScrollDown
+    ) -> None:
+        """Notice a downward wheel gesture against a hidden tail (TASK-15777)."""
+        if self._hidden_tail_ids and self._at_bottom_boundary():
+            self._schedule_tailward_hydration()
+
     def action_page_up(self) -> None:
         """Page upward and hydrate when the current window is already at y=0."""
         at_boundary = self.scroll_y <= SCROLLBACK_HYDRATION_THRESHOLD
@@ -1985,14 +2008,31 @@ class ConsoleTranscript(VerticalScroll):
         if at_boundary:
             self._schedule_scrollback_hydration()
 
+    def action_page_down(self) -> None:
+        """Page downward and reveal the hidden tail at the bottom boundary."""
+        at_boundary = bool(self._hidden_tail_ids) and self._at_bottom_boundary()
+        super().action_page_down()
+        if at_boundary:
+            self._schedule_tailward_hydration()
+
+    def _at_bottom_boundary(self) -> bool:
+        """Return True when the view cannot scroll meaningfully further down."""
+        return self.scroll_y >= self.max_scroll_y - SCROLLBACK_HYDRATION_THRESHOLD
+
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
-        """Hydrate the previous window when a detached reader reaches the top."""
+        """Hydrate the neighboring window when a detached reader hits a boundary."""
         super().watch_scroll_y(old_value, new_value)
         if (
             new_value <= old_value
             and new_value <= SCROLLBACK_HYDRATION_THRESHOLD
         ):
             self._schedule_scrollback_hydration()
+        elif (
+            new_value >= old_value
+            and self._hidden_tail_ids
+            and self._at_bottom_boundary()
+        ):
+            self._schedule_tailward_hydration()
 
     def _window_viewport_height(self) -> int:
         """Return a stable viewport height for line-budget calculations."""
@@ -2082,6 +2122,93 @@ class ConsoleTranscript(VerticalScroll):
             message.id for message in self._messages[:start]
         }
 
+    def _set_hidden_tail(self, start: int | None) -> None:
+        """Replace the view-only hidden tail with one contiguous suffix.
+
+        Args:
+            start: Index of the first hidden-tail message, or ``None`` (or an
+                index at/past the end) to mount through the true tail.
+        """
+        if start is None or start >= len(self._messages):
+            self._hidden_tail_start = None
+            self._hidden_tail_ids = set()
+            return
+        start = max(0, start)
+        self._hidden_tail_start = start
+        self._hidden_tail_ids = {
+            message.id for message in self._messages[start:]
+        }
+
+    def _hidden_tail_start_index(self) -> int:
+        """Return the hidden-tail boundary index (``len`` when no tail is hidden)."""
+        if self._hidden_tail_start is None:
+            return len(self._messages)
+        return self._hidden_tail_start
+
+    def _two_sided_active(self) -> bool:
+        """Return True when the hidden-tail boundary is allowed to engage.
+
+        TASK-15777: two-sided windowing requires ALL of
+        - windowing enabled (the kill switch restores the exact pre-15455
+          behavior, including the pruned prefix being unreachable by scroll),
+        - pruning enabled (``high_mark > 0``; with pruning off there is no
+          ceiling to lift and no height contract to trim against), and
+        - watermarks that can hold at least one scrollback chunk plus a
+          couple of viewports of reader context, with a chunk of headroom
+          between low and high.
+
+        The last condition is the fixed-point loop-breaker's replacement: with
+        sane marks, post-hydration trimming returns the mounted height to
+        ~``low`` before the prune check runs, so the prune (which fires only
+        above ``high``) can never chase hydration. Degenerate marks (e.g. the
+        45/70 test configuration, where a single chunk overshoots ``high``)
+        keep the TASK-15455 refusal-at-low-watermark behavior instead — there
+        the refusal IS the loop-breaker and must survive.
+        """
+        if not self._windowing_enabled():
+            return False
+        low_mark, high_mark = self._prune_watermarks()
+        if high_mark <= 0:
+            return False
+        chunk = self._scrollback_chunk_line_budget()
+        viewport = self._window_viewport_height()
+        return low_mark >= chunk + 2 * viewport and high_mark - low_mark >= chunk
+
+    def _reveal_tail_window(self) -> None:
+        """Drop the hidden tail and re-window onto a fresh bounded tail.
+
+        Every "take me to the newest content" path (the jump pill, a new
+        user send, any ``anchor()``) funnels here when a hidden tail exists:
+        simply clearing the suffix would remount everything between the
+        reader's scroll-back position and the tail in one pass — the exact
+        unbounded reveal this task removes — so the prefix boundary moves
+        FORWARD to a fresh tail window instead, the same shape a session
+        load produces. The dropped scroll-back stays in the store and
+        rehydrates chunk-by-chunk if the reader scrolls up again.
+        """
+        self._set_hidden_tail(None)
+        if self._windowing_enabled():
+            self._set_hidden_prefix(
+                self._tail_window_start(
+                    self._messages,
+                    line_budget=self._initial_window_line_budget(),
+                )
+            )
+
+    def anchor(self, *args, **kwargs) -> None:
+        """Engage tail-follow; a hidden tail is revealed first.
+
+        Anchoring means "follow the newest content", which requires the
+        newest content to be mounted. ``jump_to_latest`` and the send path
+        handle their windows explicitly before anchoring; this override is
+        the safety net for every other caller (TASK-15777).
+        """
+        if self._hidden_tail_ids:
+            self._reveal_tail_window()
+            if self.is_mounted:
+                self.call_later(self.refresh_messages)
+        super().anchor(*args, **kwargs)
+
     def _schedule_scrollback_hydration(self) -> None:
         """Coalesce one lazy prepend after explicit detached upward scrolling.
 
@@ -2099,6 +2226,12 @@ class ConsoleTranscript(VerticalScroll):
         mark, so a prune can never restore a hydratable state. An explicit
         ``_hydrate_scrollback()`` call is deliberately NOT gated — a caller
         asking for one chunk is not a loop.
+
+        TASK-15777: with sane watermarks the refusal is replaced by two-sided
+        windowing — hydration proceeds past the low mark and the tail is
+        trimmed back into the hidden suffix instead (see ``_two_sided_active``
+        for why the fixed point still holds). The refusal remains for the
+        kill switch and degenerate watermark configurations.
         """
         if (
             self._scrollback_hydration_scheduled
@@ -2109,7 +2242,11 @@ class ConsoleTranscript(VerticalScroll):
         ):
             return
         low_mark, high_mark = self._prune_watermarks()
-        if high_mark > 0 and self.virtual_size.height >= low_mark:
+        if (
+            high_mark > 0
+            and self.virtual_size.height >= low_mark
+            and not self._two_sided_active()
+        ):
             return
         self._scrollback_hydration_scheduled = True
         self.call_later(self._hydrate_scrollback)
@@ -2158,11 +2295,155 @@ class ConsoleTranscript(VerticalScroll):
                     animate=False,
                     release_anchor=False,
                 )
-                self._schedule_prune_check()
+                # TASK-15777: two-sided windowing — after the reader is back
+                # on the same content, trim the far end of the mounted slice
+                # into the hidden tail so sustained scroll-back keeps the DOM
+                # bounded instead of hitting the low-watermark ceiling. The
+                # trim lands the height back at ~low BEFORE the prune check
+                # runs (refresh_messages schedules it), so the prune (which
+                # fires only above high) never chases hydration.
+                trim_start = (
+                    self._compute_tail_trim_start()
+                    if self._two_sided_active()
+                    else None
+                )
+                if trim_start is not None:
+                    self._set_hidden_tail(trim_start)
+                    self.call_later(self.refresh_messages)
+                else:
+                    self._schedule_prune_check()
             finally:
                 self._hydrating_scrollback = False
 
         self.call_after_refresh(_restore_reader)
+
+    def _compute_tail_trim_start(self) -> int | None:
+        """Return the message index where the hidden tail should start, if any.
+
+        Walks the mounted slice from its newest end in ESTIMATED lines,
+        keeping at least ``max(low_mark, scroll_y + 2 viewports)`` mounted —
+        the low watermark is the same budget every other mounted state is
+        allowed, and the viewport term guarantees the trim can never touch
+        content the reader is looking at (or about to reach). Estimates are
+        the same ones the window boundaries already use; the watermarks
+        remain the measured post-layout authority. A group whose row holds
+        keyboard focus stops the walk — removing a focused widget would
+        silently steal the user's keyboard context.
+
+        Returns:
+            The new hidden-tail start index, or ``None`` when nothing should
+            be trimmed.
+        """
+        first = self._first_visible_message_index()
+        tail_start = self._hidden_tail_start_index()
+        if tail_start - first <= 1:
+            return None
+        low_mark, high_mark = self._prune_watermarks()
+        if high_mark <= 0:
+            return None
+        keep_floor = max(
+            low_mark,
+            int(self.scroll_y) + 2 * self._window_viewport_height(),
+        )
+        window = self._messages[first:tail_start]
+        heights = [self._estimated_message_lines(message) for message in window]
+        total = sum(heights)
+        focused_id = self._focused_row_message_id()
+        end = tail_start
+        while end - first > 1:
+            group_height = heights[end - 1 - first]
+            if total - group_height <= keep_floor:
+                break
+            if focused_id is not None and self._messages[end - 1].id == focused_id:
+                break
+            total -= group_height
+            end -= 1
+        return end if end < tail_start else None
+
+    def _focused_row_message_id(self) -> str | None:
+        """Return the message id of the row group holding keyboard focus."""
+        try:
+            focused = self.app.focused
+        except NoActiveAppError:
+            return None
+        if focused is None:
+            return None
+        node = focused
+        while node is not None and node.parent is not self:
+            node = node.parent
+        if node is None:
+            return None
+        key = next(
+            (key for key, widget in self._row_widgets.items() if widget is node),
+            None,
+        )
+        if key is None or ":" not in key:
+            return None
+        candidate = key.split(":", 1)[1]
+        if any(message.id == candidate for message in self._messages):
+            return candidate
+        return None
+
+    def _schedule_tailward_hydration(self) -> None:
+        """Coalesce one downward reveal after reaching the bottom boundary.
+
+        TASK-15777: the counterpart of ``_schedule_scrollback_hydration`` for
+        the hidden tail — without it, everything the tail-trim hid would only
+        be reachable via the jump pill or a send, a new reachability hole in
+        the other direction.
+        """
+        if (
+            self._tailward_hydration_scheduled
+            or self._hydrating_scrollback
+            or not self.is_mounted
+            or not self._hidden_tail_ids
+        ):
+            return
+        self._tailward_hydration_scheduled = True
+        self.call_later(self._hydrate_tailward)
+
+    async def _hydrate_tailward(self) -> None:
+        """Reveal one newer chunk from the hidden tail below the reader.
+
+        No scroll compensation is needed: revealed rows mount BELOW the
+        reader, which does not move content above them. Growth on this end
+        is bounded by the existing prefix prune (over the high mark it trims
+        the oldest rows, with its own measured scroll compensation), so an
+        up-then-down round trip oscillates between the two marks instead of
+        accumulating.
+        """
+        self._tailward_hydration_scheduled = False
+        if (
+            self._hydrating_scrollback
+            or not self.is_mounted
+            or not self._hidden_tail_ids
+        ):
+            return
+        tail_start = self._hidden_tail_start_index()
+        budget = self._scrollback_chunk_line_budget()
+        used = 0
+        end = tail_start
+        while end < len(self._messages) and used < budget:
+            used += self._estimated_message_lines(self._messages[end])
+            end += 1
+        self._hydrating_scrollback = True
+        self._set_hidden_tail(end if end < len(self._messages) else None)
+        try:
+            async with self._refresh_lock:
+                await self._reconcile_rows(self._transcript_rows())
+        finally:
+            self._hydrating_scrollback = False
+        self._schedule_prune_check()
+        # Chain while the reader is still pinned to the bottom: a reader whose
+        # anchor re-engaged at the slice bottom is auto-scrolled to the new
+        # bottom DURING the reveal (while the in-flight latch swallows the
+        # boundary signal), and once there, further scroll intents produce no
+        # ``scroll_y`` change to re-fire the watcher. Re-checking here keeps
+        # the walk converging toward the true tail; a detached reader
+        # mid-window is left alone (the reveal grew ``max_scroll_y`` past
+        # them, so they are no longer at the boundary).
+        if self._hidden_tail_ids and self._at_bottom_boundary():
+            self._schedule_tailward_hydration()
 
     def set_presentation_context(
         self,
@@ -2274,7 +2555,9 @@ class ConsoleTranscript(VerticalScroll):
             message.id
             for message in self._messages
             if message.id not in self._pruned_message_ids
+            and message.id not in self._hidden_tail_ids
         ]
+        previous_hidden_tail_ids = self._hidden_tail_ids
         self._messages = list(messages)
         message_ids = {message.id for message in self._messages}
         # Expansion is per message id, so ids that left the transcript (a
@@ -2295,6 +2578,21 @@ class ConsoleTranscript(VerticalScroll):
             if message_id in index_by_id
         ]
         preserved_start = min(preserved_indices) if preserved_indices else None
+        # TASK-15777: the hidden tail is sticky across streaming ingests,
+        # anchored to its first still-present id — otherwise every 0.2s sync
+        # tick would remount the trimmed tail under a scrolled-back reader.
+        # Because the suffix is derived from ONE index over the new list,
+        # ids appended at the end (a streamed reply while the reader is deep
+        # in scroll-back) join it automatically. A disjoint ingest (session
+        # switch) has no surviving id and clears it.
+        surviving_tail_indices = [
+            index_by_id[message_id]
+            for message_id in previous_hidden_tail_ids
+            if message_id in index_by_id
+        ]
+        self._set_hidden_tail(
+            min(surviving_tail_indices) if surviving_tail_indices else None
+        )
         if not self._windowing_enabled():
             # TASK-15455 (reconciliation): `[chat_defaults]
             # transcript_window_lines = 0` mounts the whole history, the
@@ -2337,6 +2635,20 @@ class ConsoleTranscript(VerticalScroll):
             # send/resume intent wins — the coalesced sync can deliver this
             # anchor late, and it must not yank a reader who has already
             # scrolled back.
+            #
+            # TASK-15777: a send from deep scroll-back re-windows onto a
+            # fresh bounded tail. Keeping the preserved (far-back) window
+            # start while clearing the hidden tail would remount everything
+            # from the reader's position to the tail in one pass. The
+            # ``anchor()`` override also clears the suffix, but the boundary
+            # it sets would be overwritten by ``_set_hidden_prefix`` below —
+            # hence the explicit ``window_start`` recompute here.
+            if self._hidden_tail_ids and self._windowing_enabled():
+                self._set_hidden_tail(None)
+                window_start = self._tail_window_start(
+                    self._messages,
+                    line_budget=self._initial_window_line_budget(),
+                )
             self.anchor()
         self._seen_message_ids = message_ids
         # task-501: apply a swipe-handoff selection once its id is actually in
@@ -2357,7 +2669,23 @@ class ConsoleTranscript(VerticalScroll):
                 window_start = self._turn_aligned_start(
                     self._messages, pending_index
                 )
+            elif pending_index >= self._hidden_tail_start_index():
+                # TASK-15777: same contract on the other boundary — a
+                # handed-off selection inside the hidden tail extends the
+                # mounted slice down through it.
+                self._set_hidden_tail(
+                    pending_index + 1
+                    if pending_index + 1 < len(self._messages)
+                    else None
+                )
             self.pending_selection_id = None
+        if (
+            self._hidden_tail_start is not None
+            and self._hidden_tail_start <= window_start
+        ):
+            # Degenerate reorder: the two boundaries crossed. Mounting through
+            # the tail is always safe; a crossed window never is.
+            self._set_hidden_tail(None)
         self._set_hidden_prefix(window_start)
         if self.selected_message_id not in message_ids:
             self.selected_message_id = None
@@ -2467,7 +2795,30 @@ class ConsoleTranscript(VerticalScroll):
         """Reconcile mounted message rows from the current transcript state."""
         async with self._refresh_lock:
             await self._reconcile_rows(self._transcript_rows())
+        # TASK-15777: a re-centered far jump replaced the whole window, so the
+        # previous scroll offset points at arbitrary content — put the jump
+        # target at the top of the viewport once its row has a layout.
+        target_id = self._reveal_scroll_target
+        if target_id is not None:
+            self._reveal_scroll_target = None
+            target_widget = self._row_widgets.get(f"message:{target_id}")
+            if target_widget is not None:
+                self.call_after_refresh(
+                    self._scroll_reveal_target_into_view, target_widget
+                )
         self._schedule_prune_check()
+
+    def _scroll_reveal_target_into_view(self, widget: Widget) -> None:
+        """Scroll a just-revealed jump target to the top of the viewport."""
+        if not self.is_mounted or widget.parent is not self:
+            return
+        # Textual's internal switch: this is a programmatic placement, not a
+        # fresh user gesture (the jump already released the anchor).
+        self._scroll_to(
+            y=max(0.0, float(widget.virtual_region.y) - 1.0),
+            animate=False,
+            release_anchor=False,
+        )
 
     def _schedule_prune_check(self) -> None:
         """Run one watermark pruning check after the pending refresh settles.
@@ -2691,15 +3042,69 @@ class ConsoleTranscript(VerticalScroll):
             False when the message was already mounted or is not in this
             transcript. Deliberately does NOT refresh: callers already own a
             refresh, and the restore path needs to sequence its own.
+
+        TASK-15777: a FAR reveal — one whose resulting window would exceed
+        the low watermark in estimated lines — re-centers the window on the
+        target instead of extending the boundary, mounting an
+        initial-window-sized slice from the target's turn (the same shape a
+        session load produces) with everything past it in the hidden tail.
+        Near reveals keep the plain boundary extension, so small-session
+        behavior is unchanged. Only meaningful under ``_two_sided_active``.
         """
         for index, message in enumerate(self._messages):
             if message.id != message_id:
                 continue
-            if index >= self._first_visible_message_index():
+            first_visible = self._first_visible_message_index()
+            tail_start = self._hidden_tail_start_index()
+            if first_visible <= index < tail_start:
                 return False
-            self._set_hidden_prefix(self._turn_aligned_start(self._messages, index))
+            if index < first_visible:
+                revealed_start = self._turn_aligned_start(self._messages, index)
+                revealed_end = tail_start
+            else:
+                revealed_start = first_visible
+                revealed_end = index + 1
+            if self._two_sided_active() and self._estimated_window_lines(
+                revealed_start, revealed_end
+            ) > self._prune_watermarks()[0]:
+                self._recenter_window_on(index, message_id)
+                return True
+            if index < first_visible:
+                self._set_hidden_prefix(revealed_start)
+            else:
+                self._set_hidden_tail(
+                    revealed_end if revealed_end < len(self._messages) else None
+                )
             return True
         return False
+
+    def _estimated_window_lines(self, start: int, end: int) -> int:
+        """Return the estimated rendered lines of ``_messages[start:end]``."""
+        return sum(
+            self._estimated_message_lines(message)
+            for message in self._messages[start:end]
+        )
+
+    def _recenter_window_on(self, index: int, message_id: str) -> None:
+        """Mount a bounded, load-shaped window with the target's turn on top.
+
+        The far jump detaches the reader from the tail (it IS a user
+        navigation away from it — a later send's follow intent still
+        outranks it, per TASK-336's ordering), and the target row is
+        scrolled to the top of the viewport once mounted, because the old
+        scroll offset is meaningless in the new window.
+        """
+        start = self._turn_aligned_start(self._messages, index)
+        budget = self._initial_window_line_budget()
+        used = 0
+        end = index
+        while end < len(self._messages) and used < budget:
+            used += self._estimated_message_lines(self._messages[end])
+            end += 1
+        self._set_hidden_prefix(start)
+        self._set_hidden_tail(end if end < len(self._messages) else None)
+        self.release_anchor()
+        self._reveal_scroll_target = message_id
 
     def select_message(self, message_id: str) -> None:
         """Select one message and show its contextual action row."""
@@ -2977,12 +3382,13 @@ class ConsoleTranscript(VerticalScroll):
         Keyboard selection walks this list so j/k never lands on a pruned
         (row-less) message; the store-facing ``_messages`` keeps full history.
         """
-        if not self._pruned_message_ids:
+        if not self._pruned_message_ids and not self._hidden_tail_ids:
             return self._messages
         return [
             message
             for message in self._messages
             if message.id not in self._pruned_message_ids
+            and message.id not in self._hidden_tail_ids
         ]
 
     def _notify_selection_changed(self) -> None:
@@ -2996,9 +3402,14 @@ class ConsoleTranscript(VerticalScroll):
     def _transcript_rows(self) -> list[_TranscriptRow]:
         rows: list[_TranscriptRow] = []
         for message in self._messages:
-            if message.id in self._pruned_message_ids:
+            if (
+                message.id in self._pruned_message_ids
+                or message.id in self._hidden_tail_ids
+            ):
                 # TASK-1365: pruned by the height watermarks; the store keeps
                 # the message, the view window drops every row derived from it.
+                # TASK-15777: the hidden tail is the same view-only contract
+                # on the other boundary.
                 continue
             message = self._with_expanded_tool_output(message)
             selected = message.id == self.selected_message_id

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3402,7 +3402,12 @@ prune_low_watermark = 12000
 # more. Both values are FLOORS in terminal rows -- the effective budget is the
 # larger of the floor and the mounted viewport (6x for the initial window, 4x
 # per scrollback step). Set transcript_window_lines <= 0 to mount the whole
-# history at load, as before.
+# history at load, as before. With windowing on and sane watermarks the
+# window is two-sided (TASK-15777): sustained scroll-back keeps loading older
+# history while trimming the newest end back out of the view, so the whole
+# session is reachable by scrolling at a bounded mounted size, and a jump to
+# a far-away message mounts a fresh window around it instead of everything
+# between it and the tail.
 transcript_window_lines = 144
 transcript_scrollback_lines = 96
 

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3404,10 +3404,11 @@ prune_low_watermark = 12000
 # per scrollback step). Set transcript_window_lines <= 0 to mount the whole
 # history at load, as before. With windowing on and sane watermarks the
 # window is two-sided (TASK-15777): sustained scroll-back keeps loading older
-# history while trimming the newest end back out of the view, so the whole
-# session is reachable by scrolling at a bounded mounted size, and a jump to
-# a far-away message mounts a fresh window around it instead of everything
-# between it and the tail.
+# history while trimming the newest end back out of the view (never a
+# selected message, which pauses the sliding while pinned at that end), so
+# the session stays reachable by scrolling at a bounded mounted size, and a
+# jump to a far-away message mounts a fresh window around it instead of
+# everything between it and the tail.
 transcript_window_lines = 144
 transcript_scrollback_lines = 96
 


### PR DESCRIPTION
## Summary

The console transcript's windowing was one-sided (hidden prefix, mounted tail), producing two reproduced defects: a scroll-back reachability CEILING (the hydration refusal that broke the prune/hydration fixed-point loop left 248 of 400 messages permanently unreachable) and UNBOUNDED reveal (a far jump mounted 490 rows in one pass). This adds the second hidden boundary — mounted rows are one contiguous slice by construction (two indices over one list; the review read every mutation path and every probe reported contiguous) — gated to windowing+pruning-on with a kill switch, degenerate fixtures byte-for-byte inert.

Three adversarial review rounds shaped the final mechanism:
- **Sustained scroll-back reaches m0 at a constant ~101 rows/407 height** (was: frozen forever at m248); far jumps land the target as the first visible row in a bounded window (was 490 rows; a boundary-hydration latch fixed a 34-row over-mount, its release verified under deleted-target and session-switch)
- **The trim measures real heights with the prune's own math** — round 2 proved the estimated-units version could 2-cycle forever on short-message shapes; the measured version reaches m0 with zero prune-chasing
- **Tail-follow is bypass-proof**: the predicate treats a non-empty hidden tail as not-following (Textual's End key and `_check_anchor` bypass the `anchor()` override); round 3 closed the last chain — the prune's restore no longer silently releases the raw anchor (and the old release turned out accidentally load-bearing for clamp-re-attached detached readers, now handled by an intent-stamp-free quiet release whose TASK-336 interplay the review attacked and cleared) — and `scroll_end` plants the first hydration directly because the compositor's anchor path scrolls without firing the scroll_y watcher. All three parts mutation-tested load-bearing; the End drain converges at 0/5/20/100 settle frames
- 13 born-red pins; the protected 15455/15456/15458 invariant suites stayed byte-unmodified and green through all three rounds; docs updated honestly (the round-1 "unlimited" claim corrected)

Review (opus, 3 rounds): MERGE. Follow-ups queued: head-pinned selection can disable the prune bound while the chain reveals (pre-existing shape, newly visible, Esc recovers — refuse tailward hydration over the high mark with a blocked prune); a frame-wide End-during-prune race truncating one drain chunk; the latent margin-collapse divergence comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two console transcript defects (TASK-15777): sustained scroll-back stopped at the prune low watermark and far jumps mounted unbounded rows. Introduces a hidden-tail boundary to make windowing two-sided, so scroll-back slides at a bounded DOM size and far jumps recenter into a bounded window.

- Windowing engages only when windowing is on, pruning is on, and marks are sane; `transcript_window_lines = 0` or tiny marks keep the prior one-sided behavior.
- Tail trim now uses measured heights (prune math), protects selected/focused messages, and leaves streaming rows trimmable; jump-to-latest and a user send re-window the tail; streaming ticks keep the hidden tail sticky; End plants the first drain step; a one-shot latch prevents a spurious upward hydrate during re-center.
- Prune restore preserves the raw anchor state and applies a quiet anchor release when needed, keeping detached-reader compensation while preserving End-drain convergence.
- Adds downward hydration to reveal the hidden tail at the bottom boundary; the existing prefix prune still bounds growth.

- Tests: adds `Tests/UI/test_console_transcript_two_sided_window.py`; existing windowing/reconcile suites remain unchanged; docs updated in `Docs/User_Guide/console.md`; config comments updated in `tldw_chatbook/config.py`. No migrations required; optional tuning remains under `[chat_defaults]`.

<sup>Written for commit 5e1e9e9ac8f8c52258e45c69ac119e8baacc8bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

