### PR TITLE
fix(watchlists): per-source in-flight guard — concurrent checks can no longer double-report (TASK-16838)

### DIFF
--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -14,6 +14,19 @@ Mixed | Local/Server". This screen was previously called "Subscriptions."
 - Press **Ctrl+6**, click **⌃6 Watchlists** in the nav bar, or press
   **Ctrl+P** → "Tab Navigation: Switch to Watchlists".
 
+## Checking a source while a check is already running
+
+One check of a given page runs at a time. If you press **Check now** for a
+source whose page is already being checked — usually because a scheduled
+check of it is mid-flight — the app does not run a second, duplicate check
+of the same page: your run completes immediately without touching the
+network, the toast says the check was skipped because one is already
+running, and the running check's result arrives moments later as usual.
+The skipped run stays honest in the Runs section too: its detail line
+counts the page under "skipped (check already running)" rather than
+reading like a clean check that found nothing. Different sources are
+unaffected — they check concurrently, exactly as before.
+
 ## Exporting briefings and podcast feeds
 
 The **Artifacts** section of a watchlist holds its briefings — text digests

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -21,7 +21,8 @@ source whose page is already being checked — usually because a scheduled
 check of it is mid-flight — the app does not run a second, duplicate check
 of the same page: your run completes immediately without touching the
 network, the toast says the check was skipped because one is already
-running, and the running check's result arrives moments later as usual.
+running, and the running check's result appears in the Runs section the
+next time the screen refreshes.
 The skipped run stays honest in the Runs section too: its detail line
 counts the page under "skipped (check already running)" rather than
 reading like a clean check that found nothing. Different sources are

--- a/Tests/Subscriptions/test_app_watchlists_db_wiring.py
+++ b/Tests/Subscriptions/test_app_watchlists_db_wiring.py
@@ -1,0 +1,43 @@
+"""The one-SubscriptionsDB wiring invariant the in-flight guard rests on.
+
+task-16838 (review F2). The per-(subscription, url) in-flight guard
+(`local_watchlists_service._IN_FLIGHT_URL_CHECKS`) keys its claims on
+`id(db)` — so the scheduler's checks and the UI's Check Now contend with
+each other **only because** `app.py`'s
+`_wire_watchlists_and_notifications_services` hands the SAME
+`SubscriptionsDB` object to both services (task-15463's "ONE SubscriptionsDB
+for this whole wiring"). Nothing else enforced that: if the wiring ever
+regressed to the pre-task-15463 per-call `lambda: SubscriptionsDB(...)`
+factory — or the handler grew its own instance — the guard would silently
+stop guarding across entrants **while every guard test stayed green**,
+because those tests construct their own shared object. This pin is what
+makes that regression loud.
+"""
+
+from __future__ import annotations
+
+from Tests.UI.app_factory import _build_test_app
+
+
+def test_scheduler_and_ui_watchlists_services_share_one_subscriptions_db():
+    app = _build_test_app()
+
+    # The UI-facing service resolves to the app's single held instance...
+    assert app.local_watchlists_service._db() is app.subscriptions_db
+
+    # ...and so does the scheduled-check handler's default-constructed
+    # service. The handler must exist at all for the invariant to be
+    # testable — if the harness config ever disables watchlist checks, this
+    # pin must fail loudly rather than pass vacuously.
+    handler = app.scheduler_loop.handlers.get("watchlist_job")
+    assert handler is not None, (
+        "the scheduled watchlist check handler is not wired; the guard's "
+        "cross-entrant invariant cannot be pinned"
+    )
+    assert handler.subscriptions_db is app.subscriptions_db
+    assert handler.watchlists_service._db() is app.subscriptions_db, (
+        "the scheduler's service and the UI's service must resolve to the "
+        "SAME SubscriptionsDB object — the in-flight guard keys on id(db), "
+        "so distinct instances would never contend and concurrent checks "
+        "of one source could double-report again"
+    )

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -373,6 +373,8 @@ async def test_url_list_offloads_cpu_work_for_every_url_in_order(tmp_path, monke
         "baseline": 0,
         "rebaselined": 0,
         "error": 0,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }
     assert output_orders == [[], urls]
 
@@ -454,6 +456,8 @@ async def test_local_watchlists_service_executes_url_list_sources_with_default_u
         "rebaselined": 0,
         # task-1394: no URL raised in this run.
         "error": 0,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }, "the url_list arm must aggregate one disposition per URL checked"
     assert seen_urls == ["https://example.com/a", "https://example.com/b"]
     assert [dict(row) for row in stored_items] == [
@@ -550,6 +554,8 @@ async def test_local_watchlists_service_executes_sitemap_sources_with_default_ur
         "rebaselined": 0,
         # task-1394: no URL raised in this run.
         "error": 0,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }, "the sitemap arm must aggregate one disposition per URL checked"
     assert [dict(row) for row in stored_items] == [
         {
@@ -667,6 +673,8 @@ async def test_local_watchlists_service_url_list_isolates_one_failing_url(
         "baseline": 0,
         "rebaselined": 0,
         "error": 1,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }
 
 
@@ -776,6 +784,8 @@ async def test_local_watchlists_service_sitemap_isolates_one_failing_url(
         "baseline": 0,
         "rebaselined": 0,
         "error": 1,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }
 
 
@@ -856,6 +866,8 @@ async def test_local_watchlists_service_url_list_all_error_advances_breaker_and_
         "baseline": 0,
         "rebaselined": 0,
         "error": 2,
+        # task-16838: no URL was skipped by the in-flight guard.
+        "skipped": 0,
     }
     row = db.get_subscription(source_id)
     assert row["consecutive_failures"] == 2, (

--- a/Tests/Subscriptions/test_watchlist_check_in_flight_guard.py
+++ b/Tests/Subscriptions/test_watchlist_check_in_flight_guard.py
@@ -6,18 +6,29 @@ worker on the app's event loop, and a UI "Check Now" runs `launch_run` /
 `execute_run` as a coroutine worker on the same loop -- so a scheduled check
 and a manual check of source X could interleave across `check_url`'s awaits
 (the network fetch plus the off-loop sqlite/CPU hops). Both read the same
-baseline before either wrote, and the review's forced interleave got
-`dispositions=['changed','changed']`: one page change double-reported, two
-snapshots written.
+baseline before either wrote. The 15764 review's own forced interleave
+reported `dispositions=['changed','changed']` with two snapshots written;
+this file's base-tree probes (gate released, both runs allowed to finish)
+consistently reproduced the double-CHECK with a different damage split --
+fetches=2, one item, one run `changed` and the other `unchanged`,
+nondeterministically assigned. Either split is a real defect: in the
+reproduced one, a run that fetched a genuinely changed page reports
+`unchanged`, so a user's Check Now can answer "0 found" for a change the
+other run got.
 
 The guard (`LocalWatchlistsService._check_url_guarded`) is a module-level
 in-flight set keyed `(id(db), subscription_id, url)`, claimed before the
 check and released in `finally`. The second entrant SKIPS with an honest
 `skipped` disposition; it does not queue or wait.
 
-The headline test below was born red at HEAD `1af8c0414` (pre-guard): the
-manual entrant reached the network while the scheduled fetch was still
-gated, and the run pair double-reported exactly as the review demonstrated.
+Born-red record, stated precisely: at HEAD `1af8c0414` (pre-guard) this
+file failed 5/5, but only the headline interleave test reddened ON THE
+BEHAVIOR -- the manual entrant reached the network while the scheduled
+fetch was still gated ("went to the network too"). The other four reddened
+on the then-absent `skipped` key in their exact-dict assertions: vocabulary
+pins, not behavioral reproductions. The B1 health-row test below was born
+red separately, at the guard commit `72b67f25f`, on its own behavior
+(`consecutive_failures 2 -> 0`).
 
 Threading note (same as `test_url_monitor_off_loop.py`): the file-backed DBs
 under `tmp_path` are load-bearing -- `SubscriptionsDB` keeps thread-local
@@ -218,9 +229,14 @@ async def test_scheduled_and_manual_check_of_same_source_cannot_double_report(
     assert manual_run["stats"]["dispositions"] == {**_ZERO_COUNTS, "skipped": 1}
     assert manual_run["found_count"] == 0
 
-    # ...and the durable record carries ONE report and ONE new snapshot,
-    # not two of each (pre-guard: dispositions ['changed','changed'], three
-    # snapshot rows, and the same change persisted from both runs).
+    # ...and the durable record carries ONE report and ONE new snapshot.
+    # Pre-guard (reproduced at base, 4 runs): both entrants fetched
+    # (fetches=2), 2 snapshot rows, 1 item -- and the change/unchanged
+    # dispositions split NONDETERMINISTICALLY between the two runs, so a
+    # Check Now could report `unchanged`/0-found for a change the other run
+    # got. (The 15764 review's own tighter interleave additionally observed
+    # ['changed','changed'] with two snapshots written; that exact split was
+    # not reproduced here and is credited to that review, not this file.)
     assert _item_count(db, source_id) == 1
     assert _snapshot_count(db, source_id, url) == 2
 
@@ -347,6 +363,97 @@ async def test_a_cancelled_check_releases_the_guard(tmp_path, monkeypatch):
     recovered = await _run_check(service, source_id)
     assert recovered["status"] == "completed"
     assert recovered["stats"]["dispositions"] == {**_ZERO_COUNTS, "baseline": 1}
+
+
+# --- Review B1: an entirely-skipped run must not record a successful check ---
+
+
+@pytest.mark.asyncio
+async def test_an_entirely_skipped_run_leaves_the_sources_health_row_untouched(
+    tmp_path, monkeypatch
+):
+    """Born red at `72b67f25f` (the guard commit, pre-B1): the 16838 review's
+    PROBE 1, as a pin.
+
+    An entirely-skipped run used to flow through `execute_run`'s ordinary
+    success accounting: `_all_error_check_message` returned `None` (zero
+    `error` dispositions), which routed it into `record_check_result`'s
+    SUCCESS branch -- so a run that made NO network call reset the source's
+    auto-pause breaker (`consecutive_failures`/`error_count` -> 0), cleared
+    `last_error`, and stamped `last_successful_check` on a source that had
+    never successfully checked. It also evaluated alert rules, firing
+    `no_items` for a run that looked for nothing. That is the same
+    false-clean shape the skip toast removed, one layer down -- and it
+    re-opens task-1394's breaker-delay in miniature (a Check Now during a
+    dead source's scheduled fetch wiped the streak the winner's failure
+    then restarted at 1).
+
+    The run RECORD must still persist with its skipped stats -- the Runs
+    pane shows it honestly -- but the source's health row and the alert
+    pipeline must be untouched.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url = "https://example.com/page"
+    source_id = db.add_subscription(name="Watched page", type="url", source=url)
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    # Two real failures build a genuine failure streak.
+    async def dead_host(fetch_url, *, client, max_bytes, **kwargs):
+        raise ConnectionError("host unreachable")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        dead_host,
+    )
+    for _ in range(2):
+        failed = await _run_check(service, source_id)
+        assert failed["status"] == "failed"
+
+    before = dict(db.get_subscription(source_id))
+    assert before["consecutive_failures"] == 2, "precondition: a real streak"
+    assert before["last_error"], "precondition: a recorded error"
+    assert before["last_successful_check"] is None
+
+    # A `no_items` rule would fire on any 0-item run that reaches alert
+    # evaluation -- the probe for "the skipped run travelled the ordinary
+    # completion pipeline".
+    await service.create_alert_rule(
+        name="Nothing found", condition_type="no_items", source_id=source_id
+    )
+
+    # Force the entirely-skipped run by holding the claim, exactly as a
+    # concurrent check would.
+    fetched = _serve(monkeypatch, lambda u, n: _PAGE_ONE)
+    key = (id(db), source_id, url)
+    _in_flight().add(key)
+    try:
+        skipped_run = await _run_check(service, source_id)
+    finally:
+        _in_flight().discard(key)
+
+    # The run record itself persists honestly...
+    assert skipped_run["status"] == "completed"
+    assert skipped_run["stats"]["dispositions"] == {**_ZERO_COUNTS, "skipped": 1}
+    assert fetched == [], "an entirely-skipped run must not touch the network"
+    # ...but it is not a successful CHECK: no breaker reset, no cleared
+    # error, no success stamp...
+    after = dict(db.get_subscription(source_id))
+    for column in (
+        "consecutive_failures",
+        "error_count",
+        "last_error",
+        "last_successful_check",
+        "is_paused",
+    ):
+        assert after[column] == before[column], (
+            f"an entirely-skipped run changed the source's {column} "
+            f"({before[column]!r} -> {after[column]!r}) -- it recorded a "
+            "successful check despite contacting nothing"
+        )
+    # ...and no alert rule is evaluated against it.
+    assert skipped_run.get("triggered_alerts") == [], (
+        "a run that looked for nothing must not fire `no_items`"
+    )
 
 
 # --- Same-run re-entry: sequential duplicates neither deadlock nor self-skip --

--- a/Tests/Subscriptions/test_watchlist_check_in_flight_guard.py
+++ b/Tests/Subscriptions/test_watchlist_check_in_flight_guard.py
@@ -1,0 +1,384 @@
+"""task-16838: the per-(subscription, url) in-flight guard.
+
+From the TASK-15764 review (PR #1679, finding 1): no serialization mechanism
+existed for concurrent checks of the same source. The scheduler is an async
+worker on the app's event loop, and a UI "Check Now" runs `launch_run` /
+`execute_run` as a coroutine worker on the same loop -- so a scheduled check
+and a manual check of source X could interleave across `check_url`'s awaits
+(the network fetch plus the off-loop sqlite/CPU hops). Both read the same
+baseline before either wrote, and the review's forced interleave got
+`dispositions=['changed','changed']`: one page change double-reported, two
+snapshots written.
+
+The guard (`LocalWatchlistsService._check_url_guarded`) is a module-level
+in-flight set keyed `(id(db), subscription_id, url)`, claimed before the
+check and released in `finally`. The second entrant SKIPS with an honest
+`skipped` disposition; it does not queue or wait.
+
+The headline test below was born red at HEAD `1af8c0414` (pre-guard): the
+manual entrant reached the network while the scheduled fetch was still
+gated, and the run pair double-reported exactly as the review demonstrated.
+
+Threading note (same as `test_url_monitor_off_loop.py`): the file-backed DBs
+under `tmp_path` are load-bearing -- `SubscriptionsDB` keeps thread-local
+connections, so the check path's `run_db_off_loop` hops need a database
+whose file another thread can open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.DB.Subscriptions_DB import SubscriptionsDB
+from tldw_chatbook.Subscriptions.local_watchlists_service import (
+    LocalWatchlistsService,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _in_flight() -> set:
+    """The module-level claim registry, looked up lazily.
+
+    `getattr` with a default rather than a top-level import, so this file
+    still COLLECTS on a pre-guard tree and reddens on the double-report
+    behavior itself (the born-red evidence), not on an ImportError. The
+    release guarantees are also pinned behaviorally (the recovered checks
+    below), so a renamed registry cannot silently hollow out AC#3.
+    """
+    from tldw_chatbook.Subscriptions import local_watchlists_service as svc
+
+    return getattr(svc, "_IN_FLIGHT_URL_CHECKS", set())
+
+
+_PAGE_ONE = (
+    "<html><body><p>alpha bravo charlie.</p>\n<p>delta echo foxtrot.</p></body></html>"
+)
+_PAGE_TWO = (
+    "<html><body><p>alpha bravo charlie.</p>\n<p>golf hotel india.</p></body></html>"
+)
+
+#: All the counters a url-family run zero-fills (`_disposition_counts`).
+_ZERO_COUNTS = {
+    "changed": 0,
+    "unchanged": 0,
+    "withheld": 0,
+    "baseline": 0,
+    "rebaselined": 0,
+    "error": 0,
+    "skipped": 0,
+}
+
+
+def _response(text: str, url: str):
+    """Stand in for the `httpx.Response` `guarded_fetch_httpx_async` returns."""
+    return SimpleNamespace(
+        status_code=200,
+        headers={"content-type": "text/html"},
+        text=text,
+        final_url=url,
+        raise_for_status=lambda: None,
+    )
+
+
+def _serve(monkeypatch, body_for) -> list[str]:
+    """Serve HTML from the real fetch seam. Returns the fetch log."""
+    fetched: list[str] = []
+
+    async def fake_guarded(url, *, client, max_bytes, **kwargs):
+        fetched.append(url)
+        return _response(body_for(url, len(fetched)), url)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        fake_guarded,
+    )
+    return fetched
+
+
+async def _run_check(service: LocalWatchlistsService, source_id: int) -> dict:
+    """One full check the way every real entrant does it: launch + execute."""
+    launched = await service.launch_run(source_id=source_id)
+    return await service.execute_run(launched["run_id"])
+
+
+def _snapshot_count(db: SubscriptionsDB, source_id: int, url: str) -> int:
+    with db.transaction() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM url_snapshots "
+            "WHERE subscription_id = ? AND url = ?",
+            (source_id, url),
+        ).fetchone()
+    return int(row["n"])
+
+
+def _item_count(db: SubscriptionsDB, source_id: int) -> int:
+    with db.transaction() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM subscription_items WHERE subscription_id = ?",
+            (source_id,),
+        ).fetchone()
+    return int(row["n"])
+
+
+# --- AC#1: the interleave the 15764 review demonstrated ----------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduled_and_manual_check_of_same_source_cannot_double_report(
+    tmp_path, monkeypatch
+):
+    """Born red at HEAD `1af8c0414`: one page change, reported once.
+
+    Deterministic interleave: the fetch is gated on an `asyncio.Event`. The
+    "scheduled" entrant starts and is held mid-fetch; the "manual" entrant
+    then starts for the same source. Pre-guard, the manual entrant also went
+    to the network, both read the same baseline, and the pair reported
+    `changed` twice with two new snapshots. With the guard, the manual run
+    completes as `skipped` WITHOUT touching the network, and only after that
+    is the scheduled fetch released.
+
+    Two service instances over the one shared db mirror production exactly:
+    `app.py` wires the UI's `local_watchlists_service` and the
+    `WatchlistCheckHandler`'s own default-constructed service over ONE
+    `SubscriptionsDB` (task-15463) -- which is why instance-level guard state
+    would never have seen this interleave.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url = "https://example.com/page"
+    source_id = db.add_subscription(name="Watched page", type="url", source=url)
+    scheduler_service = LocalWatchlistsService(db_factory=lambda: db)
+    ui_service = LocalWatchlistsService(db_factory=lambda: db)
+
+    # Seed the baseline with an ordinary, ungated check.
+    _serve(monkeypatch, lambda u, n: _PAGE_ONE)
+    seeded = await _run_check(scheduler_service, source_id)
+    assert seeded["stats"]["dispositions"]["baseline"] == 1
+    assert _snapshot_count(db, source_id, url) == 1
+
+    # Now the page changes, and the fetch is gated so the interleave window
+    # is held open deterministically.
+    gate = asyncio.Event()
+    fetch_started = asyncio.Event()
+    second_fetch = asyncio.Event()
+    overlap_fetches: list[str] = []
+
+    async def gated_fetch(fetch_url, *, client, max_bytes, **kwargs):
+        overlap_fetches.append(fetch_url)
+        if len(overlap_fetches) == 1:
+            fetch_started.set()
+        else:
+            second_fetch.set()
+        await gate.wait()
+        return _response(_PAGE_TWO, fetch_url)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        gated_fetch,
+    )
+
+    scheduled = asyncio.create_task(_run_check(scheduler_service, source_id))
+    await asyncio.wait_for(fetch_started.wait(), timeout=10)
+
+    manual = asyncio.create_task(_run_check(ui_service, source_id))
+    # Either the manual run finishes without the network (the guard), or it
+    # reaches the network while the scheduled fetch is still in flight (the
+    # pre-guard interleave). Wait for whichever happens so the test FAILS
+    # rather than hangs on the pre-guard shape.
+    second_waiter = asyncio.create_task(second_fetch.wait())
+    done, _ = await asyncio.wait(
+        {manual, second_waiter}, timeout=15, return_when=asyncio.FIRST_COMPLETED
+    )
+    assert done, (
+        "the manual check neither finished nor reached the network -- "
+        "no entrant made progress"
+    )
+    interleaved = second_fetch.is_set()
+
+    gate.set()
+    scheduled_run = await asyncio.wait_for(scheduled, timeout=10)
+    manual_run = await asyncio.wait_for(manual, timeout=10)
+    second_waiter.cancel()
+
+    # THE core claim, red pre-guard: while the scheduled check was mid-fetch,
+    # the manual entrant must not also have fetched the page.
+    assert not interleaved and len(overlap_fetches) == 1, (
+        "a manual Check Now overlapping a scheduled check of the same source "
+        "went to the network too -- the 15764 review's double-check interleave"
+    )
+
+    # The winner reports the change exactly once...
+    assert scheduled_run["status"] == "completed"
+    assert scheduled_run["stats"]["dispositions"] == {**_ZERO_COUNTS, "changed": 1}
+    # ...the loser says, honestly, that it checked nothing...
+    assert manual_run["status"] == "completed"
+    assert manual_run["stats"]["dispositions"] == {**_ZERO_COUNTS, "skipped": 1}
+    assert manual_run["found_count"] == 0
+
+    # ...and the durable record carries ONE report and ONE new snapshot,
+    # not two of each (pre-guard: dispositions ['changed','changed'], three
+    # snapshot rows, and the same change persisted from both runs).
+    assert _item_count(db, source_id) == 1
+    assert _snapshot_count(db, source_id, url) == 2
+
+    assert not _in_flight(), "no claim may outlive its check"
+
+
+# --- AC#2: distinct sources stay concurrent ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_distinct_sources_still_check_concurrently(tmp_path, monkeypatch):
+    """The guard is per-(subscription, url), not a global serializer.
+
+    Both sources' fetches are gated; both must be IN FLIGHT AT ONCE (both
+    gated-fetch calls observed while neither run has completed) before the
+    gate opens. A global lock would hold the second source's fetch back
+    until the first run finished, and the wait below would time out.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url_a = "https://a.example/one"
+    url_b = "https://b.example/two"
+    source_a = db.add_subscription(name="Source A", type="url", source=url_a)
+    source_b = db.add_subscription(name="Source B", type="url", source=url_b)
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    gate = asyncio.Event()
+    started: dict[str, asyncio.Event] = {
+        url_a: asyncio.Event(),
+        url_b: asyncio.Event(),
+    }
+
+    async def gated_fetch(fetch_url, *, client, max_bytes, **kwargs):
+        started[fetch_url].set()
+        await gate.wait()
+        return _response(_PAGE_ONE, fetch_url)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        gated_fetch,
+    )
+
+    run_a = asyncio.create_task(_run_check(service, source_a))
+    run_b = asyncio.create_task(_run_check(service, source_b))
+    await asyncio.wait_for(
+        asyncio.gather(started[url_a].wait(), started[url_b].wait()), timeout=10
+    )
+    assert not run_a.done() and not run_b.done()
+    gate.set()
+
+    result_a = await asyncio.wait_for(run_a, timeout=10)
+    result_b = await asyncio.wait_for(run_b, timeout=10)
+    for result in (result_a, result_b):
+        assert result["status"] == "completed"
+        assert result["stats"]["dispositions"] == {**_ZERO_COUNTS, "baseline": 1}
+    assert not _in_flight()
+
+
+# --- AC#3: nothing can strand a source as "in flight" ------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_failed_check_releases_the_guard(tmp_path, monkeypatch):
+    """A fetch that raises must not leave the pair claimed forever."""
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url = "https://example.com/page"
+    source_id = db.add_subscription(name="Watched page", type="url", source=url)
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    async def dead_host(fetch_url, *, client, max_bytes, **kwargs):
+        raise ConnectionError("host unreachable")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        dead_host,
+    )
+    failed = await _run_check(service, source_id)
+    assert failed["status"] == "failed"
+    assert not _in_flight(), (
+        "the failed check left its claim behind -- the source is stranded"
+    )
+
+    # The next check must run for real, not skip against a ghost claim.
+    _serve(monkeypatch, lambda u, n: _PAGE_ONE)
+    recovered = await _run_check(service, source_id)
+    assert recovered["status"] == "completed"
+    assert recovered["stats"]["dispositions"] == {**_ZERO_COUNTS, "baseline": 1}
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_check_releases_the_guard(tmp_path, monkeypatch):
+    """Cancellation mid-fetch (the user navigating away) releases the claim.
+
+    `execute_run`'s own `except asyncio.CancelledError` records the run as
+    failed and re-raises; the guard's `finally` must have discarded the
+    claim on that same unwind.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url = "https://example.com/page"
+    source_id = db.add_subscription(name="Watched page", type="url", source=url)
+    service = LocalWatchlistsService(db_factory=lambda: db)
+
+    gate = asyncio.Event()
+    fetch_started = asyncio.Event()
+
+    async def gated_fetch(fetch_url, *, client, max_bytes, **kwargs):
+        fetch_started.set()
+        await gate.wait()
+        return _response(_PAGE_ONE, fetch_url)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Subscriptions.monitoring_engine.guarded_fetch_httpx_async",
+        gated_fetch,
+    )
+    task = asyncio.create_task(_run_check(service, source_id))
+    await asyncio.wait_for(fetch_started.wait(), timeout=10)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not _in_flight(), (
+        "the cancelled check left its claim behind -- the source is stranded"
+    )
+
+    _serve(monkeypatch, lambda u, n: _PAGE_ONE)
+    recovered = await _run_check(service, source_id)
+    assert recovered["status"] == "completed"
+    assert recovered["stats"]["dispositions"] == {**_ZERO_COUNTS, "baseline": 1}
+
+
+# --- Same-run re-entry: sequential duplicates neither deadlock nor self-skip --
+
+
+@pytest.mark.asyncio
+async def test_duplicate_urls_within_one_run_neither_deadlock_nor_self_skip(
+    tmp_path, monkeypatch
+):
+    """A url_list that lists the same URL twice keeps its pre-guard behavior.
+
+    The 15764 review established the url_list loop is sequential: each check
+    is awaited to completion before the next starts, so by the time the loop
+    reaches the duplicate, the guard's `finally` has already released the
+    claim. The duplicate is checked (fetched) again exactly as before --
+    first `baseline`, then `unchanged` -- with no skip and no deadlock.
+    """
+    db = SubscriptionsDB(tmp_path / "subs.db", "test")
+    url = "https://a.example/one"
+    source_id = db.add_subscription(
+        name="Twice-listed page", type="url_list", source=f"{url}\n{url}"
+    )
+    service = LocalWatchlistsService(db_factory=lambda: db)
+    fetched = _serve(monkeypatch, lambda u, n: _PAGE_ONE)
+
+    run = await asyncio.wait_for(_run_check(service, source_id), timeout=30)
+
+    assert run["status"] == "completed"
+    assert run["stats"]["dispositions"] == {
+        **_ZERO_COUNTS,
+        "baseline": 1,
+        "unchanged": 1,
+    }
+    assert fetched == [url, url], "both listed occurrences must really check"
+    assert not _in_flight()

--- a/Tests/Subscriptions/test_watchlist_noise_not_volume.py
+++ b/Tests/Subscriptions/test_watchlist_noise_not_volume.py
@@ -498,11 +498,14 @@ _NO_DISPOSITIONS = {
     "rebaselined": 0,
     # task-1394: a URL that raised instead of completing `check_url`.
     "error": 0,
+    # task-16838: a URL never checked because a concurrent check of the same
+    # (subscription, url) pair was already in flight.
+    "skipped": 0,
 }
 
 
 def _counts(**overrides: int) -> dict[str, int]:
-    """The full five-key disposition-count dict, with `overrides` applied.
+    """The full zero-filled disposition-count dict, with `overrides` applied.
 
     Written as the whole dict rather than a single-key lookup so a test cannot
     pass while some *other* disposition also fired. `baseline` and
@@ -535,6 +538,11 @@ def test_disposition_count_keys_are_bound_to_the_real_constants():
     call that raised instead of returning; it is pinned here too, and by the
     same reasoning -- a rename of `DISPOSITION_ERROR` that drifted from this
     binding would `KeyError` on the very run it exists to keep from failing.
+
+    task-16838 added a seventh, `(DISPOSITION_SKIPPED_IN_FLIGHT, None)`, for a
+    `check_url` call never made at all -- a concurrent check of the same
+    (subscription, url) pair held the in-flight claim -- pinned for the same
+    anti-drift reason.
     """
     from tldw_chatbook.Subscriptions import monitoring_engine
     from tldw_chatbook.Subscriptions.local_watchlists_service import (
@@ -559,9 +567,14 @@ def test_disposition_count_keys_are_bound_to_the_real_constants():
             monitoring_engine.REASON_EXTRACTION_SETTINGS_CHANGED,
         ),
         (monitoring_engine.DISPOSITION_ERROR, None),
+        (monitoring_engine.DISPOSITION_SKIPPED_IN_FLIGHT, None),
     }
     assert (
         mapping[(monitoring_engine.DISPOSITION_ERROR, None)] == "error"
+    )
+    assert (
+        mapping[(monitoring_engine.DISPOSITION_SKIPPED_IN_FLIGHT, None)]
+        == "skipped"
     )
     assert mapping[(monitoring_engine.DISPOSITION_CHANGED, None)] == "changed"
     assert mapping[(monitoring_engine.DISPOSITION_UNCHANGED, None)] == "unchanged"

--- a/Tests/UI/test_watchlists_check_now_skipped.py
+++ b/Tests/UI/test_watchlists_check_now_skipped.py
@@ -1,0 +1,118 @@
+"""An entirely-skipped Check Now says so instead of "0 found, 0 new" — task-16838.
+
+The per-(subscription, url) in-flight guard
+(`LocalWatchlistsService._check_url_guarded`) makes a manual Check Now that
+lands while a scheduled check of the same source is mid-flight complete as a
+`skipped` run rather than double-checking. Before this test's fix, that run's
+toast read "Check complete: X — 0 found, 0 new." — which tells the user their
+page was checked and unchanged when it was not checked at all, the same
+false-clean shape TASK-1090 removed for failures.
+
+The run shape consumed here — dispositions all zero except `skipped` — is
+exactly what the guard produces, pinned at the service level in
+`Tests/Subscriptions/test_watchlist_check_in_flight_guard.py`
+(`manual_run["stats"]["dispositions"] == {..., "skipped": 1}`); this test
+closes the chain by pinning what the screen tells the user about it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.full_app_destination_context import (
+    FullAppDestinationContext as DestinationHarness,
+)
+from tldw_chatbook.UI.Watchlists_Modules.sources_pane import SourcesPane
+
+
+class Notified:
+    """Capture what the app told the user, since the toast itself is transient."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, message, *args, severity: str = "information", **kwargs) -> None:
+        self.calls.append((str(message), severity))
+
+    @property
+    def warnings(self) -> list[str]:
+        return [message for message, severity in self.calls if severity == "warning"]
+
+
+#: The zero-filled counter shape `_disposition_counts` writes, with one skip —
+#: the run the guard's losing entrant records.
+_ALL_SKIPPED_STATS = {
+    "dispositions": {
+        "changed": 0,
+        "unchanged": 0,
+        "withheld": 0,
+        "baseline": 0,
+        "rebaselined": 0,
+        "error": 0,
+        "skipped": 1,
+    }
+}
+
+
+async def _open_sources(pilot, host):
+    screen = host.screen_stack[-1]
+    screen.active_section = "sources"
+    await pilot.pause(0.3)
+    pane = screen.query_one("#watchlists-sources-pane", SourcesPane)
+    for _ in range(40):
+        await pilot.pause()
+        if pane.sources:
+            break
+    return screen, pane
+
+
+@pytest.mark.asyncio
+async def test_an_entirely_skipped_check_now_reports_the_skip_not_a_clean_zero():
+    app = _build_test_app()
+    db = app.local_watchlists_service._db()
+    db.add_subscription(
+        name="Summit Route", type="url", source="https://summitroute.com/blog"
+    )
+    notified = Notified()
+    app.notify = notified
+
+    async def already_checking(subscription):
+        # What `_default_run_executor` returns when the in-flight guard
+        # skipped the source's only URL: no items, one skipped disposition.
+        return {"items": [], "stats": dict(_ALL_SKIPPED_STATS)}
+
+    app.local_watchlists_service.run_executor = already_checking
+
+    host = DestinationHarness(app, "watchlists_collections")
+    async with host.run_test(size=(180, 50)) as pilot:
+        await pilot.pause(0.2)
+        screen, pane = await _open_sources(pilot, host)
+        assert pane.sources, "the seeded source must reach the Sources pane"
+
+        pane.select_source_by_id(str(pane.sources[0]["id"]))
+        await pilot.pause(0.2)
+        pane.query_one("#sources-check-now-button", Button).press()
+        for _ in range(60):
+            await pilot.pause()
+            if notified.warnings:
+                break
+
+        skip_warnings = [
+            message for message in notified.warnings if "Check skipped" in message
+        ]
+        assert skip_warnings, (
+            "an entirely-skipped check must be reported as skipped; "
+            f"got: {notified.calls!r}"
+        )
+        assert "already running" in skip_warnings[0], (
+            "the report must say WHY it skipped -- a concurrent check owns "
+            "the result the user is about to get"
+        )
+        assert not any(
+            "Check complete" in message for message, _severity in notified.calls
+        ), (
+            "'Check complete — 0 found, 0 new' over a run that checked "
+            "nothing is the false-clean reading this toast exists to remove"
+        )

--- a/Tests/Watchlists/test_watchlists_runs_pane.py
+++ b/Tests/Watchlists/test_watchlists_runs_pane.py
@@ -289,6 +289,28 @@ def test_stats_text_shows_the_error_count_for_a_partially_failed_run():
     assert "0 error" in clean
 
 
+def test_stats_text_shows_the_skipped_count_only_when_a_check_was_skipped():
+    """task-16838: a URL skipped by the in-flight guard is named, not silent.
+
+    A run that landed while another check of the same source was mid-flight
+    completes with a `skipped` disposition instead of double-checking. That
+    must be visible here, or the run reads like a clean check that found
+    nothing -- the exact ambiguity the disposition line exists to remove.
+    Unlike `error`, the segment is conditional: a zero is omitted (the counts
+    are zero-filled at write time, so absence always means a true zero), and
+    runs recorded before the counter existed render exactly as before.
+    """
+    text = RunsPane._stats_text(_disposition_run(unchanged=2, skipped=1))
+    assert "1 skipped (check already running)" in text
+
+    # No skip: the segment is absent entirely -- both for a new run with a
+    # zero-filled counter and for an old row with no `skipped` key at all.
+    assert "skipped" not in RunsPane._stats_text(
+        _disposition_run(changed=2, skipped=0)
+    )
+    assert "skipped" not in RunsPane._stats_text(_disposition_run(changed=2))
+
+
 def test_stats_text_distinguishes_a_first_check_from_a_settings_rebaseline():
     """Whole-branch review, Critical 1: the two must not read alike.
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4636,3 +4636,21 @@ Same task, implementation twin worth remembering: a decision that walks
 must run under the widget's reconcile lock — read mid-reconcile, the transient
 child order faked a "blocked prune" and stalled a selection-free End drain
 (218 messages stranded in the born-red End-race pin).
+
+## A born-red run that dies on ImportError is not born-red evidence (TASK-16838, 2026-08-16)
+
+The in-flight-guard test file imported the new `_IN_FLIGHT_URL_CHECKS`
+registry at module top. Run against the pre-fix tree (worktree at
+`1af8c0414`) it "failed" — but on collection, with `ImportError: cannot
+import name '_IN_FLIGHT_URL_CHECKS'`. That red proves only that the test
+mentions a symbol the fix adds — the same red a typo would produce — and it
+says nothing about whether the bug (the 15764 double-check interleave) is
+reproduced or the assertions could catch it. Rewritten with a lazy
+`getattr(svc, "_IN_FLIGHT_URL_CHECKS", set())` lookup so the file COLLECTS
+on both trees, the pre-fix run reddened on the behaviour itself: the manual
+entrant's gated fetch fired while the scheduled fetch was still in flight
+("went to the network too"), the exact double-report the review had
+demonstrated. Rule: when new-code symbols would make a born-red file
+unimportable at base, reference them lazily (or split the white-box asserts
+out) so the base-tree run fails on the assertion that carries the evidence,
+not on `import`.

--- a/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
+++ b/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16838
 title: 'Watchlists: per-(subscription,url) in-flight guard against concurrent double-reporting'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - bug
@@ -37,10 +38,98 @@ Fix direction: a per-(subscription_id, url) in-flight guard (skip-or-coalesce th
 entrant), at the `check_url` orchestration seam rather than inside the engine.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+1. Verify the single-loop claim: every entrant that can reach `check_url`
+   (scheduler worker, Check Now / Rerun coroutine workers) runs on the app's
+   event loop; shadow mode writes nothing (`persist_snapshots=False`) and
+   preview runs against a throwaway in-memory DB.
+2. Guard shape: a module-level in-flight set in `local_watchlists_service.py`
+   keyed `(id(db), subscription_id, url)` — module-level because the
+   scheduler's handler and the UI hold two different `LocalWatchlistsService`
+   instances over the one shared `SubscriptionsDB` (app.py task-15463
+   wiring); `id(db)` scopes the key so preview's throwaway DB can never
+   collide with the live one. No lock: claim/release are synchronous
+   between awaits on the one loop.
+3. Placement: a `_check_url_guarded` helper at the `check_url` orchestration
+   seam in `_default_run_executor`, wrapping all three url-family arms
+   (`url`, `url_list`, `sitemap`), released in `finally`.
+4. Second entrant: SKIP with an INFO log and an honest, caller-synthesized
+   disposition (`DISPOSITION_SKIPPED_IN_FLIGHT`, same pattern as
+   `DISPOSITION_ERROR`), surfaced as a `skipped` run-stats counter, a
+   conditional Runs-pane detail segment, and an honest Check Now toast for
+   an entirely-skipped manual run.
+5. Evidence: born-red deterministic interleave test (gated fetch, scheduled
+   + manual entrants for the same source, assert one report/one snapshot and
+   the skip), distinct-sources concurrency pin, no-strand pins (failure and
+   cancellation), duplicate-URL-in-one-run no-self-skip pin; affected suites
+   re-run against the green 1530-test baseline.
+
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A scheduled run overlapping a manual Check Now of the same source cannot double-report one page change or write two baseline snapshots for it (test forcing the interleave as evidence)
-- [ ] #2 Distinct sources still check concurrently exactly as before (no global serialization)
-- [ ] #3 The guard cannot strand a source as permanently "in flight" after a failed or cancelled check
+- [x] #1 A scheduled run overlapping a manual Check Now of the same source cannot double-report one page change or write two baseline snapshots for it (test forcing the interleave as evidence)
+- [x] #2 Distinct sources still check concurrently exactly as before (no global serialization)
+- [x] #3 The guard cannot strand a source as permanently "in flight" after a failed or cancelled check
+- [x] #4 The skipped entrant is reported honestly, not silently: the run records a `skipped` disposition count, the Runs pane detail names it, and an entirely-skipped manual Check Now toasts that a check is already running instead of "0 found, 0 new"
 <!-- AC:END -->
+
+## Implementation Notes
+
+**Guard shape and placement.** A module-level in-flight set
+(`_IN_FLIGHT_URL_CHECKS` in `local_watchlists_service.py`) keyed
+`(id(db), subscription_id, url)`, claimed in the new
+`LocalWatchlistsService._check_url_guarded` and released in `finally`. That
+helper is the choke point all three url-family arms of
+`_default_run_executor` (`url`, `url_list`, `sitemap`) now route through, so
+every entrant that can WRITE is covered: the scheduler's
+`WatchlistCheckHandler`, the UI's Check Now / Rerun, and any direct
+`launch_run`/`execute_run` caller. Module-level, not instance state, because
+production wires TWO service instances over the one shared `SubscriptionsDB`
+(app.py task-15463: the UI's `local_watchlists_service` plus the handler's
+own default-constructed one); `id(db)` in the key keeps
+`WatchlistPreviewService`'s throwaway in-memory DB (whose row ids can
+collide with live ones) out of the live registry. No lock: the single-loop
+claim was verified — the scheduler is a coroutine worker
+(`run_worker(self.scheduler_loop.run(), ...)`), Check Now/Rerun are
+coroutine workers, and claim/release are synchronous between awaits.
+Shadow mode's direct `check_url` probe is deliberately outside the guard:
+`persist_snapshots=False` means it cannot write, and the scheduler loop
+already serializes shadow probes against each other.
+
+**Second entrant = SKIP, honestly surfaced.** The loser returns a new
+caller-synthesized `DISPOSITION_SKIPPED_IN_FLIGHT` (same pattern as
+task-1394's `DISPOSITION_ERROR`), which lands in a new zero-filled `skipped`
+run-stats counter, an INFO log, a conditional Runs-pane detail segment
+("N skipped (check already running)"), and — for an ENTIRELY skipped manual
+run — a "Check skipped: … already running" toast instead of the false-clean
+"Check complete — 0 found, 0 new". `skipped` is excluded from
+`_SUCCESS_DISPOSITION_COUNTERS` (a skip proves nothing about reachability,
+so it cannot mask an all-error run's breaker advance). Same-run duplicate
+URLs neither deadlock nor self-skip: the url_list/sitemap loops await each
+check, so the claim is free before the loop reaches a duplicate (pinned).
+
+**Evidence.** `Tests/Subscriptions/test_watchlist_check_in_flight_guard.py`
+(5 tests) run against pre-fix HEAD `1af8c0414` in a throwaway worktree: all
+5 red ON BEHAVIOR — the headline interleave test failed with "a manual Check
+Now overlapping a scheduled check of the same source went to the network too"
+(the review's exact double-check), after a first attempt that reddened only
+on ImportError was rewritten with a lazy registry lookup (lesson filed in
+`lessons-testing-evidence.md`). With the fix: the manual entrant completes
+`skipped` without fetching while the scheduled fetch is still gated; one
+item, one new snapshot. Affected suites: baseline 1530 passed/1 skipped at
+HEAD; post-fix 1565 passed/1 skipped (Tests/Subscriptions, the two
+Scheduling watchlist files, Tests/Watchlists, the three check-now UI tests
+— including the 15764-ported thread-identity file). Ruff clean on every
+touched file.
+
+**Files.** `tldw_chatbook/Subscriptions/monitoring_engine.py` (new
+disposition constant), `tldw_chatbook/Subscriptions/local_watchlists_service.py`
+(registry, guard, counter vocabulary), `tldw_chatbook/UI/Watchlists_Modules/runs_pane.py`
+(conditional detail segment), `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+(`_check_was_entirely_skipped` + skip toast), `Docs/User_Guide/watchlists.md`
+(new section), tests: new `Tests/Subscriptions/test_watchlist_check_in_flight_guard.py`
+and `Tests/UI/test_watchlists_check_now_skipped.py`; counter-vocabulary pins
+updated in `Tests/Subscriptions/test_local_watchlists_service.py`,
+`test_watchlist_noise_not_volume.py` (whose `_counts` also serves
+`test_watchlist_snapshot_pruning.py`), and `Tests/Watchlists/test_watchlists_runs_pane.py`.

--- a/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
+++ b/backlog/tasks/task-16838 - Watchlists-per-subscription-url-in-flight-guard-against-concurrent-double-reporting.md
@@ -110,18 +110,72 @@ URLs neither deadlock nor self-skip: the url_list/sitemap loops await each
 check, so the claim is free before the loop reaches a duplicate (pinned).
 
 **Evidence.** `Tests/Subscriptions/test_watchlist_check_in_flight_guard.py`
-(5 tests) run against pre-fix HEAD `1af8c0414` in a throwaway worktree: all
-5 red ON BEHAVIOR — the headline interleave test failed with "a manual Check
-Now overlapping a scheduled check of the same source went to the network too"
-(the review's exact double-check), after a first attempt that reddened only
-on ImportError was rewritten with a lazy registry lookup (lesson filed in
-`lessons-testing-evidence.md`). With the fix: the manual entrant completes
-`skipped` without fetching while the scheduled fetch is still gated; one
-item, one new snapshot. Affected suites: baseline 1530 passed/1 skipped at
-HEAD; post-fix 1565 passed/1 skipped (Tests/Subscriptions, the two
-Scheduling watchlist files, Tests/Watchlists, the three check-now UI tests
-— including the 15764-ported thread-identity file). Ruff clean on every
-touched file.
+run against pre-fix HEAD `1af8c0414` in a throwaway worktree: 5 failed —
+stated precisely, ONE of the five (the headline interleave test) reddened on
+the behavior itself, "a manual Check Now overlapping a scheduled check of
+the same source went to the network too"; the other four reddened on the
+then-absent `skipped` key in their exact-dict assertions, i.e. vocabulary
+pins, not behavioral reproductions. (A first attempt that reddened only on
+ImportError was rewritten with a lazy registry lookup — lesson filed in
+`lessons-testing-evidence.md`.) The pre-guard damage shape reproduced at
+base is fetches=2, 2 snapshots, 1 item, with `changed`/`unchanged` split
+nondeterministically between the two runs — a Check Now could answer
+"0 found" for a change the other run got; the 15764 review's own
+`['changed','changed']`/two-snapshot split is credited to that review, not
+reproduced here. With the fix: the manual entrant completes `skipped`
+without fetching while the scheduled fetch is still gated; one item, one
+new snapshot. Affected suites: baseline 1530 passed/1 skipped at HEAD;
+post-fix 1565 passed/1 skipped (Tests/Subscriptions, the two Scheduling
+watchlist files, Tests/Watchlists, the three check-now UI tests — including
+the 15764-ported thread-identity file). Ruff clean on every touched file.
+
+**Scope note.** AC #4 (honest surfacing of the skip) was ADDED during
+implementation — the filed task had three ACs; the parent brief's
+second-entrant UX decision point called for reading Check Now's result
+surface and keeping it honest, and the toast/counter/Runs-segment work is
+that decision. Rerun and check-all keep their generic reporting (review F5,
+disclosed follow-up scope); the Runs-pane segment covers those runs.
+
+**Review fix wave (independent review, verdict FIX-FIRST; scratchpad
+`review16838.md`).** The guard mechanism held every attack (no leak path,
+choke point complete, single-loop verified, preview scoping correct); one
+blocker downstream plus honesty items, all addressed:
+
+- **B1 (blocker)**: an entirely-skipped run travelled `execute_run`'s
+  ordinary completion accounting — zero `error` dispositions made
+  `_all_error_check_message` return None, routing it into
+  `record_check_result`'s SUCCESS branch: auto-pause breaker reset,
+  `last_error` cleared, `last_successful_check` stamped, and a `no_items`
+  alert fired, all by a run that contacted nothing (reviewer's probe: a
+  2-failure streak wiped to clean by a skip). Fixed with option (a): new
+  `_entirely_skipped_dispositions` helper + a short-circuit in
+  `execute_run` — the run ROW still persists with its skipped stats (Runs
+  pane honesty), but `record_check_result`, stats inflation, and alert
+  evaluation are all skipped (`record_run_result` grew
+  `evaluate_alerts: bool = True`, stronger than the existing
+  `dispatch_notifications` flag which still evaluated). Born-red pin
+  (reviewer's probe shape) written FIRST and observed red at the guard
+  commit `72b67f25f` (`consecutive_failures 2 -> 0`) before the fix:
+  `test_an_entirely_skipped_run_leaves_the_sources_health_row_untouched`.
+  The `_SUCCESS_DISPOSITION_COUNTERS` comment's now-false "an
+  entirely-skipped run is unaffected either way" sentence corrected.
+- **F2**: new `Tests/Subscriptions/test_app_watchlists_db_wiring.py` pins
+  the production invariant the id(db) keying rests on — the UI service and
+  the scheduler handler's default service resolve to the ONE
+  `app.subscriptions_db` object — so a wiring regression to per-instance
+  DBs cannot leave every guard test green while the guard silently stops
+  guarding.
+- **F3**: the registry comment now states the true liveness mechanism —
+  the set entry is `(int, int, str)` with no reference; it is
+  `_check_url_guarded`'s own frame holding `db` across the await that
+  prevents id reuse, and a key-only helper extraction would drop that.
+- **F4**: single-loop caveat lines added at the three launch sites that
+  could break the invariant (Check Now and Rerun `run_worker` sites in
+  `watchlists_collections_screen.py`, the scheduler worker in `app.py`).
+- **F6**: user-guide wording — the winner's result "appears in the Runs
+  section the next time the screen refreshes" (nothing pushes it live).
+- **F7**: born-red and damage-shape claims restated precisely here and in
+  the test file's comments (see Evidence above).
 
 **Files.** `tldw_chatbook/Subscriptions/monitoring_engine.py` (new
 disposition constant), `tldw_chatbook/Subscriptions/local_watchlists_service.py`

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -200,10 +200,15 @@ def _disposition_counts(dispositions: list[dict[str, Any]]) -> dict[str, int]:
 #: excluded because a skip proves nothing about the source's reachability:
 #: the URL was never contacted, so it must not count as the "genuine
 #: progress" that resets the auto-pause breaker in
-#: `_all_error_check_message`. (An entirely-skipped run is unaffected either
-#: way -- with zero `error` dispositions that function already returns
-#: `None`; this only matters for a run where every URL actually CHECKED
-#: errored and the rest were skipped, which should record the failure.)
+#: `_all_error_check_message`. This exclusion matters for the MIXED case --
+#: a run where every URL actually checked errored and the rest were skipped
+#: still records the failure. An ENTIRELY-skipped run never reaches
+#: `_all_error_check_message` at all: `execute_run` short-circuits its
+#: source-health accounting before that point (review B1 -- see
+#: `_entirely_skipped_dispositions` there), because with zero `error`
+#: dispositions the helper would return `None` and route the run into
+#: `record_check_result`'s SUCCESS branch, resetting the breaker and
+#: stamping `last_successful_check` for a run that contacted nothing.
 _SUCCESS_DISPOSITION_COUNTERS: tuple[str, ...] = tuple(
     counter
     for counter in _DISPOSITION_COUNTERS
@@ -229,9 +234,13 @@ _SUCCESS_DISPOSITION_COUNTERS: tuple[str, ...] = tuple(
 #: `WatchlistPreviewService` runs the same executor against a throwaway
 #: in-memory `SubscriptionsDB` whose row ids can collide with live ones, and
 #: without the scope a preview could falsely skip (or be skipped by) a real
-#: check. The id cannot alias across lives: the claim holds a reference to
-#: `db` for exactly the window the key is registered, so the object cannot
-#: be collected (and its id reused) while its key is in the set.
+#: check. The id cannot alias across lives — but note WHERE that guarantee
+#: comes from: the set entry is a plain `(int, int, str)` and holds NO
+#: reference to `db`. It is `_check_url_guarded`'s own frame — its `db`
+#: parameter, alive across the awaited check — that keeps the object from
+#: being collected (and its id reused) while its key is registered. A
+#: refactor that extracts the claim into a helper receiving only the
+#: precomputed key would silently drop that liveness guarantee.
 #:
 #: A plain `set` with no lock, on the single-loop argument: every entrant
 #: that reaches `_default_run_executor` runs on the app's one event loop
@@ -242,6 +251,46 @@ _SUCCESS_DISPOSITION_COUNTERS: tuple[str, ...] = tuple(
 #: check entrant ever moves off the app loop, this needs a real lock -- see
 #: `_check_url_guarded`'s docstring.
 _IN_FLIGHT_URL_CHECKS: set[tuple[int, Any, str]] = set()
+
+
+def _entirely_skipped_dispositions(
+    dispositions_counts: Mapping[str, Any] | None,
+) -> bool:
+    """Whether a run's dispositions say it checked NOTHING because of the guard.
+
+    task-16838, review B1. True when at least one URL was `skipped` (a
+    concurrent check of the same (subscription, url) held the in-flight
+    claim) and every other counter is zero -- i.e. the run made no network
+    call and observed nothing at all. `execute_run` short-circuits the
+    source-health accounting for such a run: without this, its zero `error`
+    dispositions routed it through `record_check_result`'s SUCCESS branch,
+    which resets the auto-pause breaker, clears `last_error`, and stamps
+    `last_successful_check` -- a "successful check" by a run that never
+    contacted the source (the 16838 review's PROBE 1: a two-failure streak
+    wiped to clean by a skip). A PARTIALLY skipped run is deliberately not
+    matched: it did real work on the URLs it checked and keeps the ordinary
+    accounting.
+
+    Args:
+        dispositions_counts: The run's `_disposition_counts()` output, or
+            `None`/absent for source types with no dispositions (feed/API
+            runs, which can never skip and always return False here).
+
+    Returns:
+        True only for a non-empty counts mapping that is all zeros except
+        `skipped`.
+    """
+    if not isinstance(dispositions_counts, Mapping):
+        return False
+    skipped = int(dispositions_counts.get("skipped", 0) or 0)
+    if skipped <= 0:
+        return False
+    others = sum(
+        int(dispositions_counts.get(counter, 0) or 0)
+        for counter in _DISPOSITION_COUNTERS
+        if counter != "skipped"
+    )
+    return others == 0
 
 
 def _all_error_check_message(
@@ -1041,6 +1090,34 @@ class LocalWatchlistsService:
             stats.setdefault("items_found", len(raw_items))
             stats.setdefault("response_time_ms", int((time.time() - start_time) * 1000))
 
+            # task-16838, review B1: a run the in-flight guard made check
+            # NOTHING (every disposition `skipped` -- a concurrent check of
+            # the same source held every URL's claim) must not travel the
+            # ordinary completion accounting. It contacted the source zero
+            # times, so it is not evidence of anything: `record_check_result`
+            # below would land in its SUCCESS branch (zero `error`
+            # dispositions -> `_all_error_check_message` returns None) and
+            # reset the auto-pause breaker, clear `last_error`, stamp
+            # `last_successful_check`, and inflate `subscription_stats`;
+            # alert evaluation would fire `no_items` over an absence the run
+            # never observed. The winner -- the check that actually holds the
+            # claim -- records the source's real health moments later. Only
+            # the run ROW is written (with its skipped stats), so the Runs
+            # pane still shows honestly what this run did: nothing.
+            if _entirely_skipped_dispositions(stats.get("dispositions")) and (
+                not raw_items
+            ):
+                stats["items_ingested"] = 0
+                stats["new_items_found"] = 0
+                return await self.record_run_result(
+                    run_id,
+                    status=str(result.get("status") or "completed"),
+                    stats=stats,
+                    error_msg=result.get("error_msg"),
+                    log_text=result.get("log_text"),
+                    evaluate_alerts=False,
+                )
+
             filters = await run_db_off_loop(
                 db, self._load_source_filters, db, source_id
             )
@@ -1362,6 +1439,7 @@ class LocalWatchlistsService:
         error_msg: str | None = None,
         log_text: str | None = None,
         dispatch_notifications: bool = True,
+        evaluate_alerts: bool = True,
     ) -> dict[str, Any]:
         """Persist a completed local run and emit notifications for matching alert rules.
 
@@ -1369,6 +1447,13 @@ class LocalWatchlistsService:
         `run_db_off_loop` hop, in their existing order; the notification
         dispatch after them is unchanged and still runs on the caller's
         thread.
+
+        ``evaluate_alerts=False`` (task-16838, review B1) skips the alert-rule
+        evaluation entirely -- stronger than ``dispatch_notifications=False``,
+        which still evaluates and returns the triggered alerts. Used by
+        `execute_run` for an entirely-skipped run: a run that checked nothing
+        must not fire `no_items` (or any status-agnostic rule) over an absence
+        it never actually observed. The run row itself is still written.
         """
         db = self._db()
         current = await self.get_run(run_id)
@@ -1395,14 +1480,16 @@ class LocalWatchlistsService:
         # Reads `local_watchlist_alert_rules`; the dispatch below does not
         # touch sqlite and stays on the caller's thread, where the
         # notification dispatcher expects to be called.
-        triggered_alerts = await run_db_off_loop(
-            db,
-            self._evaluate_alert_rules_for_run,
-            run_id=int(run_id),
-            job_id=int(current.get("job_id") or current.get("source_id")),
-            stats=stats_payload,
-            status=str(status),
-        )
+        triggered_alerts: list[dict[str, Any]] = []
+        if evaluate_alerts:
+            triggered_alerts = await run_db_off_loop(
+                db,
+                self._evaluate_alert_rules_for_run,
+                run_id=int(run_id),
+                job_id=int(current.get("job_id") or current.get("source_id")),
+                stats=stats_payload,
+                status=str(status),
+            )
         if dispatch_notifications:
             for alert in triggered_alerts:
                 notification = self._dispatch_alert_notification(alert)

--- a/tldw_chatbook/Subscriptions/local_watchlists_service.py
+++ b/tldw_chatbook/Subscriptions/local_watchlists_service.py
@@ -80,6 +80,10 @@ _DISPOSITION_COUNTERS: tuple[str, ...] = (
     # that reads this tuple positionally (none of the current readers do, but
     # a future one might) sees the existing five counters shift place.
     "error",
+    # task-16838. Same appended-last rationale. A URL this run never checked
+    # at all, because another check of the same (subscription, url) pair was
+    # already in flight -- see `_check_url_guarded`.
+    "skipped",
 )
 
 
@@ -102,13 +106,16 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
     them back into one leaves the `reason` with no production consumer at all,
     which is what made spec §3's "the Runs pane says why" untrue.
 
-    Five of the six pairs below are exactly the five `_disposition` call
+    Five of the seven pairs below are exactly the five `_disposition` call
     sites in `check_url`; an unlisted pair raises `KeyError` in
     `_disposition_counts`, deliberately. The sixth, `DISPOSITION_ERROR`, is
     NOT one of `check_url`'s own outcomes -- it is synthesized by
     `_default_run_executor`'s `url_list`/`sitemap` loops around a
     `check_url` call that raised instead of returning (task-1394), so one
-    dead URL is counted rather than failing the whole run.
+    dead URL is counted rather than failing the whole run. The seventh,
+    `DISPOSITION_SKIPPED_IN_FLIGHT`, is likewise caller-synthesized
+    (`_check_url_guarded`, task-16838): the call was never made because a
+    concurrent check of the same (subscription, url) pair held the claim.
 
     The `monitoring_engine` import is deliberately local, not module-level:
     this module loads unconditionally from `Subscriptions/__init__.py`
@@ -123,6 +130,7 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
         DISPOSITION_BASELINE_STORED,
         DISPOSITION_CHANGED,
         DISPOSITION_ERROR,
+        DISPOSITION_SKIPPED_IN_FLIGHT,
         DISPOSITION_UNCHANGED,
         DISPOSITION_WITHHELD,
         REASON_BELOW_CHANGE_THRESHOLD,
@@ -144,6 +152,9 @@ def _disposition_count_keys() -> dict[tuple[str, str | None], str]:
         # URLs errored", not "which exception", so it needs exactly one
         # stable pair rather than one per exception type.
         (DISPOSITION_ERROR, None): "error",
+        # task-16838: a URL this run never checked because a concurrent
+        # check of the same (subscription, url) pair was already in flight.
+        (DISPOSITION_SKIPPED_IN_FLIGHT, None): "skipped",
     }
 
 
@@ -181,13 +192,56 @@ def _disposition_counts(dispositions: list[dict[str, Any]]) -> dict[str, int]:
 
 
 #: The `_DISPOSITION_COUNTERS` entries that mean "this URL's check_url call
-#: actually succeeded" -- every counter except `"error"`. Named as a tuple
-#: comprehension over `_DISPOSITION_COUNTERS` rather than re-spelled here so
-#: the all-error detection below cannot silently drift from the counters it
-#: is reading (same rationale as `_disposition_count_keys`'s docstring).
+#: actually succeeded" -- every counter except `"error"` and `"skipped"`.
+#: Named as a tuple comprehension over `_DISPOSITION_COUNTERS` rather than
+#: re-spelled here so the all-error detection below cannot silently drift
+#: from the counters it is reading (same rationale as
+#: `_disposition_count_keys`'s docstring). `"skipped"` (task-16838) is
+#: excluded because a skip proves nothing about the source's reachability:
+#: the URL was never contacted, so it must not count as the "genuine
+#: progress" that resets the auto-pause breaker in
+#: `_all_error_check_message`. (An entirely-skipped run is unaffected either
+#: way -- with zero `error` dispositions that function already returns
+#: `None`; this only matters for a run where every URL actually CHECKED
+#: errored and the rest were skipped, which should record the failure.)
 _SUCCESS_DISPOSITION_COUNTERS: tuple[str, ...] = tuple(
-    counter for counter in _DISPOSITION_COUNTERS if counter != "error"
+    counter
+    for counter in _DISPOSITION_COUNTERS
+    if counter not in ("error", "skipped")
 )
+
+
+#: task-16838: every URL check currently in flight, keyed
+#: `(id(db), subscription_id, url)`. This is the serialization mechanism the
+#: TASK-15764 review established did not exist: the scheduler (an async
+#: worker on the app's event loop) and a UI "Check Now" (a coroutine worker
+#: on the same loop) can otherwise interleave checks of the SAME source
+#: across `check_url`'s awaits (the network fetch plus the off-loop sqlite
+#: and CPU hops), both read the same baseline before either writes, and one
+#: page change is reported twice with two snapshots written.
+#:
+#: MODULE-level, not service-instance state, deliberately: production wiring
+#: (`app.py`, task-15463) holds TWO `LocalWatchlistsService` instances over
+#: the ONE shared `SubscriptionsDB` -- the UI's `self.local_watchlists_
+#: service` and the `WatchlistCheckHandler`'s own default-constructed one --
+#: so instance state would never see the exact cross-entrant interleave this
+#: exists to stop. `id(db)` scopes the key to that shared database object:
+#: `WatchlistPreviewService` runs the same executor against a throwaway
+#: in-memory `SubscriptionsDB` whose row ids can collide with live ones, and
+#: without the scope a preview could falsely skip (or be skipped by) a real
+#: check. The id cannot alias across lives: the claim holds a reference to
+#: `db` for exactly the window the key is registered, so the object cannot
+#: be collected (and its id reused) while its key is in the set.
+#:
+#: A plain `set` with no lock, on the single-loop argument: every entrant
+#: that reaches `_default_run_executor` runs on the app's one event loop
+#: (scheduler: `run_worker(self.scheduler_loop.run(), ...)`; Check Now /
+#: Rerun: coroutine workers; the scheduled handler awaits the service
+#: directly), and `_check_url_guarded`'s claim-check-and-add / discard are
+#: synchronous between awaits, hence atomic with respect to that loop. If a
+#: check entrant ever moves off the app loop, this needs a real lock -- see
+#: `_check_url_guarded`'s docstring.
+_IN_FLIGHT_URL_CHECKS: set[tuple[int, Any, str]] = set()
 
 
 def _all_error_check_message(
@@ -1610,7 +1664,13 @@ class LocalWatchlistsService:
         if source_type in _FEED_SOURCE_TYPES:
             items = await FeedMonitor().check_feed(subscription_config)
         elif source_type == "url":
-            result, disposition = await URLMonitor(db).check_url(subscription_config)
+            result, disposition = await self._check_url_guarded(
+                URLMonitor(db),
+                subscription_config,
+                str(subscription_config.get("source") or ""),
+                db,
+                isolated=False,
+            )
             items = [result] if result else []
             dispositions = [disposition]
         elif source_type == "url_list":
@@ -1618,8 +1678,8 @@ class LocalWatchlistsService:
             items = []
             dispositions = []
             for url in self._urls_for_url_list(subscription_config):
-                result, disposition = await self._check_url_isolated(
-                    monitor, subscription_config, url
+                result, disposition = await self._check_url_guarded(
+                    monitor, subscription_config, url, db, isolated=True
                 )
                 dispositions.append(disposition)
                 if result:
@@ -1635,8 +1695,8 @@ class LocalWatchlistsService:
             # if the sitemap itself cannot be fetched there is no per-URL
             # work to isolate).
             for url in await self._urls_for_sitemap(subscription_config):
-                result, disposition = await self._check_url_isolated(
-                    monitor, subscription_config, url
+                result, disposition = await self._check_url_guarded(
+                    monitor, subscription_config, url, db, isolated=True
                 )
                 dispositions.append(disposition)
                 if result:
@@ -1668,6 +1728,103 @@ class LocalWatchlistsService:
                 run_stats["max_withheld_pct"] = max_withheld
             result_payload["stats"] = run_stats
         return result_payload
+
+    async def _check_url_guarded(
+        self,
+        monitor: Any,
+        subscription_config: Mapping[str, Any],
+        url: str,
+        db: Any,
+        *,
+        isolated: bool,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        """One URL check behind the per-(subscription, url) in-flight guard.
+
+        task-16838, from the TASK-15764 review (PR #1679, finding 1): a
+        scheduled check and a manual Check Now of the same source both run on
+        the app's event loop and can interleave across `check_url`'s awaits
+        -- both read the same baseline before either writes, so one page
+        change is double-reported with two snapshots written. This is the
+        choke point every url-family arm of `_default_run_executor` (`url`,
+        `url_list`, `sitemap`) goes through, so it covers every entrant that
+        can write: the scheduler handler, the UI's Check Now / Rerun, and any
+        direct `launch_run`/`execute_run` caller. (Shadow mode's direct
+        `check_url` probe is deliberately outside it: `persist_snapshots=
+        False` means it cannot write a snapshot or report an item, and the
+        scheduler loop already serializes shadow probes against each other.)
+
+        The second entrant SKIPS -- it does not queue or wait. A concurrent
+        Check Now while a scheduled check runs means the user gets the
+        scheduled check's result moments later; queuing a duplicate check
+        behind it would re-fetch a page whose fresh snapshot the winner just
+        wrote and report "unchanged", i.e. do network work to say nothing.
+        The skip is honest, not silent: an INFO log here, a dedicated
+        `DISPOSITION_SKIPPED_IN_FLIGHT` disposition (-> the run's `skipped`
+        stats counter, rendered by the Runs pane), and the Check Now toast
+        for an entirely-skipped run says a check was already running.
+
+        Same-run re-entry cannot deadlock or self-skip: the `url_list`/
+        `sitemap` loops await each check to completion, so for a duplicate
+        URL within one run's list the claim registered here has already been
+        released (the `finally` below) before the loop reaches the
+        duplicate.
+
+        Single-loop atomicity: the membership test and `add` below run
+        synchronously between awaits on the app's one event loop, which every
+        entrant runs on (see `_IN_FLIGHT_URL_CHECKS`). If any entrant ever
+        moves off that loop, this check-then-add becomes a real race and
+        needs a lock keyed the same way.
+
+        Args:
+            monitor: The `URLMonitor` (or fake, in tests) to check with.
+            subscription_config: The source's execution config; must carry
+                the subscription's ``id``.
+            url: The one URL this call would check -- the claim key, and
+                (when ``isolated``) the per-URL override passed through to
+                `_check_url_isolated`.
+            db: The database this run writes to. Part of the claim key so a
+                preview's throwaway in-memory DB can never collide with the
+                live one (see `_IN_FLIGHT_URL_CHECKS`).
+            isolated: ``True`` for the `url_list`/`sitemap` loops, where a
+                raise must become a `DISPOSITION_ERROR` for this URL rather
+                than failing the whole run (task-1394); ``False`` for the
+                single-`url` arm, where a raise still fails the run exactly
+                as before.
+
+        Returns:
+            Whatever the underlying check returned, unchanged, when this
+            entrant won the claim. ``(None, {"kind":
+            DISPOSITION_SKIPPED_IN_FLIGHT, ...})`` when a concurrent check
+            of the same (subscription, url) already held it.
+        """
+        from .monitoring_engine import DISPOSITION_SKIPPED_IN_FLIGHT
+
+        subscription_id = subscription_config.get("id")
+        key = (id(db), subscription_id, url)
+        if key in _IN_FLIGHT_URL_CHECKS:
+            # Subscription id only, never the URL -- it can carry a query
+            # string with sensitive data (`_check_url_isolated`'s rule).
+            logger.info(
+                f"watchlist check skipped: subscription {subscription_id} "
+                f"already has a check of this URL in flight"
+            )
+            return None, {
+                "kind": DISPOSITION_SKIPPED_IN_FLIGHT,
+                "reason": None,
+                "withheld_percentage": None,
+            }
+        _IN_FLIGHT_URL_CHECKS.add(key)
+        try:
+            if isolated:
+                return await self._check_url_isolated(
+                    monitor, subscription_config, url
+                )
+            return await monitor.check_url(subscription_config)
+        finally:
+            # `finally`, so a raise (the non-isolated arm), a cancellation
+            # (the user navigating away mid-check), or an isolated error can
+            # never strand the pair as permanently "in flight" (AC #3).
+            _IN_FLIGHT_URL_CHECKS.discard(key)
 
     @staticmethod
     async def _check_url_isolated(

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -617,6 +617,17 @@ DISPOSITION_CHANGED = "changed"
 #: other URLs already collected; this is how that partial failure stays
 #: visible instead of silently vanishing into "0 found".
 DISPOSITION_ERROR = "error"
+#: `check_url` was never called at all: another check of this exact
+#: (subscription, url) pair was already in flight, so the entrant skipped
+#: rather than double-checking (task-16838 -- a scheduled check and a UI
+#: "Check Now" of the same source can otherwise interleave across the
+#: network await and each report the same page change once, writing two
+#: snapshots). Like `DISPOSITION_ERROR`, this is synthesized by the caller
+#: (`local_watchlists_service._check_url_guarded`), never by `check_url`
+#: itself. The concurrent check that held the claim reports the real
+#: outcome; this disposition only records, honestly, that this run did not
+#: check the URL.
+DISPOSITION_SKIPPED_IN_FLIGHT = "skipped_in_flight"
 
 #: ``reason`` values for ``DISPOSITION_BASELINE_STORED``. These two are NOT
 #: interchangeable and must never be aggregated together (whole-branch review,

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -5274,6 +5274,49 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             error_msg = stats.get("error_msg")
         return str(error_msg or "the source reported a failed run")
 
+    @staticmethod
+    def _check_was_entirely_skipped(result: Any) -> bool:
+        """Whether a completed check checked NOTHING because another was running.
+
+        task-16838. The per-(subscription, url) in-flight guard
+        (`LocalWatchlistsService._check_url_guarded`) makes a Check Now that
+        lands while a scheduled check of the same source is mid-flight skip
+        rather than double-check -- the run completes with a `skipped`
+        disposition count and nothing else. Without this, that run's toast
+        read "Check complete: X — 0 found, 0 new.", which tells the user
+        their page was checked and unchanged when it was not checked at all.
+
+        Only an ENTIRELY skipped run qualifies: a `url_list` run that checked
+        most URLs and skipped one did real work, and its ordinary completion
+        toast stays honest for it (the Runs pane detail carries the per-URL
+        skip count).
+
+        Args:
+            result: Whatever `check_now` returned.
+
+        Returns:
+            True when the run's dispositions show at least one skip and
+            zero of everything else.
+        """
+        if not isinstance(result, Mapping):
+            return False
+        stats = result.get("stats")
+        if not isinstance(stats, Mapping):
+            return False
+        dispositions = stats.get("dispositions")
+        if not isinstance(dispositions, Mapping):
+            return False
+        try:
+            skipped = int(dispositions.get("skipped", 0) or 0)
+            others = sum(
+                int(value or 0)
+                for counter, value in dispositions.items()
+                if counter != "skipped"
+            )
+        except (TypeError, ValueError):
+            return False
+        return skipped > 0 and others == 0
+
     async def _check_now_source(
         self,
         source: dict[str, Any],
@@ -5374,7 +5417,20 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                     status = str((result or {}).get("status") or "").lower()
                     reached_terminal = status in self._TERMINAL_RUN_STATUSES
                     if callable(notify):
-                        if reached_terminal:
+                        if reached_terminal and self._check_was_entirely_skipped(
+                            result
+                        ):
+                            # task-16838: the in-flight guard skipped every
+                            # URL -- say so rather than "0 found, 0 new",
+                            # which would claim the page was checked and
+                            # unchanged when it was not checked at all.
+                            notify(
+                                f"Check skipped: {name} — a check of this "
+                                f"source is already running.",
+                                severity="warning",
+                                markup=False,
+                            )
+                        elif reached_terminal:
                             # The run's own counters (TASK-2309), when the
                             # result actually carries them -- the local
                             # backend's `execute_run` always returns a

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -5099,6 +5099,9 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
     @on(RerunRunRequested)
     def handle_rerun_run_requested(self, event: RerunRunRequested) -> None:
         event.stop()
+        # A coroutine worker, never thread=True — this launches a check, so
+        # the in-flight guard's single-loop invariant applies (see
+        # `handle_check_now_requested`'s launch site).
         self.run_worker(self._rerun_run(event.source_id), exclusive=True)
 
     async def _rerun_run(self, source_id: Any) -> None:
@@ -5239,6 +5242,10 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self._notify_watchlists(
             f"Checking {name}...", severity="information", markup=False
         )
+        # A COROUTINE worker, never thread=True: the watchlists in-flight
+        # guard (`local_watchlists_service._IN_FLIGHT_URL_CHECKS`) is a
+        # lock-free set whose safety rests on every check entrant running on
+        # the app's one event loop. Moving this off-loop needs a lock there.
         self.run_worker(
             self._check_now_source(entity, source_key, name), group="wc_check_now"
         )

--- a/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/runs_pane.py
@@ -302,6 +302,16 @@ class RunsPane(RecomposeCaptureGuard, Vertical):
                 # a clean one that merely found nothing.
                 f"{dispositions.get('error', 0)} error"
             )
+            # task-16838: URLs this run never checked because another check
+            # of the same source was already running (a scheduled check
+            # overlapping a Check Now). Conditional, unlike `error`: an
+            # omitted segment always means a true zero -- the counts are
+            # zero-filled at write time and `.get(..., 0)` covers rows from
+            # before the counter existed -- so absence is not ambiguous, and
+            # a rare event does not widen every normal run's line.
+            skipped = dispositions.get("skipped", 0)
+            if skipped:
+                base += f" | {skipped} skipped (check already running)"
         return base
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -9929,6 +9929,11 @@ class TldwCli(
         self.loguru_logger.info(f"on_mount completed in {mount_duration:.3f} seconds")
 
         # Start the background scheduler loop for reminders and scheduled tasks.
+        # A COROUTINE worker, never thread=True: scheduled watchlist checks
+        # dispatch from this loop, and the watchlists in-flight guard
+        # (`local_watchlists_service._IN_FLIGHT_URL_CHECKS`) is lock-free on
+        # the invariant that every check entrant runs on the app's one event
+        # loop. Moving dispatch off-loop needs a lock there.
         self.scheduler_worker = self.run_worker(
             self.scheduler_loop.run(),
             exclusive=True,


### PR DESCRIPTION
## Summary

No serialization existed between the scheduler's check of a source and a user's Check Now on the same source — both could interleave across `check_url`'s awaits, double-fetching and splitting one page change into a nondeterministic changed/unchanged pair (the user's Check Now could report 0-found for a change the other run got). 

The guard: a module-level in-flight registry keyed `(id(db), subscription_id, url)`, claimed at the choke point all three url-family executor arms route through, released in `finally`. Review attacked every edge and found no leak path: the claim spans no awaitless gap cancellation can exploit, the fetch timeout bounds any stall, previews (throwaway DBs) can't collide with live checks, and every entrant is a coroutine on the app loop (the lock-free invariant now carries caveat lines at all three launch sites, and a new WIRING PIN asserts production hands one DB object to both services — closing the one silent-failure mode found).

Second entrants SKIP, surfaced honestly: a new `skipped` disposition (excluded from breaker-advancing success counters), a Runs-pane segment, and an entirely-skipped Check Now toast. **The review's blocker is fixed**: an entirely-skipped run no longer travels the ordinary success pipeline — previously it reset the auto-pause breaker, cleared the error, and stamped last-checked on a source that contacted nothing (a skip performed the user's explicit un-pause action); now it records only its run row, with alert evaluation gated so no_items can't fire over an absence the run didn't observe. Born-red at the reviewer's exact probe (2-failure streak wiped → untouched).

Honesty per review: born-red restated as 1-of-5 behavioral + 4 vocabulary pins; the unreproduced damage shape credited to its source; AC#4 flagged as an addition. 139 tests green across the guard/wiring/service/UI suites; 1569/1 on the wider sweep pre-fix-round.

Review (opus): FIX-FIRST → all seven items closed → merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent double-reporting in Watchlists by introducing a per-(subscription,url) in‑flight guard. Previously, a scheduled check and a user “Check now” for the same source could interleave and double-fetch; now the second entrant skips while different sources still run concurrently.

- Guard: module-level `_IN_FLIGHT_URL_CHECKS` keyed `(id(db), subscription_id, url)`, claimed in `LocalWatchlistsService._check_url_guarded` for `url`, `url_list`, and `sitemap`, released in `finally`. Lock-free on the app loop; `id(db)` scopes out previews. A new wiring pin ensures the scheduler and UI share one `SubscriptionsDB`, so the guard contends across services.
- Behavior: second entrant returns `DISPOSITION_SKIPPED_IN_FLIGHT` → zero-filled `skipped` counter, excluded from success counters. Runs pane adds “skipped (check already running)”. An entirely-skipped Check Now shows a warning toast: “Check skipped … already running.”
- Source health: an entirely-skipped run records only its run row. It does not reset the auto-pause breaker, clear `last_error`, stamp `last_successful_check`, or evaluate alerts. `execute_run` short-circuits; `record_run_result` supports `evaluate_alerts=False`.
- Safety: guard releases on failure and cancellation; duplicate URLs within one run execute sequentially (no self-skip); distinct sources remain concurrent.
- Evidence/docs: deterministic interleave test (one fetch, one item, single snapshot increment), concurrency and release tests, UI toast and Runs pane tests, and a DB wiring pin. User guide documents the skip behavior.

<sup>Written for commit 3be7a78eadddca0554f439a71529eb9bcd41335e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

