### PR TITLE
feat(agents): send_to_agent — the supervisor steers live children (fleet 3b Task 2)

### DIFF
--- a/Docs/superpowers/plans/2026-08-17-fleet-pr3b-task2-report.md
+++ b/Docs/superpowers/plans/2026-08-17-fleet-pr3b-task2-report.md
@@ -1,0 +1,158 @@
+# Fleet PR 3b — Task 2 landing report: `send_to_agent` for live children
+
+Branch `feat/fleet-3b-send-to-agent`, from origin/dev `3b069d0be` (the
+Task 1 mailbox merge, PR #1776). Plan:
+`2026-08-17-fleet-pr3b-steering.md`, Task 2 (the supervisor producer for
+Task 1's per-child mailbox). Spec bindings: §6 (two paths one mechanism,
+latency honesty), §3 invariant 4 (steering never cancels). Task 1's
+binding decision honored: **`post_steering` does not validate — the
+producer does**, with its own refusal copy per shape.
+
+## The surviving red suite
+
+A prior agent's untracked `Tests/Agents/test_fleet_send_to_agent.py`
+survived in the worktree. Verdict: **usable, and used** — every
+plan-mandated red was present and correctly constructed against the real
+fixtures (`make_fleet_service`/`FleetChat`/`CARD_CFG`), including the
+armed-and-held approval round and the forged handle/run-id collision.
+One repair was needed (below); everything else landed verbatim. It was
+committed in the first push for loss protection.
+
+## What landed (four commits, pushed incrementally)
+
+1. `81e273606` — `agent_models.py` (pure): `SEND_TO_AGENT_TOOL_NAME =
+   "send_to_agent"` joins `RUNTIME_TOOL_NAMES`; the two exact-set pins
+   (`test_agent_models.py`, `test_install_skill_runtime_tool.py`) grow
+   the name; the red suite lands.
+2. `661476d07` — `tool_catalog.py`: `SEND_TO_AGENT_SCHEMA` beside the
+   fleet schemas. `{id, message}`, BOTH required (unlike `wait_agents`'
+   optional `ids` — an id-less or message-less steer has no meaning).
+   The description teaches both id vocabularies (handle ids from spawn
+   results/`check_agents`; run ids from completion notices), honest
+   latency (next model turn; a long tool call delays it), and
+   never-cancels/never-restarts.
+3. `d6000451f` — `agent_runtime.py` (pure): `LoopDeps.send_to_agent`
+   (default `None`) + an in-loop dispatch branch in the `wait_agents`
+   shape with the same defensive coercion — non-strings become `str()`,
+   missing/null become `""`, so junk gets the service's refusal copy,
+   never a loop crash. No new imports beyond the `agent_models` name.
+4. `e1467b313` — `agent_service.py`: the closure beside `wait_agents`,
+   schema pinned + dep wired under the EXACT `fleet_active` predicate
+   (primary-only is inherited: `fleet` is `None` for every sub-agent).
+   Producer-boundary validation (non-empty after strip;
+   `MAX_STEERING_CHARS` cap, boundary-exact). Ok copy: "queued; …
+   delivered before its next model turn", naming the RESOLVED handle id.
+   Terminal refusal states the child finished and names the live ids;
+   the branch carries Task 4's continuation-seam comment. Unknown-id and
+   junk refusals name the offending id and the live ids.
+
+## Id resolution: handle id FIRST, then a live handle's run id, whole coordinator
+
+- **Order.** The coordinator minted the handle id as the primary
+  vocabulary — spawn results, `check_agents`, and the panel rows all
+  speak it — so a pathological collision (child A's run id equals child
+  B's handle id) must land on B, the handle-id owner. Mutation 1 proves
+  the order is load-bearing.
+- **Reach.** Resolution runs over `fleet.snapshot()`, never
+  `my_handle_ids`: a live survivor another turn's service spawned is
+  steerable, because the mailbox lives on the conversation-lifetime
+  coordinator and needs no per-service state — deliberately unlike
+  `cancel_subagent`, whose retained-owner walk exists only because
+  cancel Events are service-local. Mutation 4 proves the reach is
+  load-bearing.
+- **Race.** If the target goes terminal between the snapshot and the
+  post (`post_steering` returns False), the closure re-snapshots and
+  falls into the terminal refusal instead of claiming success.
+
+## The reds — before/after, measured in stages
+
+Stage 0 (untouched branch): the whole suite dies at collection —
+`ImportError: cannot import name 'SEND_TO_AGENT_TOOL_NAME'`. After
+commit 1: collection ImportError on `SEND_TO_AGENT_SCHEMA`. After
+commit 2: **13 failed, 2 passed** (the two registration tests go green).
+After commit 3: unchanged 13/2 (the dep is still None everywhere).
+After commit 4: **15 passed**.
+
+| Red | Before (post-schema stage) | After |
+|---|---|---|
+| schema absent without a fleet / present with one | `assert 'send_to_agent' in <fleet primary's system prompt>` fails | pass |
+| primary-only + child's hallucinated call refused | child-prompt/parent-prompt assertions fail | pass — child never sees it; its call → "Tool not permitted" |
+| end-to-end via fake provider | child's 2nd payload ends at the tool result, no labeled message | pass — `[Steering from supervisor]`-labeled user message LAST, after the tool result |
+| empty-message refusal | no ERROR record | pass — own copy ("empty"), nothing queued |
+| oversize refusal + at-cap acceptance | no ERROR record | pass — "too long" names 4000; at-cap queued |
+| unknown-id refusal | no ERROR record | pass — names `'nope'` AND the live ids |
+| terminal id (handle AND run id) | no ERROR record | pass — "finished", "Live sub-agent ids: none" |
+| run id reaches the same mailbox | no labeled message | pass — ok copy names the resolved HANDLE id |
+| handle id beats colliding run id | no post at all | pass — B's mailbox (0, 1) |
+| junk args never crash | crash-adjacent path unwired | pass — coerced `'123'` named in the refusal |
+| steering never cancels | no post to measure | pass — mid-turn status/row/Event untouched; ends DONE |
+| steering never satisfies an approval | no post to measure | pass — verdict pending, tool unexecuted, entry queued; delivered only at the post-approval boundary |
+| foreign live survivor steerable | no post | pass — fresh service, shared coordinator, RUNNING after the post |
+
+## One test repair — attributed at origin/dev BEFORE touching it
+
+`test_steering_never_cancels_the_child` asserted the child's raw cancel
+Event is unset AFTER `run_turn` returns. That failed — and the failure
+is **origin/dev behavior, not this branch's**: `_settle_fleet` sets
+every settling child's Event unconditionally at end of turn, documented
+in-line as "for an already-finished fleet every Event set here is
+inert". The settle path is byte-identical to origin/dev in this branch's
+diff (verified: no settle/cancel lines in `git diff origin/dev`). The
+assertion pinned a promise dev never made; it was replaced with the
+honest end-state (coordinator DONE + run row DONE, i.e. not CANCELLED)
+with a comment citing `_settle_fleet`. The invariant's real measurement
+— the mid-turn probe that the POST itself touched neither status, row,
+nor Event — stands unchanged.
+
+## Mutations — six, all killed, restores Edit-based with `git diff` proof
+
+| Mutation | Kills |
+|---|---|
+| 1. run-id resolved BEFORE handle-id (mandated) | exactly `test_a_live_handle_id_beats_a_colliding_run_id` |
+| 2. schema wired under `agent_kind == SUBAGENT` (mandated) | primary-only gate test + schema-offered test |
+| 3. posted with source `"user"` instead of SUPERVISOR | 5 died — every exact-label payload assertion (end-to-end, run-id, never-cancels, approval, foreign-survivor) |
+| 4. resolution scoped to `my_handle_ids` | exactly `test_a_foreign_live_survivor_is_steerable` |
+| 5. cap check `>=` instead of `>` | exactly the oversize/at-cap boundary test |
+| 6. empty-message refusal dropped | exactly the empty-message test |
+
+No survivors. The registration tests are killed by the stage reds
+(collection ImportError before their pieces landed).
+
+## Gate (read counts; baselines on the untouched branch first)
+
+| Suite | Baseline | Final |
+|---|---|---|
+| `Tests/Agents/test_fleet_send_to_agent.py` (new) | — (ImportError) | **15 passed** |
+| `Tests/Agents/test_fleet_steering_mailbox.py` (Task 1) | 22 passed | **22 passed** |
+| `Tests/Agents/test_fleet_runtime.py` | 107 passed | **107 passed** |
+| `Tests/Agents/` (full) | 1484 passed (new suite excluded) | **1499 passed** (= 1484 + 15) |
+| `Tests/Chat/test_console_agent_bridge.py` | 197 passed | **197 passed** |
+| `Tests/UI/test_console_mcp_approval.py` | 74 passed | **74 passed** |
+| `Tests/test_probe_import_provenance.py` | 1 passed | **1 passed** |
+
+## Notes and concerns for Tasks 3–4
+
+- **Task 3 (panel steering)**: `bridge.steer_subagent` should reuse this
+  closure's resolution SHAPE (handle-then-run-id over the whole
+  coordinator) but must re-implement validation at ITS boundary with
+  panel-facing copy — the same rule Task 1 pinned for this task. The
+  `queued_steering` count on `get()`/`snapshot()` copies is already
+  computed for its "queued (N)" surface.
+- **Task 4 (continuation)**: the terminal branch to upgrade is marked
+  in-line in the closure ("PR3b Task 4's continuation seam"). Two facts
+  it inherits: (a) the terminal lookup already speaks BOTH vocabularies
+  (the terminal-refusal test steers by the finished child's run id too —
+  keep that working when the branch becomes a resume); (b) the lookup
+  only sees handles still on the coordinator — after `prune_terminal`
+  at next turn-start, a finished child's ids fall through to the
+  UNKNOWN-id refusal, so continuation must resolve against the retention
+  store FIRST or restarted-away children will get the wrong copy.
+- **Settle sets Events on finished children** (the repaired test's
+  lesson): any future "steering never cancels" or Stop-semantics
+  assertion (Task 5) must probe Events MID-TURN or assert
+  status/row end-state — a post-`run_turn` raw-Event read measures
+  `_settle_fleet`, not the feature under test.
+- The empty-string id coercion in the dispatch branch means a missing
+  `id` arg reaches the closure as `""` and gets the unknown-id refusal
+  naming `''` — acceptable copy, but Task 3's input path should simply
+  disable submit on an empty target instead.

--- a/Tests/Agents/test_agent_models.py
+++ b/Tests/Agents/test_agent_models.py
@@ -19,6 +19,7 @@ from tldw_chatbook.Agents.agent_models import (
     RUN_SUPERSEDED,
     RUNTIME_TOOL_NAMES,
     SEARCH_RUN_LOG_TOOL_NAME,
+    SEND_TO_AGENT_TOOL_NAME,
     SPAWN_TOOL_NAME,
     TERMINAL_RUN_STATUSES,
     AgentConfig,
@@ -69,6 +70,7 @@ def test_runtime_tool_names():
         RUN_LOG_SLICE_TOOL_NAME,
         WAIT_AGENTS_TOOL_NAME,
         CHECK_AGENTS_TOOL_NAME,
+        SEND_TO_AGENT_TOOL_NAME,
     }
     assert DIRECT_DISCLOSE_THRESHOLD == 16 and LOOP_DETECTION_N == 3
 

--- a/Tests/Agents/test_fleet_send_to_agent.py
+++ b/Tests/Agents/test_fleet_send_to_agent.py
@@ -1,0 +1,918 @@
+# Tests/Agents/test_fleet_send_to_agent.py
+"""Fleet PR 3b Task 2: ``send_to_agent`` -- the supervisor steering producer.
+
+The first producer for Task 1's per-child mailbox (spec SS6 "two paths one
+mechanism"; SS3 invariant 4 "steering never cancels"). Plan:
+Docs/superpowers/plans/2026-08-17-fleet-pr3b-steering.md, Task 2.
+
+The plan-mandated reds live here:
+  - the schema is offered only to a fleet-active PRIMARY: absent without a
+    fleet, absent for a sub-agent (depth-1: children cannot steer each
+    other), and a child's hallucinated call is refused like any other
+    undisclosed name;
+  - end-to-end through the fake provider: the supervisor calls the tool
+    and the child's next model-turn payload carries the
+    ``[Steering from supervisor]``-labeled user-role message, LAST, after
+    the batch's tool results;
+  - refusal shapes, each with its own copy: empty message, oversize
+    message, unknown id (the producers validate -- Task 1 deliberately
+    left ``post_steering`` unvalidating);
+  - id resolution speaks BOTH vocabularies (handle id from spawn results /
+    check_agents; run id from completion notices), resolves over the WHOLE
+    coordinator (a foreign live survivor is steerable -- steering, unlike
+    cancel, needs no per-service state), and prefers the handle id when a
+    forged run id collides with another child's handle id;
+  - steering never cancels: after a post the child's coordinator status,
+    its run row, and its cancel Event are all untouched;
+  - steering never satisfies an approval: with a real approval round armed
+    and held open, a steering post leaves the verdict pending, the gated
+    tool unexecuted, and the entry queued -- delivered only after the
+    round resolves (mirroring the wake's not-user-input pin,
+    ``console_fleet_wake.WAKE_NOTICE_DISCLAIMER``).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from Tests.Agents.test_agent_service import FleetChat, fence
+from Tests.Agents.test_fleet_runtime import (
+    _JOIN_TIMEOUT,
+    CARD_CFG,
+    FLEET_CFG,
+    _child_row,
+    _tool_results,
+    _wait_until,
+    make_fleet_service,
+    make_inline_service,
+)
+from tldw_chatbook.Agents.agent_models import (
+    FENCE_TOOL_RESULT_PREFIX,
+    MAX_STEERING_CHARS,
+    RUN_DONE,
+    RUN_RUNNING,
+    RUNTIME_TOOL_NAMES,
+    SEND_TO_AGENT_TOOL_NAME,
+    SPAWN_TOOL_NAME,
+    STEERING_SOURCE_SUPERVISOR,
+    TERMINAL_RUN_STATUSES,
+    WAIT_AGENTS_TOOL_NAME,
+    format_steering_message,
+)
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator
+from tldw_chatbook.Agents.tool_catalog import (
+    SEND_TO_AGENT_SCHEMA,
+    BuiltinToolProvider,
+    ToolCatalogRegistry,
+)
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+#: How long a parked approval card waits for the test to answer it.
+_CARD_TIMEOUT = 10.0
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return AgentRunsDB(tmp_path / "runs.db", client_id="test")
+
+
+def _live_running_handle(coordinator):
+    """The single RUNNING handle -- these scripts keep at most one live."""
+    return next(h for h in coordinator.snapshot() if h.status == RUN_RUNNING)
+
+
+def _sends(db, run_id):
+    """The supervisor's recorded send_to_agent results, in order."""
+    return _tool_results(db.get_run(run_id), SEND_TO_AGENT_TOOL_NAME)
+
+
+# -- registration (the runtime-tool mandate: name + set + schema) ---------
+
+
+def test_send_to_agent_is_a_registered_runtime_tool():
+    assert SEND_TO_AGENT_TOOL_NAME == "send_to_agent"
+    assert SEND_TO_AGENT_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert SEND_TO_AGENT_SCHEMA.name == SEND_TO_AGENT_TOOL_NAME
+    assert SEND_TO_AGENT_SCHEMA.id == "runtime:send_to_agent"
+    # BOTH parameters are required -- an id-less or message-less steer has
+    # no meaning, unlike wait_agents' optional ids.
+    assert SEND_TO_AGENT_SCHEMA.parameters["required"] == ["id", "message"]
+    assert SEND_TO_AGENT_SCHEMA.parameters["properties"]["id"]["type"] == "string"
+    assert (
+        SEND_TO_AGENT_SCHEMA.parameters["properties"]["message"]["type"] == "string"
+    )
+
+
+def test_the_schema_teaches_ids_latency_and_never_cancels():
+    """The description is the supervisor's whole curriculum: both id
+    vocabularies, the delivery latency (next model turn; a long tool call
+    delays it), and that steering never cancels or restarts the child."""
+    text = SEND_TO_AGENT_SCHEMA.description
+    assert "handle id" in text
+    assert "run id" in text
+    assert "next model turn" in text
+    assert "long tool call" in text
+    assert "never cancels" in text
+    param_doc = SEND_TO_AGENT_SCHEMA.parameters["properties"]["id"]["description"]
+    assert "handle id" in param_doc and "run id" in param_doc
+
+
+# -- gating: fleet-active primaries only ----------------------------------
+
+
+def test_schema_offered_with_a_fleet_and_absent_without(db, monkeypatch):
+    """The schema rides the exact `fleet_active` predicate wait_agents
+    uses: offered to a primary with a live fleet, absent on the inline
+    path (max_live 1 -- there is no mailbox to post into)."""
+    service, chat, _coordinator = make_fleet_service(db, ["just answering"], {})
+    service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    fleet_prompt = chat.parent_calls[0]["messages_payload"][0]["content"]
+    assert SEND_TO_AGENT_TOOL_NAME in fleet_prompt
+
+    inline_service, inline_chat = make_inline_service(
+        db, ["just answering"], monkeypatch
+    )
+    inline_service.run_turn(
+        conversation_id="c2",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    inline_prompt = inline_chat.calls[0]["messages_payload"][0]["content"]
+    assert SEND_TO_AGENT_TOOL_NAME not in inline_prompt
+
+
+def test_schema_is_primary_only_and_a_childs_call_is_refused(db):
+    """Depth-1: children cannot steer each other. A sub-agent never sees
+    the schema, and its hallucinated call falls through to the ordinary
+    permission path like any other undisclosed tool name."""
+    service, chat, _coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "child task"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "done",
+        ],
+        {
+            "child task": [
+                # The child tries to steer a sibling anyway.
+                fence(SEND_TO_AGENT_TOOL_NAME, {"id": "some-id", "message": "hi"}),
+                "child recovered",
+            ]
+        },
+    )
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    parent_prompt = chat.parent_calls[0]["messages_payload"][0]["content"]
+    assert SEND_TO_AGENT_TOOL_NAME in parent_prompt
+    child_prompt = chat.child_calls["child task"][0]["messages_payload"][0]["content"]
+    assert SEND_TO_AGENT_TOOL_NAME not in child_prompt
+    child = next(r for r in db.list_runs("c") if r["agent_kind"] == "subagent")
+    refusals = _tool_results(child, SEND_TO_AGENT_TOOL_NAME)
+    assert refusals and "not permitted" in refusals[0]
+
+
+# -- the supervisor path, end to end --------------------------------------
+
+
+def test_supervisor_steers_a_live_child_end_to_end(db):
+    """The whole seam: the supervisor calls the tool, the ok copy states
+    queued-plus-latency honestly, and the child's next model-turn payload
+    ends with the ``[Steering from supervisor]``-labeled user message,
+    after the batch's tool result -- Task 1's coherent boundary."""
+    entered = threading.Event()
+    steered = threading.Event()
+    holder: dict = {}
+
+    def steer():
+        assert entered.wait(_JOIN_TIMEOUT), "the child never reached its model call"
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "wrap up quickly"},
+        )
+
+    def release_then_wait():
+        steered.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert steered.wait(_JOIN_TIMEOUT), "the supervisor never finished steering"
+        return fence("calculator", {"expression": "6*7"})
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "steer target"}),
+            steer,
+            release_then_wait,
+            "combined answer",
+        ],
+        {"steer target": [gated_child, "child answer"]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "wrap up quickly")
+    assert labeled.startswith("[Steering from supervisor] ")
+    child_turns = chat.child_calls["steer target"]
+    assert len(child_turns) == 2
+    second_payload = child_turns[1]["messages_payload"]
+    assert second_payload[-1] == {"role": "user", "content": labeled}
+    assert str(second_payload[-2]["content"]).startswith(
+        f"{FENCE_TOOL_RESULT_PREFIX}calculator:"
+    )
+    # The ok copy is the spec's latency honesty: queued, delivered before
+    # the child's next model turn -- never "delivered now".
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" not in sends[0]
+    assert "queued" in sends[0] and "next model turn" in sends[0]
+    # Consumed from the mailbox, and the label never leaks into the
+    # SUPERVISOR's own payloads (the mechanism prepends it for the child).
+    assert coordinator.get(holder["handle_id"]).queued_steering == 0
+    for call in chat.parent_calls:
+        assert not any(
+            labeled in str(m.get("content", "")) for m in call["messages_payload"]
+        )
+
+
+# -- refusal shapes: the producer validates (Task 1 pinned that the
+# -- mailbox does NOT) ----------------------------------------------------
+
+
+def test_an_empty_message_is_refused_and_nothing_is_queued(db):
+    entered = threading.Event()
+    released = threading.Event()
+    holder: dict = {}
+
+    def steer_empty():
+        assert entered.wait(_JOIN_TIMEOUT)
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "   \n\t "},
+        )
+
+    def capture_then_wait():
+        holder["queued_after_refusal"] = (
+            holder["coordinator"].get(holder["handle_id"]).queued_steering
+        )
+        released.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "child answer"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "the task"}),
+            steer_empty,
+            capture_then_wait,
+            "done",
+        ],
+        {"the task": [gated_child]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" in sends[0] and "empty" in sends[0]
+    assert holder["queued_after_refusal"] == 0
+
+
+def test_an_oversize_message_is_refused_and_the_cap_itself_is_accepted(db):
+    """Over the cap: refused, naming the cap. AT the cap: accepted --
+    the boundary is exact, not off by one."""
+    entered = threading.Event()
+    released = threading.Event()
+    holder: dict = {}
+
+    def steer_oversize():
+        assert entered.wait(_JOIN_TIMEOUT)
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "x" * (MAX_STEERING_CHARS + 1)},
+        )
+
+    def steer_at_cap():
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": holder["handle_id"], "message": "y" * MAX_STEERING_CHARS},
+        )
+
+    def capture_then_wait():
+        holder["queued"] = (
+            holder["coordinator"].get(holder["handle_id"]).queued_steering
+        )
+        released.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "child answer"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "the task"}),
+            steer_oversize,
+            steer_at_cap,
+            capture_then_wait,
+            "done",
+        ],
+        {"the task": [gated_child]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    sends = _sends(db, run_id)
+    assert len(sends) == 2
+    assert "ERROR" in sends[0] and "too long" in sends[0]
+    assert str(MAX_STEERING_CHARS) in sends[0]
+    assert "ERROR" not in sends[1] and "queued" in sends[1]
+    # Only the at-cap entry was queued; the child never took another model
+    # turn, so it is still sitting in the mailbox (Task 1 pinned that an
+    # undrained entry survives finish).
+    assert holder["queued"] == 1
+
+
+def test_an_unknown_id_is_refused_naming_the_live_ids(db):
+    entered = threading.Event()
+    released = threading.Event()
+    holder: dict = {}
+
+    def steer_unknown():
+        assert entered.wait(_JOIN_TIMEOUT)
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME, {"id": "nope", "message": "hello?"}
+        )
+
+    def release_then_wait():
+        released.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "child answer"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "the task"}),
+            steer_unknown,
+            release_then_wait,
+            "done",
+        ],
+        {"the task": [gated_child]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" in sends[0]
+    assert "'nope'" in sends[0]
+    # The error NAMES the known live ids, so the supervisor can correct
+    # itself without a check_agents round trip.
+    assert holder["handle_id"] in sends[0]
+    # Nothing landed anywhere.
+    assert coordinator.get(holder["handle_id"]).queued_steering == 0
+
+
+def test_a_terminal_id_states_the_child_has_finished(db):
+    """Steering a FINISHED child -- by its handle id or its run id -- is
+    refused with copy saying it finished, with no live ids left to name.
+    (PR3b Task 4 upgrades this branch to continuation; this pins the
+    pre-continuation refusal.)"""
+    holder: dict = {}
+
+    def steer_terminal_handle():
+        def _finished():
+            handles = holder["coordinator"].snapshot()
+            return bool(handles) and all(
+                h.status in TERMINAL_RUN_STATUSES for h in handles
+            )
+
+        _wait_until(_finished, "the quick child never finished")
+        [handle] = holder["coordinator"].snapshot()
+        holder["handle_id"], holder["run_id"] = handle.handle_id, handle.run_id
+        assert holder["run_id"], "precondition: the finished child has a run id"
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "too late"},
+        )
+
+    def steer_terminal_run_id():
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": holder["run_id"], "message": "still too late"},
+        )
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "quick task"}),
+            steer_terminal_handle,
+            steer_terminal_run_id,
+            "done",
+        ],
+        {"quick task": ["quick answer"]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    sends = _sends(db, run_id)
+    assert len(sends) == 2
+    for send in sends:
+        assert "ERROR" in send and "finished" in send
+        assert "Live sub-agent ids: none" in send
+
+
+# -- id vocabularies: run id resolves too; handle id wins a collision -----
+
+
+def test_a_run_id_reaches_the_same_mailbox_as_the_handle_id(db):
+    """The wake notice speaks run ids (`console_fleet_wake` identity
+    vocabulary); a supervisor pasting one must reach the same child."""
+    entered = threading.Event()
+    steered = threading.Event()
+    holder: dict = {}
+
+    def steer_by_run_id():
+        assert entered.wait(_JOIN_TIMEOUT)
+        _wait_until(
+            lambda: _live_running_handle(holder["coordinator"]).run_id is not None,
+            "the child never got a run id attached",
+        )
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.run_id, "message": "addressed by run id"},
+        )
+
+    def release_then_wait():
+        steered.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert steered.wait(_JOIN_TIMEOUT)
+        return fence("calculator", {"expression": "2+2"})
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "run id target"}),
+            steer_by_run_id,
+            release_then_wait,
+            "combined answer",
+        ],
+        {"run id target": [gated_child, "child answer"]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    labeled = format_steering_message(
+        STEERING_SOURCE_SUPERVISOR, "addressed by run id"
+    )
+    second_payload = chat.child_calls["run id target"][1]["messages_payload"]
+    assert second_payload[-1] == {"role": "user", "content": labeled}
+    # The ok copy names the HANDLE the run id resolved to -- proof the two
+    # vocabularies land on one mailbox, not two.
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" not in sends[0]
+    assert holder["handle_id"] in sends[0]
+    assert coordinator.get(holder["handle_id"]).queued_steering == 0
+
+
+def test_a_live_handle_id_beats_a_colliding_run_id(db):
+    """Resolution order: handle id FIRST, then a live handle's run id.
+
+    The coordinator minted the handle id for exactly this purpose --
+    check_agents, spawn results and the panel rows all speak it -- so a
+    (forged here, pathological anywhere) collision where child A's run id
+    equals child B's handle id must resolve to B. Mutation target: swap
+    the resolution order and this dies."""
+    entered_a = threading.Event()
+    entered_b = threading.Event()
+    released = threading.Event()
+    holder: dict = {}
+
+    def child_a():
+        entered_a.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "done a"
+
+    def child_b():
+        entered_b.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "done b"
+
+    def collide_then_steer():
+        assert entered_a.wait(_JOIN_TIMEOUT) and entered_b.wait(_JOIN_TIMEOUT)
+        coordinator = holder["coordinator"]
+        a = next(h for h in coordinator.snapshot() if h.task == "task a")
+        b = next(h for h in coordinator.snapshot() if h.task == "task b")
+        holder["a"], holder["b"] = a.handle_id, b.handle_id
+        # Forge the collision: A's run id becomes B's handle id.
+        coordinator.attach_run(a.handle_id, b.handle_id)
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": b.handle_id, "message": "for b only"},
+        )
+
+    def capture_then_wait():
+        coordinator = holder["coordinator"]
+        holder["queued"] = (
+            coordinator.get(holder["a"]).queued_steering,
+            coordinator.get(holder["b"]).queued_steering,
+        )
+        released.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "task a"}),
+            fence(SPAWN_TOOL_NAME, {"task": "task b"}),
+            collide_then_steer,
+            capture_then_wait,
+            "done",
+        ],
+        {"task a": [child_a], "task b": [child_b]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    # The message landed in B's mailbox and only B's.
+    assert holder["queued"] == (0, 1)
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" not in sends[0] and holder["b"] in sends[0]
+    # Neither child took another model turn, so B's entry is still queued
+    # after the run -- and A's mailbox stayed empty throughout.
+    assert coordinator.get(holder["b"]).queued_steering == 1
+    assert coordinator.get(holder["a"]).queued_steering == 0
+
+
+def test_junk_args_never_crash_the_loop(db):
+    """The in-loop dispatch coerces junk exactly like wait_agents' ids: a
+    numeric id/message never raises; the coerced id just fails to match
+    and the service's own refusal copy comes back."""
+    entered = threading.Event()
+    released = threading.Event()
+    holder: dict = {}
+
+    def steer_junk():
+        assert entered.wait(_JOIN_TIMEOUT)
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(SEND_TO_AGENT_TOOL_NAME, {"id": 123, "message": 456})
+
+    def release_then_wait():
+        released.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert released.wait(_JOIN_TIMEOUT)
+        return "child answer"
+
+    service, _chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "the task"}),
+            steer_junk,
+            release_then_wait,
+            "done",
+        ],
+        {"the task": [gated_child]},
+    )
+    holder["coordinator"] = coordinator
+    run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    sends = _sends(db, run_id)
+    assert sends and "ERROR" in sends[0] and "'123'" in sends[0]
+    assert coordinator.get(holder["handle_id"]).queued_steering == 0
+
+
+# -- spec SS3 invariant 4: steering never cancels --------------------------
+
+
+def test_steering_never_cancels_the_child(db):
+    """After a successful post: coordinator status untouched, run row
+    untouched, cancel Event unset -- and still unset after the child has
+    consumed the message and finished on its own terms."""
+    entered = threading.Event()
+    steered = threading.Event()
+    holder: dict = {}
+
+    def steer():
+        assert entered.wait(_JOIN_TIMEOUT)
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "keep going"},
+        )
+
+    def capture_then_wait():
+        coordinator = holder["coordinator"]
+        hid = holder["handle_id"]
+        holder["status_after_post"] = coordinator.get(hid).status
+        holder["row_after_post"] = _child_row(db)["status"]
+        holder["cancel_set_after_post"] = (
+            holder["service"]._fleet_cancels[hid].is_set()
+        )
+        steered.set()
+        return fence(WAIT_AGENTS_TOOL_NAME, {})
+
+    def gated_child():
+        entered.set()
+        assert steered.wait(_JOIN_TIMEOUT)
+        return fence("calculator", {"expression": "1+1"})
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "steady task"}),
+            steer,
+            capture_then_wait,
+            "combined answer",
+        ],
+        {"steady task": [gated_child, "child done"]},
+    )
+    holder["coordinator"] = coordinator
+    holder["service"] = service
+    _run_id, outcome = service.run_turn(
+        conversation_id="c",
+        messages=[{"role": "user", "content": "go"}],
+        config=FLEET_CFG,
+        api_endpoint="llama_cpp",
+    )
+    assert outcome.status == RUN_DONE
+    # Right after the post: nothing about the child moved.
+    assert holder["status_after_post"] == RUN_RUNNING
+    assert holder["row_after_post"] == RUN_RUNNING
+    assert holder["cancel_set_after_post"] is False
+    # And at the end: the child consumed the message, finished DONE, and
+    # its cancel Event was never set by anything on this path.
+    hid = holder["handle_id"]
+    assert service._fleet_cancels[hid].is_set() is False
+    assert coordinator.get(hid).status == RUN_DONE
+    assert _child_row(db)["status"] == RUN_DONE
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "keep going")
+    second_payload = chat.child_calls["steady task"][1]["messages_payload"]
+    assert second_payload[-1] == {"role": "user", "content": labeled}
+
+
+# -- steering never satisfies an approval ---------------------------------
+
+
+def test_steering_never_satisfies_a_pending_approval(db):
+    """A real approval round is armed and HELD OPEN (the child parked
+    inside `review_tool_calls`, where the Console parks). Steering posted
+    at that moment leaves the verdict pending, the gated tool unexecuted,
+    and the entry queued; only after the human answers does the tool run
+    -- and only at the NEXT boundary does the steering arrive. This is
+    the wake's not-user-input guarantee, mirrored for steering."""
+    parked = threading.Event()
+    answered = threading.Event()
+    review_finished = threading.Event()
+    holder: dict = {}
+
+    def review(calls, run_id):
+        # Only the CHILD's calculator call parks; the parent's own
+        # spawn/steer batches must sail through or the turn deadlocks.
+        if any(call.name == "calculator" for call in calls):
+            parked.set()
+            if not answered.wait(_CARD_TIMEOUT):
+                raise AssertionError("the card was never answered")
+            review_finished.set()
+        return {}
+
+    def steer_at_the_card():
+        assert parked.wait(_CARD_TIMEOUT), "the child never armed its card"
+        handle = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = handle.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": handle.handle_id, "message": "steer at the card"},
+        )
+
+    def capture():
+        coordinator = holder["coordinator"]
+        hid = holder["handle_id"]
+        holder["review_finished"] = review_finished.is_set()
+        holder["answered"] = answered.is_set()
+        holder["child_turns"] = len(holder["chat"].child_calls["gated task"])
+        child_row = _child_row(db)
+        holder["calc_steps"] = _tool_results(
+            db.get_run(child_row["id"]), "calculator"
+        )
+        holder["queued"] = coordinator.get(hid).queued_steering
+        holder["cancel_set"] = holder["service"]._fleet_cancels[hid].is_set()
+        return "parent answered early"
+
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "gated task"}),
+            steer_at_the_card,
+            capture,
+        ],
+        {
+            "gated task": [
+                fence("calculator", {"expression": "1+1"}),
+                "child done",
+            ]
+        },
+        review_tool_calls=review,
+    )
+    holder["coordinator"] = coordinator
+    holder["service"] = service
+    holder["chat"] = chat
+    try:
+        _run_id, outcome = service.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go"}],
+            config=CARD_CFG,
+            api_endpoint="llama_cpp",
+        )
+        assert outcome.status == RUN_DONE
+        # At the moment after the steering post, with the card still held:
+        assert holder["review_finished"] is False, "steering resolved the verdict"
+        assert holder["answered"] is False
+        assert holder["child_turns"] == 1, "the child took a turn past its card"
+        assert holder["calc_steps"] == [], "the gated tool executed"
+        assert holder["queued"] == 1, "the steering entry was not left queued"
+        assert holder["cancel_set"] is False
+    finally:
+        # The human approves -- after the turn, like the survivor-card pin.
+        answered.set()
+    _wait_until(coordinator.all_finished, "the approved child never finished")
+    assert review_finished.is_set()
+    # The gate released for real, and the steering arrived only at the
+    # post-approval boundary: tool result first, steering last.
+    child_turns = chat.child_calls["gated task"]
+    assert len(child_turns) == 2
+    payload = child_turns[1]["messages_payload"]
+    labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "steer at the card")
+    assert payload[-1] == {"role": "user", "content": labeled}
+    assert str(payload[-2]["content"]).startswith(
+        f"{FENCE_TOOL_RESULT_PREFIX}calculator:"
+    )
+    calc = _tool_results(db.get_run(_child_row(db)["id"]), "calculator")
+    assert calc and "2" in calc[0]
+    hid = holder["handle_id"]
+    assert coordinator.get(hid).status == RUN_DONE
+    assert coordinator.get(hid).queued_steering == 0
+
+
+# -- whole-coordinator reach: foreign live survivors are steerable --------
+
+
+def test_a_foreign_live_survivor_is_steerable(db):
+    """A survivor spawned by an EARLIER turn's service is steerable from
+    the current turn: the mailbox lives on the conversation-lifetime
+    coordinator and needs no per-service state -- deliberately unlike
+    `cancel_subagent`, whose ownership walk exists because cancel Events
+    are service-local."""
+    entered = threading.Event()
+    release = threading.Event()
+    holder: dict = {}
+
+    def survivor_first_turn():
+        entered.set()
+        assert release.wait(30.0), "the survivor was never released"
+        return fence("calculator", {"expression": "2+2"})
+
+    def turn_1_parent_answer():
+        assert entered.wait(_JOIN_TIMEOUT), "the survivor never started"
+        return "turn 1 done"
+
+    def steer_foreign():
+        survivor = _live_running_handle(holder["coordinator"])
+        holder["handle_id"] = survivor.handle_id
+        return fence(
+            SEND_TO_AGENT_TOOL_NAME,
+            {"id": survivor.handle_id, "message": "focus on the tests"},
+        )
+
+    registry = ToolCatalogRegistry()
+    registry.register_provider(BuiltinToolProvider())
+    chat = FleetChat(
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "survivor"}),
+            turn_1_parent_answer,
+            steer_foreign,
+            "turn 2 done",
+        ],
+        {"survivor": [survivor_first_turn, "released"]},
+    )
+    coordinator = FleetCoordinator(max_live=3, clock=time.monotonic)
+    holder["coordinator"] = coordinator
+    service_1 = AgentService(
+        db=db, registry=registry, chat_call=chat, fleet_coordinator=coordinator
+    )
+    service_2 = AgentService(
+        db=db, registry=registry, chat_call=chat, fleet_coordinator=coordinator
+    )
+    try:
+        _run_id_1, outcome_1 = service_1.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go 1"}],
+            config=FLEET_CFG,
+            api_endpoint="llama_cpp",
+        )
+        assert outcome_1.status == RUN_DONE
+        # Turn 2, on a FRESH service sharing the coordinator, steers the
+        # survivor it never spawned.
+        run_id_2, outcome_2 = service_2.run_turn(
+            conversation_id="c",
+            messages=[{"role": "user", "content": "go 2"}],
+            config=FLEET_CFG,
+            api_endpoint="llama_cpp",
+        )
+        assert outcome_2.status == RUN_DONE
+        sends = _sends(db, run_id_2)
+        assert sends and "ERROR" not in sends[0] and "queued" in sends[0]
+        assert coordinator.get(holder["handle_id"]).queued_steering == 1
+        # And the post cancelled nothing: the survivor is still running.
+        assert coordinator.get(holder["handle_id"]).status == RUN_RUNNING
+    finally:
+        release.set()
+    _wait_until(coordinator.all_finished, "the survivor never completed")
+    assert coordinator.get(holder["handle_id"]).status == RUN_DONE
+    assert coordinator.get(holder["handle_id"]).result == "released"
+    labeled = format_steering_message(
+        STEERING_SOURCE_SUPERVISOR, "focus on the tests"
+    )
+    second_payload = chat.child_calls["survivor"][1]["messages_payload"]
+    assert second_payload[-1] == {"role": "user", "content": labeled}

--- a/Tests/Agents/test_fleet_send_to_agent.py
+++ b/Tests/Agents/test_fleet_send_to_agent.py
@@ -721,10 +721,15 @@ def test_steering_never_cancels_the_child(db):
     assert holder["status_after_post"] == RUN_RUNNING
     assert holder["row_after_post"] == RUN_RUNNING
     assert holder["cancel_set_after_post"] is False
-    # And at the end: the child consumed the message, finished DONE, and
-    # its cancel Event was never set by anything on this path.
+    # And at the end: the child consumed the message and finished DONE on
+    # its own terms -- coordinator and run row both say so, which is the
+    # invariant's end-state. (Deliberately NOT asserted: the raw cancel
+    # Event after run_turn. `_settle_fleet` sets every settling child's
+    # Event unconditionally at end of turn -- documented there as inert
+    # for an already-finished child -- so that Event is end-of-turn
+    # bookkeeping, not steering's doing; the mid-turn probe above is the
+    # honest measurement of what the POST touched.)
     hid = holder["handle_id"]
-    assert service._fleet_cancels[hid].is_set() is False
     assert coordinator.get(hid).status == RUN_DONE
     assert _child_row(db)["status"] == RUN_DONE
     labeled = format_steering_message(STEERING_SOURCE_SUPERVISOR, "keep going")

--- a/Tests/Agents/test_install_skill_runtime_tool.py
+++ b/Tests/Agents/test_install_skill_runtime_tool.py
@@ -17,6 +17,7 @@ from tldw_chatbook.Agents.agent_models import (
     RUN_LOG_STATS_TOOL_NAME,
     RUN_SKILL_SCRIPT_TOOL_NAME,
     SEARCH_RUN_LOG_TOOL_NAME,
+    SEND_TO_AGENT_TOOL_NAME,
     SPAWN_TOOL_NAME,
     FIND_TOOLS_NAME,
     LOAD_TOOLS_NAME,
@@ -49,6 +50,7 @@ def test_install_skill_name_in_runtime_tool_names():
         RUN_LOG_SLICE_TOOL_NAME,
         WAIT_AGENTS_TOOL_NAME,
         CHECK_AGENTS_TOOL_NAME,
+        SEND_TO_AGENT_TOOL_NAME,
     }
 
 

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -94,6 +94,12 @@ RUN_LOG_SLICE_TOOL_NAME = "run_log_slice"
 # supposed to be bounded by the parent's own wall-clock instead.
 WAIT_AGENTS_TOOL_NAME = "wait_agents"
 CHECK_AGENTS_TOOL_NAME = "check_agents"
+# Fleet steering (PR3b Task 2, spec SS6): the supervisor's producer for the
+# per-child mailbox Task 1 added. Primary-only and fleet-gated like the two
+# tools above, dispatched IN-LOOP like them (posting to a locked in-memory
+# mailbox is instant, but the id-resolution copy lives in the service
+# closure, not behind invoke_tool's daemon-thread timeout wrapper).
+SEND_TO_AGENT_TOOL_NAME = "send_to_agent"
 RUNTIME_TOOL_NAMES = frozenset(
     {
         SPAWN_TOOL_NAME,
@@ -107,6 +113,7 @@ RUNTIME_TOOL_NAMES = frozenset(
         RUN_LOG_SLICE_TOOL_NAME,
         WAIT_AGENTS_TOOL_NAME,
         CHECK_AGENTS_TOOL_NAME,
+        SEND_TO_AGENT_TOOL_NAME,
     }
 )
 
@@ -453,7 +460,8 @@ class AgentConfig:
 
             *What it does NOT govern.* The runtime tools --
             ``RUNTIME_TOOL_NAMES`` above: ``spawn_subagent``,
-            ``wait_agents``/``check_agents``, ``find_tools``/
+            ``wait_agents``/``check_agents``/``send_to_agent``,
+            ``find_tools``/
             ``load_tools``, ``skill_file``, ``install_skill``,
             ``run_skill_script``, and ``search_run_log``/
             ``run_log_stats``/``run_log_slice``. These are not catalog

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -28,6 +28,7 @@ from .agent_models import (
     RUN_SKILL_SCRIPT_TOOL_NAME,
     RUN_STUCK,
     SEARCH_RUN_LOG_TOOL_NAME,
+    SEND_TO_AGENT_TOOL_NAME,
     SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     STEP_ERROR,
@@ -365,6 +366,17 @@ class LoopDeps:
     # child of this run"; `check_agents` takes nothing.
     wait_agents: Callable[[list[str] | None], ToolResult] | None = None
     check_agents: Callable[[], ToolResult] | None = None
+    # send_to_agent: fleet steering, the SUPERVISOR producer (PR3b Task 2,
+    # spec SS6) for the per-child mailbox drain_mailbox below consumes.
+    # Wired under the exact `fleet_active` predicate as the two fields
+    # above, same primary-only reasoning (depth-1: children cannot steer
+    # each other). Takes (id, message) -- the id in either vocabulary,
+    # resolved by the service closure -- and returns immediately: posting
+    # to the locked in-memory mailbox never blocks, so dispatching it
+    # in-loop beside wait_agents costs nothing and keeps all three fleet
+    # tools on one path. Validation (non-empty, MAX_STEERING_CHARS) and
+    # every piece of refusal copy live in the service closure, not here.
+    send_to_agent: Callable[[str, str], ToolResult] | None = None
     # drain_mailbox: fleet steering (PR3b Task 1, spec SS6). Wired ONLY for
     # a THREADED fleet child -- the service's spawn tail closes it over
     # that child's own coordinator mailbox
@@ -1329,6 +1341,24 @@ def run_agent_loop(
                 ):
                     add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
                     result = deps.check_agents()
+                elif (
+                    call.name == SEND_TO_AGENT_TOOL_NAME
+                    and deps.send_to_agent is not None
+                ):
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    # Same defensive coercion as wait_agents' `ids` above:
+                    # an unreliable local model may send numbers or JSON
+                    # nulls. Anything non-string becomes its str() form (a
+                    # numeric id then simply fails to resolve, and the
+                    # service's own refusal copy names it); a missing/null
+                    # value becomes "" so the service's empty-message and
+                    # unknown-id refusals speak, never a crash here.
+                    raw_target = call.args.get("id")
+                    raw_message = call.args.get("message")
+                    result = deps.send_to_agent(
+                        "" if raw_target is None else str(raw_target),
+                        "" if raw_message is None else str(raw_message),
+                    )
                 elif call.name == FIND_TOOLS_NAME:
                     add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
                     entries = deps.find_tools(str(call.args.get("query", "")))

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -34,10 +34,12 @@ from tldw_chatbook.Utils.token_counter import count_tokens_messages, estimate_to
 from .agent_models import (
     AGENT_KIND_PRIMARY,
     AGENT_KIND_SUBAGENT,
+    MAX_STEERING_CHARS,
     RUN_CANCELLED,
     RUN_DONE,
     RUN_ERROR,
     SPAWN_TOOL_NAME,
+    STEERING_SOURCE_SUPERVISOR,
     STEP_ERROR,
     TERMINAL_RUN_STATUSES,
     AgentConfig,
@@ -95,6 +97,7 @@ from .tool_catalog import (
     RUN_LOG_STATS_TOOL_SCHEMA,
     RUN_SKILL_SCRIPT_TOOL_SCHEMA,
     SEARCH_RUN_LOG_TOOL_SCHEMA,
+    SEND_TO_AGENT_SCHEMA,
     SKILL_FILE_TOOL_SCHEMA,
     SPAWN_TOOL_SCHEMA,
     WAIT_AGENTS_SCHEMA,
@@ -1545,6 +1548,11 @@ class AgentService:
         if fleet_active:
             runtime_schemas.append(WAIT_AGENTS_SCHEMA)
             runtime_schemas.append(CHECK_AGENTS_SCHEMA)
+            # PR3b Task 2: the steering producer rides the exact same
+            # predicate -- a sub-agent must never see it (depth-1:
+            # children cannot steer each other), and without a fleet
+            # there is no mailbox to post into.
+            runtime_schemas.append(SEND_TO_AGENT_SCHEMA)
         if offer_find_load:
             runtime_schemas.extend([FIND_TOOLS_SCHEMA, LOAD_TOOLS_SCHEMA])
         if (
@@ -2331,6 +2339,134 @@ class AgentService:
                 lines.extend(_line(handle) for handle in others)
             return ToolResult(ok=True, content="\n".join(lines))
 
+        def send_to_agent(target_id: str, message: str) -> ToolResult:
+            """Queue a steering message for a LIVE child (PR3b Task 2).
+
+            Spec SS6's supervisor path into Task 1's per-child mailbox.
+            Text validation happens HERE, at the producer boundary --
+            ``post_steering`` deliberately does not validate (Task 1's
+            pinned decision), because each producer owes its caller its
+            own refusal copy, which the mailbox's silent bool cannot
+            carry.
+
+            Resolution speaks BOTH id vocabularies over the WHOLE
+            coordinator, not ``my_handle_ids``: a live survivor another
+            turn's service spawned is steerable, because the mailbox
+            lives on the conversation-lifetime coordinator and needs no
+            per-service state -- deliberately unlike ``cancel_subagent``,
+            whose retained-owner walk exists only because cancel Events
+            are service-local. Handle id resolves FIRST (the coordinator
+            minted it as the primary vocabulary -- spawn results,
+            check_agents, and the panel rows all speak it), then a live
+            handle's run id (the vocabulary completion notices speak); a
+            pathological collision therefore lands on the handle-id
+            owner.
+
+            Steering never cancels (spec SS3 invariant 4): this posts to
+            the mailbox and touches nothing else -- no cancel Event, no
+            run row, no coordinator status.
+
+            Args:
+                target_id: A live child's handle id, or its run id.
+                message: The steering text (validated, then posted
+                    stripped; the drain point prepends the label).
+
+            Returns:
+                ok with honest queued-plus-latency copy naming the
+                resolved handle id; a refusal with its own copy for an
+                empty message, an oversize one, a finished child, or an
+                unknown id. Never raises.
+            """
+            if fleet is None:  # pragma: no cover — not wired without a fleet
+                return ToolResult(
+                    ok=False, error="send_to_agent: this run has no sub-agents"
+                )
+            text = message.strip()
+            if not text:
+                return ToolResult(
+                    ok=False,
+                    error=(
+                        "send_to_agent: the message is empty; there is "
+                        "nothing to deliver. Put the steering text in "
+                        "'message'."
+                    ),
+                )
+            if len(text) > MAX_STEERING_CHARS:
+                return ToolResult(
+                    ok=False,
+                    error=(
+                        f"send_to_agent: the message is too long "
+                        f"({len(text)} chars; the cap is "
+                        f"{MAX_STEERING_CHARS}). Shorten it and send it "
+                        f"again."
+                    ),
+                )
+            handles = fleet.snapshot()
+            live = [
+                handle
+                for handle in handles
+                if handle.status not in TERMINAL_RUN_STATUSES
+            ]
+            target = next(
+                (h for h in live if h.handle_id == target_id), None
+            ) or next((h for h in live if h.run_id == target_id), None)
+            if target is not None and fleet.post_steering(
+                target.handle_id, STEERING_SOURCE_SUPERVISOR, text
+            ):
+                return ToolResult(
+                    ok=True,
+                    content=(
+                        f"Steering for {target.handle_id} queued; it will "
+                        f"be delivered before its next model turn. If it "
+                        f"is inside a long tool call it will see the "
+                        f"message once that call returns. It was not "
+                        f"cancelled or restarted."
+                    ),
+                )
+            if target is not None:
+                # Lost the post race: it went terminal between the
+                # snapshot and the post. Re-snapshot so the terminal
+                # branch below reports the child honestly.
+                handles = fleet.snapshot()
+                live = [
+                    handle
+                    for handle in handles
+                    if handle.status not in TERMINAL_RUN_STATUSES
+                ]
+            live_ids = ", ".join(h.handle_id for h in live) or "none"
+            finished = next(
+                (
+                    h
+                    for h in handles
+                    if h.handle_id == target_id or h.run_id == target_id
+                ),
+                None,
+            )
+            if finished is not None:
+                # PR3b Task 4's continuation seam: THIS branch becomes
+                # "resume the finished child with the retained transcript
+                # + this message" (spawn-slot accounting, definition
+                # re-resolution, resumed_from_run_id). Until then the
+                # honest answer is that the child finished.
+                return ToolResult(
+                    ok=False,
+                    error=(
+                        f"send_to_agent: sub-agent '{target_id}' has "
+                        f"finished ({finished.status}); a finished "
+                        f"sub-agent takes no more model turns, so there "
+                        f"is nothing to deliver to. Live sub-agent ids: "
+                        f"{live_ids}."
+                    ),
+                )
+            return ToolResult(
+                ok=False,
+                error=(
+                    f"send_to_agent: no sub-agent matches id "
+                    f"'{target_id}' (checked handle ids and run ids). "
+                    f"Live sub-agent ids: {live_ids}."
+                ),
+            )
+
         # Skill-aware invoke_tool, built AFTER spawn (it closes over it): a
         # skill-tool call never reaches the registry/ToolProvider.invoke
         # path (SkillToolProvider.invoke raises by design -- Task 11 traced
@@ -2964,6 +3100,8 @@ class AgentService:
             # one it was not told about).
             wait_agents=wait_agents if fleet_active else None,
             check_agents=check_agents if fleet_active else None,
+            # PR3b Task 2: the steering producer, under the same predicate.
+            send_to_agent=send_to_agent if fleet_active else None,
             # PR3b Task 1: non-None ONLY for a threaded fleet child (see
             # the parameter's own comment above); the pure loop drains it
             # at its protocol-coherent pre-model-call point.

--- a/tldw_chatbook/Agents/tool_catalog.py
+++ b/tldw_chatbook/Agents/tool_catalog.py
@@ -30,6 +30,7 @@ from .agent_models import (
     RUN_SKILL_SCRIPT_TOOL_NAME,
     RunBudget,
     SEARCH_RUN_LOG_TOOL_NAME,
+    SEND_TO_AGENT_TOOL_NAME,
     SKILL_FILE_TOOL_NAME,
     SPAWN_TOOL_NAME,
     ToolCatalogEntry,
@@ -147,6 +148,49 @@ CHECK_AGENTS_SCHEMA = ToolSchema(
         "never waits -- use wait_agents to actually collect results."
     ),
     parameters={"type": "object", "properties": {}, "required": []},
+)
+
+# Fleet steering (PR3b Task 2, spec SS6). Pinned and wired under the SAME
+# `fleet_active` predicate as the two schemas above: without a live fleet
+# there is no mailbox to post into, and a sub-agent never sees it (depth-1:
+# children cannot steer each other). The description is the supervisor's
+# whole curriculum -- both id vocabularies, the honest delivery latency,
+# and spec SS3 invariant 4 (steering never cancels) -- because nothing else
+# teaches the model any of it.
+SEND_TO_AGENT_SCHEMA = ToolSchema(
+    id="runtime:send_to_agent",
+    name=SEND_TO_AGENT_TOOL_NAME,
+    description=(
+        "Send a steering message to a sub-agent that is still running. "
+        "'id' accepts either vocabulary: the handle id spawn_subagent "
+        "returned (also shown by check_agents), or the run id a "
+        "completion notice named. The message is queued and handed to the "
+        "sub-agent as a labeled user-role message at its next model turn "
+        "-- a sub-agent inside a long tool call sees it late, only after "
+        "that call returns. Steering never cancels or restarts the "
+        "sub-agent: it keeps its task and its progress, and simply reads "
+        "your message as extra direction."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "description": (
+                    "Which sub-agent: a handle id (from spawn_subagent or "
+                    "check_agents) or a run id (from a completion notice)."
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": (
+                    "The steering text to deliver. Plain text; must be "
+                    "non-empty."
+                ),
+            },
+        },
+        "required": ["id", "message"],
+    },
 )
 
 


### PR DESCRIPTION
## Fleet 3b Task 2 — `send_to_agent` for live children

The first producer for Task 1's mailbox: the supervisor can now steer a running child mid-flight. The message arrives as a `[Steering from supervisor]`-labeled user-role entry at the child's next model turn, at the protocol-coherent boundary — never cancelling, never restarting, never splitting a native tool-call pair.

**Both id vocabularies resolve** — live handle id first (the coordinator's minted vocabulary: spawn results, `check_agents`, panel rows), then a live handle's run id (the completion-notice vocabulary) — over the whole coordinator, so a *foreign* live survivor spawned by an earlier turn is steerable with no per-service state. A lost race (child settles between snapshot and post) re-resolves into the terminal refusal rather than a silent drop.

**The two safety pins, both with real fixtures:** steering never cancels (status, run row, and cancel Event untouched mid-turn), and **steering never satisfies an approval** — a real round armed and *held*, the steering posted at it, the verdict still pending, the gated tool unexecuted, the entry still queued; after the human answered, the tool executed and the steering arrived only at the post-approval boundary — tool result second-to-last, labeled message last. That ordering is the whole contract in one assertion.

**One test repaired, attributed before touching it:** the stopped predecessor's suite pinned `_fleet_cancels[hid]` unset *after* `run_turn` — behaviour origin/dev never had (`_settle_fleet` sets every settling child's Event unconditionally at end of turn, inert for finished children per its own comment; the branch diff contains zero settle lines). Replaced with the honest end-state; the mid-turn probes remain the invariant's real measurement.

**Six mutations, no survivors, each killing exactly its owner** — including run-id-resolved-first against a forged collision fixture, and the schema wired under the wrong agent kind.

Validation lives at the tool boundary (non-empty after strip, `MAX_STEERING_CHARS`) with its own refusal copy — the mailbox deliberately does not validate. Primary-only: a sub-agent never sees the schema. The terminal/unknown branch names known live ids and marks Task 4's continuation seam in a comment.

Gate: new suite 15; `Tests/Agents/` 1484→1499 (+15); bridge 197; MCP approval 74; mailbox suite 22 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables supervisors to steer live sub‑agents by adding the `send_to_agent` runtime tool. Previously there was no producer for the mailbox; now supervisors can queue a labeled message that is delivered at the child’s next model turn without cancelling or restarting it.

**Key details**
- Tool surface and gating: `SEND_TO_AGENT_SCHEMA` (`id`, `message` both required) is offered only to primaries with an active fleet; sub‑agents never see it and child calls are refused. `RUNTIME_TOOL_NAMES` updated; primary prompts now list `send_to_agent` when fleet‑active.
- Resolution and validation: resolves target by handle id first, then the run id of a live handle, across the whole coordinator (foreign survivors steerable). Empty/oversize messages are refused (cap `MAX_STEERING_CHARS`), and unknown/finished ids return explicit errors; race after snapshot re‑reports as finished. Non‑string args are defensively coerced.
- Runtime/service wiring: new `LoopDeps.send_to_agent` dispatch in `agent_runtime`; `agent_service` validates text and posts to the coordinator mailbox. Success copy states “queued; delivered before next model turn.” Drain shows a “[Steering from supervisor] …” user message after any tool results.
- Safety and ordering: steering never cancels (status, run row, cancel Event untouched mid‑turn) and never satisfies approvals (message delivered only after approval resolves), both enforced in tests.
- Tests/docs: adds `Tests/Agents/test_fleet_send_to_agent.py` (15 cases), updates exact‑set pins, and a landing report. One test repaired to reflect `_settle_fleet` setting cancel Events at turn end. Migration: none; senders must provide both `id` and `message`.

<sup>Written for commit 1f1c9f50af8a4410a5efca0dec3e98674ce5efd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

