### PR TITLE
feat(console): show what the agent is doing in the in-flight turn

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -31,6 +31,17 @@ refused with a message like "2 agents already running (…). Wait for one to
 finish or interrupt it." Runs live only while Console stays open — see
 [Console agent runs are screen-scoped](../index.md#console-agent-runs-are-screen-scoped).
 
+**In the reply row itself** — while the turn works, the unfinished
+`Assistant` row shows a live activity line in place of its (empty) text, so
+a long tool call never looks frozen: `⚙ read_file · 4s` names the tool that
+is running and how long it has been running, `Thinking… · 6s` means the
+tool finished and the model is composing the next round, and `Generating…`
+is the wait for the model's first response of the turn. The elapsed figure
+advances while you watch. The line is live-only — it vanishes the moment
+the reply's own text arrives, and a conversation you reopen later shows the
+completed `Tool` rows below instead. A sub-agent's work never appears here;
+it belongs to the **Sub-agents** panel in the left rail.
+
 **In the transcript** — inline `Tool` rows appear between your message and the
 reply:
 
@@ -903,3 +914,16 @@ presentation layer over TASK-1972's existing change-review subsystem; the
 `[console] turn_file_cards` kill switch reverts to the pre-card plain-text
 marker row byte-for-byte, confirmed by
 `test_summary_row_stays_plain_marker_when_disabled`.)*
+
+*Live turn-activity line added against dev @ feea06193 — 2026-08-16.
+Verified by execution, not by a tmux walkthrough: a real
+`ConsoleAgentBridge` ran a real `agent_runtime` turn whose tool call was
+held in flight on an Event, and the MOUNTED transcript row was read back —
+before the change it rendered the bare word `Assistant` (the row is
+`status='pending'`, `content=''`, so even the old `Generating…` copy never
+applied to it); after, it renders `Assistant  ⚙ calculator · <1s` and
+advances to `· 5s` on the next poll
+(`Tests/UI/test_console_turn_activity_line.py`, 26 passed). Not
+live-walked in a terminal — the states and the elapsed are covered by that
+suite plus mutation testing; the rest of this page's content is unchanged
+from the prior stamp.*

--- a/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
+++ b/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
@@ -1,0 +1,185 @@
+# Console turn-activity line
+
+*Branch `feat/console-turn-activity-line`, from dev @ `feea06193`, 2026-08-16.*
+
+## The request
+
+> "add visibility into agent actions in the console under/in the agent's turn
+> box, so a user can see what is going on/being done, and it doesn't look like
+> it's frozen to the user."
+
+The owner chose the shape, and it is binding:
+
+```
+Assistant  ⚙ read_file · 4s
+
+─ after it finishes ─
+
+Tool  ⚙ read_file → def main():\n    …… (+3841 chars)
+Assistant  ⚙ web_fetch · 11s
+```
+
+A live, ticking activity line **inside the in-flight assistant row**. No new
+row types; completed `Tool` rows keep appearing below exactly as before; tool
+markers stay append-only and untouched; tool **arguments** are deliberately
+not rendered (they are unbounded at the seam — a `write_file` content arg can
+be megabytes).
+
+## What "frozen" actually was
+
+The survey that preceded this work said the in-flight row sits on the
+`Generating…` placeholder for the whole multi-round turn. **Measured, it is
+worse than that.** A probe that ran a real `ConsoleAgentBridge` turn with the
+tool held on an Event, then mounted the real transcript over the real store's
+messages, read the row back as:
+
+```
+BEFORE_ROW_TEXT>>>Assistant<<<
+BEFORE_STATUS>>> 'pending'
+BEFORE_SNAPSHOT>>> running [('model', '```tool_call…'), ('tool_call', 'calculator', 'primary')]
+```
+
+The row is `status='pending'`, `content=''`. `_message_body`'s placeholder
+branch is gated on `status == "streaming"`, and the store only reaches
+`"streaming"` on the first streamed chunk (`append_stream_chunk`) — which a
+tool-calling turn's assistant row never produces, because the fence gate
+seals it from the first token. So the user watched the bare word `Assistant`
+for the entire turn; not even `Generating…` applied.
+
+The same probe confirmed the good half of the survey: the tool name is
+**already at the seam**. `AgentLiveStep('tool_call', 'calculator', 'primary')`
+is in `bridge.live_snapshot()` while the tool is held. This was wiring, not
+plumbing — except for elapsed.
+
+## The four states
+
+Derived from the primary agent's most recent step
+(`console_turn_activity_text`):
+
+| situation | line | source |
+|---|---|---|
+| a tool is running | `⚙ read_file · 4s` | last primary step is `STEP_TOOL_CALL`; `started_at` is the moment the bridge saw it, one statement before `deps.invoke_tool` |
+| between tools / after a result | `Thinking… · 6s` | last primary step is anything else; there is no "model call started" step (`STEP_MODEL` is emitted *after* the round, carrying its text), so this is derived from the negative |
+| running, no primary step yet | `Generating…` | pre-first-token. Today's copy, unchanged — and now it actually shows, because the activity path covers `pending` too |
+| turn ended | *(nothing)* | snapshot status is not `running`, or the row is no longer in flight/empty |
+
+No elapsed on `Generating…`: there is no per-step base to time from, and
+`_format_fleet_elapsed`'s own rule is that claiming a duration without a
+usable base is a lie. Same reason `_fleet_row_from_summary` omits it.
+
+## Where each piece lives, and why
+
+**Elapsed → the bridge (`Chat/console_agent_bridge.py`).** `AgentLiveStep`
+gains `started_at: float | None`, stamped with `time.monotonic()` in
+`on_step`. It cannot come from the runtime: `AgentStep.created_at` is a `str`
+that stays empty for the whole life of a live run (`AgentService` stamps the
+batch once, at end-of-run persist), and `Agents/agent_runtime.py` /
+`agent_models.py` are pure-logic modules whose contract is that they read no
+clock. `on_step` is the impure seam and is called *synchronously* inside the
+loop, so for a `STEP_TOOL_CALL` the reading is the tool's real start rather
+than a poll-quantised approximation. Resume-derived steps keep `None` —
+`AgentRunsDB` carries nothing a duration could honestly come from.
+
+**Derivation → `UI/Console_Modules/agent.py`.** `console_turn_activity_text`
+is a pure function sitting next to `_format_fleet_elapsed`, which it reuses.
+`ConsoleAgentController.console_turn_activity()` is the one impure read.
+
+**Pixels → `Widgets/Console/console_transcript.py`.** The line rides the row's
+*existing* header (markdown rows, the default) or body Content (plain rows).
+**No new widget is mounted**, so the "a bare `Static` defaults to `1fr` and
+pushes its siblings off screen" hazard cannot apply; a geometry test asserts
+it anyway.
+
+**Screen → 8 lines, 0 new methods.** `chat_screen.py` is under a one-way size
+ratchet and is already ~2,600 lines over it on dev (measured 20,359/672 vs a
+budget of 17,727/593 — that test is red at the merge base, not because of
+this work). The transcript sync reads the controller's line, hands it to the
+transcript, and folds the return into its refresh key.
+
+## The three hazards this programme paid to learn
+
+1. **No idle repaint (task-15664 AC#2).** No new timer, and none is needed:
+   during an agent turn the run is in `CONSOLE_ACTIVE_RUN_STATUSES`, which is
+   exactly the condition `_start_console_transcript_sync_timer` keeps its
+   0.2 s tick alive for. Confirmed by execution, not by reading. Two further
+   gates make "nothing live → nothing repaints" true regardless of what the
+   bridge last published: the controller refuses to derive a line unless the
+   **viewed** session's run is active, and `apply_turn_activity` returns the
+   **effective** value (`""` unless a row is genuinely in flight), which is
+   what joins the refresh key.
+2. **A torn-down screen renders nothing.** The new call sits inside
+   `_sync_native_console_transcript`, which the existing
+   `_console_screen_is_torn_down` guards in `_sync_native_console_chat_ui`
+   already cover. No new sync path was created.
+3. **Rendered geometry, not DOM presence.** No widget added; the geometry test
+   asserts every row and every child `Static` satisfies
+   `region.x + region.width <= screen width`. Markers render markup-off, so
+   the line is raw and unescaped — pinned with `fetch [docs]`.
+
+## Sub-agent isolation
+
+`console_turn_activity_text` selects the last step whose `agent_kind` is
+`AGENT_KIND_PRIMARY`, skipping the rest. This is not defensive: `on_step`
+routes a **sub-agent** step whose run id is empty into the **primary** run's
+own live feed (its documented "no run attributed" fallback), so the primary
+snapshot's last entry really can belong to a child. A child's work belongs to
+the Agent rail's fleet rows, never to the primary assistant row.
+
+## The quiet-tool decision
+
+`_QUIET_STEP_TOOLS` (`find_tools` / `load_tools`) are suppressed from
+transcript markers. **They are shown in the activity line.** The quiet rule
+exists to keep catalog plumbing out of the *permanent, append-only* markers,
+where a discovery round would be lasting clutter. The activity line is
+ephemeral and exists precisely so that no working moment looks frozen —
+suppressing these would reinstate a silent gap for the whole discovery round,
+which is the defect, not the fix. Pinned by test.
+
+## Live-only, and why that does not break the live/resumed parity rule
+
+An activity line has no resumed counterpart and must never grow one: it
+reports what an agent is doing *right now*, and a finished turn's transcript
+already carries the `Tool` markers that say what it did. This is documented on
+the function the same way `format_todo_marker` documents it — the parity rule
+that matters (`format_agent_step_marker` must render byte-identical text live
+and on resume) is untouched, because that formatter was not modified.
+
+## Mutation testing
+
+Eleven mutations. Eight killed immediately; **three survived and each was a
+real weakness**, fixed and pinned:
+
+1. `_message_row_signature` did not name `live_activity`. A markdown row (the
+   default assistant renderer) carries the line in its **header**, which that
+   signature never renders — it renders the *plain* row. The elapsed
+   therefore only ticked as a side effect of the plain renderer embedding the
+   same text; disabling that branch froze a markdown row's elapsed at its
+   first painted value. Two renderers silently depending on each other.
+2. `_with_turn_activity` stamping every message instead of the one in-flight
+   row is invisible to every display assertion (a row with content never
+   renders the line, and only assistant rows can) — yet it puts
+   `live_activity` into every row's signature, i.e. a whole-transcript
+   re-derive and re-sync once a second for the whole turn. Pinned by
+   measuring blast radius (row signatures + per-message signature compute
+   counts) rather than pixels; the target id is now hoisted out of the loop.
+3. `apply_turn_activity` skipping the empty case left a stale line on a row
+   that stays in flight after its run dies without a terminal publish —
+   frozen at its last elapsed, which is the exact defect this feature exists
+   to remove, in a new costume.
+
+A fourth pin came out of (3): a **streaming** empty row is reachable on a
+fence-gated tool turn (`reset_stream_buffer` discards leaked prose and leaves
+the row streaming-and-empty), and there the line must render dim and without
+a doubled `Streaming…` status line under it.
+
+## Known limits
+
+- A `pending` assistant row with **no agent run at all** (the direct-provider
+  path before its first token) still renders bare. Out of scope here: the
+  fix would be to widen the `Generating…` placeholder's own status gate,
+  which is a separate behaviour change to a separate path.
+- `AgentLiveStep.text` for a tool-call step *is* the tool name, by
+  construction (`agent_runtime` adds every `STEP_TOOL_CALL` with `tool_name=`
+  and no `summary`/`result`, and `_summarize`'s precedence lands on it). If a
+  future change gives those steps a summary, the line's label follows it.
+  Documented at the derivation.

--- a/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
+++ b/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
@@ -197,6 +197,55 @@ sitting on a row that stays in flight after its run dies without a terminal
 publish — frozen at its last elapsed, which is the exact defect this feature
 exists to remove, in a new costume.
 
+## Gate
+
+Every number below was READ, and every baseline was measured on a real
+pre-change worktree at the merge base (`.worktrees/turn-activity-base` @
+`feea06193`) — never inferred from "it looks unrelated".
+
+| suite | base | branch |
+|---|---|---|
+| `Tests/UI/test_console_turn_activity_line.py` (new) | n/a | **27 passed** |
+| transcript + agent-rail + agent-controller + agent-bridge + ratchet | 4 failed, 329 passed | 4 failed, 375 passed (same 4) |
+| `Tests/Agents/` | 1458 passed | 1458 passed |
+| **48-file blast radius, ONE process** | 16 failed, 1324 passed | **15 failed, 1352 passed** |
+
+The 48-file population is every `Tests/UI`/`Tests/Chat` file that touches
+`ConsoleTranscript` or `_sync_native_console_transcript`, plus the agent
+bridge/controller/rail cluster and the size ratchet — the true blast radius
+of this change. In one process it surfaced **six failures that no per-file
+run showed** (markdown-widget, css-class-coverage, moved-seam-guard,
+keyboard-trust, workbench-contract, parallel-runs), all present at base.
+
+Failure-set diff, branch vs base: **no new failures**, and one base failure
+absent — `test_the_coalesced_request_still_actually_runs_the_sync`. That is
+**not a fix and is not claimed as one**: it fails on `assert 5 == 3` because
+a spy accumulates sync calls from other tests' leaked screens, it passes 3/3
+in isolation on the base tree, and this change adds no sync dispatch (only a
+call *inside* the existing one). It is a pre-existing order-dependent flake
+that the branch run happened not to trip. Passed delta 1352 − 1324 = 28 = 27
+new tests + that one flake.
+
+The four failures that persist everywhere are all dev's at the merge base:
+the `chat_screen.py` size ratchet (measured 20,359 lines / 672 methods
+against a budget of 17,727/593 — over before this work started; this change
+adds 8 lines and no method), three speech action-row tests, and (in the
+one-process run) the citation-sources double, which lacks
+`set_change_review_provider_factory` — a call this change did not add.
+
+**What I could not afford.** The full 281-file Console population in one
+process, on both trees. It was attempted: the baseline ran ~60 minutes,
+reached 91%, and was killed by infrastructure before printing a summary; a
+narrowed 98-file retry was pacing at ~200 minutes. Two *foreign* full-suite
+`pytest` processes from other sessions were saturating the machine
+throughout (one 14 hours old). The 48-file blast radius above is what
+completed on both trees — it covers every file that touches the changed
+code, but not the whole Console population. Also not done: a live tmux
+walkthrough with a real provider. The environment rules forbid writing the
+user's live config, and a real tool-calling turn additionally needs a
+`[tools]` gate enabled; the mounted-real-screen test is the closest
+substitute and is genuinely a real `ChatScreen` with a real transcript.
+
 ## Known limits
 
 - A `pending` assistant row with **no agent run at all** (the direct-provider

--- a/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
+++ b/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
@@ -146,31 +146,56 @@ and on resume) is untouched, because that formatter was not modified.
 
 ## Mutation testing
 
-Eleven mutations. Eight killed immediately; **three survived and each was a
-real weakness**, fixed and pinned:
+Thirteen mutations, ten killed, **three survived — and each survivor was a
+real weakness.** A fourth finding came out of *how* one of the killed
+mutants died. All four are fixed and pinned.
 
-1. `_message_row_signature` did not name `live_activity`. A markdown row (the
-   default assistant renderer) carries the line in its **header**, which that
-   signature never renders — it renders the *plain* row. The elapsed
-   therefore only ticked as a side effect of the plain renderer embedding the
-   same text; disabling that branch froze a markdown row's elapsed at its
-   first painted value. Two renderers silently depending on each other.
-2. `_with_turn_activity` stamping every message instead of the one in-flight
-   row is invisible to every display assertion (a row with content never
-   renders the line, and only assistant rows can) — yet it puts
-   `live_activity` into every row's signature, i.e. a whole-transcript
-   re-derive and re-sync once a second for the whole turn. Pinned by
-   measuring blast radius (row signatures + per-message signature compute
-   counts) rather than pixels; the target id is now hoisted out of the loop.
-3. `apply_turn_activity` skipping the empty case left a stale line on a row
-   that stays in flight after its run dies without a terminal publish —
-   frozen at its last elapsed, which is the exact defect this feature exists
-   to remove, in a new costume.
+| # | mutation | outcome |
+|---|---|---|
+| 1 | `_message_body`'s activity branch disabled | killed (2) — **and diagnosed finding A** |
+| 2 | `_assistant_markdown_header`'s activity suffix disabled | killed (7) |
+| 3 | `live_activity` dropped from `_message_signature_token` | killed (2) |
+| 4 | primary-only step filter widened to include children | killed (2) |
+| 5 | every step kind treated as a tool call | killed (2) |
+| 6 | `apply_turn_activity`'s eligibility check dropped | killed (2) |
+| 7 | in-flight statuses narrowed back to `streaming` only | killed (9) |
+| 8 | controller's viewed-run status gate disabled | killed (3) |
+| 9 | `started_at` never stamped (`None`) | killed (1) |
+| 10 | `_with_turn_activity` stamps every message | **SURVIVED** |
+| 11 | `_is_generating_placeholder_body` blind to the line | **SURVIVED** |
+| 12 | `apply_turn_activity` skips the empty case | **SURVIVED** |
+| 13 | the screen's `apply_turn_activity` call removed | killed (3) |
 
-A fourth pin came out of (3): a **streaming** empty row is reachable on a
-fence-gated tool turn (`reset_stream_buffer` discards leaked prose and leaves
-the row streaming-and-empty), and there the line must render dim and without
-a doubled `Streaming…` status line under it.
+**A — the signature coupling (from how #1 died).** #1 killed two tests, but
+the *failure* was the interesting part: the production-path test's FIRST
+paint still showed `⚙ calculator · <1s`, and only the SECOND tick failed to
+advance. A markdown row carries the line in its **header**, which
+`_message_row_signature` never renders — it renders the *plain* row. So the
+elapsed only ticked as a side effect of the plain renderer embedding the same
+text; the two renderers were silently coupled, and disabling the plain branch
+froze a markdown row's elapsed at its first painted value. `live_activity` is
+now named in that signature outright, pinned by a test that paints two ticks
+differing in nothing but the elapsed and checks the row updates in place.
+
+**B — blast radius (#10).** Stamping every message rather than the one
+in-flight row is invisible to every display assertion (a row with content
+never renders the line, and only assistant rows can) — yet it puts
+`live_activity` into every row's signature: a whole-transcript re-derive and
+re-sync once a second for the entire turn. Pinned by measuring row signatures
+and per-message signature compute counts instead of pixels; the target id is
+now hoisted out of the row loop.
+
+**C — the doubled/undimmed line (#11).** A **streaming** empty row is
+reachable on a fence-gated tool turn (`reset_stream_buffer` discards leaked
+prose and leaves the row streaming-and-empty). There, a placeholder predicate
+blind to the activity line rendered it as ordinary assistant content with a
+`Streaming…` status line stacked under it. Pinned on both the absent status
+line and the dim span.
+
+**D — the stale line (#12).** Skipping the empty case left the last line
+sitting on a row that stays in flight after its run dies without a terminal
+publish — frozen at its last elapsed, which is the exact defect this feature
+exists to remove, in a new costume.
 
 ## Known limits
 

--- a/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
+++ b/Docs/superpowers/plans/2026-08-16-console-turn-activity-line.md
@@ -203,6 +203,18 @@ exists to remove, in a new costume.
   path before its first token) still renders bare. Out of scope here: the
   fix would be to widen the `Generating…` placeholder's own status gate,
   which is a separate behaviour change to a separate path.
+- `AgentLiveSnapshot.steps` is bounded to the last five. If a run's five most
+  recent steps are ALL sub-agent steps, the line falls back to `Generating…`
+  mid-turn rather than naming what the primary is doing. Narrow: a child's
+  step only lands in the primary's feed at all through the "no run
+  attributed" (empty run id) fallback, so five consecutive ones after the
+  primary's last step is unlikely — but it is not impossible, and the
+  fallback copy would read as pre-first-token when it is not. Pinned as
+  current behaviour by `test_a_turn_with_only_subagent_steps_falls_back_to_
+  generating` so a future change to it is deliberate.
+- The first model round of a turn says `Generating…` while every later one
+  says `Thinking…`. That follows the brief (pre-first-token keeps today's
+  copy) but is a wording seam an owner may want to collapse.
 - `AgentLiveStep.text` for a tool-call step *is* the tool name, by
   construction (`agent_runtime` adds every `STEP_TOOL_CALL` with `tool_name=`
   and no `summary`/`result`, and `_summarize`'s precedence lands on it). If a

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -569,9 +569,15 @@ async def test_the_activity_line_never_pushes_the_row_past_the_screen():
         )
         await pilot.pause()
         screen_width = app.screen.size.width
+        screen_height = app.screen.size.height
+        transcript_right = transcript.content_region.right
         for row_id in ("u1", "a1"):
             row = transcript.query_one(f"#console-message-{row_id}")
             assert row.region.x + row.region.width <= screen_width, (
+                row_id,
+                row.region,
+            )
+            assert row.region.x + row.region.width <= transcript_right, (
                 row_id,
                 row.region,
             )
@@ -580,6 +586,12 @@ async def test_the_activity_line_never_pushes_the_row_past_the_screen():
                     row_id,
                     child.region,
                 )
+        # The other half of the hazard: a `1fr` element in a laid-out row
+        # pushes its NEIGHBOURS off, so the earlier row must still be on
+        # screen and the in-flight row must stay a couple of lines tall.
+        user_row = transcript.query_one("#console-message-u1")
+        assert 0 <= user_row.region.y < screen_height, user_row.region
+        assert transcript.query_one("#console-message-a1").region.height <= 4
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -161,12 +161,22 @@ async def test_a_held_tool_call_names_the_tool_in_the_rendered_assistant_row(
         assert in_flight, "the turn must own an in-flight assistant row"
         assert in_flight[-1].content == "", "the row is empty while the tool runs"
 
+        # The bridge stamped a real reading off this process's monotonic
+        # clock, taken as the tool was dispatched -- not a constant, and not
+        # a poll-quantised approximation.
+        started_at = snapshot.steps[-1].started_at
+        assert started_at is not None
+        assert 0.0 <= observed_at - started_at < 20.0, (observed_at, started_at)
+
         app = _ActivityHarness()
         async with app.run_test(size=(80, 24)) as pilot:
             transcript = app.query_one(ConsoleTranscript)
 
+            # Both ticks are driven off that production reading, so the
+            # assertions below cannot flake on how long this test's own
+            # setup happened to take.
             row_id = in_flight[-1].id
-            first = console_turn_activity_text(snapshot, now=observed_at)
+            first = console_turn_activity_text(snapshot, now=started_at + 0.2)
             early = await _paint(transcript, messages, first, row_id)
             await pilot.pause()
 
@@ -175,7 +185,7 @@ async def test_a_held_tool_call_names_the_tool_in_the_rendered_assistant_row(
             assert "<1s" in early, early
 
             # A later poll tick, same held call: only the elapsed moves.
-            later_text = console_turn_activity_text(snapshot, now=observed_at + 5.0)
+            later_text = console_turn_activity_text(snapshot, now=started_at + 5.0)
             later = await _paint(transcript, messages, later_text, row_id)
             await pilot.pause()
 

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -274,6 +274,121 @@ async def test_a_finished_turn_drops_the_activity_line_from_the_row():
         assert "It is 42." in after, after
 
 
+@pytest.mark.asyncio
+async def test_only_the_elapsed_changing_repaints_the_default_markdown_row():
+    """The markdown row's header must tick on its OWN signature input.
+
+    Found by mutation. A markdown row carries the line in its HEADER, which
+    `_message_row_signature` never renders -- it renders the PLAIN row. With
+    `live_activity` absent from that signature the elapsed still advanced,
+    but only because the plain renderer happened to embed the same text; the
+    two renderers were silently coupled. This paints two ticks that differ
+    in NOTHING but the elapsed and checks the row updates in place.
+    """
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        messages = [_user(), _in_flight_assistant()]
+        row_key = "message:a1"
+
+        first = await _paint(transcript, messages, "⚙ read_file · 4s")
+        await pilot.pause()
+        assert isinstance(transcript.query_one("#console-message-a1"), ConsoleMarkdownMessage)
+        assert "4s" in first, first
+        builds = transcript.row_build_counts().get(row_key, 0)
+
+        second = await _paint(transcript, messages, "⚙ read_file · 5s")
+        await pilot.pause()
+        assert "5s" in second, second
+        assert "4s" not in second, second
+        assert transcript.row_build_counts().get(row_key, 0) == builds, (
+            "the row must update in place, not be rebuilt"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_row_still_in_flight_loses_its_line_when_the_run_goes_quiet():
+    """An empty line CLEARS the last one -- it never leaves it hanging.
+
+    Found by mutation. The row that stays ``pending`` after its run dies
+    without a terminal publish is exactly the row a stale line would sit on
+    forever, frozen at whatever elapsed it last painted -- the "looks
+    frozen" defect this feature exists to remove, in a new costume. The
+    caller's ``""`` must therefore be applied, not skipped.
+    """
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        messages = [_user(), _in_flight_assistant()]
+        during = await _paint(transcript, messages, "⚙ read_file · 4s")
+        await pilot.pause()
+        assert "read_file" in during, during
+
+        after = await _paint(transcript, messages, "")
+        await pilot.pause()
+        assert "read_file" not in after, after
+
+
+@pytest.mark.asyncio
+async def test_a_ticking_line_repaints_only_its_own_row():
+    """The line is scoped to ONE row -- every other row must be untouched.
+
+    Found by mutation, and invisible to every display assertion: stamping
+    `live_activity` on every message instead of just the in-flight one
+    changes nothing a reader can SEE (a row with content never renders the
+    line, and only assistant rows can), but it puts `live_activity` into
+    every row's signature -- so the whole transcript re-derives and re-syncs
+    once a second for the entire turn. This measures the blast radius
+    instead of the pixels.
+    """
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        history = [
+            ConsoleChatMessage(
+                role=ConsoleMessageRole.USER, content="earlier", id="u0"
+            ),
+            ConsoleChatMessage(
+                role=ConsoleMessageRole.ASSISTANT, content="a reply", id="a0"
+            ),
+            _user(),
+            _in_flight_assistant(),
+        ]
+        await _paint(transcript, history, "⚙ read_file · 4s")
+        await pilot.pause()
+        before_signatures = transcript.row_render_signatures()
+        before_computes = transcript.message_signature_compute_counts()
+
+        await _paint(transcript, history, "⚙ read_file · 5s")
+        await pilot.pause()
+        after_signatures = transcript.row_render_signatures()
+        after_computes = transcript.message_signature_compute_counts()
+
+        moved = {
+            key
+            for key in before_signatures
+            if before_signatures[key] != after_signatures.get(key)
+        }
+        assert moved == {"message:a1"}, moved
+        for message_id in ("u0", "a0", "u1"):
+            assert after_computes[message_id] == before_computes[message_id], message_id
+        assert after_computes["a1"] > before_computes["a1"]
+
+
+@pytest.mark.asyncio
+async def test_a_partially_streamed_reply_is_never_replaced_by_the_line():
+    """Once real text exists it owns the row -- the line is for empty rows."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        messages = [_user(), _in_flight_assistant(content="Once upon", status="streaming")]
+        assert transcript.apply_turn_activity("⚙ read_file · 4s") == ""
+        text = await _paint(transcript, messages, "⚙ read_file · 4s")
+        await pilot.pause()
+        assert "Once upon" in text, text
+        assert "read_file" not in text, text
+
+
 # --------------------------------------------------------------------------
 # Sub-agent isolation
 # --------------------------------------------------------------------------
@@ -386,8 +501,39 @@ async def test_the_plain_renderer_shows_the_activity_line_too():
         await pilot.pause()
         assert "read_file" in text, text
         assert "4s" in text, text
-        # The placeholder already implies streaming; no doubled status line.
         assert "Streaming…" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_a_streaming_empty_row_shows_the_line_dim_and_without_a_status_line():
+    """The line must not double up with "Streaming…", and must read as dim.
+
+    Found by mutation: with the placeholder predicate blind to the activity
+    line, a plain row that is STREAMING with empty content -- reachable on a
+    fence-gated tool turn, where `reset_stream_buffer` discards leaked prose
+    and leaves the row streaming-and-empty -- rendered the line as ordinary
+    assistant content with a "Streaming…" status line stacked under it.
+    """
+    app = _ActivityHarness()
+    app.app_config = {"chat_defaults": {"assistant_markdown": False}}
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        messages = [_user(), _in_flight_assistant(status="streaming")]
+        text = await _paint(transcript, messages, "⚙ read_file · 4s")
+        await pilot.pause()
+        assert "⚙ read_file · 4s" in text, text
+        assert "Streaming…" not in text, text
+
+        body = transcript.query_one("#console-message-a1").query_one(
+            ".console-transcript-message-body", Static
+        )
+        content = body.renderable
+        dimmed = "".join(
+            content.plain[span.start : span.end]
+            for span in content.spans
+            if "dim" in str(span.style)
+        )
+        assert "⚙ read_file · 4s" in dimmed, (content.plain, content.spans)
 
 
 # --------------------------------------------------------------------------

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -776,6 +776,50 @@ async def test_a_ticking_elapsed_alone_repaints_the_transcript():
 
 
 @pytest.mark.asyncio
+async def test_a_real_console_screen_carries_the_line_to_its_mounted_row():
+    """The stubs above meet reality: a REAL screen, a REAL mounted transcript.
+
+    Closes the gap the `MagicMock` pins leave open -- that `self._agent`
+    exists on a live `ChatScreen`, that `console_turn_activity()` resolves
+    through the controller's real property chain (returning "" on an idle
+    screen), and that the real `_sync_native_console_transcript` carries a
+    line all the way onto the real row widget.
+    """
+    from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(120, 40)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+
+        # An idle screen derives nothing -- and the read itself must work.
+        assert console._agent.console_turn_activity() == ""
+
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id or store.ensure_session().id
+        store.append_message(
+            session_id, role=ConsoleMessageRole.USER, content="run a tool"
+        )
+        pending = store.append_message(
+            session_id, role=ConsoleMessageRole.ASSISTANT, content=""
+        )
+        console._agent.console_turn_activity = lambda: "⚙ read_file · 4s"
+
+        console._last_native_transcript_refresh_key = None
+        await console._sync_native_console_transcript()
+        await pilot.pause()
+
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        text = _rendered_row_text(transcript, pending.id)
+        assert "⚙ read_file · 4s" in text, text
+        assert CONSOLE_GENERATING_PLACEHOLDER not in text, text
+
+
+@pytest.mark.asyncio
 async def test_an_ineffective_activity_never_repaints_an_idle_transcript():
     """task-15664 AC#2: no repaint on a timer when nothing is live.
 

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -38,6 +38,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
 )
 from tldw_chatbook.UI.Console_Modules.agent import (
+    CONSOLE_TURN_ACTIVITY_SEPARATOR,
     CONSOLE_TURN_ACTIVITY_THINKING,
     ConsoleAgentController,
     console_turn_activity_text,
@@ -226,10 +227,9 @@ async def test_before_the_first_step_the_row_keeps_the_generating_copy():
         await pilot.pause()
         assert CONSOLE_GENERATING_PLACEHOLDER in text, text
         # No elapsed: there is no per-step base to time from, and inventing
-        # one would be a lie (`_format_fleet_elapsed`'s own rule).
-        assert "s" not in text.replace("Assistant", "").replace(
-            CONSOLE_GENERATING_PLACEHOLDER, ""
-        ), text
+        # one would be a lie (`_format_fleet_elapsed`'s own rule). The
+        # separator is the only thing an elapsed segment can arrive behind.
+        assert CONSOLE_TURN_ACTIVITY_SEPARATOR not in text, text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -1,0 +1,647 @@
+"""The Console's live turn-activity line.
+
+An agent turn's in-flight assistant row used to show nothing at all while a
+tool ran -- measured, not assumed: with a tool call held in flight the store
+reports ``status='pending'``, ``content=''`` for that row, and the
+``CONSOLE_GENERATING_PLACEHOLDER`` branch in ``_message_body`` is gated on
+``status == 'streaming'``, so it never fired. The user watched a bare
+``Assistant`` row for the whole multi-round turn.
+
+Every assertion here reads the MOUNTED ROW WIDGET's own renderables
+(``_rendered_row_text``), never ``ConsoleTranscript._messages`` -- twice in
+this programme a "rendered" assertion turned out to only prove data reached
+the model.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Markdown, Static
+
+from Tests.Chat.test_console_agent_bridge import _bridge, _fence, _test_resolution
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Agents.agent_models import (
+    AGENT_KIND_PRIMARY,
+    AGENT_KIND_SUBAGENT,
+    STEP_MODEL,
+    STEP_TOOL_CALL,
+    STEP_TOOL_RESULT,
+)
+from tldw_chatbook.Chat.console_agent_bridge import AgentLiveSnapshot, AgentLiveStep
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.UI.Console_Modules.agent import (
+    CONSOLE_TURN_ACTIVITY_THINKING,
+    ConsoleAgentController,
+    console_turn_activity_text,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    CONSOLE_GENERATING_PLACEHOLDER,
+    ConsoleMarkdownMessage,
+    ConsoleTranscript,
+)
+
+
+class _ActivityHarness(ConsolidatedCSSApp):
+    """A bare mounted transcript -- the same surface the Console mounts."""
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTranscript(id="console-native-transcript")
+
+
+def _rendered_row_text(transcript: ConsoleTranscript, message_id: str) -> str:
+    """Visible text of ONE mounted row, read off the row's own widgets.
+
+    Deliberately resolves the row by DOM id and reads the child ``Static``
+    renderables (plus a markdown row's source), so nothing here can pass by
+    reading the transcript's message model.
+    """
+    row = transcript.query_one(f"#console-message-{message_id}")
+    parts = [str(static.renderable) for static in row.query(Static)]
+    if isinstance(row, ConsoleMarkdownMessage):
+        parts.append(row.query_one(Markdown).source)
+    if not parts:
+        parts = [str(row.renderable)]
+    return "\n".join(parts)
+
+
+def _in_flight_assistant(content: str = "", status: str = "pending"):
+    return ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content=content,
+        id="a1",
+        status=status,
+    )
+
+
+def _user():
+    return ConsoleChatMessage(role=ConsoleMessageRole.USER, content="hi", id="u1")
+
+
+async def _paint(
+    transcript: ConsoleTranscript, messages, activity: str, row_id: str = "a1"
+) -> str:
+    """Push one poll tick's worth of state and return the rendered row text."""
+    transcript.set_messages(messages)
+    transcript.apply_turn_activity(activity)
+    await transcript.refresh_messages()
+    return _rendered_row_text(transcript, row_id)
+
+
+def _snapshot(*steps, status: str = "running") -> AgentLiveSnapshot:
+    return AgentLiveSnapshot(status=status, step=len(steps), steps=tuple(steps))
+
+
+# --------------------------------------------------------------------------
+# The red: a real agent turn, a real tool held in flight, a rendered row.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_held_tool_call_names_the_tool_in_the_rendered_assistant_row(
+    tmp_path, monkeypatch
+):
+    """A tool held in flight must name itself in the in-flight row, and tick.
+
+    Production path end to end: the real ``ConsoleAgentBridge`` runs a real
+    ``agent_runtime`` turn whose scripted fence calls the real
+    ``CalculatorTool``; that tool blocks on an Event, so the run is parked
+    exactly where a slow tool parks it. The tool name reaches the row through
+    ``bridge.live_snapshot`` -> ``console_turn_activity_text`` ->
+    ``ConsoleTranscript.apply_turn_activity`` -- no test double in between.
+    """
+    from tldw_chatbook.Tools.tool_executor import CalculatorTool
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    async def _blocking_execute(self, expression):
+        entered.set()
+        release.wait(timeout=20)
+        return {"value": 42}
+
+    monkeypatch.setattr(CalculatorTool, "execute", _blocking_execute)
+    bridge, _db, store, session, assistant_id = _bridge(
+        tmp_path,
+        [[_fence("calculator", {"expression": "6*7"})], ["It is 42."]],
+    )
+
+    def _drive() -> None:
+        bridge.run_reply(
+            conversation_id="conv-1",
+            session_id=session.id,
+            resolution=_test_resolution(),
+            assistant_message_id=assistant_id,
+            model="test-model",
+            session_system_prompt="",
+            agent_messages=[{"role": "user", "content": "hi"}],
+            should_cancel=lambda: False,
+        )
+
+    worker = threading.Thread(target=_drive, daemon=True)
+    worker.start()
+    try:
+        assert entered.wait(20), "the scripted tool call never reached the tool"
+        observed_at = time.monotonic()
+        snapshot = bridge.live_snapshot("conv-1")
+        messages = store.messages_for_session(session.id)
+        in_flight = [
+            message
+            for message in messages
+            if message.role is ConsoleMessageRole.ASSISTANT
+        ]
+        assert in_flight, "the turn must own an in-flight assistant row"
+        assert in_flight[-1].content == "", "the row is empty while the tool runs"
+
+        app = _ActivityHarness()
+        async with app.run_test(size=(80, 24)) as pilot:
+            transcript = app.query_one(ConsoleTranscript)
+
+            row_id = in_flight[-1].id
+            first = console_turn_activity_text(snapshot, now=observed_at)
+            early = await _paint(transcript, messages, first, row_id)
+            await pilot.pause()
+
+            assert "calculator" in early, early
+            assert CONSOLE_GENERATING_PLACEHOLDER not in early, early
+            assert "<1s" in early, early
+
+            # A later poll tick, same held call: only the elapsed moves.
+            later_text = console_turn_activity_text(snapshot, now=observed_at + 5.0)
+            later = await _paint(transcript, messages, later_text, row_id)
+            await pilot.pause()
+
+            assert "calculator" in later, later
+            assert "5s" in later, later
+            assert "<1s" not in later, later
+    finally:
+        release.set()
+        worker.join(20)
+
+
+# --------------------------------------------------------------------------
+# The states
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_between_tool_calls_the_row_says_thinking_not_a_stale_tool_name():
+    """After a tool returns, the row reports the model turn, not the tool."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        snapshot = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, "read_file", AGENT_KIND_PRIMARY, 100.0),
+            AgentLiveStep(STEP_TOOL_RESULT, "read_file → ok", AGENT_KIND_PRIMARY, 104.0),
+        )
+        text = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(snapshot, now=110.0),
+        )
+        await pilot.pause()
+        assert CONSOLE_TURN_ACTIVITY_THINKING in text, text
+        assert "6s" in text, text
+        assert "read_file" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_before_the_first_step_the_row_keeps_the_generating_copy():
+    """A running turn with no step yet is pre-first-token: today's copy."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        text = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(_snapshot(), now=1.0),
+        )
+        await pilot.pause()
+        assert CONSOLE_GENERATING_PLACEHOLDER in text, text
+        # No elapsed: there is no per-step base to time from, and inventing
+        # one would be a lie (`_format_fleet_elapsed`'s own rule).
+        assert "s" not in text.replace("Assistant", "").replace(
+            CONSOLE_GENERATING_PLACEHOLDER, ""
+        ), text
+
+
+@pytest.mark.asyncio
+async def test_a_finished_turn_drops_the_activity_line_from_the_row():
+    """When the turn ends the line disappears -- the reply renders alone."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        running = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, "read_file", AGENT_KIND_PRIMARY, 100.0)
+        )
+        during = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(running, now=101.0),
+        )
+        await pilot.pause()
+        assert "read_file" in during, during
+
+        done = _snapshot(
+            AgentLiveStep(STEP_TOOL_RESULT, "read_file → ok", AGENT_KIND_PRIMARY, 104.0),
+            status="done",
+        )
+        assert console_turn_activity_text(done, now=110.0) == ""
+        after = await _paint(
+            transcript,
+            [
+                _user(),
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="It is 42.",
+                    id="a1",
+                    status="complete",
+                ),
+            ],
+            console_turn_activity_text(done, now=110.0),
+        )
+        await pilot.pause()
+        assert "read_file" not in after, after
+        assert CONSOLE_TURN_ACTIVITY_THINKING not in after, after
+        assert CONSOLE_GENERATING_PLACEHOLDER not in after, after
+        assert "It is 42." in after, after
+
+
+# --------------------------------------------------------------------------
+# Sub-agent isolation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_subagent_step_never_hijacks_the_primary_rows_activity_line():
+    """A child's steps belong to the rail, never to the primary's row.
+
+    Not theoretical: ``ConsoleAgentBridge.on_step`` routes a sub-agent step
+    with an EMPTY run id into the primary's own live feed (the documented
+    "no run attributed" fallback), so the primary snapshot really can carry
+    a child's step as its last entry.
+    """
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        snapshot = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, "read_file", AGENT_KIND_PRIMARY, 100.0),
+            AgentLiveStep(STEP_TOOL_CALL, "web_fetch", AGENT_KIND_SUBAGENT, 103.0),
+        )
+        text = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(snapshot, now=105.0),
+        )
+        await pilot.pause()
+        assert "web_fetch" not in text, text
+        assert "read_file" in text, text
+        # Elapsed is the PRIMARY step's, not the child's (105 - 100).
+        assert "5s" in text, text
+
+
+@pytest.mark.asyncio
+async def test_a_turn_with_only_subagent_steps_falls_back_to_generating():
+    """No primary step yet means pre-first-token, whatever a child is doing."""
+    snapshot = _snapshot(
+        AgentLiveStep(STEP_TOOL_CALL, "web_fetch", AGENT_KIND_SUBAGENT, 100.0)
+    )
+    assert (
+        console_turn_activity_text(snapshot, now=105.0)
+        == CONSOLE_GENERATING_PLACEHOLDER
+    )
+
+
+# --------------------------------------------------------------------------
+# Quiet tools, markup, and the model-step summary
+# --------------------------------------------------------------------------
+
+
+def test_quiet_catalog_tools_still_appear_in_the_activity_line():
+    """``find_tools``/``load_tools`` are quiet in MARKERS, not in the line.
+
+    The quiet rule keeps catalog plumbing out of the PERMANENT transcript.
+    The activity line is ephemeral and exists precisely so a working turn
+    never looks frozen -- suppressing these would reinstate the silent gap
+    for the whole discovery round.
+    """
+    for name in ("find_tools", "load_tools"):
+        snapshot = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, name, AGENT_KIND_PRIMARY, 100.0)
+        )
+        assert name in console_turn_activity_text(snapshot, now=102.0)
+
+
+def test_a_model_step_never_leaks_its_summary_into_the_line():
+    """``STEP_MODEL``'s summary is the raw turn text (a fence, mid-turn)."""
+    snapshot = _snapshot(
+        AgentLiveStep(STEP_MODEL, "```tool_call\n{...}", AGENT_KIND_PRIMARY, 100.0)
+    )
+    text = console_turn_activity_text(snapshot, now=103.0)
+    assert text.startswith(CONSOLE_TURN_ACTIVITY_THINKING)
+    assert "tool_call" not in text
+
+
+@pytest.mark.asyncio
+async def test_a_bracketed_tool_name_renders_literally_not_escaped():
+    """Rows render markup-off, so the line is raw -- no backslash residue."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        snapshot = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, "fetch [docs]", AGENT_KIND_PRIMARY, 100.0)
+        )
+        text = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(snapshot, now=101.0),
+        )
+        await pilot.pause()
+        assert "fetch [docs]" in text, text
+        assert "\\[" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_the_plain_renderer_shows_the_activity_line_too():
+    """The span renderer (``assistant_markdown = false``) is not left behind."""
+    app = _ActivityHarness()
+    app.app_config = {"chat_defaults": {"assistant_markdown": False}}
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        snapshot = _snapshot(
+            AgentLiveStep(STEP_TOOL_CALL, "read_file", AGENT_KIND_PRIMARY, 100.0)
+        )
+        text = await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(snapshot, now=104.0),
+        )
+        await pilot.pause()
+        assert "read_file" in text, text
+        assert "4s" in text, text
+        # The placeholder already implies streaming; no doubled status line.
+        assert "Streaming…" not in text, text
+
+
+# --------------------------------------------------------------------------
+# Geometry and the no-idle-repaint contract
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_activity_line_never_pushes_the_row_past_the_screen():
+    """Rendered geometry, not DOM presence: neighbours stay on screen."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        snapshot = _snapshot(
+            AgentLiveStep(
+                STEP_TOOL_CALL, "read_file_with_a_very_long_name", AGENT_KIND_PRIMARY, 1.0
+            )
+        )
+        await _paint(
+            transcript,
+            [_user(), _in_flight_assistant()],
+            console_turn_activity_text(snapshot, now=61.0),
+        )
+        await pilot.pause()
+        screen_width = app.screen.size.width
+        for row_id in ("u1", "a1"):
+            row = transcript.query_one(f"#console-message-{row_id}")
+            assert row.region.x + row.region.width <= screen_width, (
+                row_id,
+                row.region,
+            )
+            for child in row.query(Static):
+                assert child.region.x + child.region.width <= screen_width, (
+                    row_id,
+                    child.region,
+                )
+
+
+@pytest.mark.asyncio
+async def test_no_eligible_row_means_no_effective_activity():
+    """Nothing in flight -> the line is inert, so no poll can repaint for it.
+
+    ``apply_turn_activity`` returns the EFFECTIVE value, which is what the
+    screen folds into its transcript refresh key -- so a stale ``running``
+    snapshot on an idle transcript cannot tick that key once per second
+    (task-15664 AC#2: no repaint on a timer when nothing is live).
+    """
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages(
+            [
+                _user(),
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="It is 42.",
+                    id="a1",
+                    status="complete",
+                ),
+            ]
+        )
+        assert transcript.apply_turn_activity("⚙ read_file · 4s") == ""
+        await transcript.refresh_messages()
+        await pilot.pause()
+        assert "read_file" not in _rendered_row_text(transcript, "a1")
+
+
+@pytest.mark.asyncio
+async def test_an_eligible_row_reports_the_effective_activity():
+    """The mirror of the pin above: an in-flight row does take the line."""
+    app = _ActivityHarness()
+    async with app.run_test(size=(80, 24)):
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([_user(), _in_flight_assistant()])
+        assert transcript.apply_turn_activity("⚙ read_file · 4s") == "⚙ read_file · 4s"
+
+
+# --------------------------------------------------------------------------
+# The controller's gate: only the VIEWED session's live turn owns the line
+# --------------------------------------------------------------------------
+
+
+class _GateController(ConsoleAgentController):
+    """Exercises ``console_turn_activity``'s gate over its documented seams.
+
+    The three members it reads (``_console_chat_controller``,
+    ``_console_agent_bridge``, ``_current_console_rail_conversation_id``)
+    are class-level ``@property`` pass-throughs to the screen, so they are
+    overridden here rather than assigned -- the method body under test is
+    the real one.
+    """
+
+    def __init__(self, *, run_status, bridge, conversation_id="conv-1") -> None:
+        self._run_status = run_status
+        self._bridge = bridge
+        self._conversation_id = conversation_id
+
+    @property
+    def _console_chat_controller(self):
+        if self._run_status is None:
+            return None
+        return SimpleNamespace(run_state=SimpleNamespace(status=self._run_status))
+
+    @property
+    def _console_agent_bridge(self):
+        return self._bridge
+
+    @property
+    def _current_console_rail_conversation_id(self):
+        return lambda: self._conversation_id
+
+
+class _SnapshotBridge:
+    def __init__(self, snapshot) -> None:
+        self._snapshot = snapshot
+        self.conversation_ids: list[str] = []
+
+    def live_snapshot(self, conversation_id):
+        self.conversation_ids.append(conversation_id)
+        return self._snapshot
+
+
+def _running_tool_snapshot():
+    return _snapshot(
+        AgentLiveStep(STEP_TOOL_CALL, "read_file", AGENT_KIND_PRIMARY, time.monotonic())
+    )
+
+
+def test_an_active_viewed_run_yields_the_line_for_its_own_conversation():
+    bridge = _SnapshotBridge(_running_tool_snapshot())
+    controller = _GateController(
+        run_status=ConsoleRunStatus.STREAMING, bridge=bridge, conversation_id="conv-7"
+    )
+    assert "read_file" in controller.console_turn_activity()
+    assert bridge.conversation_ids == ["conv-7"]
+
+
+@pytest.mark.parametrize(
+    "run_status", [ConsoleRunStatus.IDLE, ConsoleRunStatus.COMPLETED, None]
+)
+def test_an_inactive_viewed_run_never_yields_a_line(run_status):
+    """The first gate: a stale ``running`` snapshot must not outlive its turn."""
+    bridge = _SnapshotBridge(_running_tool_snapshot())
+    controller = _GateController(run_status=run_status, bridge=bridge)
+    assert controller.console_turn_activity() == ""
+    assert bridge.conversation_ids == [], "the bridge is not even consulted"
+
+
+def test_no_bridge_and_a_partial_bridge_double_both_yield_nothing():
+    for bridge in (None, SimpleNamespace()):
+        controller = _GateController(
+            run_status=ConsoleRunStatus.STREAMING, bridge=bridge
+        )
+        assert controller.console_turn_activity() == ""
+
+
+# --------------------------------------------------------------------------
+# Screen wiring: the 0.2s poll's transcript sync is where the line is fed in
+# --------------------------------------------------------------------------
+
+
+def _sync_stub(activity: str, effective: str | None = None):
+    """A ``ChatScreen``-shaped stand-in for ``_sync_native_console_transcript``.
+
+    ``MagicMock`` answers everything the method merely CALLS; every member it
+    iterates, sorts or awaits is overridden explicitly, so a future
+    production addition of the first kind cannot silently no-op this test
+    while one of the second kind fails loudly and by name.
+    """
+    transcript = SimpleNamespace(
+        pending_selection_id=None,
+        set_presentation_context=Mock(),
+        set_change_review_provider_factory=Mock(),
+        set_messages=Mock(),
+        apply_turn_activity=Mock(
+            return_value=activity if effective is None else effective
+        ),
+        set_citation_counts=Mock(),
+        set_original_attempt_previews=Mock(),
+        set_summary_boundary=Mock(),
+        sync_jump_indicator=Mock(),
+        set_image_specs=Mock(),
+        set_generation_card_specs=Mock(),
+        set_video_card_specs=Mock(),
+        refresh_messages=AsyncMock(),
+    )
+    screen = MagicMock()
+    screen.query_one = Mock(return_value=transcript)
+    screen._console_transcript_region_or_none = Mock(return_value=None)
+    screen._native_console_messages = Mock(return_value=[])
+    screen._console_original_attempt_previews = {}
+    screen._console_citation_counts = {}
+    screen._console_speech_states = {}
+    screen._console_image_preparing = set()
+    screen._pending_console_swipe_selection = None
+    screen._console_chat_controller = None
+    screen._last_native_transcript_refresh_key = None
+    screen._native_console_transcript_fingerprint = Mock(return_value=("stable",))
+    screen._ensure_console_chat_store = Mock(
+        return_value=SimpleNamespace(active_session_id=None)
+    )
+    screen._current_console_run_status_value = Mock(return_value="streaming")
+    screen._image._build_console_image_specs = Mock(return_value={})
+    screen._image._build_generation_card_specs = Mock(return_value={})
+    screen._image._pending_console_generation_card_images = Mock(return_value=())
+    screen._video._build_video_card_specs = Mock(return_value={})
+    screen._ensure_console_image_view = Mock(
+        return_value=(None, SimpleNamespace(pending_ids=lambda _ids: ()))
+    )
+    screen._recent_console_image_messages = Mock(return_value=())
+    screen._agent.console_turn_activity = Mock(return_value=activity)
+    return screen, transcript
+
+
+@pytest.mark.asyncio
+async def test_the_transcript_sync_hands_the_controllers_line_to_the_transcript():
+    """The 0.2s poll's transcript sync is the one feed for this line."""
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen, transcript = _sync_stub("⚙ read_file · 4s")
+    await ChatScreen._sync_native_console_transcript(screen)
+
+    screen._agent.console_turn_activity.assert_called_once_with()
+    assert transcript.apply_turn_activity.call_args.args == ("⚙ read_file · 4s",)
+    assert transcript.refresh_messages.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_ticking_elapsed_alone_repaints_the_transcript():
+    """The refresh key must move when only the elapsed figure changed."""
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen, transcript = _sync_stub("⚙ read_file · 4s")
+    await ChatScreen._sync_native_console_transcript(screen)
+    transcript.apply_turn_activity.return_value = "⚙ read_file · 5s"
+    screen._agent.console_turn_activity.return_value = "⚙ read_file · 5s"
+    await ChatScreen._sync_native_console_transcript(screen)
+
+    assert transcript.refresh_messages.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_an_ineffective_activity_never_repaints_an_idle_transcript():
+    """task-15664 AC#2: no repaint on a timer when nothing is live.
+
+    The screen folds the EFFECTIVE value into its refresh key, so even a
+    stale ``running`` snapshot whose derived line keeps ticking cannot move
+    that key while no row is in flight.
+    """
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    screen, transcript = _sync_stub("⚙ read_file · 4s", effective="")
+    await ChatScreen._sync_native_console_transcript(screen)
+    screen._agent.console_turn_activity.return_value = "⚙ read_file · 5s"
+    await ChatScreen._sync_native_console_transcript(screen)
+
+    assert transcript.refresh_messages.await_count == 1

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4764,3 +4764,35 @@ demonstrated. Rule: when new-code symbols would make a born-red file
 unimportable at base, reference them lazily (or split the white-box asserts
 out) so the base-tree run fails on the assertion that carries the evidence,
 not on `import`.
+
+---
+
+## A per-tick view value needs its CACHE KEY and its SCOPE mutation-tested; display assertions see neither (turn-activity line, 2026-08-16)
+
+The Console's in-flight assistant row gained a live activity line (`⚙
+read_file · 4s`) refreshed on the 0.2s poll. Every display assertion was
+green, and mutation testing then found two defects that no rendered-text
+assertion could have seen:
+
+1. **The cache key.** `ConsoleTranscript` has TWO renderers — markdown (the
+   default for assistant rows, which carries the line in its *header*) and
+   plain. `_message_row_signature` is built from the PLAIN renderer only, so
+   the markdown row's elapsed advanced solely as a side effect of the plain
+   renderer embedding the same string. Disabling the plain branch left the
+   first paint correct and froze every later tick — the tell was not "the
+   line is missing" but "the FIRST tick passed and the SECOND did not".
+2. **The scope.** Stamping the value on every message instead of only the
+   in-flight row changes nothing a reader can see (a row with content never
+   renders it; only assistant rows can) — but it lands in every row's
+   signature, so the whole transcript re-derives and re-syncs once per
+   second for the entire turn. The mutant SURVIVED a suite of rendered-row
+   assertions.
+
+**What to do.** For any value the poll re-supplies each tick: (a) mutate the
+signature/cache key and require a test that paints two ticks differing in
+*nothing but that value*; (b) mutate the scope and assert **blast radius**,
+not pixels — `row_render_signatures()` and
+`message_signature_compute_counts()` make "exactly one row moved" a direct
+assertion. Also worth knowing for this widget: a signature that renders one
+of two renderers silently couples them, so name the field in the signature
+outright rather than relying on it riding along inside rendered text.

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -875,11 +875,28 @@ class AgentLiveStep:
             raw/unescaped for the rail's markup-off ``Static``.
         agent_kind: Which agent produced the step -- ``AGENT_KIND_PRIMARY``
             or ``AGENT_KIND_SUBAGENT``.
+        started_at: ``time.monotonic()`` at the moment THIS bridge observed
+            the step, or ``None`` when there is no honest base (every
+            resume-derived step; see ``_derive_historical_snapshot``).
+
+            Stamped here, in the impure seam, rather than on ``AgentStep``:
+            ``AgentStep.created_at`` is a ``str`` that stays EMPTY for the
+            whole life of a live run (``AgentService`` stamps the batch
+            once, at end-of-run persist), and ``Agents/agent_runtime.py`` /
+            ``agent_models.py`` are pure-logic modules by design -- reading
+            a clock there would put wall-time into the layer whose whole
+            contract is that it has none. ``on_step`` is called
+            SYNCHRONOUSLY from the runtime the instant a step is added --
+            for ``STEP_TOOL_CALL`` that is the statement immediately before
+            ``deps.invoke_tool(call)`` -- so this reading is the tool's own
+            start, not a poll-quantised approximation of it. Monotonic
+            (never wall clock) because the only consumer is a duration.
     """
 
     kind: str
     text: str
     agent_kind: str
+    started_at: float | None = None
 
 
 @dataclass(frozen=True)
@@ -3085,7 +3102,13 @@ class ConsoleAgentBridge:
             )
             key_steps = run_live_steps.setdefault(live_key, [])
             key_steps.append(
-                AgentLiveStep(step.kind, self._summarize(step), agent_kind)
+                # `time.monotonic()` HERE is the step's real start: this hook
+                # runs synchronously inside the runtime loop, before the work
+                # the step announces (a STEP_TOOL_CALL lands one statement
+                # ahead of `deps.invoke_tool`). See `AgentLiveStep.started_at`.
+                AgentLiveStep(
+                    step.kind, self._summarize(step), agent_kind, time.monotonic()
+                )
             )
             # TASK-1366: pair this result step with the raw before/after
             # contents the provider's diff_sink captured at the strip seam,

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -598,6 +598,15 @@ class ConsoleChatMessage:
     # resume+edit can never clobber the video payload). None for every
     # non-video message.
     video_metadata: "VideoGenerationMetadata | None" = None
+    #: Render-only live activity line for an IN-FLIGHT assistant row ("⚙
+    #: read_file · 4s"). Set by nothing that owns messages: the store never
+    #: writes it, no persistence path reads it, and it is never echoed to a
+    #: model or a run log. ``ConsoleTranscript`` alone stamps it, on a
+    #: throwaway ``replace()`` copy made inside its row-planning walk (the
+    #: same seam ``tool_output_full`` expansion uses), from a value the
+    #: 0.2s Console poll re-derives every tick. It is therefore always
+    #: ``""`` on every message the rest of the app ever sees.
+    live_activity: str = ""
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -144,13 +144,18 @@ import time
 from loguru import logger
 from textual.message_pump import NoActiveAppError
 
-from ...Agents.agent_models import TERMINAL_RUN_STATUSES
+from ...Agents.agent_models import (
+    AGENT_KIND_PRIMARY,
+    STEP_TOOL_CALL,
+    TERMINAL_RUN_STATUSES,
+)
 from ...Chat.cost_display import format_token_count
 from ...Widgets.Console.console_inspector_section import (
     ConsoleInspectorSectionState,
     InspectorSectionRow,
 )
 from ...Widgets.Console.console_run_log_modal import ConsoleRunLogModal
+from ...Widgets.Console.console_transcript import CONSOLE_GENERATING_PLACEHOLDER
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ...Agents.fleet_coordinator import FleetHandle
@@ -178,7 +183,27 @@ _AGENT_STATUS_GLYPHS: Dict[str, str] = {
 #: constant so the two sides can never drift apart.
 CONSOLE_AGENT_FLEET_SECTION_ID = "agent-fleet"
 
-__all__ = ["ConsoleAgentController", "CONSOLE_AGENT_FLEET_SECTION_ID"]
+#: Leading glyph for the turn-activity line's tool state. Same glyph the
+#: transcript's completed TOOL markers use (``format_agent_step_marker``),
+#: so "what is running now" and "what ran" read as one vocabulary.
+CONSOLE_TURN_ACTIVITY_TOOL_GLYPH = "⚙"
+#: The turn-activity line's between-tools state: the loop has handed the
+#: last tool result back to the model and is waiting on the next round.
+#: There is no step kind for "a model call started" (``STEP_MODEL`` is
+#: emitted AFTER the round returns, carrying its text), so this is derived
+#: from "the last primary step is not a tool call", not from an event.
+CONSOLE_TURN_ACTIVITY_THINKING = "Thinking…"
+#: Separator between the state and its elapsed segment.
+CONSOLE_TURN_ACTIVITY_SEPARATOR = " · "
+
+__all__ = [
+    "ConsoleAgentController",
+    "CONSOLE_AGENT_FLEET_SECTION_ID",
+    "CONSOLE_TURN_ACTIVITY_SEPARATOR",
+    "CONSOLE_TURN_ACTIVITY_THINKING",
+    "CONSOLE_TURN_ACTIVITY_TOOL_GLYPH",
+    "console_turn_activity_text",
+]
 
 
 def _format_fleet_elapsed(seconds: float | None) -> str:
@@ -210,6 +235,85 @@ def _format_fleet_elapsed(seconds: float | None) -> str:
         return f"{total_seconds}s"
     minutes, secs = divmod(total_seconds, 60)
     return f"{minutes}m {secs}s"
+
+
+def console_turn_activity_text(snapshot: Any, *, now: float) -> str:
+    """Return the live activity line for one in-flight Console turn.
+
+    **Live-only, by construction.** There is no resumed counterpart and
+    there must never be one: this line reports what an agent is doing
+    RIGHT NOW, and a finished turn's transcript already carries the TOOL
+    markers that say what it did. (Same "live rendering has no resumed
+    twin" note ``format_todo_marker`` carries -- unlike
+    ``format_agent_step_marker``, which is deliberately shared by the live
+    and resume paths so both render byte-identical text.)
+
+    The four states, derived from the primary agent's most recent step:
+
+    ===========================  ==========================================
+    situation                    line
+    ===========================  ==========================================
+    a tool is running            ``⚙ <tool> · <elapsed>``
+    between tools / after one    ``Thinking… · <elapsed>``
+    running, no primary step     ``Generating…`` (today's copy, unchanged)
+    turn ended (any non-running) ``""`` -- the caller renders nothing
+    ===========================  ==========================================
+
+    Sub-agent steps are skipped, not merely deprioritised: a child's work
+    belongs to the Agent rail's fleet rows, never to the primary assistant
+    row. This is a real path, not a defensive one -- ``ConsoleAgentBridge.
+    on_step`` routes a SUB-AGENT step whose run id is empty into the
+    PRIMARY run's own live feed (its documented "no run attributed"
+    fallback), so ``snapshot.steps[-1]`` can genuinely belong to a child.
+
+    Quiet catalog tools (``find_tools``/``load_tools``) DO appear here.
+    ``_QUIET_STEP_TOOLS`` keeps them out of the permanent, append-only TOOL
+    markers, where a discovery round would be lasting clutter; this line is
+    ephemeral and exists precisely so no working moment looks frozen, and
+    suppressing them would restore a silent gap for the whole round.
+
+    ``STEP_MODEL``'s summary is never shown. It carries the raw model turn
+    text -- mid-turn that is the tool-call fence itself -- so the state, not
+    the summary, is what the user sees.
+
+    Args:
+        snapshot: The conversation's ``AgentLiveSnapshot`` (duck-typed:
+            ``status`` plus a ``steps`` sequence).
+        now: ``time.monotonic()`` reading for this poll tick, injected so
+            the elapsed segment is testable without sleeping.
+
+    Returns:
+        The line to render, or ``""`` when nothing is live.
+    """
+    if getattr(snapshot, "status", "idle") != "running":
+        return ""
+    step = next(
+        (
+            candidate
+            for candidate in reversed(tuple(getattr(snapshot, "steps", ()) or ()))
+            if getattr(candidate, "agent_kind", "") == AGENT_KIND_PRIMARY
+        ),
+        None,
+    )
+    if step is None:
+        # Pre-first-token: the model has not come back once yet, so there is
+        # no step to name and no honest base to time from.
+        return CONSOLE_GENERATING_PLACEHOLDER
+    if step.kind == STEP_TOOL_CALL:
+        # `AgentLiveStep.text` for a tool-call step IS the tool name:
+        # `agent_runtime` adds every STEP_TOOL_CALL with `tool_name=` and
+        # neither `summary` nor `result`, and `_summarize`'s precedence
+        # (summary or result or tool_name or kind) therefore lands on it.
+        label = f"{CONSOLE_TURN_ACTIVITY_TOOL_GLYPH} {step.text}"
+    else:
+        label = CONSOLE_TURN_ACTIVITY_THINKING
+    started_at = getattr(step, "started_at", None)
+    elapsed = (
+        _format_fleet_elapsed(max(0.0, now - started_at))
+        if started_at is not None
+        else ""
+    )
+    return f"{label}{CONSOLE_TURN_ACTIVITY_SEPARATOR}{elapsed}" if elapsed else label
 
 
 def _fleet_row_from_handle(handle: "FleetHandle", *, now: float) -> InspectorSectionRow:
@@ -536,6 +640,52 @@ class ConsoleAgentController:
             ),
         )
         return self._console_agent_bridge
+
+    def console_turn_activity(self) -> str:
+        """The viewed session's live turn-activity line, or ``""``.
+
+        Read once per 0.2s Console poll tick and handed to
+        ``ConsoleTranscript.apply_turn_activity``. **No new timer**: during
+        an agent turn the viewed run's status is in
+        ``CONSOLE_ACTIVE_RUN_STATUSES``, which is exactly the condition
+        ``_start_console_transcript_sync_timer`` keeps its 0.2s tick alive
+        for, so the line already repaints for free while a turn is in
+        flight -- and never repaints when nothing is (task-15664 AC#2).
+
+        That same status check is the FIRST gate here, deliberately. The
+        bridge's published snapshot is per-conversation and only a terminal
+        publish clears it, so a run that died without one would otherwise
+        leave ``status="running"`` behind and let this line tick forever on
+        an idle transcript. ``run_state`` is the read-only facade for the
+        VIEWED session only, so it is also what keeps another session's
+        in-flight turn from writing onto this one's row.
+
+        Every bridge attribute is reached through ``getattr`` for the same
+        reason the rail's own reads are: several suites drive this cluster
+        with a bare bridge double that implements only part of the surface.
+
+        Returns:
+            The rendered line, or ``""`` when no live turn owns this view.
+        """
+        # Imported in-body for the cycle this module's docstring documents:
+        # `chat_screen` imports `Console_Modules.wiring`, which imports this
+        # module, and the constant is defined further down that file.
+        from ..Screens.chat_screen import CONSOLE_ACTIVE_RUN_STATUSES
+
+        controller = self._console_chat_controller
+        run_state = getattr(controller, "run_state", None) if controller else None
+        if run_state is None or run_state.status not in CONSOLE_ACTIVE_RUN_STATUSES:
+            return ""
+        bridge = self._console_agent_bridge
+        if bridge is None:
+            return ""
+        conversation_id = self._current_console_rail_conversation_id() or ""
+        read_snapshot = getattr(bridge, "live_snapshot", None)
+        if read_snapshot is None:
+            return ""
+        return console_turn_activity_text(
+            read_snapshot(conversation_id), now=time.monotonic()
+        )
 
     def _console_agent_section_lines(self) -> tuple[str, str, str]:
         """Return the Agent rail's (status, steps, sub-agents) line text.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -15548,6 +15548,13 @@ class ChatScreen(BaseAppScreen):
                 transcript.pending_selection_id = self._pending_console_swipe_selection
                 self._pending_console_swipe_selection = None
             transcript.set_messages(messages)
+            # Live turn-activity line. `apply_turn_activity` hands back the
+            # EFFECTIVE value ("" unless a row is actually in flight), which
+            # is what joins the refresh key below -- so an idle transcript
+            # can never repaint once a second off a stale run snapshot.
+            turn_activity = transcript.apply_turn_activity(
+                self._agent.console_turn_activity()
+            )
             visible_citation_counts = {
                 message_id: count
                 for message_id, count in self._console_citation_counts.items()
@@ -15642,6 +15649,7 @@ class ChatScreen(BaseAppScreen):
                 # before-boundary) must force a refresh so the banner appears
                 # or clears even when the message set is otherwise unchanged.
                 summary_boundary_id,
+                turn_activity,
                 tuple(sorted(self._console_original_attempt_previews.items())),
                 tuple(sorted(visible_citation_counts.items())),
                 tuple(sorted(self._console_speech_states.items())),

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -3796,6 +3796,11 @@ class ConsoleTranscript(VerticalScroll):
 
     def _transcript_rows(self) -> list[_TranscriptRow]:
         rows: list[_TranscriptRow] = []
+        # Hoisted: which row (if any) carries this tick's activity line is a
+        # property of the message list, not of any one row.
+        activity_target_id = (
+            self._turn_activity_target_id() if self._turn_activity else None
+        )
         for message in self._messages:
             if (
                 message.id in self._pruned_message_ids
@@ -3807,7 +3812,7 @@ class ConsoleTranscript(VerticalScroll):
                 # on the other boundary.
                 continue
             message = self._with_expanded_tool_output(message)
-            message = self._with_turn_activity(message)
+            message = self._with_turn_activity(message, activity_target_id)
             selected = message.id == self.selected_message_id
             rows.append(
                 _TranscriptRow(
@@ -4408,10 +4413,16 @@ class ConsoleTranscript(VerticalScroll):
             The line that will actually render, or ``""``.
         """
         effective = activity if activity and self._turn_activity_target_id() else ""
+        # Unconditional, including the empty case: found by mutation, a row
+        # that stays in flight after its run dies (no terminal publish) is
+        # exactly where a retained line would sit forever, frozen at its
+        # last elapsed -- the frozen look this feature exists to remove.
         self._turn_activity = effective
         return effective
 
-    def _with_turn_activity(self, message: ConsoleChatMessage) -> ConsoleChatMessage:
+    def _with_turn_activity(
+        self, message: ConsoleChatMessage, target_id: str | None
+    ) -> ConsoleChatMessage:
         """Return ``message`` carrying this tick's activity line, when it owns it.
 
         Applied at the ONE walk that plans rows -- the same seam, and for the
@@ -4420,17 +4431,27 @@ class ConsoleTranscript(VerticalScroll):
         message, or a row would render one thing while its signature claimed
         another and never repaint.
 
+        **Exactly one row, deliberately.** Found by mutation: stamping every
+        message instead of just the in-flight one is invisible to every
+        display assertion (a row with content never renders the line, and
+        only assistant rows can) yet puts ``live_activity`` into EVERY row's
+        signature -- so the whole transcript re-derives and re-syncs once a
+        second for the entire turn.
+
         Returns ``message`` UNCHANGED (same object) when there is nothing to
         show, so a transcript with no live turn is byte-for-byte what it was
         before this feature existed.
 
         Args:
             message: The transcript message about to be rendered.
+            target_id: The row that owns the line this pass, hoisted out of
+                the loop by the caller (``_turn_activity_target_id``), or
+                ``None`` when no row does.
 
         Returns:
             ``message``, or a render-only copy carrying ``live_activity``.
         """
-        if not self._turn_activity or message.id != self._turn_activity_target_id():
+        if target_id is None or message.id != target_id:
             return message
         return replace(message, live_activity=self._turn_activity)
 
@@ -4509,6 +4530,16 @@ class ConsoleTranscript(VerticalScroll):
             message.status,
             selected,
             variants_signature,
+            # Found by mutation: a MARKDOWN row (the default assistant
+            # renderer) carries the activity line in its HEADER, which this
+            # signature never renders -- it renders the PLAIN row. So with
+            # this field absent the elapsed still ticked, but only as a side
+            # effect of `_message_render_text` happening to embed the same
+            # text; disabling the plain renderer's activity branch froze the
+            # markdown row's elapsed at the first value it painted, with
+            # every display test still green. Named explicitly here so the
+            # two renderers cannot silently depend on each other again.
+            message.live_activity,
             presentation.revision_token,
             self._console_speech_state(message.id),
         )

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -212,6 +212,22 @@ def _message_role_label(message: ConsoleChatMessage) -> str:
     return role.title()
 
 
+#: Statuses an assistant row holds while its turn is still in flight. The
+#: store starts an empty assistant row at "pending" and only promotes it to
+#: "streaming" on the first streamed chunk (``append_stream_chunk``), which
+#: a tool-calling agent turn never produces -- so the activity line must
+#: cover both or it would never appear on the very turns it exists for.
+_IN_FLIGHT_MESSAGE_STATUSES = frozenset({"pending", "streaming"})
+
+
+def _row_is_in_flight(message: ConsoleChatMessage) -> bool:
+    """Whether this row belongs to a turn that has not finished yet."""
+    return (
+        message.role is ConsoleMessageRole.ASSISTANT
+        and message.status in _IN_FLIGHT_MESSAGE_STATUSES
+    )
+
+
 def _message_body(
     message: ConsoleChatMessage,
     presentation: ConsoleMessagePresentation | None = None,
@@ -222,6 +238,15 @@ def _message_body(
         content = message.variants.current.content
     else:
         content = message.content
+    if _row_is_in_flight(message) and not content.strip() and message.live_activity:
+        # The live turn-activity line, when the poll has one for this row.
+        # Note the WIDER status gate than the placeholder below: measured on
+        # a real agent turn with a tool held in flight, the in-flight row is
+        # "pending" (the store only reaches "streaming" on the first streamed
+        # chunk, and a tool-calling turn's assistant row never streams -- the
+        # fence gate seals it). That is why this row used to render as a bare
+        # "Assistant" for the whole multi-round turn.
+        return message.live_activity
     if message.status == "streaming" and not content.strip():
         # Between send-accepted and the first streamed token the assistant row
         # has no content; show a visible generating state instead of an empty
@@ -290,7 +315,16 @@ def _citation_notice(message: ConsoleChatMessage) -> str:
 
 
 def _is_generating_placeholder_body(message: ConsoleChatMessage, body: str) -> bool:
-    """Return True when the rendered body is the pre-first-token placeholder."""
+    """Return True when the rendered body is a render-only in-flight line.
+
+    Two bodies qualify: the pre-first-token ``Generating…`` placeholder and
+    the live turn-activity line that replaces it while an agent turn works.
+    Both are render-derived (never stored content), both render dim, and
+    both already say "this turn is running" -- so neither may also grow the
+    ``Streaming…`` status line under it.
+    """
+    if _row_is_in_flight(message) and body and body == message.live_activity:
+        return True
     return message.status == "streaming" and body == CONSOLE_GENERATING_PLACEHOLDER
 
 
@@ -896,13 +930,21 @@ def _assistant_markdown_header(
         )
     role_label = _speaker_label(message, presentation)
     suffix = ""
-    if message.status == "streaming":
+    if _row_is_in_flight(message):
         body = _assistant_markdown_body(message, presentation)
-        # task-2154.16 (FB-01): same wording as the plain renderer's dim
-        # status line -- never the raw "[streaming]" content token.
-        suffix = (
-            f"  {CONSOLE_GENERATING_PLACEHOLDER}" if not body.strip() else "  Streaming…"
-        )
+        if not body.strip() and message.live_activity:
+            # The owner's shape: "Assistant  ⚙ read_file · 4s" -- the live
+            # line rides the row's own header, so no new widget is mounted
+            # and no sibling can be pushed off screen by one.
+            suffix = f"  {message.live_activity}"
+        elif message.status == "streaming":
+            # task-2154.16 (FB-01): same wording as the plain renderer's dim
+            # status line -- never the raw "[streaming]" content token.
+            suffix = (
+                f"  {CONSOLE_GENERATING_PLACEHOLDER}"
+                if not body.strip()
+                else "  Streaming…"
+            )
     elif message.status in {"stopped", "failed"}:
         suffix = f"  {_MESSAGE_STATUS_LINES[message.status]}"
     return Content.assemble(role_label, (suffix, "dim"))
@@ -1836,6 +1878,12 @@ class ConsoleTranscript(VerticalScroll):
         #: deliberately dropped when the transcript is rebuilt for another
         #: session rather than following the user across conversations.
         self._expanded_tool_output_ids: set[str] = set()
+        #: This poll tick's live turn-activity line ("⚙ read_file · 4s"),
+        #: or "" when no turn is in flight. Pure view state, re-supplied by
+        #: the screen on every 0.2s sync tick via `apply_turn_activity`;
+        #: never derived here and never stored on the message the store
+        #: owns (see `_with_turn_activity`).
+        self._turn_activity: str = ""
         # TASK-259: per-message render-signature cache. Maps message id ->
         # (cheap change-token, expensive row signature). `_transcript_rows`
         # re-derives the render payload (Content assembly) only when the
@@ -3759,6 +3807,7 @@ class ConsoleTranscript(VerticalScroll):
                 # on the other boundary.
                 continue
             message = self._with_expanded_tool_output(message)
+            message = self._with_turn_activity(message)
             selected = message.id == self.selected_message_id
             rows.append(
                 _TranscriptRow(
@@ -4290,6 +4339,11 @@ class ConsoleTranscript(VerticalScroll):
             message.image_mime_type,
             None if message.image_data is None else len(message.image_data),
             message.citation_presentation,
+            # Load-bearing: the activity line is stamped on a `replace()`
+            # copy whose every OTHER field is identical tick to tick, so a
+            # token without it would hit this cache and the elapsed figure
+            # would freeze at the first value it ever rendered.
+            message.live_activity,
             presentation.revision_token,
             self._console_speech_state(message.id),
         )
@@ -4316,6 +4370,69 @@ class ConsoleTranscript(VerticalScroll):
             self._signature_compute_counts.get(message.id, 0) + 1
         )
         return signature
+
+    def _turn_activity_target_id(self) -> str | None:
+        """Id of the row the activity line would render on, or ``None``.
+
+        The last in-flight assistant row with no content yet -- the one
+        ``_message_body`` would otherwise render blank (or, once streaming
+        starts, as ``Generating…``). A row that already has text is showing
+        the real reply and must never be overwritten by a status line.
+        """
+        for message in reversed(self._messages):
+            if _row_is_in_flight(message):
+                content = (
+                    message.variants.current.content
+                    if message.variants is not None
+                    else message.content
+                )
+                return message.id if not content.strip() else None
+        return None
+
+    def apply_turn_activity(self, activity: str) -> str:
+        """Store this poll tick's live activity line; return what will show.
+
+        Returns the EFFECTIVE value -- ``""`` whenever no row is eligible --
+        because the screen folds this return into its transcript refresh
+        key. A stale ``running`` snapshot (a run that died without a
+        terminal publish) therefore cannot tick that key once a second on
+        an otherwise idle transcript: task-15664 AC#2 forbids repainting on
+        a timer when nothing is live, and this is the check that keeps that
+        true no matter what the bridge last published.
+
+        Args:
+            activity: The derived line (``console_turn_activity_text``), or
+                ``""`` when nothing is live.
+
+        Returns:
+            The line that will actually render, or ``""``.
+        """
+        effective = activity if activity and self._turn_activity_target_id() else ""
+        self._turn_activity = effective
+        return effective
+
+    def _with_turn_activity(self, message: ConsoleChatMessage) -> ConsoleChatMessage:
+        """Return ``message`` carrying this tick's activity line, when it owns it.
+
+        Applied at the ONE walk that plans rows -- the same seam, and for the
+        same reason, as ``_with_expanded_tool_output``: the row renderable,
+        its cached signature and its action row must all see the identical
+        message, or a row would render one thing while its signature claimed
+        another and never repaint.
+
+        Returns ``message`` UNCHANGED (same object) when there is nothing to
+        show, so a transcript with no live turn is byte-for-byte what it was
+        before this feature existed.
+
+        Args:
+            message: The transcript message about to be rendered.
+
+        Returns:
+            ``message``, or a render-only copy carrying ``live_activity``.
+        """
+        if not self._turn_activity or message.id != self._turn_activity_target_id():
+            return message
+        return replace(message, live_activity=self._turn_activity)
 
     def _with_expanded_tool_output(
         self, message: ConsoleChatMessage


### PR DESCRIPTION
## Console: the in-flight turn shows what the agent is doing

An agent turn used to look frozen. Now the in-flight assistant row carries a live, ticking activity line:

```
Assistant  ⚙ read_file · 4s

─ after it finishes ─

Tool  ⚙ read_file → def main():\n    …… (+3841 chars)
Assistant  ⚙ web_fetch · 11s
```

**The measurement corrected the diagnosis.** The survey said the row sits on `Generating…` for the whole turn. It never did: a probe running a real bridge turn with the tool blocked on an Event, mounted over the real transcript, captured `BEFORE_ROW_TEXT>>>Assistant<<<` with `status='pending'`. The placeholder branch is gated on `"streaming"`, which the store only reaches on the first streamed chunk — and a fence-gated tool turn never produces one. **The user was watching the bare word "Assistant".** Worse than described, and only execution found it.

**States**

| situation | line |
|---|---|
| tool running | `⚙ read_file · 4s` |
| between tools / after a result | `Thinking… · 6s` |
| running, no primary step yet | `Generating…` — today's copy, now actually visible |
| turn ended | nothing; the reply renders alone |

No elapsed on `Generating…`: there is no per-step base, and `_format_fleet_elapsed`'s own rule is not to claim a duration without one.

**Elapsed** is stamped in the bridge's `on_step` (`time.monotonic()`), not in the runtime — `AgentStep.created_at` is empty for a live run's entire life, and `agent_runtime.py`/`agent_models.py` are pure-logic by design. `on_step` runs one statement before `deps.invoke_tool`, so it is the tool's real start. Resume-derived steps keep `None`.

**No new timer.** The 0.2s poll already runs for the whole turn (run state is `STREAMING`), so the line ticks for free — which is what keeps this clear of task-15664's no-idle-repaint rule.

**Sub-agent isolation** is not defensive tidiness: `on_step` routes a child step with an empty run id into the *primary's* feed, so the last entry really can be a child's. Derivation takes the last step whose `agent_kind` is primary; pinned two ways, both mutation-killed.

**Quiet tools show.** `find_tools`/`load_tools` are suppressed from the permanent append-only markers to keep plumbing out of the transcript, but the activity line is ephemeral and exists precisely so no working moment looks frozen — suppressing them would restore the silent gap. Pinned.

**Three of thirteen mutations survived, and all three were real defects:**
1. **Signature coupling** — diagnosed from *how* a killed mutant died (first tick passed, second didn't): markdown rows carry the line in the header, which the row signature never renders, so the elapsed was only ticking as a side effect of the plain renderer.
2. **Blast radius** — stamping every message is invisible on screen but repaints the whole transcript once a second. Now pinned on render-signature and compute counts.
3. **Stale line** — skipping the empty case froze the last line on a row that outlived its run.

**Gate:** new suite **27 passed**; transcript+rail+controller+bridge+ratchet 4F/329P → 4F/375P (same four); `Tests/Agents/` **1458**; 48-file blast radius in one process 16F/1324P → **15F/1352P**, no new failures. The one absent baseline failure is a pre-existing order-dependent flake (passes 3/3 isolated on base) and is **not claimed as a fix**.

**Honest gaps:** the full 281-file Console population was unaffordable — a baseline run hit 91% at 60 minutes before infrastructure killed it, with two *foreign* full-suite pytest runs (one 14 hours old) saturating the machine. No live tmux walkthrough either; the mounted-real-`ChatScreen` test is the substitute. And a `pending` row with no agent run at all (direct-provider, pre-first-token) still renders bare — a separate path, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the agent’s live activity during an in-flight turn in the Console. Previously the unfinished Assistant row often rendered as bare “Assistant” and looked frozen; now it shows a ticking line like “⚙ read_file · 4s” or “Thinking… · 6s” until the reply arrives.

- Bridge: `AgentLiveStep` gains `started_at` stamped with `time.monotonic()` in `on_step` for accurate tool-call elapsed; resume-derived steps keep `None`.
- Derivation: `console_turn_activity_text(snapshot, now)` produces one of: tool running (“⚙ <tool> · <elapsed>”), between tools (“Thinking… · <elapsed>”), pre-first-token (“Generating…”), or empty when done; skips sub-agent steps; quiet tools (`find_tools`, `load_tools`) are included.
- Controller: `ConsoleAgentController.console_turn_activity()` gates on the viewed run’s status and reads the bridge snapshot; no new timer—uses the existing 0.2s transcript sync tick.
- Transcript: render the line in the existing row header/body; add ephemeral `live_activity` to `ConsoleChatMessage` and stamp only the eligible in-flight row; include it in `_message_row_signature` to ensure elapsed ticks repaint; `_message_body` handles `pending` and `streaming` empty rows and suppresses a doubled status line; `apply_turn_activity` returns the effective value for the refresh key to prevent idle repaints.
- Scope and persistence: live-only, not stored, not echoed to models or logs; resumed conversations show completed `Tool` rows as before.
- Tests and docs: new `Tests/UI/test_console_turn_activity_line.py` covers production wiring and mutation hazards; User Guide updated in `Docs/User_Guide/console/agent-runs-and-tools.md`.

<sup>Written for commit 5312ab942b2a466c255fa60ad15532159ce28a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

