### PR TITLE
feat(research): category-lane baselines + OSF/degradation fixes

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -109,6 +109,40 @@ grounding untested, not failing). En route the script gained the
 `autonomy_mode="autonomous"` fix — checkpointed (the service default since
 task-16482) would park every run at plan review and produce no report.
 
+## Category-lane live baselines (2026-08-16, task-16812)
+
+Three more lanes measured with the same runner/config (local Qwen3.8-27B on
+:9191, duckduckgo web lane, bounded):
+
+| Metric | repositories (n=3) | open_research_graph (n=3) | biomedical stress (n=3) |
+|---|---|---|---|
+| `citation_accuracy` | **1.00 (73/73)** | **1.00 (85/85)** | **1.00 (62/62)** |
+| `claim_support_rate` | 0.97 | 1.00 | 1.00 |
+| `gate_pass_rate` | **0.29** | 0.72 | 0.53 |
+| `cited_sentence_ratio` | 0.52 | 0.69 | 0.73 |
+| `quote_grounding` | 0.00 (no quotes) | 0.00 (no quotes) | 0.00 (no quotes) |
+
+The biomedical stress run used the new `--question-set biomedical` domain
+questions (CRISPR off-target effects, tau aggregation, gut microbiome) —
+PubMed held perfect citation integrity under domain-specific vocabulary.
+
+**Lane-specific finding**: the repositories lane (Zenodo/Figshare/OSF) has
+the LOWEST gate pass rate (0.29) — repository records (datasets, figures)
+frequently fail the "answers the question comprehensively" bar even when
+on-topic, confirming the relevance gate's strictness hits
+non-paper sources hardest. Citation integrity is unaffected (every kept
+source verifies).
+
+Live-verification fixes en route (task-16812): OSF intermittently 301s —
+httpx does not follow redirects by default, which yielded empty bodies;
+the OSF client now follows redirects and sends the server-parity
+`Accept: application/json` header. Malformed payloads (the OSF 301 HTML)
+previously escaped the lane's typed degradation catch as a raw
+JSONDecodeError, killing the OTHER providers' results — all provider
+JSON parsing now raises `AcademicProviderError` so one bad payload
+degrades that provider only. The script also gained
+`--question-set {default,biomedical}`.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -31,14 +31,23 @@ if str(REPO_ROOT) not in sys.path:
 
 # Default question set: neutral, stable topics so future re-runs stay
 # comparable; single-facet questions keep verification payloads small.
-# Academic-topic questions: with --academic the evidence pool is arXiv/S2
-# papers, so non-research topics (product features, protocols) legitimately
-# score zero relevance and produce no synthesis to verify.
-DEFAULT_QUESTIONS = [
-    "What is retrieval augmented generation?",
-    "What are mixture of experts language models?",
-    "How do graph neural networks work?",
-]
+# Question sets: with --academic the evidence pool is papers/datasets, so
+# non-research topics (product features, protocols) legitimately score zero
+# relevance and produce no synthesis to verify. The biomedical set stresses
+# domain-specific vocabulary the PubMed lane must match (task-16812).
+QUESTION_SETS: dict[str, list[str]] = {
+    "default": [
+        "What is retrieval augmented generation?",
+        "What are mixture of experts language models?",
+        "How do graph neural networks work?",
+    ],
+    "biomedical": [
+        "What are the mechanisms of CRISPR-Cas9 off-target effects?",
+        "How does tau protein aggregation contribute to Alzheimer's disease?",
+        "What is the role of the gut microbiome in immune regulation?",
+    ],
+}
+DEFAULT_QUESTIONS = QUESTION_SETS["default"]
 
 
 # Credential requirements per engine (None = keyless). The preflight fails
@@ -200,8 +209,10 @@ async def main_async(args: argparse.Namespace) -> int:
             service, search_params=search_params, paper_search_fn=paper_search_fn
         )
 
+        question_set = QUESTION_SETS[args.question_set]
+        print(f"question set: {args.question_set}")
         payloads = []
-        for question in DEFAULT_QUESTIONS[: args.questions]:
+        for question in question_set[: args.questions]:
             print(f"Running: {question}")
             payload = await _run_question(engine, service, question)
             if payload is not None:
@@ -240,6 +251,12 @@ async def main_async(args: argparse.Namespace) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--questions", type=int, default=3, help="number of questions to run")
+    parser.add_argument(
+        "--question-set",
+        default="default",
+        choices=sorted(QUESTION_SETS),
+        help="named question set to run (default keeps the general-purpose set)",
+    )
     parser.add_argument(
         "--max-results", type=int, default=5, help="search results per query (spend bound)"
     )

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -209,7 +209,12 @@ async def main_async(args: argparse.Namespace) -> int:
             service, search_params=search_params, paper_search_fn=paper_search_fn
         )
 
-        question_set = QUESTION_SETS[args.question_set]
+        from tldw_chatbook.Utils.input_validation import validate_text_input
+
+        question_set_name = str(args.question_set)
+        if not validate_text_input(question_set_name, max_length=100):
+            raise SystemExit(f"[args] invalid --question-set value: {question_set_name!r}")
+        question_set = QUESTION_SETS[question_set_name]
         print(f"question set: {args.question_set}")
         payloads = []
         for question in question_set[: args.questions]:

--- a/Tests/Research/test_academic_providers.py
+++ b/Tests/Research/test_academic_providers.py
@@ -754,3 +754,47 @@ def test_search_papers_accepts_categories(monkeypatch):
 
     assert calls == ["pubmed"]
     assert papers == []
+
+
+# --- malformed-payload degradation + OSF Accept header (task-16812) ----------------
+
+def test_search_osf_sends_accept_json_header(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text=json.dumps({"data": []}))])
+
+    search_osf(query="registration", client=client)
+
+    assert client.request.calls[0]["headers"] == {"Accept": "application/json"}
+
+
+def test_malformed_payload_degrades_only_the_bad_provider(monkeypatch):
+    import asyncio
+    from tldw_chatbook.Research_Interop import academic_providers as ap
+
+    def good_arxiv(**kw):
+        return {"items": [{"title": "Good", "abstract": "a", "doi": "10.1/g",
+                           "url": "https://doi.org/10.1/g", "source": "arxiv"}]}
+
+    def exploding_osf(**kw):
+        raise ap.AcademicProviderError("invalid JSON payload from osf")
+
+    monkeypatch.setattr(ap, "search_arxiv", good_arxiv)
+    monkeypatch.setattr(ap, "search_osf", exploding_osf)
+
+    papers = asyncio.run(ap.search_papers("topic", providers=["arxiv", "osf"]))
+
+    assert [p["title"] for p in papers] == ["Good"]  # good provider survived
+
+
+def test_non_json_response_raises_provider_error(monkeypatch):
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.academic_providers._sleep_backoff",
+        lambda attempt: None,
+    )
+    client = _client_returning([_response(text="<html>not json</html>")])
+
+    with pytest.raises(AcademicProviderError, match="osf"):
+        search_osf(query="x", client=client)

--- a/backlog/tasks/task-16812 - Record-repository-research-graph-and-biomedical-stress-live-baselines.md
+++ b/backlog/tasks/task-16812 - Record-repository-research-graph-and-biomedical-stress-live-baselines.md
@@ -1,0 +1,33 @@
+---
+id: TASK-16812
+title: 'Record repository, research-graph, and biomedical-stress live baselines'
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-08-16 15:52'
+updated_date: '2026-08-17 03:24'
+labels:
+  - research
+  - evals
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The biomedical lane has a recorded baseline but the repositories lane (Zenodo/Figshare/OSF) and the open_research_graph lane (OpenAlex/Semantic Scholar/Crossref) have none, and the biomedical measurement used general-purpose questions that under-stress the PubMed lane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The baseline script supports named question sets with a biomedical set of domain-tuned questions,The repositories and open_research_graph category lanes are run live and scored,The biomedical lane is re-run against the biomedical question set as a stress measurement,The baseline doc records all three results in the comparison table,Questions-per-set and spend bounds stay documented
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `--question-set {default,biomedical}` added (domain-tuned: CRISPR off-target effects, tau aggregation, gut microbiome); spend bounds unchanged.
+- Results: repositories lane 1.00 citation accuracy (73/73 markers) but gate_pass only 0.29 — repository records fail the strict relevance bar most, confirming the gate's known bias against non-paper sources. open_research_graph: 1.00 (85/85), gate 0.72. Biomedical stress: 1.00 (62/62) under domain vocabulary — PubMed held. quote_grounding 0.00 everywhere (model emitted no quotes; untested, not failing).
+- Live run exposed two real bugs, both fixed: (1) OSF intermittently 301s and httpx does not follow redirects by default → empty bodies; OSF client now follows redirects + sends the server-parity Accept header. (2) A malformed payload raised a raw JSONDecodeError that ESCAPED the lane's AcademicProviderError degradation catch, killing the OTHER providers' results (zenodo/figshare lost their papers to OSF's 301 HTML); all provider JSON parsing now goes through `_json_or_error`, which raises the typed error so one bad payload degrades that provider only. TDD: 3 new tests (Accept header pin, typed parse failure, good-provider survival).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -604,7 +604,7 @@ def search_crossref(
                 http, "GET", f"{CROSSREF_API_BASE}/works",
                 timeout=timeout, max_retries=max_retries, params=params,
             )
-            data = _json_or_error(response, "openalex")
+            data = _json_or_error(response, "crossref")
 
     message = data.get("message") or {}
     items: list[dict[str, Any]] = []
@@ -677,7 +677,7 @@ def search_zenodo(
                 http, "GET", ZENODO_API_BASE,
                 timeout=timeout, max_retries=max_retries, params=params,
             )
-            data = _json_or_error(response, "openalex")
+            data = _json_or_error(response, "zenodo")
 
     hits = (data.get("hits") or {})
     items: list[dict[str, Any]] = []
@@ -750,7 +750,7 @@ def search_figshare(
                 http, "POST", FIGSHARE_API_BASE, timeout=timeout,
                 max_retries=max_retries, body=body,
             )
-            data = _json_or_error(response, "openalex")
+            data = _json_or_error(response, "figshare")
 
     items: list[dict[str, Any]] = []
     for raw in data if isinstance(data, list) else []:
@@ -925,13 +925,13 @@ def search_biorxiv(
         response = _request_with_retries(
             client, "GET", url, timeout=timeout, max_retries=max_retries
         )
-        data = _json_or_error(response, "_validate_date")
+        data = _json_or_error(response, "biorxiv")
     else:
         with httpx.Client() as http:
             response = _request_with_retries(
                 http, "GET", url, timeout=timeout, max_retries=max_retries
             )
-            data = _json_or_error(response, "openalex")
+            data = _json_or_error(response, "biorxiv")
 
     total = 0
     messages = data.get("messages") or []

--- a/tldw_chatbook/Research_Interop/academic_providers.py
+++ b/tldw_chatbook/Research_Interop/academic_providers.py
@@ -67,6 +67,18 @@ class AcademicProviderError(Exception):
     non-retryable HTTP error)."""
 
 
+def _json_or_error(response: Any, provider: str) -> Any:
+    """Parse a provider response body as JSON; a malformed payload is a
+    typed provider failure (task-16812: a raw JSONDecodeError escaped the
+    lane's degradation catch and killed the OTHER providers' results too)."""
+    try:
+        return json.loads(response.text)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise AcademicProviderError(
+            f"invalid JSON payload from {provider}: {exc}"
+        ) from exc
+
+
 def _request_with_retries_json(
     client: Any,
     method: str,
@@ -512,14 +524,14 @@ def search_openalex(
             client, "GET", f"{OPENALEX_API_BASE}/works",
             timeout=timeout, max_retries=max_retries, params=params,
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "openalex")
     else:
         with httpx.Client() as http:
             response = _request_with_retries(
                 http, "GET", f"{OPENALEX_API_BASE}/works",
                 timeout=timeout, max_retries=max_retries, params=params,
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "openalex")
 
     items: list[dict[str, Any]] = []
     for raw in data.get("results") or []:
@@ -585,14 +597,14 @@ def search_crossref(
             client, "GET", f"{CROSSREF_API_BASE}/works",
             timeout=timeout, max_retries=max_retries, params=params,
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "crossref")
     else:
         with httpx.Client() as http:
             response = _request_with_retries(
                 http, "GET", f"{CROSSREF_API_BASE}/works",
                 timeout=timeout, max_retries=max_retries, params=params,
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "openalex")
 
     message = data.get("message") or {}
     items: list[dict[str, Any]] = []
@@ -658,14 +670,14 @@ def search_zenodo(
             client, "GET", ZENODO_API_BASE,
             timeout=timeout, max_retries=max_retries, params=params,
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "zenodo")
     else:
         with httpx.Client() as http:
             response = _request_with_retries(
                 http, "GET", ZENODO_API_BASE,
                 timeout=timeout, max_retries=max_retries, params=params,
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "openalex")
 
     hits = (data.get("hits") or {})
     items: list[dict[str, Any]] = []
@@ -731,14 +743,14 @@ def search_figshare(
             client, "POST", FIGSHARE_API_BASE, timeout=timeout,
             max_retries=max_retries, body=body,
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "figshare")
     else:
         with httpx.Client() as http:
             response = _request_with_retries_json(
                 http, "POST", FIGSHARE_API_BASE, timeout=timeout,
                 max_retries=max_retries, body=body,
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "openalex")
 
     items: list[dict[str, Any]] = []
     for raw in data if isinstance(data, list) else []:
@@ -802,19 +814,24 @@ def search_osf(
         "page[size]": max(1, min(results_per_page, 100)),
         "page[number]": 1,
     }
+    headers = {"Accept": "application/json"}  # server-adapter parity: OSF returns HTML without it
     if client is not None:
         response = _request_with_retries(
             client, "GET", OSF_API_BASE,
             timeout=timeout, max_retries=max_retries, params=params,
+            headers=headers,
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "osf")
     else:
-        with httpx.Client() as http:
+        # OSF intermittently 301s (first-hit redirects); httpx does not
+        # follow redirects by default, which yielded empty 301 bodies.
+        with httpx.Client(follow_redirects=True) as http:
             response = _request_with_retries(
                 http, "GET", OSF_API_BASE,
                 timeout=timeout, max_retries=max_retries, params=params,
+                headers=headers,
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "osf")
 
     items: list[dict[str, Any]] = []
     for raw in data.get("data") or []:
@@ -908,13 +925,13 @@ def search_biorxiv(
         response = _request_with_retries(
             client, "GET", url, timeout=timeout, max_retries=max_retries
         )
-        data = json.loads(response.text)
+        data = _json_or_error(response, "_validate_date")
     else:
         with httpx.Client() as http:
             response = _request_with_retries(
                 http, "GET", url, timeout=timeout, max_retries=max_retries
             )
-            data = json.loads(response.text)
+            data = _json_or_error(response, "openalex")
 
     total = 0
     messages = data.get("messages") or []


### PR DESCRIPTION
## Summary

Closes task-16812: the remaining two category lanes measured live, a biomedical stress run, `--question-set` for the baseline script, and two real provider bugs the runs exposed.

### Measured (all three lanes, citation accuracy 1.00)

| Metric | repositories | open_research_graph | biomedical stress |
|---|---|---|---|
| citation_accuracy | **1.00 (73/73)** | **1.00 (85/85)** | **1.00 (62/62)** |
| gate_pass_rate | **0.29** | 0.72 | 0.53 |
| cited_sentence_ratio | 0.52 | 0.69 | 0.73 |

**Lane-specific finding**: repositories has the lowest gate pass rate — dataset/figure records fail the strict relevance bar most often, confirming the gate's known bias against non-paper sources; citation integrity is unaffected.

### Bugs found by the live runs (both TDD-fixed)
1. **OSF intermittent 301s** — httpx doesn't follow redirects by default → empty bodies; the OSF client now follows redirects and sends the server-parity `Accept: application/json` header.
2. **Degradation contract violated by untyped errors** — OSF's 301 HTML raised a raw `JSONDecodeError` that escaped the lane's `AcademicProviderError` catch and killed the *other* providers' results (zenodo/figshare lost their papers). All provider JSON parsing now goes through `_json_or_error`, raising the typed error so one bad payload degrades that provider only.

## Test evidence
3 new tests (Accept-header pin, typed parse failure, good-provider survival); suites 149 passed; ruff clean; the three recorded runs are the live verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live baselines for the repositories, open_research_graph, and biomedical lanes; introduces `--question-set`; fixes OSF redirects and centralizes provider JSON parsing with correct error labels and boundary validation. Previously OSF 301s returned empty bodies and HTML raised a raw `JSONDecodeError` that escaped degradation and killed other providers; now OSF uses `httpx.Client(follow_redirects=True)` with `Accept: application/json`, and `_json_or_error` raises `AcademicProviderError` so only the bad provider degrades. Satisfies TASK-16812.

**Review focus**
- `tldw_chatbook/Research_Interop/academic_providers.py`: ensure `_json_or_error` wraps all provider JSON parsing and labels are correct in `openalex`, `crossref`, `zenodo`, `figshare`, `osf`, and `biorxiv` date validation.
- OSF client: confirm `httpx.Client(follow_redirects=True)` and `headers={"Accept": "application/json"}` in both injected-client and local paths.
- Baseline script: verify `--question-set {default, biomedical}` wiring and boundary validation via `validate_text_input`; `--questions` behavior unchanged; selected set prints.
- Docs/tests: baseline metrics recorded; tests pin Accept header, non-JSON raising a provider error, and good-provider survival.

<sup>Written for commit 4793fb77935a98a486b84122defba0d274819f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

