### PR TITLE
feat(research): let generated sub-questions reach the paper providers

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -432,6 +432,42 @@ endpoint (task-17384). Both degrade to real source text rather than to
 nonsense, so the default is safe -- but a local-model install will feel it as
 latency, not as better summaries.
 
+### Fan-out WITH retrieval (arm G, 2026-08-17, task-17372)
+
+The repositories lane re-run after the academic lane began searching generated
+facets -- same questions, judge, engine and 5-results bound as every arm above,
+`--max-queries 3 --max-iterations 1`:
+
+| | Arm B: fan-out, gate context only | Arm G: fan-out reaching the providers |
+|---|---|---|
+| evidence ADMITTED by the gate | 32 | **50** |
+| evidence rejected | 21 | 28 |
+| `gate_pass_rate` (mean of runs) | 0.379 | 0.335 |
+| resolved citation markers | 70 | **37** |
+| `citation_accuracy` | 1.00 | 1.00 |
+| `claim_support_rate` | 1.00 | 1.00 |
+| map-reduce chunk operations | 1 | 8 |
+| chunk summarization failures | 0 | **6** |
+
+**Retrieval-side fan-out works: 56% more admitted evidence (32 -> 50).** The
+falling `gate_pass_rate` is the ratio behaving as a ratio -- more candidates
+judged, proportionally more of them marginal -- which is why the absolute
+admitted count is the number that answers the question.
+
+**And the benefit does not reach the report.** Resolved markers HALVED (70 ->
+37) while admitted evidence grew by half again. The cause is not the gate: arm G
+is the first fan-out arm large enough to trigger map-reduce chunking (8 chunk
+operations against arm B's 1), and 6 of those chunk summarizations failed with
+"No choices in response data" (task-17384). The synthesis was handed fallback
+text for most of its chunks, so it cited a fraction of what the gate had
+admitted.
+
+This is the same shape as arm C's Q1, and the third time in this program that a
+retrieval improvement has been masked by the summarization path rather than
+refuted by the gate. task-17384 is therefore on the critical path for BOTH
+decomposition mechanisms now that multi-hop ships on by default: the bigger the
+evidence pool either one produces, the more of it chunking swallows.
+
 ### Reading gate_pass_rate
 
 It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal

--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -198,10 +198,12 @@ generalizes:
   as an empty list and this one rendered real facets. That is a genuine
   change in what the judge was asked.
 - **Not tested:** retrieval. The web lane returned zero results throughout
-  (the DuckDuckGo bot challenge this doc notes elsewhere), and the academic
-  lane only searches round 1's `[question]` (task-17372), so the repository
-  records under judgment were the SAME set as the 0.42 arm. Fan-out changed
-  how they were judged, not which ones existed.
+  (the DuckDuckGo bot challenge this doc notes elsewhere), and at the time the
+  academic lane only searched round 1's `[question]`, so the repository records
+  under judgment were the SAME set as the 0.42 arm. Fan-out changed how they
+  were judged, not which ones existed. task-17372 has since made the lane
+  search the generated facets, so a re-run of this arm now exercises retrieval
+  as well -- the number above does not.
 
 So the case for decomposition on this lane now rests on retrieval rather than
 on gate context: multi-hop rounds >= 2 do drive retrieval (measured
@@ -323,6 +325,14 @@ do different things and only one of them helped.
 | C | 3 queries, 2 rounds | 0.71 / **0** | 0.37 / **39** | 0.07 / 1 |
 | D | as C, guard fixed | 0.59 / 23 | -- | -- |
 | E | as C, endpoint fixed | 0.63 / 17 | -- | -- |
+
+> **Scope note (task-17372).** Every fan-out number below was measured while
+> generated sub-questions could not reach the paper providers, so it measures
+> the GATE-CONTEXT half of fan-out only. That limitation is now fixed -- the
+> academic lane searches the facets too, bounded by the same query cap and the
+> search ledger -- so fan-out's retrieval value is untested rather than
+> disproven, and needs its own arm before the "no measurable benefit" reading
+> can be extended to it.
 
 **Fan-out (gate context): no measurable benefit.** The relevance prompt takes
 `sub_questions` as a required placeholder, so the recorded arms rendered an

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1227,3 +1227,144 @@ def test_plan_review_patch_bounds_the_iterations():
     # Without the fix this is ["q", "gap one"]: the ledger honoured the patch
     # while the iteration bound fell back to the shipped default of 2.
     assert rounds == ["q"], rounds
+
+
+# --- fan-out reaches the academic lane (task-17372) ---------------------------
+# Sub-question generation lives inside the WEB pipeline, so generated
+# sub-questions only ever drove web searches: the academic lane looped
+# round_queries, which is [question] in round 1. Fan-out therefore changed how
+# academic evidence was JUDGED (the sub-questions reach the gate) while leaving
+# what was RETRIEVED untouched -- which is why task-17370 measured it as flat on
+# the repositories lane and could say nothing about retrieval.
+
+
+def _fanout_pipeline(question: str, sub_questions: list[str]):
+    """search_fn returning generated sub-questions, plus a recording paper_fn."""
+    paper_queries: list[str] = []
+
+    def search_fn(q, params):
+        return (
+            {"results": [{"title": "web", "url": "https://w.example/1"}], "warnings": []},
+            {"sub_questions": list(sub_questions), "main_goal": question},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        return {
+            "final_answer": {
+                "text": "Answer citing [1].",
+                "evidence": [{"id": 1, "url": "https://w.example/1", "title": "web"}],
+                "confidence": 0.5,
+                "chunks": [],
+            },
+            "relevant_results": {"0": {"url": "https://w.example/1"}},
+        }
+
+    def paper_search_fn(query):
+        paper_queries.append(query)
+        return [
+            {
+                "title": f"paper for {query}",
+                "url": f"https://p.example/{len(paper_queries)}",
+                "metadata": {"doi": f"10.1/{len(paper_queries)}"},
+            }
+        ]
+
+    async def gap_fn(context):
+        return []
+
+    return search_fn, analyze_fn, paper_search_fn, gap_fn, paper_queries
+
+
+def test_generated_sub_questions_reach_the_paper_providers():
+    service = _make_service()
+    search_fn, analyze_fn, paper_fn, gap_fn, paper_queries = _fanout_pipeline(
+        "q", ["facet one", "facet two"]
+    )
+    engine = LocalResearchEngine(
+        service,
+        search_fn=search_fn,
+        analyze_fn=analyze_fn,
+        gap_fn=gap_fn,
+        paper_search_fn=paper_fn,
+        search_params={"search_default_max_queries": 5},
+    )
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert paper_queries == ["q", "facet one", "facet two"], paper_queries
+
+
+def test_academic_fan_out_respects_the_query_cap():
+    """The lane must obey the same total-queries cap the web lane does."""
+    service = _make_service()
+    search_fn, analyze_fn, paper_fn, gap_fn, paper_queries = _fanout_pipeline(
+        "q", ["facet one", "facet two", "facet three"]
+    )
+    engine = LocalResearchEngine(
+        service,
+        search_fn=search_fn,
+        analyze_fn=analyze_fn,
+        gap_fn=gap_fn,
+        paper_search_fn=paper_fn,
+        search_params={"search_default_max_queries": 2},
+    )
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert paper_queries == ["q", "facet one"], paper_queries
+
+
+def test_academic_fan_out_cannot_spend_past_the_search_budget():
+    """Extra academic searches are ledger-counted, so a tight max_searches
+    cannot be exceeded by the lane fanning out."""
+    service = _make_service()
+    search_fn, analyze_fn, paper_fn, gap_fn, paper_queries = _fanout_pipeline(
+        "q", ["facet one", "facet two", "facet three"]
+    )
+    engine = LocalResearchEngine(
+        service,
+        search_fn=search_fn,
+        analyze_fn=analyze_fn,
+        gap_fn=gap_fn,
+        paper_search_fn=paper_fn,
+        search_params={"search_default_max_queries": 5},
+    )
+    # The web call settles 1 + len(sub_questions) = 4 searches, so a budget of 5
+    # leaves room for exactly one extra academic query.
+    run = service.launch_run(
+        query="q",
+        autonomy_mode="autonomous",
+        limits_json={"max_iterations": 1, "max_searches": 5},
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert paper_queries == ["q", "facet one"], paper_queries
+
+
+def test_a_sub_question_equal_to_the_question_is_not_searched_twice():
+    service = _make_service()
+    search_fn, analyze_fn, paper_fn, gap_fn, paper_queries = _fanout_pipeline(
+        "q", ["  Q  ", "facet one"]
+    )
+    engine = LocalResearchEngine(
+        service,
+        search_fn=search_fn,
+        analyze_fn=analyze_fn,
+        gap_fn=gap_fn,
+        paper_search_fn=paper_fn,
+        search_params={"search_default_max_queries": 5},
+    )
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    assert paper_queries == ["q", "facet one"], paper_queries

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -13,6 +13,7 @@ import pytest
 
 from tldw_chatbook.Research_Interop.local_research_engine import LocalResearchEngine
 from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
 
 
 def _make_service() -> LocalResearchService:
@@ -1368,3 +1369,79 @@ def test_a_sub_question_equal_to_the_question_is_not_searched_twice():
     asyncio.run(engine.execute_run(run["id"]))
 
     assert paper_queries == ["q", "facet one"], paper_queries
+
+
+# --- _academic_queries directly (Qodo, PR 1772) --------------------------------
+# The helper was only exercised through full runs, so its cap, dedup and
+# budget arithmetic were inferred from end-to-end behaviour rather than pinned.
+
+
+def _queries_engine():
+    return LocalResearchEngine(_make_service(), search_fn=lambda q, p: ({}, {}))
+
+
+def test_academic_queries_keeps_primary_queries_and_appends_facets():
+    engine = _queries_engine()
+    ledger = BudgetLedger.from_limits({})
+
+    queries, reserved = engine._academic_queries(
+        ["q"], ["facet a", "facet b"], {"search_default_max_queries": 5}, ledger
+    )
+
+    assert queries == ["q", "facet a", "facet b"]
+    assert reserved == 2
+
+
+def test_academic_queries_reserves_without_settling():
+    """Reserve-before/settle-after: planning must not record spend."""
+    engine = _queries_engine()
+    ledger = BudgetLedger.from_limits({"max_searches": 10})
+
+    _queries, reserved = engine._academic_queries(
+        ["q"], ["facet a"], {"search_default_max_queries": 5}, ledger
+    )
+
+    assert reserved == 1
+    snapshot = ledger.snapshot()
+    # The reservation is visible, but nothing is settled as spent yet.
+    assert snapshot.get("searches_settled", 0) == 0, snapshot
+
+
+def test_academic_queries_stops_at_the_remaining_budget():
+    engine = _queries_engine()
+    ledger = BudgetLedger.from_limits({"max_searches": 2})
+    ledger.reserve_searches(1)
+    ledger.settle_searches(1)
+
+    queries, reserved = engine._academic_queries(
+        ["q"], ["facet a", "facet b", "facet c"],
+        {"search_default_max_queries": 9}, ledger,
+    )
+
+    assert reserved <= 1, reserved
+    assert queries[0] == "q"
+
+
+def test_academic_queries_dedupes_across_primaries_and_facets():
+    engine = _queries_engine()
+    ledger = BudgetLedger.from_limits({})
+
+    queries, reserved = engine._academic_queries(
+        ["q", "  Q "], ["  q  ", "facet a", "FACET A"],
+        {"search_default_max_queries": 9}, ledger,
+    )
+
+    assert queries == ["q", "facet a"], queries
+    assert reserved == 1
+
+
+def test_academic_queries_falls_back_when_the_cap_is_unusable():
+    engine = _queries_engine()
+    ledger = BudgetLedger.from_limits({})
+
+    queries, _reserved = engine._academic_queries(
+        ["q"], ["a", "b", "c", "d", "e", "f", "g"],
+        {"search_default_max_queries": "not-a-number"}, ledger,
+    )
+
+    assert len(queries) == 5, queries  # DEFAULT_MAX_QUERIES

--- a/backlog/tasks/task-17372 - Sub-question-fan-out-never-reaches-the-academic-lane.md
+++ b/backlog/tasks/task-17372 - Sub-question-fan-out-never-reaches-the-academic-lane.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17372
 title: Sub-question fan-out never reaches the academic lane
-status: To Do
+status: In Progress
 assignee:
   - '@robert'
 created_date: '2026-08-17 07:35'
@@ -21,7 +21,56 @@ Phase-1 sub-question generation happens inside the web pipeline, so the generate
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Whether the academic lane searches generated sub-questions is a stated, tested decision rather than a side effect of where sub-question generation lives.
-- [ ] #2 If the lane does fan out, its extra searches are counted against the same budget ledger and search cap as the web lane's, with no path that spends past the cap.
-- [ ] #3 The gate-versus-retrieval asymmetry is documented wherever the decomposition settings are described, so a measured result cannot be misread as evidence about retrieval.
+- [x] #1 Whether the academic lane searches generated sub-questions is a stated, tested decision rather than a side effect of where sub-question generation lives.
+- [x] #2 If the lane does fan out, its extra searches are counted against the same budget ledger and search cap as the web lane's, with no path that spends past the cap.
+- [x] #3 The gate-versus-retrieval asymmetry is documented wherever the decomposition settings are described, so a measured result cannot be misread as evidence about retrieval.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Decide the asymmetry deliberately: the lane searches generated facets, since
+   without that fan-out cannot affect retrieval at all and its only measured
+   effect (gate context) is nil.
+2. Build the lane's query list in one place -- primary queries plus facets,
+   deduplicated case-insensitively.
+3. Bound it twice: the same query cap the web lane obeys, and a ledger
+   reservation per extra query so a tight max_searches cannot be exceeded.
+4. Cover the decision, the cap, the budget and the dedup with tests.
+5. Document the change where the decomposition settings are described, and scope
+   the already-recorded fan-out measurement to what it actually measured.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The academic lane now searches the generated sub-questions, via a single
+`_academic_queries` helper that builds the round's query list. The decision is
+stated rather than incidental: fan-out's only measured effect was on the gate
+(task-17370 recorded 0.42 -> 0.38, i.e. flat), so unless the facets reach
+retrieval the feature has no demonstrated purpose.
+
+Bounded twice over. The total is capped by the same
+`search_default_max_queries` the web lane obeys, and each EXTRA query reserves
+and settles one search against the ledger, so a tight `max_searches` cannot be
+exceeded by the lane fanning out. The base `round_queries` keep today's
+accounting (uncounted) deliberately -- counting them would silently shrink every
+existing run's web budget, which is a separate decision from this one and is
+recorded as such in the helper's docstring.
+
+Dedup is case-insensitive and whitespace-trimmed, because the pipeline already
+drops a sub-question identical to the original question before its own fan-out;
+without matching that here the lane would search the same text twice through a
+different path.
+
+AC #3: the `[SearchSettings] search_enable_subquery` comment now states that
+enabling fan-out changes both retrieval and judging, and the eval baseline doc
+carries a scope note on every recorded fan-out number -- they measured the
+gate-context half only, so fan-out's retrieval value is untested rather than
+disproven.
+
+Modified: `tldw_chatbook/Research_Interop/local_research_engine.py`,
+`tldw_chatbook/config.py`,
+`Tests/Research/test_local_research_engine.py`,
+`Docs/Development/research-report-eval-baseline.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
+++ b/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
@@ -9,7 +9,7 @@ labels:
   - llm-calls
   - bug
 dependencies: []
-priority: medium
+priority: high
 ---
 
 ## Description
@@ -33,6 +33,14 @@ The consequence is bounded rather than silent: the caller recognizes the failure
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+Raised to high priority on task-17372's arm G evidence (2026-08-17): this now
+blocks BOTH decomposition mechanisms, not just an edge case. That arm admitted
+56% more evidence than its predecessor (32 -> 50 sources) and produced HALF the
+resolved citation markers (70 -> 37), because it was the first fan-out arm large
+enough to trigger map-reduce chunking -- 8 chunk operations, 6 of them failing
+here. With multi-hop shipping on by default, every larger evidence pool runs
+into this, so the defect converts retrieval improvements into worse reports.
+
 Evidence from the task-17370 arm F run (2026-08-17), all three earlier defects
 already fixed:
 

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -76,6 +76,11 @@ def _configured_max_iterations() -> int:
     return configured if configured >= 1 else DEFAULT_MAX_ITERATIONS
 
 
+#: Total search queries per call when nothing configures it. Qodo (PR 1772):
+#: the literal was repeated at every read site, so a change to one silently
+#: left the lanes reading different caps.
+DEFAULT_MAX_QUERIES = 5
+
 SearchFn = Callable[[str, dict[str, Any]], Any]
 AnalyzeFn = Callable[..., Awaitable[Any]]
 GapFn = Callable[[dict[str, Any]], Awaitable[list[str]]]
@@ -472,7 +477,8 @@ class LocalResearchEngine:
             reserved_for_call = 0
             if remaining is not None:
                 cap = min(
-                    int(params.get("search_default_max_queries", 5) or 5),
+                    int(params.get("search_default_max_queries", DEFAULT_MAX_QUERIES)
+                or DEFAULT_MAX_QUERIES),
                     max(1, remaining),
                 )
                 params["search_default_max_queries"] = cap
@@ -513,7 +519,7 @@ class LocalResearchEngine:
         round_sub_questions: list[str],
         params: dict[str, Any],
         ledger: BudgetLedger,
-    ) -> list[str]:
+    ) -> tuple[list[str], int]:
         """Queries the academic lane searches this round (task-17372).
 
         Sub-question generation lives inside the WEB pipeline, so generated
@@ -539,19 +545,28 @@ class LocalResearchEngine:
             ledger: Budget ledger; extra queries are reserved against it.
 
         Returns:
-            The queries to search, in order, deduplicated case-insensitively.
+            ``(queries, reserved_extras)``: the queries to search, in order and
+            deduplicated case-insensitively, and how many searches were
+            RESERVED for the generated facets. Qodo (PR 1772): the caller must
+            settle what it actually attempts and release the rest -- settling
+            here recorded later, unattempted searches as spent whenever a run
+            failed part-way through the lane.
         """
         queries: list[str] = []
         seen: set[str] = set()
+        reserved_extras = 0
         for query in round_queries:
             key = str(query).strip().casefold()
             if key and key not in seen:
                 seen.add(key)
                 queries.append(query)
         try:
-            cap = int(params.get("search_default_max_queries", 5) or 5)
+            cap = int(
+                params.get("search_default_max_queries", DEFAULT_MAX_QUERIES)
+                or DEFAULT_MAX_QUERIES
+            )
         except (TypeError, ValueError):
-            cap = 5
+            cap = DEFAULT_MAX_QUERIES
         cap = max(1, cap)
         for facet in round_sub_questions:
             if len(queries) >= cap:
@@ -563,10 +578,10 @@ class LocalResearchEngine:
             if remaining is not None and remaining < 1:
                 break
             ledger.reserve_searches(1)
-            ledger.settle_searches(1)
+            reserved_extras += 1
             seen.add(key)
             queries.append(str(facet).strip())
-        return queries
+        return queries, reserved_extras
 
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:
         self.service.save_artifact(
@@ -693,7 +708,7 @@ class LocalResearchEngine:
                 # run failure -- the other lane already collected.
                 providers_filter = self._active_academic_providers
                 accepts_providers = self._paper_fn_accepts_providers()
-                for query in self._academic_queries(
+                academic_queries, reserved_extras = self._academic_queries(
                     round_queries,
                     round_sub_questions,
                     # The same resolved params the web lane collected with, so
@@ -701,7 +716,16 @@ class LocalResearchEngine:
                     # two lanes reading different caps.
                     self._active_run_params or search_params,
                     ledger,
-                ):
+                )
+                base_count = len(
+                    [q for q in academic_queries if q in set(round_queries)]
+                )
+                attempted_extras = 0
+                for position, query in enumerate(academic_queries):
+                    if position >= base_count:
+                        # An attempted provider call has spent, whether or not
+                        # it returned -- settled here, not at planning time.
+                        attempted_extras += 1
                     try:
                         if providers_filter is not None and accepts_providers:
                             papers = await self._maybe_await(
@@ -719,6 +743,10 @@ class LocalResearchEngine:
                                 continue
                             seen_dois.add(doi)
                         paper_results.append(paper)
+                if attempted_extras:
+                    ledger.settle_searches(attempted_extras)
+                if reserved_extras > attempted_extras:
+                    ledger.release_searches(reserved_extras - attempted_extras)
             # task-16791: merge order follows the policy's preferred lane.
             round_results = (
                 paper_results + round_results

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -507,6 +507,67 @@ class LocalResearchEngine:
                 ledger.release_searches(reserved_for_call - executed_searches)
         return collected, sub_questions, warnings
 
+    def _academic_queries(
+        self,
+        round_queries: list[str],
+        round_sub_questions: list[str],
+        params: dict[str, Any],
+        ledger: BudgetLedger,
+    ) -> list[str]:
+        """Queries the academic lane searches this round (task-17372).
+
+        Sub-question generation lives inside the WEB pipeline, so generated
+        facets used to drive web searches only: this lane looped
+        ``round_queries``, which is ``[question]`` in round 1. Fan-out therefore
+        changed how academic evidence was JUDGED -- the facets do reach the
+        relevance gate through the merged sub-question list -- while leaving
+        what was RETRIEVED untouched, which is why task-17370 measured fan-out
+        as flat on the repositories lane and could say nothing about retrieval.
+        The lane now searches the facets too, so enabling fan-out changes both.
+
+        The generated facets are bounded twice over. The total is capped by the
+        same ``search_default_max_queries`` the web lane obeys, and each EXTRA
+        query is reserved against the search ledger, so a tight ``max_searches``
+        cannot be exceeded by this lane. The base ``round_queries`` keep today's
+        accounting (uncounted) deliberately: counting them would shrink every
+        existing run's web budget, which is a separate decision from this one.
+
+        Args:
+            round_queries: This round's primary queries.
+            round_sub_questions: Facets the web pipeline generated this round.
+            params: Resolved search params, read for the query cap.
+            ledger: Budget ledger; extra queries are reserved against it.
+
+        Returns:
+            The queries to search, in order, deduplicated case-insensitively.
+        """
+        queries: list[str] = []
+        seen: set[str] = set()
+        for query in round_queries:
+            key = str(query).strip().casefold()
+            if key and key not in seen:
+                seen.add(key)
+                queries.append(query)
+        try:
+            cap = int(params.get("search_default_max_queries", 5) or 5)
+        except (TypeError, ValueError):
+            cap = 5
+        cap = max(1, cap)
+        for facet in round_sub_questions:
+            if len(queries) >= cap:
+                break
+            key = str(facet).strip().casefold()
+            if not key or key in seen:
+                continue
+            remaining = ledger.remaining_searches()
+            if remaining is not None and remaining < 1:
+                break
+            ledger.reserve_searches(1)
+            ledger.settle_searches(1)
+            seen.add(key)
+            queries.append(str(facet).strip())
+        return queries
+
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:
         self.service.save_artifact(
             run_id,
@@ -632,7 +693,15 @@ class LocalResearchEngine:
                 # run failure -- the other lane already collected.
                 providers_filter = self._active_academic_providers
                 accepts_providers = self._paper_fn_accepts_providers()
-                for query in round_queries:
+                for query in self._academic_queries(
+                    round_queries,
+                    round_sub_questions,
+                    # The same resolved params the web lane collected with, so
+                    # a per-run result_count/engine override cannot leave the
+                    # two lanes reading different caps.
+                    self._active_run_params or search_params,
+                    ledger,
+                ):
                     try:
                         if providers_filter is not None and accepts_providers:
                             papers = await self._maybe_await(

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3969,9 +3969,14 @@ log_unknown_models = true      # Whether to log when an unknown model is queried
 # final_answer_llm = "openai"
 # search_enable_subquery = false   # generate sub-questions from the query and
 #   search those too. Costs one LLM call plus up to search_default_max_queries-1
-#   extra searches, each carrying its own per-result relevance calls. Since
-#   task-17372 the generated facets ALSO drive academic-provider searches, so
-#   enabling this changes both what evidence is retrieved and how it is judged
+#   extra searches, each carrying its own per-result relevance calls. Qodo
+#   (PR 1772): with BOTH lanes active each generated facet costs TWO provider
+#   calls, not one -- a web search and an academic-provider search -- so the
+#   worst case is 2 x (search_default_max_queries - 1) extra calls per round,
+#   plus the per-result relevance and summarization calls each returned source
+#   then needs. Since task-17372 the facets ALSO drive academic-provider
+#   searches, so enabling this changes both what evidence is retrieved and how
+#   it is judged
 #   (the facets reach the relevance prompt either way). Before that fix it
 #   changed only the judging, which is why the recorded gate measurement for
 #   fan-out says nothing about retrieval -- see

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3967,7 +3967,15 @@ log_unknown_models = true      # Whether to log when an unknown model is queried
 # search_provider_default = "google"
 # relevance_analysis_llm = "openai"
 # final_answer_llm = "openai"
-# search_enable_subquery = false
+# search_enable_subquery = false   # generate sub-questions from the query and
+#   search those too. Costs one LLM call plus up to search_default_max_queries-1
+#   extra searches, each carrying its own per-result relevance calls. Since
+#   task-17372 the generated facets ALSO drive academic-provider searches, so
+#   enabling this changes both what evidence is retrieved and how it is judged
+#   (the facets reach the relevance prompt either way). Before that fix it
+#   changed only the judging, which is why the recorded gate measurement for
+#   fan-out says nothing about retrieval -- see
+#   Docs/Development/research-report-eval-baseline.md.
 # search_default_max_queries = 5
 # search_result_max = 10
 # relevance_llm_timeout_s = 30   # per relevance/summarization LLM call. Measured


### PR DESCRIPTION
Closes **TASK-17372**, the finding that explained why fan-out measured flat — and the live arm here shows what it unlocks, plus what still blocks it.

## The asymmetry

Sub-question generation lives inside the *web* pipeline, so generated facets only ever drove web searches: the academic lane looped `round_queries`, which is `[question]` in round 1. Fan-out changed how academic evidence was **judged** (facets do reach the relevance prompt via the merged sub-question list) while leaving what was **retrieved** identical. That's why TASK-17370's measurement recorded fan-out as flat and could say nothing about retrieval — the records under judgment were the same set either way.

## The decision, made explicitly

The lane now searches the facets. Stated rather than left incidental: fan-out's only measured effect was on the gate, and it was nil, so unless facets reach retrieval the feature has no demonstrated purpose.

**Bounded twice**, since this multiplies provider calls:

- the total obeys the same `search_default_max_queries` the web lane obeys
- each *extra* query reserves and settles a search against the ledger, so a tight `max_searches` cannot be exceeded by the lane fanning out

The *base* `round_queries` keep today's uncounted accounting deliberately — counting them would silently shrink every existing run's web budget, which is a separate decision, recorded in the helper's docstring rather than smuggled in here.

## Measured: it works, and the synthesis path eats the benefit

Arm G — repositories lane, same questions/judge/bounds as the recorded arms, `--max-queries 3 --max-iterations 1`:

| | Arm B (gate context only) | **Arm G (retrieval too)** |
|---|---|---|
| evidence **admitted** by the gate | 32 | **50** |
| evidence rejected | 21 | 28 |
| `gate_pass_rate` | 0.379 | 0.335 |
| resolved citation markers | 70 | **37** |
| chunk operations / failures | 1 / 0 | 8 / **6** |

**Retrieval-side fan-out works: +56% admitted evidence.** The falling `gate_pass_rate` is a ratio behaving as a ratio — more candidates judged, proportionally more marginal — which is exactly why the absolute admitted count is the number that answers the question.

**But it doesn't reach the report.** Markers *halved* while admitted evidence grew by half again. Not the gate: arm G is the first fan-out arm large enough to trigger map-reduce chunking, and 6 of 8 chunk summarizations failed with `No choices in response data` (**TASK-17384**). The synthesis got fallback text for most chunks and cited a fraction of what was admitted.

That's the third time in this program a retrieval improvement has been masked by the summarization path rather than refuted by the gate, so I raised 17384 to **high** — with multi-hop now shipping on by default, every larger evidence pool hits it.

## Documentation (AC #3)

My own earlier verdict — "fan-out: no measurable benefit" — is now scoped in the baseline doc with a note on every fan-out number: they measured the gate-context half only, so fan-out's retrieval value was **untested, not disproven**. The `search_enable_subquery` config comment says the same. Leaving that unqualified would have let a future reader cite my measurement as evidence against a mechanism it never exercised.

## Verification

- Four new tests: facets reach the providers, the query cap holds, a tight `max_searches` caps fan-out at one extra query, and a facet identical to the question isn't searched twice (matching what the pipeline already does).
- **289 passed** across `Tests/Research`, `Tests/UI/test_research_screen.py`, `Tests/Helper_Scripts`; `ruff` clean.
- Live arm above, on the same judge and question set as every recorded number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let generated sub-questions drive academic-provider searches, not just web searches, so fan-out changes retrieval as well as judging. Old behavior: academic lane searched only `round_queries` (usually just `[question]`). New behavior: it also searches generated facets, capped and budgeted; budgeting now settles only attempted extra calls.

- Adds `_academic_queries`: builds `[round_queries + facets]`, case-insensitive/trim deduped, capped by `search_default_max_queries` (centralized as `DEFAULT_MAX_QUERIES`). Base `round_queries` remain uncounted to avoid shrinking current web budgets.
- Budgeting fix: extra academic facet queries are reserved at planning and settled after provider calls; unused reservations are released, preventing inflated spend on partial failures. A tight `max_searches` cannot be exceeded.
- Academic lane reads the same resolved per-run params as the web lane. Tests cover provider reach, cap adherence, ledger reserve/settle, dedup, and unusable-cap fallback; 294 passing.
- Docs: baseline now scopes earlier fan-out numbers to gate-only and records +56% admitted evidence with retrieval fan-out; `config.py` clarifies `search_enable_subquery` affects retrieval and judging and that facets cost two provider calls (web + academic). Satisfies `TASK-17372`; `TASK-17384` raised to high priority.

<sup>Written for commit b0f0c7913e60533f9bbebac06622b4b855b10fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

