### PR TITLE
feat(research): multi-hop by default for local research runs

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -392,6 +392,36 @@ chunk's source text and marks it not-generated, so evidence stays real; the cost
 is a wasted call and summarization quality on exactly the large evidence pools
 multi-hop produces.
 
+### The shipped default that came out of this (task-17371)
+
+Local research runs are **multi-hop by default** as of this measurement:
+`DEFAULT_MAX_ITERATIONS = 2` in `local_research_engine.py`, overridable per
+install via `[SearchSettings] research_max_iterations` and per run via
+`limits_json.max_iterations`.
+
+Chosen from the numbers above rather than from caution: the second round is the
+half of decomposition that changed retrieval, and on the one question whose
+synthesis path was intact it held the gate's pass rate while taking resolved
+markers 24 -> 39 and citation density 0.77 -> 0.95. Fan-out stays OFF by
+default, because it measured flat (0.42 -> 0.38) and on this lane it cannot
+change retrieval at all while task-17372 stands.
+
+The cost is real and multiplicative: one extra search per gap, each with its own
+per-result relevance and summarization calls, plus another synthesis and gap
+analysis per round -- the measured arm went 3 -> 12 search calls over three
+questions and roughly tripled wall-clock. Recorded baselines are unaffected
+because the recorder passes `max_iterations` explicitly (default 1), which is
+the property that keeps them reproducible byte-for-byte.
+
+Two known interactions worth stating, since this default increases exposure to
+both: multi-hop enlarges the evidence pool, and (a) each new source needs its
+own summarization call, which cannot complete inside the shipped 30s timeout on
+a local model (task-17382 chain), and (b) larger pools are what trigger
+map-reduce chunking, where chunk summarization still fails against a local
+endpoint (task-17384). Both degrade to real source text rather than to
+nonsense, so the default is safe -- but a local-model install will feel it as
+latency, not as better summaries.
+
 ### Reading gate_pass_rate
 
 It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1105,3 +1105,92 @@ def test_preflight_accepts_fully_configured_params():
             "final_answer_llm": "llama_cpp",
         }
     )
+
+
+# --- multi-hop on by default (task-17371) -------------------------------------
+# Gap-driven replanning shipped but max_iterations defaulted to 1, so every
+# real run was single-pass and the mechanism never ran. task-17370 measured
+# what it is worth: on the one question whose synthesis path was intact,
+# a second round held the gate rate while taking resolved markers from 24 to
+# 39 and citation density from 0.77 to 0.95. Deep research defaults to it now.
+
+
+def _gap_pipeline(question: str, gaps_per_round):
+    """search/analyze/gap fakes recording the queries of every round."""
+    rounds: list[str] = []
+    remaining = list(gaps_per_round)
+
+    def search_fn(q, params):
+        rounds.append(q)
+        return (
+            {"results": [{"title": f"R:{q}", "url": f"https://x.example/{len(rounds)}"}],
+             "warnings": []},
+            {"sub_questions": [], "main_goal": question},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        return {
+            "final_answer": {"text": "Answer citing [1].", "evidence": [
+                {"id": 1, "url": "https://x.example/1", "title": "R"}],
+                "confidence": 0.5, "chunks": []},
+            "relevant_results": {"0": {"url": "https://x.example/1"}},
+        }
+
+    async def gap_fn(context):
+        return remaining.pop(0) if remaining else []
+
+    return search_fn, analyze_fn, gap_fn, rounds
+
+
+def test_multi_hop_runs_a_second_round_by_default():
+    """No limits at all: the run must research the gaps its first synthesis
+    left open, not stop after one pass."""
+    service = _make_service()
+    search_fn, analyze_fn, gap_fn, rounds = _gap_pipeline("q", [["gap one"], []])
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn, gap_fn=gap_fn
+    )
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    assert rounds == ["q", "gap one"], rounds
+
+
+def test_explicit_single_pass_limit_still_wins():
+    """A run that asks for one pass gets one pass -- the default must not
+    override what a caller (or the baseline recorder) states."""
+    service = _make_service()
+    search_fn, analyze_fn, gap_fn, rounds = _gap_pipeline("q", [["gap one"], []])
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn, gap_fn=gap_fn
+    )
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert rounds == ["q"], rounds
+
+
+def test_configured_iteration_default_is_honoured(monkeypatch):
+    """Operators can move the shipped default without editing code."""
+    from tldw_chatbook.Research_Interop import local_research_engine as engine_module
+
+    monkeypatch.setattr(
+        engine_module, "_configured_max_iterations", lambda: 3
+    )
+    service = _make_service()
+    search_fn, analyze_fn, gap_fn, rounds = _gap_pipeline(
+        "q", [["gap one"], ["gap two"], []]
+    )
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn, gap_fn=gap_fn
+    )
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert rounds == ["q", "gap one", "gap two"], rounds

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1194,3 +1194,36 @@ def test_configured_iteration_default_is_honoured(monkeypatch):
     asyncio.run(engine.execute_run(run["id"]))
 
     assert rounds == ["q", "gap one", "gap two"], rounds
+
+
+def test_plan_review_patch_bounds_the_iterations():
+    """Qodo (PR 1766): an approved plan-review patch reached the budget ledger
+    but not the iteration bound, which was re-read from the run record. With
+    multi-hop as the default, a run the user had just limited to ONE pass could
+    still perform a second -- spending more than the review had approved.
+
+    Driven on an AUTONOMOUS run with a pre-approved plan patch, because a
+    resumed CHECKPOINTED run restarts the phase machine from the top (a
+    documented v1 limitation), which makes counting rounds through that path
+    ambiguous. The merge under test is the same one either way.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, gap_fn, rounds = _gap_pipeline("q", [["gap one"], []])
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=analyze_fn, gap_fn=gap_fn
+    )
+    # No max_iterations of its own, so ONLY the approved patch can bound it.
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    checkpoint = service.create_checkpoint(
+        run["id"], checkpoint_type="plan_review", proposed_payload={"query": "q"}
+    )
+    service.patch_and_approve_checkpoint(
+        run["id"], checkpoint["id"], patch_payload={"limits": {"max_iterations": 1}}
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed", final.get("progress_message")
+    # Without the fix this is ["q", "gap one"]: the ledger honoured the patch
+    # while the iteration bound fell back to the shipped default of 2.
+    assert rounds == ["q"], rounds

--- a/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
+++ b/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17371
 title: Enable sub-question decomposition and bounded multi-hop for shipped research runs
-status: To Do
+status: In Progress
 assignee:
   - '@robert'
 created_date: '2026-08-17 07:30'
@@ -21,10 +21,10 @@ Sub-question fan-out and gap-driven replanning both ship but are off by default:
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The shipped default for research-run decomposition is set from the task-17370 measurement, and the choice is recorded with the numbers that justify it.
+- [x] #1 The shipped default for research-run decomposition is set from the task-17370 measurement, and the choice is recorded with the numbers that justify it.
 - [ ] #2 A user can see and change the decomposition settings for a run before launching it, and the setting persists.
-- [ ] #3 The expected spend implication of the chosen default is documented where a user meets it, since fan-out multiplies gate LLM calls per run and iterations multiply rounds on top.
-- [ ] #4 Existing runs, artifacts and tests that assume single-pass behaviour continue to pass or are updated with the reason recorded.
+- [x] #3 The expected spend implication of the chosen default is documented where a user meets it, since fan-out multiplies gate LLM calls per run and iterations multiply rounds on top.
+- [x] #4 Existing runs, artifacts and tests that assume single-pass behaviour continue to pass or are updated with the reason recorded.
 <!-- AC:END -->
 
 ## Measured evidence for the defaults decision (task-17370)
@@ -70,3 +70,41 @@ working (task-17382 chain), so these numbers describe a pipeline synthesizing
 from raw source text. A defaults decision that turns on multi-hop multiplies
 the number of sources that each need summarizing, so re-measure the cost once
 summarization completes.
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Multi-hop is on by default for local research runs:
+`DEFAULT_MAX_ITERATIONS = 2` resolved through `_configured_max_iterations()`,
+which reads `[SearchSettings] research_max_iterations` and falls back to the
+shipped value if the setting is missing, unreadable or non-positive. An explicit
+`limits_json.max_iterations` still wins, so a caller asking for one pass gets
+exactly one.
+
+Fan-out is deliberately NOT enabled: it measured flat on the gate
+(0.42 -> 0.38) and cannot change retrieval on this lane while task-17372
+stands. The decision for each mechanism is recorded with its numbers in the
+"Measured evidence" section above and in the eval baseline doc.
+
+AC #3: the spend implication is documented on the config key itself -- the
+place a user meets this setting -- quoting the measured multiplier (3 -> 12
+search calls across three questions, roughly tripled wall-clock) rather than a
+general warning. `/research` has no user-guide page to update; the Research
+window's limits input already accepts a per-run override.
+
+AC #4: 382 tests across the research, window, recorder, tools and pipeline
+suites pass unchanged. The only single-pass assumptions left are in the
+baseline recorder's tests, which pin that it passes `max_iterations`
+EXPLICITLY (default 1) -- the property that keeps recorded baselines
+reproducible byte-for-byte under a changed shipped default.
+
+AC #2 remains open: a user can override per run today only by typing limits
+into the Research window's existing input. A real control that shows the
+current setting and persists it is still to do, and is the part that matters
+more than the default itself.
+
+Modified: `tldw_chatbook/Research_Interop/local_research_engine.py`,
+`tldw_chatbook/config.py`,
+`Tests/Research/test_local_research_engine.py`,
+`Docs/Development/research-report-eval-baseline.md`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -42,6 +42,40 @@ _PROGRESS_COLLECTING = 45.0
 _PROGRESS_SYNTHESIZING = 75.0
 _PROGRESS_PACKAGING = 95.0
 
+#: Rounds a run performs when its limits say nothing (task-17371). Deep
+#: research defaults to multi-hop: round 1 researches the question, every later
+#: round researches the gaps the previous synthesis left open. Measured on the
+#: repositories lane (task-17370): a second round held the relevance gate's
+#: pass rate while taking resolved citation markers from 24 to 39 and citation
+#: density from 0.77 to 0.95. It is NOT free -- one extra search per gap, each
+#: with its own per-result gate and summarization calls, plus another synthesis
+#: and gap analysis per round; the measured arm went from 3 to 12 search calls
+#: over three questions. Operators can move it, and an explicit
+#: limits_json.max_iterations always wins (which is how recorded baselines stay
+#: single-pass).
+DEFAULT_MAX_ITERATIONS = 2
+
+
+def _configured_max_iterations() -> int:
+    """The configured default round count, or DEFAULT_MAX_ITERATIONS.
+
+    Returns:
+        A positive round count. Unreadable or non-positive configuration falls
+        back to the shipped default rather than disabling the mechanism.
+    """
+    try:
+        from ..config import get_cli_setting
+
+        configured = int(
+            get_cli_setting(
+                "SearchSettings", "research_max_iterations", DEFAULT_MAX_ITERATIONS
+            )
+        )
+    except Exception:  # noqa: BLE001 - configuration must never break a run
+        return DEFAULT_MAX_ITERATIONS
+    return configured if configured >= 1 else DEFAULT_MAX_ITERATIONS
+
+
 SearchFn = Callable[[str, dict[str, Any]], Any]
 AnalyzeFn = Callable[..., Awaitable[Any]]
 GapFn = Callable[[dict[str, Any]], Awaitable[list[str]]]
@@ -528,13 +562,17 @@ class LocalResearchEngine:
         # task-16324: collect, synthesize, then let gap analysis decide
         # whether another bounded iteration is worth spending. Iteration 1
         # researches the question; every later round researches the gaps the
-        # previous synthesis left open. max_iterations (limits_json,
-        # default 1) is the hard bound; the budget ledger bounds spend
-        # within it.
+        # previous synthesis left open. max_iterations (limits_json) is the
+        # hard bound; the budget ledger bounds spend within it.
+        # task-17371: when the run says nothing, deep research is multi-hop by
+        # default -- see DEFAULT_MAX_ITERATIONS for the measurement and the
+        # cost. An explicit value always wins, so a caller that wants one pass
+        # (the baseline recorder does) still gets exactly one.
+        default_iterations = _configured_max_iterations()
         try:
-            max_iterations = int(limits.get("max_iterations", 1) or 1)
+            max_iterations = int(limits.get("max_iterations", default_iterations) or default_iterations)
         except (TypeError, ValueError):
-            max_iterations = 1
+            max_iterations = default_iterations
         max_iterations = max(1, max_iterations)
 
         merged_results: list[dict[str, Any]] = []

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -415,7 +415,7 @@ class LocalResearchEngine:
         try:
             if self._uses_default_search_fn:
                 self._require_pipeline_params(run_params)
-            return await self._execute_phases(run, ledger)
+            return await self._execute_phases(run, ledger, limits)
         except _RunAwaitingReview as awaiting:
             logger.info(f"Research run {run_id} awaiting checkpoint review")
             return awaiting.run
@@ -516,11 +516,24 @@ class LocalResearchEngine:
         )
 
     async def _execute_phases(
-        self, run: dict[str, Any], ledger: BudgetLedger
+        self, run: dict[str, Any], ledger: BudgetLedger, limits: dict[str, Any]
     ) -> dict[str, Any]:
+        """Run the phase machine.
+
+        Args:
+            run: The run record being executed.
+            ledger: Budget ledger built from the SAME limits passed here.
+            limits: The run's effective limits, i.e. its stored limits with any
+                approved plan-review patch already merged over them. Qodo
+                (PR 1766): this used to be re-read from the run record here,
+                which silently dropped the patch -- the ledger honoured a
+                plan-review edit while the iteration bound did not, so a run
+                patched to a single pass could still perform a second round
+                (and, once multi-hop became the default, spend more than the
+                user had just asked for).
+        """
         run_id = run["id"]
         question = str(run.get("query") or "")
-        limits = run.get("limits") if isinstance(run.get("limits"), dict) else {}
         ledger.check_runtime()  # zero/degenerate runtime budgets stop here
 
         # Draft runs (window "Create Run" flow) normalize to running here.

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3949,8 +3949,21 @@ log_unknown_models = true      # Whether to log when an unknown model is queried
 # search_enable_subquery = false
 # search_default_max_queries = 5
 # search_result_max = 10
-# relevance_llm_timeout_s = 30
+# relevance_llm_timeout_s = 30   # per relevance/summarization LLM call. Measured
+#   (task-17370): per-result summarization against a local 27B took 42-131s, so
+#   30 guarantees the fallback-to-source-text path on local models. Raise it if
+#   you want summarized evidence rather than raw page text.
 # relevance_scrape_timeout_s = 30
+# research_max_iterations = 2   # rounds a local research RUN performs when it
+#   does not set its own limit: round 1 researches the question, later rounds
+#   research the gaps the previous synthesis left open (task-16324). 2 is the
+#   shipped default because a second round measurably improved evidence --
+#   resolved citation markers 24 -> 39, citation density 0.77 -> 0.95
+#   (task-17370). It costs one extra search per gap, each with its own
+#   per-result relevance and summarization calls, plus another synthesis and gap
+#   analysis per round: the measured arm went from 3 to 12 search calls across
+#   three questions and roughly tripled wall-clock. Set to 1 for single-pass
+#   runs; a run's own limits always override this.
 # deep_search_timeout_s = 240   # the agent runtime automatically allots this tool its own per-call timeout of this value plus ~50s slack (wait_for grace + thread-join + scheduling jitter), via LocalToolProvider.timeout_for -- independent of max_tool_call_seconds, any value here is safe
 
 [webfetch]


### PR DESCRIPTION
Stacked on **#1764** (`feat/research-shipped-decomposition`), which carries the measurement this decision rests on. This branch's own change is the single commit `11eda0b47`; merging #1764 first makes this diff one file plus its test and config comment.

## The decision

Gap-driven replanning has shipped since task-16324, but `max_iterations` defaulted to `1`, so **no real run ever performed a second round** — the mechanism was dead in practice. TASK-17370 measured what it's worth on the repositories lane, and the two halves of decomposition came out differently:

| Mechanism | What it changes | Measured | Shipped default |
|---|---|---|---|
| Multi-hop (`max_iterations`) | **retrieval** — round 2's queries reach the paper providers | held gate rate; markers 24 → 39; citation density 0.77 → 0.95 | **on (2)** |
| Fan-out (`subquery_generation`) | only the gate's context | 0.42 → 0.38, flat | off |

Fan-out stays off because it measured flat *and* cannot change retrieval on this lane at all while TASK-17372 stands (the academic lane only ever sees round 1's `[question]`).

## How it's wired

`DEFAULT_MAX_ITERATIONS = 2`, resolved through `_configured_max_iterations()`:

- per install: `[SearchSettings] research_max_iterations`
- per run: `limits_json.max_iterations` — always wins
- missing, unreadable or non-positive config falls back to the shipped default, so configuration can never silently disable the mechanism

The per-run override is what keeps recorded baselines honest: the baseline recorder passes `max_iterations` explicitly (default 1), so every recorded number stays reproducible byte-for-byte under the changed default.

## Cost, stated where the user meets it

Multiplicative, and documented on the config key rather than as a general warning: one extra search per gap, each with its own per-result relevance and summarization calls, plus another synthesis and gap analysis per round. **Measured: 3 → 12 search calls across three questions, roughly tripled wall-clock.**

Two interactions this default increases exposure to, both recorded in the eval baseline doc:

- each new source needs a summarization call, which cannot complete inside the shipped 30s `relevance_llm_timeout_s` on a local model (TASK-17382's chain; measured 42–131s per summary)
- larger evidence pools are what trigger map-reduce chunking, where chunk summarization still fails against a local endpoint (TASK-17384)

Both degrade to real source text rather than to nonsense, so the default is safe — but a local-model install will feel this as latency, not as better summaries.

## Verification

- New tests pin all three behaviours: a second round runs with no limits at all, an explicit `max_iterations: 1` still yields exactly one pass, and a configured default is honoured.
- **382 passed** across `Tests/Research`, `Tests/UI/test_research_screen.py`, `Tests/Helper_Scripts`, `Tests/Tools/test_web_deep_search.py`, `Tests/Web_Scraping/test_deep_search_pipeline.py`.
- `ruff check` clean on all touched files.

## Still open

TASK-17371's AC #2 — a real per-run control that shows the setting and persists it — is deliberately **not** in this PR. Today a user overrides per run only by typing limits into the Research window's existing input. That control matters more than the default itself and should be its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local research runs default to multi-hop (two rounds) to improve retrieval, and approved plan-review limits now bound iterations. Previously runs stopped after one pass by default, and a plan-review patch could be ignored for the iteration count, allowing an extra round.

- `_configured_max_iterations()` resolves the default: per-run `limits_json.max_iterations` wins; per-install `[SearchSettings] research_max_iterations` sets the default; non-positive or unreadable falls back to 2. Fan-out stays off.
- `_execute_phases` now receives the run’s effective `limits` (with any approved plan-review patch merged); it no longer re-reads limits from the run record, so the ledger and iteration bound agree.
- Baselines remain reproducible: the recorder still passes `max_iterations: 1` explicitly. Tests pin default second round, single-pass override, configured default of 3, and plan-review bounding.
- Config comments document `research_max_iterations` and `relevance_llm_timeout_s` implications. Meets `TASK-17371` ACs #1, #3, #4; AC #2 (UI control) remains out of scope.
- Expect more searches and longer wall-clock; on local models, summarization often times out at 30s and degrades to source text.

**Migration**
- To keep single-pass behavior, set `limits_json.max_iterations: 1` per run or `[SearchSettings] research_max_iterations = 1`.
- On local models, raise `relevance_llm_timeout_s` if you want summarized evidence instead of raw source text.

<sup>Written for commit 7d79b997558f03877d09be3c0b21d95958e8eb8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

