### PR TITLE
fix(research): window runs reach the pipeline; make decomposition a measured choice

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -165,6 +165,58 @@ closing the gap would need either a per-kind relevance threshold or
 category-tuned question sets — recorded as the follow-up lever, with the
 fallback (top-3 flagged) still covering the remainder.
 
+## Decomposition measured on the repositories lane (2026-08-17, task-17370)
+
+Same runner, same three questions, same judge (local Qwen3.8-27B on
+`:9191`), same 5-results bound as the 0.29 and 0.42 arms; the only change is
+`--max-queries 3`, which turns on phase-1 sub-question generation:
+
+Command:
+`python3 Helper_Scripts/Benchmarks/record_research_baseline.py --questions 3 --engine duckduckgo --academic --providers repositories --llm-base-url http://127.0.0.1:9191/v1 --max-queries 3 --max-iterations 1 --deadline-s 900`
+
+| Metric | 1 query, strict | 1 query + source-type note | **3 queries + note** |
+|---|---|---|---|
+| `gate_pass_rate` | 0.29 | 0.42 | **0.38** |
+| `citation_accuracy` | 1.00 (73/73) | 1.00 (72/72) | 1.00 (70/70) |
+| `claim_support_rate` | 0.97 | 1.00 | 1.00 |
+| `cited_sentence_ratio` | 0.52 | 0.75 | 0.70 |
+| `quote_grounding` | 0.00 | 0.33 | 0.33 |
+
+Per-question `gate_pass` in the fan-out arm: 0.54, 0.40, 0.20.
+
+**The result is negative: giving the gate narrower facets did not admit more
+repository evidence.** 0.38 against 0.42 is flat to slightly down, and this
+doc already records that gate pass-rate varies between identical runs on this
+model, so the honest reading is "no measurable improvement", not "a
+regression". Citation integrity again held (70/70 markers resolved).
+
+What this arm did and did not test, because it decides how far the result
+generalizes:
+
+- **Tested:** the gate's context. `websearch.result_relevance_eval` takes
+  `sub_questions` as a required placeholder, so the earlier arms rendered it
+  as an empty list and this one rendered real facets. That is a genuine
+  change in what the judge was asked.
+- **Not tested:** retrieval. The web lane returned zero results throughout
+  (the DuckDuckGo bot challenge this doc notes elsewhere), and the academic
+  lane only searches round 1's `[question]` (task-17372), so the repository
+  records under judgment were the SAME set as the 0.42 arm. Fan-out changed
+  how they were judged, not which ones existed.
+
+So the case for decomposition on this lane now rests on retrieval rather than
+on gate context: multi-hop rounds >= 2 do drive retrieval (measured
+separately below), and fan-out reaching the paper providers does not happen
+today at all (task-17372).
+
+One bound on the non-gate rows of every table in this document, including
+this arm's: per-result summarization was silently failing for llama.cpp
+(task-17382), so the synthesis was built from titles and gate reasoning with
+an error string where each source body belonged. `gate_pass_rate` is
+unaffected — the gate judges scraped content before summarization — but
+`cited_sentence_ratio`, `claim_support_rate` and `quote_grounding` were
+graded on reports written without their sources, and should be re-measured
+after that fix.
+
 ## What every number above was measured with (task-17370)
 
 Both of the pipeline's decomposition mechanisms were OFF for every baseline

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -217,6 +217,55 @@ unaffected — the gate judges scraped content before summarization — but
 graded on reports written without their sources, and should be re-measured
 after that fix.
 
+## Multi-hop measured on the repositories lane (2026-08-17, task-17370)
+
+The same arm plus `--max-iterations 2`, so gap analysis gets to spend a second
+round. Read this table per question, NOT by its mean: the three runs did three
+different things.
+
+| | Arm B: 1 round | Arm C: 2 rounds |
+|---|---|---|
+| Q1 RAG | gate 0.54, markers 33/33, cited 0.92 | gate **0.71**, markers **0/0**, cited 0.00 |
+| Q2 MoE | gate 0.40, markers 24/24, cited 0.77 | gate 0.37, markers **39/39**, cited **0.95** |
+| Q3 GNN | gate 0.20, markers 13/13, cited 0.42 | gate 0.07, markers 1/1, cited 0.02 |
+| mean `gate_pass_rate` | 0.379 | 0.381 |
+
+**Multi-hop does what fan-out could not: it changes retrieval.** Gap analysis
+produced well-formed follow-ups rather than restatements (for Q1: "how vector
+databases support semantic search in RAG", "RAG evaluation metrics faithfulness
+relevance hallucination", "advanced RAG variants self-RAG GraphRAG hybrid
+retrieval reranking"), and round-2 queries DO reach the paper providers,
+because the academic lane loops `round_queries` -- `[question]` in round 1, the
+gap list afterwards. Search calls: 3 in Arm B (one per question), 12 in Arm C
+(Q1 1+5, Q2 1+4, Q3 1+0).
+
+Per question, what actually happened:
+
+- **Q2 is the clean datapoint, and it is positive.** Same gate rate (0.37 vs
+  0.40) but 39 resolved markers against 24, and citation density 0.95 against
+  0.77 -- multi-hop admitted more usable evidence and the report used it.
+- **Q1 retrieved the most and cited nothing**, which is not a gate result but a
+  synthesis failure: it is the ONLY question where map-reduce chunking engaged
+  (54 chunk operations, 5 MAP calls), and under task-17382 every chunk summary
+  was the provider error string the caller's guard failed to recognize. The
+  model was handed five copies of an error message and had nothing to cite.
+  Q2, which fit in a single pass, was unaffected. That defect is now fixed, so
+  this run needs redoing before Q1's number means anything.
+- **Q3 is not a multi-hop datapoint at all**: gap analysis returned no gaps, so
+  only round 1 ran. Its 0.07 reflects a round-1 pool of 9 judged results (2
+  admitted), not the effect of iteration.
+
+So the mean `gate_pass_rate` moving 0.379 -> 0.381 states nothing. The
+measurable claims from this arm are: multi-hop retrieval works and reaches the
+academic lane; where the synthesis path held together it produced markedly more
+cited evidence; and the pipeline's bottleneck under a larger evidence pool was
+the SYNTHESIS path, not the relevance gate.
+
+`gate_pass_rate` also needs reading as the ratio it is: round 2 adds to the
+denominator, so pulling in more marginal repository records can lower the rate
+while admitting more good evidence -- Q1 (0.71) and Q2 (39 markers) are the
+same mechanism seen from two sides.
+
 ## What every number above was measured with (task-17370)
 
 Both of the pipeline's decomposition mechanisms were OFF for every baseline

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -363,6 +363,35 @@ metrics, because a report built from source text still resolves markers and
 verifies quotes. Every number above therefore describes source-text evidence.
 `--llm-timeout-s` now exists so that is measurable rather than assumed.
 
+### First run with summarization actually working (arm F)
+
+Bounded deliberately (1 question, 3 results/query, 1 query, 1 round) to isolate
+one question: does the pipeline work at all when summaries are allowed to
+finish? With `--llm-timeout-s 240`:
+
+| Metric | Value |
+|---|---|
+| per-result summarizations | **7 attempted, 7 succeeded** |
+| their durations | 42s, 94s, 131s, 64s, 81s, 115s, 93s (mean 88.5s) |
+| over the shipped 30s timeout | **7 of 7** |
+| `citation_accuracy` | 1.00 (15/15 markers) |
+| `claim_support_rate` | 1.00 |
+| `cited_sentence_ratio` | 0.65 |
+| `gate_pass_rate` | 0.54 |
+
+**The shipped `relevance_llm_timeout_s` of 30s cannot succeed on this model at
+all** -- the fastest summary took 42s. That default is calibrated for hosted
+providers; against a local 27B it guarantees the fallback path, which is why no
+recorded baseline in this document ever measured a summarized evidence pool.
+
+Residual: map-reduce CHUNK summarization still failed (2 of 2) with "No choices
+in response data" while per-result calls on the same path in the same run all
+succeeded, so it is input-size dependent -- a success status whose body carries
+none of the parsed shapes. Filed as task-17384. The caller falls back to the
+chunk's source text and marks it not-generated, so evidence stays real; the cost
+is a wasted call and summarization quality on exactly the large evidence pools
+multi-hop produces.
+
 ### Reading gate_pass_rate
 
 It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -165,6 +165,47 @@ closing the gap would need either a per-kind relevance threshold or
 category-tuned question sets — recorded as the follow-up lever, with the
 fallback (top-3 flagged) still covering the remainder.
 
+## What every number above was measured with (task-17370)
+
+Both of the pipeline's decomposition mechanisms were OFF for every baseline
+recorded above — the synthetic one, the academic and biomedical lanes, the
+category lanes, and the 0.29 -> 0.42 gate re-measurement:
+
+| Mechanism | Where it lives | Why it was off |
+|---|---|---|
+| phase-1 sub-question fan-out | `WebSearch_APIs.generate_and_search` (`subquery_generation`) | the recorder hard-coded `subquery=False, max_queries=1` as a spend bound |
+| gap-driven replanning (multi-hop) | `local_research_engine._execute_phases` (task-16324) | the recorder launched runs with no `limits_json`, so `max_iterations` fell to the engine default of 1 |
+
+That matters for how the repositories residual is read. The relevance gate is
+prompted with the run's sub-questions, so a single-query run asks the gate to
+judge every result against one broad question with an EMPTY sub-question
+list — a repository record (a dataset, a figure) has no narrower facet it
+could be relevant to. The recorded reading that the residual is "partly
+genuine" was therefore not falsifiable from these runs: the mechanism whose
+whole purpose is to give the gate narrower facets had never run.
+
+Two things make the pending measurement a clean experiment on the
+repositories lane specifically:
+
+- Sub-questions DO reach the gate: the engine passes
+  `merged_sqd = {"sub_questions": all_sub_questions, ...}` to the analyze
+  phase, so generated facets change how ALL evidence is judged.
+- Fan-out does NOT change what the academic lane retrieves: the paper lane
+  loops over `round_queries`, which is `[question]` in round 1, so phase-1
+  sub-queries never reach Zenodo/Figshare/OSF (filed as task-17372). Only
+  multi-hop rounds >= 2 change retrieval.
+
+So a `--max-queries N --max-iterations 1` re-run judges the SAME repository
+evidence set with a non-empty sub-question list, isolating the gate effect
+from any change in retrieval.
+
+The recorder now takes `--max-queries`, `--max-iterations` and `--deadline-s`
+(task-17370), and every emitted aggregate states the decomposition settings
+it ran under, so no future baseline can silently be read as measuring
+something it did not. **The decomposition-on arm is not yet measured** — it
+needs the same judge model as the recorded arms (local Qwen3.8-27B) for the
+comparison to mean anything.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -307,6 +307,69 @@ something it did not. **The decomposition-on arm is not yet measured** — it
 needs the same judge model as the recorded arms (local Qwen3.8-27B) for the
 comparison to mean anything.
 
+## What decomposition is worth: the verdict (2026-08-17, task-17370)
+
+The question this whole arm answered: the recorded repositories residual was
+read as "partly genuine" -- repository records simply ARE marginal evidence for
+a broad question -- and the counter-claim was that this is precisely what
+sub-question generation and multi-hop exist to fix. Both mechanisms had been
+off in every recorded baseline. They are now measured separately, because they
+do different things and only one of them helped.
+
+| Arm | Config | Q1 gate / markers | Q2 gate / markers | Q3 gate / markers |
+|---|---|---|---|---|
+| recorded | 1 query, 1 round | 0.42 mean over 3 (0.29 pre-note) | | |
+| B | 3 queries, 1 round | 0.54 / 33 | 0.40 / 24 | 0.20 / 13 |
+| C | 3 queries, 2 rounds | 0.71 / **0** | 0.37 / **39** | 0.07 / 1 |
+| D | as C, guard fixed | 0.59 / 23 | -- | -- |
+| E | as C, endpoint fixed | 0.63 / 17 | -- | -- |
+
+**Fan-out (gate context): no measurable benefit.** The relevance prompt takes
+`sub_questions` as a required placeholder, so the recorded arms rendered an
+empty list and Arm B rendered real facets -- a genuine change in what the judge
+was asked. Mean `gate_pass_rate` went 0.42 -> 0.38, i.e. flat within this
+model's run-to-run variance. On this lane fan-out cannot change retrieval
+either, because the paper providers only ever see round 1's `[question]`
+(task-17372).
+
+**Multi-hop (retrieval): positive where the pipeline let it through.** Gap
+analysis produced real follow-up queries, round-2 queries DO reach the paper
+providers, and search calls went 3 -> 12. On Q2 -- the one question whose
+synthesis path was unaffected by task-17382 -- it held the gate rate while
+taking markers from 24 to 39 and citation density from 0.77 to 0.95. On Q1
+every 2-round arm (0.71 / 0.59 / 0.63) beat the 1-round arm (0.54).
+
+**What had been hiding it was the synthesis path, not the gate.** Q1 retrieved
+the most evidence of any run and cited NOTHING, because it was the only
+question large enough to trigger map-reduce chunking, and under task-17382
+every chunk summary was a provider error string the caller failed to recognize.
+Fixing that took Q1 from 0/0 markers to 23/23. A negative result on the
+strongest-retrieval run was an artifact.
+
+So the reading of the residual is amended: it is not established that
+repository evidence is genuinely marginal. The gate half of the argument does
+not hold; the retrieval half does, and the measurement that appeared to refute
+it was measuring a bug.
+
+### The caveat that outlives this arm
+
+No baseline in this document has EVER measured the pipeline with per-result
+summarization working. It failed in about a millisecond (wrong config section),
+then with a 404 (base URL posted raw), then with an unparseable payload
+(OpenAI endpoint, native shape parsed), and once all three were fixed it timed
+out at exactly the shipped 30s per call on a local 27B. Each time the pipeline
+fell back to raw source content -- correct degradation, and invisible in the
+metrics, because a report built from source text still resolves markers and
+verifies quotes. Every number above therefore describes source-text evidence.
+`--llm-timeout-s` now exists so that is measurable rather than assumed.
+
+### Reading gate_pass_rate
+
+It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal
+repository records lowers the rate even when more good evidence is admitted --
+Q1's 0.71 with zero citations and Q2's 39 markers are the same mechanism seen
+from opposite ends. Read it beside the marker count, never alone.
+
 ## Recording a (fresh) live baseline
 
 1. Configure `[SearchSettings]` (`relevance_analysis_llm`,

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -110,6 +110,7 @@ def _build_search_params(
     llm_override: str | None = None,
     max_queries: int = 1,
     deadline_s: float | None = None,
+    llm_timeout_s: float | None = None,
 ) -> dict:
     """Assemble engine search params exactly like the web_deep_search tool
     does, so the baseline measures the shipped pipeline configuration.
@@ -157,6 +158,12 @@ def _build_search_params(
         "relevance_analysis_llm": relevance_llm,
         "final_answer_llm": final_llm,
     }
+    if llm_timeout_s is not None:
+        # task-17382 measurement: every per-result summarization in the live
+        # arms failed at exactly the shipped 30s, so the pipeline fell back to
+        # raw source content and no baseline has measured it with summaries
+        # completing. Local models need far longer per page.
+        extra["relevance_llm_timeout_s"] = float(llm_timeout_s)
     if deadline_s is not None:
         # Both keys: the assembly derives them from one setting, and the
         # pipeline reads them independently.
@@ -222,6 +229,7 @@ def _decorate_aggregate(aggregate: dict, *, args: argparse.Namespace) -> dict:
             "max_queries": max(1, int(getattr(args, "max_queries", 1) or 1)),
             "max_iterations": max(1, int(getattr(args, "max_iterations", 1) or 1)),
             "deadline_s": getattr(args, "deadline_s", None),
+            "llm_timeout_s": getattr(args, "llm_timeout_s", None),
         },
     }
 
@@ -244,6 +252,7 @@ async def main_async(args: argparse.Namespace) -> int:
         args.max_results,
         engine_override=args.engine,
         llm_override=args.llm,
+        llm_timeout_s=args.llm_timeout_s,
         max_queries=args.max_queries,
         deadline_s=args.deadline_s,
     )
@@ -368,6 +377,16 @@ def main() -> int:
         help=(
             "gap-driven replanning rounds per run (default 1 = single pass, "
             "the engine's own default)"
+        ),
+    )
+    parser.add_argument(
+        "--llm-timeout-s",
+        type=float,
+        default=None,
+        help=(
+            "per-call relevance/summarization LLM timeout (default: the "
+            "configured relevance_llm_timeout_s, 30s -- too short for local "
+            "models, which makes every summary fall back to source text)"
         ),
     )
     parser.add_argument("--json-out", default=None, help="optional path for the aggregate JSON")

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -6,13 +6,22 @@ with the configured deep-search pipeline settings, scores each completed
 run's verification payload with the existing self-eval scorer, and prints
 the aggregated live baseline (mean metrics + per-run detail) plus JSON.
 
-Spend bounds are the point: small result counts, no sub-query fan-out, a
-handful of questions. Expect real network search traffic and LLM calls --
-both relevance and synthesis LLMs must be configured ([SearchSettings]).
+Spend bounds are the DEFAULT, not a property of the script (task-17370):
+small result counts, a handful of questions, and -- unless asked otherwise
+-- one search query and one synthesis pass per run. Both decomposition
+mechanisms are off at those defaults, which is how every baseline recorded
+before task-17370 was measured; the flags below turn them on so their
+effect on the relevance gate can be measured instead of assumed. Expect
+real network search traffic and LLM calls -- both relevance and synthesis
+LLMs must be configured ([SearchSettings]).
+
+Decomposition costs spend super-linearly: --max-queries N multiplies the
+per-run gate LLM calls by up to N, and --max-iterations M multiplies rounds
+on top of that.
 
 Usage:
     python3 Helper_Scripts/Benchmarks/record_research_baseline.py [--questions 3]
-        [--max-results 5] [--json-out PATH]
+        [--max-results 5] [--max-queries 1] [--max-iterations 1] [--json-out PATH]
 """
 
 from __future__ import annotations
@@ -99,9 +108,27 @@ def _build_search_params(
     max_results: int,
     engine_override: str | None = None,
     llm_override: str | None = None,
+    max_queries: int = 1,
+    deadline_s: float | None = None,
 ) -> dict:
     """Assemble engine search params exactly like the web_deep_search tool
-    does, so the baseline measures the shipped pipeline configuration."""
+    does, so the baseline measures the shipped pipeline configuration.
+
+    ``max_queries`` is the TOTAL search queries per run including the
+    original question -- the pipeline's own semantics (generate_and_search
+    truncates sub-queries to cap - 1). It also decides sub-query generation:
+    at a cap of 1 there is nowhere for a generated sub-question to go, so
+    generating one would be spend with no search behind it. Deriving the
+    switch from the cap makes the two impossible to set contradictorily,
+    and keeps the config's own ``search_enable_subquery`` from silently
+    changing what a recorded baseline measured.
+
+    ``deadline_s`` overrides the phase-2 wall clock. The configured default
+    (``deep_search_timeout_s``, 240s) is calibrated for the one-query runs
+    this script used to force; under fan-out it truncates the gate loop via
+    ``cancel_event`` mid-run, and truncated results are never judged at all
+    (task-16333) -- so leaving it fixed would measure the deadline rather
+    than the gate."""
     from tldw_chatbook.Tools.web_tool_impls import (
         _deep_search_settings,
         deep_search_pipeline_params,
@@ -124,28 +151,48 @@ def _build_search_params(
             + ". Configure them, or pass --engine duckduckgo (keyless)."
         )
     # task-16484: shared assembly with the tool; spend bounds via overrides.
+    resolved_max_queries = max(1, int(max_queries or 1))
+    extra: dict = {
+        "subquery_generation_llm": relevance_llm,
+        "relevance_analysis_llm": relevance_llm,
+        "final_answer_llm": final_llm,
+    }
+    if deadline_s is not None:
+        # Both keys: the assembly derives them from one setting, and the
+        # pipeline reads them independently.
+        extra["deep_search_timeout_s"] = float(deadline_s)
+        extra["phase1_time_budget_s"] = float(deadline_s)
     return deep_search_pipeline_params(
         engine=engine,
         max_results=max_results,
-        subquery=False,  # spend bound: single query per run
-        max_queries=1,  # spend bound: no fan-out
+        subquery=resolved_max_queries > 1,  # never half-enabled (see docstring)
+        max_queries=resolved_max_queries,
         respect_robots=True,
-        extra={
-            "subquery_generation_llm": relevance_llm,
-            "relevance_analysis_llm": relevance_llm,
-            "final_answer_llm": final_llm,
-        },
+        extra=extra,
     )
 
 
-async def _run_question(engine, service, question: str) -> dict | None:
+async def _run_question(
+    engine, service, question: str, max_iterations: int = 1
+) -> dict | None:
     """Execute one bounded research run; return its verification payload (or
     None with the failure printed -- one failed question must not sink the
-    baseline)."""
+    baseline).
+
+    ``max_iterations`` is the gap-driven replanning bound (task-16324). It is
+    passed explicitly even at its default of 1 so the recorded run states
+    what it measured rather than inheriting it; 1 is byte-equivalent to the
+    engine's own default, and a limits dict carrying only max_iterations
+    leaves the budget ledger unbounded exactly as passing nothing did.
+    """
     # Autonomous mode: the baseline measures the PIPELINE, not the
     # checkpoint UX -- checkpointed runs (the service default since
     # task-16482) park at plan review and never produce a report.
-    run = service.launch_run(query=question, autonomy_mode="autonomous")
+    run = service.launch_run(
+        query=question,
+        autonomy_mode="autonomous",
+        limits_json={"max_iterations": max(1, int(max_iterations or 1))},
+    )
     final = await engine.execute_run(run["id"])
     if final.get("status") != "completed":
         print(f"  [run failed: {final.get('status')} — {final.get('progress_message')}]")
@@ -158,6 +205,25 @@ async def _run_question(engine, service, question: str) -> dict | None:
     # The full summary (not just the citation block) so gate counts flow
     # into gate_pass_rate (task-16333).
     return payload
+
+
+def _decorate_aggregate(aggregate: dict, *, args: argparse.Namespace) -> dict:
+    """Stamp the decomposition settings onto the emitted aggregate.
+
+    task-17370: the recorded 0.29 and 0.42 gate numbers were both measured
+    with fan-out and replanning off, but nothing in their JSON said so, and
+    the resulting "genuine residual" reading could not be checked. Every
+    aggregate from here on states its own conditions. Kept out of
+    ``aggregate_metrics`` so the scorer's Dict[str, float] contract stands.
+    """
+    return {
+        **aggregate,
+        "decomposition": {
+            "max_queries": max(1, int(getattr(args, "max_queries", 1) or 1)),
+            "max_iterations": max(1, int(getattr(args, "max_iterations", 1) or 1)),
+            "deadline_s": getattr(args, "deadline_s", None),
+        },
+    }
 
 
 async def main_async(args: argparse.Namespace) -> int:
@@ -178,10 +244,18 @@ async def main_async(args: argparse.Namespace) -> int:
         args.max_results,
         engine_override=args.engine,
         llm_override=args.llm,
+        max_queries=args.max_queries,
+        deadline_s=args.deadline_s,
     )
     print(
         f"engine={search_params['engine']} relevance={search_params['relevance_analysis_llm']} "
         f"synthesis={search_params['final_answer_llm']} max_results={args.max_results}"
+    )
+    print(
+        f"decomposition: max_queries={search_params['search_default_max_queries']} "
+        f"(subqueries={'ON' if search_params['subquery_generation'] else 'OFF'}) "
+        f"max_iterations={max(1, int(args.max_iterations or 1))} "
+        f"deadline_s={search_params['deep_search_timeout_s']}"
     )
 
     with tempfile.TemporaryDirectory(prefix="tldw-research-baseline-") as tmp:
@@ -219,7 +293,9 @@ async def main_async(args: argparse.Namespace) -> int:
         payloads = []
         for question in question_set[: args.questions]:
             print(f"Running: {question}")
-            payload = await _run_question(engine, service, question)
+            payload = await _run_question(
+                engine, service, question, max_iterations=args.max_iterations
+            )
             if payload is not None:
                 metrics = score_research_report(payload)
                 cv = payload.get("citation_verification") or {}
@@ -244,7 +320,7 @@ async def main_async(args: argparse.Namespace) -> int:
             "timeouts) before relying on this baseline."
         )
         return 1
-    aggregate = aggregate_metrics(payloads)
+    aggregate = _decorate_aggregate(aggregate_metrics(payloads), args=args)
     print("\n=== Live baseline (mean over runs) ===")
     print(json.dumps(aggregate, indent=2))
     if args.json_out:
@@ -264,6 +340,35 @@ def main() -> int:
     )
     parser.add_argument(
         "--max-results", type=int, default=5, help="search results per query (spend bound)"
+    )
+    parser.add_argument(
+        "--max-queries",
+        type=int,
+        default=1,
+        help=(
+            "total search queries per run including the original question; "
+            ">1 enables sub-question generation (default 1 = no fan-out, the "
+            "spend bound every pre-task-17370 baseline was recorded under)"
+        ),
+    )
+    parser.add_argument(
+        "--deadline-s",
+        type=float,
+        default=None,
+        help=(
+            "override the phase-2 wall clock (default: [SearchSettings] "
+            "deep_search_timeout_s, calibrated for single-query runs); raise it "
+            "when enabling fan-out or the gate loop is truncated mid-run"
+        ),
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=1,
+        help=(
+            "gap-driven replanning rounds per run (default 1 = single pass, "
+            "the engine's own default)"
+        ),
     )
     parser.add_argument("--json-out", default=None, help="optional path for the aggregate JSON")
     parser.add_argument(

--- a/Tests/Helper_Scripts/test_record_research_baseline.py
+++ b/Tests/Helper_Scripts/test_record_research_baseline.py
@@ -1,0 +1,133 @@
+"""Decomposition controls on the live baseline recorder (task-17370).
+
+Every gate number recorded so far (the 0.29 repositories baseline and the
+0.42 source-type-note re-measurement) came from runs with sub-query fan-out
+and gap-driven replanning both switched OFF -- hard-coded constants, not
+choices. These tests pin the two things that matter once they become flags:
+the DEFAULT invocation must stay byte-identical to the spend-bounded runs
+that produced the recorded baselines, and the flags must actually reach the
+pipeline params and the run's limits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from Helper_Scripts.Benchmarks import record_research_baseline as recorder
+
+
+_LLM_SETTINGS = {
+    "relevance_analysis_llm": "llama_cpp",
+    "final_answer_llm": "llama_cpp",
+    "search_provider_default": "duckduckgo",
+    "search_enable_subquery": True,  # config says ON: the recorder must still bound it
+    "search_default_max_queries": 5,
+    "search_result_max": 20,
+    "deep_search_timeout_s": 240,
+    "relevance_llm_timeout_s": 30,
+    "relevance_scrape_timeout_s": 30,
+}
+
+
+@pytest.fixture()
+def stub_settings(monkeypatch):
+    """Neutralize config so the params assembly is the only variable."""
+    from tldw_chatbook.Tools import web_tool_impls
+
+    monkeypatch.setattr(web_tool_impls, "_deep_search_settings", lambda: dict(_LLM_SETTINGS))
+    monkeypatch.setattr(web_tool_impls, "_webfetch_settings", lambda: {"respect_robots_txt": True})
+    return _LLM_SETTINGS
+
+
+def test_default_params_stay_spend_bounded(stub_settings):
+    """The recorded baselines' configuration, even with config subquery ON."""
+    params = recorder._build_search_params(5, engine_override="duckduckgo")
+
+    assert params["subquery_generation"] is False
+    assert params["search_default_max_queries"] == 1
+
+
+def test_max_queries_above_one_enables_decomposition(stub_settings):
+    params = recorder._build_search_params(5, engine_override="duckduckgo", max_queries=4)
+
+    assert params["subquery_generation"] is True
+    assert params["search_default_max_queries"] == 4
+
+
+def test_max_queries_of_one_keeps_fan_out_off(stub_settings):
+    """1 total query means zero sub-queries -- generating them would be spend
+    with nowhere to go, so the flag must not half-enable the feature."""
+    params = recorder._build_search_params(5, engine_override="duckduckgo", max_queries=1)
+
+    assert params["subquery_generation"] is False
+    assert params["search_default_max_queries"] == 1
+
+
+def test_default_leaves_the_configured_deadline_untouched(stub_settings):
+    params = recorder._build_search_params(5, engine_override="duckduckgo")
+
+    assert params["deep_search_timeout_s"] == 240
+    assert params["phase1_time_budget_s"] == 240
+
+
+def test_deadline_override_reaches_both_budget_keys(stub_settings):
+    """A deadline calibrated for one-query runs would truncate a fan-out run
+    mid-gate, measuring the deadline instead of the gate."""
+    params = recorder._build_search_params(5, engine_override="duckduckgo", deadline_s=1800)
+
+    assert params["deep_search_timeout_s"] == 1800
+    assert params["phase1_time_budget_s"] == 1800
+
+
+class _FakeService:
+    def __init__(self):
+        self.launch_kwargs = None
+
+    def launch_run(self, **kwargs):
+        self.launch_kwargs = kwargs
+        return {"id": "run-1"}
+
+    def get_artifact(self, _run_id, _name):
+        return {"content": {"citation_verification": {"markers_total": 1, "markers_resolved": 1}}}
+
+
+class _FakeEngine:
+    async def execute_run(self, _run_id):
+        return {"status": "completed"}
+
+
+def test_run_question_defaults_to_a_single_pass():
+    service, engine = _FakeService(), _FakeEngine()
+
+    payload = asyncio.run(recorder._run_question(engine, service, "Q"))
+
+    assert payload["citation_verification"]["markers_resolved"] == 1
+    assert (service.launch_kwargs["limits_json"] or {}).get("max_iterations", 1) == 1
+
+
+def test_run_question_carries_the_requested_iteration_bound():
+    service, engine = _FakeService(), _FakeEngine()
+
+    asyncio.run(recorder._run_question(engine, service, "Q", max_iterations=3))
+
+    assert service.launch_kwargs["limits_json"]["max_iterations"] == 3
+
+
+def test_emitted_aggregate_records_the_decomposition_settings():
+    """A recorded result must never be readable without knowing whether
+    decomposition was on -- that ambiguity is exactly what made the 0.42
+    residual unfalsifiable."""
+    aggregate = recorder._decorate_aggregate(
+        {"sample_count": 2.0, "gate_pass_rate": 0.42},
+        args=SimpleNamespace(max_queries=4, max_iterations=2, deadline_s=1800),
+    )
+
+    assert aggregate["gate_pass_rate"] == 0.42
+    assert aggregate["decomposition"] == {
+        "max_queries": 4,
+        "max_iterations": 2,
+        "deadline_s": 1800,
+    }

--- a/Tests/Helper_Scripts/test_record_research_baseline.py
+++ b/Tests/Helper_Scripts/test_record_research_baseline.py
@@ -130,4 +130,42 @@ def test_emitted_aggregate_records_the_decomposition_settings():
         "max_queries": 4,
         "max_iterations": 2,
         "deadline_s": 1800,
+        # Absent on this Namespace: recorded as None rather than omitted, so a
+        # reader can tell "ran at the configured default" from "not recorded".
+        "llm_timeout_s": None,
     }
+
+
+# --- per-call LLM timeout (task-17370, after the task-17382 measurement) ------
+# Every per-result summarization in the live arms failed at exactly 30.0s --
+# the shipped relevance_llm_timeout_s -- so the pipeline fell back to raw
+# source content and NO recorded baseline has ever measured the pipeline with
+# summaries actually completing. A baseline cannot investigate that while the
+# timeout is fixed at whatever the config happens to hold.
+
+
+def test_default_leaves_the_configured_llm_timeout_untouched(stub_settings):
+    params = recorder._build_search_params(5, engine_override="duckduckgo")
+
+    assert params["relevance_llm_timeout_s"] == 30
+
+
+def test_llm_timeout_override_reaches_the_pipeline(stub_settings):
+    params = recorder._build_search_params(
+        5, engine_override="duckduckgo", llm_timeout_s=240
+    )
+
+    assert params["relevance_llm_timeout_s"] == 240.0
+
+
+def test_emitted_aggregate_records_the_llm_timeout():
+    """A recorded result must state the timeout it ran under, for the same
+    reason it states the decomposition settings."""
+    import argparse
+
+    args = argparse.Namespace(
+        max_queries=3, max_iterations=2, deadline_s=900.0, llm_timeout_s=240.0
+    )
+    out = recorder._decorate_aggregate({"gate_pass_rate": 0.5}, args=args)
+
+    assert out["decomposition"]["llm_timeout_s"] == 240.0

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -12,13 +12,25 @@ from tldw_chatbook.LLM_Calls import Local_Summarization_Lib as lib
 
 
 class _FakeResponse:
+    """The shape llama-server's /v1/chat/completions ACTUALLY returns.
+
+    The first version of this fake returned llama.cpp's NATIVE
+    ``{"content": ...}`` shape, which is what the function parsed -- so these
+    tests passed while every real chunk summarization came back "Llama: No
+    choices in response data" (observed live). A fake that agrees with the
+    code instead of with the server proves nothing.
+    """
+
     status_code = 200
 
-    def __init__(self):
+    def __init__(self, payload=None):
         self.text = ""
+        self._payload = payload or {
+            "choices": [{"message": {"role": "assistant", "content": " SUMMARY "}}]
+        }
 
     def json(self):
-        return {"content": " SUMMARY "}
+        return self._payload
 
 
 @pytest.fixture
@@ -137,3 +149,57 @@ def test_summarize_with_llama_normalizes_the_endpoint(
     lib.summarize_with_llama(input_data="text", custom_prompt="Summarize.", api_key=None)
 
     assert captured_post["url"] == expected
+
+
+def test_summarize_with_llama_parses_the_openai_response_shape(monkeypatch):
+    """It posts to /v1/chat/completions, so it must read choices[].message."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    class _Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, *_a, **_k):
+            return _FakeResponse()
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+
+    assert lib.summarize_with_llama("text", "Summarize.", api_key=None) == "SUMMARY"
+
+
+def test_summarize_with_llama_still_parses_the_native_completion_shape(monkeypatch):
+    """llama.cpp's native endpoint returns a top-level content; a config
+    pointing at one must keep working."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    class _Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, *_a, **_k):
+            return _FakeResponse({"content": " NATIVE "})
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+
+    assert lib.summarize_with_llama("text", "Summarize.", api_key=None) == "NATIVE"
+
+
+def test_summarize_with_llama_reports_an_unusable_payload(monkeypatch):
+    """Neither shape present: return a failure the deep-search guard catches
+    rather than something that could be stored as evidence."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    class _Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, *_a, **_k):
+            return _FakeResponse({"unexpected": True})
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+
+    result = lib.summarize_with_llama("text", "Summarize.", api_key=None)
+
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    assert _is_summary_failure(result), result

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -107,3 +107,33 @@ def test_summarize_with_llama_falls_back_to_the_legacy_ip(monkeypatch, captured_
     lib.summarize_with_llama(input_data="text", custom_prompt="Summarize.", api_key=None)
 
     assert captured_post["url"] == "http://127.0.0.1:8080/v1/chat/completions"
+
+
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        # A run priming a local endpoint stores a BASE url; posting it raw
+        # returned 404 "File Not Found" from llama-server (observed live).
+        ("http://127.0.0.1:9191/v1", "http://127.0.0.1:9191/v1/chat/completions"),
+        # A full endpoint must not gain a second copy of the path.
+        (
+            "http://127.0.0.1:9191/v1/chat/completions",
+            "http://127.0.0.1:9191/v1/chat/completions",
+        ),
+        # Bare host:port is a documented shape for these keys.
+        ("127.0.0.1:9191", "http://127.0.0.1:9191/v1/chat/completions"),
+        # Trailing slash must not double up.
+        ("http://127.0.0.1:9191/", "http://127.0.0.1:9191/v1/chat/completions"),
+    ],
+)
+def test_summarize_with_llama_normalizes_the_endpoint(
+    monkeypatch, captured_post, configured, expected
+):
+    """task-17382: the summarizer POSTs directly, so whatever shape the config
+    holds has to become the chat-completions endpoint exactly once -- the same
+    normalization the chat handler applies via normalize_llamacpp_base_url."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings(modern_url=configured))
+
+    lib.summarize_with_llama(input_data="text", custom_prompt="Summarize.", api_key=None)
+
+    assert captured_post["url"] == expected

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -1,0 +1,109 @@
+"""llama.cpp summarization configuration reads (task-17382).
+
+`summarize_with_llama` read `loaded_config_data["llama_api"]`, a section that
+has never existed -- the loader builds `llama_cpp_api`. Every call therefore
+raised KeyError before contacting a server and returned an error STRING,
+which the deep-search caller stored as a result's evidence content.
+"""
+
+import pytest
+
+from tldw_chatbook.LLM_Calls import Local_Summarization_Lib as lib
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self):
+        self.text = ""
+
+    def json(self):
+        return {"content": " SUMMARY "}
+
+
+@pytest.fixture
+def captured_post(monkeypatch):
+    """Capture the POST instead of performing it; the summary path must get
+    far enough to make a request at all."""
+    captured = {}
+
+    class _FakeSession:
+        def mount(self, *_args, **_kwargs):
+            pass
+
+        def post(self, url, headers=None, json=None, stream=False):
+            captured["url"] = url
+            captured["json"] = json
+            return _FakeResponse()
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _FakeSession())
+    return captured
+
+
+def _settings(*, modern_url=None, legacy_ip="http://127.0.0.1:8080/v1/chat/completions"):
+    """A settings snapshot shaped like the real loader's: `llama_cpp_api`
+    exists, `llama_api` does NOT."""
+    settings = {
+        "llama_cpp_api": {
+            "api_key": "",
+            "api_ip": legacy_ip,
+            "temperature": 0.7,
+            "max_tokens": 4096,
+            "streaming": False,
+            "api_retries": 3,
+            "api_retry_delay": 5,
+        },
+        "api_settings": {"llama_cpp": {}},
+    }
+    if modern_url:
+        settings["api_settings"]["llama_cpp"]["api_url"] = modern_url
+    return settings
+
+
+def test_summarize_with_llama_does_not_need_a_nonexistent_config_section(
+    monkeypatch, captured_post
+):
+    """The whole defect: no KeyError, and a real summary comes back."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    result = lib.summarize_with_llama(
+        input_data="Retrieval augmented generation combines retrieval and generation.",
+        custom_prompt="Summarize in one sentence.",
+        api_key=None,
+        temp=None,
+        system_message=None,
+        streaming=False,
+    )
+
+    assert result == "SUMMARY"
+    assert "url" in captured_post, "no request was ever made"
+
+
+def test_summarize_with_llama_prefers_the_modern_api_url(monkeypatch, captured_post):
+    """Runs point local providers at their endpoint through
+    `api_settings.llama_cpp.api_url` (what the baseline recorder primes and
+    the chat handler reads). The summarizer must follow the same routing
+    instead of the legacy default, or it posts where nothing is listening."""
+    monkeypatch.setattr(
+        lib, "load_settings", lambda: _settings(modern_url="http://127.0.0.1:9191/v1/chat/completions")
+    )
+
+    result = lib.summarize_with_llama(
+        input_data="text to summarize",
+        custom_prompt="Summarize.",
+        api_key=None,
+    )
+
+    assert result == "SUMMARY"
+    assert captured_post["url"] == "http://127.0.0.1:9191/v1/chat/completions"
+
+
+def test_summarize_with_llama_falls_back_to_the_legacy_ip(monkeypatch, captured_post):
+    """With no modern entry, the historical key still routes the request."""
+    monkeypatch.setattr(
+        lib, "load_settings", lambda: _settings(legacy_ip="http://127.0.0.1:8080/v1/chat/completions")
+    )
+
+    lib.summarize_with_llama(input_data="text", custom_prompt="Summarize.", api_key=None)
+
+    assert captured_post["url"] == "http://127.0.0.1:8080/v1/chat/completions"

--- a/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
+++ b/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
@@ -149,8 +149,16 @@ class _FakeSession:
 
 
 def _local_settings(*, llama_endpoint: str = "http://llama.invalid") -> dict[str, Any]:
+    # task-17382: this fixture used to key the llama section as "llama_api",
+    # which is the name the SUMMARIZER invented -- the loader builds
+    # "llama_cpp_api". These tests therefore passed by feeding the code its own
+    # mistake, while every real llama.cpp summarization failed with
+    # KeyError('llama_api') before reaching a server. Keyed to the loader now.
+    # The "api_keys" and "local_api_ip" sections below are still names nothing
+    # produces; the Kobold/TabbyAPI summarizers that read them fail the same
+    # way in production, tracked as task-17383.
     return {
-        "llama_api": {
+        "llama_cpp_api": {
             "api_key": "fixed-llama-key",
             "api_ip": llama_endpoint,
             "temperature": 0.7,

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1057,3 +1057,51 @@ def test_injected_search_fn_skips_the_pipeline_preflight():
     final = asyncio.run(engine.execute_run(run["id"]))
 
     assert final["status"] == "completed"
+
+
+def test_preflight_refuses_params_without_usable_llms():
+    """Qodo (PR 1764): search keys alone let a run spend phase-1 searches and
+    only then fail for want of an LLM. The tool path refuses both cases before
+    phase 1; the engine matches it for every default-pipeline caller."""
+    service = _make_service()
+    engine = LocalResearchEngine(
+        service,
+        search_params={
+            "engine": "duckduckgo",
+            "content_country": "US",
+            "search_lang": "en",
+            "output_lang": "en",
+            "result_count": 5,
+            # both LLM slots present but empty -- the shape a config with no
+            # [SearchSettings] LLMs actually produces
+            "relevance_analysis_llm": "",
+            "final_answer_llm": None,
+        },
+    )
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "failed"
+    message = str(final.get("progress_message") or "")
+    assert "relevance_analysis_llm" in message and "final_answer_llm" in message
+    assert "SearchSettings" in message
+
+
+def test_preflight_accepts_fully_configured_params():
+    """The complement: a complete assembly must pass the pre-flight, or the
+    check would refuse every real run."""
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+
+    engine._require_pipeline_params(
+        {
+            "engine": "duckduckgo",
+            "content_country": "US",
+            "search_lang": "en",
+            "output_lang": "en",
+            "result_count": 5,
+            "relevance_analysis_llm": "llama_cpp",
+            "final_answer_llm": "llama_cpp",
+        }
+    )

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1012,3 +1012,48 @@ def test_provider_overrides_reach_params_and_papers():
     assert state["last_params"]["engine"] == "duckduckgo"
     assert state["last_params"]["result_count"] == 3
     assert state["papers"] == [["pubmed"]]
+
+
+# --- pipeline params pre-flight (task-17371) --------------------------------
+# A run whose engine was constructed WITHOUT search_params used to reach the
+# real pipeline and die inside generate_and_search's own validation with
+# "Invalid search_params parameter" -- a message that names neither what is
+# missing nor where it comes from. Research_Window shipped exactly that
+# construction (no search_params at all), so every window-launched run failed
+# with it. The engine now refuses the unusable configuration up front, and
+# only when the REAL pipeline is the search function.
+
+
+def test_default_pipeline_without_search_params_fails_legibly():
+    """No search_params + the default (real) pipeline: the run must fail
+    naming the missing keys and where they come from, not with the
+    pipeline's opaque 'Invalid search_params parameter'."""
+    service = _make_service()
+    engine = LocalResearchEngine(service)  # no search_params -- the window's bug
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "failed"
+    # fail_run records the reason in progress_message (service contract).
+    message = str(final.get("progress_message") or final.get("error_msg") or "")
+    # Names the missing keys...
+    assert "engine" in message and "result_count" in message
+    # ...and where they come from.
+    assert "SearchSettings" in message
+
+
+def test_injected_search_fn_skips_the_pipeline_preflight():
+    """The pre-flight is the REAL pipeline's requirement, not the engine's:
+    a caller injecting its own search_fn (every other test here, and any
+    future non-web lane) still runs with empty search_params."""
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn
+    )  # still no search_params
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -789,3 +789,37 @@ def test_parse_provider_tokens_validates_and_dedupes():
     assert _parse_provider_tokens("  ARXIV ,, biorxiv ") == ["arxiv", "biorxiv"]
     # Dangerous input fails validation -> empty list (caller warns).
     assert _parse_provider_tokens("pubmed, <script>x") == []
+
+
+def test_window_engine_start_passes_configured_pipeline_params(monkeypatch):
+    """task-17371: the window's own launch path shipped with NO search_params,
+    so every window-launched run died in the pipeline's validation
+    ("Invalid search_params parameter") before a single search. The window
+    must hand the engine the same assembly the Console /research command and
+    the baseline recorder use (deep_search_pipeline_params, task-16484)."""
+    from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import (
+        GENERATE_AND_SEARCH_REQUIRED_PARAMS,
+    )
+
+    captured = {}
+
+    class FakeEngine:
+        def __init__(self, service, **kwargs):
+            captured["search_params"] = kwargs.get("search_params")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Research_Interop.local_research_engine.LocalResearchEngine",
+        FakeEngine,
+    )
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(),
+        local_research_service=LocalResearchService(":memory:"),
+    )
+
+    ResearchWindow(app_instance=app)._start_local_engine("run-1")
+
+    search_params = captured["search_params"]
+    assert search_params, "the window must assemble pipeline params, not pass none"
+    missing = [k for k in GENERATE_AND_SEARCH_REQUIRED_PARAMS if k not in search_params]
+    assert not missing, f"assembly is missing pipeline-required keys: {missing}"

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1391,3 +1391,46 @@ async def test_relevance_gate_paper_prompt_is_byte_identical(monkeypatch):
     for prompt in captured:
         input_line = prompt.split("\n\n", 1)[0]
         assert input_line == prefix  # no note, no extra text
+
+
+# --- provider error strings must never become evidence (task-17382) ----------
+# The summarizers report failure by RETURNING a string, and the caller only
+# recognized the "Error:" prefix. A llama.cpp failure returns "Llama: Error
+# occurred while processing summary with Llama: 'llama_api'", which sailed
+# through the guard and was stored as the result's content -- so the synthesis
+# was built from an error message where the source body belonged.
+
+
+@pytest.mark.parametrize(
+    "failure_text",
+    [
+        "Llama: Error occurred while processing summary with Llama: 'llama_api'",
+        "Kobold: Error occurred while processing summary with Kobold: boom",
+        "Llama: API request failed: 502 Bad Gateway",
+        "Ollama: JSON parse error from summarization API.",
+        "Custom OpenAI API: Unexpected error occurred: boom",
+        "Custom OpenAI API-2: Error making API request: boom",
+        "Llama: No choices in response data",
+        "Error: legacy prefix still detected",
+        "Error summarizing with Oobabooga: boom",
+    ],
+)
+def test_provider_failure_strings_are_recognized(failure_text):
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    assert _is_summary_failure(failure_text) is True
+
+
+@pytest.mark.parametrize(
+    "summary_text",
+    [
+        "This dataset reports error rates for retrieval augmented generation.",
+        "The paper analyses failure modes and error propagation in MoE routing.",
+        "Graph neural networks aggregate messages over edges.",
+    ],
+)
+def test_real_summaries_are_not_mistaken_for_failures(summary_text):
+    """The detector must not eat legitimate prose that merely says "error"."""
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    assert _is_summary_failure(summary_text) is False

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1427,6 +1427,10 @@ def test_provider_failure_strings_are_recognized(failure_text):
         "This dataset reports error rates for retrieval augmented generation.",
         "The paper analyses failure modes and error propagation in MoE routing.",
         "Graph neural networks aggregate messages over edges.",
+        # A summary may legitimately OPEN with the word error; only the
+        # providers' own failure phrasings may count.
+        "Error rates in retrieval systems are reported per corpus.",
+        "Failed to converge is the outcome this dataset documents.",
     ],
 )
 def test_real_summaries_are_not_mistaken_for_failures(summary_text):

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -904,3 +904,33 @@ HOME/XDG_*/TLDW_CONFIG_PATH to a throwaway root by hand (and asserting the
 config path took). Treat an imported guard whose `install()` conftest never
 ran as adversarial: `blocked_attempts=()` from an uninstalled guard is not
 evidence of no egress.
+
+---
+
+## A worktree's live probe imports the MAIN checkout, and a redirected log hides its own progress (task-17370/17380, 2026-08-17)
+
+Two mechanical traps cost a cycle each while measuring the research pipeline
+from a worktree.
+
+The venv here is an editable install pointing at
+`/Users/.../tldw_chatbook/tldw_chatbook`, i.e. the MAIN checkout. A probe run
+from a worktree with the venv's python imported the main checkout's package,
+which was on an unrelated branch — the first attempt died with
+`ModuleNotFoundError: No module named
+'tldw_chatbook.Research_Interop.local_research_engine'` on a module that exists
+in the worktree. Fix: `PYTHONPATH=<worktree>` (or run the script from the
+worktree root, so `sys.path[0]` wins).
+
+Second: the baseline recorder prints progress with `print()`, and Python
+block-buffers stdout when it is redirected to a file — so a 50-minute run's
+per-question lines all appeared at the very end, while loguru's stderr flowed
+continuously. A monitor watching for `Running:` saw nothing for the whole run
+and a `grep -c` for it returned 0 on a live, healthy process. Fix:
+`PYTHONUNBUFFERED=1` for anything whose stdout you intend to watch.
+
+**Also worth stating**: verifying a UI launch path means launching it the way
+the UI does. A window-created research run is CHECKPOINTED (the scope service
+never passes `autonomy_mode`, so the service default applies), so it parks at
+`plan_review` and never reaches `collecting` until the checkpoint is approved.
+A harness that used `autonomy_mode="autonomous"` would have "verified" a path
+no user takes.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4836,3 +4836,60 @@ Two guards in depth meant no single observation covered both mutations;
 the four together did. Corollary: a no-work pin also needs a control that
 runs the same probes WITH work present and watches every one flip,
 otherwise a hook that never runs at all satisfies it perfectly.
+
+---
+
+## A fixture keyed to the code's invented config section hides a total production failure (task-17382, 2026-08-17)
+
+`summarize_with_llama` indexed `loaded_config_data["llama_api"]` in ten places.
+No such section has ever existed — the loader builds `llama_cpp_api` — so every
+llama.cpp summarization raised `KeyError` before contacting a server, and the
+`except` at the bottom returned an error STRING rather than raising. The
+deep-search caller tested `summary.startswith("Error:")`, which no
+provider-prefixed message matches, so `"Llama: Error occurred while processing
+summary with Llama: 'llama_api'"` was stored AS the result's evidence content
+and the synthesis was built from it. Citation verification kept passing because
+it matches quotes against `original_content` first, so the reports were graded
+sound while the model had never been shown its sources.
+
+The reason this survived a security review of that very file:
+`test_summarization_diagnostic_privacy.py`'s fixture stubbed the settings dict
+with a `"llama_api"` key — the name the summarizer had invented. The tests fed
+the code its own mistake and passed. The same fixture stubs `api_keys` and
+`local_api_ip`, which is exactly why the Kobold and TabbyAPI summarizers'
+identical defect (task-17383) also stayed invisible. Fixing the code then broke
+those tests, which is the only reason anyone looked.
+
+**What to do.** A fixture standing in for configuration must be keyed to what
+the LOADER produces, not to what the code under test reads — those are the same
+string only when the code is right, and a stub that mirrors the code's
+assumption can never fail. When you fake a provider response, fake what the
+SERVER sends: my own first fake returned llama.cpp's native `{"content": ...}`
+shape, which is what the buggy parser read, so it passed while the live
+endpoint (`/v1/chat/completions`, `choices[0].message.content`) returned "No
+choices in response data" on every call. Cheapest check available: print the
+real `load_settings()` keys once and compare, or assert the section exists.
+
+---
+
+## A metric can be graded on fallback content, and nothing in it says so (task-17370, 2026-08-17)
+
+Every live research baseline recorded in this repo reports
+`citation_accuracy 1.00` and healthy `claim_support_rate`. All of them were
+measured with per-result summarization failing: first instantly (wrong config
+section), then a 404, then an unparseable payload, and once those were fixed, a
+timeout at exactly the shipped 30s per call on a local 27B. Each failure fell
+back to raw source text, which is the CORRECT degradation — and completely
+invisible in the metrics, because a report built from source text still
+resolves its markers and still verifies its quotes.
+
+The tell was uniformity: six summarizations completing in exactly `30.0s` is a
+timeout, not a latency distribution.
+
+**What to do.** When a pipeline has a degradation path, a metric that only
+grades the OUTPUT cannot tell you which path produced it — so record the path
+alongside the number (which stage ran, which fell back), and treat suspiciously
+round, uniform timings as a budget being hit rather than work being done. Also:
+absence of an error log is not evidence of success when the code logs successes
+at INFO through stdlib `logging`, whose default level hides them; the runs above
+showed zero "Summarization successful" lines whether they worked or not.

--- a/backlog/tasks/task-17370 - Measure-the-relevance-gate-with-sub-question-decomposition-enabled.md
+++ b/backlog/tasks/task-17370 - Measure-the-relevance-gate-with-sub-question-decomposition-enabled.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17370
 title: Measure the relevance gate with sub-question decomposition enabled
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-17 07:30'
@@ -22,11 +22,11 @@ Every recorded gate number — the 0.29 repositories baseline and the 0.42 sourc
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The baseline recorder exposes sub-query fan-out and multi-hop iteration count as flags instead of hard-coded constants, with the current spend-bounded values as defaults so existing recorded baselines stay reproducible byte-for-byte.
-- [ ] #2 The recorder prints the decomposition settings in its run header and carries them into the emitted aggregate JSON, so a recorded result can never be read without knowing whether decomposition was on.
-- [ ] #3 Tests pin that the default invocation still assembles single-query, single-iteration parameters, and that the flags reach the pipeline params and the run's limits.
-- [ ] #4 The repositories lane is re-measured live with decomposition enabled against the same question set, engine and endpoint as the recorded 0.42 run.
-- [ ] #5 The baseline doc records the decomposition off/on comparison and the amended reading of the non-paper residual, including the case where decomposition closes little of the gap.
+- [x] #1 The baseline recorder exposes sub-query fan-out and multi-hop iteration count as flags instead of hard-coded constants, with the current spend-bounded values as defaults so existing recorded baselines stay reproducible byte-for-byte.
+- [x] #2 The recorder prints the decomposition settings in its run header and carries them into the emitted aggregate JSON, so a recorded result can never be read without knowing whether decomposition was on.
+- [x] #3 Tests pin that the default invocation still assembles single-query, single-iteration parameters, and that the flags reach the pipeline params and the run's limits.
+- [x] #4 The repositories lane is re-measured live with decomposition enabled against the same question set, engine and endpoint as the recorded 0.42 run.
+- [x] #5 The baseline doc records the decomposition off/on comparison and the amended reading of the non-paper residual, including the case where decomposition closes little of the gap.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,3 +40,38 @@ Every recorded gate number — the 0.29 repositories baseline and the 0.42 sourc
 6. Record the comparison and the amended residual reading in the baseline doc
 ADR required: no -- measurement instrumentation only; no change to shipped run behaviour (that is task-17371)
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The recorder's spend bounds became flags (`--max-queries`, `--max-iterations`,
+`--deadline-s`, and later `--llm-timeout-s`), defaults byte-equivalent to the
+constants they replaced, with every emitted aggregate stamping the settings it
+ran under. Five live arms followed on the repositories lane against the same
+questions, engine and judge as the recorded 0.42 run.
+
+The measured answer splits the question in two:
+
+- Fan-out changes only what the gate is ASKED (the relevance prompt takes
+  `sub_questions` as a required placeholder, so earlier arms rendered an empty
+  list). Measured: 0.42 -> 0.38, no benefit.
+- Multi-hop changes what is RETRIEVED, and round-2 queries reach the paper
+  providers. Measured: Q2 held its gate rate while going 24 -> 39 markers and
+  0.77 -> 0.95 citation density; all three 2-round arms beat the 1-round arm on
+  Q1.
+
+The arm that looked worst was the strongest evidence FOR the mechanism: Q1
+retrieved the most and cited nothing, because it alone triggered map-reduce
+chunking and every chunk summary was a provider error string the caller's guard
+missed (task-17382). Fixed, Q1 went 0/0 -> 23/23 markers.
+
+AC #5's provision for "decomposition closes little of the gap" is what
+happened on the gate half, and is recorded as such rather than smoothed over.
+The doc also records the caveat that outlives this arm: no baseline here has
+ever measured the pipeline with summarization actually working, so every number
+describes source-text evidence.
+
+Modified: `Helper_Scripts/Benchmarks/record_research_baseline.py`,
+`Tests/Helper_Scripts/test_record_research_baseline.py`,
+`Docs/Development/research-report-eval-baseline.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17370 - Measure-the-relevance-gate-with-sub-question-decomposition-enabled.md
+++ b/backlog/tasks/task-17370 - Measure-the-relevance-gate-with-sub-question-decomposition-enabled.md
@@ -1,0 +1,42 @@
+---
+id: TASK-17370
+title: Measure the relevance gate with sub-question decomposition enabled
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-17 07:30'
+updated_date: '2026-08-17 07:35'
+labels:
+  - research
+  - web-tools
+  - benchmarks
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Every recorded gate number — the 0.29 repositories baseline and the 0.42 source-type-note re-measurement — was produced with both decomposition mechanisms switched off: the baseline recorder hard-codes `subquery=False, max_queries=1` as a spend bound, and it launches runs without `limits_json`, so gap-driven replanning defaults to a single iteration. The relevance gate prompt takes the generated sub-questions as a required placeholder, so those runs asked the gate to judge every result against one broad question with an empty sub-question list. A repository record has no narrower facet to be relevant to under those conditions, which makes the recorded "genuine residual" for non-paper evidence unfalsifiable. Make the spend bound a caller choice and re-measure so the residual is either confirmed or explained.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The baseline recorder exposes sub-query fan-out and multi-hop iteration count as flags instead of hard-coded constants, with the current spend-bounded values as defaults so existing recorded baselines stay reproducible byte-for-byte.
+- [ ] #2 The recorder prints the decomposition settings in its run header and carries them into the emitted aggregate JSON, so a recorded result can never be read without knowing whether decomposition was on.
+- [ ] #3 Tests pin that the default invocation still assembles single-query, single-iteration parameters, and that the flags reach the pipeline params and the run's limits.
+- [ ] #4 The repositories lane is re-measured live with decomposition enabled against the same question set, engine and endpoint as the recorded 0.42 run.
+- [ ] #5 The baseline doc records the decomposition off/on comparison and the amended reading of the non-paper residual, including the case where decomposition closes little of the gap.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. TDD the recorder's decomposition controls: default invocation must assemble the same single-query, single-iteration params the recorded baselines used (even when config says search_enable_subquery is on), and the flags must reach the pipeline params and the run's limits_json
+2. Derive sub-query generation from the total-query cap so the two can never be set contradictorily, and pass max_iterations explicitly even at its default so a run states what it measured
+3. Expose the phase-2 wall clock as a flag -- the configured 240s is calibrated for one-query runs and would truncate a fan-out gate loop mid-run, measuring the deadline instead of the gate
+4. Stamp the decomposition settings on the emitted aggregate (outside aggregate_metrics, whose Dict[str, float] contract stands)
+5. Live re-measure the repositories lane on the same question set/engine/endpoint as the recorded 0.42: fan-out only, then fan-out plus multi-hop
+6. Record the comparison and the amended residual reading in the baseline doc
+ADR required: no -- measurement instrumentation only; no change to shipped run behaviour (that is task-17371)
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
+++ b/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
@@ -26,3 +26,47 @@ Sub-question fan-out and gap-driven replanning both ship but are off by default:
 - [ ] #3 The expected spend implication of the chosen default is documented where a user meets it, since fan-out multiplies gate LLM calls per run and iterations multiply rounds on top.
 - [ ] #4 Existing runs, artifacts and tests that assume single-pass behaviour continue to pass or are updated with the reason recorded.
 <!-- AC:END -->
+
+## Measured evidence for the defaults decision (task-17370)
+
+Recorded here so AC #1 can be decided from numbers rather than caution. All
+from the repositories lane, local Qwen3.8-27B, same questions/engine/bounds as
+the 0.42 baseline; see the "verdict" section of
+`Docs/Development/research-report-eval-baseline.md`.
+
+**Fan-out (`subquery_generation` + `search_default_max_queries`)**
+
+- Effect on the relevance gate: none measurable (0.42 -> 0.38, flat within this
+  model's run-to-run variance).
+- Effect on retrieval: none on this lane -- the paper providers only see round
+  1's `[question]`, so generated sub-queries never reach them (task-17372).
+- Cost: one extra LLM call to generate the sub-questions, plus up to
+  `max_queries - 1` extra searches, each with its own per-result gate calls.
+- Reading: do NOT turn this on by default while task-17372 stands. It buys
+  nothing measurable here and costs per-query gate spend. Re-measure after
+  17372, when fan-out would actually change what is retrieved.
+
+**Multi-hop (`max_iterations`)**
+
+- Effect: positive where the synthesis path was intact -- Q2 held its gate rate
+  while going 24 -> 39 resolved markers and 0.77 -> 0.95 citation density; all
+  three 2-round arms beat the 1-round arm on Q1's gate rate.
+- Cost, measured: search calls went 3 -> 12 for three questions (4-5 gap
+  queries per question), each gap query carrying its own gate calls, plus a
+  second full synthesis and a second gap analysis per round.
+- Latency, measured: the 3-question 2-round arm took roughly 50 minutes on a
+  local 27B, against roughly 15 for the 1-round arm.
+- Reading: this is the mechanism worth defaulting on, but its cost is
+  multiplicative and the honest default depends on who pays. A per-run control
+  (AC #2) matters more than the default itself, and the spend note (AC #3)
+  should quote the measured multiplier rather than a general warning.
+
+**Prerequisite now closed**: window-launched runs could not honour ANY of these
+settings, because the window built the engine with no pipeline params at all
+(task-17380). Per-run controls would have been inert there.
+
+**Bounding caveat**: no measurement here ran with per-result summarization
+working (task-17382 chain), so these numbers describe a pipeline synthesizing
+from raw source text. A defaults decision that turns on multi-hop multiplies
+the number of sources that each need summarizing, so re-measure the cost once
+summarization completes.

--- a/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
+++ b/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
@@ -1,0 +1,28 @@
+---
+id: TASK-17371
+title: Enable sub-question decomposition and bounded multi-hop for shipped research runs
+status: To Do
+assignee:
+  - '@robert'
+created_date: '2026-08-17 07:30'
+labels:
+  - research
+  - web-tools
+dependencies:
+  - task-17370
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Sub-question fan-out and gap-driven replanning both ship but are off by default: fan-out is opt-in via search settings, and the local research engine's `max_iterations` defaults to 1, so a real research run is single-facet and single-pass. Once task-17370 has measured what decomposition is worth, decide the shipped defaults from those numbers rather than from caution, and make the resulting spend legible to the user before a run starts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The shipped default for research-run decomposition is set from the task-17370 measurement, and the choice is recorded with the numbers that justify it.
+- [ ] #2 A user can see and change the decomposition settings for a run before launching it, and the setting persists.
+- [ ] #3 The expected spend implication of the chosen default is documented where a user meets it, since fan-out multiplies gate LLM calls per run and iterations multiply rounds on top.
+- [ ] #4 Existing runs, artifacts and tests that assume single-pass behaviour continue to pass or are updated with the reason recorded.
+<!-- AC:END -->

--- a/backlog/tasks/task-17372 - Sub-question-fan-out-never-reaches-the-academic-lane.md
+++ b/backlog/tasks/task-17372 - Sub-question-fan-out-never-reaches-the-academic-lane.md
@@ -1,0 +1,27 @@
+---
+id: TASK-17372
+title: Sub-question fan-out never reaches the academic lane
+status: To Do
+assignee:
+  - '@robert'
+created_date: '2026-08-17 07:35'
+labels:
+  - research
+  - web-tools
+dependencies:
+  - task-17370
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase-1 sub-question generation happens inside the web pipeline, so the generated sub-questions only ever drive web searches. The local research engine's first round collects with `round_queries = [question]`, and the academic lane loops over exactly those queries — so for a papers/repositories run, enabling fan-out adds no new academic evidence at all. The sub-questions do reach the relevance gate (the merged pool is analyzed with the accumulated sub-question list), so fan-out changes how academic evidence is JUDGED while leaving what is RETRIEVED untouched. Retrieval-side decomposition currently arrives only via gap-driven replanning, whose later rounds do search their gap questions. Decide whether the academic lane should search the sub-questions too, and make the asymmetry deliberate rather than incidental.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Whether the academic lane searches generated sub-questions is a stated, tested decision rather than a side effect of where sub-question generation lives.
+- [ ] #2 If the lane does fan out, its extra searches are counted against the same budget ledger and search cap as the web lane's, with no path that spends past the cap.
+- [ ] #3 The gate-versus-retrieval asymmetry is documented wherever the decomposition settings are described, so a measured result cannot be misread as evidence about retrieval.
+<!-- AC:END -->

--- a/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
+++ b/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
@@ -1,0 +1,39 @@
+---
+id: TASK-17380
+title: Research window runs never reach the deep-search pipeline
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-08-17 07:45'
+labels:
+  - research
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Every research run launched from the Research window fails immediately without searching anything. The window builds the execution engine without the deep-search pipeline settings, so the pipeline rejects the run on its own required-parameter check, and the run's recorded reason names neither what was missing nor where it comes from. The same omission leaves the engine's gap-driven replanning permanently inert for window runs, because gap analysis reads its LLM from those settings. The Research screen is reachable from navigation again, so this is the shipped path a user meets; the Console /research command is unaffected because it assembles the settings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A run launched from the Research window reaches the search phase instead of failing on missing pipeline parameters
+- [ ] #2 A window-launched run can perform gap-driven replanning, i.e. its synthesis LLM is configured like the Console command's
+- [ ] #3 When the pipeline settings cannot be assembled, the window reports that in place of launching a run that cannot succeed
+- [ ] #4 A run that reaches the real pipeline without usable parameters fails naming the missing keys and their configuration source, not with the pipeline's opaque message
+- [ ] #5 Callers that inject their own search function keep running without pipeline parameters
+- [ ] #6 Tests cover the window's assembly and both sides of the engine's pre-flight
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the failure exactly as the window launches a run (engine built with no search_params) and capture the recorded terminal reason.
+2. Export the pipeline's required-parameter list from the pipeline itself so a caller can check its own assembly without duplicating the list.
+3. Pre-flight those parameters in the engine, but only when the real pipeline is the search function, so injected search functions keep their own contract.
+4. Assemble the settings in the window through the same shared assembly the Console command and the baseline recorder use; report an assembly failure instead of launching.
+5. Cover both sides of the pre-flight and the window's assembly with tests.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
+++ b/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
@@ -21,11 +21,11 @@ Every research run launched from the Research window fails immediately without s
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 A run launched from the Research window reaches the search phase instead of failing on missing pipeline parameters
-- [ ] #2 A window-launched run can perform gap-driven replanning, i.e. its synthesis LLM is configured like the Console command's
-- [ ] #3 When the pipeline settings cannot be assembled, the window reports that in place of launching a run that cannot succeed
-- [ ] #4 A run that reaches the real pipeline without usable parameters fails naming the missing keys and their configuration source, not with the pipeline's opaque message
-- [ ] #5 Callers that inject their own search function keep running without pipeline parameters
-- [ ] #6 Tests cover the window's assembly and both sides of the engine's pre-flight
+- [x] #2 A window-launched run can perform gap-driven replanning, i.e. its synthesis LLM is configured like the Console command's
+- [x] #3 When the pipeline settings cannot be assembled, the window reports that in place of launching a run that cannot succeed
+- [x] #4 A run that reaches the real pipeline without usable parameters fails naming the missing keys and their configuration source, not with the pipeline's opaque message
+- [x] #5 Callers that inject their own search function keep running without pipeline parameters
+- [x] #6 Tests cover the window's assembly and both sides of the engine's pre-flight
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,47 @@ Every research run launched from the Research window fails immediately without s
 4. Assemble the settings in the window through the same shared assembly the Console command and the baseline recorder use; report an assembly failure instead of launching.
 5. Cover both sides of the pre-flight and the window's assembly with tests.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The window built the engine with no `search_params` at all, so the pipeline's
+own required-key check rejected every window-launched run before a single
+search. An empty dict is falsy, so the message was
+`ValueError("Invalid search_params parameter")` -- it named neither the
+missing keys nor their source. Reproduced first by launching a run exactly
+the way `_start_local_engine` does: `status: failed`,
+`progress_message: "Invalid search_params parameter"`.
+
+Three changes, smallest first:
+
+- `WebSearch_APIs` exports `GENERATE_AND_SEARCH_REQUIRED_PARAMS` and its own
+  validation loop reads it, so a caller can check its assembly without
+  duplicating the list.
+- `LocalResearchEngine` pre-flights those keys inside `execute_run`'s try, so
+  the existing terminal-failure path reports it, and only when
+  `search_fn is None` at construction -- an injected search function carries
+  its own contract, and enforcing the web pipeline's requirements on it would
+  have broken every engine test and any future non-web lane.
+- `Research_Window._start_local_engine` assembles via
+  `deep_search_pipeline_params()` (the same assembly Console `/research` and
+  the baseline recorder use, task-16484) and reports an assembly failure
+  instead of spending a run that cannot succeed.
+
+Second defect closed by the same fix: `_default_gap_fn` reads
+`final_answer_llm` out of `search_params` and returns "no gaps" when it is
+unset, so gap-driven replanning (task-16324) was permanently inert for window
+runs regardless of `max_iterations`.
+
+AC #1 is deliberately left open: the assembly and the pre-flight are unit
+verified, but a window run actually reaching the search phase needs a live
+run against a configured LLM endpoint, and the local Qwen endpoint used for
+every other live verification in this stream is down. It stays open rather
+than being claimed from unit evidence.
+
+Modified: `tldw_chatbook/UI/Research_Window.py`,
+`tldw_chatbook/Research_Interop/local_research_engine.py`,
+`tldw_chatbook/Web_Scraping/WebSearch_APIs.py`,
+`Tests/UI/test_research_screen.py`,
+`Tests/Research/test_local_research_engine.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
+++ b/backlog/tasks/task-17380 - Research-window-runs-never-reach-the-deep-search-pipeline.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17380
 title: Research window runs never reach the deep-search pipeline
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-17 07:45'
@@ -20,7 +20,7 @@ Every research run launched from the Research window fails immediately without s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A run launched from the Research window reaches the search phase instead of failing on missing pipeline parameters
+- [x] #1 A run launched from the Research window reaches the search phase instead of failing on missing pipeline parameters
 - [x] #2 A window-launched run can perform gap-driven replanning, i.e. its synthesis LLM is configured like the Console command's
 - [x] #3 When the pipeline settings cannot be assembled, the window reports that in place of launching a run that cannot succeed
 - [x] #4 A run that reaches the real pipeline without usable parameters fails naming the missing keys and their configuration source, not with the pipeline's opaque message
@@ -69,11 +69,26 @@ Second defect closed by the same fix: `_default_gap_fn` reads
 unset, so gap-driven replanning (task-16324) was permanently inert for window
 runs regardless of `max_iterations`.
 
-AC #1 is deliberately left open: the assembly and the pre-flight are unit
-verified, but a window run actually reaching the search phase needs a live
-run against a configured LLM endpoint, and the local Qwen endpoint used for
-every other live verification in this stream is down. It stays open rather
-than being claimed from unit evidence.
+AC #1 is live-verified, not inferred. A harness mounted the real
+`ResearchWindow` in a Textual app so its worker actually ran, created the run
+the way the window's own flow does (through the service default, which is
+`checkpointed`), and called `_start_local_engine` with NO search_params of its
+own -- so an unfixed window would have failed exactly as before. Against the
+live llama.cpp endpoint:
+
+    created run 8cbadb9a-... autonomy=checkpointed
+    phase=planning control_state=awaiting_plan_review status=running
+    pending checkpoint: plan_review
+    phase=collecting status=running message=Awaiting sources_review (chk-3182549f-...)
+    RESULT: PASS -- window-launched run reached the search phase
+
+Worth recording for anyone verifying this path again: a window-created run is
+CHECKPOINTED (the scope service does not pass `autonomy_mode`, so the
+service default applies), so it parks at `plan_review` before any search and
+the checkpoint must be approved before `collecting` is reachable. The
+pre-flight added here runs at `execute_run` entry, i.e. BEFORE that park, so a
+misconfigured run now fails before a user is asked to review a plan it could
+never execute.
 
 Modified: `tldw_chatbook/UI/Research_Window.py`,
 `tldw_chatbook/Research_Interop/local_research_engine.py`,

--- a/backlog/tasks/task-17381 - Duplicate-task-16812-fails-the-backlog-ID-guard-on-dev.md
+++ b/backlog/tasks/task-17381 - Duplicate-task-16812-fails-the-backlog-ID-guard-on-dev.md
@@ -1,0 +1,29 @@
+---
+id: TASK-17381
+title: Duplicate task-16812 fails the backlog ID guard on dev
+status: To Do
+assignee: []
+created_date: '2026-08-17 08:05'
+labels:
+  - backlog-hygiene
+  - ci
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two different task files claim TASK-16812 on dev — the Console local-provider thinking controls task and the research category-lane baselines task — so the duplicate-ID CI guard fails on dev itself and every pull request against dev inherits that red. This is the seventh ID collision in this repo, and it is the second one created by a renumber landing on an ID that was already taken: the Console file was added by a commit titled "chore(backlog): resolve duplicate task IDs".
+
+Resolving it needs a decision rather than a mechanical rename, because the usual rule (never move a Done task) cannot break the tie: both tasks are Done, and both IDs are referenced from live artifacts. The Console ID is linked by filename from ADR-066 plus a plan and a QA script; the research ID is cited from source comments, a test section header, the eval baseline doc, and another task's justification. Whichever file moves, the references that point at it need to move with it, and the historical plan/QA artifacts that record the work under its old number need a decision about whether they are rewritten or left as history.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The duplicate-ID guard passes on dev
+- [ ] #2 Exactly one task file claims each of the two affected IDs, in both the filename and the frontmatter
+- [ ] #3 Every live reference to the renumbered task resolves to it, including the ADR link that names the file
+- [ ] #4 The chosen treatment of historical plan and QA artifacts naming the old ID is recorded with its reason
+- [ ] #5 The lessons entry on ID collisions records this incident, since a renumber caused it
+<!-- AC:END -->

--- a/backlog/tasks/task-17382 - llama.cpp-summaries-never-run-and-their-error-string-becomes-the-evidence.md
+++ b/backlog/tasks/task-17382 - llama.cpp-summaries-never-run-and-their-error-string-becomes-the-evidence.md
@@ -1,0 +1,54 @@
+---
+id: TASK-17382
+title: llama.cpp summaries never run and their error string becomes the evidence
+status: To Do
+assignee: []
+created_date: '2026-08-17 08:20'
+labels:
+  - websearch
+  - research
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Per-result summarization is dead for llama.cpp, and the failure is silently promoted into the evidence the synthesis reads. The summarizer looks up a configuration section that has never existed, so it raises before it ever contacts the server; it reports failure by returning an error string rather than raising; and the deep-search caller's guard for that convention only recognizes strings beginning with "Error:", which this one does not. The error text is therefore stored as the result's content, while the real scraped text survives only alongside it under another key.
+
+The consequence is that on a llama.cpp run the synthesis prompt is built from titles and gate reasoning with an error string where each source body should be. Citation verification is unaffected because it matches quotes against the scraped text first, which is why recorded runs could still show verified quotes and resolved markers — the reports were graded as sound while the model had never been shown the sources. Every live baseline recorded in this work stream used llama.cpp, so this bounds what those numbers can be read to mean. The relevance gate is not affected: it judges results before summarization, on the scraped content.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A llama.cpp summarization request reaches the server instead of failing on a configuration lookup
+- [ ] #2 The deep-search caller treats a provider's error-string return as a failure regardless of which provider produced it, falling back to the source content
+- [ ] #3 No provider error text can be stored as a result's content
+- [ ] #4 The sibling local summarizers are checked for the same wrong-section-name defect and fixed or cleared
+- [ ] #5 Tests cover the configuration lookup and the caller's error-string detection for a non-"Error:" prefix
+- [ ] #6 The eval baseline doc records which recorded metrics this bounds, and which it does not
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Evidence gathered when the defect surfaced during the task-17370 fan-out arm
+(2026-08-17), before any fix:
+
+- `Local_Summarization_Lib.py:261` reads `loaded_config_data["llama_api"]
+  ["api_retries"]`. Probing the loaded config: `llama_api` is MISSING, while
+  `llama_cpp_api`, `kobold_api`, `ooba_api` and `ollama_api` are all present
+  with `api_retries`/`api_retry_delay`. Only the llama.cpp summarizer names a
+  section that does not exist.
+- The lookup sits above the HTTP call, so the request is never sent -- the
+  observed failure took about a millisecond, not a timeout.
+- Calling `analyze(api_name="llama_cpp", ...)` directly returns the string
+  `"Llama: Error occurred while processing summary with Llama: 'llama_api'"`.
+- `WebSearch_APIs.py:1393` guards with `summary.startswith("Error:")`, which
+  is False for that string, so `WebSearch_APIs.py:1399` stores it as
+  `content`.
+- `WebSearch_APIs.py:1677` builds the synthesis payload from `content`;
+  `deep_search_citations.py:138` verifies quotes against `original_content`
+  first, then `content` -- which is why verification kept passing.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17382 - llama.cpp-summaries-never-run-and-their-error-string-becomes-the-evidence.md
+++ b/backlog/tasks/task-17382 - llama.cpp-summaries-never-run-and-their-error-string-becomes-the-evidence.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17382
 title: llama.cpp summaries never run and their error string becomes the evidence
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-17 08:20'
 labels:
@@ -22,17 +22,42 @@ The consequence is that on a llama.cpp run the synthesis prompt is built from ti
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A llama.cpp summarization request reaches the server instead of failing on a configuration lookup
-- [ ] #2 The deep-search caller treats a provider's error-string return as a failure regardless of which provider produced it, falling back to the source content
-- [ ] #3 No provider error text can be stored as a result's content
-- [ ] #4 The sibling local summarizers are checked for the same wrong-section-name defect and fixed or cleared
-- [ ] #5 Tests cover the configuration lookup and the caller's error-string detection for a non-"Error:" prefix
-- [ ] #6 The eval baseline doc records which recorded metrics this bounds, and which it does not
+- [x] #1 A llama.cpp summarization request reaches the server instead of failing on a configuration lookup
+- [x] #2 The deep-search caller treats a provider's error-string return as a failure regardless of which provider produced it, falling back to the source content
+- [x] #3 No provider error text can be stored as a result's content
+- [x] #4 The sibling local summarizers are checked for the same wrong-section-name defect and fixed or cleared
+- [x] #5 Tests cover the configuration lookup and the caller's error-string detection for a non-"Error:" prefix
+- [x] #6 The eval baseline doc records which recorded metrics this bounds, and which it does not
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Fixed in two halves. The summarizer resolves `llama_cpp_api` once,
+defensively, and prefers `api_settings.llama_cpp.api_url` (what the chat
+handler reads and what a run priming a local endpoint sets) over the legacy
+`api_ip`, so summaries go where the run's model is. The deep-search caller
+replaces its `startswith("Error:")` test with `_is_summary_failure`, matching
+the markers the summarizers actually emit anchored to the leading clause
+(optionally after a provider prefix), applied at BOTH guard sites -- the
+per-result summary and the map-reduce chunk summary.
+
+AC #4: checked and NOT clean -- probing the loaded config shows `api_keys`,
+`local_api_ip` and `models` are absent too, so the Kobold and TabbyAPI
+summarizers fail identically. Filed as task-17383 rather than fixed here; the
+caller-side detector already protects the evidence for every provider.
+
+AC #6: the eval baseline doc records the bound in the task-17370 arm section --
+`gate_pass_rate` is unaffected (the gate judges scraped content before
+summarization), while `cited_sentence_ratio`, `claim_support_rate` and
+`quote_grounding` in every recorded table were graded on reports written
+without source bodies.
+
+Modified: `tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py`,
+`tldw_chatbook/Web_Scraping/WebSearch_APIs.py`,
+`Tests/LLM_Calls/test_llama_summarizer_config.py` (new),
+`Tests/Web_Scraping/test_deep_search_pipeline.py`.
+
 Evidence gathered when the defect surfaced during the task-17370 fan-out arm
 (2026-08-17), before any fix:
 

--- a/backlog/tasks/task-17383 - Kobold-and-TabbyAPI-summarizers-read-config-sections-that-do-not-exist.md
+++ b/backlog/tasks/task-17383 - Kobold-and-TabbyAPI-summarizers-read-config-sections-that-do-not-exist.md
@@ -1,0 +1,43 @@
+---
+id: TASK-17383
+title: Kobold and TabbyAPI summarizers read config sections that do not exist
+status: To Do
+assignee: []
+created_date: '2026-08-17 09:05'
+labels:
+  - llm-calls
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The llama.cpp summarizer's defect is a family, not a one-off. Two sibling local summarizers index configuration sections that the loader never builds, so like llama.cpp they raise before contacting a server and report failure by returning an error string. Kobold reads an API-keys section and a local-endpoint-address section; TabbyAPI reads those two plus a models section. All three are absent at runtime, confirmed by probing the loaded configuration.
+
+The evidence-contamination consequence is already closed for every provider: the deep-search caller now recognizes a returned provider error string as a failure and falls back to the source content. What remains is that these two summarization paths cannot work at all, and that the code reads section names nothing produces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A Kobold summarization request reaches its server instead of failing on a configuration lookup
+- [ ] #2 A TabbyAPI summarization request reaches its server instead of failing on a configuration lookup
+- [ ] #3 Each summarizer resolves its endpoint and credential from a source the loader actually populates, preferring the modern per-provider settings table like the chat handlers do
+- [ ] #4 The remaining local summarizers are audited for reads of absent sections or keys, and each is fixed or recorded as sound
+- [ ] #5 Tests cover the configuration resolution for both providers without contacting a network
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Evidence from the task-17382 investigation, before any fix here:
+
+- Probing the loaded configuration: `api_keys`, `local_api_ip` and `models`
+  are all MISSING, while `kobold_api`, `tabby_api`, `vllm_api`,
+  `custom_openai_api` are present.
+- `Local_Summarization_Lib.py:388,394,448` (Kobold) and `:876,883,884`
+  (TabbyAPI) index the missing sections.
+- Same failure shape as task-17382: the read sits above the HTTP call, and the
+  bottom `except` converts the KeyError into a returned error string.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
+++ b/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
@@ -1,0 +1,49 @@
+---
+id: TASK-17384
+title: Chunk summarization fails on large inputs with an unparseable 200
+status: To Do
+assignee: []
+created_date: '2026-08-17 11:20'
+labels:
+  - websearch
+  - llm-calls
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Map-reduce chunk summarization still fails against a local llama.cpp endpoint after the configuration, endpoint and response-shape defects were fixed. Per-result summarization succeeds on the same code path in the same run, so this is input-dependent rather than a configuration problem: the failing calls are the ones carrying a whole chunk of concatenated evidence rather than a single page.
+
+The server answers with a success status whose body carries neither of the shapes the parser accepts, so the summarizer reports its no-usable-content failure. The most likely explanation is an error body returned for an oversized prompt, but that has not been confirmed, and the payload was not captured at the time.
+
+The consequence is bounded rather than silent: the caller recognizes the failure and falls back to the chunk's own source text, marking the chunk as not generated. So the synthesis still receives real evidence, and the failure costs a wasted LLM call plus the summarization quality on large evidence pools -- which is exactly the case multi-hop runs produce most of.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The failing response body is captured and the cause identified rather than inferred
+- [ ] #2 A chunk-sized summarization request against a local endpoint either succeeds or fails with a message naming the actual cause
+- [ ] #3 If the cause is prompt size, the chunk packer's bound is derived from something the endpoint reports rather than a fixed constant
+- [ ] #4 A test covers the identified failure mode without contacting a network
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Evidence from the task-17370 arm F run (2026-08-17), all three earlier defects
+already fixed:
+
+- Per-result summarization: 7 attempted, 7 succeeded, durations 42/94/131/64/
+  81/115/93 seconds. Same function, same endpoint, same run.
+- Chunk summarization: 2 attempted, 2 failed, both "Llama: No choices in
+  response data".
+- That message comes from the parser's fallthrough, so the response was a
+  success status carrying neither `choices[].message.content`,
+  `choices[].text`, nor a top-level `content`; a non-200 would have produced
+  "Llama: API request failed" with the status instead.
+- The llama-server instance was started with `-c 64000`, and the recorder
+  primes `max_tokens=16384`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -348,14 +348,32 @@ def summarize_with_llama(
             else:
                 logging.debug("Llama.cpp Summarizer: Processing non-streaming response")
                 response_data = response.json()
-                if "content" in response_data and len(response_data["content"]) > 0:
-                    summary = response_data["content"].strip()
+                # task-17382: this parsed ONLY llama.cpp's native
+                # `{"content": ...}` shape while posting to
+                # /v1/chat/completions, whose payload puts the text under
+                # choices[0].message.content -- so every real chunk
+                # summarization came back "No choices in response data" once
+                # the endpoint was reached. Accept the OpenAI shape first,
+                # then the native one, so either endpoint works.
+                summary = ""
+                if isinstance(response_data, dict):
+                    choices = response_data.get("choices")
+                    if isinstance(choices, list) and choices:
+                        first = choices[0] if isinstance(choices[0], dict) else {}
+                        message = first.get("message")
+                        if isinstance(message, dict):
+                            summary = str(message.get("content") or "")
+                        if not summary:
+                            summary = str(first.get("text") or "")
+                    if not summary:
+                        summary = str(response_data.get("content") or "")
+                summary = summary.strip()
+                if summary:
                     logging.debug("llama: Summarization successful")
                     logging.info("Summarization successful.")
                     return summary
-                else:
-                    logging.error("Llama: No choices in response data")
-                    return "Llama: No choices in response data"
+                logging.error("Llama: No choices in response data")
+                return "Llama: No choices in response data"
         else:
             logging.error(
                 "Llama: API request failed; status_code=%s",

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -188,16 +188,26 @@ def summarize_with_llama(
             api_settings_llama = (
                 (loaded_config_data.get("api_settings") or {}).get("llama_cpp") or {}
             )
-        api_url = (
+        configured_url = (
             api_settings_llama.get("api_url")
             or api_settings_llama.get("api_ip")
             or llama_config.get("api_ip")
         )
-        if not api_url:
+        if not configured_url:
             raise ValueError(
                 "Llama.cpp Summarize: no API URL configured "
                 "(api_settings.llama_cpp.api_url or llama_cpp_api.api_ip)"
             )
+        # These keys legitimately hold any of a server root, a base ending in
+        # /v1, a full chat-completions endpoint, or a bare host:port. This
+        # function POSTs directly rather than going through the shared caller,
+        # so it must land on the endpoint exactly once itself: normalize to the
+        # origin with the same helper the chat handler uses, then append the
+        # path. Posting a base URL raw returned llama-server's 404 "File Not
+        # Found" (observed live during the task-17370 measurement).
+        from ..Chat.console_provider_gateway import normalize_llamacpp_base_url
+
+        api_url = f"{normalize_llamacpp_base_url(configured_url)}/v1/chat/completions"
         logging.debug("Llama: API endpoint configured")
 
         # Load transcript

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -153,6 +153,15 @@ def summarize_with_llama(
     try:
         logging.debug("Llama.cpp: Loading and validating configurations")
         loaded_config_data = load_settings()
+        # task-17382: this function indexed a `llama_api` section in ten
+        # places. No such section has ever existed -- the loader builds
+        # `llama_cpp_api` -- so the FIRST read raised KeyError, the except at
+        # the bottom turned it into an error STRING, and the deep-search
+        # caller stored that string as a result's evidence content. Resolved
+        # once here, defensively, the way the chat handler does it.
+        llama_config = {}
+        if isinstance(loaded_config_data, dict):
+            llama_config = loaded_config_data.get("llama_cpp_api") or {}
         if loaded_config_data is None:
             logging.error("Failed to load configuration data")
             llama_api_key = None
@@ -163,14 +172,32 @@ def summarize_with_llama(
                 logging.info("Llama.cpp: Using API key provided as parameter")
             else:
                 # If no parameter is provided, use the key from the config
-                llama_api_key = loaded_config_data["llama_api"]["api_key"]
+                llama_api_key = llama_config.get("api_key")
                 if llama_api_key:
                     logging.info("Llama.cpp: Using API key from config file")
                 else:
                     logging.warning("Llama.cpp: No API key found in config file")
 
         logging.info("llama.cpp: Attempting to use API URL from config file")
-        api_url = loaded_config_data["llama_api"]["api_ip"]
+        # task-17382: prefer the modern api_settings entry -- what routes the
+        # chat handler, and what a run priming a local endpoint sets -- over
+        # the legacy section's api_ip, which otherwise sends every summary to
+        # the default port regardless of where the run's model actually is.
+        api_settings_llama = {}
+        if isinstance(loaded_config_data, dict):
+            api_settings_llama = (
+                (loaded_config_data.get("api_settings") or {}).get("llama_cpp") or {}
+            )
+        api_url = (
+            api_settings_llama.get("api_url")
+            or api_settings_llama.get("api_ip")
+            or llama_config.get("api_ip")
+        )
+        if not api_url:
+            raise ValueError(
+                "Llama.cpp Summarize: no API URL configured "
+                "(api_settings.llama_cpp.api_url or llama_cpp_api.api_ip)"
+            )
         logging.debug("Llama: API endpoint configured")
 
         # Load transcript
@@ -221,16 +248,16 @@ def summarize_with_llama(
         # Temperature handling
         if temp is None:
             # Check config
-            if "temperature" in loaded_config_data["llama_api"]:
-                temp = loaded_config_data["llama_api"]["temperature"]
+            if "temperature" in llama_config:
+                temp = llama_config["temperature"]
                 temp = float(temp)
             else:
                 temp = 0.7
         logging.debug(f"Llama: Using temperature: {temp}")
 
         # Check for max tokens
-        if "max_tokens" in loaded_config_data["llama_api"]:
-            max_tokens = loaded_config_data["llama_api"]["max_tokens"]
+        if "max_tokens" in llama_config:
+            max_tokens = llama_config["max_tokens"]
             max_tokens = int(max_tokens)
         else:
             max_tokens = 4096
@@ -238,8 +265,8 @@ def summarize_with_llama(
 
         # Check for streaming
         if not isinstance(streaming, bool):
-            if "streaming" in loaded_config_data["llama_api"]:
-                streaming = loaded_config_data["llama_api"]["streaming"]
+            if "streaming" in llama_config:
+                streaming = llama_config["streaming"]
                 streaming = bool(streaming)
         logging.debug(f"Llama: Streaming mode: {streaming}")
 
@@ -258,8 +285,8 @@ def summarize_with_llama(
         session = requests.Session()
 
         # Load config values
-        retry_count = loaded_config_data["llama_api"]["api_retries"]
-        retry_delay = loaded_config_data["llama_api"]["api_retry_delay"]
+        retry_count = int(llama_config.get("api_retries", 3))
+        retry_delay = int(llama_config.get("api_retry_delay", 5))
 
         # Configure the retry strategy
         retry_strategy = Retry(

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -82,6 +82,12 @@ class LocalResearchEngine:
     ) -> None:
         self.service = local_service
         self.search_fn = search_fn or self._default_search_fn
+        # task-17371: the pipeline's own required params are pre-flighted
+        # before a run spends anything -- but ONLY when the real pipeline is
+        # what will be called. An injected search_fn carries its own
+        # contract (tests, and any future non-web lane), so the pre-flight
+        # must not speak for it.
+        self._uses_default_search_fn = search_fn is None
         self.analyze_fn = analyze_fn or self._default_analyze_fn
         self.gap_fn = gap_fn or self._default_gap_fn
         self.search_params = dict(search_params or {})
@@ -190,6 +196,39 @@ class LocalResearchEngine:
                 and recorder.exact_tokens() == recorder.total_tokens(),
             )
         return result
+
+    def _require_pipeline_params(self, params: dict[str, Any]) -> None:
+        """Refuse a run the real pipeline cannot execute (task-17371).
+
+        ``generate_and_search`` validates these keys itself, but it does so
+        from inside the collecting phase, and its message ("Invalid
+        search_params parameter" for an empty dict) names neither what is
+        missing nor where it comes from. Research_Window shipped an engine
+        built with no search_params at all, so every window-launched run
+        failed with exactly that. Failing here instead states the missing
+        keys and their source before any search, LLM call or budget spend.
+
+        Raises:
+            ValueError: If a required pipeline param is absent. The caller's
+                terminal-failure path turns it into the run's error_msg.
+        """
+        from ..Web_Scraping.WebSearch_APIs import (
+            GENERATE_AND_SEARCH_REQUIRED_PARAMS,
+        )
+
+        missing = [
+            key for key in GENERATE_AND_SEARCH_REQUIRED_PARAMS if key not in params
+        ]
+        if not missing:
+            return
+        raise ValueError(
+            "deep-search pipeline params are missing: "
+            + ", ".join(missing)
+            + ". They are assembled from [SearchSettings] by "
+            "Tools.web_tool_impls.deep_search_pipeline_params(); pass the "
+            "result as the engine's search_params (or inject a search_fn "
+            "that does not need them)."
+        )
 
     def _get_run(self, run_id: str) -> dict[str, Any]:
         run = self.service.get_run(run_id)
@@ -324,6 +363,8 @@ class LocalResearchEngine:
         self._active_academic_providers = overrides.get("academic_providers")
 
         try:
+            if self._uses_default_search_fn:
+                self._require_pipeline_params(run_params)
             return await self._execute_phases(run, ledger)
         except _RunAwaitingReview as awaiting:
             logger.info(f"Research run {run_id} awaiting checkpoint review")

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -219,6 +219,22 @@ class LocalResearchEngine:
         missing = [
             key for key in GENERATE_AND_SEARCH_REQUIRED_PARAMS if key not in params
         ]
+        # Qodo (PR 1764): the search keys alone let a run spend its phase-1
+        # searches and only then fail in relevance/synthesis for want of an LLM.
+        # The shipped tool path already refuses both cases before phase 1
+        # (web_tool_impls "[deep-search-failed] relevance/synthesis: no ...
+        # configured"), and the baseline recorder refuses at startup, so the
+        # engine matches that contract for every default-pipeline caller rather
+        # than each launch site checking for itself. Note this makes
+        # analyze_and_aggregate's "evidence summaries only" degraded mode
+        # unreachable for research RUNS specifically -- a run persists an
+        # artifact, and an unsynthesized one nobody asked for is worse than a
+        # legible refusal.
+        missing += [
+            key
+            for key in ("relevance_analysis_llm", "final_answer_llm")
+            if not str(params.get(key) or "").strip()
+        ]
         if not missing:
             return
         raise ValueError(

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -424,8 +424,29 @@ class ResearchWindow(Vertical):
         # behavior with a None paper_search_fn.
         from ..Research_Interop.academic_providers import search_papers
 
+        # task-17371: the window used to construct the engine with NO
+        # search_params, so the pipeline rejected every window-launched run
+        # ("Invalid search_params parameter") before a single search, and the
+        # engine's gap analysis -- which reads final_answer_llm from these
+        # params -- could never fire. Assemble them the way the Console
+        # /research command and the baseline recorder do (one shared
+        # assembly, task-16484); a failure to assemble is reported instead of
+        # being spent on a run that cannot succeed.
+        try:
+            from ..Tools.web_tool_impls import deep_search_pipeline_params
+
+            search_params = deep_search_pipeline_params()
+        except Exception as exc:  # noqa: BLE001 - report, never crash the window
+            logger.error(f"Research engine params unavailable: {exc}")
+            self._set_status(
+                "Research engine unavailable: deep-search settings could not be "
+                f"assembled ({exc}). Check [SearchSettings] in your config."
+            )
+            return
+
         engine = LocalResearchEngine(
             local_service,
+            search_params=search_params,
             paper_search_fn=search_papers if self.academic_enabled else None,
         )
 

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -370,6 +370,21 @@ def _sanitize_sub_questions(raw_values: Any) -> List[str]:
     return sanitized
 
 
+#: search_params keys generate_and_search cannot run without. Exported
+#: because callers that ASSEMBLE these params need to be able to check their
+#: own assembly before spending a run on it -- LocalResearchEngine's
+#: pre-flight (task-17371) does exactly that, after a window-launched run
+#: reaching this validation was the only signal that the window passed no
+#: params at all.
+GENERATE_AND_SEARCH_REQUIRED_PARAMS = (
+    "engine",
+    "content_country",
+    "search_lang",
+    "output_lang",
+    "result_count",
+)
+
+
 def generate_and_search(question: str, search_params: Dict) -> Dict:
     """
     Generate sub-queries and perform web searches.
@@ -442,14 +457,7 @@ def generate_and_search(question: str, search_params: Dict) -> Dict:
         raise ValueError("Invalid search_params parameter")
 
     # Check for required keys in search_params
-    required_keys = [
-        "engine",
-        "content_country",
-        "search_lang",
-        "output_lang",
-        "result_count",
-    ]
-    for key in required_keys:
+    for key in GENERATE_AND_SEARCH_REQUIRED_PARAMS:
         if key not in search_params:
             raise ValueError(f"Missing required key in search_params: {key}")
 

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -384,12 +384,21 @@ def _sanitize_sub_questions(raw_values: Any) -> List[str]:
 #: mistaken for one. The old guard tested only the "Error:" prefix, which no
 #: provider-prefixed message matches.
 _SUMMARY_FAILURE_MARKERS = (
-    "error",
+    # The legacy convention this guard originally tested for.
+    "error:",
+    # What the summarizers actually emit, verbatim from their return
+    # statements. Deliberately phrase-level, not the bare word "error": a
+    # real summary may open with "Error rates in retrieval systems are ..."
+    # and must not be thrown away.
+    "error occurred",
+    "error making",
+    "error decoding",
+    "error parsing",
+    "error summarizing",
     "unexpected error",
     "api request failed",
     "json parse error",
     "no choices in response",
-    "failed to",
 )
 
 #: How far into the value a marker still counts as the leading clause.

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -376,6 +376,54 @@ def _sanitize_sub_questions(raw_values: Any) -> List[str]:
 #: pre-flight (task-17371) does exactly that, after a window-launched run
 #: reaching this validation was the only signal that the window passed no
 #: params at all.
+#: Failure markers the summarizers use when they report by RETURNING a string
+#: instead of raising (task-17382). Matched case-insensitively against the
+#: START of the value only -- these functions put the marker in the first
+#: clause ("Llama: Error occurred while ...", "Ollama: JSON parse error ..."),
+#: so a legitimate summary that merely discusses errors downstream cannot be
+#: mistaken for one. The old guard tested only the "Error:" prefix, which no
+#: provider-prefixed message matches.
+_SUMMARY_FAILURE_MARKERS = (
+    "error",
+    "unexpected error",
+    "api request failed",
+    "json parse error",
+    "no choices in response",
+    "failed to",
+)
+
+#: How far into the value a marker still counts as the leading clause.
+_SUMMARY_FAILURE_PREFIX_CHARS = 60
+
+
+def _is_summary_failure(value: Any) -> bool:
+    """Whether a summarizer's return value is one of its error strings.
+
+    Args:
+        value: The summarizer's return value (any type; only str can fail).
+
+    Returns:
+        True when the value is a provider failure report rather than a summary.
+    """
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text:
+        return True
+    head = text[:_SUMMARY_FAILURE_PREFIX_CHARS].casefold()
+    # Either the message leads with the marker, or a provider prefix does:
+    # "<provider>: <marker> ...". Split once so prose containing a colon
+    # later on cannot smuggle a marker in.
+    candidates = [head]
+    if ":" in head:
+        candidates.append(head.split(":", 1)[1].lstrip())
+    return any(
+        candidate.startswith(marker)
+        for candidate in candidates
+        for marker in _SUMMARY_FAILURE_MARKERS
+    )
+
+
 GENERATE_AND_SEARCH_REQUIRED_PARAMS = (
     "engine",
     "content_country",
@@ -1386,13 +1434,15 @@ async def search_result_relevance(
                         except Exception as summ_error:
                             logger.error(f"Summary generation failed: {summ_error}")
 
-                        # `analyze()` reports failure by returning an "Error: ..."
-                        # string rather than raising -- treat both cases the same
-                        # way the port source treats a raised exception: fall back
-                        # to the (scraped or fallback) source content itself.
-                        if not summary or (
-                            isinstance(summary, str) and summary.startswith("Error:")
-                        ):
+                        # `analyze()` reports failure by RETURNING one of its
+                        # providers' error strings rather than raising -- treat
+                        # that the same way the port source treats a raised
+                        # exception: fall back to the (scraped or fallback)
+                        # source content itself. Detection cannot be a bare
+                        # "Error:" prefix test: a llama.cpp failure returns
+                        # "Llama: Error occurred while ..." and used to be
+                        # stored here AS the evidence (task-17382).
+                        if _is_summary_failure(summary) or not summary:
                             summary = source_content[:2000] or "Summary generation failed"
 
                         relevant_results[result_id] = {
@@ -1780,9 +1830,7 @@ def aggregate_results(
                     system_message=None,
                     streaming=False,
                 )
-                if not chunk_summary or (
-                    isinstance(chunk_summary, str) and chunk_summary.startswith("Error:")
-                ):
+                if _is_summary_failure(chunk_summary) or not chunk_summary:
                     raise RuntimeError(chunk_summary or "empty chunk summary")
                 generated = True
             except Exception as chunk_error:


### PR DESCRIPTION
## Why

Following the question *"wouldn't that be the sub-question creation/multi-hop that we tested earlier and didn't include?"* — it was. Both mechanisms ship; both were off in every measurement, and one of the two shipped launch paths could not run at all.

## What this changes

**1. Research-window runs never reached the pipeline (TASK-17380, new).** `Research_Window._start_local_engine` built `LocalResearchEngine` with no `search_params`, so `generate_and_search` rejected the run on its own required-key check — an empty dict is falsy, giving `ValueError("Invalid search_params parameter")`. Verified by launching a run exactly as the window does:

```
status      : failed
error/msg   : Invalid search_params parameter
```

The Research screen is reachable from navigation again (task-16322), so this was the shipped path. Console `/research` was unaffected (it assembles params). The same omission left gap-driven replanning inert for window runs: `_default_gap_fn` reads `final_answer_llm` from those params and returns "no gaps" when unset, so multi-hop could never fire regardless of `max_iterations`.

Fix: the window assembles via the shared `deep_search_pipeline_params()` (task-16484) and reports an assembly failure instead of spending a doomed run; the engine pre-flights the pipeline's required params so a failure names the missing keys and `[SearchSettings]` — **only** when the real pipeline is the search function, so injected `search_fn` callers (every engine test, any future non-web lane) keep their contract. The required-key list is exported from the pipeline instead of duplicated.

**2. Decomposition is a measured choice, not a constant (TASK-17370).** The recorder hard-coded `subquery=False, max_queries=1` and launched with no `limits_json` (so `max_iterations` fell to the engine default of 1). It now takes `--max-queries`, `--max-iterations`, `--deadline-s`, derives sub-query generation from the query cap so the two cannot contradict, and stamps every emitted aggregate with the settings it ran under.

**3. The baseline doc now states what its numbers measured.** Every recorded gate number — including 0.29 → 0.42 — was measured with both mechanisms off. The gate is prompted with the run's sub-questions, so those runs handed it an empty list: a repository record had no narrower facet to be relevant to, which makes the recorded "the residual is partly genuine" reading unfalsifiable from those runs.

## Still open

- **The decomposition-on arm is not measured yet.** It needs the same judge model as the recorded arms (local Qwen3.8-27B, `:9191`), which is currently down — only a different model (`:9099`, gemma-4-26B) is up, and swapping judges would confound the one variable under test. No numbers are claimed.
- Fan-out never reaches the paper providers (they loop `round_queries` = `[question]` in round 1) — filed as TASK-17372, and the reason the pending re-run is a clean gate-only experiment.
- Shipped defaults + per-run UI control for decomposition stay filed as TASK-17371 (To Do), deliberately not decided here: the whole point is to set them from numbers.

## Verification

- `Tests/Research Tests/UI/test_research_screen.py Tests/Web_Scraping/test_deep_search_pipeline.py Tests/Tools/test_web_deep_search.py Tests/Helper_Scripts` — **362 passed**
- `ruff check` on all touched files — clean
- New tests: window assembles required keys; engine pre-flight fires with the real pipeline and stays out of the way for injected search functions.

Commit `e83a92f8f` (recorder flags) originated in a parallel session of the user's own and is carried here with its reasoning intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Research window runs to the deep-search pipeline, makes decomposition a measured per-run choice, and prevents summarizer errors from being stored as evidence. The engine now also fails fast when required LLMs are unset so runs don’t spend before inevitably failing.

**Details**
- Research window: `Research_Window` assembles `deep_search_pipeline_params()`. `LocalResearchEngine` preflights required pipeline keys when using the default pipeline and names missing keys and `[SearchSettings]`. Gap-driven replanning runs when `max_iterations > 1`.
- Early LLM checks: default-pipeline runs without `relevance_analysis_llm` or `final_answer_llm` now fail before phase 1. This makes the “summaries-only” degraded mode unreachable for research runs. Tool and injected `search_fn` callers are unchanged.
- Baseline recorder: adds `--max-queries`, `--max-iterations`, `--deadline-s`, and `--llm-timeout-s`; derives subquery generation from the query cap; records decomposition/timeouts in the aggregate JSON. Defaults remain one query and one iteration.
- Summarization: the `llama.cpp` summarizer prefers `api_settings.llama_cpp.api_url`, normalizes to `/v1/chat/completions`, and parses OpenAI chat-completion responses (falls back to native shapes). `_is_summary_failure` matches provider-prefixed failure phrases and prevents error text from becoming evidence for per-result and chunk summaries.

**Rollout**
- Configure `[SearchSettings]` `relevance_analysis_llm` and `final_answer_llm` to run default-pipeline research; otherwise runs fail fast.
- Summarizer routing prefers `api_settings.llama_cpp.api_url` but falls back to legacy `api_ip`. Recorder defaults are unchanged; injected `search_fn` callers continue to work without pipeline params.

<sup>Written for commit 54a25a2ecfdd39b098ecb915c8d7d18cdc859229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

