### PR TITLE
Redact unrecognised endpoints at the chat_api_call sink (TASK-17165)

### DIFF
--- a/Tests/Chat/test_chat_api_call_endpoint_redaction.py
+++ b/Tests/Chat/test_chat_api_call_endpoint_redaction.py
@@ -1,0 +1,99 @@
+"""TASK-17165: the endpoint value is caller-supplied text, so it must never
+be echoed verbatim into logs, metrics labels, or error strings.
+
+The incident: `BaseReranker._call_llm_impl` passes its arguments to
+`chat_api_call` POSITIONALLY in the wrong order (TASK-3502's fix wave,
+TASK-17065), so an API KEY arrives as `api_endpoint`. Today that value is
+echoed at INFO on EVERY call, stamped into a metrics LABEL, logged at
+ERROR, and interpolated into two exception messages -- five sites, two of
+which fire whether or not the call fails.
+
+The defence is at the SINK (the loguru-diagnose lesson: fix where the
+value is rendered, not where the bad caller lives), and it is an
+ALLOWLIST: a recognised endpoint is safe by definition and prints
+verbatim; anything else is unknown-provenance text and is redacted. A
+blocklist of key-shaped patterns would miss any credential that does not
+look like one.
+"""
+
+import logging
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.Logging_Config import _forward_loguru_to_standard
+
+SECRET = "REDACTED-abc123def456-not-a-real-key-value"
+
+# CASE-INSENSITIVE on purpose: the sink lowercases the endpoint before
+# logging it (`endpoint_lower`), so a case-sensitive substring check passes
+# VACUOUSLY against every lowercased site -- which is exactly how the first
+# draft of the metrics-label test in this file "passed" while the label
+# still carried the whole value.
+
+
+def _leaks(haystack: str) -> bool:
+    return SECRET.lower() in str(haystack).lower()
+
+
+@pytest.fixture
+def loguru_caplog(caplog):
+    """Bridge loguru records into caplog (the repo's standard pattern)."""
+    sink_id = loguru_logger.add(_forward_loguru_to_standard, level="DEBUG")
+    caplog.set_level(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+def test_an_unrecognised_endpoint_never_reaches_a_log_record(loguru_caplog):
+    with pytest.raises(Exception):
+        chat_api_call(SECRET, [{"role": "user", "content": "q"}])
+
+    for record in loguru_caplog.records:
+        assert not _leaks(record.getMessage()), record.getMessage()
+
+
+def test_an_unrecognised_endpoint_never_reaches_the_exception_text():
+    with pytest.raises(Exception) as excinfo:
+        chat_api_call(SECRET, [{"role": "user", "content": "q"}])
+
+    assert not _leaks(str(excinfo.value))
+
+
+def test_a_recognised_endpoint_still_prints_verbatim(loguru_caplog):
+    """The allowlist must not make real diagnostics useless: a registered
+    provider name is safe by definition and stays readable."""
+    with pytest.raises(Exception):
+        # No credentials configured in the test env -> it fails later, but
+        # the ROUTING log has already happened by then.
+        chat_api_call("openai", [{"role": "user", "content": "q"}])
+
+    routing = [
+        r.getMessage()
+        for r in loguru_caplog.records
+        if "Routing to endpoint" in r.getMessage()
+    ]
+    assert routing, "expected a routing log line"
+    assert any("openai" in line for line in routing)
+
+
+def test_the_metrics_label_carries_no_unrecognised_endpoint(monkeypatch):
+    """The label is unbounded-cardinality AND a leak channel: a key-shaped
+    endpoint would be stamped into exported metrics."""
+    seen: list[dict] = []
+
+    import tldw_chatbook.Chat.Chat_Functions as cf
+
+    def _capture(name, value=1, labels=None, **kwargs):
+        seen.append(dict(labels or {}))
+
+    monkeypatch.setattr(cf, "log_counter", _capture)
+    with pytest.raises(Exception):
+        chat_api_call(SECRET, [{"role": "user", "content": "q"}])
+
+    for labels in seen:
+        for label_value in labels.values():
+            assert not _leaks(label_value), labels

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -413,9 +413,20 @@ class TestChatApiCall:
         assert '{"type":"error"' in exc_info.value.message
 
     def test_unsupported_endpoint_raises_error(self, mock_handlers):
+        """TASK-17165 changed this contract deliberately: an UNRECOGNISED
+        endpoint is no longer echoed back, because the sink cannot tell a
+        typo from a credential a mis-ordered caller put there (TASK-17065).
+        The message names the valid endpoints instead, which serves the typo
+        case better than repeating the typo."""
         mock_handlers.get.return_value = None
-        with pytest.raises(ValueError, match="Unsupported API endpoint: unsupported"):
+        with pytest.raises(ValueError, match="Unsupported API endpoint") as excinfo:
             chat_api_call("unsupported", messages_payload=[])
+
+        assert "redacted" in str(excinfo.value)
+        assert "unsupported" not in str(excinfo.value).replace(
+            "Unsupported API endpoint", ""
+        )
+        assert "Valid endpoints:" in str(excinfo.value)
 
     def test_http_error_401_raises_auth_error(self, mock_handlers, mocker):
         mock_response = MagicMock()

--- a/backlog/tasks/task-17165 - chat_api_call-unknown-endpoint-ERROR-echoes-the-raw-argument-a-mis-ordered-caller-put-an-API-key-there.md
+++ b/backlog/tasks/task-17165 - chat_api_call-unknown-endpoint-ERROR-echoes-the-raw-argument-a-mis-ordered-caller-put-an-API-key-there.md
@@ -3,7 +3,7 @@ id: taREDACTED-17165
 title: >-
   chat_api_call unknown-endpoint ERROR echoes the raw argument — a mis-ordered
   caller put an API key there
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-16'
 labels: [security, llm-calls]
@@ -32,12 +32,46 @@ someday will hand it one again.
 
 ## Acceptance Criteria (the what)
 
-- [ ] chat_api_call's unknown/unsupported-endpoint failure path redacts
+- [x] chat_api_call's unknown/unsupported-endpoint failure path redacts
       credential-shaped values (at minimum: strings matching common key
       prefixes or containing no spaces and exceeding a length bound are
       elided to a short prefix + "…redacted") before logging or raising
       into any user-visible error string
-- [ ] A test feeds a key-shaped string as the endpoint and asserts the
+- [x] A test feeds a key-shaped string as the endpoint and asserts the
       raw value appears in NO log record and NO exception text
-- [ ] The redaction is at the sink (chat_api_call's own failure path),
+- [x] The redaction is at the sink (chat_api_call's own failure path),
       not in the reranker caller — TASK-17065 owns the caller
+
+## Implementation Notes
+
+**The leak was wider than filed: FIVE sites, and two fire on EVERY call.**
+The task described the unsupported-endpoint failure path; reading the sink
+found `logger.info("Routing to endpoint: …")` and
+`log_counter(labels={"api_endpoint": …})` execute BEFORE the handler
+lookup — so a mis-ordered caller's credential was logged at INFO on every
+single call and stamped into a metrics label (also an unbounded-cardinality
+hazard, and metrics are exported). The other three: the ERROR log, the
+`ValueError`, and `ChatConfigurationError`'s provider field + message.
+
+**The defence is an ALLOWLIST, not a key-shape blocklist.** A registered
+endpoint is safe by definition and prints verbatim, so genuine diagnostics
+stay readable; anything else is unknown-provenance text and is elided to
+`<unrecognised endpoint, N chars, redacted>`. A blocklist would miss any
+credential that does not look like one, and this sink cannot know what it
+was handed. The `ValueError` now lists the valid endpoints instead of
+echoing the bad one — strictly more useful for a real typo.
+
+**A vacuous test of my own, caught before it shipped.** The first draft of
+the metrics-label test PASSED while the label still carried the whole
+value: the sink lowercases the endpoint, so a case-sensitive substring
+check could not see it. All leak assertions are now case-insensitive
+through one `_leaks()` helper, and the label test went red before the fix.
+
+**One existing contract deliberately changed**: `test_unsupported_endpoint_
+raises_error` asserted the endpoint was echoed back. It now asserts the
+redaction marker plus the valid-endpoint list, with the reason in the test.
+
+Caller repair (the mis-ordered positional call) remains TASK-17065's.
+Files: `tldw_chatbook/Chat/Chat_Functions.py` (`safe_endpoint_for_display`
++ five call sites), `Tests/Chat/test_chat_api_call_endpoint_redaction.py`
+(new, 4 tests), `Tests/Chat/test_chat_functions.py` (contract update).

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -806,6 +806,34 @@ def extract_response_content(resp: Any) -> str:
     return content if isinstance(content, str) else str(content)
 
 
+def safe_endpoint_for_display(api_endpoint: Any) -> str:
+    """Return an endpoint string that is safe to log, label, or raise.
+
+    TASK-17165. `api_endpoint` is caller-supplied text, and a mis-ordered
+    caller can put a CREDENTIAL there -- `BaseReranker._call_llm_impl` does
+    exactly that today (TASK-17065), which is how an API key reached an
+    ERROR log line, an INFO line on every call, and a metrics label.
+
+    The rule is an ALLOWLIST, not a blocklist: a registered endpoint is safe
+    by definition and prints verbatim, so real diagnostics stay readable;
+    anything else is unknown-provenance text and is elided to its length.
+    Pattern-matching key SHAPES would miss any credential that does not look
+    like one, and this sink cannot know what it was handed.
+
+    Args:
+        api_endpoint: The raw endpoint argument, of any type.
+
+    Returns:
+        The lowercased endpoint when registered, else a redaction marker
+        carrying only its length.
+    """
+    text = str(api_endpoint or "")
+    lowered = text.lower()
+    if lowered in API_CALL_HANDLERS:
+        return lowered
+    return f"<unrecognised endpoint, {len(text)} chars, redacted>"
+
+
 def chat_api_call(
     api_endpoint: str,
     messages_payload: List[Dict[str, Any]],  # CHANGED from input_data, prompt
@@ -922,14 +950,24 @@ def chat_api_call(
         :rtype: str | dict | Generator[str, Any, None]
     """
     endpoint_lower = api_endpoint.lower()
-    logger.info(f"Chat API Call - Routing to endpoint: {endpoint_lower}")
-    log_counter("chat_api_call_attempt", labels={"api_endpoint": endpoint_lower})
+    # TASK-17165: never echo the raw value -- these two fire on EVERY call,
+    # not just failures, and the label additionally lands in exported
+    # metrics (where it is also an unbounded-cardinality hazard).
+    endpoint_display = safe_endpoint_for_display(api_endpoint)
+    logger.info(f"Chat API Call - Routing to endpoint: {endpoint_display}")
+    log_counter("chat_api_call_attempt", labels={"api_endpoint": endpoint_display})
     start_time = time.time()
 
     handler = API_CALL_HANDLERS.get(endpoint_lower)
     if not handler:
-        logger.error(f"Unsupported API endpoint requested: {api_endpoint}")
-        raise ValueError(f"Unsupported API endpoint: {api_endpoint}")
+        logger.error(f"Unsupported API endpoint requested: {endpoint_display}")
+        # The message lists what IS valid instead of echoing what was passed:
+        # more useful for a genuine typo, and safe when the value is a
+        # credential (TASK-17165).
+        raise ValueError(
+            f"Unsupported API endpoint: {endpoint_display}. "
+            f"Valid endpoints: {', '.join(sorted(API_CALL_HANDLERS))}"
+        )
 
     params_map = PROVIDER_PARAM_MAP.get(endpoint_lower, {})
     call_kwargs = {}
@@ -1181,9 +1219,10 @@ def chat_api_call(
         )
         error_type = "Configuration/Parameter Error"
         if "Unsupported API endpoint" in str(e):
+            safe_endpoint = safe_endpoint_for_display(endpoint_lower)
             raise ChatConfigurationError(
-                provider=endpoint_lower,
-                message=f"Unsupported API endpoint: {endpoint_lower}",
+                provider=safe_endpoint,
+                message=f"Unsupported API endpoint: {safe_endpoint}",
             )
         else:
             error_detail = safe_llm_exception_message(e)


### PR DESCRIPTION
## The leak was five sites, and two fire on every call

Filed as "the unsupported-endpoint ERROR echoes its argument". Reading the sink found the routing log and the metrics label execute **before** the handler lookup, so they leak on *every* call regardless of success:

| site | when |
|---|---|
| `logger.info("Routing to endpoint: …")` | **every call** |
| `log_counter(labels={"api_endpoint": …})` | **every call** — and into *exported* metrics |
| `logger.error("Unsupported API endpoint requested: …")` | on failure |
| `raise ValueError(f"Unsupported API endpoint: {api_endpoint}")` | on failure |
| `ChatConfigurationError(provider=…, message=…)` | on failure |

A mis-ordered caller puts an API key in that parameter — `BaseReranker._call_llm_impl` does exactly that today (TASK-17065), so a deepseek-keyed user with reranking enabled logged their key on every search and stamped it into metrics.

## The fix: an allowlist at the sink

`safe_endpoint_for_display()` — a **registered** endpoint is safe by definition and prints verbatim, so real diagnostics stay readable; anything else is unknown-provenance text and elides to `<unrecognised endpoint, N chars, redacted>`. A key-shape blocklist was rejected deliberately: it would miss any credential that doesn't look like one, and this sink cannot know what it was handed. The `ValueError` now **lists the valid endpoints** instead of echoing the bad one — strictly more useful for a genuine typo.

Per the fix-at-the-sink lesson, the caller repair stays with TASK-17065.

## One of my own tests was vacuous — caught before it shipped

The first draft of the metrics-label test **passed while the label still carried the whole value**: the sink lowercases the endpoint, so a case-sensitive substring check couldn't see it. All four leak assertions now run through one case-insensitive `_leaks()` helper, and the label test went red before the fix. That is recorded in the test file, because it is the same species of vacuous control this programme has caught twice before.

## Deliberate contract change

`test_unsupported_endpoint_raises_error` asserted the endpoint was echoed back. It now asserts the redaction marker plus the valid-endpoint list, with the reason written in the test — an unrecognised endpoint is exactly the case that must not be echoed.

## Verification

RED-first (3 of 4 new tests red, the 4th being the recognised-endpoint control that must stay green). `Tests/Chat/test_chat_functions.py` + `Tests/RAG_Search/test_reranker_degraded_paths.py` + the new file: **85 passed**. ruff clean.

Refs TASK-17165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts unrecognised `chat_api_call` endpoints across logs, metrics, and errors to prevent credential leaks. Previously the raw endpoint was echoed at five sites; now only registered endpoints print verbatim and all others are redacted, which changes the error text users see.

- Introduces `safe_endpoint_for_display()` allowlist: returns the lowercased endpoint if registered; otherwise renders as "<unrecognised endpoint, N chars, redacted>".
- Applies redaction to the routing log, the `chat_api_call_attempt` label `api_endpoint`, the unsupported-endpoint error log, the raised `ValueError`, and `ChatConfigurationError` provider/message.
- Changes error contract: `ValueError` lists valid endpoints instead of echoing the bad value; `ChatConfigurationError` carries the redacted provider. Tests updated and new leak checks added.
- Aligns with TASK-17165’s sink-level redaction requirement; caller repair remains in TASK-17065.

<sup>Written for commit da898c760e77b533114bb5c6aa0b859e6cf32090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

