### PR TITLE
chore(backlog): file the headless skill-confirm divergence (task-16866)

### DIFF
--- a/backlog/tasks/task-16866 - Headless-skill-confirms-fail-closed-instantly-and-silently-diverging-from-tool-approvals.md
+++ b/backlog/tasks/task-16866 - Headless-skill-confirms-fail-closed-instantly-and-silently-diverging-from-tool-approvals.md
@@ -1,0 +1,31 @@
+---
+id: TASK-16866
+title: >-
+  Headless skill confirms fail closed instantly and silently, diverging from
+  tool approvals
+status: To Do
+assignee: []
+created_date: '2026-08-17 00:00'
+labels:
+  - console
+  - agents
+  - safety
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #1752 (task-15860 Task 5) made a headless MCP tool approval WAIT and announce itself app-wide: a wake turn firing with Console closed now raises a toast on whatever screen the user is on, and the card is mounted the moment Console opens. Skill install/script confirms were deliberately left untouched by that landing and still take the opposite path: with no view attached their pending-slot is None, which their read site treats as fail-closed-at-once, so the confirm denies immediately and NOTHING surfaces to the user.
+
+That divergence is now a user-visible inconsistency in the same feature: one class of gated action asks the user wherever they are, the other refuses silently. It needs an owner ruling rather than a default, because the two options differ in posture: make skill confirms wait-and-announce like tool approvals (consistent, but skill scripts execute immediately after confirm with no cancel checkpoint - see the tool-approval security stream), or keep them fail-closed and instead SURFACE the refusal so the user learns the skill did not run.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The behaviour of a headless skill install confirm and a headless skill script confirm is decided deliberately and recorded, not left as an artefact of a None slot
+- [ ] #2 Whichever posture is chosen, the user learns the outcome: either a card they can answer from any screen, or a visible notice that the action was refused
+- [ ] #3 The chosen behaviour is pinned by a test driven through the production path with Console genuinely unmounted
+- [ ] #4 Docs/User_Guide/console/agent-runs-and-tools.md states the skill-confirm behaviour alongside the tool-approval behaviour
+<!-- AC:END -->


### PR DESCRIPTION
Follow-up filed from PR #1752's concern 3: a headless MCP tool approval now waits and raises an app-wide toast, but skill install/script confirms still fail closed instantly and silently when no view is attached.

That is a user-visible inconsistency inside one feature, and it needs an owner ruling rather than a default — making skill confirms wait would be consistent, but a skill script executes immediately after confirm with no cancel checkpoint, so the safety posture genuinely differs. The task states both options and requires whichever is chosen to be pinned by a production-path test and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `TASK-16866` to resolve a user-visible inconsistency: headless MCP tool approvals wait and announce, while headless skill install/script confirms fail closed instantly and silently. No runtime changes in this PR.

- Records acceptance criteria to choose and document the skill confirm posture (wait-and-announce vs fail-closed with visible notice), aligning with `task-15860` headless approval work.
- Requires a production-path test with Console unmounted to pin the chosen behavior.
- Requires updating Docs/User_Guide/console/agent-runs-and-tools.md to state skill confirm behavior alongside tool approvals.

<sup>Written for commit 98d2ef48005261ba04b91fd58add28d1e86f14b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

