### PR TITLE
docs(research): record gate source-type re-measurement

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -143,6 +143,28 @@ JSON parsing now raises `AcademicProviderError` so one bad payload
 degrades that provider only. The script also gained
 `--question-set {default,biomedical}`.
 
+## Gate source-type re-measurement (2026-08-17, task-17066 follow-up)
+
+The repositories lane re-run with the source-type-aware gate note (same
+runner/config/questions as the recorded 0.29 baseline):
+
+| Metric | Before (strict prompt) | After (source-type note) |
+|---|---|---|
+| `gate_pass_rate` | 0.29 | **0.42 (+45% relative)** |
+| `citation_accuracy` | 1.00 (73/73) | **1.00 (72/72)** — integrity held |
+| `claim_support_rate` | 0.97 | **1.00** |
+| `cited_sentence_ratio` | 0.52 | **0.75** |
+| `quote_grounding` | 0.00 | 0.33 (one run quoted; all verified) |
+
+Honest read: the note meaningfully improves admission of repository records
+without costing verification integrity — but repositories still pass at less
+than half the paper rate (0.93). That residual is partly genuine: many
+repository records ARE marginal evidence for general-purpose questions
+(a dataset about topic X is supporting material, not an answer). Fully
+closing the gap would need either a per-kind relevance threshold or
+category-tuned question sets — recorded as the follow-up lever, with the
+fallback (top-3 flagged) still covering the remainder.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
+++ b/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
@@ -44,3 +44,8 @@ ADR required: no - prompt calibration within the existing gate contract; the fal
   `python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers repositories --llm-base-url http://127.0.0.1:<port>/v1`
   Expected signal: gate_pass_rate meaningfully above the recorded 0.29 with citation_accuracy holding at 1.00.
 - Verified TDD: 2 classifier tests + 3 gate-prompt tests (repository note, metadata note, byte-identical prompts for papers/web) written first and watched failing; sweep 100 passed; ruff clean on touched files (remaining findings in the pipeline test file are pre-existing drift).
+
+## Re-measurement (2026-08-17, endpoint on :9191)
+
+- gate_pass **0.29 → 0.42** (+45% relative); citation_accuracy **held at 1.00** (72/72 markers); claim_support 0.97 → 1.00; cited_sentence_ratio 0.52 → 0.75; quote_grounding 0.33 (one run quoted, all verified).
+- Honest residual: repositories still pass at under half the paper rate (0.93) — partly genuine (repository records are supporting material, not answers, for general-purpose questions). Fully closing would need a per-kind threshold or category-tuned question sets; the top-3 flagged fallback covers the remainder. Comparison table in the baseline doc.

--- a/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
+++ b/backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md
@@ -47,5 +47,5 @@ ADR required: no - prompt calibration within the existing gate contract; the fal
 
 ## Re-measurement (2026-08-17, endpoint on :9191)
 
-- gate_pass **0.29 → 0.42** (+45% relative); citation_accuracy **held at 1.00** (72/72 markers); claim_support 0.97 → 1.00; cited_sentence_ratio 0.52 → 0.75; quote_grounding 0.33 (one run quoted, all verified).
+- gate_pass_rate **0.29 → 0.42** (+45% relative); citation_accuracy **held at 1.00** (72/72 markers); claim_support 0.97 → 1.00; cited_sentence_ratio 0.52 → 0.75; quote_grounding 0.33 (one run quoted, all verified).
 - Honest residual: repositories still pass at under half the paper rate (0.93) — partly genuine (repository records are supporting material, not answers, for general-purpose questions). Fully closing would need a per-kind threshold or category-tuned question sets; the top-3 flagged fallback covers the remainder. Comparison table in the baseline doc.


### PR DESCRIPTION
## Summary

Closes the last open AC of task-17066 (PR #1758): the live re-measurement of the repositories lane with the source-type-aware gate note, recorded in the baseline doc.

| Metric | Before (strict prompt) | After (source-type note) |
|---|---|---|
| gate_pass_rate | 0.29 | **0.42 (+45% relative)** |
| citation_accuracy | 1.00 (73/73) | **1.00 (72/72)** — integrity held |
| claim_support_rate | 0.97 | **1.00** |
| cited_sentence_ratio | 0.52 | **0.75** |
| quote_grounding | 0.00 | 0.33 (one run quoted; all verified) |

The note meaningfully improves admission of repository records without costing verification integrity. The honest residual — repositories still pass at under half the paper rate (0.93) — is partly genuine (a dataset about a topic is supporting material, not an answer) and is recorded as the next lever, with the flagged fallback covering the remainder.

Docs-only; the recorded run is the verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the repositories-lane re-measurement with the source-type-aware relevance gate in the baseline and task docs, improving `gate_pass_rate` from 0.29 to 0.42 while `citation_accuracy` holds at 1.00. Also normalizes the metric name to `gate_pass_rate` across both docs.

- Verify the metric table and numbers match in `Docs/Development/research-report-eval-baseline.md` and `backlog/tasks/task-17066 - Source-type-aware-relevance-gate-for-non-paper-evidence.md`, and that the residual gap vs papers and follow-up levers are clear.
- Confirm the task note uses `gate_pass_rate` (no stray `gate_pass`).
- No code paths changed; no rollout or migration required.
- Satisfies the final acceptance criterion of task-17066 by recording the live re-measurement and integrity outcomes.

<sup>Written for commit 0f01bd5349f85c5e716bc226e83bcc580bd4d143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

