### PR TITLE
docs: rewrite the notes bidirectional-sync feature doc to match the live surface (TASK-16848)

### DIFF
--- a/Docs/Features/notes_bidirectional_sync.md
+++ b/Docs/Features/notes_bidirectional_sync.md
@@ -1,57 +1,114 @@
-# Notes Bi-Directional Sync Feature
+# Notes Bi-Directional Sync — engine internals
 
-## Overview
+*Verified against dev @ `766b0ff9e` — 2026-08-16 (task-16848: rewritten from
+scratch — the previous version described a SyncProfile CRUD surface removed
+by task-15781/PR #1711, and cited `notes_sync_widget.py` /
+`notes_sync_events.py`, which never exist in this repo).*
 
-The bi-directional sync feature allows you to synchronize your notes between the tldw_chatbook database and files on your local filesystem. This enables you to:
+For the user-facing walkthrough (where the "Sync" button lives, what each
+control does, screenshots) see
+**[Library notes → Notes sync panel](../User_Guide/library/notes.md#notes-sync-panel)**.
+This page covers the engine underneath that panel: what it does, how
+conflicts are decided, and what's tracked in the database. Every path,
+class, and method named below was read at the commit stamped above.
 
-- Edit notes in your favorite external editor (VSCode, Obsidian, etc.)
-- Maintain a file-based backup of your notes
-- Integrate with other note-taking systems
-- Work with notes offline and sync changes later
+## What it does
 
-## Key Features
+The sync feature mirrors Markdown/text files in a folder on disk with
+notes in the ChaChaNotes database. There is exactly one entry point in the
+running app: the Library screen's Notes surface, notes list toolbar,
+**Sync** button (`#library-notes-sync-open` in
+`tldw_chatbook/UI/Screens/library_screen.py`), which opens an in-canvas
+panel — not a separate screen, dialog, or file. There is no other way to
+start a sync (no CLI command, no scheduled job outside the panel's own
+auto-sync toggle described below).
 
-### 1. Flexible Sync Directions
-- **Disk → Database**: Import files as notes
-- **Database → Disk**: Export notes as files
-- **Bidirectional**: Keep notes and files in sync
+There used to be a **Sync Profiles** system (save/name/reuse multiple
+folder+direction+conflict configurations, one auto-sync interval per
+profile, backed by `~/.config/tldw_cli/sync_profiles.json`). That CRUD
+surface had zero callers and was removed from `NotesSyncService` by
+task-15781 (PR #1711). What remains is a single, global configuration
+(one folder, one direction, one conflict policy, one auto-sync toggle) —
+see [Configuration](#configuration) below.
 
-### 2. Smart Conflict Resolution
-- **Ask on Conflict**: Prompt user to choose which version to keep
-- **Newer Wins**: Automatically use the most recently modified version
-- **Database Wins**: Always prefer the database version
-- **Disk Wins**: Always prefer the file version
+## Components
 
-### 3. Sync Profiles
-Save your sync configurations as profiles for quick access:
-- Root folder location
-- Sync direction preference
-- Conflict resolution strategy
-- File extensions to include
-- Auto-sync settings
+| File | Role |
+|---|---|
+| `tldw_chatbook/Notes/sync_engine.py` — `NotesSyncEngine` | The sync algorithm: scans the disk, reads the DB-synced notes for the folder, diffs by content hash, and applies one of the three directions. |
+| `tldw_chatbook/Notes/sync_service.py` — `NotesSyncService` | Thin wrapper the UI calls: `sync_folder(...)` drives one engine pass; the rest of the class is DB-backed history/conflict lookups (see [Sync history & conflict tracking](#sync-history--conflict-tracking-db-only)). |
+| `tldw_chatbook/Notes/sync_paths.py` — `PinnedSyncRoot`, `SafeSyncFile`, `SyncPathError` | The filesystem boundary: opens the sync root as a directory descriptor and rejects symlinked/reparse entries, so the engine can never read or write outside the folder the user picked. |
+| `tldw_chatbook/Library/library_notes_sync_state.py` | Pure display-state helpers for the panel (label/status-line formatting, direction/conflict cycling) — no I/O. |
+| `tldw_chatbook/UI/Screens/library_screen.py` | Owns the panel's widgets, config load/persist, the `Sync now` worker dispatch (`_run_library_notes_sync`), and the auto-sync `Timer`. |
 
-### 4. Visual Sync Status
-Notes display sync status indicators:
-- ✓ Synced (up to date)
-- ↓ File changed (needs sync from disk)
-- ↑ Database changed (needs sync to disk)
-- ⚠ Conflict (both changed)
-- ✗ File missing
-- ! File error
+There is no `notes_sync_widget.py` or `notes_sync_events.py` — the panel is
+composed and event-handled directly inside `library_screen.py`, in the
+"Notes sync panel" section of that file.
 
-### 5. Progress Tracking
-Real-time progress updates during sync operations:
-- Files processed counter
-- Progress bar
-- Conflict notifications
-- Error reporting
+`NotesSyncService` is constructed fresh per run —
+`NotesSyncService(notes_service=notes_service, db=db)` — inside
+`_run_library_notes_sync`; it is not a long-lived singleton.
 
-## Database Schema
+## Sync directions
 
-The following fields are added to the notes table for sync support:
+`SyncDirection` (`sync_engine.py`), one of three, chosen in the panel's
+"Direction" choice row:
+
+- `disk_to_db` — files on disk win; new/changed files create or update
+  notes, and a file that disappeared from disk is recorded as a conflict
+  (see below), not silently deleted.
+- `db_to_disk` — notes in the DB win; new/changed notes create or update
+  files.
+- `bidirectional` (default) — both sides are diffed against the
+  last-synced hash; whichever side changed since the last sync wins for
+  that item, and an item changed on **both** sides is a conflict.
+
+## Conflict resolution
+
+`ConflictResolution` (`sync_engine.py`) has four members —
+`ASK`, `DISK_WINS`, `DB_WINS`, `NEWER_WINS` — but the Library panel only
+ever offers three of them: `newer_wins` (default), `disk_wins`, `db_wins`.
+`ASK` is deliberately excluded from the panel (`SYNC_CONFLICTS` in
+`library_notes_sync_state.py`): nothing in the Library ever prompts on a
+conflict, so the panel would never be able to act on it. In practice this
+means **the panel never asks** — every conflict is resolved automatically
+by whichever of the three policies is selected, and the resulting count is
+reported afterward in the status line and activity log.
+
+A conflict (both sides changed since the last sync, or a file the DB
+still expects went missing from disk) is always recorded as a row in the
+`sync_conflicts` table (see [Database schema](#database-schema)) before
+any auto-resolution runs, regardless of which policy is active.
+
+`newer_wins` compares the note's `last_modified` timestamp against the
+file's mtime and keeps whichever is more recent — this is the
+last-write-wins behavior CLAUDE.md's "Notes Sync" summary refers to. It is
+the Library panel's persisted config default (`sync_conflict_resolution`,
+see [Configuration](#configuration)) and its parse-fallback for an
+unrecognized stored value, though not the engine method's own parameter
+default — `NotesSyncEngine.sync()` and `NotesSyncService.sync_folder()`
+both default to `ConflictResolution.ASK` when called with no explicit
+value. The panel never relies on that default: it always resolves and
+passes one of its three exposed policies explicitly.
+
+## Path safety
+
+Every read and write goes through `PinnedSyncRoot`
+(`sync_paths.py`), which opens the sync root once as a directory file
+descriptor (`O_NOFOLLOW`/`O_DIRECTORY`, POSIX-only; the guard degrades to
+"unsupported" rather than silently trusting paths on platforms without
+those flags) and re-verifies identity on every child open. A symlink, a
+path that resolves outside the pinned root, or an entry on the wrong
+device is rejected as a `SyncPathError` and recorded in
+`SyncProgress.skipped_items` (reason only — no raw exception text) instead
+of being read or written. This is why a sync run can report skipped items
+distinct from either "no change" or "error."
+
+## Database schema
+
+Fields added to the `notes` table (`tldw_chatbook/DB/ChaChaNotes_DB.py`):
 
 ```sql
--- File sync metadata
 file_path_on_disk TEXT UNIQUE,           -- Absolute path to synced file
 relative_file_path_on_disk TEXT,         -- Path relative to sync root
 sync_root_folder TEXT,                   -- Root folder for this sync
@@ -63,236 +120,68 @@ sync_excluded BOOLEAN DEFAULT 0,         -- Exclude from sync
 file_extension TEXT DEFAULT '.md'        -- File extension to use
 ```
 
-## Architecture
+Plus two standalone tables the engine writes on every run:
+`sync_sessions` (one row per sync pass — folder, direction, conflict
+policy, status, file/conflict/error counts) and `sync_conflicts` (one row
+per detected conflict, linked to its session).
 
-### Components
+None of `is_externally_synced`, `file_path_on_disk`, or the other sync
+columns currently drive any per-note UI indicator — the Library notes list
+shows no synced/conflict badge on individual rows (confirmed: nothing in
+`library_screen.py` reads those columns for display). The only sync
+feedback surfaced to the user is the panel's own status line and activity
+log, described in the User Guide page linked above.
 
-1. **NotesSyncEngine** (`sync_engine.py`)
-   - Core sync logic
-   - File scanning and comparison
-   - Conflict detection
-   - Hash calculation
-   - Progress tracking
+## Sync history & conflict tracking (DB-only)
 
-2. **NotesSyncService** (`sync_service.py`)
-   - High-level sync operations
-   - Profile management
-   - Auto-sync scheduling
-   - History tracking
-   - Conflict resolution
+`NotesSyncService` exposes four methods that read/write `sync_sessions`
+and `sync_conflicts` directly, beyond the `sync_folder()` call the panel
+uses:
 
-3. **NotesSyncWidget** (`notes_sync_widget.py`)
-   - UI for sync configuration
-   - Profile management interface
-   - Progress visualization
-   - Status indicators
+- `get_sync_history(limit=50)` — recent sessions from `sync_sessions`.
+- `get_conflicts_for_session(session_id)` — conflict rows for one session.
+- `resolve_conflict(conflict_id, resolution, user_id)` — records a
+  resolution string on a `sync_conflicts` row. **It does not currently
+  apply the resolution** — the method body has a standing
+  `# TODO: Implement actual resolution logic based on resolution type`;
+  it only marks the row resolved.
+- `get_notes_sync_status(root_folder=None)` — computes a per-note status
+  (`synced` / `file_changed` / `db_changed` / `conflict` / `file_missing`
+  / `file_error`) by re-hashing each synced note's current DB content and
+  its file on disk.
 
-4. **Sync Event Handlers** (`notes_sync_events.py`)
-   - Handle UI interactions
-   - Trigger sync operations
-   - Update displays
-
-## Usage
-
-### Quick Sync
-
-1. Navigate to the Notes tab
-2. Open the Sync panel
-3. Select a folder to sync
-4. Choose sync direction and conflict resolution
-5. Click "Start Sync"
-
-### Creating a Sync Profile
-
-1. Configure sync settings as desired
-2. Click "Save as Profile"
-3. Enter a profile name
-4. Profile is saved for future use
-
-### Using Sync Profiles
-
-1. Select a profile from the list
-2. Click "Sync Selected"
-3. Sync runs with saved settings
-
-### Auto-Sync
-
-1. Edit a sync profile
-2. Enable "Auto-sync"
-3. Set sync interval (default: 5 minutes)
-4. Auto-sync runs in background
-
-## Sync Algorithm
-
-### Disk to Database
-1. Scan directory for supported files (.md, .txt)
-2. For each file:
-   - If new: Create note in database
-   - If changed: Update note content
-   - If deleted: Unlink from database
-
-### Database to Disk
-1. Query synced notes for folder
-2. For each note:
-   - If new: Create file on disk
-   - If changed: Update file content
-   - If file missing: Create or unlink
-
-### Bidirectional
-1. Compare all files and notes
-2. Detect changes using content hash
-3. Identify conflicts (both changed)
-4. Apply conflict resolution strategy
-5. Update metadata after sync
-
-## Conflict Resolution
-
-### Detection
-Conflicts occur when both file and database have changed since last sync:
-- Compare current hashes with last synced hash
-- Check modification timestamps
-- Flag items that changed on both sides
-
-### Resolution Strategies
-1. **Ask**: Show conflict dialog with options
-2. **Newer Wins**: Compare timestamps, use newer
-3. **Database Wins**: Always use database version
-4. **Disk Wins**: Always use file version
-
-## Performance Considerations
-
-### Optimizations
-- Incremental sync using modification times
-- Parallel file processing
-- Hash-based change detection
-- Configurable batch sizes
-- Progress callbacks for UI updates
-
-### Scalability
-- Handles thousands of notes efficiently
-- Minimal memory usage with streaming
-- Database indexes for fast queries
-- Async operations prevent UI blocking
-
-## Security & Safety
-
-### Data Protection
-- No files deleted without confirmation
-- Original content preserved in conflicts
-- Sync history tracked in database
-- Version control via optimistic locking
-
-### Error Handling
-- Graceful handling of file permissions
-- Network interruption recovery
-- Transaction rollback on failure
-- Detailed error logging
-
-## Future Enhancements
-
-### Planned Features
-1. **Three-way merge** for conflict resolution
-2. **File watcher** for real-time sync
-3. **Sync filters** by tags/keywords
-4. **Cloud storage** integration
-5. **Diff viewer** for conflicts
-6. **Backup/restore** functionality
-7. **Sync scheduling** with cron syntax
-8. **Multi-folder** sync support
-
-### Integration Possibilities
-- Git integration for version control
-- Obsidian vault compatibility
-- Notion export/import
-- Markdown preview during sync
-- Template-based file creation
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Permission Errors**
-   - Ensure read/write access to sync folder
-   - Check file ownership
-
-2. **Sync Conflicts**
-   - Review conflict resolution settings
-   - Use sync history to understand changes
-
-3. **Performance Issues**
-   - Reduce sync frequency
-   - Limit file extensions
-   - Use incremental sync
-
-### Debug Mode
-Enable debug logging for detailed sync information:
-```python
-logger.setLevel(logging.DEBUG)
-```
-
-## API Reference
-
-### NotesInteropService Methods
-
-```python
-# Get notes configured for sync
-get_notes_for_sync(user_id: str, sync_root_folder: Path = None) -> List[Dict]
-
-# Get unsynced notes
-get_unsynced_notes(user_id: str, limit: int = 100) -> List[Dict]
-
-# Update sync metadata
-update_note_sync_metadata(user_id: str, note_id: str, 
-                         sync_metadata: Dict, expected_version: int) -> bool
-
-# Link note to file
-link_note_to_file(user_id: str, note_id: str, file_path: Path,
-                  sync_root_folder: Path, sync_strategy: str) -> bool
-
-# Unlink note from file
-unlink_note_from_file(user_id: str, note_id: str) -> bool
-```
-
-### NotesSyncEngine Methods
-
-```python
-# Main sync method
-async sync(root_path: Path, user_id: str, 
-          direction: SyncDirection, 
-          conflict_resolution: ConflictResolution,
-          extensions: List[str] = None) -> Tuple[str, SyncProgress]
-
-# Cancel sync
-cancel_sync(session_id: str)
-
-# Check cancellation
-is_cancelled(session_id: str) -> bool
-```
+None of these four are called anywhere outside `sync_service.py` itself —
+there is no history browser, conflict-review list, or per-note status
+view in the running app today. They exist as service-layer API surface;
+the Library panel's own activity log (capped at 20 entries, in-memory,
+not backed by these tables) is what a user actually sees.
 
 ## Configuration
 
-### Sync Settings
-Default configuration stored in `~/.config/tldw_cli/sync_profiles.json`:
+`[notes]` in `config.toml`, read and written by the sync panel (defaults
+shown):
 
-```json
-{
-  "profiles": [
-    {
-      "name": "Work Notes",
-      "root_folder": "/path/to/notes",
-      "direction": "bidirectional",
-      "conflict_resolution": "newer_wins",
-      "extensions": [".md", ".txt"],
-      "auto_sync": true,
-      "sync_interval": 300
-    }
-  ]
-}
-```
+- `sync_directory` — `~/Documents/Notes`
+- `sync_direction` — `bidirectional`
+- `sync_conflict_resolution` — `newer_wins`
+- `auto_sync` — `false`
 
-### File Extensions
-Supported by default:
-- `.md` - Markdown files
-- `.txt` - Plain text files
+This is one global configuration, not a list of named profiles — there is
+no `sync_profiles.json` and no per-profile settings anywhere in the repo.
 
-Add custom extensions in sync profile configuration.
+When `auto_sync` is on, `library_screen.py` arms a single Textual
+`Timer` (`self.set_interval(AUTO_SYNC_INTERVAL_SECONDS, ...)`,
+`AUTO_SYNC_INTERVAL_SECONDS = 300` in `library_notes_sync_state.py` — a
+fixed five minutes, not user-configurable) that reruns `sync_folder`
+against the configured folder whenever no run is already in flight. The
+timer is scoped to that Library screen instance's lifetime: it is
+re-armed the next time the sync panel is entered while `auto_sync` is
+true, not persisted or resumed as a background job across app restarts or
+other screens.
+
+## Related docs
+
+- [Library notes — Notes sync panel](../User_Guide/library/notes.md#notes-sync-panel) —
+  the user-facing walkthrough: controls, screenshots, common tasks.
+- [Library overview](../User_Guide/library.md) — where Notes sits among
+  the other Library sources.

--- a/backlog/tasks/task-16848 - Rewrite-the-stale-notes_bidirectional_sync-doc-removed-SyncProfile-surface-nonexistent-widgets.md
+++ b/backlog/tasks/task-16848 - Rewrite-the-stale-notes_bidirectional_sync-doc-removed-SyncProfile-surface-nonexistent-widgets.md
@@ -1,9 +1,13 @@
 ---
 id: TASK-16848
-title: 'Rewrite the stale notes_bidirectional_sync doc (removed SyncProfile surface, nonexistent widgets)'
-status: To Do
-assignee: []
+title: >-
+  Rewrite the stale notes_bidirectional_sync doc (removed SyncProfile surface,
+  nonexistent widgets)
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
+updated_date: '2026-08-16 17:33'
 labels:
   - docs
 dependencies: []
@@ -34,9 +38,32 @@ with a current "Verified against" stamp. Flagged as out-of-scope-but-must-be-fil
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 The doc no longer describes SyncProfile CRUD, auto-sync profiles, or `sync_profiles.json`
-- [ ] #2 Every file the doc cites exists at the cited role, and the described flow matches the shipped `sync_folder` behavior (verified against the live code, stamp updated)
-- [ ] #3 If retired instead, User_Guide coverage of the surviving notes-sync flow is confirmed and any inbound links are repointed
+- [x] #1 The doc no longer describes SyncProfile CRUD, auto-sync profiles, or `sync_profiles.json`
+- [x] #2 Every file the doc cites exists at the cited role, and the described flow matches the shipped `sync_folder` behavior (verified against the live code, stamp updated)
+- [x] #3 If retired instead, User_Guide coverage of the surviving notes-sync flow is confirmed and any inbound links are repointed (N/A — kept as a page, not retired: `Docs/User_Guide/library/notes.md` already covers the user-facing flow and cross-links here; the two inbound links from User_Guide keep resolving since the path is unchanged)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read the live surface: Notes/sync_service.py (post-trim NotesSyncService: sync_folder + get_sync_history/get_conflicts_for_session/resolve_conflict/get_notes_sync_status), Notes/sync_engine.py (NotesSyncEngine algorithm, SyncDirection, ConflictResolution, SyncProgress), Notes/sync_paths.py (PinnedSyncRoot path-safety boundary), Library/library_notes_sync_state.py (panel display-state, SYNC_CONFLICTS excludes ASK), and library_screen.py's actual sync entry point (#library-notes-sync-open button -> in-canvas panel -> _run_library_notes_sync -> NotesSyncService.sync_folder on a worker thread; auto-sync Timer).
+2. Grep-verify every file/class/method the old doc named is either real or phantom; confirm notes_sync_widget.py / notes_sync_events.py do not exist anywhere and SyncProfile/sync_profiles.json machinery is gone from sync_service.py (task-15781/PR #1711).
+3. Check Docs/User_Guide/library/notes.md for overlap -- confirmed it already accurately documents the user-facing panel (verified 2026-08-11) and already cross-links to this Features page as "deep dive on the sync engine." Decision: keep this page, defer the user-facing walkthrough to the User_Guide page (cross-link both directions), and rewrite this page to cover engine internals only (architecture, directions, conflict resolution incl. the ASK-excluded-from-UI nuance, path safety, DB schema, the four DB-backed history/conflict methods and that none are wired to any UI, and the real [notes] config keys replacing sync_profiles.json).
+4. Rewrite Docs/Features/notes_bidirectional_sync.md against verified reality, add a "Verified against <sha>" stamp, shorten from 298 to ~188 lines since the live feature no longer supports the old doc's length.
+5. Reference-check every path/class/method cited against HEAD; confirm inbound links (Docs/User_Guide/library.md, Docs/User_Guide/library/notes.md) still resolve since the file path is unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rewrote Docs/Features/notes_bidirectional_sync.md from scratch against live code at dev 766b0ff9e. The prior version described a SyncProfile CRUD surface (save/name/reuse configs, sync_profiles.json, per-profile auto-sync) removed by task-15781/PR #1711, and cited two files (notes_sync_widget.py, notes_sync_events.py) that never exist in this repo.
+
+New doc describes the real surface: NotesSyncEngine (sync_engine.py) + NotesSyncService (sync_service.py, sync_folder() is the only method the UI calls) + the path-safety boundary (PinnedSyncRoot/sync_paths.py) + the panel's own display-state module (Library/library_notes_sync_state.py) + library_screen.py, which owns the actual Notes-surface "Sync" button, in-canvas panel, worker dispatch (_run_library_notes_sync), and the fixed-300s auto-sync Timer. Also documents: the three directions; that the panel exposes only 3 of the engine's 4 ConflictResolution values (ASK is excluded -- the panel never prompts); the engine/service method default is actually ASK even though the panel's own persisted default and parse-fallback is newer_wins; that get_sync_history/get_conflicts_for_session/resolve_conflict/get_notes_sync_status exist but are called nowhere outside sync_service.py (no history/conflict UI exists); that resolve_conflict has a standing TODO and doesn't apply the resolution; and the real [notes] config keys (sync_directory, sync_direction, sync_conflict_resolution, auto_sync) replacing sync_profiles.json.
+
+Checked Docs/User_Guide/library/notes.md first -- it already accurately documents the user-facing panel (last verified 2026-08-11) and already cross-links to this Features page as "deep dive on the sync engine behind the panel." Decision: keep this page (don't retire), defer the walkthrough/screenshots/common-tasks content to the User_Guide page, cross-link both directions, and keep this page scoped to engine internals a developer would need. Doc shrank 298 -> 188 lines (net -110) since the live feature is smaller than what the old doc described.
+
+Verification: every file path (6), class/const name, and method cited was grep/Read-confirmed present at HEAD; every relative link resolves on disk. No other Features doc in the repo carries a "Verified against" stamp (checked all 9), but the task description asked for a current one, so this page carries one anyway, matching the User_Guide convention. Inbound links (Docs/User_Guide/library.md, Docs/User_Guide/library/notes.md) both already point at this unchanged path, so no repointing was needed.
+
+Modified: Docs/Features/notes_bidirectional_sync.md.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

`Docs/Features/notes_bidirectional_sync.md` documented the SyncProfile CRUD surface removed by TASK-15781 and cited two widget files that don't exist in the repo. Rewritten (298 → 188 lines) to describe reality, with every path, class, and method grep-verified at HEAD (the reference table is in the task notes) and the phantom files confirmed absent:

- The live chain: `NotesSyncEngine` / `NotesSyncService` (`sync_folder` as the only UI-called method) / the `PinnedSyncRoot` path boundary / the Library Notes surface's Sync button and its in-canvas panel
- Non-obvious truths from reading the code, now recorded: the panel deliberately exposes 3 of 4 conflict modes (`ASK` never prompts); the engine defaults differ from the panel's persisted default; the four history/conflict methods exist but have no UI caller, and `resolve_conflict` carries a standing TODO that doesn't apply the resolution; the real `[notes]` config keys replace the removed profiles JSON
- Cross-linked both directions with the accurate User Guide page (scoped this doc to engine internals, no walkthrough duplication)

Docs-only; controller-verified (grep confirms zero references to the removed surface remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites `Docs/Features/notes_bidirectional_sync.md` to match the current notes sync surface and remove references to the retired profiles UI and nonexistent widget files. This aligns the feature doc with the engine-driven, single-configuration panel users see today.

- Replaces the outdated “Sync Profiles” flow with the real chain: `NotesSyncEngine` + `NotesSyncService` (`sync_folder` only) → Library Notes “Sync” panel; removes `notes_sync_widget.py`/`notes_sync_events.py` references.
- Clarifies conflict handling: the panel exposes `newer_wins`, `disk_wins`, `db_wins`; it never prompts. The engine’s default is `ASK`, but the panel persists and passes `newer_wins`.
- Documents the single global `[notes]` config in `config.toml` (`sync_directory`, `sync_direction`, `sync_conflict_resolution`, `auto_sync`) and the fixed 5‑minute auto‑sync timer.
- Captures path safety via `PinnedSyncRoot`; notes DB schema and that history/conflict APIs exist without UI wiring; `resolve_conflict` records a decision but does not apply it.
- Cross-links to the user-facing Library Notes page and verifies every cited path/class/method exists; satisfies TASK-16848 acceptance criteria.

<sup>Written for commit 93ddd795262405304e27e3659565bfbccd3b1da7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

