### PR TITLE
feat(console): turn file card V1.5 — hunk annotations that feed the agent's next reply (TASK-16800)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -217,17 +217,56 @@ already streaming.
 
 When an agent turn edits files, the transcript shows a **turn file card**
 directly under that turn instead of a plain summary line: a header with the
-counts ("✎ Edited 3 files  +92 −468"), then one row per changed file. Press
-**Enter** or click a row to expand its diff in place — expanding is
-per-row and the diff loads (and is cached) the first time you open it, so
-collapsing and reopening a row is instant. The card never mutates
-anything; there is no undo or revert control on it.
+counts ("✎ Edited 3 files  +92 −468"), an **expand/collapse-all** toggle, a
+**Review** button, then one row per changed file. Press **Enter** or click
+a row to expand its diff in place — expanding is per-row and the diff
+loads (and is cached) the first time you open it, so collapsing and
+reopening a row is instant. Long paths are middle-elided to fit the row
+(the start and end stay visible, with `…` in between); the row's tooltip
+always shows the full, un-elided path. The card never mutates anything
+directly; there is no undo or revert control on it.
 
-**`v`** still opens the full **Review** screen for that turn — the same
-key as before the card shipped. Reach it from the selected transcript row
-or the run inspector's **Review changes** action. Revert-all and the other
-destructive actions live only on that screen, behind a confirm, never as a
-one-keystroke action in the transcript.
+The header's chevron toggle expands or collapses every row at once. The
+first expand-all loads whatever diffs aren't cached yet one at a time (not
+all in parallel), so a turn with many changed files doesn't launch a burst
+of concurrent git work — collapsing again just hides the bodies, it never
+throws away what was loaded.
+
+Click **Review** (or press **`v`**, unchanged from before the card
+shipped) to open the full **Review** screen scoped to *this card's own
+turn* — no need to reselect it once the screen opens. Reach the same
+screen from the selected transcript row or the run inspector's **Review
+changes** action. Revert-all and the other destructive actions live only
+on that screen, behind a confirm, never as a one-keystroke action in the
+transcript.
+
+#### Leaving feedback on a hunk
+
+Expand a row and each hunk of its diff gets its own block with a small
+**✎ note** action beneath it. Click it, type a short note, and press
+**Enter** to save (**Escape** cancels without saving). The note renders in
+place under that hunk; while it's still unsent it carries a **✕** to
+delete it. You can leave more than one note per hunk, and notes on
+different hunks and files are independent.
+
+A note you leave doesn't go anywhere by itself — it's picked up
+automatically the next time you send a message that the agent runtime
+handles (not a plain-provider send with the agent runtime off). At that
+point every note still pending across the conversation is bundled into
+your message as extra context under a "Diff feedback from the user"
+heading, and once the reply is produced a TOOL-role row appears in the
+transcript disclosing exactly what was attached, e.g. `📝 Diff feedback
+attached — a.py @@ -1,4 +1,6 @@: "use the cached value here"` (one line
+per note). Once delivered, a note's row swaps its **✕** for a `sent`
+marker and becomes read-only — it's now part of the record.
+
+A note stays pending — and is never silently dropped — whenever it
+can't actually reach the model: the run fails before producing a reply
+(so nothing was sent — it rides the retry), your send doesn't go through
+the agent runtime at all, or you've queued more feedback than fits one
+message (older notes go first; anything left over waits for your next
+send). Only feedback that genuinely reached the model gets the `sent`
+marker and the disclosure row.
 
 If change tracking failed for one of a turn's roots, that failure shows up
 as its own plain-text disclosure row next to the card, not inside it — the
@@ -242,14 +281,18 @@ it from the stored snapshot.
 **`[console] turn_file_cards`** in `config.toml` (default `true`) is a pure
 presentation kill switch: set it to `false` to fall back to the original
 plain-text marker row (`` ✎ Edited N files  +A −D — review with `v` ``,
-byte-identical to the pre-card behavior). `v` and the inspector's Review
-changes action work identically either way.
+byte-identical to the pre-card behavior) — no card, no note UI, no Review
+button, no expand-all. `v` and the inspector's Review changes action work
+identically either way. Turning the switch off does **not** lose any
+feedback you already queued: notes created while the card was on still
+auto-attach and deliver on your next agent send, disclosure row included,
+exactly as if the switch had stayed on.
 
 The "✎ A sub-agent edited N files after this turn" row (see [Parallel
 sub-agents](#parallel-sub-agents-the-fleet) below) renders a card too, and
 by design it covers the same run's full set of tracked changes — turn and
 post-turn windows alike — the same union the `v` Review screen shows for
-that run.
+that run. It supports notes and Review exactly like a turn's own card.
 
 ### Parallel sub-agents (the fleet)
 
@@ -979,7 +1022,26 @@ interactive live-tmux walkthrough of the card itself. The card is a pure
 presentation layer over TASK-1972's existing change-review subsystem; the
 `[console] turn_file_cards` kill switch reverts to the pre-card plain-text
 marker row byte-for-byte, confirmed by
-`test_summary_row_stays_plain_marker_when_disabled`.)*
+`test_summary_row_stays_plain_marker_when_disabled`.) The "Change review"
+section rewritten @ HEAD — 2026-08-17 (TASK-16800 V1.5: the annotate/
+feedback loop, the `Review` button, the expand/collapse-all chevron, and
+middle-elided paths — every claim checked against the shipped code in
+`Widgets/Console/console_turn_file_card.py`,
+`Chat/console_agent_bridge.py`'s `run_reply` attach/stamp/disclosure seam,
+and `Chat/console_display_state.py`'s `render_diff_feedback_block`/
+`format_diff_feedback_disclosure`/`middle_elide_path`, then confirmed by
+the whole-module test run — `Tests/UI/test_console_turn_file_card.py`,
+`Tests/UI/test_console_turn_file_card_notes.py`,
+`Tests/UI/test_console_turn_file_card_factory.py`,
+`Tests/UI/test_change_review_screen.py`,
+`Tests/Chat/test_console_diff_hunks.py`, and
+`Tests/Chat/test_console_diff_feedback_delivery.py`, 91 passed — again a
+docs-only pass, not an interactive live-tmux walkthrough. The kill-switch
+claim ("pending notes still deliver with the switch off") is pinned by a
+new bridge-level test,
+`test_kill_switch_off_does_not_prevent_note_delivery`, which forces
+`[console] turn_file_cards = false` and confirms the attach/stamp/
+disclosure seam is entirely unaffected — it never reads that switch.)*
 
 *Live turn-activity line added against dev @ feea06193 — 2026-08-16.
 Verified by execution, not by a tmux walkthrough: a real

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -257,8 +257,12 @@ your message as extra context under a "Diff feedback from the user"
 heading, and once the reply is produced a TOOL-role row appears in the
 transcript disclosing exactly what was attached, e.g. `📝 Diff feedback
 attached — a.py @@ -1,4 +1,6 @@: "use the cached value here"` (one line
-per note). Once delivered, a note's row swaps its **✕** for a `sent`
-marker and becomes read-only — it's now part of the record.
+per note). A live card is reused in place across transcript syncs and
+never reloads its own notes, so on the still-open card the **✕** stays
+put even after delivery — pressing it can no longer delete a delivered
+note, though. The row only shows the **✕**→`sent` swap the next time the
+card is rebuilt from scratch (conversation resume or reopen); at that
+point the note is read-only and part of the record.
 
 A note stays pending — and is never silently dropped — whenever it
 can't actually reach the model: the run fails before producing a reply

--- a/Docs/superpowers/plans/2026-08-17-console-turn-file-annotate.md
+++ b/Docs/superpowers/plans/2026-08-17-console-turn-file-annotate.md
@@ -1,0 +1,179 @@
+# Console Turn File Card V1.5 — Annotate Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Users attach notes to specific hunks of an agent turn's diff in the Console transcript; the notes auto-attach to the user's next agent send (with a visible disclosure) and are durably recorded.
+
+**Architecture:** New `change_notes` table in AgentRuns_DB (idempotent DDL + audit version 8); pure hunk segmentation + block rendering in `console_display_state.py`; the card's expand path restructured into per-hunk blocks with an inline note input; delivery entirely inside `ConsoleAgentBridge.run_reply` via the `turn_bundle_block` mechanism, stamped at run completion by exact attached-note ids; disclosure rows emitted live and re-derived on resume (marker precedent); Review button / expand-all / middle-elide polish.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, SQLite (AgentRuns_DB), pytest (venv-only: `VIRTUAL_ENV=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -p no:randomly -q`).
+
+**Spec:** `Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md` — the binding authority; read it before any task. Line anchors below were verified at dev `ed49499b8`.
+
+## Global Constraints
+
+- No exception may escape a Textual `on_*` handler in the card (an escaping exception exits the whole app) — every new handler seam degrades to a logged no-op, matching the card's existing pattern.
+- All DB access from the widget goes through the provider and runs off the UI thread (`asyncio.to_thread`); tests use FILE-BACKED `AgentRunsDB(tmp_path / "runs.db", client_id="t")`, never `:memory:` (thread-affinity).
+- UI tests run on the real CSS stack (`_SCOPED, _SELF = build_css.screen_css_paths(...)` + `tldw_cli_modular.tcss` — note the return order: scoped first, self last) and query by id/class, never message type.
+- The generated CSS bundle is never hand-edited; if a `.tcss` source changes, regenerate via `python -m tldw_chatbook.css.build_css`.
+- `[console] turn_file_cards = false` must keep the plain marker byte-identical (existing pinned test must stay green); delivery must work regardless of that switch.
+- Note text: max 2,000 chars, validated at the widget boundary.
+- Every regression/guard test where a mask is plausible must be shown RED against pre-feature code (checkout or targeted revert) before it counts as evidence.
+- Widget-local CSS must not declare `$ds-*` variables (TASK-16811; the focus-contract suite enforces this).
+
+---
+
+### Task 1: `change_notes` persistence in AgentRuns_DB
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py` (DDL block ~`:170-260`; migration/audit block ~`:300-350`; new API methods near `change_snapshots_for_run_review`)
+- Test: `Tests/Chat/test_change_notes_db.py` (new)
+
+**Interfaces (Produces):**
+```python
+def add_change_note(self, *, run_id: str, root: str, path: str,
+                    hunk_index: int, hunk_header: str, hunk_excerpt: str,
+                    note: str) -> int  # returns note id
+def delete_change_note(self, note_id: int) -> bool  # False if delivered or missing
+def notes_for_run(self, run_id: str) -> list[dict]  # oldest first, all columns
+def pending_notes_for_conversation(self, conversation_id: str) -> list[dict]
+    # JOIN change_notes.run_id = agent_runs.id WHERE ar.conversation_id = ?
+    #   AND delivered_at IS NULL, ORDER BY cn.id
+def mark_notes_delivered(self, note_ids: Sequence[int]) -> None
+    # single UPDATE ... WHERE id IN (...) AND delivered_at IS NULL; timestamp _now_iso()
+```
+
+- [ ] **Step 1: Write failing tests** — file-backed DB; create two runs in one conversation via `create_run`; cover: add returns id and `notes_for_run` round-trips all fields; `pending_notes_for_conversation` sees notes from BOTH runs, oldest first, and excludes other conversations; `mark_notes_delivered([ids])` stamps only those ids (a note added after the list was captured stays pending — the mid-run race, spec §4); `delete_change_note` deletes pending, returns False for delivered; **migration test**: open a DB file created by the current code (no `change_notes`), reopen with the new code, table exists and `schema_version` contains 8; reopening twice is idempotent.
+- [ ] **Step 2: Run tests, verify failures** — `Tests/Chat/test_change_notes_db.py` fails on missing table/methods.
+- [ ] **Step 3: Implement** — add DDL to the create block (spec §1 schema verbatim: no `conversation_id` column; partial index `idx_change_notes_pending ON change_notes(run_id) WHERE delivered_at IS NULL`); append `INSERT OR IGNORE INTO schema_version (version) VALUES (8)` following the existing convention comment; implement the five methods with parameterized queries and the file's `_now_iso()`/connection patterns. Google-style docstrings with Args/Returns on all five.
+- [ ] **Step 4: Run tests to green**, plus `Tests/Chat/test_change_turn_tracking.py` and `Tests/Workspaces/test_change_revert.py` (schema neighbors) to prove no regression.
+- [ ] **Step 5: Commit** — `feat(console): change_notes table + API in AgentRuns_DB (audit v8)`
+
+---
+
+### Task 2: Pure helpers — hunk segmentation, excerpt, feedback block, disclosure text
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_display_state.py` (beside `turn_file_entries`)
+- Test: `Tests/Chat/test_console_diff_hunks.py` (new)
+
+**Interfaces (Produces):**
+```python
+@dataclass(frozen=True)
+class DiffHunk:
+    header: str                 # the "@@ -a,b +c,d @@ …" line, verbatim
+    body_lines: tuple[str, ...] # lines after the header, up to next header/prelude
+    file_prelude: str           # "diff --git…/---/+++" lines (same for every hunk of the file)
+
+def split_unified_diff(text: str) -> list[DiffHunk]
+    # ALWAYS over the full diff text; a diff with no @@ (binary/rename-only)
+    # yields one DiffHunk(header="", body_lines=<all lines>, file_prelude="")
+
+def hunk_excerpt(hunk: DiffHunk, cap: int = 40) -> str
+    # header + first `cap` body lines; "… N more lines" tail when elided
+
+def render_diff_feedback_block(notes: Sequence[dict], *, cap_bytes: int = 16384) -> tuple[str, list[int]]
+    # Spec §4 format ("## Diff feedback from the user…"); includes notes
+    # oldest-first while the running utf-8 size stays under cap_bytes;
+    # returns (block, included_ids). Excluded notes are NOT in the ids
+    # list; when any are excluded the block ends with
+    # "… N more notes held for the next message". Empty notes -> ("", []).
+
+def format_diff_feedback_disclosure(notes: Sequence[dict]) -> str
+    # "📝 Diff feedback attached — <path> <hunk_header>: "<note>"" one line
+    # per note; shared verbatim by live emission (Task 5) and resume (Task 6).
+```
+
+- [ ] **Step 1: Failing tests** — segmentation against REAL `git diff -M` output captured in the test (build a tmp repo with two commits: multi-file, multi-hunk, a rename, a binary file): hunk count, headers verbatim, body reassembly (`prelude + header + body` per file equals the original diff for text files); no-@@ diff yields the single fallback hunk; `hunk_excerpt` cap + honest tail; `render_diff_feedback_block` includes/excludes at a small `cap_bytes` and returns exactly the included ids with the holdover line; disclosure text exact-format assertions. Adapt the hunk-header regex from `Tools/patch_tool_impls.py:58` (`_HUNK_HEADER`) — do not modify the patch tool.
+- [ ] **Step 2: Verify failures.**
+- [ ] **Step 3: Implement** (pure, no I/O; docstrings with Args/Returns).
+- [ ] **Step 4: Green**, plus `Tests/Chat/test_console_turn_file_entries.py` untouched-green.
+- [ ] **Step 5: Commit** — `feat(console): pure hunk segmentation + diff-feedback block rendering`
+
+---
+
+### Task 3: Card restructure — per-hunk blocks
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_turn_file_card.py` (`on_button_pressed` expand path; `_diff_cache` shape; `DEFAULT_CSS`)
+- Test: `Tests/UI/test_console_turn_file_card.py` (extend)
+
+**Interfaces:**
+- Consumes: `split_unified_diff`, `hunk_excerpt` (Task 2); `provider.diff_text(row, path)` unchanged.
+- Produces: expanded diff body = for each hunk, a `Static` (classes `console-turn-file-hunk`, colored via the existing `_styled_diff` applied per hunk: prelude only on the first hunk, then header + capped body) followed by a `Horizontal` action row (classes `console-turn-file-hunk-actions`) that Task 4 will populate — this task mounts it empty. `self._hunk_cache: dict[int, list[DiffHunk]]` replaces the joined-string `_diff_cache`.
+
+- [ ] **Step 1: Failing tests** — expanding a row whose fake-provider diff has 3 hunks mounts exactly 3 `.console-turn-file-hunk` statics and 3 action rows inside that row's diff body; a diff longer than `diff_display_max_lines` still yields one block PER hunk with per-hunk elision (the "hunk past the old cap is still present" case — must be RED against the current flat-Static code); collapse/re-expand reuses the cache (provider `diff_text` called once — count calls on the fake); the existing expand/degrade/crash-regression tests stay green unmodified except where they queried the old flat `.console-turn-file-diff-text` (update those queries to the new classes, preserving their intent).
+- [ ] **Step 2: Verify the new tests fail.**
+- [ ] **Step 3: Implement** — segment the FULL `diff_text` in the off-thread `_read`; cache `list[DiffHunk]`; mount per-hunk blocks; per-hunk display cap = `max(1, diff_display_max_lines // max(1, len(hunks)))` floor-guarded, with the honest per-hunk elision line from `hunk_excerpt`'s convention; the whole expand body stays inside the existing single try/except-degrade. DEFAULT_CSS gains structural rules only (heights/margins — no `$ds-*` declarations).
+- [ ] **Step 4: Green** — full `Tests/UI/test_console_turn_file_card.py` + `Tests/UI/test_console_turn_file_card_factory.py` (byte-parity OFF test untouched) + `Tests/UI/test_console_native_transcript.py` selection test.
+- [ ] **Step 5: Commit** — `feat(console): per-hunk blocks in the turn file card`
+
+---
+
+### Task 4: Note UI on hunks
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_turn_file_card.py`; `tldw_chatbook/UI/Screens/change_review_screen.py` (provider note methods)
+- Test: `Tests/UI/test_console_turn_file_card_notes.py` (new)
+
+**Interfaces:**
+- Provider (`AgentRunsChangeReviewProvider`) gains thin delegates: `add_change_note(...)`, `delete_change_note(note_id)`, `notes_for_run(run_id)` → the Task 1 DB API (Google docstrings; same duck-typed-optional posture the card already uses for `turn_for_run`).
+- Card: each hunk action row gets `✎ note` (compact Button, class `console-turn-file-note-btn`, `active_effect_duration = 0`); pressing mounts a one-line `Input` (class `console-turn-file-note-input`, `max_length=2000`) under the hunk; Enter → off-thread `provider.add_change_note` with `hunk_excerpt(hunk)` captured now → on success the input is replaced by a note row (class `console-turn-file-note`, text + `✕` delete button while `delivered_at` is null; a `sent` marker and no delete once delivered); Escape unmounts the input. `_load_rows` also fetches `notes_for_run` off-thread and renders existing notes under their hunks on expand.
+
+- [ ] **Step 1: Failing tests** — REAL provider stack (copy the fixture pattern from `Tests/UI/test_change_review_screen.py::review_fixture` — real `ChangeTurnTracker`/`ShadowRepoService`/file-backed `AgentRunsDB`/`AgentRunsChangeReviewProvider`): pressing `✎ note`, typing, Enter persists a row (assert via `notes_for_run` on the DB) anchored to the right `(hunk_index, hunk_header)` and renders `.console-turn-file-note`; Escape cancels without a row; `✕` deletes pending; a delivered note (stamp it directly in the DB) renders `sent` with no delete button; **resume round-trip**: a brand-new card instance over the same DB shows the note on expand; **live-safety**: with the card mounted inside a `ConsoleTranscript` host, an open input containing typed text survives a `set_messages` sync tick and a selection move (same-instance assertion, the V1 `_update_row_widget` reuse branch); **degrade**: provider whose `add_change_note` raises → press Enter → no crash, input stays, warning logged.
+- [ ] **Step 2: Verify failures.**
+- [ ] **Step 3: Implement** — all handlers inside try/except-degrade; note text stripped and length-checked via `input_validation` before insert.
+- [ ] **Step 4: Green** — new file + Tasks 3's suites.
+- [ ] **Step 5: Commit** — `feat(console): hunk note UI on the turn file card`
+
+---
+
+### Task 5: Delivery — attach, stamp-by-id, live disclosure
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (attach point `:3343-3353`; completion points that invoke `_append_change_markers` — call sites `:3480`/`:3905`)
+- Test: `Tests/Chat/test_console_diff_feedback_delivery.py` (new)
+
+**Interfaces:**
+- Inside `run_reply`, immediately after the `turn_bundle_block` append: query `pending_notes_for_conversation(<the same conversation id the marker-append path uses>)` off the run's DB handle; `block, included_ids = render_diff_feedback_block(notes)`; if block truthy, append `f"\n\n{block}"` to the same last-user-message content (outbound copy only); retain `included_ids` on the run context object that reaches the completion seam.
+- At completion, in the same place that calls `_append_change_markers` (BESIDE it, outside its `if files:` gating), and only when the run produced assistant output: `mark_notes_delivered(included_ids)` and append one TOOL-role disclosure message with `format_diff_feedback_disclosure(included_notes)` — a plain message with NO `change_review_run_id`.
+
+- [ ] **Step 1: Failing tests** — drive `run_reply` with the existing bridge test harness/fakes for this file (find them: `grep -rn "run_reply" Tests/Chat/ | head`; reuse the established fake-service pattern): (a) pending notes → outbound copy's last user message ends with the block, the STORED message is unchanged, and `included_ids` are stamped after a successful run + disclosure row appended with note content; (b) a run erroring before assistant output → notes still pending, no disclosure; (c) mid-run race: add a new note AFTER `run_reply` captured its list (hook the fake service call) → that note remains pending after completion; (d) over-cap: only included ids stamped, holdover line present, excluded note delivers on a second `run_reply`; (e) no pending notes → payload byte-identical to before this feature (guard against unconditional mutation).
+- [ ] **Step 2: Verify failures.**
+- [ ] **Step 3: Implement** — every new bridge read/write wrapped so a notes failure NEVER breaks the reply itself (log + skip attach); stamping+disclosure inside the same protective posture the marker emission uses.
+- [ ] **Step 4: Green** — new file + the bridge's existing change-marker test files (locate via `grep -rln "format_change_summary_marker\|_append_change_markers" Tests/`).
+- [ ] **Step 5: Commit** — `feat(console): diff-feedback auto-attach with exact-id delivery stamping`
+
+---
+
+### Task 6: Disclosure resume re-derivation
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (`resume_marker_messages`, `:4536`)
+- Test: extend `Tests/Chat/test_console_diff_feedback_delivery.py` + the existing resume-marker test file (locate via `grep -rln "resume_marker_messages" Tests/`)
+
+- [ ] **Step 1: Failing tests** — a DB holding a run with snapshots AND delivered notes: `resume_marker_messages` yields the marker row AND, after it, a disclosure row whose text equals `format_diff_feedback_disclosure` over the delivered notes (grouped by `delivered_at` — two delivery batches yield two rows, in delivery order); pending notes yield NO disclosure; existing resume-marker tests stay green.
+- [ ] **Step 2: Verify failures.**
+- [ ] **Step 3: Implement** — same synthesized-message shape as live emission (TOOL role, no `change_review_run_id`).
+- [ ] **Step 4: Green.**
+- [ ] **Step 5: Commit** — `feat(console): re-derive diff-feedback disclosures on resume`
+
+---
+
+### Task 7: Affordances, docs, close-out
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Console/console_turn_file_card.py` (header row); `tldw_chatbook/UI/Screens/change_review_screen.py` (`initial_run_id`); `tldw_chatbook/UI/Screens/chat_screen.py` (handle the card's review-request message via the existing v-opener recipe); `tldw_chatbook/Chat/console_display_state.py` (`middle_elide_path`); `Docs/User_Guide/console/agent-runs-and-tools.md`; `backlog/tasks/task-16800 - *.md`
+- Test: extend `Tests/UI/test_console_turn_file_card.py`; `Tests/UI/test_change_review_screen.py`
+
+**Interfaces:**
+- `ConsoleTurnFileCard.ReviewRequested(Message)` carrying `run_id`, posted by a header `Review` button; `ChatScreen` handles it by opening `ChangeReviewScreen` through the same recipe as the `v` action, passing `initial_run_id`; `ChangeReviewScreen.__init__(..., initial_run_id: str | None = None)` selects that turn on open when present (fall back to latest when absent/unknown).
+- Header also gains an expand/collapse-all toggle button; expand-all loads uncached diffs SERIALIZED in one worker.
+- `middle_elide_path(path: str, budget: int) -> str` — keeps first + last components, `…` in the middle, returns unchanged when it fits; row labels use it, recomputed on card resize, full path in the row Button's `tooltip`.
+
+- [ ] **Step 1: Failing tests** — Review button posts `ReviewRequested(run_id)` (harness asserts the message, not the full screen push); `ChangeReviewScreen(initial_run_id=run2)` opens with run2's turn selected (real-provider fixture; unknown id falls back to latest); expand-all mounts every row's hunk blocks and collapse-all hides them; `middle_elide_path` unit cases (fits/loose/degenerate one-component); no destructive control exists on the card (assert no button with a revert/undo label/class — AC#4).
+- [ ] **Step 2: Verify failures.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Green** — both files + factory byte-parity + a kill-switch delivery test (config OFF: plain marker byte-identical AND Task 5's attach test still delivers pending notes).
+- [ ] **Step 5: Docs + close-out** — update the User Guide change-review section (annotate flow, auto-attach disclosure, Review button, expand-all, elision; verify every behavioral claim against the shipped code before writing it — V1's Task 4 lesson) + stamp; tick task-16800 ACs `- [x]` with Implementation Notes.
+- [ ] **Step 6: Commit** — `feat(console): review affordance, expand-all, path elision + V1.5 docs`

--- a/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
+++ b/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
@@ -127,13 +127,14 @@ finding #1 — this is a real widget change, planned as its own task):
 
 ### 4. Delivery: auto-attach + disclosure
 
-- **Attach seam:** `ConsoleChatController` collects
-  `pending_notes_for_conversation(...)` when building an agent reply and
-  passes a rendered `diff_feedback_block` into
-  `ConsoleAgentBridge.run_reply`, which appends it to the last
-  `role=="user"` message of its own outbound copy — the exact
-  `turn_bundle_block` mechanism (bridge `:2576/:3343-3353`). Block
-  format:
+- **Attach seam:** `ConsoleAgentBridge.run_reply` collects
+  `pending_notes_for_conversation(...)` itself at the attach point — the
+  bridge owns the AgentRuns DB, the conversation context, and the
+  completion seam, so the whole feature stays inside it; the controller
+  and `run_reply`'s signature are untouched. The rendered block is
+  appended to the last `role=="user"` message of the bridge's own
+  outbound copy, immediately after the `turn_bundle_block` append and by
+  the same mechanism (bridge `:2576/:3343-3353`). Block format:
 
   ```
   ## Diff feedback from the user (on your earlier file changes)

--- a/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
+++ b/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
@@ -1,0 +1,216 @@
+# Console turn file card V1.5 — annotate loop + Review affordance (TASK-16800)
+
+**Status:** approved design, adversarially reviewed (amendments folded in)
+**Date:** 2026-08-17
+**Task:** `backlog/tasks/task-16800 - Turn-file-card-annotate-feedback-loop-and-Review-affordance.md`
+**Predecessor:** `2026-08-15-console-turn-file-review-design.md` (V1, shipped as PR #1728
++ follow-ups #1731/#1734). This spec covers the V1.5 bucket that spec's
+"Out of scope" section named: the annotate/feedback loop, the `Review`
+affordance, and the two trimmed polish items (expand-all chevron,
+middle-elided paths).
+
+## Goal
+
+Close the loop between "the agent shows me a diff" and "I tell it what to
+change" without leaving the transcript: a user attaches short notes to
+specific hunks of a turn's diff, and those notes automatically reach the
+agent as labeled context on the user's next send — visibly, durably, and
+with zero extra clicks (owner ruling 2026-08-16: **auto-attach +
+disclosure**; no composer-draft path).
+
+## Non-goals
+
+- No mutation of the workspace from the card (revert stays exclusively on
+  the Review screen behind its confirm — TASK-1845/TASK-1972 precedent).
+- No editing of the agent's diff, no per-line commenting (hunks are the
+  anchoring unit), no threaded replies to notes.
+- No change to the V2 scope (sidebar multi-file review, git modes —
+  TASK-16801).
+
+## Architecture
+
+Five pieces, in dependency order. Every anchor below was re-verified
+against dev at `ed49499b8` (2026-08-17).
+
+### 1. Persistence: `change_notes` in AgentRuns_DB (v3 → v4)
+
+AgentRuns_DB is self-versioned (`_CURRENT_SCHEMA_VERSION = 3`,
+`DB/AgentRuns_DB.py:38`), so this is a self-contained bump — no
+ChaChaNotes migration.
+
+```sql
+CREATE TABLE change_notes (
+    id INTEGER PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,   -- denormalized for the delivery query
+    root TEXT NOT NULL,
+    path TEXT NOT NULL,
+    hunk_index INTEGER NOT NULL,     -- 0-based, over the FULL diff (see §3)
+    hunk_header TEXT NOT NULL,       -- the "@@ -a,b +c,d @@ …" line, verbatim
+    hunk_excerpt TEXT NOT NULL,      -- ≤ 40 lines of the hunk body, captured at note time
+    note TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    delivered_at TEXT                -- NULL = pending; set by the delivery seam (§4)
+);
+CREATE INDEX idx_change_notes_pending
+    ON change_notes(conversation_id) WHERE delivered_at IS NULL;
+```
+
+- **Anchor** = `(run_id, root, path, hunk_index, hunk_header)`. Snapshot
+  rows are immutable and `git diff -M <pinned-sha> <pinned-sha>` is
+  deterministic, so the anchor is stable across resume.
+- **`hunk_excerpt` is the retention safety net** (review finding #5):
+  shadow-repo retention can prune a run's snapshots, after which the hunk
+  can no longer be re-rendered. The excerpt (capped at 40 lines, elided
+  with an honest `… N more lines` tail) makes both display-after-pruning
+  and delivery self-contained. Captured once at note creation from the
+  full diff text the card already has.
+- API on `AgentRunsDB`: `add_change_note(...)`, `delete_change_note(id)`
+  (allowed only while `delivered_at IS NULL`), `notes_for_run(run_id)`,
+  `pending_notes_for_conversation(conversation_id)`,
+  `mark_notes_delivered(ids, timestamp)`.
+- All access goes through the existing thread-local connection pattern —
+  the card reads/writes off-thread via `asyncio.to_thread`, same as its
+  diff loads. Note text is length-bounded (2,000 chars) and validated via
+  `input_validation` at the widget boundary.
+
+### 2. Hunk segmentation (shared, pure)
+
+A pure helper `split_unified_diff(text) -> list[Hunk]` where
+`Hunk = (header: str, body_lines: list[str], file_prelude: str)` —
+adapted from the proven `_HUNK_HEADER` regex + `_parse_hunk` in
+`Tools/patch_tool_impls.py:58/:221` (reused, not reinvented; the patch
+tool's own parser stays untouched). Lives beside the card's other pure
+logic in `Chat/console_display_state.py`.
+
+**Segmentation always runs on the FULL `provider.diff_text` output**
+(review finding #2). The `diff_display_max_lines` cap
+(`change_review_screen.py:93`) becomes a per-hunk *display* cap: every
+hunk gets a block even when its body is elided, so hunks past the old cap
+are still annotatable and indices never shift.
+
+### 3. Widget: per-hunk blocks + note UI (the restructure)
+
+Today an expanded row mounts ONE flat `Static` with the whole colored
+diff. Per-hunk actions require restructuring the expand path (review
+finding #1 — this is a real widget change, planned as its own task):
+
+- Expanding a row mounts, inside the existing `VerticalScroll` diff body,
+  one block per hunk: a colored hunk `Static` (header + capped body,
+  reusing `_styled_diff`'s coloring) followed by a slim action row with
+  `✎ note` (and the hunk's existing notes rendered beneath, each with a
+  `✕` delete affordance while undelivered).
+- `✎ note` opens an inline one-line `Input` under that hunk. Enter saves
+  (off-thread insert, then the note renders in place); Escape cancels.
+  Delete removes an undelivered note (off-thread). Delivered notes render
+  with a `sent` marker and no delete — they are record.
+- **Live-transcript safety** (review finding #6): the final-fix-wave
+  `_update_row_widget` branch reuses the card in place when marker/run-id
+  match, which must protect an open input across sync ticks — pinned by
+  an explicit test (half-typed input survives a sync tick and a selection
+  move). All new handlers follow the card's absolute rule: no exception
+  escapes an `on_*` handler; every seam degrades logged.
+- The diff cache changes shape from joined-string to segmented hunks
+  (cache the `list[Hunk]` per row index; styling applied at mount).
+
+### 4. Delivery: auto-attach + disclosure
+
+- **Attach seam:** `ConsoleChatController` collects
+  `pending_notes_for_conversation(...)` when building an agent reply and
+  passes a rendered `diff_feedback_block` into
+  `ConsoleAgentBridge.run_reply`, which appends it to the last
+  `role=="user"` message of its own outbound copy — the exact
+  `turn_bundle_block` mechanism (bridge `:2576/:3343-3353`). Block
+  format:
+
+  ```
+  ## Diff feedback from the user (on your earlier file changes)
+  ### <path> — @@ -a,b +c,d @@   [run <short-id>]
+  > <note text>
+  <hunk_excerpt, fenced>
+  ```
+
+  The block is capped (16 KB total, oldest-first elision with an honest
+  "… N more notes elided" line) so a pile of notes cannot blow the
+  context budget.
+- **Stamping happens at run completion, not attach** (review finding #3):
+  the block is only ever in the outbound copy, so a run that dies before
+  producing assistant output must leave the notes pending for the retry.
+  `mark_notes_delivered` is called at the same run-completion point that
+  invokes `_append_change_markers` (bridge `:4695`) — **beside** it, not
+  inside it, so stamping happens even when the new turn changed no files
+  and the marker seam's `if files:` gate emits nothing. Gated on the run
+  having produced assistant output. Double-delivery is impossible by
+  construction (pending query excludes stamped rows).
+- **Disclosure row** (review finding #4 — resume amnesia): at the same
+  completion seam, a persisted TOOL-role transcript row records what was
+  attached — content, not just a count:
+  `📝 Diff feedback attached — a.py @@ -1,4 +1,6 @@: "use the cached
+  value here"` (one line per note, same message family as the change
+  markers). The row carries **no** `change_review_run_id`, so it can
+  never itself render as a turn file card. Humans, resume, and exports
+  keep the record even though the outbound copy is transient. Whether TOOL rows re-enter rebuilt provider
+  history is an inherited pipeline property (see Known boundaries).
+
+### 5. Card affordances (bounded polish)
+
+- **`Review` button** in the card header opens the existing Review screen
+  scoped to the card's run — same opener recipe as `v`, plus a small
+  addition: the screen accepts an initial `run_id` (today it opens at
+  latest; `turn_for_run` at `change_review_screen.py:157` already gives
+  the lookup). Keyboard `v` unchanged.
+- **Expand/collapse-all chevron** in the header. Expand-all loads the
+  not-yet-cached diffs **serialized in one worker** (not N concurrent git
+  subprocesses), reusing the per-row cache.
+- **Middle-elided paths** in row labels: elide middle path components to
+  the row's width budget (keep first + last), recomputed on resize, full
+  path preserved in the row's tooltip.
+
+## Kill switch
+
+`[console] turn_file_cards = false` keeps the plain marker byte-identical
+(existing pinned test). No note UI exists in that mode, but
+previously-created pending notes still deliver on the next send, with the
+disclosure row — nothing silently vanishes (AC#5). The delivery seam is
+controller/bridge-side and does not consult the presentation switch.
+
+## Known boundaries (inherited, disclosed, not changed here)
+
+- **Conversation-id drift:** temporary-conversation promotion can change
+  a conversation's id while existing runs keep the old one. Notes share
+  exactly the exposure `change_snapshots` already has; no new mitigation.
+- **TOOL-row history participation:** the disclosure row's presence in
+  rebuilt provider history follows whatever the pipeline does for the
+  change markers today; this spec relies on it only as a human/export
+  record.
+- **`git diff -M` determinism:** deterministic for pinned trees in
+  practice; the `hunk_excerpt` denormalization is the safety net if a git
+  upgrade ever changes rename scoring.
+
+## Testing
+
+- **Pure:** `split_unified_diff` against real `git diff -M` output —
+  multi-hunk, rename, binary, and the >cap case (segmentation on full
+  text; display cap per hunk).
+- **Persistence:** real file-backed `AgentRunsDB` (NOT `:memory:` —
+  thread-affinity, V1 lesson): v3→v4 migration on an existing file;
+  add/delete/pending/mark-delivered; resume round-trip (new provider +
+  card instance sees the notes).
+- **Widget:** real CSS bundle, id/class queries only. Per-hunk blocks
+  render with correct hunk count; note input opens/saves/cancels; the
+  open-input-survives-sync-tick and selection-move test; no-escape
+  degrade on injected DB failure; delivered notes lose the delete
+  affordance.
+- **Delivery:** injection test asserting the exact block lands on the
+  last user message of the outbound copy and the stored message is
+  unchanged; completion stamps `delivered_at` + emits the disclosure row
+  with note content; a run failing before assistant output leaves notes
+  pending; block cap elision.
+- **Affordances:** Review button opens the screen at the card's run;
+  expand-all mounts all diff bodies; elision keeps first+last components.
+- **Kill switch:** OFF-path byte-parity unchanged; pending notes created
+  before switching OFF still deliver.
+- **Guard-test discipline:** every regression test proven RED against
+  pre-fix/pre-feature code where a mask is plausible (V1 lesson:
+  `run_test` auto-focus; fixture-invented shapes — real-provider fixtures
+  reused from `Tests/UI/test_change_review_screen.py`).

--- a/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
+++ b/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
@@ -42,7 +42,6 @@ ChaChaNotes migration.
 CREATE TABLE change_notes (
     id INTEGER PRIMARY KEY,
     run_id TEXT NOT NULL,
-    conversation_id TEXT NOT NULL,   -- denormalized for the delivery query
     root TEXT NOT NULL,
     path TEXT NOT NULL,
     hunk_index INTEGER NOT NULL,     -- 0-based, over the FULL diff (see §3)
@@ -53,8 +52,14 @@ CREATE TABLE change_notes (
     delivered_at TEXT                -- NULL = pending; set by the delivery seam (§4)
 );
 CREATE INDEX idx_change_notes_pending
-    ON change_notes(conversation_id) WHERE delivered_at IS NULL;
+    ON change_notes(run_id) WHERE delivered_at IS NULL;
 ```
+
+No denormalized conversation id: `agent_runs` already carries
+`conversation_id NOT NULL`, so `pending_notes_for_conversation` is a
+JOIN through `change_notes.run_id = agent_runs.id`. One source of truth
+— and the card never needs to learn the conversation id at insert time
+(it only knows its `run_id`, which is exactly the key it writes).
 
 - **Anchor** = `(run_id, root, path, hunk_index, hunk_header)`. Snapshot
   rows are immutable and `git diff -M <pinned-sha> <pinned-sha>` is
@@ -130,27 +135,42 @@ finding #1 — this is a real widget change, planned as its own task):
   <hunk_excerpt, fenced>
   ```
 
-  The block is capped (16 KB total, oldest-first elision with an honest
-  "… N more notes elided" line) so a pile of notes cannot blow the
-  context budget.
+  The block is capped (16 KB total, oldest-first inclusion with an honest
+  "… N more notes held for the next message" line) so a pile of notes
+  cannot blow the context budget. **A note elided from the block is NOT
+  attached and NOT stamped** — it stays pending and rides the following
+  send; only feedback the model actually received is ever marked
+  delivered.
 - **Stamping happens at run completion, not attach** (review finding #3):
   the block is only ever in the outbound copy, so a run that dies before
   producing assistant output must leave the notes pending for the retry.
-  `mark_notes_delivered` is called at the same run-completion point that
-  invokes `_append_change_markers` (bridge `:4695`) — **beside** it, not
-  inside it, so stamping happens even when the new turn changed no files
-  and the marker seam's `if files:` gate emits nothing. Gated on the run
-  having produced assistant output. Double-delivery is impossible by
+  **The attach step captures the exact note ids it included**, and that
+  id list travels with the run; at completion, `mark_notes_delivered`
+  stamps precisely that list — never "all pending for the conversation".
+  This closes a real race: a user can annotate an *older* turn's card
+  while a new run is already in flight, and those mid-run notes were
+  never in the payload — a blanket stamp would silently swallow them.
+  Stamping is called at the same run-completion point that invokes
+  `_append_change_markers` (bridge `:4695`) — **beside** it, not inside
+  it, so it happens even when the new turn changed no files and the
+  marker seam's `if files:` gate emits nothing. Gated on the run having
+  produced assistant output. Double-delivery is impossible by
   construction (pending query excludes stamped rows).
 - **Disclosure row** (review finding #4 — resume amnesia): at the same
-  completion seam, a persisted TOOL-role transcript row records what was
-  attached — content, not just a count:
+  completion seam, a TOOL-role transcript row records what was attached —
+  content, not just a count:
   `📝 Diff feedback attached — a.py @@ -1,4 +1,6 @@: "use the cached
   value here"` (one line per note, same message family as the change
-  markers). The row carries **no** `change_review_run_id`, so it can
-  never itself render as a turn file card. Humans, resume, and exports
-  keep the record even though the outbound copy is transient. Whether TOOL rows re-enter rebuilt provider
-  history is an inherited pipeline property (see Known boundaries).
+  markers). **Durability follows the marker precedent exactly**: the
+  change markers are not persisted messages — they are emitted live and
+  re-derived on resume (`resume_marker_messages`, bridge `:4536`) — so
+  the disclosure row is likewise emitted live at completion and
+  re-derived on resume from delivered `change_notes` rows (grouped by
+  `delivered_at`, anchored after the delivering run's marker position).
+  Everything needed for re-derivation is already in the table. The row
+  carries **no** `change_review_run_id`, so it can never itself render as
+  a turn file card. Whether TOOL rows re-enter rebuilt provider history
+  is an inherited pipeline property (see Known boundaries).
 
 ### 5. Card affordances (bounded polish)
 
@@ -205,7 +225,12 @@ controller/bridge-side and does not consult the presentation switch.
   last user message of the outbound copy and the stored message is
   unchanged; completion stamps `delivered_at` + emits the disclosure row
   with note content; a run failing before assistant output leaves notes
-  pending; block cap elision.
+  pending; **the mid-run race** — a note created after attach, while the
+  run is in flight, is NOT stamped at that run's completion and rides the
+  next send; **cap elision keeps elided notes pending** (only notes in
+  the block are stamped); **disclosure resume re-derivation** — a fresh
+  session over the same DB re-derives the disclosure row with the same
+  content, anchored after its run's marker.
 - **Affordances:** Review button opens the screen at the card's run;
   expand-all mounts all diff bodies; elision keeps first+last components.
 - **Kill switch:** OFF-path byte-parity unchanged; pending notes created

--- a/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
+++ b/Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md
@@ -32,11 +32,18 @@ disclosure**; no composer-draft path).
 Five pieces, in dependency order. Every anchor below was re-verified
 against dev at `ed49499b8` (2026-08-17).
 
-### 1. Persistence: `change_notes` in AgentRuns_DB (v3 → v4)
+### 1. Persistence: `change_notes` in AgentRuns_DB (audit version 8)
 
-AgentRuns_DB is self-versioned (`_CURRENT_SCHEMA_VERSION = 3`,
-`DB/AgentRuns_DB.py:38`), so this is a self-contained bump — no
-ChaChaNotes migration.
+AgentRuns_DB migrates by its own convention — idempotent
+`CREATE TABLE IF NOT EXISTS` in the DDL block plus PRAGMA-guarded
+idempotent ALTERs, with an **append-only audit** `schema_version` table
+(`INSERT OR IGNORE ... VALUES (N)`; currently at 7 — see
+`DB/AgentRuns_DB.py:335-345`; the `_CURRENT_SCHEMA_VERSION = 3` constant
+at `:38` is not the live version gate). This feature adds the
+`change_notes` DDL to the create block and appends audit version **8** —
+self-contained, no ChaChaNotes migration. NOTE (v5 durability comment in
+the DDL): this DB holds durable user-authored content, and notes extend
+that — "clear run history" tooling must not treat it as disposable.
 
 ```sql
 CREATE TABLE change_notes (
@@ -196,6 +203,17 @@ controller/bridge-side and does not consult the presentation switch.
 
 ## Known boundaries (inherited, disclosed, not changed here)
 
+- **Agent-path-only delivery:** `turn_bundle_block` is applied only
+  inside `ConsoleAgentBridge.run_reply` (the wake feature's delivery-path
+  decision record, `Chat/console_fleet_wake.py:18-40`, documents this).
+  A send taken on the plain-provider path (agent runtime toggled off)
+  attaches nothing — notes simply **stay pending** until the next agent
+  turn, which is the turn that can act on file-change feedback anyway.
+  Unlike the wake notice, none of that record's disqualifiers apply here:
+  the notes are user-authored feedback riding the user's own real
+  message, so the "reads as user input" and "no trailing user entry"
+  concerns are moot.
+
 - **Conversation-id drift:** temporary-conversation promotion can change
   a conversation's id while existing runs keep the old one. Notes share
   exactly the exposure `change_snapshots` already has; no new mitigation.
@@ -213,7 +231,8 @@ controller/bridge-side and does not consult the presentation switch.
   multi-hunk, rename, binary, and the >cap case (segmentation on full
   text; display cap per hunk).
 - **Persistence:** real file-backed `AgentRunsDB` (NOT `:memory:` —
-  thread-affinity, V1 lesson): v3→v4 migration on an existing file;
+  thread-affinity, V1 lesson): opening a pre-existing DB file creates
+  `change_notes` and appends audit version 8 idempotently;
   add/delete/pending/mark-delivered; resume round-trip (new provider +
   card instance sees the notes).
 - **Widget:** real CSS bundle, id/class queries only. Per-hunk blocks

--- a/Tests/Chat/test_change_notes_db.py
+++ b/Tests/Chat/test_change_notes_db.py
@@ -116,6 +116,78 @@ def test_mark_notes_delivered_stamps_only_given_ids_and_sets_timestamp(db):
     assert notes[note_2]["delivered_at"] is None
 
 
+def test_mark_notes_delivered_stamps_delivered_by_run_id_when_given(db):
+    """TASK-16800 Task 6 fix round: `delivered_by_run_id` records which
+    run's COMPLETION did the delivering -- distinct from `run_id`, the
+    run whose diff the note is anchored to/critiques. A note annotated
+    against `run_a`'s diff but delivered on `run_b`'s completion must
+    carry `run_b` in `delivered_by_run_id`, not `run_a`."""
+    run_a = _make_run(db, conversation_id="conv1")
+    run_b = _make_run(db, conversation_id="conv1")
+    note_id = db.add_change_note(
+        run_id=run_a, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="anchored-to-a",
+    )
+
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_b)
+
+    row = db.notes_for_run(run_a)[0]
+    assert row["run_id"] == run_a
+    assert row["delivered_by_run_id"] == run_b
+    assert row["delivered_at"] is not None
+
+
+def test_mark_notes_delivered_leaves_delivered_by_run_id_null_when_omitted(db):
+    """The parameter is optional (back-compat with callers/rows that
+    predate the column) -- omitting it must not raise and must leave the
+    column NULL, exactly like a pre-migration stamp would read."""
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="no-deliverer",
+    )
+    db.mark_notes_delivered([note_id])
+    row = db.notes_for_run(run_id)[0]
+    assert row["delivered_at"] is not None
+    assert row["delivered_by_run_id"] is None
+
+
+def test_delivered_notes_for_conversation_joins_both_runs_oldest_first(db):
+    """Batched counterpart to `pending_notes_for_conversation` (TASK-16800
+    Task 6 fix round) -- same join shape, but for DELIVERED notes."""
+    run_a = _make_run(db, conversation_id="conv1")
+    run_b = _make_run(db, conversation_id="conv1")
+    other_conv_run = _make_run(db, conversation_id="conv2")
+
+    note_a = db.add_change_note(
+        run_id=run_a, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note-a",
+    )
+    note_b = db.add_change_note(
+        run_id=run_b, root="/r", path="b.py", hunk_index=0,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="note-b",
+    )
+    other_conv_note = db.add_change_note(
+        run_id=other_conv_run, root="/r", path="c.py", hunk_index=0,
+        hunk_header="@@ -3,1 +3,1 @@", hunk_excerpt="z", note="note-other-conv",
+    )
+    db.mark_notes_delivered([note_a, note_b, other_conv_note], delivered_by_run_id=run_b)
+
+    delivered = db.delivered_notes_for_conversation("conv1")
+    assert [row["id"] for row in delivered] == [note_a, note_b]
+    assert {row["run_id"] for row in delivered} == {run_a, run_b}
+    assert all(row["delivered_by_run_id"] == run_b for row in delivered)
+
+
+def test_delivered_notes_for_conversation_excludes_pending(db):
+    run_id = _make_run(db)
+    db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="still-pending",
+    )
+    assert db.delivered_notes_for_conversation("conv1") == []
+
+
 def test_mark_notes_delivered_mid_run_race_leaves_later_note_pending(db):
     """Spec §4: the attach step captures the exact pending-id list at
     attach time; a note added AFTER that capture — while the run is still
@@ -253,6 +325,108 @@ def test_migration_creates_table_and_appends_audit_version_8(tmp_path):
             hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="post-migration",
         )
         assert reopened.notes_for_run(run_id)[0]["id"] == note_id
+    finally:
+        reopened.close()
+
+
+def test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9(
+    tmp_path,
+):
+    """TASK-16800 Task 6 fix round: a file whose `change_notes` table
+    already exists but predates `delivered_by_run_id` (i.e. was last
+    opened by code before the fix round) must pick up the column via the
+    idempotent ALTER TABLE, not lose the table's existing rows -- same
+    mechanism/precedent as `test_migration_creates_table_and_appends_audit_version_8`,
+    but for a column ADD on an already-existing table rather than the
+    whole table's CREATE.
+    """
+    db_path = tmp_path / "migrate_v9.db"
+
+    first = AgentRunsDB(db_path, client_id="t")
+    run_id = first.create_run(conversation_id="c", agent_kind="primary")
+    pre_migration_note_id = first.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="pre-existing",
+    )
+    first.close()
+
+    # Simulate a pre-v9 file: recreate change_notes with the OLD (10-column,
+    # no delivered_by_run_id) shape and remove the version-9 audit row.
+    # (`ALTER TABLE ... DROP COLUMN` hits a SQLite schema-reconstruction
+    # quirk against this table's commented DDL -- dropping and recreating
+    # with the old shape sidesteps it and is arguably more honest: a truly
+    # pre-v9 file's `change_notes` table never had the column at all.)
+    raw = sqlite3.connect(str(db_path))
+    try:
+        old_rows = raw.execute(
+            "SELECT id, run_id, root, path, hunk_index, hunk_header, "
+            "hunk_excerpt, note, created_at, delivered_at FROM change_notes"
+        ).fetchall()
+        raw.execute("DROP TABLE change_notes")
+        raw.execute(
+            """
+            CREATE TABLE change_notes (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                root TEXT NOT NULL,
+                path TEXT NOT NULL,
+                hunk_index INTEGER NOT NULL,
+                hunk_header TEXT NOT NULL,
+                hunk_excerpt TEXT NOT NULL,
+                note TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                delivered_at TEXT
+            )
+            """
+        )
+        raw.executemany(
+            "INSERT INTO change_notes "
+            "(id, run_id, root, path, hunk_index, hunk_header, hunk_excerpt, "
+            "note, created_at, delivered_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            old_rows,
+        )
+        raw.execute("DELETE FROM schema_version WHERE version = 9")
+        raw.commit()
+    finally:
+        raw.close()
+
+    raw = sqlite3.connect(str(db_path))
+    try:
+        columns = {row[1] for row in raw.execute("PRAGMA table_info(change_notes)")}
+        assert "delivered_by_run_id" not in columns
+        versions = {row[0] for row in raw.execute("SELECT version FROM schema_version")}
+        assert 9 not in versions
+    finally:
+        raw.close()
+
+    reopened = AgentRunsDB(db_path, client_id="t")
+    try:
+        raw = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1] for row in raw.execute("PRAGMA table_info(change_notes)")
+            }
+            assert "delivered_by_run_id" in columns
+            versions = {
+                row[0] for row in raw.execute("SELECT version FROM schema_version")
+            }
+            assert 9 in versions
+        finally:
+            raw.close()
+
+        # The pre-existing row survived the ALTER, reading NULL for the
+        # new column (no DEFAULT), and the API still works against it.
+        pre_row = reopened.notes_for_run(run_id)[0]
+        assert pre_row["id"] == pre_migration_note_id
+        assert pre_row["delivered_by_run_id"] is None
+
+        post_note_id = reopened.add_change_note(
+            run_id=run_id, root="/r", path="b.py", hunk_index=1,
+            hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="post-migration",
+        )
+        reopened.mark_notes_delivered([post_note_id], delivered_by_run_id=run_id)
+        post_row = {r["id"]: r for r in reopened.notes_for_run(run_id)}[post_note_id]
+        assert post_row["delivered_by_run_id"] == run_id
     finally:
         reopened.close()
 

--- a/Tests/Chat/test_change_notes_db.py
+++ b/Tests/Chat/test_change_notes_db.py
@@ -1,0 +1,293 @@
+"""TASK-16800 Task 1: `change_notes` persistence in AgentRuns_DB.
+
+Persistence foundation for the turn-file-card annotate/feedback loop
+(spec `Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md`
+§1). Tests run against a real FILE-BACKED ``AgentRunsDB`` — never
+``:memory:`` (thread-affinity trap, V1 lesson carried into this spec).
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return AgentRunsDB(tmp_path / "runs.db", client_id="t")
+
+
+def _make_run(db: AgentRunsDB, conversation_id: str = "conv1") -> str:
+    return db.create_run(conversation_id=conversation_id, agent_kind="primary")
+
+
+def test_add_change_note_returns_id_and_round_trips_all_fields(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id,
+        root="/repo",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,4 +1,6 @@",
+        hunk_excerpt="-old\n+new",
+        note="use the cached value here",
+    )
+    assert isinstance(note_id, int)
+
+    notes = db.notes_for_run(run_id)
+    assert len(notes) == 1
+    row = notes[0]
+    assert row["id"] == note_id
+    assert row["run_id"] == run_id
+    assert row["root"] == "/repo"
+    assert row["path"] == "a.py"
+    assert row["hunk_index"] == 0
+    assert row["hunk_header"] == "@@ -1,4 +1,6 @@"
+    assert row["hunk_excerpt"] == "-old\n+new"
+    assert row["note"] == "use the cached value here"
+    assert row["created_at"]
+    assert row["delivered_at"] is None
+
+
+def test_notes_for_run_oldest_first(db):
+    run_id = _make_run(db)
+    first = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="first",
+    )
+    second = db.add_change_note(
+        run_id=run_id, root="/r", path="b.py", hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="second",
+    )
+    ids = [row["id"] for row in db.notes_for_run(run_id)]
+    assert ids == [first, second]
+
+
+def test_pending_notes_for_conversation_joins_both_runs_oldest_first(db):
+    run_a = _make_run(db, conversation_id="conv1")
+    run_b = _make_run(db, conversation_id="conv1")
+    other_conv_run = _make_run(db, conversation_id="conv2")
+
+    note_a = db.add_change_note(
+        run_id=run_a, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note-a",
+    )
+    note_b = db.add_change_note(
+        run_id=run_b, root="/r", path="b.py", hunk_index=0,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="note-b",
+    )
+    db.add_change_note(
+        run_id=other_conv_run, root="/r", path="c.py", hunk_index=0,
+        hunk_header="@@ -3,1 +3,1 @@", hunk_excerpt="z", note="note-other-conv",
+    )
+
+    pending = db.pending_notes_for_conversation("conv1")
+    assert [row["id"] for row in pending] == [note_a, note_b]
+    assert {row["run_id"] for row in pending} == {run_a, run_b}
+
+
+def test_pending_notes_for_conversation_excludes_delivered(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note",
+    )
+    db.mark_notes_delivered([note_id])
+    assert db.pending_notes_for_conversation("conv1") == []
+
+
+def test_mark_notes_delivered_stamps_only_given_ids_and_sets_timestamp(db):
+    run_id = _make_run(db)
+    note_1 = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="one",
+    )
+    note_2 = db.add_change_note(
+        run_id=run_id, root="/r", path="b.py", hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
+    )
+
+    db.mark_notes_delivered([note_1])
+
+    notes = {row["id"]: row for row in db.notes_for_run(run_id)}
+    assert notes[note_1]["delivered_at"] is not None
+    assert notes[note_2]["delivered_at"] is None
+
+
+def test_mark_notes_delivered_mid_run_race_leaves_later_note_pending(db):
+    """Spec §4: the attach step captures the exact pending-id list at
+    attach time; a note added AFTER that capture — while the run is still
+    in flight — must not be swept up by stamping the captured list, even
+    though it is technically still "pending" when the stamp runs. This is
+    load-bearing for Task 5's delivery seam.
+    """
+    run_id = _make_run(db)
+    note_1 = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="captured-before-run",
+    )
+
+    # Attach seam captures the pending id list at this instant.
+    captured_ids = [row["id"] for row in db.pending_notes_for_conversation("conv1")]
+    assert captured_ids == [note_1]
+
+    # A note lands on an older turn's card while the run is in flight.
+    note_2 = db.add_change_note(
+        run_id=run_id, root="/r", path="b.py", hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="mid-run-race",
+    )
+
+    # Completion stamps exactly the captured list, not "all pending now".
+    db.mark_notes_delivered(captured_ids)
+
+    notes = {row["id"]: row for row in db.notes_for_run(run_id)}
+    assert notes[note_1]["delivered_at"] is not None
+    assert notes[note_2]["delivered_at"] is None
+
+    still_pending = [row["id"] for row in db.pending_notes_for_conversation("conv1")]
+    assert still_pending == [note_2]
+
+
+def test_delete_change_note_deletes_pending_note(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="deleteme",
+    )
+    assert db.delete_change_note(note_id) is True
+    assert db.notes_for_run(run_id) == []
+
+
+def test_delete_change_note_returns_false_for_delivered(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="delivered",
+    )
+    db.mark_notes_delivered([note_id])
+    assert db.delete_change_note(note_id) is False
+    # Delivered note survives -- it is record, not deletable.
+    assert len(db.notes_for_run(run_id)) == 1
+
+
+def test_delete_change_note_returns_false_for_missing(db):
+    assert db.delete_change_note(999999) is False
+
+
+def test_mark_notes_delivered_empty_list_is_noop(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="untouched",
+    )
+    db.mark_notes_delivered([])
+    assert db.notes_for_run(run_id)[0]["delivered_at"] is None
+
+
+# --- Migration: change_notes DDL + audit version 8 --------------------
+
+
+def test_migration_creates_table_and_appends_audit_version_8(tmp_path):
+    db_path = tmp_path / "migrate.db"
+
+    # Open once with the current code -- this already creates change_notes
+    # and appends schema_version 8, since CREATE TABLE IF NOT EXISTS /
+    # INSERT OR IGNORE run unconditionally on every open (this DB's own
+    # migration mechanism -- there is no separate "old" binary to run
+    # here). Simulate a pre-migration file by tearing the table/version
+    # row back out via a raw sqlite3 connection, then reopening through
+    # AgentRunsDB and asserting the migration reapplies.
+    AgentRunsDB(db_path, client_id="t").close()
+
+    raw = sqlite3.connect(str(db_path))
+    try:
+        raw.execute("DROP TABLE change_notes")
+        raw.execute("DELETE FROM schema_version WHERE version = 8")
+        raw.commit()
+    finally:
+        raw.close()
+
+    # Confirm the simulated pre-migration state actually took.
+    raw = sqlite3.connect(str(db_path))
+    try:
+        tables = {
+            row[0]
+            for row in raw.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "change_notes" not in tables
+        versions = {
+            row[0] for row in raw.execute("SELECT version FROM schema_version").fetchall()
+        }
+        assert 8 not in versions
+    finally:
+        raw.close()
+
+    reopened = AgentRunsDB(db_path, client_id="t")
+    try:
+        raw = sqlite3.connect(str(db_path))
+        try:
+            tables = {
+                row[0]
+                for row in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "change_notes" in tables
+            versions = {
+                row[0]
+                for row in raw.execute("SELECT version FROM schema_version").fetchall()
+            }
+            assert 8 in versions
+        finally:
+            raw.close()
+
+        # The reopened instance's own API must work against the
+        # freshly-recreated table.
+        run_id = reopened.create_run(conversation_id="c", agent_kind="primary")
+        note_id = reopened.add_change_note(
+            run_id=run_id, root="/r", path="a.py", hunk_index=0,
+            hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="post-migration",
+        )
+        assert reopened.notes_for_run(run_id)[0]["id"] == note_id
+    finally:
+        reopened.close()
+
+
+def test_migration_reopening_twice_is_idempotent(tmp_path):
+    db_path = tmp_path / "double_open.db"
+
+    first = AgentRunsDB(db_path, client_id="t")
+    first.close()
+    second = AgentRunsDB(db_path, client_id="t")
+    try:
+        raw = sqlite3.connect(str(db_path))
+        try:
+            version_8_rows = raw.execute(
+                "SELECT COUNT(*) FROM schema_version WHERE version = 8"
+            ).fetchone()[0]
+            assert version_8_rows == 1  # INSERT OR IGNORE -- never duplicated
+
+            tables = [
+                row[0]
+                for row in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name = 'change_notes'"
+                ).fetchall()
+            ]
+            assert tables == ["change_notes"]
+        finally:
+            raw.close()
+
+        # And the API still works normally on the third open.
+        run_id = second.create_run(conversation_id="c", agent_kind="primary")
+        note_id = second.add_change_note(
+            run_id=run_id, root="/r", path="a.py", hunk_index=0,
+            hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="third-open",
+        )
+        assert note_id
+    finally:
+        second.close()

--- a/Tests/Chat/test_change_notes_db.py
+++ b/Tests/Chat/test_change_notes_db.py
@@ -109,11 +109,45 @@ def test_mark_notes_delivered_stamps_only_given_ids_and_sets_timestamp(db):
         hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
     )
 
-    db.mark_notes_delivered([note_1])
+    stamped = db.mark_notes_delivered([note_1])
+    assert stamped == [note_1]
 
     notes = {row["id"]: row for row in db.notes_for_run(run_id)}
     assert notes[note_1]["delivered_at"] is not None
     assert notes[note_2]["delivered_at"] is None
+
+
+def test_mark_notes_delivered_returns_only_actually_stamped_ids(db):
+    """Qodo #4 (PR #1779 fix round): the return value must reflect what
+    THIS call actually stamped, not merely echo back its own input -- a
+    note already delivered (by a concurrent caller, simulated here via a
+    direct pre-stamp) is silently skipped by the UPDATE's own
+    `delivered_at IS NULL` guard, and the return value must say so.
+    """
+    run_id = _make_run(db)
+    note_1 = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="one",
+    )
+    note_2 = db.add_change_note(
+        run_id=run_id, root="/r", path="b.py", hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
+    )
+
+    # Simulate a lost race: note_2 gets delivered by someone else first.
+    rival_stamped = db.mark_notes_delivered([note_2], delivered_by_run_id="rival-run")
+    assert rival_stamped == [note_2]
+
+    # This caller captured BOTH ids before the rival's stamp landed (the
+    # same shape as the bridge's attach-then-complete seam) and now tries
+    # to stamp both.
+    stamped = db.mark_notes_delivered([note_1, note_2], delivered_by_run_id="this-run")
+    assert stamped == [note_1]
+
+    notes = {row["id"]: row for row in db.notes_for_run(run_id)}
+    assert notes[note_1]["delivered_by_run_id"] == "this-run"
+    # note_2 keeps the RIVAL's stamp -- never re-stamped/overwritten.
+    assert notes[note_2]["delivered_by_run_id"] == "rival-run"
 
 
 def test_mark_notes_delivered_stamps_delivered_by_run_id_when_given(db):
@@ -254,7 +288,8 @@ def test_mark_notes_delivered_empty_list_is_noop(db):
         run_id=run_id, root="/r", path="a.py", hunk_index=0,
         hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="untouched",
     )
-    db.mark_notes_delivered([])
+    stamped = db.mark_notes_delivered([])
+    assert stamped == []
     assert db.notes_for_run(run_id)[0]["delivered_at"] is None
 
 
@@ -429,6 +464,127 @@ def test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9(
         assert post_row["delivered_by_run_id"] == run_id
     finally:
         reopened.close()
+
+
+def test_migration_adds_snapshot_id_column_and_appends_audit_version_10(tmp_path):
+    """Qodo #6 (PR #1779 fix round): same idempotent-ALTER precedent as
+    `test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9`,
+    now for `snapshot_id` -- a file whose `change_notes` table predates
+    that column must pick it up without losing existing rows, and the
+    reopened instance's API must keep working against it.
+    """
+    db_path = tmp_path / "migrate_v10.db"
+
+    first = AgentRunsDB(db_path, client_id="t")
+    run_id = first.create_run(conversation_id="c", agent_kind="primary")
+    pre_migration_note_id = first.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="pre-existing",
+    )
+    first.close()
+
+    # Simulate a pre-v10 file: recreate change_notes with the OLD
+    # (11-column, no snapshot_id) shape and remove the version-10 audit
+    # row. Same DROP-and-recreate approach as the v9 test above (`ALTER
+    # TABLE ... DROP COLUMN` hits the same SQLite schema-reconstruction
+    # quirk against this table's commented DDL).
+    raw = sqlite3.connect(str(db_path))
+    try:
+        old_rows = raw.execute(
+            "SELECT id, run_id, root, path, hunk_index, hunk_header, "
+            "hunk_excerpt, note, created_at, delivered_at, delivered_by_run_id "
+            "FROM change_notes"
+        ).fetchall()
+        raw.execute("DROP TABLE change_notes")
+        raw.execute(
+            """
+            CREATE TABLE change_notes (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                root TEXT NOT NULL,
+                path TEXT NOT NULL,
+                hunk_index INTEGER NOT NULL,
+                hunk_header TEXT NOT NULL,
+                hunk_excerpt TEXT NOT NULL,
+                note TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                delivered_at TEXT,
+                delivered_by_run_id TEXT
+            )
+            """
+        )
+        raw.executemany(
+            "INSERT INTO change_notes "
+            "(id, run_id, root, path, hunk_index, hunk_header, hunk_excerpt, "
+            "note, created_at, delivered_at, delivered_by_run_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            old_rows,
+        )
+        raw.execute("DELETE FROM schema_version WHERE version = 10")
+        raw.commit()
+    finally:
+        raw.close()
+
+    raw = sqlite3.connect(str(db_path))
+    try:
+        columns = {row[1] for row in raw.execute("PRAGMA table_info(change_notes)")}
+        assert "snapshot_id" not in columns
+        versions = {row[0] for row in raw.execute("SELECT version FROM schema_version")}
+        assert 10 not in versions
+    finally:
+        raw.close()
+
+    reopened = AgentRunsDB(db_path, client_id="t")
+    try:
+        raw = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1] for row in raw.execute("PRAGMA table_info(change_notes)")
+            }
+            assert "snapshot_id" in columns
+            versions = {
+                row[0] for row in raw.execute("SELECT version FROM schema_version")
+            }
+            assert 10 in versions
+        finally:
+            raw.close()
+
+        # The pre-existing row survived the ALTER, reading NULL for the
+        # new column (no DEFAULT), and the API still works against it.
+        pre_row = reopened.notes_for_run(run_id)[0]
+        assert pre_row["id"] == pre_migration_note_id
+        assert pre_row["snapshot_id"] is None
+
+        post_note_id = reopened.add_change_note(
+            run_id=run_id, root="/r", path="b.py", hunk_index=1,
+            hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="post-migration",
+            snapshot_id=42,
+        )
+        post_row = {r["id"]: r for r in reopened.notes_for_run(run_id)}[post_note_id]
+        assert post_row["snapshot_id"] == 42
+    finally:
+        reopened.close()
+
+
+def test_add_change_note_snapshot_id_defaults_to_none(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="no snapshot id",
+    )
+    assert db.notes_for_run(run_id)[0]["id"] == note_id
+    assert db.notes_for_run(run_id)[0]["snapshot_id"] is None
+
+
+def test_add_change_note_round_trips_snapshot_id(db):
+    run_id = _make_run(db)
+    note_id = db.add_change_note(
+        run_id=run_id, root="/r", path="a.py", hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="with snapshot id",
+        snapshot_id=7,
+    )
+    assert db.notes_for_run(run_id)[0]["id"] == note_id
+    assert db.notes_for_run(run_id)[0]["snapshot_id"] == 7
 
 
 def test_migration_reopening_twice_is_idempotent(tmp_path):

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -2563,7 +2563,7 @@ def test_resume_marker_messages_re_derives_diff_feedback_disclosure_after_marker
     )
     db.set_status(run_id, "done", result="4")
     note_id = _add_note(db, run_id, note="use the cached value here")
-    db.mark_notes_delivered([note_id])
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_id)
     delivered = db.notes_for_run(run_id)
     assert delivered[0]["delivered_at"] is not None
 
@@ -2602,9 +2602,9 @@ def test_resume_marker_messages_groups_two_delivery_batches_in_delivery_order(
     )
     db.set_status(run_id, "done", result="ok")
     first_id = _add_note(db, run_id, path="a.py", note="first batch note")
-    db.mark_notes_delivered([first_id])
+    db.mark_notes_delivered([first_id], delivered_by_run_id=run_id)
     second_id = _add_note(db, run_id, path="b.py", note="second batch note")
-    db.mark_notes_delivered([second_id])
+    db.mark_notes_delivered([second_id], delivered_by_run_id=run_id)
     delivered = db.notes_for_run(run_id)
     delivered_ats = {n["id"]: n["delivered_at"] for n in delivered}
     assert delivered_ats[first_id] <= delivered_ats[second_id]
@@ -2662,7 +2662,9 @@ def test_resume_marker_messages_heals_disclosure_when_live_append_never_happened
     run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
     db.set_status(run_id, "done", result="ok")  # no steps: a plain answer
     note_id = _add_note(db, run_id, note="healed disclosure")
-    db.mark_notes_delivered([note_id])  # stamped, as if live append then failed
+    # Stamped as if live append then failed -- delivered_by_run_id is this
+    # same run's id, matching what the real Task 5 stamp call now passes.
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_id)
 
     bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     blocks = bridge.resume_marker_messages("conv-1")
@@ -2701,7 +2703,7 @@ def test_resume_marker_messages_disclosure_survives_run_with_no_snapshot_rows(
     )
     db.set_status(run_id, "done", result="4")
     note_id = _add_note(db, run_id, note="no snapshot for this turn")
-    db.mark_notes_delivered([note_id])
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_id)
     # Sanity: no change_snapshots rows exist for this run/conversation.
     assert db.change_snapshots_for_conversation("conv-1") == []
 
@@ -2715,6 +2717,219 @@ def test_resume_marker_messages_disclosure_survives_run_with_no_snapshot_rows(
         db.notes_for_run(run_id)
     )
     assert "no snapshot for this turn" in block[-1].content
+
+
+def test_resume_marker_messages_disclosure_anchors_at_the_delivering_run(tmp_path):
+    """Fix-round CRITICAL finding: a note annotated against run A's diff
+    but DELIVERED on run B's later completion must resume with its
+    disclosure row after B's own marker row(s) -- not A's. Live emission
+    places the row at whichever run's completion actually did the
+    stamping; re-derivation must match that, matching
+    ``format_diff_feedback_disclosure`` byte-for-byte, or a resumed
+    transcript would show the disclosure attached to the wrong turn (or,
+    under the pre-fix anchor-run grouping, not at all if A had since been
+    superseded)."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_a = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_a,
+        [
+            {
+                "index": 0,
+                "kind": STEP_TOOL_RESULT,
+                "tool_name": "calculator",
+                "result": "4",
+                "summary": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_a, "done", result="4")
+    note_id = _add_note(db, run_a, note="annotated on a, delivered on b")
+
+    run_b = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_b,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "boom",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_b, "done", result="ok")
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_b)
+    delivered = db.notes_for_run(run_a)
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 2
+    block_a = blocks[0][1]
+    block_b = blocks[1][1]
+    assert "calculator" in block_a[0].content
+    assert not any("Diff feedback attached" in m.content for m in block_a)
+    assert "boom" in block_b[0].content
+    assert block_b[-1].content == format_diff_feedback_disclosure(delivered)
+    assert "annotated on a, delivered on b" in block_b[-1].content
+    assert block_b[-1].change_review_run_id is None
+
+
+def test_resume_marker_messages_batch_spanning_two_anchor_runs_stays_one_row(
+    tmp_path,
+):
+    """Fix-round finding: one live delivery batch containing notes
+    annotated against TWO different runs' diffs must stay ONE disclosure
+    row -- at the delivering run's position -- not fragment into one row
+    per anchor run."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_a = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.set_status(run_a, "done", result="ok")
+    note_a = _add_note(db, run_a, path="a.py", note="note on a")
+
+    run_b = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.set_status(run_b, "done", result="ok")
+    note_b = _add_note(db, run_b, path="b.py", note="note on b")
+
+    run_c = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_c,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "final turn",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_c, "done", result="ok")
+    # ONE call -- both notes delivered together, by run_c's completion.
+    db.mark_notes_delivered([note_a, note_b], delivered_by_run_id=run_c)
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 3
+    block_a, block_b, block_c = (b for _anchor, b in blocks)
+    assert not any("Diff feedback attached" in m.content for m in block_a)
+    assert not any("Diff feedback attached" in m.content for m in block_b)
+    disclosure_rows = [m for m in block_c if "Diff feedback attached" in m.content]
+    assert len(disclosure_rows) == 1
+    assert "note on a" in disclosure_rows[0].content
+    assert "note on b" in disclosure_rows[0].content
+
+
+def test_resume_marker_messages_legacy_null_delivered_by_run_id_falls_back_to_annotated_run(
+    tmp_path,
+):
+    """A note stamped delivered before ``delivered_by_run_id`` existed (or
+    by any caller that omits it) carries NULL there -- there is no way to
+    recover which run delivered it, so resume falls back to the note's own
+    (annotated) run's position, exactly like the original Task 6
+    mechanism. Verified against a conversation with a LATER run present,
+    so a wrong "always use the newest/last run" fallback would be
+    detectable."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_a = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_a,
+        [
+            {
+                "index": 0,
+                "kind": STEP_TOOL_RESULT,
+                "tool_name": "calculator",
+                "result": "4",
+                "summary": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_a, "done", result="4")
+    note_id = _add_note(db, run_a, note="legacy stamp, no deliverer recorded")
+    db.mark_notes_delivered([note_id])  # no delivered_by_run_id -- legacy shape
+
+    run_b = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_b,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "boom",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_b, "done", result="ok")
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 2
+    block_a = blocks[0][1]
+    block_b = blocks[1][1]
+    assert "calculator" in block_a[0].content
+    assert block_a[-1].content == format_diff_feedback_disclosure(
+        db.notes_for_run(run_a)
+    )
+    assert "legacy stamp, no deliverer recorded" in block_a[-1].content
+    assert not any("Diff feedback attached" in m.content for m in block_b)
+
+
+def test_resume_marker_messages_survives_delivered_notes_read_failure(
+    tmp_path, monkeypatch
+):
+    """Fix-round CRITICAL C1: a ``change_notes`` read failure must not
+    break conversation resume entirely -- guarded the same way the
+    ``change_snapshots_for_conversation`` fetch immediately above it
+    already is ("resume must not die on this"). A run's own step markers
+    must still come back even if the disclosure lookup blows up."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_id,
+        [
+            {
+                "index": 0,
+                "kind": STEP_TOOL_RESULT,
+                "tool_name": "calculator",
+                "result": "4",
+                "summary": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_id, "done", result="4")
+    note_id = _add_note(db, run_id, note="should not crash resume")
+    db.mark_notes_delivered([note_id], delivered_by_run_id=run_id)
+
+    def _boom(self, conversation_id):
+        raise RuntimeError("change_notes DB is on fire")
+
+    monkeypatch.setattr(AgentRunsDB, "delivered_notes_for_conversation", _boom)
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    assert "calculator" in block[0].content
+    assert not any("Diff feedback attached" in m.content for m in block)
 
 
 def _tool_marker(text: str) -> ConsoleChatMessage:

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -37,6 +37,7 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_display_state import format_diff_feedback_disclosure
 from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
 from tldw_chatbook.Chat.console_prepared_request import PreparedProviderRequest
 from tldw_chatbook.Chat.provider_continuation import (
@@ -2524,6 +2525,196 @@ def test_resume_marker_messages_skips_superseded_runs(tmp_path):
     blocks = bridge.resume_marker_messages("conv-1")
     assert len(blocks) == 1
     assert "final attempt" in blocks[0][1][0].content
+
+
+def _add_note(db, run_id, *, path="a.py", header="@@ -1,1 +1,1 @@", note="n"):
+    return db.add_change_note(
+        run_id=run_id,
+        root="/workspace",
+        path=path,
+        hunk_index=0,
+        hunk_header=header,
+        hunk_excerpt="+x",
+        note=note,
+    )
+
+
+def test_resume_marker_messages_re_derives_diff_feedback_disclosure_after_marker(
+    tmp_path,
+):
+    """Task 6 (spec §4): a run with snapshots AND delivered notes yields
+    its marker row(s) AND, after them, a disclosure row whose text equals
+    ``format_diff_feedback_disclosure`` over the delivered notes."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_id,
+        [
+            {
+                "index": 0,
+                "kind": STEP_TOOL_RESULT,
+                "tool_name": "calculator",
+                "result": "4",
+                "summary": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_id, "done", result="4")
+    note_id = _add_note(db, run_id, note="use the cached value here")
+    db.mark_notes_delivered([note_id])
+    delivered = db.notes_for_run(run_id)
+    assert delivered[0]["delivered_at"] is not None
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    assert "calculator" in block[0].content
+    assert block[-1].content == format_diff_feedback_disclosure(delivered)
+    assert "use the cached value here" in block[-1].content
+    assert block[-1].role is ConsoleMessageRole.TOOL
+    assert block[-1].change_review_run_id is None
+
+
+def test_resume_marker_messages_groups_two_delivery_batches_in_delivery_order(
+    tmp_path,
+):
+    """Two separate deliveries (two distinct ``delivered_at`` stamps) yield
+    two disclosure rows, oldest delivery first."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_id,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "boom",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_id, "done", result="ok")
+    first_id = _add_note(db, run_id, path="a.py", note="first batch note")
+    db.mark_notes_delivered([first_id])
+    second_id = _add_note(db, run_id, path="b.py", note="second batch note")
+    db.mark_notes_delivered([second_id])
+    delivered = db.notes_for_run(run_id)
+    delivered_ats = {n["id"]: n["delivered_at"] for n in delivered}
+    assert delivered_ats[first_id] <= delivered_ats[second_id]
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    disclosure_rows = [m for m in block if "Diff feedback attached" in m.content]
+    assert len(disclosure_rows) == 2
+    assert "first batch note" in disclosure_rows[0].content
+    assert "second batch note" in disclosure_rows[1].content
+
+
+def test_resume_marker_messages_omits_disclosure_for_pending_only_notes(tmp_path):
+    """Pending (undelivered) notes yield NO disclosure row on resume."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_id,
+        [
+            {
+                "index": 0,
+                "kind": STEP_ERROR,
+                "summary": "boom",
+                "tool_name": "",
+                "result": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_id, "done", result="ok")
+    _add_note(db, run_id, note="still pending")
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    assert not any("Diff feedback attached" in m.content for m in block)
+    assert not any("still pending" in m.content for m in block)
+
+
+def test_resume_marker_messages_heals_disclosure_when_live_append_never_happened(
+    tmp_path,
+):
+    """Task 5's live seam stamps ``delivered_at`` then appends the
+    disclosure row in one ``try`` -- if the append fails after the stamp
+    lands, live never shows a row. This is the designed healer: a fresh
+    resume (no prior live TOOL row in the store at all) must still surface
+    the disclosure purely from the DB stamp."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.set_status(run_id, "done", result="ok")  # no steps: a plain answer
+    note_id = _add_note(db, run_id, note="healed disclosure")
+    db.mark_notes_delivered([note_id])  # stamped, as if live append then failed
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    assert len(block) == 1  # no marker-worthy steps -- only the healed row
+    assert block[0].content == format_diff_feedback_disclosure(
+        db.notes_for_run(run_id)
+    )
+    assert "healed disclosure" in block[0].content
+
+
+def test_resume_marker_messages_disclosure_survives_run_with_no_snapshot_rows(
+    tmp_path,
+):
+    """A run can have delivered notes but NO change_snapshots rows at all
+    (change tracking failed or was never configured for that turn -- note
+    delivery does not depend on tracking having succeeded). The disclosure
+    row must still surface; it is not gated on ``snap_rows``."""
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    db.append_steps(
+        run_id,
+        [
+            {
+                "index": 0,
+                "kind": STEP_TOOL_RESULT,
+                "tool_name": "calculator",
+                "result": "4",
+                "summary": "",
+                "args": None,
+                "created_at": "",
+            },
+        ],
+    )
+    db.set_status(run_id, "done", result="4")
+    note_id = _add_note(db, run_id, note="no snapshot for this turn")
+    db.mark_notes_delivered([note_id])
+    # Sanity: no change_snapshots rows exist for this run/conversation.
+    assert db.change_snapshots_for_conversation("conv-1") == []
+
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
+    blocks = bridge.resume_marker_messages("conv-1")
+
+    assert len(blocks) == 1
+    block = blocks[0][1]
+    assert "calculator" in block[0].content
+    assert block[-1].content == format_diff_feedback_disclosure(
+        db.notes_for_run(run_id)
+    )
+    assert "no snapshot for this turn" in block[-1].content
 
 
 def _tool_marker(text: str) -> ConsoleChatMessage:

--- a/Tests/Chat/test_console_diff_feedback_delivery.py
+++ b/Tests/Chat/test_console_diff_feedback_delivery.py
@@ -195,6 +195,58 @@ def test_pending_notes_attach_stamp_and_disclose_on_success(tmp_path):
     assert tool_rows[0].change_review_run_id is None
 
 
+# -- (a2) lost race: a captured note stamped by a rival BEFORE this run's
+# own completion gets to it -- disclosure must not claim it (Qodo #4) -----
+
+
+def test_lost_race_pre_stamped_note_is_excluded_from_disclosure(tmp_path):
+    """Qodo #4 (PR #1779 fix round): the attach seam captures BOTH ids
+    before `run_turn` is even called (see the seam's own comment); this
+    simulates a concurrent delivery elsewhere stamping ONE of them first,
+    between capture and this run's own completion -- `mark_notes_
+    delivered`'s own `delivered_at IS NULL` guard correctly skips
+    re-stamping it, and the completion seam must disclose only the note
+    it ACTUALLY (verifiably) delivered, not the whole captured set.
+    """
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Done."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    note_a = _add_note(db, earlier_run, path="a.py", note="note a survives")
+    note_b = _add_note(db, earlier_run, path="b.py", note="note b stolen")
+
+    real_run_turn = AgentService.run_turn
+
+    def _steal_note_b(self, **kwargs):
+        # Simulate a concurrent delivery elsewhere stamping note_b BEFORE
+        # this run's own completion runs its own mark_notes_delivered --
+        # after the attach seam above already captured both ids.
+        db.mark_notes_delivered([note_b], delivered_by_run_id="rival-run")
+        return real_run_turn(self, **kwargs)
+
+    with patch.object(AgentService, "run_turn", _steal_note_b):
+        run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "done"
+
+    delivered = {n["id"]: n for n in db.notes_for_run(earlier_run)}
+    assert delivered[note_a]["delivered_at"] is not None
+    assert delivered[note_a]["delivered_by_run_id"] == run_id
+    # note_b keeps the rival's stamp -- this run's own stamp call must not
+    # have overwritten it.
+    assert delivered[note_b]["delivered_by_run_id"] == "rival-run"
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert "note a survives" in tool_rows[0].content
+    assert "note b stolen" not in tool_rows[0].content
+
+
 # -- (b) failed run: still pending, no disclosure -------------------------
 
 

--- a/Tests/Chat/test_console_diff_feedback_delivery.py
+++ b/Tests/Chat/test_console_diff_feedback_delivery.py
@@ -468,6 +468,64 @@ def test_no_pending_notes_leaves_payload_byte_identical(tmp_path):
     assert tool_rows == []
 
 
+# -- kill switch: presentation OFF must not affect bridge-level delivery --
+
+
+def test_kill_switch_off_does_not_prevent_note_delivery(tmp_path, monkeypatch):
+    """AC#5 / the spec's "Kill switch" section: `[console] turn_file_cards
+    = false` keeps the CARD off -- pinned separately (byte-identical plain
+    marker, no card mounts) by
+    `Tests/UI/test_console_turn_file_card_factory.py`'s
+    `test_summary_row_stays_plain_marker_when_disabled`, using the same
+    monkeypatch shape as here. This is the OTHER half of AC#5: the
+    delivery seam lives in ``ConsoleAgentBridge.run_reply`` and never
+    consults that presentation switch at all, so a pending note must
+    still auto-attach, stamp, and disclose exactly like every other run in
+    this file even while the switch is OFF -- "no note UI" must never mean
+    "notes silently vanish".
+
+    Patches ``tldw_chatbook.config.get_cli_setting`` itself (not a
+    module-local re-export) because every ``get_cli_setting`` call this
+    exercises -- including the bridge's own -- is a LOCAL `from
+    tldw_chatbook.config import get_cli_setting` inside a function body;
+    patching the defining module is the only patch point every one of
+    those local imports actually resolves through.
+    """
+    import tldw_chatbook.config as config_module
+
+    real_get_cli_setting = config_module.get_cli_setting
+
+    def _turn_file_cards_off(section, key, default=None):
+        if (section, key) == ("console", "turn_file_cards"):
+            return False
+        return real_get_cli_setting(section, key, default)
+
+    monkeypatch.setattr(config_module, "get_cli_setting", _turn_file_cards_off)
+
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Done."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    _add_note(db, earlier_run, note="fix this even with the card switched off")
+
+    run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "done"
+    assert db.pending_notes_for_conversation("conv-1") == []
+    delivered = db.notes_for_run(earlier_run)
+    assert len(delivered) == 1
+    assert delivered[0]["delivered_at"] is not None
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert "fix this even with the card switched off" in tool_rows[0].content
+
+
 # -- protective posture: notes subsystem failures never break the reply ---
 
 

--- a/Tests/Chat/test_console_diff_feedback_delivery.py
+++ b/Tests/Chat/test_console_diff_feedback_delivery.py
@@ -1,0 +1,449 @@
+"""Task 5 (console-turn-file-annotate, spec §4): diff-feedback delivery.
+
+Covers the auto-attach + exact-id stamp + live disclosure seam in
+``ConsoleAgentBridge.run_reply``: pending ``change_notes`` are appended to
+the next reply's OUTBOUND (provider-facing) payload only, and stamped
+delivered at run completion by exactly the ids that made it into that
+payload -- never a blanket "all pending for the conversation" stamp.
+
+The bridge-level harness (``_ChunkGateway`` / ``_bridge_with_gateway`` /
+``_run_kwargs``, and the ``patch.object(AgentService, "run_turn", ...)``
+spy for inspecting the exact outbound ``messages`` payload) mirrors the
+established shape already used by ``Tests/Chat/test_console_agent_bridge.py``
+(see ``test_run_reply_appends_bundle_block_copy_safely`` there for the
+precedent this file's copy-safety assertions are modeled on) -- reused,
+not invented.
+
+``AgentRunsDB`` is FILE-BACKED throughout (``tmp_path / "runs.db"``),
+never ``:memory:`` -- the V1 thread-affinity lesson (Task 1's own test
+suite, carried forward here).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_display_state import (
+    format_diff_feedback_disclosure,
+    render_diff_feedback_block,
+)
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+# -- harness (mirrors test_console_agent_bridge.py's _ChunkGateway /
+# _bridge_with_gateway / _run shape) -----------------------------------
+
+
+class _ChunkGateway:
+    """Replays one scripted list of chunks per call, in call order."""
+
+    def __init__(self, scripts):
+        self._scripts = list(scripts)
+        self.calls = 0
+
+    async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+        chunks = self._scripts[min(self.calls, len(self._scripts) - 1)]
+        self.calls += 1
+        for chunk in chunks:
+            yield chunk
+
+
+class _ExplodingGateway:
+    """Streams a partial reply, then raises -- never reaches a final answer.
+
+    Mirrors ``test_console_agent_bridge.py``'s ``_ExplodingGateway`` (a
+    genuine provider failure, not a usage-accounting hiccup).
+    """
+
+    async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+        yield "Wor"
+        raise RuntimeError("provider connection dropped")
+
+
+def _bridge_with_gateway(tmp_path, gateway, *, db=None):
+    db = db if db is not None else AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="hi")
+    assistant = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
+    return bridge, db, store, session, assistant.id
+
+
+def _resolution(**over):
+    fields = dict(provider="TestProvider", base_url="", model=None, ready=True)
+    fields.update(over)
+    return ConsoleProviderResolution(**fields)
+
+
+def _run_kwargs(session, assistant_id, **over):
+    kwargs = dict(
+        conversation_id="conv-1",
+        session_id=session.id,
+        resolution=_resolution(),
+        assistant_message_id=assistant_id,
+        model="test-model",
+        session_system_prompt="",
+        agent_messages=[{"role": "user", "content": "hi"}],
+        should_cancel=lambda: False,
+    )
+    kwargs.update(over)
+    return kwargs
+
+
+def _spy_run_turn(captured):
+    """Records the exact ``messages=`` payload every ``run_turn`` call
+    received -- the truest "outbound copy", since it is literally what the
+    bridge handed to the run loop (not a re-derivation)."""
+    real_run_turn = AgentService.run_turn
+
+    def spy(self, **kwargs):
+        captured.setdefault("messages_by_call", []).append(kwargs.get("messages"))
+        return real_run_turn(self, **kwargs)
+
+    return spy
+
+
+def _add_note(db, run_id, *, path="a.py", header="@@ -1,1 +1,1 @@", excerpt="+x", note="n"):
+    return db.add_change_note(
+        run_id=run_id,
+        root="/workspace",
+        path=path,
+        hunk_index=0,
+        hunk_header=header,
+        hunk_excerpt=excerpt,
+        note=note,
+    )
+
+
+# -- (a) happy path: attach + stamp + disclosure -------------------------
+
+
+def test_pending_notes_attach_stamp_and_disclose_on_success(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Done."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    _add_note(
+        db,
+        earlier_run,
+        path="a.py",
+        header="@@ -1,2 +1,3 @@",
+        excerpt="+cache = {}\n def f():\n+    return cache",
+        note="use the cached value here",
+    )
+
+    original_user_message = {"role": "user", "content": "hi"}
+    agent_messages = [original_user_message]
+    captured: dict = {}
+
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
+        run_id, outcome = bridge.run_reply(
+            **_run_kwargs(session, aid, agent_messages=agent_messages)
+        )
+
+    assert outcome.status == "done"
+
+    # The OUTBOUND copy carries the block on the last user message.
+    sent = captured["messages_by_call"][-1]
+    assert sent is not agent_messages
+    assert sent[-1]["role"] == "user"
+    assert sent[-1]["content"].startswith("hi\n\n## Diff feedback from the user")
+    assert "use the cached value here" in sent[-1]["content"]
+    assert "a.py" in sent[-1]["content"]
+
+    # The caller's OWN list/dict were never mutated (turn_bundle_block's
+    # copy-safety contract, extended to this seam).
+    assert agent_messages == [original_user_message]
+    assert agent_messages[0] is original_user_message
+    assert original_user_message["content"] == "hi"
+
+    # The STORED (persisted transcript) user message is unchanged -- the
+    # block only ever lived in the ephemeral LLM payload.
+    stored_user = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.USER
+    ][0]
+    assert stored_user.content == "hi"
+
+    # Stamped delivered by exact id.
+    assert db.pending_notes_for_conversation("conv-1") == []
+    delivered = db.notes_for_run(earlier_run)
+    assert len(delivered) == 1
+    assert delivered[0]["delivered_at"] is not None
+
+    # Disclosure row: TOOL role, note content, no change_review_run_id.
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert tool_rows[0].content == format_diff_feedback_disclosure(delivered)
+    assert "use the cached value here" in tool_rows[0].content
+    assert tool_rows[0].change_review_run_id is None
+
+
+# -- (b) failed run: still pending, no disclosure -------------------------
+
+
+def test_failed_run_leaves_notes_pending_and_appends_no_disclosure(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ExplodingGateway()
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    note_id = _add_note(db, earlier_run, note="fix this")
+
+    captured: dict = {}
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
+        run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "error"
+    assert outcome.final_text == ""
+
+    # The block WAS in the outbound payload (attach isn't gated on the
+    # run's eventual outcome)...
+    sent = captured["messages_by_call"][-1]
+    assert "## Diff feedback from the user" in sent[-1]["content"]
+
+    # ...but nothing was stamped and no disclosure was emitted: the block
+    # only ever lived in a copy nobody persisted, so nothing was lost by
+    # leaving the note pending for the retry.
+    pending = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in pending] == [note_id]
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert tool_rows == []
+
+
+# -- (c) mid-run race: a note created while the run is in flight ----------
+
+
+def test_note_created_mid_run_is_not_stamped_at_that_runs_completion(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    early_note_id = _add_note(
+        db, earlier_run, path="a.py", note="captured before the run started"
+    )
+    late_note_ids: list[int] = []
+
+    class _RacingGateway:
+        async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+            # This fires AFTER run_reply's attach seam already captured
+            # its id list (it runs before `run_turn`, which is what
+            # eventually drives this call) -- so a note created here is
+            # exactly the "mid-run" race the stamp must not sweep up.
+            late_note_ids.append(
+                _add_note(
+                    db,
+                    earlier_run,
+                    path="b.py",
+                    note="added while the run was in flight",
+                )
+            )
+            yield "Done."
+
+    bridge, _db, store, session, aid = _bridge_with_gateway(
+        tmp_path, _RacingGateway(), db=db
+    )
+
+    run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "done"
+    assert len(late_note_ids) == 1
+
+    pending = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in pending] == late_note_ids
+
+    delivered_ids = {
+        n["id"] for n in db.notes_for_run(earlier_run) if n["delivered_at"]
+    }
+    assert delivered_ids == {early_note_id}
+
+
+# -- (d) over-cap: only included ids stamped; holdover rides the next send -
+
+
+def test_over_cap_only_included_stamped_and_second_run_delivers_the_rest(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    small_id = _add_note(db, earlier_run, path="a.py", excerpt="+small", note="small note")
+    # Sized so its OWN entry fits comfortably under the 16 KiB default cap
+    # alone (so it must deliver on a second, uncontested run), but combined
+    # with the first note's entry it pushes the block over the cap (so it
+    # must be excluded -- and NOT stamped -- on this run).
+    big_excerpt = "x" * 16_200
+    big_id = _add_note(db, earlier_run, path="b.py", excerpt=big_excerpt, note="big note")
+
+    # Self-check the fixture actually exercises the cap branch (this is
+    # the SAME function production calls -- not a re-implementation).
+    pending = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in pending] == [small_id, big_id]
+    expected_block, expected_included = render_diff_feedback_block(pending)
+    assert expected_included == [small_id]
+    assert "more notes held for the next message" in expected_block
+
+    gateway1 = _ChunkGateway([["ack one."]])
+    bridge1, _db1, store, session, aid1 = _bridge_with_gateway(
+        tmp_path, gateway1, db=db
+    )
+    run_id1, outcome1 = bridge1.run_reply(**_run_kwargs(session, aid1))
+    assert outcome1.status == "done"
+
+    remaining = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in remaining] == [big_id]
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert "small note" in tool_rows[0].content
+    assert "big note" not in tool_rows[0].content
+
+    # Second run: the held-over note is now the only pending one, and it
+    # fits alone -- it must deliver.
+    aid2 = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content=""
+    ).id
+    gateway2 = _ChunkGateway([["ack two."]])
+    bridge2 = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway2)
+    run_id2, outcome2 = bridge2.run_reply(**_run_kwargs(session, aid2))
+
+    assert outcome2.status == "done"
+    assert db.pending_notes_for_conversation("conv-1") == []
+    tool_rows_after = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows_after) == 2
+    assert "big note" in tool_rows_after[1].content
+
+
+# -- (e) no pending notes: byte-identical payload --------------------------
+
+
+def test_no_pending_notes_leaves_payload_byte_identical(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Done."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    original_user_message = {"role": "user", "content": "hi"}
+    agent_messages = [original_user_message]
+    captured: dict = {}
+
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
+        run_id, outcome = bridge.run_reply(
+            **_run_kwargs(session, aid, agent_messages=agent_messages)
+        )
+
+    assert outcome.status == "done"
+    sent = captured["messages_by_call"][-1]
+    # Byte-identical to pre-feature behavior: the very same list object,
+    # not merely equal content -- guards against an unconditional mutation
+    # seam that would just happen to be a no-op today.
+    assert sent is agent_messages
+    assert sent[-1]["content"] == "hi"
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert tool_rows == []
+
+
+# -- protective posture: notes subsystem failures never break the reply ---
+
+
+def test_attach_query_failure_never_breaks_the_reply(tmp_path, monkeypatch):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Fine."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    def _boom(self, conversation_id):
+        raise RuntimeError("notes DB is on fire")
+
+    monkeypatch.setattr(AgentRunsDB, "pending_notes_for_conversation", _boom)
+
+    run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "done"
+    assert outcome.final_text.strip() == "Fine."
+
+
+def test_stamp_failure_never_breaks_the_reply_and_leaves_note_pending(
+    tmp_path, monkeypatch
+):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Fine."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    _add_note(db, earlier_run, note="n")
+
+    def _boom(self, note_ids):
+        raise RuntimeError("stamp DB is on fire")
+
+    monkeypatch.setattr(AgentRunsDB, "mark_notes_delivered", _boom)
+
+    run_id, outcome = bridge.run_reply(**_run_kwargs(session, aid))
+
+    assert outcome.status == "done"
+    assert outcome.final_text.strip() == "Fine."
+    # The stamp never landed, so the note correctly stays pending rather
+    # than being silently lost.
+    assert len(db.pending_notes_for_conversation("conv-1")) == 1
+
+
+# -- fallback hunk (hunk_header == "") renders sanely (Task 4 carried minor)
+
+
+def test_fallback_hunk_with_empty_header_renders_sanely_in_block_and_disclosure():
+    """A note anchored to a fallback (no-``@@``) hunk stores
+    ``hunk_header == ""`` (binary files / clean renames -- Task 2's
+    ``split_unified_diff`` fallback). Task 2's formatters already accept
+    it; this pins that the OUTPUT stays coherent -- no dangling ``@@``
+    artifact, no broken line shape -- not merely "doesn't crash"."""
+    note = {
+        "id": 1,
+        "run_id": "run-xyz12345",
+        "root": "/workspace",
+        "path": "assets/logo.png",
+        "hunk_index": 0,
+        "hunk_header": "",
+        "hunk_excerpt": "Binary files differ",
+        "note": "please regenerate this at 2x",
+        "created_at": "2026-08-17T00:00:00",
+        "delivered_at": None,
+    }
+
+    block, included_ids = render_diff_feedback_block([note])
+    assert included_ids == [1]
+    assert "@@" not in block
+    assert "assets/logo.png" in block
+    assert "please regenerate this at 2x" in block
+    assert "[run run-xyz1]" in block  # short_id = run_id[:8]
+
+    disclosure = format_diff_feedback_disclosure([note])
+    assert "\n" not in disclosure
+    assert "@@" not in disclosure
+    assert disclosure.startswith("📝 Diff feedback attached — assets/logo.png ")
+    assert '"please regenerate this at 2x"' in disclosure

--- a/Tests/Chat/test_console_diff_feedback_delivery.py
+++ b/Tests/Chat/test_console_diff_feedback_delivery.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import tldw_chatbook.Agents.agent_service as agent_service_module
 from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
@@ -231,6 +232,103 @@ def test_failed_run_leaves_notes_pending_and_appends_no_disclosure(tmp_path):
     assert tool_rows == []
 
 
+# -- (f) attach found no carrier: never stamp/disclose what the payload
+# could not carry (CRITICAL fix-round finding) ----------------------------
+
+
+def test_no_user_message_leaves_notes_pending_and_appends_no_disclosure(tmp_path):
+    """Reviewer-found critical: the attach loop's backward scan can find NO
+    ``role=="user"`` string-content message to carry the block -- e.g. a
+    payload with no user message at all. ``render_diff_feedback_block`` ran
+    and returned included ids/notes, but the block never actually reached
+    the outbound payload -- completion must not stamp/disclose feedback the
+    model never saw.
+    """
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Fine."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    note_id = _add_note(db, earlier_run, note="never reaches the model")
+
+    captured: dict = {}
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
+        run_id, outcome = bridge.run_reply(
+            **_run_kwargs(
+                session,
+                aid,
+                agent_messages=[{"role": "system", "content": "no user turn here"}],
+            )
+        )
+
+    assert outcome.status == "done"
+    assert outcome.final_text.strip() == "Fine."
+
+    # Confirm the block was never silently injected anywhere in the
+    # outbound payload either.
+    sent = captured["messages_by_call"][-1]
+    assert all("Diff feedback" not in str(m.get("content")) for m in sent)
+
+    pending = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in pending] == [note_id]
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert tool_rows == []
+
+
+def test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosure(
+    tmp_path,
+):
+    """Same failure family: the ONLY/last user message has LIST content (a
+    vision/attachment turn shape, e.g. ``[{"type": "text", "text": "hi"}]``),
+    which ``isinstance(content, str)`` correctly excludes as a carrier -- so
+    again nothing was actually attached, and nothing may be stamped.
+    """
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Fine."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    note_id = _add_note(db, earlier_run, note="never reaches the model")
+
+    vision_message = {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+    captured: dict = {}
+    # Unrelated pre-existing gap, worked around here rather than fixed
+    # (out of this task's scope): the fake gateway reports no usage, so
+    # the "no usage" fallback estimates tokens by iterating message
+    # content as characters -- which raises on LIST content. Forcing a
+    # usage value skips that estimate path so this test can isolate the
+    # attach-loop behavior under test instead of tripping an unrelated
+    # token-counter limitation.
+    with (
+        patch.object(AgentService, "run_turn", _spy_run_turn(captured)),
+        patch.object(agent_service_module, "_usage_total_tokens", lambda resp: 5),
+    ):
+        run_id, outcome = bridge.run_reply(
+            **_run_kwargs(session, aid, agent_messages=[vision_message])
+        )
+
+    assert outcome.status == "done"
+    assert outcome.final_text.strip() == "Fine."
+
+    sent = captured["messages_by_call"][-1]
+    assert sent[-1]["content"] == [{"type": "text", "text": "hi"}]
+
+    pending = db.pending_notes_for_conversation("conv-1")
+    assert [n["id"] for n in pending] == [note_id]
+
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert tool_rows == []
+
+
 # -- (c) mid-run race: a note created while the run is in flight ----------
 
 
@@ -411,6 +509,115 @@ def test_stamp_failure_never_breaks_the_reply_and_leaves_note_pending(
     # The stamp never landed, so the note correctly stays pending rather
     # than being silently lost.
     assert len(db.pending_notes_for_conversation("conv-1")) == 1
+
+
+# -- minor: RUN_CANCELLED with truthy final_text still stamps (deliberate) -
+
+
+def test_cancelled_run_with_partial_final_text_still_stamps_and_discloses(tmp_path):
+    """Deliberate, not a gap: completion gates on ``outcome.final_text``
+    being truthy, not on ``outcome.status == "done"``. ``agent_runtime``
+    checks ``should_cancel()`` again AFTER a tool-call-free turn has
+    already produced its full text (see the ``if not calls:`` branch),
+    returning ``RUN_CANCELLED`` with that text attached as
+    ``final_text``. The outbound payload -- notes included -- genuinely
+    reached the model in that case, so stamping/disclosing here is
+    correct: "produced assistant output" is the spec's actual gate, and a
+    cancelled-but-answered turn satisfies it.
+    """
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Cancelled but answered."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    _add_note(db, earlier_run, note="n")
+
+    class _CancelAfterFirstProbe:
+        """False on the pre-model-call check, True on the post-turn one --
+        so the model's own turn completes before cancellation is observed."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self):
+            self.calls += 1
+            return self.calls > 1
+
+    run_id, outcome = bridge.run_reply(
+        **_run_kwargs(session, aid, should_cancel=_CancelAfterFirstProbe())
+    )
+
+    assert outcome.status == "cancelled"
+    assert outcome.final_text.strip() == "Cancelled but answered."
+
+    assert db.pending_notes_for_conversation("conv-1") == []
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert "n" in tool_rows[0].content
+
+
+# -- minor: turn_bundle_block + diff-feedback block stack on one message --
+
+
+def test_bundle_block_and_diff_feedback_block_stack_on_the_same_message(tmp_path):
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    gateway = _ChunkGateway([["Done."]])
+    bridge, _db, store, session, aid = _bridge_with_gateway(tmp_path, gateway, db=db)
+
+    earlier_run = db.create_run(conversation_id="conv-1", agent_kind="primary")
+    _add_note(db, earlier_run, note="fix the bundled file too")
+
+    bundle_block = "Bundled files (readable via skill_file): notes.md (1 bytes)"
+    original_user_message = {"role": "user", "content": "hi"}
+    agent_messages = [original_user_message]
+    captured: dict = {}
+
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
+        run_id, outcome = bridge.run_reply(
+            **_run_kwargs(
+                session,
+                aid,
+                agent_messages=agent_messages,
+                turn_bundle_block=bundle_block,
+            )
+        )
+
+    assert outcome.status == "done"
+
+    # Bundle block first, feedback block appended after -- same message,
+    # same order the two seams run in.
+    sent = captured["messages_by_call"][-1]
+    assert sent[-1]["content"].startswith(
+        f"hi\n\n{bundle_block}\n\n## Diff feedback from the user"
+    )
+    assert "fix the bundled file too" in sent[-1]["content"]
+
+    # Caller's own list/dict untouched.
+    assert agent_messages == [original_user_message]
+    assert agent_messages[0] is original_user_message
+    assert original_user_message["content"] == "hi"
+
+    # Stored transcript message unchanged.
+    stored_user = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.USER
+    ][0]
+    assert stored_user.content == "hi"
+
+    # Stamped + disclosed correctly despite the stacked bundle block.
+    assert db.pending_notes_for_conversation("conv-1") == []
+    tool_rows = [
+        m
+        for m in store.messages_for_session(session.id)
+        if m.role is ConsoleMessageRole.TOOL
+    ]
+    assert len(tool_rows) == 1
+    assert "fix the bundled file too" in tool_rows[0].content
 
 
 # -- fallback hunk (hunk_header == "") renders sanely (Task 4 carried minor)

--- a/Tests/Chat/test_console_diff_hunks.py
+++ b/Tests/Chat/test_console_diff_hunks.py
@@ -252,12 +252,17 @@ def _expected_entry(note: dict) -> str:
     """Independently reproduce spec §4's per-note entry format (heading
     excluded) -- duplicated here rather than imported from the module
     under test, so an exact-format test can't be satisfied by a change to
-    the implementation's own formatting helper."""
+    the implementation's own formatting helper.
+
+    Fenced with FOUR backticks (final-review fix wave): a three-backtick
+    fence breaks when the excerpt itself contains a triple-backtick line
+    (a markdown-file diff), so the implementation escapes one level up.
+    """
     short_id = note["run_id"][:8]
     return (
         f"### {note['path']} — {note['hunk_header']}   [run {short_id}]\n"
         f"> {note['note']}\n"
-        f"```\n{note['hunk_excerpt']}\n```"
+        f"````\n{note['hunk_excerpt']}\n````"
     )
 
 
@@ -279,12 +284,41 @@ def test_render_diff_feedback_block_exact_format_for_one_note():
         "## Diff feedback from the user (on your earlier file changes)\n"
         "### a.py — @@ -1,4 +1,6 @@   [run 12345678]\n"
         "> use the cached value here\n"
-        "```\n"
+        "````\n"
         "some excerpt\n"
-        "```"
+        "````"
     )
     assert block == expected
     assert included_ids == [7]
+
+
+def test_render_diff_feedback_block_four_backtick_fence_survives_triple_backtick_excerpt():
+    """A hunk excerpt containing its OWN triple-backtick line (a diff of a
+    markdown file with a fenced code block) must not break out of the
+    entry's own fence -- the fence must be four backticks precisely so a
+    three-backtick line inside the excerpt stays inert content rather than
+    closing the fence early.
+    """
+    excerpt = "+```python\n+def foo():\n+    pass\n+```"
+    note = _note(
+        id=9,
+        path="README.md",
+        hunk_header="@@ -1,2 +1,4 @@",
+        hunk_excerpt=excerpt,
+        note="fenced code block added here",
+    )
+    block, included_ids = render_diff_feedback_block([note])
+    assert included_ids == [9]
+    expected_entry = _expected_entry(note)
+    assert f"````\n{excerpt}\n````" in block
+    assert block == (
+        "## Diff feedback from the user (on your earlier file changes)\n"
+        + expected_entry
+    )
+    # The excerpt's own ``` lines must survive verbatim, unescaped, inside
+    # the four-backtick fence -- not stripped, not escaped.
+    assert "+```python" in block
+    assert "+```" in block.splitlines()[-2]
 
 
 def test_render_diff_feedback_block_short_id_is_first_8_chars_of_run_id():
@@ -308,9 +342,11 @@ def test_render_diff_feedback_block_includes_multiple_notes_oldest_first_under_c
 def _equal_length_note(i: int) -> dict:
     """A `_note` whose rendered entry is the SAME byte length for every
     `i` (same-length path/header/note/excerpt) -- lets a test hand-derive
-    exact block byte counts (137 / 213 / 289 bytes for 1 / 2 / 3 such
-    notes, +76 bytes per note) without depending on `render_diff_feedback_
-    block` to compute its own expected values."""
+    exact block byte counts (139 / 217 / 295 bytes for 1 / 2 / 3 such
+    notes, +78 bytes per note -- 76 bytes of text plus the 2 extra fence
+    backticks the final-review fix wave added per entry) without
+    depending on `render_diff_feedback_block` to compute its own expected
+    values."""
     return _note(
         id=i,
         run_id="12345678-abcd-4a4a-9a9a-abcdefabcdef",
@@ -327,22 +363,24 @@ def test_render_diff_feedback_block_holdover_line_bytes_are_included_in_cap():
     final block exceed the cap (reviewer reproduced 441 bytes against a
     398-byte cap on the pre-fix version).
 
-    Byte arithmetic (independent of the function under test, computed by
-    hand from `_equal_length_note`'s fixed entry size): 1/2/3-note blocks
-    (no holdover) are 137 / 213 / 289 bytes; the holdover suffix
-    "\\n\\n… N more notes held for the next message" is 44 bytes for any
-    single-digit N. At cap_bytes=214, two notes fit on their own (213 <
-    214) -- the PRE-FIX code stopped there and appended the 44-byte
-    holdover unconditionally, producing a 257-byte block that blows the
-    214-byte cap. The fix must instead notice 213 + 44 > 214, evict the
-    second note, and land on the one-note-plus-holdover block (137 + 44 =
-    181 bytes), which fits.
+    Byte arithmetic (independent of the function under test, re-derived by
+    hand from `_equal_length_note`'s fixed entry size after the
+    final-review fix wave's four-backtick fence): 1/2/3-note blocks (no
+    holdover) are 139 / 217 / 295 bytes; the holdover suffix "\\n\\n… N
+    more notes held for the next message" is 44 bytes for any
+    single-digit N (unaffected by the fence change -- it carries no
+    backticks). At cap_bytes=218, two notes fit on their own (217 <
+    218) -- the PRE-FIX (pre-holdover-fix) code would have stopped there
+    and appended the 44-byte holdover unconditionally, producing a
+    261-byte block that blows the 218-byte cap. The fix must instead
+    notice 217 + 44 > 218, evict the second note, and land on the
+    one-note-plus-holdover block (139 + 44 = 183 bytes), which fits.
     """
     notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
 
-    block, included_ids = render_diff_feedback_block(notes, cap_bytes=214)
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=218)
 
-    assert len(block.encode("utf-8")) <= 214, (
+    assert len(block.encode("utf-8")) <= 218, (
         "the rendered block, holdover line included, must never exceed cap_bytes"
     )
     assert included_ids == [1]
@@ -353,7 +391,7 @@ def test_render_diff_feedback_block_holdover_line_bytes_are_included_in_cap():
         + "\n\n… 2 more notes held for the next message"
     )
     assert block == expected
-    assert len(expected.encode("utf-8")) == 181
+    assert len(expected.encode("utf-8")) == 183
 
 
 def test_render_diff_feedback_block_holdover_never_exceeds_cap_across_boundary_caps():
@@ -362,7 +400,7 @@ def test_render_diff_feedback_block_holdover_never_exceeds_cap_across_boundary_c
     (holdover line included) must stay within cap_bytes, and included_ids
     must remain an oldest-first prefix."""
     notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
-    for cap in range(150, 290, 7):
+    for cap in range(145, 300, 7):
         block, included_ids = render_diff_feedback_block(notes, cap_bytes=cap)
         assert len(block.encode("utf-8")) <= cap or included_ids == [], (
             f"cap={cap} block exceeded cap_bytes with a non-empty inclusion set"
@@ -380,11 +418,11 @@ def test_render_diff_feedback_block_no_holdover_reserved_when_nothing_excluded()
     notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
     full_block, full_ids = render_diff_feedback_block(notes, cap_bytes=1_000_000)
     full_bytes = len(full_block.encode("utf-8"))
-    assert full_bytes == 289
+    assert full_bytes == 295
 
     # One byte above the exact all-notes size: a naive "always reserve the
     # holdover budget" implementation would still evict the last note here
-    # (289 + 44 > 290); the correct implementation must not.
+    # (295 + 44 > 296); the correct implementation must not.
     block, included_ids = render_diff_feedback_block(notes, cap_bytes=full_bytes + 1)
 
     assert included_ids == [1, 2, 3]
@@ -410,7 +448,7 @@ def test_render_diff_feedback_block_embeds_real_hunk_excerpt(diff_fixture):
     note = _note(id=1, path="single.py", hunk_header=hunks[0].header, hunk_excerpt=excerpt, note="fix this")
     block, included_ids = render_diff_feedback_block([note])
     assert included_ids == [1]
-    assert f"```\n{excerpt}\n```" in block
+    assert f"````\n{excerpt}\n````" in block
 
 
 def test_format_diff_feedback_disclosure_exact_format_for_one_note():

--- a/Tests/Chat/test_console_diff_hunks.py
+++ b/Tests/Chat/test_console_diff_hunks.py
@@ -24,6 +24,7 @@ from tldw_chatbook.Chat.console_display_state import (
     DiffHunk,
     format_diff_feedback_disclosure,
     hunk_excerpt,
+    middle_elide_path,
     render_diff_feedback_block,
     split_unified_diff,
 )
@@ -432,3 +433,65 @@ def test_format_diff_feedback_disclosure_one_line_per_note():
 
 def test_format_diff_feedback_disclosure_empty_notes_returns_empty_string():
     assert format_diff_feedback_disclosure([]) == ""
+
+
+# -- middle_elide_path (Task 7, spec §5: row-label path elision) ----------
+
+
+def test_middle_elide_path_fits_returns_unchanged():
+    assert middle_elide_path("a/b/c.py", 100) == "a/b/c.py"
+
+
+def test_middle_elide_path_exact_budget_returns_unchanged():
+    path = "a/b/c.py"
+    assert middle_elide_path(path, len(path)) == path
+
+
+def test_middle_elide_path_loose_elides_the_middle_keeping_ends():
+    path = "root/sub1/sub2/sub3/file.py"
+    elided = middle_elide_path(path, 15)
+    assert elided == "root/…/file.py"
+    assert len(elided) <= 15
+    assert elided.startswith("root/")
+    assert elided.endswith("/file.py")
+
+
+def test_middle_elide_path_many_components_still_yields_one_ellipsis():
+    """Regardless of how many components sit between the first and last,
+    only ONE "…" placeholder replaces all of them -- never one per
+    dropped component."""
+    path = "a/b/c/d/e/f/g/h/deep_file_name.py"
+    elided = middle_elide_path(path, 20)
+    assert elided == "a/…/deep_file_name.py"
+    assert elided.count("…") == 1
+    assert len(elided) < len(path)
+
+
+def test_middle_elide_path_degenerate_one_component_returns_unchanged():
+    """A bare filename with no "/" at all has no middle to drop -- eliding
+    it would mangle the one meaningful fragment left, so it is returned
+    unchanged even though it doesn't fit the budget."""
+    path = "a_very_long_filename_with_no_directory_component.py"
+    assert middle_elide_path(path, 10) == path
+
+
+def test_middle_elide_path_two_components_returns_unchanged():
+    """Both ends already ARE the whole path -- there is no middle
+    component to remove, and the elided 3-part form would not even be
+    shorter than the original two-part path."""
+    path = "dir/file.py"
+    assert middle_elide_path(path, 5) == path
+
+
+def test_middle_elide_path_empty_string_returns_unchanged():
+    assert middle_elide_path("", 10) == ""
+
+
+def test_middle_elide_path_best_effort_when_even_elided_form_overflows():
+    """Neither end is shrinkable at the component granularity this helper
+    works at -- the 3-part elided form is still returned, even though it
+    remains longer than the budget."""
+    path = "a_very_long_first_component/mid/another_very_long_last_component.py"
+    elided = middle_elide_path(path, 10)
+    assert elided == "a_very_long_first_component/…/another_very_long_last_component.py"
+    assert len(elided) > 10

--- a/Tests/Chat/test_console_diff_hunks.py
+++ b/Tests/Chat/test_console_diff_hunks.py
@@ -247,6 +247,19 @@ def _note(
     }
 
 
+def _expected_entry(note: dict) -> str:
+    """Independently reproduce spec §4's per-note entry format (heading
+    excluded) -- duplicated here rather than imported from the module
+    under test, so an exact-format test can't be satisfied by a change to
+    the implementation's own formatting helper."""
+    short_id = note["run_id"][:8]
+    return (
+        f"### {note['path']} — {note['hunk_header']}   [run {short_id}]\n"
+        f"> {note['note']}\n"
+        f"```\n{note['hunk_excerpt']}\n```"
+    )
+
+
 def test_render_diff_feedback_block_empty_notes_returns_empty_and_no_ids():
     assert render_diff_feedback_block([]) == ("", [])
 
@@ -291,23 +304,92 @@ def test_render_diff_feedback_block_includes_multiple_notes_oldest_first_under_c
     assert "more notes held" not in block
 
 
-def test_render_diff_feedback_block_excludes_over_cap_notes_and_appends_holdover_line():
-    notes = [
-        _note(id=1, path="a.py", note="first note"),
-        _note(id=2, path="b.py", note="second note"),
-        _note(id=3, path="c.py", note="third note"),
-    ]
-    # Learn the byte-exact size of the block with only the first two notes,
-    # then cap just past it so the third note cannot fit -- deterministic
-    # without hand-computed magic numbers.
-    two_note_block, two_ids = render_diff_feedback_block(notes[:2], cap_bytes=1_000_000)
-    assert two_ids == [1, 2]
-    cap = len(two_note_block.encode("utf-8")) + 1
+def _equal_length_note(i: int) -> dict:
+    """A `_note` whose rendered entry is the SAME byte length for every
+    `i` (same-length path/header/note/excerpt) -- lets a test hand-derive
+    exact block byte counts (137 / 213 / 289 bytes for 1 / 2 / 3 such
+    notes, +76 bytes per note) without depending on `render_diff_feedback_
+    block` to compute its own expected values."""
+    return _note(
+        id=i,
+        run_id="12345678-abcd-4a4a-9a9a-abcdefabcdef",
+        path=f"p{i}.py",
+        hunk_header="@@ -1,4 +1,6 @@",
+        hunk_excerpt="excerptX",
+        note="edit here",
+    )
 
-    block, included_ids = render_diff_feedback_block(notes, cap_bytes=cap)
-    assert included_ids == [1, 2]
-    assert block.startswith(two_note_block)
-    assert block == two_note_block + "\n\n… 1 more notes held for the next message"
+
+def test_render_diff_feedback_block_holdover_line_bytes_are_included_in_cap():
+    """Regression: the holdover line's own bytes must fit under cap_bytes
+    too -- appending it unconditionally after the per-note check let the
+    final block exceed the cap (reviewer reproduced 441 bytes against a
+    398-byte cap on the pre-fix version).
+
+    Byte arithmetic (independent of the function under test, computed by
+    hand from `_equal_length_note`'s fixed entry size): 1/2/3-note blocks
+    (no holdover) are 137 / 213 / 289 bytes; the holdover suffix
+    "\\n\\n… N more notes held for the next message" is 44 bytes for any
+    single-digit N. At cap_bytes=214, two notes fit on their own (213 <
+    214) -- the PRE-FIX code stopped there and appended the 44-byte
+    holdover unconditionally, producing a 257-byte block that blows the
+    214-byte cap. The fix must instead notice 213 + 44 > 214, evict the
+    second note, and land on the one-note-plus-holdover block (137 + 44 =
+    181 bytes), which fits.
+    """
+    notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
+
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=214)
+
+    assert len(block.encode("utf-8")) <= 214, (
+        "the rendered block, holdover line included, must never exceed cap_bytes"
+    )
+    assert included_ids == [1]
+    entry_one = _expected_entry(notes[0])
+    expected = (
+        "## Diff feedback from the user (on your earlier file changes)\n"
+        + entry_one
+        + "\n\n… 2 more notes held for the next message"
+    )
+    assert block == expected
+    assert len(expected.encode("utf-8")) == 181
+
+
+def test_render_diff_feedback_block_holdover_never_exceeds_cap_across_boundary_caps():
+    """Property sweep (not tied to one hand-picked cap): for every cap in
+    the range where at least one note is excluded, the returned block
+    (holdover line included) must stay within cap_bytes, and included_ids
+    must remain an oldest-first prefix."""
+    notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
+    for cap in range(150, 290, 7):
+        block, included_ids = render_diff_feedback_block(notes, cap_bytes=cap)
+        assert len(block.encode("utf-8")) <= cap or included_ids == [], (
+            f"cap={cap} block exceeded cap_bytes with a non-empty inclusion set"
+        )
+        assert included_ids == [n["id"] for n in notes[: len(included_ids)]]
+        if len(included_ids) < len(notes):
+            held = len(notes) - len(included_ids)
+            assert block.endswith(f"… {held} more notes held for the next message")
+
+
+def test_render_diff_feedback_block_no_holdover_reserved_when_nothing_excluded():
+    """Boundary: a cap that exactly fits all notes' own bytes (no note
+    excluded) must not be short by the holdover line's size -- the reserve
+    must only apply once exclusion is actually happening."""
+    notes = [_equal_length_note(1), _equal_length_note(2), _equal_length_note(3)]
+    full_block, full_ids = render_diff_feedback_block(notes, cap_bytes=1_000_000)
+    full_bytes = len(full_block.encode("utf-8"))
+    assert full_bytes == 289
+
+    # One byte above the exact all-notes size: a naive "always reserve the
+    # holdover budget" implementation would still evict the last note here
+    # (289 + 44 > 290); the correct implementation must not.
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=full_bytes + 1)
+
+    assert included_ids == [1, 2, 3]
+    assert block == full_block
+    assert "more notes held" not in block
+    assert len(block.encode("utf-8")) <= full_bytes + 1
 
 
 def test_render_diff_feedback_block_excludes_all_notes_when_cap_too_small():

--- a/Tests/Chat/test_console_diff_hunks.py
+++ b/Tests/Chat/test_console_diff_hunks.py
@@ -1,0 +1,352 @@
+"""Tests for the turn-file-card annotate loop's pure diff-hunk helpers.
+
+TASK-16800 (spec `Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-
+design.md` §2/§4). Covers `DiffHunk`, `split_unified_diff`, `hunk_excerpt`,
+`render_diff_feedback_block`, and `format_diff_feedback_disclosure` in
+`tldw_chatbook/Chat/console_display_state.py`.
+
+Segmentation is exercised against REAL `git diff -M` output captured from a
+tmp repo with two commits (multi-hunk file, single-hunk file, a clean
+rename, and a binary file) -- not hand-written diff fixtures. The whole
+module is skipped when git is unavailable, matching the precedent in
+`Tests/Tools/test_git_tool_impls.py`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Chat.console_display_state import (
+    DiffHunk,
+    format_diff_feedback_disclosure,
+    hunk_excerpt,
+    render_diff_feedback_block,
+    split_unified_diff,
+)
+
+GIT_AVAILABLE = shutil.which("git") is not None
+pytestmark = pytest.mark.skipif(not GIT_AVAILABLE, reason="git is not available on this system")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _diff_text(repo: Path, sha1: str, sha2: str, *paths: str) -> str:
+    result = subprocess.run(
+        ["git", "diff", "-M", sha1, sha2, "--", *paths],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+@pytest.fixture
+def diff_fixture(tmp_path: Path) -> dict:
+    """Real `git diff -M` text for four cases: multi-hunk, single-hunk,
+    clean rename (no content change), and binary."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    multi_lines = [f"line{i}\n" for i in range(40)]
+    (repo / "multi.py").write_text("".join(multi_lines), encoding="utf-8")
+    (repo / "single.py").write_text("a\nb\nc\nd\ne\n", encoding="utf-8")
+    (repo / "old_name.txt").write_text("unchanged content\nline two\n", encoding="utf-8")
+    (repo / "image.bin").write_bytes(bytes(range(10)) * 5)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "commit1")
+    sha1 = _git_output(repo, "rev-parse", "HEAD")
+
+    multi_lines[5] = "line5-CHANGED\n"
+    multi_lines[30] = "line30-CHANGED\n"
+    (repo / "multi.py").write_text("".join(multi_lines), encoding="utf-8")
+    (repo / "single.py").write_text("a\nb\nc-changed\nd\ne\n", encoding="utf-8")
+    (repo / "image.bin").write_bytes(bytes(range(9, -1, -1)) * 5)
+    _git(repo, "mv", "old_name.txt", "new_name.txt")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "commit2")
+    sha2 = _git_output(repo, "rev-parse", "HEAD")
+
+    return {
+        "multi": _diff_text(repo, sha1, sha2, "multi.py"),
+        "single": _diff_text(repo, sha1, sha2, "single.py"),
+        # Both the old and new path must be in the pathspec for `-M` to
+        # correlate the deletion with the addition and report a clean
+        # rename instead of "new file" -- verified live against real git
+        # before writing this fixture.
+        "rename": _diff_text(repo, sha1, sha2, "old_name.txt", "new_name.txt"),
+        "binary": _diff_text(repo, sha1, sha2, "image.bin"),
+    }
+
+
+# --------------------------------------------------------------------------
+# split_unified_diff
+# --------------------------------------------------------------------------
+
+
+def test_multi_hunk_diff_segments_into_two_hunks_with_verbatim_headers(diff_fixture):
+    text = diff_fixture["multi"]
+    hunks = split_unified_diff(text)
+    assert len(hunks) == 2
+
+    all_lines = text.splitlines()
+    expected_header_1 = next(l for l in all_lines if l.startswith("@@ -3,7 +3,7 @@"))
+    expected_header_2 = next(l for l in all_lines if l.startswith("@@ -28,7 +28,7 @@"))
+    assert hunks[0].header == expected_header_1
+    assert hunks[1].header == expected_header_2
+
+    # Prelude is the "diff --git"/"index"/"---"/"+++" block, shared by
+    # every hunk of this file.
+    expected_prelude = "\n".join(all_lines[:4])
+    assert hunks[0].file_prelude == expected_prelude
+    assert hunks[1].file_prelude == expected_prelude
+    assert all_lines[0].startswith("diff --git")
+    assert all_lines[2] == "--- a/multi.py"
+    assert all_lines[3] == "+++ b/multi.py"
+
+
+def test_single_hunk_diff_segments_into_one_hunk(diff_fixture):
+    text = diff_fixture["single"]
+    hunks = split_unified_diff(text)
+    assert len(hunks) == 1
+    assert hunks[0].header.startswith("@@ -1,5 +1,5 @@")
+    assert hunks[0].file_prelude == "\n".join(text.splitlines()[:4])
+
+
+@pytest.mark.parametrize("key", ["multi", "single"])
+def test_body_reassembly_equals_original_diff_lines(diff_fixture, key):
+    """prelude + header + body per file reassembles the original diff,
+    line for line, for text-file diffs."""
+    text = diff_fixture[key]
+    hunks = split_unified_diff(text)
+
+    reassembled: list[str] = list(hunks[0].file_prelude.splitlines())
+    for hunk in hunks:
+        reassembled.append(hunk.header)
+        reassembled.extend(hunk.body_lines)
+
+    assert reassembled == text.splitlines()
+
+
+def test_rename_only_diff_yields_single_fallback_hunk(diff_fixture):
+    text = diff_fixture["rename"]
+    assert "@@" not in text  # sanity: this really is a no-hunk diff
+    hunks = split_unified_diff(text)
+    assert hunks == [
+        DiffHunk(header="", body_lines=tuple(text.splitlines()), file_prelude="")
+    ]
+
+
+def test_binary_diff_yields_single_fallback_hunk(diff_fixture):
+    text = diff_fixture["binary"]
+    assert "@@" not in text
+    assert "Binary files" in text
+    hunks = split_unified_diff(text)
+    assert hunks == [
+        DiffHunk(header="", body_lines=tuple(text.splitlines()), file_prelude="")
+    ]
+
+
+def test_empty_text_yields_single_fallback_hunk_with_empty_body():
+    assert split_unified_diff("") == [DiffHunk(header="", body_lines=(), file_prelude="")]
+
+
+# --------------------------------------------------------------------------
+# hunk_excerpt
+# --------------------------------------------------------------------------
+
+
+def test_hunk_excerpt_under_cap_has_no_elision_tail(diff_fixture):
+    hunks = split_unified_diff(diff_fixture["single"])
+    hunk = hunks[0]
+    excerpt = hunk_excerpt(hunk, cap=40)
+    assert excerpt == hunk.header + "\n" + "\n".join(hunk.body_lines)
+    assert "more lines" not in excerpt
+
+
+def test_hunk_excerpt_caps_body_and_adds_honest_tail(diff_fixture):
+    hunks = split_unified_diff(diff_fixture["multi"])
+    hunk = hunks[0]
+    assert len(hunk.body_lines) == 8  # fixture invariant: 6 context + 1 remove + 1 add
+
+    excerpt = hunk_excerpt(hunk, cap=3)
+    lines = excerpt.splitlines()
+    assert lines[0] == hunk.header
+    assert lines[1:4] == list(hunk.body_lines[:3])
+    assert lines[4] == "… 5 more lines"
+    assert len(lines) == 5
+
+
+def test_hunk_excerpt_default_cap_is_40():
+    hunk = DiffHunk(header="@@ -1,2 +1,2 @@", body_lines=tuple(f"l{i}" for i in range(50)), file_prelude="")
+    excerpt = hunk_excerpt(hunk)
+    lines = excerpt.splitlines()
+    assert lines[1:41] == [f"l{i}" for i in range(40)]
+    assert lines[41] == "… 10 more lines"
+
+
+def test_hunk_excerpt_fallback_hunk_omits_empty_header_line(diff_fixture):
+    hunks = split_unified_diff(diff_fixture["rename"])
+    hunk = hunks[0]
+    assert hunk.header == ""
+    excerpt = hunk_excerpt(hunk, cap=2)
+    lines = excerpt.splitlines()
+    # No leading blank line for the empty header.
+    assert lines[0] == hunk.body_lines[0]
+    assert lines == [hunk.body_lines[0], hunk.body_lines[1], "… 2 more lines"]
+
+
+# --------------------------------------------------------------------------
+# render_diff_feedback_block / format_diff_feedback_disclosure
+# --------------------------------------------------------------------------
+
+
+def _note(
+    *,
+    id: int = 1,
+    run_id: str = "12345678-abcd-4a4a-9a9a-abcdefabcdef",
+    root: str = "/ws",
+    path: str = "a.py",
+    hunk_index: int = 0,
+    hunk_header: str = "@@ -1,4 +1,6 @@",
+    hunk_excerpt: str = "some excerpt",
+    note: str = "use the cached value here",
+    created_at: str = "2026-08-17T00:00:00Z",
+    delivered_at: str | None = None,
+) -> dict:
+    """Build a `change_notes` row dict, matching the columns Task 1's
+    `AgentRunsDB.notes_for_run`/`pending_notes_for_conversation` return."""
+    return {
+        "id": id,
+        "run_id": run_id,
+        "root": root,
+        "path": path,
+        "hunk_index": hunk_index,
+        "hunk_header": hunk_header,
+        "hunk_excerpt": hunk_excerpt,
+        "note": note,
+        "created_at": created_at,
+        "delivered_at": delivered_at,
+    }
+
+
+def test_render_diff_feedback_block_empty_notes_returns_empty_and_no_ids():
+    assert render_diff_feedback_block([]) == ("", [])
+
+
+def test_render_diff_feedback_block_exact_format_for_one_note():
+    note = _note(
+        id=7,
+        run_id="12345678-abcd-4a4a-9a9a-abcdefabcdef",
+        path="a.py",
+        hunk_header="@@ -1,4 +1,6 @@",
+        hunk_excerpt="some excerpt",
+        note="use the cached value here",
+    )
+    block, included_ids = render_diff_feedback_block([note])
+    expected = (
+        "## Diff feedback from the user (on your earlier file changes)\n"
+        "### a.py — @@ -1,4 +1,6 @@   [run 12345678]\n"
+        "> use the cached value here\n"
+        "```\n"
+        "some excerpt\n"
+        "```"
+    )
+    assert block == expected
+    assert included_ids == [7]
+
+
+def test_render_diff_feedback_block_short_id_is_first_8_chars_of_run_id():
+    note = _note(run_id="deadbeef-0000-0000-0000-000000000000")
+    block, _ = render_diff_feedback_block([note])
+    assert "[run deadbeef]" in block
+
+
+def test_render_diff_feedback_block_includes_multiple_notes_oldest_first_under_cap():
+    notes = [
+        _note(id=1, path="a.py", note="first note"),
+        _note(id=2, path="b.py", note="second note"),
+        _note(id=3, path="c.py", note="third note"),
+    ]
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=1_000_000)
+    assert included_ids == [1, 2, 3]
+    assert block.index("a.py") < block.index("b.py") < block.index("c.py")
+    assert "more notes held" not in block
+
+
+def test_render_diff_feedback_block_excludes_over_cap_notes_and_appends_holdover_line():
+    notes = [
+        _note(id=1, path="a.py", note="first note"),
+        _note(id=2, path="b.py", note="second note"),
+        _note(id=3, path="c.py", note="third note"),
+    ]
+    # Learn the byte-exact size of the block with only the first two notes,
+    # then cap just past it so the third note cannot fit -- deterministic
+    # without hand-computed magic numbers.
+    two_note_block, two_ids = render_diff_feedback_block(notes[:2], cap_bytes=1_000_000)
+    assert two_ids == [1, 2]
+    cap = len(two_note_block.encode("utf-8")) + 1
+
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=cap)
+    assert included_ids == [1, 2]
+    assert block.startswith(two_note_block)
+    assert block == two_note_block + "\n\n… 1 more notes held for the next message"
+
+
+def test_render_diff_feedback_block_excludes_all_notes_when_cap_too_small():
+    notes = [_note(id=1, path="a.py", note="first note")]
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=1)
+    assert included_ids == []
+    assert block.startswith("## Diff feedback from the user (on your earlier file changes)")
+    assert block.endswith("… 1 more notes held for the next message")
+    assert "a.py" not in block
+
+
+def test_render_diff_feedback_block_embeds_real_hunk_excerpt(diff_fixture):
+    """End-to-end: a real segmented hunk's excerpt lands verbatim in the
+    fenced block."""
+    hunks = split_unified_diff(diff_fixture["single"])
+    excerpt = hunk_excerpt(hunks[0])
+    note = _note(id=1, path="single.py", hunk_header=hunks[0].header, hunk_excerpt=excerpt, note="fix this")
+    block, included_ids = render_diff_feedback_block([note])
+    assert included_ids == [1]
+    assert f"```\n{excerpt}\n```" in block
+
+
+def test_format_diff_feedback_disclosure_exact_format_for_one_note():
+    note = _note(path="a.py", hunk_header="@@ -1,4 +1,6 @@", note="use the cached value here")
+    text = format_diff_feedback_disclosure([note])
+    assert text == '\U0001F4DD Diff feedback attached — a.py @@ -1,4 +1,6 @@: "use the cached value here"'
+
+
+def test_format_diff_feedback_disclosure_one_line_per_note():
+    notes = [
+        _note(path="a.py", hunk_header="@@ -1,2 +1,2 @@", note="first"),
+        _note(path="b.py", hunk_header="@@ -3,4 +3,4 @@", note="second"),
+    ]
+    text = format_diff_feedback_disclosure(notes)
+    lines = text.splitlines()
+    assert len(lines) == 2
+    assert lines[0].endswith('a.py @@ -1,2 +1,2 @@: "first"')
+    assert lines[1].endswith('b.py @@ -3,4 +3,4 @@: "second"')
+
+
+def test_format_diff_feedback_disclosure_empty_notes_returns_empty_string():
+    assert format_diff_feedback_disclosure([]) == ""

--- a/Tests/Chat/test_console_diff_hunks.py
+++ b/Tests/Chat/test_console_diff_hunks.py
@@ -215,6 +215,78 @@ def test_hunk_excerpt_fallback_hunk_omits_empty_header_line(diff_fixture):
 
 
 # --------------------------------------------------------------------------
+# hunk_excerpt byte cap (Qodo #5, PR #1779 fix round)
+# --------------------------------------------------------------------------
+
+
+def test_hunk_excerpt_default_byte_cap_is_4096():
+    """A hunk whose (line-capped) rendering exceeds 4096 UTF-8 bytes is
+    further truncated by the DEFAULT byte_cap, with no explicit argument
+    needed -- the line cap alone (40 lines) does not bound bytes."""
+    # 200 lines of 40 bytes each easily clears both the 40-line cap (so
+    # only the first 40 lines would ever be line-cap-eligible) but this
+    # exercises the byte cap on a body that's short enough in LINE COUNT
+    # (well under 40) yet still oversized in BYTES -- one enormous single
+    # line, the exact "minified file" shape the fix targets.
+    huge_line = "x" * 20_000
+    hunk = DiffHunk(header="@@ -1,1 +1,1 @@", body_lines=(huge_line,), file_prelude="")
+    excerpt = hunk_excerpt(hunk)
+    assert len(excerpt.encode("utf-8")) <= 4096
+    assert excerpt.endswith("… truncated")
+    assert excerpt.startswith("@@ -1,1 +1,1 @@\n" + "x" * 10)
+
+
+def test_hunk_excerpt_under_byte_cap_is_unaffected():
+    hunk = DiffHunk(header="@@ -1,1 +1,1 @@", body_lines=("short line",), file_prelude="")
+    excerpt = hunk_excerpt(hunk)
+    assert excerpt == "@@ -1,1 +1,1 @@\nshort line"
+    assert "truncated" not in excerpt
+
+
+def test_hunk_excerpt_custom_byte_cap_truncates_at_line_boundary():
+    """Whole lines are kept for as long as they fit; the ONE line that
+    finally overflows the budget is included as a partial (byte-safe)
+    prefix rather than dropped outright -- so the surviving content is
+    exactly a prefix of the original header+body text, never content from
+    a later line jumping ahead of a dropped one."""
+    body = tuple(f"line{i}-{'y' * 20}" for i in range(20))  # ~25 bytes/line
+    hunk = DiffHunk(header="@@ -1,1 +1,1 @@", body_lines=body, file_prelude="")
+    excerpt = hunk_excerpt(hunk, byte_cap=120)
+    assert len(excerpt.encode("utf-8")) <= 120
+    assert excerpt.endswith("… truncated")
+
+    tail = "\n… truncated"
+    assert excerpt.endswith(tail)
+    kept_text = excerpt[: -len(tail)]
+    full_text = "\n".join([hunk.header, *body])
+    assert full_text.startswith(kept_text)
+    assert kept_text != full_text  # genuinely truncated, not the whole text
+
+
+def test_hunk_excerpt_single_line_wider_than_byte_cap_hard_truncates_within_it():
+    """The line-boundary preference degrades gracefully: when even the
+    FIRST body line alone overflows byte_cap (no earlier newline to stop
+    at), the excerpt still respects byte_cap via a hard truncation inside
+    that one line, rather than either overflowing the cap or dropping the
+    line's content entirely."""
+    hunk = DiffHunk(header="", body_lines=("z" * 500,), file_prelude="")
+    excerpt = hunk_excerpt(hunk, byte_cap=50)
+    assert len(excerpt.encode("utf-8")) <= 50
+    assert excerpt.endswith("… truncated")
+    assert excerpt.startswith("z")
+
+
+def test_hunk_excerpt_byte_cap_and_line_cap_both_apply():
+    """The line cap's own "… N more lines" tail is itself subject to the
+    byte cap when the surviving (line-capped) text is still oversized."""
+    body = tuple(f"l{i}-{'a' * 30}" for i in range(60))
+    hunk = DiffHunk(header="@@ -1,1 +1,1 @@", body_lines=body, file_prelude="")
+    excerpt = hunk_excerpt(hunk, cap=40, byte_cap=200)
+    assert len(excerpt.encode("utf-8")) <= 200
+    assert excerpt.endswith("… truncated")
+
+
+# --------------------------------------------------------------------------
 # render_diff_feedback_block / format_diff_feedback_disclosure
 # --------------------------------------------------------------------------
 
@@ -438,6 +510,79 @@ def test_render_diff_feedback_block_excludes_all_notes_when_cap_too_small():
     assert block.startswith("## Diff feedback from the user (on your earlier file changes)")
     assert block.endswith("… 1 more notes held for the next message")
     assert "a.py" not in block
+
+
+# --------------------------------------------------------------------------
+# render_diff_feedback_block queue-blocker guard (Qodo #5, PR #1779 fix
+# round): the OLDEST pending note must always be deliverable, even one
+# whose captured excerpt (a legacy row predating hunk_excerpt's own byte
+# cap) is bigger than the whole block cap on its own.
+# --------------------------------------------------------------------------
+
+
+def test_render_diff_feedback_block_oversized_oldest_note_is_truncated_not_dropped():
+    """Pre-fix, a note whose rendered entry alone exceeds cap_bytes made
+    the loop `break` on the very first iteration with NOTHING included
+    (included_ids == []) -- that note (and every note behind it, since it
+    is always the oldest/first considered on every subsequent call) was
+    never delivered, permanently blocking the whole queue. This is the
+    regression pin: the oversized note's id MUST appear in included_ids,
+    truncated to fit, rather than being silently excluded forever.
+    """
+    huge_excerpt = "x" * 20_000  # single "line" -- the minified-file shape
+    oversized = _note(id=1, path="minified.js", hunk_excerpt=huge_excerpt, note="huge one")
+    normal = _note(id=2, path="b.py", note="normal one")
+
+    block, included_ids = render_diff_feedback_block([oversized, normal])
+
+    assert len(block.encode("utf-8")) <= 16384
+    # The queue-blocker regression: id 1 must be deliverable.
+    assert 1 in included_ids
+    assert included_ids[0] == 1
+    assert "minified.js" in block
+    assert "huge one" in block
+    assert "… excerpt truncated to fit" in block
+    # The oldest note's own truncated excerpt is a genuine (long) prefix
+    # of the original -- not reduced to nothing.
+    assert "x" * 100 in block
+
+
+def test_render_diff_feedback_block_oversized_oldest_note_leaves_later_notes_pending():
+    """The note behind the truncated oldest one follows the ordinary
+    break-at-cap behavior -- held for the next send, not lost, not
+    force-included alongside it."""
+    huge_excerpt = "x" * 20_000
+    oversized = _note(id=1, path="minified.js", hunk_excerpt=huge_excerpt, note="huge one")
+    normal = _note(id=2, path="b.py", note="normal one")
+
+    block, included_ids = render_diff_feedback_block([oversized, normal])
+
+    assert included_ids == [1]
+    assert "b.py" not in block
+    assert block.endswith("… 1 more notes held for the next message")
+
+
+def test_render_diff_feedback_block_oversized_note_still_excluded_when_metadata_alone_overflows():
+    """When the cap is so small even the note's fixed metadata (path,
+    header, note text -- never touched by the truncation guard) can't
+    fit, the note is excluded exactly like the pre-fix floor case -- the
+    guard only ever shrinks the EXCERPT, never other fields."""
+    notes = [_note(id=1, path="a.py", hunk_excerpt="x" * 20_000, note="first note")]
+    block, included_ids = render_diff_feedback_block(notes, cap_bytes=1)
+    assert included_ids == []
+    assert block.endswith("… 1 more notes held for the next message")
+
+
+def test_render_diff_feedback_block_only_note_oversized_and_alone_still_delivered():
+    """A single-note queue: no holdover line is needed once the oldest
+    (only) note is truncated to fit, since nothing is left pending."""
+    huge_excerpt = "y" * 20_000
+    note = _note(id=1, path="solo.js", hunk_excerpt=huge_excerpt, note="alone")
+    block, included_ids = render_diff_feedback_block([note])
+    assert included_ids == [1]
+    assert len(block.encode("utf-8")) <= 16384
+    assert "more notes held" not in block
+    assert "… excerpt truncated to fit" in block
 
 
 def test_render_diff_feedback_block_embeds_real_hunk_excerpt(diff_fixture):

--- a/Tests/UI/test_change_review_screen.py
+++ b/Tests/UI/test_change_review_screen.py
@@ -91,12 +91,15 @@ def review_fixture(tmp_path):
 class _Harness(App[None]):
     CSS_PATH = str(BUNDLE)
 
-    def __init__(self, provider) -> None:
+    def __init__(self, provider, initial_run_id: str | None = None) -> None:
         super().__init__()
         self._provider = provider
+        self._initial_run_id = initial_run_id
 
     def on_mount(self) -> None:
-        self.push_screen(ChangeReviewScreen(self._provider))
+        self.push_screen(
+            ChangeReviewScreen(self._provider, initial_run_id=self._initial_run_id)
+        )
 
 
 async def _wait_for(pilot, predicate, what: str, timeout: float = 8.0):
@@ -764,3 +767,61 @@ def test_turn_for_run_matches_the_full_scan(review_fixture):
         direct = provider.turn_for_run(run_id)
         assert direct == scanned[run_id]
     assert provider.turn_for_run("no-such-run") is None
+
+
+# -- Task 7 (console-turn-file-annotate): initial_run_id --------------------
+
+
+@pytest.mark.asyncio
+async def test_initial_run_id_opens_directly_on_that_turn(review_fixture):
+    """The card's `Review` button opens the screen already scoped to its
+    OWN run -- not the conversation's latest turn. `turns()` returns
+    newest-first (`run2` here), so opening with `initial_run_id=run1`
+    proves the constructor arg actually wins over the "latest" default.
+    """
+    provider, root, run1, run2 = review_fixture
+    app = _Harness(provider, initial_run_id=run1)
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        labels = await _wait_for(
+            pilot,
+            lambda: (
+                lambda ls: ls if any("first_turn.txt" in l for l in ls) else None
+            )(_tree_labels(screen.query_one(Tree))),
+            "run1's files on initial open",
+        )
+        text = "\n".join(labels)
+        assert "first_turn.txt" in text
+        assert "new.txt" not in text, "opened on the latest turn, not run1"
+        select = screen.query_one("#change-review-turn-select", Select)
+        assert select.value == run1
+
+
+@pytest.mark.asyncio
+async def test_unknown_initial_run_id_falls_back_to_the_latest_turn(review_fixture):
+    """A stale/unknown run id (e.g. the run's history was later pruned)
+    must degrade to today's default -- opening on the latest turn -- not
+    an empty or broken screen."""
+    provider, root, run1, run2 = review_fixture
+    app = _Harness(provider, initial_run_id="no-such-run")
+    async with app.run_test(size=(160, 48)) as pilot:
+        screen = await _wait_for(
+            pilot,
+            lambda: app.screen if isinstance(app.screen, ChangeReviewScreen) else None,
+            "review screen",
+        )
+        labels = await _wait_for(
+            pilot,
+            lambda: (
+                lambda ls: ls if any("new.txt" in l for l in ls) else None
+            )(_tree_labels(screen.query_one(Tree))),
+            "the latest turn's files as fallback",
+        )
+        text = "\n".join(labels)
+        assert "new.txt" in text
+        select = screen.query_one("#change-review-turn-select", Select)
+        assert select.value == run2

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -834,9 +834,14 @@ async def test_console_transcript_selection_onto_turn_file_card_does_not_rebuild
         # ConsoleTranscript, which is unrelated to what this test pins; the
         # expand mechanism itself is already covered by
         # Tests/UI/test_console_turn_file_card.py.
+        from tldw_chatbook.Chat.console_display_state import DiffHunk
+
         body = card.query(".console-turn-file-diff").first()
         body.display = True
-        card._diff_cache[0] = "SENTINEL_DIFF_TEXT"
+        sentinel_hunks = [
+            DiffHunk(header="", body_lines=("SENTINEL_DIFF_TEXT",), file_prelude="")
+        ]
+        card._hunk_cache[0] = sentinel_hunks
 
         # Move selection ONTO the card row (same direct-state + refresh
         # pattern this file's other rebuild-avoidance tests use above).
@@ -850,7 +855,7 @@ async def test_console_transcript_selection_onto_turn_file_card_does_not_rebuild
         assert card.query(".console-turn-file-diff").first().display, (
             "expanded diff collapsed on selection"
         )
-        assert card._diff_cache.get(0) == "SENTINEL_DIFF_TEXT", (
+        assert card._hunk_cache.get(0) == sentinel_hunks, (
             "diff cache dropped on selection"
         )
 
@@ -865,7 +870,7 @@ async def test_console_transcript_selection_onto_turn_file_card_does_not_rebuild
         assert card.query(".console-turn-file-diff").first().display, (
             "expanded diff lost on deselection"
         )
-        assert card._diff_cache.get(0) == "SENTINEL_DIFF_TEXT", (
+        assert card._hunk_cache.get(0) == sentinel_hunks, (
             "diff cache dropped on deselection"
         )
 

--- a/Tests/UI/test_console_turn_file_card.py
+++ b/Tests/UI/test_console_turn_file_card.py
@@ -3,10 +3,13 @@
 Runs on the REAL app CSS stack (screen css + bundle): geometry measured
 without the bundle is not measured (task-15110's lesson).
 """
+import time
 from pathlib import Path
 
 import pytest
+from textual import on
 from textual.app import App, ComposeResult
+from textual.widgets import Button
 
 from tldw_chatbook.css import build_css
 from tldw_chatbook.Widgets.Console.console_turn_file_card import (
@@ -506,3 +509,179 @@ async def test_selected_card_uses_the_bundles_focus_background():
         plain_bg = pilot.app.query_one("#card-unselected").styles.background
         assert card_bg == peer_bg
         assert card_bg != plain_bg
+
+
+# -- Task 7: Review button, expand/collapse-all, elided paths, AC#4 guard --
+
+
+class _ReviewCaptureHost(_Host):
+    """`_Host`, plus a capture of every posted `ReviewRequested`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.review_requests: list[str] = []
+
+    @on(ConsoleTurnFileCard.ReviewRequested)
+    def _capture_review_requested(
+        self, event: ConsoleTurnFileCard.ReviewRequested
+    ) -> None:
+        self.review_requests.append(event.run_id)
+
+
+@pytest.mark.asyncio
+async def test_review_button_posts_review_requested_with_the_cards_run_id():
+    async with _ReviewCaptureHost().run_test(size=(120, 40)) as pilot:
+        await _settled_card(pilot)
+        review_btn = pilot.app.query_one(".console-turn-file-review-btn", Button)
+        review_btn.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert pilot.app.review_requests == ["run-1"]
+
+
+async def _toggle_all_and_wait_expanded(pilot, card):
+    """Press the header toggle-all button and wait for every body to show."""
+    toggle_btn = card.query_one(".console-turn-file-toggle-all-btn", Button)
+    toggle_btn.focus()
+    await pilot.press("enter")
+    for _ in range(120):
+        bodies = list(card.query(".console-turn-file-diff"))
+        if bodies and all(body.display for body in bodies):
+            return bodies
+        await pilot.pause(0.02)
+    raise AssertionError("expand-all never showed every row's body")
+
+
+@pytest.mark.asyncio
+async def test_toggle_all_expands_every_row_then_collapses_them_all():
+    async with _Host().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        bodies = await _toggle_all_and_wait_expanded(pilot, card)
+        assert len(bodies) == 2
+        for body in bodies:
+            assert list(body.query(".console-turn-file-hunk")), (
+                "expand-all must mount every row's hunk blocks, not just "
+                "flip display"
+            )
+        toggle_btn = card.query_one(".console-turn-file-toggle-all-btn", Button)
+        toggle_btn.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+        bodies = list(card.query(".console-turn-file-diff"))
+        assert not any(body.display for body in bodies), (
+            "collapse-all must hide every row's body"
+        )
+        # display-managed, never unmounted (parity with the single-row
+        # collapse/re-expand cache contract).
+        assert all(body.is_mounted for body in bodies)
+
+
+@pytest.mark.asyncio
+async def test_toggle_all_loads_uncached_diffs_serialized_never_concurrently():
+    """Hard constraint (spec §5): expand-all must load uncached diffs
+    SERIALIZED in one worker, never N concurrent git subprocesses. A
+    provider that tracks its own concurrent-call high-water mark, with a
+    real sleep inside the off-thread read to widen the race window, would
+    catch a switch to `asyncio.gather`-style concurrent loading.
+    """
+
+    class _ConcurrencyTrackingProvider(_FakeProvider):
+        def __init__(self):
+            super().__init__()
+            self.active = 0
+            self.max_active = 0
+
+        def diff_text(self, row, path):
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            try:
+                time.sleep(0.05)
+                return "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n"
+            finally:
+                self.active -= 1
+
+    provider = _ConcurrencyTrackingProvider()
+
+    class _ConcurrencyHost(_Host):
+        def compose(self) -> ComposeResult:
+            yield ConsoleTurnFileCard(
+                MARKER, "run-1", lambda: provider, id="card-under-test"
+            )
+
+    async with _ConcurrencyHost().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        await _toggle_all_and_wait_expanded(pilot, card)
+        assert provider.max_active == 1, (
+            "expand-all loaded more than one diff concurrently"
+        )
+
+
+@pytest.mark.asyncio
+async def test_row_tooltip_carries_the_full_unelided_path():
+    async with _Host().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        rows = list(card.query(".console-turn-file-row"))
+        assert rows[0].tooltip == "a.py"
+        assert rows[1].tooltip == "b.md"
+
+
+@pytest.mark.asyncio
+async def test_narrow_card_elides_a_long_path_but_tooltip_keeps_it_whole():
+    long_path = (
+        "very/deeply/nested/directory/structure/that/is/quite/long/module.py"
+    )
+
+    class _LongPathProvider(_FakeProvider):
+        def changed_files(self, row):
+            from tldw_chatbook.Workspaces.change_tracking import ChangedFile
+
+            return [ChangedFile(path=long_path, status="M", adds=1, dels=1)]
+
+    provider = _LongPathProvider()
+
+    class _NarrowHost(App):
+        CSS_PATH = [str(_SELF), str(_CSS_DIR / "tldw_cli_modular.tcss"), str(_SCOPED)]
+
+        def compose(self) -> ComposeResult:
+            yield ConsoleTurnFileCard(
+                MARKER, "run-1", lambda: provider, id="card-under-test"
+            )
+
+    async with _NarrowHost().run_test(size=(40, 20)) as pilot:
+        card = await _settled_card(pilot)
+        row = card.query_one(".console-turn-file-row", Button)
+        rendered = str(row.render())
+        assert long_path not in rendered, (
+            "a long path in a narrow card must be elided, not shown whole"
+        )
+        assert "…" in rendered
+        assert row.tooltip == long_path, (
+            "the FULL path must still be reachable via the row's tooltip"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_destructive_control_exists_anywhere_on_the_card():
+    """AC#4 guard: no button on the card matches a revert/undo label or
+    class -- revert stays exclusively on the Review screen behind its own
+    confirm (the TASK-1845/TASK-1972 precedent). Checked against the FULL
+    button surface (header + expanded per-hunk note/delete buttons), not
+    just the header, by expanding every row first.
+    """
+    async with _Host().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        await _toggle_all_and_wait_expanded(pilot, card)
+
+        forbidden = ("revert", "undo")
+        buttons = list(card.query(Button))
+        assert buttons, "expected at least the header + row buttons to exist"
+        for button in buttons:
+            label_text = str(button.render()).lower()
+            classes_text = " ".join(button.classes).lower()
+            for word in forbidden:
+                assert word not in label_text, (
+                    f"destructive-looking label on {button!r}: {label_text!r}"
+                )
+                assert word not in classes_text, (
+                    f"destructive-looking class on {button!r}: {classes_text!r}"
+                )

--- a/Tests/UI/test_console_turn_file_card.py
+++ b/Tests/UI/test_console_turn_file_card.py
@@ -45,6 +45,48 @@ class _FakeProvider:
         return "--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-old line\n+new line\n"
 
 
+def _multi_hunk_diff_text(n_hunks: int, body_lines_per_hunk: int) -> str:
+    """Build a synthetic unified diff with ``n_hunks`` hunks, each carrying
+    a unique marker in its header and body so segmentation can be asserted
+    independent of any single hunk's content.
+    """
+    lines = ["--- a/big.py", "+++ b/big.py"]
+    for hunk_idx in range(n_hunks):
+        start = hunk_idx * 10 + 1
+        lines.append(
+            f"@@ -{start},{body_lines_per_hunk} +{start},{body_lines_per_hunk} "
+            f"@@ hunk_{hunk_idx}_marker"
+        )
+        for line_idx in range(body_lines_per_hunk):
+            lines.append(f"+hunk{hunk_idx}_body_line{line_idx}")
+    return "\n".join(lines) + "\n"
+
+
+class _MultiHunkProvider(_FakeProvider):
+    """Fake provider whose ``diff_text`` returns a multi-hunk synthetic
+    diff, with a configurable display cap and a call counter -- used to
+    assert per-hunk segmentation/elision and that collapse/re-expand reuses
+    the cache instead of re-fetching.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_hunks: int = 3,
+        body_lines_per_hunk: int = 5,
+        diff_display_max_lines: int = 2000,
+    ):
+        super().__init__()
+        self.diff_display_max_lines = diff_display_max_lines
+        self._n_hunks = n_hunks
+        self._body_lines_per_hunk = body_lines_per_hunk
+        self.diff_text_calls = 0
+
+    def diff_text(self, row, path):
+        self.diff_text_calls += 1
+        return _multi_hunk_diff_text(self._n_hunks, self._body_lines_per_hunk)
+
+
 class _Host(App):
     CSS_PATH = [str(_SELF), str(_CSS_DIR / "tldw_cli_modular.tcss"), str(_SCOPED)]
 
@@ -93,8 +135,8 @@ async def test_expand_shows_capped_scrolling_diff():
         assert body is not None, "diff body never displayed"
         # `body` is the VerticalScroll container -- its own render() is a
         # Blank placeholder (containers paint children, not self-content).
-        # The diff text lives on the mounted Static child.
-        diff_text_widget = body.query_one(".console-turn-file-diff-text")
+        # The diff text lives on the mounted per-hunk Static child(ren).
+        diff_text_widget = body.query_one(".console-turn-file-hunk")
         assert "+new line" in str(diff_text_widget.render())
         assert str(body.styles.overflow_y) == "auto"
         assert body.styles.max_height is not None
@@ -103,6 +145,117 @@ async def test_expand_shows_capped_scrolling_diff():
         await pilot.press("enter")
         await pilot.pause()
         assert not body.display and body.is_mounted
+
+
+async def _expand_first_row(pilot, card):
+    """Press the first row open and return its diff body once displayed."""
+    row = card.query(".console-turn-file-row").first()
+    row.focus()
+    await pilot.press("enter")
+    for _ in range(60):
+        bodies = card.query(".console-turn-file-diff")
+        if bodies and bodies.first().display:
+            return bodies.first()
+        await pilot.pause(0.02)
+    raise AssertionError("diff body never displayed")
+
+
+@pytest.mark.asyncio
+async def test_expand_multi_hunk_diff_mounts_one_block_per_hunk():
+    """Expanding a row whose diff has 3 hunks mounts exactly 3
+    ``.console-turn-file-hunk`` statics and 3 ``.console-turn-file-hunk-
+    actions`` rows inside that row's diff body -- one pair per hunk.
+    """
+    provider = _MultiHunkProvider(n_hunks=3, body_lines_per_hunk=5)
+
+    class _MultiHunkHost(_Host):
+        def compose(self) -> ComposeResult:
+            yield ConsoleTurnFileCard(
+                MARKER, "run-1", lambda: provider, id="card-under-test"
+            )
+
+    async with _MultiHunkHost().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+        hunks = list(body.query(".console-turn-file-hunk"))
+        actions = list(body.query(".console-turn-file-hunk-actions"))
+        assert len(hunks) == 3
+        assert len(actions) == 3
+        for hunk_idx in range(3):
+            assert f"hunk_{hunk_idx}_marker" in str(hunks[hunk_idx].render())
+
+
+@pytest.mark.asyncio
+async def test_expand_hunk_past_old_cap_still_present():
+    """A diff longer than ``diff_display_max_lines`` still yields ONE BLOCK
+    PER HUNK, with per-hunk elision -- hunks past where the OLD flat-Static
+    global cap would have cut off the whole diff are still present (and,
+    later, annotatable).
+
+    Pre-fix (flat ``.console-turn-file-diff-text`` Static) this is RED: the
+    old code capped the WHOLE joined diff text at ``diff_display_max_lines``
+    lines, so with a small cap the THIRD hunk's header never appeared in the
+    rendered output at all -- it fell past the global cutoff before its
+    line was ever reached. The per-hunk display cap (``max(1,
+    diff_display_max_lines // len(hunks))``) guarantees every hunk gets its
+    own block, each with its own honest "... N more lines" elision,
+    regardless of how many hunks precede it.
+    """
+    # 3 hunks x 5 body lines + prelude(2) + 3 headers = 20 lines total.
+    # diff_display_max_lines=4: the OLD global cap only ever showed the
+    # prelude + hunk 0's header + one body line -- hunks 1 and 2 (including
+    # their headers) never rendered at all.
+    provider = _MultiHunkProvider(
+        n_hunks=3, body_lines_per_hunk=5, diff_display_max_lines=4
+    )
+
+    class _CappedHost(_Host):
+        def compose(self) -> ComposeResult:
+            yield ConsoleTurnFileCard(
+                MARKER, "run-1", lambda: provider, id="card-under-test"
+            )
+
+    async with _CappedHost().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+        hunks = list(body.query(".console-turn-file-hunk"))
+        assert len(hunks) == 3, (
+            "every hunk must get its own block, even past the old global cap"
+        )
+        combined = "\n".join(str(hunk.render()) for hunk in hunks)
+        assert "hunk_2_marker" in combined, (
+            "third hunk's header must survive segmentation past the old "
+            "global line cap"
+        )
+        # Per-hunk elision: cap=4 // 3 == 1 body line kept per hunk, so
+        # each hunk's block carries an honest "more lines" tail rather than
+        # silently vanishing.
+        assert "more lines" in str(hunks[0].render())
+
+
+@pytest.mark.asyncio
+async def test_expand_collapse_reexpand_reuses_cache_single_diff_text_call():
+    """Collapsing and re-expanding a row reuses the cached hunks -- the
+    provider's ``diff_text`` is called exactly once, not once per expand.
+    """
+    provider = _MultiHunkProvider(n_hunks=1, body_lines_per_hunk=2)
+
+    class _CountingHost(_Host):
+        def compose(self) -> ComposeResult:
+            yield ConsoleTurnFileCard(
+                MARKER, "run-1", lambda: provider, id="card-under-test"
+            )
+
+    async with _CountingHost().run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        await _expand_first_row(pilot, card)  # expand (cache miss)
+        row = card.query(".console-turn-file-row").first()
+        row.focus()
+        await pilot.press("enter")  # collapse
+        await pilot.pause()
+        await pilot.press("enter")  # re-expand (cache hit)
+        await pilot.pause(0.3)
+        assert provider.diff_text_calls == 1
 
 
 @pytest.mark.asyncio
@@ -284,7 +437,7 @@ async def test_real_provider_two_windows_on_same_root_no_duplicates_own_diffs(tm
                     break
                 await pilot.pause(0.02)
             assert body is not None, f"diff body {index} never displayed"
-            return str(body.query_one(".console-turn-file-diff-text").render())
+            return str(body.query_one(".console-turn-file-hunk").render())
 
         turn_diff = await _expand(0)
         assert "ALPHA_TURN_MARKER" in turn_diff

--- a/Tests/UI/test_console_turn_file_card_notes.py
+++ b/Tests/UI/test_console_turn_file_card_notes.py
@@ -447,6 +447,163 @@ async def test_note_input_survives_sync_tick_and_selection_move(notes_fixture):
 
 
 @pytest.mark.asyncio
+async def test_note_button_second_press_does_not_double_mount_input(notes_fixture):
+    """Pressing ``✎ note`` again while an input is already open on that
+    hunk must NOT mount a second input -- the existing one is refocused
+    (value intact) instead, matching ``_open_note_input``'s "already
+    open" branch.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "typed before second press"
+
+        note_btn = body.query_one(".console-turn-file-note-btn", Button)
+        note_btn.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.1)
+
+        inputs = list(body.query(".console-turn-file-note-input"))
+        assert len(inputs) == 1, "a second press must not mount a second input"
+        assert inputs[0] is note_input, "second press must reuse the same input"
+        assert inputs[0].value == "typed before second press"
+        assert pilot.app.focused is inputs[0], (
+            "second press must refocus the existing input"
+        )
+
+
+@pytest.mark.asyncio
+async def test_note_input_enter_submits_inside_real_transcript_not_select(
+    notes_fixture,
+):
+    """The highest-risk interaction: a real Enter keypress INSIDE the note
+    ``Input`` while it is mounted inside a REAL ``ConsoleTranscript`` host
+    must submit the note -- not fall through to the transcript's own
+    ``"enter" -> confirm_selection`` binding.
+
+    Textual resolves the FOCUSED widget's own binding
+    (``Input``'s built-in ``enter -> submit``) before walking up to any
+    ancestor's BINDINGS, so this is expected to work by construction --
+    but nothing pinned it before this test, and the row/note-button-open
+    steps in this same file needed a click instead of focus+Enter
+    specifically because of a DIFFERENT widget (``Button``) racing
+    ``ConsoleTranscript``'s focus handling. This test proves the ``Input``
+    itself is not subject to the same race: it polls for ``app.focused
+    is note_input`` (never a fixed sleep) before pressing Enter, so a
+    genuine focus-race would show up as this assertion timing out rather
+    than as a silently-wrong pass.
+    """
+    from Tests.UI.test_console_native_transcript import MutableTranscriptHarness
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleChatMessage,
+        ConsoleMessageRole,
+    )
+    from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+    db, service, provider, root, run_id = notes_fixture
+
+    card_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content=MARKER,
+        id="m-card",
+        change_review_run_id=run_id,
+    )
+    other_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER, content="hello", id="m-other"
+    )
+
+    app = MutableTranscriptHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_change_review_provider_factory(lambda: provider)
+        transcript.set_messages([card_message, other_message])
+        await transcript.refresh_messages()
+
+        card = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        for _ in range(60):
+            if card.query(".console-turn-file-row"):
+                break
+            await pilot.pause(0.02)
+        assert card.query(".console-turn-file-row"), "card rows never loaded"
+
+        transcript.scroll_home(animate=False)
+        await pilot.pause()
+
+        # Click (not focus+Enter) to expand the row and open the note
+        # input -- the `Button` presses race `ConsoleTranscript`'s own
+        # "enter" binding, per the earlier live-safety test's comment.
+        # The interaction THIS test pins starts only once the `Input`
+        # itself is confirmed focused, below.
+        row = card.query(".console-turn-file-row").first()
+        await pilot.click(row)
+        body = None
+        for _ in range(60):
+            bodies = card.query(".console-turn-file-diff")
+            if bodies and bodies.first().display:
+                body = bodies.first()
+                break
+            await pilot.pause(0.02)
+        assert body is not None, "diff body never displayed"
+
+        note_btn = body.query_one(".console-turn-file-note-btn", Button)
+        await pilot.click(note_btn)
+        note_input = None
+        for _ in range(60):
+            inputs = body.query(".console-turn-file-note-input")
+            if inputs:
+                note_input = inputs.first()
+                break
+            await pilot.pause(0.02)
+        assert note_input is not None, "note input never opened"
+
+        # Wait until the Input has ACTUALLY gained focus -- not a fixed
+        # pause racing the transition -- before typing/submitting.
+        for _ in range(120):
+            if pilot.app.focused is note_input:
+                break
+            await pilot.pause(0.02)
+        assert pilot.app.focused is note_input, (
+            "note input never actually gained focus after the click"
+        )
+
+        note_input.value = "enter must submit, not select"
+        await pilot.press("enter")
+
+        note_row = None
+        for _ in range(60):
+            rows = body.query(".console-turn-file-note")
+            if rows:
+                note_row = rows.first()
+                break
+            await pilot.pause(0.02)
+        assert note_row is not None, (
+            "Enter inside a focused note input must persist+render the "
+            "note, not merely toggle transcript row selection"
+        )
+        assert "enter must submit, not select" in _note_text(note_row)
+        assert not body.query(".console-turn-file-note-input"), (
+            "input must be replaced by the note row"
+        )
+
+        # The transcript must NOT have treated this Enter as
+        # confirm_selection on the card's row.
+        assert not card.has_class("console-turn-file-card-selected"), (
+            "Enter in the note input must not select the transcript row"
+        )
+        assert transcript.selected_message_id != card_message.id
+
+        rows = db.notes_for_run(run_id)
+        assert len(rows) == 1
+        assert rows[0]["note"] == "enter must submit, not select"
+
+
+@pytest.mark.asyncio
 async def test_degrade_provider_add_change_note_raises_no_crash(notes_fixture):
     """A provider whose `add_change_note` raises must not crash the app:
     the input stays mounted (nothing lost) and a warning is logged --

--- a/Tests/UI/test_console_turn_file_card_notes.py
+++ b/Tests/UI/test_console_turn_file_card_notes.py
@@ -1,0 +1,486 @@
+"""Turn file card: note UI on hunks (TASK-16800 Task 4).
+
+REAL provider stack -- same fixture pattern as
+``Tests/UI/test_change_review_screen.py::review_fixture`` (real
+``ChangeTurnTracker``/``ShadowRepoService``, a FILE-BACKED ``AgentRunsDB``,
+the real ``AgentRunsChangeReviewProvider``) and the real CSS bundle host
+from ``Tests/UI/test_console_turn_file_card.py`` -- the fixture-invented-
+shapes trap has bitten this repo five separate times, so no fake provider
+shapes are hand-rolled here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input
+
+from tldw_chatbook.css import build_css
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.UI.Screens.change_review_screen import (
+    AgentRunsChangeReviewProvider,
+)
+from tldw_chatbook.Widgets.Console.console_turn_file_card import (
+    ConsoleTurnFileCard,
+)
+from tldw_chatbook.Workspaces.change_tracking import ShadowRepoService
+from tldw_chatbook.Workspaces.change_turn_tracker import ChangeTurnTracker
+
+_CSS_DIR = Path(build_css.__file__).parent
+_SELF, _SCOPED = build_css.screen_css_paths(_CSS_DIR)
+
+MARKER = "✎ Edited 1 file  +1 −1 — review with `v`"
+
+CONV_ID = "conv-1"
+
+
+def _record_turn(db, tracker, root, run_id: str, mutate) -> None:
+    """One real tracked turn: baseline, mutate the tree, end, store rows."""
+    handle = tracker.begin_turn([root])
+    handle.await_baseline()
+    mutate()
+    for rec in tracker.end_turn(handle):
+        db.record_change_snapshot(
+            run_id=run_id,
+            root=rec.root,
+            baseline_sha=rec.baseline_sha,
+            end_sha=rec.end_sha,
+            files_changed=rec.files_changed,
+            adds=rec.adds,
+            dels=rec.dels,
+            tracking_error=rec.tracking_error,
+            untracked_oversize=rec.untracked_oversize,
+            nested_repos=rec.nested_repos,
+        )
+
+
+@pytest.fixture()
+def notes_fixture(tmp_path):
+    """One real tracked turn touching a single file (`a.py`, one hunk)."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "a.py").write_text("line1\nline2\nline3\n")
+
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id=CONV_ID, agent_kind="primary")
+
+    def mutate():
+        (root / "a.py").write_text("line1\nCHANGED\nline3\n")
+
+    _record_turn(db, tracker, root, run_id, mutate)
+
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id=CONV_ID
+    )
+    return db, service, provider, root, run_id
+
+
+class _Host(App):
+    CSS_PATH = [str(_SELF), str(_CSS_DIR / "tldw_cli_modular.tcss"), str(_SCOPED)]
+
+    def __init__(self, provider_factory, run_id: str) -> None:
+        super().__init__()
+        self._provider_factory = provider_factory
+        self._run_id = run_id
+
+    def compose(self) -> ComposeResult:
+        yield ConsoleTurnFileCard(
+            MARKER, self._run_id, self._provider_factory, id="card-under-test"
+        )
+
+
+async def _settled_card(pilot):
+    card = pilot.app.query_one("#card-under-test", ConsoleTurnFileCard)
+    for _ in range(60):
+        if card.query(".console-turn-file-row"):
+            break
+        await pilot.pause(0.02)
+    return card
+
+
+async def _expand_first_row(pilot, card):
+    """Press the first row open and return its diff body once displayed.
+
+    Focus+keyboard-Enter (not a positional click) -- matches
+    ``test_console_turn_file_card.py``'s own proven-stable expand
+    mechanism, which is layout-independent (a click's screen coordinates
+    can race a not-yet-settled compositor under heavier parallel test
+    load; focus+Enter only needs the widget reference).
+    """
+    row = card.query(".console-turn-file-row").first()
+    row.focus()
+    await pilot.press("enter")
+    for _ in range(60):
+        bodies = card.query(".console-turn-file-diff")
+        if bodies and bodies.first().display:
+            return bodies.first()
+        await pilot.pause(0.02)
+    raise AssertionError("diff body never displayed")
+
+
+async def _open_note_input(pilot, body):
+    """Press the hunk's `note` button and return the opened Input."""
+    note_btn = body.query_one(".console-turn-file-note-btn", Button)
+    note_btn.focus()
+    await pilot.press("enter")
+    for _ in range(60):
+        inputs = body.query(".console-turn-file-note-input")
+        if inputs:
+            return inputs.first()
+        await pilot.pause(0.02)
+    raise AssertionError("note input never opened")
+
+
+def _note_text(note_row) -> str:
+    """The visible text of a mounted `.console-turn-file-note` row.
+
+    The row is a `Horizontal` container -- its own `render()` is a Blank
+    placeholder (containers paint children, not self-content, the same
+    lesson `test_console_turn_file_card.py` already documents for the
+    diff body); the text lives on the `.console-turn-file-note-text`
+    child Static.
+    """
+    from textual.widgets import Static
+
+    return str(note_row.query_one(".console-turn-file-note-text", Static).render())
+
+
+@pytest.mark.asyncio
+async def test_note_save_persists_and_renders_anchored(notes_fixture):
+    """Enter in the note input persists an anchored ``change_notes`` row
+    (spec §1/§3: run_id/root/path/hunk_index/hunk_header/hunk_excerpt) and
+    renders the `.console-turn-file-note` row in place of the input.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "use the cached value here"
+        note_input.focus()
+        await pilot.press("enter")
+
+        note_row = None
+        for _ in range(60):
+            rows = body.query(".console-turn-file-note")
+            if rows:
+                note_row = rows.first()
+                break
+            await pilot.pause(0.02)
+        assert note_row is not None, "note row never rendered after save"
+        assert "use the cached value here" in _note_text(note_row)
+        assert not body.query(".console-turn-file-note-input"), (
+            "input must be replaced by the note row"
+        )
+
+        rows = db.notes_for_run(run_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["run_id"] == run_id
+        assert row["root"] == str(root)
+        assert row["path"] == "a.py"
+        assert row["hunk_index"] == 0
+        assert row["hunk_header"].startswith("@@")
+        assert row["note"] == "use the cached value here"
+        assert row["delivered_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_escape_cancels_note_input_without_saving(notes_fixture):
+    """Escape unmounts the open note input; nothing is persisted."""
+    db, service, provider, root, run_id = notes_fixture
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "abandoned draft"
+        note_input.focus()
+        await pilot.pause()
+
+        await pilot.press("escape")
+        for _ in range(60):
+            if not body.query(".console-turn-file-note-input"):
+                break
+            await pilot.pause(0.02)
+        assert not body.query(".console-turn-file-note-input")
+        assert not body.query(".console-turn-file-note")
+        assert db.notes_for_run(run_id) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_pending_note(notes_fixture):
+    """The ✕ button on a pending note deletes it, off-thread, and its row
+    is removed from the card.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "delete me"
+        note_input.focus()
+        await pilot.press("enter")
+
+        delete_btn = None
+        for _ in range(60):
+            buttons = body.query(".console-turn-file-note-delete")
+            if buttons:
+                delete_btn = buttons.first()
+                break
+            await pilot.pause(0.02)
+        assert delete_btn is not None, "delete button never rendered"
+        assert len(db.notes_for_run(run_id)) == 1
+
+        delete_btn.focus()
+        await pilot.press("enter")
+        for _ in range(60):
+            if not body.query(".console-turn-file-note"):
+                break
+            await pilot.pause(0.02)
+        assert not body.query(".console-turn-file-note")
+        assert db.notes_for_run(run_id) == []
+
+
+@pytest.mark.asyncio
+async def test_delivered_note_renders_sent_without_delete(notes_fixture):
+    """A note stamped `delivered_at` (via `mark_notes_delivered` directly,
+    per spec) renders a `sent` marker and carries no delete affordance --
+    delivered notes are record.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    note_id = db.add_change_note(
+        run_id=run_id,
+        root=str(root),
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,3 +1,3 @@",
+        hunk_excerpt="-line2\n+CHANGED",
+        note="already delivered feedback",
+    )
+    db.mark_notes_delivered([note_id])
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_row = None
+        for _ in range(60):
+            rows = body.query(".console-turn-file-note")
+            if rows:
+                note_row = rows.first()
+                break
+            await pilot.pause(0.02)
+        assert note_row is not None, "delivered note never rendered on expand"
+        text = _note_text(note_row)
+        assert "already delivered feedback" in text
+        assert "sent" in text
+        assert not body.query(".console-turn-file-note-delete")
+
+
+@pytest.mark.asyncio
+async def test_resume_round_trip_new_card_instance_shows_note(notes_fixture):
+    """A brand-new card instance over the SAME DB shows a note written
+    directly to it -- resume amnesia guard (spec §1: the anchor is stable
+    across resume since snapshot rows are immutable).
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    note_id = db.add_change_note(
+        run_id=run_id,
+        root=str(root),
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,3 +1,3 @@",
+        hunk_excerpt="-line2\n+CHANGED",
+        note="pending across resume",
+    )
+
+    fresh_provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id=CONV_ID
+    )
+    async with _Host(lambda: fresh_provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_row = None
+        for _ in range(60):
+            rows = body.query(".console-turn-file-note")
+            if rows:
+                note_row = rows.first()
+                break
+            await pilot.pause(0.02)
+        assert note_row is not None, "resumed note never rendered"
+        assert "pending across resume" in _note_text(note_row)
+        # Undelivered -- keeps its delete affordance.
+        assert body.query(".console-turn-file-note-delete")
+
+    assert db.notes_for_run(run_id)[0]["id"] == note_id
+
+
+@pytest.mark.asyncio
+async def test_note_input_survives_sync_tick_and_selection_move(notes_fixture):
+    """Live-safety guard (spec §3, review finding #6): a note input with
+    typed-but-unsaved text must survive a transcript sync tick (the SAME
+    messages re-applied) and a selection move -- the final-review-wave
+    ``_update_row_widget`` reuse branch protects card identity across
+    both; this pins that the note input (a live descendant untouched by
+    that method) rides along instead of being rebuilt out from under the
+    user, exactly like an expanded diff already is (Task 3).
+    """
+    from Tests.UI.test_console_native_transcript import MutableTranscriptHarness
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleChatMessage,
+        ConsoleMessageRole,
+    )
+    from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+    db, service, provider, root, run_id = notes_fixture
+
+    card_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content=MARKER,
+        id="m-card",
+        change_review_run_id=run_id,
+    )
+    other_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER, content="hello", id="m-other"
+    )
+
+    app = MutableTranscriptHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_change_review_provider_factory(lambda: provider)
+        transcript.set_messages([card_message, other_message])
+        await transcript.refresh_messages()
+
+        card = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        for _ in range(60):
+            if card.query(".console-turn-file-row"):
+                break
+            await pilot.pause(0.02)
+        assert card.query(".console-turn-file-row"), "card rows never loaded"
+
+        transcript.scroll_home(animate=False)
+        await pilot.pause()
+        # A CLICK, not focus+Enter: `ConsoleTranscript` is itself focusable
+        # and owns its OWN "enter" binding ("confirm_selection", for
+        # keyboard row navigation) -- inside a real transcript host,
+        # `row.focus()` racing that container's own focus handling can
+        # leave "enter" landing on the transcript rather than the row
+        # `Button`, selecting the message instead of expanding the row.
+        # A click always resolves to exactly the `Button.Pressed` this
+        # card's own `on_button_pressed` expects, matching how the
+        # existing header-click assertion in
+        # `test_console_native_transcript.py` also uses `pilot.click`
+        # rather than focus+Enter for interactions inside this same host.
+        row = card.query(".console-turn-file-row").first()
+        await pilot.click(row)
+        body = None
+        for _ in range(60):
+            bodies = card.query(".console-turn-file-diff")
+            if bodies and bodies.first().display:
+                body = bodies.first()
+                break
+            await pilot.pause(0.02)
+        assert body is not None, "diff body never displayed"
+        # Same click-not-focus+Enter reasoning as the row expand above --
+        # the note button is likewise a descendant of `ConsoleTranscript`.
+        note_btn = body.query_one(".console-turn-file-note-btn", Button)
+        await pilot.click(note_btn)
+        note_input = None
+        for _ in range(60):
+            inputs = body.query(".console-turn-file-note-input")
+            if inputs:
+                note_input = inputs.first()
+                break
+            await pilot.pause(0.02)
+        assert note_input is not None, "note input never opened"
+        note_input.value = "half-typed feedback"
+        note_input.focus()
+        await pilot.pause()
+
+        # Sync tick: the SAME messages re-applied.
+        transcript.set_messages([card_message, other_message])
+        await transcript.refresh_messages()
+        card_after_sync = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        assert card_after_sync is card, "sync tick rebuilt the card widget"
+        surviving = card.query_one(".console-turn-file-note-input", Input)
+        assert surviving is note_input, "sync tick rebuilt the note input"
+        assert surviving.is_mounted
+        assert surviving.value == "half-typed feedback"
+
+        # Selection move onto the card row.
+        transcript.selected_message_id = card_message.id
+        await transcript.refresh_messages()
+        card_after_select = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        assert card_after_select is card, "selection move rebuilt the card widget"
+        surviving = card.query_one(".console-turn-file-note-input", Input)
+        assert surviving.is_mounted
+        assert surviving.value == "half-typed feedback"
+
+        # And a further move OFF the card row.
+        transcript.selected_message_id = other_message.id
+        await transcript.refresh_messages()
+        card_after_deselect = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        assert card_after_deselect is card, "deselection rebuilt the card widget"
+        surviving = card.query_one(".console-turn-file-note-input", Input)
+        assert surviving.is_mounted
+        assert surviving.value == "half-typed feedback"
+
+
+@pytest.mark.asyncio
+async def test_degrade_provider_add_change_note_raises_no_crash(notes_fixture):
+    """A provider whose `add_change_note` raises must not crash the app:
+    the input stays mounted (nothing lost) and a warning is logged --
+    the card's absolute "no exception escapes an `on_*` handler" rule.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    class _RaisingAddNoteProvider(AgentRunsChangeReviewProvider):
+        def add_change_note(self, **kwargs):
+            raise RuntimeError("simulated DB write failure")
+
+    raising_provider = _RaisingAddNoteProvider(
+        db=db, service=service, conversation_id=CONV_ID
+    )
+
+    async with _Host(lambda: raising_provider, run_id).run_test(
+        size=(120, 40)
+    ) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "this will fail to save"
+        note_input.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.2)
+
+        assert pilot.app.is_running, (
+            "a raising add_change_note must not crash the app"
+        )
+        assert card.is_mounted
+
+        surviving = body.query(".console-turn-file-note-input")
+        assert surviving, "input must stay mounted after a save failure"
+        assert surviving.first().value == "this will fail to save"
+        assert not body.query(".console-turn-file-note")
+        assert db.notes_for_run(run_id) == []

--- a/Tests/UI/test_console_turn_file_card_notes.py
+++ b/Tests/UI/test_console_turn_file_card_notes.py
@@ -251,6 +251,66 @@ async def test_delete_removes_pending_note(notes_fixture):
 
 
 @pytest.mark.asyncio
+async def test_delete_press_on_note_delivered_behind_cards_back_notifies_instead_of_noop(
+    notes_fixture,
+):
+    """Doc-honesty fix (final-review fix wave): a live card is reused in
+    place across transcript syncs and never reloads its own notes, so a
+    note delivered elsewhere while this card stays open still shows its
+    stale ✕ button. `delete_change_note` correctly refuses to delete a
+    delivered note (returns False), but a silent no-op there would look
+    like a bug to the user -- pressing ✕ must now notify instead, and the
+    row must survive untouched.
+    """
+    db, service, provider, root, run_id = notes_fixture
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        body = await _expand_first_row(pilot, card)
+
+        note_input = await _open_note_input(pilot, body)
+        note_input.value = "will be delivered behind this card's back"
+        note_input.focus()
+        await pilot.press("enter")
+
+        delete_btn = None
+        for _ in range(60):
+            buttons = body.query(".console-turn-file-note-delete")
+            if buttons:
+                delete_btn = buttons.first()
+                break
+            await pilot.pause(0.02)
+        assert delete_btn is not None, "delete button never rendered"
+        note_id = db.notes_for_run(run_id)[0]["id"]
+
+        # Delivered BEHIND the card's back -- the card is never told and
+        # keeps rendering the pending ✕, exactly the documented live-card
+        # scenario (Docs/User_Guide/console/agent-runs-and-tools.md).
+        db.mark_notes_delivered([note_id])
+
+        notify_calls: list[tuple[tuple, dict]] = []
+        pilot.app.notify = lambda *a, **kw: notify_calls.append((a, kw))
+
+        delete_btn.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.1)
+
+        assert notify_calls, (
+            "pressing delete on an already-delivered note must notify "
+            "the user, not silently no-op"
+        )
+        message = notify_calls[0][0][0]
+        assert "already sent" in message.lower()
+        assert notify_calls[0][1].get("severity") == "warning"
+        # Nothing was actually deleted -- the row (and its ✕) survives.
+        assert body.query(".console-turn-file-note")
+        assert body.query(".console-turn-file-note-delete")
+        stored = db.notes_for_run(run_id)
+        assert len(stored) == 1
+        assert stored[0]["delivered_at"] is not None
+
+
+@pytest.mark.asyncio
 async def test_delivered_note_renders_sent_without_delete(notes_fixture):
     """A note stamped `delivered_at` (via `mark_notes_delivered` directly,
     per spec) renders a `sent` marker and carries no delete affordance --
@@ -641,3 +701,292 @@ async def test_degrade_provider_add_change_note_raises_no_crash(notes_fixture):
         assert surviving.first().value == "this will fail to save"
         assert not body.query(".console-turn-file-note")
         assert db.notes_for_run(run_id) == []
+
+
+@pytest.mark.asyncio
+async def test_two_windows_same_root_path_note_scoped_to_its_own_hunk_header(
+    tmp_path,
+):
+    """Regression (final-review fix wave): a run's ``change_snapshots`` can
+    hold rows from TWO windows on the SAME root+path -- the turn's own
+    window and its surviving sub-agents' post-turn window
+    (``console_agent_bridge.py``'s ``_close_post_turn_change_window``,
+    same real-provider two-window pattern as
+    ``test_console_turn_file_card.py``'s
+    ``test_real_provider_two_windows_on_same_root_no_duplicates_own_diffs``)
+    -- each producing its OWN ``TurnFileEntry`` with its OWN diff, even
+    when BOTH windows touch the exact same file.
+
+    Pre-fix, ``_mount_hunk_blocks`` matched existing notes to a hunk by
+    ``(root, path)`` + ``hunk_index`` alone: a note saved on one window's
+    hunk 0 would ALSO render under the other window's hunk 0 of the same
+    file -- wrong diff, wrong entry. The fix additionally requires
+    ``note["hunk_header"] == hunk.header``, which the two windows' hunks
+    never share (their diffs are against different baselines).
+
+    Real stack (``ChangeTurnTracker``/``ShadowRepoService``/
+    ``AgentRunsDB``/``AgentRunsChangeReviewProvider``) over a ``tmp_path``
+    FILE-backed DB -- required for the same reason as the sibling
+    two-window test: the card reads off ``asyncio.to_thread``, a
+    different OS thread than the one that wrote the rows, and
+    ``AgentRunsDB`` holds one connection PER THREAD.
+    """
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        CHANGE_KIND_SUBAGENT_POST_TURN,
+        CHANGE_KIND_TURN,
+    )
+
+    root = tmp_path / "root"
+    root.mkdir()
+    lines = [f"line{i}\n" for i in range(1, 11)]
+    (root / "shared.py").write_text("".join(lines))
+
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id=CONV_ID, agent_kind="primary")
+
+    def _record_window(kind: str, mutate) -> None:
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        mutate()
+        for rec in tracker.end_turn(handle):
+            db.record_change_snapshot(
+                run_id=run_id,
+                root=rec.root,
+                baseline_sha=rec.baseline_sha,
+                end_sha=rec.end_sha,
+                files_changed=rec.files_changed,
+                adds=rec.adds,
+                dels=rec.dels,
+                tracking_error=rec.tracking_error,
+                untracked_oversize=rec.untracked_oversize,
+                nested_repos=rec.nested_repos,
+                kind=kind,
+            )
+
+    def _mutate_turn() -> None:
+        edited = lines[:]
+        edited[1] = "line2-TURN\n"
+        (root / "shared.py").write_text("".join(edited))
+
+    def _mutate_post_turn() -> None:
+        edited = lines[:]
+        edited[1] = "line2-TURN\n"
+        edited[8] = "line9-POST\n"
+        (root / "shared.py").write_text("".join(edited))
+
+    # Window 1: the turn's own window -- recorded first, matching
+    # production's insertion order.
+    _record_window(CHANGE_KIND_TURN, _mutate_turn)
+    # Window 2: the post-turn window -- same root, same run_id, same
+    # FILE, recorded second, against window 1's end state as its baseline.
+    _record_window(CHANGE_KIND_SUBAGENT_POST_TURN, _mutate_post_turn)
+
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id=CONV_ID
+    )
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        rows: list = []
+        for _ in range(120):
+            rows = list(card.query(".console-turn-file-row"))
+            if len(rows) >= 2:
+                break
+            await pilot.pause(0.02)
+        assert len(rows) == 2, "row count must equal one entry per window"
+        labels = [str(row.render()) for row in rows]
+        # Sanity: both entries really are the SAME file -- exactly the
+        # shape that collides under the pre-fix (root, path)+hunk_index
+        # filter.
+        assert "shared.py" in labels[0], labels
+        assert "shared.py" in labels[1], labels
+
+        async def _expand(index: int):
+            rows[index].focus()
+            await pilot.press("enter")
+            for _ in range(60):
+                bodies = list(card.query(".console-turn-file-diff"))
+                if bodies[index].display:
+                    return bodies[index]
+                await pilot.pause(0.02)
+            raise AssertionError(f"diff body {index} never displayed")
+
+        turn_body = await _expand(0)
+        turn_hunk_text = str(turn_body.query_one(".console-turn-file-hunk").render())
+        assert "line2-TURN" in turn_hunk_text
+        assert "line9-POST" not in turn_hunk_text
+
+        note_btn = turn_body.query_one(".console-turn-file-note-btn", Button)
+        note_btn.focus()
+        await pilot.press("enter")
+        note_input = None
+        for _ in range(60):
+            inputs = turn_body.query(".console-turn-file-note-input")
+            if inputs:
+                note_input = inputs.first()
+                break
+            await pilot.pause(0.02)
+        assert note_input is not None, "note input never opened on the turn window's hunk"
+        note_input.value = "belongs to the TURN window's hunk only"
+        note_input.focus()
+        await pilot.press("enter")
+        for _ in range(60):
+            if turn_body.query(".console-turn-file-note"):
+                break
+            await pilot.pause(0.02)
+        assert turn_body.query(".console-turn-file-note"), (
+            "note never rendered on the turn window's own entry"
+        )
+
+        post_turn_body = await _expand(1)
+        post_turn_hunk_text = str(
+            post_turn_body.query_one(".console-turn-file-hunk").render()
+        )
+        assert "line9-POST" in post_turn_hunk_text
+        assert "line2-TURN" not in post_turn_hunk_text
+        # Sanity: the two windows' hunk headers for this same file really
+        # do differ -- confirming this fixture exercises the collision
+        # shape and isn't accidentally passing because both hunks happen
+        # to share one header.
+        assert "@@" in turn_hunk_text and "@@" in post_turn_hunk_text
+        turn_header_line = next(
+            line for line in turn_hunk_text.splitlines() if line.startswith("@@")
+        )
+        post_turn_header_line = next(
+            line for line in post_turn_hunk_text.splitlines() if line.startswith("@@")
+        )
+        assert turn_header_line != post_turn_header_line
+
+        await pilot.pause(0.1)
+        post_turn_notes = list(post_turn_body.query(".console-turn-file-note"))
+        assert post_turn_notes == [], (
+            "a note saved on the turn window's hunk must not bleed into "
+            "the post-turn window's same-index hunk of the same file"
+        )
+
+        # Persisted exactly once, anchored to the turn window's own hunk
+        # header.
+        stored = db.notes_for_run(run_id)
+        assert len(stored) == 1
+        assert stored[0]["path"] == "shared.py"
+        assert stored[0]["hunk_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_note_input_swallows_up_down_arrow_keys_no_selection_move(
+    notes_fixture,
+):
+    """Regression (final-review fix wave): the card's ``on_key`` reclaimed
+    only enter/escape from a focused note input's ancestors; up/down
+    bubbled past it to ``ConsoleTranscript.on_key``, which moves ROW
+    SELECTION on those keys -- so a user typing a note who happened to
+    press an arrow key would silently move the transcript's selected row
+    mid-edit. An ``Input`` has no cursor-navigation use for either key on
+    a single-line field, so both must be pure no-op reclaims here.
+
+    Driven inside a REAL ``ConsoleTranscript`` host (not the standalone
+    ``_Host``) -- the bug is specifically about the bubble race with that
+    ancestor's own ``on_key``, matching this file's other
+    real-transcript-host tests
+    (``test_note_input_survives_sync_tick_and_selection_move``,
+    ``test_note_input_enter_submits_inside_real_transcript_not_select``).
+    """
+    from Tests.UI.test_console_native_transcript import MutableTranscriptHarness
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleChatMessage,
+        ConsoleMessageRole,
+    )
+    from tldw_chatbook.Widgets.Console.console_transcript import ConsoleTranscript
+
+    db, service, provider, root, run_id = notes_fixture
+
+    card_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content=MARKER,
+        id="m-card",
+        change_review_run_id=run_id,
+    )
+    other_message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER, content="hello", id="m-other"
+    )
+
+    app = MutableTranscriptHarness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        transcript = app.query_one("#console-native-transcript", ConsoleTranscript)
+        transcript.set_change_review_provider_factory(lambda: provider)
+        transcript.set_messages([card_message, other_message])
+        await transcript.refresh_messages()
+
+        card = transcript.query_one(
+            f"#console-turn-file-card-{card_message.id}", ConsoleTurnFileCard
+        )
+        for _ in range(60):
+            if card.query(".console-turn-file-row"):
+                break
+            await pilot.pause(0.02)
+        assert card.query(".console-turn-file-row"), "card rows never loaded"
+
+        transcript.scroll_home(animate=False)
+        await pilot.pause()
+
+        # Click, not focus+Enter -- `ConsoleTranscript` owns its own
+        # "enter" binding and can race a `Button.focus()` (same reasoning
+        # as this file's other real-transcript tests).
+        row = card.query(".console-turn-file-row").first()
+        await pilot.click(row)
+        body = None
+        for _ in range(60):
+            bodies = card.query(".console-turn-file-diff")
+            if bodies and bodies.first().display:
+                body = bodies.first()
+                break
+            await pilot.pause(0.02)
+        assert body is not None, "diff body never displayed"
+
+        note_btn = body.query_one(".console-turn-file-note-btn", Button)
+        await pilot.click(note_btn)
+        note_input = None
+        for _ in range(60):
+            inputs = body.query(".console-turn-file-note-input")
+            if inputs:
+                note_input = inputs.first()
+                break
+            await pilot.pause(0.02)
+        assert note_input is not None, "note input never opened"
+
+        for _ in range(120):
+            if pilot.app.focused is note_input:
+                break
+            await pilot.pause(0.02)
+        assert pilot.app.focused is note_input, (
+            "note input never actually gained focus after the click"
+        )
+
+        note_input.value = "typed before arrow keys"
+        assert transcript.selected_message_id is None, (
+            "baseline: nothing selected before the arrow-key presses"
+        )
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert transcript.selected_message_id is None, (
+            "down inside a focused note input must not move transcript "
+            "row selection"
+        )
+        assert pilot.app.focused is note_input, (
+            "down must not move focus off the note input"
+        )
+        assert note_input.value == "typed before arrow keys"
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert transcript.selected_message_id is None, (
+            "up inside a focused note input must not move transcript row "
+            "selection"
+        )
+        assert pilot.app.focused is note_input, (
+            "up must not move focus off the note input"
+        )
+        assert note_input.value == "typed before arrow keys"

--- a/Tests/UI/test_console_turn_file_card_notes.py
+++ b/Tests/UI/test_console_turn_file_card_notes.py
@@ -875,6 +875,191 @@ async def test_two_windows_same_root_path_note_scoped_to_its_own_hunk_header(
 
 
 @pytest.mark.asyncio
+async def test_two_windows_same_hunk_header_note_scoped_by_snapshot_id(tmp_path):
+    """Qodo #6 (PR #1779 fix round): the sibling test above proves
+    hunk_header disambiguates the common two-window collision -- but a
+    hunk header ("@@ -a,b +c,d @@") encodes only POSITIONS and COUNTS,
+    never content. Two windows that each replace the exact same line
+    POSITION with a 1-for-1 line-count edit (no other change) therefore
+    produce a byte-IDENTICAL header, even though their diffs are against
+    different baselines and their content differs. hunk_index+hunk_header
+    matching alone can no longer tell the windows apart in that case; the
+    `snapshot_id` column (Qodo #6) must.
+    """
+    from tldw_chatbook.Chat.console_agent_bridge import (
+        CHANGE_KIND_SUBAGENT_POST_TURN,
+        CHANGE_KIND_TURN,
+    )
+
+    root = tmp_path / "root"
+    root.mkdir()
+    lines = [f"line{i}\n" for i in range(1, 11)]
+    (root / "shared.py").write_text("".join(lines))
+
+    service = ShadowRepoService(data_dir=tmp_path / "appdata")
+    tracker = ChangeTurnTracker(service=service)
+    db = AgentRunsDB(tmp_path / "runs.db", client_id="t")
+    run_id = db.create_run(conversation_id=CONV_ID, agent_kind="primary")
+
+    def _record_window(kind: str, mutate) -> None:
+        handle = tracker.begin_turn([root])
+        handle.await_baseline()
+        mutate()
+        for rec in tracker.end_turn(handle):
+            db.record_change_snapshot(
+                run_id=run_id,
+                root=rec.root,
+                baseline_sha=rec.baseline_sha,
+                end_sha=rec.end_sha,
+                files_changed=rec.files_changed,
+                adds=rec.adds,
+                dels=rec.dels,
+                tracking_error=rec.tracking_error,
+                untracked_oversize=rec.untracked_oversize,
+                nested_repos=rec.nested_repos,
+                kind=kind,
+            )
+
+    def _mutate_window1() -> None:
+        edited = lines[:]
+        edited[1] = "line2-WINDOW1\n"
+        (root / "shared.py").write_text("".join(edited))
+
+    def _mutate_window2() -> None:
+        # Window 2's baseline is window 1's END state -- a SECOND 1-for-1
+        # replacement of the exact same line position (never touching any
+        # other line), so the resulting hunk header is
+        # position/count-identical to window 1's own header.
+        current = (root / "shared.py").read_text().splitlines(keepends=True)
+        current[1] = "line2-WINDOW2\n"
+        (root / "shared.py").write_text("".join(current))
+
+    _record_window(CHANGE_KIND_TURN, _mutate_window1)
+    _record_window(CHANGE_KIND_SUBAGENT_POST_TURN, _mutate_window2)
+
+    provider = AgentRunsChangeReviewProvider(
+        db=db, service=service, conversation_id=CONV_ID
+    )
+
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        rows: list = []
+        for _ in range(120):
+            rows = list(card.query(".console-turn-file-row"))
+            if len(rows) >= 2:
+                break
+            await pilot.pause(0.02)
+        assert len(rows) == 2, "row count must equal one entry per window"
+
+        async def _expand_body(index: int):
+            rows[index].focus()
+            await pilot.press("enter")
+            for _ in range(60):
+                bodies = list(card.query(".console-turn-file-diff"))
+                if bodies[index].display:
+                    return bodies[index]
+                await pilot.pause(0.02)
+            raise AssertionError(f"diff body {index} never displayed")
+
+        window1_body = await _expand_body(0)
+        window1_hunk_text = str(
+            window1_body.query_one(".console-turn-file-hunk").render()
+        )
+        assert "line2-WINDOW1" in window1_hunk_text
+
+        window2_body = await _expand_body(1)
+        window2_hunk_text = str(
+            window2_body.query_one(".console-turn-file-hunk").render()
+        )
+        assert "line2-WINDOW2" in window2_hunk_text
+
+        # Fixture invariant: confirm this really does exercise the
+        # ambiguous same-header collision, not accidentally two different
+        # headers (which the sibling test above already covers).
+        window1_header = next(
+            line for line in window1_hunk_text.splitlines() if line.startswith("@@")
+        )
+        window2_header = next(
+            line for line in window2_hunk_text.splitlines() if line.startswith("@@")
+        )
+        assert window1_header == window2_header, (
+            "fixture invariant: both windows must share one hunk header "
+            "text for this to exercise the ambiguous-collision case"
+        )
+
+        # Save a note on window 1's hunk only.
+        note_btn = window1_body.query_one(".console-turn-file-note-btn", Button)
+        note_btn.focus()
+        await pilot.press("enter")
+        note_input = None
+        for _ in range(60):
+            inputs = window1_body.query(".console-turn-file-note-input")
+            if inputs:
+                note_input = inputs.first()
+                break
+            await pilot.pause(0.02)
+        assert note_input is not None, "note input never opened on window 1's hunk"
+        note_input.value = "belongs to window 1's hunk only"
+        note_input.focus()
+        await pilot.press("enter")
+        for _ in range(60):
+            if window1_body.query(".console-turn-file-note"):
+                break
+            await pilot.pause(0.02)
+        assert window1_body.query(".console-turn-file-note"), (
+            "note never rendered on window 1's own entry"
+        )
+
+        await pilot.pause(0.1)
+        window2_notes = list(window2_body.query(".console-turn-file-note"))
+        assert window2_notes == [], (
+            "a note saved on window 1's hunk must not bleed into window "
+            "2's SAME-HEADER hunk -- exactly the ambiguity snapshot_id "
+            "disambiguates"
+        )
+
+        stored = db.notes_for_run(run_id)
+        assert len(stored) == 1
+        assert stored[0]["hunk_header"] == window1_header
+        assert stored[0]["snapshot_id"] is not None
+
+    # Resume round trip: a FRESH card instance, reading the persisted note
+    # (with its persisted snapshot_id) back from the DB, must scope it
+    # identically -- proving the fix holds on reload, not just for the
+    # in-session cached note_record.
+    async with _Host(lambda: provider, run_id).run_test(size=(120, 40)) as pilot:
+        card = await _settled_card(pilot)
+        rows = []
+        for _ in range(120):
+            rows = list(card.query(".console-turn-file-row"))
+            if len(rows) >= 2:
+                break
+            await pilot.pause(0.02)
+        assert len(rows) == 2
+
+        async def _expand_body(index: int):
+            rows[index].focus()
+            await pilot.press("enter")
+            for _ in range(60):
+                bodies = list(card.query(".console-turn-file-diff"))
+                if bodies[index].display:
+                    return bodies[index]
+                await pilot.pause(0.02)
+            raise AssertionError(f"diff body {index} never displayed")
+
+        window1_body = await _expand_body(0)
+        assert window1_body.query(".console-turn-file-note"), (
+            "resumed note never rendered on window 1's own entry"
+        )
+        window2_body = await _expand_body(1)
+        await pilot.pause(0.1)
+        assert list(window2_body.query(".console-turn-file-note")) == [], (
+            "resumed note must still not bleed into window 2's same-header "
+            "hunk after a fresh reload from the DB"
+        )
+
+
+@pytest.mark.asyncio
 async def test_note_input_swallows_up_down_arrow_keys_no_selection_move(
     notes_fixture,
 ):

--- a/backlog/tasks/task-16800 - Turn-file-card-annotate-feedback-loop-and-Review-affordance.md
+++ b/backlog/tasks/task-16800 - Turn-file-card-annotate-feedback-loop-and-Review-affordance.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-16800
 title: 'Turn file card: annotate/feedback loop and Review affordance'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-15'
-updated_date: '2026-08-17 03:28'
+updated_date: '2026-08-17 16:50'
 labels:
   - console
   - change-review
@@ -43,9 +43,160 @@ fit the row).
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An expanded diff row exposes an action to attach a note to a specific hunk, without leaving the transcript
-- [ ] #2 A note attached to a hunk is durably recorded (survives session resume, like the rest of the card's source data) and is available to the agent as context on its next reply
-- [ ] #3 The card exposes a `Review` affordance that opens the existing Review screen scoped to that turn — equivalent to pressing `v`, reachable without the keyboard shortcut
-- [ ] #4 No control added to the card performs a destructive action; revert remains exclusively on the Review screen behind its existing confirm (the TASK-1845/TASK-1972 precedent)
-- [ ] #5 With `[console] turn_file_cards` set to `false`, the plain-text marker row and its `v` binding are unaffected by this feature (no regression to the kill-switch fallback)
+- [x] #1 An expanded diff row exposes an action to attach a note to a specific hunk, without leaving the transcript
+- [x] #2 A note attached to a hunk is durably recorded (survives session resume, like the rest of the card's source data) and is available to the agent as context on its next reply
+- [x] #3 The card exposes a `Review` affordance that opens the existing Review screen scoped to that turn — equivalent to pressing `v`, reachable without the keyboard shortcut
+- [x] #4 No control added to the card performs a destructive action; revert remains exclusively on the Review screen behind its existing confirm (the TASK-1845/TASK-1972 precedent)
+- [x] #5 With `[console] turn_file_cards` set to `false`, the plain-text marker row and its `v` binding are unaffected by this feature (no regression to the kill-switch fallback)
 <!-- AC:END -->
+
+## Implementation Plan
+
+Executed as a 7-task plan (`.superpowers/sdd/2026-08-17-console-turn-file-annotate/`,
+spec `Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md`):
+
+1. `change_notes` table + CRUD API in `AgentRunsDB` (audit version 8, this
+   DB's own append-only convention).
+2. Pure hunk segmentation (`split_unified_diff`/`DiffHunk`/`hunk_excerpt`)
+   and the diff-feedback block/disclosure formatters in
+   `console_display_state.py`.
+3. Restructure the card's expand path from one flat `Static` per row to
+   one block per hunk, with a cached `list[DiffHunk]` replacing the old
+   joined-string cache.
+4. Hunk-level note UI (`✎ note` → inline `Input` → save/cancel/delete) and
+   the `on_key` reclaim fix for Enter/Escape inside a nested
+   `ConsoleTranscript`.
+5. Delivery: `ConsoleAgentBridge.run_reply` auto-attaches pending notes to
+   the outbound copy of the next agent-path send, stamps exactly the
+   attached ids delivered at run completion, and emits a disclosure row.
+6. Disclosure resume re-derivation, anchored at the delivering run
+   (`delivered_by_run_id`, audit version 9).
+7. Affordances + docs + close-out (this task's own final wave): `Review`
+   button, expand/collapse-all chevron, middle-elided paths, User Guide
+   update, task close-out.
+
+## Implementation Notes
+
+**Approach.** Tasks 1-6 landed the persistence, segmentation, per-hunk
+note UI, and delivery/disclosure/resume mechanics (see their own commits
+for detail: `5bac23c74`, `82d21b626`, `4808b9455`, `53fcb8475`,
+`121ec831f`, `a47fc325c`, `9efea3d8a`, `83e1a2494`, `9d0213b92`,
+`608b3c56a`). Task 7 (this close-out) added the three remaining
+affordances and closed the loop:
+
+- **`Review` button.** `ConsoleTurnFileCard.ReviewRequested(Message)`
+  carries the card's own `run_id`; a compact header button (`compact
+  =True`, `active_effect_duration = 0`) posts it on press.
+  `ChatScreen.handle_console_turn_file_card_review_requested` handles it
+  by calling the screen's existing `_open_change_review(run_id)` opener —
+  the same recipe the `v` binding and the run inspector's own "Review
+  changes" button already use. **Finding:** `ChangeReviewScreen.
+  __init__`'s `initial_run_id` parameter and `AgentRunsChangeReviewProvider
+  .turn_for_run` already existed, landed with the ORIGINAL TASK-1972 work
+  (commit `e1480f831`), predating this whole V1.5 series — so this task
+  needed no change to `change_review_screen.py` at all, only to wire a
+  new caller into the opener that was already there. Unknown/stale run
+  ids already fell back to the latest turn (`_initialize_turns`), so
+  AC#3's "equivalent to pressing `v`" holds for that edge case for free.
+- **Expand/collapse-all.** A header toggle button reads live DOM state
+  (`all(body.display for body in bodies)`) rather than tracking its own
+  boolean — a user can still expand/collapse one row individually via its
+  own button without the toggle drifting out of sync. Expand-all loads
+  any uncached row's diff SERIALIZED inside one coroutine (sequential
+  `await`s, never `asyncio.gather` or N `run_worker` calls), reusing the
+  existing per-row `_hunk_cache`; a single row's provider/diff failure is
+  caught and logged without aborting the rest. The per-hunk mounting
+  logic (colored `Static` + action row + notes box + existing notes) was
+  factored out of `on_button_pressed` into `_mount_hunk_blocks` so the
+  single-row expand path and expand-all can never render a row
+  differently.
+- **Middle-elided paths.** `middle_elide_path(path, budget)` in
+  `console_display_state.py`: keeps the first and last `/`-split
+  components, replaces everything between with a single `…`, and returns
+  the path unchanged when it already fits or has ≤2 components (nothing
+  meaningful left to drop). The card computes each row's label budget
+  from `self.size.width` at mount, on toggle, and in a new `on_resize`
+  handler (`Resize` does not bubble, so this only fires for the card's
+  own width changes); the row `Button`'s `tooltip` always carries the
+  full, un-elided path.
+- **AC#4 guard.** A new test asserts no button anywhere on a fully
+  expanded card (header + every hunk's note/delete buttons) has a label
+  or class matching `revert`/`undo` — proven RED by construction, since
+  neither string appears anywhere in the card's source.
+- **Kill switch (AC#5).** The existing byte-parity factory test was left
+  untouched (still green); a new bridge-level test,
+  `test_kill_switch_off_does_not_prevent_note_delivery`, forces
+  `[console] turn_file_cards = false` via the same monkeypatch shape as
+  the factory test and confirms a pending note still auto-attaches,
+  stamps, and discloses on the next agent send — the delivery seam lives
+  in `ConsoleAgentBridge.run_reply` and never reads that presentation
+  switch.
+
+**Decisions carried from earlier tasks, restated for this close-out:**
+
+- **The delivering-run ruling (Task 5/6).** A note is stamped delivered
+  only by the exact id list its OWN attach step captured for the run that
+  actually carried it — never a blanket "all pending for the
+  conversation" stamp. This closes a real race: annotating an older
+  turn's card while a newer run is already in flight must not let that
+  newer run's completion silently swallow the older card's just-created
+  note. The disclosure row's resume re-derivation was anchored the same
+  way (`delivered_by_run_id`, audit version 9, Task 6) so a fresh session
+  re-derives the SAME disclosure content, anchored after the SAME run's
+  marker, rather than after whichever run happens to be newest.
+- **The Enter-key `on_key` fix (Task 4).** A `BINDINGS`-only approach for
+  the note input's Enter/Escape is provably wrong once the card is
+  mounted inside a real `ConsoleTranscript`: that ancestor's own raw
+  `on_key` (`enter -> confirm_selection`, `escape -> clear_selection`)
+  unconditionally stops the event before Textual's non-priority binding
+  resolution ever sees it, so a real Enter keypress inside a focused note
+  `Input` selected the transcript row instead of saving — silently, with
+  nothing raised or logged. The card now defines its own raw `on_key`,
+  closer to the input than `ConsoleTranscript`, and reclaims both keys
+  there; this is pinned by a live-transcript regression test (Task 4) and
+  remains the single source of truth for both keys in every host.
+
+**Modified/added files (whole TASK-16800 V1.5 arc, Tasks 1-7):**
+
+- `tldw_chatbook/DB/AgentRuns_DB.py` — `change_notes` table + CRUD (Task 1).
+- `tldw_chatbook/Chat/console_display_state.py` — hunk segmentation,
+  delivery block/disclosure formatters (Task 2), `middle_elide_path`
+  (Task 7).
+- `tldw_chatbook/Widgets/Console/console_turn_file_card.py` — per-hunk
+  blocks + note UI (Tasks 3-4); `ReviewRequested`, expand/collapse-all,
+  path elision + `on_resize`, `_mount_hunk_blocks`/`_read_hunks`
+  refactor (Task 7).
+- `tldw_chatbook/Chat/console_agent_bridge.py` — auto-attach, exact-id
+  stamping, disclosure emission + resume re-derivation (Tasks 5-6).
+- `tldw_chatbook/UI/Screens/change_review_screen.py` — `turn_for_run`
+  run-scoped read (Task 3-era; `initial_run_id` itself predates this
+  series, from TASK-1972).
+- `tldw_chatbook/UI/Screens/chat_screen.py` — imports
+  `ConsoleTurnFileCard`; `handle_console_turn_file_card_review_requested`
+  handler (Task 7).
+- `Docs/User_Guide/console/agent-runs-and-tools.md` — Change review
+  section rewritten (annotate flow, Review button, expand-all, elision,
+  kill-switch note) + stamp (Task 7).
+- Tests: `Tests/Chat/test_change_notes_db.py`,
+  `Tests/Chat/test_console_agent_bridge.py`,
+  `Tests/Chat/test_console_diff_hunks.py`,
+  `Tests/Chat/test_console_diff_feedback_delivery.py`,
+  `Tests/UI/test_console_turn_file_card.py`,
+  `Tests/UI/test_console_turn_file_card_notes.py`,
+  `Tests/UI/test_console_native_transcript.py`,
+  `Tests/UI/test_change_review_screen.py` (across all 7 tasks; Task 7 added
+  the Review-button/expand-all/AC#4-guard/tooltip/elision cases, the
+  `initial_run_id` open/fallback cases, the pure `middle_elide_path` cases,
+  and the kill-switch delivery case).
+
+**Verification.** `Tests/UI/test_console_turn_file_card.py`,
+`Tests/UI/test_console_turn_file_card_notes.py`,
+`Tests/UI/test_console_turn_file_card_factory.py`,
+`Tests/UI/test_change_review_screen.py`,
+`Tests/Chat/test_console_diff_hunks.py`, and
+`Tests/Chat/test_console_diff_feedback_delivery.py` — 91 passed. Full
+`Tests/UI/` collection swept clean (13,122 tests, no import errors) after
+the `chat_screen.py` import addition. No live-tmux walkthrough of this
+task's own affordances (a real end-to-end scenario needs a real agent run
+against a real git root); the app was smoke-launched on a scratch profile
+and confirmed to start and render without a crash after these changes.

--- a/backlog/tasks/task-16800 - Turn-file-card-annotate-feedback-loop-and-Review-affordance.md
+++ b/backlog/tasks/task-16800 - Turn-file-card-annotate-feedback-loop-and-Review-affordance.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-16800
 title: 'Turn file card: annotate/feedback loop and Review affordance'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-15'
+updated_date: '2026-08-17 03:28'
 labels:
   - console
   - change-review
@@ -40,7 +42,6 @@ fit the row).
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
 - [ ] #1 An expanded diff row exposes an action to attach a note to a specific hunk, without leaving the transcript
 - [ ] #2 A note attached to a hunk is durably recorded (survives session resume, like the rest of the card's source data) and is available to the agent as context on its next reply

--- a/backlog/tasks/task-17610 - token_counter-char-fallback-crashes-on-list-shaped-message-content.md
+++ b/backlog/tasks/task-17610 - token_counter-char-fallback-crashes-on-list-shaped-message-content.md
@@ -1,0 +1,39 @@
+---
+id: TASK-17610
+title: 'token_counter char-fallback crashes on list-shaped message content'
+status: To Do
+assignee: []
+created_date: '2026-08-17 17:19'
+labels: [bug, tokens]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pre-existing bug found during TASK-16800 Task 5 (the diff-feedback auto-attach/delivery loop):
+a vision-shaped user message whose `content` is a list (e.g.
+`[{"type": "text", "text": "hi"}]`, the multimodal/attachment turn shape) crashes
+`Utils/token_counter.py`'s char-based fallback estimator whenever no provider usage is reported
+for that turn. `estimate_tokens` -> `_chars_estimate`/`_is_cjk` both iterate `text` expecting a
+`str` and call `ord(ch)` per character; over a `list`, the "characters" are actually dict items,
+and `ord()` on a dict raises `TypeError`. The bug is currently masked in production by the
+common case (most sends have either a plain string message or real provider usage), but any
+no-usage-reported call with list-shaped content hits it.
+
+Found and worked around (not fixed, deliberately out of that task's scope) in
+`Tests/Chat/test_console_diff_feedback_delivery.py`'s
+`test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosure`: the test
+monkeypatches `agent_service_module._usage_total_tokens` to force a non-`None` usage value so
+the no-usage char-estimate fallback path is never exercised, purely to isolate the diff-feedback
+attach-loop behavior the test is actually about.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The char-based fallback estimator in `Utils/token_counter.py` handles list-shaped message content without raising: text parts are counted normally, non-text parts (e.g. image/attachment blocks) contribute a fixed, documented estimate instead of crashing.
+- [ ] #2 The monkeypatch workaround in `Tests/Chat/test_console_diff_feedback_delivery.py::test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosure` is removed -- the test exercises the real no-usage fallback path.
+- [ ] #3 A regression test in `Tests/Utils/` (or the existing token_counter test module) calls the fallback estimator directly on a vision-shaped message (list content with at least one text and one non-text part) and asserts it returns a sane token count instead of raising.
+<!-- AC:END -->

--- a/backlog/tasks/task-17611 - Turn-file-card-polish-follow-ups-from-V1.5-final-review.md
+++ b/backlog/tasks/task-17611 - Turn-file-card-polish-follow-ups-from-V1.5-final-review.md
@@ -1,0 +1,30 @@
+---
+id: TASK-17611
+title: 'Turn-file-card polish follow-ups from V1.5 final review'
+status: To Do
+assignee: []
+created_date: '2026-08-17 17:19'
+labels: [console, ux-polish]
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Five parked minors from the turn-file-card annotate feature's V1.5 final review
+(`feat/console-turn-file-annotate`), each a real but low-priority polish item deliberately not
+folded into the final-review fix wave (which scoped itself to correctness/safety fixes and doc
+honesty). Filed together as one follow-up task since each is small and independent; none blocks
+the others.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `ConsoleTurnFileCard`'s hunk blocks have an honest ceiling: a file with an unusually large number of hunks stops mounting one block per hunk past a cap and instead shows a "… N more hunks" tail, rather than mounting an unbounded number of blocks.
+- [ ] #2 The header's expand/collapse-all toggle button label derives from the live DOM state at every render (not just at toggle-press time), so it never shows a stale "expand all" chevron/tooltip after the user has manually expanded some rows individually.
+- [ ] #3 The card's ✎ (note)/✕ (delete)/📝 (delivery disclosure) glyphs are all routed through `resolve_glyph` for terminal-fallback safety, matching the card's existing chevron glyphs.
+- [ ] #4 The bundle-attach and diff-feedback-attach loops in `run_reply` (`Chat/console_agent_bridge.py` or wherever `run_reply` lives) share one "append to the last user message" helper instead of two near-duplicate inline loops.
+- [ ] #5 `middle_elide_path` budgets in terminal display CELLS (accounting for double-width characters) rather than raw `len()` characters, so a path containing wide characters elides to the correct visual width instead of overflowing or under-filling the row.
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -3422,6 +3422,7 @@ class ConsoleAgentBridge:
                 : len(diff_feedback_included_ids)
             ]
             if diff_feedback_block:
+                attached = False
                 for index in range(len(run_messages) - 1, -1, -1):
                     message = run_messages[index]
                     content = message.get("content")
@@ -3434,7 +3435,25 @@ class ConsoleAgentBridge:
                             **message,
                             "content": f"{content}\n\n{diff_feedback_block}",
                         }
+                        attached = True
                         break
+                if not attached:
+                    # No user message with str content could carry the
+                    # block (no user message at all, or the only/last one
+                    # has LIST content -- a vision/attachment turn). The
+                    # notes were rendered but never actually reached the
+                    # payload, so completion below must not stamp/
+                    # disclose them: reset both to empty so they stay
+                    # pending and ride the next send that DOES have a
+                    # carrier.
+                    logger.warning(
+                        "change_review: "
+                        f"{len(diff_feedback_included_ids)} pending diff-"
+                        "feedback note(s) held back -- no user message "
+                        "could carry the block this turn"
+                    )
+                    diff_feedback_included_ids = []
+                    diff_feedback_included_notes = []
         except Exception:  # noqa: BLE001 -- notes must never break the reply
             logger.opt(exception=True).warning(
                 "change_review: could not attach pending diff-feedback notes"

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -4710,6 +4710,16 @@ class ConsoleAgentBridge:
         tool/spawn/error step) yields an empty block; callers should skip
         those rather than inject nothing.
 
+        task-6 (turn-file-annotate, spec §4): each block also ends with
+        one diff-feedback disclosure row per delivery batch of that run's
+        own ``change_notes`` (notes anchored to this run's diff, grouped
+        by ``delivered_at``, oldest batch first), rendered with the same
+        ``format_diff_feedback_disclosure`` the live completion seam uses.
+        Pending notes yield nothing. This is the designed healer for the
+        live seam's stamp-then-append: if the live append never happened
+        (e.g. it raised after the stamp landed), resume still surfaces the
+        row from the DB.
+
         Placement of the returned blocks into a transcript is the caller's
         job -- see ``inject_resume_agent_markers``.
         """
@@ -4819,6 +4829,49 @@ class ConsoleAgentBridge:
                             status="complete",
                         )
                     )
+            # task-6 (turn-file-annotate, spec §4): re-derive the
+            # diff-feedback disclosure row(s) this run's own notes produced
+            # once delivered -- the designed healer for Task 5's live seam,
+            # which stamps `delivered_at` and appends the disclosure row in
+            # one `try`: if the append fails after the stamp lands, the DB
+            # still records the delivery but the live transcript never got
+            # a row. A fresh resume must surface it regardless. Uses the
+            # SAME shared formatter the live seam uses
+            # (`format_diff_feedback_disclosure`) so a re-derived row is
+            # byte-identical to what live emission would have produced.
+            #
+            # `notes_for_run` returns notes ANCHORED to this run (the run
+            # whose diff the note critiques), not notes "delivered by" it
+            # -- `change_notes` carries no delivered-by-run column, so
+            # there is no way to recover which LATER run's completion
+            # actually stamped a note delivered. The anchor run is the
+            # only per-run key available, so that is where its disclosure
+            # row(s) land on resume: after this run's own marker rows,
+            # grouped by `delivered_at` (one row per delivery batch, oldest
+            # batch first -- ISO-8601 timestamps sort chronologically).
+            # This loop never consults `snap_rows`, so a run with delivered
+            # notes but no snapshot rows at all (change tracking failed or
+            # was never configured -- delivery does not depend on tracking
+            # succeeding) still yields its disclosure row(s). Pending
+            # notes (`delivered_at IS NULL`) are silently skipped -- only
+            # what the model actually saw is ever disclosed.
+            notes = self._db.notes_for_run(str(record.get("id")))
+            delivered_batches: dict[str, list[dict]] = {}
+            for _note in notes:
+                _delivered_at = _note.get("delivered_at")
+                if not _delivered_at:
+                    continue
+                delivered_batches.setdefault(str(_delivered_at), []).append(_note)
+            for _delivered_at in sorted(delivered_batches):
+                block.append(
+                    ConsoleChatMessage(
+                        role=ConsoleMessageRole.TOOL,
+                        content=format_diff_feedback_disclosure(
+                            delivered_batches[_delivered_at]
+                        ),
+                        status="complete",
+                    )
+                )
             blocks.append((record.get("assistant_message_id"), block))
         return blocks
 

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -3638,7 +3638,14 @@ class ConsoleAgentBridge:
                 and diff_feedback_included_ids
             ):
                 try:
-                    self._db.mark_notes_delivered(diff_feedback_included_ids)
+                    # task-6 fix round: stamp with the id of THIS
+                    # (completing) run -- the run whose completion is
+                    # actually doing the delivering, which resume
+                    # re-derivation anchors the disclosure row to. `run_id`
+                    # is already known-bound by the `locals()` check above.
+                    self._db.mark_notes_delivered(
+                        diff_feedback_included_ids, delivered_by_run_id=run_id
+                    )
                     self._store.append_message(
                         session_id,
                         role=ConsoleMessageRole.TOOL,
@@ -4710,15 +4717,19 @@ class ConsoleAgentBridge:
         tool/spawn/error step) yields an empty block; callers should skip
         those rather than inject nothing.
 
-        task-6 (turn-file-annotate, spec §4): each block also ends with
-        one diff-feedback disclosure row per delivery batch of that run's
-        own ``change_notes`` (notes anchored to this run's diff, grouped
-        by ``delivered_at``, oldest batch first), rendered with the same
-        ``format_diff_feedback_disclosure`` the live completion seam uses.
-        Pending notes yield nothing. This is the designed healer for the
-        live seam's stamp-then-append: if the live append never happened
-        (e.g. it raised after the stamp landed), resume still surfaces the
-        row from the DB.
+        task-6 (turn-file-annotate, spec §4) + fix round: each block also
+        ends with one diff-feedback disclosure row per delivery batch
+        DELIVERED BY that run's own completion (grouped by
+        ``(delivered_by_run_id, delivered_at)``, oldest batch first),
+        rendered with the same ``format_diff_feedback_disclosure`` the
+        live completion seam uses -- so a re-derived row is
+        byte-identical to what live emission produced, and lands at the
+        same run's position live placed it at (not the position of
+        whichever earlier run the notes happen to be anchored/annotated
+        against). Pending notes yield nothing. This is the designed
+        healer for the live seam's stamp-then-append: if the live append
+        never happened (e.g. it raised after the stamp landed), resume
+        still surfaces the row from the DB.
 
         Placement of the returned blocks into a transcript is the caller's
         job -- see ``inject_resume_agent_markers``.
@@ -4738,6 +4749,41 @@ class ConsoleAgentBridge:
                 snap_by_run.setdefault(str(_row["run_id"]), []).append(_row)
         except Exception:  # noqa: BLE001 -- resume must not die on this
             snap_by_run = {}
+        # task-6 fix round (CRITICAL C1): ONE batched, GUARDED query for
+        # the whole conversation -- same no-N+1 precedent as the snapshot
+        # fetch immediately above, and the same "resume must not die on
+        # this" posture: a change_notes read failure must degrade to no
+        # disclosure rows, not break conversation resume entirely.
+        #
+        # Grouped by (target_run_id, delivered_at) where target_run_id is
+        # `delivered_by_run_id` -- the run whose COMPLETION actually
+        # stamped the note delivered, matching live emission's placement
+        # exactly, and immune to both failure modes an earlier version of
+        # this method had: (a) one live batch spanning notes anchored to
+        # TWO different runs no longer fragments into two resume rows --
+        # it stays one row, keyed on the single delivering run; (b) a note
+        # annotated against a run that later became superseded (and so is
+        # excluded from `records`, silently dropping any block keyed to
+        # it) still surfaces, because the delivering run -- typically
+        # still live/non-superseded -- is what the row is keyed to, not
+        # the (possibly off-branch) annotated run.
+        #
+        # `delivered_by_run_id` is NULL on rows stamped before that column
+        # existed (a pre-migration DB) or by any future caller that omits
+        # it -- there is no way to recover which run delivered those, so
+        # they fall back to the note's OWN `run_id` (the annotated run):
+        # the same position this method used before the fix round, kept
+        # here only as the legacy floor, not the common path.
+        disclosure_batches: dict[str, dict[str, list[dict]]] = {}
+        try:
+            for _note in self._db.delivered_notes_for_conversation(conversation_id):
+                _target = _note.get("delivered_by_run_id") or _note.get("run_id")
+                _delivered_at = str(_note.get("delivered_at"))
+                disclosure_batches.setdefault(str(_target), {}).setdefault(
+                    _delivered_at, []
+                ).append(_note)
+        except Exception:  # noqa: BLE001 -- resume must not die on this
+            disclosure_batches = {}
         blocks: list[tuple[str | None, list[ConsoleChatMessage]]] = []
         for record in records:
             block: list[ConsoleChatMessage] = []
@@ -4829,45 +4875,30 @@ class ConsoleAgentBridge:
                             status="complete",
                         )
                     )
-            # task-6 (turn-file-annotate, spec §4): re-derive the
-            # diff-feedback disclosure row(s) this run's own notes produced
-            # once delivered -- the designed healer for Task 5's live seam,
-            # which stamps `delivered_at` and appends the disclosure row in
-            # one `try`: if the append fails after the stamp lands, the DB
-            # still records the delivery but the live transcript never got
-            # a row. A fresh resume must surface it regardless. Uses the
-            # SAME shared formatter the live seam uses
-            # (`format_diff_feedback_disclosure`) so a re-derived row is
-            # byte-identical to what live emission would have produced.
-            #
-            # `notes_for_run` returns notes ANCHORED to this run (the run
-            # whose diff the note critiques), not notes "delivered by" it
-            # -- `change_notes` carries no delivered-by-run column, so
-            # there is no way to recover which LATER run's completion
-            # actually stamped a note delivered. The anchor run is the
-            # only per-run key available, so that is where its disclosure
-            # row(s) land on resume: after this run's own marker rows,
-            # grouped by `delivered_at` (one row per delivery batch, oldest
-            # batch first -- ISO-8601 timestamps sort chronologically).
-            # This loop never consults `snap_rows`, so a run with delivered
-            # notes but no snapshot rows at all (change tracking failed or
-            # was never configured -- delivery does not depend on tracking
-            # succeeding) still yields its disclosure row(s). Pending
-            # notes (`delivered_at IS NULL`) are silently skipped -- only
-            # what the model actually saw is ever disclosed.
-            notes = self._db.notes_for_run(str(record.get("id")))
-            delivered_batches: dict[str, list[dict]] = {}
-            for _note in notes:
-                _delivered_at = _note.get("delivered_at")
-                if not _delivered_at:
-                    continue
-                delivered_batches.setdefault(str(_delivered_at), []).append(_note)
-            for _delivered_at in sorted(delivered_batches):
+            # task-6 (turn-file-annotate, spec §4) + fix round: append this
+            # run's own diff-feedback disclosure row(s) -- i.e. every
+            # delivery batch keyed to THIS run as the delivering run (see
+            # `disclosure_batches` construction above for the grouping and
+            # legacy-fallback rules). Placed after this run's own marker
+            # rows (steps, change-summary/failure rows), never gated on
+            # `snap_rows`, so a run with delivered notes but no snapshot
+            # rows at all (tracking failed or was never configured --
+            # delivery does not depend on tracking succeeding) still
+            # yields its disclosure row(s). This is the designed healer
+            # for Task 5's live seam, which stamps `delivered_at` then
+            # appends the disclosure row in one `try`: if the append fails
+            # after the stamp lands, the DB still records the delivery but
+            # the live transcript never got a row -- a fresh resume
+            # surfaces it regardless, byte-identical to what live emission
+            # would have produced (same shared `format_diff_feedback_disclosure`).
+            for _delivered_at in sorted(
+                disclosure_batches.get(str(record.get("id")), {})
+            ):
                 block.append(
                     ConsoleChatMessage(
                         role=ConsoleMessageRole.TOOL,
                         content=format_diff_feedback_disclosure(
-                            delivered_batches[_delivered_at]
+                            disclosure_batches[str(record.get("id"))][_delivered_at]
                         ),
                         status="complete",
                     )

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -68,6 +68,10 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
     ConsoleMessageRole,
 )
+from tldw_chatbook.Chat.console_display_state import (
+    format_diff_feedback_disclosure,
+    render_diff_feedback_block,
+)
 from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
 from tldw_chatbook.Chat.console_prepared_request import (
     CONTINUATION_OWNER_KEY,
@@ -3392,6 +3396,51 @@ class ConsoleAgentBridge:
                         "content": f"{content}\n\n{turn_bundle_block}",
                     }
                     break
+        # task-5 (turn-file-annotate, spec §4): auto-attach this
+        # conversation's pending diff-feedback notes to the SAME outbound
+        # copy, immediately after the bundle block above and by the same
+        # mechanism -- appended to the last role=="user" entry, never
+        # mutating the caller's `agent_messages`. `diff_feedback_included_
+        # ids`/`diff_feedback_included_notes` are captured HERE, before
+        # `run_turn` is even called, and read again at the completion seam
+        # below (same stack frame -- a local suffices, no run-context
+        # object needed). That freeze is the mid-run-race guard: a note
+        # created by the user WHILE this run is in flight is simply absent
+        # from this list, so completion below can never stamp it delivered
+        # even though `pending_notes_for_conversation` would return it if
+        # queried again later. A notes-subsystem failure must never break
+        # the reply -- this whole seam degrades to "no notes this turn"
+        # and logs, exactly like the marker/tracking seams above.
+        diff_feedback_included_ids: list[int] = []
+        diff_feedback_included_notes: list[dict] = []
+        try:
+            pending_notes = self._db.pending_notes_for_conversation(conversation_id)
+            diff_feedback_block, diff_feedback_included_ids = (
+                render_diff_feedback_block(pending_notes)
+            )
+            diff_feedback_included_notes = pending_notes[
+                : len(diff_feedback_included_ids)
+            ]
+            if diff_feedback_block:
+                for index in range(len(run_messages) - 1, -1, -1):
+                    message = run_messages[index]
+                    content = message.get("content")
+                    if message.get(
+                        "role"
+                    ) == ConsoleMessageRole.USER.value and isinstance(content, str):
+                        if run_messages is agent_messages:
+                            run_messages = list(agent_messages)
+                        run_messages[index] = {
+                            **message,
+                            "content": f"{content}\n\n{diff_feedback_block}",
+                        }
+                        break
+        except Exception:  # noqa: BLE001 -- notes must never break the reply
+            logger.opt(exception=True).warning(
+                "change_review: could not attach pending diff-feedback notes"
+            )
+            diff_feedback_included_ids = []
+            diff_feedback_included_notes = []
         try:
             # FIRST statement in the block that owns this thread's
             # shutdown -- see its construction above. Not merely *before*
@@ -3542,6 +3591,45 @@ class ConsoleAgentBridge:
                 except Exception:  # noqa: BLE001 -- never mask the run's outcome
                     logger.opt(exception=True).warning(
                         "change_review: end_turn failed; turn changes untracked"
+                    )
+            # task-5 (turn-file-annotate, spec §4): stamp exactly the
+            # notes this run's attach seam included (captured above,
+            # before `run_turn` was even called) and disclose what was
+            # sent. Placed BESIDE the marker seam above -- not inside
+            # `_append_change_markers`, and deliberately NOT nested under
+            # `if change_handle is not None:`: diff-feedback notes are
+            # about what the user told the agent, unrelated to whether
+            # THIS turn's own tracked roots changed, or whether change
+            # tracking is even configured for this run at all -- the
+            # marker seam's internal `if files:` gate ("nothing to
+            # report") must not become a reason to strand notes that were
+            # genuinely delivered in the outbound payload. Gated only on
+            # the run having actually produced assistant output: a run
+            # that errors, gets cancelled empty-handed, or crashes before
+            # a run row exists leaves every attached note pending for the
+            # retry -- the block only ever lived in the outbound COPY (see
+            # the attach seam above run_turn), so nothing is lost by not
+            # stamping. `run_id`/`outcome` are bound together by the same
+            # assignment, so the one `locals()` check covers both. Double
+            # delivery is impossible by construction (the pending query
+            # excludes already-stamped rows). Never breaks the reply.
+            if (
+                "run_id" in locals()
+                and outcome.final_text
+                and diff_feedback_included_ids
+            ):
+                try:
+                    self._db.mark_notes_delivered(diff_feedback_included_ids)
+                    self._store.append_message(
+                        session_id,
+                        role=ConsoleMessageRole.TOOL,
+                        content=format_diff_feedback_disclosure(
+                            diff_feedback_included_notes
+                        ),
+                    )
+                except Exception:  # noqa: BLE001 -- notes must never break the reply
+                    logger.opt(exception=True).warning(
+                        "change_review: could not stamp/disclose diff feedback"
                     )
         for step in outcome.steps:
             logger.info(

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -3643,16 +3643,35 @@ class ConsoleAgentBridge:
                     # actually doing the delivering, which resume
                     # re-derivation anchors the disclosure row to. `run_id`
                     # is already known-bound by the `locals()` check above.
-                    self._db.mark_notes_delivered(
-                        diff_feedback_included_ids, delivered_by_run_id=run_id
+                    #
+                    # Qodo #4 (PR #1779 fix round): disclose only the ids
+                    # `mark_notes_delivered` reports ACTUALLY stamped, not
+                    # every id this seam captured -- a concurrent delivery
+                    # elsewhere could have already stamped one of them
+                    # first (the UPDATE's own `delivered_at IS NULL` guard
+                    # silently skips it), and disclosing a note nobody
+                    # verifiably delivered on THIS run's completion would
+                    # be dishonest. Concurrent replies on one conversation
+                    # are architecturally serialized today, so this is
+                    # defense in depth, not a reachable-today bug.
+                    stamped_ids = set(
+                        self._db.mark_notes_delivered(
+                            diff_feedback_included_ids, delivered_by_run_id=run_id
+                        )
                     )
-                    self._store.append_message(
-                        session_id,
-                        role=ConsoleMessageRole.TOOL,
-                        content=format_diff_feedback_disclosure(
-                            diff_feedback_included_notes
-                        ),
-                    )
+                    disclosed_notes = [
+                        note
+                        for note in diff_feedback_included_notes
+                        if int(note["id"]) in stamped_ids
+                    ]
+                    if disclosed_notes:
+                        self._store.append_message(
+                            session_id,
+                            role=ConsoleMessageRole.TOOL,
+                            content=format_diff_feedback_disclosure(
+                                disclosed_notes
+                            ),
+                        )
                 except Exception:  # noqa: BLE001 -- notes must never break the reply
                     logger.opt(exception=True).warning(
                         "change_review: could not stamp/disclose diff feedback"

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1165,6 +1165,39 @@ def turn_file_entries(
     return paired
 
 
+def middle_elide_path(path: str, budget: int) -> str:
+    """Middle-elide a path to fit a display budget, preserving both ends.
+
+    Keeps the first and last path components intact -- the two fragments a
+    user actually recognizes a file by (its directory of origin and its
+    own name) -- and collapses everything between them into a single "…"
+    placeholder component. Splits on "/" rather than going through
+    `pathlib`: every path this renders (``TurnFileEntry.label``) is
+    already a root-relative git path, not a local filesystem path to
+    resolve, and git always uses "/" regardless of host OS.
+
+    Args:
+        path: The path to elide.
+        budget: Maximum character length of the result.
+
+    Returns:
+        ``path`` unchanged when it already fits within ``budget``, or when
+        it has two or fewer components -- there is no middle left to drop
+        without mangling the one meaningful fragment that remains (a bare
+        filename, or a directory/filename pair where both ends already
+        ARE the whole path). Otherwise ``"<first>/…/<last>"``, even when
+        that combined form itself still exceeds ``budget`` -- a single
+        overlong component can't be shortened further at this
+        path-component granularity.
+    """
+    if len(path) <= budget:
+        return path
+    parts = path.split("/")
+    if len(parts) <= 2:
+        return path
+    return f"{parts[0]}/…/{parts[-1]}"
+
+
 # --------------------------------------------------------------------------
 # Diff hunk segmentation + annotate/feedback loop (task: turn-file-card
 # annotate loop, TASK-16800)

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from html import escape as html_escape
 from pathlib import PurePath
@@ -1162,3 +1163,177 @@ def turn_file_entries(
                 )
             )
     return paired
+
+
+# --------------------------------------------------------------------------
+# Diff hunk segmentation + annotate/feedback loop (task: turn-file-card
+# annotate loop, TASK-16800)
+# --------------------------------------------------------------------------
+
+#: Matches a unified-diff hunk header line verbatim, e.g. "@@ -1,4 +1,6 @@"
+#: or "@@ -1,4 +1,6 @@ def foo():" (git's optional trailing function
+#: context). Adapted from ``Tools/patch_tool_impls.py:58``'s
+#: ``_HUNK_HEADER`` -- copied locally rather than imported so this module's
+#: segmentation stays independent of the patch tool's own parser, which is
+#: not to be modified for this feature.
+_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
+
+#: The delivery block's heading (spec §4). Shared verbatim between
+#: ``render_diff_feedback_block`` and its consumer (the bridge attach seam,
+#: Task 5) so the format can't drift between definition and use.
+_DIFF_FEEDBACK_HEADING = "## Diff feedback from the user (on your earlier file changes)"
+
+
+@dataclass(frozen=True)
+class DiffHunk:
+    """One hunk of a single file's unified diff, plus its shared prelude.
+
+    ``file_prelude`` (the ``diff --git``/``index``/``---``/``+++`` lines)
+    is identical across every hunk of the same file -- it is repeated on
+    each ``DiffHunk`` rather than factored out so a hunk is a
+    self-contained unit callers can pass around individually (e.g. one
+    hunk per note).
+    """
+
+    header: str
+    body_lines: tuple[str, ...]
+    file_prelude: str
+
+
+def split_unified_diff(text: str) -> list[DiffHunk]:
+    """Segment one file's unified-diff text into per-hunk blocks.
+
+    Always runs over the FULL diff text (spec §2) -- never a
+    display-truncated slice -- so hunk indices are stable regardless of any
+    display cap a caller later applies. Expects ``text`` to be a single
+    file's diff output (e.g. ``provider.diff_text(row, path)``); a
+    multi-file diff is not a supported input shape.
+
+    Args:
+        text: The unified diff text for one file, verbatim.
+
+    Returns:
+        One ``DiffHunk`` per ``@@ ... @@`` header found, in order. When
+        the diff has no hunk headers at all (a binary file, or a clean
+        rename with no content change), returns a single fallback
+        ``DiffHunk`` with an empty ``header``/``file_prelude`` and every
+        line of ``text`` as ``body_lines`` -- this keeps such diffs
+        annotatable as one unit instead of vanishing from segmentation.
+    """
+    lines = text.splitlines()
+    header_indices = [i for i, line in enumerate(lines) if _HUNK_HEADER.match(line)]
+    if not header_indices:
+        return [DiffHunk(header="", body_lines=tuple(lines), file_prelude="")]
+
+    file_prelude = "\n".join(lines[: header_indices[0]])
+    hunks: list[DiffHunk] = []
+    for position, start in enumerate(header_indices):
+        end = (
+            header_indices[position + 1]
+            if position + 1 < len(header_indices)
+            else len(lines)
+        )
+        hunks.append(
+            DiffHunk(
+                header=lines[start],
+                body_lines=tuple(lines[start + 1 : end]),
+                file_prelude=file_prelude,
+            )
+        )
+    return hunks
+
+
+def hunk_excerpt(hunk: DiffHunk, cap: int = 40) -> str:
+    """Render a capped, self-contained excerpt of one hunk.
+
+    This is the retention safety net (spec §1): captured once at note
+    creation, it keeps a note's display and delivery self-contained even
+    after the shadow repo prunes the snapshots the hunk came from.
+
+    Args:
+        hunk: The hunk to excerpt.
+        cap: Maximum number of body lines to include before eliding.
+
+    Returns:
+        The header (when non-empty) followed by up to ``cap`` body lines,
+        newline-joined. When the body is longer than ``cap``, an honest
+        "… N more lines" tail line is appended.
+    """
+    parts: list[str] = []
+    if hunk.header:
+        parts.append(hunk.header)
+    body = hunk.body_lines
+    parts.extend(body[:cap])
+    if len(body) > cap:
+        parts.append(f"… {len(body) - cap} more lines")
+    return "\n".join(parts)
+
+
+def _diff_feedback_note_entry(note: Mapping[str, Any]) -> str:
+    """Render one note's block entry (spec §4), sans the shared heading."""
+    short_id = str(note["run_id"])[:8]
+    return (
+        f"### {note['path']} — {note['hunk_header']}   [run {short_id}]\n"
+        f"> {note['note']}\n"
+        f"```\n{note['hunk_excerpt']}\n```"
+    )
+
+
+def render_diff_feedback_block(
+    notes: Sequence[dict], *, cap_bytes: int = 16384
+) -> "tuple[str, list[int]]":
+    """Render the auto-attached diff-feedback block (spec §4).
+
+    Notes are included oldest-first (callers pass ``ORDER BY id``) while
+    the running UTF-8 size of the block-so-far stays under ``cap_bytes``:
+    a note is included only if adding its full rendering keeps the total
+    strictly under the cap. The first note that would push the block over
+    the cap, and every note after it, are excluded and NOT stamped
+    delivered by the caller -- they stay pending and ride the next send.
+
+    Args:
+        notes: ``change_notes`` row dicts, oldest first.
+        cap_bytes: Maximum UTF-8 byte size of the rendered block.
+
+    Returns:
+        A ``(block, included_ids)`` pair. ``included_ids`` holds exactly
+        the ``id`` of every note that made it into ``block``, in the same
+        order. When any notes were excluded by the cap, ``block`` ends
+        with a "… N more notes held for the next message" line. Empty
+        ``notes`` returns ``("", [])``.
+    """
+    if not notes:
+        return "", []
+
+    lines: list[str] = [_DIFF_FEEDBACK_HEADING]
+    included_ids: list[int] = []
+    for index, note in enumerate(notes):
+        candidate = "\n".join(lines + [_diff_feedback_note_entry(note)])
+        if len(candidate.encode("utf-8")) >= cap_bytes:
+            held = len(notes) - index
+            block = "\n".join(lines) + f"\n\n… {held} more notes held for the next message"
+            return block, included_ids
+        lines.append(_diff_feedback_note_entry(note))
+        included_ids.append(int(note["id"]))
+    return "\n".join(lines), included_ids
+
+
+def format_diff_feedback_disclosure(notes: Sequence[dict]) -> str:
+    """Render the disclosure text for delivered diff-feedback notes.
+
+    Shared verbatim by live emission at run completion and by resume
+    re-derivation from delivered ``change_notes`` rows (spec §4) -- both
+    callers must render identical text for the same notes.
+
+    Args:
+        notes: ``change_notes`` row dicts to disclose, one line each.
+
+    Returns:
+        One "📝 Diff feedback attached — ``<path>`` ``<hunk_header>``:
+        ``"<note>"``" line per note, newline-joined. Empty ``notes``
+        returns ``""``.
+    """
+    return "\n".join(
+        f'📝 Diff feedback attached — {note["path"]} {note["hunk_header"]}: "{note["note"]}"'
+        for note in notes
+    )

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1276,21 +1276,135 @@ def split_unified_diff(text: str) -> list[DiffHunk]:
     return hunks
 
 
-def hunk_excerpt(hunk: DiffHunk, cap: int = 40) -> str:
+#: Byte cap applied to a captured hunk excerpt (Qodo #5, PR #1779 fix
+#: round). The line cap (``hunk_excerpt``'s ``cap`` parameter) alone is not
+#: enough: a minified single-line file's ONE body line can carry far more
+#: bytes than the whole delivery block's cap, and `render_diff_feedback_
+#: block`'s per-note inclusion loop treats any note whose entry alone
+#: exceeds the block cap as an unconditional queue-blocker (see that
+#: function's own fix below). Bounding excerpt bytes at CAPTURE time keeps
+#: newly-saved notes well clear of that failure mode; the render-time
+#: truncation-to-fit guard below is what protects notes captured before
+#: this cap existed.
+_EXCERPT_BYTE_CAP = 4096
+_EXCERPT_BYTE_CAP_TAIL = "… truncated"
+#: Tail appended when `render_diff_feedback_block` truncates the OLDEST
+#: pending note's excerpt to guarantee it is always deliverable (Qodo #5).
+_EXCERPT_TRUNCATED_TO_FIT_TAIL = "… excerpt truncated to fit"
+
+
+def _byte_safe_truncate(text: str, max_bytes: int) -> str:
+    """Truncate ``text`` to at most ``max_bytes`` UTF-8 bytes.
+
+    Never splits a multi-byte codepoint: backs off byte-by-byte from a
+    raw slice of the UTF-8 encoding until the remainder decodes cleanly.
+
+    Args:
+        text: The text to truncate.
+        max_bytes: The maximum UTF-8 byte length of the result.
+
+    Returns:
+        The longest prefix of ``text`` that both decodes cleanly and fits
+        in ``max_bytes`` bytes. Empty when ``max_bytes <= 0``.
+    """
+    if max_bytes <= 0:
+        return ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    truncated = encoded[:max_bytes]
+    while truncated:
+        try:
+            return truncated.decode("utf-8")
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+    return ""
+
+
+def _cap_text_to_byte_budget(text: str, budget_bytes: int, tail: str) -> str:
+    """Truncate ``text`` to fit ``budget_bytes`` UTF-8 bytes, tail included.
+
+    Prefers a line boundary: keeps whole lines from the start for as long
+    as they fit, then appends ``"\\n" + tail``. The one line that does NOT
+    fit whole is not simply dropped, though -- whatever budget remains
+    after the last whole line is spent on a byte-safe PARTIAL prefix of
+    it, so a body that is one huge line (e.g. a minified file's single
+    diff line -- the motivating case for this cap) still yields a useful,
+    budget-respecting excerpt instead of empty content past the header.
+
+    Args:
+        text: The text to cap.
+        budget_bytes: Maximum UTF-8 byte length of the result, tail
+            included.
+        tail: An honest elision marker appended (on its own line) when
+            truncation actually happens.
+
+    Returns:
+        ``text`` unchanged when it already fits ``budget_bytes``;
+        otherwise a truncated prefix plus ``"\\n" + tail``, guaranteed to
+        encode to at most ``budget_bytes`` UTF-8 bytes.
+    """
+    if len(text.encode("utf-8")) <= budget_bytes:
+        return text
+
+    tail_line = f"\n{tail}"
+    tail_bytes = len(tail_line.encode("utf-8"))
+    content_budget = budget_bytes - tail_bytes
+    if content_budget <= 0:
+        # No room for the tail alongside any content -- best effort: a
+        # bare hard truncation, no tail, still honoring the byte budget.
+        return _byte_safe_truncate(text, max(budget_bytes, 0))
+
+    lines = text.split("\n")
+    kept: list[str] = []
+    used = 0
+    for line in lines:
+        sep = "\n" if kept else ""
+        sep_bytes = len(sep)  # sep is ASCII ("" or "\n") -- 1 byte or 0
+        line_bytes = len(line.encode("utf-8"))
+        if used + sep_bytes + line_bytes <= content_budget:
+            kept.append(line)
+            used += sep_bytes + line_bytes
+            continue
+        # This line doesn't fit whole -- spend whatever budget remains on
+        # a byte-safe PARTIAL prefix of it rather than dropping its
+        # content outright.
+        remaining = content_budget - used - sep_bytes
+        if remaining > 0:
+            partial = _byte_safe_truncate(line, remaining)
+            if partial:
+                kept.append(partial)
+        break
+
+    return "\n".join(kept) + tail_line
+
+
+def hunk_excerpt(hunk: DiffHunk, cap: int = 40, byte_cap: int = _EXCERPT_BYTE_CAP) -> str:
     """Render a capped, self-contained excerpt of one hunk.
 
     This is the retention safety net (spec §1): captured once at note
     creation, it keeps a note's display and delivery self-contained even
     after the shadow repo prunes the snapshots the hunk came from.
 
+    Two independent caps apply, in order: ``cap`` bounds the number of
+    body LINES (as before); ``byte_cap`` then bounds the whole rendered
+    excerpt's UTF-8 BYTE size (Qodo #5, PR #1779 fix round) -- a line cap
+    alone does not bound a minified single-line file's excerpt, which can
+    carry far more bytes in that one line than the entire delivery
+    block's cap.
+
     Args:
         hunk: The hunk to excerpt.
         cap: Maximum number of body lines to include before eliding.
+        byte_cap: Maximum UTF-8 byte size of the rendered excerpt.
 
     Returns:
         The header (when non-empty) followed by up to ``cap`` body lines,
         newline-joined. When the body is longer than ``cap``, an honest
-        "… N more lines" tail line is appended.
+        "… N more lines" tail line is appended. When the result (line cap
+        already applied) still exceeds ``byte_cap`` bytes, it is further
+        truncated at a line boundary where possible with an honest
+        "… truncated" tail.
     """
     parts: list[str] = []
     if hunk.header:
@@ -1299,7 +1413,8 @@ def hunk_excerpt(hunk: DiffHunk, cap: int = 40) -> str:
     parts.extend(body[:cap])
     if len(body) > cap:
         parts.append(f"… {len(body) - cap} more lines")
-    return "\n".join(parts)
+    text = "\n".join(parts)
+    return _cap_text_to_byte_budget(text, byte_cap, _EXCERPT_BYTE_CAP_TAIL)
 
 
 def _diff_feedback_note_entry(note: Mapping[str, Any]) -> str:
@@ -1323,6 +1438,58 @@ def _diff_feedback_note_entry(note: Mapping[str, Any]) -> str:
     )
 
 
+def _oldest_note_entry_truncated_to_fit(
+    note: Mapping[str, Any], *, cap_bytes: int, held_after: int
+) -> "str | None":
+    """Shrink ONLY this note's excerpt so its entry fits under ``cap_bytes``.
+
+    Queue-blocker guard (Qodo #5, PR #1779 fix round): the oldest pending
+    note must always be deliverable, even one whose captured excerpt (a
+    legacy row from before ``hunk_excerpt`` grew its own byte cap) is
+    larger than the whole block cap. Only the excerpt is shrunk -- path,
+    hunk header, and note text are never touched -- and the shrink budget
+    already reserves room for the "… N more notes held" line the caller
+    will need to append when ``held_after`` notes remain uninspected.
+
+    Args:
+        note: The oldest pending note's row dict.
+        cap_bytes: The block's overall byte cap.
+        held_after: How many notes after this one will be left pending
+            (the caller always stops considering further notes once this
+            guard engages, so this count is fixed at call time).
+
+    Returns:
+        The rendered entry (heading NOT included) when a truncation makes
+        it fit; ``None`` when even a zero-length excerpt can't -- the
+        note's own fixed metadata alone already exceeds the budget, so
+        the caller falls back to the pre-fix excluded/held behavior.
+    """
+    heading_bytes = len(_DIFF_FEEDBACK_HEADING.encode("utf-8"))
+    sep_bytes = 1  # the "\n" joining the heading and this entry
+    if held_after > 0:
+        holdover_bytes = len(
+            f"\n\n… {held_after} more notes held for the next message".encode(
+                "utf-8"
+            )
+        )
+    else:
+        holdover_bytes = 0
+
+    # -1 for a strict-inequality safety margin, matching the rest of this
+    # module's "strictly under cap" per-note convention.
+    entry_budget = cap_bytes - heading_bytes - sep_bytes - holdover_bytes - 1
+    skeleton = _diff_feedback_note_entry({**note, "hunk_excerpt": ""})
+    skeleton_bytes = len(skeleton.encode("utf-8"))
+    excerpt_budget = entry_budget - skeleton_bytes
+    if excerpt_budget <= 0:
+        return None
+
+    truncated_excerpt = _cap_text_to_byte_budget(
+        str(note["hunk_excerpt"]), excerpt_budget, _EXCERPT_TRUNCATED_TO_FIT_TAIL
+    )
+    return _diff_feedback_note_entry({**note, "hunk_excerpt": truncated_excerpt})
+
+
 def render_diff_feedback_block(
     notes: Sequence[dict], *, cap_bytes: int = 16384
 ) -> "tuple[str, list[int]]":
@@ -1334,6 +1501,16 @@ def render_diff_feedback_block(
     strictly under the cap. The first note that would push the block over
     the cap, and every note after it, are excluded and NOT stamped
     delivered by the caller -- they stay pending and ride the next send.
+
+    Queue-blocker guard (Qodo #5, PR #1779 fix round): when the very
+    FIRST (oldest) note alone doesn't fit -- typically a legacy row whose
+    excerpt predates ``hunk_excerpt``'s own byte cap, since a freshly
+    captured excerpt is now bounded well under this block's cap -- its
+    excerpt is truncated to fit instead of excluding it outright, so the
+    oldest pending note is (almost) always deliverable and can never
+    permanently block every note behind it. Every note after it still
+    follows the pre-existing break-at-cap behavior (they stay pending,
+    riding the next send, holdover line as today).
 
     The cap covers the WHOLE rendered block, including the trailing
     "… N more notes held for the next message" line when one is needed --
@@ -1358,12 +1535,34 @@ def render_diff_feedback_block(
 
     lines: list[str] = [_DIFF_FEEDBACK_HEADING]
     included_count = 0
-    for note in notes:
-        candidate = "\n".join(lines + [_diff_feedback_note_entry(note)])
-        if len(candidate.encode("utf-8")) >= cap_bytes:
-            break
-        lines.append(_diff_feedback_note_entry(note))
-        included_count += 1
+    floor = 0
+    for index, note in enumerate(notes):
+        entry = _diff_feedback_note_entry(note)
+        candidate = "\n".join(lines + [entry])
+        if len(candidate.encode("utf-8")) < cap_bytes:
+            lines.append(entry)
+            included_count += 1
+            continue
+
+        if index == 0:
+            # Queue-blocker guard: this oldest note doesn't fit even alone
+            # -- try shrinking ITS excerpt (only) so it is deliverable
+            # anyway, rather than leaving it (and everything behind it)
+            # pending forever.
+            held_after = len(notes) - 1
+            truncated_entry = _oldest_note_entry_truncated_to_fit(
+                note, cap_bytes=cap_bytes, held_after=held_after
+            )
+            if truncated_entry is not None:
+                lines.append(truncated_entry)
+                included_count = 1
+                # Guaranteed (by construction, see the helper's budget
+                # math) to already fit under cap_bytes with the holdover
+                # line included -- never evict it below this floor.
+                floor = 1
+        # Every note after the oldest keeps the pre-existing break-at-cap
+        # behavior regardless of whether the guard above engaged.
+        break
 
     if included_count == len(notes):
         # Everything fit -- no holdover line, so nothing needed to be
@@ -1374,14 +1573,15 @@ def render_diff_feedback_block(
     # account for the holdover line's own bytes). Evict from the tail
     # until the holdover-inclusive block actually fits under cap_bytes --
     # each eviction both shrinks the notes portion and (usually) shrinks
-    # "held"'s digit count, so this converges quickly. `included_count ==
-    # 0` is the irreducible floor (heading + holdover for every note) and
-    # is returned even if it still exceeds cap_bytes -- there is nothing
-    # left to evict.
+    # "held"'s digit count, so this converges quickly. ``floor`` is the
+    # irreducible bound (0 normally; 1 when the queue-blocker guard above
+    # already placed a guaranteed-to-fit truncated oldest note that must
+    # never be evicted) and is returned even if it still exceeds
+    # cap_bytes -- there is nothing left that may be evicted.
     while True:
         held = len(notes) - included_count
         block = "\n".join(lines) + f"\n\n… {held} more notes held for the next message"
-        if len(block.encode("utf-8")) <= cap_bytes or included_count == 0:
+        if len(block.encode("utf-8")) <= cap_bytes or included_count <= floor:
             included_ids = [int(note["id"]) for note in notes[:included_count]]
             return block, included_ids
         included_count -= 1

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1291,6 +1291,13 @@ def render_diff_feedback_block(
     the cap, and every note after it, are excluded and NOT stamped
     delivered by the caller -- they stay pending and ride the next send.
 
+    The cap covers the WHOLE rendered block, including the trailing
+    "… N more notes held for the next message" line when one is needed --
+    that line is never allowed to push the total over ``cap_bytes`` on its
+    own. When nothing is excluded, no such line is appended and nothing is
+    reserved for one, so a cap that exactly fits every note's own bytes is
+    never needlessly short by the holdover line's size.
+
     Args:
         notes: ``change_notes`` row dicts, oldest first.
         cap_bytes: Maximum UTF-8 byte size of the rendered block.
@@ -1306,16 +1313,35 @@ def render_diff_feedback_block(
         return "", []
 
     lines: list[str] = [_DIFF_FEEDBACK_HEADING]
-    included_ids: list[int] = []
-    for index, note in enumerate(notes):
+    included_count = 0
+    for note in notes:
         candidate = "\n".join(lines + [_diff_feedback_note_entry(note)])
         if len(candidate.encode("utf-8")) >= cap_bytes:
-            held = len(notes) - index
-            block = "\n".join(lines) + f"\n\n… {held} more notes held for the next message"
-            return block, included_ids
+            break
         lines.append(_diff_feedback_note_entry(note))
-        included_ids.append(int(note["id"]))
-    return "\n".join(lines), included_ids
+        included_count += 1
+
+    if included_count == len(notes):
+        # Everything fit -- no holdover line, so nothing needed to be
+        # reserved for one either.
+        return "\n".join(lines), [int(note["id"]) for note in notes]
+
+    # At least one note was excluded by the loop above (which did not yet
+    # account for the holdover line's own bytes). Evict from the tail
+    # until the holdover-inclusive block actually fits under cap_bytes --
+    # each eviction both shrinks the notes portion and (usually) shrinks
+    # "held"'s digit count, so this converges quickly. `included_count ==
+    # 0` is the irreducible floor (heading + holdover for every note) and
+    # is returned even if it still exceeds cap_bytes -- there is nothing
+    # left to evict.
+    while True:
+        held = len(notes) - included_count
+        block = "\n".join(lines) + f"\n\n… {held} more notes held for the next message"
+        if len(block.encode("utf-8")) <= cap_bytes or included_count == 0:
+            included_ids = [int(note["id"]) for note in notes[:included_count]]
+            return block, included_ids
+        included_count -= 1
+        lines.pop()
 
 
 def format_diff_feedback_disclosure(notes: Sequence[dict]) -> str:

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1303,12 +1303,23 @@ def hunk_excerpt(hunk: DiffHunk, cap: int = 40) -> str:
 
 
 def _diff_feedback_note_entry(note: Mapping[str, Any]) -> str:
-    """Render one note's block entry (spec §4), sans the shared heading."""
+    """Render one note's block entry (spec §4), sans the shared heading.
+
+    The excerpt is fenced with FOUR backticks, not the usual three
+    (final-review fix wave): the excerpt is a verbatim hunk body, and a
+    hunk from a markdown-file diff can itself contain a triple-backtick
+    line -- with a three-backtick fence that would prematurely close the
+    fence mid-excerpt and corrupt the rest of the model payload. A bare
+    diff line can start with a literal backtick but a *fenced code block*
+    delimiter inside a diff of a markdown file is exactly the case this
+    guards; four backticks is the standard "fence one level up" escape
+    used for exactly this nesting problem.
+    """
     short_id = str(note["run_id"])[:8]
     return (
         f"### {note['path']} — {note['hunk_header']}   [run {short_id}]\n"
         f"> {note['note']}\n"
-        f"```\n{note['hunk_excerpt']}\n```"
+        f"````\n{note['hunk_excerpt']}\n````"
     )
 
 

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -296,7 +296,23 @@ class AgentRunsDB(BaseDB):
                     -- instead of fragmenting/mis-anchoring at the
                     -- annotated run. NULL until stamped, and NULL forever
                     -- on rows stamped by code that predates this column.
-                    delivered_by_run_id TEXT
+                    delivered_by_run_id TEXT,
+                    -- v10 (Qodo #6, PR #1779 fix round): the exact
+                    -- change_snapshots row (its own DB `id`) this note's
+                    -- hunk was read from. Two windows on the SAME run+
+                    -- root+path (a turn's own window and its surviving
+                    -- sub-agents' post-turn window, PR3a-1 Task 6c) can
+                    -- theoretically carry the same hunk_header at the
+                    -- same hunk_index (identical position/line-count
+                    -- edits against different baselines produce
+                    -- byte-identical "@@ ... @@" headers, since a header
+                    -- encodes only positions/counts, never content) --
+                    -- (run_id, hunk_index, hunk_header) alone can't then
+                    -- say which window's diff was actually annotated.
+                    -- NULL for legacy rows saved before this column
+                    -- existed; the card falls back to hunk_index+
+                    -- hunk_header matching for those.
+                    snapshot_id INTEGER
                 );
                 CREATE INDEX IF NOT EXISTS idx_change_notes_pending
                     ON change_notes(run_id) WHERE delivered_at IS NULL;
@@ -382,6 +398,17 @@ class AgentRunsDB(BaseDB):
                 conn.execute(
                     "ALTER TABLE change_notes ADD COLUMN delivered_by_run_id TEXT"
                 )
+            # v9->v10 (Qodo #6, PR #1779 fix round): a file created while
+            # change_notes existed but before snapshot_id did keeps its
+            # old 11-column table -- same idempotent-ALTER mechanism as
+            # every column above. No DEFAULT: every pre-existing row
+            # correctly reads as NULL (unknown snapshot), which is exactly
+            # the legacy hunk_index+hunk_header fallback the card's
+            # matching is built to handle.
+            if "snapshot_id" not in note_columns:
+                conn.execute(
+                    "ALTER TABLE change_notes ADD COLUMN snapshot_id INTEGER"
+                )
             # Keep the (write-only, audit) version table in step with the
             # DDL -- append-per-version, matching the INSERT OR IGNORE
             # convention above (UPDATE would collide on the UNIQUE column
@@ -403,6 +430,9 @@ class AgentRunsDB(BaseDB):
             )
             conn.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (9)"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (10)"
             )
 
     def record_change_snapshot(
@@ -597,6 +627,7 @@ class AgentRunsDB(BaseDB):
         hunk_header: str,
         hunk_excerpt: str,
         note: str,
+        snapshot_id: int | None = None,
     ) -> int:
         """Record a user-authored note anchored to one hunk of a turn's diff.
 
@@ -615,6 +646,18 @@ class AgentRunsDB(BaseDB):
             hunk_excerpt: The hunk body captured at note time (already
                 capped/elided by the caller).
             note: The user's note text.
+            snapshot_id: The owning ``change_snapshots`` row's own DB
+                ``id`` (Qodo #6, PR #1779 fix round) -- disambiguates
+                which of TWO same-``run_id``/root/path windows (a turn's
+                own window and its surviving sub-agents' post-turn
+                window, PR3a-1 Task 6c) this note's hunk actually came
+                from, for the rare case where both windows happen to
+                produce the exact same ``hunk_index``/``hunk_header``
+                (identical position/line-count edits against different
+                baselines yield byte-identical headers, since a header
+                encodes only positions/counts, never content). ``None``
+                (the default) only by callers that predate this column or
+                have no snapshot row to anchor to.
 
         Returns:
             The newly created note's row id.
@@ -624,8 +667,9 @@ class AgentRunsDB(BaseDB):
                 """
                 INSERT INTO change_notes
                     (run_id, root, path, hunk_index, hunk_header,
-                     hunk_excerpt, note, created_at, delivered_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                     hunk_excerpt, note, created_at, delivered_at,
+                     snapshot_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
                 """,
                 (
                     run_id,
@@ -636,6 +680,7 @@ class AgentRunsDB(BaseDB):
                     hunk_excerpt,
                     note,
                     _now_iso(),
+                    snapshot_id,
                 ),
             )
             return int(cursor.lastrowid)
@@ -737,7 +782,7 @@ class AgentRunsDB(BaseDB):
 
     def mark_notes_delivered(
         self, note_ids: Sequence[int], delivered_by_run_id: str | None = None
-    ) -> None:
+    ) -> list[int]:
         """Stamp exactly the given notes as delivered.
 
         Spec §4: the delivery seam captures the precise id list it
@@ -745,6 +790,17 @@ class AgentRunsDB(BaseDB):
         completion -- never "all pending for the conversation". A note
         created after the list was captured (the mid-run race) is not in
         ``note_ids`` and so stays pending, riding the next send.
+
+        Qodo #4 (PR #1779 fix round): the UPDATE's own
+        ``AND delivered_at IS NULL`` guard means a note already stamped by
+        a concurrent delivery (elsewhere) is silently skipped rather than
+        re-stamped -- correct for the DB, but the caller previously had no
+        way to know that skip happened, so the bridge's completion seam
+        disclosed every id it captured regardless of what actually got
+        stamped. Concurrent replies on one conversation are architecturally
+        serialized today, so that race is not currently reachable in
+        practice, but this makes the seam self-defending rather than
+        relying on that invariant holding forever.
 
         Args:
             note_ids: The note ids to stamp delivered.
@@ -757,18 +813,40 @@ class AgentRunsDB(BaseDB):
                 disclosure at the run that actually delivered it. Left
                 ``None`` (the default) only by callers that predate this
                 column or do not know/care which run is delivering.
+
+        Returns:
+            The subset of ``note_ids`` that this call ACTUALLY stamped
+            (i.e. were still pending at the moment of the UPDATE) -- never
+            more than ``note_ids``, and possibly fewer when a concurrent
+            caller already delivered one of them first. Order is not
+            significant to callers, all of which only ever test set
+            membership against it.
         """
         ids = [int(note_id) for note_id in note_ids]
         if not ids:
-            return
+            return []
         placeholders = ",".join("?" for _ in ids)
+        stamp = _now_iso()
         with self.transaction() as conn:
             conn.execute(
                 f"UPDATE change_notes SET delivered_at = ?, "
                 f"delivered_by_run_id = ? "
                 f"WHERE id IN ({placeholders}) AND delivered_at IS NULL",
-                (_now_iso(), delivered_by_run_id, *ids),
+                (stamp, delivered_by_run_id, *ids),
             )
+            # Portable (works against any bundled SQLite -- no RETURNING
+            # dependency): re-select, in the SAME transaction/connection,
+            # exactly the rows this UPDATE just wrote. `delivered_at =
+            # stamp` alone (a value only this call could have produced)
+            # already uniquely identifies them; `delivered_by_run_id IS ?`
+            # is belt-and-suspenders (SQLite's `IS` compares correctly
+            # against a NULL-bound parameter too).
+            rows = conn.execute(
+                f"SELECT id FROM change_notes WHERE id IN ({placeholders}) "
+                f"AND delivered_at = ? AND delivered_by_run_id IS ?",
+                (*ids, stamp, delivered_by_run_id),
+            ).fetchall()
+        return [int(row["id"]) for row in rows]
 
     @staticmethod
     def _row_to_dict(row: sqlite3.Row) -> dict:

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -284,7 +284,19 @@ class AgentRunsDB(BaseDB):
                     hunk_excerpt TEXT NOT NULL,
                     note TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    delivered_at TEXT
+                    delivered_at TEXT,
+                    -- v9 (TASK-16800 Task 6 fix round): which run's
+                    -- COMPLETION actually stamped this note delivered --
+                    -- distinct from `run_id` above, which anchors the note
+                    -- to the run whose DIFF it critiques. A note written
+                    -- against an earlier run's diff is commonly delivered
+                    -- on a LATER run's completion, so resume re-derivation
+                    -- needs this to place the disclosure row at the
+                    -- delivering run's position (matching live emission)
+                    -- instead of fragmenting/mis-anchoring at the
+                    -- annotated run. NULL until stamped, and NULL forever
+                    -- on rows stamped by code that predates this column.
+                    delivered_by_run_id TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_change_notes_pending
                     ON change_notes(run_id) WHERE delivered_at IS NULL;
@@ -353,6 +365,23 @@ class AgentRunsDB(BaseDB):
                     "ALTER TABLE change_snapshots ADD COLUMN "
                     "kind TEXT NOT NULL DEFAULT 'turn'"
                 )
+            # v8->v9 (TASK-16800 Task 6 fix round): a file created while
+            # change_notes existed but before delivered_by_run_id did
+            # keeps its old 10-column table -- same idempotent-ALTER
+            # mechanism as every column above. No DEFAULT: every
+            # pre-existing row correctly reads as NULL (unknown delivering
+            # run), which is exactly the legacy fallback resume
+            # re-derivation is built to handle.
+            note_columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(change_notes)"
+                ).fetchall()
+            }
+            if "delivered_by_run_id" not in note_columns:
+                conn.execute(
+                    "ALTER TABLE change_notes ADD COLUMN delivered_by_run_id TEXT"
+                )
             # Keep the (write-only, audit) version table in step with the
             # DDL -- append-per-version, matching the INSERT OR IGNORE
             # convention above (UPDATE would collide on the UNIQUE column
@@ -371,6 +400,9 @@ class AgentRunsDB(BaseDB):
             )
             conn.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (8)"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (9)"
             )
 
     def record_change_snapshot(
@@ -672,7 +704,40 @@ class AgentRunsDB(BaseDB):
             ).fetchall()
         return [dict(row) for row in rows]
 
-    def mark_notes_delivered(self, note_ids: Sequence[int]) -> None:
+    def delivered_notes_for_conversation(self, conversation_id: str) -> list[dict]:
+        """Return a conversation's delivered notes, oldest first.
+
+        TASK-16800 Task 6 fix round: the batched counterpart to
+        ``pending_notes_for_conversation`` (same join shape, same
+        precedent as the TASK-1972 no-N+1 fix for ``change_snapshots``)
+        -- resume re-derivation needs every delivered note across every
+        run of the conversation in ONE query, not one ``notes_for_run``
+        call per re-derived run.
+
+        Args:
+            conversation_id: The Console conversation id.
+
+        Returns:
+            Delivered (``delivered_at IS NOT NULL``) note rows across
+            every run of the conversation, oldest first. Each row carries
+            ``delivered_by_run_id`` -- NULL for notes stamped before that
+            column existed.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT cn.* FROM change_notes cn
+                JOIN agent_runs ar ON ar.id = cn.run_id
+                WHERE ar.conversation_id = ? AND cn.delivered_at IS NOT NULL
+                ORDER BY cn.id
+                """,
+                (conversation_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def mark_notes_delivered(
+        self, note_ids: Sequence[int], delivered_by_run_id: str | None = None
+    ) -> None:
         """Stamp exactly the given notes as delivered.
 
         Spec §4: the delivery seam captures the precise id list it
@@ -683,6 +748,15 @@ class AgentRunsDB(BaseDB):
 
         Args:
             note_ids: The note ids to stamp delivered.
+            delivered_by_run_id: The id of the run whose completion is
+                doing this delivery (TASK-16800 Task 6 fix round) --
+                distinct from each note's own ``run_id`` (the run whose
+                diff it critiques). Stamped verbatim onto every row in
+                ``note_ids``, alongside the same ``delivered_at``
+                timestamp, so resume re-derivation can anchor the
+                disclosure at the run that actually delivered it. Left
+                ``None`` (the default) only by callers that predate this
+                column or do not know/care which run is delivering.
         """
         ids = [int(note_id) for note_id in note_ids]
         if not ids:
@@ -690,9 +764,10 @@ class AgentRunsDB(BaseDB):
         placeholders = ",".join("?" for _ in ids)
         with self.transaction() as conn:
             conn.execute(
-                f"UPDATE change_notes SET delivered_at = ? "
+                f"UPDATE change_notes SET delivered_at = ?, "
+                f"delivered_by_run_id = ? "
                 f"WHERE id IN ({placeholders}) AND delivered_at IS NULL",
-                (_now_iso(), *ids),
+                (_now_iso(), delivered_by_run_id, *ids),
             )
 
     @staticmethod

--- a/tldw_chatbook/DB/AgentRuns_DB.py
+++ b/tldw_chatbook/DB/AgentRuns_DB.py
@@ -262,6 +262,32 @@ class AgentRunsDB(BaseDB):
                 -- soft-deleted row releases its name for re-creation.
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_name
                     ON agent_definitions(name) WHERE deleted = 0;
+
+                -- v8 (TASK-16800 annotate loop, spec §1): user-authored
+                -- feedback notes anchored to a specific hunk of a turn's
+                -- diff. DURABILITY NOTE (carries the v5 note forward):
+                -- this DB holds durable USER-AUTHORED CONTENT -- notes
+                -- extend that -- any "clear run history" tooling must not
+                -- treat this table as disposable. No denormalized
+                -- conversation_id: agent_runs already carries
+                -- conversation_id NOT NULL, so pending_notes_for_conversation
+                -- joins through change_notes.run_id = agent_runs.id --
+                -- one source of truth, and the card never needs to learn
+                -- the conversation id at insert time.
+                CREATE TABLE IF NOT EXISTS change_notes (
+                    id INTEGER PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    root TEXT NOT NULL,
+                    path TEXT NOT NULL,
+                    hunk_index INTEGER NOT NULL,
+                    hunk_header TEXT NOT NULL,
+                    hunk_excerpt TEXT NOT NULL,
+                    note TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    delivered_at TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_change_notes_pending
+                    ON change_notes(run_id) WHERE delivered_at IS NULL;
                 """
             )
             # v1->v2: this DB has no migration framework -- _initialize_schema
@@ -342,6 +368,9 @@ class AgentRunsDB(BaseDB):
             )
             conn.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (7)"
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (8)"
             )
 
     def record_change_snapshot(
@@ -525,6 +554,146 @@ class AgentRunsDB(BaseDB):
                 (conversation_id,),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def add_change_note(
+        self,
+        *,
+        run_id: str,
+        root: str,
+        path: str,
+        hunk_index: int,
+        hunk_header: str,
+        hunk_excerpt: str,
+        note: str,
+    ) -> int:
+        """Record a user-authored note anchored to one hunk of a turn's diff.
+
+        TASK-16800 (spec §1). The anchor is ``(run_id, root, path,
+        hunk_index, hunk_header)``; ``hunk_excerpt`` is captured once, at
+        note-creation time, from the full diff text the card already has
+        -- it is the retention safety net that keeps display and delivery
+        self-contained even after shadow-repo snapshot pruning.
+
+        Args:
+            run_id: The agent run whose diff this note is anchored to.
+            root: Canonical root path of the changed file.
+            path: The changed file's path (root-relative).
+            hunk_index: 0-based index of the hunk over the FULL diff.
+            hunk_header: The hunk's ``"@@ -a,b +c,d @@ ..."`` line, verbatim.
+            hunk_excerpt: The hunk body captured at note time (already
+                capped/elided by the caller).
+            note: The user's note text.
+
+        Returns:
+            The newly created note's row id.
+        """
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO change_notes
+                    (run_id, root, path, hunk_index, hunk_header,
+                     hunk_excerpt, note, created_at, delivered_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    run_id,
+                    root,
+                    path,
+                    hunk_index,
+                    hunk_header,
+                    hunk_excerpt,
+                    note,
+                    _now_iso(),
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def delete_change_note(self, note_id: int) -> bool:
+        """Delete a pending (undelivered) note.
+
+        Delivered notes are record -- once ``delivered_at`` is set a note
+        can no longer be deleted, matching the card's "delivered notes
+        lose the delete affordance" rule.
+
+        Args:
+            note_id: The note's row id.
+
+        Returns:
+            True if a pending note was deleted; False if the note does
+            not exist or has already been delivered.
+        """
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                "DELETE FROM change_notes WHERE id = ? AND delivered_at IS NULL",
+                (note_id,),
+            )
+            return cursor.rowcount > 0
+
+    def notes_for_run(self, run_id: str) -> list[dict]:
+        """Return a run's change notes, oldest first.
+
+        Args:
+            run_id: The agent run id.
+
+        Returns:
+            One dict per note row (all columns), oldest first.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM change_notes WHERE run_id = ? ORDER BY id",
+                (run_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def pending_notes_for_conversation(self, conversation_id: str) -> list[dict]:
+        """Return a conversation's undelivered notes, oldest first.
+
+        Joins through ``change_notes.run_id = agent_runs.id`` rather than
+        a denormalized conversation id column (spec §1) -- ``agent_runs``
+        is the one source of truth for which conversation a run belongs
+        to, and notes span however many runs a conversation has had.
+
+        Args:
+            conversation_id: The Console conversation id.
+
+        Returns:
+            Pending (``delivered_at IS NULL``) note rows across every run
+            of the conversation, oldest first.
+        """
+        with self.connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT cn.* FROM change_notes cn
+                JOIN agent_runs ar ON ar.id = cn.run_id
+                WHERE ar.conversation_id = ? AND cn.delivered_at IS NULL
+                ORDER BY cn.id
+                """,
+                (conversation_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def mark_notes_delivered(self, note_ids: Sequence[int]) -> None:
+        """Stamp exactly the given notes as delivered.
+
+        Spec §4: the delivery seam captures the precise id list it
+        attached to the outbound message and stamps only that list at run
+        completion -- never "all pending for the conversation". A note
+        created after the list was captured (the mid-run race) is not in
+        ``note_ids`` and so stays pending, riding the next send.
+
+        Args:
+            note_ids: The note ids to stamp delivered.
+        """
+        ids = [int(note_id) for note_id in note_ids]
+        if not ids:
+            return
+        placeholders = ",".join("?" for _ in ids)
+        with self.transaction() as conn:
+            conn.execute(
+                f"UPDATE change_notes SET delivered_at = ? "
+                f"WHERE id IN ({placeholders}) AND delivered_at IS NULL",
+                (_now_iso(), *ids),
+            )
 
     @staticmethod
     def _row_to_dict(row: sqlite3.Row) -> dict:

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -323,6 +323,74 @@ class AgentRunsChangeReviewProvider:
         repo = self._service.repo_for_root(row["root"])
         return repo.diff_text(str(row["baseline_sha"]), str(row["end_sha"]), path)
 
+    def add_change_note(
+        self,
+        *,
+        run_id: str,
+        root: str,
+        path: str,
+        hunk_index: int,
+        hunk_header: str,
+        hunk_excerpt: str,
+        note: str,
+    ) -> int:
+        """Record a user-authored note anchored to one hunk of a turn's diff.
+
+        Thin delegate onto :meth:`AgentRunsDB.add_change_note` (TASK-16800
+        spec §1/§3) -- the turn file card writes notes through the
+        provider exactly like every other change-review read/write, never
+        touching the database directly.
+
+        Args:
+            run_id: The agent run whose diff this note is anchored to.
+            root: Canonical root path of the changed file.
+            path: The changed file's path (root-relative).
+            hunk_index: 0-based index of the hunk over the file's full diff.
+            hunk_header: The hunk's ``"@@ -a,b +c,d @@ ..."`` line, verbatim.
+            hunk_excerpt: The hunk body captured at note time (already
+                capped/elided by the caller).
+            note: The user's note text.
+
+        Returns:
+            The newly created note's row id.
+        """
+        return self._db.add_change_note(
+            run_id=run_id,
+            root=root,
+            path=path,
+            hunk_index=hunk_index,
+            hunk_header=hunk_header,
+            hunk_excerpt=hunk_excerpt,
+            note=note,
+        )
+
+    def delete_change_note(self, note_id: int) -> bool:
+        """Delete a pending (undelivered) note.
+
+        Thin delegate onto :meth:`AgentRunsDB.delete_change_note`.
+
+        Args:
+            note_id: The note's row id.
+
+        Returns:
+            True if a pending note was deleted; False if the note does
+            not exist or has already been delivered.
+        """
+        return self._db.delete_change_note(note_id)
+
+    def notes_for_run(self, run_id: str) -> list[dict]:
+        """Return a run's change notes, oldest first.
+
+        Thin delegate onto :meth:`AgentRunsDB.notes_for_run`.
+
+        Args:
+            run_id: The agent run id.
+
+        Returns:
+            One dict per note row (all columns), oldest first.
+        """
+        return self._db.notes_for_run(run_id)
+
 
 class ChangeReviewScreen(Screen):
     """Changed-file tree + windowed diff viewer for one conversation."""

--- a/tldw_chatbook/UI/Screens/change_review_screen.py
+++ b/tldw_chatbook/UI/Screens/change_review_screen.py
@@ -333,6 +333,7 @@ class AgentRunsChangeReviewProvider:
         hunk_header: str,
         hunk_excerpt: str,
         note: str,
+        snapshot_id: int | None = None,
     ) -> int:
         """Record a user-authored note anchored to one hunk of a turn's diff.
 
@@ -350,6 +351,11 @@ class AgentRunsChangeReviewProvider:
             hunk_excerpt: The hunk body captured at note time (already
                 capped/elided by the caller).
             note: The user's note text.
+            snapshot_id: The owning ``change_snapshots`` row's own DB
+                ``id`` (Qodo #6, PR #1779 fix round) -- disambiguates
+                which of two same-run/root/path windows this note's hunk
+                came from. ``None`` when the caller has no snapshot row
+                to anchor to.
 
         Returns:
             The newly created note's row id.
@@ -362,6 +368,7 @@ class AgentRunsChangeReviewProvider:
             hunk_header=hunk_header,
             hunk_excerpt=hunk_excerpt,
             note=note,
+            snapshot_id=snapshot_id,
         )
 
     def delete_change_note(self, note_id: int) -> bool:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -435,6 +435,7 @@ from ...Widgets.Console.console_control_bar import (
     CONSOLE_CONTROL_BAR_HEIGHT,
 )
 from ...Widgets.Console.console_settings_modal import ConsoleSettingsResult
+from ...Widgets.Console.console_turn_file_card import ConsoleTurnFileCard
 from ...Widgets.Console.console_context_controls import (
     ConsoleContextControlState,
     build_console_context_control_state,
@@ -18027,6 +18028,20 @@ class ChatScreen(BaseAppScreen):
         """Open the Change Review screen from the run inspector (TASK-1972)."""
         event.stop()
         self._open_change_review()
+
+    @on(ConsoleTurnFileCard.ReviewRequested)
+    def handle_console_turn_file_card_review_requested(
+        self, event: ConsoleTurnFileCard.ReviewRequested
+    ) -> None:
+        """Open the Change Review screen from a card's own `Review` button.
+
+        TASK-16800 (V1.5): the same opener recipe as `v` and the run
+        inspector's own button above, except the run id needs no lookup at
+        all -- the card that posted this message already knows exactly
+        which run it renders.
+        """
+        event.stop()
+        self._open_change_review(event.run_id)
 
     @on(Button.Pressed, f"#{CONSOLE_INSPECTOR_REVIEW_APPROVAL_ID}")
     def handle_console_inspector_review_approval(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -16,9 +16,10 @@ from typing import Any, Callable
 
 from loguru import logger
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Click
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_display_state import (
     DiffHunk,
@@ -27,10 +28,41 @@ from tldw_chatbook.Chat.console_display_state import (
     split_unified_diff,
     turn_file_entries,
 )
+from tldw_chatbook.Utils.input_validation import validate_text_input
 from tldw_chatbook.Widgets.glyph_fallback import resolve_glyph
 
 _CHEVRON_CLOSED = "▸"
 _CHEVRON_OPEN = "▾"
+
+#: Note text cap (TASK-16800 spec §1) -- matches the `Input`'s own
+#: `max_length` so the widget-level typing limit and this boundary check
+#: can never drift apart.
+NOTE_MAX_LENGTH = 2000
+
+
+def _validate_note_text(raw: str) -> "str | None":
+    """Strip and bound-check a note before it reaches the DB.
+
+    The strip-then-empty check runs first because
+    ``input_validation.validate_text_input`` treats an empty string as
+    valid (it only rejects *oversized*/dangerous text) -- this widget
+    boundary additionally rejects a note that is empty after stripping.
+
+    Args:
+        raw: The raw ``Input.value`` text.
+
+    Returns:
+        The stripped note text, or ``None`` when it is empty or fails
+        validation (over ``NOTE_MAX_LENGTH`` chars, or a dangerous
+        HTML/script pattern -- defense in depth, since the excerpt is
+        later embedded literally in the delivery block).
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    if not validate_text_input(text, max_length=NOTE_MAX_LENGTH):
+        return None
+    return text
 
 
 class ConsoleTurnFileCard(Vertical):
@@ -65,7 +97,33 @@ class ConsoleTurnFileCard(Vertical):
     ConsoleTurnFileCard .console-turn-file-hunk-actions {
         height: auto;
     }
+    ConsoleTurnFileCard .console-turn-file-note-btn {
+        min-width: 10;
+    }
+    ConsoleTurnFileCard .console-turn-file-hunk-notes {
+        height: auto;
+    }
+    ConsoleTurnFileCard .console-turn-file-note {
+        height: auto;
+        min-height: 1;
+    }
+    ConsoleTurnFileCard .console-turn-file-note-text {
+        width: 1fr;
+    }
+    ConsoleTurnFileCard .console-turn-file-note-input {
+        width: 100%;
+    }
     """
+
+    BINDINGS = [
+        # Not priority: only takes effect while a note `Input` is focused
+        # (gated by `check_action` below) -- otherwise `escape` must keep
+        # bubbling to `ConsoleTranscript`'s own "clear selection" binding
+        # and the screen's composer-focus fallback, exactly like every
+        # other widget-level escape in this app.
+        Binding("escape", "cancel_note_input", "Cancel note", show=False),
+    ]
+
     # Selection styling (parity with `.console-transcript-message-selected`)
     # deliberately does NOT live in DEFAULT_CSS: it needs the app bundle's
     # `$ds-focus-bg`/`$ds-focus-fg` tokens, and Textual resolves `$vars`
@@ -106,6 +164,17 @@ class ConsoleTurnFileCard(Vertical):
         #: are applied at MOUNT time, from these raw hunks, so re-expanding
         #: a collapsed row never re-derives anything from a lossy cache.
         self._hunk_cache: dict[int, list[DiffHunk]] = {}
+        #: Whether the provider exposes the full note read/write/delete
+        #: trio -- duck-typed-optional, mirroring how ``turn_for_run`` is
+        #: treated: a provider missing any of the three renders NO note UI
+        #: at all rather than a partially-working one. Set once, from the
+        #: same off-thread read as ``notes_for_run`` itself, in
+        #: ``_load_rows``.
+        self._notes_capable: bool = False
+        #: Existing notes keyed by ``(root, path)`` -- the anchor's file
+        #: identity -- populated from ``notes_for_run`` on load and kept in
+        #: sync as notes are added/deleted through this card instance.
+        self._notes_by_key: dict[tuple[str, str], list[dict]] = {}
 
     @property
     def marker_text(self) -> str:
@@ -190,7 +259,9 @@ class ConsoleTurnFileCard(Vertical):
             if provider is None:
                 return
 
-            def _read() -> tuple[list[TurnFileEntry], dict[int, dict]]:
+            def _read() -> tuple[
+                list[TurnFileEntry], dict[int, dict], list[dict], bool
+            ]:
                 # Run-scoped read when the provider offers it (Qodo,
                 # PR #1728): a transcript can hold many cards, and each
                 # `turns()` call scans and groups the WHOLE conversation's
@@ -205,7 +276,7 @@ class ConsoleTurnFileCard(Vertical):
                         None,
                     )
                 if turn is None:
-                    return [], {}
+                    return [], {}, [], False
                 # Per-row pairing, never root-keyed: `turn.rows` can hold
                 # rows from TWO windows on the SAME root (a turn's own
                 # window and its surviving sub-agents' post-turn window,
@@ -224,13 +295,33 @@ class ConsoleTurnFileCard(Vertical):
                 paired = turn_file_entries(row_files)
                 entries = [entry for entry, _row in paired]
                 mapping = {idx: row for idx, (_entry, row) in enumerate(paired)}
-                return entries, mapping
+                # Task 4: note capability is duck-typed-optional, the same
+                # posture as `turn_for_run` above -- a provider missing any
+                # of the trio renders no note UI at all (checked once here,
+                # off-thread, and cached on the instance for every later
+                # note-UI decision).
+                notes_capable = all(
+                    callable(getattr(provider, name, None))
+                    for name in (
+                        "add_change_note",
+                        "delete_change_note",
+                        "notes_for_run",
+                    )
+                )
+                notes = provider.notes_for_run(self._run_id) if notes_capable else []
+                return entries, mapping, notes, notes_capable
 
-            entries, mapping = await asyncio.to_thread(_read)
+            entries, mapping, notes, notes_capable = await asyncio.to_thread(_read)
             if not self.is_mounted or not entries:
                 return
             self._entries = entries
             self._row_for_entry = mapping
+            self._notes_capable = notes_capable
+            notes_by_key: dict[tuple[str, str], list[dict]] = {}
+            for note in notes:
+                key = (str(note["root"]), str(note["path"]))
+                notes_by_key.setdefault(key, []).append(note)
+            self._notes_by_key = notes_by_key
             rows_box = self.query_one(".console-turn-file-rows", Vertical)
             for idx, entry in enumerate(entries):
                 chevron = resolve_glyph(_CHEVRON_CLOSED)
@@ -257,7 +348,16 @@ class ConsoleTurnFileCard(Vertical):
             return
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
-        idx = getattr(event.button, "entry_index", None)
+        button = event.button
+        if button.has_class("console-turn-file-note-btn"):
+            event.stop()
+            await self._open_note_input(button)
+            return
+        if button.has_class("console-turn-file-note-delete"):
+            event.stop()
+            await self._delete_note(button)
+            return
+        idx = getattr(button, "entry_index", None)
         if idx is None:
             return
         event.stop()
@@ -330,13 +430,32 @@ class ConsoleTurnFileCard(Vertical):
                             markup=False,
                         )
                     )
-                    # Task 4 populates this row with the `✎ note` affordance
-                    # and any existing notes; mounted empty here so the
-                    # per-hunk block/action-row pairing is in place ahead of
-                    # that task.
-                    await body.mount(
-                        Horizontal(classes="console-turn-file-hunk-actions")
-                    )
+                    actions_row = Horizontal(classes="console-turn-file-hunk-actions")
+                    await body.mount(actions_row)
+                    notes_box = Vertical(classes="console-turn-file-hunk-notes")
+                    await body.mount(notes_box)
+                    if self._notes_capable:
+                        note_btn = Button(
+                            "✎ note",
+                            classes="console-turn-file-note-btn",
+                            compact=True,
+                        )
+                        note_btn.entry_index = idx
+                        note_btn.hunk_index = hunk_idx
+                        # Same guard as the row button above -- a quick
+                        # second press must never be silently swallowed by
+                        # the default "-active" flash.
+                        note_btn.active_effect_duration = 0
+                        await actions_row.mount(note_btn)
+                        existing_notes = [
+                            note
+                            for note in self._notes_by_key.get(
+                                (entry.root, entry.path), []
+                            )
+                            if int(note.get("hunk_index", -1)) == hunk_idx
+                        ]
+                        for note in existing_notes:
+                            await notes_box.mount(self._build_note_row(note))
             except Exception:
                 logger.opt(exception=True).warning(
                     "Turn file card diff load failed for {}", entry.label
@@ -347,6 +466,241 @@ class ConsoleTurnFileCard(Vertical):
             f"{resolve_glyph(_CHEVRON_OPEN)} {entry.status}  "
             f"{entry.label}  +{entry.adds} −{entry.dels}"
         )
+
+    def check_action(
+        self, action: str, parameters: "tuple[object, ...]"
+    ) -> "bool | None":
+        """Gate the escape-cancels-note-input binding to when it applies.
+
+        ``escape`` must otherwise keep bubbling to ``ConsoleTranscript``'s
+        own "clear selection" binding (and the screen's composer-focus
+        fallback) exactly as it does for every widget without a note input
+        open -- returning ``False`` here (rather than always claiming the
+        key) is what lets Textual's binding resolution continue up the
+        chain instead of swallowing escape whenever ANY descendant of this
+        card happens to be focused.
+
+        Args:
+            action: Textual action name being checked.
+            parameters: Parsed positional parameters for the action.
+
+        Returns:
+            Whether a ``console-turn-file-note-input`` is currently
+            focused, for ``cancel_note_input``; the superclass result for
+            every other action.
+        """
+        if action == "cancel_note_input":
+            focused = self.app.focused
+            return focused is not None and focused.has_class(
+                "console-turn-file-note-input"
+            )
+        return super().check_action(action, parameters)
+
+    async def action_cancel_note_input(self) -> None:
+        """Escape: unmount the focused note input without saving.
+
+        ``check_action`` above guarantees this only fires while a note
+        input actually has focus.
+        """
+        try:
+            focused = self.app.focused
+            if focused is not None and focused.has_class(
+                "console-turn-file-note-input"
+            ):
+                await focused.remove()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card note-input cancel failed."
+            )
+
+    async def _open_note_input(self, button: Button) -> None:
+        """Mount an inline note ``Input`` under the pressed hunk's block.
+
+        Args:
+            button: The pressed ``✎ note`` button, carrying ``entry_index``/
+                ``hunk_index`` attributes set at mount time.
+        """
+        try:
+            idx = getattr(button, "entry_index", None)
+            hunk_idx = getattr(button, "hunk_index", None)
+            if idx is None or hunk_idx is None:
+                return
+            bodies = list(self.query(".console-turn-file-diff"))
+            if idx >= len(bodies):
+                return
+            notes_boxes = list(bodies[idx].query(".console-turn-file-hunk-notes"))
+            if hunk_idx >= len(notes_boxes):
+                return
+            notes_box = notes_boxes[hunk_idx]
+            existing_inputs = list(
+                notes_box.query(".console-turn-file-note-input")
+            )
+            if existing_inputs:
+                # Already open -- focus it rather than mounting a second
+                # input for the same hunk.
+                existing_inputs[0].focus()
+                return
+            note_input = Input(
+                classes="console-turn-file-note-input",
+                placeholder="Add a note…",
+                max_length=NOTE_MAX_LENGTH,
+            )
+            note_input.entry_index = idx
+            note_input.hunk_index = hunk_idx
+            await notes_box.mount(note_input)
+            note_input.focus()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card note-input open failed."
+            )
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Enter in a note input: save the note off-thread."""
+        if not event.input.has_class("console-turn-file-note-input"):
+            return
+        event.stop()
+        await self._save_note(event.input)
+
+    async def _save_note(self, note_input: Input) -> None:
+        """Validate, persist off-thread, and render one hunk note.
+
+        On success the input is replaced in place by a rendered note row.
+        A raising ``provider.add_change_note`` (or any other failure) is
+        swallowed here -- the input stays mounted with the user's text
+        intact so nothing is lost, and a warning is logged -- this is the
+        card's absolute "no exception escapes an `on_*` handler" rule.
+
+        Args:
+            note_input: The submitted note ``Input``.
+        """
+        try:
+            idx = getattr(note_input, "entry_index", None)
+            hunk_idx = getattr(note_input, "hunk_index", None)
+            if idx is None or hunk_idx is None:
+                return
+            if idx >= len(self._entries) or idx not in self._hunk_cache:
+                return
+            hunks = self._hunk_cache[idx]
+            if hunk_idx >= len(hunks):
+                return
+            text = _validate_note_text(note_input.value)
+            if text is None:
+                return
+            entry = self._entries[idx]
+            hunk = hunks[hunk_idx]
+            # Captured NOW, at save time -- not at input-open time -- per
+            # spec §1/§3: the excerpt is the retention safety net, and the
+            # card's own cached hunk is the full-diff-derived source for it.
+            excerpt = hunk_excerpt(hunk)
+            provider = self._provider_factory()
+            if provider is None:
+                return
+            add_change_note = getattr(provider, "add_change_note", None)
+            if not callable(add_change_note):
+                return
+
+            def _write() -> int:
+                return add_change_note(
+                    run_id=self._run_id,
+                    root=entry.root,
+                    path=entry.path,
+                    hunk_index=hunk_idx,
+                    hunk_header=hunk.header,
+                    hunk_excerpt=excerpt,
+                    note=text,
+                )
+
+            note_id = await asyncio.to_thread(_write)
+            if not note_input.is_mounted:
+                return
+            notes_box = note_input.parent
+            note_record = {
+                "id": note_id,
+                "note": text,
+                "delivered_at": None,
+                "root": entry.root,
+                "path": entry.path,
+                "hunk_index": hunk_idx,
+            }
+            self._notes_by_key.setdefault(
+                (entry.root, entry.path), []
+            ).append(note_record)
+            await note_input.remove()
+            if notes_box is not None and notes_box.is_mounted:
+                await notes_box.mount(self._build_note_row(note_record))
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card note save failed."
+            )
+
+    async def _delete_note(self, button: Button) -> None:
+        """Delete a pending note off-thread and remove its rendered row.
+
+        Args:
+            button: The pressed ``✕`` button, carrying a ``note_id``
+                attribute set at mount time.
+        """
+        try:
+            note_id = getattr(button, "note_id", None)
+            if note_id is None:
+                return
+            provider = self._provider_factory()
+            if provider is None:
+                return
+            delete_change_note = getattr(provider, "delete_change_note", None)
+            if not callable(delete_change_note):
+                return
+
+            def _delete() -> bool:
+                return delete_change_note(note_id)
+
+            deleted = await asyncio.to_thread(_delete)
+            if not deleted:
+                return
+            for notes in self._notes_by_key.values():
+                notes[:] = [
+                    note for note in notes if int(note.get("id", -1)) != int(note_id)
+                ]
+            note_row = button.parent
+            if note_row is not None and note_row.is_mounted:
+                await note_row.remove()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card note delete failed."
+            )
+
+    @staticmethod
+    def _build_note_row(note: dict) -> Horizontal:
+        """Render one note as a ``.console-turn-file-note`` row.
+
+        Args:
+            note: A ``change_notes`` row dict (at minimum ``id``, ``note``,
+                ``delivered_at``).
+
+        Returns:
+            A row with the note text, plus a ``✕`` delete button while
+            ``delivered_at`` is null -- delivered notes render a ``sent``
+            marker instead and carry no delete affordance (they are
+            record).
+        """
+        delivered = note.get("delivered_at") is not None
+        text = str(note.get("note", ""))
+        label_text = f"{text}  · sent" if delivered else text
+        children: list[Any] = [
+            Static(
+                label_text,
+                classes="console-turn-file-note-text",
+                markup=False,
+            )
+        ]
+        if not delivered:
+            delete_btn = Button(
+                "✕", classes="console-turn-file-note-delete", compact=True
+            )
+            delete_btn.note_id = int(note["id"])
+            delete_btn.active_effect_duration = 0
+            children.append(delete_btn)
+        return Horizontal(*children, classes="console-turn-file-note")
 
     @staticmethod
     def _hunk_display_text(hunk: DiffHunk, cap: int, *, include_prelude: bool) -> str:

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -16,12 +16,15 @@ from typing import Any, Callable
 
 from loguru import logger
 from textual.app import ComposeResult
-from textual.containers import Vertical, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Click
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Chat.console_display_state import (
+    DiffHunk,
     TurnFileEntry,
+    hunk_excerpt,
+    split_unified_diff,
     turn_file_entries,
 )
 from tldw_chatbook.Widgets.glyph_fallback import resolve_glyph
@@ -54,6 +57,13 @@ class ConsoleTurnFileCard(Vertical):
         overflow-y: auto;
         overflow-x: hidden;
         scrollbar-size: 1 1;
+    }
+    ConsoleTurnFileCard .console-turn-file-hunk {
+        height: auto;
+        margin-bottom: 1;
+    }
+    ConsoleTurnFileCard .console-turn-file-hunk-actions {
+        height: auto;
     }
     """
     # Selection styling (parity with `.console-transcript-message-selected`)
@@ -90,7 +100,12 @@ class ConsoleTurnFileCard(Vertical):
         self._selected = selected
         self._entries: list[TurnFileEntry] = []
         self._row_for_entry: dict[int, dict] = {}
-        self._diff_cache: dict[int, str] = {}
+        #: Segmented hunks per row index, over the FULL diff text (never a
+        #: display-truncated slice -- see ``split_unified_diff``). Replaces
+        #: the old joined-string cache: styling and the per-hunk display cap
+        #: are applied at MOUNT time, from these raw hunks, so re-expanding
+        #: a collapsed row never re-derives anything from a lossy cache.
+        self._hunk_cache: dict[int, list[DiffHunk]] = {}
 
     @property
     def marker_text(self) -> str:
@@ -266,12 +281,12 @@ class ConsoleTurnFileCard(Vertical):
                 f"{entry.label}  +{entry.adds} −{entry.dels}"
             )
             return
-        if idx not in self._diff_cache:
+        if idx not in self._hunk_cache:
             snapshot_row = self._row_for_entry.get(idx)
             if snapshot_row is None:
                 return
-            # Provider construction, the cap read, the off-thread diff read,
-            # and the mount all live in one try/except -- a transient
+            # Provider construction, the off-thread diff read + segmentation,
+            # and the mounts all live in one try/except -- a transient
             # provider-construction failure on first expand must degrade the
             # row (stay collapsed) rather than raise out of this `on_*`
             # handler, which Textual would otherwise propagate to
@@ -280,24 +295,48 @@ class ConsoleTurnFileCard(Vertical):
                 provider = self._provider_factory()
                 if provider is None:
                     return
-                text = await asyncio.to_thread(
-                    provider.diff_text, snapshot_row, entry.path
-                )
-                cap = int(getattr(provider, "diff_display_max_lines", 2000))
-                lines = text.splitlines()
-                if len(lines) > cap:
-                    hidden = len(lines) - cap
-                    lines = lines[:cap] + [f"… {hidden} more lines (diff capped)"]
-                self._diff_cache[idx] = "\n".join(lines)
+
+                def _read() -> list[DiffHunk]:
+                    # Segmentation always runs on the FULL diff text (spec
+                    # §2) -- never a display-truncated slice -- so hunk
+                    # indices stay stable regardless of the per-hunk display
+                    # cap applied below at mount time.
+                    text = provider.diff_text(snapshot_row, entry.path)
+                    return split_unified_diff(text)
+
+                hunks = await asyncio.to_thread(_read)
+                self._hunk_cache[idx] = hunks
                 if not body.is_mounted:
                     return
-                await body.mount(
-                    Static(
-                        self._styled_diff(self._diff_cache[idx]),
-                        classes="console-turn-file-diff-text",
-                        markup=False,
+                cap = int(getattr(provider, "diff_display_max_lines", 2000))
+                # Per-hunk display cap (ruling): every hunk gets its own
+                # block even when its body is elided, so hunks past the old
+                # single-Static's global cap are still present (and,
+                # later, annotatable) -- floor-guarded so a diff with more
+                # hunks than cap lines still shows at least 1 body line
+                # each.
+                per_hunk_cap = max(1, cap // max(1, len(hunks)))
+                for hunk_idx, hunk in enumerate(hunks):
+                    await body.mount(
+                        Static(
+                            self._styled_diff(
+                                self._hunk_display_text(
+                                    hunk,
+                                    per_hunk_cap,
+                                    include_prelude=hunk_idx == 0,
+                                )
+                            ),
+                            classes="console-turn-file-hunk",
+                            markup=False,
+                        )
                     )
-                )
+                    # Task 4 populates this row with the `✎ note` affordance
+                    # and any existing notes; mounted empty here so the
+                    # per-hunk block/action-row pairing is in place ahead of
+                    # that task.
+                    await body.mount(
+                        Horizontal(classes="console-turn-file-hunk-actions")
+                    )
             except Exception:
                 logger.opt(exception=True).warning(
                     "Turn file card diff load failed for {}", entry.label
@@ -308,6 +347,32 @@ class ConsoleTurnFileCard(Vertical):
             f"{resolve_glyph(_CHEVRON_OPEN)} {entry.status}  "
             f"{entry.label}  +{entry.adds} −{entry.dels}"
         )
+
+    @staticmethod
+    def _hunk_display_text(hunk: DiffHunk, cap: int, *, include_prelude: bool) -> str:
+        """Render one hunk's display text: prelude (first hunk only) plus
+        its header and a per-hunk-capped, honestly-elided body.
+
+        Reuses ``hunk_excerpt``'s own elision convention (the "... N more
+        lines" tail) so the card and the note-delivery block (Task 5) never
+        drift on how a capped hunk reads.
+
+        Args:
+            hunk: The hunk to render.
+            cap: Maximum number of body lines to show before eliding.
+            include_prelude: Whether to prepend ``hunk.file_prelude`` (only
+                the first hunk of a file carries it in the UI -- every
+                hunk's own copy is identical, see ``DiffHunk``'s docstring).
+
+        Returns:
+            The combined prelude/header/body text, ready for
+            ``_styled_diff``.
+        """
+        parts: list[str] = []
+        if include_prelude and hunk.file_prelude:
+            parts.append(hunk.file_prelude)
+        parts.append(hunk_excerpt(hunk, cap=cap))
+        return "\n".join(parts)
 
     @staticmethod
     def _styled_diff(text: str):

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -540,12 +540,22 @@ class ConsoleTurnFileCard(Vertical):
                 # "-active" flash.
                 note_btn.active_effect_duration = 0
                 await actions_row.mount(note_btn)
+                # (root, path) alone is not a unique key: a run can hold
+                # TWO rows on the same root+path (a turn's own window and
+                # its post-turn window, `turn_file_entries`'s docstring) --
+                # each producing its OWN entry with its OWN diff. Matching
+                # by hunk_index alone let a note saved on one window's
+                # hunk N bleed into the OTHER window's same-index hunk N,
+                # rendering under the wrong diff there (final-review fix
+                # wave). The hunk's header text is what actually
+                # disambiguates which window's hunk a note anchors to.
                 existing_notes = [
                     note
                     for note in self._notes_by_key.get(
                         (entry.root, entry.path), []
                     )
                     if int(note.get("hunk_index", -1)) == hunk_idx
+                    and note.get("hunk_header") == hunk.header
                 ]
                 for note in existing_notes:
                     await notes_box.mount(self._build_note_row(note))
@@ -719,7 +729,7 @@ class ConsoleTurnFileCard(Vertical):
             )
 
     async def on_key(self, event: Key) -> None:
-        """Reclaim Enter/Escape from a focused note input's ancestors.
+        """Reclaim Enter/Escape/Up/Down from a focused note input's ancestors.
 
         A BINDINGS-only approach here (the first cut of this feature) is
         provably wrong once this card is mounted inside a real
@@ -754,6 +764,18 @@ class ConsoleTurnFileCard(Vertical):
         Enter keypress no longer reaches it -- this handler saves
         directly.
 
+        Up/Down get the same bubble-race treatment for the same root
+        cause (final-review fix wave): ``ConsoleTranscript.on_key`` also
+        binds ``"up"``/``"down"`` to row navigation
+        (``action_select_previous``/``action_select_next``), so a user
+        typing into a focused note input who happens to press an arrow
+        key -- cursor movement is not even meaningful inside a
+        single-line ``Input`` here, there is nothing above/below to move
+        to -- would otherwise silently move the transcript's row
+        selection out from under them mid-edit. Swallowed here with no
+        action of its own: an ``Input`` has no built-in use for either
+        key, so this is a pure no-op reclaim, not a redirect.
+
         Args:
             event: The bubbling key event.
         """
@@ -771,6 +793,9 @@ class ConsoleTurnFileCard(Vertical):
                 event.stop()
                 event.prevent_default()
                 await self.action_cancel_note_input()
+            elif event.key in ("up", "down"):
+                event.stop()
+                event.prevent_default()
         except Exception:
             logger.opt(exception=True).warning(
                 "Turn file card note-input key handling failed."
@@ -901,6 +926,11 @@ class ConsoleTurnFileCard(Vertical):
                 "root": entry.root,
                 "path": entry.path,
                 "hunk_index": hunk_idx,
+                # Mirrors the DB row's own column (see `notes_for_run`) --
+                # needed so an in-session note cached here matches
+                # `_mount_hunk_blocks`'s hunk_header-qualified filter the
+                # same way a reloaded-from-DB note record does.
+                "hunk_header": hunk.header,
             }
             self._notes_by_key.setdefault(
                 (entry.root, entry.path), []
@@ -936,6 +966,17 @@ class ConsoleTurnFileCard(Vertical):
 
             deleted = await asyncio.to_thread(_delete)
             if not deleted:
+                # A live card is reused in place across transcript syncs and
+                # never reloads its own notes (final-review fix wave) -- so
+                # a note delivered while this card stayed open still shows
+                # its stale ✕ button. `delete_change_note` correctly refuses
+                # (``delivered_at IS NOT NULL``), but a silent no-op here
+                # would look like a bug to the user. Surface it instead of
+                # leaving the press unexplained.
+                self.notify(
+                    "Note already sent — no longer deletable",
+                    severity="warning",
+                )
                 return
             for notes in self._notes_by_key.values():
                 notes[:] = [

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -16,9 +16,8 @@ from typing import Any, Callable
 
 from loguru import logger
 from textual.app import ComposeResult
-from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.events import Click
+from textual.events import Click, Key
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_display_state import (
@@ -114,15 +113,6 @@ class ConsoleTurnFileCard(Vertical):
         width: 100%;
     }
     """
-
-    BINDINGS = [
-        # Not priority: only takes effect while a note `Input` is focused
-        # (gated by `check_action` below) -- otherwise `escape` must keep
-        # bubbling to `ConsoleTranscript`'s own "clear selection" binding
-        # and the screen's composer-focus fallback, exactly like every
-        # other widget-level escape in this app.
-        Binding("escape", "cancel_note_input", "Cancel note", show=False),
-    ]
 
     # Selection styling (parity with `.console-transcript-message-selected`)
     # deliberately does NOT live in DEFAULT_CSS: it needs the app bundle's
@@ -467,40 +457,69 @@ class ConsoleTurnFileCard(Vertical):
             f"{entry.label}  +{entry.adds} −{entry.dels}"
         )
 
-    def check_action(
-        self, action: str, parameters: "tuple[object, ...]"
-    ) -> "bool | None":
-        """Gate the escape-cancels-note-input binding to when it applies.
+    async def on_key(self, event: Key) -> None:
+        """Reclaim Enter/Escape from a focused note input's ancestors.
 
-        ``escape`` must otherwise keep bubbling to ``ConsoleTranscript``'s
-        own "clear selection" binding (and the screen's composer-focus
-        fallback) exactly as it does for every widget without a note input
-        open -- returning ``False`` here (rather than always claiming the
-        key) is what lets Textual's binding resolution continue up the
-        chain instead of swallowing escape whenever ANY descendant of this
-        card happens to be focused.
+        A BINDINGS-only approach here (the first cut of this feature) is
+        provably wrong once this card is mounted inside a real
+        ``ConsoleTranscript`` -- traced (and pinned by a regression test)
+        after review flagged the interaction as unverified. The root
+        cause is Textual's actual key-dispatch order, not a focus race:
+        ``App.on_event`` checks *priority* bindings app-wide, then
+        forwards the raw ``Key`` MESSAGE to the focused widget, which
+        bubbles up the DOM like any other message; **non-priority**
+        bindings -- including an `Input`'s own built-in ``enter ->
+        submit`` and this card's escape binding -- are resolved only in
+        ``App._on_key``, i.e. only once that message reaches the App
+        completely UNSTOPPED (see ``textual/app.py``'s
+        ``_check_bindings``/``_on_key``). ``ConsoleTranscript`` defines
+        its OWN raw ``on_key`` for row navigation
+        (``"enter" -> confirm_selection``, ``"escape" ->
+        clear_selection``) that unconditionally calls ``event.stop()`` --
+        so when this card is nested inside it, that ancestor's handler
+        wins the bubble race every time, and the focused note `Input`'s
+        own binding never even gets checked. A live-transcript regression
+        test proved this: Enter inside the note input selected the
+        transcript row instead of saving, with nothing raised or logged.
+
+        Reclaiming both keys HERE -- on this card, a closer ancestor of
+        the note input than ``ConsoleTranscript`` -- wins the bubble race
+        instead, mirroring ``ConsoleTranscriptActionButton.on_key``'s
+        existing reclaiming of Enter/Tab/Escape in this same codebase for
+        the identical reason. This is now the single source of truth for
+        both keys, in every host (the standalone-card tests keep passing
+        unchanged): ``on_input_submitted`` stays as a harmless fallback
+        for a programmatically-posted ``Input.Submitted``, but a real
+        Enter keypress no longer reaches it -- this handler saves
+        directly.
 
         Args:
-            action: Textual action name being checked.
-            parameters: Parsed positional parameters for the action.
-
-        Returns:
-            Whether a ``console-turn-file-note-input`` is currently
-            focused, for ``cancel_note_input``; the superclass result for
-            every other action.
+            event: The bubbling key event.
         """
-        if action == "cancel_note_input":
+        try:
             focused = self.app.focused
-            return focused is not None and focused.has_class(
+            if focused is None or not focused.has_class(
                 "console-turn-file-note-input"
+            ):
+                return
+            if event.key == "enter":
+                event.stop()
+                event.prevent_default()
+                await self._save_note(focused)
+            elif event.key == "escape":
+                event.stop()
+                event.prevent_default()
+                await self.action_cancel_note_input()
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card note-input key handling failed."
             )
-        return super().check_action(action, parameters)
 
     async def action_cancel_note_input(self) -> None:
-        """Escape: unmount the focused note input without saving.
+        """Unmount the focused note input without saving.
 
-        ``check_action`` above guarantees this only fires while a note
-        input actually has focus.
+        Called from ``on_key`` above once it has confirmed a note input
+        is focused and the pressed key was escape.
         """
         try:
             focused = self.app.focused

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -66,6 +66,35 @@ def _validate_note_text(raw: str) -> "str | None":
     return text
 
 
+def _note_matches_snapshot(note: dict, current_snapshot_id: "int | None") -> bool:
+    """Qodo #6 (PR #1779 fix round): the snapshot-identity leg of a note's
+    hunk match, on top of the existing hunk_index+hunk_header check.
+
+    Two windows on the SAME run+root+path (a turn's own window and its
+    surviving sub-agents' post-turn window, PR3a-1 Task 6c) can
+    theoretically produce the exact same ``hunk_index``/``hunk_header`` --
+    identical position/line-count edits against different baselines yield
+    byte-identical ``"@@ ... @@"`` headers, since a header encodes only
+    positions/counts, never content. When a note carries a non-null
+    ``snapshot_id`` it must equal the CURRENT entry's own snapshot row id
+    to match; a legacy note (``snapshot_id`` is ``None``, saved before
+    this column existed) falls back to matching on hunk_index+hunk_header
+    alone, exactly as before this fix.
+
+    Args:
+        note: A note record (DB row dict or in-session ``note_record``).
+        current_snapshot_id: The entry currently being rendered's own
+            ``change_snapshots`` row id (``None`` when unavailable).
+
+    Returns:
+        Whether this note belongs under the current entry's hunk.
+    """
+    note_snapshot_id = note.get("snapshot_id")
+    if note_snapshot_id is None:
+        return True
+    return note_snapshot_id == current_snapshot_id
+
+
 class ConsoleTurnFileCard(Vertical):
     """Stacked, expandable per-file diff card rendered under a turn marker."""
 
@@ -509,6 +538,15 @@ class ConsoleTurnFileCard(Vertical):
         # floor-guarded so a diff with more hunks than cap lines still shows
         # at least 1 body line each.
         per_hunk_cap = max(1, cap // max(1, len(hunks)))
+        # Qodo #6 (PR #1779 fix round): this entry's own snapshot row id,
+        # used by `_note_matches_snapshot` below to disambiguate two
+        # same-header windows on the same root+path.
+        current_snapshot_row = self._row_for_entry.get(idx)
+        current_snapshot_id = (
+            current_snapshot_row.get("id")
+            if current_snapshot_row is not None
+            else None
+        )
         for hunk_idx, hunk in enumerate(hunks):
             await body.mount(
                 Static(
@@ -548,7 +586,12 @@ class ConsoleTurnFileCard(Vertical):
                 # hunk N bleed into the OTHER window's same-index hunk N,
                 # rendering under the wrong diff there (final-review fix
                 # wave). The hunk's header text is what actually
-                # disambiguates which window's hunk a note anchors to.
+                # disambiguates which window's hunk a note anchors to --
+                # EXCEPT when both windows happen to produce the exact
+                # same header (Qodo #6): `_note_matches_snapshot` adds the
+                # snapshot-identity tiebreaker on top for notes that carry
+                # one, falling back to today's hunk_index+hunk_header-only
+                # match for legacy (``snapshot_id is None``) notes.
                 existing_notes = [
                     note
                     for note in self._notes_by_key.get(
@@ -556,6 +599,7 @@ class ConsoleTurnFileCard(Vertical):
                     )
                     if int(note.get("hunk_index", -1)) == hunk_idx
                     and note.get("hunk_header") == hunk.header
+                    and _note_matches_snapshot(note, current_snapshot_id)
                 ]
                 for note in existing_notes:
                     await notes_box.mount(self._build_note_row(note))
@@ -897,6 +941,17 @@ class ConsoleTurnFileCard(Vertical):
             # spec §1/§3: the excerpt is the retention safety net, and the
             # card's own cached hunk is the full-diff-derived source for it.
             excerpt = hunk_excerpt(hunk)
+            # Qodo #6 (PR #1779 fix round): the owning snapshot row's own
+            # DB id -- disambiguates which of two same-run/root/path
+            # windows (a turn's own window and its post-turn window) this
+            # note's hunk actually came from, for the rare case where both
+            # windows produce the exact same hunk_index/hunk_header. None
+            # when the row isn't available (degrades to the legacy
+            # hunk_index+hunk_header matching, same as any pre-fix note).
+            snapshot_row = self._row_for_entry.get(idx)
+            snapshot_id = (
+                snapshot_row.get("id") if snapshot_row is not None else None
+            )
             provider = self._provider_factory()
             if provider is None:
                 return
@@ -913,6 +968,7 @@ class ConsoleTurnFileCard(Vertical):
                     hunk_header=hunk.header,
                     hunk_excerpt=excerpt,
                     note=text,
+                    snapshot_id=snapshot_id,
                 )
 
             note_id = await asyncio.to_thread(_write)
@@ -931,6 +987,8 @@ class ConsoleTurnFileCard(Vertical):
                 # `_mount_hunk_blocks`'s hunk_header-qualified filter the
                 # same way a reloaded-from-DB note record does.
                 "hunk_header": hunk.header,
+                # Mirrors the DB row's own column too, same reason.
+                "snapshot_id": snapshot_id,
             }
             self._notes_by_key.setdefault(
                 (entry.root, entry.path), []

--- a/tldw_chatbook/Widgets/Console/console_turn_file_card.py
+++ b/tldw_chatbook/Widgets/Console/console_turn_file_card.py
@@ -17,13 +17,15 @@ from typing import Any, Callable
 from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.events import Click, Key
+from textual.events import Click, Key, Resize
+from textual.message import Message
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_display_state import (
     DiffHunk,
     TurnFileEntry,
     hunk_excerpt,
+    middle_elide_path,
     split_unified_diff,
     turn_file_entries,
 )
@@ -72,9 +74,18 @@ class ConsoleTurnFileCard(Vertical):
         height: auto;
         min-height: 1;
     }
+    ConsoleTurnFileCard .console-turn-file-header-row {
+        height: 1;
+        width: 100%;
+    }
     ConsoleTurnFileCard .console-turn-file-header {
+        width: 1fr;
         height: 1;
         text-style: bold;
+    }
+    ConsoleTurnFileCard .console-turn-file-toggle-all-btn,
+    ConsoleTurnFileCard .console-turn-file-review-btn {
+        min-width: 3;
     }
     ConsoleTurnFileCard .console-turn-file-row {
         height: 1;
@@ -121,6 +132,20 @@ class ConsoleTurnFileCard(Vertical):
     # shadow the bundle's values (TASK-16811, caught again by Qodo on
     # PR #1728). The rules live beside the message-selected block in
     # `css/components/_agentic_terminal.tcss`.
+
+    class ReviewRequested(Message):
+        """The header ``Review`` button asking to open the Change Review
+        screen scoped to this card's run.
+
+        Carries ``run_id`` directly (the card always knows it, unlike the
+        plain marker's own "review with `v`" action, which must resolve it
+        from the transcript's display model by message id) -- the handler
+        can open the screen with no lookup at all.
+        """
+
+        def __init__(self, run_id: str) -> None:
+            self.run_id = run_id
+            super().__init__()
 
     def __init__(
         self,
@@ -221,13 +246,37 @@ class ConsoleTurnFileCard(Vertical):
     def compose(self) -> ComposeResult:
         # Header keeps the marker's counts but drops its "review with v"
         # trailer -- the rows ARE the review affordance now; `v` still
-        # works and stays documented in the F1 help.
+        # works and stays documented in the F1 help. The header also gains
+        # two compact, non-destructive affordances (spec §5, AC#3/AC#4): a
+        # `Review` button (a mouse-clickable equivalent of `v`, scoped to
+        # this card's own run -- no message-id lookup needed, unlike the
+        # marker's action) and an expand/collapse-all toggle.
         head = self._marker_text.split(" — ")[0]
-        yield Static(
-            head,
-            classes="console-turn-file-header",
-            markup=False,
-        )
+        with Horizontal(classes="console-turn-file-header-row"):
+            yield Static(
+                head,
+                classes="console-turn-file-header",
+                markup=False,
+            )
+            toggle_btn = Button(
+                f"{resolve_glyph(_CHEVRON_CLOSED)} All",
+                classes="console-turn-file-toggle-all-btn",
+                compact=True,
+                tooltip="Expand every file's diff",
+            )
+            # Same guard as every other row/note button in this card: a
+            # quick second press must never be silently swallowed by the
+            # default "-active" flash.
+            toggle_btn.active_effect_duration = 0
+            yield toggle_btn
+            review_btn = Button(
+                "Review",
+                classes="console-turn-file-review-btn",
+                compact=True,
+                tooltip="Open the Change Review screen for this turn",
+            )
+            review_btn.active_effect_duration = 0
+            yield review_btn
         yield Vertical(classes="console-turn-file-rows")
 
     def on_mount(self) -> None:
@@ -314,10 +363,8 @@ class ConsoleTurnFileCard(Vertical):
             self._notes_by_key = notes_by_key
             rows_box = self.query_one(".console-turn-file-rows", Vertical)
             for idx, entry in enumerate(entries):
-                chevron = resolve_glyph(_CHEVRON_CLOSED)
                 row = Button(
-                    f"{chevron} {entry.status}  {entry.label}  "
-                    f"+{entry.adds} −{entry.dels}",
+                    self._row_label_text(entry, expanded=False),
                     classes="console-turn-file-row",
                     compact=True,
                 )
@@ -327,6 +374,10 @@ class ConsoleTurnFileCard(Vertical):
                 # for a submit button, but this row toggles open/closed and a
                 # quick second press should never be silently swallowed.
                 row.active_effect_duration = 0
+                # The row's own label is middle-elided to the card's width
+                # (spec §5) -- the tooltip always carries the FULL,
+                # un-elided path so nothing is lost to the elision.
+                row.tooltip = entry.label
                 diff_body = VerticalScroll(classes="console-turn-file-diff")
                 diff_body.display = False
                 await rows_box.mount(row)
@@ -339,6 +390,14 @@ class ConsoleTurnFileCard(Vertical):
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         button = event.button
+        if button.has_class("console-turn-file-review-btn"):
+            event.stop()
+            self.post_message(self.ReviewRequested(self._run_id))
+            return
+        if button.has_class("console-turn-file-toggle-all-btn"):
+            event.stop()
+            await self._toggle_all(button)
+            return
         if button.has_class("console-turn-file-note-btn"):
             event.stop()
             await self._open_note_input(button)
@@ -366,10 +425,7 @@ class ConsoleTurnFileCard(Vertical):
         entry = self._entries[idx]
         if body.display:
             body.display = False
-            row.label = (
-                f"{resolve_glyph(_CHEVRON_CLOSED)} {entry.status}  "
-                f"{entry.label}  +{entry.adds} −{entry.dels}"
-            )
+            row.label = self._row_label_text(entry, expanded=False)
             return
         if idx not in self._hunk_cache:
             snapshot_row = self._row_for_entry.get(idx)
@@ -385,77 +441,282 @@ class ConsoleTurnFileCard(Vertical):
                 provider = self._provider_factory()
                 if provider is None:
                     return
-
-                def _read() -> list[DiffHunk]:
-                    # Segmentation always runs on the FULL diff text (spec
-                    # §2) -- never a display-truncated slice -- so hunk
-                    # indices stay stable regardless of the per-hunk display
-                    # cap applied below at mount time.
-                    text = provider.diff_text(snapshot_row, entry.path)
-                    return split_unified_diff(text)
-
-                hunks = await asyncio.to_thread(_read)
+                hunks = await self._read_hunks(provider, snapshot_row, entry)
                 self._hunk_cache[idx] = hunks
                 if not body.is_mounted:
                     return
-                cap = int(getattr(provider, "diff_display_max_lines", 2000))
-                # Per-hunk display cap (ruling): every hunk gets its own
-                # block even when its body is elided, so hunks past the old
-                # single-Static's global cap are still present (and,
-                # later, annotatable) -- floor-guarded so a diff with more
-                # hunks than cap lines still shows at least 1 body line
-                # each.
-                per_hunk_cap = max(1, cap // max(1, len(hunks)))
-                for hunk_idx, hunk in enumerate(hunks):
-                    await body.mount(
-                        Static(
-                            self._styled_diff(
-                                self._hunk_display_text(
-                                    hunk,
-                                    per_hunk_cap,
-                                    include_prelude=hunk_idx == 0,
-                                )
-                            ),
-                            classes="console-turn-file-hunk",
-                            markup=False,
-                        )
-                    )
-                    actions_row = Horizontal(classes="console-turn-file-hunk-actions")
-                    await body.mount(actions_row)
-                    notes_box = Vertical(classes="console-turn-file-hunk-notes")
-                    await body.mount(notes_box)
-                    if self._notes_capable:
-                        note_btn = Button(
-                            "✎ note",
-                            classes="console-turn-file-note-btn",
-                            compact=True,
-                        )
-                        note_btn.entry_index = idx
-                        note_btn.hunk_index = hunk_idx
-                        # Same guard as the row button above -- a quick
-                        # second press must never be silently swallowed by
-                        # the default "-active" flash.
-                        note_btn.active_effect_duration = 0
-                        await actions_row.mount(note_btn)
-                        existing_notes = [
-                            note
-                            for note in self._notes_by_key.get(
-                                (entry.root, entry.path), []
-                            )
-                            if int(note.get("hunk_index", -1)) == hunk_idx
-                        ]
-                        for note in existing_notes:
-                            await notes_box.mount(self._build_note_row(note))
+                await self._mount_hunk_blocks(body, idx, entry, provider, hunks)
             except Exception:
                 logger.opt(exception=True).warning(
                     "Turn file card diff load failed for {}", entry.label
                 )
                 return
         body.display = True
-        row.label = (
-            f"{resolve_glyph(_CHEVRON_OPEN)} {entry.status}  "
-            f"{entry.label}  +{entry.adds} −{entry.dels}"
-        )
+        row.label = self._row_label_text(entry, expanded=True)
+
+    @staticmethod
+    async def _read_hunks(
+        provider: Any, snapshot_row: dict, entry: TurnFileEntry
+    ) -> list[DiffHunk]:
+        """Off-thread read + segmentation of one entry's full diff text.
+
+        Segmentation always runs on the FULL diff text (spec §2) -- never a
+        display-truncated slice -- so hunk indices stay stable regardless
+        of the per-hunk display cap applied at mount time.
+
+        Args:
+            provider: The turn's data source (``diff_text(row, path)``).
+            snapshot_row: The ``change_snapshots`` row this entry came from.
+            entry: The file entry being expanded.
+
+        Returns:
+            The entry's diff, segmented into hunks.
+        """
+
+        def _read() -> list[DiffHunk]:
+            text = provider.diff_text(snapshot_row, entry.path)
+            return split_unified_diff(text)
+
+        return await asyncio.to_thread(_read)
+
+    async def _mount_hunk_blocks(
+        self,
+        body: VerticalScroll,
+        idx: int,
+        entry: TurnFileEntry,
+        provider: Any,
+        hunks: list[DiffHunk],
+    ) -> None:
+        """Mount one colored ``Static`` + action row + notes box per hunk.
+
+        Shared by a single row's first expand (``on_button_pressed``) and
+        expand-all (``_expand_all``) so the two paths can never render a
+        row's hunks differently.
+
+        Args:
+            body: The row's (already-mounted) diff body container.
+            idx: The row's entry index (carried onto each note button).
+            entry: The file entry being expanded.
+            provider: The turn's data source (only ``diff_display_max_lines``
+                is read here).
+            hunks: The entry's segmented hunks (already cached by the
+                caller).
+        """
+        cap = int(getattr(provider, "diff_display_max_lines", 2000))
+        # Per-hunk display cap (ruling): every hunk gets its own block even
+        # when its body is elided, so hunks past the old single-Static's
+        # global cap are still present (and, later, annotatable) --
+        # floor-guarded so a diff with more hunks than cap lines still shows
+        # at least 1 body line each.
+        per_hunk_cap = max(1, cap // max(1, len(hunks)))
+        for hunk_idx, hunk in enumerate(hunks):
+            await body.mount(
+                Static(
+                    self._styled_diff(
+                        self._hunk_display_text(
+                            hunk,
+                            per_hunk_cap,
+                            include_prelude=hunk_idx == 0,
+                        )
+                    ),
+                    classes="console-turn-file-hunk",
+                    markup=False,
+                )
+            )
+            actions_row = Horizontal(classes="console-turn-file-hunk-actions")
+            await body.mount(actions_row)
+            notes_box = Vertical(classes="console-turn-file-hunk-notes")
+            await body.mount(notes_box)
+            if self._notes_capable:
+                note_btn = Button(
+                    "✎ note",
+                    classes="console-turn-file-note-btn",
+                    compact=True,
+                )
+                note_btn.entry_index = idx
+                note_btn.hunk_index = hunk_idx
+                # Same guard as the row button above -- a quick second
+                # press must never be silently swallowed by the default
+                # "-active" flash.
+                note_btn.active_effect_duration = 0
+                await actions_row.mount(note_btn)
+                existing_notes = [
+                    note
+                    for note in self._notes_by_key.get(
+                        (entry.root, entry.path), []
+                    )
+                    if int(note.get("hunk_index", -1)) == hunk_idx
+                ]
+                for note in existing_notes:
+                    await notes_box.mount(self._build_note_row(note))
+
+    async def _toggle_all(self, button: Button) -> None:
+        """Header expand/collapse-all: a plain state-derived toggle.
+
+        Reads the CURRENT display state of every row's body rather than
+        tracking a separate "all expanded" flag -- a user can always
+        collapse or expand one row individually via its own button, and
+        deriving from the live DOM means this toggle can never drift out of
+        sync with what is actually on screen. "Everything already
+        expanded" collapses all; anything else (including a mix, or
+        nothing yet expanded) expands all.
+
+        Args:
+            button: The pressed toggle button (its label/tooltip are
+                updated in place to reflect the new state).
+        """
+        try:
+            bodies = list(self.query(".console-turn-file-diff"))
+            if bodies and all(body.display for body in bodies):
+                self._collapse_all(button)
+            else:
+                await self._expand_all(button)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card expand/collapse-all failed."
+            )
+
+    async def _expand_all(self, button: Button) -> None:
+        """Expand every row, loading any uncached diff SERIALIZED.
+
+        Deliberately sequential -- one ``await`` per uncached row inside
+        this single coroutine, never ``asyncio.gather`` or N separate
+        workers -- so a turn with many changed files never launches N
+        concurrent git subprocesses at once (spec §5). A single row's
+        provider-construction or diff-read failure degrades that ONE row
+        (logged, left collapsed) without aborting the rest.
+
+        Args:
+            button: The header toggle button, updated to the "expanded"
+                state once every row has been processed.
+        """
+        rows = list(self.query(".console-turn-file-row"))
+        bodies = list(self.query(".console-turn-file-diff"))
+        provider: Any = None
+        provider_attempted = False
+        for idx, entry in enumerate(self._entries):
+            if idx >= len(rows) or idx >= len(bodies):
+                continue
+            row = rows[idx]
+            body = bodies[idx]
+            if idx not in self._hunk_cache:
+                if not provider_attempted:
+                    provider_attempted = True
+                    try:
+                        provider = self._provider_factory()
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Turn file card expand-all provider "
+                            "construction failed."
+                        )
+                        provider = None
+                if provider is None:
+                    continue
+                snapshot_row = self._row_for_entry.get(idx)
+                if snapshot_row is None:
+                    continue
+                try:
+                    hunks = await self._read_hunks(provider, snapshot_row, entry)
+                    self._hunk_cache[idx] = hunks
+                    if not body.is_mounted:
+                        continue
+                    await self._mount_hunk_blocks(body, idx, entry, provider, hunks)
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Turn file card expand-all diff load failed for {}",
+                        entry.label,
+                    )
+                    continue
+            if not body.display:
+                body.display = True
+                row.label = self._row_label_text(entry, expanded=True)
+        self._update_toggle_all_button(button, expanded=True)
+
+    def _collapse_all(self, button: Button) -> None:
+        """Hide every row's diff body (display-managed, never unmounted).
+
+        Args:
+            button: The header toggle button, updated to the "collapsed"
+                state.
+        """
+        rows = list(self.query(".console-turn-file-row"))
+        bodies = list(self.query(".console-turn-file-diff"))
+        for idx, entry in enumerate(self._entries):
+            if idx >= len(rows) or idx >= len(bodies):
+                continue
+            body = bodies[idx]
+            if body.display:
+                body.display = False
+                rows[idx].label = self._row_label_text(entry, expanded=False)
+        self._update_toggle_all_button(button, expanded=False)
+
+    @staticmethod
+    def _update_toggle_all_button(button: Button, *, expanded: bool) -> None:
+        """Sync the toggle button's chevron/tooltip to the new state."""
+        if expanded:
+            button.label = f"{resolve_glyph(_CHEVRON_OPEN)} All"
+            button.tooltip = "Collapse every file's diff"
+        else:
+            button.label = f"{resolve_glyph(_CHEVRON_CLOSED)} All"
+            button.tooltip = "Expand every file's diff"
+
+    def _row_label_text(self, entry: TurnFileEntry, *, expanded: bool) -> str:
+        """Build one row's label, middle-eliding the path to the card's width.
+
+        The full, un-elided path always stays available in the row
+        Button's ``tooltip`` (set once, at row-creation time) -- this only
+        controls what the label itself prints.
+
+        Args:
+            entry: The file entry the row renders.
+            expanded: Whether the row's diff body is (or is about to be)
+                shown -- selects the chevron glyph.
+
+        Returns:
+            The row's display label.
+        """
+        chevron = resolve_glyph(_CHEVRON_OPEN if expanded else _CHEVRON_CLOSED)
+        prefix = f"{chevron} {entry.status}  "
+        suffix = f"  +{entry.adds} −{entry.dels}"
+        width = int(self.size.width)
+        if width > 0:
+            budget = max(1, width - len(prefix) - len(suffix))
+            path_text = middle_elide_path(entry.label, budget)
+        else:
+            # Not yet laid out (or a bare unit-construction host with no
+            # real geometry) -- show the full path rather than guessing a
+            # budget; `on_resize` recomputes once real geometry lands.
+            path_text = entry.label
+        return f"{prefix}{path_text}{suffix}"
+
+    def on_resize(self, event: Resize) -> None:
+        """Recompute every mounted row's elided label for the new width.
+
+        ``Resize`` does not bubble (``textual.events.Resize(bubble=False)``)
+        so this fires only when THIS card's own width changes -- exactly
+        the right trigger, since every row Button spans the card's full
+        width (``DEFAULT_CSS``'s ``.console-turn-file-row { width: 100%;
+        }``).
+
+        Args:
+            event: The card's resize event (unused; the new size is read
+                straight off ``self.size``).
+        """
+        del event
+        try:
+            if not self._entries:
+                return
+            rows = list(self.query(".console-turn-file-row"))
+            bodies = list(self.query(".console-turn-file-diff"))
+            for idx, entry in enumerate(self._entries):
+                if idx >= len(rows):
+                    continue
+                expanded = idx < len(bodies) and bodies[idx].display
+                rows[idx].label = self._row_label_text(entry, expanded=expanded)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Turn file card resize label refresh failed."
+            )
 
     async def on_key(self, event: Key) -> None:
         """Reclaim Enter/Escape from a focused note input's ancestors.


### PR DESCRIPTION
## Summary

V1.5 of the Console turn file card: **annotate a turn's diff, and the feedback reaches the agent automatically**. Implements `Docs/superpowers/specs/2026-08-17-console-turn-file-annotate-design.md` (owner-ruled: auto-attach + disclosure).

- **Notes on hunks**: expanded diffs now render per-hunk blocks; `✎ note` opens an inline input (Enter saves, Escape cancels — via a card-level `on_key` reclaim, see below). Notes anchor to `(run, root, path, hunk_index, hunk_header)` with a 40-line excerpt captured at note time (retention-proof). Pending notes show `✕` delete; delivered notes render `sent` and refuse deletion (with a notify).
- **Persistence**: new `change_notes` table in AgentRuns_DB (audit v8, then `delivered_by_run_id` at v9), file's idempotent-DDL convention; five-method API; mid-run-race and exact-id semantics pinned.
- **Delivery**: on the next agent send, pending notes attach to the outbound copy's last user message (the `turn_bundle_block` mechanism), capped at 16 KB with holdover-stays-pending semantics; stamped delivered **by exact attached id** at run completion, only when the run produced assistant output; a content-carrying "📝 Diff feedback attached" TOOL disclosure row is emitted live and **re-derived on resume anchored at the delivering run** (marker precedent).
- **Affordances**: header `Review` button (opens the Review screen at the card's run via the existing `v` recipe + TASK-1972's `initial_run_id`), expand/collapse-all (serialized loads), middle-elided paths with full-path tooltips.
- **Kill switch**: `[console] turn_file_cards=false` stays byte-identical plain marker; delivery is bridge-side and unaffected (pinned).

## Review trail (SDD: 7 tasks, per-task reviews, final whole-branch review on the most capable model)

Real bugs the review loops caught before merge:
- **Enter was being swallowed by the transcript** — the "correct by construction" binding-chain analysis was WRONG; the pinning test proved `ConsoleTranscript.on_key` stops Enter as a raw key, selecting the row instead of saving the note. Fixed with a card-level `on_key` reclaim (existing ActionButton pattern).
- **False delivery stamp on non-attachable payloads** (no trailing user string message / vision-turn list content) — notes were marked delivered though the model never saw them. Fixed with an attached-flag guard; both shapes red-proven.
- **Resume anchoring**: the initial annotated-run derivation fragmented delivery batches and silently dropped disclosures for off-branch runs in the NORMAL flow — ruled and reworked to delivering-run placement (`delivered_by_run_id`, audit v9), plus a guarded batched query so a notes read failure can never break conversation resume.
- **Holdover-line cap overflow** in the feedback block (140k+ randomized trials green after fix); **two-window same-file note bleed** (hunk_header disambiguation); **arrow-key leak** from the note input; four-backtick fence hardening.

Follow-ups filed: **TASK-17610** (pre-existing `token_counter` crash on list-shaped message content, found during delivery testing), **TASK-17611** (five parked polish minors: hunk-count ceiling, toggle-all label staleness, glyph fallback, attach-helper dedupe, cell-width elision).

## Testing

- 358 targeted tests green on the final tree (notes DB + hunks + delivery + card/notes/factory UI + review screen + bridge + tracking + marker-anchoring e2e); 49,647 tests collect cleanly.
- Guard-test discipline: every load-bearing regression test proven RED against pre-fix/pre-feature code; real-provider fixtures (tracker/shadow-repo/file-backed AgentRunsDB) throughout; real CSS stack for UI tests.
- User Guide updated with claims verified against shipped seams (including the honest "sent marker appears on rebuild, not live" wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotate per-hunk diffs on the Console turn file card and auto-attach those notes to the next agent send, with live TOOL disclosures and resume re-derivation. Previously the card only displayed diffs; now users can add per-hunk notes that persist, deliver once, and become non-deletable after delivery. This update hardens delivery (byte-capped excerpts, exact-id stamping/disclosure) and disambiguates anchors with snapshot scope. Satisfies TASK-16800.

- Per-hunk UI: each expanded file renders hunk blocks with a note input; Enter saves, Escape cancels; delivered notes render “sent” and refuse deletion. Header adds Review, expand/collapse-all, and middle-elided paths with full-path tooltips.
- Persistence: new `change_notes` table and API in the runs DB; notes anchor by `(run_id, root, path, hunk_index, hunk_header, snapshot_id)` and store a 40‑line excerpt bounded to 4096 UTF‑8 bytes.
- Delivery: on the next agent send, pending notes append to the last user string message via the bundle‑block path; cap at 16 KB; if the oldest note alone would overflow, its excerpt is truncated to fit so it never blocks the queue; stamp delivered by the exact attached ids at run completion only when the run produced assistant output; disclose only ids the DB confirms stamped; emit a “Diff feedback attached” disclosure row.
- Resume: disclosures re‑derive anchored at the delivering run (`delivered_by_run_id`), batching by delivery time; pending notes never surface on resume.
- Safety and affordances: kill switch `[console] turn_file_cards=false` keeps delivery logic active; robust key handling prevents the transcript from swallowing Enter/Escape/arrow keys while typing; no revert/undo on the card.
- Docs and tests: User Guide updated; extensive DB/bridge/UI tests added, including byte‑cap, delivery‑stamp correctness, delivering‑run resume anchoring, and snapshot‑scoped anchoring.

**Rollout/Migration**
- The runs DB auto‑migrates to schema v10; ensure write access on startup.
- Treat `change_notes` as durable user‑authored content; do not drop it in any “clear history” tooling.
- No config changes required; existing `[console]` settings remain compatible.

<sup>Written for commit 51c8ddc7049309a636b2ff7176f76ef59f70b1fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

