### PR TITLE
fix(console): trajectory launch used Screen.call_from_thread and Screen.push_screen — neither exists (TASK-16847)

### DIFF
--- a/Tests/UI/test_trajectory_live.py
+++ b/Tests/UI/test_trajectory_live.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from textual.app import App, ComposeResult
+from textual.screen import Screen
 from textual.widgets import DataTable, Static
 
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
@@ -371,10 +372,20 @@ def test_build_trajectory_snapshot_renders_compaction_and_variants(tmp_path):
         db.close()
 
 
-def test_trajectory_launch_action_presents_screen():
-    """The action pushes a TrajectoryScreen built from the active session."""
-    instance = ChatScreen.__new__(ChatScreen)  # bypass heavy __init__
-    pushed: list[object] = []
+async def test_trajectory_launch_action_presents_screen():
+    """The `y` action builds off-thread and pushes a real TrajectoryScreen.
+
+    Regression shape matters here (task-16847): the first version of this
+    test monkeypatched ``instance.call_from_thread`` and
+    ``instance.push_screen`` directly onto the ChatScreen instance --
+    doubles for attributes that do not exist on ``Screen`` at all (both are
+    App-only in Textual 8). The test passed while pressing ``y`` in the
+    real app raised ``AttributeError`` inside the thread worker and never
+    presented anything. This version exercises the real seams instead: the
+    real ``run_worker(thread=True)``, the real ``App.call_from_thread``
+    marshal from the worker thread, and the real ``App.push_screen`` -- so
+    a bare-``self.`` regression on any of them fails loudly.
+    """
 
     class _Store:
         active_session_id = "sess-1"
@@ -390,13 +401,26 @@ def test_trajectory_launch_action_presents_screen():
         def get_payload_revision(self, conversation_id):
             return 1
 
-    instance._console_chat_store = _Store()
-    instance.push_screen = lambda screen, **kwargs: pushed.append(screen)
-    instance.notify = lambda *args, **kwargs: None
-    # Run the launch worker synchronously: build -> present -> push_screen.
-    instance.run_worker = lambda fn, **kwargs: fn()
-    instance.call_from_thread = lambda fn, *args: fn(*args)
+    class _HostApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("base")
 
-    ChatScreen.action_open_trajectory_view(instance)
-    assert pushed and isinstance(pushed[0], TrajectoryScreen)
-    assert pushed[0]._conversation_id == "conv-1"
+    app = _HostApp()
+    async with app.run_test() as pilot:
+        instance = ChatScreen.__new__(ChatScreen)  # bypass heavy __init__
+        # Real DOMNode/MessagePump plumbing without ChatScreen's heavy
+        # __init__, then graft onto the running app so `self.app` (the
+        # attribute the production code must reach through) resolves.
+        Screen.__init__(instance)
+        instance._parent = app
+        instance._console_chat_store = _Store()
+        instance.notify = lambda *args, **kwargs: None  # not under test
+
+        ChatScreen.action_open_trajectory_view(instance)
+        # build() runs on a real worker thread; present() is marshaled back
+        # via the real App.call_from_thread and pushes onto the real stack.
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert isinstance(app.screen, TrajectoryScreen)
+        assert app.screen._conversation_id == "conv-1"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -315,6 +315,17 @@ LIVE_RESPONSE = { ... }                                    # pasted from the wir
 
 A fake can agree with a wrong assumption; `inspect.signature` cannot.
 
+**Sharpest variant (task-16847, 2026-08-16).** A double can stand in for an attribute
+that does not exist at all. `a8082fe85`'s launch test set
+`instance.call_from_thread = ...` and `instance.push_screen = ...` on a
+`ChatScreen.__new__` instance — but `Screen` defines *neither* (both are App-only in
+Textual 8), so pressing `y` in the real app raised `AttributeError` inside the thread
+worker while the test stayed green, and the repo-wide guard
+(`Tests/test_call_from_thread_guard.py`) sat red on dev for two days. When a unit test
+must fake threading/navigation seams, patch the **collaborator** (`app`) — never spell
+a new attribute onto the class under test; an instance monkeypatch is also an
+existence claim, and nothing checks it.
+
 ---
 
 ## Mutation-test every guard you add

--- a/backlog/tasks/task-16847 - chat_screen-bare-self.call_from_thread-breaks-the-repo-wide-guard-dev-red.md
+++ b/backlog/tasks/task-16847 - chat_screen-bare-self.call_from_thread-breaks-the-repo-wide-guard-dev-red.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16847
 title: 'chat_screen bare self.call_from_thread breaks the repo-wide guard (dev red)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - bug
@@ -40,7 +41,85 @@ running in whatever gate the merge queue actually exercises).
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 `Tests/test_call_from_thread_guard.py` passes on dev (both tests)
-- [ ] #2 The corrected call path is exercised once for real (or by test) so the presented snapshot is shown to actually work, not just to stop raising
-- [ ] #3 The guard is not weakened (no new allowlist entry for chat_screen.py)
+- [x] #1 `Tests/test_call_from_thread_guard.py` passes on dev (both tests)
+- [x] #2 The corrected call path is exercised once for real (or by test) so the presented snapshot is shown to actually work, not just to stop raising
+- [x] #3 The guard is not weakened (no new allowlist entry for chat_screen.py)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Baseline at `ecbcd5cd8`: run the guard file (expect the 3054 red) and
+   `Tests/UI/test_trajectory_live.py` (expect green — established the masking).
+2. Read the site in context: `action_open_trajectory_view` — a thread worker
+   builds the snapshot, then marshals `present` back. Verify against installed
+   Textual 8.2.8 what `Screen` actually has (probe found: NEITHER
+   `call_from_thread` NOR `push_screen` — `present` is broken twice over).
+3. `git log -S` for the introducing commit; check the same diff for other bare
+   sites and for allowlist absorption.
+4. Fix: `self.app.call_from_thread(present, snapshot)` at the worker seam and
+   `self.app.push_screen(...)` inside `present` (the AC#2 "actually work" check —
+   fixing only the marshal would move the AttributeError one frame later).
+5. Rewrite `test_trajectory_launch_action_presents_screen`: the shipped version
+   monkeypatched `instance.call_from_thread`/`instance.push_screen` — doubles for
+   attributes that do not exist on Screen, which is exactly how the bug shipped
+   green. Replace with a real-app async test: graft the action onto a minimal
+   running App so the real thread worker, real `App.call_from_thread`, and real
+   `App.push_screen` execute, and assert a `TrajectoryScreen` lands on the stack.
+6. Re-run the guard file (both tests) + the trajectory file; ruff on touched
+   files; document why dev being red raised no alarm.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**The bug was twice as deep as filed.** The site (`action_open_trajectory_view`,
+the Console `y` binding — thread worker builds a `TrajectorySnapshot` off the UI
+thread, marshals `present` back) was broken at BOTH seams: `Screen` in Textual
+8.2.8 defines neither `call_from_thread` nor `push_screen` (probed:
+`hasattr(Screen, ...)` is False for both — App-only). Fixing only the filed
+`self.call_from_thread(present, snapshot)` would have moved the AttributeError
+one frame later, into `present`'s bare `self.push_screen(...)`. Both are now
+`self.app.` (`UI/Screens/chat_screen.py` ~3042/3058, with a task-16847 comment).
+No broad except swallows this one, contrary to the filing's guess: the worker
+runs with `exit_on_error=True` defaults, so pressing `y` on a persisted Console
+conversation would have errored the worker, not just silently dropped the screen.
+
+**Introducing commit:** `a8082fe85` (2026-08-14, "feat(console): trajectory
+screen launch + live tail-follow", via the task-15791 console-clusters branch).
+No allowlist absorption — the same diff's other new call is the CORRECT
+`self.app.call_from_thread` in `trajectory_screen.py`, so the bare form was a
+one-off slip, not a pattern.
+
+**Why green tests shipped it:** the same commit's own launch test
+(`Tests/UI/test_trajectory_live.py::test_trajectory_launch_action_presents_screen`)
+monkeypatched `instance.call_from_thread` and `instance.push_screen` directly
+onto the `ChatScreen.__new__` instance — doubles for attributes that do not
+exist on the class at all. Rewrote it as a real-seam async test: a minimal real
+App under `run_test()`, `Screen.__init__` + `_parent` graft so `self.app`
+resolves, then the REAL `run_worker(thread=True)`, REAL `App.call_from_thread`
+marshal, and REAL `App.push_screen`; asserts a `TrajectoryScreen` lands on the
+app's screen stack. Mutation-checked: reverting either seam to the bare form
+fails the new test (both mutants killed, then restored via Edit).
+
+**Why the red guard raised no alarm on dev:** CI checks are intentionally
+cancelled in this repo (local verification is the gate), and the programme's
+targeted-tests rule means a chat_screen.py implementer runs `Tests/UI/...`
+suites — the repo-wide guard lives at `Tests/test_call_from_thread_guard.py`
+(top level) and is only exercised by a full-suite run. It argues for the guard
+file being added to whatever fast gate the merge flow actually runs; left as a
+programme-level observation rather than a config change here.
+
+**Evidence:** baseline at `ecbcd5cd8`: guard 1 failed (chat_screen.py:3054),
+trajectory file 9 passed (masked). After fix: guard 2 passed + trajectory 9
+passed (11 total). Ruff clean on touched files (the one F401 `inspect` hit in
+chat_screen.py pre-exists at base, untouched). Swept the package for the same
+push_screen family: app.py sites are on the App, `Console_Modules/*` controllers
+define their own delegating `push_screen` (documented pattern), Third_Party hits
+are vendored example Apps — chat_screen.py:3042 was the only real one.
+
+**Files:** `tldw_chatbook/UI/Screens/chat_screen.py` (2-line fix + comment),
+`Tests/UI/test_trajectory_live.py` (real-seam rewrite of the launch test),
+`backlog/docs/lessons-testing-evidence.md` (addendum to "A fake written to
+match your call site": an instance monkeypatch is also an existence claim).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -3038,8 +3038,12 @@ class ChatScreen(BaseAppScreen):
         def build() -> TrajectorySnapshot:
             return _build_trajectory_snapshot(store, conv_id)
 
+        # task-16847: `Screen` defines NEITHER `call_from_thread` NOR
+        # `push_screen` (both are App-only in Textual 8) -- the original
+        # bare `self.` spelling of each raised AttributeError inside the
+        # thread worker, so pressing `y` never presented anything.
         def present(snapshot: TrajectorySnapshot) -> None:
-            self.push_screen(
+            self.app.push_screen(
                 TrajectoryScreen(
                     snapshot,
                     screen_title=screen_title,
@@ -3051,7 +3055,7 @@ class ChatScreen(BaseAppScreen):
 
         def build_worker() -> None:
             snapshot = build()
-            self.call_from_thread(present, snapshot)
+            self.app.call_from_thread(present, snapshot)
 
         self.notify("Building trajectory…")
         self.run_worker(


### PR DESCRIPTION
## Summary

The Console's `y` (trajectory view) binding was AttributeError-dead on a persisted conversation: its thread worker marshaled back via `self.call_from_thread` on a SCREEN — and Textual 8.2.8's Screen defines neither `call_from_thread` nor `push_screen` (both App-only), so fixing just the guard-flagged line would have moved the crash one frame into the bare `self.push_screen`. Both now route through `self.app.` — behavior-identical to the code's intent.

Why it shipped green: the introducing commit's launch test monkeypatched `call_from_thread`/`push_screen` onto the INSTANCE — doubles for attributes the class never had. That test is rewritten as a real-seam async test (real App, real thread worker → real `App.call_from_thread` → real `App.push_screen`, asserts the screen on the stack), and each seam individually mutation-checked red. The repo-wide guard test goes red→green (the filed born-red); a package sweep confirms this was the only real bare `push_screen` outside App subclasses and delegating controllers.

One filing correction recorded: nothing swallowed the error — the worker runs `exit_on_error=True`, so the action errored loudly rather than failing silently. Lessons addendum: an instance monkeypatch is also an existence claim.

11 tests green (guard 2 + trajectory 9); ruff clean. Controller-verified (2-line fix, guard-red as born-red, mutation checks documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console trajectory launch by routing thread marshal and navigation through `self.app`. Previously pressing "y" on a persisted conversation called `Screen.call_from_thread` and `Screen.push_screen` (not defined in `textual` 8), raising `AttributeError` in the worker and never presenting the screen; now it builds on a worker and pushes `TrajectoryScreen` as intended.

- In `ChatScreen.action_open_trajectory_view`, use `self.app.call_from_thread` and `self.app.push_screen`; behavior matches the original intent with the crash removed.
- Rewrote `test_trajectory_launch_action_presents_screen` to run against a real `App`: exercises the real worker, `App.call_from_thread`, and `App.push_screen`; removes instance-level monkeypatches that masked the bug.
- Guard `Tests/test_call_from_thread_guard.py` passes; no new allowlist entries; package sweep found no other bare `push_screen` sites. Satisfies TASK-16847 acceptance criteria.

<sup>Written for commit 96c1c27ab293433dfba3994d4ff05927380fd533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

