### PR TITLE
fix(llm): give summarization the token budget its caller configured

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -468,6 +468,39 @@ refuted by the gate. task-17384 is therefore on the critical path for BOTH
 decomposition mechanisms now that multi-hop ships on by default: the bigger the
 evidence pool either one produces, the more of it chunking swallows.
 
+### The chunk fix, and where the bottleneck went next (arm H, task-17384)
+
+Arm G's conditions repeated with map-reduce chunk summarization fixed (the
+summarizer was pinned to a 4096 token budget while the chat path ran on 16384,
+and the model spends ~3.6-4k of that on reasoning):
+
+| | Arm G (chunk summaries failing) | Arm H (fixed) |
+|---|---|---|
+| chunk summarization failures | 6 of 8 | **0 of 2** |
+| evidence admitted | 50 | **66** |
+| resolved citation markers | 37 over 3 runs | 55 over 2 runs (**2.2x per run**) |
+| `cited_sentence_ratio` | 0.63 | **1.00** |
+| `citation_accuracy` | 1.00 | 1.00 |
+| questions scored | 3 of 3 | **2 of 3** |
+
+**The retrieval gain now reaches the report.** Citation density hit 1.00 --
+every sentence in both scored reports carried a marker -- and markers per run
+more than doubled. Chunk summarization stopped failing entirely.
+
+**And the bottleneck moved again, to the synthesis call's wall clock.** The
+third question produced NOTHING: its single synthesis call hit the provider read
+timeout (600s, what the recorder primes) and the run left no report and no
+verification payload, so it is absent from the aggregate rather than scored as a
+failure. Filed as task-17386.
+
+That is the fourth time in this program that fixing one stage has revealed the
+next one as the binding constraint -- gate, then chunk summarization, then
+per-result summarization, now synthesis wall clock. The pattern is worth stating
+plainly: **each measured improvement in what the pipeline RETRIEVES raises the
+load on what it must then SUMMARIZE and WRITE**, and every one of those stages
+had a bound calibrated for the single-query runs this document used to record.
+
+
 ### Reading gate_pass_rate
 
 It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -216,6 +216,8 @@ def test_summarize_with_llama_reports_an_unusable_payload(monkeypatch):
 
 
 def test_summarize_with_llama_prefers_the_modern_max_tokens(monkeypatch, captured_post):
+    """A run priming a local endpoint sets the budget in the modern table; the
+    summarizer must spend it rather than the legacy default."""
     settings = _settings()
     settings["api_settings"]["llama_cpp"]["max_tokens"] = 16384
     monkeypatch.setattr(lib, "load_settings", lambda: settings)
@@ -228,6 +230,7 @@ def test_summarize_with_llama_prefers_the_modern_max_tokens(monkeypatch, capture
 def test_summarize_with_llama_falls_back_to_the_legacy_max_tokens(
     monkeypatch, captured_post
 ):
+    """With no modern entry the historical key still governs the budget."""
     monkeypatch.setattr(lib, "load_settings", lambda: _settings())
 
     lib.summarize_with_llama("text", "Summarize.", api_key=None)
@@ -268,3 +271,56 @@ def test_empty_content_failure_names_the_actual_cause(monkeypatch):
     assert _is_summary_failure(result), result
     lowered = result.lower()
     assert "length" in lowered and "reasoning" in lowered, result
+
+
+def test_budget_and_diagnostic_reach_the_public_analyze_boundary(monkeypatch):
+    """Qodo (PR 1774): the other tests call summarize_with_llama directly. This
+    one goes through `analyze`, which is the seam the deep-search pipeline
+    actually calls, so the budget resolution and the reasoning-only diagnostic
+    are verified where a caller meets them rather than one layer in."""
+    from tldw_chatbook.LLM_Calls.Summarization_General_Lib import analyze
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    settings = _settings()
+    settings["api_settings"]["llama_cpp"]["max_tokens"] = 16384
+    monkeypatch.setattr(lib, "load_settings", lambda: settings)
+
+    seen = {}
+
+    class _Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, url, headers=None, json=None, stream=False):
+            seen["max_tokens"] = json["max_tokens"]
+            return _FakeResponse(
+                {
+                    "choices": [
+                        {
+                            "finish_reason": "length",
+                            "message": {
+                                "role": "assistant",
+                                "content": "",
+                                "reasoning_content": "thought " * 400,
+                            },
+                        }
+                    ],
+                    "usage": {"completion_tokens": 16384},
+                }
+            )
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+
+    result = analyze(
+        input_data="a chunk of packed evidence",
+        custom_prompt_arg="Summarize.",
+        api_name="llama_cpp",
+        api_key=None,
+        temp=0.3,
+        system_message=None,
+        streaming=False,
+    )
+
+    assert seen["max_tokens"] == 16384, seen
+    assert _is_summary_failure(result), result
+    assert "reasoning" in result.lower() and "length" in result.lower(), result

--- a/Tests/LLM_Calls/test_llama_summarizer_config.py
+++ b/Tests/LLM_Calls/test_llama_summarizer_config.py
@@ -203,3 +203,68 @@ def test_summarize_with_llama_reports_an_unusable_payload(monkeypatch):
     from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
 
     assert _is_summary_failure(result), result
+
+
+# --- token budget and empty-content reporting (task-17384) --------------------
+# Chunk summarization failed with "No choices in response data" while
+# per-result calls on the same path succeeded. Captured live: the model spends
+# its budget on reasoning_content (4028 of 4096 completion tokens on a real
+# 6000-char chunk, leaving 465 chars of content), so a chunk that reasons a
+# little longer returns EMPTY content. The summarizer was reading max_tokens
+# from the legacy section only, never the modern table a run primes -- the same
+# split that sent its requests to the wrong port.
+
+
+def test_summarize_with_llama_prefers_the_modern_max_tokens(monkeypatch, captured_post):
+    settings = _settings()
+    settings["api_settings"]["llama_cpp"]["max_tokens"] = 16384
+    monkeypatch.setattr(lib, "load_settings", lambda: settings)
+
+    lib.summarize_with_llama("text", "Summarize.", api_key=None)
+
+    assert captured_post["json"]["max_tokens"] == 16384
+
+
+def test_summarize_with_llama_falls_back_to_the_legacy_max_tokens(
+    monkeypatch, captured_post
+):
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    lib.summarize_with_llama("text", "Summarize.", api_key=None)
+
+    assert captured_post["json"]["max_tokens"] == 4096
+
+
+def test_empty_content_failure_names_the_actual_cause(monkeypatch):
+    """The old message blamed missing choices; the real cause is a completion
+    that spent its budget on reasoning. A caller reading the run's warnings
+    should be able to tell those apart."""
+    monkeypatch.setattr(lib, "load_settings", lambda: _settings())
+
+    class _Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, *_a, **_k):
+            return _FakeResponse(
+                {
+                    "choices": [
+                        {
+                            "finish_reason": "length",
+                            "message": {"role": "assistant", "content": "",
+                                        "reasoning_content": "thinking..." * 50},
+                        }
+                    ],
+                    "usage": {"completion_tokens": 4096},
+                }
+            )
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: _Session())
+
+    result = lib.summarize_with_llama("text", "Summarize.", api_key=None)
+
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    assert _is_summary_failure(result), result
+    lowered = result.lower()
+    assert "length" in lowered and "reasoning" in lowered, result

--- a/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
+++ b/backlog/tasks/task-17384 - Chunk-summarization-fails-on-large-inputs-with-an-unparseable-200.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17384
 title: Chunk summarization fails on large inputs with an unparseable 200
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-17 11:20'
 labels:
@@ -24,10 +24,10 @@ The consequence is bounded rather than silent: the caller recognizes the failure
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The failing response body is captured and the cause identified rather than inferred
-- [ ] #2 A chunk-sized summarization request against a local endpoint either succeeds or fails with a message naming the actual cause
-- [ ] #3 If the cause is prompt size, the chunk packer's bound is derived from something the endpoint reports rather than a fixed constant
-- [ ] #4 A test covers the identified failure mode without contacting a network
+- [x] #1 The failing response body is captured and the cause identified rather than inferred
+- [x] #2 A chunk-sized summarization request against a local endpoint either succeeds or fails with a message naming the actual cause
+- [x] #3 The bound that actually governs the failure is read from configuration rather than a fixed constant (AMENDED: the cause is not prompt size -- see notes)
+- [x] #4 A test covers the identified failure mode without contacting a network
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,6 +40,50 @@ resolved citation markers (70 -> 37), because it was the first fan-out arm large
 enough to trigger map-reduce chunking -- 8 chunk operations, 6 of them failing
 here. With multi-hop shipping on by default, every larger evidence pool runs
 into this, so the defect converts retrieval improvements into worse reports.
+
+## Cause, captured rather than inferred (AC #1)
+
+**The oversized-prompt guess recorded below when this was filed is DISPROVEN.**
+The chunk packer caps chunks at 6000 characters (`_build_chunk_infos`,
+`max_chars=6000`) against a server started with a 64k context, and a probe at
+2,000 and 20,000 characters returned HTTP 200 with `choices` present. "No
+choices in response data" was this function's parser fallthrough on EMPTY
+content, not a missing `choices` array.
+
+A faithful reproduction -- the real 6000-char packed chunk, the verbatim chunk
+prompt, `max_tokens=4096` as the summarizer resolved it -- captured the actual
+answer:
+
+    finish_reason='stop'  content_len=465  reasoning_len=13209
+    usage: completion_tokens=4028  (of max_tokens=4096)
+
+The model spends its completion budget on `reasoning_content` and emits content
+at the very edge of it. A chunk that reasons slightly longer returns empty
+content, which is why 6 of 8 chunk summarizations failed in the task-17372 arm
+while per-result calls in the same run succeeded: the margin is razor-thin and
+input-dependent, not a size threshold.
+
+An earlier probe appeared to refute this because it used a small input and spent
+only 168 completion tokens -- 24x less than the real chunk. Recorded because the
+mistake is instructive: a token-budget hypothesis cannot be tested on an input
+that does not provoke the reasoning.
+
+## Fix
+
+`max_tokens` now prefers the modern `api_settings.llama_cpp` entry before the
+legacy `llama_cpp_api` section -- the same split that had been sending these
+requests to the wrong port (task-17382). A run priming a local endpoint sets
+16384 there; reading only the legacy section pinned summarization to 4096 while
+the chat path ran on four times that. That is AC #3 in its amended form: the
+bound that governs this failure is the token budget, and it now comes from
+configuration rather than a constant.
+
+The failure message now names the real cause -- finish reason, tokens spent
+against the budget, and whether the completion was reasoning-only -- while the
+`logging.error` text stays verbatim, because that one is tracked in the reviewed
+diagnostic inventory (task-492/3750) and this change is about the RETURNED
+value a caller surfaces in a run's warnings. The "no choices in response" prefix
+is preserved so the deep-search failure detector still recognizes it.
 
 Evidence from the task-17370 arm F run (2026-08-17), all three earlier defects
 already fixed:

--- a/backlog/tasks/task-17386 - Synthesis-exceeds-the-provider-timeout-on-large-evidence-pools.md
+++ b/backlog/tasks/task-17386 - Synthesis-exceeds-the-provider-timeout-on-large-evidence-pools.md
@@ -1,0 +1,52 @@
+---
+id: TASK-17386
+title: Synthesis exceeds the provider timeout on large evidence pools
+status: To Do
+assignee: []
+created_date: '2026-08-17 16:45'
+labels:
+  - research
+  - websearch
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A research run whose evidence pool is large enough can lose its entire report to the provider's request timeout during final synthesis. The run collects and judges its sources normally, the gate admits them, and then the single synthesis call never returns within the configured wall clock, so the run produces no answer and no verification payload at all — the work spent on collection and judgement is discarded.
+
+This now matters much more than when it was harmless. Multi-hop ships enabled by default and sub-question fan-out reaches the academic providers, so evidence pools are substantially larger than the ones every earlier measurement used; and per-chunk summarization now succeeds rather than failing fast, which lengthens the reduce step it feeds. The failure is silent in the metrics, because a run that produces no payload is simply absent from the aggregate rather than scored as a failure.
+
+Bounding the synthesis input, streaming it, or deriving the timeout from the pool size are all plausible answers; deciding between them needs the measurement below rather than taste.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A run whose synthesis cannot complete within the wall clock produces a recorded, legible terminal state instead of vanishing from results
+- [ ] #2 The relationship between evidence-pool size and synthesis wall clock is measured, not assumed
+- [ ] #3 A run on a local model with a pool the size of a default multi-hop run completes its synthesis, or is bounded so that it can
+- [ ] #4 Whatever bound is chosen is stated where a user meets it, alongside the existing decomposition spend notes
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Observed in task-17384's arm H (2026-08-17), the first arm carrying both the
+academic fan-out fix (task-17372) and the chunk-summarization fix:
+
+- Two of three questions scored normally and well: markers 23/23 and 32/32,
+  `cited_sentence_ratio` 1.00 on both, zero chunk failures.
+- The third produced nothing. Its log ends in
+  `urllib3.exceptions.ReadTimeoutError: HTTPConnectionPool(host='127.0.0.1',
+  port=9191): Read timed out. (read timeout=600)` on `/v1/chat/completions`,
+  followed by the recorder's `[no citation verification on the synthesis
+  branch]`.
+- That run's pool was the largest of the three: the arm admitted 66 sources
+  across its questions, against 50 in the arm before the fan-out fix and 32
+  before that.
+- 600s is what `record_research_baseline._prime_local_llm_url` sets as
+  `api_timeout`; the shipped provider default is lower, so an ordinary run is
+  more exposed than this measurement was.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -265,11 +265,22 @@ def summarize_with_llama(
                 temp = 0.7
         logging.debug(f"Llama: Using temperature: {temp}")
 
-        # Check for max tokens
-        if "max_tokens" in llama_config:
-            max_tokens = llama_config["max_tokens"]
-            max_tokens = int(max_tokens)
-        else:
+        # Check for max tokens. task-17384: prefer the modern api_settings entry
+        # for the same reason as the URL above -- that is what a run priming a
+        # local endpoint sets, and reading only the legacy section left this at
+        # 4096 while the chat path ran on 16384. Captured live on a real
+        # 6000-char chunk: the model spent 4028 of 4096 completion tokens on
+        # reasoning_content and emitted 465 characters of content, so a chunk
+        # that reasons slightly longer returns EMPTY content -- which is exactly
+        # how map-reduce chunk summarization was failing.
+        raw_max_tokens = api_settings_llama.get("max_tokens")
+        if raw_max_tokens is None:
+            raw_max_tokens = llama_config.get("max_tokens")
+        try:
+            max_tokens = int(raw_max_tokens) if raw_max_tokens is not None else 4096
+        except (TypeError, ValueError):
+            max_tokens = 4096
+        if max_tokens < 1:
             max_tokens = 4096
         logging.debug(f"Llama: Using max tokens: {max_tokens}")
 
@@ -372,8 +383,40 @@ def summarize_with_llama(
                     logging.debug("llama: Summarization successful")
                     logging.info("Summarization successful.")
                     return summary
+                # The log line stays verbatim -- it is tracked in the reviewed
+                # diagnostic inventory (task-492/3750) and this change is about
+                # the RETURNED value, which is what a caller surfaces in a run's
+                # warnings. task-17384: "no choices" was a guess at the cause;
+                # the real one is a completion that spent its token budget on
+                # reasoning and emitted no content. The "no choices in response"
+                # prefix is preserved so the deep-search failure detector still
+                # recognizes it.
                 logging.error("Llama: No choices in response data")
-                return "Llama: No choices in response data"
+                detail = ""
+                if isinstance(response_data, dict):
+                    first = (response_data.get("choices") or [{}])[0]
+                    if isinstance(first, dict):
+                        finish = first.get("finish_reason")
+                        message = first.get("message")
+                        reasoning = ""
+                        if isinstance(message, dict):
+                            reasoning = str(message.get("reasoning_content") or "")
+                        spent = (response_data.get("usage") or {}).get(
+                            "completion_tokens"
+                        )
+                        parts = []
+                        if finish:
+                            parts.append(f"finish_reason={finish}")
+                        if spent is not None:
+                            parts.append(f"completion_tokens={spent}/{max_tokens}")
+                        if reasoning:
+                            parts.append(
+                                f"reasoning-only completion ({len(reasoning)} chars "
+                                "of reasoning, no content)"
+                            )
+                        if parts:
+                            detail = " (" + "; ".join(parts) + ")"
+                return f"Llama: No choices in response data{detail}"
         else:
             logging.error(
                 "Llama: API request failed; status_code=%s",

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -142,6 +142,13 @@ def summarize_with_local_llm(
         return f"Local LLM: Error occurred while processing summary: {str(e)}"
 
 
+#: Completion budget used when neither the modern api_settings entry nor the
+#: legacy section names one (Qodo, PR 1774: the literal was repeated at each
+#: fallback). Measured against a thinking model, this is TIGHT: a real 6000-char
+#: chunk spent 4028 of these on reasoning before emitting content (task-17384).
+DEFAULT_SUMMARY_MAX_TOKENS = 4096
+
+
 def summarize_with_llama(
     input_data,
     custom_prompt,
@@ -277,11 +284,15 @@ def summarize_with_llama(
         if raw_max_tokens is None:
             raw_max_tokens = llama_config.get("max_tokens")
         try:
-            max_tokens = int(raw_max_tokens) if raw_max_tokens is not None else 4096
+            max_tokens = (
+                int(raw_max_tokens)
+                if raw_max_tokens is not None
+                else DEFAULT_SUMMARY_MAX_TOKENS
+            )
         except (TypeError, ValueError):
-            max_tokens = 4096
+            max_tokens = DEFAULT_SUMMARY_MAX_TOKENS
         if max_tokens < 1:
-            max_tokens = 4096
+            max_tokens = DEFAULT_SUMMARY_MAX_TOKENS
         logging.debug(f"Llama: Using max tokens: {max_tokens}")
 
         # Check for streaming


### PR DESCRIPTION
Closes **TASK-17384**. The cause is captured, not inferred — and **the cause I wrote into that task when I filed it was wrong**, so this PR corrects the record as well as the code.

## What it isn't

I filed 17384 guessing "an error body returned for an oversized prompt." Disproven:

- the chunk packer caps chunks at **6000 chars** (`_build_chunk_infos`) against a server with a 64k context
- probes at 2,000 and 20,000 chars returned **HTTP 200 with `choices` present**

`"No choices in response data"` was my own parser's fallthrough on **empty content**, never a missing `choices` array.

## What it is

A faithful reproduction — the real 6000-char packed chunk, the verbatim chunk prompt, `max_tokens=4096` exactly as the summarizer resolved it:

```
finish_reason='stop'   content_len=465   reasoning_len=13209
usage: completion_tokens=4028   (of max_tokens=4096)
```

The model spends its completion budget on `reasoning_content` and emits content at the very edge of it. A chunk that reasons slightly longer returns **nothing** — which is why 6 of 8 chunks failed in TASK-17372's arm while per-result calls in the same run succeeded. It's variance at a razor-thin margin, not a size threshold.

Measured headroom, same chunk, two budgets:

| `max_tokens` | reasoning tokens | content | headroom |
|---|---|---|---|
| 4096 | 4028 | 465 chars | **68 tokens** |
| 16384 | 3617 | 564 chars | **12,767 tokens** |

**An earlier probe of mine appeared to refute this hypothesis** — it used a small input and spent 168 completion tokens, 24× less than a real chunk. A token-budget hypothesis cannot be tested on an input that doesn't provoke the reasoning. That's recorded in the task notes, because it's the kind of mistake that repeats.

## The fix

Same root cause as the other three defects in this function: **reading configuration from a place the rest of the app stopped using.** `max_tokens` now prefers the modern `api_settings.llama_cpp` entry before legacy `llama_cpp_api` — a run priming a local endpoint sets 16384 there, while the legacy default pinned summarization to 4096 with the chat path on four times that.

The failure message now names the actual cause: finish reason, tokens spent against the budget, and whether the completion was reasoning-only. The `logging.error` text stays **verbatim** — it's tracked in the reviewed diagnostic inventory (task-492/3750), and this changes the *returned* value a caller surfaces in run warnings. The `"no choices in response"` prefix is preserved so the deep-search failure detector still catches it.

## Verification

- Three new tests: modern budget preferred, legacy fallback intact, and an empty reasoning-only completion reported with its real cause.
- **No governed-diagnostic churn**: the privacy suite fails exactly the 3 manifest-boundary tests clean `dev` fails (3 failed / 254 passed on both sides).
- **390 passed** across `Tests/Web_Scraping`, `Tests/Research` and the summarizer config tests; `ruff` clean.
- A live arm is running now that reproduces TASK-17372's conditions **with** this fix, to test whether the markers that arm lost (70 → 37, while admitted evidence rose 32 → 50) come back. I'll post the numbers here either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give chunk summarization the caller’s configured token budget and explain empty content when the model spends the budget on reasoning. Previously it always used a 4096-token limit and returned “Llama: No choices in response data” without context.

- Prefer `api_settings.llama_cpp.max_tokens` over legacy `llama_cpp_api.max_tokens`; validate and fall back to `DEFAULT_SUMMARY_MAX_TOKENS` (4096).
- Returned message now appends `finish_reason`, `completion_tokens/max_tokens`, and a reasoning‑only marker; keep the “Llama: No choices in response data” prefix and the unchanged `logging.error` line for detectors.
- Tests: modern-budget preference, legacy fallback, and diagnostic details; new integration test through `analyze` verifies budget propagation and reasoning‑only failure at the public seam.
- Docs/backlog: update research baseline; add TASK-17386 for synthesis timeouts exposed by the fix.
- Migration: set `api_settings.llama_cpp.max_tokens` (e.g., 16384) to align chunk summarization with chat-path budgets.

<sup>Written for commit 89e0fe2f857a5a7649bcb57b70538a8588de8262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

