### PR TITLE
feat(websearch): source-type-aware relevance gate for non-paper evidence

### DIFF
--- a/Tests/Research/test_research_source_catalog.py
+++ b/Tests/Research/test_research_source_catalog.py
@@ -100,3 +100,11 @@ def test_source_kind_unknown_and_missing_default_to_paper():
     assert source_kind_for_provider("not_a_provider") == "paper"
     assert source_kind_for_provider("") == "paper"
     assert source_kind_for_provider(None) == "paper"
+
+
+def test_source_kind_classifier_is_cached():
+    from tldw_chatbook.Research_Interop import research_source_catalog as rsc
+
+    first = rsc._entries_by_id()
+    second = rsc._entries_by_id()
+    assert first is second  # memoized, not rebuilt per call

--- a/Tests/Research/test_research_source_catalog.py
+++ b/Tests/Research/test_research_source_catalog.py
@@ -70,3 +70,33 @@ def test_paper_provider_constants_in_sync_with_catalog():
     assert set(LOCAL_SUPPORTED_PAPER_PROVIDERS) <= catalog_ids
     # Every catalog source is runnable by the lane (full parity, not a subset).
     assert set(LOCAL_SUPPORTED_PAPER_PROVIDERS) == catalog_ids
+
+
+# --- source-kind classification (task-17066) ---------------------------------------
+
+def test_source_kind_for_provider_maps_categories():
+    from tldw_chatbook.Research_Interop.research_source_catalog import (
+        source_kind_for_provider,
+    )
+
+    assert source_kind_for_provider("zenodo") == "repository"
+    assert source_kind_for_provider("figshare") == "repository"
+    assert source_kind_for_provider("osf") == "repository"
+    assert source_kind_for_provider("openalex") == "metadata"
+    assert source_kind_for_provider("crossref") == "metadata"
+    # Papers/preprints stay strict; graph members (which include
+    # semantic_scholar/openalex by catalog category) take the metadata note.
+    assert source_kind_for_provider("arxiv") == "paper"
+    assert source_kind_for_provider("pubmed") == "paper"
+    assert source_kind_for_provider("biorxiv") == "paper"
+    assert source_kind_for_provider("semantic_scholar") == "metadata"
+
+
+def test_source_kind_unknown_and_missing_default_to_paper():
+    from tldw_chatbook.Research_Interop.research_source_catalog import (
+        source_kind_for_provider,
+    )
+
+    assert source_kind_for_provider("not_a_provider") == "paper"
+    assert source_kind_for_provider("") == "paper"
+    assert source_kind_for_provider(None) == "paper"

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1358,10 +1358,12 @@ async def test_relevance_gate_prompt_unchanged_for_papers_and_web(monkeypatch):
 
     await WebSearch_APIs.search_result_relevance([paper, web], "q", [], "openai")
 
+    # Byte-identical eval INPUT for both kinds (prefix equality -- absence
+    # checks alone would miss any other drift in the input line).
     assert len(prompts) == 2
+    prefix = "Evaluate the relevance of the search result."
     for prompt in prompts:
-        assert "repository record" not in prompt
-        assert "metadata record" not in prompt
+        assert prompt.split("\n\n", 1)[0] == prefix
 
 
 @pytest.mark.asyncio

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1304,3 +1304,61 @@ async def test_aggregate_carries_gate_unverified_flag_into_evidence(monkeypatch)
         "q", [], "openai",
     )
     assert out["evidence"][0]["gate_unverified"] is True
+
+
+# --- source-type-aware gate prompt (task-17066) -------------------------------------
+
+@pytest.mark.asyncio
+async def test_relevance_gate_carries_source_note_for_repository_records(monkeypatch):
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured["prompt"] = kwargs["messages_payload"][0]["content"]
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    result = _std_result("Folding dataset", "https://zenodo.org/records/1", "Simulations of folding")
+    result["metadata"] = {"source": "academic", "provider": "zenodo", "doi": "10.5281/x"}
+
+    await WebSearch_APIs.search_result_relevance([result], "how do proteins fold", [], "openai")
+
+    assert "repository record" in captured["prompt"]
+    assert "does NOT need to directly answer" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_relevance_gate_carries_source_note_for_metadata_records(monkeypatch):
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured["prompt"] = kwargs["messages_payload"][0]["content"]
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    result = _std_result("Registry record", "https://openalex.org/W1", "Citation metadata")
+    result["metadata"] = {"source": "academic", "provider": "openalex"}
+
+    await WebSearch_APIs.search_result_relevance([result], "any question", [], "openai")
+
+    assert "metadata record" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_relevance_gate_prompt_unchanged_for_papers_and_web(monkeypatch):
+    prompts = []
+
+    def fake_chat(**kwargs):
+        prompts.append(kwargs["messages_payload"][0]["content"])
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    paper = _std_result("A paper", "https://arxiv.org/abs/1", "Full text")
+    paper["metadata"] = {"source": "academic", "provider": "arxiv"}
+    web = _std_result("A page", "https://example.com/", "content")
+
+    await WebSearch_APIs.search_result_relevance([paper, web], "q", [], "openai")
+
+    assert len(prompts) == 2
+    for prompt in prompts:
+        assert "repository record" not in prompt
+        assert "metadata record" not in prompt

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1362,3 +1362,30 @@ async def test_relevance_gate_prompt_unchanged_for_papers_and_web(monkeypatch):
     for prompt in prompts:
         assert "repository record" not in prompt
         assert "metadata record" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_relevance_gate_paper_prompt_is_byte_identical(monkeypatch):
+    captured = []
+
+    def fake_chat(**kwargs):
+        captured.append(kwargs["messages_payload"][0]["content"])
+        return "Selected Answer: False\nReasoning: no"
+
+    monkeypatch.setattr(WebSearch_APIs, "chat_api_call", fake_chat)
+    plain_result = _std_result("T", "https://e.example/", "c")
+    paper = _std_result("P", "https://arxiv.org/abs/1", "c")
+    paper["metadata"] = {"source": "academic", "provider": "arxiv"}
+
+    await WebSearch_APIs.search_result_relevance(
+        [plain_result, paper], "q", [], "openai"
+    )
+
+    # The eval INPUT (everything before the "\n\nSearch Results" payload)
+    # must be byte-identical for unclassified and paper-classified results
+    # -- only the embedded result content differs.
+    prefix = "Evaluate the relevance of the search result."
+    assert len(captured) == 2
+    for prompt in captured:
+        input_line = prompt.split("\n\n", 1)[0]
+        assert input_line == prefix  # no note, no extra text

--- a/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
+++ b/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
@@ -1,0 +1,46 @@
+---
+id: TASK-17066
+title: Source-type-aware relevance gate for non-paper evidence
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-17 03:58'
+updated_date: '2026-08-17 03:59'
+labels:
+  - research
+  - web-tools
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The recorded repositories-lane baseline (gate_pass 0.29 vs 0.72 for papers) shows the relevance gate's single usefulness prompt is calibrated for papers: dataset/software/figure records and scholarly metadata records fail the comprehensively-answers bar even when topically on-point. Teach the gate what kind of evidence it is judging, using the catalog's own categories.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] A source-kind classifier maps catalog categories to evidence kinds (repositories to repository records, open_research_graph to metadata records, everything else and unknowns to the paper default) driven by the result's provider metadata,Repository and metadata records are evaluated with a source-type note that counts topically-related supporting evidence (data, methods, artifacts) as relevant without needing to directly answer the question,Paper-classified and unclassified results keep the current prompt byte-for-byte,Tests pin the classifier mapping, the note's presence per kind, and unchanged prompts for papers/unclassified,The repositories lane is re-measured live and the baseline doc records the gate_pass comparison against the recorded 0.29
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD source_kind_for_provider in research_source_catalog (category-driven: repositories -> repository, open_research_graph -> metadata, else paper default for unknowns)
+2. TDD the gate prompt variant in search_result_relevance: results whose metadata.provider classifies as non-paper carry a source-type note in the eval input; papers and unclassified results keep the current input unchanged
+3. Full suites plus lint
+4. Live re-measurement of the repositories lane against the recorded 0.29 gate_pass; doc update
+5. PR, Qodo loop, merge
+ADR required: no - prompt calibration within the existing gate contract; the fallback and honesty footer unchanged
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+- `source_kind_for_provider(provider)` in the catalog module: category-driven (repositories -> "repository", open_research_graph -> "metadata", everything else including unknowns/None -> "paper" -- the strict default the gate prompt was calibrated for). Classification keys off the result's `metadata.provider`, which `papers_to_evidence` already stamps.
+- `search_result_relevance` prepends a source-type note to the eval input for non-paper kinds: repository records count as relevant when "topically related and could serve as supporting evidence (data, methods, or artifacts)" without needing to directly answer; metadata records when they "describe a work topically related". The prompt template itself is untouched (note rides the input line), and paper/unclassified results get the byte-identical input as before (pinned by test).
+- Measured justification: repositories lane gate_pass 0.29 vs 0.72 (graph) / 0.93 (papers) in the task-16812 baselines; the note targets exactly that gap. The zero-relevant fallback remains the backstop either way.
+- **Live re-measurement blocked at ship time**: both local llama.cpp endpoints (9191 and 52864) refused connections. Re-run once the endpoint is back and record in the baseline doc:
+  `python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers repositories --llm-base-url http://127.0.0.1:<port>/v1`
+  Expected signal: gate_pass_rate meaningfully above the recorded 0.29 with citation_accuracy holding at 1.00.
+- Verified TDD: 2 classifier tests + 3 gate-prompt tests (repository note, metadata note, byte-identical prompts for papers/web) written first and watched failing; sweep 100 passed; ruff clean on touched files (remaining findings in the pipeline test file are pre-existing drift).

--- a/tldw_chatbook/Research_Interop/research_source_catalog.py
+++ b/tldw_chatbook/Research_Interop/research_source_catalog.py
@@ -220,8 +220,17 @@ def source_kind_for_provider(provider: str | None) -> str:
     return _SOURCE_KIND_BY_CATEGORY.get(entry.category, "paper")
 
 
+_ENTRIES_BY_ID: dict[str, ResearchSourceCatalogEntry] | None = None
+
+
 def _entries_by_id() -> dict[str, ResearchSourceCatalogEntry]:
-    return {entry.source_id: entry for entry in catalog_entries()}
+    """Memoized source_id -> entry index (the classifier runs once per
+    search result; rebuilding the catalog mapping per call was avoidable
+    work in the relevance loop)."""
+    global _ENTRIES_BY_ID
+    if _ENTRIES_BY_ID is None:
+        _ENTRIES_BY_ID = {entry.source_id: entry for entry in catalog_entries()}
+    return _ENTRIES_BY_ID
 
 
 def expand_source_selection(tokens: list[str]) -> list[str]:

--- a/tldw_chatbook/Research_Interop/research_source_catalog.py
+++ b/tldw_chatbook/Research_Interop/research_source_catalog.py
@@ -14,6 +14,7 @@ from typing import Tuple
 
 __all__ = [
     "CATEGORIES",
+    "source_kind_for_provider",
     "SOURCES_BY_CATEGORY",
     "ResearchSourceCatalogEntry",
     "catalog_entries",
@@ -191,6 +192,36 @@ def sources_by_category() -> dict[str, Tuple[str, ...]]:
 
 SOURCES_BY_CATEGORY = sources_by_category()
 CATEGORIES = tuple(SOURCES_BY_CATEGORY)
+
+
+_SOURCE_KIND_BY_CATEGORY = {
+    "repositories": "repository",
+    "open_research_graph": "metadata",
+}
+
+
+def source_kind_for_provider(provider: str | None) -> str:
+    """Classify a provider for gate calibration (task-17066).
+
+    Args:
+        provider: A result's ``metadata.provider`` (catalog source id).
+
+    Returns:
+        ``"repository"`` for repository records (datasets/software/
+        figures), ``"metadata"`` for scholarly-graph metadata records,
+        and ``"paper"`` for papers, preprints, and anything unknown --
+        the strict default the gate's prompt was calibrated for.
+    """
+    if not provider:
+        return "paper"
+    entry = _entries_by_id().get(str(provider).strip().lower())
+    if entry is None:
+        return "paper"
+    return _SOURCE_KIND_BY_CATEGORY.get(entry.category, "paper")
+
+
+def _entries_by_id() -> dict[str, ResearchSourceCatalogEntry]:
+    return {entry.source_id: entry for entry in catalog_entries()}
 
 
 def expand_source_selection(tokens: list[str]) -> list[str]:

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -1108,34 +1108,38 @@ async def search_result_relevance(
         # records (datasets/software/figures) and scholarly metadata records
         # fail the "answers the question" bar even when topically on-point
         # (measured: repositories gate_pass 0.29 vs 0.72 for papers).
-        from tldw_chatbook.Research_Interop.research_source_catalog import (
-            source_kind_for_provider,
-        )
-
-        _provider = None
-        _metadata = result.get("metadata")
-        if isinstance(_metadata, dict):
-            _provider = _metadata.get("provider")
-        _source_kind = source_kind_for_provider(_provider)
-        _source_notes = {
-            "repository": (
-                "Note: this result is a repository record (dataset, software, "
-                "or figure) rather than a paper. It is relevant if it is "
-                "topically related to the question and could serve as "
-                "supporting evidence (data, methods, or artifacts); it does "
-                "NOT need to directly answer the question."
-            ),
-            "metadata": (
-                "Note: this result is a scholarly metadata record rather "
-                "than full text. It is relevant if it describes a work "
-                "topically related to the question; it does NOT need to "
-                "directly answer the question."
-            ),
-        }
         input_data = "Evaluate the relevance of the search result."
-        _source_note = _source_notes.get(_source_kind)
-        if _source_note:
-            input_data = f"{input_data} {_source_note}"
+        try:
+            from tldw_chatbook.Research_Interop.research_source_catalog import (
+                source_kind_for_provider,
+            )
+
+            _provider = None
+            _metadata = result.get("metadata")
+            if isinstance(_metadata, dict):
+                _provider = _metadata.get("provider")
+            _source_kind = source_kind_for_provider(_provider)
+            _source_notes = {
+                "repository": (
+                    "Note: this result is a repository record (dataset, "
+                    "software, or figure) rather than a paper. It is relevant "
+                    "if it is topically related to the question and could "
+                    "serve as supporting evidence (data, methods, or "
+                    "artifacts); it does NOT need to directly answer the "
+                    "question."
+                ),
+                "metadata": (
+                    "Note: this result is a scholarly metadata record rather "
+                    "than full text. It is relevant if it describes a work "
+                    "topically related to the question; it does NOT need to "
+                    "directly answer the question."
+                ),
+            }
+            _source_note = _source_notes.get(_source_kind)
+            if _source_note:
+                input_data = f"{input_data} {_source_note}"
+        except Exception:  # noqa: BLE001 - note computation fails OPEN to the strict paper prompt
+            logger.debug("source-kind note skipped", exc_info=True)
 
         try:
             # Add delay to avoid rate limiting

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -1103,7 +1103,39 @@ async def search_result_relevance(
             sub_questions=sub_questions,
             content=content,
         )
+        # task-17066: calibrate for the kind of evidence under judgment.
+        # The strict usefulness prompt is calibrated for papers; repository
+        # records (datasets/software/figures) and scholarly metadata records
+        # fail the "answers the question" bar even when topically on-point
+        # (measured: repositories gate_pass 0.29 vs 0.72 for papers).
+        from tldw_chatbook.Research_Interop.research_source_catalog import (
+            source_kind_for_provider,
+        )
+
+        _provider = None
+        _metadata = result.get("metadata")
+        if isinstance(_metadata, dict):
+            _provider = _metadata.get("provider")
+        _source_kind = source_kind_for_provider(_provider)
+        _source_notes = {
+            "repository": (
+                "Note: this result is a repository record (dataset, software, "
+                "or figure) rather than a paper. It is relevant if it is "
+                "topically related to the question and could serve as "
+                "supporting evidence (data, methods, or artifacts); it does "
+                "NOT need to directly answer the question."
+            ),
+            "metadata": (
+                "Note: this result is a scholarly metadata record rather "
+                "than full text. It is relevant if it describes a work "
+                "topically related to the question; it does NOT need to "
+                "directly answer the question."
+            ),
+        }
         input_data = "Evaluate the relevance of the search result."
+        _source_note = _source_notes.get(_source_kind)
+        if _source_note:
+            input_data = f"{input_data} {_source_note}"
 
         try:
             # Add delay to avoid rate limiting


### PR DESCRIPTION
## Summary

Closes the measured lever from the category-lane baselines (task-17066): repositories gate_pass was **0.29** vs 0.72 (graph) / 0.93 (papers) — the gate's single usefulness prompt is calibrated for papers, so dataset/software/figure records fail the comprehensively-answers bar even when topically on-point.

### The change
- **`source_kind_for_provider`** (catalog module): category-driven classification — `repositories` → repository records, `open_research_graph` → metadata records, everything else and unknowns → the strict paper default. Keys off the result's `metadata.provider`, which `papers_to_evidence` already stamps.
- **`search_result_relevance`** prepends a source-type note for non-paper kinds: *"relevant if topically related and could serve as supporting evidence (data, methods, or artifacts); does NOT need to directly answer the question."* The prompt template is untouched; paper/unclassified results get the **byte-identical input** as before (pinned by test).
- The zero-relevant flagged fallback remains the backstop either way.

### Live re-measurement
Blocked at ship time (both local llama.cpp endpoints down). The task documents the exact re-run command; expected signal is gate_pass meaningfully above 0.29 with citation_accuracy holding at 1.00. Will record in the baseline doc once the endpoint is back.

## Test evidence
TDD: 5 new tests (classifier mapping incl. unknown/None defaults, repository note, metadata note, byte-identical prompts for papers/web). Sweep 100 passed; ruff clean on touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the web search relevance gate source-type aware so repository and metadata results count as supporting evidence. Previously all results used a paper‑calibrated prompt; now non‑paper results include a short note while papers and unclassified keep a byte‑identical eval input line. Note computation fails open to the strict paper prompt.

- Adds `source_kind_for_provider(provider)` keyed by `result.metadata.provider` to classify providers: repositories → repository, `open_research_graph` → metadata, else/unknown → paper; memoizes `_entries_by_id()` to avoid per-result rebuilds.
- Updates `search_result_relevance` to prepend a source-type note for repository and metadata; papers/unclassified receive the identical eval input line (tests assert prefix byte equality). Expected effect: higher gate_pass for repositories with citation accuracy unchanged; zero-relevant fallback unchanged. No migration required.

<sup>Written for commit 0302d44d5d65a83deb12fcce79b517833c1ce90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

