### PR TITLE
fix(tts): ChapterDetector emitted ~2× chapters — one per heading plus a stray body row (TASK-16850)

### DIFF
--- a/Tests/TTS/test_chapter_detector.py
+++ b/Tests/TTS/test_chapter_detector.py
@@ -1,0 +1,146 @@
+"""ChapterDetector must emit ONE chapter per titled heading (task-16850).
+
+Pre-fix, `ChapterDetector.detect_chapters` appended an empty-content
+"placeholder" Chapter for every titled heading match AND appended the body
+accumulated after that heading as a SEPARATE chapter when the next heading
+arrived; only the final placeholder was ever back-filled (by the
+"don't forget the last chapter" branch). Net effect, probed by the
+task-15773 review on a 13-header book: 25 chapters alternating
+`content_len=0` placeholders with body rows — roughly 2x the true count.
+Since task-15773 made the chapter table truthful, users saw the doubled
+rows, and the editor preview landed on the empty placeholder first.
+
+These tests were born red at `c8b951616` (13-header book detected 25
+chapters there) and pin the fixed scan: on a new heading, the previous
+heading's chapter closes WITH the body accumulated since it; at EOF the
+last one closes the same way.
+
+The edge shapes deliberately KEEP their pre-fix behavior (task-16850 AC #2),
+verified by probing the detector at `c8b951616` before restructuring:
+
+- preamble text before the first heading -> an untitled `number=0` /
+  "Chapter 0" row (it was already emitted that way by the old
+  "save previous chapter" branch);
+- headerless document -> ONE chapter `number=1` / "Chapter 1" holding
+  everything (the old EOF branch's numbering, NOT the "Full Content"
+  fallback);
+- whitespace-only input -> the "Full Content" fallback chapter;
+- a heading with no body before the next heading (or EOF) -> its chapter is
+  kept, empty, so the user still sees every heading they pasted (pre-fix
+  those placeholders were empty too — consumers already tolerate
+  `content == ""`).
+"""
+
+from __future__ import annotations
+
+from tldw_chatbook.TTS.audiobook_generator import ChapterDetector
+
+
+def _thirteen_header_book() -> tuple[str, list[str]]:
+    """The 15773-review probe shape: 13 'Chapter N' headings, each with a body.
+
+    Returns the text and the per-chapter expected body strings.
+    """
+    parts: list[str] = []
+    bodies: list[str] = []
+    for n in range(1, 14):
+        body = f"Body of chapter {n}, where things happen."
+        parts.append(f"Chapter {n}")
+        parts.append(body)
+        parts.append("")
+        bodies.append(body)
+    return "\n".join(parts), bodies
+
+
+class TestOneChapterPerHeading:
+    """AC #1: N titled headings -> exactly N chapters, title AND body."""
+
+    def test_thirteen_headers_detect_exactly_thirteen_chapters(self):
+        text, _ = _thirteen_header_book()
+        chapters = ChapterDetector.detect_chapters(text)
+        assert len(chapters) == 13, (
+            f"expected 13 chapters for 13 headings, got {len(chapters)}: "
+            f"{[(c.title, len(c.content)) for c in chapters]}"
+        )
+
+    def test_every_chapter_carries_its_own_heading_and_body(self):
+        """Not just non-empty: the body must be the one following ITS heading.
+
+        Pre-fix, titled rows had content_len=0 and the prose sat in separate
+        rows — so this asserts the pairing, not merely fullness.
+        """
+        text, bodies = _thirteen_header_book()
+        chapters = ChapterDetector.detect_chapters(text)
+        for i, (chapter, body) in enumerate(zip(chapters, bodies), start=1):
+            assert chapter.number == i
+            assert chapter.title == f"Chapter {i}"
+            assert chapter.content.strip() == body, (
+                f"chapter {i} ({chapter.title!r}) should own the body that "
+                f"follows its heading; got {chapter.content!r}"
+            )
+
+    def test_no_zero_content_chapter_for_a_heading_that_has_body_text(self):
+        """AC #2, first half — the pre-fix alternating-placeholder shape."""
+        text, _ = _thirteen_header_book()
+        chapters = ChapterDetector.detect_chapters(text)
+        empties = [c.title for c in chapters if not c.content.strip()]
+        assert empties == [], f"zero-content chapters emitted: {empties}"
+
+    def test_positions_span_from_heading_line_to_body_end(self):
+        text = "Chapter 1\nBody one.\nChapter 2\nBody two."
+        chapters = ChapterDetector.detect_chapters(text)
+        assert [(c.start_position, c.end_position) for c in chapters] == [
+            (0, 1),
+            (2, 3),
+        ]
+
+
+class TestEdgeShapesKeepCurrentBehavior:
+    """AC #2, second half — pinned against the pre-fix probe at c8b951616."""
+
+    def test_preamble_before_the_first_heading_stays_an_untitled_chapter_zero(self):
+        text = "Preamble text before any heading.\nChapter 1\nBody one."
+        chapters = ChapterDetector.detect_chapters(text)
+        assert [(c.number, c.title, c.content) for c in chapters] == [
+            (0, "Chapter 0", "Preamble text before any heading."),
+            (1, "Chapter 1", "Body one."),
+        ]
+
+    def test_headerless_document_stays_one_chapter_one(self):
+        """Pre-fix, a headerless document came out of the EOF branch as a
+        single `number=1` / "Chapter 1" chapter (not the "Full Content"
+        fallback, which only fires on whitespace-only input)."""
+        text = "Just some prose.\nMore prose here."
+        chapters = ChapterDetector.detect_chapters(text)
+        assert len(chapters) == 1
+        assert chapters[0].number == 1
+        assert chapters[0].title == "Chapter 1"
+        assert chapters[0].content == "Just some prose.\nMore prose here."
+
+    def test_whitespace_only_input_stays_the_full_content_fallback(self):
+        text = "   \n\n  "
+        chapters = ChapterDetector.detect_chapters(text)
+        assert len(chapters) == 1
+        assert chapters[0].title == "Full Content"
+        assert chapters[0].content == text
+
+    def test_back_to_back_headings_keep_an_empty_chapter_for_the_bodiless_one(self):
+        """A heading with no body before the next heading still gets its own
+        (empty) chapter — dropping it would silently eat a title the user
+        pasted. Pre-fix these placeholders were empty too, so every consumer
+        already tolerates `content == ""`; what changes is that a heading
+        WITH a body can no longer be empty."""
+        text = "Chapter 1\nChapter 2\nBody two."
+        chapters = ChapterDetector.detect_chapters(text)
+        assert [(c.number, c.title, c.content) for c in chapters] == [
+            (1, "Chapter 1", ""),
+            (2, "Chapter 2", "Body two."),
+        ]
+
+    def test_trailing_bodiless_heading_at_eof_keeps_its_empty_chapter(self):
+        text = "Chapter 1\nBody one.\nChapter 2"
+        chapters = ChapterDetector.detect_chapters(text)
+        assert [(c.number, c.title, c.content) for c in chapters] == [
+            (1, "Chapter 1", "Body one."),
+            (2, "Chapter 2", ""),
+        ]

--- a/backlog/tasks/task-16850 - ChapterDetector-emits-an-empty-placeholder-chapter-per-titled-heading-doubling-the-rows.md
+++ b/backlog/tasks/task-16850 - ChapterDetector-emits-an-empty-placeholder-chapter-per-titled-heading-doubling-the-rows.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16850
 title: 'ChapterDetector emits an empty placeholder chapter per titled heading, doubling the rows'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - bug
@@ -42,7 +43,86 @@ currently pin the doubled behavior implicitly via totals).
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A document with N titled headings detects exactly N chapters, each carrying its own title AND its body text (born-red test on the 13-header shape)
-- [ ] #2 No zero-content chapter is emitted for a heading that has body text; the untitled/edge shapes (preamble before the first heading, headerless documents) keep their current behavior, stated in the test
-- [ ] #3 Detection and editor suites re-baselined and green, with the count changes justified in the notes
+- [x] #1 A document with N titled headings detects exactly N chapters, each carrying its own title AND its body text (born-red test on the 13-header shape)
+- [x] #2 No zero-content chapter is emitted for a heading that has body text; the untitled/edge shapes (preamble before the first heading, headerless documents) keep their current behavior, stated in the test
+- [x] #3 Detection and editor suites re-baselined and green, with the count changes justified in the notes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Baseline the chapter suites at HEAD (`c8b951616`): detection UI suite, editor
+   population-race + tuple-order suites, audiobooks client suite.
+2. Probe the bug at HEAD: 13-header synthetic book through
+   `ChapterDetector.detect_chapters` — expect ~25 alternating empty/full rows
+   (review residual 5 shape).
+3. Write a born-red unit suite `Tests/TTS/test_chapter_detector.py`: 13 headings
+   → exactly 13 chapters, each titled AND carrying the body that follows ITS
+   heading; edge pins for preamble ("Chapter 0" row, current behavior),
+   headerless document ("Chapter 1" single row, current behavior), whitespace-only
+   input ("Full Content" fallback), and back-to-back headings (empty chapter kept
+   for the bodiless heading — the title must not be dropped). Run: red at HEAD.
+4. Restructure `detect_chapters` to the classic scan: keep ONE open chapter at a
+   time (`current_title` = the pending heading's title, or None for preamble); on
+   a new heading, close the open chapter with the body accumulated since its
+   heading; at EOF close the last. No placeholder append, no back-fill branch.
+5. Green the born-red suite; re-run the baseline suites; correct any pins that
+   encoded the doubled count (per task description); ruff on touched files.
+6. Task notes + Done.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restructured `ChapterDetector.detect_chapters`
+(`tldw_chatbook/TTS/audiobook_generator.py`) to the classic scan: exactly one
+chapter is "open" at a time — `current_title` holds the pending heading's title
+(None while still in preamble); a new heading closes the open chapter with the
+body accumulated since its own heading, and EOF closes the last one the same
+way. The placeholder append ("Will be filled later") and the back-fill-only-
+the-last branch are gone.
+
+**Born-red evidence**: at base `c8b951616`, the 13-header probe (the 15773
+review's shape) detected **25** chapters alternating `title='Chapter 1'
+content_len=0` / `title='Chapter 1' content_len=57` — exactly the review's
+residual-5 finding. The new suite `Tests/TTS/test_chapter_detector.py` ran 5
+failed / 4 passed at that HEAD (the 4 passers are the edge-preservation pins,
+green by design); 9/9 green post-fix, with the pairing asserted (each chapter's
+content == the body following ITS heading), not just non-emptiness.
+
+**Edge decisions** (each probed at the base sha before restructuring, pinned in
+the test docstrings per AC #2):
+- Preamble before the first heading: kept as the historical untitled
+  `number=0` / "Chapter 0" row.
+- Headerless document: kept as one `number=1` / "Chapter 1" chapter (the old
+  EOF branch's numbering — NOT the "Full Content" fallback, which fires only
+  on whitespace-only input and is also kept).
+- Back-to-back headings / trailing bodiless heading: the bodiless heading
+  keeps an empty chapter — dropping it would silently eat a pasted title, and
+  consumers already tolerate `content == ""` (pre-fix output was full of empty
+  placeholders; the editor's duration estimate handles 0 words). AC #2's
+  guarantee is scoped to headings that HAVE body text.
+- Positions: a merged chapter spans heading line → last body line (the old
+  placeholder pinned start=end=heading line; the old body rows already used
+  the heading line as start).
+- Duration/word-count estimates: nothing to recompute in the detector — it
+  never set `estimated_duration`; both the editor preview
+  (`chapter_editor_widget._update_chapter_preview`) and
+  `AudioBookProgress.estimated_duration` derive from content at use time, and
+  content is now correctly attached.
+
+**Re-baselining (AC #3)**: no existing pin actually encoded the doubled count.
+`Tests/UI/test_speech_audiobook_chapter_detection.py` asserts
+`len(detected_chapters) >= 1` / truthiness / stub-chapter lists, and the
+editor suites use synthetic `_chapters(n)` fixtures — so **zero count
+corrections were needed**; the whole pre-fix baseline set (13 tests) passes
+unchanged post-fix, plus the 9 new detector tests (22 total). Broader sweep:
+`Tests/TTS/` + audiobook/STTS UI suites = 4105 passed; the 9 failures there
+(audio_cpp managed-integration, app-ownership drain, connection-error copy,
+request-admission ×4, stts-capability ×2) were re-run against the pristine
+base detector via an edit-safe file swap and fail identically at HEAD —
+pre-existing on the base, unrelated to this change.
+
+**Files**: `tldw_chatbook/TTS/audiobook_generator.py` (detector restructure),
+`Tests/TTS/test_chapter_detector.py` (new born-red suite).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/TTS/audiobook_generator.py
+++ b/tldw_chatbook/TTS/audiobook_generator.py
@@ -150,6 +150,15 @@ class ChapterDetector:
         """
         lines = content.split("\n")
         chapters = []
+        # Exactly ONE chapter is "open" at a time: either the most recent
+        # titled heading (current_title is its title) or, before any heading
+        # has been seen, the untitled preamble (current_title is None). A new
+        # heading closes the open chapter with the body accumulated since it;
+        # EOF closes the last one the same way. (Task-16850: the previous
+        # shape appended an empty "placeholder" per heading AND the body as a
+        # separate chapter, back-filling only the final placeholder — a
+        # 13-header book came out as ~25 alternating empty/full rows.)
+        current_title: Optional[str] = None
         current_chapter_content = []
         current_chapter_start = 0
         chapter_number = 0
@@ -165,57 +174,68 @@ class ChapterDetector:
             chapter_match = cls._match_chapter_pattern(line)
 
             if chapter_match:
-                # Save previous chapter if exists
-                if current_chapter_content:
-                    chapter_text = "\n".join(current_chapter_content)
-                    if chapter_text.strip():
-                        chapters.append(
-                            Chapter(
-                                number=chapter_number,
-                                title=f"Chapter {chapter_number}",
-                                content=chapter_text,
-                                start_position=current_chapter_start,
-                                end_position=i - 1,
-                            )
-                        )
-
-                # Start new chapter
-                chapter_number += 1
-                current_chapter_content = []
-                current_chapter_start = i
-
-                # Extract chapter title if present
-                if chapter_match.get("title"):
+                chapter_text = "\n".join(current_chapter_content)
+                if current_title is not None:
+                    # Close the pending titled chapter with its own body. A
+                    # bodiless heading (back-to-back headings) keeps its
+                    # (empty) chapter: dropping it would silently eat a title
+                    # the user pasted.
                     chapters.append(
                         Chapter(
                             number=chapter_number,
-                            title=chapter_match["title"],
-                            content="",  # Will be filled later
-                            start_position=i,
-                            end_position=i,
+                            title=current_title,
+                            content=chapter_text if chapter_text.strip() else "",
+                            start_position=current_chapter_start,
+                            end_position=i - 1,
                         )
                     )
+                elif chapter_text.strip():
+                    # Preamble text before the first heading keeps its
+                    # historical shape: an untitled number=0 / "Chapter 0" row.
+                    chapters.append(
+                        Chapter(
+                            number=chapter_number,
+                            title=f"Chapter {chapter_number}",
+                            content=chapter_text,
+                            start_position=current_chapter_start,
+                            end_position=i - 1,
+                        )
+                    )
+
+                # Open the new chapter for this heading
+                chapter_number += 1
+                current_title = (
+                    chapter_match.get("title") or f"Chapter {chapter_number}"
+                )
+                current_chapter_content = []
+                current_chapter_start = i
             else:
                 current_chapter_content.append(line)
 
-        # Don't forget the last chapter
-        if current_chapter_content:
-            chapter_text = "\n".join(current_chapter_content)
-            if chapter_text.strip():
-                if chapters and not chapters[-1].content:
-                    # Fill the last chapter's content
-                    chapters[-1].content = chapter_text
-                    chapters[-1].end_position = len(lines) - 1
-                else:
-                    chapters.append(
-                        Chapter(
-                            number=chapter_number + 1,
-                            title=f"Chapter {chapter_number + 1}",
-                            content=chapter_text,
-                            start_position=current_chapter_start,
-                            end_position=len(lines) - 1,
-                        )
-                    )
+        # Close the last open chapter at EOF
+        chapter_text = "\n".join(current_chapter_content)
+        if current_title is not None:
+            chapters.append(
+                Chapter(
+                    number=chapter_number,
+                    title=current_title,
+                    content=chapter_text if chapter_text.strip() else "",
+                    start_position=current_chapter_start,
+                    end_position=len(lines) - 1,
+                )
+            )
+        elif chapter_text.strip():
+            # Headerless document: one chapter holding everything (historical
+            # numbering from the old EOF branch: number=1 / "Chapter 1").
+            chapters.append(
+                Chapter(
+                    number=chapter_number + 1,
+                    title=f"Chapter {chapter_number + 1}",
+                    content=chapter_text,
+                    start_position=current_chapter_start,
+                    end_position=len(lines) - 1,
+                )
+            )
 
         # If no chapters detected, treat entire content as one chapter
         if not chapters:


### PR DESCRIPTION
## Summary

`ChapterDetector.detect_chapters` appended an empty placeholder Chapter per titled heading AND the accumulated body as a separate Chapter, back-filling only the last placeholder — a 13-header book yielded ~25 chapters alternating empty/full. Since TASK-15773 made the editor's table truthful, users SAW the doubled rows, the preview replay hit the empty placeholder first — and review found the cost was larger than filed: `generate_audiobook` calls the detector directly and looped per-chapter TTS synthesis over the doubled list, wasting synthesis on empty chapters.

Restructured to the classic one-open-chapter scan: a new heading closes the previous chapter with the body accumulated since ITS heading; EOF closes the last. Edge behavior preserved byte-identically against base (review re-probed preamble→Chapter 0 and headerless→Chapter 1 side-by-side in one process); position spans verified safe against all consumers (intra-chapter arithmetic only).

- Born-red: the 13-header probe yields 25-alternating at base, 13 correctly-paired after; the pairing pin asserts each chapter's content equals the body following ITS OWN heading against distinct bodies (review confirmed it catches the classic off-by-one)
- The task's guess that existing pins encoded the doubled count was WRONG — verified: only >=1/truthiness assertions exist; stated honestly
- 9 new + 22 target tests green; the TTS sweep's 9 pre-existing failures reproduced by name with byte-identical-file proof

Review: independent pass → MERGE; zero coupling with 16849 (safe either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits exactly one chapter per titled heading in `ChapterDetector`, fixing doubled chapter rows and wasted per-chapter TTS synthesis. Previously, the detector appended an empty placeholder for each heading and a separate body chapter; now a new heading closes the previous chapter with its body, and EOF closes the last.

- Restructures `ChapterDetector.detect_chapters` to a single-open-chapter scan; removes placeholder/backfill logic. Callers see the correct chapter count; TTS synthesizes once per real chapter.
- Preserves edge behavior: preamble → `number=0`/"Chapter 0"; headerless document → one `number=1`/"Chapter 1"; whitespace-only → "Full Content"; bodiless headings keep an empty chapter. Positions span heading line to last body line.
- Adds `Tests/TTS/test_chapter_detector.py`: 13 headings now yield 13 titled chapters with the correct body; asserts title↔body pairing. No existing tests required count updates.
- Satisfies TASK-16850 AC #1–#3.

<sup>Written for commit 67d0f1eb29df4353c18b3891accb5a878e1e459d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

