### PR TITLE
fix(ui): close the dev-red six -- settings picker/echo, rail width, library discard toolbar (task-16480)

### DIFF
--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -546,11 +546,19 @@ async def test_prompts_provider_recovery_uses_existing_console_settings_seam() -
 
 @pytest.mark.asyncio
 async def test_console_left_rail_keeps_session_and_moves_staged_context_out():
-    """Task-400: staged sources render in the Inspector, not the left rail."""
+    """Task-400: staged sources render in the Inspector, not the left rail.
+
+    task-16480: widened from 120x40 to 140x42 -- 6476d84f0 (compact rail
+    focus) made the width-aware rail reveal deliberately close the left
+    rail at 120 columns (its own resize-reflow tests encode that), so the
+    rail-contract assertions now run at a width where the rail is present.
+    The contract itself (rail keeps Conversations; staged context lives in
+    the Inspector) is unchanged.
+    """
     app = _build_test_app()
     host = ConsoleHarness(app)
 
-    async with host.run_test(size=(120, 40)) as pilot:
+    async with host.run_test(size=(140, 42)) as pilot:
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-shell")
 

--- a/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
+++ b/backlog/tasks/task-16480 - Six-new-dev-red-rows-from-the-mid-August-churn.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16480
 title: Six new dev-red rows from the mid-August churn
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Robert'
 labels:
   - test-health
 priority: medium
@@ -36,8 +37,59 @@ fresh origin/dev-tip throwaway worktree with the identical assertion:
 (id='nav-lab', ...)` -- i.e. tab-order focus stranding on the nav-lab
 button, not a notes-editor defect.
 
+## Implementation Plan (the how)
+
+1. Verified all six still red on dev tip 5b4820931 (2026-08-16)
+2. Cluster A (settings hub x3): reproduce, attribute (the route-echo pair per
+   the task note: look for a repopulation site missing the prevent()/nav-echo
+   convention), fix at the convention seam
+3. Cluster B (workbench contract left-rail): reproduce, attribute, fix
+4. Cluster C (library capability matrix x2): reproduce, attribute, fix
+5. Each attribution via parent-check/bisect before touching expectations
+6. Whole modules green + lint; closeout; PR to dev
+
+ADR required: no
+ADR path: N/A
+Reason: test-health repairs of existing behavior
+
+
 ## Acceptance Criteria
 
-- [ ] Each of the six is attributed to its causing commit
-- [ ] Genuine product breaks are fixed rather than absorbed into expectations
-- [ ] The three modules pass whole on dev
+- [x] Each of the six is attributed to its causing commit
+- [x] Genuine product breaks are fixed rather than absorbed into expectations
+- [x] The three modules pass whole on dev
+
+## Implementation Notes
+
+All six verified still red on dev tip 5b4820931 before work; each attributed
+to its causing commit first (2026-08-16, TASK-16480).
+
+- Settings hub x3: two of the three landed red at their OWN introducing
+  commits (a1405b154 picker, 449fab8ca route-echo -- both Aug 13 "preserve
+  provider ..." fixes whose fixes did not work). Fixed forward: (i) the
+  picker now gets its highlight at COMPOSE time (factored
+  `_apply_provider_picker_highlight`) because the commit's
+  `call_after_refresh(_refresh_provider_picker)` fires before the category
+  body mounts and its QueryError is swallowed -- fresh pickers kept the
+  first-selectable default; (ii) `_sync_provider_credential_widget` re-arms
+  the credential suppress queue when the value changes (inside the
+  task-15740 prevent block) so navigation-applied credentials stay
+  suppressible across the widget-lifecycle echo -- prevent() silences only
+  the live write, and the recompose echo fires un-prevented.
+- Workbench contract (left rail): bisected to 6476d84f0 (compact rail
+  focus), which deliberately closes the left rail at 120 columns -- its own
+  resize-reflow tests encode that. The task-400 contract test's 120x40
+  premise is stale under that responsive design; retargeted to 140x42 with
+  the attribution documented in the test docstring. Contract unchanged.
+- Library capability matrix x2: bisected (2-run-majority predicate after a
+  flake fooled the first bisect) to d5a08b0fe (reconcile retained Library
+  transitions). GENUINE product bug: the discard coroutine's list
+  reconcile runs while the mutation interlock is still held, so the
+  rebuilt canvas freezes operation_running=True into the browse toolbar --
+  New/Sort/Select permanently disabled (keyboard AND mouse) after
+  discarding a freshly created note. Fixed by re-syncing the canvas after
+  releasing the interlock in the discard finally, mirroring
+  `_execute_library_notes_tree_mutation`'s own finally.
+- Whole modules on this branch: settings hub + workbench contract 420
+  passed, library shell 594 passed, 0 failures. Ruff findings on touched
+  files all pre-exist on dev.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -27985,6 +27985,13 @@ class LibraryScreen(BaseAppScreen):
             await self._discard_new_library_note_claimed(create_token)
         finally:
             self._library_notes_mutation_in_flight = False
+            # task-16480: the claimed coroutine's list reconcile runs while
+            # the interlock is still held, so the rebuilt canvas freezes
+            # operation_running=True into the browse action toolbar
+            # (permanently disabled New/Sort/Select -- keyboard AND mouse).
+            # Re-sync after releasing the lock, the same way
+            # ``_execute_library_notes_tree_mutation``'s finally does.
+            LibraryScreen._sync_library_notes_tree_canvas_if_present(self)
 
     async def _discard_new_library_note_claimed(self, create_token: str) -> None:
         """Delete one untouched create through typed destructive admission."""

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -9207,17 +9207,16 @@ class SettingsScreen(BaseAppScreen):
         except QueryError:
             return ""
 
-    def _refresh_provider_picker(self, query: str | None = None) -> None:
-        try:
-            picker = self.query_one("#settings-provider-picker", OptionList)
-            status = self.query_one("#settings-provider-search-status", Static)
-        except QueryError:
-            return
-        search_query = self._provider_picker_query() if query is None else query
-        groups = self._provider_picker_groups(search_query)
-        picker.clear_options()
-        picker.add_options(self._provider_picker_options(groups))
+    def _apply_provider_picker_highlight(self, picker: OptionList) -> None:
+        """Highlight the current provider's option, else the first selectable.
 
+        task-16480: factored out of ``_refresh_provider_picker`` so the
+        COMPOSE-time picker can carry the right highlight too -- the
+        ``call_after_refresh`` refresh added in a1405b154 fires before the
+        category body (and the picker) is mounted, its QueryError is
+        swallowed, and the fresh picker used to keep the compose default
+        (first selectable) instead of the configured provider.
+        """
         current_provider = str(
             self._provider_display_setting_values().get("provider") or ""
         )
@@ -9238,6 +9237,18 @@ class SettingsScreen(BaseAppScreen):
         picker.highlighted = (
             selected_index if selected_index is not None else first_selectable
         )
+
+    def _refresh_provider_picker(self, query: str | None = None) -> None:
+        try:
+            picker = self.query_one("#settings-provider-picker", OptionList)
+            status = self.query_one("#settings-provider-search-status", Static)
+        except QueryError:
+            return
+        search_query = self._provider_picker_query() if query is None else query
+        groups = self._provider_picker_groups(search_query)
+        picker.clear_options()
+        picker.add_options(self._provider_picker_options(groups))
+        self._apply_provider_picker_highlight(picker)
 
         normalized_query = search_query.strip()
         if normalized_query and not self._provider_picker_has_catalog_matches(groups):
@@ -9567,7 +9578,18 @@ class SettingsScreen(BaseAppScreen):
                 # staged the new provider's env var against the old
                 # provider's original.
                 with credential_input.prevent(Input.Changed):
-                    credential_input.value = self._provider_credential_env_var(provider)
+                    credential_value = self._provider_credential_env_var(provider)
+                    # task-16480: prevent() silences only THIS write. The
+                    # widget-lifecycle (recompose/category-return) echo
+                    # re-populates the input un-prevented, so the queue must
+                    # be armed the same way the endpoint sync arms its own --
+                    # route-echo regression: navigation-applied credentials
+                    # stopped being suppressible across recompose.
+                    if credential_input.value != credential_value:
+                        self._provider_credential_env_var_suppress_queue.append(
+                            credential_value
+                        )
+                    credential_input.value = credential_value
                 credential_input.placeholder = self._provider_credential_placeholder(
                     provider
                 )
@@ -11764,11 +11786,17 @@ class SettingsScreen(BaseAppScreen):
                     id="settings-provider-search",
                     placeholder="Search providers by name or ID",
                 )
-                yield OptionList(
+                picker = OptionList(
                     *self._provider_picker_options(self._provider_picker_groups()),
                     id="settings-provider-picker",
                     compact=True,
                 )
+                # task-16480: compose-time highlight so the configured
+                # provider is selected on the very first paint; the
+                # post-refresh highlight arrives too early (pre-mount) to
+                # serve as the only source.
+                self._apply_provider_picker_highlight(picker)
+                yield picker
                 yield Static(
                     "Choose a provider or enter a provider ID.",
                     id="settings-provider-search-status",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -9582,10 +9582,16 @@ class SettingsScreen(BaseAppScreen):
                     # task-16480: prevent() silences only THIS write. The
                     # widget-lifecycle (recompose/category-return) echo
                     # re-populates the input un-prevented, so the queue must
-                    # be armed the same way the endpoint sync arms its own --
-                    # route-echo regression: navigation-applied credentials
-                    # stopped being suppressible across recompose.
-                    if credential_input.value != credential_value:
+                    # be armed for navigation-applied credentials the same
+                    # way the endpoint sync arms its own. Armed ONLY while a
+                    # navigation context is active (Qodo review, PR #1760):
+                    # an always-armed queue could swallow a later genuine
+                    # user edit that returns the field to the queued value,
+                    # and this sync runs on every provider switch.
+                    if (
+                        credential_input.value != credential_value
+                        and self._navigation_provider
+                    ):
                         self._provider_credential_env_var_suppress_queue.append(
                             credential_value
                         )


### PR DESCRIPTION
## Summary

Closes TASK-16480: the six dev-red rows from the mid-August churn, each attributed to its causing commit before any change (per the task's own discipline). All six verified still red on the dev tip before work; whole modules green after.

**Genuine product fixes (3):**
- **Settings provider picker highlight** — the Aug-13 "preserve provider picker state" fix landed with its own test red: its `call_after_refresh(_refresh_provider_picker)` fires *before* the category body mounts and the resulting QueryError is silently swallowed, so a fresh picker kept the compose default (first selectable) instead of the configured provider. The highlight now also applies at compose time (`_apply_provider_picker_highlight`, factored from the refresh).
- **Settings credential suppress queue** — the route-echo pair failed at their own introducing commit too: `_sync_provider_credential_widget` switched to `prevent(Input.Changed)` (task-15740) but stopped arming `_provider_credential_env_var_suppress_queue`. `prevent()` silences only the live write; the widget-lifecycle (recompose/category-return) echo fires un-prevented and relies on the queue. Seeding restored, mirroring the endpoint sync.
- **Library notes toolbar after discard** — bisected (2-run-majority predicate after a flake fooled the first bisect) to `d5a08b0fe` (retained-transitions reconcile). The discard coroutine's list reconcile runs while the mutation interlock is still held, so the rebuilt canvas freezes `operation_running=True` into the browse toolbar: **New/Sort/Select stay permanently disabled — keyboard and mouse — after discarding a freshly created note.** Fixed by re-syncing the canvas after the interlock releases in the discard `finally`, mirroring the tree-mutation path's own `finally`.

**Deliberate-design accommodation (1):**
- Left-rail contract test retargeted 120x40 → 140x42 with attribution in its docstring: `6476d84f0` (compact rail focus) deliberately closes the left rail at 120 columns and its own resize-reflow tests encode that. The task-400 contract (rail keeps Conversations; staged context lives in the Inspector) is unchanged.

## Test plan

- [x] All six previously-red tests pass
- [x] Whole modules on this branch: `test_settings_configuration_hub.py` + `test_console_workbench_contract.py` **420 passed, 0 failed**; `test_library_shell.py` **594 passed, 0 failed**
- [x] ruff findings on touched files verified identical to the dev baseline (all pre-existing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six dev-red UI regressions in settings, library, and console (TASK-16480). Restores initial provider selection, suppresses navigation-driven credential echoes, keeps library toolbar actions enabled after discard, and ensures the console left rail is present in its contract test.

- Settings provider picker: previously selected the first selectable on first paint; now highlights the configured provider at compose time and on refresh.
- Settings credential sync: previously `prevent()` silenced only the live write and the widget-lifecycle echo re-applied as user input; now arms the suppress queue only during an active navigation context so navigation-applied credentials do not emit unintended updates and genuine edits are preserved.
- Library discard toolbar: previously froze `operation_running=True` during interlock and disabled New/Sort/Select; now re-syncs the canvas after releasing the interlock so actions remain enabled.
- Console left rail contract test: previously ran at 120x40 where the rail closes; now runs at 140x42 so the rail is present. Contract is unchanged.

<sup>Written for commit 7e519bb517d572014b57fa40e135c131edcf12dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

