### PR TITLE
Reranker dispatch repair: delete the bespoke path, disclose the real spend (TASK-17065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ and this project adheres to Some kind of Versioning
   `CodeRepoCopyPasteWindow` is unaffected.
 
 ### Changed
+- **Behaviour change — reranking now really calls the provider, and really spends
+  (TASK-17065).** Reranking has silently no-opped since the feature existed: the
+  reranker resolved credentials from a `settings["API"]` table `load_settings()`
+  never builds, and dispatched `chat_api_call` with a positional argument list that
+  did not match its signature, so it could complete a scoring call for **none** of
+  the 29 chat providers the picker offers. It now calls `chat_api_call` the way every
+  other caller in this app does — by keyword, resolving no credential of its own and
+  letting each provider handler apply the documented precedence. **A profile that has
+  "Enable reranking" ticked therefore begins issuing real provider calls on its next
+  search — one per candidate result, up to the configured "Rerank results" top-k —
+  where it previously failed and skipped.** Nothing else has to be turned on for the
+  spend to start; untick "Enable reranking" to opt out. This lands on top of
+  TASK-3502's disclosure surfaces, which are what make the spend visible: the cost
+  line under the Reranking toggle in Settings ▸ RAG ("Reranking scores each result
+  with a separate `<provider>` call — up to `<n>` calls per search, billed at that
+  provider's rates"), and the skipped/degraded sentence on the Library results screen.
+  Two consequences of the old broken call worth naming: it put the token cap into the
+  `streaming` slot, so any scoring call that *had* resolved a credential would have
+  STREAMED — scoring calls are now non-streaming, each handler's default; and the
+  reranker's configured `max_tokens` (default 100) and `temperature` (default 0.0)
+  now reach providers for the first time.
 - Unsupported direct imports of `get_user_database_path`, `USER_DB_DIR`, and
   `USER_DB_PATH` have been removed.
 - Textual 8.x is now required (`>=8.0.0,<9`). This corrects the previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ and this project adheres to Some kind of Versioning
   retries every failure twice** (`max_retries = 2`, on *any* exception, a bad
   credential included), so the honest ceiling is `top-k × 3`: 3 candidates against a
   failing provider issued 9 calls, 20 issued 60. **listwise** issues exactly **1** call
-  per search (10 documents max). **pairwise** is a merge sort, so it issues `≈ n·log₂n`
+  per search (10 documents max) — but the same retry rule applies, so a failing
+  provider costs **3**. **pairwise** is a merge sort, so it issues `≈ n·log₂n`
   *comparisons*, not `n` scorings — **40–69** calls at top-k 20, ~200 with retries; no
   built-in preset uses it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,20 +51,43 @@ and this project adheres to Some kind of Versioning
   did not match its signature, so it could complete a scoring call for **none** of
   the 29 chat providers the picker offers. It now calls `chat_api_call` the way every
   other caller in this app does — by keyword, resolving no credential of its own and
-  letting each provider handler apply the documented precedence. **A profile that has
-  "Enable reranking" ticked therefore begins issuing real provider calls on its next
-  search — one per candidate result, up to the configured "Rerank results" top-k —
-  where it previously failed and skipped.** Nothing else has to be turned on for the
-  spend to start; untick "Enable reranking" to opt out. This lands on top of
-  TASK-3502's disclosure surfaces, which are what make the spend visible: the cost
-  line under the Reranking toggle in Settings ▸ RAG ("Reranking scores each result
-  with a separate `<provider>` call — up to `<n>` calls per search, billed at that
-  provider's rates"), and the skipped/degraded sentence on the Library results screen.
-  Two consequences of the old broken call worth naming: it put the token cap into the
-  `streaming` slot, so any scoring call that *had* resolved a credential would have
-  STREAMED — scoring calls are now non-streaming, each handler's default; and the
-  reranker's configured `max_tokens` (default 100) and `temperature` (default 0.0)
-  now reach providers for the first time.
+  letting each provider handler apply the documented precedence. **A profile that
+  carries a reranker config therefore begins issuing real provider calls on its next
+  search, where it previously failed and skipped.** Nothing else has to be turned on
+  for the spend to start.
+
+  *What one search costs* (measured against the real reranker with the provider seam
+  faked, not estimated): **pointwise** — the strategy the "Enable reranking" toggle
+  creates — issues one call per candidate up to the configured "Rerank results", **and
+  retries every failure twice** (`max_retries = 2`, on *any* exception, a bad
+  credential included), so the honest ceiling is `top-k × 3`: 3 candidates against a
+  failing provider issued 9 calls, 20 issued 60. **listwise** issues exactly **1** call
+  per search (10 documents max). **pairwise** is a merge sort, so it issues `≈ n·log₂n`
+  *comparisons*, not `n` scorings — **40–69** calls at top-k 20, ~200 with retries; no
+  built-in preset uses it.
+
+  *Who is spending* — the tick is not the only door. Reranking is on for any profile
+  that carries a reranker config, and three read-only built-ins ship with one:
+  **Hybrid Full** (pointwise, 15), **High Accuracy** (pointwise, 15) and **Research
+  Papers** (listwise, 10), all billing `openai` by default. Making one of them active
+  is a spend decision with no checkbox in it. The out-of-the-box active profile,
+  Hybrid Basic, carries none — so a fresh install still spends nothing until you pick
+  or configure otherwise. Untick "Enable reranking" on your own profile to opt out;
+  clone a built-in and untick it there.
+
+  This lands on top of TASK-3502's disclosure surfaces, which are what make the spend
+  visible: the cost line under the Reranking toggle in Settings ▸ RAG ("Reranking
+  scores each result with a separate `<provider>` call — up to `<n>` calls per search,
+  or `<n×3>` if calls fail and are retried, billed at that provider's rates"), and the
+  skipped/degraded sentence on the Library results screen. Three further consequences
+  worth naming: the old broken call put the token cap into the `streaming` slot, so any
+  scoring call that *had* resolved a credential would have STREAMED — scoring calls now
+  pass `streaming=False` explicitly rather than inheriting a handler default; the
+  reranker's configured `max_tokens` (default 100) and `temperature` (default 0.0) now
+  reach providers for the first time; and `High Accuracy` and `Research Papers` no
+  longer ask for a free-form `reasoning` field under that 100-token cap — nothing
+  outside the reranker ever read it, and truncating it turned a billed call into an
+  unscored row (listwise: a wholly failed rerank).
 - Unsupported direct imports of `get_user_database_path`, `USER_DB_DIR`, and
   `USER_DB_PATH` have been removed.
 - Textual 8.x is now required (`>=8.0.0,<9`). This corrects the previously

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -131,9 +131,16 @@ not:
   see all requested results." **Cost:** stated on the fold itself, directly
   under the toggle and readable before you turn anything on — "Reranking
   scores each result with a separate `<provider>` call — up to `<n>` calls
-  per search, billed at that provider's rates." — and it tracks the
-  provider and **Rerank results** you have staged, so the number you read
-  is the ceiling you would actually buy. **Reranker provider** enumerates
+  per search, or `<n×3>` if calls fail and are retried, billed at that
+  provider's rates." — and it tracks the provider and **Rerank results**
+  you have staged, so the number you read is the ceiling you would
+  actually buy. The `×3` is the retry loop: a failed scoring call is
+  retried twice (`max_retries = 2`), on *any* error including a wrong
+  credential, so 20 candidates against a provider that is down cost 60
+  calls, not 20 (measured). That line describes the **pointwise** strategy
+  — the one this toggle creates and the only one these four fields edit;
+  the "Reranking is not free" quirk below states all three shapes and what
+  each really costs. **Reranker provider** enumerates
   every chat provider this build registers, with the default shown
   explicitly as "openai (default)" — and since TASK-17065 the reranker
   dispatches through that same table, so the name you pick really is the
@@ -201,11 +208,15 @@ testing a connection ("RAG check started." → "RAG check: `<state>` index ·
    **Reranker model** (blank uses the reranker's default), keep **Rerank
    results** at or below **Default results**, and **Save (s)** — no backfill
    needed. Every search this profile runs now issues one extra provider
-   call per candidate result, at that provider's rates — and since
-   TASK-17065 those calls really go out. Before that fix reranking silently
-   no-opped for every provider the picker offered, so a profile with the
-   toggle already ticked starts spending on its next search without you
-   touching anything; untick **Enable reranking** to opt out. If the
+   call per candidate result — three, if that call keeps failing — at that
+   provider's rates, and since TASK-17065 those calls really go out. Before
+   that fix reranking silently no-opped for every provider the picker
+   offered, so a profile with the toggle already ticked starts spending on
+   its next search without you touching anything; untick **Enable
+   reranking** to opt out. The tick is not the only door: the built-in
+   **Hybrid Full**, **High Accuracy** and **Research Papers** presets carry
+   a reranker config of their own, so making one of them active spends too
+   (see Quirks). If the
    provider has no credential configured, or the call fails, the search
    still returns, with the reranking line on the results screen saying so.
 6. **Delete a profile you no longer want.** With a profile *of your own* active
@@ -261,14 +272,37 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   the next Library query does, not anything already rendered. **Default
   results** now drives the Library window's "Evidence · top N per source"
   cap (clamped at 50) — see [Library Search/RAG](../library/search-and-rag.md).
-- **Reranking is not free.** The default (pointwise) strategy scores every
-  candidate result with a separate provider call, so a profile with
-  **Rerank results** at 15 can spend up to 15 calls on a single search —
-  every surface that reads this profile (Library, Console manual/auto
-  retrieval) pays that cost, not just this pane. Until TASK-17065 those
-  calls never actually reached a provider (reranking failed and was skipped,
-  for every provider); they do now, so an already-ticked profile begins
-  spending on its next search.
+- **Reranking is not free — and "one call per result" is only one of three
+  shapes.** Every surface that reads this profile (Library, Console
+  manual/auto retrieval) pays the cost, not just this pane. Until
+  TASK-17065 those calls never actually reached a provider (reranking
+  failed and was skipped, for every provider); they do now, so an
+  already-ticked profile begins spending on its next search. What ONE
+  search costs, measured against the real reranker with the provider seam
+  faked (`Tests/RAG_Search/test_reranker_degraded_paths.py` is the same
+  seam):
+
+  | Strategy | Calls for ONE search | With the retry loop (`max_retries = 2`) |
+  |---|---|---|
+  | **pointwise** (this fold's toggle, `Hybrid Full`, `High Accuracy`) | one per candidate, up to **Rerank results** — 20 at the default | up to **×3** — 3 candidates against a failing provider issued **9** calls; 20 issued **60** |
+  | **listwise** (`Research Papers`) | exactly **1**, covering at most 10 documents — the fold's line over-states here | up to **3** |
+  | **pairwise** (no built-in preset; a hand-written profile only) | a merge sort over the candidates, ≈ `n·log₂n` **comparisons** — **40–69** at `Rerank results` 20, not 20 | up to **×3** (≈200) |
+
+  The retry loop fires on *any* exception, including a wrong or missing
+  credential — the case where the calls buy nothing at all.
+
+- **Three built-in presets rerank without you ticking anything.** Reranking
+  is on for a profile whenever that profile carries a reranker config —
+  the **Enable reranking** tick is how *your own* profiles get one, not the
+  only way one exists. **Hybrid Full** (pointwise, 15 candidates), **High
+  Accuracy** (pointwise, 15) and **Research Papers** (listwise, 10) all
+  ship with one, all bill `openai` unless you clone and change them, and
+  all three are pickable from the profile picker. Selecting one with
+  **Set active** is therefore a spend decision, with no checkbox in it.
+  The out-of-the-box active profile, **Hybrid Basic**, carries no reranker
+  config, so a fresh install spends nothing until you pick or configure
+  otherwise. Built-ins are read-only: to run one *without* reranking,
+  **Clone…** it and untick **Enable reranking** on the copy.
 - **Backfill needs embeddings support.** Without it you get "Semantic indexing
   is unavailable (missing embeddings extras, or disabled in config)." and the
   index never builds; keyword search keeps working regardless. "RAG backfill
@@ -319,3 +353,17 @@ each provider handler resolves its own. Pinned by
 real caller and binds through `inspect.signature(chat_api_call)`, plus nine
 parametrised provider cells covering the five keyless locals and four remotes).
 No live provider call was made; the picker itself was not touched.*
+
+*Verified against `fix/task-17065-reranker-dispatch` — 2026-08-17 (TASK-17065
+final-review fix wave, F1/F2): the spend numbers above are MEASURED, not
+inferred — counting `chat_api_call` invocations through the real reranker with
+the provider seam faked, one `rerank()` at a time. Pointwise with the shipped
+retry settings: 9 calls for 3 candidates against an erroring provider, 60 for
+20. Pairwise at `Rerank results` 20: 40 calls best case, 69 worst (49–65 across
+200 randomised comparison outcomes), matching the merge sort's own bounds.
+Listwise: exactly 1. The three built-in presets that carry a reranker config
+were read back off `ConfigProfileManager` over an empty profiles dir — Hybrid
+Full, High Accuracy, Research Papers, all `openai`; the other nine built-ins,
+including the default Hybrid Basic, carry none. The Settings cost line was
+changed to disclose the retried ceiling and re-pinned in
+`Tests/UI/test_settings_rag_profile_region.py`. No live provider call was made.*

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -361,7 +361,7 @@ the provider seam faked, one `rerank()` at a time. Pointwise with the shipped
 retry settings: 9 calls for 3 candidates against an erroring provider, 60 for
 20. Pairwise at `Rerank results` 20: 40 calls best case, 69 worst (49–65 across
 200 randomised comparison outcomes), matching the merge sort's own bounds.
-Listwise: exactly 1. The three built-in presets that carry a reranker config
+Listwise: exactly 1 on success, 3 against an erroring provider (the retry rule is strategy-independent). The three built-in presets that carry a reranker config
 were read back off `ConfigProfileManager` over an empty profiles dir — Hybrid
 Full, High Accuracy, Research Papers, all `openai`; the other nine built-ins,
 including the default Hybrid Basic, carry none. The Settings cost line was

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -135,11 +135,15 @@ not:
   provider and **Rerank results** you have staged, so the number you read
   is the ceiling you would actually buy. **Reranker provider** enumerates
   every chat provider this build registers, with the default shown
-  explicitly as "openai (default)" — note that the reranker's own
-  credential path currently reaches far fewer of them than the list offers,
-  so a pick can fail at search time (you get the skipped/degraded line
-  below, never a broken search); TASK-17065 tracks which providers the
-  reranker can actually call. **Reranker model** blank means the
+  explicitly as "openai (default)" — and since TASK-17065 the reranker
+  dispatches through that same table, so the name you pick really is the
+  provider that gets called and billed. It resolves no credential of its
+  own: each provider handler finds its key the usual way (explicit
+  `api_settings.<provider>.api_key` over env var over legacy `[API]`), and
+  the local providers that need no key at all need none here either. Pick
+  one you have not configured and the call fails at search time — you get
+  the skipped/degraded line below, never a broken search. **Reranker
+  model** blank means the
   reranker's own default model. If the reranker can't run, search results
   still come back — reranking is skipped, disclosed on the results screen
   ([Library Search/RAG](../library/search-and-rag.md#evidence-rows)), and
@@ -196,12 +200,14 @@ testing a connection ("RAG check started." → "RAG check: `<state>` index ·
    **Reranker provider** (or leave "openai (default)"), optionally name a
    **Reranker model** (blank uses the reranker's default), keep **Rerank
    results** at or below **Default results**, and **Save (s)** — no backfill
-   needed. Every search this profile runs will now attempt one extra provider
-   call per candidate result, at that provider's rates. Whether the call
-   actually goes out depends on the provider: the reranker's credential path
-   covers only some of the names the picker offers (TASK-17065), and when it
-   cannot call one the search still returns, with the reranking line on the
-   results screen saying so.
+   needed. Every search this profile runs now issues one extra provider
+   call per candidate result, at that provider's rates — and since
+   TASK-17065 those calls really go out. Before that fix reranking silently
+   no-opped for every provider the picker offered, so a profile with the
+   toggle already ticked starts spending on its next search without you
+   touching anything; untick **Enable reranking** to opt out. If the
+   provider has no credential configured, or the call fails, the search
+   still returns, with the reranking line on the results screen saying so.
 6. **Delete a profile you no longer want.** With a profile *of your own* active
    (see Quirks), pick the one to remove, press **Delete**, confirm — delete the
    active one and the pointer falls back to a built-in.
@@ -259,7 +265,10 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   candidate result with a separate provider call, so a profile with
   **Rerank results** at 15 can spend up to 15 calls on a single search —
   every surface that reads this profile (Library, Console manual/auto
-  retrieval) pays that cost, not just this pane.
+  retrieval) pays that cost, not just this pane. Until TASK-17065 those
+  calls never actually reached a provider (reranking failed and was skipped,
+  for every provider); they do now, so an already-ticked profile begins
+  spending on its next search.
 - **Backfill needs embeddings support.** Without it you get "Semantic indexing
   is unavailable (missing embeddings extras, or disabled in config)." and the
   index never builds; keyword search keeps working regardless. "RAG backfill
@@ -299,3 +308,14 @@ over-claim and now points at TASK-17065 instead.*
 Quirks bullet above to match B3's already-shipped behavior — **Default
 results** drives the Library window's per-source cap, clamped at 50; no
 code changed here).*
+
+*Verified against `fix/task-17065-reranker-dispatch` — 2026-08-17 (TASK-17065,
+doc-only on this page): the reranker's bespoke credential lookup and its
+mis-ordered positional `chat_api_call` are deleted, so the copy above that said
+its credential path "reaches far fewer" providers than the picker offers is no
+longer true and has been corrected — the reranker now passes no credential and
+each provider handler resolves its own. Pinned by
+`Tests/RAG_Search/test_reranker_degraded_paths.py` (a seam guard that drives the
+real caller and binds through `inspect.signature(chat_api_call)`, plus nine
+parametrised provider cells covering the five keyless locals and four remotes).
+No live provider call was made; the picker itself was not touched.*

--- a/Docs/superpowers/plans/2026-08-17-reranker-dispatch-repair.md
+++ b/Docs/superpowers/plans/2026-08-17-reranker-dispatch-repair.md
@@ -1,0 +1,55 @@
+# TASK-17065: Reranker Dispatch Repair — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the reranker's bespoke credential path and positional dispatch; call `chat_api_call` the way every other caller in this repo already does. Flip the red-on-repair seam guard, and fix the fakes that hid the defect.
+
+**Architecture:** Two tasks. T1 = the repair + the seam/fake corrections (all ten ACs' code). T2 = closure, the spend release note, and the lesson. No live provider calls anywhere.
+
+**Spec:** `Docs/superpowers/specs/2026-08-17-reranker-dispatch-repair-design.md` — its central decision (delete, don't rewrite) is settled; do not re-litigate.
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-17065-reranker-dispatch`, branch `fix/task-17065-reranker-dispatch` (off dev `1c328e1a7`). Venv EXISTS (pinned; provenance verified).
+- **EVERY Bash block starts with its own `cd <worktree>` AND echoes `pwd` + branch before any mutating git op.** Two cwd incidents in this programme; the second was caught only by a permission classifier. A cleanup block that leaves the worktree must be the LAST block of its group.
+- Never `git stash`; Edit restores; RED-first; do NOT run `Tests/UI/test_library_shell.py`. ruff via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff`.
+- **NO live provider calls.** Every seam fake must bind through `inspect.signature(chat_api_call).bind(...)` so a mis-ordered call raises instead of passing.
+- Commits reference TASK-17065 + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; push after every task.
+
+## Verified findings (this session — do not re-derive)
+
+- **All 29 handlers resolve their own credential or need none.** Enumerated live from `API_CALL_HANDLERS`: 22 use the `api_key or <config>` idiom; the other 7 were regex false-positives — `qwencloud` (`resolve_qwencloud_api_key`), `custom-openai-api` (`api_key_resolved`), `moonshot`/`zai` (`explicit_api_key=api_key` → `api_settings` → `resolve_provider_api_key`, in `LLM_Calls/moonshot.py`/`zai.py`), and `mlx_lm`/`local_mlx_lm`/`local-llm` (keyless by design). **So the reranker need not pass `api_key` at all.**
+- **Every other `chat_api_call` caller already uses keywords and omits `api_key`** — `UI/Tools_Settings_Window.py:4157`/`:4296`, `UI/Screens/evals_screen.py:193`, `Chat/console_provider_gateway.py:2534` (`**kwargs`). The reranker is the sole outlier; the repair makes it match the house pattern.
+- Real signature: `chat_api_call(api_endpoint, messages_payload, api_key=None, temp=None, system_message=None, streaming=None, minp=None, maxp=None, model=None, topk=None, topp=None, logprobs=None, ...)` (`Chat/Chat_Functions.py:809+`). Note the existing callers pass `max_tokens=` and `seed=` — confirm those names against the signature when writing the call.
+- The reranker's current call: `RAG_Search/reranker.py:224-237` (positional, via `run_in_executor`), credential `if/elif` at `:183-206`, `self._settings = load_settings()` at `:128`.
+- **AC#8 is already satisfied on dev** (picker repairability, TASK-3502 Qodo remediation) — T2 verifies and cites; no code.
+
+---
+
+### Task 1: The repair, the guard flip, the fakes
+
+**Files:** Modify `tldw_chatbook/RAG_Search/reranker.py`; `Tests/RAG_Search/test_reranker_degraded_paths.py` (the guard + the fake at `:75`); any other reranker test fake that mirrors the wrong order (grep `fake_chat_api_call` under `Tests/`).
+
+- [ ] **Step 1:** `backlog task edit 17065 -s "In Progress"` + `--plan`. Grep every reranker-seam fake in `Tests/` and list them in the report — each must be corrected, not just the one the task names.
+- [ ] **Step 2 (RED — the guard flip is the proof):** rewrite `test_reranker_dispatch_binding_against_the_real_chat_api_call_signature` to assert the CORRECT binding: `api_endpoint` ← `config.model_provider`, `model` ← `config.model_name`, `temp` ← `config.temperature`, and no argument carrying a credential. It must FAIL against today's caller — paste that failure; it is the arc's central evidence.
+- [ ] **Step 3 (RED):** a test asserting the reranker no longer reads a settings table: `BaseReranker` has no `_settings` attribute (or it is unused) and `load_settings` is not called during `__init__` (monkeypatch it to raise; construction must succeed).
+- [ ] **Step 4 (RED):** a per-provider test over a representative set INCLUDING a keyless local (`ollama`) and a remote (`openai`): with a signature-binding fake, `_call_llm_impl` completes and the fake records `api_endpoint == the provider`; none raises `No API key found for provider:` (AC#4/#5). Parametrize; state which providers are covered.
+- [ ] **Step 5:** Implement — delete the `if/elif` credential block and the `load_settings()` read; call `chat_api_call` with KEYWORDS via `functools.partial` (or a small lambda) inside `run_in_executor`, passing `api_endpoint=self.config.model_provider`, `messages_payload=…`, `model=self.config.model_name`, `temp=self.config.temperature`, and the token cap under whatever name the signature accepts (verify — the existing callers use `max_tokens=`). **Do not pass `api_key`.** Remove now-dead imports.
+- [ ] **Step 6:** GREEN all four. Fix every other fake found in Step 1 to bind against the real signature. Then the full `Tests/RAG_Search/` + `Tests/Chat/test_chat_functions.py` + the redaction file; counts READ; ruff.
+- [ ] **Step 7:** Gate (`RAG_EVAL=1 … Tests/RAG_Eval/`) — run it and report it, while repeating the established caveat that **it is vacuous for the reranker** (no gated cell runs one). Commit `fix(rag): reranker calls chat_api_call the way the rest of the app does (TASK-17065)` + trailer. Push (cd + echo pwd in the same block).
+
+---
+
+### Task 2: Closure, the spend note, the lesson
+
+- [ ] **Step 1:** Close TASK-17065 — all ten ACs against evidence. #8 cites dev's existing repairability test by name (verify it exists and passes). #10 is discharged by the release note below. Implementation Notes: the deletion-over-rewrite decision, the 29/29 verification, and the fact that the sole outlier caller is what broke.
+- [ ] **Step 2 (AC#10, the spend note):** add a short "Behaviour change" entry where this repo keeps user-facing release notes (grep `CHANGELOG`/`Docs/User_Guide` release surfaces; if none exists, put it in `Docs/User_Guide/`'s reranking section and say so): reranking-enabled profiles now issue real provider calls — one per candidate up to the configured top-k — where they previously failed silently; the cost disclosure and the skipped/degraded notice shipped in TASK-3502 are the surfaces that make it visible.
+- [ ] **Step 3 (the lesson, if earned):** `backlog/docs/lessons-testing-evidence.md` — the incident: a feature module grew its own credential path and its own dispatch convention; every test fake at that seam mirrored the caller's assumption, so ~2,500 green tests could not see that the feature called zero of twenty-nine providers. The rule: a fake at a shared seam must bind against the real signature (`inspect.signature(...).bind(...)`), and a feature that resolves credentials itself is a divergence to justify, not a default. Check for a near-duplicate first and extend rather than duplicate.
+- [ ] **Step 4:** Batteries re-read; collection sweep vs merge-base `1c328e1a7`; commit + push (cd + echo pwd in-block).
+
+---
+
+## Self-review (plan time)
+- AC coverage: #1/#2/#5/#6 → T1 S3+S5 (deletion); #3 → T1 S2+S5; #4 → T1 S4; #7 → T1 S2+S6 (all fakes); #8 → T2 S1 (cite); #9 → untouched picker, stated in T2; #10 → T2 S2.
+- The guard flip is the arc's proof-of-repair and is scheduled RED-first, before the fix.
+- No placeholders; every test names its assertion. Ordering: guard/fakes before implementation so the repair is what turns them green.

--- a/Docs/superpowers/specs/2026-08-17-reranker-dispatch-repair-design.md
+++ b/Docs/superpowers/specs/2026-08-17-reranker-dispatch-repair-design.md
@@ -1,0 +1,114 @@
+# Reranker dispatch repair: delete the bespoke path, use the app's (TASK-17065)
+
+Date: 2026-08-17
+Status: draft-pending-user-review
+Programme: RAG server-port (fifteen merged; last: 17165 endpoint redaction #1759)
+Worktree: `.worktrees/rag-17065-reranker-dispatch`, branch
+`fix/task-17065-reranker-dispatch`, off dev `1c328e1a7`.
+
+## The decision, pre-registered: REMOVE the reranker's credential code
+
+TASK-17065 offers two arms for AC#1. Spec review found a third option that
+subsumes the better one, and it is a **deletion**:
+
+**Every `chat_with_<provider>` handler already resolves its own credential
+when the caller passes `api_key=None`** — `final_api_key = api_key or
+<provider>_config.get("api_key")` (`LLM_Calls/LLM_API_Calls.py:590`,
+`:1226`, `:2191`, `:2902`, …), with `resolve_provider_api_key` imported at
+`:55` and the precedence CLAUDE.md documents (explicit
+`api_settings.<provider>.api_key` → env → legacy `[API]`, every source
+validity-checked) applied there.
+
+So the reranker should not resolve credentials at all. Delete
+`_call_llm_impl`'s hand-rolled `if/elif` (`RAG_Search/reranker.py:183-206`)
+and the `self._settings = load_settings()` read it exists for
+(`:128`), and call `chat_api_call` with KEYWORD arguments, passing
+`api_key=None`. That single change satisfies:
+
+- **AC#1/#2** — credentials come from the normalised path; the
+  `self._settings["API"]` read that `load_settings()` never builds is gone
+  rather than repaired.
+- **AC#3** — keyword arguments; no positional list can misroute a key into
+  `api_endpoint` again.
+- **AC#5** — local providers (`ollama`/`llama_cpp`/`vllm`/`koboldcpp`/
+  `mlx_lm`) are never rejected for a key they do not need, because the
+  reranker stops judging keys entirely; each handler decides.
+- **AC#6** — the documented precedence is obeyed by construction, because
+  it is the same code every other call in the app uses.
+- **AC#9** — the picker's enumeration stays derived (untouched).
+
+Writing a second resolver inside the reranker would re-create the divergence
+that caused this defect. The lesson this arc records is that one: a bespoke
+credential path in a feature module is how a feature ends up calling zero of
+twenty-nine providers while its tests stay green.
+
+## What the arc must NOT assume (plan-phase verification)
+
+1. **Do all 29 handlers self-resolve?** Verified for openai/anthropic/
+   cohere/deepseek. The plan must enumerate `API_CALL_HANDLERS` and check
+   each handler for the `api_key or <config>` fallback, and record the list
+   of any that do NOT — those either need `api_key` passed explicitly from
+   the shared resolver, or are honestly named as not-yet-callable in the
+   arc's report (no silent gap).
+2. **Does `chat_api_call` forward `api_key=None` cleanly** through
+   `PROVIDER_PARAM_MAP` for each handler, or does any provider require a
+   non-None value at the dispatcher level?
+3. **What `messages_payload` shape does the reranker build**, and does the
+   real signature's `temp`/`system_message`/`streaming`/`model` mapping
+   accept it as keywords with the reranker's config values?
+4. Whether any other caller in the repo copies the reranker's positional
+   pattern (grep for `chat_api_call` call sites; the seam guard covers only
+   the reranker's).
+
+## Scope
+
+- **In:** `RAG_Search/reranker.py`'s credential + dispatch path; the seam
+  guard rewrite (below); the fakes that mirror the caller's wrong order;
+  the spend release note (AC#10).
+- **Out:** the picker (untouched — AC#9 holds by not touching it), the
+  reranker's strategies/scoring, `cross_encoder` (TASK-16965), anything
+  retrieval-affecting. **AC#8 is ALREADY SATISFIED** on dev — the picker's
+  repairability shipped in TASK-3502's Qodo remediation; the arc verifies
+  and cites it rather than re-doing it.
+
+## The seam guard MUST flip (AC#7)
+
+`test_reranker_dispatch_binding_against_the_real_chat_api_call_signature`
+was written deliberately RED-ON-REPAIR: it asserts today's wrong landing
+(`api_endpoint`←the key, …). This arc MUST rewrite it to assert the CORRECT
+binding, and that rewrite is the proof the repair happened. Any fake at this
+seam must match the real signature — the existing ones
+(`Tests/RAG_Search/test_reranker_degraded_paths.py:75`) mirror the caller's
+wrong assumption and are exactly why ~2,500 green tests never saw this.
+Every fake this arc touches or adds binds through
+`inspect.signature(chat_api_call).bind(...)` so a future mis-order cannot
+pass.
+
+## AC#4 — the acceptance evidence
+
+A provider with a valid credential configured completes a scoring call. No
+live provider call is permitted in tests; AC#4 is demonstrated by a fake
+that (a) binds against the real signature and (b) asserts the reranker
+handed it the endpoint/model/temperature it was configured with — i.e. the
+call is well-formed at the seam. Whether the network round-trip succeeds is
+the provider's business, not this arc's.
+
+## AC#10 — the spend consequence, stated
+
+This repair converts a silent no-op into real provider calls: one call per
+candidate, up to the configured rerank top-k, on the first search of any
+reranking-enabled profile. It lands on a build that already carries
+TASK-3502's pre-enable cost disclosure and the skipped/degraded notice. The
+arc's close-out and the release note must say plainly that reranking-enabled
+profiles begin spending.
+
+## Testing
+- Credential seam: no credential logic left in the reranker to test —
+  instead, a test asserting the reranker passes `api_key=None` and does not
+  read a settings table (structural: the `load_settings` import/read is
+  gone).
+- Dispatch seam: the rewritten guard + signature-bound fakes.
+- Batteries: `Tests/RAG_Search`, `Tests/Chat`, the settings-RAG files.
+- The gated suite is **vacuous for the reranker** (no gated cell runs it —
+  established in TASK-3502); it is still run, and the close-out repeats that
+  caveat rather than implying coverage.

--- a/Tests/Library/test_library_local_rag_search_service.py
+++ b/Tests/Library/test_library_local_rag_search_service.py
@@ -1572,7 +1572,7 @@ class TestLibraryRagAnswerRealRuntime:
     "tag,detail",
     [
         ("reranking_degraded", "3/5 scorings failed"),
-        ("reranking_skipped", "No API key found for provider: openai"),
+        ("reranking_skipped", "provider call failed (fake)"),
     ],
 )
 async def test_reranking_disclosure_tag_survives_into_the_panels_result_rows(

--- a/Tests/Library/test_library_rag_state.py
+++ b/Tests/Library/test_library_rag_state.py
@@ -2488,11 +2488,11 @@ class TestLibraryRagRerankingNotice:
         rows = (
             self._row(
                 source_type="note",
-                reranking_skipped="No API key found for provider: openai",
+                reranking_skipped="provider call failed (fake)",
             ),
         )
         assert library_rag_coverage_note({}, rows) == (
-            "Reranking was skipped (No API key found for provider: openai) "
+            "Reranking was skipped (provider call failed (fake)) "
             "— these results are in their original retrieval order."
         )
 

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -78,6 +78,37 @@ def test_every_builtin_profile_reranking_config_constructs(tmp_path):
             create_reranker_from_config(rc)  # must not raise
 
 
+def test_no_builtin_profile_asks_for_reasoning_it_cannot_fit_or_read(tmp_path):
+    """AC#11 (spend safety): shipped presets never set `include_reasoning`.
+
+    `RerankingConfig.max_tokens` defaults to 100 and reaches providers for
+    the first time since TASK-17065. `include_reasoning=True` appends a
+    free-form `"reasoning"` string to the JSON the parser needs, leaving
+    ~60 tokens for it on pointwise and ~40 on listwise -- and a truncated
+    body is a `json.JSONDecodeError`, i.e. a row that was BILLED and left
+    `scored=False` (listwise: `except Exception` fails the ENTIRE rerank).
+    It buys nothing in exchange: `RerankingResult.reasoning` is written
+    only by `PointwiseReranker._score_result` and is read nowhere outside
+    `reranker.py` -- `_apply_scores` copies only `rerank_score` into the
+    row. `high_accuracy` (pointwise) and `research_papers` (listwise)
+    shipped with the flag on; both are read-only profiles a user can pick
+    from the Settings picker, so neither can be repaired from the UI.
+    """
+    manager = get_profile_manager(profiles_dir=tmp_path)
+    offenders = [
+        profile.id
+        for name in manager.list_profiles()
+        if (profile := manager.get_profile(name)) is not None
+        and profile.read_only
+        and profile.reranking_config is not None
+        and profile.reranking_config.include_reasoning
+    ]
+    assert offenders == [], (
+        "built-in profiles asking for unreadable reasoning under a "
+        f"{RerankingConfig().max_tokens}-token cap: {offenders}"
+    )
+
+
 def _make_v2_service_with_reranking(tmp_path, enable_cache=False):
     """EnhancedRAGServiceV2 with mock embeddings, in-memory store, and a
     real (pointwise) reranking config -- mirrors the mock-embeddings pattern

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -349,7 +349,7 @@ async def test_reranking_degraded_tag_when_scoring_silently_fails_for_every_resu
     assert len(baseline_order) == 2
 
     async def _always_fail_scoring(query, result, original_rank):
-        raise ValueError("No API key found for provider: openai")
+        raise ValueError("provider call failed (fake)")
 
     service.reranker._score_result = _always_fail_scoring
 
@@ -393,7 +393,7 @@ async def test_pairwise_reranker_counts_failed_comparisons():
     reranker = PairwiseReranker(cfg)
 
     async def _always_raise(prompt, system_prompt=None):
-        raise ValueError("No API key found for provider: openai")
+        raise ValueError("provider call failed (fake)")
 
     reranker._call_llm = _always_raise
 
@@ -419,7 +419,7 @@ async def test_listwise_reranker_counts_total_failure():
     reranker = ListwiseReranker(cfg)
 
     async def _always_raise(prompt, system_prompt=None):
-        raise ValueError("No API key found for provider: openai")
+        raise ValueError("provider call failed (fake)")
 
     reranker._call_llm = _always_raise
 

--- a/Tests/RAG_Search/test_reranker_degraded_paths.py
+++ b/Tests/RAG_Search/test_reranker_degraded_paths.py
@@ -27,15 +27,21 @@ CLAIMS when its provider calls fail. This module pins all three:
 
 **No live provider calls.** Every test here fakes `chat_api_call` -- the
 reranker's single provider seam (imported at `RAG_Search/reranker.py`
-module level, invoked through `run_in_executor` in `_call_llm_impl`) -- and
-plants a fake API key on the instance so the whole real path
-(`rerank` -> `_call_llm` -> `_call_llm_impl` -> the fake) executes.
+module level, invoked through `run_in_executor` in `_call_llm_impl`) -- so
+the whole real path (`rerank` -> `_call_llm` -> `_call_llm_impl` -> the
+fake) executes. The fake BINDS what it is handed against the real
+`chat_api_call` signature (TASK-17065): the previous one declared the
+caller's own mis-ordered positional list and therefore agreed with the bug.
+No credential is planted any more -- the reranker resolves none, so nothing
+gates the call before the seam.
 """
 
+import inspect
 from typing import Callable, List
 
 import pytest
 
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call as real_chat_api_call
 from tldw_chatbook.RAG_Search import reranker as reranker_module
 from tldw_chatbook.RAG_Search.reranker import (
     ListwiseReranker,
@@ -57,28 +63,39 @@ class _FakeProviderDown(RuntimeError):
 
 
 def _install_fake_provider(
-    monkeypatch, reranker, responder: Callable[[list], str]
+    monkeypatch, responder: Callable[[list], str] | None = None
 ) -> List[dict]:
-    """Fake the reranker's ONLY provider seam and return the call log.
+    """Fake the reranker's ONLY provider seam, BOUND to the real signature.
 
     `responder` receives the messages payload and returns the raw model
-    string (or raises, to simulate a failing provider call). A fake key is
-    planted on the instance because `_call_llm_impl` raises before it ever
-    reaches `chat_api_call` when no credential is configured -- without it
-    the fake would never be exercised and the test would be measuring the
-    key check instead of the degraded path.
-    """
-    calls: List[dict] = []
+    string (or raises, to simulate a failing provider call); it defaults to
+    a fixed valid score.
 
-    def fake_chat_api_call(api_key, messages_payload, provider, model, temp, maxp):
-        calls.append(
-            {"provider": provider, "model": model, "messages": messages_payload}
-        )
-        return responder(messages_payload)
+    Everything the reranker passes is run through
+    `inspect.signature(chat_api_call).bind(...)`, so a mis-ordered positional
+    call or a mis-named keyword raises HERE. The fake this replaces declared
+    the caller's OWN (wrong) positional list -- `(api_key, messages_payload,
+    provider, model, temp, maxp)` -- so it agreed with the bug, and a green
+    suite could not see that the reranker reached zero of the 29 providers it
+    offers (TASK-17065). No fake at this seam may be written that way again.
+    No credential is planted either: the reranker resolves none, so nothing
+    gates the call before the seam.
+
+    Returns each call's `BoundArguments.arguments` -- what was ACTUALLY
+    passed, defaults NOT applied, so "sent no credential at all" stays
+    distinguishable from "sent `api_key=None`".
+    """
+    signature = inspect.signature(real_chat_api_call)
+    landings: List[dict] = []
+
+    def fake_chat_api_call(*args, **kwargs):
+        bound = signature.bind(*args, **kwargs)
+        landings.append(dict(bound.arguments))
+        payload = bound.arguments["messages_payload"]
+        return responder(payload) if responder is not None else '{"score": 0.5}'
 
     monkeypatch.setattr(reranker_module, "chat_api_call", fake_chat_api_call)
-    reranker._settings = {"API": {"openai_api_key": "fake-key-never-sent-anywhere"}}
-    return calls
+    return landings
 
 
 def _always_fails(_messages) -> str:
@@ -138,7 +155,7 @@ async def test_degraded_rerank_never_touches_the_callers_cached_objects(
     the RETURNED list only."""
     cls = {"pairwise": PairwiseReranker, "listwise": ListwiseReranker}[strategy]
     reranker = cls(_degraded_config(strategy))
-    _install_fake_provider(monkeypatch, reranker, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
 
     cached_list = _results(4)
     cache = {"quokka marsupial": cached_list}  # simulates rag_service's cache
@@ -186,7 +203,7 @@ async def test_degraded_tag_does_not_poison_the_search_cache(
     not see the stale tag."""
     service = _make_v2_service(tmp_path, strategy, enable_cache=True)
     assert service.reranker is not None
-    _install_fake_provider(monkeypatch, service.reranker, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
 
     await service.index_batch_optimized(_quokka_platypus_docs())
     query = "quokka marsupial"
@@ -228,7 +245,7 @@ async def test_failed_pointwise_rows_do_not_claim_the_reranked_score_kind(monkey
 
     reranker = PointwiseReranker(_degraded_config("pointwise"))
     _install_fake_provider(
-        monkeypatch, reranker, _fail_for_titles(["doc-0", "doc-2", "doc-4"], score=0.95)
+        monkeypatch, _fail_for_titles(["doc-0", "doc-2", "doc-4"], score=0.95)
     )
 
     originals = {r.id: r for r in _results(5)}
@@ -272,9 +289,7 @@ async def test_failed_pointwise_rows_keep_their_kind_through_the_cache_hit(monke
     scored?" fact has to survive that round trip, or the second identical
     search re-acquires the over-claim."""
     reranker = PointwiseReranker(_degraded_config("pointwise"))
-    calls = _install_fake_provider(
-        monkeypatch, reranker, _fail_for_titles(["doc-0"], score=0.8)
-    )
+    calls = _install_fake_provider(monkeypatch, _fail_for_titles(["doc-0"], score=0.8))
 
     first = await reranker.rerank("q", _results(3))
     assert first.failed == 1
@@ -310,7 +325,7 @@ async def test_rerank_returns_its_own_failure_counts(strategy, monkeypatch):
         "listwise": ListwiseReranker,
     }[strategy]
     reranker = cls(_degraded_config(strategy))
-    _install_fake_provider(monkeypatch, reranker, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
 
     outcome = await reranker.rerank("q", _results(3))
 
@@ -327,7 +342,7 @@ async def test_reranker_keeps_no_cross_call_failure_state(monkeypatch):
     that call returned -- not a field another coroutine/thread may have
     overwritten between `rerank()` returning and the disclosure being built."""
     reranker = PointwiseReranker(_degraded_config("pointwise"))
-    _install_fake_provider(monkeypatch, reranker, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
 
     await reranker.rerank("q", _results(2))
 
@@ -338,7 +353,7 @@ async def test_reranker_keeps_no_cross_call_failure_state(monkeypatch):
     assert not hasattr(PointwiseReranker, "_record_rerank_outcome")
 
     pairwise = PairwiseReranker(_degraded_config("pairwise"))
-    _install_fake_provider(monkeypatch, pairwise, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
     await pairwise.rerank("q", _results(3))
     for leaked in ("_pairwise_comparisons_failed", "_pairwise_comparisons_total"):
         assert not hasattr(pairwise, leaked), (
@@ -359,7 +374,7 @@ async def test_disclosure_survives_a_concurrent_write_in_its_own_window(
     returned rather than stored, that write is inert."""
     service = _make_v2_service(tmp_path, "pointwise", enable_cache=False)
     reranker = service.reranker
-    _install_fake_provider(monkeypatch, reranker, _always_fails)
+    _install_fake_provider(monkeypatch, _always_fails)
     await service.index_batch_optimized(_quokka_platypus_docs())
 
     real_log = reranker._log_reranking_metrics
@@ -440,47 +455,117 @@ def _make_v2_service(tmp_path, strategy: str, enable_cache: bool):
 # ---------------------------------------------------------------------------
 
 
-def test_reranker_dispatch_binding_against_the_real_chat_api_call_signature():
-    """CHARACTERIZATION PIN — asserts the CURRENT, BROKEN binding on purpose.
+@pytest.mark.asyncio
+async def test_reranker_dispatch_binding_against_the_real_chat_api_call_signature(
+    monkeypatch,
+):
+    """PROOF OF REPAIR (TASK-17065) -- the CORRECT binding, observed live.
 
-    Qodo PR-1751 finding 3: every fake at this seam copies the caller's own
-    parameter order, so a suite full of green reranker tests cannot see that
-    the caller is mis-ordered. This test binds what the reranker actually
-    passes against the REAL `chat_api_call` signature and states where each
-    argument LANDS -- which is how TASK-3502's fix wave established that
-    end-to-end dispatch reaches 0 of 29 providers.
+    This test was written red-on-repair by Qodo PR-1751 finding 3: it used to
+    assert the BROKEN landing (the credential in `api_endpoint`, every later
+    argument displaced by one) reconstructed from the caller's source. The
+    repair flips it, and this is the arc's proof.
 
-    It is deliberately red-on-repair: when TASK-17065 fixes the caller, this
-    test MUST fail and be rewritten to assert the correct binding. That is
-    the point -- the seam gets a mechanical guard instead of agreeable fakes.
+    Two things changed beyond the assertions. It now drives the REAL caller
+    (`_call_llm_impl`) instead of re-typing its argument list, so it cannot
+    drift from the code it guards; and the seam fake binds through
+    `inspect.signature(chat_api_call).bind(...)`, so a future positional
+    mis-order raises instead of being agreed with.
     """
-    import inspect
-
-    from tldw_chatbook.Chat.Chat_Functions import chat_api_call
-
-    # Exactly the positional sequence `BaseReranker._call_llm_impl` hands to
-    # `loop.run_in_executor(None, chat_api_call, ...)`.
-    caller_positionals = (
-        "THE-API-KEY",
-        [{"role": "user", "content": "q"}],
-        "the-provider",
-        "the-model",
-        0.25,
-        128,
+    config = RerankingConfig(
+        model_provider="openai",
+        model_name="gpt-4o-mini",
+        temperature=0.25,
+        max_tokens=128,
     )
-    bound = inspect.signature(chat_api_call).bind(*caller_positionals)
-    landed = dict(bound.arguments)
+    reranker = PointwiseReranker(config)
+    landings = _install_fake_provider(monkeypatch)
 
-    # The credential lands in the ENDPOINT parameter -- the root of both the
-    # "Unsupported API endpoint" failure and the key-echoing ERROR log
-    # (TASK-17165).
-    assert landed["api_endpoint"] == "THE-API-KEY"
-    assert landed["messages_payload"] == [{"role": "user", "content": "q"}]
-    # ...and every remaining argument is displaced by one position.
-    assert landed["api_key"] == "the-provider"
-    assert landed["temp"] == "the-model"
-    assert landed["system_message"] == 0.25
-    assert landed["streaming"] == 128
-    # Nothing reaches the parameters the caller's own inline comments claim.
-    assert "model" not in landed
-    assert "maxp" not in landed
+    await reranker._call_llm_impl("score this document")
+
+    assert len(landings) == 1
+    landed = landings[0]
+    # The three the config owns land where the signature says they belong.
+    assert landed["api_endpoint"] == "openai"
+    assert landed["model"] == "gpt-4o-mini"
+    assert landed["temp"] == 0.25
+    assert landed["max_tokens"] == 128
+    assert landed["messages_payload"][-1] == {
+        "role": "user",
+        "content": "score this document",
+    }
+    # No argument carries a credential: the reranker resolves none, and each
+    # `chat_with_<provider>` handler resolves its own from the normalised
+    # config path (CLAUDE.md's documented precedence) -- which is what every
+    # other `chat_api_call` caller in this repo already relies on.
+    assert "api_key" not in landed
+    # And nothing lands in the parameters the broken positional call filled
+    # by displacement.
+    assert "system_message" not in landed
+    assert "streaming" not in landed
+
+
+def test_reranker_does_not_read_a_settings_table(monkeypatch):
+    """AC#2: the phantom `self._settings["API"]` read is GONE, not repaired.
+
+    `BaseReranker.__init__` used to do `self._settings = load_settings()` and
+    `_call_llm_impl` read `self._settings["API"]["<p>_api_key"]` -- a table
+    `load_settings()` never builds, so three of its four provider branches
+    read `None` for every user, always. The fix deletes the read rather than
+    re-pointing it: credential resolution is not the reranker's job.
+    """
+    assert not hasattr(reranker_module, "load_settings"), (
+        "reranker.py must not import load_settings -- a settings read here is "
+        "the divergence that produced TASK-17065"
+    )
+
+    def _explode():
+        raise AssertionError("BaseReranker must not call load_settings()")
+
+    monkeypatch.setattr(reranker_module, "load_settings", _explode, raising=False)
+
+    reranker = PointwiseReranker(RerankingConfig())
+
+    assert not hasattr(reranker, "_settings")
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        # keyless locals -- AC#5: never rejected for a key they do not need
+        "ollama",
+        "llama_cpp",
+        "vllm",
+        "koboldcpp",
+        "mlx_lm",
+        # remotes whose handlers resolve their own credential -- AC#4
+        "openai",
+        "anthropic",
+        "groq",
+        "deepseek",
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_sampled_provider_reaches_the_seam_without_a_credential_gate(
+    monkeypatch, provider
+):
+    """AC#4/AC#5: the reranker dispatches; it does not judge credentials.
+
+    Sampled across the 29 rows of `API_CALL_HANDLERS` the picker enumerates:
+    the five keyless locals TASK-17065 names, plus the four remotes the old
+    hand-rolled `if/elif` claimed to cover. Every one used to die before the
+    seam with `No API key found for provider: X` (three of them because the
+    table they read does not exist); every one now arrives at `chat_api_call`
+    with its own name in `api_endpoint`.
+    """
+    reranker = PointwiseReranker(
+        RerankingConfig(model_provider=provider, model_name="the-model")
+    )
+    landings = _install_fake_provider(monkeypatch)
+
+    response = await reranker._call_llm_impl("score this document")
+
+    assert response == '{"score": 0.5}'
+    assert [landed["api_endpoint"] for landed in landings] == [provider]
+    assert landings[0]["model"] == "the-model"
+    assert "api_key" not in landings[0]

--- a/Tests/RAG_Search/test_reranker_degraded_paths.py
+++ b/Tests/RAG_Search/test_reranker_degraded_paths.py
@@ -29,9 +29,10 @@ CLAIMS when its provider calls fail. This module pins all three:
 reranker's single provider seam (imported at `RAG_Search/reranker.py`
 module level, invoked through `run_in_executor` in `_call_llm_impl`) -- so
 the whole real path (`rerank` -> `_call_llm` -> `_call_llm_impl` -> the
-fake) executes. The fake BINDS what it is handed against the real
-`chat_api_call` signature (TASK-17065): the previous one declared the
-caller's own mis-ordered positional list and therefore agreed with the bug.
+fake) executes. The fake REFUSES positional arguments and BINDS what it is
+handed against the real `chat_api_call` signature (TASK-17065): the previous
+one declared the caller's own mis-ordered positional list and therefore
+agreed with the bug.
 No credential is planted any more -- the reranker resolves none, so nothing
 gates the call before the seam.
 """
@@ -41,6 +42,7 @@ from typing import Callable, List
 
 import pytest
 
+from tldw_chatbook import config as config_module
 from tldw_chatbook.Chat.Chat_Functions import chat_api_call as real_chat_api_call
 from tldw_chatbook.RAG_Search import reranker as reranker_module
 from tldw_chatbook.RAG_Search.reranker import (
@@ -72,8 +74,13 @@ def _install_fake_provider(
     a fixed valid score.
 
     Everything the reranker passes is run through
-    `inspect.signature(chat_api_call).bind(...)`, so a mis-ordered positional
-    call or a mis-named keyword raises HERE. The fake this replaces declared
+    `inspect.signature(chat_api_call).bind(...)`, which raises HERE on a
+    mis-named keyword or on arity drift. It does NOT see argument ORDER --
+    `bind("KEY", [...], "openai", "gpt-4o-mini", 0.25, 128)` is accepted
+    quite happily, it just lands the key in `api_endpoint` -- so this fake
+    ALSO refuses positional arguments outright, and the seam guard below
+    asserts what each keyword actually carries. Between them, mis-ordering
+    cannot pass. The fake this replaces declared
     the caller's OWN (wrong) positional list -- `(api_key, messages_payload,
     provider, model, temp, maxp)` -- so it agreed with the bug, and a green
     suite could not see that the reranker reached zero of the 29 providers it
@@ -89,6 +96,14 @@ def _install_fake_provider(
     landings: List[dict] = []
 
     def fake_chat_api_call(*args, **kwargs):
+        # `bind` cannot see order, so refuse positionals rather than pretend
+        # it can: this seam is keyword-only by contract (`run_in_executor`
+        # forwards positionals only, which is exactly how the credential
+        # used to land in `api_endpoint`).
+        assert not args, (
+            "the reranker must call chat_api_call by keyword; positional "
+            f"arguments landed here: {args!r}"
+        )
         bound = signature.bind(*args, **kwargs)
         landings.append(dict(bound.arguments))
         payload = bound.arguments["messages_payload"]
@@ -469,8 +484,13 @@ async def test_reranker_dispatch_binding_against_the_real_chat_api_call_signatur
     Two things changed beyond the assertions. It now drives the REAL caller
     (`_call_llm_impl`) instead of re-typing its argument list, so it cannot
     drift from the code it guards; and the seam fake binds through
-    `inspect.signature(chat_api_call).bind(...)`, so a future positional
-    mis-order raises instead of being agreed with.
+    `inspect.signature(chat_api_call).bind(...)` and refuses positionals.
+    Be precise about which half catches what (final-review F4): `bind`
+    catches a mis-named keyword and arity drift, and is BLIND to order --
+    it accepts the old positional list without complaint. A future
+    mis-ordering is caught by the fake's no-positionals rule and by the
+    landing assertions below, which is why this test drives the real
+    caller instead of asserting a tuple it typed itself.
     """
     config = RerankingConfig(
         model_provider="openai",
@@ -499,10 +519,21 @@ async def test_reranker_dispatch_binding_against_the_real_chat_api_call_signatur
     # config path (CLAUDE.md's documented precedence) -- which is what every
     # other `chat_api_call` caller in this repo already relies on.
     assert "api_key" not in landed
-    # And nothing lands in the parameters the broken positional call filled
-    # by displacement.
+    # And nothing lands in the parameter the broken positional call filled by
+    # displacement (`system_message` took the temperature).
     assert "system_message" not in landed
-    assert "streaming" not in landed
+    # NON-STREAMING IS PINNED, NOT INHERITED (final-review F5). The old
+    # positional list put the token cap into `streaming` (truthy), so a
+    # scoring call that had resolved a credential would have STREAMED. Today
+    # non-streaming holds only because all 29 handlers DECLARE
+    # `streaming=False` and therefore never consult the config -- while the
+    # shipped `CONFIG_TOML_CONTENT` sets `streaming = true` for 18 of them,
+    # including every keyless local. One future handler declaring
+    # `streaming: bool | None = None` would flip reranking to streaming for
+    # those, and `_call_llm_impl` would return the repr of a generator: no
+    # exception, every row `scored=False`, the whole rerank billed and
+    # unscored. So the reranker states it.
+    assert landed["streaming"] is False
 
 
 def test_reranker_does_not_read_a_settings_table(monkeypatch):
@@ -519,14 +550,20 @@ def test_reranker_does_not_read_a_settings_table(monkeypatch):
         "the divergence that produced TASK-17065"
     )
 
-    def _explode():
-        raise AssertionError("BaseReranker must not call load_settings()")
+    # The exploder goes on the SOURCE, not on `reranker_module` (final-review
+    # F7): monkeypatching the name the assertion above just proved absent
+    # planted something nothing could call. Patched here it is live -- a
+    # re-grown read fires it even if it arrives as a late import inside
+    # `__init__` rather than a module-level one -- and it is quiet today:
+    # constructing all three strategies reads no settings at all.
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("a reranker must not call load_settings()")
 
-    monkeypatch.setattr(reranker_module, "load_settings", _explode, raising=False)
+    monkeypatch.setattr(config_module, "load_settings", _explode)
 
-    reranker = PointwiseReranker(RerankingConfig())
-
-    assert not hasattr(reranker, "_settings")
+    for strategy_class in (PointwiseReranker, PairwiseReranker, ListwiseReranker):
+        reranker = strategy_class(RerankingConfig())
+        assert not hasattr(reranker, "_settings")
 
 
 @pytest.mark.parametrize(

--- a/Tests/UI/test_settings_rag_profile_adapter.py
+++ b/Tests/UI/test_settings_rag_profile_adapter.py
@@ -1336,3 +1336,21 @@ def test_reranker_provider_default_constant_matches_rerankingconfig_default():
     )
 
     assert DEFAULT_RERANKER_PROVIDER == RerankingConfig().model_provider
+
+
+def test_reranker_attempts_constant_matches_rerankingconfig_retries():
+    """The cost disclosure's retry multiplier is the same hardcode trade.
+
+    `BaseReranker._call_llm` retries EVERY exception (not only transient
+    ones) `max_retries` times, so one candidate can cost `1 + max_retries`
+    provider calls and the fold's honest ceiling is `top_k` x that. If the
+    dataclass default moves, the disclosed number must move with it
+    (TASK-17065 final review F1).
+    """
+    from tldw_chatbook.UI.Screens.settings_library_rag_defaults import (
+        RERANKER_ATTEMPTS_PER_CANDIDATE,
+    )
+
+    cfg = RerankingConfig()
+    assert cfg.retry_on_failure is True
+    assert RERANKER_ATTEMPTS_PER_CANDIDATE == 1 + cfg.max_retries

--- a/Tests/UI/test_settings_rag_profile_region.py
+++ b/Tests/UI/test_settings_rag_profile_region.py
@@ -4002,7 +4002,9 @@ async def test_reranker_cost_disclosure_is_visible_without_enabling_reranking(
     """AC#2: the per-candidate spend is stated adjacent to the toggle and
     readable BEFORE committing to it -- a fresh clone has reranking OFF, and
     the line must still be on screen, naming the configured rerank top-k as
-    the call ceiling."""
+    the call ceiling AND the retried ceiling behind it (TASK-17065 F1: the
+    reranker retries every exception twice, so `top_k` alone understated a
+    failing provider's spend threefold)."""
     _wire_rag_profile_adapter(monkeypatch, tmp_path)
     app = _build_test_app()
     host = DestinationHarness(app, "settings")
@@ -4023,7 +4025,8 @@ async def test_reranker_cost_disclosure_is_visible_without_enabling_reranking(
         text = str(disclosure.renderable)
         assert text == (
             "Reranking scores each result with a separate openai call — up "
-            "to 20 calls per search, billed at that provider's rates."
+            "to 20 calls per search, or 60 if calls fail and are retried, "
+            "billed at that provider's rates."
         )
         assert "20" in _visible_text(screen)
 
@@ -4059,7 +4062,8 @@ async def test_reranker_cost_disclosure_tracks_the_staged_top_k_and_provider(
         )
         assert str(disclosure.renderable) == (
             "Reranking scores each result with a separate anthropic call — "
-            "up to 50 calls per search, billed at that provider's rates."
+            "up to 50 calls per search, or 150 if calls fail and are retried, "
+            "billed at that provider's rates."
         )
 
 
@@ -4204,7 +4208,8 @@ async def test_previewing_a_profile_discloses_that_profiles_reranking_cost(
         assert screen._rag_preview_profile_id == other.id
         assert str(disclosure.renderable) == (
             "Reranking scores each result with a separate anthropic call — "
-            "up to 42 calls per search, billed at that provider's rates."
+            "up to 42 calls per search, or 126 if calls fail and are retried, "
+            "billed at that provider's rates."
         )
         # ...and browsing back restores the active profile's own line.
         select.value = profile.id

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -326,6 +326,41 @@ must fake threading/navigation seams, patch the **collaborator** (`app`) — nev
 a new attribute onto the class under test; an instance monkeypatch is also an
 existence claim, and nothing checks it.
 
+**Widest blast radius (TASK-17065, 2026-08-17).** One module diverged from the house
+pattern in *two* ways at once, and the single fake at its seam mirrored both.
+`RAG_Search/reranker.py` grew its own credential path (`self._settings =
+load_settings()`, then a hand-rolled `if/elif` reading
+`settings["API"]["<provider>_api_key"]` — a key `load_settings()` never builds) *and*
+its own dispatch convention (a positional argument list handed to `chat_api_call`
+through `run_in_executor`, which forwards positionals only). The seam fake,
+`Tests/RAG_Search/test_reranker_degraded_paths.py`'s `def
+fake_chat_api_call(api_key, messages_payload, provider, model, temp, maxp)`, declared
+the caller's own wrong order *and* planted a `_settings` table so the call got past
+the credential gate. Agreeing with both defects, it left ~2,500 green tests unable to
+see that reranking completed a scoring call for **zero of the 29 providers**
+`chat_api_call` dispatches — for the entire life of the feature. Binding the same call
+through `inspect.signature(chat_api_call).bind(...)` printed the truth in one line:
+`api_endpoint='THE-API-KEY'`, `api_key='openai'`, `temp='gpt-4o-mini'`,
+`system_message=0.25`, `streaming=128` — the mis-binding had also silently switched
+STREAMING on, a third defect nobody had filed.
+
+Two rules out of it:
+
+- **A fake at a seam you share with the rest of the app must bind against the real
+  signature, never re-type the call site's argument list.** Note how far this reaches:
+  even the guard written specifically to catch this
+  (`test_reranker_dispatch_binding_against_the_real_chat_api_call_signature`) first
+  asserted a literal tuple *it typed itself*, so it guarded a copy of the caller and
+  caught nothing. It only became evidence once it drove the real `_call_llm_impl` and
+  observed what landed.
+- **A feature that resolves credentials itself is a divergence to justify, not a
+  default.** The fix here was a DELETION: all 29 handlers already resolve their own key
+  or need none, and every other `chat_api_call` caller in the repo
+  (`UI/Tools_Settings_Window.py`, `UI/Screens/evals_screen.py`,
+  `Chat/console_provider_gateway.py`) already passes keywords and omits `api_key`. The
+  reranker was the sole outlier, and being the sole outlier is exactly what broke it.
+  Before writing a lookup at a shared seam, count the callers who do not have one.
+
 ---
 
 ## Mutation-test every guard you add

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -352,7 +352,17 @@ Two rules out of it:
   (`test_reranker_dispatch_binding_against_the_real_chat_api_call_signature`) first
   asserted a literal tuple *it typed itself*, so it guarded a copy of the caller and
   caught nothing. It only became evidence once it drove the real `_call_llm_impl` and
-  observed what landed.
+  observed what landed. **And know exactly what `bind` buys you**, because the fixed
+  fake's first docstring over-claimed it and the final review caught that:
+  `inspect.signature(...).bind()` checks arity and keyword *names* only — it is BLIND
+  to order. Re-measured on this very call:
+  `bind("THE-KEY", [...], "openai", "gpt-4o-mini", 0.25, 128)` is ACCEPTED (it simply
+  lands the key in `api_endpoint`), while `bind(provider="x", ...)` raises
+  `unexpected keyword argument`. What actually catches a mis-ordering is the landing
+  ASSERTIONS on a guard that drives the real caller — plus, cheaply, refusing
+  positional arguments at the fake (`assert not args`) when the seam is keyword-only
+  by contract. Mutation-checked: reverting the call site to positional now fails with
+  *"positional arguments landed here: ('openai',)"*, not with a bind error.
 - **A feature that resolves credentials itself is a divergence to justify, not a
   default.** The fix here was a DELETION: all 29 handlers already resolve their own key
   or need none, and every other `chat_api_call` caller in the repo

--- a/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
+++ b/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
@@ -4,11 +4,11 @@ title: >-
   Reranker credential and dispatch path can call NONE of the 29 offered
   providers -- a settings table that is never built, plus swapped chat_api_call
   arguments
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-16'
-updated_date: '2026-08-17 05:41'
+updated_date: '2026-08-17 06:02'
 labels:
   - rag
   - settings
@@ -187,16 +187,16 @@ explicit invalid row.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A decision is implemented, either arm acceptable: the reranker resolves credentials through the normalised config path for every provider it offers, OR the Settings provider Select is bounded to the providers the reranker can actually call
-- [ ] #2 The reranker's credential read targets a table `load_settings()` actually builds -- `self._settings["API"]` is gone, and a configured openai/anthropic/groq credential is found rather than silently read as `None`
-- [ ] #3 `chat_api_call` is invoked with arguments its real signature accepts (keyword, not the current positional list) -- no call routes the API KEY into `api_endpoint`, and no credential can reach a log line as an "endpoint"
-- [ ] #4 A provider offered in the Reranking fold, with a valid credential configured for it, completes a scoring call instead of failing the first search with `No API key found for provider: X` or `Unsupported API endpoint: <key>`
-- [ ] #5 Providers needing no credential (local `ollama`/`llama_cpp`/`vllm`/`koboldcpp`/`mlx_lm`) either rerank successfully or are absent from the picker -- they are never rejected for a missing key they do not need
-- [ ] #6 The reranker's credential lookup obeys the documented precedence (explicit `api_settings.<provider>.api_key` over env var over legacy `[API]`, every source validity-checked through `resolve_provider_api_key`)
-- [ ] #7 The chosen arm is pinned by tests at BOTH the credential and the dispatch seam, with no live provider calls -- and any `chat_api_call` fake matches the REAL signature, since today's fakes mirror the caller's wrong positional order and is why the defect survived a green suite
-- [ ] #8 A stored provider this build cannot dispatch is displayed honestly and is repairable from the UI: picking a valid provider over it stages and saves, rather than being folded back to the invalid stored value by the effective-provider guard
-- [ ] #9 The picker's enumeration stays derived, not hand-listed: whichever arm ships, adding a chat provider must not silently desynchronise Settings from the engine
-- [ ] #10 The spend consequence is handled deliberately: the change lands on a build carrying TASK-3502's cost disclosure and skipped/degraded notice, and the release note states that reranking-enabled profiles begin spending real provider calls
+- [x] #1 A decision is implemented, either arm acceptable: the reranker resolves credentials through the normalised config path for every provider it offers, OR the Settings provider Select is bounded to the providers the reranker can actually call
+- [x] #2 The reranker's credential read targets a table `load_settings()` actually builds -- `self._settings["API"]` is gone, and a configured openai/anthropic/groq credential is found rather than silently read as `None`
+- [x] #3 `chat_api_call` is invoked with arguments its real signature accepts (keyword, not the current positional list) -- no call routes the API KEY into `api_endpoint`, and no credential can reach a log line as an "endpoint"
+- [x] #4 A provider offered in the Reranking fold, with a valid credential configured for it, completes a scoring call instead of failing the first search with `No API key found for provider: X` or `Unsupported API endpoint: <key>`
+- [x] #5 Providers needing no credential (local `ollama`/`llama_cpp`/`vllm`/`koboldcpp`/`mlx_lm`) either rerank successfully or are absent from the picker -- they are never rejected for a missing key they do not need
+- [x] #6 The reranker's credential lookup obeys the documented precedence (explicit `api_settings.<provider>.api_key` over env var over legacy `[API]`, every source validity-checked through `resolve_provider_api_key`)
+- [x] #7 The chosen arm is pinned by tests at BOTH the credential and the dispatch seam, with no live provider calls -- and any `chat_api_call` fake matches the REAL signature, since today's fakes mirror the caller's wrong positional order and is why the defect survived a green suite
+- [x] #8 A stored provider this build cannot dispatch is displayed honestly and is repairable from the UI: picking a valid provider over it stages and saves, rather than being folded back to the invalid stored value by the effective-provider guard
+- [x] #9 The picker's enumeration stays derived, not hand-listed: whichever arm ships, adding a chat provider must not silently desynchronise Settings from the engine
+- [x] #10 The spend consequence is handled deliberately: the change lands on a build carrying TASK-3502's cost disclosure and skipped/degraded notice, and the release note states that reranking-enabled profiles begin spending real provider calls
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -210,3 +210,157 @@ explicit invalid row.
 6. GREEN all; correct every seam fake found in step 1 to bind via inspect.signature(chat_api_call).bind; batteries: Tests/RAG_Search + Tests/Chat/test_chat_functions.py + the redaction file; ruff.
 7. Gate (RAG_EVAL=1 Tests/RAG_Eval/) with the vacuity caveat; commit + push.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**The fix is a DELETION, not a rewrite.** Both defects lived in code the reranker
+should never have had. `RAG_Search/reranker.py` now holds no credential logic and no
+settings read at all: `from ..config import load_settings`, `self._settings =
+load_settings()`, the whole `if/elif` chain and its `raise ValueError(f"No API key
+found for provider: ...")` are gone, and the dispatch is
+
+```python
+functools.partial(
+    chat_api_call,
+    api_endpoint=self.config.model_provider,
+    messages_payload=messages_payload,
+    model=self.config.model_name,
+    temp=self.config.temperature,
+    max_tokens=self.config.max_tokens,
+)
+```
+
+handed to `run_in_executor` (which forwards positionals only -- a positional list at
+this signature is the defect, so the `partial` is load-bearing; do not "simplify" it
+back). **No `api_key` is passed.**
+
+**Why deleting the lookup is safe (measured, 29/29).** Every row of
+`API_CALL_HANDLERS` resolves its own credential or needs none: 22 use the
+`api_key or <config>` idiom; the remaining 7 were regex false-positives --
+`qwencloud` (`resolve_qwencloud_api_key`), `custom-openai-api` (`api_key_resolved`),
+`moonshot`/`zai` (`explicit_api_key` -> `api_settings` -> `resolve_provider_api_key`),
+and `mlx_lm`/`local_mlx_lm`/`local-llm` (keyless by design). Also checked: all 29
+`PROVIDER_PARAM_MAP` entries map `max_tokens` (openai->`max_tokens`,
+ollama->`num_predict`), and the dispatcher DROPS `None` generics, so omitting
+`api_key`/`streaming` leaves each handler's own resolution and non-streaming default
+in force.
+
+**The sole outlier is what broke.** Every other `chat_api_call` caller in the repo
+already passes keywords and omits `api_key` -- `UI/Tools_Settings_Window.py:4157`/
+`:4296`, `UI/Screens/evals_screen.py:193`, `Chat/console_provider_gateway.py:2534`.
+The reranker was the only caller that hand-rolled a credential path and the only one
+that dispatched positionally, and being the only one is exactly why nothing else
+caught it.
+
+**Extra finding (the third defect, unfiled).** A signature-binding probe over the OLD
+call (no live call; the legacy settings shape planted only to get past the credential
+gate that fires first) showed where the arguments actually landed:
+`api_endpoint='THE-API-KEY'`, `api_key='openai'`, `temp='gpt-4o-mini'`,
+`system_message=0.25`, **`streaming=128`**. The old positional list also silently
+switched STREAMING ON (truthy `max_tokens`), so every scoring call would have STREAMED
+had a credential ever resolved. Scoring calls are now non-streaming (handler default),
+and `RerankingConfig`'s `max_tokens=100` / `temperature=0.0` reach a provider for the
+first time.
+
+**Evidence per AC**
+
+- **#1** (arm A: fix the engine, keep the picker) -- the reranker now reaches every
+  provider `chat_api_call` can route.
+  `test_every_sampled_provider_reaches_the_seam_without_a_credential_gate`,
+  9 parametrised cells.
+- **#2** -- `self._settings` and the `["API"]` read are deleted outright;
+  `test_reranker_does_not_read_a_settings_table` monkeypatches `load_settings` to
+  raise and construction still succeeds. The openai/anthropic/groq credential is now
+  FOUND -- by the provider handler, which is the acceptable variant the task's "Fix
+  shape" blesses ("simply not resolving at all and letting the provider handler
+  resolve ... is an acceptable variant").
+- **#3** -- keyword dispatch, pinned by
+  `test_reranker_dispatch_binding_against_the_real_chat_api_call_signature`, which now
+  DRIVES the real `_call_llm_impl` and binds what lands through
+  `inspect.signature(chat_api_call)`: `api_endpoint <- model_provider`,
+  `model <- model_name`, `temp <- temperature`, `max_tokens <- max_tokens`, and NO
+  argument carrying a credential. A credential can no longer reach the
+  `Unsupported API endpoint: <value>` log line because no credential is passed at all.
+- **#4** -- both named failure modes are now structurally impossible: `No API key
+  found for provider: X` because the raise is deleted, `Unsupported API endpoint:
+  <key>` because `api_endpoint` carries the provider name. Pinned at the seam by the
+  9 provider cells. **Honest bound: no live provider call was made anywhere in this
+  arc (a hard constraint), so "completes a scoring call" is evidenced up to the
+  dispatcher, not over the wire.**
+- **#5** -- the five keyless locals (`ollama`, `llama_cpp`, `vllm`, `koboldcpp`,
+  `mlx_lm`) are among the 9 parametrised cells; each reaches the seam with its own
+  name in `api_endpoint` and no `api_key` argument. They stay in the picker.
+- **#6** -- the reranker performs no lookup, so it cannot violate the precedence: it
+  now uses the same path as every other chat call, and each handler applies
+  `api_settings.<provider>.api_key` -> env -> legacy `[API]`, validity-checked through
+  `resolve_provider_api_key`. CLAUDE.md's known open caveat (env-only credentials for
+  `google`) is inherited by every chat path and is not introduced or worsened here.
+- **#7** -- pinned at BOTH seams (the settings-table test and the dispatch guard),
+  no live calls. Every reranker-seam fake corrected: `_install_fake_provider` in
+  `Tests/RAG_Search/test_reranker_degraded_paths.py` (it declared the CALLER's wrong
+  positional order and planted `reranker._settings` -- now binds through the real
+  signature and plants nothing; 8 call sites), the guard itself (it re-typed the
+  caller's argument list as a literal tuple, so it guarded a copy; it now drives the
+  real caller), and 3 fakes in `test_reranker_construction.py` raising an error the
+  code can no longer produce. Other `chat_api_call` fakes in the repo (Console
+  gateway, Evals, Tools, Web_Scraping) are keyword-only and not at this seam.
+- **#8** -- ALREADY SATISFIED ON DEV, no code written here: the picker-repair half
+  shipped with TASK-3502's Qodo remediation (the reranker-provider change guard folds
+  back only a loaded value the fold-back PRESERVES -- blank or registered -- so an
+  unrecognised loaded value no longer swallows the corrective pick,
+  `settings_screen.py:18790-18798`). Verified by running
+  `Tests/UI/test_settings_rag_profile_region.py::
+  test_an_unrecognised_stored_provider_is_repairable_from_the_picker` -> **1 passed**
+  (the test is present at the merge-base, dev `1c328e1a7`). Display side, stated
+  plainly: an unrecognised stored name still RENDERS as the default row (the Select
+  cannot show a value it has no option for without raising out of `compose()`), and
+  the honesty is delivered at the point of use -- the stored name goes to
+  `chat_api_call`, which cannot route it, and the results screen discloses
+  "Reranking was skipped (...)". `normalise_library_rag_reranker_provider`'s docstring
+  claimed this branch was unrepairable and pointed at this task; corrected here.
+- **#9** -- the picker was NOT TOUCHED. `library_rag_reranker_providers()` still
+  derives its options from `Chat_Functions.API_CALL_HANDLERS`; the only change in
+  `settings_library_rag_defaults.py` is docstring text. Adding a chat provider still
+  adds a picker row and, now, a provider the reranker can actually dispatch to.
+- **#10** -- release note added to `CHANGELOG.md` (Unreleased -> Changed), plus the
+  user-facing copy in `Docs/User_Guide/settings/rag.md`, which had documented the
+  defect as an open gap ("its credential path currently reaches far fewer of them
+  than the list offers ... TASK-17065") and is now corrected in all three places it
+  said so. The note states that an already-ticked profile begins spending real
+  provider calls on its NEXT SEARCH with no further user action (one call per
+  candidate up to the configured top-k), names TASK-3502's cost line and
+  skipped/degraded notice as the surfaces that make it visible, names the
+  streaming-128 consequence, and names `max_tokens=100`/`temperature=0.0` reaching
+  providers for the first time. The build carries both TASK-3502 surfaces.
+
+**Tests.** New/rewritten in `Tests/RAG_Search/test_reranker_degraded_paths.py`: the
+dispatch guard (rewritten), `test_reranker_does_not_read_a_settings_table`,
+`test_every_sampled_provider_reaches_the_seam_without_a_credential_gate` (9 cells).
+11 RED before the fix -- the guard's RED was `ValueError: No API key found for
+provider: openai` at `reranker.py:204`, i.e. defect 1 firing before defect 2 is even
+reachable -- and 11 GREEN after. Batteries: `Tests/RAG_Search/` 358 passed / 12
+skipped; `Tests/Chat/test_chat_functions.py` + `Tests/RAG/` + the reranker prompt
+parity file 815 passed (4 failures are missing optional deps `tomli`/`nltk` in the
+pinned venv, in files that never import the reranker); redaction + settings + library
+files 354 passed; RAG UI files 215 passed. Gate `RAG_EVAL=1 ... Tests/RAG_Eval/` 307
+passed -- **VACUOUS for the reranker** (no gated cell constructs or runs one), stated
+as established in TASK-3502; the repair's evidence is the guard and the 9 provider
+cells.
+
+**Lesson.** `backlog/docs/lessons-testing-evidence.md` -- extended the existing entry
+"A fake written to match your call site validates the mistake" with this incident
+rather than filing a duplicate: a module that grew BOTH its own credential path and
+its own dispatch convention, with a seam fake that mirrored both, so ~2,500 green
+tests could not see zero-of-29 coverage. Two rules: a fake at a shared seam must bind
+against the real signature (even the guard written to catch this first re-typed the
+caller's argument list and caught nothing); and a feature that resolves credentials
+itself is a divergence to justify, not a default.
+
+**Files.** `tldw_chatbook/RAG_Search/reranker.py`,
+`tldw_chatbook/UI/Screens/settings_library_rag_defaults.py` (docstrings only),
+`Tests/RAG_Search/test_reranker_degraded_paths.py`,
+`Tests/RAG_Search/test_reranker_construction.py`, `CHANGELOG.md`,
+`Docs/User_Guide/settings/rag.md`, `backlog/docs/lessons-testing-evidence.md`, plus
+the spec/plan under `Docs/superpowers/`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
+++ b/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
@@ -4,9 +4,11 @@ title: >-
   Reranker credential and dispatch path can call NONE of the 29 offered
   providers -- a settings table that is never built, plus swapped chat_api_call
   arguments
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
+updated_date: '2026-08-17 05:41'
 labels:
   - rag
   - settings
@@ -184,7 +186,6 @@ explicit invalid row.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
 - [ ] #1 A decision is implemented, either arm acceptable: the reranker resolves credentials through the normalised config path for every provider it offers, OR the Settings provider Select is bounded to the providers the reranker can actually call
 - [ ] #2 The reranker's credential read targets a table `load_settings()` actually builds -- `self._settings["API"]` is gone, and a configured openai/anthropic/groq credential is found rather than silently read as `None`
@@ -198,14 +199,14 @@ explicit invalid row.
 - [ ] #10 The spend consequence is handled deliberately: the change lands on a build carrying TASK-3502's cost disclosure and skipped/degraded notice, and the release note states that reranking-enabled profiles begin spending real provider calls
 <!-- AC:END -->
 
-**Seam guard added by TASK-3502's Qodo round (PR #1751, finding 3):**
-`Tests/RAG_Search/test_reranker_degraded_paths.py::
-test_reranker_dispatch_binding_against_the_real_chat_api_call_signature`
-binds the caller's positional sequence against the REAL `chat_api_call`
-signature and asserts where each argument LANDS today
-(`api_endpoint`←the key, `api_key`←the provider, `temp`←the model,
-`system_message`←the temperature, `streaming`←max_tokens; `model`/`maxp`
-never reached at all). It is deliberately RED-ON-REPAIR: fixing the
-caller here MUST break it, and the repair includes rewriting it to assert
-the correct binding. Every other fake at this seam copies the caller's
-wrong order, which is why a green suite never caught this.
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Grep and list every reranker-seam chat_api_call fake under Tests/.
+2. RED: rewrite test_reranker_dispatch_binding_against_the_real_chat_api_call_signature so it OBSERVES the real caller through a signature-binding fake and asserts api_endpoint<-model_provider, model<-model_name, temp<-temperature, no credential argument. Must fail against today's caller.
+3. RED: assert the reranker no longer reads a settings table (no _settings; load_settings not called during __init__).
+4. RED: per-provider parametrised test (keyless local ollama + remote openai + anthropic/groq/deepseek) - _call_llm_impl completes, fake records api_endpoint == the provider, no 'No API key found for provider:'.
+5. Implement: delete the if/elif credential block and the load_settings() read; call chat_api_call with KEYWORDS (functools.partial in run_in_executor): api_endpoint, messages_payload, model, temp, max_tokens. Pass NO api_key. Remove dead imports.
+6. GREEN all; correct every seam fake found in step 1 to bind via inspect.signature(chat_api_call).bind; batteries: Tests/RAG_Search + Tests/Chat/test_chat_functions.py + the redaction file; ruff.
+7. Gate (RAG_EVAL=1 Tests/RAG_Eval/) with the vacuity caveat; commit + push.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
+++ b/backlog/tasks/task-17065 - Reranker-credential-and-dispatch-path-can-call-NONE-of-the-29-offered-providers-a-settings-table-that-is-never-built-plus-swapped-chat_api_call-arguments.md
@@ -197,6 +197,7 @@ explicit invalid row.
 - [x] #8 A stored provider this build cannot dispatch is displayed honestly and is repairable from the UI: picking a valid provider over it stages and saves, rather than being folded back to the invalid stored value by the effective-provider guard
 - [x] #9 The picker's enumeration stays derived, not hand-listed: whichever arm ships, adding a chat provider must not silently desynchronise Settings from the engine
 - [x] #10 The spend consequence is handled deliberately: the change lands on a build carrying TASK-3502's cost disclosure and skipped/degraded notice, and the release note states that reranking-enabled profiles begin spending real provider calls
+- [x] #11 Spend safety: no shipped read-only profile asks a provider for free-form `reasoning` text under the reranker's 100-token cap -- `RerankingResult.reasoning` is never read outside `reranker.py`, so on `high_accuracy` (pointwise) and `research_papers` (listwise) the flag only buys extra output tokens and a truncated JSON body, i.e. a billed-but-unscored row (listwise: a wholly failed rerank)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -270,8 +271,10 @@ first time.
   `test_every_sampled_provider_reaches_the_seam_without_a_credential_gate`,
   9 parametrised cells.
 - **#2** -- `self._settings` and the `["API"]` read are deleted outright;
-  `test_reranker_does_not_read_a_settings_table` monkeypatches `load_settings` to
-  raise and construction still succeeds. The openai/anthropic/groq credential is now
+  `test_reranker_does_not_read_a_settings_table` asserts the module-level import is
+  absent and (final-review F7) monkeypatches `load_settings` on `tldw_chatbook.config`
+  -- the SOURCE, so a re-grown read fires it even as a late import inside `__init__`
+  -- while constructing all three strategies. The openai/anthropic/groq credential is now
   FOUND -- by the provider handler, which is the acceptable variant the task's "Fix
   shape" blesses ("simply not resolving at all and letting the provider handler
   resolve ... is an acceptable variant").
@@ -303,7 +306,14 @@ first time.
   signature and plants nothing; 8 call sites), the guard itself (it re-typed the
   caller's argument list as a literal tuple, so it guarded a copy; it now drives the
   real caller), and 3 fakes in `test_reranker_construction.py` raising an error the
-  code can no longer produce. Other `chat_api_call` fakes in the repo (Console
+  code can no longer produce. **Corrected in the final-review fix wave (F4): binding
+  does NOT catch a mis-ORDERED positional call.** `inspect.signature(...).bind()`
+  checks arity and keyword NAMES; re-measured,
+  `bind("THE-KEY", [...], "openai", "gpt-4o-mini", 0.25, 128)` is accepted and only
+  `bind(provider=...)` raises. The mis-order catchers are the guard's landing
+  assertions plus the fake's new `assert not args` (this seam is keyword-only by
+  contract) -- mutation-checked: reverting the call site to positional now fails with
+  "positional arguments landed here: ('openai',)". Other `chat_api_call` fakes in the repo (Console
   gateway, Evals, Tools, Web_Scraping) are keyword-only and not at this seam.
 - **#8** -- ALREADY SATISFIED ON DEV, no code written here: the picker-repair half
   shipped with TASK-3502's Qodo remediation (the reranker-provider change guard folds
@@ -363,4 +373,50 @@ itself is a divergence to justify, not a default.
 `Tests/RAG_Search/test_reranker_construction.py`, `CHANGELOG.md`,
 `Docs/User_Guide/settings/rag.md`, `backlog/docs/lessons-testing-evidence.md`, plus
 the spec/plan under `Docs/superpowers/`.
+
+### Final-review fix wave (2026-08-17, same branch)
+
+The whole-branch review returned SHIP-WITH-FIXES with two BLOCKING doc findings; all
+seven findings are addressed here, plus one AC amendment.
+
+- **F1 (blocked) -- the disclosed ceiling was wrong for two strategies and understated
+  by the retry loop.** Re-measured independently by counting `chat_api_call`
+  invocations through the real reranker with the seam faked: pointwise with shipped
+  settings costs `top_k x 3` (**9** calls for 3 candidates against an erroring
+  provider, **60** for 20) because `_call_llm` retries EVERY exception twice; pairwise
+  is a merge sort and costs **40-69** comparison calls at top_k=20 (49-65 across 200
+  randomised runs; the 40 and 69 are the algorithm's own bounds, reproduced by an
+  external simulation of the same merge), not 20; listwise costs exactly **1**. The
+  shape is now stated per strategy in `CHANGELOG.md` and
+  `Docs/User_Guide/settings/rag.md`, and the Settings cost line discloses the retried
+  ceiling ("... up to `<n>` calls per search, or `<n x 3>` if calls fail and are
+  retried ..."), driven by a new `RERANKER_ATTEMPTS_PER_CANDIDATE` constant pinned to
+  `1 + RerankingConfig().max_retries`.
+- **F2 (blocked) -- enablement is not the tick.** Reranking is on for any profile
+  carrying a `reranking_config`, and three read-only built-ins do: Hybrid Full
+  (pointwise, 15), High Accuracy (pointwise, 15), Research Papers (listwise, 10), all
+  billing `openai`. Read back off `ConfigProfileManager` over an empty profiles dir;
+  the other nine built-ins, including the active default Hybrid Basic, carry none.
+  Both surfaces now name all three and say a preset switch is a spend decision.
+- **F5 -- non-streaming is now STATED.** It previously held only because all 29
+  handlers declare `streaming=False`, while the shipped config sets `streaming = true`
+  for 18 providers; a generator return would have yielded `scored=False` on every row,
+  billed and silent. `_call_llm_impl` passes `streaming=False`, pinned RED-first by
+  `assert landed["streaming"] is False` in the dispatch guard.
+- **AC#11 (new) -- `include_reasoning=False` on `high_accuracy` and
+  `research_papers`.** `RerankingResult.reasoning` is read nowhere outside
+  `reranker.py`, and under `max_tokens=100` the extra free-form string is the only
+  real truncation risk -> `JSONDecodeError` -> a billed-but-unscored row (listwise:
+  the whole rerank). AC added to this file BEFORE implementing, per CLAUDE.md. Pinned
+  RED-first by `test_no_builtin_profile_asks_for_reasoning_it_cannot_fit_or_read`.
+- **F4 -- the bind over-claim corrected** in the fake's docstring, the guard's
+  docstring, this file (AC#7 above) and the lesson; the fake now also refuses
+  positional arguments outright, which does catch a mis-order.
+- **F6/F7 -- test hygiene.** Two `Tests/Library/` files stopped simulating
+  `"No API key found for provider: openai"`, an error the code can no longer produce;
+  the settings-table test's unreachable half now patches the source module.
+- **F3 -- NOT fixed here, filed as TASK-17265.** The reranker passes its system prompt
+  in-band and never as `system_message=`; `chat_with_anthropic` discards it and
+  `chat_with_google` skips non-user/assistant roles, so the JSON contract never reaches
+  those models. Out of scope for a fix wave whose blocking findings were doc-only.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17265 - Reranker-system-prompt-never-reaches-anthropic-or-google-passed-in-band-never-as-system_message.md
+++ b/backlog/tasks/task-17265 - Reranker-system-prompt-never-reaches-anthropic-or-google-passed-in-band-never-as-system_message.md
@@ -1,0 +1,53 @@
+---
+id: TASK-17265
+title: >-
+  Reranker system prompt never reaches anthropic or google — passed in-band,
+  never as system_message
+status: To Do
+assignee: []
+created_date: '2026-08-17'
+labels:
+  - rag
+  - llm-calls
+dependencies:
+  - TASK-17065
+priority: medium
+---
+
+## Description (the why)
+
+Found by TASK-17065's final whole-branch review (finding F3), on the branch
+that made the reranker actually call providers for the first time.
+
+`BaseReranker._call_llm_impl` (`RAG_Search/reranker.py`) puts its system
+prompt INSIDE `messages_payload` as `{"role": "system", ...}` and never
+passes `chat_api_call`'s own `system_message=` argument, even though all 29
+provider maps carry it. Two mainstream providers drop an in-band system
+turn on the floor:
+
+* `chat_with_anthropic` assembles its payload from user/assistant turns only
+  ("Skipping message with unsupported role: system") and fills `data["system"]`
+  from the `system_message` argument alone. The reviewer's fake-transport probe
+  produced `PAYLOAD messages roles: ['user']`, `PAYLOAD has top-level system:
+  False` — the system turn was discarded outright.
+* `chat_with_google` maps `user→user`, `assistant→model` and `continue`s past
+  every other role, and sets `system_instruction` only from `system_message`.
+
+The system prompt is what tells the model "return only a JSON object with a
+`score` field". Without it the parse-failure rate rises, and every parse
+failure is a call that was BILLED and produced no score (`scored=False`; for
+listwise, a single failure fails the entire rerank). This is not a regression
+— nothing called anything before TASK-17065 — but it is newly reachable, and
+it weakens that task's "completes a scoring call" claim for two of the
+providers its picker offers.
+
+`chat_with_openai` keeps an in-band system message and de-duplicates against
+`system_message`, so passing both is safe there; the fix shape the review
+suggests is to pass `system_message=` in addition to the in-band copy.
+
+## Acceptance Criteria (the what)
+
+- [ ] #1 The reranker's system prompt reaches the model on anthropic and google — asserted at the provider-handler boundary (fake transport, no live call) by inspecting the assembled payload, not just the reranker's own call site
+- [ ] #2 Providers that accept an in-band system turn (openai and the local family) still receive exactly one system instruction — no duplicated or conflicting system text on the wire
+- [ ] #3 A test pins the reranker's dispatch as carrying the system prompt in a form each of the sampled providers actually forwards, alongside the existing seam guard in `Tests/RAG_Search/test_reranker_degraded_paths.py`
+- [ ] #4 No live provider call is made to satisfy any of the above

--- a/backlog/tasks/task-17365 - User-cloned reranking profiles keep include_reasoning=true and pay for unscored calls.md
+++ b/backlog/tasks/task-17365 - User-cloned reranking profiles keep include_reasoning=true and pay for unscored calls.md
@@ -1,0 +1,44 @@
+---
+id: task-17365
+title: >-
+  User-cloned reranking profiles keep include_reasoning=true and pay for
+  unscored calls
+status: To Do
+assignee: []
+created_date: '2026-08-17'
+labels: [rag, settings, config]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+TASK-17065 (AC#11) set `include_reasoning = False` on the two shipped
+read-only profiles that carried it (`high_accuracy`, `research_papers`),
+because with `max_tokens = 100` the free-form reasoning text leaves ~60
+tokens for the JSON payload: truncation causes a parse failure, and the
+call is **billed but unscored** (for listwise, the whole rerank fails).
+Built-in profiles never persist to disk, so every install picks the fix up.
+
+**A profile a user CLONED from either of those before the fix keeps
+`include_reasoning = true` in their own saved profile**, and no migration
+was written. Until TASK-17065, reranking called zero providers, so this
+cost nothing; it now spends on every search for those users — the exact
+failure mode AC#11 exists to prevent, just on the copies rather than the
+originals.
+
+## Acceptance Criteria (the what)
+
+- [ ] A decision is recorded, either arm acceptable: user profiles carrying
+      `include_reasoning = true` alongside a small `max_tokens` are migrated
+      on load, OR `max_tokens` is made strategy/reasoning-aware so the
+      combination cannot truncate (the review's alternative: >= 400 tokens
+      when reasoning is on)
+- [ ] Whichever arm ships, a saved profile with
+      `include_reasoning = true, max_tokens = 100` no longer produces a
+      billed-but-unscored call
+- [ ] A test drives the chosen path with a faked provider seam (no live
+      calls) and asserts the reranked rows come back scored
+- [ ] If migration is the arm: it is idempotent, and a profile the user
+      deliberately set to a large `max_tokens` with reasoning on is left
+      alone

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -401,12 +401,18 @@ class ConfigProfileManager:
         accurate_rag.search.include_citations = True
         accurate_rag.search.score_threshold = 0.7
 
+        # include_reasoning stays OFF (TASK-17065 AC#11). The flag appends a
+        # free-form "reasoning" string to the JSON body the parser needs,
+        # under RerankingConfig.max_tokens=100 -- and a truncated body is a
+        # JSONDecodeError, i.e. a row that was billed and left scored=False.
+        # It buys nothing: RerankingResult.reasoning is read nowhere outside
+        # reranker.py (_apply_scores copies only rerank_score onto the row).
         accurate_rerank = RerankingConfig(
             model_provider="openai",
             model_name="gpt-3.5-turbo",
             strategy="pointwise",
             top_k_to_rerank=15,
-            include_reasoning=True,
+            include_reasoning=False,
         )
 
         self._profiles["high_accuracy"] = ProfileConfig(
@@ -516,8 +522,12 @@ class ConfigProfileManager:
         research_rag.search.include_citations = True
         research_rag.search.default_top_k = 15
 
+        # include_reasoning OFF for the same reason as high_accuracy above,
+        # and more sharply here: listwise already spends ~40 of its 100
+        # tokens on the ranking array, and its one call covers the whole
+        # batch -- a truncated body fails the ENTIRE rerank, billed.
         research_rerank = RerankingConfig(
-            strategy="listwise", top_k_to_rerank=10, include_reasoning=True
+            strategy="listwise", top_k_to_rerank=10, include_reasoning=False
         )
 
         self._profiles["research_papers"] = ProfileConfig(

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -228,6 +228,18 @@ class BaseReranker(ABC):
                     model=self.config.model_name,
                     temp=self.config.temperature,
                     max_tokens=self.config.max_tokens,
+                    # STATED, not inherited. Every handler currently
+                    # DECLARES `streaming=False`, so the config is never
+                    # consulted -- but the shipped `CONFIG_TOML_CONTENT`
+                    # sets `streaming = true` for 18 of the 29 providers
+                    # (every keyless local among them), and one handler
+                    # declaring `streaming: bool | None = None` would hand
+                    # this function a generator. Nothing here would raise:
+                    # `str(<generator>)` parses as no JSON, every row comes
+                    # back `scored=False`, and the search is billed in full
+                    # for an entirely unscored rerank. Pinned by
+                    # Tests/RAG_Search/test_reranker_degraded_paths.py.
+                    streaming=False,
                 ),
             )
 

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -6,6 +6,7 @@ to evaluate and reorder search results based on their relevance to the query.
 """
 
 import asyncio
+import functools
 from typing import List, Optional, Union, Literal, Tuple
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
@@ -22,7 +23,6 @@ except ImportError:
     np = None
 
 from ..Chat.Chat_Functions import chat_api_call
-from ..config import load_settings
 from ..Metrics.metrics_logger import log_counter, log_histogram, timeit
 from tldw_chatbook.Internal_Prompts import get_internal_prompt, safe_substitute
 from .simplified.vector_store import SearchResult, SearchResultWithCitations
@@ -125,7 +125,6 @@ class BaseReranker(ABC):
     def __init__(self, config: RerankingConfig):
         self.config = config
         self._cache = {} if config.cache_results else None
-        self._settings = load_settings()
         # NOTE (TASK-3502 AC#4): a reranker carries NO per-call state. How
         # many scoring attempts failed is part of `rerank()`'s RETURN value
         # (`RerankOutcome`), because the service holds this object as a
@@ -183,28 +182,20 @@ class BaseReranker(ABC):
     async def _call_llm_impl(
         self, prompt: str, system_prompt: Optional[str] = None
     ) -> str:
-        """Implementation of LLM call."""
-        # Get API key from settings
-        api_key = None
-        if self.config.model_provider == "openai":
-            api_key = self._settings.get("API", {}).get("openai_api_key")
-        elif self.config.model_provider == "anthropic":
-            api_key = self._settings.get("API", {}).get("anthropic_api_key")
-        elif self.config.model_provider == "groq":
-            api_key = self._settings.get("API", {}).get("groq_api_key")
-        elif self.config.model_provider == "deepseek":
-            api_key = (
-                self._settings.get("api_settings", {})
-                .get("deepseek", {})
-                .get("api_key")
-            )
-        # Add other providers as needed
+        """Implementation of LLM call.
 
-        if not api_key:
-            raise ValueError(
-                f"No API key found for provider: {self.config.model_provider}"
-            )
-
+        The reranker resolves NO credential of its own (TASK-17065). Each
+        ``chat_with_<provider>`` handler behind ``chat_api_call`` resolves
+        its own key when the caller passes none -- through the normalised
+        config path, with the precedence CLAUDE.md documents and
+        ``resolve_provider_api_key``'s validity check applied -- and the
+        keyless local providers (``ollama``/``llama_cpp``/``vllm``/
+        ``koboldcpp``/``mlx_lm``/...) need none at all. This module used to
+        hand-roll an ``if/elif`` over ``self._settings["API"]``, a table
+        ``load_settings()`` never builds, and then reject every provider it
+        did not name; that is how reranking reached 0 of the 29 providers
+        the picker offers. Credential resolution is not this module's job.
+        """
         # Prepare messages
         messages_payload = []
         if system_prompt or self.config.system_prompt:
@@ -221,19 +212,23 @@ class BaseReranker(ABC):
 
         # Call using chat_api_call
         try:
-            # Run in executor since chat_api_call is sync
-            import asyncio
-
+            # Run in executor since chat_api_call is sync. KEYWORDS, through
+            # a partial: `run_in_executor` forwards only positionals, and a
+            # positional list at this signature is exactly what used to route
+            # the credential into `api_endpoint` -- the "Unsupported API
+            # endpoint: <key>" failure, and the key-in-a-log-line disclosure
+            # TASK-17165 had to redact downstream.
             loop = asyncio.get_event_loop()
             response = await loop.run_in_executor(
                 None,
-                chat_api_call,
-                api_key,  # api_key
-                messages_payload,  # messages_payload
-                self.config.model_provider,  # provider
-                self.config.model_name,  # model
-                self.config.temperature,  # temp
-                self.config.max_tokens,  # maxp
+                functools.partial(
+                    chat_api_call,
+                    api_endpoint=self.config.model_provider,
+                    messages_payload=messages_payload,
+                    model=self.config.model_name,
+                    temp=self.config.temperature,
+                    max_tokens=self.config.max_tokens,
+                ),
             )
 
             # Extract the text response

--- a/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
@@ -322,10 +322,17 @@ def normalise_library_rag_reranker_provider(value: Any) -> str:
         a blank value the control shows the provider that would really be
         billed. A name this build does not register (a hand-edited profile
         file, a provider from a newer build) resolves there too rather than
-        raising ``InvalidSelectValueError`` out of ``compose()`` -- and in
-        THAT branch the control is showing the default while the profile
-        still carries the unrecognised name, which the picker cannot
-        currently repair (TASK-17065 owns display + repair for it).
+        raising ``InvalidSelectValueError`` out of ``compose()`` -- so in
+        THAT branch the control shows the default while the profile still
+        carries the unrecognised name. That branch IS repairable: the
+        reranker-provider change guard no longer folds an unrecognised
+        loaded value back (see ``settings_screen``'s
+        ``handle_library_rag_reranker_provider_changed``), so picking a
+        registered provider over it stages and saves
+        (``Tests/UI/test_settings_rag_profile_region.py::
+        test_an_unrecognised_stored_provider_is_repairable_from_the_picker``).
+        Left unrepaired, the stored name reaches ``chat_api_call``, which
+        cannot route it, and the results screen discloses the skip.
     """
     text = str(value).strip()
     if not text:

--- a/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
@@ -25,6 +25,14 @@ DEFAULT_DISTANCE_METRIC = "cosine"
 #: it); kept honest by
 #: ``test_reranker_provider_default_constant_matches_rerankingconfig_default``.
 DEFAULT_RERANKER_PROVIDER = "openai"
+#: ``1 + RerankingConfig().max_retries`` (RAG_Search/reranker.py) -- the
+#: attempts ONE candidate can cost. `BaseReranker._call_llm` retries every
+#: `Exception`, not just transient ones, so a provider that is down (or a
+#: credential that is wrong) multiplies the per-search call count by this,
+#: measured: 3 candidates against an erroring provider issue 9 calls. Same
+#: hardcode-not-import trade as the two constants above; kept honest by
+#: ``test_reranker_attempts_constant_matches_rerankingconfig_retries``.
+RERANKER_ATTEMPTS_PER_CANDIDATE = 3
 MIN_RAG_RESULT_COUNT = 1
 MAX_RAG_RESULT_COUNT = 100
 MIN_RAG_BALANCE = 0.0

--- a/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_library_rag_defaults.py
@@ -269,13 +269,13 @@ def library_rag_reranker_providers() -> tuple[str, ...]:
     deliberately light (see ``load_direct_library_tools``), and
     ``Chat_Functions`` is not.
 
-    This enumerates what ``chat_api_call`` can ROUTE, which is not the same
-    as what the reranker can currently CALL: its credential lookup
-    (``_call_llm_impl``) covers far fewer providers than the table has
-    rows, so most picks fail at run time -- disclosed on the results screen
-    ("Reranking was skipped (No API key found for provider: X)") rather
-    than silently. TASK-17065 owns closing that gap, and until it does the
-    honest reading of this list is "offered", not "guaranteed callable".
+    This enumerates what ``chat_api_call`` can ROUTE, and since TASK-17065
+    that is also what the reranker can CALL: it resolves no credential of
+    its own any more and dispatches by keyword, so each row reaches its
+    registered handler and each handler resolves its own key (the keyless
+    local providers need none). Whether a given provider then ANSWERS is
+    that provider's business -- a refusal is disclosed on the results
+    screen ("Reranking was skipped (...)") rather than silently.
 
     Returns:
         Every registered chat provider name, ``DEFAULT_RERANKER_PROVIDER``

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -265,6 +265,7 @@ from .settings_appearance_defaults import (
 from .settings_library_rag_defaults import (
     CONSOLE_DIRECT_LIBRARY_TOOLS_COPY,
     DEFAULT_RERANKER_PROVIDER,
+    RERANKER_ATTEMPTS_PER_CANDIDATE,
     SettingsLibraryRagDefaults,
     build_library_rag_save_sections,
     library_rag_reranker_provider_options,
@@ -12979,30 +12980,52 @@ class SettingsScreen(BaseAppScreen):
     def _library_rag_rerank_cost_disclosure(values: Mapping[str, object]) -> str:
         """The Reranking fold's cost disclosure (TASK-3502 AC#2).
 
-        Pointwise reranking -- the shipped strategy -- issues ONE provider
-        call per candidate, so enabling it silently multiplies a search's
-        spend by the rerank top-k. That was stated nowhere before the user
-        committed to the toggle. Static honest text, deliberately NOT a
-        live price estimate: this repo owns no per-provider pricing table
-        for the reranker's models, and a wrong number would be worse than
-        an honest ceiling.
+        Pointwise reranking -- what this toggle creates (a bare
+        ``RerankingConfig()``) and the strategy this fold can edit --
+        issues ONE provider call per candidate, so enabling it silently
+        multiplies a search's spend by the rerank top-k. That was stated
+        nowhere before the user committed to the toggle. Static honest
+        text, deliberately NOT a live price estimate: this repo owns no
+        per-provider pricing table for the reranker's models, and a wrong
+        number would be worse than an honest ceiling.
+
+        The retry factor is part of the ceiling (TASK-17065 final review
+        F1): ``BaseReranker._call_llm`` retries EVERY exception, twice by
+        default, so the honest worst case is ``top_k x 3`` -- measured, 3
+        candidates against an erroring provider issue 9 calls and 20 issue
+        60. The other two strategies are not reachable from this fold: a
+        built-in preset may carry ``listwise`` (exactly 1 call per search,
+        so this line over-states there) or ``pairwise`` (a merge sort:
+        40-69 comparisons at top_k=20, so it would under-state); see
+        Docs/User_Guide/settings/rag.md, which states all three shapes.
 
         Args:
             values: The category's current (draft-aware) field values.
 
         Returns:
             One sentence naming the provider the calls are billed to and
-            the configured per-search call ceiling.
+            the configured per-search call ceiling, retries included.
         """
         provider = (
             str(values.get("reranker_provider") or "").strip()
             or DEFAULT_RERANKER_PROVIDER
         )
         top_k = values.get("reranker_top_k")
+        try:
+            retry_ceiling = int(top_k) * RERANKER_ATTEMPTS_PER_CANDIDATE
+        except (TypeError, ValueError):
+            # The box holds free text mid-edit; disclose the base ceiling
+            # rather than crash the fold on a half-typed number.
+            retry_ceiling = None
+        retries = (
+            f", or {retry_ceiling} if calls fail and are retried"
+            if retry_ceiling is not None
+            else ""
+        )
         return (
             f"Reranking scores each result with a separate {provider} call "
-            f"— up to {top_k} calls per search, billed at that provider's "
-            "rates."
+            f"— up to {top_k} calls per search{retries}, billed at that "
+            "provider's rates."
         )
 
     def _update_library_rag_rerank_disclosure(


### PR DESCRIPTION
## What this fixes

Reranking has never worked. TASK-3502's review established that credential resolution reached 1 of 29 providers and end-to-end dispatch reached **0 of 29**: the reranker read a settings table `load_settings()` never builds, then called `chat_api_call` with the wrong positional order, so the API key landed in `api_endpoint`.

**The repair is a deletion.** Verified live: all 29 handlers either resolve their own credential (22 via `api_key or <config>`; `qwencloud`, `custom-openai-api`, `moonshot`, `zai` via their own resolvers) or need no key (`mlx_lm`, `local_mlx_lm`, `local-llm`). And every other `chat_api_call` caller in the repo already uses keywords and omits `api_key`. So the reranker's credential block and its `load_settings()` read are gone, and the call is now `functools.partial(chat_api_call, api_endpoint=…, messages_payload=…, model=…, temp=…, max_tokens=…, streaming=False)` — the house pattern. Writing a second resolver would have re-created the divergence that caused this.

A third defect fell out of the repair: the old positional list put the token cap into `streaming` (truthy), so any call that *had* resolved a credential would have streamed.

## The spend disclosure — measured, not estimated

This converts a silent no-op into real provider calls, so the note has to be right. The first draft said "one call per candidate, up to top-k". The final review measured it and that was **wrong for two of three strategies**; the wave re-measured independently (200 randomised pairwise runs plus an external simulation of the same merge):

| strategy | calls per search |
|---|---|
| pointwise | up to **top_k × 3** — retries fire on *any* exception (9 calls for 3 candidates, 60 for 20) |
| pairwise | **40–69** at top_k=20 (merge sort) |
| listwise | **1** |

The Settings cost line derives its multiplier from `1 + RerankingConfig().max_retries` rather than hardcoding it. And a second correction: **three shipped profiles** (Hybrid Full, High Accuracy, Research Papers) carry a reranking config and therefore spend *without* the user ticking "Enable reranking" — both surfaces now name them and say switching preset is itself a spend decision. The active default, Hybrid Basic, carries none.

`Docs/User_Guide/settings/rag.md` needed correcting regardless: it documented the defect as an open gap in three places.

## Spend safety (AC#11, added before implementing)

`include_reasoning=True` on two shipped profiles left ~60 tokens for free-form text under `max_tokens=100` — truncation causes a JSON parse failure and a **billed-but-unscored** call (listwise fails the entire rerank). Since `reasoning` is never read outside the reranker, it is now off on those two profiles. Because that exceeded the filed ACs, AC#11 was added to the task file first, per the repo's own rule.

## Test honesty

- The red-on-repair seam guard was **flipped** — that rewrite is the proof the repair happened.
- Every fake at this seam was corrected. One didn't merely mirror the caller's wrong order, it *planted* `reranker._settings`, simulating the phantom table production could never have.
- A claim of mine was wrong and is corrected everywhere it appeared: `inspect.signature(...).bind()` does **not** reject a mis-ordered positional call. The fakes now reject positionals explicitly (`assert not args`), and that is mutation-verified — a positional revert fails **12** tests.
- The lesson in `lessons-testing-evidence.md` was extended (not duplicated) with this incident, including that the purpose-built guard originally re-typed the caller's own tuple and therefore caught nothing.

## Verification and its limits

`Tests/RAG_Search/` 359 passed / 12 skipped; settings+library 355; RAG UI 215; the 4 pre-existing `tomli`/`nltk` reds are environmental and named. The gated eval suite passes and **is vacuous for the reranker** — no gated cell constructs one; it is evidence of no regression elsewhere and evidence of nothing about this repair.

**Two honest limits.** AC#4 is evidenced to the dispatcher, not over the wire — no live provider call was permitted, so the first real reranking search is both the last mile of that AC and the first spend. And the scoped re-review of the fix wave **did not finish**: the account hit its weekly limit mid-run. It died during its F4 mutation check and left the mutation in the tree; I caught that (12 sudden failures), restored it Edit-based, and verified byte-exact against HEAD with the suite back to 359. I then completed its remaining checks inline — `streaming=False` at the call site, `include_reasoning=False` on exactly the two profiles, the fake's positional rejection, both follow-ups filed. What never got a *third* independent pass is the spend figures (measured twice: review, then wave) and F6/F7's substance.

## Follow-ups filed

- **TASK-17265** — the reranker's system prompt goes in-band and never as `system_message=`; `chat_with_anthropic` discards it and `chat_with_google` skips non-user/assistant roles, so the JSON contract never reaches those models.
- **TASK-17365** — built-ins never persist, so a profile a user *cloned* from High Accuracy or Research Papers keeps `include_reasoning=true` and will pay for unscored calls; migrate on load, or make `max_tokens` reasoning-aware.

Refs TASK-17065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reranking now calls real providers through `chat_api_call` with keyword args and no credential lookup, with `streaming=False`. Previously it read a non-existent settings table and called positionally, so 0/29 providers ran; profiles with a reranker now issue real calls and incur spend.

**Review and rollout notes**
- Code: delete `load_settings` and positional dispatch in `RAG_Search/reranker.py`; bind `chat_api_call` via `functools.partial` with keywords and `streaming=False`. Tests bind against the real signature and reject positionals; fakes report a generic provider failure.
- Spend disclosure: UI and User Guide state measured per-strategy call counts and retries. Pointwise: up to `top_k × 3`; pairwise: 40–69 calls at `top_k=20`; listwise: 1 call, up to 3 with retries. New `RERANKER_ATTEMPTS_PER_CANDIDATE = 3` mirrors `1 + RerankingConfig.max_retries`.
- Presets: Hybrid Full, High Accuracy, and Research Papers include a reranker and will spend without toggling “Enable reranking”; Hybrid Basic remains no‑spend. `high_accuracy` and `research_papers` now set `include_reasoning=False` to avoid billed‑but‑unscored calls.
- Migration action: If you cloned `high_accuracy` or `research_papers`, set `include_reasoning=false` in your saved profile.
- Follow‑ups: TASK‑17265 (deliver system prompts to anthropic/google) and TASK‑17365 (migrate cloned profiles’ `include_reasoning`).

<sup>Written for commit 769e86e02e70c9ca4b31ce6be144a20f322d181e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

