### PR TITLE
docs(backlog): file the burn-down's second-wave follow-ups (16835-16852)

### DIFF
--- a/Docs/Design/2026-08-11-input-latency-audit.md
+++ b/Docs/Design/2026-08-11-input-latency-audit.md
@@ -184,3 +184,31 @@ tracked as task-3070).
 - **task-15780** — Verify-then-retire `CCPDictionaryEditorWidget`/`CCPPromptEditorWidget` (zero production callers; the CCP `__init__` docstring already says the chrome was retired).
 - **task-15781** — Verify-then-trim `NotesSyncService`'s `SyncProfile` CRUD surface (zero production callers beyond `sync_folder`).
 - **task-15782** — Repair `test_options_persist_to_config`'s stale hardcoded expectation (found by task-15470, unmasked once its `run_worker` crash fix stopped swallowing it).
+
+## Second-wave follow-ups (2026-08-16)
+
+Filed at the close of the follow-up burn-down (the 34 tasks above all merged). Each
+candidate was re-verified live against dev `ee741cf10` before filing; three candidates
+from the reviews' filing queue were dropped as already resolved or already tracked
+(the stale `test_current_schema_version_is_37` contract red — fixed by `4a2d48046`;
+the ChatScreen `_wait_for_production_chat_screen` gate cluster — 141/141 green at HEAD;
+the Library note capability-matrix reds — already tracked as task-16480).
+
+- **task-16835** — Wire or retire the multi-item review batch-analysis path (`app.llm_api_client` never assigned; `BatchAnalysisStartEvent` has no poster since the widget's deletion).
+- **task-16836** — TTS export claims: key by path and honour them in `_discard_tts_artifact` (16199 review F2+F3, merged: one path-keyed redesign covers both).
+- **task-16837** — Wire or retire the TTS export feature (`TTSExportEvent` never posted; handler is not a MessagePump; F6/F4 residuals become live if wired).
+- **task-16838** — Watchlists: per-(subscription,url) in-flight guard against scheduled+manual double-reporting (15764 review finding 1).
+- **task-16839** — Fix and bound `calculate_change_percentage` (autojunk-degenerate pct=1.0 on large Latin pages; quadratic to ~7 min at the 10 MB cap; 15764 review finding 5, merged as one entangled redesign).
+- **task-16840** — Replace the ChaChaNotes rollback registry with bootstrap-under-patched-`_CURRENT_SCHEMA_VERSION` fixtures (15765 review F3; registry has already grown v38/v39 entries).
+- **task-16841** — SiteConfigSettings `#auth-type-select` is backwards (6th instance of the class) + repo-wide backwards-Select AST sweep and permanent guard.
+- **task-16842** — `stts_profile_library` flake family: five timing-sensitive focus-assertion tests, one reproducing standalone.
+- **task-16843** — Extend the reactive-default guard to shared mutable instance defaults (`reactive(SomeClass())`, 5 sites confirmed at HEAD; 15771 review F2).
+- **task-16844** — `FileListItemEnhanced.compose` passes `tooltip=` to `Static`: any non-empty `FileListEnhanced` crashes on compose (15771 review, live traceback).
+- **task-16845** — Study: wire or remove the four undispatched buttons (add-child / create-course / generate-guide / add-milestone) and the placeholder Structured Learning pane (16195/16196 residuals).
+- **task-16846** — Wire up or retire `ScraperBuilderWindow` (ADR-020 Accepted, nav-unreachable; now composes fine after task-15991).
+- **task-16847** — `chat_screen.py:3054` bare `self.call_from_thread(` keeps the repo-wide TASK-929 guard red on dev.
+- **task-16848** — Rewrite the stale `Docs/Features/notes_bidirectional_sync.md` (removed SyncProfile surface; two nonexistent widget files; 15781 residual).
+- **task-16849** — Chapter editor in-place edits (add/split/merge/delete) never refresh the now-truthful chapter table (15773 review residual 4).
+- **task-16850** — `ChapterDetector` emits an empty placeholder chapter per titled heading, ~2x rows (15773 review residual 5).
+- **task-16851** — Console transcript: a head-pinned selection disables the prune while tailward hydration reveals — unbounded mount (15777 round-3 finding, plus the one-frame End-during-prune race).
+- **task-16852** — Watchlists artifacts: script selection still rebuilds the scripts table inside the detail region (15779's disclosed one-level-down residual).

--- a/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
+++ b/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
@@ -28,6 +28,14 @@ missed the prevent()/nav-echo convention before calling the tests stale.
 Another session may already be on some of these -- check `.worktrees/` and
 open branches before starting (a task's status is not a lock).
 
+Extra evidence for the capability-matrix pair (added 2026-08-16, burn-down
+close-out): both still fail at dev `ee741cf10` (re-run this session). The
+task-15774 review reproduced them standalone at its branch HEAD AND at a
+fresh origin/dev-tip throwaway worktree with the identical assertion:
+`#library-notes-new was not reachable with tab; focused=NavigationButton
+(id='nav-lab', ...)` -- i.e. tab-order focus stranding on the nav-lab
+button, not a notes-editor defect.
+
 ## Acceptance Criteria
 
 - [ ] Each of the six is attributed to its causing commit

--- a/backlog/tasks/task-16835 - Wire-or-retire-the-multi-item-review-batch-analysis-path-dead-LLM-branch-no-event-poster.md
+++ b/backlog/tasks/task-16835 - Wire-or-retire-the-multi-item-review-batch-analysis-path-dead-LLM-branch-no-event-poster.md
@@ -1,0 +1,48 @@
+---
+id: TASK-16835
+title: 'Wire or retire the multi-item review batch-analysis path (dead LLM branch, no event poster)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - dead-code
+  - event-handlers
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-16194 (PR #1671) repaired `Event_Handlers/multi_item_review_events.py`'s four
+nonexistent `app.run_in_thread` calls, but its review surfaced a pre-existing gap it
+correctly left unfixed: **`app.llm_api_client` is never assigned anywhere in the live
+app**. `grep -rn "llm_api_client" tldw_chatbook/` finds only the guards that read it
+(`multi_item_review_events.py:85`, `:174`) and the call through it (`:194`
+`app.llm_api_client.chat_with_model`), and `git log --all -S "llm_api_client"` shows the
+attribute was never introduced in `app.py` at any point in history (review16194 §5). The
+`hasattr` guard has therefore always been False in production: every "LLM analysis"
+silently falls back to `generate_placeholder_analysis`.
+
+Verified still true at dev `ee741cf10` — and the situation is one step worse than the
+review recorded: the only production consumer of this module is `app.py:11727-11730`,
+which dispatches `handle_batch_analysis_start` on a `BatchAnalysisStartEvent`, and
+**nothing constructs or posts that event anywhere in `tldw_chatbook/`** — its poster was
+`MultiItemReviewWindow`, deleted as dead code by TASK-1010 (PR #1019). So the whole
+batch-analysis handler path is unreachable, and even if reached it would only produce
+placeholders.
+
+Decide: either wire the feature (assign a real LLM client — the codebase's actual
+dispatcher is the sync `chat_api_call()` in `Chat/Chat_Functions.py:789`, so the existing
+`asyncio.to_thread` hop at `:194` is the right shape — and give the event a real poster),
+or retire the module the way TASK-16196 retired the legacy Study handlers. Do not leave a
+third state where the code looks maintained but cannot execute.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 An explicit wire-or-retire decision is recorded (owner call if product-facing)
+- [ ] #2 If wired: `BatchAnalysisStartEvent` has a real production poster, `app.llm_api_client` (or a replacement seam) is genuinely assigned, and a test proves a batch analysis reaches a real (mockable) LLM dispatch instead of the placeholder
+- [ ] #3 If retired: the module, its app.py dispatch branch, and its tests are removed with the same per-symbol reachability evidence TASK-16196 used
+- [ ] #4 No silent placeholder fallback remains presented as an "LLM analysis" either way
+<!-- AC:END -->

--- a/backlog/tasks/task-16836 - TTS-export-claims-key-by-path-and-honour-them-in-_discard_tts_artifact.md
+++ b/backlog/tasks/task-16836 - TTS-export-claims-key-by-path-and-honour-them-in-_discard_tts_artifact.md
@@ -1,0 +1,52 @@
+---
+id: TASK-16836
+title: 'TTS export claims: key by path and honour them in _discard_tts_artifact'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - concurrency
+  - tts
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two findings from the TASK-16199 review (PR #1676), merged here because one redesign
+covers both (F2+F3 of that review; both re-verified at dev `ee741cf10`):
+
+1. **`_discard_tts_artifact` is the last secure-delete path that ignores export claims
+entirely** (`Event_Handlers/TTS_Events/tts_events.py:3112-3138`). It zeroes-and-unlinks
+with no `_exporting_audio_refcounts` check, and is reachable from the cache-replacement
+path (`:3045`), cancelled-artifact cleanup (`:2946`), stale-console-completion discard
+(`:3147`), and several playback-error paths (`:2089`, `:2113`, `:2141`, `:2186`,
+`:2238`). The TASK-15471 claim invariant is honoured by exactly two call sites
+(`_cleanup_audio_file` and the 16199 shutdown sweep) — contradicting 15471's "verified on
+every path" claim. It also means `cleanup_tts_resources`' own
+`_drain_retained_tts_artifact_work()` awaits (`:3909`, `:3978`) can let a retained
+discard complete during shutdown and zero a claimed file.
+
+2. **The claim is keyed by message id, and the id→path join breaks exactly when it is
+needed** (review F3). The export copies a *path*; the sweep's retry-pass protection maps
+claimed ids through the current `_audio_files` (`:3931-3935`) — but `_discard_tts_artifact`
+deletes the id→path cache entry in the same lock hold that adds the path to the retry set
+(`:3131-3134`), so a retry-set path is normally no longer `_audio_files[id]` for any
+claimed id, and the skip cannot fire for precisely the evicted-entry case. Mutation-
+confirmed untested: disabling the retry skip left all 26 TTS-improvement tests green.
+
+Fix direction: record the claimed **source path** with the claim (refcount keyed by path,
+or store the path beside the id), and have every secure-delete path —
+`_discard_tts_artifact` included — consult it. Note the whole surface is latent today
+(the export path has no production poster — see the companion wire-or-retire task filed
+alongside this one), but it becomes live the moment export is wired.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 No secure-delete path in tts_events.py can destroy a file an export currently claims — `_discard_tts_artifact` included (forced-interleave test or probe as evidence)
+- [ ] #2 The protection survives eviction of the id→path cache entry (the F3 case is pinned by a test that fails against the id-keyed join)
+- [ ] #3 The existing 15471/16199 claim tests stay green
+<!-- AC:END -->

--- a/backlog/tasks/task-16837 - Wire-or-retire-the-TTS-export-feature-TTSExportEvent-is-never-posted.md
+++ b/backlog/tasks/task-16837 - Wire-or-retire-the-TTS-export-feature-TTSExportEvent-is-never-posted.md
@@ -1,0 +1,47 @@
+---
+id: TASK-16837
+title: 'Wire or retire the TTS export feature (TTSExportEvent is never posted)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - dead-code
+  - tts
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The TASK-16199 review (PR #1676, its F1) established — and it still holds at dev
+`ee741cf10` — that the TTS export path is dead code in the shipped app:
+
+- `TTSExportEvent` (`Event_Handlers/TTS_Events/tts_events.py:430`) is **never constructed
+  or posted anywhere in production** — repo-wide grep finds only the class definition,
+  `handle_tts_export` (`:3694`), and `on_tts_export_event` (`:3850`), plus tests.
+- Even if something posted it, it would not arrive: `TTSEventHandler` is **not a
+  `MessagePump`** — it is a plain class instantiated at `app.py:11127` and driven by
+  direct method calls, so Textual name-dispatch never reaches `on_tts_export_event`.
+
+Meanwhile three merged tasks (15471, 16194-era claim work, 16199) have invested real
+concurrency engineering in protecting exports that cannot currently happen. Decide
+whether export gets a UI affordance (a Save/Export action on TTS-bearing messages posting
+through a real dispatch path) or gets retired along with its claim machinery's
+export-only half.
+
+If wired, two known residuals from the same review become live and belong to the wiring
+task: **F6** — the check-then-act window between the shutdown sweep's single up-front
+union read (`:3928`) and its per-file deletes across awaits (demonstrated by probe: an
+export claiming in that gap loses its source); and **F4** — the union's live half
+(exports admitted after the cancel pass) is untested: mutating the union to
+snapshot-only left all 26 tests green, so a refactor can delete that half for free.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 An explicit wire-or-retire decision is recorded (owner call)
+- [ ] #2 If wired: a user-reachable affordance posts the export through a dispatch path that actually reaches the handler, and the F6 residual window is closed or bounded with evidence
+- [ ] #3 If wired: a test pins the shutdown-sweep union's live half (F4) so it cannot be silently removed
+- [ ] #4 If retired: the event, both handlers, and the export-only claim machinery are removed with reachability evidence, and the 15471/16199 tests are re-scoped accordingly
+<!-- AC:END -->

--- a/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
+++ b/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
@@ -1,0 +1,46 @@
+---
+id: TASK-16838
+title: 'Watchlists: per-(subscription,url) in-flight guard against concurrent double-reporting'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - concurrency
+  - watchlists
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from the TASK-15764 review (PR #1679, finding 1), re-verified at dev `ee741cf10`:
+there is **no serialization mechanism for concurrent checks of the same source** —
+`grep -rn "asyncio.Lock\|Semaphore\|in_flight" tldw_chatbook/Subscriptions/
+tldw_chatbook/Scheduling/` still returns nothing relevant. Serialization is structural
+only (the scheduler loop awaits one due task at a time, `Scheduling/scheduler/loop.py:141`;
+url_list/sitemap loops are sequential, `Subscriptions/local_watchlists_service.py:1616-1643`).
+
+But the scheduler runs as an async worker on the app's own event loop (`app.py`,
+`run_worker(self.scheduler_loop.run(), ...)`), and a UI "Check Now" runs
+`launch_run` → `execute_run` on the same loop
+(`watchlists_collections_screen.py:4896-4903` → `watchlist_scope_service.py:606-624`) —
+so a scheduled check of source X and a manual check of source X **can interleave**.
+`check_url`'s read-baseline → await (network fetch at `monitoring_engine.py:1248`,
+plus the off-loop hops) → write-snapshot shape means both runs can read the same baseline
+before either writes: the review forced the interleave and got
+`dispositions=['changed','changed']`, i.e. one page change **double-reported with two
+snapshots written**. This pre-dates 15764 (identical on base) — the off-loop work only
+widened an already network-wide window by ~35 ms.
+
+Fix direction: a per-(subscription_id, url) in-flight guard (skip-or-coalesce the second
+entrant), at the `check_url` orchestration seam rather than inside the engine.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A scheduled run overlapping a manual Check Now of the same source cannot double-report one page change or write two baseline snapshots for it (test forcing the interleave as evidence)
+- [ ] #2 Distinct sources still check concurrently exactly as before (no global serialization)
+- [ ] #3 The guard cannot strand a source as permanently "in flight" after a failed or cancelled check
+<!-- AC:END -->

--- a/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
+++ b/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
@@ -1,0 +1,52 @@
+---
+id: TASK-16839
+title: 'Fix and bound calculate_change_percentage (quadratic cost and autojunk-degenerate ratios)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - perf
+  - watchlists
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two entangled defects in one function, from the TASK-15764 review (PR #1679, finding 5);
+merged into one task because any fix to one must account for the other (they are opposite
+regimes of the same `SequenceMatcher` call). Verified at dev `ee741cf10`:
+`Subscriptions/monitoring_engine.py:255-273` still runs
+`SequenceMatcher(None, old_content, new_content)` — character-level, default
+`autojunk=True`, unbounded input.
+
+1. **Correctness — autojunk makes the percentage meaningless for large Latin pages.**
+With `autojunk=True`, any element occurring in >1% of a ≥200-element sequence is junked;
+for Latin text at ~160 KB every letter clears that bar, the matcher degenerates, and the
+review measured **pct=1.0 ("100% changed") for a 5%-edited page**. Downstream this feeds
+`change_info["change_percentage"]` and every noise/threshold decision built on it.
+
+2. **Cost — quadratic in the large-repertoire regime.** For content where nothing is
+junked (CJK, heavy unicode), the review measured a clean 4x-per-doubling curve: 7.1 ms at
+10k chars → 257.9 ms at 80k chars, extrapolating to **~7 minutes at the 10 MB
+`MAX_FETCH_BYTES_PAGE` cap** — on a worker thread that holds the GIL the whole time
+(difflib is pure Python), so it starves the app even off-loop (task-15764 moved it off
+the event loop; it did not bound it).
+
+Fixing the cost by capping input changes the reported percentage; disabling autojunk to
+fix correctness explodes the cost — hence one task. A segment-level (line/sentence) diff
+with an input-size bound is the likely shape; whatever ships must state what the
+percentage now means. Note the 15764 lesson entry in `lessons-testing-evidence.md`
+carries the old (wrong) mechanism claim for this function's cost — correct it if this
+task changes the story it tells.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A 5%-edited large Latin page reports a small change percentage, not 1.0 (regression test)
+- [ ] #2 Worst-case runtime at the 10 MB fetch cap is bounded to sub-second, measured and stated
+- [ ] #3 Existing change-classification behavior for ordinary pages is preserved or the delta is characterized (byte-diff over the 15764 semantic-identity cases or equivalent)
+- [ ] #4 The stale mechanism/number claims in the 15764 lesson entry are corrected to match the shipped behavior
+<!-- AC:END -->

--- a/backlog/tasks/task-16840 - Replace-the-ChaChaNotes-rollback-registry-with-bootstrap-under-patched-schema-version-fixtures.md
+++ b/backlog/tasks/task-16840 - Replace-the-ChaChaNotes-rollback-registry-with-bootstrap-under-patched-schema-version-fixtures.md
@@ -1,0 +1,48 @@
+---
+id: TASK-16840
+title: 'Replace the ChaChaNotes rollback registry with bootstrap-under-patched-schema-version fixtures'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - test-health
+  - db
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+From the TASK-15765 review (PR #1695, F3): a knowledge-free alternative to the whole
+`Tests/ChaChaNotesDB/schema_rollback.py` registry already exists in this repo —
+`Tests/DB/test_chachanotes_note_folders_migration.py:31-38` bootstraps a genuinely
+vN-shaped DB by patching `_CURRENT_SCHEMA_VERSION` to N and running the **real**
+migration chain. The review verified for v16/v17/v34 that this yields true historical
+schemas (sync triggers present, zero future tables/columns) and replays to current with
+full object parity — with **zero hand-maintained per-version knowledge**, no ratchet, no
+sweep, immune by construction to the v20..v27 trigger-loss class the registry's sweep
+exists to catch.
+
+The registry's costs are compounding, as predicted: at dev `ee741cf10` it has already
+grown hand-written entries for v38 and v39 (schema is now 39,
+`DB/ChaChaNotes_DB.py:247`), each a new chance for the class of error the guard only
+partially sees. The review's F1 proved the parity sweep is **blind to column loss**
+(a seeded `DROP COLUMN` mutation left all 22 replay targets green while four replayed to
+a DB permanently missing a production column — columns are not sqlite_master rows), F2
+documented three comments falsely describing the fixtures as historical, and F4 noted
+column-order divergence for v16..v29 targets.
+
+Migrate the three registry consumers to the bootstrap-under-patched-version primitive and
+delete the registry + ratchet + sweep, or — if the registry is deliberately kept —
+close F1 (per-table column-**set** comparison in `_schema_objects`, sets not tuples per
+F4) and fix the F2 comments. Replacement is the durable end state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Migration-fixture tests obtain vN-shaped DBs without any hand-maintained per-version rollback knowledge (or, explicitly declined, with F1/F2/F4 closed instead)
+- [ ] #2 The trigger-loss and column-loss error classes are both impossible-by-construction or guarded with a mutation-tested oracle
+- [ ] #3 All current consumers (`test_chachanotes_db.py` v17, local-marks, dictionary-backfill fixtures) stay green and still pin what they pinned
+- [ ] #4 A version bump no longer demands a new rollback entry (no ratchet debt), or the remaining debt is documented at the registry
+<!-- AC:END -->

--- a/backlog/tasks/task-16841 - SiteConfigSettings-auth-type-Select-is-backwards-plus-a-repo-wide-backwards-Select-sweep-and-guard.md
+++ b/backlog/tasks/task-16841 - SiteConfigSettings-auth-type-Select-is-backwards-plus-a-repo-wide-backwards-Select-sweep-and-guard.md
@@ -1,0 +1,46 @@
+---
+id: TASK-16841
+title: 'SiteConfigSettings auth-type Select is backwards; repo-wide backwards-Select sweep and guard'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - ui
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The TASK-15991 review (PR #1701) found a sixth instance of the backwards-`Select` bug
+class, still live at dev `ee741cf10`: `UI/SiteConfigSettings.py:241-249` composes
+`#auth-type-select` as `("none", "None"), ("basic", "Basic Auth"), ...` — `(value, label)`
+order, backwards against Textual's `(label, value)` contract. Its consumer
+`display_config` sets `auth_select.value = config.auth_type or "none"`, which raises
+`InvalidSelectValueError` (the Select's real values are the display labels) — swallowed
+by the bare `try/except Exception: logger.error(...)` around the
+`call_from_thread(self.display_config, config)` in `load_site_config`, so selecting a
+site with a saved config silently truncates the config-display refresh. Severity is
+capped only because `SiteConfigSettings` is itself nav-unreachable (same as
+`ScraperBuilderWindow`, task-15991).
+
+This is the bug class TASK-15772 (PR #1691, six sites across `UI/STTS_Window.py` +
+`Widgets/TTS/`) and TASK-15991 (two sites in `ScraperBuilderWindow.py`) fixed piecemeal —
+**three file families, always found by review rather than by tooling, always paired with
+a broad `except` that swallows the crash**. Two of the found sites hid from a plain
+`grep "Select("` sweep because the options arrive later via `.set_options()`. Fix the
+auth-type Select, then do the systematic version: an AST-based sweep for
+`(id_string, "Display Text")`-shaped option tuples covering `Select(options=...)`,
+`set_options(...)`, and option-list constructions, classify every hit, and land a
+permanent guard (Tests/Architecture — none exists for this class today) so the seventh
+instance cannot ship.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `#auth-type-select` composes `(label, value)` and `display_config` restores a saved auth type without raising (born-red test)
+- [ ] #2 A repo-wide sweep (AST-level, covering deferred `.set_options()` population) classifies every Select option construction; every backwards site found is fixed or justified in the notes
+- [ ] #3 A permanent guard fails on a reintroduced backwards `(value, label)` options list (proven by temporary reintroduction)
+<!-- AC:END -->

--- a/backlog/tasks/task-16842 - stts_profile_library-flake-family-five-timing-sensitive-focus-assertion-tests.md
+++ b/backlog/tasks/task-16842 - stts_profile_library-flake-family-five-timing-sensitive-focus-assertion-tests.md
@@ -1,0 +1,48 @@
+---
+id: TASK-16842
+title: 'stts_profile_library flake family: five timing-sensitive focus-assertion tests'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - test-health
+  - tts
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_stts_profile_library.py` carries a pre-existing flake family that two
+independent reviews hit and characterized (task-15772 review round 2, PR #1691; task-15771
+review F4, PR #1699). It is broader than any single pair of tests: across the 15772
+reviewer's three full-file runs, **five distinct tests** flaked —
+
+- `test_reference_export_defaults_sanitized_and_bundle_requires_ack`
+- `test_windows_clone_export_keeps_sanitized_default_and_disables_bundle`
+- `test_delete_shows_advisory_count_but_repository_conflict_is_final`
+- `test_unavailable_profile_disables_playground_action_with_clear_recovery`
+- `test_import_warns_before_picker_and_stale_successor_requires_reconfirm`
+
+— and the first **reproduced standalone** (single test, own process):
+`AssertionError: assert (None is not None)` on `app.focused.id == "bundle-warning-ack"`
+after `_wait_until` confirmed the button was *mounted*. So the root cause looks like each
+test's own internal focus-settle race (mounted ≠ focused yet), not cross-test pollution.
+The 15771 review saw the family degrade under machine load (3 failed normally, 14 failed
+in a run at 2x wall-clock). At dev `ee741cf10` the file has had no stabilization commit
+since (last touched by 15772's own fix), and one standalone re-run of the first test
+passed — consistent with intermittency, not with a fix having landed.
+
+Root-cause the focus-settle pattern (likely one shared helper/idiom around
+export/bundle-ack focus) and make the family deterministic — condition-polls on the
+actual focus state, not mounted-state proxies or fixed sleeps (the repo's GGUF-settle
+lessons apply).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The mechanism of the focus-settle race is identified and stated (not just retried around)
+- [ ] #2 All five named tests pass repeatedly under load (e.g. 10 consecutive full-file runs, at least a few under parallel CPU load), with the run evidence recorded
+- [ ] #3 No fixed-duration sleep is introduced as the fix
+<!-- AC:END -->

--- a/backlog/tasks/task-16843 - Extend-the-reactive-default-guard-to-shared-mutable-instance-defaults-five-sites.md
+++ b/backlog/tasks/task-16843 - Extend-the-reactive-default-guard-to-shared-mutable-instance-defaults-five-sites.md
@@ -1,0 +1,46 @@
+---
+id: TASK-16843
+title: 'Extend the reactive-default guard to shared mutable instance defaults (5 sites)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - ui
+  - architecture
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-15771 (PR #1699) converted all literal/`list()`-call mutable reactive defaults to
+callable factories and landed the AST guard
+`Tests/Architecture/test_reactive_mutable_default_inventory.py`. Its review's F2 flagged
+the natural next hole, still open at dev `ee741cf10`: **`reactive(SomeClass())` — a
+shared mutable *instance* default — is the same one-object-per-class aliasing bug and is
+not detected** (the guard flags `list()/dict()/set()` call results specifically, not
+arbitrary constructor calls). Five occurrences confirmed live at HEAD:
+
+- `Widgets/Console/console_context_modal.py:62-64` — `snapshot = reactive(ConsoleContextSnapshot(current_messages=[], next_send_payload={}))` (carries mutable list/dict fields)
+- `UI/Screens/watchlists_collections_screen.py:547` — `region_layout = reactive(RegionLayout())`
+- `UI/Screens/watchlists_collections_screen.py:582` — `selected_scope = reactive(TreeScope(kind="all"))`
+- `UI/Screens/watchlists_collections_screen.py:583` — `tree_scope = reactive(TreeScope(kind="all"))`
+- `UI/Watchlists_Modules/watchlists_workbench.py:98` — `region_layout = reactive(RegionLayout())`
+
+Whether each is *actually* mutated in place is per-type and untraced (the review did not
+trace them) — that classification is this task's first job, exactly as 15771's LIVE/LATENT
+table did for the literal sites. Note task-15775 already reconciled the
+`RegionLayout` default's *value*; identity-sharing across instances is a separate
+question. Convert genuinely mutable defaults to factories (`reactive(RegionLayout)` /
+lambdas), then teach the guard to flag instance-call defaults — with an explicit
+allowlist mechanism for frozen/immutable types so the guard states its contract honestly
+instead of overclaiming (the 15771 F1/F3 lesson).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Each of the 5 sites is classified LIVE/LATENT/immutable with in-place-mutation evidence, and every mutable one is converted to a per-instance factory
+- [ ] #2 The AST guard detects `reactive(SomeClass())`-shaped defaults (proven born-red by temporary reintroduction), with immutable types handled by a documented allowlist rather than silence
+- [ ] #3 Existing 15771 aliasing/guard tests and the touched widgets' suites stay green
+<!-- AC:END -->

--- a/backlog/tasks/task-16844 - FileListItemEnhanced-passes-tooltip-to-Static-any-non-empty-FileListEnhanced-crashes-on-compose.md
+++ b/backlog/tasks/task-16844 - FileListItemEnhanced-passes-tooltip-to-Static-any-non-empty-FileListEnhanced-crashes-on-compose.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16844
+title: 'FileListItemEnhanced passes tooltip= to Static: any non-empty FileListEnhanced crashes on compose'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - ui
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found live during the TASK-15771 review (PR #1699) and still present at dev `ee741cf10`:
+`Widgets/file_list_item_enhanced.py:123-127` yields
+`Static(self._metadata["name"], classes="file-name", tooltip=str(self.file_path))`, but
+Textual 8.2.8's `Static.__init__` takes only
+`content, *, expand, shrink, markup, name, id, classes, disabled` — **no `tooltip`
+parameter**. The review reproduced it deterministically: mounting `FileListEnhanced` and
+setting a one-element `files` list raises
+
+```
+TypeError: FileListItemEnhanced(id='file-item-...') compose() method returned an invalid
+result; Static.__init__() got an unexpected keyword argument 'tooltip'
+```
+
+Any non-empty `FileListEnhanced` hits it — `files` is a `recompose=True` reactive, so the
+first real row triggers the crash (the irony noted by the review: it is one of the four
+recompose sites 15771 fixed, and the one that cannot be exercised). That no test caught
+it says the widget currently mounts nowhere with data in the tested surface — so
+establish reachability first: if something real feeds it, fix the tooltip (set the
+`.tooltip` attribute after construction, or on the row widget) and pin with a born-red
+non-empty-list test; if nothing does, this is a wire-or-retire candidate rather than a
+one-line patch.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Reachability is established and stated: what (if anything) mounts `FileListEnhanced` with a non-empty list in the live app
+- [ ] #2 A mounted `FileListEnhanced` with at least one file composes without error, and the intended tooltip behavior actually works (test born-red against the current code)
+- [ ] #3 If the widget is dead, it is retired with reachability evidence instead of patched
+<!-- AC:END -->

--- a/backlog/tasks/task-16845 - Study-wire-or-remove-the-four-undispatched-buttons-and-the-placeholder-Structured-Learning-pane.md
+++ b/backlog/tasks/task-16845 - Study-wire-or-remove-the-four-undispatched-buttons-and-the-placeholder-Structured-Learning-pane.md
@@ -1,0 +1,49 @@
+---
+id: TASK-16845
+title: 'Study: wire or remove the four undispatched buttons and the placeholder Structured Learning pane'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - ui
+  - dead-code
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16195 (PR #1681) removed the orphaned "Add Topic" affordance and TASK-16196
+(PR #1688) deleted the legacy Study event-handler module whose table was the only thing
+that ever named these buttons. Both reviews confirmed — and it still holds at dev
+`ee741cf10` — that **four more Study buttons compose live with no handler anywhere**:
+
+- `UI/Study_Window.py:440` — `Button("Add Child", id="add-child-btn")`
+- `UI/Study_Window.py:524` — `Button("Create Course", id="create-course-btn")`
+- `UI/Study_Window.py:612` — `Button("Generate from Topic", id="generate-guide-btn")`
+- `UI/Study_Window.py:671` — `Button("Add Milestone", id="add-milestone-btn")`
+
+Zero `@on(Button.Pressed, ...)` decorators reference any of the four (re-grepped at
+HEAD), and `StudyWindow.on_button_pressed` early-returns unless the id is one of two
+sidebar ids or starts with `view-` — so each press is a **silent no-op**: a user can fill
+in the adjacent inputs, click, and get no signal at all. Same shape as the removed
+add-topic button, which 16195's review called worse UX than "does nothing" implies.
+
+The same review raised the coherence question this task should settle alongside: the
+Structured Learning pane's residual chrome (`#topic-tree` rooted at a static "Learning
+Paths" node that can never gain children; `#topic-content`, a disabled TextArea whose
+placeholder promises "Select a topic from the tree..." with nothing selectable and topics
+write-only in the DB — no row-level read method exists) reads as broken rather than
+intentionally empty. Per affordance: wire it to the live Study rebuild
+(`UI/Study_Modules/` is flashcards + quizzes only today), remove it with 16195's
+per-affordance evidence pattern, or replace the pane with honest empty-state copy /
+gate the section until its backing feature exists.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 No composed Study control silently swallows a press: every remaining button has a real handler or is removed (per-button evidence, 16195-style)
+- [ ] #2 The Structured Learning pane either gains a real read path or presents an honest, intentional empty state (no dead tree + disabled content pane promising interaction)
+- [ ] #3 Study suites stay green and the pinning tests forbid the removed affordances from returning
+<!-- AC:END -->

--- a/backlog/tasks/task-16846 - Wire-up-or-retire-ScraperBuilderWindow-ADR-020-designed-nav-unreachable.md
+++ b/backlog/tasks/task-16846 - Wire-up-or-retire-ScraperBuilderWindow-ADR-020-designed-nav-unreachable.md
@@ -1,0 +1,44 @@
+---
+id: TASK-16846
+title: 'Wire up or retire ScraperBuilderWindow (ADR-020 designed, nav-unreachable)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - ui
+  - dead-code
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-15991 (PR #1701) made `UI/ScraperBuilderWindow.py` *openable* — it had never once
+composed successfully (nonexistent `FormBuilder.create_switch`, a `Collapsible`
+positional-string `MountError`, two backwards Selects), proof that nothing had ever
+reached it. But it remains **nav-unreachable** at dev `ee741cf10`: repo-wide grep finds
+`ScraperBuilderWindow` referenced only by its own file and its regression test
+(`Tests/UI/test_scraper_builder_window.py`); zero matches in
+`UI/Navigation/screen_registry.py` or any command-palette provider. User impact of the
+15991 fix is nil until this decision is made.
+
+The design record says it is a feature, not a leftover: "ADR-020: Visual Scraper Builder"
+(`Docs/Development/Subscriptions/Subscriptions-Implementation-1.md:303`, Status:
+Accepted, 2025-08-01 — note the number collides with an unrelated `backlog/decisions/`
+ADR-020, a pre-existing doc-set collision) describes an interactive UI for testing
+selectors and building extraction rules. Nothing anywhere marks it retired.
+
+Decide (owner call): wire it into navigation/the Watchlists surface it was designed to
+serve, or retire it and amend the ADR — the same fork its nav-unreachable sibling
+`UI/SiteConfigSettings.py` sits on (whose own live Select bug is filed separately). If
+wired, a live-drive check of the full build-test-export flow is due, since the window has
+never been exercised by a user.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 An explicit decision is recorded against ADR-020 (wire or retire), with the ADR/doc updated to match
+- [ ] #2 If wired: the window is reachable through real navigation, and its primary flow works in a live drive (not just the mount test)
+- [ ] #3 If retired: the window, its test, and its `SiteConfigSettings` sibling's disposition are handled together with reachability evidence
+<!-- AC:END -->

--- a/backlog/tasks/task-16847 - chat_screen-bare-self.call_from_thread-breaks-the-repo-wide-guard-dev-red.md
+++ b/backlog/tasks/task-16847 - chat_screen-bare-self.call_from_thread-breaks-the-repo-wide-guard-dev-red.md
@@ -1,0 +1,46 @@
+---
+id: TASK-16847
+title: 'chat_screen bare self.call_from_thread breaks the repo-wide guard (dev red)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - test-health
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/test_call_from_thread_guard.py::test_no_bare_self_call_from_thread_outside_app`
+(the TASK-929 repo-wide backstop) is red on dev — re-verified at `ee741cf10` this
+session:
+
+```
+AssertionError: found bare 'self.call_from_thread(' outside App subclasses ...
+    UI/Screens/chat_screen.py: lines [3054]
+```
+
+The site is `self.call_from_thread(present, snapshot)` at
+`UI/Screens/chat_screen.py:3054` (line 3029 when the 15991 review first caught it, PR
+#1701 — the file has since shifted; the review also confirmed the identical red at the
+then-current origin/dev tip, so this pre-dates and post-dates that whole burn-down).
+`ChatScreen` is a `Screen`, not an `App` — only `App` defines `call_from_thread` — so
+when this thread-worker path executes, it raises `AttributeError` instead of presenting
+the snapshot, most likely swallowed by a broad except (the exact TASK-929 failure mode:
+the notification path breaks precisely when it is needed, invisibly).
+
+Fix is the standard `self.app.call_from_thread(present, snapshot)`, plus a check of what
+`present`/`snapshot` actually surface so the newly-working call does not present broken
+copy — and find why the guard being red on dev raised no alarms (it argues for the guard
+running in whatever gate the merge queue actually exercises).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `Tests/test_call_from_thread_guard.py` passes on dev (both tests)
+- [ ] #2 The corrected call path is exercised once for real (or by test) so the presented snapshot is shown to actually work, not just to stop raising
+- [ ] #3 The guard is not weakened (no new allowlist entry for chat_screen.py)
+<!-- AC:END -->

--- a/backlog/tasks/task-16848 - Rewrite-the-stale-notes_bidirectional_sync-doc-removed-SyncProfile-surface-nonexistent-widgets.md
+++ b/backlog/tasks/task-16848 - Rewrite-the-stale-notes_bidirectional_sync-doc-removed-SyncProfile-surface-nonexistent-widgets.md
@@ -1,0 +1,42 @@
+---
+id: TASK-16848
+title: 'Rewrite the stale notes_bidirectional_sync doc (removed SyncProfile surface, nonexistent widgets)'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - docs
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Docs/Features/notes_bidirectional_sync.md` documents a feature surface that no longer
+exists, confirmed by the TASK-15781 review (PR #1711) and re-verified at dev
+`ee741cf10`:
+
+- It documents the **SyncProfile CRUD surface** ("### 3. Sync Profiles" line 25,
+  "Creating a Sync Profile" 105, "Using Sync Profiles" 112, "Auto-Sync" 118, and a
+  `sync_profiles.json` config example ~275) — all removed from `Notes/sync_service.py`
+  by task-15781, which verified the profile CRUD had zero callers and trimmed
+  `NotesSyncService` down to the live `sync_folder` path.
+- It cites **two widget files that do not exist anywhere in the repo**:
+  `notes_sync_widget.py` (line 84) and `notes_sync_events.py` (line 90) —
+  `find`-verified absent.
+
+The live reality: `NotesSyncService(notes_service=, db=)` constructed in one place
+(`UI/Screens/library_screen.py`, Library's notes-sync flow), `sync_folder` the only
+method called; conflict handling and history are what remain. Rewrite the page against
+that (or fold it into the relevant `Docs/User_Guide/` library page and retire this one),
+with a current "Verified against" stamp. Flagged as out-of-scope-but-must-be-filed by
+15781's own notes; no existing backlog task targets this doc.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The doc no longer describes SyncProfile CRUD, auto-sync profiles, or `sync_profiles.json`
+- [ ] #2 Every file the doc cites exists at the cited role, and the described flow matches the shipped `sync_folder` behavior (verified against the live code, stamp updated)
+- [ ] #3 If retired instead, User_Guide coverage of the surviving notes-sync flow is confirmed and any inbound links are repointed
+<!-- AC:END -->

--- a/backlog/tasks/task-16849 - Chapter-editor-in-place-edits-never-refresh-the-now-truthful-chapter-table.md
+++ b/backlog/tasks/task-16849 - Chapter-editor-in-place-edits-never-refresh-the-now-truthful-chapter-table.md
@@ -1,0 +1,45 @@
+---
+id: TASK-16849
+title: 'Chapter editor in-place edits never refresh the now-truthful chapter table'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - ui
+  - tts
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-15773 (PR #1710) fixed the recompose race that left the audiobook chapter table
+empty for every population, so the table finally shows real rows. Its review's residual 4
+(pre-existing, disclosed, not that task's regression) is now user-visible and still holds
+at dev `ee741cf10`: the editor's own edit buttons mutate the `chapters` reactive **in
+place** and never notify anything, so the table the fix made truthful goes stale on the
+first edit.
+
+`Widgets/TTS/chapter_editor_widget.py`: `_add_chapter` (`:369`,
+`self.chapters.insert(...)`), `_split_chapter` (`:390`), `_merge_chapters` (`:424`),
+`_delete_chapter` (`:446`) all mutate `self.chapters` directly and post a
+`ChapterEditEvent`; none of them calls `_refresh_chapter_table` (`:263`) or
+`mutate_reactive`. The review probed it post-fix: after `_add_chapter`, `chapters=6` but
+`rows=5`; after `_delete_chapter`, `chapters=5`, `rows=5` — counts, titles, and the
+selected-row mapping all drift from reality, and the preview/selection indices then point
+at the wrong chapters. Only `set_chapters` (the detection path) refreshes.
+
+Fix direction: route the four mutations through `mutate_reactive(...)` or an explicit
+refresh (table + preview + selection clamp) after each edit — mirroring what
+`watch_chapters`/`on_mount` already do for the set-path. Note `chapters` must stay
+`reactive(list)` (callable default, task-15771's merged guard pins it).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 After each of add/split/merge/delete, the table's rows, numbering, and the selected row match the chapters list (born-red tests per operation)
+- [ ] #2 The preview pane reflects the post-edit selection (no stale index into the old list)
+- [ ] #3 The 15773 population-race and detection suites stay green
+<!-- AC:END -->

--- a/backlog/tasks/task-16850 - ChapterDetector-emits-an-empty-placeholder-chapter-per-titled-heading-doubling-the-rows.md
+++ b/backlog/tasks/task-16850 - ChapterDetector-emits-an-empty-placeholder-chapter-per-titled-heading-doubling-the-rows.md
@@ -1,0 +1,48 @@
+---
+id: TASK-16850
+title: 'ChapterDetector emits an empty placeholder chapter per titled heading, doubling the rows'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - tts
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pre-existing detector defect made newly visible by TASK-15773's table fix (PR #1710,
+review residual 5); code re-read at dev `ee741cf10` confirms the shape unchanged.
+`ChapterDetector.detect_chapters` (`tldw_chatbook/TTS/audiobook_generator.py:141-231`):
+
+- For every titled heading match it appends a **placeholder** `Chapter` with
+  `content=""` ("Will be filled later", `~:188-197`).
+- When the *next* heading arrives, the accumulated body is appended as a **separate**
+  untitled `Chapter {n}` entry (`~:168-180`) — the preceding placeholder is never
+  back-filled.
+- Only the **final** placeholder ever gets filled, by the "don't forget the last
+  chapter" branch (`~:203-208`, `if chapters and not chapters[-1].content`).
+
+Net effect, probed by the review on a 13-header book: **25 chapters**, alternating
+`title='Chapter 1', content_len=0` placeholders with unnamed body rows — roughly 2x the
+true count. The chapter table (now truthful post-15773) shows the doubled list, the
+first selected row is an empty placeholder (which is why the editor preview shows
+nothing on landing), and downstream audiobook generation iterates phantom empty
+chapters bearing the real titles while the actual prose sits in untitled rows.
+
+Fix direction: back-fill the pending titled placeholder with the accumulated body when
+the next heading (or EOF) arrives, instead of appending the body as a separate chapter —
+one titled Chapter per heading, numbering contiguous. Re-baseline
+`Tests/UI/test_speech_audiobook_chapter_detection.py` counts deliberately (they
+currently pin the doubled behavior implicitly via totals).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A document with N titled headings detects exactly N chapters, each carrying its own title AND its body text (born-red test on the 13-header shape)
+- [ ] #2 No zero-content chapter is emitted for a heading that has body text; the untitled/edge shapes (preamble before the first heading, headerless documents) keep their current behavior, stated in the test
+- [ ] #3 Detection and editor suites re-baselined and green, with the count changes justified in the notes
+<!-- AC:END -->

--- a/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
+++ b/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
@@ -1,0 +1,51 @@
+---
+id: TASK-16851
+title: 'Console transcript: head-pinned selection disables the prune while tailward hydration reveals'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - bug
+  - console
+  - design
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+From the TASK-15777 round-3 review (PR #1733, merged `ee741cf10`), verified against the
+exact merged commit (`5e1e9e9ac`) and explicitly deferred out of that merge gate as
+pre-existing (it reproduces identically at the round-2 commit; round 3's End-drain fix
+only unmasked it):
+
+**A far jump both selects its target and lands it at the top of the window.** The prune
+protects `selected_message_id` and stops at the first protected group
+(`console_transcript.py`, `_compute_prunable_prefix`), so with the target selected at
+the *head*, the prune can never trim anything — while the tailward hydration chain keeps
+revealing. Probe on the headline flow (far jump, then scroll down): mounted rows
+24 → **490**, virtual height **1966 against a high watermark of 900** (2.18x), stable
+after 120 idle frames; clearing the selection with Esc collapses it to 150/603. Bounded
+only by session length — a 10k-message session would mount all of it. This is the mirror
+image of the disclosed tail-pinned trade-off (which stays bounded because the prune still
+trims the head); the head-pinned case is genuinely unbounded. Diagnosable (the prune logs
+its blocked walk) but invisible to the user; the only recovery is Esc.
+
+Suggested fixes from the review: refuse `_hydrate_tailward` while
+`virtual_size.height >= high_mark` and the prune is blocked (the 15455 loop-breaker
+applied to the other boundary), or stop protecting the selection when it is the first
+mounted group. Include the review's second residual while in the file: a **one-frame
+End-during-prune race** — an End pressed between prune entry and `_restore_scroll` has
+its anchor cancelled by `_release_anchor_quietly` (entry state wins), so the drain may
+stop after one chunk; pill is up and a second End resumes, but a settle-varied pin would
+document the bound.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 With a head-pinned selection, a downward walk keeps total mounted height bounded near the high watermark (probe or test on the far-jump-then-scroll-down flow as evidence)
+- [ ] #2 The selection and its action row survive whatever bounding mechanism ships (no teleport, no selection loss)
+- [ ] #3 The 15777 two-sided suite (13), protected pruning suite, and End-drain pins stay green
+- [ ] #4 The one-frame End-during-prune residual is either closed or pinned-and-documented with its recovery
+<!-- AC:END -->

--- a/backlog/tasks/task-16852 - Watchlists-artifacts-script-selection-still-rebuilds-the-scripts-table-inside-the-detail-region.md
+++ b/backlog/tasks/task-16852 - Watchlists-artifacts-script-selection-still-rebuilds-the-scripts-table-inside-the-detail-region.md
@@ -1,0 +1,44 @@
+---
+id: TASK-16852
+title: 'Watchlists artifacts: script selection still rebuilds the scripts table inside the detail region'
+status: To Do
+assignee: []
+created_date: '2026-08-16'
+labels:
+  - ui
+  - watchlists
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-15779 (PR #1732) fixed briefing selection destroying the briefings table by moving
+the detail chrome into a `BriefingDetailRegion` that recomposes alone. Its
+Implementation Notes disclose the deliberately unexpanded scope — the same defect one
+level down — and it still holds at dev `ee741cf10`:
+
+Selecting a **script** rebuilds the WHOLE detail region, including the scripts table the
+user is interacting with. `UI/Watchlists_Modules/artifacts_pane.py:1840-1842` —
+`watch_selected_script` calls `_refresh_detail_region()` (`:1789`), which does
+`region.refresh(recompose=True)`, and `#artifacts-scripts-table` is composed inside
+`compose_briefing_detail()`, i.e. inside the region being torn down. So the 15779 bug's
+symptom set (focused table destroyed under the user, scroll position lost, the
+immediately-following arrow key press dead because the focused widget was unmounted)
+recurs at the scripts level. The briefings table is unaffected either way — 15779's fix
+stands.
+
+Fix direction is the 15779 recipe applied one level down: split the script-detail chrome
+into its own sub-region (or patch script-selection-dependent bits in place) so a script
+selection updates the script detail without recomposing `#artifacts-scripts-table`.
+The 15779 pin suite (`Tests/Watchlists/test_watchlists_artifacts_selection_in_place.py`)
+is the template for the born-red evidence.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting a script updates the script detail without unmounting `#artifacts-scripts-table` (same widget instance, focus and scroll preserved; born-red test)
+- [ ] #2 An arrow-key press immediately after a script selection moves the selection on (the 15779 AC symptom, at the scripts level)
+- [ ] #3 The 15779 selection-in-place suite and the artifacts pane suites stay green
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Close-out of the follow-up burn-down (all 34 actionable tasks merged, PRs #1671–#1733): 18 second-wave tasks filed from what the programme's ~25 adversarial review rounds surfaced, each re-verified live at HEAD with file:line + source-PR citations.

- **Bugs**: the dead multi-item-analysis LLM branch (broadened — the whole path lost its poster in an earlier deletion); `FileListItemEnhanced`'s tooltip compose crash; the sixth backwards-Select plus a repo-wide AST sweep + guard the six-instance recurrence now justifies; the chat_screen `call_from_thread` guard red; ChapterDetector's ~2× placeholder rows; the chapter editor's in-place mutations never refreshing its now-truthful table
- **Concurrency/design residue**: the last unguarded TTS delete path merged with the key-by-path redesign that covers both; wire-or-retire for the unwired TTS export and ScraperBuilder windows; the Watchlists same-source in-flight guard; the transcript's head-pinned-selection prune-disable + End-race (verified against the exact merged commit and explicitly deferred out of #1733); the artifacts scripts-table rebuild residual
- **Test-health/hygiene**: the change-percentage quadratic bound merged with its entangled autojunk degeneracy; the knowledge-free migration-fixture direction (stronger now — the registry already grew two more version entries); the stts flake family; the `reactive(SomeClass())` guard extension; four undispatched Study buttons; the stale bidirectional-sync doc
- **Verify-before-filing caught 3**: the schema-version red fixed by a concurrent session (test now asserts 39); the ChatScreen wait-gate cluster healed (141/141 green at HEAD); the capability-matrix reds already tracked in task-16480, which gained the review's evidence instead

IDs claimed at board-max+20 (sweep found minting to 16815), re-verified collision-free before and after writing; the audit doc gains a second-wave section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files 18 second‑wave follow‑up backlog tasks from recent adversarial reviews and indexes them in the input‑latency audit to capture dead paths, concurrency gaps, UI defects, and test hygiene, with grouped fixes where one redesign covers multiple findings. This organizes outstanding work, sets acceptance criteria, and documents three candidates already resolved or tracked elsewhere.

- Adds `backlog/tasks/task-16835..task-16852` with acceptance criteria covering: dead/wire‑or‑retire paths (multi‑item LLM batch analysis, TTS export, `ScraperBuilderWindow`, Study buttons), concurrency/data‑safety (TTS secure‑delete honoring export claims, watchlists double‑report guard), performance/correctness (`calculate_change_percentage` cost and autojunk degeneracy), UI issues (backwards `Select` plus repo‑wide guard, `FileListEnhanced` tooltip crash, chapter editor refresh, chapter detection placeholders, artifacts scripts table rebuild), test stability (STTS focus flakes), and architecture hygiene (reactive default guard extension), plus a doc rewrite for notes sync.
- Updates `Docs/Design/2026-08-11-input-latency-audit.md` with a “Second‑wave follow‑ups” index and notes three dropped items as already green or tracked; appends evidence to `backlog/tasks/task-16480`.
- Required decisions: wire or retire multi‑item batch analysis, TTS export, `ScraperBuilderWindow`, and the Study Structured Learning pane/undispatched buttons; reviewers should validate these decisions and the new AST/test guards called out in the tasks.
- No runtime behavior changes; review by skimming each task’s scope and ACs and confirming the audit index and evidence updates.

<sup>Written for commit 8d8041755e48e01e6461542b190fdc0ecf502ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

