### PR TITLE
fix(study): remove the four undispatched buttons and the placeholder pane's false promise (TASK-16845)

### DIFF
--- a/Tests/UI/test_study_screen.py
+++ b/Tests/UI/test_study_screen.py
@@ -748,8 +748,149 @@ async def test_structured_learning_pane_composes_no_orphaned_add_topic_controls(
         await pilot.pause()
 
         study_window = app.screen.query_one(StudyWindow)
-        # The pane itself still renders: the topic tree is composed...
-        study_window.query_one("#topic-tree", Tree)
-        # ...but the orphaned add-topic affordance is gone end-to-end.
+        # ...the orphaned add-topic affordance is gone end-to-end.
         assert not study_window.query("#add-topic-btn")
         assert not study_window.query("#new-topic-title")
+        # task-16845: the pane's placeholder tree + disabled content preview
+        # were dead chrome too (topics have no read path, and nothing
+        # dispatches Tree.NodeSelected since task-16196 deleted the legacy
+        # module) -- replaced with an honest empty-state notice.
+        assert not study_window.query("#topic-tree")
+        assert not study_window.query("#topic-content")
+        empty_state = study_window.query_one("#structured-learning-empty-state", Static)
+        assert "no way to" in _text(empty_state).lower()
+
+
+@pytest.mark.asyncio
+async def test_mindmaps_pane_composes_no_orphaned_add_child_button():
+    """task-16845: `#add-child-btn` (task-16196's per-symbol sweep confirmed
+    `handle_add_mindmap_child` was dead) has no dispatcher anywhere, and
+    ChaChaNotes_DB's `create_mindmap`/`add_mindmap_node` are write-only with
+    no read/list method -- the mindmap tree can never show what the button
+    would write. `#add-sibling-btn` is a separate, equally-undispatched
+    button out of this task's scope, and shares `#node-text` with the
+    removed button, so that input must survive the removal."""
+    StudyScopeContext, StudyScopeType = _load_study_scope_models()
+    app_instance = SimpleNamespace(
+        scope_context=StudyScopeContext(scope_type=StudyScopeType.GLOBAL),
+        current_runtime_backend="local",
+        runtime_backend=None,
+        open_notes_workspace=Mock(),
+        open_study_screen=Mock(),
+        notify=Mock(),
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#view-mindmaps-btn", Button).press()
+        await pilot.pause()
+
+        study_window = app.screen.query_one(StudyWindow)
+        assert not study_window.query("#add-child-btn")
+        # Out-of-scope siblings, and the input they share, still compose.
+        study_window.query_one("#mindmap-tree", Tree)
+        study_window.query_one("#node-text")
+        study_window.query_one("#add-sibling-btn", Button)
+
+
+@pytest.mark.asyncio
+async def test_course_creation_pane_composes_no_orphaned_create_course_form():
+    """task-16845: `#create-course-btn` has no dispatcher anywhere, and no
+    `course`/`courses` table exists in ChaChaNotes_DB at all (zero schema
+    support, unlike the other three buttons which at least have a
+    write-only sink) -- so the "Course Details" form (title/description/
+    level/prerequisites) that existed solely to feed this one dead button
+    is removed with it. Course Modules and Export Options are separate,
+    equally-undispatched sections out of this task's scope and still
+    compose."""
+    StudyScopeContext, StudyScopeType = _load_study_scope_models()
+    app_instance = SimpleNamespace(
+        scope_context=StudyScopeContext(scope_type=StudyScopeType.GLOBAL),
+        current_runtime_backend="local",
+        runtime_backend=None,
+        open_notes_workspace=Mock(),
+        open_study_screen=Mock(),
+        notify=Mock(),
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#view-course-btn", Button).press()
+        await pilot.pause()
+
+        study_window = app.screen.query_one(StudyWindow)
+        assert not study_window.query("#create-course-btn")
+        assert not study_window.query("#course-title")
+        assert not study_window.query("#course-description")
+        assert not study_window.query("#course-level")
+        assert not study_window.query("#course-prerequisites")
+        # Out-of-scope sections still compose.
+        study_window.query_one("#module-list")
+        study_window.query_one("#add-module-btn", Button)
+        study_window.query_one("#export-pdf-btn", Button)
+
+
+@pytest.mark.asyncio
+async def test_study_guide_pane_composes_no_orphaned_generate_guide_button():
+    """task-16845: `#generate-guide-btn` ("Generate from Topic") has no
+    dispatcher anywhere, and `#guide-topic-select` is hard-coded to a
+    single static "New Topic" option with no code populating it from the
+    (write-only, unreadable) topics table -- there is no topic it could
+    ever generate from. `#generate-questions-btn`/`#save-guide-btn` are
+    separate, equally-undispatched buttons out of this task's scope."""
+    StudyScopeContext, StudyScopeType = _load_study_scope_models()
+    app_instance = SimpleNamespace(
+        scope_context=StudyScopeContext(scope_type=StudyScopeType.GLOBAL),
+        current_runtime_backend="local",
+        runtime_backend=None,
+        open_notes_workspace=Mock(),
+        open_study_screen=Mock(),
+        notify=Mock(),
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#view-study-guide-btn", Button).press()
+        await pilot.pause()
+
+        study_window = app.screen.query_one(StudyWindow)
+        assert not study_window.query("#generate-guide-btn")
+        # Out-of-scope siblings still compose.
+        study_window.query_one("#guide-topic-select")
+        study_window.query_one("#generate-questions-btn", Button)
+        study_window.query_one("#save-guide-btn", Button)
+
+
+@pytest.mark.asyncio
+async def test_learning_map_pane_composes_no_orphaned_add_milestone_button():
+    """task-16845: `#add-milestone-btn` has no dispatcher anywhere, no
+    `milestone` concept exists in ChaChaNotes_DB's schema at all, and the
+    learning-map tree has no population code (same shape as the topic
+    tree) -- so there is no path to add or ever display a milestone.
+    `#mark-complete-btn`/`#set-dependencies-btn` are separate,
+    equally-undispatched buttons out of this task's scope."""
+    StudyScopeContext, StudyScopeType = _load_study_scope_models()
+    app_instance = SimpleNamespace(
+        scope_context=StudyScopeContext(scope_type=StudyScopeType.GLOBAL),
+        current_runtime_backend="local",
+        runtime_backend=None,
+        open_notes_workspace=Mock(),
+        open_study_screen=Mock(),
+        notify=Mock(),
+    )
+    app = _build_full_study_app(app_instance)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#view-learning-map-btn", Button).press()
+        await pilot.pause()
+
+        study_window = app.screen.query_one(StudyWindow)
+        assert not study_window.query("#add-milestone-btn")
+        # Out-of-scope siblings still compose.
+        study_window.query_one("#learning-map-tree", Tree)
+        study_window.query_one("#mark-complete-btn", Button)
+        study_window.query_one("#set-dependencies-btn", Button)

--- a/backlog/tasks/task-16845 - Study-wire-or-remove-the-four-undispatched-buttons-and-the-placeholder-Structured-Learning-pane.md
+++ b/backlog/tasks/task-16845 - Study-wire-or-remove-the-four-undispatched-buttons-and-the-placeholder-Structured-Learning-pane.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16845
 title: 'Study: wire or remove the four undispatched buttons and the placeholder Structured Learning pane'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - ui
@@ -43,7 +44,128 @@ gate the section until its backing feature exists.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 No composed Study control silently swallows a press: every remaining button has a real handler or is removed (per-button evidence, 16195-style)
-- [ ] #2 The Structured Learning pane either gains a real read path or presents an honest, intentional empty state (no dead tree + disabled content pane promising interaction)
-- [ ] #3 Study suites stay green and the pinning tests forbid the removed affordances from returning
+- [x] #1 No composed Study control silently swallows a press: every remaining button has a real handler or is removed (per-button evidence, 16195-style)
+- [x] #2 The Structured Learning pane either gains a real read path or presents an honest, intentional empty state (no dead tree + disabled content pane promising interaction)
+- [x] #3 Study suites stay green and the pinning tests forbid the removed affordances from returning
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Evidence pass per button: grep the whole tree for `mindmaps`/`mindmap_nodes`,
+   `learning_paths`/`topics`, `course`, `study_guide`/`guide`, `milestone` schema
+   tables and any read (list/get) DB methods, plus `Study_Interop/*` service methods,
+   to establish whether each of the four panes (Mindmaps, Course Creation, Study
+   Guide, Learning Map) has any live backing beyond a write-only sink.
+2. Confirm (re-grep) all four target buttons still have zero `@on(Button.Pressed, ...)`
+   dispatch anywhere and that the legacy `Event_Handlers/Study_Events` module stays
+   deleted (task-16196 baseline).
+3. Decide wire vs remove per button on that evidence, and separately decide the
+   Structured Learning pane's coherence treatment (honest empty state vs real read
+   path vs gating), recording the reasoning.
+4. Write/extend born-red pinning tests in `Tests/UI/test_study_screen.py` for each
+   pane, run them at HEAD to confirm red for the right reason (control assertions
+   still pass, target assertions fail).
+5. Implement the chosen removals/pane rewrite in `tldw_chatbook/UI/Study_Window.py`
+   with explanatory comments at each removal site (matching the task-16195 pattern).
+6. Re-run the new/updated tests (green) plus the full Study suite family used by
+   16195/16196 (`test_study_screen.py`, `test_study_flashcards_screen.py`,
+   `test_study_quizzes_screen.py`, `test_study_dashboard.py`,
+   `test_study_origin_navigation.py`, `test_mount_io_off_pump.py`,
+   `ChaChaNotesDB/test_study_functionality.py`).
+7. ruff check/format on touched files; hand-edit the task file's ACs/notes/status
+   (5-digit IDs mangle under the CLI); commit locally (no push/PR/merge).
+
+## Implementation Notes
+
+**Decision: REMOVE all four buttons.** None had schema/service support strong
+enough to justify wiring, and each pane's surrounding chrome (tree/select
+population, save destinations) is dead in the same shape 16195 already
+documented for `topics`. Per-button evidence:
+
+| Button | Verdict | Evidence |
+|---|---|---|
+| `add-child-btn` (Mindmaps, "Add Child") | REMOVE | `ChaChaNotes_DB.create_mindmap`/`add_mindmap_node` exist but are write-only — grepping the whole file for `get_mindmap`/`list_mindmap*` returns nothing, and `#mindmap-tree` composes with a static "Root Topic" root and no population code. A written node could never be displayed, in any session (same shape as 16195's topics finding). |
+| `create-course-btn` (Course Creation) | REMOVE | No `course`/`courses` table exists **anywhere** in `ChaChaNotes_DB.py` (zero grep hits) — unlike the other three, there isn't even a write-only sink to point the button at. The "course" hits elsewhere in the tree (`study_screen.py`'s sidebar dispatch, `study_scope_models.py`, `Stats/user_statistics.py`, `ChatbookTemplatesWindow.py`) are unrelated: pure UI navigation to the placeholder pane, an unrelated stat-category label, and unrelated placeholder copy respectively — none of them back this button. |
+| `generate-guide-btn` (Study Guide, "Generate from Topic") | REMOVE | `#guide-topic-select` is hard-coded to a single static `("new", "New Topic")` option with zero code populating it from the `topics` table (also write-only, per 16195) — there is no topic the button could ever generate from, and no `study_guide`/`guide` table exists to save output to either. A coincidentally-named, architecturally unrelated "study guide" feature exists in `Chat/document_generator.py` (`generate_study_guide`, wired via `Widgets/document_generation_modal.py::handle_study_guide`) — it generates from **conversation** context, not topics, lives on a different screen, and is not a viable redirect target without a feature build (same "unrelated, coincidentally-named" shape 16196 found for `handle_create_card`). |
+| `add-milestone-btn` (Learning Map) | REMOVE | No `milestone` concept exists anywhere in the schema (zero grep hits in `ChaChaNotes_DB.py`); `#learning-map-tree` composes with a static "Learning Path" root and no population code, and `#overall-progress`/`#current-topic` are hard-coded statics nothing ever updates. Same placeholder-grade shape as the topic tree. |
+
+**Removal scope per button** (mirroring 16195's "remove the whole affordance,
+not just the button" when other controls exist solely to feed it):
+- Mindmaps: removed only the `Button` line — `#node-text` Input stays because
+  the separate, equally-undispatched `#add-sibling-btn` still uses it.
+- Course Creation: removed the entire "Course Details" form (title/
+  description/level/prerequisites), since none of those four fields fed
+  any other remaining button — leaving them would have produced four
+  orphaned inputs with no possible destination at all, which 16195's review
+  already called worse than a dead button. Course Modules and Export
+  Options are separate sections with their own (also undispatched, out of
+  scope) buttons and were left untouched.
+- Study Guide / Learning Map: removed only the `Button` line in both cases —
+  their neighboring fields/statics are either shared with a remaining
+  button or already general-purpose/unpopulated regardless.
+
+**Structured Learning pane coherence (AC #2): replaced the dead chrome with
+an honest empty-state notice**, not a real read path. Building list/get
+methods for `learning_paths`/`topics` plus tree-population plumbing would be
+a feature build, not a wiring fix — the same call 16195 made for the
+add-topic write path. `#topic-tree` (static "Learning Paths" root, no
+population code, no `Tree.NodeSelected` handler anywhere since 16196 deleted
+the legacy module that held one) and the disabled `#topic-content` TextArea
+(placeholder promising "Select a topic from the tree to view content..."
+with nothing ever selectable) were removed and replaced with a single
+`Static` (`#structured-learning-empty-state`) stating plainly that
+Structured Learning has no browsing UI yet.
+
+**Explicitly out of scope** (same discipline 16195/16196 applied): every
+*other* button in the Mindmaps/Course Creation/Study Guide/Learning Map
+panes — `add-sibling-btn`, `delete-node-btn`, `edit-node-btn`,
+`import-notes-btn`, `export-md-btn` (×2, one per pane), `generate-mindmap-btn`,
+`add-module-btn`, `export-pdf-btn`, `export-scorm-btn`, `add-concept-btn`,
+`generate-questions-btn`, `save-guide-btn`, `mark-complete-btn`,
+`set-dependencies-btn`, `import-course-btn`, `export-path-btn`,
+`generate-suggestions-btn` — is equally undispatched (confirmed while
+reading each pane's `compose()` in full: none of these classes define any
+`@on`/`on_button_pressed` method beyond `compose()` itself) but was never
+part of the legacy `STUDY_BUTTON_HANDLERS` table this task's four buttons
+came from, and is a materially larger surface (an entire-pane rebuild, not
+a per-button wire/remove call). Left untouched, same as 16195/16196 deferred
+them.
+
+**Pinning tests (born red):** five tests in `Tests/UI/test_study_screen.py`,
+each mounting the production app via the existing `_build_full_study_app`
+harness and navigating to the relevant pane via its `#view-*-btn` sidebar
+button:
+- `test_structured_learning_pane_composes_no_orphaned_add_topic_controls`
+  (extended) — asserts `#topic-tree`/`#topic-content` are gone and
+  `#structured-learning-empty-state` renders the honest notice.
+- `test_mindmaps_pane_composes_no_orphaned_add_child_button` (new)
+- `test_course_creation_pane_composes_no_orphaned_create_course_form` (new)
+- `test_study_guide_pane_composes_no_orphaned_generate_guide_button` (new)
+- `test_learning_map_pane_composes_no_orphaned_add_milestone_button` (new)
+
+Each also asserts the relevant out-of-scope sibling controls still compose
+(e.g. `#add-sibling-btn`, `#add-module-btn`, `#save-guide-btn`,
+`#mark-complete-btn`), so the pinning is precise about what was and wasn't
+removed. Ran all five at HEAD before the product change: all 5 failed for
+the expected reason (target control still present / empty-state Static
+absent). After the change: all 5 pass.
+
+**Tests:** `test_study_screen.py` 23 passed (18 pre-existing + 5 new/extended).
+Full 16195/16196 suite family (`test_study_screen.py`,
+`test_study_flashcards_screen.py`, `test_study_quizzes_screen.py`,
+`test_study_dashboard.py`, `test_study_origin_navigation.py`,
+`test_mount_io_off_pump.py`, `Tests/ChaChaNotesDB/test_study_functionality.py`)
+→ 141 passed. `Tests/UI` collect-only sweep → 13,067 collected, 0 errors.
+`ruff check`/`format --check` clean on both touched files. Grepped
+`tldw_chatbook/` + `Tests/` for the four removed ids and the removed course
+form's ids (`course-title`, `course-description`, `course-level`,
+`course-prerequisites`, `topic-content`) — no remaining references outside
+`Study_Window.py` (removal comments) and `Tests/UI/test_study_screen.py`
+(absence assertions). No `Docs/User_Guide` page exists for Study (same as
+16195's finding), so no docs update needed.
+
+**Files changed:** `tldw_chatbook/UI/Study_Window.py` (four button removals
++ Structured Learning pane rewrite + matching dead-CSS cleanup:
+`.topic-tree`/`.topic-content` → `.structured-learning-empty-state`,
+`.course-form` and `.course-description` rules dropped), `Tests/UI/test_study_screen.py`
+(one extended test + four new tests).

--- a/tldw_chatbook/UI/Study_Window.py
+++ b/tldw_chatbook/UI/Study_Window.py
@@ -50,26 +50,18 @@ class StructuredLearningWidget(Widget):
         height: 100%;
         width: 100%;
     }
-    
+
     .structured-learning-container {
         padding: 1;
         height: 100%;
     }
-    
-    .topic-tree {
-        height: 1fr;
-        width: 50%;
-        border: round $surface;
-        margin-right: 1;
-    }
-    
-    .topic-content {
-        height: 1fr;
-        width: 50%;
+
+    .structured-learning-empty-state {
         border: round $surface;
         padding: 1;
+        color: $text-muted;
     }
-    
+
     .section-title {
         text-style: bold;
         margin-bottom: 1;
@@ -81,29 +73,32 @@ class StructuredLearningWidget(Widget):
         with ScrollableContainer(classes="structured-learning-container"):
             yield Label("📚 Structured Learning", classes="section-title")
 
-            with Horizontal():
-                # Topic tree on the left
-                with Vertical(classes="topic-tree-container"):
-                    yield Label("Learning Topics:", classes="subsection-title")
-                    yield Tree("Learning Paths", id="topic-tree", classes="topic-tree")
-
-                # Content display on the right
-                with Vertical(classes="topic-content-container"):
-                    yield Label("Topic Content:", classes="subsection-title")
-                    yield TextArea(
-                        "Select a topic from the tree to view content...",
-                        id="topic-content",
-                        classes="topic-content",
-                        disabled=True,
-                    )
-
-            # task-16195: the "Add New Topic" row (Input #new-topic-title +
-            # Button #add-topic-btn) was removed here. Its only handler lived
-            # in the legacy Event_Handlers/Study_Events table, which nothing
-            # dispatched since the Study rebuild, and no code in the app reads
-            # the topics table back -- the button was a dead affordance whose
-            # restored flow would have been a write-only sink. task-16196
-            # deleted that entire legacy module (it had no other importer).
+            # task-16195 removed the dead "Add New Topic" row (Input
+            # #new-topic-title + Button #add-topic-btn) here; its only
+            # handler lived in the legacy Event_Handlers/Study_Events table,
+            # which nothing dispatched since the Study rebuild, and no code
+            # in the app reads the topics table back.
+            #
+            # task-16845: the residual chrome left behind -- a #topic-tree
+            # that could only ever show its static "Learning Paths" root
+            # (nothing populates it, and no Tree.NodeSelected handler exists
+            # anywhere since task-16196 deleted the legacy module that held
+            # one) next to a disabled #topic-content TextArea whose
+            # placeholder promised "Select a topic from the tree to view
+            # content..." -- read as broken rather than intentionally empty.
+            # ChaChaNotes_DB's create_learning_path/create_topic are
+            # write-only (no list/get method exists for learning_paths or
+            # topics anywhere), so a real browsing UI would be a feature
+            # build, not a wiring fix (same call task-16195 made for the
+            # add-topic write path). Replaced with an honest notice instead
+            # of building that feature or leaving the misleading chrome.
+            yield Static(
+                "Structured Learning does not have a browsing UI yet in "
+                "this build. There is currently no way to list or view "
+                "learning paths and topics from this screen.",
+                id="structured-learning-empty-state",
+                classes="structured-learning-empty-state",
+            )
 
 
 class AnkiFlashcardsWidget(Widget):
@@ -437,7 +432,14 @@ class MindmapsWidget(Widget):
                 with Vertical(classes="mindmap-controls"):
                     yield Label("Add Node:", classes="subsection-title")
                     yield Input(placeholder="Node text...", id="node-text")
-                    yield Button("Add Child", id="add-child-btn", variant="primary")
+                    # task-16845: "Add Child" (#add-child-btn) had no
+                    # dispatcher anywhere, and ChaChaNotes_DB's
+                    # create_mindmap/add_mindmap_node are write-only (no
+                    # read/list method exists) while #mindmap-tree has no
+                    # population code -- a written node could never be
+                    # displayed. Removed; #node-text stays for Add Sibling,
+                    # which is a separate, equally-undispatched button out
+                    # of this task's scope.
                     yield Button("Add Sibling", id="add-sibling-btn", variant="default")
 
                     yield Label("Actions:", classes="subsection-title")
@@ -467,13 +469,7 @@ class CourseCreationWidget(Widget):
         padding: 1;
         height: 100%;
     }
-    
-    .course-form {
-        border: round $surface;
-        padding: 1;
-        margin-bottom: 1;
-    }
-    
+
     .module-list {
         height: 15;
         border: round $surface;
@@ -491,37 +487,15 @@ class CourseCreationWidget(Widget):
         with ScrollableContainer(classes="course-creation-container"):
             yield Label("📖 Course Creation", classes="section-title")
 
-            # Course details form
-            with Vertical(classes="course-form"):
-                yield Label("Course Details:", classes="subsection-title")
-
-                yield Label("Course Title:")
-                yield Input(placeholder="Enter course title...", id="course-title")
-
-                yield Label("Description:")
-                yield TextArea(
-                    "Enter course description...",
-                    id="course-description",
-                    classes="course-description",
-                )
-
-                with Horizontal(classes="form-row"):
-                    yield Label("Level:", classes="form-label")
-                    yield Select(
-                        options=[
-                            ("beginner", "Beginner"),
-                            ("intermediate", "Intermediate"),
-                            ("advanced", "Advanced"),
-                        ],
-                        id="course-level",
-                    )
-
-                yield Label("Prerequisites:")
-                yield Input(
-                    placeholder="Enter prerequisites...", id="course-prerequisites"
-                )
-
-                yield Button("Create Course", id="create-course-btn", variant="primary")
+            # task-16845: the "Course Details" form (title/description/
+            # level/prerequisites feeding "Create Course", #create-course-btn)
+            # was removed here. #create-course-btn had no dispatcher
+            # anywhere, and unlike the other three panes' buttons there is
+            # no schema support to remove-to-write-only either -- no
+            # `course`/`courses` table exists anywhere in ChaChaNotes_DB.
+            # Those four fields fed only this one dead button, so they were
+            # removed with it rather than left as an orphaned dead-end form
+            # (worse UX than the button alone, per the task-16195 finding).
 
             # Module management
             yield Label("Course Modules:", classes="subsection-title")
@@ -607,10 +581,14 @@ class StudyGuideWidget(Widget):
             yield ListView(id="practice-questions-list", classes="practice-questions")
 
             # Action buttons
+            # task-16845: "Generate from Topic" (#generate-guide-btn) had no
+            # dispatcher anywhere, and #guide-topic-select above is
+            # hard-coded to a single static "New Topic" option -- nothing
+            # populates it from the topics table (write-only, no read
+            # method), so there was no topic it could ever generate from.
+            # Removed; the remaining two buttons are separate,
+            # equally-undispatched buttons out of this task's scope.
             with Horizontal(classes="form-row"):
-                yield Button(
-                    "Generate from Topic", id="generate-guide-btn", variant="success"
-                )
                 yield Button("Generate Questions", id="generate-questions-btn")
                 yield Button("Save Guide", id="save-guide-btn", variant="primary")
 
@@ -667,9 +645,14 @@ class LearningMapWidget(Widget):
                         yield Static("None selected", id="current-topic")
 
                     yield Label("Path Actions:", classes="subsection-title")
-                    yield Button(
-                        "Add Milestone", id="add-milestone-btn", variant="primary"
-                    )
+                    # task-16845: "Add Milestone" (#add-milestone-btn) had
+                    # no dispatcher anywhere, no `milestone` concept exists
+                    # in ChaChaNotes_DB's schema at all, and #learning-map-tree
+                    # above has no population code (same shape as the
+                    # Structured Learning pane's topic tree) -- there was no
+                    # path to add or ever display one. Removed; the
+                    # remaining buttons are separate, equally-undispatched
+                    # buttons out of this task's scope.
                     yield Button(
                         "Mark Complete", id="mark-complete-btn", variant="success"
                     )
@@ -752,11 +735,6 @@ class StudyWindow(Container):
     }
     
     .card-input {
-        height: 5;
-        margin-bottom: 1;
-    }
-    
-    .course-description {
         height: 5;
         margin-bottom: 1;
     }


### PR DESCRIPTION
## Summary

Four more Study buttons were silent no-ops — composed with zero handlers, never routed by `on_button_pressed` (the same class TASK-16195 removed for add-topic). Each removed on schema evidence, review-reproduced:

- **create-course**: no course table exists in ANY DB file — not even a write-only sink; the whole dead-end Course Details form went with it (four inputs feeding nothing)
- **add-child** (mindmaps): `create_mindmap`/`add_mindmap_node` are write-only with zero callers; review went further — `DB/Mindmap_DB.py` (named in CLAUDE.md) doesn't exist, and the separate `Tools/Mind_Map` subsystem's `load_from_database()` is a literal `pass` stub on a viewer never mounted anywhere
- **generate-guide**: its topic Select is hard-coded to one static option; no guide table to save to
- **add-milestone**: no milestone concept in the schema; the Learning Map chrome is static

The Structured Learning pane's dead tree + disabled editor (placeholder copy promising selection that could never come) replaced with one honest empty-state line. Explicitly out of scope and disclosed: ~17 more undispatched buttons across these panes (individually re-verified present+undispatched in review) — queued for filing.

Born-red ×5 (pane-navigated compose censuses; review reproduced the course pin at the exact assertion); 23 + 141 tests green; collection clean; ruff clean.

Review: independent pass → MERGE, all claims reproduced, none on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes four undispatched Study buttons and replaces the Structured Learning pane’s fake tree/content with a clear empty state, eliminating dead affordances that swallowed clicks and implied functionality without handlers or read paths (TASK-16845).

- Removed controls: `#add-child-btn` (Mindmaps), `#create-course-btn` and its entire “Course Details” form (`#course-title`, `#course-description`, `#course-level`, `#course-prerequisites`), `#generate-guide-btn` (Study Guide), and `#add-milestone-btn` (Learning Map). Structured Learning now renders `#structured-learning-empty-state` instead of `#topic-tree`/`#topic-content`.
- Kept neighboring controls intact (e.g., `#node-text`, `#add-sibling-btn`, `#add-module-btn`, `#generate-questions-btn`, `#save-guide-btn`, `#mark-complete-btn`) to avoid collateral UI loss; these remain out of scope.
- Tests: `Tests/UI/test_study_screen.py` adds/extends five tests to pin the removals and ensure out-of-scope controls still compose.
- No migration required; this is a UI cleanup only. Review focus: `tldw_chatbook/UI/Study_Window.py` for removals and the new empty state; test updates for precise absence/presence assertions.

<sup>Written for commit facd895ad44a01da802566ea5b2ba4c2041354e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

