### PR TITLE
Four-seam AND-strictness: measured, decided, and the naive fix ruled out (TASK-3997)

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md
+++ b/Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md
@@ -1,0 +1,65 @@
+# Four-seam AND-strictness: what it costs, and what the alternatives buy (TASK-3997)
+
+Date: 2026-08-18 · Branch `docs/task-3997-and-strictness` off dev `59300e234`
+Measured on the gated fixture corpus (172 docs) and golden set (60 queries,
+53 with ground truth; 7 negatives excluded from scoring). No network, no spend.
+
+## AC#1 — the baseline: what AND-strictness costs today
+
+`build_fts_match_query` (`Library/library_fts_query.py`) OR-groups a term's
+spelling variants but joins **every group with AND**, so one absent term
+zeroes the seam.
+
+On the golden set, the Library's plain four-seam path returns:
+
+| | queries |
+|---|---|
+| **zero rows** | **39 of 60** (32 of the 53 ground-truthed) |
+| exactly 1 row | 21 |
+| more than 1 row | **0** |
+
+The original filing measured "2 of 15" on the smaller P1 set. On the current
+instrument it is **two thirds of the query set returning nothing**.
+
+## AC#2 — the alternatives, measured rather than argued
+
+Three constructions, same corpus, same queries, MRR over the 53 scored:
+
+| construction | MRR | zero-row | what it does |
+|---|---|---|---|
+| **AND-strict** (shipped) | 0.396 | 32/53 | one absent term ⇒ nothing |
+| **pure prefix OR** | **0.261** | 0/53 | every query returns 20–30 rows |
+| **`and_then_prefix`** (the engine's shipped shape) | **0.423** | 25/53 | AND primary; prefix **only** where the primary found nothing |
+
+**The naive fix is measurably worse.** Replacing AND with OR/prefix rescues
+every zero-row query and *halves* ranking quality — 20–30 loosely-matching
+rows per query on a 172-document corpus bury the answers that AND was getting
+right. Recall bought at that price is not recall worth having.
+
+**`and_then_prefix` is better than both**, and its shape is why: the 21
+queries whose AND primary already returns a row are **untouched by
+construction**, so the only queries it can change are the ones currently
+returning nothing. It rescues **7 of 32** zero-row queries with the *right*
+document, for **+0.027 MRR**, and cannot regress the precise answers.
+
+## The second argument, which is not about metrics
+
+The Library screen's plain **Search** mode is this path; **RAG Answer** on the
+same screen is the engine leg, which has shipped `and_then_prefix` since
+TASK-15700. A user switching between the two tabs on one screen gets **two
+different matching rules** — an inflection miss ("guy tension" vs
+"tensions") answers in one and returns nothing in the other. Adopting
+`and_then_prefix` on the four-seam path collapses that divergence to zero as
+a side effect of the better-measuring option.
+
+## Method notes (so the numbers can be trusted or refuted)
+
+- The first A/B run reported **identical** results for both arms. That was a
+  monkeypatch that never took: `library_local_rag_search_service` does
+  `from ... import build_fts_match_query`, binding the name at import, so
+  patching the defining module changed nothing. Re-patched at the consumer
+  namespace, with a **call counter proving the arm ran** (173 calls). An
+  intervention that silently does nothing produces a perfect-looking null.
+- `and_then_prefix` is computed per query from both runs (AND result where it
+  returned rows, prefix result otherwise), which is exactly the engine's
+  fallback rule; it is not a third live run.

--- a/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
+++ b/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
@@ -1,0 +1,56 @@
+---
+id: task-17755
+title: Adopt and_then_prefix on the four-seam keyword path
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [rag, retrieval]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+TASK-3997 investigated the four-seam (plain Search) path's AND-strictness and
+the owner took the decision on 2026-08-18: **adopt `and_then_prefix`** — the
+construction the engine leg has shipped since TASK-15700. That task was scoped
+to investigate and propose; this one implements.
+
+The measured case (`Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md`,
+172-doc corpus, 53 ground-truthed golden queries):
+
+| construction | MRR | zero-row queries |
+|---|---|---|
+| AND-strict (shipped) | 0.396 | 32 of 53 |
+| pure prefix OR | 0.261 | 0 |
+| **`and_then_prefix`** | **0.423** | 25 |
+
+Two properties make this the low-risk arm. The 21 queries whose AND primary
+already returns a row are **untouched by construction** — the fallback only
+fires where the primary returned nothing — so there is no regression path to
+the answers AND currently gets right. And pure OR was measured *worse* than
+the status quo, which kills the naive alternative rather than leaving it as a
+plausible-sounding option.
+
+It also ends a live divergence: the Library screen's **Search** mode is this
+path while **RAG Answer** is the engine leg, so one screen has two matching
+rules today (an inflection miss answers in one and returns nothing in the
+other).
+
+## Acceptance Criteria (the what)
+
+- [ ] The four-seam keyword path applies an `and_then_prefix` construction:
+      the existing AND-of-variant-groups stays the primary, and a per-token
+      prefix form runs **only** for a sub-leg whose primary returned zero rows
+- [ ] A query whose AND primary returns rows produces byte-identical results
+      to today — pinned by a test, since this is the property that makes the
+      change low-risk
+- [ ] The zero-row rescue is demonstrated on the golden set, and the measured
+      MRR does not fall below the AND-strict baseline (0.396 on the corpus in
+      TASK-3997's report)
+- [ ] Plain Search and RAG Answer answer the same inflection-miss query on the
+      same corpus — the divergence TASK-3997 documented is gone
+- [ ] The gated retrieval suite reads `PASSED: No regression. 105 metric(s)`;
+      note that its `plain` cells CAN legitimately move here, unlike in
+      reranking arcs — if they do, the move is the deliverable and the
+      baselines are re-stamped deliberately with the reason recorded

--- a/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
+++ b/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
@@ -1,0 +1,42 @@
+---
+id: task-17855
+title: Investigate the remaining zero-row queries — absent content words
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [rag, retrieval, investigation]
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+Filed at the owner's request alongside TASK-3997's decision (2026-08-18).
+
+Adopting `and_then_prefix` on the four-seam path (TASK-17755) rescues 7 of
+32 zero-row golden queries. **Twenty-five still return nothing**, and
+TASK-15400's sweep already identified why on both paths: the dominant blocker
+is **absent CONTENT words**, not function words or inflection. No construction
+that rearranges the tokens a user typed can fix a term the corpus does not
+contain.
+
+That makes this a different question from AND-strictness, and it is
+deliberately an INVESTIGATION rather than a fix: the candidate answers
+(synonym/expansion, a vocabulary bridge, falling back to the semantic leg when
+the keyword legs return nothing) are each their own measured arc, and this
+programme has already retired expansion, acronym and compositional
+query-formulation candidates on measurement. **A null result here — "the
+remaining 25 are not reachable by keyword construction at all" — is a
+publishable outcome and is sufficient to close this task.**
+
+## Acceptance Criteria (the what)
+
+- [ ] The 25 residual zero-row queries are characterised: for each, whether
+      the relevant document is reachable by ANY keyword construction over the
+      terms the user typed, or only by semantic retrieval
+- [ ] At least one candidate is proposed with its measured or estimated
+      precision cost, judged against the finding that pure OR HALVED MRR —
+      recall bought by broadening is not free and must be priced
+- [ ] A decision is recorded: pursue a specific candidate as its own arc, or
+      record that keyword construction has reached its ceiling on this corpus
+      and the remainder is the semantic leg's job

--- a/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
+++ b/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
@@ -3,7 +3,7 @@ id: TASK-3997
 title: >-
   Investigate: four-seam keyword (plain) search is AND-strict, returning zero
   rows when one query term is absent
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-09 05:17'
 updated_date: '2026-08-11 18:06'
@@ -23,9 +23,9 @@ Found by the P1 eval harness (TASK-3894). build_fts_match_query (Library/library
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The current AND-strict behavior effect on the P1 golden query set is documented (which queries return zero or partial results and why) as a baseline for the decision.
-- [ ] #2 At least one alternative (for example OR-with-ranking, or configurable strictness) is proposed with its precision-versus-recall tradeoffs for the four-seam keyword path.
-- [ ] #3 A product decision on whether and how to change the AND-join behavior is recorded, in this task or a follow-up task.
+- [x] #1 The current AND-strict behavior effect on the P1 golden query set is documented (which queries return zero or partial results and why) as a baseline for the decision.
+- [x] #2 At least one alternative (for example OR-with-ranking, or configurable strictness) is proposed with its precision-versus-recall tradeoffs for the four-seam keyword path.
+- [x] #3 A product decision on whether and how to change the AND-join behavior is recorded, in this task or a follow-up task.
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -37,3 +37,43 @@ OUTCOME OF THE OTHER HALF (2026-08-12, TASK-15400 CLOSED — this task is NOT cl
 
 UPDATE (2026-08-13, TASK-15700 closed): the ENGINE leg's construction moved again — it now ships `and_then_prefix` (FULL AND over every token as the primary — function words INCLUDED — with per-token prefix matching as a fallback for a sub-leg whose primary returned zero rows). So the divergence between the two paths grew rather than shrank: the engine leg now answers an inflection miss ("guy tension" against a document saying "tensions") that the four-seam path still cannot, and the stopword trim that this note describes as the engine's construction now lives only in the engine's FALLBACK. The product judgment this task owns is unchanged and is now worth more: a user switching between "Search" and "RAG Answer" on the same screen gets two matching rules that differ in two dimensions, not one.
 <!-- SECTION:NOTES:END -->
+
+## Investigation outcome (2026-08-18)
+
+**AC#1 — the baseline.** The four-seam path returns **zero rows for 39 of 60**
+golden queries (32 of the 53 ground-truthed) and exactly one row for the other
+21; never more than one. The original filing's "2 of 15" was the smaller P1
+set — on the current instrument the effect is two thirds of the query set.
+
+**AC#2 — the alternatives, measured.** Over the 53 scored queries:
+
+| construction | MRR | zero-row |
+|---|---|---|
+| AND-strict (shipped) | 0.396 | 32 |
+| pure prefix OR | **0.261** | 0 |
+| `and_then_prefix` (the engine's shape) | **0.423** | 25 |
+
+The naive fix is **measurably worse**: OR rescues every zero-row query and
+halves ranking quality, because 20–30 loosely-matching rows on a 172-document
+corpus bury the answers AND was getting right. `and_then_prefix` beats both,
+and its shape is why — the 21 queries whose primary already returns a row are
+untouched by construction, so it can only change queries that currently return
+nothing. It rescues **7 of 32** with the right document.
+
+Full report + method notes:
+`Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md`. One method
+note matters: the first A/B reported identical arms because the monkeypatch
+never took (`from ... import` binds at import time), which is how an
+intervention that does nothing produces a perfect-looking null; re-run at the
+consumer namespace with a call counter proving the arm executed.
+
+**AC#3 — the decision (owner, 2026-08-18): ADOPT `and_then_prefix`.** Filed
+as **TASK-17755** (implementation, with the untouched-primaries property as a
+pinned AC). The owner also asked for the deeper recall question to be carried
+forward: **TASK-17855** investigates the 25 residual zero-row queries, whose
+blocker is absent CONTENT words — a different question that no token
+rearrangement can answer, and where a null is an acceptable outcome.
+
+This also answers the divergence TASK-15400's AC#8 deferred here: adopting the
+engine's construction collapses the two matching rules on the Library screen
+to one.


### PR DESCRIPTION
An investigation task, closed with numbers and an owner decision. Docs and backlog only — no production change.

## What AND-strictness actually costs

`build_fts_match_query` OR-groups a term's spelling variants but joins **every group with AND**, so one absent term zeroes the seam. On the golden set the plain four-seam path returns:

- **zero rows for 39 of 60 queries** (32 of the 53 ground-truthed)
- exactly one row for the other 21
- **never more than one**

The original filing measured "2 of 15" on the smaller P1 set. On the current instrument it is two thirds of the query set returning nothing.

## The alternatives, measured rather than argued

| construction | MRR | zero-row |
|---|---|---|
| **AND-strict** (shipped) | 0.396 | 32 of 53 |
| **pure prefix OR** | **0.261** | 0 |
| **`and_then_prefix`** (the engine's shipped shape) | **0.423** | 25 |

**The naive fix is measurably worse.** Swapping AND for OR rescues every zero-row query and *halves* ranking quality — 20–30 loosely-matching rows on a 172-document corpus bury the answers AND was getting right. That result is worth as much as the recommendation: it kills a plausible-sounding option that would otherwise keep resurfacing.

**`and_then_prefix` beats both, and its shape is why it is low-risk:** the 21 queries whose AND primary already returns a row are **untouched by construction** — the fallback only fires where the primary found nothing — so there is no regression path to what AND currently gets right. It rescues **7 of 32** zero-row queries with the right document.

## The second argument, which is not about metrics

The Library screen's plain **Search** is this path; **RAG Answer** on the same screen is the engine leg, which has shipped `and_then_prefix` since TASK-15700. One screen, two matching rules: an inflection miss ("guy tension" vs "tensions") answers in one tab and returns nothing in the other. The better-measuring option collapses that divergence as a side effect.

## Decision and follow-ups

**Owner decision (2026-08-18): adopt `and_then_prefix`.**

- **TASK-17755** — the implementation, with the untouched-primaries property as a *pinned* AC, and a note that unlike reranking arcs the gate's `plain` cells legitimately CAN move here (if they do, the move is the deliverable and re-stamping is deliberate).
- **TASK-17855** — filed at the owner's request: the 25 residual zero-row queries, whose blocker is **absent content words**, not construction. No token rearrangement can fix a term the corpus lacks, so it is an investigation with a null pre-authorised as an acceptable outcome.

This also answers the question TASK-15400's AC#8 deferred here.

## Method note

The first A/B reported **identical** results for both arms — a monkeypatch that never took, because `library_local_rag_search_service` does `from ... import build_fts_match_query`, binding the name at import. Re-patched at the consumer namespace with a **call counter proving the arm ran** (173 calls). Recorded in the report because an intervention that silently does nothing produces a perfect-looking null, which is the same failure mode the cross-encoder arc caught last week.

Refs TASK-3997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents four-seam AND-strictness effects, measures alternatives, and records the decision to adopt `and_then_prefix`. No production changes; adds a QA report and follow-up tasks so implementation and remaining gaps proceed.

**Review focus**
- New QA report (`Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md`): AND-strict MRR 0.396 with 32/53 zero-row; pure prefix OR 0.261 despite 0 zero-row; `and_then_prefix` 0.423, rescuing 7/32 while leaving already-answered queries untouched. Includes a method note: initial monkeypatch was a no-op due to a from-import; re-run at the consumer proved execution via call counter.
- TASK-3997 set to Done with the baseline, alternatives, and owner decision captured; links to the report.
- Backlog:
  - TASK-17755 to implement `and_then_prefix` with the “untouched-primaries” property pinned as AC.
  - TASK-17855 to investigate the 25 residual zero-row queries due to absent content words.

**Next steps**
- Implementation and verification track in TASK-17755; no migration and no release risk.
- Adopting `and_then_prefix` aligns Library Search with RAG Answer on the same screen.

<sup>Written for commit da3a89a30ebd787a37c3cfbec3d98eac1f26f9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

