### PR TITLE
Shadow-name drift guard: report all gaps, see gated-off tools (TASK-13214)

### DIFF
--- a/Tests/Library/test_library_skills_state.py
+++ b/Tests/Library/test_library_skills_state.py
@@ -220,41 +220,50 @@ def test_shadow_name_set_stays_in_sync_with_real_sources():
     """Drift guard: _SHADOWED_BUILTIN_NAMES must cover all real builtin/command names.
 
     This test fails when a new builtin tool/command isn't added to the shadow set
-    — update _SHADOWED_BUILTIN_NAMES in library_skills_state.py when it fires.
+    -- update _SHADOWED_BUILTIN_NAMES in library_skills_state.py when it fires.
+
+    TASK-13214 AC#3: the four sources are collected FIRST and asserted ONCE,
+    so one source's gap can no longer mask another's -- the original
+    three-assert version short-circuited in order, and the fleet-tools gap
+    hid the video-command gap which hid the /research gap, serially, across
+    three sightings.
+
+    TASK-13214/F6: the builtin source is the GATE TABLE
+    (`gateable_builtin_tools()`), not the live catalog -- `list_catalog()`
+    omits gated-OFF tools, which is exactly how `expand_document` stayed
+    invisible to this guard while every gate defaults OFF.
     """
     from tldw_chatbook.Agents.agent_models import RUNTIME_TOOL_NAMES
-    from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider
+    from tldw_chatbook.Agents.tool_catalog import (
+        BuiltinToolProvider,
+        gateable_builtin_tools,
+    )
     from tldw_chatbook.Chat.console_command_grammar import default_console_registry
     from tldw_chatbook.Library.library_skills_state import _SHADOWED_BUILTIN_NAMES
 
-    # Assert RUNTIME_TOOL_NAMES (spawn_subagent, find_tools, load_tools) is a subset
-    assert RUNTIME_TOOL_NAMES <= _SHADOWED_BUILTIN_NAMES, (
-        "RUNTIME_TOOL_NAMES not covered: "
-        f"{RUNTIME_TOOL_NAMES - _SHADOWED_BUILTIN_NAMES}. "
+    sources = {
+        "RUNTIME_TOOL_NAMES": set(RUNTIME_TOOL_NAMES),
+        "BuiltinToolProvider catalog": {
+            e.name for e in BuiltinToolProvider().list_catalog()
+        },
+        "gateable builtins (gate table, incl. gated-off)": {
+            gate.tool_name for gate in gateable_builtin_tools()
+        },
+        "ConsoleCommandRegistry": set(default_console_registry().available_names()),
+    }
+    uncovered = {
+        source: names - _SHADOWED_BUILTIN_NAMES
+        for source, names in sources.items()
+        if names - _SHADOWED_BUILTIN_NAMES
+    }
+    assert not uncovered, (
+        "Shadow-guard drift -- ALL gaps across ALL sources (nothing masked): "
+        f"{ {source: sorted(names) for source, names in uncovered.items()} }. "
         "Add them to _SHADOWED_BUILTIN_NAMES in "
         "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
         "as a baseline failure (task-580)."
     )
 
-    # Assert builtin tool names (calculator, get_current_datetime) are a subset
-    builtin_names = {e.name for e in BuiltinToolProvider().list_catalog()}
-    assert builtin_names <= _SHADOWED_BUILTIN_NAMES, (
-        "BuiltinToolProvider names not covered: "
-        f"{builtin_names - _SHADOWED_BUILTIN_NAMES}. "
-        "Add them to _SHADOWED_BUILTIN_NAMES in "
-        "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
-        "as a baseline failure (task-580)."
-    )
-
-    # Assert console command names (prompt, system) are a subset
-    command_names = set(default_console_registry().available_names())
-    assert command_names <= _SHADOWED_BUILTIN_NAMES, (
-        "ConsoleCommandRegistry names not covered: "
-        f"{command_names - _SHADOWED_BUILTIN_NAMES}. "
-        "Add them to _SHADOWED_BUILTIN_NAMES in "
-        "tldw_chatbook/Library/library_skills_state.py -- do not accept this "
-        "as a baseline failure (task-580)."
-    )
 
 
 def test_build_editor_state_marks_derived_description_and_keeps_field_empty():

--- a/backlog/tasks/task-13214 - Library-shadow-name-drift-guard-is-red-on-generate-video-stream-video-masking-later-drift.md
+++ b/backlog/tasks/task-13214 - Library-shadow-name-drift-guard-is-red-on-generate-video-stream-video-masking-later-drift.md
@@ -3,7 +3,7 @@ id: TASK-13214
 title: >-
   Library shadow-name drift guard is red on generate-video/stream-video, masking
   later drift
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-10 00:29'
 updated_date: '2026-08-16 10:05'
@@ -20,9 +20,9 @@ Tests/Library/test_library_skills_state.py::test_shadow_name_set_stays_in_sync_w
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 generate-video and stream-video are covered by _SHADOWED_BUILTIN_NAMES (or deliberately exempted with a documented reason)
-- [ ] #2 The guard passes on a clean dev checkout
-- [ ] #3 The assertion reports ALL uncovered names across the three sources in one failure rather than short-circuiting on the first subset, so one gap cannot mask another
+- [x] #1 generate-video and stream-video are covered by _SHADOWED_BUILTIN_NAMES (or deliberately exempted with a documented reason)
+- [x] #2 The guard passes on a clean dev checkout
+- [x] #3 The assertion reports ALL uncovered names across the three sources in one failure rather than short-circuiting on the first subset, so one gap cannot mask another
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,3 +40,19 @@ builtin is listed there precisely because this drift guard cannot see
 gated tools — a skill could shadow it undetected. Same family as the
 `research` gap above; whoever repairs the guard should add it in the same
 pass.
+
+**CLOSED 2026-08-16 (fix/task-13214-shadow-guard).** AC#1 was already
+satisfied on dev (generate-video/stream-video covered by the video arc);
+what remained was the masked tail. AC#3 shipped as the structural fix:
+the guard now collects FOUR sources (RUNTIME_TOOL_NAMES, the live
+catalog, **the gate table via `gateable_builtin_tools()` — so gated-OFF
+tools are no longer invisible (F6)**, and the Console command registry)
+and asserts ONCE, reporting every gap across every source. The RED run
+proved the design: it surfaced BOTH remaining gaps simultaneously —
+`research` (masked) and `expand_document` (invisible to the old guard by
+construction). Both added to `_SHADOWED_BUILTIN_NAMES` with reasons.
+AC#2: `Tests/Library/` 1995 passed / 2 skipped / **0 failed** — the
+standing dev red is gone. Behaviour note: skills named `research` or
+`expand_document` are now correctly flagged as shadowing builtins (the
+set's consumer at `library_skills_state.py:287` is the shadow-warning
+path — that is the feature working).

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -58,6 +58,15 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # The run_skill_script runtime tool (same drift-guard rationale as
         # skill_file/install_skill above).
         "run_skill_script",
+        # The /research Console command (task-16481) -- the drift guard's
+        # third sighting (TASK-13214): it was MASKED behind the video-command
+        # gap until the guard learned to report all sources at once.
+        "research",
+        # The expand_document gated builtin (TASK-16174). Gated-OFF tools are
+        # invisible to the live catalog, so the guard now reads the gate
+        # TABLE (TASK-13214/F6) -- and every gateable tool is listed here
+        # regardless of gate state.
+        "expand_document",
         # The agent run-log search runtime tool must not be shadowed by an
         # installed skill with the same invocation name.
         "search_run_log",


### PR DESCRIPTION
## The standing dev red, repaired at its root

`test_shadow_name_set_stays_in_sync_with_real_sources` has been red on dev through three recorded sightings, each one *masking the next*: the guard asserted three subsets in order, so the fleet-tools gap hid the video-command gap, which hid the `/research` gap. High priority precisely because a red drift guard gives nobody a drift signal.

## The fix (AC#3 is the structural one)

- The guard now collects **four** sources and asserts **once**, reporting every uncovered name across every source — one gap can no longer mask another.
- The fourth source is new and closes F6 from the 16688 review: **the gate table** (`gateable_builtin_tools()`) instead of only the live catalog. `list_catalog()` omits gated-OFF tools, which is exactly how `expand_document` — a tool whose gate defaults OFF, like every gateable builtin — was structurally invisible to this guard.
- The RED run vindicated the design immediately, surfacing **both** remaining gaps at once: `research` (masked behind the video gap since `e1f3a4424`) and `expand_document` (never visible to the old guard at all). Both are now in `_SHADOWED_BUILTIN_NAMES` with reasons.

## Verification

- `Tests/Library/`: **1,995 passed, 2 skipped, 0 failed** — the standing dev red is gone.
- Behaviour note (intended): skills named `research` or `expand_document` are now correctly flagged as shadowing builtins — the set's consumer is the shadow-warning path, so this is the feature doing its job.
- ruff clean on both touched files.

Refs TASK-13214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shadow-name drift guard to report all uncovered names across four sources (including gated-off tools), restoring a reliable drift signal. Previously it asserted three subsets in order and read only the live catalog, which masked later gaps and hid gated-off builtins.

- Aggregates and asserts once across `RUNTIME_TOOL_NAMES`, `BuiltinToolProvider().list_catalog()`, the gate table via `gateable_builtin_tools()`, and `default_console_registry().available_names()`.
- Reports all uncovered names by source; no gap can mask another.
- Adds `research` and `expand_document` to `_SHADOWED_BUILTIN_NAMES` with reasons; skills with these names now correctly trigger shadow warnings.
- Tests: 1,995 passed / 2 skipped / 0 failed. Satisfies TASK-13214 (AC#3); AC#1/2 hold. No migrations or other runtime behavior changes.

<sup>Written for commit 89e71b3a3392783b7d0043c47295503a4d046d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

