### PR TITLE
feat(console): deliver an owed wake at launch, mark-gated (task-15860)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -543,12 +543,29 @@ to the conversation, and the `◈` mark stays set so you can see on return
 that something happened while you were away. Navigating back shows the
 completed turn already in the transcript.
 
-One honest limit remains. **Nothing wakes while the app is not running**
-— completions are recorded durably (mark + ledger) and claimed the next
-time the app starts and Console opens; a wake at launch, before Console
-has ever been opened in that session, is follow-up work (task-15860).
-A wake turn also spends model tokens with no window open — the `◈` mark
-is your signal that it did.
+**A wake you were owed is delivered at the next launch, without opening
+Console.** Nothing runs while the app is closed — a completion that
+lands then is recorded durably (the `◈` mark plus the ledger) and waits.
+At the next start, once the app is up and interactive, any conversation
+that still carries a `◈` mark *and* still owes a result has its
+supervisor woken there and then: the conversation is reopened in the
+background, the turn runs, and you find it already in the transcript
+with its `◈` still lit when you open Console. Nothing else is woken —
+never a conversation without a mark, and never one whose results were
+already delivered — and the whole thing is off when `[agents]
+autowake_enabled` is off (there is no separate launch switch). If you
+have never run a background sub-agent, launch does exactly what it did
+before: one indexed check that finds nothing.
+
+One case cannot be delivered and is cleaned up instead: sub-agent work
+started in a **temporary (unsaved) chat** belongs to a session that does
+not survive the app, so there is no conversation left to wake. Its `◈`
+mark is cleared at the next launch rather than left pointing at nothing.
+Save the chat before starting long background work you want to come back
+to.
+
+A wake turn spends model tokens with no window open — the `◈` mark is
+your signal that it did.
 
 **A headless wake that needs approval asks you, wherever you are.** When
 a woken turn reaches a tool that requires your approval, a toast names it

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -557,6 +557,10 @@ autowake_enabled` is off (there is no separate launch switch). If you
 have never run a background sub-agent, launch does exactly what it did
 before: one indexed check that finds nothing.
 
+If Console is your startup tab, the woken conversation opens as another
+tab beside the one you landed on; it never switches you away from the tab
+you started in.
+
 One case cannot be delivered and is cleaned up instead: sub-agent work
 started in a **temporary (unsaved) chat** belongs to a session that does
 not survive the app, so there is no conversation left to wake. Its `◈`

--- a/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
@@ -88,10 +88,11 @@ Two genuinely separate `TldwCli` processes over one `tmp_path`:
   never constructs a `ChatScreen` at all — asserted as a precondition in
   every test in the file, not assumed.
 
-**BEFORE** (at `ed49499b8`, zero bytes of this branch, the finished file
-copied into the detached baseline worktree — measured twice: **6 failed,
-3 passed** against the first draft and **8 failed, 3 passed** against the
-final ten-test file):
+**BEFORE** (at `ed49499b8`, zero bytes of this branch, the file copied
+into the detached baseline worktree — re-measured against every version
+rather than quoted from the first: **6 failed, 3 passed** (9 tests),
+**8 failed, 3 passed** (10 tests), **9 failed, 3 passed** (the final 11,
+155.4s)):
 
 ```
 FAILED …::test_a_launch_delivers_a_wake_owed_from_a_previous_process
@@ -100,6 +101,7 @@ E   AssertionError: a background sub-agent finished before this process
     launch delivered no wake turn at all
 FAILED …::test_a_second_launch_does_not_re_announce_a_delivered_wake
 FAILED …::test_a_launch_into_console_delivers_without_stealing_the_active_tab
+FAILED …::test_a_launch_built_controller_is_not_sticky_when_console_opens
 FAILED …::test_a_launch_with_no_marks_constructs_nothing_and_reads_once
 E   AssertionError: a launch with no marks must cost exactly one indexed
     mark listing; got []
@@ -107,7 +109,7 @@ FAILED …::test_the_startup_cost_pin_is_not_vacuous
 FAILED …::test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing
 FAILED …::test_an_unresolvable_ephemeral_mark_is_cleared_at_launch
 FAILED …::test_a_launch_hydrates_only_the_conversations_that_are_owed
-8 failed, 3 passed, 3 warnings in 138.82s
+9 failed, 3 passed, 3 warnings in 155.42s
 ```
 
 The file COLLECTS cleanly at the merge-base — every symbol it imports
@@ -452,7 +454,7 @@ summary line.**
 | Gate | Baseline @ merge-base `ed49499b8` | Branch | Delta |
 |---|---|---|---|
 | **The specified battery** — `test_console_headless_wake_fires` (1), `test_console_headless_approval` (14), `test_console_sync_outlives_screen` (5), `test_console_store_continuity` (4), `test_console_viewless_hooks` (12), `test_console_runtime_lifetime` (14), `test_console_runtime_ownership` (7), `test_screen_residency` (7), `test_console_headless_wake_invariants` (13), the 16-file wake glob (109), probe (1) | **187 passed, 0 failed** (216.4s) | **198 passed, 0 failed** (280.0s), same files **plus** the two new suites | **+11** = the 9 launch tests and 2 hydration tests that existed when it ran (the launch file later grew to 11) |
-| **The new suites** — `test_console_launch_wake` (11) + `test_console_conversation_hydration` (2) | **8 failed, 3 passed** (the launch file only, at the merge-base; the hydration file cannot COLLECT there — its subject does not exist — so it is reported separately rather than folded in) | **13 passed** | — |
+| **The new suites** — `test_console_launch_wake` (11) + `test_console_conversation_hydration` (2) | **9 failed, 3 passed** (the launch file + probe only, at the merge-base; the hydration file cannot COLLECT there — its subject does not exist — so it is reported separately rather than folded in) | **13 passed** (+ probe) | — |
 | **The resume-owning suites** — `test_console_resume_active_path`, `test_console_workspace_controller`, `test_console_session_settings`, `test_console_generation_store`, `test_console_video_message`, probe | **286 passed, 0 failed** (133.5s) | **286 passed, 0 failed** (128.8s) | **0** |
 | `Tests/Agents/` + probe | not measured — a green final cannot hide a regression | **1459 passed, 0 failed** (43.0s) | — |
 | **The whole Console population in ONE process** — every `Tests/UI/test_console_*.py` + `test_screen_residency` + probe (166 files branch / 165 base) | see §10.2 | see §10.2 | — |
@@ -489,6 +491,13 @@ Order dependence is therefore ruled out as well as timing flakiness.
 - **A launch wake's approval round was not driven end to end.** The app
   handle it needs is asserted (§7, M9); the behaviour is owned by the
   approval landing's suite. Naming it rather than implying coverage.
+- **TWO owed conversations at one launch is not tested here.** The launch
+  hydrates both and `retry_soon` delivers them one at a time under
+  `_delivering` — but that serialization is the coordinator's, already
+  pinned by the wake suites, and the Console mount claim can seed several
+  conversations too, so the shape is not new to this slice. The launch
+  suite covers one owed + one unowed
+  (`test_a_launch_hydrates_only_the_conversations_that_are_owed`).
 - **The launch-hydrated session becomes the store's ACTIVE session**,
   because at launch there is no other. A user who opens Console after a
   launch wake therefore lands in the woken conversation rather than a

--- a/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
@@ -498,12 +498,16 @@ Order dependence is therefore ruled out as well as timing flakiness.
   conversations too, so the shape is not new to this slice. The launch
   suite covers one owed + one unowed
   (`test_a_launch_hydrates_only_the_conversations_that_are_owed`).
-- **The launch-hydrated session becomes the store's ACTIVE session**,
-  because at launch there is no other. A user who opens Console after a
-  launch wake therefore lands in the woken conversation rather than a
-  fresh chat. That is arguably right — the ◈ points there and money was
-  just spent there — but it is a UX change nobody has ruled on, and it is
-  named here rather than buried.
+- **The launch-hydrated session becomes the store's ACTIVE session when
+  nothing else is open**, because at launch there is no other. A user who
+  opens Console after a headless launch wake therefore lands in the woken
+  conversation rather than a fresh chat. That is arguably right — the ◈
+  points there and money was just spent there — but it is a UX change
+  nobody has ruled on, and it is named here rather than buried. The
+  *other* direction is handled rather than left: when Console IS the
+  startup tab, `_restore_active_session` puts the user's tab back, pinned
+  by `test_a_launch_into_console_delivers_without_stealing_the_active_tab`
+  and killed by M13.
 
 ## 12. The User Guide sentence
 
@@ -529,6 +533,10 @@ It now says:
 > autowake_enabled` is off (there is no separate launch switch). If you
 > have never run a background sub-agent, launch does exactly what it did
 > before: one indexed check that finds nothing.
+>
+> If Console is your startup tab, the woken conversation opens as another
+> tab beside the one you landed on; it never switches you away from the tab
+> you started in.
 >
 > One case cannot be delivered and is cleaned up instead: sub-agent work
 > started in a **temporary (unsaved) chat** belongs to a session that does

--- a/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
@@ -554,12 +554,15 @@ It now says:
    signal until the user opens Console.
 2. **The woken conversation becomes the active session** (§11). Worth an
    owner eyeball before this reaches users.
-3. **The launch fires once, at startup.** A completion that lands while
-   the app is running but Console has never been opened in that process
-   still has no fire point: the fan-out consumer that records it lives on
-   the agent bridge, which nothing built. That is not a regression (it was
-   unreachable before too — with no Console there is no bridge to run a
-   sub-agent from), but it means "wake at launch" is exactly what it says.
+3. **The launch fires once, at startup — and that is the whole extent of
+   it.** With no marks nothing is built, so no sub-agent can run and
+   nothing can land: the absence of a later fire point is a definition,
+   not a gap. With marks, the launch DOES build the bridge and its
+   fan-out, so a survivor spawned by the launch wake's own turn settles
+   into a live consumer and delivers headlessly through the fires
+   landing's path. The one thing that never happens is a *second* mark
+   sweep later in the same run; a mark set after startup waits for the
+   next Console visit or the next launch, exactly as before.
 4. **The stale-mark clearing is a durable delete.** It is narrowed three
    ways (§8) and uncertainty always keeps the mark, but it is the only
    write in this slice that destroys user-visible state.

--- a/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
@@ -1,0 +1,501 @@
+# Launch-wake report — delivering what was owed while the app was closed (task-15860, plan Task 6)
+
+- Branch `feat/task-15860-launch-wake`, worktree
+  `.worktrees/headless-approval/.worktrees/headless-launch`.
+- **Merge-base `ed49499b8`** (contains all seven merged headless-wake
+  landings: ownership, lifetime, viewless, continuity, wake-fires, the
+  cross-suite sync fix, and headless approval). Every baseline below was
+  measured either on the untouched branch before any production edit, or
+  in a detached worktree at that commit
+  (`.worktrees/headless-launch-base`) — never against `dev`'s tip.
+  (`dev` moved to `feea06193` during this task; `ed49499b8` is still the
+  merge-base, confirmed by `git merge-base`.)
+- Predecessors: `…-fires-report.md` (§9's "launch / first-boot wake is
+  untouched" — this report executes and closes it), `…-approval-report.md`,
+  `…-viewless-report.md`, `…-continuity-report.md`.
+
+**One sentence:** a background sub-agent that finished while the app was
+closed now wakes its supervisor at the next launch — mark-gated, behind
+the existing `[agents] autowake_enabled`, and costing an install that has
+never run one exactly one indexed read and zero constructed objects.
+
+---
+
+## 1. What was actually missing, executed rather than read
+
+The fires landing removed the "no Console mounted" limit *inside a
+process that had opened Console once*. `ConsoleRuntime.ensure_chat_
+controller` / `ensure_agent_bridge` are lazy and their only callers were
+`ChatScreen` and its Console modules, so with Console never opened there
+is no controller, no `ConsoleFleetWakeCoordinator` and no fan-out
+registration. That report labelled it an inference. `Tests/UI/
+test_probe_launch_wake.py` executes it:
+
+```
+PROBE P1 deferred-startup reached: True
+PROBE P1 screen stack: ['Screen', 'LibraryScreen']
+PROBE P2 chat_controller: None
+PROBE P2 chat_store: None
+PROBE P2 agent_bridge: None
+PROBE P2 ui_ready: True
+```
+
+So the app *does* reach `_schedule_deferred_startup_work` on a launch that
+never opens Console — there was a hook site, and nothing used it.
+
+---
+
+## 2. The design, and the two things it is NOT
+
+**The owner's ruling, implemented literally:** at startup do ONE cheap
+indexed read; deliver only for a conversation that already carries a
+`FLEET_UNSEEN` mark **and** an owed `agent_runs` ledger row. Behind
+`[agents] autowake_enabled`; **no** separate `autowake_on_launch` switch.
+
+`tldw_chatbook/Chat/console_launch_wake.py`:
+
+| Function | What it costs |
+|---|---|
+| `marked_conversations_at_launch(app)` | the kill switch, then ONE `conversation_local_marks` listing. Nothing else. |
+| `deliver_launch_wakes(app, marked)` | builds the runtime **viewlessly**, seeds through the same `seed_from_marks` the Console mount claim uses, hydrates one session per owed conversation, and hands off. |
+
+`app.py._schedule_launch_wake()` hangs it on the existing deferred
+startup work, after the first interactive frame.
+
+It is **not** a second wake path. Everything after the hand-off is the
+already-shipped machinery, unchanged: the kill switch again at
+`_attempt`'s fire point, `send_refusal_copy` (run state, queue ownership,
+`max_parallel_runs`), user-wins-ties, one delivery at a time app-wide,
+the `wake_delivered_at` ledger for exactly-once, and the viewless
+`wake_conversation_in_view` that KEEPS the ◈ mark on a delivery nobody
+watched.
+
+It is **not** ledger-seeded. See §5.
+
+---
+
+## 3. The red, and its before/after
+
+`Tests/UI/test_console_launch_wake.py::
+test_a_launch_delivers_a_wake_owed_from_a_previous_process`
+
+Two genuinely separate `TldwCli` processes over one `tmp_path`:
+
+- **process one** mounts a real `ChatScreen`, sends once through
+  `submit_draft` (so the conversation really persists), writes a terminal
+  survivor run into the real sibling `agent_runs.db`, and sets the ◈ mark;
+- **process two** boots with `default_tab="library"`, so the real routing
+  never constructs a `ChatScreen` at all — asserted as a precondition in
+  every test in the file, not assumed.
+
+**BEFORE** (at `ed49499b8`, zero bytes of this branch, the finished file
+copied into the detached baseline worktree — measured twice: **6 failed,
+3 passed** against the first draft and **8 failed, 3 passed** against the
+final ten-test file):
+
+```
+FAILED …::test_a_launch_delivers_a_wake_owed_from_a_previous_process
+E   AssertionError: a background sub-agent finished before this process
+    started, its ◈ mark and its owed ledger row both survived -- and the
+    launch delivered no wake turn at all
+FAILED …::test_a_second_launch_does_not_re_announce_a_delivered_wake
+FAILED …::test_a_launch_into_console_delivers_without_stealing_the_active_tab
+FAILED …::test_a_launch_with_no_marks_constructs_nothing_and_reads_once
+E   AssertionError: a launch with no marks must cost exactly one indexed
+    mark listing; got []
+FAILED …::test_the_startup_cost_pin_is_not_vacuous
+FAILED …::test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing
+FAILED …::test_an_unresolvable_ephemeral_mark_is_cleared_at_launch
+FAILED …::test_a_launch_hydrates_only_the_conversations_that_are_owed
+8 failed, 3 passed, 3 warnings in 138.82s
+```
+
+The file COLLECTS cleanly at the merge-base — every symbol it imports
+exists there — so each red is the behaviour failing, not an `ImportError`
+(the trap `lessons-testing-evidence.md`'s TASK-16838 entry names; observed
+again here for the *hydration* file, which cannot collect at base because
+its subject does not exist, and is therefore reported separately rather
+than folded into a red count).
+
+**AFTER: 10 passed.**
+
+The three that pass at the merge-base are named rather than hidden: the
+phantom-wake test and the nothing-owed test pass because at the baseline
+*nothing happens at all*, and the provenance probe. Both are still worth
+having — they are the pins that must stay green, not reds.
+
+The chain the red asserts, not merely the send:
+
+1. exactly ONE wake turn reaches the provider, its payload's trailing
+   entry `role="user"` carrying the machine marking and the child's
+   result — **and the payload carries the conversation's real prior
+   history**, which is what makes hydration load-bearing rather than
+   decorative (a supervisor woken with an empty session spends money to
+   say nothing);
+2. the machine-origin SYSTEM notice (exactly one `metadata.origin ==
+   "agent_wake"` row) and the assistant reply are in the app-owned store
+   *and* in ChaChaNotes — persisted senders exactly
+   `["user", "assistant", "system", "assistant"]`;
+3. `agent_runs.wake_delivered_at` is stamped;
+4. **no USER row** anywhere — the store's only USER row is process one's,
+   and the DB has exactly one `user` sender;
+5. the **◈ mark SURVIVES**, because a runtime with no view reports the
+   conversation as not watched.
+
+---
+
+## 4. The startup-cost pin, and its mutation
+
+`test_a_launch_with_no_marks_constructs_nothing_and_reads_once` — the pin
+that protects every user who never touches the fleet. Four independent
+observations, because "nothing was constructed" is exactly the claim a
+weak test states and never checks:
+
+1. the marks service saw **exactly one** `list_marked_conversation_ids`
+   call, for `fleet_unseen`;
+2. the runtime holds no store, no gateway, no bridge, no controller;
+3. **no `agent_runs.db` file exists on disk** — constructing the bridge
+   opens (and creates) it, so the filesystem is an observer production
+   code cannot lie to;
+4. no `deferred_launch_wake` task was ever created.
+
+Its control, `test_the_startup_cost_pin_is_not_vacuous`, runs the same
+four probes WITH a mark and watches every one flip. Without it, a launch
+hook that never ran at all would satisfy the pin perfectly.
+
+"Indexed" is verified, not asserted:
+`ChaChaNotes_DB.py`'s `idx_conversation_local_marks_type` is
+`(mark_type, updated_at DESC, conversation_id)`, which covers
+`list_marked_conversation_ids`' `WHERE mark_type = ? ORDER BY updated_at
+DESC, conversation_id ASC LIMIT ?` completely.
+
+**Mutations against the pin:**
+
+| # | Mutation | Result |
+|---|---|---|
+| M3 | `app.py`'s `if not marked: return` → `if False:` | **1 failed** — the pin, on observation 4 (`a launch with no marks scheduled the wake task: ['deferred_launch_wake', …]`). The construction observations did **not** fire, because `deliver_launch_wakes` has its own `if not marked: return 0`. Defence in depth, and worth recording: one guard's removal is not observable through the other. |
+| M3b | **both** guards removed | **2 failed** — the pin on observation 1 (`got ['fleet_unseen', 'fleet_unseen']`; `seed_from_marks` does its own listing) **and** the phantom test on `an unmarked owed row still built the whole Console runtime at launch` |
+
+---
+
+## 5. The phantom-wake case stays green
+
+`test_a_crash_killed_child_swept_to_error_wakes_nobody_at_launch`.
+
+A child left `running` by a crash is swept to `error` by the next
+`AgentRunsDB.__init__` (modelled the way `Tests/DB/test_agent_runs_db.py`
+models a restart — discarding the per-process `_swept_paths` entry). That
+makes it terminal, undelivered and therefore **owed by the ledger's own
+definition**. It carries no mark, because nothing ever settled it through
+the fan-out.
+
+The test's two harness preconditions are what stop it passing for the
+wrong reason:
+
+```
+the reconcile sweep must have marked the crash-killed child as error   -> ok
+the ledger must consider this orphan OWED                              -> [child_id]
+a crash-killed child leaves no ◈ mark                                  -> ()
+```
+
+and then: nothing reaches the provider, **and** `console_runtime.
+chat_controller is None` — the launch did not even build the runtime.
+That second assertion is what makes it a pin on the mark gate rather than
+on the send gate.
+
+**Result: green on this branch, and green at the merge-base** (it is a
+"must not fire" property, so it passes on both sides — stated plainly).
+M3b is what proves it is not vacuous.
+
+---
+
+## 6. Hydration — extracted, with a characterization pin
+
+**Decision: EXTRACTED, as a pure refactor, in its own commit, before the
+launch path used it** (`ccd1fd8f9`).
+
+The plan flagged that this policy is screen-bound and asked for a
+decision from the code as it now stands. As it stands,
+`ChatScreen._resume_console_workspace_conversation`
+(`UI/Console_Modules/workspace.py`) interleaves the session-producing
+policy with a screen's own work, and the session-producing half turns out
+to read only two app members — `chat_conversation_scope_service` and
+`chachanotes_db`. Duplicating it for the launch path would have put a
+second, worse resume policy in the codebase, which is what the plan
+warned against; extracting it is a ~110-line move.
+
+Moved to `tldw_chatbook/Chat/console_conversation_hydration.py`:
+
+| Moved | Why it is policy, not plumbing |
+|---|---|
+| `console_messages_from_conversation_tree` | ALL branches (not the latest), parenthood from tree NESTING, empty rows dropped but transparent to their children, plus the one batched attachment fetch for positions ≥ 1 |
+| `load_console_conversation_tree` | the `depth_cap=10_000, root_limit=10_000` caps: the service defaults are 50, and a truncated tree makes a wrong provider payload |
+| `hydrate_console_session` | workspace/title resolution, the durable active-leaf pointer, the runtime-backend/assistant/character field discipline, `restore_persisted_session`, the roleplay overlay |
+| `apply_resume_settings_overrides` | the two things the CONVERSATION ROW contributes to settings — saved system prompt (verbatim, only blank collapses) and pinned prefill |
+
+`default_console_session_settings` joined `console_session_settings.py` so
+the llama.cpp base-url rule that always accompanied
+`build_default_console_session_settings` at the screen's call site has one
+home too.
+
+The screen keeps every view concern: draft snapshot, both failure toasts,
+resume-marker overlay, character-name/label resolution, retrieval-scope
+warm, repaint, focus. `_console_messages_from_conversation_tree` keeps its
+name and signature — **eight test files call it directly**.
+
+**The one difference between the callers, named rather than hidden:** the
+screen's base settings are inherited from the currently ACTIVE session; a
+launch has no active session, so it starts from the config defaults the
+screen itself falls back to. That is inherent to having no view.
+
+**The characterization pin** —
+`Tests/Chat/test_console_conversation_hydration.py`, two tests:
+
+- `test_the_screen_tree_walk_still_flattens_every_branch` pins the
+  screen's public seam on a deliberately awkward fixture (two branches off
+  one root, a truly-empty node mid-branch whose child must re-parent
+  through it): `[("m1", None), ("m2", "m1"), ("m4", "m2"), ("m5", "m1")]`;
+- `test_a_launch_hydrated_session_matches_a_screen_resumed_one` is the
+  equivalence test the plan asked for: for one fixture conversation, the
+  session a launch hydrates headlessly and the session the screen resumes
+  agree on the whole message tree with its parenthood, on ten identity /
+  roleplay fields, and on the **full settings snapshot**.
+
+An equivalence test between two callers of the same function is weak by
+construction — a mutation inside the shared function breaks both sides
+equally. So the test also carries absolute assertions (the system prompt
+restored verbatim including its leading spaces and trailing newline; the
+roleplay `user_name_override`; different session uuids so the two stores
+are provably distinct). **M11** (the roleplay overlay dropped) dies on the
+absolute assertion, not on the comparison — measured.
+
+**Evidence the refactor is behaviour-preserving:** the five resume-owning
+suites are **286 passed** on this branch and **286 passed** at the
+merge-base in the detached baseline worktree, same invocation.
+
+---
+
+## 7. Mutations run and killed
+
+Every mutation applied by **Edit** and restored by **Edit**; after the
+last one `grep -rn "MUTATION-" tldw_chatbook/ Tests/` returns **0** and
+`git diff` against the commits is empty.
+
+| # | Mutation | Killed by | Result |
+|---|---|---|---|
+| M1 | the whole change absent (the untouched merge-base, the new file copied in) | the six behavioural tests | **6 failed, 3 passed** (§3) |
+| M2 | `marked_conversations_at_launch` ignores `autowake_enabled` | the kill-switch test **only** | 1 failed, 8 passed |
+| M3 | `app.py`'s empty-marks guard removed | the startup-cost pin only | 1 failed, 8 passed |
+| M3b | **both** empty-marks guards removed | the pin **and** the phantom test | 2 failed |
+| M4 | `_conversation_exists_locally` → always `True` | the ephemeral-mark test **only** | 1 failed, 8 passed |
+| M5 | `_conversation_exists_locally` → always `False` | 5 tests (e2e, second-launch, pin control, kill switch, owed-only) | 5 failed, 4 passed |
+| M7 | the per-conversation `has_pending` guard removed | `test_a_launch_hydrates_only_the_conversations_that_are_owed` only | 1 failed, 8 passed **after the fix below** |
+| M8 | `wake.retry_soon()` never called | 5 tests | 5 failed, 4 passed |
+| M9 | `controller.app = app` dropped | the e2e **after the fix below** | 1 failed, 8 passed |
+| M10 | `wake.wire(app=app)` dropped | 6 tests | 6 failed, 3 passed |
+| M11 | `hydrate_console_session` drops the roleplay overlay | the equivalence test's absolute assertion | 1 failed, 1 passed |
+| M12 | the tree walk follows only the last child | the characterization test **and** three of `test_console_resume_active_path`'s own | 4 failed, 27 passed |
+| M13 | the active-session restore removed | `test_a_launch_into_console_delivers_without_stealing_the_active_tab`, on exactly the tab-stealing assertion | 1 failed, 9 passed |
+
+### The two that survived, and what they taught
+
+**M7 survived the first draft**, and investigating it found a real gap
+rather than a nuisance. With a single unowed mark the launch returns at
+`seed_from_marks() == 0` *before* the per-conversation loop, so
+`has_pending` was unreachable and owned nothing at all — the suite could
+not tell the difference between "we checked each conversation" and "we
+never got that far". Fix:
+`test_a_launch_hydrates_only_the_conversations_that_are_owed` gives the
+launch TWO marks, one owed, and asserts the unowed one is **never
+hydrated** — because otherwise the user opens Console to an unexplained
+tab for a conversation nothing happened in.
+`test_a_mark_with_nothing_owed_is_left_alone_at_launch` gained the same
+"no session was hydrated" half; it previously asserted only that the mark
+survived.
+
+**M9 would have survived**: nothing in the suite touched
+`controller.app`. It is not a slot the viewless machinery covers — it is
+deliberately excluded from `CONSOLE_VIEW_HOOK_SLOTS` because it is the
+APP — and it is what carries a headless approval round's app-wide toast
+and its `call_from_thread` bridge. The e2e now asserts it, **labelled as
+a wiring assertion**: the consequence itself is owned by
+`Tests/UI/test_console_headless_approval.py`, and driving a risk-tagged
+tool through a launch wake was out of this slice's budget.
+
+M10's kill list is the positive result worth reading: dropping
+`wake.wire(app=app)` takes out six tests including the ephemeral-mark one,
+because `seed_from_marks` reads the marks service off the wired app — so
+the stale-mark clearing depends on the same wiring the delivery does.
+
+---
+
+## 8. The stale / ephemeral mark — verdict
+
+**The leak is real, and both halves are now executed.**
+
+- `Tests/UI/test_probe_launch_wake.py::test_probe_p3a…` drives the
+  production source: `ConsoleChatController._agent_conversation_id`
+  returns `session.persisted_conversation_id or session_id`, so an
+  **unsaved** session's fleet work is keyed by a uuid.
+  Measured: `persisted_conversation_id=None`, keyed id
+  `23ddaee4-9394-4f91-9561-006cc2daba92`, `get_conversation_by_id` →
+  `None`.
+- `…::test_probe_p3…` drives the durability half: a second app over the
+  same on-disk DB still lists that mark, and it still resolves to nothing.
+
+**What this branch does about it:** a launch that owes such a conversation
+a wake it can never deliver **clears the mark** rather than retrying it on
+every boot for the life of the install
+(`test_an_unresolvable_ephemeral_mark_is_cleared_at_launch`). Three
+deliberate narrowings, each pinned:
+
+1. the authority is the **local DB** (`get_conversation_by_id is None`),
+   not a failed tree load — a tree load can fail for reasons that have
+   nothing to do with the row existing (a scope service in server mode, a
+   transient error), and clearing a live user's badge on one of those
+   would be a real loss. A DB that cannot answer reads as "exists", so
+   uncertainty keeps the mark;
+2. only for a mark that is **otherwise owed**, i.e. one the launch was
+   about to act on;
+3. the owed `agent_runs` rows are **left unstamped** — they are stamped by
+   delivery, never by give-up — and with the mark gone nothing indexes
+   them, so nothing re-announces them. Asserted.
+
+One consequence worth naming because it was not designed for and is
+correct anyway: `get_conversation_by_id` filters `deleted = 0`, so a
+**soft-deleted** conversation reads as absent too. A ◈ badge left behind
+by a conversation the user deleted is therefore cleared at the next launch
+by the same path — and it could never have been resolved either.
+
+**Deliberately not touched:** a mark with **nothing owed** is left alone
+even if its conversation is missing. With nothing owed, a mark is the
+*delivered-but-unseen* badge task-15971 exists to show, and this slice has
+no way to tell "an ephemeral chat whose results were all delivered" from
+"a badge the user has not looked at yet" without inventing new badge
+policy. `test_a_mark_with_nothing_owed_is_left_alone_at_launch` pins the
+current behaviour. The residual cost is one indexed `undelivered_wake_runs`
+read per launch per such mark.
+
+---
+
+## 9. Kill switch
+
+`test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing`,
+driven through the real env-var seam (`TLDW_AGENTS_AUTOWAKE_ENABLED`),
+across three processes over one durable state:
+
+- **OFF**: nothing reaches the provider, `console_runtime.chat_controller
+  is None` (the switch is read *before* the mark listing, so an install
+  with auto-wake off pays nothing at all), the ◈ mark survives, and
+  `wake_delivered_at` is still NULL;
+- **ON, next launch**: the same owed completion is delivered, and its
+  notice carries the child's result.
+
+M2 (the switch dropped from the launch read) kills exactly this test and
+nothing else. Note that `seed_from_marks` honours the switch too, so the
+kill is not from the delivery itself but from the runtime being
+constructed — which is why that assertion is in the test.
+
+---
+
+## 10. Gate
+
+Runner both sides: `.venv/bin/pytest <paths> -p no:randomly
+-p no:cacheprovider -q --no-header -rf`, cwd = the worktree.
+`Tests/test_probe_import_provenance.py` is in every row — the venv's
+editable install resolves `tldw_chatbook` to a FOREIGN worktree and loses
+only by `sys.meta_path` ordering. **Every count below was READ off a
+summary line.**
+
+| Gate | Baseline @ merge-base `ed49499b8` | Branch | Delta |
+|---|---|---|---|
+| **The specified battery** — `test_console_headless_wake_fires` (1), `test_console_headless_approval` (14), `test_console_sync_outlives_screen` (5), `test_console_store_continuity` (4), `test_console_viewless_hooks` (12), `test_console_runtime_lifetime` (14), `test_console_runtime_ownership` (7), `test_screen_residency` (7), `test_console_headless_wake_invariants` (13), the 16-file wake glob (109), probe (1) | **187 passed, 0 failed** (216.4s) | see §10.1 | — |
+| **The new suites** — `test_console_launch_wake` + `test_console_conversation_hydration` + probe | **6 failed, 3 passed** (launch file only; the hydration file cannot exist there — its subject does not) | **11 passed** | +6 |
+| **The resume-owning suites** — `test_console_resume_active_path`, `test_console_workspace_controller`, `test_console_session_settings`, `test_console_generation_store`, `test_console_video_message`, probe | **286 passed, 0 failed** (133.5s) | **286 passed, 0 failed** (128.8s) | **0** |
+| `Tests/Agents/` + probe | not measured — a green final cannot hide a regression | see §10.1 | — |
+| **The whole Console population in ONE process** — every `Tests/UI/test_console_*.py` + `test_screen_residency` + probe | see §10.1 | see §10.1 | — |
+
+### 10.1 Final counts
+
+*(filled in below from the completed runs)*
+
+---
+
+## 11. Deliberately not done
+
+- **The invariant gate (plan Task 7)** and **the docs sweep (Task 8)** are
+  out of scope. Only the User Guide sentence about *this* behaviour was
+  written (§12), because shipping a false one is not acceptable for even
+  one merge.
+- **The page's "Verified against" stamp is untouched.** This slice
+  verified two paragraphs, not the page.
+- **The spec's own superseding note** (`…supervisor-agent-fleet-design.md`
+  §7's "honest architectural limit as built") is Task 8's.
+- **A launch wake's approval round was not driven end to end.** The app
+  handle it needs is asserted (§7, M9); the behaviour is owned by the
+  approval landing's suite. Naming it rather than implying coverage.
+- **The launch-hydrated session becomes the store's ACTIVE session**,
+  because at launch there is no other. A user who opens Console after a
+  launch wake therefore lands in the woken conversation rather than a
+  fresh chat. That is arguably right — the ◈ points there and money was
+  just spent there — but it is a UX change nobody has ruled on, and it is
+  named here rather than buried.
+
+## 12. The User Guide sentence
+
+`Docs/User_Guide/console/agent-runs-and-tools.md` said:
+
+> One honest limit remains. **Nothing wakes while the app is not running**
+> — completions are recorded durably (mark + ledger) and claimed the next
+> time the app starts and Console opens; a wake at launch, before Console
+> has ever been opened in that session, is follow-up work (task-15860).
+
+It now says:
+
+> **A wake you were owed is delivered at the next launch, without opening
+> Console.** Nothing runs while the app is closed — a completion that
+> lands then is recorded durably (the `◈` mark plus the ledger) and waits.
+> At the next start, once the app is up and interactive, any conversation
+> that still carries a `◈` mark *and* still owes a result has its
+> supervisor woken there and then: the conversation is reopened in the
+> background, the turn runs, and you find it already in the transcript
+> with its `◈` still lit when you open Console. Nothing else is woken —
+> never a conversation without a mark, and never one whose results were
+> already delivered — and the whole thing is off when `[agents]
+> autowake_enabled` is off (there is no separate launch switch). If you
+> have never run a background sub-agent, launch does exactly what it did
+> before: one indexed check that finds nothing.
+>
+> One case cannot be delivered and is cleaned up instead: sub-agent work
+> started in a **temporary (unsaved) chat** belongs to a session that does
+> not survive the app, so there is no conversation left to wake. Its `◈`
+> mark is cleared at the next launch rather than left pointing at nothing.
+> Save the chat before starting long background work you want to come back
+> to.
+
+## 13. Concerns
+
+1. **A launch now spends money before the user has done anything.** That
+   is the point of the task and it is triple-gated (kill switch, ◈ mark,
+   owed ledger row), but it is a real behavioural change: opening the app
+   can now start a paid turn with no window on it. The ◈ mark is the only
+   signal until the user opens Console.
+2. **The woken conversation becomes the active session** (§11). Worth an
+   owner eyeball before this reaches users.
+3. **The launch fires once, at startup.** A completion that lands while
+   the app is running but Console has never been opened in that process
+   still has no fire point: the fan-out consumer that records it lives on
+   the agent bridge, which nothing built. That is not a regression (it was
+   unreachable before too — with no Console there is no bridge to run a
+   sub-agent from), but it means "wake at launch" is exactly what it says.
+4. **The stale-mark clearing is a durable delete.** It is narrowed three
+   ways (§8) and uncertainty always keeps the mark, but it is the only
+   write in this slice that destroys user-visible state.
+5. **`AgentRunsDB`'s reconcile sweep now runs earlier** for an install
+   with marks: at launch rather than at the first Console open. Same
+   sweep, same per-process guard, just sooner. Named because it changes
+   *when* a crash-killed child's row turns `error`.
+6. **The equivalence pin is structurally weak** (§6) and leans on its
+   absolute assertions. If someone later changes the shared hydration
+   function, the comparison will not catch it; M11 is the evidence that
+   the absolute half does.

--- a/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
+++ b/Docs/superpowers/plans/2026-08-14-headless-wake-launch-report.md
@@ -117,7 +117,20 @@ again here for the *hydration* file, which cannot collect at base because
 its subject does not exist, and is therefore reported separately rather
 than folded into a red count).
 
-**AFTER: 10 passed.**
+**AFTER: 11 passed** (the file grew to eleven tests across mutation
+testing and review; the baseline red was re-measured against each version
+rather than quoted from the first).
+
+**The harness is the production one, twice over.** Process one mounts a
+real `ChatScreen` and sends through `submit_draft`; process two loads its
+tree through the **real `ChatConversationService`**, not a double. Every
+resume test in this suite injects a `StaticConversationTreeService`
+because `_build_test_app` patches `get_chachanotes_db_lazy` to `None` and
+the app's own `_wire_chat_conversation_services()` therefore ran at
+`__init__` with no DB. Probe P4 executed that re-running that wiring after
+`_attach_real_dbs` gives the real service, and six of the eleven tests now
+use it — so "the payload carried real prior history" is not a claim about
+a fixture I wrote.
 
 The three that pass at the merge-base are named rather than hidden: the
 phantom-wake test and the nothing-owed test pass because at the baseline
@@ -163,11 +176,23 @@ Its control, `test_the_startup_cost_pin_is_not_vacuous`, runs the same
 four probes WITH a mark and watches every one flip. Without it, a launch
 hook that never ran at all would satisfy the pin perfectly.
 
-"Indexed" is verified, not asserted:
-`ChaChaNotes_DB.py`'s `idx_conversation_local_marks_type` is
-`(mark_type, updated_at DESC, conversation_id)`, which covers
-`list_marked_conversation_ids`' `WHERE mark_type = ? ORDER BY updated_at
-DESC, conversation_id ASC LIMIT ?` completely.
+**Constants re-measured rather than quoted** (the approval landing found
+the plan's own 120s figure had gone stale):
+
+- "Indexed" is verified: `ChaChaNotes_DB.py`'s
+  `idx_conversation_local_marks_type` is
+  `(mark_type, updated_at DESC, conversation_id)`, which covers
+  `list_marked_conversation_ids`' `WHERE mark_type = ? ORDER BY updated_at
+  DESC, conversation_id ASC LIMIT ?` completely.
+- `list_marked_conversation_ids`' `limit` still defaults to **100**, so a
+  launch considers at most 100 marked conversations. That is not a new
+  bound: `seed_from_marks` calls it exactly the same way, so the launch
+  claim and the Console mount claim see the same set. Named because it is
+  a silent ceiling in both.
+- `ChatConversationService.get_conversation_tree`'s `root_limit` and
+  `depth_cap` still default to **50** each, which is why the shared
+  loader's `10_000`/`10_000` are policy and were moved verbatim rather
+  than re-chosen.
 
 **Mutations against the pin:**
 
@@ -327,6 +352,23 @@ M10's kill list is the positive result worth reading: dropping
 because `seed_from_marks` reads the marks service off the wired app — so
 the stale-mark clearing depends on the same wiring the delivery does.
 
+### A vacuity guard that caught its own author
+
+`test_a_launch_built_controller_is_not_sticky_when_console_opens` pins the
+hazard this task introduces: `ensure_chat_controller` is idempotent and
+ignores its parameters after the first call, and a launch now MAKES that
+first call, with config defaults. The module docstring claimed "nothing
+here is sticky" from a reading of `_sync_console_chat_core_state`; the
+test executes it by CHANGING the model between the launch and the mount.
+
+Its first draft changed `[chat_defaults] model` — and `configured_model`
+is derived from `[api_settings.<provider>] model`, so both sides would
+have read `'local-model'` and the test would have passed while proving
+nothing. The assertion that caught it is the one line that says so:
+`assert expected.configured_model == "mounted-model", "the fixture never
+changed anything…"`. Recorded because a vacuity guard is cheap and this is
+the second time in this slice one has paid for itself.
+
 ---
 
 ## 8. The stale / ephemeral mark — verdict
@@ -409,13 +451,26 @@ summary line.**
 
 | Gate | Baseline @ merge-base `ed49499b8` | Branch | Delta |
 |---|---|---|---|
-| **The specified battery** — `test_console_headless_wake_fires` (1), `test_console_headless_approval` (14), `test_console_sync_outlives_screen` (5), `test_console_store_continuity` (4), `test_console_viewless_hooks` (12), `test_console_runtime_lifetime` (14), `test_console_runtime_ownership` (7), `test_screen_residency` (7), `test_console_headless_wake_invariants` (13), the 16-file wake glob (109), probe (1) | **187 passed, 0 failed** (216.4s) | see §10.1 | — |
-| **The new suites** — `test_console_launch_wake` + `test_console_conversation_hydration` + probe | **6 failed, 3 passed** (launch file only; the hydration file cannot exist there — its subject does not) | **11 passed** | +6 |
+| **The specified battery** — `test_console_headless_wake_fires` (1), `test_console_headless_approval` (14), `test_console_sync_outlives_screen` (5), `test_console_store_continuity` (4), `test_console_viewless_hooks` (12), `test_console_runtime_lifetime` (14), `test_console_runtime_ownership` (7), `test_screen_residency` (7), `test_console_headless_wake_invariants` (13), the 16-file wake glob (109), probe (1) | **187 passed, 0 failed** (216.4s) | **198 passed, 0 failed** (280.0s), same files **plus** the two new suites | **+11** = the 9 launch tests and 2 hydration tests that existed when it ran (the launch file later grew to 11) |
+| **The new suites** — `test_console_launch_wake` (11) + `test_console_conversation_hydration` (2) | **8 failed, 3 passed** (the launch file only, at the merge-base; the hydration file cannot COLLECT there — its subject does not exist — so it is reported separately rather than folded in) | **13 passed** | — |
 | **The resume-owning suites** — `test_console_resume_active_path`, `test_console_workspace_controller`, `test_console_session_settings`, `test_console_generation_store`, `test_console_video_message`, probe | **286 passed, 0 failed** (133.5s) | **286 passed, 0 failed** (128.8s) | **0** |
-| `Tests/Agents/` + probe | not measured — a green final cannot hide a regression | see §10.1 | — |
-| **The whole Console population in ONE process** — every `Tests/UI/test_console_*.py` + `test_screen_residency` + probe | see §10.1 | see §10.1 | — |
+| `Tests/Agents/` + probe | not measured — a green final cannot hide a regression | **1459 passed, 0 failed** (43.0s) | — |
+| **The whole Console population in ONE process** — every `Tests/UI/test_console_*.py` + `test_screen_residency` + probe (166 files branch / 165 base) | see §10.2 | see §10.2 | — |
 
-### 10.1 Final counts
+### 10.1 Stability
+
+The new files drive real navigation, real threads, real timers and up to
+four `TldwCli` lifetimes per test, so they were re-run for flakiness **with
+random ordering left ON** (no `-p no:randomly`), while the two Console
+population runs were saturating the machine:
+
+- before the production-tree-loader change: **12 passed** ×3
+  (59.8s / 60.4s / 59.7s);
+- after it: **12 passed** ×3 (59.8s / 59.8s / …).
+
+Order dependence is therefore ruled out as well as timing flakiness.
+
+### 10.2 Final counts
 
 *(filled in below from the completed runs)*
 

--- a/Tests/Chat/test_console_conversation_hydration.py
+++ b/Tests/Chat/test_console_conversation_hydration.py
@@ -1,0 +1,257 @@
+"""One hydration policy, two callers (task-15860 Task 6).
+
+`ChatScreen._resume_console_workspace_conversation` used to be the ONLY
+code that could turn a persisted conversation into a Console session, and
+it interleaved that policy with a screen's own work. A wake fired at
+launch needs a session for a conversation nobody has opened, so the
+session-producing half moved to
+`Chat/console_conversation_hydration.py` -- a pure refactor, pinned here
+in both directions:
+
+* **characterization** -- the screen's `_console_messages_from_conversation
+  _tree` seam (eight test files call it by name) still produces the same
+  flattened tree, branches, parenthood and dropped-empty-row transparency;
+* **equivalence** -- for one fixture conversation, the session a LAUNCH
+  hydrates headlessly and the session the SCREEN resumes agree field for
+  field on everything that reaches a provider payload.
+
+The equivalence test is the one that matters: it is what stops the launch
+path quietly drifting into a second, worse resume policy -- which is the
+failure the plan named ("rather than duplicating it").
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import (
+    StaticConversationTreeService,
+    _configure_native_ready_console,
+)
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    apply_resume_settings_overrides,
+    console_messages_from_conversation_tree,
+    hydrate_console_session,
+    load_console_conversation_tree,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    default_console_session_settings,
+)
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+CONVERSATION_ID = "conv-fixture"
+
+#: Deliberately awkward: two branches off one root, a truly-empty node in
+#: the middle of a branch (its child must re-parent through it), a system
+#: prompt, roleplay metadata and a pinned prefill.
+FIXTURE_TREE = {
+    "conversation": {
+        "id": CONVERSATION_ID,
+        "title": "Fixture conversation",
+        "system_prompt": "  you are a careful assistant\n",
+        "workspace_id": "ws-fixture",
+        "runtime_backend": "local",
+        "assistant_kind": "generic",
+        "assistant_id": "console",
+        "metadata": {
+            "console_roleplay_context": {
+                "version": 1,
+                "user_name_override": "Robert",
+                "character_system_template": "You are {{char}}.",
+            },
+            "pinned_response_prefill": "Certainly,",
+        },
+    },
+    "root_threads": [
+        {
+            "id": "m1",
+            "sender": "user",
+            "content": "first user message",
+            "children": [
+                {
+                    "id": "m2",
+                    "sender": "assistant",
+                    "content": "branch A reply",
+                    "children": [
+                        {
+                            "id": "m3-empty",
+                            "sender": "assistant",
+                            "content": "",
+                            "children": [
+                                {
+                                    "id": "m4",
+                                    "sender": "user",
+                                    "content": "after an empty row",
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "id": "m5",
+                    "sender": "assistant",
+                    "content": "branch B reply",
+                    "children": [],
+                },
+            ],
+        }
+    ],
+}
+
+
+def _fixture_app(tmp_path):
+    app = _build_test_app()
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    app.app_config.setdefault("console", {})["agent_runtime"] = False
+    if app.chachanotes_db.get_conversation_by_id(CONVERSATION_ID) is None:
+        app.chachanotes_db.add_conversation(
+            {"id": CONVERSATION_ID, "title": "Fixture conversation"}
+        )
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {CONVERSATION_ID: FIXTURE_TREE}
+    )
+    return app
+
+
+def _message_shape(store, session_id):
+    return [
+        (
+            m.role.value,
+            m.content,
+            m.persisted_message_id,
+            m.parent_message_id,
+        )
+        for m in store.messages_for_session(session_id)
+    ]
+
+
+def test_the_screen_tree_walk_still_flattens_every_branch(tmp_path):
+    """Characterization: the screen seam eight test files call by name.
+
+    Asserts the three properties the walk owns -- ALL branches (not the
+    latest), parenthood taken from NESTING, and an empty row dropped but
+    transparent to its children -- so a refactor that quietly kept only the
+    active path cannot pass.
+    """
+    app = _fixture_app(tmp_path)
+    screen = ChatScreen(app)
+    messages = screen._console_messages_from_conversation_tree(FIXTURE_TREE)
+
+    shape = [(m.persisted_message_id, m.parent_message_id) for m in messages]
+    assert shape == [
+        ("m1", None),
+        ("m2", "m1"),
+        ("m4", "m2"),
+        ("m5", "m1"),
+    ], (
+        "the walk must keep BOTH branches, take parenthood from nesting, and "
+        f"re-parent through the dropped empty row; got {shape}"
+    )
+    assert [m.role.value for m in messages] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    # `ConsoleChatMessage.id` is a per-instance uuid, so compare the fields
+    # the walk actually decides rather than object identity.
+    def _walk_shape(built):
+        return [
+            (m.role.value, m.content, m.persisted_message_id, m.parent_message_id)
+            for m in built
+        ]
+
+    assert _walk_shape(messages) == _walk_shape(
+        console_messages_from_conversation_tree(FIXTURE_TREE, db=app.chachanotes_db)
+    ), "the screen seam and the module function disagree"
+
+
+@pytest.mark.asyncio
+async def test_a_launch_hydrated_session_matches_a_screen_resumed_one(tmp_path):
+    """The equivalence pin: both callers, one fixture, identical sessions.
+
+    Everything that can reach a provider payload is compared -- the whole
+    message tree with its parenthood, the durable identity fields, the
+    roleplay overlay, and the full settings snapshot.
+
+    The one field that legitimately differs is named rather than skipped:
+    the session's own `id` is a fresh uuid per session.
+    """
+    screen_app = _fixture_app(tmp_path)
+    screen = ChatScreen(screen_app)
+    async with screen_app.run_test(size=(160, 48)) as pilot:
+        await screen_app.push_screen(screen)
+        screen_app._initial_screen_pushed = True
+        await pilot.pause()
+        resumed = await screen._workspace._resume_console_workspace_conversation(
+            CONVERSATION_ID
+        )
+        assert resumed is True, f"the screen resume did not succeed: {resumed!r}"
+        screen_store = screen._console_chat_store
+        screen_session = next(
+            s
+            for s in screen_store.sessions()
+            if s.persisted_conversation_id == CONVERSATION_ID
+        )
+        screen_shape = _message_shape(screen_store, screen_session.id)
+
+    # A second app, no screen at all: the launch shape.
+    launch_app = _fixture_app(tmp_path)
+    launch_store = launch_app.console_runtime.ensure_chat_store()
+    tree = await load_console_conversation_tree(launch_app, CONVERSATION_ID)
+    assert tree is not None
+    conversation = tree["conversation"]
+    launch_session = hydrate_console_session(
+        app=launch_app,
+        store=launch_store,
+        conversation_id=CONVERSATION_ID,
+        tree=tree,
+        settings=apply_resume_settings_overrides(
+            default_console_session_settings(launch_app.app_config), conversation
+        ),
+    )
+
+    assert _message_shape(launch_store, launch_session.id) == screen_shape, (
+        "the launch-hydrated transcript differs from the screen-resumed one"
+    )
+    for field in (
+        "title",
+        "workspace_id",
+        "persisted_conversation_id",
+        "runtime_backend",
+        "assistant_kind",
+        "assistant_id",
+        "assistant_authority_id",
+        "character_id",
+        "user_display_name_override",
+        "character_system_template",
+    ):
+        assert getattr(launch_session, field) == getattr(screen_session, field), (
+            f"session field {field!r} differs: "
+            f"launch={getattr(launch_session, field)!r} "
+            f"screen={getattr(screen_session, field)!r}"
+        )
+    assert launch_session.settings == screen_session.settings, (
+        "the settings snapshots differ:\n"
+        f"launch={launch_session.settings!r}\nscreen={screen_session.settings!r}"
+    )
+    assert launch_session.settings is not None
+    assert launch_session.settings.system_prompt == (
+        "  you are a careful assistant\n"
+    ), (
+        "the saved system prompt must be restored VERBATIM -- the comparison "
+        "above is worthless if both sides restored nothing"
+    )
+    assert launch_session.user_display_name_override == "Robert", (
+        "the roleplay overlay never reached either session, so comparing them "
+        "proved nothing"
+    )
+    assert launch_session.id != screen_session.id, (
+        "session ids are per-session uuids; equal ids would mean the two "
+        "stores are the same object and this test is not comparing two callers"
+    )

--- a/Tests/UI/test_console_launch_wake.py
+++ b/Tests/UI/test_console_launch_wake.py
@@ -292,6 +292,18 @@ async def test_a_launch_delivers_a_wake_owed_from_a_previous_process(tmp_path):
             "mark -- the user has no way to learn the supervisor turn ever ran"
         )
 
+        # The app handle the launch-built controller needs. Deliberately not
+        # a view-hook slot (it is the APP, which outlives every view), and
+        # nothing else here would notice it missing: it is what carries a
+        # headless approval round's app-wide toast and its
+        # `call_from_thread` bridge (the headless-approval landing). A
+        # wiring assertion, labelled as one -- the consequence itself is
+        # owned by `Tests/UI/test_console_headless_approval.py`.
+        assert app.console_runtime.chat_controller.app is app, (
+            "the launch-built controller has no app handle, so a headless "
+            "approval round in a launch wake could surface nothing"
+        )
+
 
 @pytest.mark.asyncio
 async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
@@ -626,7 +638,17 @@ async def test_a_mark_with_nothing_owed_is_left_alone_at_launch(tmp_path):
     app0.chachanotes_db.add_conversation({"id": "conv-seen-later", "title": "Delivered"})
     marks0.set_mark("conv-seen-later", FLEET_UNSEEN)
 
-    app, marks, gateway = _launch_app(tmp_path)
+    app, marks, gateway = _launch_app(
+        tmp_path,
+        tree={
+            "conv-seen-later": {
+                "conversation": {"id": "conv-seen-later", "title": "Delivered"},
+                "root_threads": [
+                    {"id": "m1", "sender": "user", "content": "earlier work"}
+                ],
+            }
+        },
+    )
     async with app.run_test(size=(120, 40)) as pilot:
         assert await _quiet(pilot, lambda: bool(gateway.payloads), seconds=4.0), (
             f"a launch delivered a wake for a conversation owing none: {gateway.payloads!r}"
@@ -635,3 +657,50 @@ async def test_a_mark_with_nothing_owed_is_left_alone_at_launch(tmp_path):
             "the launch cleared a delivered-but-unseen ◈ badge -- the user "
             "loses the only pointer they had to a result they never saw"
         )
+        store = app.console_runtime.chat_store
+        opened = [] if store is None else [
+            s.persisted_conversation_id for s in store.sessions()
+        ]
+        assert "conv-seen-later" not in opened, (
+            "the launch hydrated a session for a conversation owing nothing -- "
+            "the user opens Console to an unexplained tab, and the work was "
+            f"pointless: {opened}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_launch_hydrates_only_the_conversations_that_are_owed(tmp_path):
+    """Two marks, one owed. The owed one is hydrated and delivered; the
+    other is not opened at all.
+
+    This is the case that makes the per-conversation `has_pending` guard
+    load-bearing rather than decorative: with a SINGLE unowed mark the
+    launch returns before the loop, so removing that guard changes nothing
+    observable.
+    """
+    conversation_id, _run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    app0 = _build_test_app("library")
+    marks0 = _attach_real_dbs(app0, tmp_path)
+    app0.chachanotes_db.add_conversation({"id": "conv-quiet", "title": "Quiet"})
+    marks0.set_mark("conv-quiet", FLEET_UNSEEN)
+
+    tree = _fixture_tree(conversation_id, rows)
+    tree["conv-quiet"] = {
+        "conversation": {"id": "conv-quiet", "title": "Quiet"},
+        "root_threads": [{"id": "q1", "sender": "user", "content": "quiet work"}],
+    }
+    app, marks, gateway = _launch_app(tmp_path, tree=tree)
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _settle(pilot, lambda: bool(gateway.payloads)), (
+            "precondition: the OWED conversation must still be delivered"
+        )
+        opened = [
+            s.persisted_conversation_id
+            for s in app.console_runtime.chat_store.sessions()
+        ]
+        assert conversation_id in opened, opened
+        assert "conv-quiet" not in opened, (
+            "a marked-but-unowed conversation was hydrated alongside an owed "
+            f"one: {opened}"
+        )
+        assert marks.has_mark("conv-quiet", FLEET_UNSEEN)

--- a/Tests/UI/test_console_launch_wake.py
+++ b/Tests/UI/test_console_launch_wake.py
@@ -52,6 +52,7 @@ from Tests.UI.test_console_native_chat_flow import (
 from Tests.UI.test_console_store_continuity import (
     _StallingWakeGateway,
     _db_chain,
+    _navigate,
     _seed_console,
 )
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
@@ -425,6 +426,60 @@ async def test_a_launch_into_console_delivers_without_stealing_the_active_tab(
             "the wake landed in a tab the user was not viewing, so the ◈ mark "
             "must survive to point them at it"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_launch_built_controller_is_not_sticky_when_console_opens(tmp_path):
+    """The hazard this task introduces, pinned.
+
+    `ConsoleRuntime.ensure_chat_controller` is idempotent and IGNORES its
+    parameters after the first call. A launch now makes that first call --
+    with config defaults, because there is no control bar to read -- so if
+    `ChatScreen` did not re-apply its own selection on every
+    `_ensure_console_chat_controller()`, a user whose launch happened to
+    wake a supervisor would run the whole session on the launch's guesses.
+
+    Executed rather than read: the config's model is CHANGED between the
+    launch and the Console mount, and the controller must end up on the new
+    one.
+    """
+    conversation_id, _run_id, _rows = await _seed_a_finished_background_job(tmp_path)
+    app, _marks, gateway = _launch_app(tmp_path, real_service=True)
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        assert await _settle(pilot, lambda: bool(gateway.payloads)), (
+            "precondition: the launch must have built the controller"
+        )
+        controller = app.console_runtime.chat_controller
+        assert controller is not None
+        _assert_console_never_mounted(app)
+
+        # The user changes their model in Settings, then opens Console.
+        # `configured_model` is derived from `[api_settings.<provider>]`,
+        # not `[chat_defaults]` -- the first draft changed the wrong key and
+        # the test's own vacuity guard caught it.
+        app.app_config["api_settings"]["llama_cpp"]["model"] = "mounted-model"
+        chat = await _navigate(app, pilot, "chat", expect="ChatScreen")
+        assert isinstance(chat, ChatScreen)
+        await pilot.pause()
+        assert controller is app.console_runtime.chat_controller, (
+            "harness precondition: the mount must REUSE the launch-built "
+            "controller, or this test is not about stickiness at all"
+        )
+        expected = chat._build_console_provider_selection()
+        assert await _settle(
+            pilot,
+            lambda: controller.configured_model == expected.configured_model,
+        ), (
+            "the launch-built controller kept the launch's model after Console "
+            f"opened: controller={controller.configured_model!r} "
+            f"screen={expected.configured_model!r}"
+        )
+        assert expected.configured_model == "mounted-model", (
+            "the fixture never changed anything, so the comparison above is "
+            f"vacuous: {expected.configured_model!r}"
+        )
+        del conversation_id
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_launch_wake.py
+++ b/Tests/UI/test_console_launch_wake.py
@@ -357,6 +357,60 @@ async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
         )
 
 
+@pytest.mark.asyncio
+async def test_a_launch_into_console_delivers_without_stealing_the_active_tab(
+    tmp_path,
+):
+    """The OTHER launch shape, and the shipped default: `default_tab` is
+    Console, so the startup screen IS a `ChatScreen` with its own fresh
+    session.
+
+    The owed wake must still be delivered -- the User Guide's promise is
+    "at the next start", not "at the next start if you land somewhere
+    else" -- and it must NOT move the user off the tab they landed on.
+    `restore_persisted_session` activates what it creates, so the second
+    half is a real hazard rather than a hypothetical.
+    """
+    conversation_id, _run_id, rows = await _seed_a_finished_background_job(tmp_path)
+
+    app = _build_test_app("chat")
+    marks = _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    app.app_config.setdefault("console", {})["agent_runtime"] = False
+    gateway = _StallingWakeGateway(reply=LAUNCH_REPLY)
+    app.console_provider_gateway_factory = lambda: gateway
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        _fixture_tree(conversation_id, rows)
+    )
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        assert await _settle(
+            pilot, lambda: any(isinstance(s, ChatScreen) for s in app.screen_stack)
+        ), (
+            "harness precondition: this test is about launching INTO Console; "
+            f"stack is {[type(s).__name__ for s in app.screen_stack]}"
+        )
+        store = app.console_runtime.chat_store
+        assert await _settle(pilot, lambda: store.active_session_id is not None), (
+            "harness precondition: the Console mount must have made a session "
+            "active, or there is no tab to steal"
+        )
+        landed_on = store.active_session_id
+        assert await _settle(pilot, lambda: bool(gateway.payloads)), (
+            "launching INTO Console delivered no owed wake at all -- the "
+            "shipped default tab would get nothing"
+        )
+        assert CHILD_RESULT in str(gateway.payloads[-1][-1]["content"])
+        assert store.active_session_id == landed_on, (
+            "the launch wake moved the user off the tab they landed on: "
+            f"{landed_on} -> {store.active_session_id}"
+        )
+        assert marks.has_mark(conversation_id, FLEET_UNSEEN), (
+            "the wake landed in a tab the user was not viewing, so the ◈ mark "
+            "must survive to point them at it"
+        )
+
+
 # ---------------------------------------------------------------------------
 # The startup-cost pin -- the one that protects everyone who never uses
 # the fleet.

--- a/Tests/UI/test_console_launch_wake.py
+++ b/Tests/UI/test_console_launch_wake.py
@@ -87,12 +87,26 @@ async def _quiet(pilot, predicate, seconds: float = 2.0) -> bool:
     return not predicate()
 
 
-def _launch_app(tmp_path, *, tree=None, gateway_reply=LAUNCH_REPLY):
+def _launch_app(
+    tmp_path, *, tree=None, gateway_reply=LAUNCH_REPLY, real_service=False
+):
     """A SECOND process over the same durable state, Console never opened.
 
     `default_tab="library"` is what keeps Console out of it: the real
     routing builds the Library screen and nothing ever constructs a
     `ChatScreen`.
+
+    Args:
+        tree: Trees for a `StaticConversationTreeService` double.
+        real_service: Re-run the app's own
+            `_wire_chat_conversation_services()` instead, so the tree comes
+            from the PRODUCTION `ChatConversationService` reading the real
+            on-disk rows. `_build_test_app` patches
+            `get_chachanotes_db_lazy` to `None`, so that wiring ran at
+            `__init__` with no DB and left the local service `None` — which
+            is why every resume test in this suite otherwise injects a
+            double. Used by the headline e2e so its "the payload carried
+            real prior history" claim is not a claim about a fixture.
     """
     app = _build_test_app("library")
     marks = _attach_real_dbs(app, tmp_path)
@@ -100,7 +114,12 @@ def _launch_app(tmp_path, *, tree=None, gateway_reply=LAUNCH_REPLY):
     app.app_config.setdefault("console", {})["agent_runtime"] = False
     gateway = _StallingWakeGateway(reply=gateway_reply)
     app.console_provider_gateway_factory = lambda: gateway
-    if tree is not None:
+    if real_service:
+        app._wire_chat_conversation_services()
+        assert app.local_chat_conversation_service is not None, (
+            "harness precondition: the real conversation service must be wired"
+        )
+    elif tree is not None:
         app.chat_conversation_scope_service = StaticConversationTreeService(tree)
     return app, marks, gateway
 
@@ -195,9 +214,9 @@ async def test_a_launch_delivers_a_wake_owed_from_a_previous_process(tmp_path):
        watched it.
     """
     conversation_id, run_id, rows = await _seed_a_finished_background_job(tmp_path)
-    app, marks, gateway = _launch_app(
-        tmp_path, tree=_fixture_tree(conversation_id, rows)
-    )
+    # The PRODUCTION tree loader, not a double: this test's history claim
+    # must be about the real persisted rows, not about a fixture.
+    app, marks, gateway = _launch_app(tmp_path, real_service=True)
 
     async with app.run_test(size=(120, 40)) as pilot:
         delivered = await _settle(pilot, lambda: bool(gateway.payloads))
@@ -316,10 +335,9 @@ async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
     SECOND run in the same conversation IS delivered by a third launch, and
     its notice names the second child, never the first.
     """
-    conversation_id, _run_id, rows = await _seed_a_finished_background_job(tmp_path)
-    tree = _fixture_tree(conversation_id, rows)
+    conversation_id, _run_id, _rows = await _seed_a_finished_background_job(tmp_path)
 
-    app1, marks1, gateway1 = _launch_app(tmp_path, tree=tree)
+    app1, marks1, gateway1 = _launch_app(tmp_path, real_service=True)
     async with app1.run_test(size=(120, 40)) as pilot:
         assert await _settle(pilot, lambda: bool(gateway1.payloads)), (
             "precondition: the first launch must deliver"
@@ -329,7 +347,7 @@ async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
         "exactly what makes the second launch a real test"
     )
 
-    app2, _marks2, gateway2 = _launch_app(tmp_path, tree=tree)
+    app2, _marks2, gateway2 = _launch_app(tmp_path, real_service=True)
     async with app2.run_test(size=(120, 40)) as pilot:
         assert await _quiet(pilot, lambda: bool(gateway2.payloads), seconds=6.0), (
             "a second launch re-announced a wake the first launch already "
@@ -344,7 +362,7 @@ async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
     runs_db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="seed-2")
     _terminal_subagent_run(runs_db, conversation_id, result="second child result")
     runs_db.close()
-    app3, _marks3, gateway3 = _launch_app(tmp_path, tree=tree)
+    app3, _marks3, gateway3 = _launch_app(tmp_path, real_service=True)
     async with app3.run_test(size=(120, 40)) as pilot:
         assert await _settle(pilot, lambda: bool(gateway3.payloads)), (
             "the exactly-once drop is too wide: a genuinely undelivered "
@@ -379,9 +397,7 @@ async def test_a_launch_into_console_delivers_without_stealing_the_active_tab(
     app.app_config.setdefault("console", {})["agent_runtime"] = False
     gateway = _StallingWakeGateway(reply=LAUNCH_REPLY)
     app.console_provider_gateway_factory = lambda: gateway
-    app.chat_conversation_scope_service = StaticConversationTreeService(
-        _fixture_tree(conversation_id, rows)
-    )
+    app._wire_chat_conversation_services()
 
     async with app.run_test(size=(160, 48)) as pilot:
         assert await _settle(
@@ -597,11 +613,10 @@ async def test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing(
     durable: the ◈ mark and the owed ledger row are both still there
     afterwards -- and a later launch with the switch back ON delivers
     exactly what OFF recorded."""
-    conversation_id, run_id, rows = await _seed_a_finished_background_job(tmp_path)
-    tree = _fixture_tree(conversation_id, rows)
+    conversation_id, run_id, _rows = await _seed_a_finished_background_job(tmp_path)
 
     monkeypatch.setenv("TLDW_AGENTS_AUTOWAKE_ENABLED", "false")
-    app_off, marks_off, gateway_off = _launch_app(tmp_path, tree=tree)
+    app_off, marks_off, gateway_off = _launch_app(tmp_path, real_service=True)
     async with app_off.run_test(size=(120, 40)) as pilot:
         assert await _quiet(pilot, lambda: bool(gateway_off.payloads), seconds=5.0), (
             "the kill switch is OFF and a launch still woke the supervisor: "
@@ -620,7 +635,7 @@ async def test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing(
     off_runs.close()
 
     monkeypatch.setenv("TLDW_AGENTS_AUTOWAKE_ENABLED", "true")
-    app_on, _marks_on, gateway_on = _launch_app(tmp_path, tree=tree)
+    app_on, _marks_on, gateway_on = _launch_app(tmp_path, real_service=True)
     async with app_on.run_test(size=(120, 40)) as pilot:
         assert await _settle(pilot, lambda: bool(gateway_on.payloads)), (
             "flipping the kill switch back on did not deliver the wake that "

--- a/Tests/UI/test_console_launch_wake.py
+++ b/Tests/UI/test_console_launch_wake.py
@@ -1,0 +1,637 @@
+"""Wake at LAUNCH -- delivering what was owed while the app was closed.
+
+task-15860 plan Task 6, and the last fire point in the arc.
+
+The wake-fires-headless landing made a survivor settling with no Console
+mounted deliver a full supervisor turn -- inside a process that had opened
+Console at least once. `ensure_chat_controller`/`ensure_agent_bridge` are
+lazy and their only callers were `ChatScreen` and its Console modules, so
+a child that finished while the app was CLOSED waited for the next Console
+visit, however many launches later that was. (That was recorded as an
+inference in the fires report's §9; `Tests/UI/test_probe_launch_wake.py`
+executed it: with Console never opened the runtime holds
+`chat_controller=None, chat_store=None, agent_bridge=None`.)
+
+The owner's ruling, implemented literally and pinned here:
+
+* wake at launch is **YES**, and **mark-gated** -- one cheap indexed read,
+  and delivery only for a conversation that already carries a
+  `FLEET_UNSEEN` mark AND an owed `agent_runs` row;
+* it stays behind the existing `[agents] autowake_enabled`; there is no
+  separate launch switch;
+* **when there are no marks, construct NOTHING** -- startup is
+  byte-identical to before. That is
+  `test_a_launch_with_no_marks_constructs_nothing_and_reads_once`, and it
+  is the pin that protects every user who never touches the fleet.
+
+Rig notes:
+
+* a "restart" is a genuinely SECOND `TldwCli` over the SAME on-disk DBs
+  (`tmp_path/chacha.sqlite` + its sibling `agent_runs.db`), never a
+  re-used app object;
+* the second process boots with `default_tab="library"`, so the real
+  routing never constructs a `ChatScreen` at all -- every test asserts
+  that as a precondition rather than assuming it;
+* the delivery is produced by the app's own deferred-startup path, not by
+  calling the launch module directly, except where a test says otherwise.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from Tests.Chat.test_console_fleet_wake import _terminal_subagent_run
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import (
+    StaticConversationTreeService,
+    _configure_native_ready_console,
+)
+from Tests.UI.test_console_store_continuity import (
+    _StallingWakeGateway,
+    _db_chain,
+    _seed_console,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_fleet_wake import WAKE_NOTICE_HEADER
+from tldw_chatbook.Chat.conversation_local_marks_service import (
+    ConversationLocalMarksService,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+CHILD_RESULT = "the child's finished answer"
+LAUNCH_REPLY = "LAUNCH-WAKE-REPLY"
+FLEET_UNSEEN = ConversationLocalMarksService.FLEET_UNSEEN
+
+
+async def _settle(pilot, predicate, seconds: float = 15.0) -> bool:
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await pilot.pause(0.05)
+    return bool(predicate())
+
+
+async def _quiet(pilot, predicate, seconds: float = 2.0) -> bool:
+    """True when `predicate` stayed False for the whole window."""
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return False
+        await pilot.pause(0.05)
+    return not predicate()
+
+
+def _launch_app(tmp_path, *, tree=None, gateway_reply=LAUNCH_REPLY):
+    """A SECOND process over the same durable state, Console never opened.
+
+    `default_tab="library"` is what keeps Console out of it: the real
+    routing builds the Library screen and nothing ever constructs a
+    `ChatScreen`.
+    """
+    app = _build_test_app("library")
+    marks = _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    app.app_config.setdefault("console", {})["agent_runtime"] = False
+    gateway = _StallingWakeGateway(reply=gateway_reply)
+    app.console_provider_gateway_factory = lambda: gateway
+    if tree is not None:
+        app.chat_conversation_scope_service = StaticConversationTreeService(tree)
+    return app, marks, gateway
+
+
+async def _seed_a_finished_background_job(tmp_path):
+    """Process ONE: a real Console conversation plus a survivor that
+    finished after its turn, marked ◈ and never delivered.
+
+    Everything here goes through production: a mounted `ChatScreen`, a real
+    accepted send that PERSISTS the conversation, and the real runs DB the
+    app-owned bridge opens.
+
+    Returns:
+        (conversation_id, run_id, the seeded conversation's persisted rows)
+    """
+    app = _build_test_app()
+    marks = _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    app.app_config.setdefault("console", {})["agent_runtime"] = False
+    gateway = _StallingWakeGateway()
+    app.console_provider_gateway_factory = lambda: gateway
+    async with app.run_test(size=(160, 48)) as pilot:
+        _chat, controller, _store, session_id, conversation_id = await _seed_console(
+            app, pilot, gateway
+        )
+        runs_db = controller._agent_bridge.runs_db
+        _parent, run_id = _terminal_subagent_run(
+            runs_db, conversation_id, result=CHILD_RESULT
+        )
+        marks.set_mark(conversation_id, FLEET_UNSEEN)
+        rows = _db_chain(app.chachanotes_db, conversation_id)
+        assert len(rows) == 2, (
+            "harness precondition: the seeded turn must have persisted two "
+            f"rows; got {[(r[1], r[2][:24]) for r in rows]}"
+        )
+        assert session_id
+    return conversation_id, run_id, rows
+
+
+def _fixture_tree(conversation_id, rows):
+    """A conversation tree matching the rows process one persisted."""
+    nodes = []
+    parent = None
+    for row in rows:
+        node = {
+            "id": str(row[0]),
+            "sender": row[1],
+            "content": row[2],
+            "children": [],
+        }
+        if parent is None:
+            nodes.append(node)
+        else:
+            parent["children"].append(node)
+        parent = node
+    return {
+        conversation_id: {
+            "conversation": {"id": conversation_id, "title": "Seeded"},
+            "root_threads": nodes,
+        }
+    }
+
+
+def _assert_console_never_mounted(app):
+    assert not any(isinstance(s, ChatScreen) for s in app.screen_stack), (
+        "harness precondition: this test is about a launch with Console "
+        f"NEVER opened; stack is {[type(s).__name__ for s in app.screen_stack]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The red: a launch delivers what a previous process left owed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_launch_delivers_a_wake_owed_from_a_previous_process(tmp_path):
+    """RED before this task: the second process boots, reads nothing,
+    builds nothing, and the owed wake sits until the user opens Console.
+
+    Asserted here (the whole chain, not just the send):
+
+    1. exactly ONE wake turn reaches the provider, its payload ending on a
+       machine-labelled `user` entry carrying the child's result -- and
+       carrying the conversation's REAL prior history, which is what makes
+       hydration load-bearing rather than decorative;
+    2. the machine-origin SYSTEM notice and the assistant reply are in the
+       app-owned store AND in ChaChaNotes;
+    3. `agent_runs.wake_delivered_at` is stamped;
+    4. no USER row is added anywhere -- a wake is never user input;
+    5. the ◈ mark SURVIVES: a launch delivery has no view, so nobody
+       watched it.
+    """
+    conversation_id, run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    app, marks, gateway = _launch_app(
+        tmp_path, tree=_fixture_tree(conversation_id, rows)
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        delivered = await _settle(pilot, lambda: bool(gateway.payloads))
+        _assert_console_never_mounted(app)
+        assert delivered, (
+            "a background sub-agent finished before this process started, its "
+            "◈ mark and its owed ledger row both survived -- and the launch "
+            "delivered no wake turn at all"
+        )
+        assert await _quiet(pilot, lambda: len(gateway.payloads) > 1), (
+            f"one launch delivered more than one wake turn: {len(gateway.payloads)}"
+        )
+
+        # (1) the payload: machine-labelled trailing user entry, real history.
+        payload = gateway.payloads[-1]
+        trailing = payload[-1]
+        assert trailing["role"] == ConsoleMessageRole.USER.value, (
+            "the notice must be the payload's trailing user-role entry (a "
+            f"payload ending on an assistant row is a prefill); got {trailing['role']!r}"
+        )
+        assert WAKE_NOTICE_HEADER in str(trailing["content"])
+        assert CHILD_RESULT in str(trailing["content"]), (
+            "the child's result never reached the supervisor"
+        )
+        seeded_user = rows[0][2]
+        assert any(seeded_user in str(entry.get("content") or "") for entry in payload), (
+            "the launch-hydrated session carried NO prior history -- the "
+            "supervisor was woken with no idea what it had been doing: "
+            f"{[(e.get('role'), str(e.get('content'))[:32]) for e in payload]}"
+        )
+
+        # (2) both rows landed in the app-owned store AND in ChaChaNotes.
+        store = app.console_runtime.chat_store
+        session = next(
+            s
+            for s in store.sessions()
+            if s.persisted_conversation_id == conversation_id
+        )
+        assert await _settle(
+            pilot,
+            lambda: any(
+                m.content == LAUNCH_REPLY
+                for m in store.messages_for_session(session.id)
+            ),
+        ), (
+            "the launch wake turn never landed in the app-owned store: "
+            f"{[(m.role.value, m.content[:28]) for m in store.messages_for_session(session.id)]}"
+        )
+        notices = [
+            m
+            for m in store.messages_for_session(session.id)
+            if getattr(m.metadata, "origin", "") == "agent_wake"
+        ]
+        assert len(notices) == 1, f"expected one machine-origin notice, got {len(notices)}"
+        assert notices[0].role is ConsoleMessageRole.SYSTEM
+
+        assert await _settle(
+            pilot,
+            lambda: len(_db_chain(app.chachanotes_db, conversation_id)) == 4,
+        ), (
+            "the launch wake turn never PERSISTED: "
+            f"{[(r[1], r[2][:28]) for r in _db_chain(app.chachanotes_db, conversation_id)]}"
+        )
+        db_rows = _db_chain(app.chachanotes_db, conversation_id)
+        senders = [row[1] for row in db_rows]
+        assert senders == ["user", "assistant", "system", "assistant"], (
+            f"unexpected persisted row shape: {senders}"
+        )
+        assert db_rows[2][2].startswith(WAKE_NOTICE_HEADER)
+        assert db_rows[3][2] == LAUNCH_REPLY
+
+        # (3) the ledger is stamped.
+        runs_db = app.console_runtime.agent_bridge.runs_db
+        assert (runs_db.get_run(run_id) or {}).get("wake_delivered_at"), (
+            "the launch delivery never stamped agent_runs.wake_delivered_at"
+        )
+
+        # (4) no USER row was added.
+        assert senders.count("user") == 1, f"the launch wake persisted a USER row: {senders}"
+        store_user_rows = [
+            m
+            for m in store.messages_for_session(session.id)
+            if m.role is ConsoleMessageRole.USER
+        ]
+        assert [m.content for m in store_user_rows] == [rows[0][2]], (
+            f"the launch wake wrote a USER transcript row: {store_user_rows!r}"
+        )
+
+        # (5) the ◈ mark survives -- nobody could have watched this.
+        assert marks.has_mark(conversation_id, FLEET_UNSEEN), (
+            "a wake delivered at launch with no Console mounted cleared the ◈ "
+            "mark -- the user has no way to learn the supervisor turn ever ran"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_second_launch_does_not_re_announce_a_delivered_wake(tmp_path):
+    """Exactly-once across launches. The ◈ mark deliberately SURVIVES the
+    first launch's delivery (nobody watched it), so the second launch reads
+    a mark and must still stay silent -- the ledger, not the mark, is what
+    says a result was delivered.
+
+    The control that stops this passing vacuously: a genuinely undelivered
+    SECOND run in the same conversation IS delivered by a third launch, and
+    its notice names the second child, never the first.
+    """
+    conversation_id, _run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    tree = _fixture_tree(conversation_id, rows)
+
+    app1, marks1, gateway1 = _launch_app(tmp_path, tree=tree)
+    async with app1.run_test(size=(120, 40)) as pilot:
+        assert await _settle(pilot, lambda: bool(gateway1.payloads)), (
+            "precondition: the first launch must deliver"
+        )
+    assert marks1.has_mark(conversation_id, FLEET_UNSEEN), (
+        "precondition: the unwatched delivery must KEEP the mark, which is "
+        "exactly what makes the second launch a real test"
+    )
+
+    app2, _marks2, gateway2 = _launch_app(tmp_path, tree=tree)
+    async with app2.run_test(size=(120, 40)) as pilot:
+        assert await _quiet(pilot, lambda: bool(gateway2.payloads), seconds=6.0), (
+            "a second launch re-announced a wake the first launch already "
+            f"delivered: {gateway2.payloads!r}"
+        )
+        _assert_console_never_mounted(app2)
+        assert len(_db_chain(app2.chachanotes_db, conversation_id)) == 4, (
+            "the second launch persisted more rows"
+        )
+
+    # The control: a genuinely new completion IS delivered on a later launch.
+    runs_db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="seed-2")
+    _terminal_subagent_run(runs_db, conversation_id, result="second child result")
+    runs_db.close()
+    app3, _marks3, gateway3 = _launch_app(tmp_path, tree=tree)
+    async with app3.run_test(size=(120, 40)) as pilot:
+        assert await _settle(pilot, lambda: bool(gateway3.payloads)), (
+            "the exactly-once drop is too wide: a genuinely undelivered "
+            "completion was never announced"
+        )
+        notice = str(gateway3.payloads[-1][-1]["content"])
+        assert "second child result" in notice
+        assert CHILD_RESULT not in notice, (
+            "the launch re-announced the already-delivered first child"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The startup-cost pin -- the one that protects everyone who never uses
+# the fleet.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_launch_with_no_marks_constructs_nothing_and_reads_once(tmp_path):
+    """With no marks, a launch does ONE indexed read and nothing else.
+
+    Four independent observations, because "nothing was constructed" is
+    exactly the claim a weak test states and never checks:
+
+    1. the marks service saw exactly ONE `list_marked_conversation_ids`
+       call, for `fleet_unseen`;
+    2. the runtime holds no store, no gateway, no bridge, no controller;
+    3. **no `agent_runs.db` file exists on disk** -- constructing the
+       bridge opens (and creates) it, so the filesystem is an observer the
+       production code cannot lie to;
+    4. no `deferred_launch_wake` task was ever created.
+
+    The control against vacuity is
+    `test_the_startup_cost_pin_is_not_vacuous` below, which runs the same
+    probes WITH a mark and sees every one of them flip.
+    """
+    app = _build_test_app("library")
+    marks = _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    calls: list[str] = []
+    real_list = marks.list_marked_conversation_ids
+
+    def recording_list(mark_type=None, **kwargs):
+        calls.append(str(mark_type))
+        return real_list(mark_type, **kwargs)
+
+    marks.list_marked_conversation_ids = recording_list
+    task_names: list[str] = []
+    real_create = type(app)._create_deferred_startup_task
+
+    def recording_create(self, coroutine, *, name):
+        task_names.append(name)
+        return real_create(self, coroutine, name=name)
+
+    type(app)._create_deferred_startup_task = recording_create
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _settle(pilot, lambda: getattr(app, "_ui_ready", False)), (
+                "harness precondition: the app never became ready, so the "
+                "deferred startup work never ran and this pin proves nothing"
+            )
+            await pilot.pause(0.2)
+            _assert_console_never_mounted(app)
+            assert calls == [ConversationLocalMarksService.FLEET_UNSEEN], (
+                "a launch with no marks must cost exactly one indexed mark "
+                f"listing; got {calls}"
+            )
+            runtime = app.console_runtime
+            assert runtime.chat_store is None, "a launch with no marks built a store"
+            assert runtime.provider_gateway is None, (
+                "a launch with no marks built a provider gateway"
+            )
+            assert runtime.agent_bridge is None, (
+                "a launch with no marks built an agent bridge"
+            )
+            assert runtime.chat_controller is None, (
+                "a launch with no marks built a chat controller"
+            )
+            assert not (tmp_path / "agent_runs.db").exists(), (
+                "a launch with no marks opened the agent runs DB -- the bridge "
+                "was constructed after all"
+            )
+            assert "deferred_launch_wake" not in task_names, (
+                f"a launch with no marks scheduled the wake task: {task_names}"
+            )
+    finally:
+        type(app)._create_deferred_startup_task = real_create
+
+
+@pytest.mark.asyncio
+async def test_the_startup_cost_pin_is_not_vacuous(tmp_path):
+    """The control for the pin above: with a mark present, every one of its
+    four observations flips. Without this, a launch hook that never ran at
+    all would satisfy the pin perfectly."""
+    conversation_id, _run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    app, _marks, gateway = _launch_app(
+        tmp_path, tree=_fixture_tree(conversation_id, rows)
+    )
+    task_names: list[str] = []
+    real_create = type(app)._create_deferred_startup_task
+
+    def recording_create(self, coroutine, *, name):
+        task_names.append(name)
+        return real_create(self, coroutine, name=name)
+
+    type(app)._create_deferred_startup_task = recording_create
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _settle(pilot, lambda: bool(gateway.payloads))
+            runtime = app.console_runtime
+            assert runtime.chat_store is not None
+            assert runtime.provider_gateway is not None
+            assert runtime.agent_bridge is not None
+            assert runtime.chat_controller is not None
+            assert (tmp_path / "agent_runs.db").exists()
+            assert "deferred_launch_wake" in task_names, task_names
+    finally:
+        type(app)._create_deferred_startup_task = real_create
+
+
+# ---------------------------------------------------------------------------
+# AC#3's phantom-wake case, at the launch fire point.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_crash_killed_child_swept_to_error_wakes_nobody_at_launch(tmp_path):
+    """A child left `running` by a crash is swept to `error` by the next
+    `AgentRunsDB.__init__`, which makes it terminal, undelivered and
+    therefore OWED by the ledger's own definition -- and it carries no
+    mark, because nothing ever settled it through the fan-out.
+
+    Seeding from the ledger alone would manufacture a wake here. The claim
+    is marks-indexed, so nothing fires. The assertion that stops this
+    passing for the wrong reason: `undelivered_wake_runs` genuinely DOES
+    report the orphan, so the silence is the mark gate's doing, not an
+    empty ledger.
+    """
+    app0 = _build_test_app("library")
+    _attach_real_dbs(app0, tmp_path)
+    app0.chachanotes_db.add_conversation({"id": "conv-crashed", "title": "Crashed"})
+    runs_db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="seed")
+    parent_id = runs_db.create_run(conversation_id="conv-crashed", agent_kind="primary")
+    runs_db.set_status(parent_id, "done", "turn final")
+    child_id = runs_db.create_run(
+        conversation_id="conv-crashed",
+        agent_kind="subagent",
+        task="killed mid-flight",
+        parent_run_id=parent_id,
+    )
+    runs_db.close()
+    # The restart sweep: a fresh AgentRunsDB over the same file, with the
+    # per-process guard discarded the way Tests/DB/test_agent_runs_db.py
+    # models a restart.
+    AgentRunsDB._swept_paths.discard(str(tmp_path / "agent_runs.db"))
+    swept = AgentRunsDB(tmp_path / "agent_runs.db", client_id="sweep")
+    assert (swept.get_run(child_id) or {}).get("status") == "error", (
+        "harness precondition: the reconcile sweep must have marked the "
+        "crash-killed child as error"
+    )
+    assert [row["id"] for row in swept.undelivered_wake_runs("conv-crashed")] == [
+        child_id
+    ], (
+        "harness precondition: the ledger must consider this orphan OWED -- "
+        "otherwise the silence below proves nothing about the mark gate"
+    )
+    swept.close()
+
+    app, marks, gateway = _launch_app(tmp_path)
+    assert marks.list_marked_conversation_ids(FLEET_UNSEEN) == (), (
+        "harness precondition: a crash-killed child leaves no ◈ mark"
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _quiet(pilot, lambda: bool(gateway.payloads), seconds=5.0), (
+            "a crash-killed child with no ◈ mark woke the supervisor at "
+            f"launch -- a phantom wake: {gateway.payloads!r}"
+        )
+        _assert_console_never_mounted(app)
+        assert app.console_runtime.chat_controller is None, (
+            "an unmarked owed row still built the whole Console runtime at "
+            "launch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The kill switch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_silences_the_launch_fire_point_and_loses_nothing(
+    tmp_path, monkeypatch
+):
+    """`autowake_enabled = false` seeds nothing at launch and loses nothing
+    durable: the ◈ mark and the owed ledger row are both still there
+    afterwards -- and a later launch with the switch back ON delivers
+    exactly what OFF recorded."""
+    conversation_id, run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    tree = _fixture_tree(conversation_id, rows)
+
+    monkeypatch.setenv("TLDW_AGENTS_AUTOWAKE_ENABLED", "false")
+    app_off, marks_off, gateway_off = _launch_app(tmp_path, tree=tree)
+    async with app_off.run_test(size=(120, 40)) as pilot:
+        assert await _quiet(pilot, lambda: bool(gateway_off.payloads), seconds=5.0), (
+            "the kill switch is OFF and a launch still woke the supervisor: "
+            f"{gateway_off.payloads!r}"
+        )
+        assert app_off.console_runtime.chat_controller is None, (
+            "the kill switch is OFF and the launch still built the runtime"
+        )
+    assert marks_off.has_mark(conversation_id, FLEET_UNSEEN), (
+        "the kill switch lost the ◈ mark"
+    )
+    off_runs = AgentRunsDB(tmp_path / "agent_runs.db", client_id="check")
+    assert not (off_runs.get_run(run_id) or {}).get("wake_delivered_at"), (
+        "the kill switch stamped the ledger for a wake it never delivered"
+    )
+    off_runs.close()
+
+    monkeypatch.setenv("TLDW_AGENTS_AUTOWAKE_ENABLED", "true")
+    app_on, _marks_on, gateway_on = _launch_app(tmp_path, tree=tree)
+    async with app_on.run_test(size=(120, 40)) as pilot:
+        assert await _settle(pilot, lambda: bool(gateway_on.payloads)), (
+            "flipping the kill switch back on did not deliver the wake that "
+            "OFF recorded"
+        )
+        assert CHILD_RESULT in str(gateway_on.payloads[-1][-1]["content"])
+
+
+# ---------------------------------------------------------------------------
+# Stale / unresolvable marks.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_ephemeral_mark_is_cleared_at_launch(tmp_path):
+    """A fleet turn in an UNSAVED session is keyed by the ephemeral
+    `session.id` (`_agent_conversation_id` returns
+    `persisted_conversation_id or session_id`), so its ◈ mark names no
+    ChaChaNotes conversation once that process is gone. Executed in
+    `Tests/UI/test_probe_launch_wake.py`: the mark survives the restart and
+    resolves to nothing, forever.
+
+    A launch that owes that conversation a wake it can never deliver clears
+    the mark instead of retrying it every boot for the life of the install.
+    The owed ledger rows are deliberately untouched -- with the mark gone,
+    nothing indexes them, so nothing re-announces them.
+    """
+    app0 = _build_test_app("library")
+    marks0 = _attach_real_dbs(app0, tmp_path)
+    ephemeral_id = "console-session-9f3ac1"
+    runs_db = AgentRunsDB(tmp_path / "agent_runs.db", client_id="seed")
+    _parent, run_id = _terminal_subagent_run(
+        runs_db, ephemeral_id, result="work nobody can be shown"
+    )
+    runs_db.close()
+    marks0.set_mark(ephemeral_id, FLEET_UNSEEN)
+    assert app0.chachanotes_db.get_conversation_by_id(ephemeral_id) is None, (
+        "harness precondition: an ephemeral session id names no conversation"
+    )
+
+    app, marks, gateway = _launch_app(tmp_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _settle(
+            pilot, lambda: not marks.has_mark(ephemeral_id, FLEET_UNSEEN)
+        ), (
+            "a ◈ mark that can never be resolved again survived the launch -- "
+            "it will be retried on every boot for the life of the install"
+        )
+        assert await _quiet(pilot, lambda: bool(gateway.payloads), seconds=2.0), (
+            "the launch tried to deliver into a conversation that does not "
+            f"exist: {gateway.payloads!r}"
+        )
+    check = AgentRunsDB(tmp_path / "agent_runs.db", client_id="check")
+    assert not (check.get_run(run_id) or {}).get("wake_delivered_at"), (
+        "clearing an unresolvable mark must not stamp the ledger -- the "
+        "result was never delivered to anyone"
+    )
+    check.close()
+
+
+@pytest.mark.asyncio
+async def test_a_mark_with_nothing_owed_is_left_alone_at_launch(tmp_path):
+    """A ◈ mark with no owed ledger row is NOT stale: it is the
+    delivered-but-unseen badge the wake sets when it delivers off-view
+    (task-15971). A launch must not deliver anything for it, and must not
+    clear it -- the user has still not seen that result."""
+    app0 = _build_test_app("library")
+    marks0 = _attach_real_dbs(app0, tmp_path)
+    app0.chachanotes_db.add_conversation({"id": "conv-seen-later", "title": "Delivered"})
+    marks0.set_mark("conv-seen-later", FLEET_UNSEEN)
+
+    app, marks, gateway = _launch_app(tmp_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _quiet(pilot, lambda: bool(gateway.payloads), seconds=4.0), (
+            f"a launch delivered a wake for a conversation owing none: {gateway.payloads!r}"
+        )
+        assert marks.has_mark("conv-seen-later", FLEET_UNSEEN), (
+            "the launch cleared a delivered-but-unseen ◈ badge -- the user "
+            "loses the only pointer they had to a result they never saw"
+        )

--- a/Tests/UI/test_probe_launch_wake.py
+++ b/Tests/UI/test_probe_launch_wake.py
@@ -64,6 +64,43 @@ async def test_probe_p1_deferred_startup_runs_and_console_is_absent(tmp_path):
     assert reached, "the app never reached _schedule_deferred_startup_work"
 
 
+@pytest.mark.asyncio
+async def test_probe_p4_the_real_conversation_service_can_be_wired_after_the_db(
+    tmp_path,
+):
+    """Can a launch test use the PRODUCTION tree loader instead of a double?
+
+    `_build_test_app` patches `get_chachanotes_db_lazy` to None, so
+    `_wire_chat_conversation_services` runs at `__init__` with no DB and
+    leaves `local_chat_conversation_service` None -- which is why every
+    resume test in the suite injects a `StaticConversationTreeService`.
+    Re-running the wiring after `_attach_real_dbs` should give the real one.
+    """
+    from tldw_chatbook.Chat.console_conversation_hydration import (
+        load_console_conversation_tree,
+    )
+
+    app = _build_test_app("library")
+    _attach_real_dbs(app, tmp_path)
+    print(f"\nPROBE P4 before rewire: {app.local_chat_conversation_service!r}")
+    app._wire_chat_conversation_services()
+    print(f"PROBE P4 after rewire: {app.local_chat_conversation_service!r}")
+    app.chachanotes_db.add_conversation({"id": "conv-real", "title": "Real"})
+    app.chachanotes_db.add_message(
+        {
+            "id": "msg-real",
+            "conversation_id": "conv-real",
+            "sender": "user",
+            "content": "a real persisted message",
+        }
+    )
+    tree = await load_console_conversation_tree(app, "conv-real")
+    print(f"PROBE P4 tree keys: {sorted(tree) if tree else tree!r}")
+    if tree:
+        print(f"PROBE P4 root_threads: {tree.get('root_threads')!r}")
+    assert tree is not None, "the real service could not load a real conversation"
+
+
 def test_probe_p3a_an_unsaved_session_is_keyed_by_its_own_session_id(tmp_path):
     """The PRODUCTION source of an unresolvable mark, executed.
 

--- a/Tests/UI/test_probe_launch_wake.py
+++ b/Tests/UI/test_probe_launch_wake.py
@@ -1,0 +1,86 @@
+"""PROBE (task-15860 Task 6, throwaway): what a launch actually runs.
+
+Three questions, each answered by execution rather than by reading:
+
+P1. Does a `_build_test_app()` under `app.run_test()` actually reach
+    `_post_mount_setup` -> `_schedule_deferred_startup_work`? That is the
+    only place a launch-time hook could live.
+P2. With Console never opened, what does the app hold: is there a
+    controller, a bridge, a wake coordinator?
+P3. Is the ephemeral/stale mark leak real -- does a completion in an
+    UNSAVED (ephemeral) session write a durable FLEET_UNSEEN mark whose
+    conversation id names nothing after a restart?
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from tldw_chatbook.Chat.conversation_local_marks_service import (
+    ConversationLocalMarksService,
+)
+
+
+async def _settle(pilot, predicate, seconds: float = 8.0) -> bool:
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await pilot.pause(0.05)
+    return bool(predicate())
+
+
+@pytest.mark.asyncio
+async def test_probe_p1_deferred_startup_runs_and_console_is_absent(tmp_path):
+    app = _build_test_app("library")
+    _attach_real_dbs(app, tmp_path)
+    _configure_native_ready_console(app)
+    seen: list[str] = []
+    real = type(app)._schedule_deferred_startup_work
+
+    def recording(self):
+        seen.append("deferred")
+        return real(self)
+
+    type(app)._schedule_deferred_startup_work = recording
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            reached = await _settle(pilot, lambda: bool(seen), seconds=15.0)
+            print(f"\nPROBE P1 deferred-startup reached: {reached}")
+            print(f"PROBE P1 screen stack: {[type(s).__name__ for s in app.screen_stack]}")
+            runtime = app.console_runtime
+            print(f"PROBE P2 runtime: {runtime!r}")
+            print(f"PROBE P2 chat_controller: {runtime.chat_controller!r}")
+            print(f"PROBE P2 chat_store: {runtime.chat_store!r}")
+            print(f"PROBE P2 agent_bridge: {runtime.agent_bridge!r}")
+            print(f"PROBE P2 ui_ready: {getattr(app, '_ui_ready', None)}")
+    finally:
+        type(app)._schedule_deferred_startup_work = real
+    assert reached, "the app never reached _schedule_deferred_startup_work"
+
+
+@pytest.mark.asyncio
+async def test_probe_p3_ephemeral_conversation_id_leaks_a_permanent_mark(tmp_path):
+    """The stale-mark shape: mark an id that names no ChaChaNotes row (an
+    ephemeral session id is exactly that), then 'restart' over the same DB
+    and see whether anything can resolve it."""
+    app = _build_test_app("library")
+    marks = _attach_real_dbs(app, tmp_path)
+    ephemeral_id = "console-session-abc123"
+    marks.set_mark(ephemeral_id, ConversationLocalMarksService.FLEET_UNSEEN)
+
+    # "restart": a second app over the SAME on-disk DB.
+    app2 = _build_test_app("library")
+    marks2 = _attach_real_dbs(app2, tmp_path)
+    listed = marks2.list_marked_conversation_ids(
+        ConversationLocalMarksService.FLEET_UNSEEN
+    )
+    row = app2.chachanotes_db.get_conversation_by_id(ephemeral_id)
+    print(f"\nPROBE P3 marks after restart: {listed}")
+    print(f"PROBE P3 ChaChaNotes row for that id: {row!r}")
+    assert ephemeral_id in listed

--- a/Tests/UI/test_probe_launch_wake.py
+++ b/Tests/UI/test_probe_launch_wake.py
@@ -64,6 +64,36 @@ async def test_probe_p1_deferred_startup_runs_and_console_is_absent(tmp_path):
     assert reached, "the app never reached _schedule_deferred_startup_work"
 
 
+def test_probe_p3a_an_unsaved_session_is_keyed_by_its_own_session_id(tmp_path):
+    """The PRODUCTION source of an unresolvable mark, executed.
+
+    `ConsoleChatController._agent_conversation_id` is what the agent bridge
+    (and therefore the fleet drain, and therefore the mark writer) keys a
+    conversation by. For an UNSAVED session it returns the ephemeral
+    `session.id`, which names no ChaChaNotes conversation.
+    """
+    from Tests.Chat.test_console_fleet_wake import _controller_rig
+
+    chacha, _app, runs_db, _store, session, _gw, _bridge, controller = _controller_rig(
+        tmp_path
+    )
+    try:
+        keyed = controller._agent_conversation_id(session.id)
+        print(f"\nPROBE P3a session.persisted_conversation_id: "
+              f"{session.persisted_conversation_id!r}")
+        print(f"PROBE P3a keyed conversation id: {keyed!r}")
+        print(
+            "PROBE P3a ChaChaNotes row for that id: "
+            f"{chacha.get_conversation_by_id(keyed)!r}"
+        )
+        assert session.persisted_conversation_id is None
+        assert keyed == session.id
+        assert chacha.get_conversation_by_id(keyed) is None
+    finally:
+        runs_db.close()
+        chacha.close_connection()
+
+
 @pytest.mark.asyncio
 async def test_probe_p3_ephemeral_conversation_id_leaks_a_permanent_mark(tmp_path):
     """The stale-mark shape: mark an id that names no ChaChaNotes row (an

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4764,3 +4764,44 @@ demonstrated. Rule: when new-code symbols would make a born-red file
 unimportable at base, reference them lazily (or split the white-box asserts
 out) so the base-tree run fails on the assertion that carries the evidence,
 not on `import`.
+
+## A guard sitting behind an earlier early-return is unreachable, so no fixture can own it (task-15860, 2026-08-16)
+
+Third mutation-survivor in this arc, and a different shape from the two
+above (which were two guards in SERIES at one read site). The launch-wake
+loop skips a marked conversation that owes nothing —
+`if not wake.has_pending(cid): continue` — and mutating that line to
+`if False:` left the whole suite **green**. Investigating rather than
+patching around it: every test that exercised an unowed mark used exactly
+ONE mark, and with one unowed mark the function returns earlier, at
+`if not wake.seed_from_marks(): return 0`, before the loop runs at all.
+The guard was not weakly tested, it was *unreachable* for every fixture in
+the file, so no assertion anywhere could have distinguished "we checked
+each conversation" from "we never got that far". The repair is a fixture
+change, not an assertion change: a test with TWO marks, one owed and one
+not, gets past the earlier return and then asserts the unowed conversation
+was never hydrated. Under the same mutation it now dies alone (1 failed,
+8 passed). Rule: when a mutation survives, before touching assertions ask
+whether the mutated line *executes* under any fixture you have — an
+earlier `return` upstream of it is the commonest reason it does not, and
+it is invisible in the diff you are mutating.
+
+## A "constructs nothing" pin needs an observer the production code cannot lie to (task-15860, 2026-08-16)
+
+The owner's ruling on wake-at-launch required that an install with no
+background work pay one indexed read and build NOTHING, so startup stays
+byte-identical. "Nothing was constructed" is exactly the claim a weak test
+states and never checks, so the pin took four independent observations:
+the marks service's call list, the four `ConsoleRuntime` slots being
+`None`, no `deferred_launch_wake` task ever created — and **the absence of
+the `agent_runs.db` FILE on disk**, because constructing the agent bridge
+opens (and creates) it. The filesystem one is the observation that cannot
+be satisfied by a mock, a stub or a lazily-`None` attribute. It earned its
+place under mutation: removing both empty-marks guards was caught by the
+call-count and by a sibling test's runtime assertion, and removing only
+the outer guard was caught *solely* by the task-name observation — the
+`None` slots stayed `None` because the inner function had its own guard.
+Two guards in depth meant no single observation covered both mutations;
+the four together did. Corollary: a no-work pin also needs a control that
+runs the same probes WITH work present and watches every one flip,
+otherwise a hook that never runs at all satisfies it perfectly.

--- a/tldw_chatbook/Chat/console_conversation_hydration.py
+++ b/tldw_chatbook/Chat/console_conversation_hydration.py
@@ -1,0 +1,435 @@
+"""Turning a persisted conversation into a Console session, with no view.
+
+task-15860 Task 6 (wake at launch). A wake delivered at process start has
+to run in a **session** for a conversation nobody has opened -- and until
+this module existed, the only code that could build one lived on
+`ChatScreen`: `_resume_console_workspace_conversation`
+(`UI/Console_Modules/workspace.py`) interleaved the session-producing
+policy with a screen's own work (composer snapshot, toasts, resume-marker
+overlay, retrieval-scope warm, transcript repaint, focus).
+
+This module is the **session-producing half, moved verbatim** so the two
+callers share one policy instead of two:
+
+| Caller | View work it keeps |
+|---|---|
+| `ChatScreen._resume_console_workspace_conversation` | draft snapshot, both failure toasts, resume-marker overlay, character-name/label resolution, scope warm, UI sync, focus |
+| the launch wake (`console_launch_wake.py`) | none -- it has no view |
+
+**What is deliberately NOT here.** The screen's base settings come from
+the currently active session (`_console_session_settings_for_resume` ->
+`_active_console_session_settings`); a launch has no active session, so it
+uses the config defaults the screen falls back to
+(`default_console_session_settings`). That difference is inherent to
+having no view, and the part that a *conversation* contributes -- its
+saved system prompt and pinned prefill -- IS shared, through
+`apply_resume_settings_overrides`.
+
+Nothing here touches the DOM, `app.notify`, or any screen attribute; the
+only app members read are `chat_conversation_scope_service` and
+`chachanotes_db`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import replace
+from typing import Any, Mapping, Sequence
+
+from loguru import logger
+
+from tldw_chatbook.Chat.console_chat_models import (
+    CONSOLE_GLOBAL_WORKSPACE_ID,
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+    MessageAttachment,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_prefill import (
+    pinned_prefill_from_conversation_metadata,
+)
+from tldw_chatbook.Chat.console_roleplay_metadata import (
+    parse_console_roleplay_context,
+)
+from tldw_chatbook.Chat.message_metadata import MessageMetadata
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.Video_Generation.video_metadata import VideoGenerationMetadata
+
+__all__ = [
+    "ConversationLoadFailed",
+    "ConversationServiceUnavailable",
+    "apply_resume_settings_overrides",
+    "console_messages_from_conversation_tree",
+    "hydrate_console_session",
+    "load_console_conversation_tree",
+]
+
+class ConversationServiceUnavailable(RuntimeError):
+    """The app has no conversation service that can load a tree."""
+
+
+class ConversationLoadFailed(RuntimeError):
+    """The conversation service raised while loading the tree."""
+
+
+def _console_message_role_from_persisted(
+    message: Mapping[str, Any],
+) -> ConsoleMessageRole:
+    """Return a native Console role for a persisted Chat message row."""
+    raw_role = str(message.get("role") or "").strip().lower()
+    if raw_role:
+        try:
+            return ConsoleMessageRole(raw_role)
+        except ValueError:
+            pass
+    sender = str(message.get("sender") or "").strip().lower()
+    if sender in {"user", "system", "tool"}:
+        return ConsoleMessageRole(sender)
+    return ConsoleMessageRole.ASSISTANT
+
+
+def _batch_fetch_resume_attachments(
+    db: Any, messages: Sequence[ConsoleChatMessage]
+) -> None:
+    """Fill positions >= 1 for resumed multi-attachment messages, once.
+
+    ``get_conversation_tree`` only returns the legacy image columns
+    (position 0); the ``message_attachments`` table (positions >= 1) is
+    fetched here in a SINGLE batched call covering every message this
+    resume produced, then folded into each message's attachments tuple via
+    ``_apply_console_message_attachments`` (see that helper for the store
+    mirror invariant it replicates by hand).
+    """
+    from tldw_chatbook.UI.Console_Modules.message import (
+        _apply_console_message_attachments,
+    )
+
+    ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
+    if not ids:
+        return
+    getter = getattr(db, "get_attachments_for_messages", None)
+    if not callable(getter):
+        return
+    try:
+        rows_by_id = getter(ids)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Console resume attachment batch fetch failed."
+        )
+        return
+    if not isinstance(rows_by_id, dict):
+        return
+    for message in messages:
+        extra_rows = (
+            rows_by_id.get(message.persisted_message_id)
+            if message.persisted_message_id
+            else None
+        )
+        if not extra_rows:
+            continue
+        extras = [
+            MessageAttachment(
+                data=row.get("data"),
+                mime_type=row.get("mime_type") or "",
+                display_name=row.get("display_name") or "",
+                position=int(row.get("position", 0)),
+            )
+            for row in extra_rows
+        ]
+        _apply_console_message_attachments(message, list(message.attachments) + extras)
+
+
+def console_messages_from_conversation_tree(
+    tree: Mapping[str, Any], *, db: Any = None
+) -> list[ConsoleChatMessage]:
+    """Build native Console messages from a persisted conversation tree.
+
+    Task 8: flattens the ENTIRE tree (every node, all branches -- not just
+    the ``children[-1]`` latest branch), each message carrying its
+    ``persisted_message_id`` and persisted ``parent_message_id`` so the
+    store can reconnect the full tree and pick the active branch from the
+    stored active-leaf pointer.
+
+    Parenthood is taken from the tree's own NESTING (the id of the node we
+    recursed from), not the row's ``parent_message_id`` field: the real DB
+    tree sets both consistently, but a node's structural position is the
+    authoritative source and stays correct even for trees whose rows omit
+    the field. A truly-empty node (no content and no image) is dropped but
+    transparent to parenthood -- its children re-parent to the nearest kept
+    ancestor -- so a skipped row never orphans a branch.
+
+    Args:
+        tree: The persisted conversation tree.
+        db: The ChaChaNotes DB used for the one batched attachment fetch
+            (positions >= 1). ``None`` skips it, exactly as a DB without
+            ``get_attachments_for_messages`` does.
+
+    Returns:
+        Every node of the tree, pre-order, as Console messages.
+    """
+    messages: list[ConsoleChatMessage] = []
+
+    def _walk(node: Any, parent_persisted_id: str | None) -> None:
+        if not isinstance(node, dict):
+            return
+        content = str(node.get("content") or "")
+        raw_image = node.get("image_data")
+        image_data = (
+            bytes(raw_image) if isinstance(raw_image, (bytes, bytearray)) else None
+        )
+        raw_mime = node.get("image_mime_type")
+        image_mime_type = str(raw_mime) if raw_mime else None
+        usage = ProviderUsage.from_json(node.get("usage_json"))
+        raw_metadata_json = node.get("metadata_json")
+        # task-3401.4: a video generation row's metadata_json carries the
+        # namespaced video payload instead of turn provenance -- hydrate
+        # it into video_metadata and leave ``metadata`` None (the two
+        # shapes never co-write one row; persistence prefers the video
+        # payload so a later edit cannot clobber it).
+        video_metadata = VideoGenerationMetadata.from_json(raw_metadata_json)
+        metadata = (
+            None
+            if video_metadata is not None
+            else MessageMetadata.from_json(raw_metadata_json)
+        )
+        raw_id = node.get("id")
+        node_persisted_id = str(raw_id) if raw_id is not None else None
+        kept = bool(content) or image_data is not None
+        if kept:
+            # The tree only carries the legacy position-0 columns; positions
+            # >= 1 (multi-attachment table rows) are batch-fetched below,
+            # once for the whole resumed list.
+            attachments: tuple[MessageAttachment, ...] = (
+                (
+                    MessageAttachment(
+                        data=image_data,
+                        mime_type=image_mime_type or "",
+                        display_name="",
+                        position=0,
+                    ),
+                )
+                if image_data is not None
+                else ()
+            )
+            messages.append(
+                ConsoleChatMessage(
+                    role=_console_message_role_from_persisted(node),
+                    content=content,
+                    status="complete",
+                    persisted_message_id=node_persisted_id,
+                    parent_message_id=parent_persisted_id,
+                    image_data=image_data,
+                    image_mime_type=image_mime_type,
+                    attachments=attachments,
+                    usage=usage,
+                    metadata=metadata,
+                    video_metadata=video_metadata,
+                )
+            )
+        # Children re-parent to this node when kept, else pass the nearest
+        # kept ancestor straight through (a dropped empty row is invisible
+        # to the tree linkage).
+        child_parent_id = node_persisted_id if kept else parent_persisted_id
+        children = node.get("children")
+        if isinstance(children, list):
+            for child in children:
+                _walk(child, child_parent_id)
+
+    root_threads = tree.get("root_threads")
+    if isinstance(root_threads, list):
+        for root in root_threads:
+            _walk(root, None)
+    _batch_fetch_resume_attachments(db, messages)
+    return messages
+
+
+async def load_console_conversation_tree(
+    app: Any, conversation_id: str
+) -> Mapping[str, Any] | None:
+    """Load one persisted conversation's WHOLE tree.
+
+    The depth/root caps are policy, not tuning: the service defaults (50)
+    truncate a long or branchy conversation, and a truncated tree produces
+    a wrong provider payload for whoever sends next. Raising them here
+    once is what keeps the screen resume and the launch wake honest about
+    the same conversation.
+
+    Args:
+        app: The app object; read for ``chat_conversation_scope_service``.
+        conversation_id: The durable conversation id.
+
+    Returns:
+        The tree, or ``None`` when the conversation record is MISSING (the
+        caller owns that failure's UX).
+
+    Raises:
+        ConversationServiceUnavailable: No conversation service is wired.
+        ConversationLoadFailed: The service raised.
+    """
+    service = getattr(app, "chat_conversation_scope_service", None)
+    get_conversation_tree = getattr(service, "get_conversation_tree", None)
+    if not callable(get_conversation_tree):
+        raise ConversationServiceUnavailable(
+            "Saved conversation resume is unavailable in this build."
+        )
+    try:
+        # Task 8: raise the depth/root caps well past the service defaults
+        # (50) so a long or branchy conversation's full tree -- every
+        # branch, not just the latest -- is loaded intact, not truncated.
+        maybe_tree = get_conversation_tree(
+            conversation_id, mode="local", depth_cap=10_000, root_limit=10_000
+        )
+        tree = await maybe_tree if inspect.isawaitable(maybe_tree) else maybe_tree
+    except Exception as exc:  # noqa: BLE001 -- re-raised as this module's type
+        raise ConversationLoadFailed(str(conversation_id)) from exc
+    if not isinstance(tree, dict) or not tree.get("conversation"):
+        return None
+    return tree
+
+
+def apply_resume_settings_overrides(
+    settings: ConsoleSessionSettings, conversation: Mapping[str, Any]
+) -> ConsoleSessionSettings:
+    """Overlay what the CONVERSATION ROW contributes to a resumed session.
+
+    Only ``system_prompt`` and ``pinned_prefill`` come from the persisted
+    conversation; every other field is inherited from whatever base the
+    caller supplied (the screen: the active session's settings; a launch:
+    the config defaults). A saved system prompt is never seeded from
+    ``[chat_defaults]``, which is why it has to travel this way.
+
+    Blank/whitespace-only prompt text collapses to "no system prompt";
+    anything else is restored verbatim (leading/trailing whitespace and
+    internal formatting included) rather than stripped, so a
+    formatting-sensitive prompt survives close/resume unchanged.
+
+    Args:
+        settings: The base settings snapshot.
+        conversation: The persisted conversation row.
+
+    Returns:
+        The same settings with the conversation's two contributions applied.
+    """
+    raw_system_prompt = conversation.get("system_prompt")
+    system_prompt = (
+        raw_system_prompt
+        if isinstance(raw_system_prompt, str) and raw_system_prompt.strip()
+        else None
+    )
+    pinned_prefill = pinned_prefill_from_conversation_metadata(
+        conversation.get("metadata")
+    )
+    return replace(settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill)
+
+
+def hydrate_console_session(
+    *,
+    app: Any,
+    store: Any,
+    conversation_id: str,
+    tree: Mapping[str, Any],
+    settings: ConsoleSessionSettings | None,
+    target_scope_type: str | None = None,
+    target_workspace_id: str | None = None,
+) -> Any:
+    """Create and activate a Console session from a persisted tree.
+
+    Moved verbatim out of `_resume_console_workspace_conversation`: the
+    workspace resolution, the title fallback, the whole-tree node build,
+    the durable active-leaf pointer, the runtime-backend/assistant/character
+    field discipline, the `restore_persisted_session` call and the roleplay
+    overlay. The screen's own work (marker overlay, character name, scope
+    warm, repaint) stays in the screen.
+
+    Args:
+        app: The app object; read for ``chachanotes_db`` only.
+        store: The Console chat store the session is created in.
+        conversation_id: The durable conversation id being resumed.
+        tree: The tree from `load_console_conversation_tree`.
+        settings: The settings snapshot for the new session.
+        target_scope_type: ``"global"`` pins the global workspace.
+        target_workspace_id: Requested workspace, used only when the
+            conversation carries none.
+
+    Returns:
+        The newly created and ACTIVATED `ConsoleChatSession`.
+    """
+    target = str(conversation_id or "").strip()
+    conversation = tree.get("conversation")
+    if not isinstance(conversation, dict):
+        conversation = {}
+    active_workspace_id = str(
+        store.workspace_context.active_workspace_id or ""
+    ).strip()
+    persisted_workspace_id = (
+        str(conversation.get("workspace_id")).strip()
+        if conversation.get("workspace_id") is not None
+        else ""
+    )
+    target_scope = str(target_scope_type or "").strip()
+    requested_workspace_id = (
+        str(target_workspace_id).strip() if target_workspace_id is not None else ""
+    )
+    if target_scope == "global":
+        workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
+    else:
+        workspace_id = (
+            persisted_workspace_id
+            or requested_workspace_id
+            or active_workspace_id
+            or None
+        )
+    title = str(conversation.get("title") or "Saved conversation").strip()
+    if not title:
+        title = "Saved conversation"
+    # Task 8: load the WHOLE persisted tree (every branch), then reconstruct
+    # the active branch from the stored active-leaf pointer. Loading all
+    # branches (not just the latest) is what makes off-path siblings
+    # navigable (swipe) right after resume.
+    db = getattr(app, "chachanotes_db", None)
+    all_nodes = console_messages_from_conversation_tree(tree, db=db)
+    active_leaf_id = getattr(db, "get_conversation_active_leaf", lambda _c: None)(target)
+    raw_runtime_backend = conversation.get("runtime_backend")
+    if type(raw_runtime_backend) is str:
+        runtime_backend = raw_runtime_backend
+    else:
+        runtime_backend = ""
+    raw_assistant_kind = conversation.get("assistant_kind")
+    assistant_kind = raw_assistant_kind if type(raw_assistant_kind) is str else None
+    raw_assistant_id = conversation.get("assistant_id")
+    assistant_id = raw_assistant_id if type(raw_assistant_id) is str else None
+    raw_assistant_authority_id = conversation.get("assistant_authority_id")
+    assistant_authority_id = (
+        raw_assistant_authority_id
+        if type(raw_assistant_authority_id) is str
+        else None
+    )
+    raw_character_id = conversation.get("character_id")
+    character_id = (
+        raw_character_id
+        if (
+            runtime_backend == "local"
+            and assistant_kind == "character"
+            and type(raw_character_id) is int
+            and raw_character_id > 0
+            and assistant_id == str(raw_character_id)
+        )
+        else None
+    )
+    session = store.restore_persisted_session(
+        title=title,
+        workspace_id=workspace_id,
+        persisted_conversation_id=target,
+        all_nodes=all_nodes,
+        active_leaf_persisted_id=active_leaf_id,
+        settings=settings,
+        runtime_backend=runtime_backend,
+        assistant_kind=assistant_kind,
+        assistant_id=assistant_id,
+        assistant_authority_id=assistant_authority_id,
+        character_id=character_id,
+    )
+    roleplay_context = parse_console_roleplay_context(conversation.get("metadata"))
+    session.user_display_name_override = roleplay_context.user_name_override
+    session.character_system_template = roleplay_context.character_system_template
+    return session

--- a/tldw_chatbook/Chat/console_launch_wake.py
+++ b/tldw_chatbook/Chat/console_launch_wake.py
@@ -191,12 +191,22 @@ def _ensure_launch_runtime(app: Any) -> Any:
     """
     runtime = ensure_console_runtime(app)
     app_config = getattr(app, "app_config", {}) or {}
-    console_config = app_config.get("console", {})
-    if not isinstance(console_config, dict):
-        console_config = {}
 
     def _gate(name: str) -> bool:
-        value = console_config.get(name, True)
+        """One `[console]` boolean gate, read FRESH.
+
+        Re-reads `app.app_config` per call rather than closing over a
+        snapshot: `native_tools_enabled` is stored by the bridge and called
+        much later, and `ChatScreen`'s own factory
+        (`_console_native_tool_calls_enabled`) re-reads too. A launch-built
+        bridge that never sees a Console mount would otherwise hold the
+        boot-time answer for the whole run.
+        """
+        config = getattr(app, "app_config", {}) or {}
+        section = config.get("console", {})
+        if not isinstance(section, dict):
+            section = {}
+        value = section.get(name, True)
         return bool(value) if isinstance(value, (bool, int)) else True
 
     store = runtime.ensure_chat_store()

--- a/tldw_chatbook/Chat/console_launch_wake.py
+++ b/tldw_chatbook/Chat/console_launch_wake.py
@@ -166,8 +166,8 @@ def _conversation_exists_locally(app: Any, conversation_id: str) -> bool:
         return True
 
 
-def _build_viewless_runtime(app: Any) -> Any:
-    """Build the Console runtime objects a launch delivery needs, viewless.
+def _ensure_launch_runtime(app: Any) -> Any:
+    """Return the Console controller a launch delivery needs, building it.
 
     Mirrors `ChatScreen`'s own `_ensure_console_*` chain with the screen
     removed. The constructor arguments that a mounted Console derives from
@@ -179,6 +179,10 @@ def _build_viewless_runtime(app: Any) -> Any:
     (`_provider_selection_for_session`), not from these fields. The first
     real Console mount re-applies the whole selection through
     `_sync_console_chat_core_state`, so nothing here is sticky.
+
+    Every `ensure_*` is idempotent, so when Console IS the startup tab this
+    returns the screen's own, fully-wired controller and every argument
+    below is ignored — which is why the function is not named "viewless".
 
     Returns:
         The `ConsoleChatController`, or `None` when there is no durable
@@ -273,7 +277,7 @@ async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
     """
     if not marked:
         return 0
-    controller = _build_viewless_runtime(app)
+    controller = _ensure_launch_runtime(app)
     if controller is None:
         return 0
     wake = getattr(controller, "fleet_wake", None)

--- a/tldw_chatbook/Chat/console_launch_wake.py
+++ b/tldw_chatbook/Chat/console_launch_wake.py
@@ -226,6 +226,31 @@ def _build_viewless_runtime(app: Any) -> Any:
     return controller
 
 
+def _restore_active_session(store: Any, session_id: str | None) -> None:
+    """Put the active tab back where hydration found it.
+
+    A launch with Console as the startup tab already has an active session
+    -- the one the user is looking at. Hydrating a marked conversation
+    activates the session it creates, so without this the wake would move
+    the user off their tab while they watched. With nothing open (the
+    headless launch) there is no prior session and the hydrated one stays
+    active, which is the only sensible answer there.
+    """
+    if not session_id or getattr(store, "active_session_id", None) == session_id:
+        return
+    switch = getattr(store, "switch_session", None)
+    if not callable(switch):
+        return
+    try:
+        switch(session_id)
+    except Exception as exc:  # noqa: BLE001 -- a gone session is not an error
+        logger.debug(
+            "launch wake could not restore the prior active session "
+            "(exception_type={})",
+            type(exc).__name__,
+        )
+
+
 async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
     """Hydrate and fire every wake this launch already owed.
 
@@ -263,6 +288,11 @@ async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
         return 0
     store = controller.store
     app_config = getattr(app, "app_config", {}) or {}
+    # `restore_persisted_session` ACTIVATES what it creates, which is right
+    # for a launch with nothing open and wrong for one where Console is the
+    # startup tab: a wake must never move the user off the tab they landed
+    # on. Captured here and restored below.
+    prior_active_session_id = getattr(store, "active_session_id", None)
     hydrated = 0
     for conversation_id in marked:
         if not wake.has_pending(conversation_id):
@@ -311,5 +341,6 @@ async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
             continue
         hydrated += 1
     if hydrated:
+        _restore_active_session(store, prior_active_session_id)
         wake.retry_soon()
     return hydrated

--- a/tldw_chatbook/Chat/console_launch_wake.py
+++ b/tldw_chatbook/Chat/console_launch_wake.py
@@ -1,0 +1,315 @@
+"""Wake at launch: deliver what was already owed when the app starts.
+
+task-15860 Task 6, and the last fire point the arc was missing. The
+wake-fires-headless landing made a survivor settling with **no Console
+mounted** deliver a full supervisor turn — but only inside a process that
+had opened Console at least once, because `ensure_chat_controller` /
+`ensure_agent_bridge` are lazy and their only callers were `ChatScreen`
+and its Console modules. A child that finished while the app was closed —
+or one whose delivery the user quit out from under — waited for the next
+Console visit, however many launches later that was.
+
+**The owner's ruling, which this module implements literally:** wake at
+launch is YES, and it is **mark-gated**. At startup do ONE cheap indexed
+read; deliver only for a conversation that already carries a
+`FLEET_UNSEEN` mark AND an owed `agent_runs` ledger row — i.e. only work
+the user already started that already finished. It stays behind the
+existing `[agents] autowake_enabled`; there is **no** separate
+`autowake_on_launch` switch.
+
+## When there are no marks, this constructs NOTHING
+
+That is the overwhelmingly common case and it is pinned as such
+(`Tests/UI/test_console_launch_wake.py::
+test_a_launch_with_no_marks_constructs_nothing_and_reads_once`): the kill
+switch is read, one indexed `conversation_local_marks` listing runs, and
+the function returns. No `ConsoleChatStore`, no provider gateway, no
+`ConsoleAgentBridge` — so no `agent_runs.db` file is even opened — and no
+`ConsoleChatController`. Startup for a user who never uses the fleet is
+byte-identical to before this module existed.
+
+## Why the claim stays MARKS-indexed
+
+Seeding from the ledger alone manufactures phantom wakes. A crash-killed
+child is swept to `error` by `AgentRunsDB`'s reconcile pass, which makes
+it a terminal, undelivered row — genuinely "owed" by the ledger's own
+definition — but it carries **no mark**, because nothing ever settled it
+through the fan-out. `undelivered_wake_runs` defines *what* is owed; the
+mark defines *which conversations*. Both are needed, and this module asks
+them in that order.
+
+## Hydration, and the stale-mark case it exposes
+
+A launch wake needs a session for a conversation nobody has opened, so
+this module hydrates one through the shared
+`Chat/console_conversation_hydration.py` policy — the same tree load, the
+same whole-tree node build, the same active-leaf pointer and the same
+roleplay overlay `ChatScreen`'s saved-conversation resume uses. Only the
+BASE settings differ, and only because they must: the screen inherits the
+active session's settings and a launch has none, so it starts from the
+config defaults the screen itself falls back to.
+
+Some marked conversations **cannot** be hydrated, ever. A fleet turn in an
+UNSAVED (temporary) session is keyed by the ephemeral `session.id`
+(`ConsoleChatController._agent_conversation_id` returns
+`session.persisted_conversation_id or session_id`), and that id names no
+ChaChaNotes conversation once the process that held the session is gone.
+Executed, not assumed: the mark survives the restart and resolves to
+nothing. Leaving it costs a permanent, undismissable row and a futile
+hydration attempt on every launch for the rest of the install's life, so
+this module CLEARS such a mark — but only when the local DB itself says
+the conversation does not exist, and only for a mark that is otherwise
+owed, i.e. one this module was about to act on.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from loguru import logger
+
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    ConversationLoadFailed,
+    ConversationServiceUnavailable,
+    apply_resume_settings_overrides,
+    hydrate_console_session,
+    load_console_conversation_tree,
+)
+from tldw_chatbook.Chat.console_fleet_attention import clear_fleet_unseen_completion
+from tldw_chatbook.Chat.console_fleet_wake import autowake_enabled
+from tldw_chatbook.Chat.console_runtime import ensure_console_runtime
+from tldw_chatbook.Chat.console_session_settings import (
+    default_console_session_settings,
+)
+
+__all__ = [
+    "LAUNCH_WAKE_TASK_NAME",
+    "deliver_launch_wakes",
+    "marked_conversations_at_launch",
+]
+
+#: The name the app gives the deferred startup task, so a test (and a log
+#: reader) can name it rather than matching on a coroutine repr.
+LAUNCH_WAKE_TASK_NAME = "deferred_launch_wake"
+
+
+def marked_conversations_at_launch(app: Any) -> tuple[str, ...]:
+    """The one cheap indexed read a launch is allowed to pay for.
+
+    Reads the `[agents] autowake_enabled` kill switch FIRST, so an install
+    with auto-wake off pays nothing at all — not even the listing. An
+    empty result must lead the caller to construct nothing; see this
+    module's docstring.
+
+    Args:
+        app: The app object; read for `conversation_local_marks_service`.
+
+    Returns:
+        The conversation ids carrying a durable `FLEET_UNSEEN` mark, or an
+        empty tuple (switch off / no marks service / a failed read — a
+        launch must never die on this).
+    """
+    if not autowake_enabled():
+        return ()
+    service = getattr(app, "conversation_local_marks_service", None)
+    if service is None:
+        return ()
+    try:
+        return tuple(service.list_marked_conversation_ids(service.FLEET_UNSEEN))
+    except Exception as exc:  # noqa: BLE001 -- a launch never dies on a claim
+        logger.warning(
+            "launch wake mark listing failed (exception_type={})",
+            type(exc).__name__,
+        )
+        return ()
+
+
+def _clear_unresolvable_mark(app: Any, conversation_id: str) -> None:
+    """Drop a `FLEET_UNSEEN` mark that can never be resolved again.
+
+    Only reached for a conversation the ledger still owes AND that the
+    local ChaChaNotes DB has no row for — the ephemeral-session shape in
+    this module's docstring. The owed `agent_runs` rows are deliberately
+    left alone: they are stamped by delivery, never by give-up, and with
+    the mark gone nothing indexes them, so nothing re-announces them.
+    """
+    logger.info(
+        "launch wake: clearing an unresolvable ◈ mark (the conversation no "
+        "longer exists locally; an unsaved chat's fleet work is keyed by a "
+        "session id that dies with its process)"
+    )
+    clear_fleet_unseen_completion(app, conversation_id)
+
+
+def _conversation_exists_locally(app: Any, conversation_id: str) -> bool:
+    """Whether the local ChaChaNotes DB still has this conversation.
+
+    Asked of the DB directly rather than inferred from a failed tree load:
+    a tree load can fail for reasons that have nothing to do with the row
+    existing (a scope service in server mode, a transient error), and
+    clearing a live user's badge on one of those would be a real loss. A
+    DB that cannot answer is treated as "exists", so uncertainty keeps the
+    mark.
+    """
+    db = getattr(app, "chachanotes_db", None)
+    getter = getattr(db, "get_conversation_by_id", None)
+    if not callable(getter):
+        return True
+    try:
+        return getter(conversation_id) is not None
+    except Exception as exc:  # noqa: BLE001 -- uncertainty keeps the mark
+        logger.debug(
+            "launch wake conversation existence check raised; keeping the mark "
+            "(exception_type={})",
+            type(exc).__name__,
+        )
+        return True
+
+
+def _build_viewless_runtime(app: Any) -> Any:
+    """Build the Console runtime objects a launch delivery needs, viewless.
+
+    Mirrors `ChatScreen`'s own `_ensure_console_*` chain with the screen
+    removed. The constructor arguments that a mounted Console derives from
+    widget state are deliberately NOT reconstructed here: every screen-owned
+    callable is a `CONSOLE_VIEW_HOOK_SLOTS` entry that
+    `ensure_chat_controller` gives its viewless default (the runtime is
+    "viewless from birth" — `console_runtime.py`), and the send-time
+    provider selection comes from the SESSION's settings
+    (`_provider_selection_for_session`), not from these fields. The first
+    real Console mount re-applies the whole selection through
+    `_sync_console_chat_core_state`, so nothing here is sticky.
+
+    Returns:
+        The `ConsoleChatController`, or `None` when there is no durable
+        ChaChaNotes DB to key an `AgentRunsDB` off (an in-memory harness) —
+        in which case nothing could be owed in the first place.
+    """
+    runtime = ensure_console_runtime(app)
+    app_config = getattr(app, "app_config", {}) or {}
+    console_config = app_config.get("console", {})
+    if not isinstance(console_config, dict):
+        console_config = {}
+
+    def _gate(name: str) -> bool:
+        value = console_config.get(name, True)
+        return bool(value) if isinstance(value, (bool, int)) else True
+
+    store = runtime.ensure_chat_store()
+    gateway = runtime.ensure_provider_gateway(
+        config_provider=lambda: getattr(app, "app_config", {}) or {}
+    )
+    bridge = runtime.ensure_agent_bridge(
+        store_factory=lambda: store,
+        provider_gateway_factory=lambda: gateway,
+        skills_service=getattr(app, "skills_scope_service", None),
+        native_tools_enabled_factory=lambda: (lambda: _gate("native_tool_calls")),
+    )
+    if bridge is None:
+        return None
+    defaults = default_console_session_settings(app_config)
+    controller = runtime.ensure_chat_controller(
+        store=store,
+        provider_gateway=gateway,
+        provider=defaults.provider,
+        model=defaults.model,
+        base_url=defaults.base_url,
+        agent_bridge=bridge,
+        agent_runtime_enabled=_gate("agent_runtime"),
+        skills_service=getattr(app, "skills_scope_service", None),
+    )
+    # Deliberately NOT a view-hook slot: this is the APP, which outlives
+    # every view, and a headless approval round's `call_from_thread` bridge
+    # (and its app-wide toast) needs it. `ChatScreen` sets the same handle
+    # one line after its own construction call.
+    controller.app = app
+    return controller
+
+
+async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
+    """Hydrate and fire every wake this launch already owed.
+
+    Runs as a deferred startup task, after the first interactive frame.
+    Every gate the mounted case passes still applies unchanged — this
+    function seeds and hydrates, and `ConsoleFleetWakeCoordinator` does the
+    rest: the kill switch again at the fire point, the send gate
+    (`send_refusal_copy`: run state, queue ownership, `max_parallel_runs`),
+    user-wins-ties, one delivery at a time app-wide, the `wake_delivered_at`
+    ledger for exactly-once, and the viewless `wake_conversation_in_view`
+    that keeps the ◈ mark on a delivery nobody watched.
+
+    Args:
+        app: The app object.
+        marked: The conversation ids from `marked_conversations_at_launch`.
+            An empty sequence returns immediately, having built nothing.
+
+    Returns:
+        How many conversations were hydrated for delivery.
+    """
+    if not marked:
+        return 0
+    controller = _build_viewless_runtime(app)
+    if controller is None:
+        return 0
+    wake = getattr(controller, "fleet_wake", None)
+    if wake is None:
+        return 0
+    wake.wire(app=app)
+    # The ledger read that turns "which conversations" into "what is owed".
+    # Honours the kill switch itself, and drops anything an earlier process
+    # already delivered (`_rows_for`'s stale drop / `undelivered_wake_runs`'
+    # NULL filter), so a second launch re-announces nothing.
+    if not wake.seed_from_marks():
+        return 0
+    store = controller.store
+    app_config = getattr(app, "app_config", {}) or {}
+    hydrated = 0
+    for conversation_id in marked:
+        if not wake.has_pending(conversation_id):
+            continue  # marked, but nothing owed: a delivered-but-unseen badge
+        if any(
+            conversation_id
+            in (session.persisted_conversation_id, session.id)
+            for session in store.sessions()
+        ):
+            continue  # already open (a re-entrant call); the coordinator has it
+        if not _conversation_exists_locally(app, conversation_id):
+            _clear_unresolvable_mark(app, conversation_id)
+            continue
+        try:
+            tree = await load_console_conversation_tree(app, conversation_id)
+        except (ConversationServiceUnavailable, ConversationLoadFailed) as exc:
+            logger.warning(
+                "launch wake could not load a marked conversation; it stays "
+                "staged for the next Console visit (exception_type={})",
+                type(exc).__name__,
+            )
+            continue
+        if tree is None:
+            # The row vanished between the existence check and the load.
+            _clear_unresolvable_mark(app, conversation_id)
+            continue
+        conversation = tree.get("conversation")
+        if not isinstance(conversation, dict):
+            conversation = {}
+        try:
+            hydrate_console_session(
+                app=app,
+                store=store,
+                conversation_id=conversation_id,
+                tree=tree,
+                settings=apply_resume_settings_overrides(
+                    default_console_session_settings(app_config), conversation
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 -- one bad row never stops the rest
+            logger.warning(
+                "launch wake hydration failed for a marked conversation "
+                "(exception_type={})",
+                type(exc).__name__,
+            )
+            continue
+        hydrated += 1
+    if hydrated:
+        wake.retry_soon()
+    return hydrated

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable, Mapping, Sequence
 from urllib.parse import urlparse, urlunparse
 
@@ -472,6 +472,45 @@ def build_default_console_session_settings(
             default_sources, "thinking_budget_tokens"
         ),
         streaming=_bool_setting_from_sources(default_sources, "streaming", True),
+    )
+
+
+def default_console_session_settings(
+    app_config: Mapping[str, object],
+    provider: str | None = None,
+    model: str | None = None,
+) -> ConsoleSessionSettings:
+    """The default settings snapshot a NEW Console session starts from.
+
+    `build_default_console_session_settings` plus the one rule that always
+    accompanied it at the screen's call site: a llama.cpp session takes no
+    `base_url` from configuration (the gateway normalizes the origin at
+    send time; a stale configured URL here would pin it).
+
+    Named here, and not left inline in
+    `ConsoleSessionController._default_console_session_settings`, because
+    task-15860's launch wake builds a session with no screen in existence
+    and must start from the same defaults rather than a second spelling of
+    them.
+
+    Args:
+        app_config: The live app configuration snapshot.
+        provider: An explicit provider override (the Console control bar's
+            selection when there is a view), or ``None``.
+        model: An explicit model override, or ``None``.
+
+    Returns:
+        The default settings for a new session.
+    """
+    settings = build_default_console_session_settings(app_config, provider, model)
+    provider_key = provider_config_key(settings.provider)
+    return replace(
+        settings,
+        base_url=(
+            None
+            if provider_key in {"llama_cpp", "local_llamacpp"}
+            else settings.base_url
+        ),
     )
 
 

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -125,6 +125,9 @@ from ...Chat.console_chat_models import (
     MessageAttachment,
 )
 from ...Chat.console_chat_store import ConsoleChatStore
+from ...Chat.console_conversation_hydration import (
+    console_messages_from_conversation_tree,
+)
 from ...Chat.console_command_grammar import (
     GENERATE_IMAGE_COMMAND_HANDLER_ID,
     GENERATE_VIDEO_COMMAND_HANDLER_ID,
@@ -230,10 +233,10 @@ class ConsoleMessageController:
     ) -> None:
         """Build the controller and bind everything its moved bodies need.
 
-        Every one of the 36 method bodies below (29 of the pre-move
-        `*message*`-named cluster, plus 7 exclusively-owned helpers whose
+        Every one of the 35 method bodies below (29 of the pre-move
+        `*message*`-named cluster, plus 6 exclusively-owned helpers whose
         names don't match that pattern -- `_apply_console_message_
-        attachments`, `_batch_fetch_console_resume_attachments`,
+        attachments`,
         `_serialize_console_variants`, `_restore_console_variants`,
         `_console_save_as_destinations`, `_console_save_source_title`,
         `_clear_console_original_attempt_preview`) is a byte-for-byte copy
@@ -551,6 +554,12 @@ class ConsoleMessageController:
     ) -> list[ConsoleChatMessage]:
         """Build native Console messages from a persisted conversation tree.
 
+        task-15860 Task 6: the walk itself moved to
+        `Chat/console_conversation_hydration.py` so the launch wake -- which
+        has to hydrate a conversation with no screen at all -- shares this
+        policy instead of copying it. This method keeps its name and
+        signature: eight test files call it directly.
+
         Task 8: flattens the ENTIRE tree (every node, all branches -- not just
         the ``children[-1]`` latest branch), each message carrying its
         ``persisted_message_id`` and persisted ``parent_message_id`` so the
@@ -565,129 +574,9 @@ class ConsoleMessageController:
         transparent to parenthood -- its children re-parent to the nearest kept
         ancestor -- so a skipped row never orphans a branch.
         """
-        messages: list[ConsoleChatMessage] = []
-
-        def _walk(node: Any, parent_persisted_id: str | None) -> None:
-            if not isinstance(node, dict):
-                return
-            content = str(node.get("content") or "")
-            raw_image = node.get("image_data")
-            image_data = (
-                bytes(raw_image) if isinstance(raw_image, (bytes, bytearray)) else None
-            )
-            raw_mime = node.get("image_mime_type")
-            image_mime_type = str(raw_mime) if raw_mime else None
-            usage = ProviderUsage.from_json(node.get("usage_json"))
-            raw_metadata_json = node.get("metadata_json")
-            # task-3401.4: a video generation row's metadata_json carries the
-            # namespaced video payload instead of turn provenance -- hydrate
-            # it into video_metadata and leave ``metadata`` None (the two
-            # shapes never co-write one row; persistence prefers the video
-            # payload so a later edit cannot clobber it).
-            video_metadata = VideoGenerationMetadata.from_json(raw_metadata_json)
-            metadata = (
-                None
-                if video_metadata is not None
-                else MessageMetadata.from_json(raw_metadata_json)
-            )
-            raw_id = node.get("id")
-            node_persisted_id = str(raw_id) if raw_id is not None else None
-            kept = bool(content) or image_data is not None
-            if kept:
-                # The tree only carries the legacy position-0 columns; positions
-                # >= 1 (multi-attachment table rows) are batch-fetched below,
-                # once for the whole resumed list.
-                attachments: tuple[MessageAttachment, ...] = (
-                    (
-                        MessageAttachment(
-                            data=image_data,
-                            mime_type=image_mime_type or "",
-                            display_name="",
-                            position=0,
-                        ),
-                    )
-                    if image_data is not None
-                    else ()
-                )
-                messages.append(
-                    ConsoleChatMessage(
-                        role=self._console_message_role_from_persisted(node),
-                        content=content,
-                        status="complete",
-                        persisted_message_id=node_persisted_id,
-                        parent_message_id=parent_persisted_id,
-                        image_data=image_data,
-                        image_mime_type=image_mime_type,
-                        attachments=attachments,
-                        usage=usage,
-                        metadata=metadata,
-                        video_metadata=video_metadata,
-                    )
-                )
-            # Children re-parent to this node when kept, else pass the nearest
-            # kept ancestor straight through (a dropped empty row is invisible
-            # to the tree linkage).
-            child_parent_id = node_persisted_id if kept else parent_persisted_id
-            children = node.get("children")
-            if isinstance(children, list):
-                for child in children:
-                    _walk(child, child_parent_id)
-
-        root_threads = tree.get("root_threads")
-        if isinstance(root_threads, list):
-            for root in root_threads:
-                _walk(root, None)
-        self._batch_fetch_console_resume_attachments(messages)
-        return messages
-
-    def _batch_fetch_console_resume_attachments(
-        self, messages: list[ConsoleChatMessage]
-    ) -> None:
-        """Fill positions >= 1 for resumed multi-attachment messages, once.
-
-        ``get_conversation_tree`` only returns the legacy image columns
-        (position 0); the ``message_attachments`` table (positions >= 1) is
-        fetched here in a SINGLE batched call covering every message this
-        resume produced, then folded into each message's attachments tuple
-        via ``_apply_console_message_attachments`` (see that helper for the
-        store mirror invariant it replicates by hand).
-        """
-        ids = [m.persisted_message_id for m in messages if m.persisted_message_id]
-        if not ids:
-            return
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        getter = getattr(db, "get_attachments_for_messages", None)
-        if not callable(getter):
-            return
-        try:
-            rows_by_id = getter(ids)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Console resume attachment batch fetch failed."
-            )
-            return
-        if not isinstance(rows_by_id, dict):
-            return
-        for message in messages:
-            extra_rows = (
-                rows_by_id.get(message.persisted_message_id)
-                if message.persisted_message_id
-                else None
-            )
-            if not extra_rows:
-                continue
-            extras = [
-                MessageAttachment(
-                    data=row.get("data"),
-                    mime_type=row.get("mime_type") or "",
-                    display_name=row.get("display_name") or "",
-                    position=int(row.get("position", 0)),
-                )
-                for row in extra_rows
-            ]
-            _apply_console_message_attachments(
-                message, list(message.attachments) + extras
-            )
+        return console_messages_from_conversation_tree(
+            tree, db=getattr(self.app_instance, "chachanotes_db", None)
+        )
 
     @staticmethod
     def _serialize_console_variants(

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -149,11 +149,11 @@ from ...Chat.console_roleplay_identity import (
     expand_character_template,
     normalize_chat_display_name,
 )
-from ...Chat.console_prefill import pinned_prefill_from_conversation_metadata
+from ...Chat.console_conversation_hydration import apply_resume_settings_overrides
 from ...Chat.console_session_settings import (
     ConsoleSessionSettings,
     build_console_settings_readiness,
-    build_default_console_session_settings,
+    default_console_session_settings,
 )
 from ...Chat.console_turn_context import ConsoleTurnExecutionContext
 from ...Chat.provider_readiness import provider_config_key
@@ -1702,17 +1702,10 @@ class ConsoleSessionController:
     def _default_console_session_settings(self) -> ConsoleSessionSettings:
         """Build the default settings snapshot for a new native Console session."""
         provider, model = self._effective_console_provider_model()
-        settings = build_default_console_session_settings(
+        return default_console_session_settings(
             self._provider_readiness_app_config(),
             str(provider).strip() if _has_selected_text(provider) else None,
             str(model).strip() if _has_selected_text(model) else None,
-        )
-        provider_key = provider_config_key(settings.provider)
-        return replace(
-            settings,
-            base_url=None
-            if provider_key in {"llama_cpp", "local_llamacpp"}
-            else settings.base_url,
         )
 
     def _ensure_active_console_session_settings(self) -> ConsoleSessionSettings:
@@ -1865,22 +1858,12 @@ class ConsoleSessionController:
             self._active_console_session_settings()
             or self._default_console_session_settings()
         )
-        raw_system_prompt = conversation.get("system_prompt")
-        # Only blank/whitespace-only text collapses to "no system prompt";
-        # anything else is restored verbatim (leading/trailing whitespace
-        # and internal formatting included) rather than stripped, so a
-        # formatting-sensitive prompt survives close/resume unchanged.
-        system_prompt = (
-            raw_system_prompt
-            if isinstance(raw_system_prompt, str) and raw_system_prompt.strip()
-            else None
-        )
-        pinned_prefill = pinned_prefill_from_conversation_metadata(
-            conversation.get("metadata")
-        )
-        return replace(
-            settings, system_prompt=system_prompt, pinned_prefill=pinned_prefill
-        )
+        # task-15860 Task 6: what the CONVERSATION ROW contributes is shared
+        # with the launch wake's viewless hydration
+        # (`Chat/console_conversation_hydration.py`); only the BASE above --
+        # the currently active session's settings -- is screen state, and a
+        # launch has no active session to inherit from.
+        return apply_resume_settings_overrides(settings, conversation)
 
     def _apply_console_session_system_prompt(
         self, system_prompt: Optional[str]

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -38,7 +38,12 @@ from ...Chat.console_chat_models import (
 )
 from ...Chat.console_display_state import evidence_bundle_from_launch
 from ...Chat.console_live_work import ConsoleLiveWorkLaunch
-from ...Chat.console_roleplay_metadata import parse_console_roleplay_context
+from ...Chat.console_conversation_hydration import (
+    ConversationLoadFailed,
+    ConversationServiceUnavailable,
+    hydrate_console_session,
+    load_console_conversation_tree,
+)
 from ...Chat.rag_scope import RagScope
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.glyph_fallback import resolve_glyph
@@ -1999,30 +2004,22 @@ class ConsoleWorkspaceController:
         # TASK-339: keystrokes typed while the conversation tree loads
         # belong to the resumed session — snapshot the composer now.
         self._capture_console_draft_switch_snapshot()
-        conversation_service = getattr(
-            self.app_instance,
-            "chat_conversation_scope_service",
-            None,
-        )
-        get_conversation_tree = getattr(
-            conversation_service, "get_conversation_tree", None
-        )
-        if not callable(get_conversation_tree):
+        # task-15860 Task 6: the tree load and the session build moved to
+        # `Chat/console_conversation_hydration.py` -- the launch wake has to
+        # hydrate a conversation with no screen in existence, and one policy
+        # beats two. Everything BELOW the hydration call is this screen's own
+        # work (marker overlay, character identity, scope warm, repaint,
+        # focus) and stays here; so do both failure toasts, because the UX
+        # for each failure is a view concern.
+        try:
+            tree = await load_console_conversation_tree(self.app_instance, target)
+        except ConversationServiceUnavailable:
             self.app_instance.notify(
                 "Saved conversation resume is unavailable in this build.",
                 severity="warning",
             )
             return None
-
-        try:
-            # Task 8: raise the depth/root caps well past the service defaults
-            # (50) so a long or branchy conversation's full tree -- every
-            # branch, not just the latest -- is loaded intact, not truncated.
-            maybe_tree = get_conversation_tree(
-                target, mode="local", depth_cap=10_000, root_limit=10_000
-            )
-            tree = await maybe_tree if inspect.isawaitable(maybe_tree) else maybe_tree
-        except Exception:
+        except ConversationLoadFailed:
             logger.exception(
                 f"Unable to resume Console saved conversation: conversation_id={target}"
             )
@@ -2032,7 +2029,7 @@ class ConsoleWorkspaceController:
             )
             return None
 
-        if not isinstance(tree, dict) or not tree.get("conversation"):
+        if tree is None:
             # TASK-717: missing record - the caller owns this failure's UX
             # (honest toast + marking the row visibly broken), so do not
             # stack a second notification here.
@@ -2042,82 +2039,15 @@ class ConsoleWorkspaceController:
         if not isinstance(conversation, dict):
             conversation = {}
         store = self._ensure_console_chat_store()
-        active_workspace_id = str(
-            store.workspace_context.active_workspace_id or ""
-        ).strip()
-        persisted_workspace_id = (
-            str(conversation.get("workspace_id")).strip()
-            if conversation.get("workspace_id") is not None
-            else ""
-        )
-        target_scope = str(target_scope_type or "").strip()
-        requested_workspace_id = (
-            str(target_workspace_id).strip() if target_workspace_id is not None else ""
-        )
-        if target_scope == "global":
-            workspace_id = CONSOLE_GLOBAL_WORKSPACE_ID
-        else:
-            workspace_id = (
-                persisted_workspace_id
-                or requested_workspace_id
-                or active_workspace_id
-                or None
-            )
-        title = str(conversation.get("title") or "Saved conversation").strip()
-        if not title:
-            title = "Saved conversation"
-        # Task 8: load the WHOLE persisted tree (every branch), then reconstruct
-        # the active branch from the stored active-leaf pointer. Loading all
-        # branches (not just the latest) is what makes off-path siblings
-        # navigable (swipe) right after resume.
-        all_nodes = self._console_messages_from_conversation_tree(tree)
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        active_leaf_id = getattr(db, "get_conversation_active_leaf", lambda _c: None)(
-            target
-        )
-        raw_runtime_backend = conversation.get("runtime_backend")
-        if type(raw_runtime_backend) is str:
-            runtime_backend = raw_runtime_backend
-        else:
-            runtime_backend = ""
-        raw_assistant_kind = conversation.get("assistant_kind")
-        assistant_kind = raw_assistant_kind if type(raw_assistant_kind) is str else None
-        raw_assistant_id = conversation.get("assistant_id")
-        assistant_id = raw_assistant_id if type(raw_assistant_id) is str else None
-        raw_assistant_authority_id = conversation.get("assistant_authority_id")
-        assistant_authority_id = (
-            raw_assistant_authority_id
-            if type(raw_assistant_authority_id) is str
-            else None
-        )
-        raw_character_id = conversation.get("character_id")
-        character_id = (
-            raw_character_id
-            if (
-                runtime_backend == "local"
-                and assistant_kind == "character"
-                and type(raw_character_id) is int
-                and raw_character_id > 0
-                and assistant_id == str(raw_character_id)
-            )
-            else None
-        )
-        session = store.restore_persisted_session(
-            title=title,
-            workspace_id=workspace_id,
-            persisted_conversation_id=target,
-            all_nodes=all_nodes,
-            active_leaf_persisted_id=active_leaf_id,
+        session = hydrate_console_session(
+            app=self.app_instance,
+            store=store,
+            conversation_id=target,
+            tree=tree,
             settings=self._console_session_settings_for_resume(conversation),
-            runtime_backend=runtime_backend,
-            assistant_kind=assistant_kind,
-            assistant_id=assistant_id,
-            assistant_authority_id=assistant_authority_id,
-            character_id=character_id,
+            target_scope_type=target_scope_type,
+            target_workspace_id=target_workspace_id,
         )
-        roleplay_context = parse_console_roleplay_context(conversation.get("metadata"))
-        session.user_display_name_override = roleplay_context.user_name_override
-        session.character_system_template = roleplay_context.character_system_template
         # Re-derive display-only agent TOOL markers from AgentRunsDB and overlay
         # them onto the restored active-path VIEW (markers are never tree nodes;
         # the next tree mutation's recompute rebuilds the view from live nodes

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10821,6 +10821,45 @@ class TldwCli(
                 self._migrate_legacy_citations_idle_unit(),
                 name="deferred_legacy_citation_migration",
             )
+        self._schedule_launch_wake()
+
+    def _schedule_launch_wake(self) -> None:
+        """Deliver a supervisor wake this install already owed at launch.
+
+        task-15860 Task 6. A background sub-agent that finished while the
+        app was closed -- or one whose delivery the user quit out from
+        under -- used to wait for the next Console visit. It no longer
+        does, under the owner's mark-gated ruling: only a conversation
+        that already carries a durable ``FLEET_UNSEEN`` mark AND an owed
+        ``agent_runs`` row is delivered, behind the existing ``[agents]
+        autowake_enabled`` (there is no separate launch switch).
+
+        **The common path costs one indexed read and constructs nothing.**
+        With no marks -- every install that has never run a background
+        sub-agent, and every one whose results have all been seen -- this
+        returns before touching the Console store, provider gateway, agent
+        bridge (so ``agent_runs.db`` is not even opened) or controller.
+        That is pinned in ``Tests/UI/test_console_launch_wake.py``.
+        """
+        try:
+            from tldw_chatbook.Chat.console_launch_wake import (
+                LAUNCH_WAKE_TASK_NAME,
+                deliver_launch_wakes,
+                marked_conversations_at_launch,
+            )
+
+            marked = marked_conversations_at_launch(self)
+            if not marked:
+                return
+            self._create_deferred_startup_task(
+                deliver_launch_wakes(self, marked),
+                name=LAUNCH_WAKE_TASK_NAME,
+            )
+        except Exception:  # noqa: BLE001 -- a launch never dies on this
+            logger.opt(exception=True).warning(
+                "Launch wake scheduling failed; owed wakes stay staged for "
+                "the next Console visit."
+            )
 
     async def _reconcile_citation_artifact_ownership(self) -> None:
         """Run one bounded recovery batch without blocking the UI loop."""


### PR DESCRIPTION
## Headless wake — a completion owed from a previous run is delivered at launch

Eighth landing for task-15860, and the last capability piece. Per the owner's ruling: **mark-gated, no new config switch**, and **nothing constructed when there are no marks** so startup stays byte-identical for every user who never touches the fleet.

**The red:** 11 tests, **9 failed / 3 passed** at the merge-base → **11 passed**. Built from two real `TldwCli` processes over one `tmp_path`, with the second loading its conversation tree through the real `ChatConversationService` rather than a double — so the delivery is proven through the production loader, not a harness shortcut.

**The startup-cost pin** is the one protecting everyone else: with no marks, four observations including *no `agent_runs.db` file on disk at all*. Mutation-killed twice over — once by a task-name observation and once by the call-count plus the phantom test.

**Phantom wake stays impossible:** a crash-killed child swept to `error` carries no mark and wakes nobody. The test asserts the ledger genuinely *does* owe that orphan, so the silence is provably the mark gate's doing rather than an empty ledger — the difference between a passing test and a meaningful one.

**Hydration was extracted, not duplicated.** A launch wake needs a session for a conversation nobody has opened, and that policy was screen-bound. It moved to `Chat/console_conversation_hydration.py` as a pure refactor, with the resume-owning suites at **286 passed on both sides**.

**A real leak found and fixed by execution:** an unsaved session keys durable rows by a uuid that names nothing after the process dies, leaving a permanent badge. Stale marks are now cleared — but only when the local DB says the conversation is genuinely gone *and* something is owed, so a mark is never dropped on ambiguity.

Two further guards came from mutations the launch suite itself could not see, and one from a case worth naming: **a launch wake must not steal the tab you landed on.**

**Counts:** 13 mutations with 2 survivors investigated and closed; `Tests/Agents/` **1458**; specified battery **198 passed** vs a **187** baseline; the arc's sibling suites (fires, approval, continuity, sync-outlives, residency, lifetime) all green after merging current dev.

The User Guide's launch limit is removed — it is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers owed headless wakes at app launch under a mark gate, so completions recorded while the app was closed are delivered on startup. Previously, owed work waited until Console opened; now it runs after the first interactive frame. With no marks, startup constructs nothing. It does not steal the active tab, and it clears stale marks from unsaved sessions that can never be delivered. Supports `task-15860` without a new switch (uses `[agents] autowake_enabled`).

- Key changes: `Chat/console_launch_wake.py` (launch wake loop, mark/ledger gate, exactly-once), `app.py::_schedule_launch_wake` (hook after interactive startup), extracted shared hydration to `Chat/console_conversation_hydration.py` and `default_console_session_settings` to `Chat/console_session_settings.py`. Console modules now call the shared hydration; resume behavior is unchanged.
- Guards: single indexed marks read at launch; delivers only when both `FLEET_UNSEEN` mark and owed `agent_runs` row exist; clears only truly stale marks from unsaved sessions; maintains the user’s active tab when Console is the startup tab.
- Tests: launch path proves production tree load, exactly-once delivery, zero construction with no marks (including no `agent_runs.db` file), non-sticky controller settings, and mutation-killed guards. Docs updated to remove the “no launch wake” limit.

<sup>Written for commit 8b44176c8b51085445391b11382b59be11b3a64e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

