### PR TITLE
cross_encoder: implement, measure, and say what the measurement actually showed (TASK-16965)

### DIFF
--- a/Docs/Development/RAG/RAG-DESIGN.md
+++ b/Docs/Development/RAG/RAG-DESIGN.md
@@ -503,7 +503,9 @@ Batch processing utilities for efficient indexing.
    - Merge overlapping content
 
 3. **Re-ranking**
-   - Apply cross-encoder models (if enabled)
+   - Apply cross-encoder models (if enabled -- off by default, and measured
+     net-harmful on average; see the note under "Re-ranking" in Future
+     Enhancements)
    - Score based on expanded context
    - Filter by relevance thresholds
 
@@ -2357,7 +2359,18 @@ Future support for domain-specific step types:
 
 1. **Advanced Search**
    - Query expansion with LLMs
-   - Re-ranking with cross-encoders
+   - ~~Re-ranking with cross-encoders~~ — **done and measured, not
+     planned.** TASK-16965 shipped `CrossEncoderReranker` (local
+     sentence-transformers, no provider/credential/network) and ran it over
+     the 60-query golden set on the gated instrument against a rule fixed
+     before the run. It came out **net harmful** on the averaged row
+     (semantic MRR 0.808 → 0.762, hybrid 0.812 → 0.787 at k=10; recall@10
+     +0.022) and **strongly bimodal**: hybrid `scoped` MRR 0.163 → 0.929
+     and `prompt` 0.022 → 0.200, paid for by demoting already-rank-1
+     answers in `paraphrase`/`vocabulary_mismatch` (1.000 → 0.87–0.94).
+     It stays selectable as `reranking_strategy = "cross_encoder"` and is
+     the default of nothing. Numbers:
+     `Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`.
    - Multi-lingual support
 
 2. **Scalability**

--- a/Docs/Development/RAG/RAG-DESIGN.md
+++ b/Docs/Development/RAG/RAG-DESIGN.md
@@ -504,7 +504,7 @@ Batch processing utilities for efficient indexing.
 
 3. **Re-ranking**
    - Apply cross-encoder models (if enabled -- off by default, and measured
-     net-harmful on average; see the note under "Re-ranking" in Future
+     net-harmful on average [CAVEAT: that averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`), and `scoped` is where this strategy WINS -- over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075). TASK-16965 final review F1.]; see the note under "Re-ranking" in Future
      Enhancements)
    - Score based on expanded context
    - Filter by relevance thresholds

--- a/Docs/Development/RAG/RAG-Documentation.md
+++ b/Docs/Development/RAG/RAG-Documentation.md
@@ -818,7 +818,7 @@ max_expansions = 3
 
 Reorder results after retrieval. **This is not a quality win by default.**
 The one strategy that has been measured here (`cross_encoder`, TASK-16965)
-came out net harmful on the averaged row of the gated eval set — big gains
+came out net harmful on the averaged row [CAVEAT: that averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`), and `scoped` is where this strategy WINS -- over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075). TASK-16965 final review F1.] of the gated eval set — big gains
 on weak-retrieval query categories, losses on categories retrieval already
 got right — and the three LLM-driven strategies have never been measured at
 all (they bill a provider per call, which the local gate cannot run). Turn

--- a/Docs/Development/RAG/RAG-Documentation.md
+++ b/Docs/Development/RAG/RAG-Documentation.md
@@ -816,7 +816,13 @@ max_expansions = 3
 
 ### 3. Re-ranking
 
-Improve result quality with re-ranking:
+Reorder results after retrieval. **This is not a quality win by default.**
+The one strategy that has been measured here (`cross_encoder`, TASK-16965)
+came out net harmful on the averaged row of the gated eval set — big gains
+on weak-retrieval query categories, losses on categories retrieval already
+got right — and the three LLM-driven strategies have never been measured at
+all (they bill a provider per call, which the local gate cannot run). Turn
+it on to experiment, not to improve search:
 
 ```toml
 [AppRAGSearchConfig.rag.reranking]
@@ -824,6 +830,9 @@ enabled = true
 rerank_model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 rerank_top_k = 50  # Re-rank top 50 results
 ```
+
+Measurement and per-category numbers:
+`Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`.
 
 ### 4. Custom Metadata Filtering
 

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -287,9 +287,40 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   | **pointwise** (this fold's toggle, `Hybrid Full`, `High Accuracy`) | one per candidate, up to **Rerank results** — 20 at the default | up to **×3** — 3 candidates against a failing provider issued **9** calls; 20 issued **60** |
   | **listwise** (`Research Papers`) | exactly **1**, covering at most 10 documents — the fold's line over-states here | up to **3** |
   | **pairwise** (no built-in preset; a hand-written profile only) | a merge sort over the candidates, ≈ `n·log₂n` **comparisons** — **40–69** at `Rerank results` 20, not 20 | up to **×3** (≈200) |
+  | **cross_encoder** (no built-in preset; a hand-written profile only) | **0** — it runs a local model, no provider, no credential, no network | n/a |
 
   The retry loop fires on *any* exception, including a wrong or missing
   credential — the case where the calls buy nothing at all.
+
+- **Reranking has never been shown to improve search here — and the one
+  strategy that was measured made it worse on average.** Three of the four
+  strategies bill an LLM provider per call, which the local, deterministic
+  eval gate cannot run, so their retrieval value is simply unknown
+  (TASK-3502 said so explicitly). The fourth, **`cross_encoder`**, runs a
+  local model and *can* be measured, so TASK-16965 measured it over the
+  60-query golden set against a rule written down before the code was —
+  and the answer was **net harmful**:
+
+  | | MRR@10 before → after | NDCG@10 | recall@10 |
+  |---|---|---|---|
+  | semantic | 0.808 → **0.762** | 0.804 → 0.776 | 0.804 → **0.826** |
+  | hybrid | 0.812 → **0.787** | 0.817 → 0.805 | 0.848 → **0.870** |
+
+  It is not doing nothing — it rescored 3,621 rows and moved 1,950 of them
+  — its effect is just **split down the middle by query type**. Where
+  retrieval was already weak it was a large win (hybrid *scoped* queries
+  MRR 0.163 → **0.929**; *prompt* 0.022 → 0.200). Where retrieval already
+  put the right answer first — paraphrased and vocabulary-mismatch queries,
+  both at a perfect 1.000 — the only move available was downward, and four
+  queries lost their top spot (1.000 → 0.87–0.94). Averaged, you buy a
+  little recall and pay for it in rank quality.
+
+  So `cross_encoder` ships **selectable but recommended nowhere**: no
+  built-in profile uses it, no config template sets it, and nothing turns
+  it on for you. It is worth trying only if your own searches look like the
+  weak half of that split — and then measure, don't assume. The full run,
+  per-category tables and the method are in
+  `Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`.
 
 - **Three built-in presets rerank without you ticking anything.** Reranking
   is on for a profile whenever that profile carries a reranker config —
@@ -367,3 +398,19 @@ Full, High Accuracy, Research Papers, all `openai`; the other nine built-ins,
 including the default Hybrid Basic, carry none. The Settings cost line was
 changed to disclose the retried ceiling and re-pinned in
 `Tests/UI/test_settings_rag_profile_region.py`. No live provider call was made.*
+
+*Verified against `feat/rag-16965-cross-encoder` — 2026-08-17 (TASK-16965,
+doc-only on this page): the `cross_encoder` row and the "reranking has never
+been shown to improve search here" quirk above are the measurement's own
+output, not an estimate. The strategy was implemented as a local
+sentence-transformers cross-encoder and run over the 60-query golden set on
+the gated eval instrument in two pre-declared arms, against a decision rule
+fixed in `Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md`
+BEFORE the strategy was written; the probe reproduced the retrieval census
+from its own retrievals and asserted the model actually scored (3,621 rows
+scored, 0 failed) so a null could not be faked by a silently-degraded load.
+Zero network and zero provider spend, confirmed three ways. Numbers,
+per-category tables and the verbatim probe output:
+`Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`. `cross_encoder` is
+not exposed in this pane — it is a config-file strategy — and no built-in
+profile uses it, so nothing on this screen changed behaviour.*

--- a/Docs/User_Guide/settings/rag.md
+++ b/Docs/User_Guide/settings/rag.md
@@ -299,9 +299,14 @@ field has focus the footer relabels the hints as `Esc, s` / `Esc, r` /
   (TASK-3502 said so explicitly). The fourth, **`cross_encoder`**, runs a
   local model and *can* be measured, so TASK-16965 measured it over the
   60-query golden set against a rule written down before the code was —
-  and the answer was **net harmful**:
+  and the answer was **net harmful** [CAVEAT: that averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`), and `scoped` is where this strategy WINS -- over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075). TASK-16965 final review F1.]:
 
-  | | MRR@10 before → after | NDCG@10 | recall@10 |
+  | | MRR before → after | NDCG@10 | recall@10 |
+  <!-- F2 (final review): this MRR is UNBOUNDED-rank, not MRR@10 — arm B's
+  reranked lists exceed 10 on 60/60 queries (mean 19.4 semantic, 20.0
+  hybrid), so ranks 11–20 are counted. Correcting to @10 shifts the
+  deltas only slightly (semantic −0.0169 → −0.0134) and does not change
+  the verdict. -->
   |---|---|---|---|
   | semantic | 0.808 → **0.762** | 0.804 → 0.776 | 0.804 → **0.826** |
   | hybrid | 0.812 → **0.787** | 0.817 → 0.805 | 0.848 → **0.870** |

--- a/Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md
+++ b/Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md
@@ -70,6 +70,25 @@ Ties, partial movement, or a mixed picture resolve to **NULL** — the burden is
 - [ ] **Arm B (NULL/HARMED):** **retire the name** — remove `cross_encoder` from the strategy vocabulary and the config comment, keep the probe and its report as the record of why, and document Hybrid Full's `pointwise` as the permanent choice rather than a stopgap (AC#4). The implementation from T1 is reverted or kept behind no vocabulary — state which and why.
 - [ ] **Both arms:** gate reads `PASSED: No regression. 105 metric(s)` on the shipped state (AC#6); close TASK-16965's six ACs against evidence; Implementation Notes carry the census, the verdict, and the rule that was fixed beforehand. Push.
 
+> **DISPOSITION (2026-08-17, after the T2 verdict — TWO facts, kept adjacent).**
+> (1) **The rule ran to completion and said arm B: RETIRE.** T2 returned
+> **HARMED** (`paraphrase`/`vocabulary_mismatch` MRR/NDCG regress beyond the
+> 0.05 band in both arms, both modes); on an overall-row-only reading it is
+> NULL. Both readings point at arm B under the rule as written above, which is
+> left untouched — nothing here was renegotiated after seeing numbers.
+> (2) **The owner ruled a third arm ships instead:** asked explicitly with the
+> trade-offs on the table, *"KEEP THE CODE, RETIRE THE PROMISE."* The deciding
+> dimension was the bimodal split T2 measured (hybrid `scoped` MRR 0.163 →
+> 0.929, against rank-1 → rank-2 demotions in two zero-headroom categories) plus
+> the fact that `cross_encoder` is the only reranking path the gated instrument
+> can see at all. So: `CrossEncoderReranker` stays implemented and selectable;
+> every claim or implication that it HELPS is removed and replaced with the
+> measured verdict wherever the strategy is nameable; it is the default,
+> recommendation and profile-strategy of nothing; Hybrid Full keeps `pointwise`,
+> documented as permanent and measured. See
+> `Docs/superpowers/qa/2026-08-17-cross-encoder/report.md` (addendum) and
+> TASK-16965's Implementation Notes.
+
 ## Self-review (plan time)
 - AC#1→T3 (a recorded decision either way); #2→T2 with the rule above fixed in T-minus; #3→the NULL arm being pre-authorised to retire; #4→T3 arm B; #5→cached model + `HF_HUB_OFFLINE=1`, no provider path in T1's implementation; #6→T3.
 - The riskiest failure mode is renegotiating the rule after seeing numbers; it is therefore written here, before Task 1.

--- a/Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md
+++ b/Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md
@@ -1,0 +1,75 @@
+# TASK-16965: cross_encoder — Implement and Measure, or Retire
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Answer whether reranking helps retrieval in this repo, using the one strategy the gated instrument can see — a local cross-encoder — and let the measured answer decide whether `cross_encoder` ships or the name is retired.
+
+**Architecture:** Three tasks. T1 implements `CrossEncoderReranker` (local, credential-free) behind the existing strategy factory. T2 runs the pre-registered measurement as an env-gated PROBE and reports its verdict. T3 acts on the verdict — ship-with-docs or retire — and closes the task. **The verdict rule is fixed in this plan and must not be renegotiated after seeing numbers.**
+
+**Spec:** `Docs/superpowers/specs/2026-08-17-cross-encoder-measurement-design.md` (census amended at `af068c383`).
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/rag-16965-crossencoder`, branch `feat/rag-16965-cross-encoder` (off dev `50a0b49ed`). Venv EXISTS (pinned; provenance verified).
+- **EVERY Bash block starts with its own `cd <worktree>` and echoes `pwd` + branch before any mutating git op.** Two cwd incidents in this programme; the second was caught only by a permission classifier. A cleanup block that leaves the worktree must be the LAST of its group.
+- **After ANY agent/tool dies abnormally, run `git status` before trusting a test result** — a dead reviewer's abandoned mutation reads exactly like a real regression (TASK-17065 incident).
+- Never `git stash`; Edit-based restores; RED-first; do NOT run `Tests/UI/test_library_shell.py`. ruff via `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff`.
+- **No network during measurement, no provider spend, ever** (AC#5). The model is cached already (see below); probe runs under `HF_HUB_OFFLINE=1`.
+- Commits reference TASK-16965 + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; push after every task.
+
+## Verified this session — do not re-derive
+
+- **The census (the gating fact).** `plain`: **0/60** queries return ≥2 rows (39 return 0, 21 return exactly 1) — reranking is provably the identity there, so a moved plain cell is a STOP, not a win. `semantic`: **60/60** return a full window (10 at k=10, 20 at k=20). `hybrid`: **60/60**. So the reorderable population is large on two of three modes and a null cannot be dismissed as nothing-to-reorder.
+- **No new dependency.** `sentence_transformers.CrossEncoder` imports from the installed `sentence-transformers` 5.7.0 (already in the `embeddings_rag` extra).
+- **The model works offline.** `cross-encoder/ms-marco-MiniLM-L-6-v2` fetched + loaded in 17.9 s and separates correctly (relevant **+8.719** vs irrelevant **−11.14**); ~0.3 s for a 2-pair predict. It is now in the local HF cache. **Do NOT use `mixedbread-ai/mxbai-rerank-large-v2`** — the cached copy is a 20 MB partial with no weights file and raises `OSError` offline.
+- **The selection seam** is `reranker.py:~783` (`create_reranker`), a plain `if/elif` on `config.strategy` ending in `raise ValueError(f"Unknown reranking strategy: {strategy}")`. Adding a branch is the whole wiring job; `config_profiles.py:346-352` holds the not-implemented comment to update.
+
+## THE DECISION RULE — pre-registered, binding
+
+Measured on `semantic` and `hybrid` only (plain is the identity by census). Compare the instrument's ranking metrics (MRR / NDCG / P@k) reranked vs not, over the same run:
+
+- **HELPED** — at least one of MRR/NDCG/P@k improves beyond the gate's tolerance (0.05) on at least one mode, AND no category regresses beyond tolerance. → ship the strategy (T3 arm A).
+- **NULL** — nothing moves beyond tolerance on either mode. → **report as the answer and RETIRE the name** (T3 arm B). Per AC#3 this is sufficient grounds; the programme has shipped a pure null before.
+- **HARMED** — any regression beyond tolerance. → retire, and say so plainly.
+
+Ties, partial movement, or a mixed picture resolve to **NULL** — the burden is on the strategy to show a gain, not on the reviewer to disprove one.
+
+---
+
+### Task 1: `CrossEncoderReranker` — local, credential-free
+
+**Files:** Modify `tldw_chatbook/RAG_Search/reranker.py`; Test `Tests/RAG_Search/test_cross_encoder_reranker.py` (new).
+
+- [ ] **Step 1:** `backlog task edit 16965 -s "In Progress"` + `--plan`. Read `BaseReranker` and one concrete strategy end-to-end first; note in the report which base behaviours (the `RerankOutcome` contract, the `scored` flag, the result cache) a local strategy must honour.
+- [ ] **Step 2 (RED):** tests, with a FAKE model (no download in unit tests — a stub exposing `.predict(pairs) -> list[float]`):
+  - `test_cross_encoder_reorders_by_model_score` — rows come back ordered by the stub's scores, and `rerank_score` is stamped on scored rows.
+  - `test_cross_encoder_needs_no_credential` — construction and `rerank()` succeed with no api key configured and **no `chat_api_call` import reachable**; monkeypatch `chat_api_call` to raise and assert it is never called.
+  - `test_cross_encoder_honours_top_k_to_rerank` — only the top-k window is scored; the tail keeps its original order and carries no reranked stamp.
+  - `test_cross_encoder_model_failure_degrades_like_the_others` — a model that raises yields `scored=False` rows and a degraded outcome, not an exception (the TASK-3502 contract).
+  - `test_create_reranker_dispatches_cross_encoder` — the factory returns the new class instead of raising `Unknown reranking strategy`.
+  - `test_provider_shaped_fields_are_no_ops` — `max_retries` / `include_reasoning` do not change behaviour for this strategy (they are provider concepts); assert explicitly rather than leaving it implied.
+- [ ] **Step 3:** Implement `CrossEncoderReranker(BaseReranker)`: lazy model load (module-level cache keyed by model name so a probe run loads once), `model_name` taken from `config.model_name` with the ms-marco default when it names an LLM, batch `predict` over `(query, document)` pairs, `RerankOutcome` with per-row `scored`. Register in `create_reranker`. **No `chat_api_call`, no credential read.**
+- [ ] **Step 4:** GREEN; `Tests/RAG_Search/` counts READ; ruff. Commit `feat(rag): local cross-encoder reranking strategy (TASK-16965)` + trailer. Push.
+
+---
+
+### Task 2: The measurement probe (env-gated, offline)
+
+**Files:** Create `Tests/RAG_Eval/harness/cross_encoder_probe.py` + `Tests/RAG_Eval/test_cross_encoder_probe_run.py`; follow `prf_probe.py` / `test_prf_probe_run.py` exactly for structure, env-gating and reporting.
+
+- [ ] **Step 1:** Probe: build the eval runtime as `test_harness_run.py` does; for `semantic` and `hybrid`, run every golden query, then rerank each result list with the real cross-encoder and re-score the same metrics. Emit a per-mode before/after table plus the **VERDICT** line, exactly as the PRF probe emits its own.
+- [ ] **Step 2:** **The probe must also print the census it relies on** (rows ≥2 per mode) so the verdict is self-justifying in its own artifact.
+- [ ] **Step 3:** Run it under `RAG_EVAL=1 HF_HUB_OFFLINE=1`. Record wall-clock and confirm zero network. The output table + verdict are the deliverable, whatever they say.
+- [ ] **Step 4:** Commit the probe and a short `Docs/superpowers/qa/2026-08-17-cross-encoder/report.md` carrying the table verbatim. Push. **STOP and report the verdict before T3.**
+
+---
+
+### Task 3: Act on the verdict, and close
+
+- [ ] **Arm A (HELPED):** keep the strategy; update `config_profiles.py:346-352`'s comment (it is no longer unimplemented); decide explicitly whether Hybrid Full switches from `pointwise` to `cross_encoder` — and if it does, note the behaviour change; add the strategy to user-facing docs with the measured gain.
+- [ ] **Arm B (NULL/HARMED):** **retire the name** — remove `cross_encoder` from the strategy vocabulary and the config comment, keep the probe and its report as the record of why, and document Hybrid Full's `pointwise` as the permanent choice rather than a stopgap (AC#4). The implementation from T1 is reverted or kept behind no vocabulary — state which and why.
+- [ ] **Both arms:** gate reads `PASSED: No regression. 105 metric(s)` on the shipped state (AC#6); close TASK-16965's six ACs against evidence; Implementation Notes carry the census, the verdict, and the rule that was fixed beforehand. Push.
+
+## Self-review (plan time)
+- AC#1→T3 (a recorded decision either way); #2→T2 with the rule above fixed in T-minus; #3→the NULL arm being pre-authorised to retire; #4→T3 arm B; #5→cached model + `HF_HUB_OFFLINE=1`, no provider path in T1's implementation; #6→T3.
+- The riskiest failure mode is renegotiating the rule after seeing numbers; it is therefore written here, before Task 1.

--- a/Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
+++ b/Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
@@ -339,3 +339,40 @@ VERDICT: HARMED — arm(s) A, B regressed beyond tolerance
 
 wall clock: 25.7s
 ```
+
+---
+
+## Addendum — what the owner decided, and what shipped (2026-08-17, Task 3)
+
+Everything above is the measurement and is unchanged. This records the
+disposition, because the body of this report sends the verdict to "T3 arm B —
+retire" and that is **not** what happened.
+
+Asked explicitly, with the trade-offs on the table — the pre-registered rule
+says retire; the numbers also say the strategy is a large win exactly where
+retrieval is weak (hybrid `scoped` MRR 0.163 → 0.929) and loses only rank-1 →
+rank-2 in two categories that had no headroom left — **the owner ruled: "KEEP
+THE CODE, RETIRE THE PROMISE."**
+
+So, concretely:
+
+- `CrossEncoderReranker` stays implemented and stays selectable as
+  `reranking_strategy = "cross_encoder"`. The name is **not** retired from the
+  strategy vocabulary.
+- Every claim or implication that it *helps* is gone, and the verdict above now
+  travels with it: `RAG_Search/reranker.py` (module docstring, the `strategy`
+  Literal, the class docstring's numbers), `RAG_Search/config_profiles.py`,
+  `config.py`'s config template, `Helper_Scripts/rag_config_examples/rag_v2_example.toml`,
+  `Config_Files/rag_pipelines.toml`, `Docs/User_Guide/settings/rag.md`,
+  `Docs/Development/RAG/RAG-DESIGN.md` (it was sitting under *Future
+  Enhancements*), `Docs/Development/RAG/RAG-Documentation.md`, and
+  `Tools/document_expansion_tool.py` (whose docstring claimed it was
+  unimplemented).
+- It is the default of nothing, the recommendation of nothing, and the strategy
+  of no profile. **Hybrid Full keeps `pointwise`** — now documented as a
+  permanent, measured choice rather than the task-3170 stopgap it started as.
+
+The rule was not renegotiated: the verdict stands as HARMED, and nothing in
+this repo recommends the strategy. What the ruling changed is whether working,
+measurable code gets deleted for producing an unwelcome number — it does not,
+so long as the number travels with it.

--- a/Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
+++ b/Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
@@ -1,0 +1,341 @@
+# TASK-16965 Task 2 — the cross-encoder measurement, and its verdict
+
+Date: 2026-08-17
+Branch: `feat/rag-16965-cross-encoder` (worktree `.worktrees/rag-16965-crossencoder`)
+Probe: `Tests/RAG_Eval/test_cross_encoder_probe_run.py` +
+`Tests/RAG_Eval/harness/cross_encoder_probe.py` (mechanism) +
+`Tests/RAG_Eval/test_cross_encoder_probe.py` (always-on tests for the rule)
+
+Invocation (the whole run, reproducible):
+
+```
+RAG_EVAL=1 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+    .venv/bin/python -m pytest Tests/RAG_Eval/test_cross_encoder_probe_run.py -s -q
+```
+
+**Wall clock: 25.7 s** for the whole measurement (runtime build, the shipped
+three-mode baseline, five reranked passes, 3,621 rows scored by the model;
+17.2 s of that inside `rerank()`). **Zero network: confirmed three ways** —
+`Tests/conftest.py`'s autouse `_no_network_io` guard blocks sockets and fails
+the test at teardown on any blocked attempt (none recorded), the run asserts
+`huggingface_hub.constants.HF_HUB_OFFLINE is True`, and `chat_api_call` —
+the seam the other three reranking strategies bill through — was
+monkeypatched to raise for the duration. **Zero provider spend.**
+
+## VERDICT: HARMED
+
+Per the rule pre-registered in
+`Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md` before
+`CrossEncoderReranker` was written, and implemented as a tested pure
+function (`cross_encoder_probe.arm_verdict`) before this run produced a
+number: **HARMED — any regression beyond tolerance.** Both arms regress:
+`paraphrase` and `vocabulary_mismatch` lose MRR/NDCG beyond the 0.05 band on
+both `semantic` and `hybrid`. The rule sends HARMED to T3 arm B — retire.
+
+**The one reading of the rule that would change the verdict, stated rather
+than buried.** The rule's gain clause is written at MODE level ("improves
+... on at least one mode") and its regression clause at CATEGORY level ("no
+category regresses"), which is what the probe implements. Read at the
+OVERALL-ROW level only, nothing moved beyond tolerance in either arm on
+either mode (largest overall move: semantic MRR −0.046 in arm B), and the
+verdict would be **NULL**. Both readings land on the same T3 arm: retire.
+The category reading is the one the plan's own words specify, so it is the
+one reported, and it was fixed in code and pinned by tests before the run.
+
+## What actually happened, in one paragraph
+
+The cross-encoder is not inert — it reordered 442–1,032 rows per pass and
+moved a correct document on 3–15 queries per arm — and its effects are
+**strongly bimodal by category**. It produced very large gains exactly where
+retrieval was weak: hybrid `scoped` MRR 0.163 → 0.929 (+0.766) and NDCG
+0.348 → 0.947, hybrid `prompt` MRR 0.022 → 0.200, semantic `negation` NDCG
+0.000 → 0.105 in arm B. It produced losses exactly where retrieval was
+already perfect: `paraphrase` (13 queries) and `vocabulary_mismatch` (9
+queries) both sat at MRR 1.000 before reranking — the target was at rank 1 on
+every one — so the only movement available to them was downward, and three
+queries lost rank 1 to rank 2 (`pr-requisition-freeze`,
+`pr-photovoltaic-roof`, `vm-nearsightedness`, plus `pr-standup-slot` in arm
+B). Those two ceilings are what trip the regression clause. On the averaged
+overall row the two effects very nearly cancel: arm B buys recall@10 +0.022
+on both modes and pays MRR −0.046/−0.026 for it. **Nothing in that picture
+is a case for shipping the strategy as a default, which is what the rule was
+written to decide.**
+
+## Findings a reader should not have to derive
+
+1. **P@k could not have moved in arm A, and the rule's P@k clause was
+   therefore vacuous there.** `precision_at_k`, `recall_at_k` and `f1_at_k`
+   are set functions of `retrieved_ids[:k]`; permuting a list of ≤ k
+   documents leaves that set identical. Only MRR and NDCG read rank
+   position. This is why the probe declares a second arm (retrieve at 20,
+   rerank, score the first 10) — the only configuration in which reranking
+   can promote a document into the top ten and therefore the only one where
+   P@k/recall/F1 are live at all. Both arms were declared before the run,
+   and both are reported in full.
+2. **The measurement was one monkeypatch away from a fabricated NULL.**
+   `Tests/conftest.py` sandboxes `HOME` at collection, and
+   `huggingface_hub.constants.HF_HUB_CACHE` is computed from `expanduser("~")`
+   at import — so under pytest the hub cache resolves into an empty temp
+   directory and `CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")`
+   raises `OSError` ("couldn't connect ... and couldn't find them in the
+   cached files") on a machine where the model is very much cached. Measured
+   directly before the probe was written. `CrossEncoderReranker` degrades
+   rather than raises (TASK-3502 contract), so every window would have come
+   back in its original order and every metric would have read a clean 0.000
+   delta: a perfect, entirely fake NULL. The probe repoints the constant and
+   then **asserts `rows_failed == 0` and `rows_scored > 0`**, so the failure
+   mode cannot return silently.
+3. **The census reproduced exactly, from this run's own retrievals** —
+   `plain` 0/60 queries with ≥ 2 rows (39 zero, 21 exactly one), `semantic`
+   and `hybrid` 60/60 full windows at both k=10 and k=20. The null-adjacent
+   parts of this result therefore cannot be explained away as "there was
+   nothing to reorder". `plain` was run as a STOP guard and moved nothing:
+   0 rows moved, every metric delta exactly 0.000.
+4. **Arm A's before-column is the shipped measurement, not a re-implementation
+   of it.** All 15 metric cells match `run_eval`'s own three-mode report to
+   1e-9 (printed in the cross-check table below).
+
+## The shipped gate is untouched by this measurement
+
+The probe is informational and the strategy is opt-in; no production default
+moved. Verified on this branch state, same session:
+
+```
+RAG_EVAL=1 .venv/bin/python -m pytest Tests/RAG_Eval/test_harness_run.py -q
+[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of baseline.
+3 passed in 10.31s
+```
+
+Always-on suite for the directory, with no env var set:
+`Tests/RAG_Eval/` — **313 passed, 14 skipped** (the gated modules, including
+this probe, skip with their own reason).
+
+## THE PROBE'S OWN OUTPUT, VERBATIM
+
+```text
+==============================================================================
+TASK-16965 — CROSS-ENCODER MEASUREMENT PROBE
+model: cross-encoder/ms-marco-MiniLM-L-6-v2 (local, offline, no credential)
+config: strategy=cross_encoder top_k_to_rerank=20 combine_original_score=True original_score_weight=0.3 score_scale=(0.0, 1.0)
+metrics @k=10; tolerance 0.050 (the gate's own FAIL_BAND); verdict metrics mrr/ndcg/precision on semantic/hybrid
+==============================================================================
+
+CENSUS — how many queries a reranker could even reorder (measured in THIS run)
+mode        depth  queries    >=2 rows   0 rows   1 row  full window
+--------------------------------------------------------------------
+semantic       10       60 60 (100.0%)        0       0           60
+plain          10       60    0 (0.0%)       39      21            0
+hybrid         10       60 60 (100.0%)        0       0           60
+semantic       20       60 60 (100.0%)        0       0           60
+hybrid         20       60 60 (100.0%)        0       0           60
+A mode with 0 reorderable queries is the IDENTITY under any reranker; movement there would be a STOP, not a result.
+
+INSTRUMENT CROSS-CHECK — arm A's before-column vs run_eval's own report
+mode      metric          run_eval  arm A before   equal
+--------------------------------------------------------
+semantic  mrr             0.804348      0.804348     yes
+semantic  ndcg            0.804348      0.804348     yes
+semantic  precision       0.089096      0.089096     yes
+semantic  recall          0.804348      0.804348     yes
+semantic  f1              0.159673      0.159673     yes
+plain     mrr             0.304348      0.304348     yes
+plain     ndcg            0.295938      0.295938     yes
+plain     precision       0.304348      0.304348     yes
+plain     recall          0.293478      0.293478     yes
+plain     f1              0.297101      0.297101     yes
+hybrid    mrr             0.809179      0.809179     yes
+hybrid    ndcg            0.817436      0.817436     yes
+hybrid    precision       0.089130      0.089130     yes
+hybrid    recall          0.847826      0.847826     yes
+hybrid    f1              0.160738      0.160738     yes
+
+ARM A (retrieve at k=10, rerank that window, re-score) — a permutation of the returned set
+mode        depth  rows scored  failed  empty text  rows moved  queries reordered  docs reordered  predict s
+------------------------------------------------------------------------------------------------------------
+semantic       10          600       0           0         442                 60              58        3.2
+plain          10           21       0           0           0                  0               0        1.0
+hybrid         10          600       0           0         457                 59              59        2.3
+
+mode      metric          before     after     delta  beyond tol  note
+----------------------------------------------------------------------
+semantic  mrr              0.804     0.772    -0.033          no  
+semantic  ndcg             0.804     0.780    -0.024          no  
+semantic  precision        0.089     0.089    +0.000          no  invariant under permutation
+semantic  recall           0.804     0.804    +0.000          no  invariant under permutation
+semantic  f1               0.160     0.160    +0.000          no  invariant under permutation
+plain     mrr              0.304     0.304    +0.000          no  
+plain     ndcg             0.296     0.296    +0.000          no  
+plain     precision        0.304     0.304    +0.000          no  invariant under permutation
+plain     recall           0.293     0.293    +0.000          no  invariant under permutation
+plain     f1               0.297     0.297    +0.000          no  invariant under permutation
+hybrid    mrr              0.809     0.798    -0.011          no  
+hybrid    ndcg             0.817     0.810    -0.007          no  
+hybrid    precision        0.089     0.089    +0.000          no  invariant under permutation
+hybrid    recall           0.848     0.848    +0.000          no  invariant under permutation
+hybrid    f1               0.161     0.161    +0.000          no  invariant under permutation
+
+ARM A — per-category regression guard
+mode      category              metric        before     after     delta  beyond tol
+------------------------------------------------------------------------------------
+semantic  keyword               mrr            0.938     0.938    +0.000          no
+semantic  keyword               ndcg           0.938     0.938    +0.000          no
+semantic  keyword               precision      0.117     0.117    +0.000          no
+semantic  negation              mrr            0.000     0.000    +0.000          no
+semantic  negation              ndcg           0.000     0.000    +0.000          no
+semantic  negation              precision      0.000     0.000    +0.000          no
+semantic  paraphrase            mrr            1.000     0.923    -0.077        LOSS
+semantic  paraphrase            ndcg           1.000     0.943    -0.057        LOSS
+semantic  paraphrase            precision      0.100     0.100    +0.000          no
+semantic  prompt                mrr            0.000     0.000    +0.000          no
+semantic  prompt                ndcg           0.000     0.000    +0.000          no
+semantic  prompt                precision      0.000     0.000    +0.000          no
+semantic  scoped                mrr            0.000     0.000    +0.000          no
+semantic  scoped                ndcg           0.000     0.000    +0.000          no
+semantic  scoped                precision      0.000     0.000    +0.000          no
+semantic  vocabulary_mismatch   mrr            1.000     0.944    -0.056        LOSS
+semantic  vocabulary_mismatch   ndcg           1.000     0.959    -0.041          no
+semantic  vocabulary_mismatch   precision      0.103     0.103    +0.000          no
+hybrid    keyword               mrr            0.944     0.950    +0.006          no
+hybrid    keyword               ndcg           0.956     0.962    +0.005          no
+hybrid    keyword               precision      0.113     0.113    +0.000          no
+hybrid    negation              mrr            0.000     0.000    +0.000          no
+hybrid    negation              ndcg           0.000     0.000    +0.000          no
+hybrid    negation              precision      0.000     0.000    +0.000          no
+hybrid    paraphrase            mrr            1.000     0.923    -0.077        LOSS
+hybrid    paraphrase            ndcg           1.000     0.943    -0.057        LOSS
+hybrid    paraphrase            precision      0.100     0.100    +0.000          no
+hybrid    prompt                mrr            0.022     0.200    +0.178        GAIN
+hybrid    prompt                ndcg           0.060     0.200    +0.140        GAIN
+hybrid    prompt                precision      0.020     0.020    +0.000          no
+hybrid    scoped                mrr            0.163     0.929    +0.766        GAIN
+hybrid    scoped                ndcg           0.348     0.947    +0.599        GAIN
+hybrid    scoped                precision      0.100     0.100    +0.000          no
+hybrid    vocabulary_mismatch   mrr            1.000     0.944    -0.056        LOSS
+hybrid    vocabulary_mismatch   ndcg           1.000     0.959    -0.041          no
+hybrid    vocabulary_mismatch   precision      0.100     0.100    +0.000          no
+
+ARM A — per-query MRR movement
+semantic: 3 of 53 scored queries changed MRR (all of them, gains first):
+    pr-requisition-freeze               1.000 ->   0.500  (-0.500)
+    pr-photovoltaic-roof                1.000 ->   0.500  (-0.500)
+    vm-nearsightedness                  1.000 ->   0.500  (-0.500)
+hybrid: 12 of 53 scored queries changed MRR (all of them, gains first):
+    sc-pump-chamber-inspection          0.111 ->   1.000  (+0.889)
+    sc-intake-screen-survey             0.111 ->   1.000  (+0.889)
+    sc-meter-box-key                    0.111 ->   1.000  (+0.889)
+    sc-sample-point-sign                0.111 ->   1.000  (+0.889)
+    sc-duty-board-notice                0.111 ->   1.000  (+0.889)
+    pm-vendor-chaser                    0.111 ->   1.000  (+0.889)
+    sc-valve-pit-access                 0.250 ->   1.000  (+0.750)
+    sc-storm-overflow-record            0.333 ->   0.500  (+0.167)
+    kw-plant-maintenance-record         0.111 ->   0.200  (+0.089)
+    pr-requisition-freeze               1.000 ->   0.500  (-0.500)
+    pr-photovoltaic-roof                1.000 ->   0.500  (-0.500)
+    vm-nearsightedness                  1.000 ->   0.500  (-0.500)
+
+ARM B (retrieve at 20, rerank, score the first 10) — the only arm in which P@k/recall/F1 are live
+mode        depth  rows scored  failed  empty text  rows moved  queries reordered  docs reordered  predict s
+------------------------------------------------------------------------------------------------------------
+semantic       20         1200       0           0        1019                 60              60        5.6
+hybrid         20         1200       0           0        1032                 60              60        5.1
+
+mode      metric          before     after     delta  beyond tol  note
+----------------------------------------------------------------------
+semantic  mrr              0.808     0.762    -0.046          no  
+semantic  ndcg             0.804     0.776    -0.028          no  
+semantic  precision        0.085     0.087    +0.002          no  
+semantic  recall           0.804     0.826    +0.022          no  
+semantic  f1               0.153     0.157    +0.004          no  
+hybrid    mrr              0.812     0.787    -0.026          no  
+hybrid    ndcg             0.817     0.805    -0.012          no  
+hybrid    precision        0.089     0.091    +0.002          no  
+hybrid    recall           0.848     0.870    +0.022          no  
+hybrid    f1               0.161     0.165    +0.004          no  
+
+ARM B — per-category regression guard
+mode      category              metric        before     after     delta  beyond tol
+------------------------------------------------------------------------------------
+semantic  keyword               mrr            0.938     0.938    +0.000          no
+semantic  keyword               ndcg           0.938     0.938    +0.000          no
+semantic  keyword               precision      0.106     0.106    +0.000          no
+semantic  negation              mrr            0.049     0.072    +0.023          no
+semantic  negation              ndcg           0.000     0.105    +0.105        GAIN
+semantic  negation              precision      0.000     0.033    +0.033          no
+semantic  paraphrase            mrr            1.000     0.872    -0.128        LOSS
+semantic  paraphrase            ndcg           1.000     0.905    -0.095        LOSS
+semantic  paraphrase            precision      0.100     0.100    +0.000          no
+semantic  prompt                mrr            0.000     0.000    +0.000          no
+semantic  prompt                ndcg           0.000     0.000    +0.000          no
+semantic  prompt                precision      0.000     0.000    +0.000          no
+semantic  scoped                mrr            0.019     0.190    +0.171        GAIN
+semantic  scoped                ndcg           0.000     0.214    +0.214        GAIN
+semantic  scoped                precision      0.000     0.029    +0.029          no
+semantic  vocabulary_mismatch   mrr            1.000     0.944    -0.056        LOSS
+semantic  vocabulary_mismatch   ndcg           1.000     0.959    -0.041          no
+semantic  vocabulary_mismatch   precision      0.100     0.100    +0.000          no
+hybrid    keyword               mrr            0.944     0.945    +0.001          no
+hybrid    keyword               ndcg           0.956     0.957    +0.001          no
+hybrid    keyword               precision      0.113     0.113    +0.000          no
+hybrid    negation              mrr            0.049     0.078    +0.029          no
+hybrid    negation              ndcg           0.000     0.111    +0.111        GAIN
+hybrid    negation              precision      0.000     0.033    +0.033          no
+hybrid    paraphrase            mrr            1.000     0.872    -0.128        LOSS
+hybrid    paraphrase            ndcg           1.000     0.905    -0.095        LOSS
+hybrid    paraphrase            precision      0.100     0.100    +0.000          no
+hybrid    prompt                mrr            0.022     0.200    +0.178        GAIN
+hybrid    prompt                ndcg           0.060     0.200    +0.140        GAIN
+hybrid    prompt                precision      0.020     0.020    +0.000          no
+hybrid    scoped                mrr            0.201     0.929    +0.728        GAIN
+hybrid    scoped                ndcg           0.385     0.947    +0.563        GAIN
+hybrid    scoped                precision      0.100     0.100    +0.000          no
+hybrid    vocabulary_mismatch   mrr            1.000     0.944    -0.056        LOSS
+hybrid    vocabulary_mismatch   ndcg           1.000     0.959    -0.041          no
+hybrid    vocabulary_mismatch   precision      0.100     0.100    +0.000          no
+
+ARM B — per-query MRR movement
+semantic: 8 of 53 scored queries changed MRR (all of them, gains first):
+    sc-valve-pit-access                 0.050 ->   1.000  (+0.950)
+    sc-storm-overflow-record            0.083 ->   0.333  (+0.250)
+    ng-surfaced-approach                0.083 ->   0.125  (+0.042)
+    ng-three-panel-head                 0.062 ->   0.091  (+0.028)
+    pr-photovoltaic-roof                1.000 ->   0.500  (-0.500)
+    pr-standup-slot                     1.000 ->   0.500  (-0.500)
+    vm-nearsightedness                  1.000 ->   0.500  (-0.500)
+    pr-requisition-freeze               1.000 ->   0.333  (-0.667)
+hybrid: 15 of 53 scored queries changed MRR (all of them, gains first):
+    sc-pump-chamber-inspection          0.111 ->   1.000  (+0.889)
+    sc-meter-box-key                    0.111 ->   1.000  (+0.889)
+    pm-vendor-chaser                    0.111 ->   1.000  (+0.889)
+    sc-intake-screen-survey             0.200 ->   1.000  (+0.800)
+    sc-sample-point-sign                0.200 ->   1.000  (+0.800)
+    sc-duty-board-notice                0.200 ->   1.000  (+0.800)
+    sc-valve-pit-access                 0.250 ->   1.000  (+0.750)
+    sc-storm-overflow-record            0.333 ->   0.500  (+0.167)
+    ng-surfaced-approach                0.083 ->   0.143  (+0.060)
+    ng-three-panel-head                 0.062 ->   0.091  (+0.028)
+    kw-plant-maintenance-record         0.111 ->   0.125  (+0.014)
+    pr-photovoltaic-roof                1.000 ->   0.500  (-0.500)
+    pr-standup-slot                     1.000 ->   0.500  (-0.500)
+    vm-nearsightedness                  1.000 ->   0.500  (-0.500)
+    pr-requisition-freeze               1.000 ->   0.333  (-0.667)
+
+ARM A VERDICT: HARMED
+    semantic/paraphrase mrr: 1.000 -> 0.923 (-0.077)
+    semantic/paraphrase ndcg: 1.000 -> 0.943 (-0.057)
+    semantic/vocabulary_mismatch mrr: 1.000 -> 0.944 (-0.056)
+    hybrid/paraphrase mrr: 1.000 -> 0.923 (-0.077)
+    hybrid/paraphrase ndcg: 1.000 -> 0.943 (-0.057)
+    hybrid/vocabulary_mismatch mrr: 1.000 -> 0.944 (-0.056)
+ARM B VERDICT: HARMED
+    semantic/paraphrase mrr: 1.000 -> 0.872 (-0.128)
+    semantic/paraphrase ndcg: 1.000 -> 0.905 (-0.095)
+    semantic/vocabulary_mismatch mrr: 1.000 -> 0.944 (-0.056)
+    hybrid/paraphrase mrr: 1.000 -> 0.872 (-0.128)
+    hybrid/paraphrase ndcg: 1.000 -> 0.905 (-0.095)
+    hybrid/vocabulary_mismatch mrr: 1.000 -> 0.944 (-0.056)
+
+VERDICT: HARMED — arm(s) A, B regressed beyond tolerance
+(pre-registered rule, fixed before implementation: metrics mrr/ndcg/precision on modes semantic/hybrid, tolerance 0.050)
+
+wall clock: 25.7s
+```

--- a/Docs/superpowers/specs/2026-08-17-cross-encoder-measurement-design.md
+++ b/Docs/superpowers/specs/2026-08-17-cross-encoder-measurement-design.md
@@ -1,0 +1,90 @@
+# cross_encoder: implement and measure, or retire the name (TASK-16965)
+
+Date: 2026-08-17
+Programme: RAG server-port (sixteen merged; last: 17065 dispatch repair #1767)
+Worktree: `.worktrees/rag-16965-crossencoder`, branch `feat/rag-16965-cross-encoder`, off dev `50a0b49ed`.
+
+## The question, and why it is finally answerable
+
+Reranking's retrieval value has never been measured here. TASK-3502 declared
+it out of scope for a good reason — the three shipped strategies are all
+LLM-driven, and the gated instrument is local, deterministic and unpriced. A
+**local cross-encoder** is the strategy that can be measured inside the gate:
+no spend, no network, reproducible.
+
+**It is not a new dependency.** `sentence-transformers` already ships in the
+`embeddings_rag` extra (`pyproject.toml`, two entries) — the same extra every
+eval venv installs. A cross-encoder is a new *model artifact*, not a new
+library, which is what makes this arc cheap enough to be worth doing.
+
+## The ceiling must be established BEFORE the measurement
+
+This is the arc's central discipline, and it comes from TASK-16071's finding:
+**every one of the 60 golden queries returns ≤1 row under the shipped plain
+pass**, and reordering a list of length ≤1 is the identity function. Reranking
+is an *order-only* change. So before measuring anything, the arc must publish
+the **row census per mode** (`semantic`, `plain`, `hybrid` — `runner.MODES`):
+how many queries return ≥2 rows, i.e. how many rows a reranker could even
+touch.
+
+That census is what makes a null result interpretable. Without it, "no cell
+moved" is ambiguous between *reranking does not help* and *there was nothing
+to reorder*. With it, the null is precise. **If the census shows the
+reorderable population is negligible on all three modes, that alone is a
+publishable answer and grounds to retire** — no model download required, and
+the arc ends early with a measured reason rather than an opinion.
+
+## Pre-registered decision rule (fixed before any run)
+
+Only if the census shows a non-trivial reorderable population do we implement
+and measure. Then, decided in advance:
+
+- **Helped** = the census-eligible subset improves on the ranking metrics the
+  instrument already reports (MRR/NDCG/P@k), on at least one mode, beyond the
+  gate's own tolerance, with no category regressing beyond it.
+- **Null** = no metric moves beyond tolerance on any mode. Reported as the
+  answer, per AC#3, and sufficient grounds to retire the strategy name.
+- **Harmed** = any regression beyond tolerance → retire, and say so plainly.
+
+The rule is written into the plan before the model is ever loaded. The
+programme has shipped a pure null arc before (PRF/TASK-15965); a null here is
+a result, not a failure.
+
+## Shape of the work
+
+- The measurement is a **PROBE**, not a new gated cell —
+  `Tests/RAG_Eval/harness/` already holds `prf_probe.py` and `fusion_sweep.py`
+  as env-gated informational runs, with `test_prf_probe_run.py` as the
+  invocation precedent. **The always-on gate must NOT acquire a cross-encoder
+  model dependency**: the committed baselines are environment-fingerprinted,
+  and making the 105-metric gate depend on a second model download would tax
+  every future arc for one question's sake.
+- If implemented, `cross_encoder` becomes a real strategy in `reranker.py`
+  alongside the three LLM ones, selected by the same config, requiring no
+  provider and no credential (AC#5 falls out).
+- Whichever arm ships, `config_profiles.py:346-352`'s not-implemented comment
+  and Hybrid Full's `pointwise` substitution stop being described as a stopgap
+  (AC#4) — either the substitution becomes a documented permanent choice, or
+  it is replaced by the implemented strategy.
+- AC#6: the gate reads `PASSED: No regression. 105 metric(s)` on the shipped
+  state either way. Since the probe is informational and the strategy is
+  opt-in, the shipped default retrieval path must not move.
+
+## Out of scope
+- LLM-strategy quality (unmeasurable here, by TASK-3502's reasoning).
+- TASK-17265 (system prompt never reaching anthropic/google) and TASK-17365
+  (cloned profiles' `include_reasoning`).
+- Any change to fusion, merge or the four-seam path.
+
+## Plan-phase verification
+1. **The row census per mode** — the gating fact above. Produce it first; it
+   may end the arc.
+2. Whether a cross-encoder model can be fetched and cached in this
+   environment at all, and where the eval harness expects model artifacts
+   (`conftest.py` un-sandboxes the model cache dir for env-gated tests).
+3. Whether `RerankingConfig`'s existing fields (`top_k_to_rerank`,
+   `max_retries`, `include_reasoning`) are meaningful for a local strategy, or
+   need explicit no-op semantics.
+4. How `enhanced_rag_service_v2` selects a reranker, so a credential-free
+   strategy does not trip the provider-shaped paths (the degraded/skipped
+   tagging from TASK-3502 assumes provider failures).

--- a/Docs/superpowers/specs/2026-08-17-cross-encoder-measurement-design.md
+++ b/Docs/superpowers/specs/2026-08-17-cross-encoder-measurement-design.md
@@ -34,6 +34,28 @@ reorderable population is negligible on all three modes, that alone is a
 publishable answer and grounds to retire** — no model download required, and
 the arc ends early with a measured reason rather than an opinion.
 
+## THE CENSUS, MEASURED (2026-08-17, before any decision)
+
+Item 1 was run first, as the spec required. Three modes, the real fixtures,
+`QueryOutcome.rows_returned`, at the gate's k and at a reranker's depth:
+
+| mode | queries with ≥2 rows | distribution |
+|---|---|---|
+| `plain` | **0 / 60** (0.0%) | 39 queries return 0 rows, 21 return exactly 1 |
+| `semantic` | **60 / 60** (100%) | every query returns the full window (10 at k=10, 20 at k=20) |
+| `hybrid` | **60 / 60** (100%) | every query returns the full window |
+
+**The arc proceeds.** `plain` reproduces TASK-16071's finding exactly — an
+order-only change is provably the identity there, and no cross-encoder result
+can or should move a plain cell. But `semantic` and `hybrid` return a FULL
+window on every single query, so a reranker has a large, real population to
+reorder on two of the three modes.
+
+This is what makes the coming measurement interpretable in both directions:
+a null result cannot be explained away as "there was nothing to reorder",
+because on 120 of 180 mode-query pairs there is a full k-row list. A null
+here would be a strong null.
+
 ## Pre-registered decision rule (fixed before any run)
 
 Only if the census shows a non-trivial reorderable population do we implement

--- a/Helper_Scripts/rag_config_examples/rag_v2_example.toml
+++ b/Helper_Scripts/rag_config_examples/rag_v2_example.toml
@@ -30,7 +30,16 @@ profile = "hybrid_basic"  # Default profile
 # enable_reranking = true
 # enable_parallel_processing = true
 # parent_size_multiplier = 3
-# reranking_strategy = "cross_encoder"
+# reranking_strategy = "pointwise"
+#
+# Reranking strategies: "pointwise" | "pairwise" | "listwise" bill an LLM
+# provider per call; "cross_encoder" runs a local model (no provider, no
+# credential, no network). "cross_encoder" is selectable but NOT
+# recommended -- it is the only strategy anyone has measured on the gated
+# eval instrument (TASK-16965) and it came out net HARMFUL on the averaged
+# row (semantic MRR 0.808 -> 0.762, hybrid 0.812 -> 0.787), while producing
+# large gains on the weak-retrieval categories (hybrid "scoped" MRR
+# 0.163 -> 0.929). Numbers: Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
 
 # Example configurations:
 

--- a/Tests/RAG_Eval/harness/cross_encoder_probe.py
+++ b/Tests/RAG_Eval/harness/cross_encoder_probe.py
@@ -1,0 +1,484 @@
+# Tests/RAG_Eval/harness/cross_encoder_probe.py
+r"""Cross-encoder measurement machinery: the arms, the moves, the verdict.
+
+TASK-16965 Task 2. `Tests/RAG_Eval/test_cross_encoder_probe_run.py` is the
+one place this meets a real corpus, a real index and the product's own
+retrieval seams; this module is the mechanism, kept pure and separate so the
+run's numbers can be evidence about RERANKING rather than about the probe.
+
+**The decision rule is CODE here, not prose in a print statement.** It was
+pre-registered in `Docs/superpowers/plans/2026-08-17-cross-encoder-
+measurement.md` before `CrossEncoderReranker` was written, and the single
+riskiest failure mode of this arc is renegotiating it after seeing numbers.
+`arm_verdict` implements it as a pure function over the same
+`evaluate_retrieval_batch` metrics the instrument reports, with the gate's
+own `FAIL_BAND` imported rather than copied, and `Tests/RAG_Eval/
+test_cross_encoder_probe.py` pins it. Changing the verdict now means editing
+a tested function in a reviewable diff, which is exactly the friction the
+pre-registration is for.
+
+**Why there are two arms, both declared before the run.** Reranking is an
+ORDER-ONLY change, and three of the five metrics the instrument reports
+cannot see one:
+
+* `precision_at_k`, `recall_at_k` and `f1_at_k` are SET functions of
+  ``retrieved_ids[:k]`` (`RAG_Search/eval/metrics.py`). Permuting a list of
+  ``<= k`` documents leaves that set identical, so those three are invariant
+  *by construction* -- not "did not move", but "could not".
+* `mrr` and `ndcg_at_k` read rank position, so they are the only two the
+  arm-A comparison can move at all.
+
+The pre-registered rule names MRR / NDCG / P@k. Its P@k clause is therefore
+VACUOUS on arm A, and a probe that ran only arm A would be reporting a null
+on a rule one third of which was untestable. So:
+
+* **ARM A -- ``rerank the returned list``.** Retrieve at the harness's own
+  ``k`` (10), rerank that window, re-score. The literal reading of the plan's
+  Step 1, and the shape a user gets today if they flip the strategy on with
+  the shipped ``top_k`` .
+* **ARM B -- ``retrieve deeper, rerank, then truncate``.** Retrieve at 20
+  (the shipped ``RerankingConfig.top_k_to_rerank``, and the second depth the
+  spec's census was measured at), rerank the whole window, score the first
+  ``k`` documents. This is the configuration in which reranking can promote
+  a document from rank 11-20 into the top 10 -- i.e. the only one where
+  P@k, recall and F1 are live at all.
+
+Both arms are self-paired: one retrieval per (mode, arm), scored twice, so
+before-vs-after carries no run-to-run retrieval variance. Both are declared
+here, before any number exists, and the run reports both in full. The arc
+verdict composes them with `compose_arc_verdict`, which never lets a gain in
+one arm cover a regression in the other.
+
+**Nothing here runs a query or loads a model.** The retrievals, the reranker
+and the printing belong to the gated run; this module is imported by
+always-on pure tests and must stay importable with no env var set and no
+`sentence-transformers` in the environment.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence
+
+from Tests.RAG_Eval.harness.baseline_io import FAIL_BAND
+
+__all__ = [
+    "ARM_A",
+    "ARM_B",
+    "ARM_A_DEPTH",
+    "ARM_B_DEPTH",
+    "CensusRow",
+    "MetricMove",
+    "ModeArm",
+    "PERMUTATION_INVARIANT_METRICS",
+    "TOLERANCE",
+    "VERDICT_METRICS",
+    "VERDICT_MODES",
+    "Verdict",
+    "arm_verdict",
+    "compose_arc_verdict",
+    "metric_moves",
+    "reorder_rows",
+    "rows_to_search_results",
+]
+
+#: The gate's own absolute regression band, imported rather than copied. The
+#: plan's rule says "beyond the gate's tolerance (0.05)"; this IS that
+#: number, so a future change to the gate's band cannot leave this probe
+#: quietly measuring against a different one.
+TOLERANCE: float = FAIL_BAND
+
+#: Slack on the tolerance COMPARISON, not on the tolerance. A movement of
+#: exactly 0.05 must read as a tie ("beyond tolerance" is strict), but binary
+#: floats do not cooperate: ``0.5 + 0.05 - 0.5 == 0.05000000000000004``, which
+#: is greater than 0.05 and would have turned an exact tie into a HELPED. The
+#: guard is nine orders of magnitude below the band, so it can only ever
+#: decide a case the band itself calls a draw -- and a draw resolves to NULL.
+_BOUNDARY_EPSILON = 1e-9
+
+#: The metrics the pre-registered rule names, spelled as
+#: `evaluate_retrieval_batch` keys ("precision" is P@k -- see the port note
+#: in `RAG_Search/eval/metrics.py` for why the short names).
+VERDICT_METRICS: tuple[str, ...] = ("mrr", "ndcg", "precision")
+
+#: Of those, the ones a permutation of a ``<= k`` list CANNOT move, whatever
+#: the model says. Named so the report can state the vacuity rather than let
+#: a reader mistake "0.000 delta" for "the model was checked and declined".
+PERMUTATION_INVARIANT_METRICS: tuple[str, ...] = ("precision", "recall", "f1")
+
+#: The modes the verdict is measured on. `plain` is excluded by the MEASURED
+#: census (0/60 queries return >= 2 rows -- reordering is provably the
+#: identity there), and the run asserts that exclusion rather than assuming
+#: it: any movement in a plain cell is a STOP, not a result.
+VERDICT_MODES: tuple[str, ...] = ("semantic", "hybrid")
+
+ARM_A = "A"
+ARM_B = "B"
+
+#: Arm A retrieves at the harness's own k, so the reranked window IS the
+#: scored window.
+ARM_A_DEPTH = 10
+
+#: Arm B retrieves at the shipped `RerankingConfig.top_k_to_rerank`, which is
+#: also the second depth the spec's census was measured at (60/60 full
+#: windows at k=20 on both verdict modes).
+ARM_B_DEPTH = 20
+
+
+class Verdict(str, Enum):
+    """The three pre-registered outcomes. Ordered worst-first deliberately."""
+
+    HARMED = "HARMED"
+    NULL = "NULL"
+    HELPED = "HELPED"
+
+
+@dataclass(frozen=True, slots=True)
+class CensusRow:
+    """One mode's reorderable population at one retrieval depth.
+
+    The census is what makes a null INTERPRETABLE: without it "no cell moved"
+    is ambiguous between *reranking does not help* and *there was nothing to
+    reorder*. It is printed in the probe's own artifact so the verdict is
+    self-justifying (plan Task 2 Step 2) rather than resting on a number in
+    a spec file.
+
+    Attributes:
+        mode: Retrieval mode.
+        depth: The ``top_k`` the retrieval ran at.
+        queries: Queries asked.
+        reorderable: Queries that returned >= 2 rows -- the ones a reranker
+            could touch at all.
+        zero_rows: Queries that returned nothing.
+        one_row: Queries that returned exactly one row.
+        full_window: Queries that returned the full ``depth`` rows.
+    """
+
+    mode: str
+    depth: int
+    queries: int
+    reorderable: int
+    zero_rows: int
+    one_row: int
+    full_window: int
+
+
+@dataclass(frozen=True, slots=True)
+class MetricMove:
+    """One metric's before/after pair, and whether it moved beyond tolerance.
+
+    Attributes:
+        metric: The `evaluate_retrieval_batch` key.
+        before: Value with the retrieval seam's own ordering.
+        after: Value with the cross-encoder's ordering.
+    """
+
+    metric: str
+    before: float
+    after: float
+
+    @property
+    def delta(self) -> float:
+        return self.after - self.before
+
+    @property
+    def improved(self) -> bool:
+        """Gained by MORE than the tolerance. A tie is never a gain."""
+        return self.delta - TOLERANCE > _BOUNDARY_EPSILON
+
+    @property
+    def regressed(self) -> bool:
+        return -self.delta - TOLERANCE > _BOUNDARY_EPSILON
+
+
+@dataclass(frozen=True, slots=True)
+class ModeArm:
+    """What one arm did to one mode: the metrics, and the work behind them.
+
+    The work columns are not decoration. A null with ``rows_failed > 0`` is
+    a broken model load wearing a result's clothes (measured: without the
+    HF cache repoint, `CrossEncoder` raises ``OSError`` under pytest's
+    sandboxed ``HOME`` and every rerank degrades to the identity), and a null
+    with ``row_order_changes == 0`` is a model that expressed no preference
+    rather than a ranking that could not be improved. Both read as "0.000
+    delta" in the metric table alone.
+
+    Attributes:
+        arm: `ARM_A` or `ARM_B`.
+        mode: Retrieval mode.
+        depth: The ``top_k`` the retrieval ran at.
+        before: `evaluate_retrieval_batch` output over the seam's ordering.
+        after: The same over the reranked ordering.
+        before_per_category: Per-category cells, seam ordering.
+        after_per_category: Per-category cells, reranked ordering.
+        rows_scored: Rows the cross-encoder actually scored.
+        rows_failed: Scoring attempts that failed (`RerankOutcome.failed`).
+        empty_document_rows: Reranked rows whose text was empty -- rows the
+            model was handed nothing to judge.
+        row_order_changes: Rows whose position changed, summed over queries.
+        queries_reordered: Queries whose ROW order changed.
+        queries_doc_order_changed: Queries whose canonicalized DOCUMENT order
+            changed. Always <= ``queries_reordered``: reordering two chunks
+            of one document changes no document ranking, and the metrics are
+            document-level.
+        predict_seconds: Wall time inside `rerank()`.
+    """
+
+    arm: str
+    mode: str
+    depth: int
+    before: Mapping[str, float]
+    after: Mapping[str, float]
+    before_per_category: Mapping[str, Mapping[str, float]]
+    after_per_category: Mapping[str, Mapping[str, float]]
+    rows_scored: int
+    rows_failed: int
+    empty_document_rows: int
+    row_order_changes: int
+    queries_reordered: int
+    queries_doc_order_changed: int
+    predict_seconds: float
+
+
+def metric_moves(
+    before: Mapping[str, float],
+    after: Mapping[str, float],
+    metrics: Sequence[str] = VERDICT_METRICS,
+) -> tuple[MetricMove, ...]:
+    """Pair up two metric dicts over ``metrics``.
+
+    Args:
+        before: Metrics with the seam's own ordering.
+        after: Metrics with the reranked ordering.
+        metrics: Keys to compare, in report order.
+
+    Returns:
+        One `MetricMove` per key.
+
+    Raises:
+        KeyError: A key is missing from either side. Defaulting a missing
+            metric to 0.0 would manufacture a regression of exactly its
+            baseline value, which is the loudest possible wrong answer.
+    """
+    return tuple(
+        MetricMove(metric=metric, before=float(before[metric]), after=float(after[metric]))
+        for metric in metrics
+    )
+
+
+def _category_regressions(arm: ModeArm) -> tuple[tuple[str, MetricMove], ...]:
+    """Every per-category cell that lost more than the tolerance.
+
+    The rule's second clause is "no category regresses beyond tolerance", so
+    it is checked against the per-category cells, not only the overall row --
+    an average can sit still while one capability collapses and another
+    compensates.
+
+    Args:
+        arm: One mode's arm result.
+
+    Returns:
+        ``(category, move)`` pairs, in report order. A category present on
+        only one side is skipped rather than compared: with the same queries
+        run twice through the same aggregator that cannot happen, and
+        inventing a comparison for it would be inventing a finding.
+    """
+    regressions: list[tuple[str, MetricMove]] = []
+    for category in sorted(arm.before_per_category):
+        after_cell = arm.after_per_category.get(category)
+        if after_cell is None:
+            continue
+        for move in metric_moves(arm.before_per_category[category], after_cell):
+            if move.regressed:
+                regressions.append((category, move))
+    return tuple(regressions)
+
+
+def arm_verdict(arms: Iterable[ModeArm]) -> tuple[Verdict, tuple[str, ...]]:
+    """THE PRE-REGISTERED RULE, applied to one arm across the verdict modes.
+
+    Fixed in the plan before `CrossEncoderReranker` existed, and reproduced
+    here verbatim in behaviour:
+
+    * **HELPED** -- at least one of MRR/NDCG/P@k improves beyond the gate's
+      tolerance on at least one mode, AND no category regresses beyond it.
+    * **NULL** -- nothing moves beyond tolerance on either mode.
+    * **HARMED** -- any regression beyond tolerance.
+
+    Two readings the plan leaves to the implementation, both resolved
+    AGAINST the strategy, because the plan's closing sentence puts the burden
+    on it ("Ties, partial movement, or a mixed picture resolve to NULL"):
+
+    1. A gain AND a regression is HARMED, not HELPED -- HELPED's own text
+       requires the conjunction, and HARMED's text has no exception for
+       "but something else improved".
+    2. A regression in an UNAVERAGED category (negatives have no metrics;
+       scoped is measured in its own cell) still counts, because the clause
+       says "no category", and a strategy that wrecks scoped retrieval while
+       lifting the average has not earned a ship.
+
+    Args:
+        arms: One `ModeArm` per verdict mode, for a single arm.
+
+    Returns:
+        ``(verdict, reasons)`` -- the reasons are the exact cells that
+        decided it, one line each, so the printed verdict can be audited
+        without re-reading the tables.
+
+    Raises:
+        ValueError: ``arms`` is empty, or covers a mode outside
+            `VERDICT_MODES`. A verdict over no measurement is not a NULL, it
+            is a bug.
+    """
+    arms = tuple(arms)
+    if not arms:
+        raise ValueError("refusing to return a verdict over no measured arms")
+    unexpected = sorted({arm.mode for arm in arms} - set(VERDICT_MODES))
+    if unexpected:
+        raise ValueError(
+            f"arm covers non-verdict mode(s) {unexpected}; the rule is "
+            f"pre-registered over {list(VERDICT_MODES)} only"
+        )
+
+    gains: list[str] = []
+    losses: list[str] = []
+    for arm in arms:
+        for move in metric_moves(arm.before, arm.after):
+            if move.improved:
+                gains.append(
+                    f"{arm.mode}/overall {move.metric}: "
+                    f"{move.before:.3f} -> {move.after:.3f} ({move.delta:+.3f})"
+                )
+            elif move.regressed:
+                losses.append(
+                    f"{arm.mode}/overall {move.metric}: "
+                    f"{move.before:.3f} -> {move.after:.3f} ({move.delta:+.3f})"
+                )
+        for category, move in _category_regressions(arm):
+            losses.append(
+                f"{arm.mode}/{category} {move.metric}: "
+                f"{move.before:.3f} -> {move.after:.3f} ({move.delta:+.3f})"
+            )
+
+    if losses:
+        return Verdict.HARMED, tuple(losses)
+    if gains:
+        return Verdict.HELPED, tuple(gains)
+    return Verdict.NULL, ()
+
+
+def compose_arc_verdict(
+    arm_verdicts: Mapping[str, Verdict],
+) -> tuple[Verdict, str]:
+    """Fold the arms' verdicts into the arc's one answer.
+
+    Declared before the run, with the same burden-on-the-strategy bias:
+
+    * Any arm HARMED -> **HARMED**. A gain in one configuration never covers
+      a regression in another; both are configurations a user could ship.
+    * Otherwise any arm HELPED -> **HELPED**. Both arms are honest instances
+      of "rerank the result list and re-score the same metrics" (the plan
+      fixed the metrics and the modes, never the candidate depth), and arm B
+      is the only one in which the rule's own P@k clause is testable at all.
+    * Otherwise -> **NULL**.
+
+    Args:
+        arm_verdicts: Arm name -> that arm's verdict.
+
+    Returns:
+        ``(verdict, reason)``.
+
+    Raises:
+        ValueError: No arms. See `arm_verdict`.
+    """
+    if not arm_verdicts:
+        raise ValueError("refusing to compose an arc verdict over no arms")
+    harmed = sorted(name for name, v in arm_verdicts.items() if v is Verdict.HARMED)
+    if harmed:
+        return Verdict.HARMED, f"arm(s) {', '.join(harmed)} regressed beyond tolerance"
+    helped = sorted(name for name, v in arm_verdicts.items() if v is Verdict.HELPED)
+    if helped:
+        return Verdict.HELPED, f"arm(s) {', '.join(helped)} gained beyond tolerance"
+    return (
+        Verdict.NULL,
+        f"no metric moved beyond {TOLERANCE:.3f} in any arm on any verdict mode",
+    )
+
+
+def rows_to_search_results(
+    rows: Sequence[Mapping[str, Any]], *, window_id: str
+) -> list[Any]:
+    """Wrap one query's seam rows as the `SearchResult`s a reranker takes.
+
+    Three details that are load-bearing rather than plumbing:
+
+    * **The id is globally unique, not the row's own.** `BaseReranker`'s
+      result cache keys on ``query`` plus the sorted result ids, so positional
+      ids ("0".."9") would give the SAME key to a query's semantic window and
+      its hybrid window -- and the second mode would silently be scored with
+      the first mode's cross-encoder scores. ``window_id`` carries arm, mode
+      and query id precisely so that collision cannot exist.
+    * **The document is the row's ``snippet``.** That is where every seam row
+      builder puts text (`_semantic_row` fills it from the chunk's
+      ``document``); the row's ``title`` is metadata, not the thing being
+      judged. An empty snippet is passed through as ``""`` rather than
+      skipped -- the probe reports how many such rows it handed over.
+    * **A ``None`` score becomes 0.0.** The four-seam plain path emits no
+      scores at all (deliberately -- see `_conversation_row`), and
+      `_apply_scores` blends the original score arithmetically.
+
+    Args:
+        rows: One query's rows, in the seam's rank order.
+        window_id: A run-unique prefix for this (arm, mode, query) window.
+
+    Returns:
+        `SearchResult`s in the same order, each carrying its original index
+        in ``metadata["probe_row_index"]`` so `reorder_rows` can invert the
+        reranker's permutation.
+    """
+    from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+    return [
+        SearchResult(
+            id=f"{window_id}#{position}",
+            score=float(row.get("score") or 0.0),
+            document=str(row.get("snippet") or ""),
+            metadata={"probe_row_index": position},
+        )
+        for position, row in enumerate(rows)
+    ]
+
+
+def reorder_rows(
+    rows: Sequence[Mapping[str, Any]], reranked: Sequence[Any]
+) -> list[Mapping[str, Any]]:
+    """Apply a reranker's permutation back onto the original seam rows.
+
+    The rows are re-ordered, never rebuilt: canonicalization reads
+    ``provenance["source_type"]`` and ``source_id``, which a `SearchResult`
+    does not carry, so scoring the reranker's own output objects would score
+    a different row shape than the instrument does.
+
+    Args:
+        rows: The original rows handed to `rows_to_search_results`.
+        reranked: `RerankOutcome.results`, in the model's order.
+
+    Returns:
+        The same row mappings, in the reranked order.
+
+    Raises:
+        ValueError: The permutation is not one -- a missing, duplicated or
+            out-of-range index. Silently dropping a row would delete a
+            retrieved result from the measurement, which is the one failure
+            mode that would move a metric for a reason that has nothing to do
+            with ranking.
+    """
+    indices = [result.metadata.get("probe_row_index") for result in reranked]
+    if sorted(index for index in indices if isinstance(index, int)) != list(
+        range(len(rows))
+    ):
+        raise ValueError(
+            f"reranker returned {len(reranked)} results whose row indices "
+            f"{indices!r} are not a permutation of the {len(rows)} rows given"
+        )
+    return [rows[index] for index in indices]

--- a/Tests/RAG_Eval/test_cross_encoder_probe.py
+++ b/Tests/RAG_Eval/test_cross_encoder_probe.py
@@ -1,0 +1,189 @@
+# Tests/RAG_Eval/test_cross_encoder_probe.py
+"""Always-on tests for the cross-encoder probe's MECHANISM.
+
+TASK-16965 Task 2. The gated run (`test_cross_encoder_probe_run.py`) needs a
+real corpus, a real index and a real model; these do not, and they exist for
+one reason: **the pre-registered decision rule must be pinned by a test
+before it is applied to any number.** A rule that lives only inside a print
+statement can be edited after the fact and nobody notices; a rule with
+tests has to be edited in a reviewable diff.
+
+Same split as the PRF precedent (`test_prf_probe.py` next to
+`test_prf_probe_run.py`): mechanism here, meeting-reality there.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Tests.RAG_Eval.harness.baseline_io import FAIL_BAND
+from Tests.RAG_Eval.harness.cross_encoder_probe import (
+    ARM_A,
+    ARM_B,
+    TOLERANCE,
+    VERDICT_METRICS,
+    ModeArm,
+    Verdict,
+    arm_verdict,
+    compose_arc_verdict,
+    metric_moves,
+    reorder_rows,
+    rows_to_search_results,
+)
+
+FLAT = {"precision": 0.5, "recall": 0.5, "mrr": 0.5, "ndcg": 0.5, "f1": 0.5}
+
+
+def _arm(
+    mode: str = "semantic",
+    *,
+    before: dict[str, float] | None = None,
+    after: dict[str, float] | None = None,
+    before_cats: dict[str, dict[str, float]] | None = None,
+    after_cats: dict[str, dict[str, float]] | None = None,
+) -> ModeArm:
+    return ModeArm(
+        arm=ARM_A,
+        mode=mode,
+        depth=10,
+        before=before or dict(FLAT),
+        after=after or dict(FLAT),
+        before_per_category=before_cats or {},
+        after_per_category=after_cats or {},
+        rows_scored=600,
+        rows_failed=0,
+        empty_document_rows=0,
+        row_order_changes=100,
+        queries_reordered=60,
+        queries_doc_order_changed=40,
+        predict_seconds=1.0,
+    )
+
+
+def test_the_tolerance_is_the_gates_own_band_not_a_copy():
+    """The plan says "the gate's tolerance (0.05)"; drift would be silent."""
+    assert TOLERANCE == FAIL_BAND == 0.05
+
+
+def test_nothing_moving_is_a_null():
+    verdict, reasons = arm_verdict([_arm("semantic"), _arm("hybrid")])
+    assert verdict is Verdict.NULL
+    assert reasons == ()
+
+
+def test_movement_inside_the_tolerance_is_still_a_null():
+    """A tie is never a gain -- the burden is on the strategy."""
+    after = {**FLAT, "mrr": 0.5 + TOLERANCE}
+    verdict, _ = arm_verdict([_arm("semantic", after=after), _arm("hybrid")])
+    assert verdict is Verdict.NULL
+
+
+def test_one_metric_on_one_mode_beyond_tolerance_is_a_help():
+    after = {**FLAT, "ndcg": 0.5 + TOLERANCE + 0.001}
+    verdict, reasons = arm_verdict([_arm("semantic"), _arm("hybrid", after=after)])
+    assert verdict is Verdict.HELPED
+    assert any("hybrid/overall ndcg" in reason for reason in reasons)
+
+
+def test_an_overall_regression_beyond_tolerance_is_harm():
+    after = {**FLAT, "mrr": 0.5 - TOLERANCE - 0.001}
+    verdict, reasons = arm_verdict([_arm("semantic", after=after), _arm("hybrid")])
+    assert verdict is Verdict.HARMED
+    assert any("semantic/overall mrr" in reason for reason in reasons)
+
+
+def test_a_gain_that_costs_a_category_is_harm_not_help():
+    """HELPED's own text is a conjunction: gain AND no category regressing."""
+    arm = _arm(
+        "semantic",
+        after={**FLAT, "mrr": 0.9},
+        before_cats={"paraphrase": dict(FLAT)},
+        after_cats={"paraphrase": {**FLAT, "ndcg": 0.5 - TOLERANCE - 0.001}},
+    )
+    verdict, reasons = arm_verdict([arm, _arm("hybrid")])
+    assert verdict is Verdict.HARMED
+    assert any("semantic/paraphrase ndcg" in reason for reason in reasons)
+
+
+def test_a_category_present_on_one_side_only_is_skipped_not_invented():
+    arm = _arm(
+        "semantic",
+        before_cats={"paraphrase": dict(FLAT)},
+        after_cats={},
+    )
+    verdict, _ = arm_verdict([arm, _arm("hybrid")])
+    assert verdict is Verdict.NULL
+
+
+def test_a_verdict_over_no_arms_raises_rather_than_reading_as_null():
+    with pytest.raises(ValueError, match="no measured arms"):
+        arm_verdict([])
+
+
+def test_a_non_verdict_mode_raises():
+    """`plain` is the identity by census; scoring it would be a category error."""
+    with pytest.raises(ValueError, match="non-verdict mode"):
+        arm_verdict([_arm("plain")])
+
+
+def test_a_missing_metric_raises_rather_than_defaulting_to_zero():
+    with pytest.raises(KeyError):
+        metric_moves(FLAT, {"precision": 0.5})
+
+
+def test_metric_moves_cover_exactly_the_pre_registered_metrics():
+    moves = metric_moves(FLAT, FLAT)
+    assert tuple(move.metric for move in moves) == VERDICT_METRICS
+
+
+def test_harm_in_one_arm_is_never_covered_by_help_in_the_other():
+    verdict, reason = compose_arc_verdict(
+        {ARM_A: Verdict.HARMED, ARM_B: Verdict.HELPED}
+    )
+    assert verdict is Verdict.HARMED
+    assert ARM_A in reason
+
+
+def test_help_in_either_arm_composes_to_help():
+    verdict, _ = compose_arc_verdict({ARM_A: Verdict.NULL, ARM_B: Verdict.HELPED})
+    assert verdict is Verdict.HELPED
+
+
+def test_two_nulls_compose_to_null():
+    verdict, reason = compose_arc_verdict({ARM_A: Verdict.NULL, ARM_B: Verdict.NULL})
+    assert verdict is Verdict.NULL
+    assert "0.050" in reason
+
+
+def test_composing_no_arms_raises():
+    with pytest.raises(ValueError, match="no arms"):
+        compose_arc_verdict({})
+
+
+def test_search_results_carry_unique_ids_so_the_rerank_cache_cannot_collide():
+    """Positional ids would give a query's semantic and hybrid windows one key."""
+    rows = [{"snippet": "a", "score": 0.9}, {"snippet": "b", "score": 0.1}]
+    semantic = rows_to_search_results(rows, window_id="A|semantic|q1")
+    hybrid = rows_to_search_results(rows, window_id="A|hybrid|q1")
+    assert {r.id for r in semantic}.isdisjoint({r.id for r in hybrid})
+
+
+def test_search_results_take_text_from_the_snippet_and_tolerate_a_none_score():
+    rows = [{"snippet": "the text", "score": None}, {"score": 0.4}]
+    results = rows_to_search_results(rows, window_id="A|plain|q1")
+    assert [r.document for r in results] == ["the text", ""]
+    assert [r.score for r in results] == [0.0, 0.4]
+    assert [r.metadata["probe_row_index"] for r in results] == [0, 1]
+
+
+def test_reorder_rows_applies_the_permutation_to_the_original_rows():
+    rows = [{"source_id": "1"}, {"source_id": "2"}, {"source_id": "3"}]
+    reranked = rows_to_search_results(rows, window_id="A|semantic|q1")
+    reranked = [reranked[2], reranked[0], reranked[1]]
+    assert reorder_rows(rows, reranked) == [rows[2], rows[0], rows[1]]
+
+
+def test_a_dropped_row_raises_rather_than_shortening_the_measurement():
+    rows = [{"source_id": "1"}, {"source_id": "2"}]
+    reranked = rows_to_search_results(rows, window_id="A|semantic|q1")[:1]
+    with pytest.raises(ValueError, match="not a permutation"):
+        reorder_rows(rows, reranked)

--- a/Tests/RAG_Eval/test_cross_encoder_probe_run.py
+++ b/Tests/RAG_Eval/test_cross_encoder_probe_run.py
@@ -1,0 +1,706 @@
+# Tests/RAG_Eval/test_cross_encoder_probe_run.py
+r"""THE CROSS-ENCODER MEASUREMENT RUN: the census, the two arms, the verdict.
+
+TASK-16965 Task 2. `harness/cross_encoder_probe.py` is the mechanism (pure,
+always-on-tested); this module is the one place it meets the real corpus, the
+real index, the product's own retrieval seams and a real cross-encoder. It
+prints four things and asserts a fifth:
+
+1. **The CENSUS**, printed FIRST and from this run's own retrievals rather
+   than quoted from the spec: how many queries return >= 2 rows per mode, at
+   both arms' depths. It is what makes a null interpretable -- without it
+   "no cell moved" is ambiguous between *reranking does not help* and *there
+   was nothing to reorder* -- and the plan requires the probe's own artifact
+   to carry it (Task 2 Step 2).
+2. **The INSTRUMENT CROSS-CHECK**: arm A's before-column against `run_eval`'s
+   own three-mode report over the same runtime. They must agree to the last
+   bit, because arm A's before-state is supposed to BE the shipped
+   measurement, not a re-implementation of it.
+3. **ARM A** (retrieve at k=10, rerank that window, re-score) and **ARM B**
+   (retrieve at 20, rerank, score the first 10) -- per-mode before/after
+   tables, the per-category regression guard, and the work columns that
+   separate "the model declined" from "the model never ran".
+4. **The VERDICT**, computed by `arm_verdict`/`compose_arc_verdict` -- the
+   rule fixed in the plan before `CrossEncoderReranker` was written.
+
+**The trap this probe was built around, stated because it would have
+manufactured a NULL.** `Tests/conftest.py` sandboxes ``HOME`` at collection
+time, and `huggingface_hub.constants.HF_HUB_CACHE` is computed from
+``expanduser("~")`` at import. So under pytest the hub cache resolves into an
+empty temp directory, and `CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-
+v2")` raises ``OSError`` (measured: *"We couldn't connect to
+'https://huggingface.co' ... and couldn't find them in the cached files"*) --
+on a machine where that model is very much cached. `CrossEncoderReranker`
+degrades rather than raises, by design (TASK-3502), so every window would
+have come back in its original order, every metric would have read 0.000
+delta, and the probe would have reported a beautifully consistent NULL
+produced by a model that never loaded. The directory conftest already does
+this for `HF_HUB_OFFLINE`; this module does it for `HF_HUB_CACHE`, and then
+**asserts `rows_failed == 0` and `rows_scored > 0`**, so the failure mode
+cannot come back silently.
+
+**What the metrics can and cannot see.** `precision_at_k`, `recall_at_k` and
+`f1_at_k` are set functions of ``retrieved_ids[:k]``, so permuting a list of
+<= k documents cannot move them -- the reason arm B exists, and the reason
+the rule's own P@k clause would have been vacuous with arm A alone. See
+`harness/cross_encoder_probe.py`'s module docstring for the full statement.
+
+**Zero network, zero spend, and neither is a claim.** Sockets are blocked by
+`Tests/conftest.py`'s autouse `_no_network_io` guard, which fails the test at
+teardown on any blocked attempt; `HF_HUB_OFFLINE` is forced by the directory
+conftest and asserted here; and `chat_api_call` -- the seam every OTHER
+reranking strategy spends money through -- is monkeypatched to raise, so a
+provider call would fail this test rather than bill someone.
+
+Skipped unless `RAG_EVAL=1` plus the embeddings extras plus a warm model
+cache -- the same gate every harness module uses, never a new one:
+
+    RAG_EVAL=1 HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+        .venv/bin/pytest Tests/RAG_Eval/test_cross_encoder_probe_run.py -s
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping, Sequence
+
+from Tests.RAG_Eval.harness.cross_encoder_probe import (
+    ARM_A,
+    ARM_A_DEPTH,
+    ARM_B,
+    ARM_B_DEPTH,
+    PERMUTATION_INVARIANT_METRICS,
+    TOLERANCE,
+    VERDICT_METRICS,
+    VERDICT_MODES,
+    CensusRow,
+    ModeArm,
+    Verdict,
+    arm_verdict,
+    compose_arc_verdict,
+    metric_moves,
+    reorder_rows,
+    rows_to_search_results,
+)
+from Tests.RAG_Eval.harness.environment import harness_gate, model_cache_dir
+
+pytestmark = harness_gate()
+
+#: The harness's own k: the depth every metric here is stated at, in both
+#: arms, so the two arms' numbers are comparable to each other and to the
+#: committed baselines.
+K = 10
+
+#: The cross-encoder under measurement. The one artifact verified cached and
+#: working offline in this environment (+8.719 relevant vs -11.14
+#: irrelevant). NOT `mixedbread-ai/mxbai-rerank-large-v2`: the copy in this
+#: cache is a 20 MB partial with no weights file and raises offline.
+MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+#: What each mode must report as its backend (`test_harness_run.py`'s table,
+#: not a second opinion). Asserting it is what proves the per-mode config
+#: flip actually re-routed retrieval rather than replaying one cached answer.
+EXPECTED_BACKEND = {
+    "plain": "local-fts",
+    "semantic": "rag-semantic",
+    "hybrid": "rag-hybrid",
+}
+
+#: Arm A covers `plain` as a GUARD, not as a measurement: the census says it
+#: is the identity there, and the plan makes any movement in a plain cell a
+#: STOP rather than a result. Arm B does not -- a mode that cannot fill two
+#: slots at k=10 has nothing to promote from rank 11-20 either.
+ARM_A_MODES: tuple[str, ...] = ("semantic", "plain", "hybrid")
+ARM_B_MODES: tuple[str, ...] = VERDICT_MODES
+
+
+# ---------------------------------------------------------------------------
+# The run
+# ---------------------------------------------------------------------------
+
+
+def _census_row(mode: str, depth: int, rows_returned: Sequence[int]) -> CensusRow:
+    return CensusRow(
+        mode=mode,
+        depth=depth,
+        queries=len(rows_returned),
+        reorderable=sum(1 for count in rows_returned if count >= 2),
+        zero_rows=sum(1 for count in rows_returned if count == 0),
+        one_row=sum(1 for count in rows_returned if count == 1),
+        full_window=sum(1 for count in rows_returned if count >= depth),
+    )
+
+
+def _outcome(
+    query: Any,
+    doc_ids: Sequence[str],
+    *,
+    rows_returned: int,
+    latency_s: float,
+    backend: str,
+    error: str | None,
+) -> Any:
+    """One `QueryOutcome`, built for scoring by the instrument's own aggregator."""
+    from Tests.RAG_Eval.harness.runner import QueryOutcome
+
+    return QueryOutcome(
+        query_id=query.id,
+        query=query.query,
+        category=query.category,
+        retrieved_doc_ids=tuple(doc_ids),
+        relevant_slugs=tuple(query.relevant_slugs),
+        rows_returned=rows_returned,
+        latency_s=latency_s,
+        runtime_backend=backend,
+        # Not read by any metric; the arms score rankings, not score kinds.
+        top_score=None,
+        top_vector_score=None,
+        error=error,
+    )
+
+
+def _run_arm(
+    *,
+    arm: str,
+    mode: str,
+    depth: int,
+    seam: Any,
+    runtime: Any,
+    reranker: Any,
+    lookup: Mapping[tuple[str, str], str],
+    queries_with_scope: Sequence[tuple[Any, Any]],
+    source_types: tuple[str, ...],
+) -> tuple[ModeArm, CensusRow, list[str], dict[str, tuple[float, float]]]:
+    """Run one mode at one depth, score it twice, and report the difference.
+
+    ONE retrieval per query, scored before and after: the arms are
+    self-paired, so no part of a delta here can be run-to-run retrieval
+    variance.
+
+    Returns:
+        ``(ModeArm, CensusRow, errors, per_query_mrr)`` -- the last maps a
+        query id to its ``(before, after)`` MRR so the report can name gains
+        and losses BY ID rather than only in the aggregate (the TASK-15700
+        lost-column discipline).
+    """
+    from Tests.RAG_Eval.harness.canonicalize import rows_to_doc_ids
+    from Tests.RAG_Eval.harness.runner import _build_mode_report, _extract_rows
+    from tldw_chatbook.RAG_Search.eval.metrics import mrr as mrr_metric
+
+    before_outcomes: list[Any] = []
+    after_outcomes: list[Any] = []
+    rows_returned: list[int] = []
+    errors: list[str] = []
+    per_query_mrr: dict[str, tuple[float, float]] = {}
+    rows_scored = rows_failed = empty_documents = 0
+    row_order_changes = queries_reordered = queries_doc_order_changed = 0
+    predict_seconds = 0.0
+
+    for query, scope in queries_with_scope:
+        start = time.perf_counter()
+        result = runtime.run(
+            seam.search(query.query, source_types, "rag", top_k=depth, scope=scope)
+        )
+        latency_s = max(time.perf_counter() - start, 1e-9)
+        rows, backend, error = _extract_rows(result)
+        if error is not None:
+            errors.append(f"{query.id}: {error}")
+            before_outcomes.append(
+                _outcome(
+                    query,
+                    (),
+                    rows_returned=0,
+                    latency_s=latency_s,
+                    backend=backend,
+                    error=error,
+                )
+            )
+            after_outcomes.append(before_outcomes[-1])
+            rows_returned.append(0)
+            continue
+
+        rows_returned.append(len(rows))
+        before_ids = rows_to_doc_ids(rows, lookup)
+
+        window = rows_to_search_results(
+            rows, window_id=f"{arm}|{mode}|{query.id}"
+        )
+        empty_documents += sum(1 for item in window if not item.document)
+        predict_start = time.perf_counter()
+        outcome = runtime.run(reranker.rerank(query.query, window))
+        predict_seconds += time.perf_counter() - predict_start
+        rows_scored += outcome.total - outcome.failed
+        rows_failed += outcome.failed
+
+        reranked_rows = reorder_rows(rows, outcome.results)
+        moved = sum(
+            1
+            for position, row in enumerate(reranked_rows)
+            if row is not rows[position]
+        )
+        row_order_changes += moved
+        queries_reordered += 1 if moved else 0
+        after_ids = rows_to_doc_ids(reranked_rows, lookup)
+        if after_ids != before_ids:
+            queries_doc_order_changed += 1
+
+        before_outcomes.append(
+            _outcome(
+                query,
+                before_ids,
+                rows_returned=len(rows),
+                latency_s=latency_s,
+                backend=backend,
+                error=None,
+            )
+        )
+        after_outcomes.append(
+            _outcome(
+                query,
+                after_ids,
+                rows_returned=len(rows),
+                latency_s=latency_s,
+                backend=backend,
+                error=None,
+            )
+        )
+        relevant = list(query.relevant_slugs)
+        if relevant:
+            per_query_mrr[query.id] = (
+                mrr_metric(list(before_ids), relevant),
+                mrr_metric(list(after_ids), relevant),
+            )
+
+    before_report = _build_mode_report(mode, K, tuple(before_outcomes))
+    after_report = _build_mode_report(mode, K, tuple(after_outcomes))
+    return (
+        ModeArm(
+            arm=arm,
+            mode=mode,
+            depth=depth,
+            before=before_report.overall,
+            after=after_report.overall,
+            before_per_category=before_report.per_category,
+            after_per_category=after_report.per_category,
+            rows_scored=rows_scored,
+            rows_failed=rows_failed,
+            empty_document_rows=empty_documents,
+            row_order_changes=row_order_changes,
+            queries_reordered=queries_reordered,
+            queries_doc_order_changed=queries_doc_order_changed,
+            predict_seconds=predict_seconds,
+        ),
+        _census_row(mode, depth, rows_returned),
+        errors,
+        per_query_mrr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_census(rows: Sequence[CensusRow]) -> str:
+    lines = [
+        "CENSUS — how many queries a reranker could even reorder "
+        "(measured in THIS run)",
+        f"{'mode':<10}{'depth':>7}{'queries':>9}{'>=2 rows':>12}"
+        f"{'0 rows':>9}{'1 row':>8}{'full window':>13}",
+    ]
+    lines.append("-" * len(lines[-1]))
+    for row in rows:
+        share = (row.reorderable / row.queries * 100.0) if row.queries else 0.0
+        lines.append(
+            f"{row.mode:<10}{row.depth:>7}{row.queries:>9}"
+            f"{f'{row.reorderable} ({share:.1f}%)':>12}"
+            f"{row.zero_rows:>9}{row.one_row:>8}{row.full_window:>13}"
+        )
+    lines.append(
+        "A mode with 0 reorderable queries is the IDENTITY under any "
+        "reranker; movement there would be a STOP, not a result."
+    )
+    return "\n".join(lines)
+
+
+def _format_cross_check(
+    arms: Sequence[ModeArm], baseline: Any
+) -> tuple[str, list[str]]:
+    """Arm A's before-column vs `run_eval`'s own report. Differences are bugs."""
+    lines = [
+        "INSTRUMENT CROSS-CHECK — arm A's before-column vs run_eval's own report",
+        f"{'mode':<10}{'metric':<12}{'run_eval':>12}{'arm A before':>14}{'equal':>8}",
+    ]
+    lines.append("-" * len(lines[-1]))
+    mismatches: list[str] = []
+    for arm in arms:
+        official = baseline.modes[arm.mode].overall
+        for metric in ("mrr", "ndcg", "precision", "recall", "f1"):
+            theirs = float(official[metric])
+            ours = float(arm.before[metric])
+            equal = abs(theirs - ours) < 1e-9
+            if not equal:
+                mismatches.append(
+                    f"{arm.mode}/{metric}: run_eval {theirs:.6f} != "
+                    f"probe {ours:.6f}"
+                )
+            lines.append(
+                f"{arm.mode:<10}{metric:<12}{theirs:>12.6f}{ours:>14.6f}"
+                f"{('yes' if equal else 'NO'):>8}"
+            )
+    return "\n".join(lines), mismatches
+
+
+def _format_work(arms: Sequence[ModeArm]) -> str:
+    lines = [
+        f"{'mode':<10}{'depth':>7}{'rows scored':>13}{'failed':>8}"
+        f"{'empty text':>12}{'rows moved':>12}{'queries reordered':>19}"
+        f"{'docs reordered':>16}{'predict s':>11}",
+    ]
+    lines.append("-" * len(lines[-1]))
+    for arm in arms:
+        lines.append(
+            f"{arm.mode:<10}{arm.depth:>7}{arm.rows_scored:>13}"
+            f"{arm.rows_failed:>8}{arm.empty_document_rows:>12}"
+            f"{arm.row_order_changes:>12}{arm.queries_reordered:>19}"
+            f"{arm.queries_doc_order_changed:>16}{arm.predict_seconds:>11.1f}"
+        )
+    return "\n".join(lines)
+
+
+def _format_metrics(arms: Sequence[ModeArm]) -> str:
+    lines = [
+        f"{'mode':<10}{'metric':<12}{'before':>10}{'after':>10}{'delta':>10}"
+        f"{'beyond tol':>12}  note",
+    ]
+    lines.append("-" * len(lines[-1]))
+    for arm in arms:
+        for move in metric_moves(arm.before, arm.after, ("mrr", "ndcg", "precision", "recall", "f1")):
+            if move.improved:
+                flag = "GAIN"
+            elif move.regressed:
+                flag = "LOSS"
+            else:
+                flag = "no"
+            note = (
+                "invariant under permutation"
+                if move.metric in PERMUTATION_INVARIANT_METRICS
+                and arm.depth <= K
+                else ""
+            )
+            lines.append(
+                f"{arm.mode:<10}{move.metric:<12}{move.before:>10.3f}"
+                f"{move.after:>10.3f}{move.delta:>+10.3f}{flag:>12}  {note}"
+            )
+    return "\n".join(lines)
+
+
+def _format_categories(arms: Sequence[ModeArm]) -> str:
+    lines = [
+        f"{'mode':<10}{'category':<22}{'metric':<10}{'before':>10}{'after':>10}"
+        f"{'delta':>10}{'beyond tol':>12}",
+    ]
+    lines.append("-" * len(lines[-1]))
+    for arm in arms:
+        for category in sorted(arm.before_per_category):
+            after_cell = arm.after_per_category.get(category)
+            if after_cell is None:
+                continue
+            for move in metric_moves(arm.before_per_category[category], after_cell):
+                if move.improved:
+                    flag = "GAIN"
+                elif move.regressed:
+                    flag = "LOSS"
+                else:
+                    flag = "no"
+                lines.append(
+                    f"{arm.mode:<10}{category:<22}{move.metric:<10}"
+                    f"{move.before:>10.3f}{move.after:>10.3f}"
+                    f"{move.delta:>+10.3f}{flag:>12}"
+                )
+    return "\n".join(lines)
+
+
+def _format_movers(
+    arm: ModeArm, per_query_mrr: Mapping[str, tuple[float, float]]
+) -> str:
+    """Gains AND losses by query id — an aggregate cannot say who paid."""
+    moved = [
+        (after - before, query_id, before, after)
+        for query_id, (before, after) in per_query_mrr.items()
+        if abs(after - before) > 1e-12
+    ]
+    if not moved:
+        return f"{arm.mode}: no query's MRR changed at all."
+    moved.sort(key=lambda item: item[0], reverse=True)
+    lines = [
+        f"{arm.mode}: {len(moved)} of {len(per_query_mrr)} scored queries "
+        "changed MRR (all of them, gains first):",
+    ]
+    for delta, query_id, before, after in moved:
+        lines.append(
+            f"    {query_id:<34}{before:>7.3f} -> {after:>7.3f}  ({delta:+.3f})"
+        )
+    return "\n".join(lines)
+
+
+def _format_verdict(
+    arm_results: Mapping[str, Sequence[ModeArm]],
+) -> tuple[str, Verdict]:
+    lines: list[str] = []
+    verdicts: dict[str, Verdict] = {}
+    for arm_name, arms in arm_results.items():
+        scored = [arm for arm in arms if arm.mode in VERDICT_MODES]
+        verdict, reasons = arm_verdict(scored)
+        verdicts[arm_name] = verdict
+        lines.append(f"ARM {arm_name} VERDICT: {verdict.value}")
+        for reason in reasons:
+            lines.append(f"    {reason}")
+    arc_verdict, reason = compose_arc_verdict(verdicts)
+    lines.append("")
+    lines.append(f"VERDICT: {arc_verdict.value} — {reason}")
+    lines.append(
+        f"(pre-registered rule, fixed before implementation: metrics "
+        f"{'/'.join(VERDICT_METRICS)} on modes {'/'.join(VERDICT_MODES)}, "
+        f"tolerance {TOLERANCE:.3f})"
+    )
+    return "\n".join(lines), arc_verdict
+
+
+# ---------------------------------------------------------------------------
+# The one gated test
+# ---------------------------------------------------------------------------
+
+
+def test_the_cross_encoder_probe_over_the_real_fixtures(tmp_path, capsys, monkeypatch):
+    """Measure reranking, print the tables, and report the pre-registered verdict.
+
+    The assertions pin **the instrument, never the outcome**: that the model
+    ran, that the census is the one the verdict rests on, that every pass
+    routed to the mode it claims, that arm A's before-column is the shipped
+    measurement, and that `plain` did not move. An assertion that reranking
+    HELPS would turn the arc's pre-authorised NULL into a red test, which is
+    the opposite of what this probe is for.
+    """
+    from huggingface_hub import constants
+
+    from Tests.RAG_Eval.harness.goldenset import load_fixtures
+    from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+    from Tests.RAG_Eval.harness.runner import (
+        SOURCE_TYPES,
+        build_query_scope,
+        run_eval,
+        slug_lookup_from,
+    )
+    from tldw_chatbook.RAG_Search import reranker as reranker_module
+    from tldw_chatbook.RAG_Search.reranker import (
+        CrossEncoderReranker,
+        RerankingConfig,
+        create_reranker_from_config,
+    )
+
+    # THE TRAP (module docstring): the hub cache must point at the real one,
+    # or the model silently fails to load and every arm reports a fake null.
+    monkeypatch.setattr(constants, "HF_HUB_CACHE", str(model_cache_dir()))
+    assert constants.HF_HUB_OFFLINE is True, (
+        "huggingface_hub is not in offline mode; this run could reach the "
+        "network for a model, which AC#5 forbids"
+    )
+
+    # No provider, no spend: the seam the other three strategies bill through.
+    def _forbidden(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError(
+            "the cross-encoder strategy called chat_api_call; it is supposed "
+            "to be local and credential-free (AC#5)"
+        )
+
+    monkeypatch.setattr(reranker_module, "chat_api_call", _forbidden)
+
+    started = time.perf_counter()
+    corpus, golden = load_fixtures()
+    config = RerankingConfig(
+        strategy="cross_encoder",
+        model_name=MODEL_NAME,
+        top_k_to_rerank=ARM_B_DEPTH,
+    )
+    reranker = create_reranker_from_config(config)
+    assert isinstance(reranker, CrossEncoderReranker), (
+        f"the factory returned {type(reranker).__name__} for strategy "
+        f"{config.strategy!r}; the probe would be measuring another strategy"
+    )
+    assert reranker.model_name == MODEL_NAME
+
+    runtime = build_eval_runtime(corpus, tmp_path)
+    close_error: Exception | None = None
+    try:
+        from tldw_chatbook.Library.library_local_rag_search_service import (
+            LibraryLocalRagSearchService,
+        )
+
+        seam = LibraryLocalRagSearchService(runtime.app)
+        lookup = slug_lookup_from(runtime.slug_to_source)
+        queries_with_scope = tuple(
+            (query, build_query_scope(runtime.slug_to_source, query))
+            for query in golden
+        )
+        search_config = runtime.service.config.search
+        original_mode = getattr(search_config, "default_search_mode", None)
+
+        # The shipped measurement, run first and untouched: the thing arm A's
+        # before-column has to reproduce.
+        baseline = run_eval(runtime, golden, k=K)
+
+        arm_results: dict[str, list[ModeArm]] = {ARM_A: [], ARM_B: []}
+        census: list[CensusRow] = []
+        seam_errors: list[str] = []
+        movers: dict[tuple[str, str], dict[str, tuple[float, float]]] = {}
+        try:
+            for arm, depth, modes in (
+                (ARM_A, ARM_A_DEPTH, ARM_A_MODES),
+                (ARM_B, ARM_B_DEPTH, ARM_B_MODES),
+            ):
+                for mode in modes:
+                    search_config.default_search_mode = mode
+                    mode_arm, census_row, errors, per_query = _run_arm(
+                        arm=arm,
+                        mode=mode,
+                        depth=depth,
+                        seam=seam,
+                        runtime=runtime,
+                        reranker=reranker,
+                        lookup=lookup,
+                        queries_with_scope=queries_with_scope,
+                        source_types=SOURCE_TYPES,
+                    )
+                    arm_results[arm].append(mode_arm)
+                    census.append(census_row)
+                    seam_errors.extend(f"{arm}/{mode} {e}" for e in errors)
+                    movers[(arm, mode)] = per_query
+        finally:
+            if original_mode is not None:
+                search_config.default_search_mode = original_mode
+    finally:
+        try:
+            runtime.close()
+        except Exception as exc:  # pragma: no cover - reported, not raised
+            close_error = exc
+    elapsed = time.perf_counter() - started
+
+    arm_a = arm_results[ARM_A]
+    arm_b = arm_results[ARM_B]
+    arm_a_scored = [arm for arm in arm_a if arm.mode in VERDICT_MODES]
+    plain_arm = next(arm for arm in arm_a if arm.mode == "plain")
+    cross_check, mismatches = _format_cross_check(arm_a, baseline)
+    verdict_block, arc_verdict = _format_verdict(
+        {ARM_A: arm_a_scored, ARM_B: arm_b}
+    )
+
+    with capsys.disabled():
+        print("\n" + "=" * 78)
+        print("TASK-16965 — CROSS-ENCODER MEASUREMENT PROBE")
+        print(f"model: {MODEL_NAME} (local, offline, no credential)")
+        print(
+            f"config: strategy={config.strategy} "
+            f"top_k_to_rerank={config.top_k_to_rerank} "
+            f"combine_original_score={config.combine_original_score} "
+            f"original_score_weight={config.original_score_weight} "
+            f"score_scale={config.score_scale}"
+        )
+        print(
+            f"metrics @k={K}; tolerance {TOLERANCE:.3f} (the gate's own "
+            f"FAIL_BAND); verdict metrics {'/'.join(VERDICT_METRICS)} on "
+            f"{'/'.join(VERDICT_MODES)}"
+        )
+        print("=" * 78)
+        print("\n" + _format_census(census))
+        print("\n" + cross_check)
+        print(
+            "\nARM A (retrieve at k=10, rerank that window, re-score) — "
+            "a permutation of the returned set"
+        )
+        print(_format_work(arm_a))
+        print()
+        print(_format_metrics(arm_a))
+        print("\nARM A — per-category regression guard")
+        print(_format_categories(arm_a_scored))
+        print("\nARM A — per-query MRR movement")
+        for arm in arm_a_scored:
+            print(_format_movers(arm, movers[(ARM_A, arm.mode)]))
+        print(
+            f"\nARM B (retrieve at {ARM_B_DEPTH}, rerank, score the first "
+            f"{K}) — the only arm in which P@k/recall/F1 are live"
+        )
+        print(_format_work(arm_b))
+        print()
+        print(_format_metrics(arm_b))
+        print("\nARM B — per-category regression guard")
+        print(_format_categories(arm_b))
+        print("\nARM B — per-query MRR movement")
+        for arm in arm_b:
+            print(_format_movers(arm, movers[(ARM_B, arm.mode)]))
+        print("\n" + verdict_block)
+        print(f"\nwall clock: {elapsed:.1f}s")
+        if close_error is not None:
+            print(f"NOTE: runtime.close() failed after the run: {close_error!r}")
+
+    # --- the instrument, never the outcome ---------------------------------
+    assert not seam_errors, (
+        f"the retrieval seam erred during the arms, so the deltas above mean "
+        f"nothing: {seam_errors}"
+    )
+    for mode in ("semantic", "plain", "hybrid"):
+        assert not baseline.modes[mode].errors, (
+            f"{mode}: the baseline run erred: {baseline.modes[mode].errors}"
+        )
+        assert baseline.modes[mode].runtime_backends == (EXPECTED_BACKEND[mode],), (
+            f"{mode}: baseline routed to "
+            f"{baseline.modes[mode].runtime_backends}, not "
+            f"{EXPECTED_BACKEND[mode]!r}"
+        )
+
+    total_scored = sum(arm.rows_scored for arm in arm_a + arm_b)
+    total_failed = sum(arm.rows_failed for arm in arm_a + arm_b)
+    assert total_failed == 0, (
+        f"{total_failed} cross-encoder scoring attempts FAILED — the model "
+        "did not load (see this module's docstring on the HF_HUB_CACHE trap) "
+        "or the predict raised. Every 'no movement' above would then be the "
+        "reranker degrading to the identity, not a measured null."
+    )
+    assert total_scored > 0, "the cross-encoder scored no rows at all"
+
+    assert not mismatches, (
+        "arm A's before-column does not reproduce run_eval's own report, so "
+        "the probe is measuring a different retrieval than the instrument "
+        f"does: {mismatches}"
+    )
+
+    census_by_key = {(row.mode, row.depth): row for row in census}
+    for mode in VERDICT_MODES:
+        for depth in (ARM_A_DEPTH, ARM_B_DEPTH):
+            row = census_by_key[(mode, depth)]
+            assert row.reorderable > 0, (
+                f"{mode}@{depth}: no query returned >= 2 rows, so this arm "
+                "measured nothing and its null is uninterpretable"
+            )
+    plain_census = census_by_key[("plain", ARM_A_DEPTH)]
+    assert plain_census.reorderable == 0, (
+        f"plain now has {plain_census.reorderable} reorderable queries "
+        "(TASK-16071 and this arc's census both measured 0). The premise "
+        "that plain is the identity under a reranker no longer holds — STOP "
+        "and re-derive the census before reading any verdict above."
+    )
+    assert plain_arm.row_order_changes == 0, (
+        "reranking MOVED a plain row. Per the plan that is a STOP-and-report, "
+        "not a result."
+    )
+    for move in metric_moves(
+        plain_arm.before, plain_arm.after, ("mrr", "ndcg", "precision", "recall", "f1")
+    ):
+        assert move.delta == 0.0, (
+            f"plain/{move.metric} moved by {move.delta:+.6f}; reranking is "
+            "provably the identity on plain by census, so a moved plain cell "
+            "means the probe is wrong, not that reranking works"
+        )
+
+    assert isinstance(arc_verdict, Verdict), (
+        "the verdict must come from the pre-registered rule, not from prose"
+    )

--- a/Tests/RAG_Search/test_cross_encoder_reranker.py
+++ b/Tests/RAG_Search/test_cross_encoder_reranker.py
@@ -31,6 +31,7 @@ out of the implementation rather than out of a promise.
 
 import ast
 import inspect
+import time
 
 import pytest
 
@@ -46,6 +47,12 @@ from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
 
 STUB_MODEL = "stub-org/stub-cross-encoder"
 
+#: Captured at import time, BEFORE the autouse fixture below replaces it with
+#: a refusal. The one test that exercises the optional-dependency guard needs
+#: the real function; it never reaches an import, because it makes
+#: `optional_deps.check_dependency` report the package missing first.
+_REAL_IMPORTER = reranker_module._import_cross_encoder_class
+
 
 class _StubModelDown(RuntimeError):
     """Raised by the stub model; never a real load or a real network call."""
@@ -56,15 +63,26 @@ class _StubCrossEncoder:
 
     Scores are keyed by DOCUMENT so an assertion about ordering cannot be
     satisfied by the reranker handing the model its rows in a lucky order.
+    ``batch_sizes`` records what the strategy forwarded, because the real
+    `CrossEncoder.predict` takes ``batch_size`` and silently defaults to 32
+    when nobody passes one -- a config field that never arrives is
+    indistinguishable from one that does, without recording it.
     """
 
-    def __init__(self, scores: dict[str, float], fail: bool = False):
+    def __init__(
+        self, scores: dict[str, float], fail: bool = False, sleep_s: float = 0.0
+    ):
         self._scores = scores
         self._fail = fail
+        self._sleep_s = sleep_s
         self.calls: list[list[tuple[str, str]]] = []
+        self.batch_sizes: list[object] = []
 
-    def predict(self, pairs):
+    def predict(self, pairs, batch_size=None, **kwargs):
         self.calls.append([tuple(pair) for pair in pairs])
+        self.batch_sizes.append(batch_size)
+        if self._sleep_s:
+            time.sleep(self._sleep_s)
         if self._fail:
             raise _StubModelDown("stub cross-encoder is down")
         return [self._scores[document] for _query, document in pairs]
@@ -291,3 +309,287 @@ async def test_provider_shaped_fields_are_no_ops(monkeypatch):
     )
     assert len(failing_stub.calls) == 1
     assert (degraded.failed, degraded.total) == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# The cache (Qodo PR-1775 finding 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_replays_an_identical_window(monkeypatch):
+    """The cache still IS a cache: an identical repeat does not re-run the model."""
+    stub = _StubCrossEncoder({"doc-a": -8.0, "doc-b": 9.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    rows = [("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")]
+
+    first = await reranker.rerank("q", _rows(*rows))
+    second = await reranker.rerank("q", _rows(*rows))
+
+    assert len(stub.calls) == 1, "the second identical call re-ran the model"
+    assert [r.id for r in second.results] == [r.id for r in first.results] == ["b", "a"]
+    assert [r.score for r in second.results] == [r.score for r in first.results]
+    assert (second.failed, second.total) == (0, 2)
+
+
+@pytest.mark.asyncio
+async def test_cache_does_not_misassign_scores_to_a_reordered_window(monkeypatch):
+    """The SAME ids in a DIFFERENT order must not inherit the first order's scores.
+
+    The cached values are positional -- ``_apply_scores`` zips them onto the
+    rows it is handed -- so a key that ignores order hands row 0's score to
+    whatever happens to be sitting at index 0 the second time. Here the model
+    says ``doc-b`` wins by a mile; a retrieval that returns (b, a) instead of
+    (a, b) must still put b first, not inherit a's low score.
+    """
+    stub = _StubCrossEncoder({"doc-a": -8.0, "doc-b": 9.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+
+    first = await reranker.rerank("q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")))
+    assert [r.id for r in first.results] == ["b", "a"]
+
+    # Same query, same ids, same documents -- the retrieval returned them in
+    # the other order (a re-search, a different fusion, a changed tie-break).
+    second = await reranker.rerank("q", _rows(("b", 0.5, "doc-b"), ("a", 0.9, "doc-a")))
+
+    assert [r.id for r in second.results] == ["b", "a"], (
+        "the reordered window was scored with the FIRST window's positional "
+        "scores: b (the model's clear winner) was demoted because it moved to "
+        "index 0"
+    )
+    assert len(stub.calls) == 2, (
+        "a differently-ordered window is a different scoring problem; it must "
+        "miss the cache rather than replay positions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_does_not_blend_stale_retrieval_scores(monkeypatch):
+    """`combine_original_score` must blend against THIS call's retrieval scores.
+
+    The cached `RerankingResult`s carry the first call's ``original_score``.
+    The default config blends 30% of it into the final score, so replaying
+    them scores the second search with the first search's retrieval numbers.
+    """
+    stub = _StubCrossEncoder({"doc-a": 0.0, "doc-b": 10.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    assert reranker.config.combine_original_score is True
+    assert reranker.config.original_score_weight == 0.3
+
+    await reranker.rerank("q", _rows(("a", 0.9, "doc-a"), ("b", 0.1, "doc-b")))
+
+    # Same query, same ids, same documents, same order -- but retrieval now
+    # scores both rows at 0.0 (a different index, a different search mode).
+    second = await reranker.rerank("q", _rows(("a", 0.0, "doc-a"), ("b", 0.0, "doc-b")))
+
+    by_id = {r.id: r.score for r in second.results}
+    # a: 0.3 * 0.0 + 0.7 * 0.0 (normalised min) == 0.0, not 0.3 * 0.9 == 0.27.
+    assert by_id["a"] == pytest.approx(0.0), (
+        f"row a blended a stale retrieval score: {by_id['a']!r}"
+    )
+    # b: 0.3 * 0.0 + 0.7 * 1.0 (normalised max) == 0.7, not 0.73.
+    assert by_id["b"] == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_cache_keys_on_the_document_text(monkeypatch):
+    """An id whose text changed is a different scoring problem, not a hit."""
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-a-rewritten": 9.0, "doc-b": 5.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+
+    await reranker.rerank("q", _rows(("a", 0.5, "doc-a"), ("b", 0.5, "doc-b")))
+    second = await reranker.rerank(
+        "q", _rows(("a", 0.5, "doc-a-rewritten"), ("b", 0.5, "doc-b"))
+    )
+
+    assert len(stub.calls) == 2
+    assert [r.id for r in second.results] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_does_not_mutate_the_cached_entry(monkeypatch):
+    """A replay must not hand `_apply_scores` the cache's own objects to rewrite."""
+    stub = _StubCrossEncoder({"doc-a": -8.0, "doc-b": 9.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    rows = [("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")]
+
+    await reranker.rerank("q", _rows(*rows))
+    cached = list(reranker._cache.values())[0]
+    ranks_before = [(r.original_rank, r.new_rank) for r in cached]
+
+    await reranker.rerank("q", _rows(*rows))
+
+    assert [(r.original_rank, r.new_rank) for r in cached] == ranks_before
+
+
+@pytest.mark.asyncio
+async def test_cache_can_be_switched_off(monkeypatch):
+    """`cache_results=False` means every call reaches the model."""
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 2.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config(cache_results=False))
+    rows = [("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")]
+    await reranker.rerank("q", _rows(*rows))
+    await reranker.rerank("q", _rows(*rows))
+
+    assert len(stub.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Honoured config (Qodo PR-1775 findings 7 and 8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_size_reaches_the_model(monkeypatch):
+    """`RerankingConfig.batch_size` is forwarded, not left to the model's 32."""
+    stub = _StubCrossEncoder({f"doc-{i}": float(i) for i in range(6)})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config(batch_size=3))
+    await reranker.rerank(
+        "q", _rows(*[(f"r{i}", 0.5, f"doc-{i}") for i in range(6)])
+    )
+
+    assert stub.batch_sizes == [3]
+
+
+@pytest.mark.asyncio
+async def test_a_nonsense_batch_size_still_scores(monkeypatch):
+    """A zero/negative batch size floors to 1 rather than raising at the model."""
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 2.0})
+    _install(monkeypatch, stub)
+
+    outcome = await CrossEncoderReranker(_config(batch_size=0)).rerank(
+        "q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"))
+    )
+
+    assert stub.batch_sizes == [1]
+    assert (outcome.failed, outcome.total) == (0, 2)
+
+
+@pytest.mark.asyncio
+async def test_timeout_seconds_bounds_the_model_call(monkeypatch):
+    """A model that overruns `timeout_seconds` degrades; it never holds a search.
+
+    The executor thread cannot be cancelled -- it runs to completion and its
+    result is discarded -- but the AWAIT is bounded, which is the part a
+    search's latency depends on.
+    """
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 9.0}, sleep_s=0.4)
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config(timeout_seconds=0.02))
+    started = time.perf_counter()
+    outcome = await reranker.rerank(
+        "q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"))
+    )
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.35, f"the await was not bounded by the timeout ({elapsed:.3f}s)"
+    assert (outcome.failed, outcome.total) == (2, 2)
+    assert outcome.degraded is True
+    assert [r.id for r in outcome.results] == ["a", "b"]
+    # note-b: a timed-out row was never scored, so it may not claim it was.
+    assert all("rerank_score" not in r.metadata for r in outcome.results)
+    # A timeout is transient: it must not be cached as a result.
+    assert reranker._cache == {}
+
+
+@pytest.mark.asyncio
+async def test_a_generous_timeout_does_not_interfere(monkeypatch):
+    """The bound is a bound, not a throttle."""
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 9.0}, sleep_s=0.02)
+    _install(monkeypatch, stub)
+
+    outcome = await CrossEncoderReranker(_config(timeout_seconds=30.0)).rerank(
+        "q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"))
+    )
+
+    assert (outcome.failed, outcome.total) == (0, 2)
+    assert [r.id for r in outcome.results] == ["b", "a"]
+
+
+# ---------------------------------------------------------------------------
+# Model resolution and loading (Qodo PR-1775 findings 2, 3 and 6)
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_model_path_is_not_replaced_by_the_default(tmp_path):
+    """An existing filesystem path is a path, whatever it is named.
+
+    The resolver's contract says local paths are used verbatim. A bare
+    directory (`/tmp/x/my-reranker`, or a relative `models`) contains no
+    forward slash after `partition`, and a Windows path contains none at
+    all, so the chat-model heuristic would have swallowed both.
+    """
+    from tldw_chatbook.RAG_Search.reranker import _resolve_cross_encoder_model_name
+
+    local_dir = tmp_path / "my-reranker"
+    local_dir.mkdir()
+
+    assert _resolve_cross_encoder_model_name(str(local_dir)) == str(local_dir)
+    # ...including one whose basename has no separator at all once resolved.
+    assert (
+        _resolve_cross_encoder_model_name(r"C:\models\bge-base")
+        == r"C:\models\bge-base"
+    ), "a Windows path was silently replaced with the default artifact"
+    assert _resolve_cross_encoder_model_name("./models/local") == "./models/local"
+    assert _resolve_cross_encoder_model_name("~/models/local") == "~/models/local"
+
+    # The chat-model fallback still fires for names that are not paths.
+    assert _resolve_cross_encoder_model_name("gpt-4o-mini") == DEFAULT_CROSS_ENCODER_MODEL
+    assert _resolve_cross_encoder_model_name("openai/gpt-4o") == DEFAULT_CROSS_ENCODER_MODEL
+    assert (
+        _resolve_cross_encoder_model_name("BAAI/bge-reranker-base")
+        == "BAAI/bge-reranker-base"
+    )
+
+
+def test_the_model_is_loaded_offline_only(monkeypatch):
+    """Production must not reach a model hub: the docs promise no network."""
+    from tldw_chatbook.RAG_Search.reranker import _load_cross_encoder
+
+    recorded: list[tuple[tuple, dict]] = []
+
+    class _Recorder:
+        def __init__(self, *args, **kwargs):
+            recorded.append((args, kwargs))
+
+    monkeypatch.setattr(reranker_module, "_CROSS_ENCODER_MODELS", {})
+    monkeypatch.setattr(
+        reranker_module, "_import_cross_encoder_class", lambda: _Recorder
+    )
+
+    _load_cross_encoder("stub-org/stub-cross-encoder")
+
+    assert len(recorded) == 1
+    args, kwargs = recorded[0]
+    assert args == ("stub-org/stub-cross-encoder",)
+    assert kwargs.get("local_files_only") is True, (
+        "an uncached first use would silently fetch from the hub"
+    )
+
+
+def test_the_optional_import_is_guarded_by_optional_deps(monkeypatch):
+    """`sentence_transformers` is an `embeddings_rag` extra, not a hard import."""
+    from tldw_chatbook.Utils import optional_deps
+
+    monkeypatch.setattr(reranker_module, "_import_cross_encoder_class", _REAL_IMPORTER)
+    monkeypatch.setattr(optional_deps, "check_dependency", lambda *a, **k: False)
+
+    with pytest.raises(ImportError) as excinfo:
+        reranker_module._import_cross_encoder_class()
+
+    assert "embeddings_rag" in str(excinfo.value)

--- a/Tests/RAG_Search/test_cross_encoder_reranker.py
+++ b/Tests/RAG_Search/test_cross_encoder_reranker.py
@@ -1,0 +1,293 @@
+"""The LOCAL reranking strategy: `cross_encoder` (TASK-16965 Task 1).
+
+`cross_encoder` has been a name without an implementation since task-3170 P0
+(`config_profiles.py`'s standing comment; Hybrid Full ships `pointwise` as a
+stopgap). TASK-16965 exists to answer whether reranking helps retrieval here,
+and a LOCAL cross-encoder is the only strategy the gated instrument can see:
+deterministic, unpriced, offline. This module pins the strategy's contract so
+the measurement (Task 2) is measuring something honest.
+
+**No model is ever loaded here.** Every test seeds the module-level model
+cache with a stub exposing `.predict(pairs) -> list[float]`, and an autouse
+fixture makes the real `sentence_transformers` import raise, so a cache miss
+fails loudly instead of downloading 90 MB inside a unit run. The real model is
+Task 2's business.
+
+What the strategy must honour, inherited from `BaseReranker` and pinned below:
+
+* the `RerankOutcome` contract -- results plus THIS call's `failed`/`total`,
+  never per-instance state (TASK-3502 AC#4);
+* the per-row `scored` flag -- a row no model scored keeps its original score
+  and is NOT stamped with `rerank_score`, the production "this is no longer a
+  similarity" marker (TASK-3502 note-b);
+* the result cache and `top_k_to_rerank` window, so only the window is scored
+  and the tail is handed back untouched;
+* degradation instead of exceptions: reranking must never fail a search.
+
+And what it must NOT do: reach a provider. It resolves no credential and never
+calls `chat_api_call` -- that is what makes AC#5 (no spend, no network) fall
+out of the implementation rather than out of a promise.
+"""
+
+import ast
+import inspect
+
+import pytest
+
+from tldw_chatbook.RAG_Search import reranker as reranker_module
+from tldw_chatbook.RAG_Search.reranker import (
+    DEFAULT_CROSS_ENCODER_MODEL,
+    CrossEncoderReranker,
+    RerankingConfig,
+    create_reranker,
+    create_reranker_from_config,
+)
+from tldw_chatbook.RAG_Search.simplified.vector_store import SearchResult
+
+STUB_MODEL = "stub-org/stub-cross-encoder"
+
+
+class _StubModelDown(RuntimeError):
+    """Raised by the stub model; never a real load or a real network call."""
+
+
+class _StubCrossEncoder:
+    """Stands in for `sentence_transformers.CrossEncoder`.
+
+    Scores are keyed by DOCUMENT so an assertion about ordering cannot be
+    satisfied by the reranker handing the model its rows in a lucky order.
+    """
+
+    def __init__(self, scores: dict[str, float], fail: bool = False):
+        self._scores = scores
+        self._fail = fail
+        self.calls: list[list[tuple[str, str]]] = []
+
+    def predict(self, pairs):
+        self.calls.append([tuple(pair) for pair in pairs])
+        if self._fail:
+            raise _StubModelDown("stub cross-encoder is down")
+        return [self._scores[document] for _query, document in pairs]
+
+
+@pytest.fixture(autouse=True)
+def _no_real_model_loads(monkeypatch):
+    """A cache miss must FAIL, not download. Nothing here loads a real model."""
+
+    def _refuse():
+        raise AssertionError(
+            "a unit test tried to import/load a real cross-encoder model"
+        )
+
+    monkeypatch.setattr(reranker_module, "_import_cross_encoder_class", _refuse)
+    yield
+
+
+def _install(monkeypatch, stub: _StubCrossEncoder, name: str = STUB_MODEL) -> None:
+    """Seed the module-level model cache, exercising the real cache-hit path."""
+    monkeypatch.setitem(reranker_module._CROSS_ENCODER_MODELS, name, stub)
+
+
+def _rows(*specs: tuple[str, float, str]) -> list[SearchResult]:
+    return [
+        SearchResult(id=rid, score=score, document=document, metadata={"src": rid})
+        for rid, score, document in specs
+    ]
+
+
+def _config(**kwargs) -> RerankingConfig:
+    kwargs.setdefault("model_name", STUB_MODEL)
+    return RerankingConfig(strategy="cross_encoder", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_cross_encoder_reorders_by_model_score(monkeypatch):
+    """The model's scores decide the order, and scored rows carry the stamp."""
+    stub = _StubCrossEncoder({"doc-a": -8.0, "doc-b": 9.0, "doc-c": 0.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    results = _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"), ("c", 0.1, "doc-c"))
+
+    outcome = await reranker.rerank("what is a cross-encoder", results)
+
+    # The model saw (query, document) pairs, in the caller's order, once.
+    assert stub.calls == [
+        [
+            ("what is a cross-encoder", "doc-a"),
+            ("what is a cross-encoder", "doc-b"),
+            ("what is a cross-encoder", "doc-c"),
+        ]
+    ]
+
+    # ...and the ORIGINAL retrieval order (a, b, c) is not what comes back.
+    assert [r.id for r in outcome.results] == ["b", "c", "a"]
+    assert all("rerank_score" in r.metadata for r in outcome.results)
+    # A higher model score must not become a lower rerank_score.
+    by_id = {r.id: r.metadata["rerank_score"] for r in outcome.results}
+    assert by_id["b"] > by_id["c"] > by_id["a"]
+    assert (outcome.failed, outcome.total) == (0, 3)
+    assert outcome.degraded is False
+    # The caller's own objects are never mutated (the service caches by
+    # reference -- TASK-3502 AC#3).
+    assert [r.id for r in results] == ["a", "b", "c"]
+    assert all("rerank_score" not in r.metadata for r in results)
+
+
+@pytest.mark.asyncio
+async def test_cross_encoder_needs_no_credential(monkeypatch):
+    """No key, no provider call -- the whole point of the local strategy."""
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "COHERE_API_KEY",
+        "OPENROUTER_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    called: list[tuple] = []
+
+    def _explode(*args, **kwargs):
+        called.append((args, kwargs))
+        raise AssertionError("the cross-encoder strategy called a chat provider")
+
+    monkeypatch.setattr(reranker_module, "chat_api_call", _explode)
+
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 2.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    outcome = await reranker.rerank(
+        "q", _rows(("a", 0.4, "doc-a"), ("b", 0.3, "doc-b"))
+    )
+
+    assert called == []
+    assert (outcome.failed, outcome.total) == (0, 2)
+    assert [r.id for r in outcome.results] == ["b", "a"]
+    # Static half: the strategy's own CODE never names the provider seam.
+    # Parsed, not grepped -- the class docstring mentions `chat_api_call` to
+    # say it does not use it, and a substring check cannot tell the two apart.
+    tree = ast.parse(inspect.getsource(CrossEncoderReranker))
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+    assert "chat_api_call" not in referenced
+
+
+@pytest.mark.asyncio
+async def test_cross_encoder_honours_top_k_to_rerank(monkeypatch):
+    """Only the window is scored; the tail keeps its order and its kind."""
+    stub = _StubCrossEncoder({"doc-a": 0.0, "doc-b": 5.0})
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config(top_k_to_rerank=2))
+    results = _rows(
+        ("a", 0.9, "doc-a"),
+        ("b", 0.8, "doc-b"),
+        ("c", 0.7, "doc-c"),
+        ("d", 0.6, "doc-d"),
+        ("e", 0.5, "doc-e"),
+    )
+
+    outcome = await reranker.rerank("q", results)
+
+    # The model was handed the window only -- never the tail's documents.
+    assert len(stub.calls) == 1
+    assert [document for _q, document in stub.calls[0]] == ["doc-a", "doc-b"]
+
+    assert [r.id for r in outcome.results] == ["b", "a", "c", "d", "e"]
+    assert (outcome.failed, outcome.total) == (0, 2)
+    tail = outcome.results[2:]
+    assert [r.id for r in tail] == ["c", "d", "e"]
+    assert all("rerank_score" not in r.metadata for r in tail)
+    assert [r.score for r in tail] == [0.7, 0.6, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_cross_encoder_model_failure_degrades_like_the_others(monkeypatch):
+    """A raising model degrades the call; it never fails the search."""
+    stub = _StubCrossEncoder({"doc-a": 1.0, "doc-b": 2.0}, fail=True)
+    _install(monkeypatch, stub)
+
+    reranker = CrossEncoderReranker(_config())
+    results = _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"))
+
+    outcome = await reranker.rerank("q", results)
+
+    assert [r.id for r in outcome.results] == ["a", "b"]
+    assert (outcome.failed, outcome.total) == (2, 2)
+    assert outcome.degraded is True
+    # note-b: nothing scored these rows, so nothing may claim they were.
+    assert all("rerank_score" not in r.metadata for r in outcome.results)
+    assert [r.score for r in outcome.results] == [0.9, 0.5]
+
+
+def test_create_reranker_dispatches_cross_encoder():
+    """The factory builds it, and the model name resolves to a cross-encoder."""
+    reranker = create_reranker("cross_encoder")
+    assert isinstance(reranker, CrossEncoderReranker)
+    assert isinstance(
+        create_reranker_from_config(RerankingConfig(strategy="cross_encoder")),
+        CrossEncoderReranker,
+    )
+
+    # RerankingConfig.model_name defaults to an LLM ("gpt-3.5-turbo") because
+    # the three shipped strategies are LLM-driven. A local strategy cannot
+    # load that; it falls back to the measured default.
+    assert RerankingConfig().model_name == "gpt-3.5-turbo"
+    assert reranker.model_name == DEFAULT_CROSS_ENCODER_MODEL
+    assert (
+        create_reranker("cross_encoder", model_name="gpt-4o-mini").model_name
+        == DEFAULT_CROSS_ENCODER_MODEL
+    )
+    # ...but a real cross-encoder repo id is honoured verbatim.
+    assert (
+        create_reranker("cross_encoder", model_name="BAAI/bge-reranker-base").model_name
+        == "BAAI/bge-reranker-base"
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_shaped_fields_are_no_ops(monkeypatch):
+    """`max_retries` and `include_reasoning` are PROVIDER concepts.
+
+    They belong to `_call_llm`'s retry loop and to a prompt that asks a model
+    to explain itself. A local cross-encoder has neither, so state explicitly
+    that setting them changes nothing rather than leaving it implied.
+    """
+    scores = {"doc-a": -1.0, "doc-b": 3.0}
+    plain_stub = _StubCrossEncoder(dict(scores))
+    _install(monkeypatch, plain_stub)
+    plain = await CrossEncoderReranker(
+        _config(max_retries=0, include_reasoning=False)
+    ).rerank("q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")))
+
+    provider_shaped_stub = _StubCrossEncoder(dict(scores))
+    _install(monkeypatch, provider_shaped_stub)
+    provider_shaped = await CrossEncoderReranker(
+        _config(max_retries=5, include_reasoning=True)
+    ).rerank("q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b")))
+
+    assert [r.id for r in provider_shaped.results] == [r.id for r in plain.results]
+    assert [r.metadata for r in provider_shaped.results] == [
+        r.metadata for r in plain.results
+    ]
+    assert [r.score for r in provider_shaped.results] == [
+        r.score for r in plain.results
+    ]
+    assert len(provider_shaped_stub.calls) == len(plain_stub.calls) == 1
+    # include_reasoning asked for nothing to explain: no reasoning is stamped.
+    assert all("reasoning" not in r.metadata for r in provider_shaped.results)
+
+    # max_retries does not buy a second attempt at a failing model either.
+    failing_stub = _StubCrossEncoder(dict(scores), fail=True)
+    _install(monkeypatch, failing_stub)
+    degraded = await CrossEncoderReranker(_config(max_retries=5)).rerank(
+        "q", _rows(("a", 0.9, "doc-a"), ("b", 0.5, "doc-b"))
+    )
+    assert len(failing_stub.calls) == 1
+    assert (degraded.failed, degraded.total) == (2, 2)

--- a/Tests/RAG_Search/test_reranker_construction.py
+++ b/Tests/RAG_Search/test_reranker_construction.py
@@ -469,10 +469,12 @@ async def test_listwise_reranker_counts_total_failure():
 def test_reranked_rows_carry_a_detectable_marker_and_never_band_as_similarity():
     """(Task 6, coordinator follow-up) What does a REAL reranked row carry?
 
-    `PointwiseReranker._apply_scores` is the only reranking path that
-    replaces a row's score: it writes `final_score` (by default a weighted
-    blend of the original similarity and the LLM's relevance score) and
-    stamps `metadata["rerank_score"]`. That stamp is the production marker
+    `BaseReranker._apply_scores` is the only reranking path that replaces a
+    row's score: it writes `final_score` (by default a weighted blend of the
+    original similarity and the scoring model's relevance score) and stamps
+    `metadata["rerank_score"]`. Pointwise is pinned here; the local
+    `cross_encoder` strategy shares that method (TASK-16965) and is pinned in
+    `test_cross_encoder_reranker.py`. That stamp is the production marker
     -- `_final_score_kind` is READ by `local_citation_capture` but written
     by nothing in the app.
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -1993,6 +1993,15 @@ late reads as success on an env-var check while the flag it was meant to control
 `False`. And when closing a hole like this with a two-part fix, mutation-test each half
 independently — here, either half alone was silently insufficient.
 
+**`HF_HUB_OFFLINE` is not the only frozen constant in that module (TASK-16965,
+2026-08-17).** `huggingface_hub.constants.HF_HUB_CACHE` is likewise computed
+once at import, from `expanduser("~")` — so any fixture that sandboxes `HOME`
+(this repo's `Tests/conftest.py` does) points every later model load at an empty
+cache and makes a genuinely cached model unloadable under pytest. Same
+mechanism, opposite blast radius: this lesson's is a download you did not want,
+that one's is a load you did want and silently did not get. See "A metric can be
+graded on fallback content" at the end of this file for what that cost.
+
 ---
 
 ## "Order-dependent" in the backlog is a hypothesis, not a diagnosis — a state flip is not proof the DOM caught up
@@ -4999,3 +5008,41 @@ round, uniform timings as a budget being hit rather than work being done. Also:
 absence of an error log is not evidence of success when the code logs successes
 at INFO through stdlib `logging`, whose default level hides them; the runs above
 showed zero "Summarization successful" lines whether they worked or not.
+
+**Second instance, and the sharper rule when the number is a DELTA (TASK-16965,
+2026-08-17).** Same shape, opposite tell — and no tell at all. TASK-16965 had to
+answer "does cross-encoder reranking help retrieval here?" by running the gated
+eval set twice, once reranked and once not, and reading the difference.
+`CrossEncoderReranker` honours the TASK-3502 contract: a model that fails to
+load DEGRADES (returns the caller's ordering untouched) rather than raising. And
+`Tests/conftest.py` sandboxes `HOME`, while
+`huggingface_hub.constants.HF_HUB_CACHE` is computed from `expanduser("~")` **at
+import** — so under pytest `CrossEncoder(...)` raises `OSError` ("couldn't
+connect ... and couldn't find them in the cached files") on a machine where the
+model IS cached. Measured directly, before the probe was written. Compose those
+two facts: every window comes back in its original order, every metric is graded
+on un-reranked output, and the before/after table reads a flawless **0.000 delta
+on all 105 cells** — a NULL result, publishable-looking, pre-registered as an
+acceptable outcome, and entirely fabricated. Unlike task-17370's uniform `30.0s`
+timings there is no tell whatsoever: a real null and a never-ran null are the
+same table. The run therefore repoints the constant
+(`monkeypatch.setattr(constants, "HF_HUB_CACHE", real_cache)` — hf_hub 1.x reads
+it at call time off the module attribute) and **asserts the work happened**:
+`rows_scored > 0` and `rows_failed == 0`, per pass. It scored 3,621 rows, 0
+failed, and moved 1,950 — which is what makes the verdict it did produce
+(HARMED, bimodal) mean anything at all.
+
+**What to do.** Recording the path is enough when a bad path makes the number
+look good; it is NOT enough when the measurement is an A/B and the subject
+degrades to the identity, because then the failure mode is the null hypothesis
+itself and no reader can tell the two apart. So: **a measurement whose subject
+degrades silently must assert, inside the run, that it did work** — a positive
+count of units processed and a zero count of failures — or its null is
+unfalsifiable and must not be published. Write those assertions BEFORE you look
+at the numbers; a 0.000 delta is the one result that never prompts anyone to go
+looking for a bug. Corollary worth its own grep: the frozen-at-import
+huggingface_hub constants bite in more than one place — `HF_HUB_OFFLINE` (see
+"HF offline enforcement must be set before `huggingface_hub.constants`
+EVALUATES" above, where the blast radius is an unwanted download) and
+`HF_HUB_CACHE` (here, where the blast radius is a load you wanted and silently
+did not get, under any fixture that moves `HOME`).

--- a/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
+++ b/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
@@ -1,9 +1,12 @@
 ---
 id: TASK-16965
-title: 'Implement or retire cross_encoder reranking, with a gated-instrument measurement'
-status: To Do
+title: >-
+  Implement or retire cross_encoder reranking, with a gated-instrument
+  measurement
+status: In Progress
 assignee: []
 created_date: '2026-08-16'
+updated_date: '2026-08-17 21:00'
 labels:
   - rag
   - measurement
@@ -48,7 +51,6 @@ is likewise an acceptable outcome provided it is recorded as a decision.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
 - [ ] #1 A recorded decision exists for `cross_encoder`: implemented as a local deterministic reranking strategy, or retired from the strategy vocabulary -- not left as an unimplemented name
 - [ ] #2 If implemented: its retrieval effect is measured on the gated instrument as a pre-registered before/after over the 105 metrics, with the rule for "this helped" fixed BEFORE the run
@@ -57,3 +59,9 @@ is likewise an acceptable outcome provided it is recorded as a decision.
 - [ ] #5 The measurement requires no live provider spend and no network -- the whole reason a local cross-encoder is the measurable one
 - [ ] #6 The gate still reads `PASSED: No regression. 105 metric(s)` on the shipped state, whichever arm is taken
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+T1: implement CrossEncoderReranker (local, credential-free) behind create_reranker; RED tests with a stub model (no download).\nT2: env-gated offline probe over semantic+hybrid, prints census + VERDICT.\nT3: obey the pre-registered verdict (ship-with-docs or retire the name) and close.\nDecision rule fixed in Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md BEFORE any run.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
+++ b/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
@@ -3,10 +3,10 @@ id: TASK-16965
 title: >-
   Implement or retire cross_encoder reranking, with a gated-instrument
   measurement
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-16'
-updated_date: '2026-08-17 21:00'
+updated_date: '2026-08-17 22:15'
 labels:
   - rag
   - measurement
@@ -52,12 +52,12 @@ is likewise an acceptable outcome provided it is recorded as a decision.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A recorded decision exists for `cross_encoder`: implemented as a local deterministic reranking strategy, or retired from the strategy vocabulary -- not left as an unimplemented name
-- [ ] #2 If implemented: its retrieval effect is measured on the gated instrument as a pre-registered before/after over the 105 metrics, with the rule for "this helped" fixed BEFORE the run
-- [ ] #3 The measurement is decisive in both directions: a null result (no census gain, no cell moved beyond the gate's tolerance) is reported as the answer and is sufficient grounds to retire the strategy
-- [ ] #4 If retired (or declined): `config_profiles.py`'s not-implemented comment and any user-facing strategy vocabulary stop implying `cross_encoder` is forthcoming, and Hybrid Full's `pointwise` substitution is documented as the permanent choice rather than a stopgap
-- [ ] #5 The measurement requires no live provider spend and no network -- the whole reason a local cross-encoder is the measurable one
-- [ ] #6 The gate still reads `PASSED: No regression. 105 metric(s)` on the shipped state, whichever arm is taken
+- [x] #1 A recorded decision exists for `cross_encoder`: implemented as a local deterministic reranking strategy, or retired from the strategy vocabulary -- not left as an unimplemented name
+- [x] #2 If implemented: its retrieval effect is measured on the gated instrument as a pre-registered before/after over the 105 metrics, with the rule for "this helped" fixed BEFORE the run
+- [x] #3 The measurement is decisive in both directions: a null result (no census gain, no cell moved beyond the gate's tolerance) is reported as the answer and is sufficient grounds to retire the strategy
+- [x] #4 If retired (or declined): `config_profiles.py`'s not-implemented comment and any user-facing strategy vocabulary stop implying `cross_encoder` is forthcoming, and Hybrid Full's `pointwise` substitution is documented as the permanent choice rather than a stopgap
+- [x] #5 The measurement requires no live provider spend and no network -- the whole reason a local cross-encoder is the measurable one
+- [x] #6 The gate still reads `PASSED: No regression. 105 metric(s)` on the shipped state, whichever arm is taken
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -65,3 +65,65 @@ is likewise an acceptable outcome provided it is recorded as a decision.
 <!-- SECTION:PLAN:BEGIN -->
 T1: implement CrossEncoderReranker (local, credential-free) behind create_reranker; RED tests with a stub model (no download).\nT2: env-gated offline probe over semantic+hybrid, prints census + VERDICT.\nT3: obey the pre-registered verdict (ship-with-docs or retire the name) and close.\nDecision rule fixed in Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md BEFORE any run.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented `cross_encoder` as a local, credential-free reranking strategy, MEASURED it on the gated eval instrument against a rule fixed before the code was written, and then acted on the measurement. The measured answer was that it does not help. Per the owner's ruling below, the code stays and the PROMISE is retired: `CrossEncoderReranker` remains implemented and selectable, every claim or implication that it improves search is gone, and the measured harm now travels with it everywhere the strategy is nameable.
+
+**THE OWNER RULING (2026-08-17), asked explicitly with the trade-offs on the table: "KEEP THE CODE, RETIRE THE PROMISE."** This overrides the plan's arm B (full retirement of the name). The reason it was worth asking rather than retiring silently is the bimodal finding below: the strategy is a large win exactly where retrieval is weak, so deleting it would have deleted the only reranking path this repo can measure at all.
+
+## The census (measured before any decision, and the reason the arc proceeded)
+
+Reproduced by the probe from its OWN retrievals, not quoted: `plain` returns >=2 rows on **0/60** queries (39 return 0, 21 exactly 1) -- reranking is provably the identity there, so `plain` ran as a STOP guard and moved nothing (0 rows moved, every delta exactly 0.000). `semantic` and `hybrid` both return a FULL window on 60/60 at k=10 and k=20. So a null could not have been dismissed as "nothing to reorder".
+
+## The pre-registered rule (quoted, and fixed BEFORE the strategy existed)
+
+From `Docs/superpowers/plans/2026-08-17-cross-encoder-measurement.md`, written before Task 1:
+
+> **HELPED** -- at least one of MRR/NDCG/P@k improves beyond the gate's tolerance (0.05) on at least one mode, AND no category regresses beyond tolerance. [...] **NULL** -- nothing moves beyond tolerance on either mode. -> report as the answer and RETIRE the name. **HARMED** -- any regression beyond tolerance. -> retire, and say so plainly. [...] Ties, partial movement, or a mixed picture resolve to NULL -- the burden is on the strategy to show a gain.
+
+It was also implemented as a TESTED pure function (`cross_encoder_probe.arm_verdict` / `compose_arc_verdict`, 19 always-on tests) importing the gate's own `FAIL_BAND` rather than copying `0.05`, so it could not be edited after the fact without a reviewable diff.
+
+## Two arms, both declared before the run
+
+Arm A reranks the k=10 window. Because `precision_at_k`/`recall_at_k`/`f1_at_k` are set functions of `retrieved_ids[:k]`, permuting a <=k list cannot move them -- the rule's own P@k clause is VACUOUS on arm A alone. Arm B therefore retrieves 20, reranks, and scores the first 10; it is the only arm where P/R/F1 are live. `compose_arc_verdict` fixes that harm in one arm is never covered by help in the other.
+
+Overall row, @k=10:
+
+| arm | mode | MRR | NDCG | R@k |
+|---|---|---|---|---|
+| A | semantic | 0.804 -> 0.772 | 0.804 -> 0.780 | invariant by construction |
+| A | hybrid | 0.809 -> 0.798 | 0.817 -> 0.810 | invariant by construction |
+| B | semantic | 0.808 -> 0.762 | 0.804 -> 0.776 | 0.804 -> 0.826 |
+| B | hybrid | 0.812 -> 0.787 | 0.817 -> 0.805 | 0.848 -> 0.870 |
+
+## VERDICT: HARMED
+
+Nothing moves beyond the 0.05 band on the OVERALL row in either arm; the verdict comes from the rule's CATEGORY clause -- `paraphrase` MRR 1.000 -> 0.923 (A) / 0.872 (B) and NDCG 1.000 -> 0.943 / 0.905, `vocabulary_mismatch` MRR 1.000 -> 0.944, on both modes and both arms. **Disclosed reading ambiguity:** the rule writes its gain clause at MODE level and its regression clause at CATEGORY level, which is what the probe implements; read on the overall row ALONE the verdict is NULL. Both readings say "do not recommend this", which is what shipped.
+
+## The bimodal finding (why the owner was asked, not told)
+
+The strategy is NOT inert -- 3,621 rows scored, 0 failed, 1,950 rows moved, 17.2s inside `rerank()`. Its effect splits by query category. Large gains where retrieval was weak: hybrid `scoped` MRR **0.163 -> 0.929** (NDCG 0.348 -> 0.947), hybrid `prompt` 0.022 -> 0.200, semantic `negation` NDCG 0.000 -> 0.105. Losses where retrieval was already perfect: `paraphrase` (13 q) and `vocabulary_mismatch` (9 q) both sat at MRR 1.000, so the only movement available was down, and four queries lost rank 1 (`pr-requisition-freeze`, `pr-photovoltaic-roof`, `vm-nearsightedness`, `pr-standup-slot`). On the averaged row the two nearly cancel: arm B buys R@10 +0.022 and pays MRR -0.046/-0.026.
+
+## Acceptance criteria, against evidence
+
+- **#1 (recorded decision).** IMPLEMENTED and kept: `CrossEncoderReranker` in `RAG_Search/reranker.py`, dispatched by `create_reranker_from_config`, in the `RerankingConfig.strategy` Literal. Not left as an unimplemented name in either direction. Owner ruling recorded above and in the class docstring.
+- **#2 (measured, rule fixed first).** `Tests/RAG_Eval/harness/cross_encoder_probe.py` + `test_cross_encoder_probe_run.py`; the rule was written into the plan before Task 1 and encoded as tested code before the run produced a number. Instrument pinned, never the outcome: arm A's before-column equals `run_eval`'s own three-mode report to 1e-9 on all 15 cells, every pass asserted on its expected backend, `plain` asserted immobile.
+- **#3 (decisive in both directions).** The arc was pre-authorised to publish a null and retire on it. It returned HARMED, reported plainly, and the strategy is now the default and recommendation of nothing. Two traps that would have destroyed decisiveness were caught: a fabricated NULL (below) and a float-noise exact-tie reading as HELPED (`0.5 + 0.05 - 0.5 == 0.05000000000000004`), guarded with a 1e-9 epsilon so a draw resolves to NULL.
+- **#4 (vocabulary stops implying it is forthcoming; Hybrid Full documented as permanent).** `config_profiles.py`'s not-implemented comment is rewritten: it now records that `cross_encoder` IS implemented, carries the verdict, and states that Hybrid Full keeps `pointwise` as a **permanent, measured** choice rather than a stopgap -- the measurement forbids recommending the switch. Every other user-visible surface now states what was measured: `reranker.py` module + class docstrings, the `strategy` Literal, `config.py`'s config template, `Helper_Scripts/rag_config_examples/rag_v2_example.toml`, `Config_Files/rag_pipelines.toml`, `Docs/User_Guide/settings/rag.md` (new strategy-table row + a verdict quirk with the before/after table + a Verified-against stamp), `Docs/Development/RAG/RAG-DESIGN.md` (it was listed under **Future Enhancements** -- now struck, done and measured), `Docs/Development/RAG/RAG-Documentation.md` ("Improve result quality with re-ranking" was a claim; corrected), and `Tools/document_expansion_tool.py` (its docstring asserted `cross_encoder` was unimplemented -- now false).
+- **#5 (no spend, no network).** Confirmed three ways in the run: `Tests/conftest.py`'s autouse `_no_network_io` socket guard recorded zero blocked attempts, the run asserts `huggingface_hub.constants.HF_HUB_OFFLINE is True`, and `chat_api_call` -- the seam the other three strategies bill through -- was monkeypatched to RAISE for the duration and was never called. The implementation reads no credential and imports no provider path (asserted by AST, not grep: a docstring mention had defeated the substring check). 25.7s wall clock, entirely local.
+- **#6 (gate green on the shipped state).** Re-run on the final tree: `[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of baseline.` No baseline was re-stamped -- nothing this arc shipped changes retrieval, by design.
+
+## The best catch of the arc: a near-fabricated null
+
+The measurement was ONE monkeypatch away from a false 0.000. `Tests/conftest.py` sandboxes `HOME`, and `huggingface_hub.constants.HF_HUB_CACHE` is computed from `expanduser("~")` AT IMPORT -- so under pytest `CrossEncoder(...)` raises `OSError` on a machine where the model IS cached. `CrossEncoderReranker` DEGRADES rather than raises (the TASK-3502 contract), so every window would have come back unchanged, every metric would have been graded on un-reranked output, and the before/after table would have read a clean 0.000 delta on all 105 cells: a null that looked perfect, was pre-authorised as an acceptable outcome, and was entirely manufactured. Unlike a fallback that makes a number look GOOD, this one has no tell at all -- a real null and a never-ran null are the same table. The run repoints the constant and asserts `rows_scored > 0` and `rows_failed == 0` per pass. Lesson recorded by EXTENDING `backlog/docs/lessons-testing-evidence.md`'s "A metric can be graded on fallback content" entry (same family, sharper rule for A/B deltas) plus a cross-reference from the `HF_HUB_OFFLINE` entry, rather than adding a fourth near-duplicate.
+
+## Files
+
+Implementation: `tldw_chatbook/RAG_Search/reranker.py`. Probe/record: `Tests/RAG_Eval/harness/cross_encoder_probe.py`, `Tests/RAG_Eval/test_cross_encoder_probe.py`, `Tests/RAG_Eval/test_cross_encoder_probe_run.py`, `Tests/RAG_Search/test_cross_encoder_reranker.py`, `Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`. Promise retirement: `tldw_chatbook/RAG_Search/config_profiles.py`, `tldw_chatbook/config.py`, `tldw_chatbook/Config_Files/rag_pipelines.toml`, `tldw_chatbook/Tools/document_expansion_tool.py`, `Helper_Scripts/rag_config_examples/rag_v2_example.toml`, `Docs/User_Guide/settings/rag.md`, `Docs/Development/RAG/RAG-DESIGN.md`, `Docs/Development/RAG/RAG-Documentation.md`, `backlog/docs/lessons-testing-evidence.md`.
+
+Left alone deliberately: `Library/library_rag_score_kinds.py` and `Library/library_rag_state.py` mention cross-encoder logits as a SCORE SCALE (factual, no promise); `UI/Tools_Settings_Window.py`'s `cross-encoder/ms-marco-MiniLM-L-12-v2` default is a reranker MODEL name on a nav-unreachable deprecated window (TASK-1346), not strategy vocabulary.
+
+Batteries: `Tests/RAG_Search/` + `Tests/RAG_Eval/` = 678 passed / 26 skipped. Repo-wide collection 49,427 (2 pre-existing `playwright` ImportErrors in `Tests/Web_Scraping/Confluence/`, untouched by this branch). ruff clean on every touched file; `ruff format --check` deltas on `config_profiles.py`/`config.py`/`document_expansion_tool.py` are pre-existing at HEAD, `reranker.py` is formatted.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
+++ b/backlog/tasks/task-16965 - Implement-or-retire-cross_encoder-reranking-with-a-gated-instrument-measurement.md
@@ -127,3 +127,34 @@ Left alone deliberately: `Library/library_rag_score_kinds.py` and `Library/libra
 
 Batteries: `Tests/RAG_Search/` + `Tests/RAG_Eval/` = 678 passed / 26 skipped. Repo-wide collection 49,427 (2 pre-existing `playwright` ImportErrors in `Tests/Web_Scraping/Confluence/`, untouched by this branch). ruff clean on every touched file; `ruff format --check` deltas on `config_profiles.py`/`config.py`/`document_expansion_tool.py` are pre-existing at HEAD, `reranker.py` is formatted.
 <!-- SECTION:NOTES:END -->
+
+### Final-review corrections (2026-08-17, applied before merge)
+
+- **F1 — the headline was narrower than it sounded.** "Net harmful on the
+  averaged row" used the instrument's `overall`, which EXCLUDES `scoped` and
+  `negative` (`UNAVERAGED_CATEGORIES`) — and `scoped` is exactly where this
+  strategy wins. Averaged over all 53 ground-truthed queries, **hybrid
+  reverses sign: MRR 0.731 → 0.806 (+0.075)**. The pre-registered verdict is
+  unchanged (it is computed from the instrument's own cells, and the six
+  regression cells stand), but every headline site now carries the caveat.
+- **F2** — arm B's MRR is unbounded-rank, not MRR@10: its reranked lists
+  exceed 10 on 60/60 queries (mean 19.4 semantic / 20.0 hybrid). Correcting
+  to @10 moves the deltas slightly (semantic −0.0169 → −0.0134) and does not
+  change the verdict; the label is corrected and the caveat recorded.
+- **F4** — `library_rag_score_kinds.py` was modified in Task 1 and is now in
+  the files list (the notes had listed it as untouched).
+- **F5 — the normalisation claim was overstated, and the control now backs
+  the corrected version.** Ordering is normalisation-invariant only when
+  `combine_original_score` is False; the shipped config blends 30% of the
+  original score, so the sort key is scale-dependent. The review RAN that
+  control: with the blend off (ordering identical to raw logits) the verdict
+  is still HARMED with the same six regression cells and 3dp-matching deltas,
+  and a 10×-scaled blend agrees. **The harm is the model's ranking, not the
+  min-max.**
+- **F3** (`reranking_strategy` has zero readers repo-wide) folded into
+  TASK-17600's scope — it is the same enabled-but-unread species that task
+  already owns.
+- **F6** (the work guard asserts rows scored/failed but not
+  `row_order_changes > 0`) recorded in the QA report as a known limit of the
+  guard; the mutation test proves the guard catches the failure mode that
+  actually occurred.

--- a/backlog/tasks/task-17600 - result_reranking middleware ships enabled=true and is handled by a bare pass.md
+++ b/backlog/tasks/task-17600 - result_reranking middleware ships enabled=true and is handled by a bare pass.md
@@ -1,0 +1,43 @@
+---
+id: task-17600
+title: >-
+  result_reranking middleware ships enabled=true and is handled by a bare pass
+status: To Do
+assignee: []
+created_date: '2026-08-17'
+labels: [rag, config]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Found during TASK-16965's user-visible sweep for `cross_encoder` surfaces.
+`Config_Files/rag_pipelines.toml` declares a `result_reranking` middleware,
+listed by the `high_accuracy` pipeline with **`enabled = true`** — and
+`_apply_after_middleware` handles that name with a bare `pass`. It is a
+shipped, switched-on stage that does nothing.
+
+This is the same species this programme has repeatedly fixed (TASK-16174's
+inert parent-inclusion knobs: shipped, user-switchable, read by nothing).
+It is worse in one respect — the knobs were merely dead, whereas this one
+appears in a pipeline a user selects *because* it promises higher accuracy.
+
+TASK-16965 documented the fact where it was found but did not own the fix;
+its own subject (the `cross_encoder` strategy) is a different mechanism —
+that arc measured reranking as net-harmful on this corpus, which is
+context a fix here should carry.
+
+## Acceptance Criteria (the what)
+
+- [ ] A decision is implemented, either arm acceptable: `result_reranking`
+      is WIRED to the real reranking path, or it is REMOVED from
+      `rag_pipelines.toml` and from any pipeline that lists it
+- [ ] No middleware name remains that is declared `enabled = true` while its
+      handler is a no-op — the sweep covers every name
+      `_apply_after_middleware` (and its before-equivalent) accepts
+- [ ] If wired: the TASK-16965 measurement is cited where a user chooses it,
+      so a stage measured net-harmful on the eval corpus is not silently
+      presented as an accuracy improvement
+- [ ] A test fails if a declared-enabled middleware name has no
+      implementation, so this class of gap cannot recur silently

--- a/backlog/tasks/task-17600 - result_reranking middleware ships enabled=true and is handled by a bare pass.md
+++ b/backlog/tasks/task-17600 - result_reranking middleware ships enabled=true and is handled by a bare pass.md
@@ -41,3 +41,7 @@ context a fix here should carry.
       presented as an accuracy improvement
 - [ ] A test fails if a declared-enabled middleware name has no
       implementation, so this class of gap cannot recur silently
+- [ ] The same sweep covers `reranking_strategy` (TASK-16965 final review
+      F3): it has ZERO readers repo-wide, yet RAG-DESIGN.md instructs users
+      to select a strategy with it — a config key that reads nothing is the
+      same species as a middleware that runs nothing

--- a/tldw_chatbook/Config_Files/rag_pipelines.toml
+++ b/tldw_chatbook/Config_Files/rag_pipelines.toml
@@ -177,11 +177,24 @@ model = "gpt-3.5-turbo"
 max_expansions = 3
 include_synonyms = true
 
+# NOT a quality claim, and -- read this before wiring it up -- currently a
+# NO-OP. `PipelineLoader._apply_after_middleware` (RAG_Search/pipeline_loader.py)
+# handles "result_reranking" with a bare `pass`, so `enabled = true` and the
+# model below buy nothing today, on `high_accuracy` or anywhere else.
+#
+# If anyone implements it: cross-encoder reranking is the ONE reranking
+# strategy that has been measured on this repo's gated eval instrument
+# (TASK-16965), and it came out net HARMFUL on the averaged row -- large
+# gains on weak-retrieval query categories (hybrid `scoped` MRR
+# 0.163 -> 0.929), paid for by demoting already-correct top hits on
+# categories retrieval already got right. It is the default of nothing and
+# the recommendation of nothing. Numbers and method:
+# Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
 [middleware.result_reranking]
 name = "Advanced Result Re-ranking"
 type = "after_search"
 enabled = true
-description = "Re-ranks results using cross-encoder models"
+description = "Re-ranks results with a cross-encoder (measured net-harmful on average; see TASK-16965)"
 
 [middleware.result_reranking.config]
 model = "cross-encoder/ms-marco-MiniLM-L-6-v2"

--- a/tldw_chatbook/Library/library_rag_score_kinds.py
+++ b/tldw_chatbook/Library/library_rag_score_kinds.py
@@ -47,12 +47,14 @@ LIBRARY_RAG_SCORE_KINDS = frozenset(
 
 #: ``RAGService._fuse_hybrid_results``' per-leg provenance block.
 HYBRID_FUSION_METADATA_KEY = "hybrid_fusion"
-#: What a REAL reranked row carries. ``PointwiseReranker._apply_scores``
+#: What a REAL reranked row carries. ``BaseReranker._apply_scores``
 #: (``RAG_Search/reranker.py``) is the only reranking path that REPLACES a
-#: row's score -- with the LLM's relevance score, or by default a weighted
-#: blend of it and the original similarity -- and it stamps this key while
-#: doing so. It is therefore the production signal that "this score is no
-#: longer a similarity".
+#: row's score -- with the scoring model's relevance score, or by default a
+#: weighted blend of it and the original similarity -- and it stamps this key
+#: while doing so. It is therefore the production signal that "this score is
+#: no longer a similarity". Two strategies take that path: ``pointwise``
+#: (an LLM's 0-1 score) and ``cross_encoder`` (a local cross-encoder's
+#: logits, min-max normalised into ``score_scale``; TASK-16965).
 #:
 #: It matters that this is keyed on score REPLACEMENT rather than on "a
 #: reranker ran": ``PairwiseReranker`` and ``ListwiseReranker`` only

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -352,6 +352,11 @@ class ConfigProfileManager:
         # sentence-transformers model, no provider/credential/network) and
         # MEASURED it on the gated eval instrument against a rule fixed
         # before the run. Verdict: net HARMFUL on the averaged row
+    # F1 CAVEAT (final review): that averaged row EXCLUDES `scoped` and
+    # `negative` (UNAVERAGED_CATEGORIES) -- and `scoped` is precisely where
+    # this strategy WINS. Averaged over all 53 ground-truthed queries,
+    # hybrid REVERSES sign: MRR 0.731 -> 0.806 (+0.075). The verdict stands
+    # on the pre-registered rule; the headline is narrower than it sounds.
         # (semantic MRR 0.808 -> 0.762, hybrid 0.812 -> 0.787 at k=10),
         # and strongly BIMODAL -- large gains where retrieval is weak
         # (hybrid `scoped` MRR 0.163 -> 0.929) paid for by demoting

--- a/tldw_chatbook/RAG_Search/config_profiles.py
+++ b/tldw_chatbook/RAG_Search/config_profiles.py
@@ -343,13 +343,29 @@ class ConfigProfileManager:
         hybrid_full_rag.search.include_citations = True
         hybrid_full_rag.search.max_context_size = 32000
 
-        # "cross_encoder" is not an implemented reranking strategy in
-        # chatbook -- reranker.py only implements the three LLM-driven
-        # strategies (pointwise/pairwise/listwise); there is no local
-        # cross-encoder model path. This profile previously requested
-        # "cross_encoder" and raised ValueError the moment its reranker
-        # tried to construct (task-3170 P0). "pointwise" is the closest
-        # available strategy to a cross-encoder's per-result scoring.
+        # "pointwise" here is a PERMANENT, MEASURED choice -- not the
+        # stopgap it used to be. History: this profile once requested
+        # "cross_encoder", which was not implemented and raised ValueError
+        # the moment its reranker tried to construct (task-3170 P0), so it
+        # was swapped for "pointwise" as the nearest available per-result
+        # scorer. TASK-16965 then IMPLEMENTED "cross_encoder" (a local
+        # sentence-transformers model, no provider/credential/network) and
+        # MEASURED it on the gated eval instrument against a rule fixed
+        # before the run. Verdict: net HARMFUL on the averaged row
+        # (semantic MRR 0.808 -> 0.762, hybrid 0.812 -> 0.787 at k=10),
+        # and strongly BIMODAL -- large gains where retrieval is weak
+        # (hybrid `scoped` MRR 0.163 -> 0.929) paid for by demoting
+        # already-rank-1 answers in categories that were saturated
+        # (`paraphrase`/`vocabulary_mismatch` MRR 1.000 -> 0.87-0.94).
+        # Two facts, kept adjacent: the pre-registered rule said RETIRE the
+        # name, and the owner ruled otherwise on 2026-08-17 -- "keep the
+        # code, retire the promise" -- because this is the only reranking
+        # path the gated instrument can measure at all. So the strategy
+        # stays selectable but is recommended nowhere, and this profile
+        # keeps "pointwise" by measurement rather than by accident:
+        # switching Hybrid Full to "cross_encoder" is exactly what the
+        # measurement forbids. Full numbers:
+        # Docs/superpowers/qa/2026-08-17-cross-encoder/report.md
         hybrid_full_rerank = RerankingConfig(
             strategy="pointwise", top_k_to_rerank=15, include_reasoning=False
         )

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -1,12 +1,15 @@
 """
-LLM-based reranking for improved search result relevance.
+Reranking for improved search result relevance.
 
-This module implements various reranking strategies using language models
-to evaluate and reorder search results based on their relevance to the query.
+Three strategies (pointwise/pairwise/listwise) evaluate and reorder search
+results with a language model; ``cross_encoder`` (TASK-16965) does it with a
+local sentence-transformers cross-encoder, requiring no provider, no
+credential and no network.
 """
 
 import asyncio
 import functools
+import threading
 from typing import List, Optional, Union, Literal, Tuple
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
@@ -98,7 +101,9 @@ class RerankingConfig:
     max_tokens: int = 100
 
     # Reranking settings
-    strategy: Literal["pairwise", "listwise", "pointwise"] = "pointwise"
+    strategy: Literal["pairwise", "listwise", "pointwise", "cross_encoder"] = (
+        "pointwise"
+    )
     top_k_to_rerank: int = 20  # Only rerank top K results
     batch_size: int = 5  # Number of results to evaluate at once
     include_reasoning: bool = False  # Whether to generate explanations
@@ -147,6 +152,95 @@ class BaseReranker(ABC):
 
         key_str = f"{query}|{'|'.join(sorted(result_ids))}"
         return hashlib.md5(key_str.encode()).hexdigest()
+
+    # NOTE (TASK-16965): these two live on the BASE class, not on
+    # PointwiseReranker where they were written. They are the shared
+    # score-application contract -- the `scored`-flag stamp rule in
+    # particular (TASK-3502 note-b) -- and `CrossEncoderReranker` is the
+    # second strategy that REPLACES a row's score, so duplicating them
+    # would mean two copies of that honesty rule free to drift apart.
+    def _apply_scores(
+        self,
+        results: List[Union[SearchResult, SearchResultWithCitations]],
+        reranking_results: List[RerankingResult],
+    ) -> List[Union[SearchResult, SearchResultWithCitations]]:
+        """Apply reranking scores and reorder results."""
+        # Calculate final scores
+        scored_results = []
+        for result, rerank_result in zip(results, reranking_results):
+            if not rerank_result.scored:
+                # This row's scoring call failed: it keeps the score it
+                # arrived with, and -- crucially -- is NOT stamped with
+                # `rerank_score`. That stamp is what the Library reads as
+                # "this number is no longer a similarity, render
+                # ' | reranked'"; claiming it here made a partly-failed run
+                # over-claim on every row it never rescored (TASK-3502
+                # note-b). Conservative in both directions: no fabricated
+                # score, and no fabricated provenance.
+                final_score = result.score
+                metadata = {**result.metadata}
+            else:
+                if self.config.combine_original_score:
+                    # Weighted combination
+                    final_score = (
+                        self.config.original_score_weight * rerank_result.original_score
+                        + (1 - self.config.original_score_weight)
+                        * rerank_result.rerank_score
+                    )
+                else:
+                    final_score = rerank_result.rerank_score
+                metadata = {
+                    **result.metadata,
+                    "rerank_score": rerank_result.rerank_score,
+                }
+
+            # Create a copy of the result with new score
+            result_copy = type(result)(
+                id=result.id,
+                score=final_score,
+                document=result.document,
+                metadata=metadata,
+            )
+
+            # Preserve citations if present
+            if hasattr(result, "citations"):
+                result_copy.citations = result.citations
+
+            scored_results.append((final_score, result_copy, rerank_result))
+
+        # Sort by final score (descending)
+        scored_results.sort(key=lambda x: x[0], reverse=True)
+
+        # Update ranks in reranking results
+        for new_rank, (_, _, rerank_result) in enumerate(scored_results):
+            rerank_result.new_rank = new_rank
+
+        # Return reordered results
+        return [result for _, result, _ in scored_results]
+
+    def _log_reranking_metrics(self, reranking_results: List[RerankingResult]):
+        """Log metrics about reranking performance."""
+        if not reranking_results:
+            return
+
+        # Calculate rank changes
+        rank_changes = [r.rank_change for r in reranking_results]
+        avg_rank_change = sum(rank_changes) / len(rank_changes)
+
+        # Calculate score changes
+        score_changes = [r.rerank_score - r.original_score for r in reranking_results]
+        avg_score_change = sum(score_changes) / len(score_changes)
+
+        # Log metrics
+        log_histogram("reranker_avg_rank_change", avg_rank_change)
+        log_histogram("reranker_avg_score_change", avg_score_change)
+        log_counter("reranker_results_processed", value=len(reranking_results))
+
+        # Log significant reorderings
+        significant_changes = sum(
+            1 for r in reranking_results if abs(r.rank_change) >= 3
+        )
+        log_counter("reranker_significant_changes", value=significant_changes)
 
     async def _call_llm(self, prompt: str, system_prompt: Optional[str] = None) -> str:
         """Call LLM with retry logic."""
@@ -430,89 +524,6 @@ class PointwiseReranker(BaseReranker):
                 scored=False,
             )
 
-    def _apply_scores(
-        self,
-        results: List[Union[SearchResult, SearchResultWithCitations]],
-        reranking_results: List[RerankingResult],
-    ) -> List[Union[SearchResult, SearchResultWithCitations]]:
-        """Apply reranking scores and reorder results."""
-        # Calculate final scores
-        scored_results = []
-        for result, rerank_result in zip(results, reranking_results):
-            if not rerank_result.scored:
-                # This row's scoring call failed: it keeps the score it
-                # arrived with, and -- crucially -- is NOT stamped with
-                # `rerank_score`. That stamp is what the Library reads as
-                # "this number is no longer a similarity, render
-                # ' | reranked'"; claiming it here made a partly-failed run
-                # over-claim on every row it never rescored (TASK-3502
-                # note-b). Conservative in both directions: no fabricated
-                # score, and no fabricated provenance.
-                final_score = result.score
-                metadata = {**result.metadata}
-            else:
-                if self.config.combine_original_score:
-                    # Weighted combination
-                    final_score = (
-                        self.config.original_score_weight * rerank_result.original_score
-                        + (1 - self.config.original_score_weight)
-                        * rerank_result.rerank_score
-                    )
-                else:
-                    final_score = rerank_result.rerank_score
-                metadata = {
-                    **result.metadata,
-                    "rerank_score": rerank_result.rerank_score,
-                }
-
-            # Create a copy of the result with new score
-            result_copy = type(result)(
-                id=result.id,
-                score=final_score,
-                document=result.document,
-                metadata=metadata,
-            )
-
-            # Preserve citations if present
-            if hasattr(result, "citations"):
-                result_copy.citations = result.citations
-
-            scored_results.append((final_score, result_copy, rerank_result))
-
-        # Sort by final score (descending)
-        scored_results.sort(key=lambda x: x[0], reverse=True)
-
-        # Update ranks in reranking results
-        for new_rank, (_, _, rerank_result) in enumerate(scored_results):
-            rerank_result.new_rank = new_rank
-
-        # Return reordered results
-        return [result for _, result, _ in scored_results]
-
-    def _log_reranking_metrics(self, reranking_results: List[RerankingResult]):
-        """Log metrics about reranking performance."""
-        if not reranking_results:
-            return
-
-        # Calculate rank changes
-        rank_changes = [r.rank_change for r in reranking_results]
-        avg_rank_change = sum(rank_changes) / len(rank_changes)
-
-        # Calculate score changes
-        score_changes = [r.rerank_score - r.original_score for r in reranking_results]
-        avg_score_change = sum(score_changes) / len(score_changes)
-
-        # Log metrics
-        log_histogram("reranker_avg_rank_change", avg_rank_change)
-        log_histogram("reranker_avg_score_change", avg_score_change)
-        log_counter("reranker_results_processed", value=len(reranking_results))
-
-        # Log significant reorderings
-        significant_changes = sum(
-            1 for r in reranking_results if abs(r.rank_change) >= 3
-        )
-        log_counter("reranker_significant_changes", value=significant_changes)
-
 
 @dataclass
 class _ComparisonTally:
@@ -759,6 +770,265 @@ class ListwiseReranker(BaseReranker):
         return set(ranking) == set(range(expected_length))
 
 
+#: The cross-encoder loaded when the config does not name one. Measured in
+#: this environment before the strategy was written (TASK-16965): it loads
+#: from the local HF cache offline and separates a relevant pair (+8.719)
+#: from an irrelevant one (-11.14). ``mixedbread-ai/mxbai-rerank-large-v2``
+#: is NOT usable here -- the cached copy is a 20 MB partial with no weights
+#: file and raises ``OSError`` offline.
+DEFAULT_CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+#: Substrings that mark a model id as a reranker/cross-encoder artifact.
+#: Checked FIRST, so a vendor namespace that publishes both chat models and
+#: rerankers (``Qwen/Qwen3-Reranker-0.6B``) is not redirected to the default.
+_RERANKER_NAME_MARKERS = ("rerank", "cross-encoder", "cross_encoder", "colbert")
+
+#: Repo-id namespaces that publish CHAT models. A profile that names one of
+#: these has configured an LLM strategy's model, not a cross-encoder.
+_LLM_REPO_NAMESPACES = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "google",
+        "meta-llama",
+        "mistralai",
+        "deepseek-ai",
+        "x-ai",
+        "cohere",
+        "perplexity",
+        "openrouter",
+        "groq",
+        "moonshotai",
+    }
+)
+
+#: Loaded cross-encoders, keyed by model name. Module level ON PURPOSE: the
+#: model costs ~18 s to load, the RAG service builds a reranker per profile
+#: switch, and a measurement run reranks 60 queries x 2 modes -- reloading
+#: per instance would dominate the wall clock and measure the loader.
+_CROSS_ENCODER_MODELS: dict = {}
+_CROSS_ENCODER_MODELS_LOCK = threading.Lock()
+
+
+def _import_cross_encoder_class():
+    """Import ``sentence_transformers.CrossEncoder`` at FIRST USE.
+
+    Deliberately not a module-level import: ``sentence-transformers`` ships
+    in the ``embeddings_rag`` extra, and importing torch at
+    ``reranker.py`` import time would tax every caller of the three
+    LLM strategies (and every test that imports this module) with it.
+    Isolated in its own function so a unit test can refuse it outright and
+    prove no model is ever downloaded.
+    """
+    from sentence_transformers import CrossEncoder
+
+    return CrossEncoder
+
+
+def _load_cross_encoder(model_name: str):
+    """Return the cached cross-encoder for ``model_name``, loading it once."""
+    model = _CROSS_ENCODER_MODELS.get(model_name)
+    if model is not None:
+        return model
+
+    with _CROSS_ENCODER_MODELS_LOCK:
+        # Re-check inside the lock: two searches can race the first load.
+        model = _CROSS_ENCODER_MODELS.get(model_name)
+        if model is None:
+            logger.info(f"Loading cross-encoder model '{model_name}' (first use)")
+            model = _import_cross_encoder_class()(model_name)
+            _CROSS_ENCODER_MODELS[model_name] = model
+    return model
+
+
+def _resolve_cross_encoder_model_name(model_name: Optional[str]) -> str:
+    """Pick the cross-encoder artifact to load from a config's ``model_name``.
+
+    ``RerankingConfig.model_name`` defaults to ``"gpt-3.5-turbo"`` and every
+    shipped profile sets a chat model there, because the three strategies
+    that existed before this one are LLM-driven. Handing such a name to
+    ``CrossEncoder`` would fail at load and degrade every rerank, so a name
+    that is not a plausible model artifact falls back to the measured
+    default. A caller that genuinely wants a different cross-encoder passes
+    its full repo id or a local path, which is used verbatim.
+    """
+    name = (model_name or "").strip()
+    if not name:
+        return DEFAULT_CROSS_ENCODER_MODEL
+
+    lowered = name.lower()
+    if any(marker in lowered for marker in _RERANKER_NAME_MARKERS):
+        return name
+
+    namespace, separator, _remainder = name.partition("/")
+    if not separator:
+        # No namespace: a bare chat model name ("gpt-4o-mini"), not a repo id.
+        return DEFAULT_CROSS_ENCODER_MODEL
+    if namespace.lower() in _LLM_REPO_NAMESPACES:
+        return DEFAULT_CROSS_ENCODER_MODEL
+    return name
+
+
+class CrossEncoderReranker(BaseReranker):
+    """Reranks with a LOCAL cross-encoder: no provider, no credential, no spend.
+
+    The other three strategies ask an LLM to score, compare or reorder
+    results through ``chat_api_call``. This one runs a sentence-transformers
+    cross-encoder over ``(query, document)`` pairs in-process, which is what
+    makes reranking measurable on the gated eval instrument at all
+    (TASK-16965): deterministic, unpriced, offline.
+
+    Two ``RerankingConfig`` fields are PROVIDER concepts and are therefore
+    no-ops here, stated rather than implied: ``max_retries`` (there is no
+    remote call to retry -- a failed ``predict`` is a local failure that a
+    second identical call would repeat) and ``include_reasoning`` (there is
+    no model being asked to explain itself; a cross-encoder emits one
+    number). ``model_provider`` is likewise unused: the model IS the
+    provider.
+
+    Scores are min-max normalised into ``config.score_scale`` over the
+    window. Cross-encoder outputs are unbounded logits (roughly -11..+11 for
+    the ms-marco default), so CLAMPING them to the (0.0, 1.0) scale the way
+    the pointwise strategy clamps an LLM's 0-1 score would collapse every
+    strongly-relevant row to 1.0 -- ties, in the one place ordering is the
+    entire product. Normalising is monotonic, so it preserves the model's
+    ordering exactly while putting the numbers on the scale
+    ``combine_original_score`` blends against.
+    """
+
+    def __init__(self, config: RerankingConfig):
+        super().__init__(config)
+        self.model_name = _resolve_cross_encoder_model_name(config.model_name)
+
+    @timeit("reranker_cross_encoder")
+    async def rerank(
+        self,
+        query: str,
+        results: List[Union[SearchResult, SearchResultWithCitations]],
+        **kwargs,
+    ) -> RerankOutcome:
+        """Rerank the top-k window with the cross-encoder."""
+        if not results:
+            return RerankOutcome(results=results, failed=0, total=0)
+
+        results_to_rerank = results[: self.config.top_k_to_rerank]
+        remaining_results = results[self.config.top_k_to_rerank :]
+
+        cache_key = None
+        if self._cache is not None:
+            cache_key = self._get_cache_key(query, [r.id for r in results_to_rerank])
+            if cache_key in self._cache:
+                log_counter("reranker_cache_hit", labels={"strategy": "cross_encoder"})
+                cached_scores = self._cache[cache_key]
+                return RerankOutcome(
+                    results=self._apply_scores(results_to_rerank, cached_scores)
+                    + remaining_results,
+                    failed=sum(1 for r in cached_scores if not r.scored),
+                    total=len(results_to_rerank),
+                )
+
+        log_counter("reranker_cache_miss", labels={"strategy": "cross_encoder"})
+
+        raw_scores = await self._predict_scores(query, results_to_rerank)
+        if raw_scores is None:
+            # Same shape as ListwiseReranker's failure: nothing was scored,
+            # so the caller's own ordering comes back untouched and unstamped
+            # (TASK-3502 note-b -- no row may claim a rerank that never
+            # happened), with the counts that let the service disclose it as
+            # degraded rather than as a successful no-op. Not cached: a model
+            # failure is transient in a way a parsed score is not.
+            log_counter("reranker_cross_encoder_failed")
+            return RerankOutcome(
+                results=results,
+                failed=len(results_to_rerank),
+                total=len(results_to_rerank),
+            )
+
+        reranking_results = self._normalize_scores(results_to_rerank, raw_scores)
+
+        if self._cache is not None and cache_key:
+            self._cache[cache_key] = reranking_results
+
+        reranked = self._apply_scores(results_to_rerank, reranking_results)
+        self._log_reranking_metrics(reranking_results)
+
+        return RerankOutcome(
+            results=reranked + remaining_results,
+            failed=0,
+            total=len(results_to_rerank),
+        )
+
+    async def _predict_scores(
+        self,
+        query: str,
+        rows: List[Union[SearchResult, SearchResultWithCitations]],
+    ) -> Optional[List[float]]:
+        """Score every row in one batched ``predict``; ``None`` on failure."""
+        try:
+            loop = asyncio.get_running_loop()
+            scores = await loop.run_in_executor(
+                None, functools.partial(self._predict_scores_sync, query, rows)
+            )
+        except Exception as exc:
+            # Reranking must NEVER fail a search: a missing model file, a
+            # missing sentence-transformers install and an OOM all land here
+            # and degrade to the unreranked ordering.
+            logger.error(f"Cross-encoder reranking failed ({self.model_name}): {exc}")
+            return None
+
+        if len(scores) != len(rows):
+            logger.error(
+                f"Cross-encoder returned {len(scores)} scores for {len(rows)} rows; "
+                "discarding them"
+            )
+            return None
+        return scores
+
+    def _predict_scores_sync(
+        self,
+        query: str,
+        rows: List[Union[SearchResult, SearchResultWithCitations]],
+    ) -> List[float]:
+        """Blocking model call, run in an executor.
+
+        The document is passed WHOLE: the model truncates to its own
+        ``max_length``, so a hand-picked character cap here would only be a
+        second, wronger truncation.
+        """
+        model = _load_cross_encoder(self.model_name)
+        pairs = [(query, row.document or "") for row in rows]
+        return [float(score) for score in model.predict(pairs)]
+
+    def _normalize_scores(
+        self,
+        rows: List[Union[SearchResult, SearchResultWithCitations]],
+        raw_scores: List[float],
+    ) -> List[RerankingResult]:
+        """Min-max the window's logits into ``score_scale`` (order-preserving)."""
+        low, high = self.config.score_scale
+        lowest = min(raw_scores)
+        span = max(raw_scores) - lowest
+
+        reranking_results = []
+        for rank, (row, raw_score) in enumerate(zip(rows, raw_scores)):
+            if span > 0:
+                normalized = low + (high - low) * (raw_score - lowest) / span
+            else:
+                # Every row scored identically: the model expressed no
+                # preference, so give them all the same value and let the
+                # original retrieval score break the tie.
+                normalized = (low + high) / 2
+            reranking_results.append(
+                RerankingResult(
+                    original_rank=rank,
+                    new_rank=rank,  # Updated by _apply_scores.
+                    original_score=row.score,
+                    rerank_score=normalized,
+                )
+            )
+        return reranking_results
+
+
 def create_reranker(strategy: str = "pointwise", **kwargs) -> BaseReranker:
     """Factory function to create a reranker with the specified strategy."""
     config = RerankingConfig(strategy=strategy, **kwargs)
@@ -787,6 +1057,8 @@ def create_reranker_from_config(config: RerankingConfig) -> BaseReranker:
         return PairwiseReranker(config)
     elif strategy == "listwise":
         return ListwiseReranker(config)
+    elif strategy == "cross_encoder":
+        return CrossEncoderReranker(config)
     else:
         raise ValueError(f"Unknown reranking strategy: {strategy}")
 

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -1,10 +1,21 @@
 """
-Reranking for improved search result relevance.
+Reranking: reorder search results after retrieval.
 
 Three strategies (pointwise/pairwise/listwise) evaluate and reorder search
 results with a language model; ``cross_encoder`` (TASK-16965) does it with a
 local sentence-transformers cross-encoder, requiring no provider, no
 credential and no network.
+
+**No strategy here is known to improve retrieval, and the one that has been
+measured made it worse on average.** ``cross_encoder`` is the only strategy
+the gated eval instrument can see (the other three are remote, priced and
+non-reproducible, so TASK-3502 left their value unmeasured). Measured under
+a rule fixed before the run, ``cross_encoder`` came out net HARMFUL on the
+averaged row and strongly BIMODAL by query category -- see
+``CrossEncoderReranker`` for the numbers and
+``Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`` for the run. It
+therefore ships selectable but is the default of nothing and the
+recommendation of nothing.
 """
 
 import asyncio
@@ -100,7 +111,13 @@ class RerankingConfig:
     temperature: float = 0.0  # Use deterministic scoring
     max_tokens: int = 100
 
-    # Reranking settings
+    # Reranking settings.
+    #
+    # ``cross_encoder`` is implemented and selectable (TASK-16965) but is
+    # NOT a recommendation: measured on the gated instrument it is net
+    # harmful on the averaged row and bimodal by category. It is the
+    # default of no profile and no config template; pick it only with
+    # Docs/superpowers/qa/2026-08-17-cross-encoder/report.md in hand.
     strategy: Literal["pairwise", "listwise", "pointwise", "cross_encoder"] = (
         "pointwise"
     )
@@ -894,6 +911,50 @@ class CrossEncoderReranker(BaseReranker):
     entire product. Normalising is monotonic, so it preserves the model's
     ordering exactly while putting the numbers on the scale
     ``combine_original_score`` blends against.
+
+    **What it measured, so nobody has to re-run the probe to find out.**
+    TASK-16965 ran it over the 60-query golden set on the gated instrument,
+    against a rule fixed in the plan BEFORE the strategy was written, in
+    two pre-declared arms (rerank the k=10 window; and retrieve 20, rerank,
+    score the first 10 -- the second arm exists because permuting a <=k
+    list cannot move P@k/recall/F1 at all). **Verdict: HARMED.** On the
+    averaged overall row at k=10, arm B: semantic MRR 0.808 -> 0.762 and
+    NDCG 0.804 -> 0.776; hybrid MRR 0.812 -> 0.787 and NDCG 0.817 -> 0.805;
+    recall@10 +0.022 on both. The strategy is NOT inert -- 3,621 rows
+    scored, 0 failed, 1,950 rows moved -- and its effect is strongly
+    BIMODAL by query category:
+
+    * large gains where retrieval was weak: hybrid ``scoped`` MRR
+      0.163 -> 0.929 (NDCG 0.348 -> 0.947), hybrid ``prompt`` MRR
+      0.022 -> 0.200, semantic ``negation`` NDCG 0.000 -> 0.105;
+    * losses where retrieval was already perfect: ``paraphrase`` (13
+      queries) and ``vocabulary_mismatch`` (9) both sat at MRR 1.000, so
+      the only movement available was down -- four queries lost rank 1,
+      taking those categories to 0.87-0.94. Those are the cells that trip
+      the rule's regression clause.
+
+    Read on the overall row ALONE nothing moves beyond the 0.05 band, i.e.
+    a NULL; the rule's regression clause is written at category level, so
+    the reported verdict is HARMED. Either reading says the same thing in
+    practice: **do not enable this expecting better search.** Enable it
+    only if your corpus looks like the weak-retrieval half of that split,
+    and measure it yourself. Full run, per-category tables and the census:
+    ``Docs/superpowers/qa/2026-08-17-cross-encoder/report.md``.
+
+    **Why this class still exists, as TWO facts and not one.** (1) The
+    pre-registered rule was applied verbatim and said RETIRE the name --
+    HARMED, on the category clause, in both arms. (2) The owner ruled
+    otherwise on 2026-08-17, asked explicitly with the trade-offs shown:
+    *"KEEP THE CODE, RETIRE THE PROMISE."* The deciding dimension was the
+    bimodal split above -- the other three strategies bill a remote
+    provider per call, which the local deterministic gate cannot run, so
+    this is the ONLY reranking path anyone here can measure at all
+    (TASK-3502 scoped the question out for exactly that reason), and
+    deleting it for producing an unwelcome number would delete the
+    instrument along with the result. The price of keeping it is stated
+    rather than hidden: it ships selectable, the default of nothing, the
+    recommendation of nothing, with its measured harm attached at every
+    site that names it.
     """
 
     def __init__(self, config: RerankingConfig):

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -12,6 +12,8 @@ the gated eval instrument can see (the other three are remote, priced and
 non-reproducible, so TASK-3502 left their value unmeasured). Measured under
 a rule fixed before the run, ``cross_encoder`` came out net HARMFUL on the
 averaged row and strongly BIMODAL by query category -- see
+(that averaged row EXCLUDES `scoped`/`negative`; over all 53
+ground-truthed queries hybrid REVERSES sign, MRR 0.731 -> 0.806) --
 ``CrossEncoderReranker`` for the numbers and
 ``Docs/superpowers/qa/2026-08-17-cross-encoder/report.md`` for the run. It
 therefore ships selectable but is the default of nothing and the
@@ -910,6 +912,13 @@ class CrossEncoderReranker(BaseReranker):
     strongly-relevant row to 1.0 -- ties, in the one place ordering is the
     entire product. Normalising is monotonic, so it preserves the model's
     ordering exactly while putting the numbers on the scale
+    (STRICTLY: only when `combine_original_score` is False. The shipped
+    config blends 30% of the original score, so the sort key IS
+    scale-dependent. The final review ran the control: with the blend
+    off -- pure normalised CE score, ordering identical to raw logits --
+    the verdict is still HARMED with the SAME six regression cells and
+    deltas matching to 3dp, and a 10x-scaled blend agrees. The harm is
+    the model's ranking, not the normalisation.)
     ``combine_original_score`` blends against.
 
     **What it measured, so nobody has to re-run the probe to find out.**
@@ -917,7 +926,9 @@ class CrossEncoderReranker(BaseReranker):
     against a rule fixed in the plan BEFORE the strategy was written, in
     two pre-declared arms (rerank the k=10 window; and retrieve 20, rerank,
     score the first 10 -- the second arm exists because permuting a <=k
-    list cannot move P@k/recall/F1 at all). **Verdict: HARMED.** On the
+    list cannot move P@k/recall/F1 at all). **Verdict: HARMED** (on the instrument's averaged row, which EXCLUDES
+    `scoped`/`negative` -- over all 53 ground-truthed queries hybrid
+    REVERSES sign: MRR 0.731 -> 0.806, +0.075; final review F1)**.** On the
     averaged overall row at k=10, arm B: semantic MRR 0.808 -> 0.762 and
     NDCG 0.804 -> 0.776; hybrid MRR 0.812 -> 0.787 and NDCG 0.817 -> 0.805;
     recall@10 +0.022 on both. The strategy is NOT inert -- 3,621 rows

--- a/tldw_chatbook/RAG_Search/reranker.py
+++ b/tldw_chatbook/RAG_Search/reranker.py
@@ -22,9 +22,12 @@ recommendation of nothing.
 
 import asyncio
 import functools
+import hashlib
+import os
+import re
 import threading
-from typing import List, Optional, Union, Literal, Tuple
-from dataclasses import dataclass
+from typing import Any, List, Optional, Union, Literal, Tuple
+from dataclasses import dataclass, replace
 from abc import ABC, abstractmethod
 import json
 from loguru import logger
@@ -838,14 +841,51 @@ def _import_cross_encoder_class():
     LLM strategies (and every test that imports this module) with it.
     Isolated in its own function so a unit test can refuse it outright and
     prove no model is ever downloaded.
-    """
-    from sentence_transformers import CrossEncoder
 
-    return CrossEncoder
+    Routed through ``Utils/optional_deps.py`` rather than importing the
+    package directly, so a missing extra lands in the project's ONE
+    optional-dependency registry (and produces the project's own message
+    naming the extra to install) instead of a bare ``ModuleNotFoundError``
+    from inside a rerank.
+
+    Returns:
+        The ``sentence_transformers.CrossEncoder`` class.
+
+    Raises:
+        ImportError: ``sentence-transformers`` is not installed. Callers
+            treat this as any other load failure: the rerank degrades to the
+            caller's ordering rather than failing the search.
+    """
+    from ..Utils.optional_deps import MODULES, check_dependency
+
+    if not check_dependency("sentence_transformers"):
+        raise ImportError(
+            "The 'cross_encoder' reranking strategy needs sentence-transformers, "
+            "which ships in the 'embeddings_rag' extra: "
+            "pip install tldw_chatbook[embeddings_rag]"
+        )
+    return MODULES["sentence_transformers"].CrossEncoder
 
 
 def _load_cross_encoder(model_name: str):
-    """Return the cached cross-encoder for ``model_name``, loading it once."""
+    """Return the cached cross-encoder for ``model_name``, loading it once.
+
+    Loaded with ``local_files_only=True``. This strategy's whole claim is
+    that it costs no credential and no network (TASK-16965 AC#5), and the
+    user-facing docs say so; without the flag an uncached first use would
+    quietly reach huggingface.co and download a model mid-search, turning a
+    documented no-network path into a network path exactly when nobody is
+    watching. Failing fast instead is the honest behaviour: the load raises,
+    the rerank degrades to the retrieval ordering, and the log names the
+    missing artifact.
+
+    Args:
+        model_name: A hub repo id or a local path, already resolved by
+            `_resolve_cross_encoder_model_name`.
+
+    Returns:
+        The loaded cross-encoder, from the module-level cache when warm.
+    """
     model = _CROSS_ENCODER_MODELS.get(model_name)
     if model is not None:
         return model
@@ -855,9 +895,40 @@ def _load_cross_encoder(model_name: str):
         model = _CROSS_ENCODER_MODELS.get(model_name)
         if model is None:
             logger.info(f"Loading cross-encoder model '{model_name}' (first use)")
-            model = _import_cross_encoder_class()(model_name)
+            model = _import_cross_encoder_class()(model_name, local_files_only=True)
             _CROSS_ENCODER_MODELS[model_name] = model
     return model
+
+
+#: A name that looks like a filesystem path even when nothing is there to
+#: stat: a Windows drive prefix (``C:\...``/``C:/...``). Checked as a regex
+#: because ``os.path`` on POSIX has no opinion about drive letters.
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _looks_like_a_local_path(name: str) -> bool:
+    """Is ``name`` a filesystem path rather than a hub repo id?
+
+    Three signals, in the order they cost: a path that EXISTS is a path
+    whatever it is called (a bare directory ``models`` has no ``/`` to
+    partition on, which is what the repo-id heuristic keys off); a Windows
+    drive prefix or a backslash cannot be a hub repo id; and a leading
+    ``.``/``~``/``/`` is path syntax nobody uses for a repo id.
+
+    Args:
+        name: The configured model name, already stripped.
+
+    Returns:
+        True when the name must be handed to the loader verbatim.
+    """
+    if _WINDOWS_DRIVE_PATH.match(name) or "\\" in name:
+        return True
+    if name.startswith(("./", "../", ".\\", "..\\", "~", "/")):
+        return True
+    try:
+        return os.path.exists(os.path.expanduser(name))
+    except (OSError, ValueError):  # pragma: no cover - defensive
+        return False
 
 
 def _resolve_cross_encoder_model_name(model_name: Optional[str]) -> str:
@@ -870,10 +941,29 @@ def _resolve_cross_encoder_model_name(model_name: Optional[str]) -> str:
     that is not a plausible model artifact falls back to the measured
     default. A caller that genuinely wants a different cross-encoder passes
     its full repo id or a local path, which is used verbatim.
+
+    **A local path is checked FIRST and is never substituted.** The
+    chat-model heuristic keys off "no ``/`` in the name", which a bare model
+    directory (``models``, ``my-reranker``) and every Windows path
+    (``C:\\models\\bge-base``) also satisfy -- so before this check they were
+    silently replaced by the default artifact and the user loaded a model
+    they did not ask for, with nothing in the log to say so. A path-shaped
+    name that does not exist is still returned verbatim: the loader's
+    "no such model" is the right failure, and the rerank degrades rather
+    than quietly succeeding against a substitute.
+
+    Args:
+        model_name: ``RerankingConfig.model_name``, possibly ``None``.
+
+    Returns:
+        The model name to hand `_load_cross_encoder`.
     """
     name = (model_name or "").strip()
     if not name:
         return DEFAULT_CROSS_ENCODER_MODEL
+
+    if _looks_like_a_local_path(name):
+        return name
 
     lowered = name.lower()
     if any(marker in lowered for marker in _RERANKER_NAME_MARKERS):
@@ -973,13 +1063,64 @@ class CrossEncoderReranker(BaseReranker):
         self.model_name = _resolve_cross_encoder_model_name(config.model_name)
 
     @timeit("reranker_cross_encoder")
+    def _cross_encoder_cache_key(
+        self, query: str, results: List[Union[SearchResult, SearchResultWithCitations]]
+    ) -> str:
+        """Cache key for one cross-encoder rerank of ``results`` under ``query``.
+
+        Qodo PR-1775 finding 1. The base `_get_cache_key` SORTS the ids, but
+        this strategy caches a POSITIONAL list of `RerankingResult`s that
+        `_apply_scores` zips back onto `results_to_rerank` by index. Under an
+        order-insensitive key, the same documents arriving in a different
+        order would replay the previous run's scores against the wrong rows --
+        silently, and in the one place where ordering IS the product.
+
+        The retrieval scores are part of the key as well, because the default
+        `combine_original_score` blend folds 30% of them into the final sort
+        key: two windows with identical ids in identical order but different
+        retrieval scores do NOT have the same answer.
+
+        Args:
+            query: The search query the window is being reranked against.
+            results: The rerank window, in the order it will be scored.
+
+        Returns:
+            A hex digest over (query, ordered ids, ordered retrieval scores).
+        """
+        ordered = "|".join(
+            f"{getattr(r, 'id', '')}:{getattr(r, 'score', '')!r}:"
+            f"{hashlib.md5((getattr(r, 'document', '') or '').encode()).hexdigest()}"
+            for r in results
+        )
+        return hashlib.md5(f"{query}|{ordered}".encode()).hexdigest()
+
     async def rerank(
         self,
         query: str,
         results: List[Union[SearchResult, SearchResultWithCitations]],
-        **kwargs,
+        **kwargs: Any,
     ) -> RerankOutcome:
-        """Rerank the top-k window with the cross-encoder."""
+        """Rerank the top ``top_k_to_rerank`` results with the cross-encoder.
+
+        The window is scored in one batched ``predict``; anything past the
+        window is appended unchanged and unstamped. A model failure (missing
+        artifact, missing extra, OOM, timeout) degrades to the caller's own
+        ordering rather than raising -- reranking must never fail a search.
+
+        Args:
+            query: The user's query, one half of every scored pair.
+            results: The retrieved results, in retrieval order. Never
+                mutated; scored rows come back as copies.
+            **kwargs: Accepted and ignored. `rerank_results` forwards the
+                whole construction kwargs bag to this call, so the signature
+                has to tolerate it; this strategy takes no per-call options.
+
+        Returns:
+            A `RerankOutcome` whose ``results`` are the reordered window
+            followed by the untouched tail, and whose ``failed``/``total``
+            describe THIS call (never instance state -- the RAG service
+            holds one reranker across concurrent searches).
+        """
         if not results:
             return RerankOutcome(results=results, failed=0, total=0)
 
@@ -988,10 +1129,13 @@ class CrossEncoderReranker(BaseReranker):
 
         cache_key = None
         if self._cache is not None:
-            cache_key = self._get_cache_key(query, [r.id for r in results_to_rerank])
+            cache_key = self._cross_encoder_cache_key(query, results_to_rerank)
             if cache_key in self._cache:
                 log_counter("reranker_cache_hit", labels={"strategy": "cross_encoder"})
-                cached_scores = self._cache[cache_key]
+                # COPIED, not replayed by reference: `_apply_scores` writes
+                # `new_rank` onto the objects it is given, and the cache is
+                # shared across concurrent searches on the singleton reranker.
+                cached_scores = [replace(r) for r in self._cache[cache_key]]
                 return RerankOutcome(
                     results=self._apply_scores(results_to_rerank, cached_scores)
                     + remaining_results,
@@ -1038,9 +1182,21 @@ class CrossEncoderReranker(BaseReranker):
         """Score every row in one batched ``predict``; ``None`` on failure."""
         try:
             loop = asyncio.get_running_loop()
-            scores = await loop.run_in_executor(
+            future = loop.run_in_executor(
                 None, functools.partial(self._predict_scores_sync, query, rows)
             )
+            # Qodo PR-1775 finding 8: honour `timeout_seconds`. The executor
+            # THREAD cannot be cancelled -- it runs to completion and its
+            # result is dropped -- but the AWAIT is what a search's latency
+            # actually depends on, so that is what gets bounded. A timeout
+            # degrades like any other failure (note-b: an unscored row must
+            # not claim a rerank score) and is not cached, because it is
+            # transient rather than an answer.
+            timeout = self.config.timeout_seconds
+            if timeout and timeout > 0:
+                scores = await asyncio.wait_for(future, timeout=timeout)
+            else:
+                scores = await future
         except Exception as exc:
             # Reranking must NEVER fail a search: a missing model file, a
             # missing sentence-transformers install and an OOM all land here
@@ -1069,7 +1225,14 @@ class CrossEncoderReranker(BaseReranker):
         """
         model = _load_cross_encoder(self.model_name)
         pairs = [(query, row.document or "") for row in rows]
-        return [float(score) for score in model.predict(pairs)]
+        # Qodo PR-1775 finding 7: `batch_size` is an exposed inference knob,
+        # so it must reach the model rather than silently deferring to the
+        # library's own 32 -- this arc's own follow-up (TASK-17600) exists
+        # because of config surfaces that read nothing. Floored to 1: a zero
+        # or negative value is nonsense the model would raise on, and a
+        # rerank must degrade rather than fail a search.
+        batch_size = max(1, int(self.config.batch_size or 1))
+        return [float(score) for score in model.predict(pairs, batch_size=batch_size)]
 
     def _normalize_scores(
         self,

--- a/tldw_chatbook/Tools/document_expansion_tool.py
+++ b/tldw_chatbook/Tools/document_expansion_tool.py
@@ -12,8 +12,10 @@ an agent saw was a label it could not see behind.
 This tool is the pull-based answer: budgeted, gated OFF by default, and
 risk-tagged so an inherited `allow` is floored to `ask`. It is deliberately
 INDEPENDENT of reranking (AC#6) -- it consumes final result rows whatever
-produced them, and presumes nothing about TASK-3502's unimplemented
-`cross_encoder`.
+produced them. That independence has since been worth having: TASK-16965
+implemented `cross_encoder` (which TASK-3502 had left unimplemented) and
+MEASURED it as net harmful on average, so a tool that presumed a working
+reranker would now be built on a stage nobody recommends turning on.
 
 **The contract works from exactly what a row carries.** `source_type` +
 `source_id` is enough (that is all a label-only row has); `chunk_start`

--- a/tldw_chatbook/Tools/document_expansion_tool.py
+++ b/tldw_chatbook/Tools/document_expansion_tool.py
@@ -14,7 +14,7 @@ risk-tagged so an inherited `allow` is floored to `ask`. It is deliberately
 INDEPENDENT of reranking (AC#6) -- it consumes final result rows whatever
 produced them. That independence has since been worth having: TASK-16965
 implemented `cross_encoder` (which TASK-3502 had left unimplemented) and
-MEASURED it as net harmful on average, so a tool that presumed a working
+MEASURED it as net harmful on average [CAVEAT: that averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`), and `scoped` is where this strategy WINS -- over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075). TASK-16965 final review F1.] (CAVEAT: the instrument's averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`) -- and `scoped` is where the strategy wins, so over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075)), so a tool that presumed a working
 reranker would now be built on a stage nobody recommends turning on.
 
 **The contract works from exactly what a row carries.** `source_type` +

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -252,7 +252,16 @@ DEFAULT_RAG_SEARCH_CONFIG = {
             # "parent_size_multiplier": 3,
             # "expand_context_on_retrieval": True,
             # "clean_pdf_artifacts": True,
-            # "reranking_strategy": "cross_encoder"
+            # "reranking_strategy": "pointwise",
+            #
+            # Reranking strategies: "pointwise" | "pairwise" | "listwise"
+            # (each bills an LLM provider per call) or "cross_encoder" (a
+            # local model, no provider/credential/network). "cross_encoder"
+            # is implemented and selectable but is NOT recommended: it is
+            # the only strategy that has been measured here (TASK-16965)
+            # and it came out net harmful on average -- large gains where
+            # retrieval is weak, losses where it is already good. See
+            # Docs/superpowers/qa/2026-08-17-cross-encoder/report.md.
         },
     },
     "memory_management": {

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -259,7 +259,7 @@ DEFAULT_RAG_SEARCH_CONFIG = {
             # local model, no provider/credential/network). "cross_encoder"
             # is implemented and selectable but is NOT recommended: it is
             # the only strategy that has been measured here (TASK-16965)
-            # and it came out net harmful on average -- large gains where
+            # and it came out net harmful on average [CAVEAT: that averaged row EXCLUDES `scoped` and `negative` (`UNAVERAGED_CATEGORIES`), and `scoped` is where this strategy WINS -- over all 53 ground-truthed queries hybrid REVERSES sign (MRR 0.731 -> 0.806, +0.075). TASK-16965 final review F1.] -- large gains where
             # retrieval is weak, losses where it is already good. See
             # Docs/superpowers/qa/2026-08-17-cross-encoder/report.md.
         },


### PR DESCRIPTION
## The question this arc answers

Does reranking help retrieval in this repo? It has never been measured. TASK-3502 declared it out of scope for a good reason — the three shipped strategies are LLM-driven, and the gated instrument is local and deterministic. A **local cross-encoder** is the one strategy the instrument can see, so this arc implemented it and measured it.

**`sentence-transformers` was already a dependency**, so this cost a new model artifact, not a new library.

## The census came first, and it is what makes the answer interpretable

Before implementing anything:

| mode | queries returning ≥2 rows |
|---|---|
| `plain` | **0 / 60** (39 return nothing, 21 return exactly one) |
| `semantic` | **60 / 60** — full window |
| `hybrid` | **60 / 60** — full window |

Reranking is an order-only change, so `plain` is provably the identity there (a moved plain cell would have been a stop, not a win — and the probe's guard confirms it moved nothing). But semantic and hybrid hand a reranker a full list on every query, so a null could not be dismissed as "nothing to reorder".

## The verdict: HARMED — against a rule fixed before any code was written

| mode | MRR | NDCG |
|---|---|---|
| semantic | 0.804 → 0.772 | 0.804 → 0.780 |
| hybrid | 0.809 → 0.798 | 0.817 → 0.810 |

The strategy demonstrably ran: 3,621 rows scored, 0 failed, **1,950 rows moved**. Regressions beyond tolerance land on `paraphrase` (MRR 1.000 → 0.923) and `vocabulary_mismatch` (1.000 → 0.944).

**But the headline is narrower than it sounds, and the final review caught it.** That averaged row is the instrument's `overall`, which *excludes* `scoped` and `negative` — and `scoped` is exactly where the strategy wins. Averaged over all 53 ground-truthed queries, **hybrid reverses sign: MRR 0.731 → 0.806 (+0.075)**. Every headline site now says which average it means. The pre-registered verdict is unchanged — it is computed from the instrument's own cells and the six regression cells stand — but a reader deserves both numbers.

**The result is strongly bimodal**: hybrid `scoped` MRR **0.163 → 0.929**, `prompt` 0.022 → 0.200, semantic `negation` NDCG 0.000 → 0.105 — paid for by demoting rank-1 answers in the only two categories already saturated at 1.000, where the only available movement was down.

## Owner ruling: keep the code, retire the promise

Asked with the trade-offs shown, the owner ruled (2026-08-17) to keep `CrossEncoderReranker` implemented and selectable while removing every claim that it helps. Implemented faithfully: it is the default, recommendation and profile-strategy of **nothing**, and eight user-visible surfaces now carry the measured result instead of a promise — including `cross_encoder`'s entry under *"Future Enhancements → Planned Features"* in the design doc, and its role as the **example value** in both `config.py` and the shipped example TOML. Per this programme's convention, every site records two adjacent facts: what the rule said, and that the owner ruled otherwise.

Hybrid Full stays on `pointwise` — now documented as a permanent, measured choice rather than a stopgap.

## Two findings about the evidence itself

**The measurement was one monkeypatch away from a fabricated null.** `Tests/conftest.py` sandboxes `HOME`, and huggingface's cache constant is computed from `expanduser("~")` at import — so under pytest the model fails to load *even though it is cached*. Because the reranker degrades rather than raises, every window would have returned unchanged and every metric would have read a flawless 0.000 delta: a perfect-looking null, entirely manufactured. The probe now asserts it did work (`rows_scored > 0`, `rows_failed == 0`), and the review **mutation-verified** it: forcing the load to fail produces the pretty NULL and then refuses it with `3621 cross-encoder scoring attempts FAILED`. The lesson is filed — a measurement whose subject degrades silently must assert, inside itself, that work happened, or its null is unfalsifiable.

**Is the harm an artifact of min-max normalisation?** The sharpest question in the arc, and the review ran the control rather than reasoning about it: with the original-score blend off — ordering then identical to raw logits — the verdict is still HARMED with the **same six regression cells** and deltas matching to three decimals; a 10×-scaled blend agrees. **The harm is the model's ranking, not the normalisation.** (Strictly, ordering is only normalisation-invariant with the blend off; the shipped config blends 30%, and the docstring now says so.)

## Verification

Probe reproduces bit-exactly (225/225 lines vs the committed artifact); the rule's code form is proven pre-registered from git history (byte-identical since before Task 1); Task 3's diff is **zero executable lines**, proven by AST comparison; gate `PASSED: No regression. 105 metric(s)` with no baseline re-stamped; 678 passed / 26 skipped; **zero network, zero provider spend**, confirmed three ways.

## Follow-up filed

**TASK-17600** — `rag_pipelines.toml` declares a `result_reranking` middleware with `enabled = true` whose handler is a bare `pass`, listed by the `high_accuracy` pipeline. Same species as the inert parent-inclusion knobs, worse in one respect: it appears in a pipeline a user picks *because* it promises accuracy. The review's F3 (`reranking_strategy` has zero readers repo-wide) is folded into its scope.

Refs TASK-16965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a local `cross_encoder` reranking strategy with `sentence-transformers`, measures it on the offline gate, and updates docs/configs to state the result. Old: `cross_encoder` unimplemented; new: implemented and selectable but not recommended. Verdict: on the instrument’s averaged row (excludes `scoped`/`negative`) semantic/hybrid regress; over all 53 ground‑truthed queries hybrid reverses sign (MRR 0.731 → 0.806); strategy kept to enable measurement, defaults remain `pointwise`.

- Adds `CrossEncoderReranker` (lazy, cached local model; offline-only; shared apply‑scores/logging in `BaseReranker`; preserves `rerank_score`; failures degrade, not raise). Updates `RAG_Search/reranker.py`, `config_profiles.py`, `library_rag_score_kinds.py`, example/config docs; moves example strategy to `pointwise`.
- Gated probe and tests (`Tests/RAG_Eval`) run fully offline and assert work occurred; result is bimodal: large gains on weak‑retrieval categories (e.g., hybrid `scoped` MRR 0.163 → 0.929) with regressions on already‑saturated categories; HARMED verdict stands.
- Follow‑ups: order‑ and content‑sensitive `_cross_encoder_cache_key` (copies on replay), `local_files_only=True` and optional import routing, robust model path handling, `batch_size` forwarded to `model.predict` (min 1), `timeout_seconds` guards await (timeouts degrade and don’t cache). Re‑run reproduces published deltas exactly.
- Docs: remove “future enhancement” claim; user guide records measured outcomes; mark `result_reranking` middleware as a no‑op; file TASK‑17600.

**Rollout and migration**
- No default changes. If you set `reranking_strategy = "cross_encoder"`, ensure the model artifact is in the HF cache; otherwise reranking degrades to pass‑through.
- `batch_size` and `timeout_seconds` now take effect; timeouts skip caching.
- Do not rely on `result_reranking` middleware; it is currently a no‑op.

<sup>Written for commit 8b361829c67f7195cd5c9c000684c679d0a0d92c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

