### PR TITLE
fix(console): the approval card no longer unrenders itself on first open (task-17500)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -605,16 +605,30 @@ still expires the request on schedule — being away does not buy the
 request extra time. The shipped default is `0`, which means no deadline:
 the request waits for you.
 
-**Known bug — the card opens empty; click the session tab to see it.**
-As shipped on 2026-08-17, opening Console in response to that toast shows
-an approval card with its "Approval required" title and *nothing else*:
-no tool name, no arguments, no Approve/Deny buttons. The round is fine —
-**clicking that conversation's session tab re-renders the card complete
-and answerable.** Until you do, the run stays blocked, and because only
-one wake is delivered at a time app-wide, other conversations' finished
-sub-agents wait behind it as well. Answering (or denying) the round
-releases them immediately. Tracked as task-17500; found by driving the
-real app, not by a test.
+**The card is rendered and answerable the first time you open Console —
+no session switch needed.** (Fixed as task-17500, 2026-08-17.) As first
+shipped, opening Console in response to that toast showed the card's
+"Approval required" title and *nothing else* — no tool row, no arguments,
+no Approve/Deny buttons — until you clicked that conversation's session
+tab. The cause was an ordering race inside the card itself: its initial
+"hide the batch body" step was deferred mount work, and on a real
+terminal the fresh Console screen's first paint delivered that hide
+*after* the mount-time sync had rendered the round, unrendering it. The
+hide is now construction state, so it cannot land on top of a rendered
+card.
+
+**While an approval waits, other conversations' owed wakes wait behind
+it — by design.** Wake deliveries are serialized app-wide (one delivery
+at a time for the whole app), so a pending approval round in one
+conversation holds every other conversation's owed wake until you answer
+it. Nothing is lost while it waits: the other conversations' `◈` marks
+and ledger rows are already durable, and answering (or denying) the
+round releases them immediately — observed live as a stalled
+conversation delivering the instant a blocked round was denied. This is
+the deliberate trade of the app-wide serialization invariant (one
+`_delivering` per runtime; see the headless-wake close-out report). With
+the card rendering correctly the hold is always answerable, so it lasts
+exactly as long as you leave the question open.
 
 One further limitation: if a woken turn arms two approval rounds for the
 same conversation, only the most recent one has a card to mount; the
@@ -1003,11 +1017,25 @@ every claim below checked against the app's own ChaChaNotes and
   row and fired no wake turn; turning it back on delivered exactly what
   OFF had recorded.*
 
-*Two things this pass could NOT confirm and which the text above now
-states honestly: the headless approval card mounts empty until you click
-the session tab (task-17500), and the live activity line's `⚙ <tool> ·
-Ns` state was not observable in a real run — every tool call in the
-session started and finished inside the same second (per the app's own
-Trajectory view), while the one long wait, an approval, renders
-`Thinking… · Ns`. The advancing elapsed itself was seen live
-(`Generating…` → `Thinking… · 1s` … `· 18s`).*
+*Two things that pass could NOT confirm: the headless approval card
+mounted empty until you clicked the session tab (filed then as
+task-17500, **since fixed — see the re-verification stamp below**), and
+the live activity line's `⚙ <tool> · Ns` state was not observable in a
+real run — every tool call in the session started and finished inside
+the same second (per the app's own Trajectory view), while the one long
+wait, an approval, renders `Thinking… · Ns`. The advancing elapsed
+itself was seen live (`Generating…` → `Thinking… · 1s` … `· 18s`).*
+
+*Headless-approval card re-verified against dev @ ee6c3d709 +
+fix/task-17500 — 2026-08-17. **Driven live in tmux** on an isolated
+scratch profile with a real Anthropic model, repeating the close-out's
+failing scenario: a risk-tagged `write_file` in a wake turn armed with
+the user on Library; the app-wide toast fired there; opening Console
+painted the FULL card the first time — `Built-in · write_file (high
+risk)`, the arguments, `Approve once / Deny` and the bulk buttons — with
+no session switch, and it stayed complete for the whole observation
+window (minutes, vs. the pre-fix pane that was title-only and stable
+that way). Answering through the rendered control is pinned by the
+automated first-open suite (a press on the painted button resolves the
+round); in the tmux rig the round was ended through the documented
+quit-denies path, and nothing was written to disk while it waited.*

--- a/Docs/superpowers/plans/2026-08-17-task-17500-report.md
+++ b/Docs/superpowers/plans/2026-08-17-task-17500-report.md
@@ -1,0 +1,255 @@
+# task-17500 report — the headless approval card mounted empty and could not be answered
+
+- Branch `fix/task-17500-empty-approval-card`, worktree `.worktrees/fix-17500`,
+  base `origin/dev` `ee6c3d709`.
+- Filed by the task-15860 close-out live pass (its §3.3 is the reproduction);
+  the approval landing's report (`…-headless-wake-approval-report.md`) is the
+  history of the path this bug lives on.
+
+**One sentence:** the card's own initial "hide the batch body" step was
+*deferred mount work* that a real terminal's slow first paint delivered
+AFTER the mount-time sync had rendered the round — unrendering it into the
+"Approval required"-and-nothing-else pane the live pass photographed; every
+initial hide is now construction state, so no late write can land on a
+rendered card, and both headless paths paint a full, answerable card on
+first open.
+
+---
+
+## 1. The mechanism — proven by state reachability before any code moved
+
+The live pane showed: the `ChatTaskCards` container visible, the card's
+"Approval required" title visible, and **no body** (no tool row, no
+arguments, no buttons). Enumerating every writer of those three `display`
+slots on dev:
+
+- `ChatTaskCards.display = True` is written **only** by
+  `ChatTaskCards.sync_state`'s final line — which requires
+  `ChatApprovalCard.set_batch` to have COMPLETED without raising.
+- `ChatApprovalCard.display = True` is written **only** by a completed
+  `set_batch(calls)` — which also sets `#approval-batch-body.display = True`
+  and mounts the rows.
+- `#approval-batch-body.display = False` (with the card left visible) is
+  written **only** by `_hide_batch_body` — the callback
+  `ChatApprovalCard.on_mount` deferred via `call_after_refresh`.
+
+So the observed state is reachable exactly one way: a completed `set_batch`
+(the screen's one-shot `set_timer(0.05, sync_task_resume_state)` mount
+sync, fed by the approval landing's attach-time remount) **followed by**
+the card's own deferred initial hide. Textual parks after-refresh callbacks
+on `Screen._callbacks` until the screen has actually repainted
+(`Screen._on_idle` early-returns while dirty), and a fresh 17k-line Console
+screen's first paint on a real tty takes longer than 50ms — so live, the
+hide always lands LAST. The `run_test` harness paints in microseconds, so
+in tests the hide always landed FIRST, which is why the merged e2e never
+saw it (measured: `Tests/UI/test_probe_17500_first_open_ordering.py` — at
+the first sample after real navigation the card is already fully painted).
+
+**Verdict on the two-seam suspicion:** close, but it was not a third
+payload overwrite. The payload funnel (attach re-derive + restore-state
+re-derive) worked; `_task_resume_state` held the right round the whole
+time. The overwrite was one layer down, at the WIDGET: the card's own
+deferred initialization clobbering the DOM the sync had just built. It is
+the same category as the restore-overwrite the approval landing fixed —
+a later write with no ordering contract landing on a correct earlier one —
+one slot further out.
+
+Two corroborations that this was already visible and unrecognised:
+
+- `Tests/UI/test_approval_row_information_budget.py`'s `_show_batch` had
+  already worked around this exact race as TEST flakiness (TASK-1900:
+  "land `set_batch` first and the hide runs afterwards, leaving every
+  region at 0") without anyone reading it as a production defect.
+- The session-tab-click repair is exactly `switch_session`'s re-derive
+  running `set_batch` again *after* the one-shot hide has been spent —
+  the same working render path, just a second invocation of it.
+
+Also explained: why the merged e2e's assertions passed against the broken
+state. `query(".approval-row")` and a `renderable` walk both see through
+`display: none`, and `Button.press()` works on an invisible button — the
+"data arrived ≠ rendered" trap, for the third time in this programme.
+
+## 2. The red, and its rendered-assertion before/after
+
+New suite `Tests/UI/test_console_approval_first_open_render.py` (6 tests)
+plus the ordering probe. The e2e tests drive the full production path —
+real DBs, real navigation both ways, the round armed by
+`request_mcp_approvals` on a worker thread — and make the live ordering
+deterministic by capturing the card's `call_after_refresh` work at the
+production scheduling seam and delivering it only after the mount sync has
+rendered the card (a delivery time Textual explicitly permits, and the one
+a real terminal produces). Assertions are on the **painted frame**
+(`export_screenshot` `<text>` nodes, the compositor-honest idiom) and on
+answering through the rendered control — never on queries that see
+through `display: none`.
+
+RED at `ee6c3d709` (5 of 6):
+
+| Test | Failure on dev |
+|---|---|
+| `…nav_away_path` | `the card painted TITLE-ONLY -- no tool row, no arguments, no controls (title_painted=True tool_painted=False controls_painted=False)` — the live pane, verbatim |
+| `…launch_path` | identical, on the launch path |
+| `…deferred_mount_work_cannot_unrender_a_live_batch` | painted frame after the deferred work: `'Approval required\n\n…'` and nothing else |
+| `…constructed_card_shows_nothing_until_a_batch_is_set` | both widgets born visible (the hide was deferred) |
+| `…set_batch_does_not_half_apply…` | a failed `set_batch` left `display=True` — title-only through a second writer |
+
+(`…mounted_but_never_synced_surface_paints_nothing` was green on dev and
+exists to pin the initial-hide contract the fix must keep.)
+
+**AFTER: all 6 pass; the probe still measures a fully painted card.**
+
+## 3. The fix
+
+`tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py`,
+`chat_task_cards.py`:
+
+1. Every initial hide is **construction state**: `ChatApprovalCard.__init__`
+   and `ChatTaskCards.__init__` set `display = False`; the batch body is
+   built hidden in `compose`. Both `on_mount` handlers and
+   `_hide_batch_body` are deleted — there is no deferred initialization
+   left to race anything.
+2. `set_batch` is **all-or-nothing**: it resolves `#approval-batch-body`
+   and `#approval-batch-rows` before mutating any state (display flags AND
+   the round-id stash), so a call that lands before the children attach
+   raises cleanly into `sync_task_resume_state`'s existing `QueryError`
+   swallow instead of stranding a visible title-only card.
+
+After the fix the observed defect state is unreachable by construction:
+the only writers of "card visible" and "body hidden" can no longer
+interleave that way. Unify-don't-duplicate: nothing new was added to the
+mount path — the mount sync and `switch_session` both flow through the
+same `sync_state`/`set_batch` funnel as before; what was removed is the
+one writer that raced it.
+
+## 4. Mutations — run and killed (restores by Edit, `git diff` read 0 after each)
+
+| # | Mutation | Result |
+|---|---|---|
+| M1 | re-add the deferred `_hide_batch_body` mount work (construction hides kept) | **KILLED** — 3: both e2e + the widget mechanism pin |
+| M2 | drop `ChatApprovalCard.__init__`'s construction hide | **KILLED** — 2: constructed pin + half-apply pin |
+| M3 | drop the compose-time batch-body hide | **KILLED** — 9: the never-synced pin + 8 tests in `test_approval_row_information_budget.py` (its `_show_batch` contract check bites) |
+| M4 | `set_batch` mutates state before resolving containers (the dev order) | **KILLED** — the half-apply pin |
+| M5 | `ChatTaskCards` hide moved back to `on_mount` | **KILLED** — the constructed pin |
+
+## 5. The app-wide stall — AC#4 decided as documented-by-design
+
+While an approval round is unanswered, every other conversation's owed
+wake is held behind it. That is the close-out's own AC#3 invariant
+("deliveries stay serialized app-wide — one `_delivering` per runtime"),
+mutation-tested there and observed live here in both directions: the
+close-out watched a stalled conversation jump 4→6 rows the instant the
+blocked round was denied. **This task does not change the serialization.**
+What made it a defect was that the holding card was invisible and
+unanswerable — an indefinite hold with no affordance. With the card
+rendering, the hold is answerable-blocking and lasts exactly as long as
+the user leaves the question open. Decided as **intended and now
+documented**: the User Guide's agent-runs-and-tools page states the
+behaviour plainly ("While an approval waits, other conversations' owed
+wakes wait behind it — by design", with the durable-marks caveat), so the
+owner can rule differently later with the trade in front of them. If that
+ruling comes, it is a design change to the delivery serialization, not a
+bug fix.
+
+## 6. Live re-verification — the close-out's failing scenario, now passing
+
+Rig: tmux (`-L t17500`, 220×58), scratch profile (own `HOME`, `XDG_*`,
+`TLDW_CONFIG_PATH`, `[paths] data_dir` all under the session scratchpad),
+real Anthropic `claude-sonnet-5`, app run from this worktree's checkout
+(provenance: the worktree's `chat_approval_card.cpython-312.pyc` was
+compiled at launch time; the process held 44 open files under the scratch
+profile and its cwd was the worktree).
+
+Scenario (the close-out's §3.3, nav-away): a fresh Console tab was sent
+*"Two instructions. FIRST: use spawn_subagent to write a 500-word essay
+about the history of papermaking … SECOND: later, when you are woken with
+the sub-agent result, use the write_file tool to save the essay to
+paper-essay.txt."* The spawn turn ended, Console was left through the
+real "Leave Console?" dialog to Library, the child finished and the wake
+turn armed `write_file` with nothing mounted. The app-wide toast fired
+**on Library**:
+
+```
+│ Agent in Two instructions. FIRST: us... needs approval   │
+```
+
+Opening Console (command palette, first open of a fresh screen, **no
+session switch**) and capturing every second:
+
+- **t≈1-2s** (`frame_2`): "Approval required" + the action bar
+  (`Approve all  Submit  Deny all`) already painted, the tool row still
+  mounting — on dev these buttons would have vanished after the first
+  paint and never returned.
+- **t≈2-3s onward** (`frame_3`…`frame_8` and repeated captures over ~8
+  minutes): the FULL card, stable:
+
+```
+█  Approval required
+█  Built-in · write_file (high risk)
+█  {"file_path":"paper-essay.txt","content":"# The History of Papermaking\n\n…}
+█  ▊▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▎ Approve once      Deny
+█  ▊  Approve once       ▼  ▎
+█    Approve all        Submit         Deny all
+```
+
+with `Approvals: 1 pending` in the status bar and `◆ Two instructions.…`
+on the session tab. The pre-fix pane at this exact point was the title
+and nothing else, stable that way for 20s (close-out §3.3).
+
+The round was ended through the **documented quit-denies path** (Ctrl+Q →
+Leave): the ledger then shows the wake turn `cancelled`, the child's
+`wake_delivered_at` stamped, and **no `paper-essay.txt`/`papernote.txt`
+anywhere on disk** — nothing ran without a human. Answering through the
+rendered control itself is owned by the automated e2e (the fast-approve
+press resolves the round with `{'builtin__write_file': 'approve_once'}`),
+because the tmux rig turned out not to deliver synthetic SGR mouse events
+to widgets inside the transcript region (tab-strip clicks landed; card
+clicks did not — a harness limitation recorded below, not a product one).
+
+Hygiene: the run regenerated only the CSS bundle's timestamp line,
+restored by Edit (`git diff --name-only tldw_chatbook/` → 0);
+`git diff | grep -c sk-ant` → 0; the scratch profile owned `HOME`,
+`XDG_*`, `TLDW_CONFIG_PATH` and `[paths] data_dir`, and the real
+`~/.config/tldw_cli` was never touched.
+
+## 7. Gate — read counts, cwd = this worktree, parent `.venv/bin/pytest`, `-p no:randomly`
+
+| Run | Result |
+|---|---|
+| Baseline, untouched branch @ `ee6c3d709`: `test_console_headless_approval` + `test_console_mcp_approval` + `test_console_headless_wake_fires` + `test_console_launch_wake` + `Tests/Chat/test_console_runtime_lifetime` + `test_console_runtime_ownership` + `Tests/Agents` + the provenance probe | **1584 passed, 0 failed**, exit 0 (193.49s) |
+| Same invocation + the new suite + the ordering probe, after the fix | **1591 passed, 0 failed**, exit 0 (208.27s) — +7 = exactly the new tests |
+| Widget-adjacent suites (`test_approval_argument_budget`, `test_chat_approval_card`, `test_chat_task_cards_sync`, `test_console_workbench_contract`, `test_skill_script_confirm_card`, + provenance) | **130 passed** |
+| `Tests/UI/test_approval_row_information_budget.py` (docstring updated; behaviour contract unchanged) | **8 passed** |
+| `Tests/MCP/test_mcp_documentation_contract.py` (the User Guide page it pins was edited) | **69 passed** |
+
+Import provenance in every invocation:
+`PROBE imported tldw_chatbook from: …/.worktrees/fix-17500/tldw_chatbook/__init__.py`.
+
+## 8. Concerns / residue
+
+1. **The one-shot mount sync is still one-shot.** If
+   `sync_task_resume_state`'s 0.05s timer ever fires before
+   `#console-task-surface` is queryable (or before the card's children
+   attach), the sync is swallowed and never retried, and the card would be
+   fully invisible until a session switch — a cousin of this bug through
+   the same funnel. The live evidence rules it out as what happened (the
+   painted title requires a COMPLETED `set_batch`), no red could be
+   produced for it honestly, and the all-or-nothing `set_batch` at least
+   makes the half-applied variant impossible. Named, not fixed —
+   reproduce-red-before-fixing.
+2. **The sibling cards keep the `on_mount` hide pattern.**
+   `SkillInstallConfirmCard`, `SkillScriptConfirmCard` and
+   `ChatResumePanel` still do `on_mount: self.display = False` (whole-card
+   only, no after-refresh deferral, so the window is the Mount-message gap
+   rather than a full repaint). Headless skill confirms fail closed and
+   never park, so the headless path cannot hit them; a mounted-console
+   slow-paint interleaving is theoretically possible for the resume
+   panel's restore. Same family, no observed defect, left alone.
+3. **The deterministic rig patches `ChatApprovalCard.call_after_refresh`
+   class-wide inside the two e2e tests** (captured, then delivered after
+   the sync, then restored in `finally`). If a future card feature uses
+   `call_after_refresh` for something load-bearing during the capture
+   window, its work would be delivered late in these tests — which is
+   also exactly what a slow terminal would do to it, so that is the
+   scenario being tested, but it is worth knowing the patch exists.
+4. **task-15661** (two rounds, one payload slot) is unchanged and still
+   filed.

--- a/Tests/UI/test_approval_row_information_budget.py
+++ b/Tests/UI/test_approval_row_information_budget.py
@@ -42,13 +42,17 @@ class _StyledCardHarness(App[None]):
 async def _show_batch(app, pilot, calls: list[dict]) -> None:
     """Render `calls` on the card and wait for real geometry, by CONDITION.
 
-    `ChatApprovalCard.on_mount` hides `#approval-batch-body` through
-    `call_after_refresh`. A fixed number of `pilot.pause()` calls RACES that
-    deferred hide: land `set_batch` first and the hide runs afterwards,
-    leaving every region at 0 -- a machine-speed-dependent failure, and the
-    exact shape of the flaky test filed as TASK-1900. So this waits for the
-    two states it actually depends on instead of counting frames: first that
-    the deferred hide has run, then that the rows have been laid out.
+    `#approval-batch-body` starts hidden. Before task-17500 that hide was
+    DEFERRED mount work (`on_mount` -> `call_after_refresh`), and a fixed
+    number of `pilot.pause()` calls RACED it: land `set_batch` first and
+    the hide ran afterwards, leaving every region at 0 -- a machine-speed-
+    dependent failure, the exact shape of the flaky test filed as
+    TASK-1900, and (recognised much later) the exact mechanism of the
+    task-17500 production bug, where a real terminal's slow first paint
+    made the hide land last and unrender a headless round's card. The card
+    is now hidden at CONSTRUCTION, so the first wait below is satisfied
+    immediately; it is kept as a cheap contract check. The second wait --
+    rows actually laid out -- is still load-bearing.
 
     Args:
         app: The mounted harness app.

--- a/Tests/UI/test_console_approval_first_open_render.py
+++ b/Tests/UI/test_console_approval_first_open_render.py
@@ -1,0 +1,448 @@
+"""task-17500: a headless approval card must PAINT answerable on first open.
+
+The close-out live pass (2026-08-17, real tty) opened Console on a round
+armed headless and saw the card VISIBLE AND EMPTY -- the "Approval
+required" title, no tool row, no arguments, no decision controls -- on
+both headless paths (nav-away and launch). A session-tab click repaired
+it; a round armed with Console mounted rendered fully.
+
+The mechanism, proven by state reachability before any code was changed:
+the only writer sequence that can produce the observed state
+(`ChatApprovalCard.display=True` + `#approval-batch-body.display=False`
+with the surrounding `ChatTaskCards` shown) is a COMPLETED
+`set_batch(calls)` followed by `_hide_batch_body` -- the card's
+mount-deferred initial hide (`on_mount` -> `call_after_refresh`) landing
+AFTER the screen's one-shot 0.05s mount sync (`ChatScreen.on_mount` ->
+`set_timer(0.05, sync_task_resume_state)`). On a real terminal the fresh
+Console screen's first paint takes longer than 50ms, so the deferred hide
+runs LAST and unrenders the batch it was never meant to touch. Textual
+gives no ordering guarantee between a screen timer and a widget's
+after-refresh callback; `Tests/UI/test_approval_row_information_budget.py`
+had already documented the same race as TEST flakiness (TASK-1900's
+`_show_batch` workaround: "land `set_batch` first and the hide runs
+afterwards") without anyone recognising it as a production defect.
+
+The `run_test` harness resolves the race FAVOURABLY -- measured by
+`test_probe_17500_first_open_ordering.py`: at first sample after the real
+navigation the card is already fully painted -- which is exactly why the
+merged e2e (`test_console_headless_approval.py`) never saw the bug: its
+`.approval-row` query and `_rendered` walk also find rows inside a
+`display: none` container, the "data arrived" trap. So the tests here do
+two things differently:
+
+1. they assert on the PAINTED FRAME (`export_screenshot` `<text>` nodes,
+   the compositor-honest idiom) and on the display chain, never on
+   queries that see through `display: none`;
+2. they make the live ordering deterministic by capturing the card's
+   `call_after_refresh` callbacks and delivering them only after the
+   mount sync has rendered the card -- the same callbacks, the same
+   production scheduling seam, delivered at the time a slow first paint
+   delivers them. After the fix the card defers no mount work at all, so
+   there is nothing to capture and the delivery step is inert.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import time
+from html import unescape
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
+from textual.widgets import Button
+
+from Tests.Chat.test_console_fleet_wake import _drain, _settle, _survivor
+from Tests.UI.test_console_headless_approval import (
+    _arm,
+    _build_console_app,
+    _risk_row,
+    _round_is_claimable,
+)
+from Tests.UI.test_console_launch_wake import (
+    _assert_console_never_mounted,
+    _fixture_tree,
+    _launch_app,
+    _seed_a_finished_background_job,
+)
+from Tests.UI.test_console_store_continuity import (
+    _drain_from_child_thread,
+    _navigate,
+    _seed_console,
+    _terminal_survivor_run,
+)
+
+from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
+from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
+from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+
+
+# ---------------------------------------------------------------------------
+# rendered-frame helpers
+# ---------------------------------------------------------------------------
+
+
+def _compositor_text(svg: str) -> str:
+    """Rejoin an exported-screenshot SVG's `<text>` nodes into plain text.
+
+    The established compositor-honest idiom (see
+    `test_library_media_trash._compositor_text`): content hidden by
+    `display: none` never becomes a `<text>` node at all, unlike a
+    widget's `.renderable`/`query` results, which exist regardless of
+    paint.
+    """
+    joined = "".join(re.findall(r"<text[^>]*>([^<]*)</text>", svg))
+    return unescape(joined).replace("\xa0", " ")
+
+
+def _painted(app) -> str:
+    return _compositor_text(app.export_screenshot(simplify=True))
+
+
+def _card_paint_state(app) -> str:
+    """One-line summary quoted by every failure message."""
+    painted = _painted(app)
+    return (
+        f"title_painted={'Approval required' in painted} "
+        f"tool_painted={'write_file (high risk)' in painted} "
+        f"controls_painted={'Approve all' in painted}"
+    )
+
+
+class _DeferredCardWork:
+    """Capture `ChatApprovalCard.call_after_refresh` work; deliver it late.
+
+    This is the deterministic stand-in for a slow first paint: Textual
+    parks after-refresh callbacks on `Screen._callbacks` until the screen
+    has actually repainted (`Screen._on_idle` early-returns while dirty),
+    so on a real terminal a fresh Console screen delivers the card's
+    mount-deferred work AFTER the 0.05s mount sync. `run_test` paints in
+    microseconds and always delivers it BEFORE. Capturing the callback at
+    the production scheduling seam and invoking it after the sync
+    reproduces the terminal's ordering exactly -- same callable, same
+    seam, later delivery, which is a delivery time Textual explicitly
+    permits.
+    """
+
+    def __init__(self) -> None:
+        self.work: list[functools.partial] = []
+        self._real = ChatApprovalCard.call_after_refresh
+
+    def install(self) -> None:
+        capture = self
+
+        def deferred(self, callback, *args, **kwargs):  # noqa: ANN001
+            capture.work.append(functools.partial(callback, *args, **kwargs))
+            return True
+
+        ChatApprovalCard.call_after_refresh = deferred
+
+    def restore(self) -> None:
+        ChatApprovalCard.call_after_refresh = self._real
+
+    def deliver(self) -> int:
+        delivered = len(self.work)
+        for callback in self.work:
+            callback()
+        self.work.clear()
+        return delivered
+
+
+async def _assert_card_paints_answerable(app, pilot, chat_screen, box) -> None:
+    """The shared verdict: rendered on the frame, then answerable by press."""
+    deadline_msg = _card_paint_state(app)
+    painted = _painted(app)
+    assert "Approval required" in painted, (
+        f"the approval card is not painted at all ({deadline_msg}); the round "
+        "is invisible and unanswerable"
+    )
+    assert "write_file (high risk)" in painted, (
+        "task-17500's live pane: the card painted TITLE-ONLY -- no tool row, "
+        f"no arguments, no controls ({deadline_msg})"
+    )
+    assert "Approve all" in painted, (
+        f"the decision controls are not painted ({deadline_msg}); the user "
+        "was told to come and answer and cannot"
+    )
+    body = chat_screen.query_one("#approval-batch-body")
+    assert body.display is True, (
+        "the batch body is display:none -- the mount-deferred initial hide "
+        "unrendered the batch the mount sync had just set"
+    )
+    # Answerable, through the rendered control.
+    chat_screen.query_one(".approval-row-fast-approve", Button).press()
+    await pilot.pause()
+    assert await _settle(lambda: "decisions" in box, seconds=10.0), (
+        "pressing the painted card's Approve never resolved the round"
+    )
+    assert box["decisions"] == {"builtin__write_file": "approve_once"}, box[
+        "decisions"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# THE RED -- both headless paths, through the real navigation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_open_paints_an_answerable_card_nav_away_path(tmp_path):
+    """AC#1: wake armed with Console unmounted (left via real navigation);
+    the FIRST open must paint the full card -- no session switch.
+
+    RED before the fix: after the deferred mount work lands (as it does
+    last on a real terminal), the frame shows 'Approval required' and
+    nothing else, exactly the close-out pane.
+    """
+    app, gateway = _build_console_app(tmp_path)
+    deferred = _DeferredCardWork()
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        chat, controller, store, session_id, conversation_id = await _seed_console(
+            app, pilot, gateway
+        )
+        wake = controller.fleet_wake
+        runs_db = controller._agent_bridge.runs_db
+        run_id = _terminal_survivor_run(runs_db, conversation_id)
+
+        gateway.stall = True
+        _drain_from_child_thread(
+            wake, _drain(conversation_id, _survivor(run_id, session_id=session_id))
+        )
+        assert await _settle(lambda: gateway.entered_stall.is_set(), seconds=10.0), (
+            "harness precondition: the wake turn must be in flight"
+        )
+
+        await _navigate(app, pilot, "library", expect="LibraryScreen")
+        assert chat not in app.screen_stack, "Console must actually unmount"
+
+        thread, box = _arm(controller, session_id, call=_risk_row())
+        assert await _settle(
+            lambda: _round_is_claimable(controller, session_id), seconds=5.0
+        ), "harness precondition: the round must be registered AND payload-retained"
+
+        deferred.install()
+        try:
+            chat2 = await _navigate(app, pilot, "chat", expect="ChatScreen")
+            assert chat2 is not chat, "screens are never cached"
+            assert await _settle(
+                lambda: bool(list(chat2.query(".approval-row"))), seconds=5.0
+            ), "harness precondition: the mount sync must have built the rows"
+            assert await _settle(
+                lambda: "write_file (high risk)" in _painted(app), seconds=5.0
+            ), (
+                "harness precondition: the card must be PAINTED before the "
+                "deferred work is delivered, or the delivery proves nothing: "
+                f"{_card_paint_state(app)}"
+            )
+            # The slow first paint completes: the card's mount-deferred work
+            # (none, after the fix) lands after the sync.
+            deferred.deliver()
+        finally:
+            deferred.restore()
+        await pilot.pause()
+        await pilot.pause(0.1)
+
+        await _assert_card_paints_answerable(app, pilot, chat2, box)
+        thread.join(timeout=5)
+        gateway.release.set()
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_first_ever_open_paints_an_answerable_card_launch_path(tmp_path):
+    """AC#2: the round armed before ANY ChatScreen ever existed in the
+    process (launch wake, Console never opened); the first-ever open must
+    paint the full card.
+    """
+    conversation_id, run_id, rows = await _seed_a_finished_background_job(tmp_path)
+    app, marks, gateway = _launch_app(
+        tmp_path, tree=_fixture_tree(conversation_id, rows)
+    )
+    deferred = _DeferredCardWork()
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        gateway.stall = True
+        # The launch wake fires on its own; wait for the launch-built
+        # controller and its hydrated session, with Console never mounted.
+        assert await _settle(
+            lambda: getattr(app.console_runtime, "chat_controller", None) is not None,
+            seconds=10.0,
+        ), "harness precondition: the launch never built a controller"
+        controller = app.console_runtime.chat_controller
+        store = app.console_runtime.chat_store
+
+        def _hydrated_session_id():
+            for session in store.sessions():
+                if session.persisted_conversation_id == conversation_id:
+                    return session.id
+            return None
+
+        assert await _settle(
+            lambda: _hydrated_session_id() is not None, seconds=10.0
+        ), "harness precondition: the launch never hydrated the owed session"
+        session_id = _hydrated_session_id()
+        assert await _settle(lambda: gateway.entered_stall.is_set(), seconds=10.0), (
+            "harness precondition: the launch wake turn must be in flight"
+        )
+        _assert_console_never_mounted(app)
+
+        thread, box = _arm(controller, session_id, call=_risk_row())
+        assert await _settle(
+            lambda: _round_is_claimable(controller, session_id), seconds=5.0
+        ), "harness precondition: the round must be registered AND payload-retained"
+
+        deferred.install()
+        try:
+            chat = await _navigate(app, pilot, "chat", expect="ChatScreen")
+            assert store.active_session_id == session_id, (
+                "harness precondition: the woken session must be the active "
+                "one at first open -- a session SWITCH is the repair path "
+                "this test must not take"
+            )
+            assert await _settle(
+                lambda: bool(list(chat.query(".approval-row"))), seconds=5.0
+            ), "harness precondition: the mount sync must have built the rows"
+            assert await _settle(
+                lambda: "write_file (high risk)" in _painted(app), seconds=5.0
+            ), (
+                "harness precondition: the card must be PAINTED before the "
+                f"deferred work is delivered: {_card_paint_state(app)}"
+            )
+            deferred.deliver()
+        finally:
+            deferred.restore()
+        await pilot.pause()
+        await pilot.pause(0.1)
+
+        await _assert_card_paints_answerable(app, pilot, chat, box)
+        thread.join(timeout=5)
+        gateway.release.set()
+        await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# the mechanism, pinned at the widget layer
+# ---------------------------------------------------------------------------
+
+
+class _SurfaceHarness(App[None]):
+    def compose(self) -> ComposeResult:
+        yield ChatTaskCards(id="console-task-surface")
+
+
+def _approval_payload() -> dict:
+    """The parked-payload shape `remount_pending_approval_for_active_session`
+    and `switch_session` push into the view seam."""
+    return {
+        "calls": [
+            {
+                "llm_name": "builtin__write_file",
+                "server_key": "agent:builtin",
+                "tool_name": "write_file",
+                "reason": "risk_floored",
+                "arguments": {"path": "essay.txt", "content": "x"},
+            }
+        ],
+        "timeout_seconds": 0.0,
+        "round_id": "round-17500",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deferred_mount_work_cannot_unrender_a_live_batch():
+    """The mechanism in one widget: whatever work the card defers at mount
+    must not unrender a batch that `sync_state` has ALREADY built.
+
+    RED before the fix: the deferred `_hide_batch_body` hides
+    `#approval-batch-body` after `set_batch` showed it -- title-only.
+    """
+    deferred = _DeferredCardWork()
+    deferred.install()
+    app = _SurfaceHarness()
+    try:
+        async with app.run_test(size=(120, 36)) as pilot:
+            surface = app.query_one("#console-task-surface", ChatTaskCards)
+            assert await _settle(
+                lambda: bool(app.query("#approval-batch-body")), seconds=5.0
+            ), "harness precondition: the card's children must be attached"
+            await pilot.pause()
+            state = TaskResumeState(pending_approval=_approval_payload())
+            surface.sync_state(state)
+            await pilot.pause()
+            assert "write_file (high risk)" in _painted(app), (
+                f"harness precondition: sync must paint first: {_painted(app)!r}"
+            )
+            deferred.deliver()
+            await pilot.pause()
+            painted = _painted(app)
+            assert "write_file (high risk)" in painted and "Approve all" in painted, (
+                "the card's mount-deferred work unrendered a live batch: "
+                f"painted={painted!r}"
+            )
+            assert app.query_one("#approval-batch-body").display is True
+    finally:
+        deferred.restore()
+
+
+def test_a_constructed_card_shows_nothing_until_a_batch_is_set():
+    """The initial hide must be CONSTRUCTION state, not deferred mount work.
+
+    A hide applied at mount (or after a refresh) is a write racing every
+    other writer of the same slot; a hide applied at construction cannot
+    race anything. RED before the fix: both widgets are built visible and
+    only become hidden when their mount handlers eventually run.
+    """
+    assert ChatApprovalCard().display is False, (
+        "a freshly constructed approval card is visible before its mount "
+        "handler runs -- the initial hide is deferred, so it can land after "
+        "a sync and unrender it"
+    )
+    assert ChatTaskCards().display is False, (
+        "a freshly constructed task surface is visible before its mount "
+        "handler runs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_mounted_but_never_synced_surface_paints_nothing():
+    """The initial-hide contract itself (what the deferred hide existed
+    for): with no batch ever set, nothing of the card reaches the frame.
+    Kills the mutation that drops the construction-time hides outright.
+    """
+    app = _SurfaceHarness()
+    async with app.run_test(size=(120, 36)) as pilot:
+        assert await _settle(
+            lambda: bool(app.query("#approval-batch-body")), seconds=5.0
+        ), "harness precondition: the card's children must be attached"
+        await pilot.pause()
+        painted = _painted(app)
+        assert "Approval required" not in painted and "Approve all" not in painted, (
+            f"an empty task surface painted card chrome: {painted!r}"
+        )
+        assert app.query_one("#approval-batch-body").display is False
+
+
+def test_set_batch_does_not_half_apply_when_the_body_is_missing():
+    """All-or-nothing: a `set_batch` that cannot reach its containers must
+    not leave the card title-only.
+
+    `sync_task_resume_state` swallows `QueryError`, so a `set_batch` that
+    raises AFTER flipping `self.display = True` strands a visible, empty
+    card with no retry -- the same user-visible state as the deferred-hide
+    clobber, through a different writer. RED before the fix: the display
+    flip happened before the body query.
+    """
+    card = ChatApprovalCard()
+    with pytest.raises(NoMatches):
+        card.set_batch(
+            _approval_payload()["calls"], timeout_seconds=0.0, round_id="r"
+        )
+    assert card.display is False, (
+        "a set_batch that could not reach its containers left the card "
+        "visible and empty -- title-only, unanswerable"
+    )
+    assert card._batch_round_id is None, (
+        "a failed set_batch stashed the new round id without rendering it"
+    )

--- a/Tests/UI/test_probe_17500_first_open_ordering.py
+++ b/Tests/UI/test_probe_17500_first_open_ordering.py
@@ -1,0 +1,121 @@
+"""PROBE (task-17500): measure the harness's natural first-open ordering.
+
+The live pass observed a headless approval card mount VISIBLE AND EMPTY
+("Approval required" and nothing else) on first Console open. By state
+reachability, the only writer sequence that produces (card.display=True,
+#approval-batch-body.display=False) is `set_batch(calls)` followed by
+`_hide_batch_body` -- i.e. the card's mount-deferred initial hide landing
+AFTER the screen's 0.05s mount sync. This probe measures which order the
+run_test harness produces naturally, sampling the display chain over time
+and capturing the painted frame at the end. It asserts nothing beyond
+harness preconditions; its output is the finding.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from html import unescape
+
+import pytest
+
+from Tests.Chat.test_console_fleet_wake import _drain, _quiet, _settle, _survivor
+from Tests.UI.test_console_headless_approval import (
+    _arm,
+    _armed_round_ids,
+    _build_console_app,
+    _risk_row,
+    _round_is_claimable,
+)
+from Tests.UI.test_console_store_continuity import (
+    _drain_from_child_thread,
+    _navigate,
+    _seed_console,
+    _terminal_survivor_run,
+)
+
+from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
+
+
+def _compositor_text(svg: str) -> str:
+    joined = "".join(re.findall(r"<text[^>]*>([^<]*)</text>", svg))
+    return unescape(joined).replace("\xa0", " ")
+
+
+def _snap(screen):
+    try:
+        card = screen.query_one(ChatApprovalCard)
+    except Exception:  # noqa: BLE001
+        return ("no-card",)
+    try:
+        body_disp = card.query_one("#approval-batch-body").display
+    except Exception:  # noqa: BLE001
+        body_disp = "body-missing"
+    try:
+        tc_disp = screen.query_one("#console-task-surface").display
+    except Exception:  # noqa: BLE001
+        tc_disp = "surface-missing"
+    rows = len(list(card.query(".approval-row")))
+    return (tc_disp, card.display, body_disp, rows)
+
+
+@pytest.mark.asyncio
+async def test_probe_first_open_natural_ordering(tmp_path):
+    app, gateway = _build_console_app(tmp_path)
+    samples: list[tuple[float, tuple]] = []
+    painted = ""
+
+    async with app.run_test(size=(160, 48), notifications=True) as pilot:
+        chat, controller, store, session_id, conversation_id = await _seed_console(
+            app, pilot, gateway
+        )
+        wake = controller.fleet_wake
+        runs_db = controller._agent_bridge.runs_db
+        run_id = _terminal_survivor_run(runs_db, conversation_id)
+
+        gateway.stall = True
+        _drain_from_child_thread(
+            wake, _drain(conversation_id, _survivor(run_id, session_id=session_id))
+        )
+        assert await _settle(lambda: gateway.entered_stall.is_set(), seconds=10.0)
+
+        await _navigate(app, pilot, "library", expect="LibraryScreen")
+        assert chat not in app.screen_stack
+
+        thread, box = _arm(controller, session_id, call=_risk_row())
+        assert await _settle(
+            lambda: _round_is_claimable(controller, session_id), seconds=5.0
+        )
+
+        chat2 = await _navigate(app, pilot, "chat", expect="ChatScreen")
+        t0 = time.monotonic()
+        last = None
+        while time.monotonic() - t0 < 3.0:
+            snap = _snap(chat2)
+            if snap != last:
+                samples.append((round(time.monotonic() - t0, 4), snap))
+                last = snap
+            await pilot.pause(0.01)
+        painted = _compositor_text(app.export_screenshot(simplify=True))
+
+        # Resolve the round so the worker thread does not outlive the app.
+        from textual.widgets import Button
+
+        buttons = list(chat2.query(".approval-row-fast-approve"))
+        if buttons:
+            buttons[0].press()
+            await pilot.pause()
+        else:
+            controller.resolve_pending_approval({"builtin__write_file": "deny"})
+        await _settle(lambda: "decisions" in box, seconds=10.0)
+        thread.join(timeout=5)
+        gateway.release.set()
+        await pilot.pause()
+
+    print("PROBE samples (t, (surface.display, card.display, body.display, rows)):")
+    for entry in samples:
+        print("  ", entry)
+    print("PROBE painted-frame markers:")
+    print("   'Approval required' painted:", "Approval required" in painted)
+    print("   'write_file' painted:", "write_file" in painted)
+    print("   'Approve' painted:", "Approve" in painted)

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -995,3 +995,27 @@ never passes `autonomy_mode`, so the service default applies), so it parks at
 `plan_review` and never reaches `collecting` until the checkpoint is approved.
 A harness that used `autonomy_mode="autonomous"` would have "verified" a path
 no user takes.
+
+## tmux synthetic mouse (`send-keys -l` SGR bytes) reaches some widgets and not others — a dead click is not a dead control (task-17500, 2026-08-17)
+
+**What happened.** Live-verifying the fixed approval card, clicks synthesized as
+raw SGR sequences (`\e[<0;COL;ROWM` / `…m` via `tmux send-keys -l`) worked on
+the Console session TAB STRIP (they created a tab and switched sessions, with
+one-shot coordinates computed from a single capture) but never registered on
+anything inside the transcript region — the approval card's fast Deny, Deny
+all, and its decision Select all ignored identical sequences at verified
+coordinates, across press/release timing variants and a hover-first attempt.
+Real user mouse input is not this selective; ~15 minutes went into suspecting
+the buttons before the pattern (tab strip yes, transcript region no) showed it
+was the harness. Blind Tab-walking (25 presses with probes) never reached the
+card either.
+
+**What to do.** When a synthetic click does not land, test a KNOWN-clickable
+control elsewhere on screen before concluding anything about the target — and
+compute coordinates from ONE capture in the same shell invocation as the click
+(captures taken across separate invocations race the UI and land clicks on
+stale coordinates). If the control stays unreachable, do not force it: prove
+press-resolution with the automated widget test (a mounted-widget `press()`
+drives the same production seam) and use a documented keyboard path (here:
+quit-denies) to end the live round. Record which regions accepted synthetic
+mouse so the next rig starts there.

--- a/backlog/tasks/task-17500 - A-headless-approval-card-mounts-empty-and-cannot-be-answered.md
+++ b/backlog/tasks/task-17500 - A-headless-approval-card-mounts-empty-and-cannot-be-answered.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-17500
-title: 'A headless approval card mounts empty and cannot be answered'
-status: To Do
-assignee: []
+title: A headless approval card mounts empty and cannot be answered
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-17 13:55'
+updated_date: '2026-08-17 21:53'
 labels:
   - console
   - agents
@@ -51,38 +53,35 @@ re-parked").
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 A risk-tagged tool call in a wake turn that armed while Console was unmounted shows a fully rendered, answerable approval card (tool name, arguments, decision controls) the first time the user opens Console — with no session switch required
-- [ ] #2 The same holds on the launch-wake path (the round armed before any Console screen ever existed in the process)
-- [ ] #3 A regression test drives the failure through the real attach path and fails on current dev before the fix
-- [ ] #4 While an approval round is unanswered, other conversations' owed wakes are either delivered or the blocking is documented as intended — the current behaviour (all app-wide wakes silently held behind one unanswerable card) is decided one way or the other, not left implicit
-- [ ] #5 `Docs/User_Guide/console/agent-runs-and-tools.md` describes what actually ships
+- [x] #1 A risk-tagged tool call in a wake turn that armed while Console was unmounted shows a fully rendered, answerable approval card (tool name, arguments, decision controls) the first time the user opens Console — with no session switch required
+- [x] #2 The same holds on the launch-wake path (the round armed before any Console screen ever existed in the process)
+- [x] #3 A regression test drives the failure through the real attach path and fails on current dev before the fix
+- [x] #4 While an approval round is unanswered, other conversations' owed wakes are either delivered or the blocking is documented as intended — the current behaviour (all app-wide wakes silently held behind one unanswerable card) is decided one way or the other, not left implicit
+- [x] #5 `Docs/User_Guide/console/agent-runs-and-tools.md` describes what actually ships
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Reproduce first; the seams below are where the live evidence points, not a
-diagnosis.
-
-1. Reproduce in a test: arm a risk-floored round through a wake turn with
-   the view detached, then attach a fresh `ChatScreen` through the real
-   navigation API and assert the card's rows/buttons exist (not merely
-   that the card is displayed). Expect RED.
-2. `ConsoleRuntime.attach_view` calls `_bind_view_hooks()` before
-   `remount_pending_approval()`, so the hook ordering is right; the
-   suspect is WHERE in the screen lifecycle the attach happens.
-   `attach_view` runs from `_ensure_console_chat_store` during
-   `restore_state`, i.e. BEFORE the incoming screen's widgets are
-   composed, and `ChatScreen.sync_task_resume_state` swallows
-   `QueryError` when `#console-task-surface` does not exist yet
-   (`chat_screen.py`). Check whether anything re-pushes
-   `_task_resume_state` into the widgets once they mount.
-3. `ChatTaskCards.sync_state` shows the container from
-   `has_pending_approval()` (truthy dict) but populates the card from
-   `approval.get("calls")` — so a payload that arrives with no calls, or
-   never arrives at the widgets at all, produces exactly the observed
-   "title only" state. Distinguish those two before fixing.
-4. Mutation-test the new test against the fix.
+1. Baseline gate on untouched branch (READ counts)
+2. Probe the harness ordering: full production e2e (nav-away), measure the painted frame + display chain of the approval card at first open
+3. RED: new suite driving both headless paths through real navigation, asserting on the PAINTED card (compositor text) and the display chain; deterministic delivery of the card's deferred initial-hide after the mount sync (the live slow-tty ordering)
+4. Fix: make the approval card's initial hide construction-time (no deferred call_after_refresh clobber); same for the task-cards container
+5. Mutation-test the fix; re-run gate; live re-verify the close-out scenario in tmux with a scratch profile
+6. Docs: User_Guide agent-runs-and-tools.md + serialization statement (AC#4 decided as documented-by-design); report
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Mechanism (proven by state reachability, then reproduced): the card's initial batch-body hide was DEFERRED mount work (on_mount -> call_after_refresh(_hide_batch_body)); a real terminal's slow first Console paint delivers it AFTER the screen's one-shot 0.05s mount sync has rendered the headless round, unrendering it -- the only writer sequence that can produce the observed card-visible/body-hidden state. Not a third payload overwrite: the state funnel was correct; the clobber was at the widget. run_test paints in microseconds (hide lands first), which is why the merged e2e never saw it -- and its .approval-row/renderable assertions see through display:none anyway.
+
+Fix: every initial hide is construction state (ChatApprovalCard.__init__, compose-built batch body, ChatTaskCards.__init__); both on_mount handlers and _hide_batch_body deleted; set_batch made all-or-nothing (containers resolved before any state mutation). The observed defect state is unreachable by construction.
+
+Red: Tests/UI/test_console_approval_first_open_render.py -- 5 of 6 red at ee6c3d709 through the real navigation on BOTH headless paths, asserting on the PAINTED frame (compositor text) and answering through the rendered control; live ordering made deterministic by capturing the card's after-refresh work and delivering it post-sync. Probe file pins that the harness's natural ordering is favourable. 5 mutations run, all KILLED (incl. re-adding the deferred hide and reverting each construction hide); Edit-based restores verified git-clean.
+
+AC#4 decided: the app-wide hold behind an unanswered approval is the close-out's serialization invariant working as designed; now answerable (card renders) and documented plainly in the User Guide for a later owner ruling. Serialization unchanged.
+
+Gate (read counts): baseline 1584 passed / final 1591 passed (delta = exactly the 7 new tests), 0 failed both sides; +130 widget-adjacent; doc contract 69. Live re-verified in tmux (scratch profile, real Anthropic model): toast on Library, first Console open painted the FULL card (write_file (high risk), args, all controls) with no session switch, stable ~8 min; round ended via documented quit-denies; no file written. Report: Docs/superpowers/plans/2026-08-17-task-17500-report.md. Residue named: one-shot mount sync (lost-sync cousin, no red), sibling cards' on_mount hides, task-15661.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py
@@ -479,6 +479,17 @@ class ChatApprovalCard(Container):
         #: whenever no batch (or a caller that predates round ids) is
         #: showing.
         self._batch_round_id: str | None = None
+        # task-17500: the initial hide is CONSTRUCTION state, never deferred
+        # mount work. This used to live in `on_mount` (`self.display =
+        # False` plus a `call_after_refresh(_hide_batch_body)` for the batch
+        # body) -- and on a real terminal the fresh Console screen's first
+        # paint takes longer than the screen's 0.05s mount sync, so the
+        # deferred hide landed AFTER `set_batch` had rendered a headless
+        # round's card and unrendered it: the "Approval required"-and-
+        # nothing-else pane the close-out live pass reproduced on both
+        # headless paths. A hide applied here cannot race anything; the
+        # batch body gets the same treatment in `compose`.
+        self.display = False
 
     def compose(self) -> ComposeResult:
         yield Static("Approval required", id="approval-title")
@@ -487,7 +498,10 @@ class ChatApprovalCard(Container):
         deadline = Static("", id="approval-deadline", markup=False)
         deadline.display = False
         yield deadline
-        with Container(id="approval-batch-body"):
+        # task-17500: built hidden, like the deadline above -- see __init__.
+        batch_body = Container(id="approval-batch-body")
+        batch_body.display = False
+        with batch_body:
             yield Vertical(id="approval-batch-rows")
             with Horizontal(id="approval-batch-actions"):
                 yield Button(
@@ -507,22 +521,6 @@ class ChatApprovalCard(Container):
                     variant="error",
                     tooltip="Set every pending tool call's decision to Deny.",
                 )
-
-    def on_mount(self) -> None:
-        self.display = False
-        # Mount can fire before this widget's composed children are attached
-        # to the DOM (observed as a NoMatches crash on '#approval-batch-body'
-        # during Console screen mount), so defer the initial batch-body hide
-        # until after the children have settled.
-        self.call_after_refresh(self._hide_batch_body)
-
-    def _hide_batch_body(self) -> None:
-        try:
-            self.query_one("#approval-batch-body").display = False
-        except NoMatches:
-            # The card is hidden anyway (display = False above); a missing
-            # batch body at this point is harmless.
-            pass
 
     # -- batch-approval API (task-5) -----------------------------------------
 
@@ -555,7 +553,20 @@ class ChatApprovalCard(Container):
                 resolve THIS exact round rather than guessing from
                 whichever session happens to be active when the decision
                 is delivered.
+
+        Raises:
+            NoMatches: When the card's composed containers are not attached
+                yet. Raised BEFORE any state is touched (task-17500): the
+                production caller (``sync_task_resume_state``) swallows
+                ``QueryError`` with no retry, so a ``set_batch`` that
+                mutated ``display`` first would strand a visible,
+                title-only card -- the same user-visible state as the
+                mount-ordering bug, through a different writer.
         """
+        # task-17500: all-or-nothing -- resolve every container this method
+        # writes to before mutating anything, including the round-id stash.
+        batch_body = self.query_one("#approval-batch-body")
+        rows_container = self.query_one("#approval-batch-rows", Vertical)
         self._batch_round_id = round_id
         # TASK-1844: actually surface the deadline the docstring promised.
         try:
@@ -567,7 +578,7 @@ class ChatApprovalCard(Container):
             pass
         if not calls:
             self.display = False
-            self.query_one("#approval-batch-body").display = False
+            batch_body.display = False
             self._batch_names = []
             self._batch_selects = []
             self._batch_legal_values = []
@@ -576,7 +587,7 @@ class ChatApprovalCard(Container):
             return
 
         self.display = True
-        self.query_one("#approval-batch-body").display = True
+        batch_body.display = True
         # task-1234 review round 1: a submit-shaped control (Submit, or
         # either fast button) disables itself right after a press to close
         # the double-submit window -- see `_disable_batch_submit_controls`.
@@ -701,7 +712,6 @@ class ChatApprovalCard(Container):
         self._batch_rows = rows
         self._batch_fast_buttons = fast_buttons
 
-        rows_container = self.query_one("#approval-batch-rows", Vertical)
         rows_container.remove_children()
         if rows:
             rows_container.mount(*rows)

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from textual.app import ComposeResult
 from textual.containers import Container
 from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
@@ -13,14 +15,24 @@ from tldw_chatbook.Widgets.Chat_Widgets.skill_script_confirm_card import (
 class ChatTaskCards(Container):
     """Inline task-surface wrapper for approvals, skill-install/script, and resume."""
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the surface hidden.
+
+        task-17500: construction state, not an ``on_mount`` write. The
+        screen's mount-time ``sync_task_resume_state`` (a 0.05s timer) and
+        this widget's own Mount handler had no ordering contract, so a
+        sync that landed first had its ``display = True`` clobbered by the
+        late mount hide -- the same race family as the approval card's
+        deferred batch-body hide, which produced the live title-only card.
+        """
+        super().__init__(*args, **kwargs)
+        self.display = False
+
     def compose(self) -> ComposeResult:
         yield ChatApprovalCard(id="chat-approval-card")
         yield SkillInstallConfirmCard(id="chat-skill-install-card")
         yield SkillScriptConfirmCard(id="chat-skill-script-card")
         yield ChatResumePanel(id="chat-resume-panel")
-
-    def on_mount(self) -> None:
-        self.display = False
 
     def sync_state(self, task_state) -> None:
         """Sync the approval, skill-install/script, and resume cards from task state.


### PR DESCRIPTION
## task-17500 — the empty headless approval card

The headless-wake close-out's live pass found a headless approval's card rendering as `█ Approval required` and nothing else — no tool, no arguments, no buttons — while holding every other conversation's wakes behind it. This fixes it.

**The mechanism (proved by state reachability before any code moved):** the payload funnel was innocent — the two-seam mounting from the approval landing was correct the whole time. The clobber was inside the widget: `ChatApprovalCard.on_mount` deferred its initial batch-body hide via `call_after_refresh`, and Textual parks after-refresh callbacks until the screen actually repaints. On a real tty, a fresh Console's first paint takes longer than the one-shot 0.05s mount sync — so `set_batch` rendered the round, and *then* the parked hide unrendered it. The observed pane (title visible, body hidden) is producible by exactly one writer sequence, which is what nailed it.

**Why no test ever saw it:** the harness paints in microseconds, so the hide always landed first — the favorable ordering. And the merged e2e's assertions see through `display:none`. Best of all: an existing suite had already worked around this exact race **as test flakiness** (TASK-1900) without recognizing it as a production defect. That's now a recorded lesson.

**The fix removes the racing writer instead of adding coordination:** every initial hide is construction state; both `on_mount` handlers and the deferred hide are deleted, and `set_batch` is all-or-nothing (containers resolved before any state mutation), which also kills the half-applied title-only variant. Nothing new on the mount path.

**Rendered assertions, both headless paths:** the new suite asserts on the **painted frame** (compositor text nodes) and answers via the rendered control, with the live ordering made deterministic by capturing and re-delivering the card's after-refresh work. Dev failure reproduces the live pane verbatim (`title_painted=True tool_painted=False controls_painted=False`); after, all six pass. Live re-verified on a real tty: first open, no session switch, full card — tool, args, all five controls — stable for ~8 minutes where pre-fix it survived 20 seconds.

**Serialization stated for the owner, unchanged by design:** while an approval waits, other conversations' owed wakes wait behind it (one `_delivering` per runtime). Now in the User Guide so it can be ruled on later.

5 mutations, 5 killed (one killing 8 pre-existing budget-suite tests too — the construction hides are now load-bearing). Gate: 1584 → 1591 passed, 0 failed (+7 = the new suite). Named, not fixed: the one-shot mount sync's theoretical loss window (no red producible); sibling cards keep the smaller-window pattern (same family, no observed defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that rendered headless approval cards title‑only on first Console open. Before: opening Console after a headless approval showed “Approval required” with no tool, args, or controls until a session switch; after: the full, answerable card paints on first open, with app‑wide wake serialization unchanged and now documented.

- Moves initial hides to construction state in `ChatApprovalCard` and `ChatTaskCards`; removes `on_mount`/`call_after_refresh` deferred hide.
- Makes `set_batch` all‑or‑nothing by resolving containers before any state change, preventing title‑only half‑applies when children aren’t attached.
- Adds e2e tests asserting the painted frame and press‑through on both headless paths, plus a widget‑level mechanism pin and a harness ordering probe.
- Updates the User Guide to reflect the fixed first‑open behavior and to state the deliberate app‑wide delivery serialization.
- Satisfies task‑17500 ACs; gate +7 tests, no failures.

**Review notes**
- Focus on `tldw_chatbook/Widgets/Chat_Widgets/chat_approval_card.py` and `chat_task_cards.py`: verify no deferred mount writes remain and `set_batch` queries before mutating `display`/round id.
- New tests temporarily patch `ChatApprovalCard.call_after_refresh` inside test scope only to reproduce slow‑terminal ordering. Potential follow‑ups noted in docs: one‑shot mount sync remains one‑shot; sibling cards still use `on_mount` hides but showed no defect.

<sup>Written for commit e15dade3935116cf4705dff1c383e0202b245d9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

