### PR TITLE
feat(agents): per-child steering mailbox + protocol-coherent drain seam (fleet 3b Task 1)

### DIFF
--- a/Docs/superpowers/plans/2026-08-17-fleet-pr3b-task1-report.md
+++ b/Docs/superpowers/plans/2026-08-17-fleet-pr3b-task1-report.md
@@ -1,0 +1,124 @@
+# Fleet PR 3b — Task 1 landing report: mailbox + drain seam
+
+Branch `feat/fleet-3b-mailbox`, from origin/dev `e0d47f4be`. Plan:
+`2026-08-17-fleet-pr3b-steering.md`, Task 1 (child-side plumbing, no
+producer). Spec bindings: §6 (protocol-coherent drain, source labels),
+§3 invariant 4 (steering never cancels).
+
+## Citation-base verification
+
+Every seam-map line this task relies on was re-verified at
+`e0d47f4be`. `git diff a2b621c80..e0d47f4be -- tldw_chatbook/Agents/
+Tests/Agents/` is EMPTY (the only commits between are the plan-docs
+merge), so the plan's `a2b621c80` citations hold byte-for-byte at this
+branch's base. **The code had not moved; the drain landed exactly where
+the plan reasoned it must** — the non-restoring branch (`agent_runtime.py`
+`:901-911` at the citation base), immediately before the model call,
+after the budget/cancel checks (`:880-893`).
+
+## What landed (four commits, pushed incrementally)
+
+1. `804e8a5d5` — `agent_models.py` (pure): `STEP_STEERING`,
+   `STEERING_SOURCE_SUPERVISOR`/`STEERING_SOURCE_USER`,
+   `MAX_STEERING_CHARS = 4000`, and the ONE formatter
+   `format_steering_message(source, text)` →
+   `"[Steering from {source}] {text}"`.
+2. `744936225` — `fleet_coordinator.py` (pure, locked):
+   `post_steering(handle_id, source, text) -> bool` (False for
+   unknown/terminal), `drain_steering(handle_id)` (one locked
+   return-and-clear pop), `FleetHandle.queued_steering` COMPUTED onto the
+   copies `get()`/`snapshot()` return (stored state lives only in the
+   mailbox dict, so a copy can never disagree with the mailbox).
+   Mailboxes die with `prune_terminal`; undrained remnants survive
+   `finish()` until then (Task 4 claims them at retention time — pinned).
+3. `fe55b5cd8` — `agent_runtime.py` (pure):
+   `LoopDeps.drain_mailbox: Callable[[], list[tuple[str, str]]] | None`.
+   The drain sits in the non-restoring branch immediately before the
+   model call; per entry it appends the labeled user-role message, adds a
+   `STEP_STEERING` step, and emits a `"steering"` run-log record with the
+   source as `status`. Wrapped never-raise (the `on_step` containment
+   rule).
+4. `a63f011ce` — `agent_service.py`: `_run_one` gains
+   `drain_mailbox=None` (the `on_run_id` threading precedent); spawn's
+   fleet branch supplies
+   `lambda handle_id=handle.handle_id: fleet.drain_steering(handle_id)`
+   via `child_kwargs`; primaries and inline children keep `None`.
+
+Suite: `Tests/Agents/test_fleet_steering_mailbox.py` (22 tests).
+
+## The seven reds — each measured failing before its piece landed
+
+| Red | Test(s) | Before | After |
+|---|---|---|---|
+| (a) boundary delivery, exact `messages` sequence, BOTH protocols | `test_red_a_fence_…`, `test_red_a_native_…` | `TypeError: LoopDeps.__init__() got an unexpected keyword argument 'drain_mailbox'` | pass — exact 4-/5-message sequences asserted, steering last, after every tool result |
+| (b) never interleaves among `role:"tool"` results | `test_red_b_two_native_batches_…` (two consecutive 2-call batches, posts between dispatches, plus a pairing-scan over EVERY payload) | same `TypeError` | pass — exact 9-message final payload |
+| (c) restore-batch path never drains | `test_red_c_restore_batch_path_never_drains` | same `TypeError` | pass — `order == ["invoke", "drain", "model"]`; entry delivered after the restored rows, RUN_DONE |
+| (d) drain under ACTIVE checkpoint → no `continuation_error` | `test_red_d_…` | same `TypeError` | pass — full barrier cycle `[ToolBatchReady, Executing, Finished, Final]`, RUN_DONE, no error step |
+| (e) raising drain never aborts | `test_red_e_a_raising_drain_…` | same `TypeError` | pass — RUN_DONE, drain retried at every boundary |
+| (f) concurrent post/drain thread-safety | `test_red_f_concurrent_post_and_drain_…` (4 posters × 50 entries vs 2 drainers) | `AttributeError: 'FleetCoordinator' object has no attribute 'post_steering'` | pass — 200/200 delivered exactly once |
+| (g) a dead run never consumes a mailbox | 4 tests: loop-top cancel, mid-batch cancel, budget-exhausted, cycle-stuck | same `TypeError` | pass — zero drains for pre-posted entries on dead runs; late posts stay queued on the coordinator |
+
+Service-wiring reds (Task 1's `agent_service` deliverable): the
+end-to-end delivery test failed with the child's second payload ending
+at the tool result (no steering message), and the `run_agent_loop` spy
+saw `drain_mailbox=None` on the fleet child. One deliberate
+characterization PIN (not a red, labeled as such in the test):
+`test_inline_children_and_their_primary_stay_unwired` — current behavior
+is already correct; wiring them would be the regression it catches.
+
+## The four mutations — all killed, restores Edit-based with `git diff` proof
+
+| Mutation | Kills (owner in bold) |
+|---|---|
+| 1. drain moved to AFTER the assistant-echo append | 9 died: **(a) fence, (a) native, (b)** + (c), (d), (e), both late-post (g)s, end-to-end |
+| 2. label dropped from the formatter call (`steer_message = steer_text`) | 6 died: **both (a)s' and (d)'s label assertions** + (b), (c), end-to-end |
+| 3. drain added in the restoring branch | exactly 1 died: **(c)** |
+| 4. drain moved BEFORE the budget/cancel checks (non-restoring-guarded, isolating the ordering claim) | 2 died: **(g) loop-top-cancelled, (g) budget-exhausted** |
+
+No survivors. Note on mutation 4: the two late-post (g) variants
+(mid-batch cancel, cycle-stuck) pass under it BY CONSTRUCTION — their
+entries are posted after the loop-top boundary, so no pre-check drain
+can reach them; their claim (mid-batch death leaves the mailbox intact)
+is untouched by this mutant and is killed by mutation 1 instead. Every
+test in the suite is killed by at least one of the four mutants except
+the pure constant/coordinator pins, which the stage reds covered
+(TypeError/AttributeError before their pieces landed).
+
+## Purity
+
+`agent_models.py`, `fleet_coordinator.py`, `agent_runtime.py`: the
+branch diff adds NO imports of any kind to any of them (verified by
+grep over `git diff e0d47f4be..HEAD`) — the runtime's two new names come
+through its existing `from .agent_models import` block. No I/O, no
+config reads, stdlib only.
+
+## Gate (read counts; baselines taken on the untouched branch first)
+
+| Suite | Baseline | Final |
+|---|---|---|
+| `Tests/Agents/test_fleet_steering_mailbox.py` (new) | — | **22 passed** |
+| `Tests/Agents/test_fleet_runtime.py` | 107 passed | **107 passed** |
+| `Tests/Agents/` (full) | 1462 passed | **1484 passed** (= 1462 + 22 new) |
+| `Tests/Chat/test_console_agent_bridge.py` | 197 passed | **197 passed** |
+| `Tests/Chat/test_fleet_settle_fanout.py` | 7 passed | **7 passed** |
+| `Tests/test_probe_import_provenance.py` | 1 passed | **1 passed** |
+
+## Decisions and notes for Tasks 2–4
+
+- **Text validation (non-empty, `MAX_STEERING_CHARS`) is NOT in
+  `post_steering`.** The plan's global constraint places it "at both
+  boundaries" — the producers (Task 2's `send_to_agent`, Task 3's panel
+  input), each of which needs its own user-facing refusal copy that a
+  silent bool cannot carry. `post_steering`'s contract is exactly the
+  plan's: False for unknown/terminal, True otherwise. Task 2 must not
+  assume the mailbox validates for it.
+- **`queued_steering` is computed at copy time**, not stored on the live
+  handle — one source of truth (the mailbox dict), so Task 3's
+  "queued (N)" surface can trust any `get()`/`snapshot()` copy.
+- **Undrained remnants survive `finish()` until `prune_terminal`** —
+  pinned by `test_undrained_entries_survive_finish_until_prune_terminal`
+  so Task 4's `retain_transcript` has the window the plan promises it.
+- The drain consumes step budget (each delivery adds a `STEP_STEERING`
+  step). At default budgets this is negligible (steering is rare and
+  capped by the producers), and it keeps `max_steps` a true ceiling on
+  step-log growth.

--- a/Tests/Agents/test_fleet_steering_mailbox.py
+++ b/Tests/Agents/test_fleet_steering_mailbox.py
@@ -30,14 +30,40 @@ import json
 import threading
 
 from tldw_chatbook.Agents.agent_models import (
+    FENCE_TOOL_RESULT_PREFIX,
     MAX_STEERING_CHARS,
+    RUN_CANCELLED,
     RUN_DONE,
+    RUN_STUCK,
+    STEP_ERROR,
+    STEP_MODEL,
     STEP_STEERING,
+    STEP_TOOL_CALL,
+    STEP_TOOL_RESULT,
     STEERING_SOURCE_SUPERVISOR,
     STEERING_SOURCE_USER,
+    AgentConfig,
+    ContinuationEventContext,
+    FinalContinuation,
+    ModelTurn,
+    RunBudget,
+    ToolBatchReady,
+    ToolCall,
+    ToolCallExecuting,
+    ToolCallFinished,
+    ToolResult,
+    ToolSchema,
     format_steering_message,
 )
+from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
 from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationCall,
+    ContinuationRestoreTarget,
+    ContinuationResult,
+    ContinuationRound,
+    ProviderContinuationCheckpoint,
+)
 
 
 # -- the one formatter (agent_models, pure) -------------------------------
@@ -194,3 +220,633 @@ def test_red_f_concurrent_post_and_drain_lose_and_duplicate_nothing():
     )
     assert sorted(text for _source, text in drained) == expected
     assert c.get(h.handle_id).queued_steering == 0
+
+
+# -- the protocol-coherent drain (agent_runtime, pure) --------------------
+#
+# Runtime-level reds (a)-(e), (g). These fake the mailbox with a plain
+# list (the coordinator's own contract is pinned above); (g) uses the real
+# coordinator because "leaves entries queued" is a claim ABOUT the
+# coordinator's mailbox.
+
+CALC = ToolSchema(
+    id="builtin:calculator",
+    name="calculator",
+    description="math",
+    parameters={"type": "object"},
+)
+STEER_CFG = AgentConfig(
+    model="test-model", system_prompt="s", allowed_tools=("calculator",)
+)
+
+
+def fence(name, args):
+    return f"```tool_call\n{json.dumps({'name': name, 'arguments': args})}\n```"
+
+
+def _snapshot(messages):
+    """Deep-enough copy of a payload the loop hands its (live) list to."""
+    return [dict(message) for message in messages]
+
+
+def make_deps(call_model, *, invoke=None, cancel=None, drain=None, on_record=None):
+    return LoopDeps(
+        call_model=call_model,
+        invoke_tool=invoke or (lambda call: ToolResult(ok=True, content="42")),
+        spawn=lambda task: ToolResult(ok=True, content="sub done"),
+        find_tools=lambda query: [],
+        load_schemas=lambda ids: [CALC],
+        should_cancel=cancel or (lambda: False),
+        clock=lambda: 0.0,
+        drain_mailbox=drain,
+        on_record=on_record,
+    )
+
+
+def _list_mailbox():
+    """A fake mailbox: (post, drain) over one shared list, single-threaded."""
+    entries: list[tuple[str, str]] = []
+
+    def post(source: str, text: str) -> None:
+        entries.append((source, text))
+
+    def drain() -> list[tuple[str, str]]:
+        got = list(entries)
+        entries.clear()
+        return got
+
+    return post, drain
+
+
+def _raw_call(call: ToolCall) -> dict:
+    return {
+        "id": call.call_id,
+        "type": "function",
+        "function": {
+            "name": call.name,
+            "arguments": json.dumps(call.args, separators=(",", ":")),
+        },
+    }
+
+
+def _assert_batch_pairing_unbroken(payload):
+    """No injected message may sit inside an assistant/tool-result batch.
+
+    Every ``role:"tool"`` message must directly follow either its
+    ``tool_calls`` assistant message or another ``role:"tool"`` result --
+    the pairing native providers reject when broken.
+    """
+    for index, message in enumerate(payload):
+        if message.get("role") != "tool":
+            continue
+        previous = payload[index - 1]
+        assert previous.get("role") == "tool" or (
+            previous.get("role") == "assistant" and previous.get("tool_calls")
+        ), (
+            f"message {index} (role=tool) follows a "
+            f"{previous.get('role')!r} message: an injected message split "
+            f"a native batch in {payload!r}"
+        )
+
+
+def test_red_a_fence_mid_batch_post_delivers_only_at_the_next_boundary():
+    """Red (a), fence protocol: exact ``messages`` sequence asserted."""
+    post, drain = _list_mailbox()
+    fence_text = fence("calculator", {"expression": "6*7"})
+    script = [ModelTurn(text=fence_text), ModelTurn(text="It is 42.")]
+    seen = []
+
+    def call_model(messages, active):
+        seen.append(_snapshot(messages))
+        return script.pop(0)
+
+    def invoke(call):
+        # Mid-batch: the entry lands while the tool is executing.
+        post(STEERING_SOURCE_SUPERVISOR, "focus on X")
+        return ToolResult(ok=True, content="42")
+
+    records = []
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(
+            call_model,
+            invoke=invoke,
+            drain=drain,
+            on_record=lambda kind, payload: records.append((kind, dict(payload))),
+        ),
+    )
+
+    assert out.status == RUN_DONE and out.final_text == "It is 42."
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "focus on X")
+    assert labeled == "[Steering from supervisor] focus on X"
+    assert seen[0] == [{"role": "user", "content": "hi"}]
+    # THE boundary: after every pending tool result of the previous
+    # assistant message, before the next assistant message.
+    assert seen[1] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": fence_text},
+        {"role": "user", "content": f"{FENCE_TOOL_RESULT_PREFIX}calculator: 42"},
+        {"role": "user", "content": labeled},
+    ]
+    # The step log shows WHEN the entry reached the model.
+    assert [step.kind for step in out.steps] == [
+        STEP_MODEL,
+        STEP_TOOL_CALL,
+        STEP_TOOL_RESULT,
+        STEP_STEERING,
+        STEP_MODEL,
+    ]
+    assert out.steps[3].summary == labeled
+    # The run log records the delivery with the source as status.
+    steering_records = [payload for kind, payload in records if kind == "steering"]
+    assert steering_records == [
+        {
+            "content": labeled,
+            "tool": "",
+            "status": STEERING_SOURCE_SUPERVISOR,
+            "call_id": "",
+        }
+    ]
+
+
+def test_red_a_native_mid_batch_post_delivers_only_at_the_next_boundary():
+    """Red (a), native protocol: exact ``messages`` sequence asserted."""
+    post, drain = _list_mailbox()
+    call_one = ToolCall("calculator", {"expression": "1"}, "c1", '{"expression":"1"}')
+    call_two = ToolCall("calculator", {"expression": "2"}, "c2", '{"expression":"2"}')
+    echo = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [_raw_call(call_one), _raw_call(call_two)],
+    }
+    script = [
+        ModelTurn(tool_calls=(call_one, call_two), assistant_message=echo),
+        ModelTurn(text="done"),
+    ]
+    seen = []
+
+    def call_model(messages, active):
+        seen.append(_snapshot(messages))
+        return script.pop(0)
+
+    def invoke(call):
+        if call.call_id == "c1":
+            # Posted BETWEEN the batch's dispatches.
+            post(STEERING_SOURCE_USER, "change course")
+        return ToolResult(ok=True, content=f"r-{call.call_id}")
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(call_model, invoke=invoke, drain=drain),
+    )
+
+    assert out.status == RUN_DONE
+    labeled = format_steering_message(STEERING_SOURCE_USER, "change course")
+    assert seen[1] == [
+        {"role": "user", "content": "hi"},
+        echo,
+        {"role": "tool", "tool_call_id": "c1", "content": "r-c1"},
+        {"role": "tool", "tool_call_id": "c2", "content": "r-c2"},
+        {"role": "user", "content": labeled},
+    ]
+    for payload in seen:
+        _assert_batch_pairing_unbroken(payload)
+
+
+def test_red_b_two_native_batches_never_interleave_steering_among_tool_results():
+    """Red (b): consecutive multi-call batches, posts between dispatches.
+
+    The injected message must never sit between a ``tool_calls`` assistant
+    echo and its ``role:"tool"`` results, nor between two results of one
+    batch -- in ANY payload the model ever sees.
+    """
+    post, drain = _list_mailbox()
+    batch_one = (
+        ToolCall("calculator", {"expression": "1"}, "c1", '{"expression":"1"}'),
+        ToolCall("calculator", {"expression": "2"}, "c2", '{"expression":"2"}'),
+    )
+    batch_two = (
+        ToolCall("calculator", {"expression": "3"}, "c3", '{"expression":"3"}'),
+        ToolCall("calculator", {"expression": "4"}, "c4", '{"expression":"4"}'),
+    )
+    echo_one = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [_raw_call(call) for call in batch_one],
+    }
+    echo_two = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [_raw_call(call) for call in batch_two],
+    }
+    script = [
+        ModelTurn(tool_calls=batch_one, assistant_message=echo_one),
+        ModelTurn(tool_calls=batch_two, assistant_message=echo_two),
+        ModelTurn(text="done"),
+    ]
+    seen = []
+
+    def call_model(messages, active):
+        seen.append(_snapshot(messages))
+        return script.pop(0)
+
+    def invoke(call):
+        if call.call_id in ("c1", "c3"):
+            post(STEERING_SOURCE_SUPERVISOR, f"steer after {call.call_id}")
+        return ToolResult(ok=True, content=f"r-{call.call_id}")
+
+    out = run_agent_loop(
+        # Two 2-call batches spend 11 steps before the final turn; the
+        # default max_steps=8 would end this RUN_STUCK before turn 3.
+        AgentConfig(
+            model="test-model",
+            system_prompt="s",
+            allowed_tools=("calculator",),
+            budget=RunBudget(max_steps=40, max_model_turns=40),
+        ),
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(call_model, invoke=invoke, drain=drain),
+    )
+
+    assert out.status == RUN_DONE
+    steer_one = format_steering_message(STEERING_SOURCE_SUPERVISOR, "steer after c1")
+    steer_two = format_steering_message(STEERING_SOURCE_SUPERVISOR, "steer after c3")
+    assert seen[2] == [
+        {"role": "user", "content": "hi"},
+        echo_one,
+        {"role": "tool", "tool_call_id": "c1", "content": "r-c1"},
+        {"role": "tool", "tool_call_id": "c2", "content": "r-c2"},
+        {"role": "user", "content": steer_one},
+        echo_two,
+        {"role": "tool", "tool_call_id": "c3", "content": "r-c3"},
+        {"role": "tool", "tool_call_id": "c4", "content": "r-c4"},
+        {"role": "user", "content": steer_two},
+    ]
+    for payload in seen:
+        _assert_batch_pairing_unbroken(payload)
+
+
+# -- continuation fixtures (the deepseek shape the 4a/4c suites pin) ------
+
+
+def _checkpoint(
+    *calls: ContinuationCall,
+    revision: int = 1,
+    state: str = "active",
+    assistant_content: str = "",
+    reasoning: tuple[str, ...] = ("private",),
+) -> ProviderContinuationCheckpoint:
+    return ProviderContinuationCheckpoint(
+        schema_version=1,
+        checkpoint_revision=revision,
+        provider="deepseek",
+        protocol="responses",
+        model="deepseek-v4-flash",
+        api_base_url="https://api.deepseek.com/v1",
+        state=state,  # type: ignore[arg-type]
+        rounds=(
+            ContinuationRound(
+                assistant_content=assistant_content,
+                reasoning_blocks=reasoning,
+                calls=tuple(calls),
+            ),
+        ),
+    )
+
+
+def _pending_call(call_id: str = "call-1") -> ContinuationCall:
+    return ContinuationCall(
+        call_id=call_id,
+        name="calculator",
+        arguments=json.dumps({"expression": "2+2"}, separators=(",", ":")),
+        state="pending",
+    )
+
+
+_RESTORE_TARGET = ContinuationRestoreTarget(
+    "deepseek", "deepseek-v4-flash", "responses", "https://api.deepseek.com/v1"
+)
+_CONTEXT = ContinuationEventContext(
+    owner_message_id="assistant-owner",
+    run_id="run-1",
+    agent_kind="primary",
+    durability="persistent",
+)
+
+
+def _final_checkpoint() -> ProviderContinuationCheckpoint:
+    return _checkpoint(
+        ContinuationCall(
+            call_id="call-1",
+            name="calculator",
+            arguments=json.dumps({"expression": "2+2"}, separators=(",", ":")),
+            state="completed",
+            result=ContinuationResult("4"),
+        ),
+        revision=4,
+        state="complete",
+    )
+
+
+def test_red_c_restore_batch_path_never_drains():
+    """Red (c): an entry posted before a resume survives to the
+    post-restore turn -- the restoring branch itself never drains (a drain
+    there would be wiped by ``expand_restore_history``'s slice-rewrite)."""
+    order = []
+    mailbox = [(STEERING_SOURCE_USER, "posted before resume")]
+
+    def drain():
+        order.append("drain")
+        got = list(mailbox)
+        mailbox.clear()
+        return got
+
+    def invoke(call):
+        order.append("invoke")
+        return ToolResult(ok=True, content="4")
+
+    seen = []
+
+    def call_model(messages, active):
+        order.append("model")
+        seen.append(_snapshot(messages))
+        return ModelTurn(text="final", provider_continuation=_final_checkpoint())
+
+    def expand(actual):
+        return [
+            {
+                "role": "tool",
+                "tool_call_id": call.call_id,
+                "content": call.result.value if call.result else "…pending…",
+            }
+            for round_ in actual.rounds
+            for call in round_.calls
+        ]
+
+    deps = make_deps(call_model, invoke=invoke, drain=drain)
+    deps.continuation_context = _CONTEXT
+    deps.persist_provider_continuation = lambda event: None
+    deps.expand_provider_continuation = expand
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "go"}],
+        [CALC],
+        deps,
+        restore_provider_continuation=_checkpoint(_pending_call()),
+        restore_provider_target=_RESTORE_TARGET,
+        resume_provider_continuation=True,
+    )
+
+    assert out.status == RUN_DONE and out.final_text == "final"
+    # The restored batch executed FIRST, undrained; the one drain happened
+    # at the next (non-restoring) boundary, before the model call.
+    assert order == ["invoke", "drain", "model"]
+    labeled = format_steering_message(STEERING_SOURCE_USER, "posted before resume")
+    assert seen == [
+        [
+            {"role": "user", "content": "go"},
+            {"role": "tool", "tool_call_id": "call-1", "content": "4"},
+            {"role": "user", "content": labeled},
+        ]
+    ]
+
+
+def test_red_d_drain_under_an_active_checkpoint_produces_no_continuation_error():
+    """Red (d): the full 4a barrier cycle with a mid-batch post stays
+    RUN_DONE -- the injected user message never trips a continuation
+    barrier, because no barrier validates ``messages``."""
+    post, drain = _list_mailbox()
+    call = ToolCall(
+        "calculator", {"expression": "2+2"}, "call-1", '{"expression":"2+2"}'
+    )
+    events = []
+    script = [
+        ModelTurn(
+            tool_calls=(call,),
+            assistant_message={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [_raw_call(call)],
+            },
+            provider_continuation=_checkpoint(_pending_call()),
+        ),
+        ModelTurn(text="4", provider_continuation=_final_checkpoint()),
+    ]
+    seen = []
+
+    def call_model(messages, active):
+        seen.append(_snapshot(messages))
+        return script.pop(0)
+
+    def invoke(actual):
+        post(STEERING_SOURCE_SUPERVISOR, "keep it brief")
+        return ToolResult(ok=True, content="4")
+
+    deps = make_deps(call_model, invoke=invoke, drain=drain)
+    deps.continuation_context = _CONTEXT
+    deps.persist_provider_continuation = lambda event: events.append(type(event))
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "2+2?"}],
+        [CALC],
+        deps,
+    )
+
+    assert out.status == RUN_DONE and out.final_text == "4"
+    assert not [step for step in out.steps if step.kind == STEP_ERROR]
+    # The full barrier sequence ran -- no barrier was skipped or repeated.
+    assert events == [
+        ToolBatchReady,
+        ToolCallExecuting,
+        ToolCallFinished,
+        FinalContinuation,
+    ]
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "keep it brief")
+    # Delivered under the ACTIVE checkpoint, at the coherent boundary.
+    assert seen[1][-2:] == [
+        {"role": "tool", "tool_call_id": "call-1", "content": "4"},
+        {"role": "user", "content": labeled},
+    ]
+
+
+def test_red_e_a_raising_drain_does_not_abort_the_run():
+    """Red (e): the on_step containment rule -- a broken drain callable
+    costs the delivery, never the run."""
+    drain_calls = []
+
+    def drain():
+        drain_calls.append(True)
+        raise RuntimeError("mailbox exploded")
+
+    script = [
+        ModelTurn(text=fence("calculator", {"expression": "6*7"})),
+        ModelTurn(text="recovered"),
+    ]
+    seen = []
+
+    def call_model(messages, active):
+        seen.append(_snapshot(messages))
+        return script.pop(0)
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(call_model, drain=drain),
+    )
+
+    assert out.status == RUN_DONE and out.final_text == "recovered"
+    assert len(drain_calls) == 2  # tried at every boundary, kept failing
+    assert not [step for step in out.steps if step.kind == STEP_ERROR]
+    for payload in seen:
+        assert not [
+            message
+            for message in payload
+            if "[Steering from" in str(message.get("content", ""))
+        ]
+
+
+# -- red (g): a dead run never consumes a mailbox -------------------------
+
+
+def _coordinator_drain(coordinator, handle_id, drain_calls):
+    def drain():
+        drain_calls.append(True)
+        return coordinator.drain_steering(handle_id)
+
+    return drain
+
+
+def test_red_g_a_cancelled_run_leaves_entries_queued():
+    coordinator = _coord()
+    handle = coordinator.reserve(task="child", agent=None)
+    coordinator.post_steering(
+        handle.handle_id, STEERING_SOURCE_USER, "still queued"
+    )
+    drain_calls = []
+
+    def call_model(messages, active):
+        raise AssertionError("a cancelled run must never call the model")
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(
+            call_model,
+            cancel=lambda: True,
+            drain=_coordinator_drain(coordinator, handle.handle_id, drain_calls),
+        ),
+    )
+
+    assert out.status == RUN_CANCELLED
+    assert drain_calls == []
+    assert coordinator.get(handle.handle_id).queued_steering == 1
+    assert coordinator.drain_steering(handle.handle_id) == [
+        (STEERING_SOURCE_USER, "still queued")
+    ]
+
+
+def test_red_g_a_mid_batch_cancel_leaves_a_late_post_queued():
+    """A Stop landing DURING a model turn kills the batch before dispatch
+    (:1068-1069); an entry posted after that turn's drain stays queued."""
+    coordinator = _coord()
+    handle = coordinator.reserve(task="child", agent=None)
+    drain_calls = []
+    cancelled = []
+
+    def call_model(messages, active):
+        coordinator.post_steering(
+            handle.handle_id, STEERING_SOURCE_SUPERVISOR, "too late"
+        )
+        cancelled.append(True)
+        return ModelTurn(text=fence("calculator", {"expression": "6*7"}))
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(
+            call_model,
+            invoke=lambda call: (_ for _ in ()).throw(
+                AssertionError("cancel must precede dispatch")
+            ),
+            cancel=lambda: bool(cancelled),
+            drain=_coordinator_drain(coordinator, handle.handle_id, drain_calls),
+        ),
+    )
+
+    assert out.status == RUN_CANCELLED
+    assert len(drain_calls) == 1  # the one boundary before the model call
+    assert coordinator.get(handle.handle_id).queued_steering == 1
+
+
+def test_red_g_a_budget_exhausted_run_leaves_entries_queued():
+    coordinator = _coord()
+    handle = coordinator.reserve(task="child", agent=None)
+    coordinator.post_steering(
+        handle.handle_id, STEERING_SOURCE_SUPERVISOR, "never consumed"
+    )
+    drain_calls = []
+
+    def call_model(messages, active):
+        raise AssertionError("an exhausted run must never call the model")
+
+    out = run_agent_loop(
+        AgentConfig(
+            model="test-model",
+            system_prompt="s",
+            allowed_tools=("calculator",),
+            budget=RunBudget(max_model_turns=0),
+        ),
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(
+            call_model,
+            drain=_coordinator_drain(coordinator, handle.handle_id, drain_calls),
+        ),
+    )
+
+    assert out.status == RUN_STUCK
+    assert "model-turn budget exhausted" in out.steps[-1].summary
+    assert drain_calls == []
+    assert coordinator.get(handle.handle_id).queued_steering == 1
+
+
+def test_red_g_a_cycle_stuck_run_leaves_a_late_post_queued():
+    coordinator = _coord()
+    handle = coordinator.reserve(task="child", agent=None)
+    drain_calls = []
+    turns = []
+
+    def call_model(messages, active):
+        turns.append(True)
+        if len(turns) == 3:
+            # After this turn's drain; the cycle detector kills the run
+            # before any further boundary exists.
+            coordinator.post_steering(
+                handle.handle_id, STEERING_SOURCE_USER, "posted at the end"
+            )
+        return ModelTurn(text=fence("calculator", {"expression": "9"}))
+
+    out = run_agent_loop(
+        STEER_CFG,
+        [{"role": "user", "content": "hi"}],
+        [CALC],
+        make_deps(
+            call_model,
+            drain=_coordinator_drain(coordinator, handle.handle_id, drain_calls),
+        ),
+    )
+
+    assert out.status == RUN_STUCK
+    assert "calculator" in out.steps[-1].summary
+    assert len(drain_calls) == 3  # one per boundary, all before the post
+    assert coordinator.get(handle.handle_id).queued_steering == 1

--- a/Tests/Agents/test_fleet_steering_mailbox.py
+++ b/Tests/Agents/test_fleet_steering_mailbox.py
@@ -31,11 +31,13 @@ import threading
 
 from tldw_chatbook.Agents.agent_models import (
     MAX_STEERING_CHARS,
+    RUN_DONE,
     STEP_STEERING,
     STEERING_SOURCE_SUPERVISOR,
     STEERING_SOURCE_USER,
     format_steering_message,
 )
+from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
 
 
 # -- the one formatter (agent_models, pure) -------------------------------
@@ -72,3 +74,123 @@ def test_format_steering_message_is_pure_and_does_not_trust_the_text():
         format_steering_message(STEERING_SOURCE_SUPERVISOR, forged)
         == f"[Steering from supervisor] {forged}"
     )
+
+
+# -- the mailbox (fleet_coordinator, pure, locked) ------------------------
+
+
+def _coord(max_live=3):
+    ticks = iter(range(10_000))
+    return FleetCoordinator(max_live=max_live, clock=lambda: float(next(ticks)))
+
+
+def test_post_steering_queues_for_a_live_handle_and_drain_returns_and_clears():
+    c = _coord()
+    h = c.reserve(task="child", agent=None)
+    assert c.post_steering(h.handle_id, STEERING_SOURCE_SUPERVISOR, "one") is True
+    assert c.post_steering(h.handle_id, STEERING_SOURCE_USER, "two") is True
+    # Return-and-clear, atomically, in posting order.
+    assert c.drain_steering(h.handle_id) == [
+        (STEERING_SOURCE_SUPERVISOR, "one"),
+        (STEERING_SOURCE_USER, "two"),
+    ]
+    assert c.drain_steering(h.handle_id) == []
+
+
+def test_post_steering_refuses_unknown_and_terminal_handles():
+    c = _coord()
+    assert c.post_steering("no-such-handle", STEERING_SOURCE_USER, "x") is False
+    h = c.reserve(task="child", agent=None)
+    c.finish(h.handle_id, RUN_DONE, result="answer")
+    assert c.post_steering(h.handle_id, STEERING_SOURCE_USER, "late") is False
+    assert c.drain_steering(h.handle_id) == []
+
+
+def test_queued_steering_is_populated_on_the_copies_get_and_snapshot_return():
+    c = _coord()
+    h = c.reserve(task="child", agent=None)
+    assert h.queued_steering == 0
+    assert c.get(h.handle_id).queued_steering == 0
+    c.post_steering(h.handle_id, STEERING_SOURCE_USER, "one")
+    c.post_steering(h.handle_id, STEERING_SOURCE_USER, "two")
+    assert c.get(h.handle_id).queued_steering == 2
+    assert [x.queued_steering for x in c.snapshot()] == [2]
+    c.drain_steering(h.handle_id)
+    assert c.get(h.handle_id).queued_steering == 0
+    assert [x.queued_steering for x in c.snapshot()] == [0]
+
+
+def test_undrained_entries_survive_finish_until_prune_terminal():
+    # Between finish() and prune_terminal() the remnant mailbox still
+    # exists -- Task 4's retain_transcript claims it at retention time.
+    # Task 1 pins only that prune_terminal is where mailboxes die.
+    c = _coord()
+    h = c.reserve(task="child", agent=None)
+    c.post_steering(h.handle_id, STEERING_SOURCE_USER, "undelivered")
+    c.finish(h.handle_id, RUN_DONE, result="answer")
+    assert c.get(h.handle_id).queued_steering == 1
+    assert c.prune_terminal() == 1
+    # The mailbox died with the handle: nothing left to drain, and a
+    # handle re-using the id namespace starts from zero.
+    assert c.drain_steering(h.handle_id) == []
+
+
+def test_mailboxes_are_per_child_not_shared():
+    c = _coord()
+    first = c.reserve(task="one", agent=None)
+    second = c.reserve(task="two", agent=None)
+    c.post_steering(first.handle_id, STEERING_SOURCE_USER, "for one")
+    c.post_steering(second.handle_id, STEERING_SOURCE_SUPERVISOR, "for two")
+    assert c.drain_steering(first.handle_id) == [(STEERING_SOURCE_USER, "for one")]
+    assert c.drain_steering(second.handle_id) == [
+        (STEERING_SOURCE_SUPERVISOR, "for two")
+    ]
+
+
+def test_red_f_concurrent_post_and_drain_lose_and_duplicate_nothing():
+    """Red (f): concurrent post/drain from threads under the coordinator lock.
+
+    Four posters race two drainers on one live handle. Every entry posted
+    must be delivered exactly once: none lost to a torn read-modify-write,
+    none duplicated by a drain that returned without clearing.
+    """
+    c = _coord()
+    h = c.reserve(task="child", agent=None)
+    posters, per_poster = 4, 50
+    drained: list[tuple[str, str]] = []
+    drained_lock = threading.Lock()
+    stop = threading.Event()
+
+    def post(worker: int) -> None:
+        for i in range(per_poster):
+            assert c.post_steering(
+                h.handle_id, STEERING_SOURCE_USER, f"w{worker}-{i}"
+            )
+
+    def drain() -> None:
+        while not stop.is_set():
+            got = c.drain_steering(h.handle_id)
+            if got:
+                with drained_lock:
+                    drained.extend(got)
+
+    drainers = [threading.Thread(target=drain) for _ in range(2)]
+    for thread in drainers:
+        thread.start()
+    poster_threads = [
+        threading.Thread(target=post, args=(worker,)) for worker in range(posters)
+    ]
+    for thread in poster_threads:
+        thread.start()
+    for thread in poster_threads:
+        thread.join(timeout=10.0)
+    stop.set()
+    for thread in drainers:
+        thread.join(timeout=10.0)
+    drained.extend(c.drain_steering(h.handle_id))
+
+    expected = sorted(
+        f"w{worker}-{i}" for worker in range(posters) for i in range(per_poster)
+    )
+    assert sorted(text for _source, text in drained) == expected
+    assert c.get(h.handle_id).queued_steering == 0

--- a/Tests/Agents/test_fleet_steering_mailbox.py
+++ b/Tests/Agents/test_fleet_steering_mailbox.py
@@ -29,12 +29,20 @@ from __future__ import annotations
 import json
 import threading
 
+import pytest
+
+from Tests.Agents.test_agent_service import SUBAGENT_PROMPT_PREFIX
+from Tests.Agents.test_fleet_runtime import FLEET_CFG, make_fleet_service, make_inline_service
+from tldw_chatbook.Agents import agent_service
 from tldw_chatbook.Agents.agent_models import (
     FENCE_TOOL_RESULT_PREFIX,
     MAX_STEERING_CHARS,
     RUN_CANCELLED,
     RUN_DONE,
+    RUN_RUNNING,
     RUN_STUCK,
+    SPAWN_TOOL_NAME,
+    WAIT_AGENTS_TOOL_NAME,
     STEP_ERROR,
     STEP_MODEL,
     STEP_STEERING,
@@ -57,6 +65,7 @@ from tldw_chatbook.Agents.agent_models import (
 )
 from tldw_chatbook.Agents.agent_runtime import LoopDeps, run_agent_loop
 from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationCall,
     ContinuationRestoreTarget,
@@ -850,3 +859,144 @@ def test_red_g_a_cycle_stuck_run_leaves_a_late_post_queued():
     assert "calculator" in out.steps[-1].summary
     assert len(drain_calls) == 3  # one per boundary, all before the post
     assert coordinator.get(handle.handle_id).queued_steering == 1
+
+
+# -- service threading (agent_service: _run_one + spawn's fleet branch) ---
+#
+# The impure seam: a THREADED fleet child's LoopDeps.drain_mailbox is the
+# service-built closure over that child's own coordinator mailbox;
+# primaries and inline children stay unwired (None).
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return AgentRunsDB(tmp_path / "runs.db", client_id="test")
+
+
+def test_fleet_child_drain_is_wired_to_its_own_coordinator_mailbox(db):
+    """End-to-end: a post to the child's handle reaches the child's NEXT
+    provider payload as the labeled user-role message, at the boundary."""
+    holder = {}
+
+    def steer_then_call():
+        [handle] = [
+            h for h in holder["coordinator"].snapshot() if h.status == RUN_RUNNING
+        ]
+        assert holder["coordinator"].post_steering(
+            handle.handle_id, STEERING_SOURCE_SUPERVISOR, "wrap up quickly"
+        )
+        holder["handle_id"] = handle.handle_id
+        return fence("calculator", {"expression": "6*7"})
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "combined answer",
+        ],
+        {"task one": [steer_then_call, "child answer"]},
+    )
+    holder["coordinator"] = coordinator
+
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+
+    assert outcome.status == RUN_DONE
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "wrap up quickly")
+    second_payload = chat.child_calls["task one"][1]["messages_payload"]
+    # Delivered at the coherent boundary: after the batch's tool result,
+    # as the final message before the child's next assistant turn.
+    assert second_payload[-1] == {"role": "user", "content": labeled}
+    assert str(second_payload[-2]["content"]).startswith(
+        f"{FENCE_TOOL_RESULT_PREFIX}calculator:"
+    )
+    # Consumed from THAT child's mailbox, not merely copied.
+    assert coordinator.drain_steering(holder["handle_id"]) == []
+    # The PRIMARY's payloads never carry the steering message -- the wiring
+    # is per-child, not per-service.
+    for call in chat.parent_calls:
+        assert not [
+            message
+            for message in call["messages_payload"]
+            if labeled in str(message.get("content", ""))
+        ]
+
+
+def test_only_the_threaded_fleet_child_is_wired_for_drain(db, monkeypatch):
+    """The primary's LoopDeps.drain_mailbox is None; the fleet child's is
+    the service-built closure."""
+    recorded = []
+    real_loop = agent_service.run_agent_loop
+
+    def spy(config, messages, active, deps, **kwargs):
+        recorded.append((config.system_prompt, deps.drain_mailbox))
+        return real_loop(config, messages, active, deps, **kwargs)
+
+    monkeypatch.setattr(agent_service, "run_agent_loop", spy)
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task one"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "combined answer",
+        ],
+        {"task one": ["child answer"]},
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+
+    assert outcome.status == RUN_DONE
+    primary_drains = [
+        drain
+        for prompt, drain in recorded
+        if not prompt.startswith(SUBAGENT_PROMPT_PREFIX)
+    ]
+    child_drains = [
+        drain
+        for prompt, drain in recorded
+        if prompt.startswith(SUBAGENT_PROMPT_PREFIX)
+    ]
+    assert primary_drains == [None]
+    assert len(child_drains) == 1 and child_drains[0] is not None
+
+
+def test_inline_children_and_their_primary_stay_unwired(db, monkeypatch):
+    """CHARACTERIZATION PIN (not a red -- current behavior is already
+    correct): the inline path has no handle and so no mailbox; wiring a
+    drain there would be the regression this test exists to catch."""
+    recorded = []
+    real_loop = agent_service.run_agent_loop
+
+    def spy(config, messages, active, deps, **kwargs):
+        recorded.append(deps.drain_mailbox)
+        return real_loop(config, messages, active, deps, **kwargs)
+
+    monkeypatch.setattr(agent_service, "run_agent_loop", spy)
+    service, _chat = make_inline_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "inline task"}),
+            "inline child answer",
+            "final answer",
+        ],
+        monkeypatch,
+    )
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+
+    assert outcome.status == RUN_DONE and outcome.final_text == "final answer"
+    assert len(recorded) == 2  # primary + one inline child
+    assert recorded == [None, None]

--- a/Tests/Agents/test_fleet_steering_mailbox.py
+++ b/Tests/Agents/test_fleet_steering_mailbox.py
@@ -1,0 +1,74 @@
+# Tests/Agents/test_fleet_steering_mailbox.py
+"""Fleet PR 3b Task 1: per-child steering mailbox + protocol-coherent drain.
+
+Child-side plumbing only -- no producer exists yet (send_to_agent is Task 2,
+the panel input is Task 3). Spec: 2026-08-08-supervisor-agent-fleet-design.md
+SS6 (two paths one mechanism; protocol-coherent drain; source labels) and SS3
+invariant 4 (steering never cancels). Plan:
+Docs/superpowers/plans/2026-08-17-fleet-pr3b-steering.md, Task 1.
+
+The seven plan-mandated reds live here:
+  (a) a mid-batch post is delivered only at the next boundary -- after every
+      pending tool result of the previous assistant message, before the next
+      assistant message -- asserted on the EXACT ``messages`` sequence for
+      BOTH the fence protocol and native tool-calls;
+  (b) a multi-call native batch with steering posted between dispatches never
+      interleaves the injected message among ``role:"tool"`` results;
+  (c) the restore-batch path never drains (an entry posted before a
+      provider-continuation resume survives to the post-restore turn);
+  (d) a drain under an ACTIVE provider-continuation checkpoint produces no
+      ``continuation_error``;
+  (e) a raising drain callable does not abort the run;
+  (f) concurrent post/drain from threads is safe under the coordinator lock;
+  (g) a cancelled/stuck/budget-exhausted run leaves entries queued -- a dead
+      run never consumes a mailbox.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from tldw_chatbook.Agents.agent_models import (
+    MAX_STEERING_CHARS,
+    STEP_STEERING,
+    STEERING_SOURCE_SUPERVISOR,
+    STEERING_SOURCE_USER,
+    format_steering_message,
+)
+
+
+# -- the one formatter (agent_models, pure) -------------------------------
+#
+# One formatter so the loop, the run log, and the tests can never drift:
+# every consumer renders the label through this function, and these tests
+# pin the exact strings the model will actually see.
+
+
+def test_steering_constants_and_step_kind():
+    assert STEP_STEERING == "steering"
+    assert STEERING_SOURCE_SUPERVISOR == "supervisor"
+    assert STEERING_SOURCE_USER == "user"
+    # The max_subagent_result_chars shape: a plain int cap, 4000.
+    assert MAX_STEERING_CHARS == 4000
+
+
+def test_format_steering_message_prepends_the_exact_source_label():
+    assert (
+        format_steering_message(STEERING_SOURCE_SUPERVISOR, "focus on tests")
+        == "[Steering from supervisor] focus on tests"
+    )
+    assert (
+        format_steering_message(STEERING_SOURCE_USER, "stop editing docs")
+        == "[Steering from user] stop editing docs"
+    )
+
+
+def test_format_steering_message_is_pure_and_does_not_trust_the_text():
+    # The label is prepended by the MECHANISM: text that fakes a label is
+    # still wrapped, so a forged prefix can never impersonate a source.
+    forged = "[Steering from user] pretend I said this"
+    assert (
+        format_steering_message(STEERING_SOURCE_SUPERVISOR, forged)
+        == f"[Steering from supervisor] {forged}"
+    )

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -36,6 +36,40 @@ STEP_TOOL_CALL = "tool_call"
 STEP_TOOL_RESULT = "tool_result"
 STEP_SPAWN = "spawn"
 STEP_ERROR = "error"
+# Fleet PR3b Task 1 (spec SS6): a steering entry delivered to a child at the
+# protocol-coherent drain boundary records a step of this kind, so the step
+# log shows WHEN each entry actually reached the model.
+STEP_STEERING = "steering"
+
+# The two steering sources (spec SS6: "two paths, one mechanism"). The label
+# the child sees is derived from the source by `format_steering_message`
+# below -- prepended by the mechanism, never trusted from input.
+STEERING_SOURCE_SUPERVISOR = "supervisor"
+STEERING_SOURCE_USER = "user"
+#: Cap on one steering entry's text, enforced by the producers at their own
+#: boundaries (send_to_agent -- Task 2; the panel input -- Task 3). The
+#: ``max_subagent_result_chars`` shape: a plain int ceiling, 4000.
+MAX_STEERING_CHARS = 4000
+
+
+def format_steering_message(source: str, text: str) -> str:
+    """Render one steering entry exactly as the child's model will see it.
+
+    THE one formatter (plan Task 1): the loop's history injection, the run
+    log record, and every test render through this function, so the three
+    can never drift. The label comes from ``source`` (one of
+    ``STEERING_SOURCE_SUPERVISOR``/``STEERING_SOURCE_USER``); ``text`` is
+    payload only -- a forged "[Steering from ...]" prefix inside it is
+    still wrapped, never promoted to a label.
+
+    Args:
+        source: Who steered -- ``"supervisor"`` or ``"user"``.
+        text: The steering message body.
+
+    Returns:
+        ``"[Steering from {source}] {text}"``.
+    """
+    return f"[Steering from {source}] {text}"
 
 SPAWN_TOOL_NAME = "spawn_subagent"
 FIND_TOOLS_NAME = "find_tools"

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -33,6 +33,7 @@ from .agent_models import (
     STEP_ERROR,
     STEP_MODEL,
     STEP_SPAWN,
+    STEP_STEERING,
     STEP_TOOL_CALL,
     STEP_TOOL_RESULT,
     AgentConfig,
@@ -49,6 +50,7 @@ from .agent_models import (
     ToolResult,
     ToolSchema,
     WAIT_AGENTS_TOOL_NAME,
+    format_steering_message,
 )
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationResult,
@@ -363,6 +365,24 @@ class LoopDeps:
     # child of this run"; `check_agents` takes nothing.
     wait_agents: Callable[[list[str] | None], ToolResult] | None = None
     check_agents: Callable[[], ToolResult] | None = None
+    # drain_mailbox: fleet steering (PR3b Task 1, spec SS6). Wired ONLY for
+    # a THREADED fleet child -- the service's spawn tail closes it over
+    # that child's own coordinator mailbox
+    # (`FleetCoordinator.drain_steering`); primaries and inline children
+    # get None (a primary is steered by the user talking to it; an inline
+    # child has no handle and so no mailbox). Called by the loop at the
+    # single protocol-coherent point -- in the non-restoring branch,
+    # immediately before each model call, AFTER the budget/cancel checks --
+    # returning the queued `(source, text)` entries, which the loop appends
+    # as `format_steering_message`-labeled user-role messages. Draining
+    # there can never split a native `tool_calls` <-> `role:"tool"` pair
+    # (every batch's results are fully appended by then via
+    # `_append_tool_result`), never collides with `expand_restore_history`'s
+    # slice-rewrite (the restoring branch is structurally skipped), and a
+    # dead run (cancelled/stuck/exhausted) never consumes a mailbox.
+    # Wrapped never-raise at the call site, the `on_step` containment rule:
+    # a broken drain costs the delivery, never the run.
+    drain_mailbox: Callable[[], list[tuple[str, str]]] | None = None
     # on_record: full-fidelity capture for the run log (run_log.py). Called
     # with (record_type, payload) at the two points where the COMPLETE value
     # exists -- which the step log does not carry, since `add()` truncates
@@ -900,6 +920,38 @@ def run_agent_loop(
             turn = ModelTurn(tool_calls=tuple(calls))
         else:
             restored_calls = None
+            # Fleet steering drain (PR3b Task 1) -- THE protocol-coherent
+            # point, deliberately here and nowhere else: every previous
+            # batch's results are fully appended by now (via
+            # `_append_tool_result`, both protocols), the restoring branch
+            # above is structurally skipped (so this can never collide
+            # with `expand_restore_history`'s slice-rewrite), and the
+            # budget/cancel checks at the loop top ran first (a dead run
+            # never consumes a mailbox). Wrapped never-raise like
+            # `on_step`: a broken drain costs the delivery, never the run.
+            if deps.drain_mailbox is not None:
+                try:
+                    for steer_source, steer_text in deps.drain_mailbox():
+                        steer_message = format_steering_message(
+                            steer_source, steer_text
+                        )
+                        messages.append(
+                            {"role": "user", "content": steer_message}
+                        )
+                        add(STEP_STEERING, summary=steer_message[:200])
+                        _emit_record(
+                            deps,
+                            "steering",
+                            content=steer_message,
+                            tool="",
+                            status=steer_source,
+                            call_id="",
+                        )
+                except Exception:  # noqa: BLE001 — containment, like on_step
+                    logger.opt(exception=True).warning(
+                        "drain_mailbox raised; steering delivery skipped "
+                        "for this turn"
+                    )
             turn = (
                 deps.call_model_with_continuation(
                     messages,

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -1431,6 +1431,14 @@ class AgentService:
         agent_definition: str | None = None,
         definition_fingerprint: str | None = None,
         on_run_id: Callable[[str], None] | None = None,
+        # PR3b Task 1 (fleet steering): the per-child mailbox drain, built
+        # by spawn's fleet branch as a closure over THIS child's own
+        # coordinator mailbox (`fleet.drain_steering(handle_id)`) and
+        # threaded through `child_kwargs` exactly like `on_run_id` above.
+        # None -- the default every other caller keeps -- for primaries
+        # and inline children: a primary is steered by the user talking to
+        # it, and an inline child has no handle, so no mailbox exists.
+        drain_mailbox: Callable[[], list[tuple[str, str]]] | None = None,
         run_log_writer: "RunLogWriter | None" = None,
         continuation_owner_message_id: str | None = None,
         continuation_durability: Literal["persistent", "ephemeral"] = "persistent",
@@ -1979,6 +1987,15 @@ class AgentService:
             # without cancelling the parent.
             child_cancel = threading.Event()
             child_kwargs["continuation_agent_kind"] = "fleet"
+            # PR3b Task 1: THIS child's steering drain -- a closure over
+            # its own mailbox on the conversation-lifetime coordinator,
+            # reachable from the UI thread and any turn's supervisor while
+            # the child runs on its own thread. handle_id is default-bound
+            # (the run_child style) so the closure can never pick up a
+            # later spawn's handle.
+            child_kwargs["drain_mailbox"] = (
+                lambda handle_id=handle.handle_id: fleet.drain_steering(handle_id)
+            )
             self._fleet_cancels[handle.handle_id] = child_cancel
             my_handle_ids.append(handle.handle_id)
 
@@ -2947,6 +2964,10 @@ class AgentService:
             # one it was not told about).
             wait_agents=wait_agents if fleet_active else None,
             check_agents=check_agents if fleet_active else None,
+            # PR3b Task 1: non-None ONLY for a threaded fleet child (see
+            # the parameter's own comment above); the pure loop drains it
+            # at its protocol-coherent pre-model-call point.
+            drain_mailbox=drain_mailbox,
             on_record=on_record,
             continuation_context=ContinuationEventContext(
                 owner_message_id=continuation_owner_message_id,

--- a/tldw_chatbook/Agents/fleet_coordinator.py
+++ b/tldw_chatbook/Agents/fleet_coordinator.py
@@ -73,6 +73,13 @@ class FleetHandle:
     started_at: float = 0.0
     finished_at: float | None = None
     total_tokens: int = 0
+    # PR3b Task 1 (steering). How many posted steering entries are queued
+    # for this child, still awaiting its next drain boundary -- the
+    # panel's honest "queued (N)" figure (spec SS6 latency honesty).
+    # Stored state lives in the coordinator's mailbox dict, never here:
+    # this field is COMPUTED onto the copies ``get()``/``snapshot()``
+    # return, so a stale handle copy can never disagree with the mailbox.
+    queued_steering: int = 0
 
 
 class FleetCoordinator:
@@ -96,6 +103,11 @@ class FleetCoordinator:
         self._handles: dict[str, FleetHandle] = {}
         self._live_ids: set[str] = set()  # handle_ids with status != terminal
         self._events: list[FleetEvent] = []
+        # PR3b Task 1: per-child steering mailboxes, keyed by handle id.
+        # Guarded by the same lock as every other public method. A key
+        # exists only while entries are queued (drain pops the whole
+        # list), and dies with its handle in prune_terminal.
+        self._steering: dict[str, list[tuple[str, str]]] = {}
 
     def reserve(self, task: str, agent: str | None) -> FleetHandle | None:
         """Reserve a slot for a new task, returning a handle or None if at cap.
@@ -157,6 +169,58 @@ class FleetCoordinator:
         with self._lock:
             if handle_id in self._handles and handle_id in self._live_ids:
                 self._handles[handle_id].run_id = run_id
+
+    def post_steering(self, handle_id: str, source: str, text: str) -> bool:
+        """Queue one steering entry for a LIVE child (PR3b Task 1, spec SS6).
+
+        Steering never cancels and never restarts (spec SS3 invariant 4):
+        this only appends to the child's mailbox; the child consumes it at
+        its own next protocol-coherent drain boundary
+        (``agent_runtime.run_agent_loop``'s pre-model-call drain).
+
+        Text validation (non-empty, ``MAX_STEERING_CHARS``) is the
+        PRODUCERS' job at their own boundaries -- ``send_to_agent`` (Task
+        2) and the panel input (Task 3) each need their own user-facing
+        refusal copy, which a silent bool here could not carry. The label
+        is likewise not this method's concern: the drain point renders it
+        via ``format_steering_message``, so raw ``(source, text)`` pairs
+        are what the mailbox holds.
+
+        Args:
+            handle_id: The target child's handle id.
+            source: ``STEERING_SOURCE_SUPERVISOR`` or
+                ``STEERING_SOURCE_USER``.
+            text: The steering message body (raw, unlabeled).
+
+        Returns:
+            True when queued. False for an unknown handle or a TERMINAL
+            one -- a finished child has no next model turn to deliver at,
+            and the caller must say so instead of queueing into a void
+            (Task 2's terminal branch upgrades that refusal into
+            finished-agent continuation).
+        """
+        with self._lock:
+            if handle_id not in self._handles or handle_id not in self._live_ids:
+                return False
+            self._steering.setdefault(handle_id, []).append((source, text))
+            return True
+
+    def drain_steering(self, handle_id: str) -> list[tuple[str, str]]:
+        """Return-and-clear this child's queued steering, atomically.
+
+        One locked pop: a concurrent ``post_steering`` either lands before
+        the pop (and is returned here) or after it (and waits for the next
+        drain) -- an entry is never lost or delivered twice.
+
+        Args:
+            handle_id: The child's handle id.
+
+        Returns:
+            The queued ``(source, text)`` entries in posting order; empty
+            for an unknown handle or an empty mailbox.
+        """
+        with self._lock:
+            return self._steering.pop(handle_id, [])
 
     def finish(
         self,
@@ -234,7 +298,7 @@ class FleetCoordinator:
         with self._lock:
             if handle_id not in self._handles:
                 return None
-            return dataclasses.replace(self._handles[handle_id])
+            return self._copy_with_queued(self._handles[handle_id])
 
     def snapshot(self) -> list[FleetHandle]:
         """Return a snapshot of all handles.
@@ -246,8 +310,21 @@ class FleetCoordinator:
         """
         with self._lock:
             return [
-                dataclasses.replace(h) for h in self._handles.values()
+                self._copy_with_queued(h) for h in self._handles.values()
             ]
+
+    def _copy_with_queued(self, handle: FleetHandle) -> FleetHandle:
+        """A point-in-time copy carrying the CURRENT mailbox depth.
+
+        Caller must hold ``self._lock``. ``queued_steering`` is computed
+        from the mailbox here rather than stored on the live handle, so
+        the copies ``get()``/``snapshot()`` return can never disagree with
+        what ``drain_steering`` would actually deliver.
+        """
+        return dataclasses.replace(
+            handle,
+            queued_steering=len(self._steering.get(handle.handle_id, ())),
+        )
 
     @property
     def max_live(self) -> int:
@@ -310,6 +387,11 @@ class FleetCoordinator:
             ]
             for handle_id in terminal:
                 del self._handles[handle_id]
+                # PR3b Task 1: the mailbox dies with its handle. An
+                # undelivered remnant is claimed BEFORE this point by Task
+                # 4's retention (retain_transcript runs at finish time,
+                # from run_child's finally); by prune time it is garbage.
+                self._steering.pop(handle_id, None)
             return len(terminal)
 
     def live_count(self) -> int:


### PR DESCRIPTION
## Fleet 3b Task 1 — the mailbox and the drain seam

The child-side plumbing for steering, complete and tested, with **no producer yet** — inert until `send_to_agent` (Task 2) and the panel input (Task 3) land.

- **One formatter** (`format_steering_message`) produces the `[Steering from supervisor|user]` label, so the loop, the run log, and the tests can never drift.
- **The mailbox lives on `FleetCoordinator`**, under its existing lock: `post_steering` (False for unknown/terminal), `drain_steering` (return-and-clear atomically), `queued_steering` on handle copies. Mailboxes die with `prune_terminal` — pinned, which is the window Task 4's retention claims.
- **The drain is one optional `LoopDeps` callable**, invoked at the loop's single protocol-coherent point: after every batch result appends, before the next model call, in the branch provider-continuation restore structurally never enters, and *after* the budget/cancel checks so a dead run never consumes steering.

**Seven reds** (each failing before its piece landed), including the two subtle ones: steering posted mid-batch never interleaves among `role:"tool"` results (exact `messages`-sequence assertions for both protocols), and a cancelled/stuck/budget-exhausted run leaves its entries queued. **Four mutations, no survivors** — including the ownership nuance stated rather than glossed: the late-post variants of the dead-run tests pass the check-ordering mutation *by construction* and are owned by the drain-position mutation instead.

Purity preserved: zero imports added to the three pure modules. Gate: `Tests/Agents/` 1462→1484 (+22 = the new suite), bridge 197, fanout 7. Delivered entries cost one `max_steps` step each — negligible at defaults, noted in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-child steering mailbox and a single drain point that injects queued steering into threaded fleet children before each model call. Previously steering could not be queued or delivered; now `FleetCoordinator.post_steering` enqueues entries that the loop drains and appends as labeled user messages, without splitting tool-call batches. Dead or exhausted runs do not consume mailboxes.

- `FleetCoordinator`: adds `post_steering(handle_id, source, text) -> bool`, `drain_steering(handle_id) -> list[(source, text)]`, and `queued_steering` on `get()`/`snapshot()` copies. Mailboxes are per child and cleared at `prune_terminal`.
- `agent_runtime`: adds `LoopDeps.drain_mailbox` and drains at the non-restoring, pre-model-call boundary (after budget/cancel, after tool results). Each delivered entry appends `format_steering_message(...)`, records a `STEP_STEERING` step, and emits a `"steering"` run-log record with `status=source`. Drain exceptions are contained and do not abort runs.
- `agent_service`: wires `drain_mailbox` only for threaded fleet children via a closure over `fleet.drain_steering(handle_id)`. Primaries and inline children remain unwired (no behavior change).
- `agent_models`: adds `STEP_STEERING`, `STEERING_SOURCE_SUPERVISOR`/`USER`, `MAX_STEERING_CHARS = 4000`, and a single `format_steering_message` used by loop and logs.

**Review focus**
- Verify drain placement in `run_agent_loop`: outside the restore path, after tool results, and after budget/cancel checks.
- Check that child wiring binds the correct handle id in `spawn` and that primaries/inline paths keep `drain_mailbox=None`.
- Confirm `drain_steering` is atomic under the coordinator lock and that `queued_steering` is computed on copies.

**Rollout notes**
- No migrations required. Producers must validate text and call `post_steering` in follow-up work; this PR only enables delivery. Each delivered entry consumes one step from `max_steps` (negligible at defaults).

<sup>Written for commit e39e615c743fec44f37a9212db3653b62052d906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

