### PR TITLE
feat(research): show and persist the multi-hop rounds a run will use

### DIFF
--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -372,14 +373,16 @@ def test_window_academic_toggle_defaults_off_and_persists_in_state():
     window = ResearchWindow(app_instance=app)
 
     assert window.academic_enabled is False
+    # "rounds" joined the persisted state in task-17371 -- the window now shows
+    # and remembers how many multi-hop rounds it will launch with.
     assert window.save_state() == {"source": "local", "academic": False,
                                    "limits": "", "policy": "balanced",
-                                   "providers": ""}
+                                   "providers": "", "rounds": 2}
 
     window.academic_enabled = True
     assert window.save_state() == {"source": "local", "academic": True,
                                    "limits": "", "policy": "balanced",
-                                   "providers": ""}
+                                   "providers": "", "rounds": 2}
 
 
 def test_window_academic_toggle_restores_from_state():
@@ -463,8 +466,10 @@ async def test_create_run_carries_parsed_limits(monkeypatch):
     await window.create_run({"query": "Budgeted question"})
 
     create_call = [c for c in service.calls if c[0] == "create_run"][0]
+    # max_iterations rides along from the rounds control (task-17371) whenever
+    # the limits text does not state one; the typed budget keys are untouched.
     assert create_call[2]["limits_json"] == {
-        "max_searches": 3, "max_fetched_docs": 10.0,
+        "max_searches": 3, "max_fetched_docs": 10.0, "max_iterations": 2,
     }
 
 
@@ -779,7 +784,7 @@ async def test_create_run_reads_limits_and_providers_from_inputs(monkeypatch):
     create_call = [c for c in service.calls if c[0] == "create_run"][0]
     payload = create_call[2]
     assert payload["provider_overrides"]["academic_providers"] == ["pubmed", "arxiv"]
-    assert payload["limits_json"] == {"max_searches": 3}
+    assert payload["limits_json"] == {"max_searches": 3, "max_iterations": 2}
 
 
 def test_parse_provider_tokens_validates_and_dedupes():
@@ -823,3 +828,114 @@ def test_window_engine_start_passes_configured_pipeline_params(monkeypatch):
     assert search_params, "the window must assemble pipeline params, not pass none"
     missing = [k for k in GENERATE_AND_SEARCH_REQUIRED_PARAMS if k not in search_params]
     assert not missing, f"assembly is missing pipeline-required keys: {missing}"
+
+
+# --- per-run multi-hop control (task-17371 AC #2) -----------------------------
+# The shipped default became 2 rounds, but a user could only override it by
+# typing "max_iterations=N" into the limits box -- i.e. the setting existed and
+# was invisible. The window now shows the rounds it will launch with, persists
+# the choice, and carries it into the run's limits.
+
+
+def test_rounds_control_defaults_to_the_engine_default(monkeypatch):
+    from tldw_chatbook.Research_Interop import local_research_engine as engine_module
+
+    monkeypatch.setattr(engine_module, "_configured_max_iterations", lambda: 2)
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(), local_research_service=None
+    )
+
+    assert ResearchWindow(app_instance=app).iteration_rounds == 2
+
+
+def test_rounds_choice_survives_a_state_round_trip():
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(), local_research_service=None
+    )
+    window = ResearchWindow(app_instance=app)
+    window.iteration_rounds = 3
+
+    restored = ResearchWindow(app_instance=app)
+    restored.restore_state(window.save_state())
+
+    assert restored.iteration_rounds == 3
+
+
+def test_rounds_choice_reaches_the_run_limits():
+    """The control is pointless unless the launched run carries it."""
+    captured = {}
+
+    class _Controller:
+        async def create_run(self, source, payload):
+            captured.update(payload)
+            return {"id": "run-1"}
+
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(), local_research_service=None
+    )
+    window = ResearchWindow(app_instance=app)
+    window.controller = _Controller()
+    window.iteration_rounds = 3
+    window._start_local_engine = lambda run_id: None
+
+    asyncio.run(window.create_run({"query": "q"}))
+
+    assert captured["limits_json"]["max_iterations"] == 3
+
+
+def test_typed_limits_win_over_the_rounds_control():
+    """A typed max_iterations is the more specific statement of intent, and is
+    what the engine treats as authoritative -- the control must not silently
+    overwrite it."""
+    captured = {}
+
+    class _Controller:
+        async def create_run(self, source, payload):
+            captured.update(payload)
+            return {"id": "run-1"}
+
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(), local_research_service=None
+    )
+    window = ResearchWindow(app_instance=app)
+    window.controller = _Controller()
+    window.iteration_rounds = 3
+    window.limits_text = "max_iterations=1"
+    window._start_local_engine = lambda run_id: None
+
+    asyncio.run(window.create_run({"query": "q"}))
+
+    assert captured["limits_json"]["max_iterations"] == 1
+
+
+def test_rounds_control_mounts_and_reports_its_choice():
+    """Compose-level check: an int-valued Select renders with the default
+    selected, and choosing a value updates both state and the status line."""
+    from textual.app import App, ComposeResult
+    from textual.widgets import Select
+
+    class _Harness(App):
+        def __init__(self):
+            super().__init__()
+            self.research_scope_service = FakeResearchScopeService()
+            self.local_research_service = None
+            self.window = None
+
+        def compose(self) -> ComposeResult:
+            self.window = ResearchWindow(app_instance=self)
+            yield self.window
+
+    async def _drive():
+        app = _Harness()
+        async with app.run_test() as pilot:
+            select = app.window.query_one("#research-rounds-select", Select)
+            assert select.value == 2, select.value
+
+            select.value = 1
+            await pilot.pause()
+            assert app.window.iteration_rounds == 1
+            assert "single pass" in app.window.status_message.lower(), (
+                app.window.status_message
+            )
+
+    asyncio.run(_drive())

--- a/Tests/UI/test_research_screen.py
+++ b/Tests/UI/test_research_screen.py
@@ -838,6 +838,8 @@ def test_window_engine_start_passes_configured_pipeline_params(monkeypatch):
 
 
 def test_rounds_control_defaults_to_the_engine_default(monkeypatch):
+    """The control must show the engine's own default, not a second one that
+    could drift from what a run would actually use."""
     from tldw_chatbook.Research_Interop import local_research_engine as engine_module
 
     monkeypatch.setattr(engine_module, "_configured_max_iterations", lambda: 2)
@@ -849,6 +851,7 @@ def test_rounds_control_defaults_to_the_engine_default(monkeypatch):
 
 
 def test_rounds_choice_survives_a_state_round_trip():
+    """A chosen round count is remembered, not reset on the next visit."""
     app = SimpleNamespace(
         research_scope_service=FakeResearchScopeService(), local_research_service=None
     )
@@ -939,3 +942,93 @@ def test_rounds_control_mounts_and_reports_its_choice():
             )
 
     asyncio.run(_drive())
+
+
+def test_rounds_control_mounts_when_the_configured_default_exceeds_the_options():
+    """Qodo (PR 1769): the Select offered 1-4 with allow_blank=False, so an
+    install configuring more rounds -- or restoring such a state -- raised
+    InvalidSelectValueError and the whole window failed to mount."""
+    from textual.app import App, ComposeResult
+    from textual.widgets import Select
+    from tldw_chatbook.Research_Interop import local_research_engine as engine_module
+    import pytest as _pytest
+
+    class _Harness(App):
+        def __init__(self):
+            super().__init__()
+            self.research_scope_service = FakeResearchScopeService()
+            self.local_research_service = None
+            self.window = None
+
+        def compose(self) -> ComposeResult:
+            self.window = ResearchWindow(app_instance=self)
+            yield self.window
+
+    async def _drive(monkeypatched_default: int):
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            select = app.window.query_one("#research-rounds-select", Select)
+            assert select.value == monkeypatched_default, select.value
+
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(engine_module, "_configured_max_iterations", lambda: 6)
+        asyncio.run(_drive(6))
+
+
+def test_restoring_a_high_rounds_state_does_not_crash_the_mounted_control():
+    """Same failure mode reached through restore_state rather than config."""
+    from textual.app import App, ComposeResult
+    from textual.widgets import Select
+
+    class _Harness(App):
+        def __init__(self):
+            super().__init__()
+            self.research_scope_service = FakeResearchScopeService()
+            self.local_research_service = None
+            self.window = None
+
+        def compose(self) -> ComposeResult:
+            self.window = ResearchWindow(app_instance=self)
+            yield self.window
+
+    async def _drive():
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.window.restore_state({"source": "local", "rounds": 7})
+            await pilot.pause()
+            select = app.window.query_one("#research-rounds-select", Select)
+            assert app.window.iteration_rounds == 7
+            assert select.value == 7, select.value
+
+    asyncio.run(_drive())
+
+
+def test_typed_max_iterations_wins_whatever_its_casing():
+    """Qodo (PR 1769): _parse_limits_text preserves key casing, so a typed
+    "Max_Iterations=1" was invisible to the presence check -- the control
+    injected its own value and the engine, which reads the canonical lowercase
+    key, silently used that instead of what the user asked for."""
+    captured = {}
+
+    class _Controller:
+        async def create_run(self, source, payload):
+            captured.update(payload)
+            return {"id": "run-1"}
+
+    app = SimpleNamespace(
+        research_scope_service=FakeResearchScopeService(), local_research_service=None
+    )
+    window = ResearchWindow(app_instance=app)
+    window.controller = _Controller()
+    window.iteration_rounds = 3
+    window.limits_text = "Max_Iterations=1, max_searches=5"
+    window._start_local_engine = lambda run_id: None
+
+    asyncio.run(window.create_run({"query": "q"}))
+
+    limits = captured["limits_json"]
+    assert limits["max_iterations"] == 1, limits
+    assert [k for k in limits if k.lower() == "max_iterations"] == ["max_iterations"], limits
+    assert limits["max_searches"] == 5

--- a/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
+++ b/backlog/tasks/task-17371 - Enable-sub-question-decomposition-and-bounded-multi-hop-for-shipped-research-runs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17371
 title: Enable sub-question decomposition and bounded multi-hop for shipped research runs
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-08-17 07:30'
@@ -22,7 +22,7 @@ Sub-question fan-out and gap-driven replanning both ship but are off by default:
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 The shipped default for research-run decomposition is set from the task-17370 measurement, and the choice is recorded with the numbers that justify it.
-- [ ] #2 A user can see and change the decomposition settings for a run before launching it, and the setting persists.
+- [x] #2 A user can see and change the decomposition settings for a run before launching it, and the setting persists.
 - [x] #3 The expected spend implication of the chosen default is documented where a user meets it, since fan-out multiplies gate LLM calls per run and iterations multiply rounds on top.
 - [x] #4 Existing runs, artifacts and tests that assume single-pass behaviour continue to pass or are updated with the reason recorded.
 <!-- AC:END -->
@@ -98,10 +98,19 @@ baseline recorder's tests, which pin that it passes `max_iterations`
 EXPLICITLY (default 1) -- the property that keeps recorded baselines
 reproducible byte-for-byte under a changed shipped default.
 
-AC #2 remains open: a user can override per run today only by typing limits
-into the Research window's existing input. A real control that shows the
-current setting and persists it is still to do, and is the part that matters
-more than the default itself.
+AC #2: the Research window now carries a rounds Select beside its policy
+picker, defaulting to the ENGINE's own resolver (`_configured_max_iterations`)
+rather than a second default that could drift from it, persisted through
+`save_state`/`restore_state` like the academic lane toggle, and merged into the
+launched run's `limits_json`. A typed `max_iterations=N` in the limits box still
+wins, because that is the more specific statement of intent and is what the
+engine treats as authoritative. Selecting a value states the trade-off in the
+status line rather than leaving the spend implicit.
+
+Three existing tests asserted the exact persisted state and `limits_json` and
+were updated with the reason recorded in-line (AC #4's requirement): the
+window's state gained `rounds`, and a launched run now carries `max_iterations`
+whenever the limits text does not state one.
 
 Modified: `tldw_chatbook/Research_Interop/local_research_engine.py`,
 `tldw_chatbook/config.py`,

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -100,6 +100,23 @@ def _parse_config_bool(value: Any) -> bool:
     return str(value or "").strip().lower() in {"true", "1", "yes", "on"}
 
 
+def _iteration_rounds_default() -> int:
+    """Rounds the window offers by default (task-17371).
+
+    Deliberately delegates to the engine's own resolver so the number a user
+    sees is the number a run would have used anyway -- a second default here
+    would drift from it. Lazy import keeps the window's module import cheap.
+    """
+    try:
+        from ..Research_Interop.local_research_engine import (
+            _configured_max_iterations,
+        )
+
+        return max(1, int(_configured_max_iterations()))
+    except Exception:  # noqa: BLE001 - a UI default must never fail to load
+        return 1
+
+
 def _academic_lane_default() -> bool:
     """Config default for the academic lane toggle: [SearchSettings]
     research_academic_lane (default False). Failures default OFF -- the
@@ -130,6 +147,10 @@ class ResearchWindow(Vertical):
         # task-16328: academic lane toggle (arXiv + Semantic Scholar papers
         # join the run's evidence pool when enabled).
         self.academic_enabled = _academic_lane_default()
+        # task-17371: rounds this window will launch with (multi-hop). Shown
+        # rather than buried in the limits box, and persisted like the lane
+        # toggle; a typed max_iterations still wins on create.
+        self.iteration_rounds = _iteration_rounds_default()
         # task-16334: budget limits text (parsed into limits_json on create)
         # and the rendered follow-up answer.
         self.limits_text = ""
@@ -169,6 +190,12 @@ class ResearchWindow(Vertical):
                 value=self.source_policy,
                 allow_blank=False,
                 id="research-policy-select",
+            )
+            yield Select(
+                [("1 round", 1), ("2 rounds", 2), ("3 rounds", 3), ("4 rounds", 4)],
+                value=self.iteration_rounds,
+                allow_blank=False,
+                id="research-rounds-select",
             )
             yield Input(
                 placeholder="Providers: arxiv, pubmed",
@@ -219,6 +246,7 @@ class ResearchWindow(Vertical):
             "limits": self.limits_text,
             "policy": self.source_policy,
             "providers": self.providers_text,
+            "rounds": self.iteration_rounds,
         }
 
     def restore_state(self, state: dict[str, Any]) -> None:
@@ -233,7 +261,16 @@ class ResearchWindow(Vertical):
             } else "balanced"
         )
         self.providers_text = str((state or {}).get("providers") or "")
+        try:
+            rounds = int((state or {}).get("rounds") or 0)
+        except (TypeError, ValueError):
+            rounds = 0
+        self.iteration_rounds = rounds if rounds >= 1 else _iteration_rounds_default()
         self._sync_academic_toggle()
+        try:
+            self.query_one("#research-rounds-select", Select).value = self.iteration_rounds
+        except Exception:
+            pass  # not mounted yet; compose()'s initial value covers it
         try:
             self.query_one("#research-limits-input", Input).value = self.limits_text
         except Exception:
@@ -331,6 +368,21 @@ class ResearchWindow(Vertical):
         self.source_policy = str(event.value or "balanced")
         self._set_status(f"Source policy: {self.source_policy}")
 
+    @on(Select.Changed, "#research-rounds-select")
+    def _on_rounds_changed(self, event: Select.Changed) -> None:
+        try:
+            self.iteration_rounds = max(1, int(event.value))
+        except (TypeError, ValueError):
+            return
+        if self.iteration_rounds == 1:
+            self._set_status("Rounds: 1 (single pass -- no gap-driven follow-up).")
+        else:
+            self._set_status(
+                f"Rounds: {self.iteration_rounds}. Each extra round researches the "
+                "gaps the previous answer left open -- more evidence, and "
+                "proportionally more searches and LLM calls."
+            )
+
     @on(Checkbox.Changed, "#research-academic-toggle")
     def _on_academic_toggle_changed(self, event: Checkbox.Changed) -> None:
         self.academic_enabled = bool(event.value)
@@ -378,6 +430,11 @@ class ResearchWindow(Vertical):
         limits, warnings = _parse_limits_text(self.limits_text)
         if warnings:
             self._set_status("Limits: " + "; ".join(warnings))
+        # task-17371: the rounds control contributes max_iterations unless the
+        # limits box already states one -- a typed value is the more specific
+        # statement of intent, and is what the engine treats as authoritative.
+        if "max_iterations" not in limits:
+            limits = {**limits, "max_iterations": max(1, int(self.iteration_rounds or 1))}
         if limits:
             payload = {**payload, "limits_json": limits}
         # task-16791: lane routing + provider selection ride the run record.

--- a/tldw_chatbook/UI/Research_Window.py
+++ b/tldw_chatbook/UI/Research_Window.py
@@ -100,6 +100,26 @@ def _parse_config_bool(value: Any) -> bool:
     return str(value or "").strip().lower() in {"true", "1", "yes", "on"}
 
 
+def _rounds_options(current: int) -> list[tuple[str, int]]:
+    """Rounds options that always include ``current`` (Qodo, PR 1769).
+
+    The control offered a fixed 1-4 with ``allow_blank=False``, so an install
+    configuring more rounds -- or a restored state holding more -- raised
+    InvalidSelectValueError and the window failed to mount entirely. Extending
+    the options rather than clamping the value keeps the control honest: it
+    shows what the run will actually do instead of quietly displaying a
+    different number.
+
+    Args:
+        current: The value that must be selectable.
+
+    Returns:
+        Ascending (label, value) pairs covering 1-4 plus ``current``.
+    """
+    values = sorted({1, 2, 3, 4, max(1, int(current or 1))})
+    return [(f"{n} round" if n == 1 else f"{n} rounds", n) for n in values]
+
+
 def _iteration_rounds_default() -> int:
     """Rounds the window offers by default (task-17371).
 
@@ -163,6 +183,11 @@ class ResearchWindow(Vertical):
         )
 
     def compose(self) -> ComposeResult:
+        """Build the window: toolbar, run-creation row, run list and detail pane.
+
+        Yields:
+            The window's child widgets, in mount order.
+        """
         yield Label("Research Sessions")
         with Horizontal(id="research-toolbar"):
             yield Select(
@@ -192,7 +217,7 @@ class ResearchWindow(Vertical):
                 id="research-policy-select",
             )
             yield Select(
-                [("1 round", 1), ("2 rounds", 2), ("3 rounds", 3), ("4 rounds", 4)],
+                _rounds_options(self.iteration_rounds),
                 value=self.iteration_rounds,
                 allow_blank=False,
                 id="research-rounds-select",
@@ -240,6 +265,12 @@ class ResearchWindow(Vertical):
                 )
 
     def save_state(self) -> dict[str, Any]:
+        """Capture the operator's run-creation choices for later restoration.
+
+        Returns:
+            The source, academic-lane flag, limits text, source policy,
+            provider tokens and multi-hop round count.
+        """
         return {
             "source": self.current_source,
             "academic": self.academic_enabled,
@@ -250,6 +281,15 @@ class ResearchWindow(Vertical):
         }
 
     def restore_state(self, state: dict[str, Any]) -> None:
+        """Reapply saved choices, falling back to defaults for bad values.
+
+        Every field is validated rather than trusted: an unknown source or
+        policy, or a non-positive round count, resolves to its default instead
+        of reaching a widget that would reject it.
+
+        Args:
+            state: A mapping previously produced by ``save_state`` (or empty).
+        """
         source = str((state or {}).get("source") or "local").strip().lower()
         self.current_source = source if source in {"local", "server"} else "local"
         self.academic_enabled = bool((state or {}).get("academic"))
@@ -268,7 +308,11 @@ class ResearchWindow(Vertical):
         self.iteration_rounds = rounds if rounds >= 1 else _iteration_rounds_default()
         self._sync_academic_toggle()
         try:
-            self.query_one("#research-rounds-select", Select).value = self.iteration_rounds
+            rounds_select = self.query_one("#research-rounds-select", Select)
+            # Widen first: assigning a value the mounted control does not offer
+            # raises InvalidSelectValueError (Qodo, PR 1769).
+            rounds_select.set_options(_rounds_options(self.iteration_rounds))
+            rounds_select.value = self.iteration_rounds
         except Exception:
             pass  # not mounted yet; compose()'s initial value covers it
         try:
@@ -415,6 +459,19 @@ class ResearchWindow(Vertical):
         return self.runs
 
     async def create_run(self, payload: dict[str, Any]) -> Any:
+        """Create a run from the payload plus this window's live inputs.
+
+        Reads the limits and providers inputs directly (rather than trusting
+        the seeded attributes), folds in the source policy, provider overrides
+        and the multi-hop round count, then starts the local engine for a
+        freshly created local run.
+
+        Args:
+            payload: Base run fields from the caller, e.g. the query.
+
+        Returns:
+            The created run record, or whatever the controller returned.
+        """
         # Qodo (PR 1722): read the inputs live -- restore_state seeds the
         # attributes, but typing in the widgets must reach the payload.
         try:
@@ -433,7 +490,22 @@ class ResearchWindow(Vertical):
         # task-17371: the rounds control contributes max_iterations unless the
         # limits box already states one -- a typed value is the more specific
         # statement of intent, and is what the engine treats as authoritative.
-        if "max_iterations" not in limits:
+        # Qodo (PR 1769): _parse_limits_text preserves key casing, so a typed
+        # "Max_Iterations=1" used to be invisible here AND invisible to the
+        # engine (which reads the canonical lowercase key), leaving the control's
+        # value in charge of a run the user had explicitly bounded. Any casing
+        # now counts, and is normalized onto the canonical key; a later variant
+        # wins, as a repeated key would.
+        typed_variants = [key for key in limits if key.lower() == "max_iterations"]
+        if typed_variants:
+            typed_value = limits[typed_variants[-1]]
+            limits = {
+                key: value
+                for key, value in limits.items()
+                if key not in typed_variants
+            }
+            limits["max_iterations"] = typed_value
+        else:
             limits = {**limits, "max_iterations": max(1, int(self.iteration_rounds or 1))}
         if limits:
             payload = {**payload, "limits_json": limits}


### PR DESCRIPTION
Closes **TASK-17371**'s last open criterion (AC #2). Single commit on top of `dev`, which now contains #1764 and #1766.

## Why

#1766 made multi-hop the shipped default (2 rounds), chosen from measured numbers. But a user could only *change* it by typing `max_iterations=N` into the limits box — a setting that existed and was invisible. AC #2 asked for a control that shows the setting and persists it, and I argued in that PR that the control matters more than the default itself.

## What

A rounds `Select` beside the policy picker in the Research window.

**Its default comes from the engine's own resolver** (`_configured_max_iterations`), not a second default of its own. A number displayed here that could drift from the number a run actually uses would be worse than showing nothing.

**Persistence** rides the existing `save_state`/`restore_state` path, exactly like the academic-lane toggle.

**Precedence:** the control contributes `max_iterations` to the launched run's `limits_json` **only when the limits text doesn't already state one**. A typed value is the more specific statement of intent, and it's what the engine treats as authoritative — the control must not silently overwrite it.

**Spend at the point of decision:** selecting a value states the trade-off in the status line ("each extra round researches the gaps the previous answer left open — more evidence, and proportionally more searches and LLM calls") rather than leaving it to a config comment the user will never open.

## Existing tests changed, with reasons in-line

Three tests pinned the exact persisted state and `limits_json` and now see the new key. Updated with the reason recorded at each site, which is what AC #4 requires:

- the window's persisted state gained `rounds`
- a launched run carries `max_iterations` whenever the limits text doesn't state one

## Verification

- **200 passed** across `Tests/UI/test_research_screen.py` and `Tests/Research`; `ruff` clean.
- Four new unit tests: default sourced from the engine, state round-trip, the value reaching `limits_json`, and typed limits winning.
- One **compose-level** test mounts the window in a Textual app and drives the `Select` — an int-valued `Select` rendering with the right option selected isn't something unit-level state can prove, and that's exactly the kind of thing that breaks silently.

## Note

I have not merged this one. Your merge authorization covered #1764 and #1766 specifically; this is new work, so it's yours to call. Qodo review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows and persists the multi-hop rounds a research run will use, and fixes two defects in the new control. Previously rounds were hidden and only changeable via limits text; now a visible rounds Select persists and adds max_iterations to limits unless the limits text already sets it.

- Default comes from the engine’s configured max_iterations to avoid drift; selecting a value updates the status line with expected spend. Satisfies TASK-17371 AC #2.
- Persistence: save_state adds rounds; restore_state restores it with a safe fallback and widens the mounted Select’s options to include the current value so high configured/restored rounds do not crash the window.
- Precedence and casing: a typed max_iterations wins over the control regardless of key casing; the value is normalized onto the canonical lowercase key so the engine receives it.
- Tests updated where persisted state and limits_json were pinned; new unit and compose-level tests cover default sourcing, round-trip, payload merge, casing precedence, and mounting with high rounds. 203 tests pass.

<sup>Written for commit 1bb7126326725a1874472804a4b0982acab2d6fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

