### PR TITLE
fix(console): head-pinned selection can no longer disable the transcript's height bound (TASK-16851)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -166,7 +166,10 @@ default), scrolling further back keeps loading older history while the newest
 end of the stretch is set aside the same way — so a very long session stays
 reachable by scrolling, at a roughly constant memory cost. One deliberate
 exception: a selected message is never set aside, so a selection pinned at
-the newest end of the stretch pauses the sliding until you clear it (Esc).
+either end of the stretch pauses the sliding in that direction until you
+clear it (Esc) — after a jump to an old message, the jumped-to selection
+sits at the oldest end, so reading far enough past it eventually pauses the
+forward walk the same way (the view stays bounded instead of growing).
 Scrolling back down (or a jump to an old message — selecting one far outside
 the stretch lands you on a fresh window around it instead of loading
 everything in between) walks forward the same way, and the jump-to-latest
@@ -410,4 +413,7 @@ delta — shipped tests and an isolated 500-message load probe; not re-checked
 live. "Long conversations" sliding scroll-back and bounded far jumps
 verified against TASK-15777 — shipped tests plus isolated 400/500-message
 mounted probes (scroll-back walked m360→m0 at a constant 101 mounted rows;
-a far jump mounted 5 rows instead of 490); not re-checked live.*
+a far jump mounted 5 rows instead of 490); not re-checked live. The
+head-pinned-selection pause (TASK-16851) verified by shipped tests — a
+post-jump walk-down held ≤1100 virtual rows against a 900 high mark where
+it previously grew to 1966 and kept growing; not re-checked live.*

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -412,7 +412,8 @@ verified against the TASK-15455 windowing (PR #1538) plus its reconciliation
 delta — shipped tests and an isolated 500-message load probe; not re-checked
 live. "Long conversations" sliding scroll-back and bounded far jumps
 verified against TASK-15777 — shipped tests plus isolated 400/500-message
-mounted probes (scroll-back walked m360→m0 at a constant 101 mounted rows;
+mounted probes (scroll-back walks the full history with mounted rows bounded
+by the watermarks — measured ~150 rows / height ~600 at the default marks;
 a far jump mounted 5 rows instead of 490); not re-checked live. The
 head-pinned-selection pause (TASK-16851) verified by shipped tests — a
 post-jump walk-down held ≤1100 virtual rows against a 900 high mark where

--- a/Tests/UI/test_console_transcript_selection_prune_bound.py
+++ b/Tests/UI/test_console_transcript_selection_prune_bound.py
@@ -129,7 +129,7 @@ async def test_head_pinned_selection_walkdown_stays_bounded_near_high_mark():
             transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
             await _settle(pilot)
             height = transcript.virtual_size.height
-            assert height <= 1100, (
+            assert height <= 1000, (
                 "a head-pinned selection must not disable the height bound: "
                 f"virtual height {height} escaped the 900 high watermark"
             )
@@ -141,7 +141,7 @@ async def test_head_pinned_selection_walkdown_stays_bounded_near_high_mark():
 
         # The bound is a fixed point, not a lucky frame: idle does not grow it.
         await _settle(pilot, times=20)
-        assert transcript.virtual_size.height <= 1100
+        assert transcript.virtual_size.height <= 1000
 
         # Selection UX survives the bounding mechanism: the jumped-to row is
         # still mounted, still first, still selected, action row and all.

--- a/Tests/UI/test_console_transcript_selection_prune_bound.py
+++ b/Tests/UI/test_console_transcript_selection_prune_bound.py
@@ -1,0 +1,307 @@
+"""TASK-16851: head-pinned selection must not let tailward hydration outrun the prune.
+
+Deferred out of TASK-15777's merge gate (PR #1733): a far jump both SELECTS its
+target and lands it at the HEAD of the re-centered window. The prune protects
+the selected message and stops its walk at the first protected group, so with
+the target selected at the head it can never trim anything — while the tailward
+hydration chain keeps revealing. The round-3 review measured 490 mounted rows /
+virtual height 1966 against a high watermark of 900 (2.18x), growing with
+session length; Esc was the only recovery.
+
+The fix restores the invariant the other three boundary regimes already hold —
+mounted height stays bounded by ~high regardless of selection position — by
+refusing ``_hydrate_tailward`` while the measured height is at/over the high
+mark AND the prune walk is blocked: hydration must not outrun a prune that
+cannot make room. The selection is never evicted (contiguity + a mounted
+selection + a mounted far tail are mutually exclusive, so with the selection
+HELD the downward walk stalls bounded); clearing the selection (Esc) or the
+jump pill restores full downward reachability.
+
+Also pinned here: the frame-wide End-during-prune race the same review filed —
+an End pressed between the prune's entry-capture and its restore had its anchor
+cancelled by the restore's quiet release (entry state won), truncating the
+drain to one chunk until a second End.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+
+class TwoSidedHarness(App):
+    """Transcript host with sane, scaled watermarks (two-sided regime)."""
+
+    CSS = "ConsoleTranscript { height: 24; width: 100; }"
+
+    def __init__(self, *, low: int = 600, high: int = 900) -> None:
+        super().__init__()
+        self.app_config = {
+            "chat_defaults": {
+                "assistant_markdown": False,
+                "prune_low_watermark": low,
+                "prune_high_watermark": high,
+            }
+        }
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _messages(count: int) -> list[ConsoleChatMessage]:
+    return [
+        ConsoleChatMessage(
+            id=f"m{index}",
+            role=(
+                ConsoleMessageRole.USER
+                if index % 2 == 0
+                else ConsoleMessageRole.ASSISTANT
+            ),
+            content="\n".join(f"message {index} line {line}" for line in range(4)),
+        )
+        for index in range(count)
+    ]
+
+
+def _mounted_message_ids(transcript: ConsoleTranscript) -> list[str]:
+    return [row.message_id for row in transcript.query(".console-transcript-message")]
+
+
+async def _settle(pilot, *, times: int = 6) -> None:
+    for _ in range(times):
+        await pilot.pause()
+
+
+async def _wait_for(pilot, predicate, *, attempts: int = 80) -> bool:
+    for _ in range(attempts):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+async def _far_jump_to_m10(pilot, transcript: ConsoleTranscript) -> None:
+    """Select a windowed-out early message: re-center + head-pinned selection."""
+    transcript.select_message("m10")
+    assert await _wait_for(
+        pilot, lambda: "m10" in _mounted_message_ids(transcript)
+    ), "selecting a windowed-out message never mounted it"
+    await _settle(pilot)
+    assert _mounted_message_ids(transcript)[0] == "m10", (
+        "precondition: the jump target must be head-pinned (first mounted row)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: the head-pinned walk-down (born red at ecbcd5cd8: the reviewer's
+# paced repro grew to 490 rows / height 1966 vs a high mark of 900).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_head_pinned_selection_walkdown_stays_bounded_near_high_mark():
+    """Jump -> paced walk down: height stays ~high, the selection stays mounted.
+
+    Born red at HEAD (`ecbcd5cd8`): with the selection pinned at the window
+    head, ``_compute_prunable_prefix`` stops at the first (protected) group
+    on every check, so nothing ever trims while ``_hydrate_tailward`` keeps
+    revealing — the mounted height escaped the high watermark and kept
+    growing with every gesture, bounded only by session length.
+    """
+    app = TwoSidedHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        await _far_jump_to_m10(pilot, transcript)
+
+        # The reviewer's paced walk: repeated bottom-boundary gestures with
+        # frames between each, exactly how a reader walks down from a jump.
+        for _ in range(40):
+            transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            await _settle(pilot)
+            height = transcript.virtual_size.height
+            assert height <= 1100, (
+                "a head-pinned selection must not disable the height bound: "
+                f"virtual height {height} escaped the 900 high watermark"
+            )
+            # ~4 measured rows per message in this harness: the 1100-line
+            # height budget holds ~275 messages. HEAD mounted 490.
+            assert len(_mounted_message_ids(transcript)) <= 300, (
+                "the mounted DOM must stay bounded during the walk-down"
+            )
+
+        # The bound is a fixed point, not a lucky frame: idle does not grow it.
+        await _settle(pilot, times=20)
+        assert transcript.virtual_size.height <= 1100
+
+        # Selection UX survives the bounding mechanism: the jumped-to row is
+        # still mounted, still first, still selected, action row and all.
+        mounted = _mounted_message_ids(transcript)
+        assert mounted[0] == "m10", "the head-pinned selection must stay mounted"
+        assert transcript.selected_message_id == "m10", "no selection loss"
+        assert transcript.query(".console-transcript-action-row"), (
+            "the selection must keep its action row while it blocks the prune"
+        )
+
+
+@pytest.mark.asyncio
+async def test_head_pinned_walkdown_stalls_then_esc_restores_reachability():
+    """With the selection HELD the walk stalls bounded; Esc resumes it.
+
+    Born red at HEAD (`ecbcd5cd8`) in the stall half: the walk reached the
+    true tail by mounting everything between the selection and m499 in one
+    contiguous, unbounded slice. Contiguity + a mounted selection + a mounted
+    far tail are mutually exclusive, so under the height bound the walk MUST
+    stall while the head-pinned selection is held — and clearing it (Esc)
+    unblocks the prune, which makes room, which lets hydration resume all the
+    way to the tail. That recovery is the second half of this pin.
+    """
+    app = TwoSidedHarness()
+    history = _messages(500)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+        await _far_jump_to_m10(pilot, transcript)
+
+        for _ in range(40):
+            transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            await _settle(pilot)
+        assert "m499" not in _mounted_message_ids(transcript), (
+            "reaching the tail with the head-pinned selection still mounted "
+            "would mean the slice grew unbounded again"
+        )
+        assert transcript._hidden_tail_ids, (
+            "the stall must be a paused hidden tail, not a dropped one"
+        )
+
+        # Esc: the documented recovery. Clearing the selection unblocks the
+        # prune (which trims the head and makes room), and the next REAL
+        # boundary gestures — PageDown here; wheel-down and End share the
+        # same hook — slide the window to the tail. A bare scroll_to(max) is
+        # not a user path: once the reader sits exactly at max it produces
+        # no scroll_y change, so nothing re-fires the boundary watcher.
+        transcript.action_clear_selection()
+        await _settle(pilot)
+        reached = False
+        for _ in range(80):
+            transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            transcript.action_page_down()
+            await _settle(pilot)
+            assert len(_mounted_message_ids(transcript)) <= 260, (
+                "the post-Esc walk must slide (bounded), not grow"
+            )
+            if "m499" in _mounted_message_ids(transcript):
+                reached = True
+                break
+        assert reached, "clearing the selection must restore tail reachability"
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: the frame-wide End-during-prune race (round-3 residual).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_pressed_inside_the_prune_window_still_drains_to_the_tail():
+    """An End that lands between prune entry-capture and restore must win.
+
+    Born red at HEAD (`ecbcd5cd8`): the prune's restore compares the anchor
+    state against its ENTRY capture, so an End pressed inside the entry ->
+    restore window — engaging the raw anchor AFTER the capture — was read as
+    the shrink-clamp's spurious re-attach and quietly released, and the
+    entry-offset compensation then pulled the reader off the bottom. The
+    drain truncated after ~one chunk; the pill was up and a SECOND End
+    resumed it (annoying, not stranding). The fix stamps ``scroll_end`` with
+    an intent time: a stamp newer than prune entry is the user's End, so the
+    restore keeps the anchor, skips the stale entry-offset compensation, and
+    re-arms the drain.
+    """
+    app = TwoSidedHarness()
+    history = _messages(400)
+    async with app.run_test(size=(100, 30)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(history)
+        await transcript.refresh_messages()
+        await _settle(pilot)
+
+        # Deep scroll-back: build a hidden tail, then park DETACHED mid-window
+        # (not at either boundary) — the entry state the race needs.
+        transcript.release_anchor()
+        for _ in range(80):
+            transcript.scroll_to(y=0, animate=False)
+            await _settle(pilot)
+            if "m0" in _mounted_message_ids(transcript):
+                break
+        assert transcript._hidden_tail_ids, "precondition: a tail must be hidden"
+        transcript.scroll_to(y=min(300, transcript.max_scroll_y // 2), animate=False)
+        await _settle(pilot)
+        assert not transcript._raw_anchor_engaged(), (
+            "precondition: the reader must be detached at prune entry"
+        )
+
+        # Shrink the marks so the settled ~low-height view is now over high:
+        # the next prune check fires deterministically, entry-detached.
+        app.app_config["chat_defaults"]["prune_low_watermark"] = 300
+        app.app_config["chat_defaults"]["prune_high_watermark"] = 400
+        assert transcript.virtual_size.height > 400, (
+            "precondition: the mounted view must sit over the shrunken high mark"
+        )
+
+        # Inject the End INSIDE the race window. `Widget.scroll_end` engages
+        # the raw anchor synchronously but DEFERS its scroll via
+        # call_after_refresh; pressing End during the prune's reconcile (after
+        # entry-capture, before `call_after_refresh(_restore_scroll)` is even
+        # enqueued) puts the End's deferred scroll AHEAD of the restore in
+        # the after-refresh queue — so the restore has the last word on the
+        # anchor, exactly the frame-wide interleaving the round-3 review
+        # measured. (An End that lands after the restore is enqueued has its
+        # deferred scroll run last and self-heals; that ordering is not the
+        # race.)
+        fired: dict[str, object] = {
+            "end": False,
+            "pruned_len": len(transcript._pruned_message_ids),
+        }
+        original_reconcile = transcript._reconcile_rows
+
+        async def reconcile_then_press_end(rows) -> None:
+            grew = len(transcript._pruned_message_ids) > fired["pruned_len"]
+            await original_reconcile(rows)
+            fired["pruned_len"] = len(transcript._pruned_message_ids)
+            if not fired["end"] and grew and transcript._hidden_tail_ids:
+                fired["end"] = True
+                transcript.scroll_end(animate=False)
+
+        transcript._reconcile_rows = reconcile_then_press_end  # type: ignore[method-assign]
+        try:
+            transcript._schedule_prune_check()
+            assert await _wait_for(pilot, lambda: bool(fired["end"]), attempts=40), (
+                "the harness never landed an End inside the prune window"
+            )
+        finally:
+            transcript._reconcile_rows = original_reconcile  # type: ignore[method-assign]
+
+        # No further input: the End alone must drain the hidden tail to the
+        # true tail. At HEAD the restore cancelled the anchor and the drain
+        # stopped after one chunk.
+        assert await _wait_for(
+            pilot, lambda: not transcript._hidden_tail_ids, attempts=300
+        ), (
+            "the End-during-prune race truncated the drain: "
+            f"{len(transcript._hidden_tail_ids)} messages still hidden at "
+            f"last={_mounted_message_ids(transcript)[-1]}"
+        )
+        assert _mounted_message_ids(transcript)[-1] == "m399"
+        assert transcript._is_following_tail(), (
+            "the honored End must leave the reader following the tail"
+        )

--- a/Tests/UI/test_console_transcript_two_sided_window.py
+++ b/Tests/UI/test_console_transcript_two_sided_window.py
@@ -242,7 +242,19 @@ async def test_far_jump_mounts_a_bounded_recentered_window():
 
 @pytest.mark.asyncio
 async def test_far_jump_then_scrolling_down_walks_back_to_the_tail():
-    """After a far jump the tail stays reachable by scrolling down."""
+    """After a far jump the tail stays reachable by scrolling down.
+
+    TASK-16851: the jump's selection is cleared before the walk. The jump
+    SELECTS its target at the window head, and a head-pinned selection now
+    pauses tailward hydration once the mounted height reaches the high
+    watermark (the prune cannot trim past a protected head group, so
+    hydration no longer outruns it — the original form of this test reached
+    the tail only by mounting an unbounded contiguous slice from m10 to
+    m499, the exact growth that task removed). The held-selection stall,
+    its height bound, and the Esc recovery are pinned in
+    ``test_console_transcript_selection_prune_bound.py``; this test keeps
+    pinning that a selection-free downward walk reaches the tail.
+    """
     app = TwoSidedHarness()
     history = _messages(500)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -258,8 +270,12 @@ async def test_far_jump_then_scrolling_down_walks_back_to_the_tail():
         await _settle(pilot)
         assert "m499" not in _mounted_message_ids(transcript)
 
+        transcript.action_clear_selection()
+        await _settle(pilot)
+
         for _ in range(120):
             transcript.scroll_to(y=transcript.max_scroll_y, animate=False)
+            transcript.action_page_down()
             await _settle(pilot, times=4)
             if "m499" in _mounted_message_ids(transcript):
                 break

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4611,3 +4611,28 @@ pre-fix commit, where it finally failed. Rules: (1) a regression test for a
 visual fix is only evidence once it has been RUN against the pre-fix tree
 and observed red there; (2) any style probe on a widget mounted first in a
 test App is probing the focused state whether you meant it or not.
+## A bare scroll_to(max) walk is not a user gesture — it self-terminates the moment the boundary stops moving
+
+**TASK-16851, 2026-08-16.** The head-pinned-selection fix (refuse tailward
+hydration while over the high mark with a blocked prune) passed its stall pin
+but "failed" its Esc-recovery pin: after Esc unblocked the prune, an 80-round
+`scroll_to(y=max_scroll_y)` walk never advanced a single chunk. Probe: reader
+parked at exactly `scroll_y == max_scroll_y`, so every subsequent `scroll_to`
+produced NO scroll_y change — `watch_scroll_y` never fired, nothing scheduled
+hydration, and the loop measured the harness gesture, not the product. Every
+REAL input path (wheel-down, PageDown, End) has its own boundary hook and
+recovered immediately. The pre-existing two-sided walks had only ever worked
+because hydration kept GROWING max_scroll_y under them, re-arming the watcher
+each round — a walk test that relies on that is green only while the feature
+under test keeps moving the goalposts for it.
+
+**What to do.** Drive boundary-walk tests with the product's real gestures
+(`action_page_down()`, wheel events, `scroll_end`) — or at minimum pair the
+positioning `scroll_to` with one. Before concluding a recovery path is broken,
+check whether the loop's gesture can still produce a state change at all.
+
+Same task, implementation twin worth remembering: a decision that walks
+`self.children` (the hydration refusal reusing `_compute_prunable_prefix`)
+must run under the widget's reconcile lock — read mid-reconcile, the transient
+child order faked a "blocked prune" and stalled a selection-free End drain
+(218 messages stranded in the born-red End-race pin).

--- a/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
+++ b/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16851
 title: 'Console transcript: head-pinned selection disables the prune while tailward hydration reveals'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-16'
@@ -45,10 +45,10 @@ document the bound.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 With a head-pinned selection, a downward walk keeps total mounted height bounded near the high watermark (probe or test on the far-jump-then-scroll-down flow as evidence)
-- [ ] #2 The selection and its action row survive whatever bounding mechanism ships (no teleport, no selection loss)
-- [ ] #3 The 15777 two-sided suite (13), protected pruning suite, and End-drain pins stay green
-- [ ] #4 The one-frame End-during-prune residual is either closed or pinned-and-documented with its recovery
+- [x] #1 With a head-pinned selection, a downward walk keeps total mounted height bounded near the high watermark (probe or test on the far-jump-then-scroll-down flow as evidence)
+- [x] #2 The selection and its action row survive whatever bounding mechanism ships (no teleport, no selection loss)
+- [x] #3 The 15777 two-sided suite (13), protected pruning suite, and End-drain pins stay green
+- [x] #4 The one-frame End-during-prune residual is either closed or pinned-and-documented with its recovery
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -86,3 +86,73 @@ document the bound.
 5. Verification: new pins born red at HEAD; two-sided suite green; protected
    `window_reconcile` + `windowing` suites green AND byte-unmodified;
    pruning suite green; ruff on touched files.
+
+## Implementation Notes
+
+Both findings closed, on base `ecbcd5cd8`, commit `aefd3b60e`.
+
+**Finding 1 — head-pinned selection (the review's suggested shape shipped).**
+`_hydrate_tailward` now refuses to reveal another chunk while the measured
+`virtual_size.height` is at/over the high mark AND the prune walk is blocked
+(`_compute_prunable_prefix` returns empty) — hydration must not outrun a
+prune that cannot make room. Reading the code confirmed no better boring
+option exists: contiguity (one mounted slice by construction) + a mounted
+selection + a mounted far tail are mutually exclusive, so the only
+alternatives were evicting the selection (review D's teleport, forbidden) or
+islands (rejected by 15455). The refusal logs a debug line mirroring the
+prune's and trim's blocked-walk logs. Two consequences, both deliberate:
+
+- With the selection HELD, the downward walk stalls BOUNDED at ~high + one
+  chunk; Esc (clear selection → the prune trims → real boundary gestures
+  resume the slide) or the jump pill restore full reachability. This is the
+  exact mirror of finding D's ACCEPTED twin (tail-pinned selection pauses
+  the slide upward while the prune bounds height) — that twin is upward
+  territory and is untouched (its pin stays green).
+- `test_far_jump_then_scrolling_down_walks_back_to_the_tail` reached the
+  tail only BY the unbounded mount (selection held the whole walk), so it
+  was updated to the new contract: clear the selection before the walk (and
+  walk with `action_page_down`, a real gesture). The held-selection stall +
+  bound + Esc recovery are pinned in the new suite.
+
+Trap found while landing it: the refusal's `_compute_prunable_prefix` walks
+`self.children`, and the first version ran it OUTSIDE `_refresh_lock` — read
+mid-reconcile (a prune's), the transient child order faked "blocked" and
+stalled a selection-free drain. The whole hydrate decision now runs under
+the lock, with the guards re-checked after acquiring it.
+
+**Finding 2 — End-during-prune race: CLOSED (clean shape existed).**
+`scroll_end` stamps `_scroll_end_intent_time = monotonic()`; the prune
+captures `entry_time` beside its anchor-state capture, and the restore's
+entry-detached-but-now-engaged branch treats a stamp newer than entry as
+the user's End: keep the anchor, skip the stale entry-offset compensation,
+re-arm the drain (`_schedule_tailward_hydration`). Every other restore path
+is byte-identical, so the round-2/3 faithful-restore semantics survive (the
+detached-reader pin and the End-drain pin both stay green). The racing
+interleaving, pinned deterministically: `Widget.scroll_end` engages the raw
+anchor synchronously but DEFERS its scroll via `call_after_refresh`, so an
+End injected during the prune's reconcile enqueues its scroll AHEAD of
+`_restore_scroll` — the restore had the last word and quietly cancelled the
+user's drain (218 of 400 messages stranded, second End resumed).
+
+**Evidence.**
+- Born-red on the unmodified base widget (all three, re-run against
+  `git show ecbcd5cd8:` of the widget after the fix was committed):
+  walk-down height escaped to 1966 vs the 900 high mark (the review's exact
+  number) at 490 mounted rows; the stall pin reached m499 on an unbounded
+  slice; the End-race pin stranded 218 messages at last=m181.
+- Post-fix: walk-down peaks at 934 virtual rows (900 high + one ~34-row
+  chunk overshoot), 232 mounted rows, stable across 20 idle frames; the
+  selection row stays first + mounted + selected with its action row; Esc
+  resumes the slide to m499 bounded (≤260 rows).
+- Suites: new pins 3/3; two-sided 13/13; protected `window_reconcile` +
+  `windowing` 17/17 green AND byte-unmodified (`git diff` empty); pruning
+  8/8 (41 total green). Adjacent transcript set 153 passed + the 3
+  speak-action reds reproduced on the UNMODIFIED base widget in the same
+  run (pre-existing, per the 15777 notes). ruff clean.
+
+**Files.** `tldw_chatbook/Widgets/Console/console_transcript.py`,
+`Tests/UI/test_console_transcript_selection_prune_bound.py` (new, 3 pins),
+`Tests/UI/test_console_transcript_two_sided_window.py` (walk-back test
+updated to the new contract), `Docs/User_Guide/console.md` ("Long
+conversations" prose + stamp), `backlog/docs/lessons-testing-evidence.md`
+(bare-scroll_to walk trap + children-walk-under-lock twin), this file.

--- a/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
+++ b/backlog/tasks/task-16851 - Console-transcript-head-pinned-selection-disables-the-prune-while-tailward-hydration-reveals.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16851
 title: 'Console transcript: head-pinned selection disables the prune while tailward hydration reveals'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - bug
@@ -49,3 +50,39 @@ document the bound.
 - [ ] #3 The 15777 two-sided suite (13), protected pruning suite, and End-drain pins stay green
 - [ ] #4 The one-frame End-during-prune residual is either closed or pinned-and-documented with its recovery
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce the head-pinned unbounded reveal as a born-red test: far jump
+   (`select_message` on a windowed-out target, which re-centers and pins the
+   selection at the window head), then a paced walk down; assert
+   `virtual_size.height` stays bounded near the high watermark and the
+   selection row + action row stay mounted. Run it RED at HEAD first.
+2. Fix shape (the review's suggestion — reading the code confirmed it is the
+   only shape compatible with slice-contiguity + the no-eviction rule):
+   `_hydrate_tailward` refuses to reveal another chunk while the measured
+   height is at/over the high mark AND the prune walk is blocked (empty
+   `_compute_prunable_prefix`) — hydration must not outrun a prune that
+   cannot make room. Selection stays mounted and highlighted; recovery for
+   full downward reachability is Esc (clear selection → prune unblocks →
+   hydration resumes) or the jump pill, both pinned.
+3. Consequence, documented: with a head-pinned selection HELD, the downward
+   walk now stalls bounded instead of mounting to the tail — contiguity
+   (one slice), a mounted selection, and a mounted far tail are mutually
+   exclusive, so full reachability under a held head-pinned selection is
+   mathematically impossible.
+   `test_far_jump_then_scrolling_down_walks_back_to_the_tail` is updated to
+   the new contract (clear the selection, then the walk reaches the tail);
+   the head-pinned stall + bound + Esc-resume is pinned by the new test.
+   Finding D's accepted twin (tail-pinned selection pauses the slide,
+   prune still bounds) is upward-hydration territory — untouched.
+4. End-during-prune race: stamp `scroll_end` with a monotonic intent time;
+   the prune's restore, on seeing an entry-detached reader whose raw anchor
+   is engaged at restore time, honors a stamp NEWER than prune entry — skip
+   the quiet release and the offset compensation, re-arm the drain — instead
+   of cancelling the user's End. Entry-state restore for every other case is
+   byte-identical (round-3 semantics preserved). Born-red pin injects End in
+   the entry→restore window via a wrapped `_run_prune_check`.
+5. Verification: new pins born red at HEAD; two-sided suite green; protected
+   `window_reconcile` + `windowing` suites green AND byte-unmodified;
+   pruning suite green; ruff on touched files.

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1805,6 +1805,14 @@ class ConsoleTranscript(VerticalScroll):
         self.summary_boundary_message_id: str | None = None
         self._follow_intent_time = 0.0
         self._user_scroll_time = 0.0
+        #: TASK-16851: when the last ``scroll_end`` (the End key) was issued.
+        #: The prune's restore compares this against its ENTRY capture: an
+        #: End that lands inside the entry->restore window engages the raw
+        #: anchor AFTER the capture, and without the stamp the restore reads
+        #: that engagement as the shrink-clamp's spurious re-attach and
+        #: quietly cancels the user's drain (the frame-wide End-during-prune
+        #: race the TASK-15777 round-3 review filed).
+        self._scroll_end_intent_time = 0.0
         self._refresh_lock = asyncio.Lock()
         self._empty_card_state = ConsoleSetupCardState(
             mode="quiet", body_copy=CONSOLE_QUIET_EMPTY_COPY
@@ -2286,7 +2294,13 @@ class ConsoleTranscript(VerticalScroll):
         events. Callers that already handled the window (``jump_to_latest``
         via ``anchor()``, the prune's following-branch restore) reach here
         with no hidden tail, making this a no-op for them.
+
+        TASK-16851: the intent stamp lets a prune whose entry-capture
+        predates this call recognize the anchor engagement as the user's
+        End rather than the shrink-clamp's re-attach (see
+        ``_run_prune_check``'s restore).
         """
+        self._scroll_end_intent_time = monotonic()
         super().scroll_end(*args, **kwargs)
         if self._hidden_tail_ids:
             self._schedule_tailward_hydration()
@@ -2598,6 +2612,20 @@ class ConsoleTranscript(VerticalScroll):
         the oldest rows, with its own measured scroll compensation), so an
         up-then-down round trip oscillates between the two marks instead of
         accumulating.
+
+        TASK-16851: that bound is real only while the prune can actually
+        make room. A far jump SELECTS its target and lands it at the window
+        HEAD, and the prune's walk stops at the first protected group — so a
+        head-pinned selection blocks the prune entirely while this chain
+        kept revealing (round-3 review: 490 rows / height 2.18x the high
+        mark, growing with session length). Hydration must not outrun a
+        prune that cannot make room: while the measured height is at/over
+        the high mark AND the prune walk is blocked, the reveal is refused
+        and the walk stalls BOUNDED instead (the mirror of the trim's
+        blocked-by-selection pause on the other boundary — the eviction
+        alternative would unmount the selection's action row, review D's
+        teleport). Clearing the selection (Esc) or the jump pill restores
+        full downward reachability.
         """
         self._tailward_hydration_scheduled = False
         if (
@@ -2606,20 +2634,47 @@ class ConsoleTranscript(VerticalScroll):
             or not self._hidden_tail_ids
         ):
             return
-        tail_start = self._hidden_tail_start_index()
-        budget = self._scrollback_chunk_line_budget()
-        used = 0
-        end = tail_start
-        while end < len(self._messages) and used < budget:
-            used += self._estimated_message_lines(self._messages[end])
-            end += 1
-        self._hydrating_scrollback = True
-        self._set_hidden_tail(end if end < len(self._messages) else None)
-        try:
-            async with self._refresh_lock:
+        async with self._refresh_lock:
+            # Re-check under the lock: the guards above ran while another
+            # reconcile (a prune's, most often) could still be in flight,
+            # and the refusal below walks ``self.children`` — reading them
+            # mid-reconcile sees a transient order whose first child may not
+            # be a message row, which makes the prune walk look blocked when
+            # it is not (measured: the walk broke immediately and stalled a
+            # selection-free drain).
+            if not self.is_mounted or not self._hidden_tail_ids:
+                return
+            low_mark, high_mark = self._prune_watermarks()
+            if (
+                high_mark > 0
+                and self.virtual_size.height >= high_mark
+                and not self._compute_prunable_prefix(
+                    self.virtual_size.height, low_mark
+                )[0]
+            ):
+                # Mirror of the prune's and the trim's blocked-walk logs: an
+                # unexplained stalled downward walk must be diagnosable.
+                logger.debug(
+                    "Console transcript tailward hydration refused: mounted "
+                    f"height {self.virtual_size.height} at/over high mark "
+                    f"{high_mark} and the prune walk is blocked (a protected "
+                    "group holds the window head) — hydration must not "
+                    "outrun a prune that cannot make room"
+                )
+                return
+            tail_start = self._hidden_tail_start_index()
+            budget = self._scrollback_chunk_line_budget()
+            used = 0
+            end = tail_start
+            while end < len(self._messages) and used < budget:
+                used += self._estimated_message_lines(self._messages[end])
+                end += 1
+            self._hydrating_scrollback = True
+            self._set_hidden_tail(end if end < len(self._messages) else None)
+            try:
                 await self._reconcile_rows(self._transcript_rows())
-        finally:
-            self._hydrating_scrollback = False
+            finally:
+                self._hydrating_scrollback = False
         self._schedule_prune_check()
         # Chain while the reader is still pinned to the bottom: a reader whose
         # anchor re-engaged at the slice bottom is auto-scrolled to the new
@@ -3123,6 +3178,7 @@ class ConsoleTranscript(VerticalScroll):
         )
         following = self._is_following_tail()
         raw_anchor_at_entry = self._raw_anchor_engaged()
+        entry_time = monotonic()
         anchor_y = self.scroll_y
         self._pruned_message_ids.update(prune_ids)
         logger.info(
@@ -3157,6 +3213,20 @@ class ConsoleTranscript(VerticalScroll):
                 # TASK-336), and leave an entry-engaged anchor engaged so
                 # the drain keeps converging.
                 if not raw_anchor_at_entry and self._raw_anchor_engaged():
+                    if self._scroll_end_intent_time > entry_time:
+                        # TASK-16851 (the round-3 residual): this engagement
+                        # is a user End that landed INSIDE the entry->restore
+                        # window, not the shrink-clamp's re-attach — its
+                        # deferred scroll was enqueued before this callback,
+                        # so quietly releasing here would cancel the drain
+                        # after ~one chunk (the pill stayed up and a second
+                        # End resumed). Honor it instead: keep the anchor,
+                        # skip the now-stale entry-offset compensation (the
+                        # user asked for the bottom, not their old position),
+                        # and re-arm the drain's self-chain.
+                        if self._hidden_tail_ids:
+                            self._schedule_tailward_hydration()
+                        return
                     self._release_anchor_quietly()
                 # Content: keep the same rows in view by shifting the
                 # offset up by the height actually removed (measured, not


### PR DESCRIPTION
## Summary

Closes the two findings TASK-15777's round-3 review deferred out of PR #1733:

**The head-pinned prune bypass**: a far jump selects its target AND places it at the window head; the prune protects the selection and can never trim, while tailward hydration keeps revealing — measured 490 rows / height 2.18× the high mark, growing with session length. Fix per the review's own suggestion: `_hydrate_tailward` refuses to reveal while measured height ≥ high AND the prune walk is blocked — hydration cannot outrun a prune that can't make room. The refusal decides UNDER `_refresh_lock` (the first cut read `self.children` mid-reconcile and a transient order faked "blocked", stalling clean drains) and logs as the third member of the blocked-walk family. Reviewer re-drove their own repro: 232 rows / peak 934 vs high 900 (one chunk overshoot), stable, selection intact, Esc resumes bounded; the accepted tail-pinned twin untouched.

**The End-during-prune race**: `scroll_end` stamps monotonic intent; the prune restore honors a stamp newer than prune entry (keep anchor, skip the now-moot compensation, re-arm the drain) — structurally incapable of misfiring on stale stamps (compared against per-prune entry time), all other restore paths byte-identical, round-3 anchor semantics preserved. At base this stranded 218/400 messages.

One suite test re-scoped, not weakened (review verdict): the walk-back test's old pass rode the unbounded mount; it now clears the selection and walks with real gestures, with the removed coverage carried by three new born-red pins (independently verified red at base). Protected 17 wholly absent from the diff; 41/41 combined; the review's two cosmetic nits (stale docs figure, loose bound) applied pre-merge. Lesson filed: bare `scroll_to(max)` walks self-terminate — drive boundary tests with real gestures.

Review (the 15777 specialist, 4th round on this widget): MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds tailward hydration when a selection is pinned at the window head and fixes the End-during-prune race. Previously a far jump selected the head, blocked the prune, and hydration grew past the high watermark; now hydration refuses when height ≥ high and the prune walk is blocked. End pressed during a prune is honored so the drain continues.

- Old: head-pinned selection prevented trimming and the view grew unbounded; End during prune was quietly cancelled after ~one chunk.
- New: selection stays mounted and the walk stalls bounded near the high mark; Esc or the jump pill restores reachability. End stamps intent and the restore keeps the anchor and re-arms the drain.

**Review focus**
- Core changes in `tldw_chatbook/Widgets/Console/console_transcript.py`: hydration refusal under `_refresh_lock`; `scroll_end` intent stamp; restore honors a post-entry End and skips stale offset compensation.
- Verify height stays within the high watermark and the selection/action row remain mounted; selection-free walks still reach the tail.
- No config or API changes; watermarks unchanged.

**Tests and docs**
- New `Tests/UI/test_console_transcript_selection_prune_bound.py` pins the bounded head-pinned walk, stall + Esc recovery, and End-during-prune fix.
- Updated `Tests/UI/test_console_transcript_two_sided_window.py` to clear selection before the walk; `Docs/User_Guide/console.md` documents the head-pinned pause; backlog adds the `scroll_to(max)` lesson.
- Addresses Linear TASK-16851.

<sup>Written for commit eb0a17fd2a0ccb5b5eb6c64915073b133c1a2bd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

