### PR TITLE
fix(research): a synthesis that never returns must not vanish

### DIFF
--- a/Docs/Development/research-report-eval-baseline.md
+++ b/Docs/Development/research-report-eval-baseline.md
@@ -501,6 +501,41 @@ load on what it must then SUMMARIZE and WRITE**, and every one of those stages
 had a bound calibrated for the single-query runs this document used to record.
 
 
+
+### Synthesis wall clock against pool size (task-17386)
+
+Measured from the arms above, pairing each question's admitted-evidence count
+with the wall clock of its single synthesis call:
+
+| arm | admitted (cumulative) | synthesis |
+|---|---|---|
+| B | 14 / 26 / 32 | 241s / 328s / 287s |
+| G | 22 / 38 / 50 | 185s / 247s / 282s |
+| H | 22 / 46 / 66 | 155s / **1200s FAILED** / 970s |
+
+The two large numbers are the shape of the failure. With a 600s per-attempt
+provider timeout and one retry, **1200s is two timeouts** (the run's log ends in
+`MaxRetryError`), and the 970s "success" is a first attempt timing out and the
+retry landing. So synthesis on a default multi-hop pool routinely exceeds the
+per-attempt budget: retries hide it sometimes and lose the entire run other
+times.
+
+A lost run used to be invisible. The pipeline returned a generic "Could not
+create the report due to an error" with no verdict, the run COMPLETED, and the
+eval -- finding no citation payload -- simply left the sample out of the
+aggregate. A metric computed over surviving runs looks better precisely because
+the failures removed themselves from the sample. Runs now carry
+`synthesis_failed` (the failure class and the pool size it failed on) in their
+warnings and verification summary, so the stage that failed is nameable.
+
+**Not fixed here**: making a large-pool synthesis actually complete. The
+per-call timeout is not plumbable through `chat_api_call`, whose signature is
+shared by ~9 providers, so a size-aware synthesis budget is its own change.
+Until then, an install running default multi-hop against a local model needs a
+provider `api_timeout` well above the 600s these measurements used -- the 66
+source pool took 970s of successful synthesis.
+
+
 ### Reading gate_pass_rate
 
 It is a ratio, and multi-hop adds to its denominator. Pulling in more marginal

--- a/Helper_Scripts/Benchmarks/record_research_baseline.py
+++ b/Helper_Scripts/Benchmarks/record_research_baseline.py
@@ -207,14 +207,23 @@ async def _run_question(
     verification = service.get_artifact(run["id"], "verification_summary.json") or {}
     payload = verification.get("content") or {}
     if not payload.get("citation_verification"):
-        print("  [no citation verification on the synthesis branch]")
-        return None
+        # Qodo (PR 1782): returning None here is what made failed runs vanish.
+        # A run with no citation verdict has no metrics to average, but it MUST
+        # still be counted, or the aggregate is computed over survivors and
+        # reads as if every run produced a report (task-17386).
+        failure = payload.get("synthesis_failed") or {}
+        stage = failure.get("stage") or "unknown"
+        error_type = failure.get("error_type") or "no citation verification"
+        print(f"  [no report: {stage} failed -- {error_type}]")
+        return {"__unscored__": {"stage": stage, "error_type": error_type}}
     # The full summary (not just the citation block) so gate counts flow
     # into gate_pass_rate (task-16333).
     return payload
 
 
-def _decorate_aggregate(aggregate: dict, *, args: argparse.Namespace) -> dict:
+def _decorate_aggregate(
+    aggregate: dict, *, args: argparse.Namespace, unscored_runs: list | None = None
+) -> dict:
     """Stamp the decomposition settings onto the emitted aggregate.
 
     task-17370: the recorded 0.29 and 0.42 gate numbers were both measured
@@ -230,6 +239,10 @@ def _decorate_aggregate(aggregate: dict, *, args: argparse.Namespace) -> dict:
             "max_iterations": max(1, int(getattr(args, "max_iterations", 1) or 1)),
             "deadline_s": getattr(args, "deadline_s", None),
             "llm_timeout_s": getattr(args, "llm_timeout_s", None),
+        },
+        "unscored_runs": {
+            "count": len(unscored_runs or []),
+            "reasons": list(unscored_runs or []),
         },
     }
 
@@ -300,12 +313,17 @@ async def main_async(args: argparse.Namespace) -> int:
         question_set = QUESTION_SETS[question_set_name]
         print(f"question set: {args.question_set}")
         payloads = []
+        # Runs that produced no report at all: kept so the aggregate can state
+        # them rather than quietly averaging over the survivors.
+        unscored: list[dict] = []
         for question in question_set[: args.questions]:
             print(f"Running: {question}")
             payload = await _run_question(
                 engine, service, question, max_iterations=args.max_iterations
             )
-            if payload is not None:
+            if payload is not None and "__unscored__" in payload:
+                unscored.append(payload["__unscored__"])
+            elif payload is not None:
                 metrics = score_research_report(payload)
                 cv = payload.get("citation_verification") or {}
                 gate = payload.get("gate") or {}
@@ -329,7 +347,9 @@ async def main_async(args: argparse.Namespace) -> int:
             "timeouts) before relying on this baseline."
         )
         return 1
-    aggregate = _decorate_aggregate(aggregate_metrics(payloads), args=args)
+    aggregate = _decorate_aggregate(
+        aggregate_metrics(payloads), args=args, unscored_runs=unscored
+    )
     print("\n=== Live baseline (mean over runs) ===")
     print(json.dumps(aggregate, indent=2))
     if args.json_out:

--- a/Tests/Helper_Scripts/test_record_research_baseline.py
+++ b/Tests/Helper_Scripts/test_record_research_baseline.py
@@ -169,3 +169,54 @@ def test_emitted_aggregate_records_the_llm_timeout():
     out = recorder._decorate_aggregate({"gate_pass_rate": 0.5}, args=args)
 
     assert out["decomposition"]["llm_timeout_s"] == 240.0
+
+
+# --- unscored runs must be counted, not dropped (Qodo, PR 1782) ---------------
+# Recording synthesis_failed on the RUN was only half the fix: the recorder
+# still returned None for any payload without citation_verification, so a run
+# that produced no report never reached the aggregate at all and the means were
+# computed over survivors -- the exact distortion task-17386 exists to stop.
+
+
+def test_a_run_without_a_report_is_counted_not_dropped():
+    """The payload has no metrics to average, but the aggregate must say it
+    happened, and say which stage failed."""
+    payload = {
+        "synthesis_failed": {
+            "stage": "synthesis",
+            "error_type": "ReadTimeoutError",
+            "evidence_count": 46,
+            "chunk_count": 6,
+        }
+    }
+
+    class _Service:
+        def launch_run(self, **kwargs):
+            return {"id": "run-1"}
+
+        def get_artifact(self, run_id, name):
+            return {"content": payload}
+
+    class _Engine:
+        async def execute_run(self, run_id):
+            return {"id": run_id, "status": "completed"}
+
+    out = asyncio.run(recorder._run_question(_Engine(), _Service(), "Q"))
+
+    assert out is not None, "a failed-synthesis run must not be dropped"
+    assert out["__unscored__"]["stage"] == "synthesis"
+    assert out["__unscored__"]["error_type"] == "ReadTimeoutError"
+
+
+def test_aggregate_states_how_many_runs_produced_no_report():
+    aggregate = recorder._decorate_aggregate(
+        {"sample_count": 2.0, "gate_pass_rate": 0.5},
+        args=SimpleNamespace(
+            max_queries=3, max_iterations=2, deadline_s=1200, llm_timeout_s=None
+        ),
+        unscored_runs=[{"stage": "synthesis", "error_type": "ReadTimeoutError"}],
+    )
+
+    assert aggregate["sample_count"] == 2.0
+    assert aggregate["unscored_runs"]["count"] == 1
+    assert aggregate["unscored_runs"]["reasons"][0]["stage"] == "synthesis"

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1289,39 +1289,6 @@ def test_generated_sub_questions_reach_the_paper_providers():
         paper_search_fn=paper_fn,
         search_params={"search_default_max_queries": 5},
     )
-
-def test_a_failed_synthesis_is_recorded_on_the_run():
-    """task-17386: a synthesis that never returns leaves no citation verdict,
-    which used to make the run indistinguishable from one nobody scored -- it
-    completed quietly and vanished from any aggregate. The run must say so."""
-    service = _make_service()
-
-    def search_fn(q, params):
-        return (
-            {"results": [{"title": "One", "url": "https://one.example/"}], "warnings": []},
-            {"sub_questions": [], "main_goal": q},
-        )
-
-    async def analyze_fn(wsr, sqd, params, cancel_event=None):
-        # Exactly what aggregate_results returns when synthesis raises.
-        return {
-            "final_answer": {
-                "text": "Could not create the report due to an error (ReadTimeoutError).",
-                "evidence": [],
-                "confidence": 0.0,
-                "chunks": [],
-                "synthesis_failed": {
-                    "stage": "synthesis",
-                    "error_type": "ReadTimeoutError",
-                    "evidence_count": 46,
-                    "chunk_count": 6,
-                },
-            },
-            "relevant_results": {},
-        }
-
-    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
-
     run = service.launch_run(
         query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
     )
@@ -1479,6 +1446,42 @@ def test_academic_queries_falls_back_when_the_cap_is_unusable():
 
     assert len(queries) == 5, queries  # DEFAULT_MAX_QUERIES
 
+
+def test_a_failed_synthesis_is_recorded_on_the_run():
+    """task-17386: a synthesis that never returns leaves no citation verdict,
+    which used to make the run indistinguishable from one nobody scored -- it
+    completed quietly and vanished from any aggregate. The run must say so."""
+    service = _make_service()
+
+    def search_fn(q, params):
+        return (
+            {"results": [{"title": "One", "url": "https://one.example/"}], "warnings": []},
+            {"sub_questions": [], "main_goal": q},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        # Exactly what aggregate_results returns when synthesis raises.
+        return {
+            "final_answer": {
+                "text": "Could not create the report due to an error (ReadTimeoutError).",
+                "evidence": [],
+                "confidence": 0.0,
+                "chunks": [],
+                "synthesis_failed": {
+                    "stage": "synthesis",
+                    "error_type": "ReadTimeoutError",
+                    "evidence_count": 46,
+                    "chunk_count": 6,
+                },
+            },
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
     final = asyncio.run(engine.execute_run(run["id"]))
 
     assert final["status"] == "completed"
@@ -1487,4 +1490,3 @@ def test_academic_queries_falls_back_when_the_cap_is_unusable():
     assert content.get("synthesis_failed", {}).get("error_type") == "ReadTimeoutError"
     warnings = " ".join(str(w) for w in (content.get("warnings") or []))
     assert "synthesis produced no report" in warnings, content.get("warnings")
-

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1289,6 +1289,39 @@ def test_generated_sub_questions_reach_the_paper_providers():
         paper_search_fn=paper_fn,
         search_params={"search_default_max_queries": 5},
     )
+
+def test_a_failed_synthesis_is_recorded_on_the_run():
+    """task-17386: a synthesis that never returns leaves no citation verdict,
+    which used to make the run indistinguishable from one nobody scored -- it
+    completed quietly and vanished from any aggregate. The run must say so."""
+    service = _make_service()
+
+    def search_fn(q, params):
+        return (
+            {"results": [{"title": "One", "url": "https://one.example/"}], "warnings": []},
+            {"sub_questions": [], "main_goal": q},
+        )
+
+    async def analyze_fn(wsr, sqd, params, cancel_event=None):
+        # Exactly what aggregate_results returns when synthesis raises.
+        return {
+            "final_answer": {
+                "text": "Could not create the report due to an error (ReadTimeoutError).",
+                "evidence": [],
+                "confidence": 0.0,
+                "chunks": [],
+                "synthesis_failed": {
+                    "stage": "synthesis",
+                    "error_type": "ReadTimeoutError",
+                    "evidence_count": 46,
+                    "chunk_count": 6,
+                },
+            },
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+
     run = service.launch_run(
         query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
     )
@@ -1445,3 +1478,13 @@ def test_academic_queries_falls_back_when_the_cap_is_unusable():
     )
 
     assert len(queries) == 5, queries  # DEFAULT_MAX_QUERIES
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed"
+    summary = service.get_artifact(run["id"], "verification_summary.json") or {}
+    content = summary.get("content") or {}
+    assert content.get("synthesis_failed", {}).get("error_type") == "ReadTimeoutError"
+    warnings = " ".join(str(w) for w in (content.get("warnings") or []))
+    assert "synthesis produced no report" in warnings, content.get("warnings")
+

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -361,7 +361,14 @@ def test_aggregate_llm_failure_still_typed(monkeypatch):
     from tldw_chatbook.LLM_Calls import Summarization_General_Lib
     monkeypatch.setattr(Summarization_General_Lib, "analyze", lambda *a, **k: "chunk summary")
     out = WebSearch_APIs.aggregate_results(_REL, "q", [], "openai")
-    assert set(out) == {"text", "evidence", "confidence", "chunks"}  # no "summary" key ever
+    # Typed shape holds and no "summary" key ever appears; task-17386 adds
+    # synthesis_failed so the run records WHY it has no citation verdict.
+    assert set(out) == {
+        "text", "evidence", "confidence", "chunks", "synthesis_failed",
+    }
+    assert "summary" not in out
+    assert out["synthesis_failed"]["error_type"] == "RuntimeError"
+    assert "RuntimeError" in out["text"]
 
 
 def test_aggregate_no_llm_fallback():

--- a/Tests/Web_Scraping/test_deep_search_pipeline.py
+++ b/Tests/Web_Scraping/test_deep_search_pipeline.py
@@ -1445,3 +1445,24 @@ def test_real_summaries_are_not_mistaken_for_failures(summary_text):
     from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
 
     assert _is_summary_failure(summary_text) is False
+
+
+def test_verification_failure_is_not_labelled_a_synthesis_failure(monkeypatch):
+    """Qodo (PR 1782): verify_citations runs after the provider returns, inside
+    the same try, so a verification defect used to be recorded as a SYNTHESIS
+    failure -- corrupting the failure-class measurement the field exists for."""
+    monkeypatch.setattr(
+        WebSearch_APIs, "chat_api_call", lambda **kwargs: "a report citing [1]"
+    )
+    from tldw_chatbook.LLM_Calls import Summarization_General_Lib
+    monkeypatch.setattr(Summarization_General_Lib, "analyze", lambda *a, **k: "chunk summary")
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("citation verifier defect")
+
+    monkeypatch.setattr(WebSearch_APIs.deep_search_citations, "verify_citations", boom)
+
+    out = WebSearch_APIs.aggregate_results(_REL, "q", [], "openai")
+
+    assert out["synthesis_failed"]["stage"] == "verification", out["synthesis_failed"]
+    assert out["synthesis_failed"]["error_type"] == "ValueError"

--- a/backlog/tasks/task-17386 - Synthesis-exceeds-the-provider-timeout-on-large-evidence-pools.md
+++ b/backlog/tasks/task-17386 - Synthesis-exceeds-the-provider-timeout-on-large-evidence-pools.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17386
 title: Synthesis exceeds the provider timeout on large evidence pools
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-17 16:45'
 labels:
@@ -24,10 +24,10 @@ Bounding the synthesis input, streaming it, or deriving the timeout from the poo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A run whose synthesis cannot complete within the wall clock produces a recorded, legible terminal state instead of vanishing from results
-- [ ] #2 The relationship between evidence-pool size and synthesis wall clock is measured, not assumed
+- [x] #1 A run whose synthesis cannot complete within the wall clock produces a recorded, legible terminal state instead of vanishing from results
+- [x] #2 The relationship between evidence-pool size and synthesis wall clock is measured, not assumed
 - [ ] #3 A run on a local model with a pool the size of a default multi-hop run completes its synthesis, or is bounded so that it can
-- [ ] #4 Whatever bound is chosen is stated where a user meets it, alongside the existing decomposition spend notes
+- [x] #4 Whatever bound is chosen is stated where a user meets it, alongside the existing decomposition spend notes
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -49,4 +49,36 @@ academic fan-out fix (task-17372) and the chunk-summarization fix:
 - 600s is what `record_research_baseline._prime_local_llm_url` sets as
   `api_timeout`; the shipped provider default is lower, so an ordinary run is
   more exposed than this measurement was.
+<!-- SECTION:NOTES:END -->
+
+## Implementation Notes (partial -- AC #3 remains open)
+
+<!-- SECTION:NOTES:BEGIN -->
+AC #1, #2 and #4 are closed; **AC #3 is deliberately NOT closed** and the task
+stays open for it.
+
+The failure is now legible. `aggregate_results` records the failure CLASS --
+never its message, since a timeout's text carries host:port and this value
+travels into a run's artifacts -- with the pool size it failed on, and the
+engine appends the warning while the round's warning list is still being built,
+so the reason reaches the run's warnings and bundle rather than only a summary
+written later. `FinalAnswerDict` declares the field rather than growing an
+undocumented key. Before this, such a run completed with a generic string,
+carried no citation verdict, and was simply absent from any aggregate: the
+failure removed itself from the sample, so metrics over surviving runs looked
+better for it.
+
+AC #2, measured from the recorded arms rather than assumed: pools of 14-32
+sources synthesized in 185-328s, while pools of 46-66 hit 1200s (two 600s
+attempts, `MaxRetryError`) and 970s (a timed-out attempt plus a successful
+retry). Synthesis on a default multi-hop pool routinely exceeds a 600s
+per-attempt budget, so this is the normal shape of a large-pool run rather than
+an exotic error.
+
+AC #3 needs a size-aware synthesis budget, and the per-call timeout is not
+plumbable through `chat_api_call` -- its signature is shared by roughly nine
+providers, so threading one through is a change to the shared dispatcher rather
+than to this pipeline, and belongs in its own task. Until it exists, the
+documented answer is a provider `api_timeout` well above 600s for local models,
+recorded beside the measurement in the eval baseline doc.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -853,6 +853,19 @@ class LocalResearchEngine:
             )
             final_answer = (phase2 or {}).get("final_answer") or {}
             relevant_results = (phase2 or {}).get("relevant_results") or {}
+            # task-17386: recorded HERE, while the round's warning list is still
+            # being built, so the reason reaches the run's warnings and its
+            # bundle -- not just the verification summary written later. A
+            # synthesis that never returns leaves no citation verdict, which
+            # made such a run indistinguishable from one nobody scored.
+            synthesis_failure = final_answer.get("synthesis_failed")
+            if isinstance(synthesis_failure, dict):
+                merged_warnings.append(
+                    "synthesis produced no report ("
+                    f"{synthesis_failure.get('error_type')}; "
+                    f"{synthesis_failure.get('evidence_count')} sources, "
+                    f"{synthesis_failure.get('chunk_count')} chunks)"
+                )
 
             # Gap analysis runs after EVERY synthesis so the final report can
             # name what is still unresolved; iterating further is bounded by
@@ -930,6 +943,13 @@ class LocalResearchEngine:
         }
         if "gate" in final_answer:
             verification_summary["gate"] = final_answer["gate"]
+        # task-17386: a run whose synthesis never returned carries no citation
+        # verdict, which used to make it indistinguishable from a run nobody
+        # scored. Record the reason on the run and in its verification summary
+        # so it is legible as a failure of the synthesis stage.
+        if isinstance(final_answer.get("synthesis_failed"), dict):
+            verification_summary["synthesis_failed"] = final_answer["synthesis_failed"]
+        verification_summary["warnings"] = list(merged_warnings)
         if "citation_verification" in final_answer:
             verification_summary["citation_verification"] = final_answer[
                 "citation_verification"

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -1896,6 +1896,11 @@ def aggregate_results(
     input_data = "Follow the above instructions."
 
     synthesis_error: str | None = None
+    # Qodo (PR 1782): verify_citations runs inside this same block AFTER the
+    # provider has returned a report, so a citation-verification defect used to
+    # be recorded as a SYNTHESIS failure -- corrupting the very failure-class
+    # measurement this records. The stage is tracked as the block progresses.
+    failed_stage = "synthesis"
     try:
         logger.info("Generating the report")
         messages_payload = [
@@ -1927,6 +1932,7 @@ def aggregate_results(
             # Unknown ids are flagged inline ("[n?]") and counted, never
             # deleted; failure/empty branches below carry no verdict rather
             # than a fabricated clean one.
+            failed_stage = "verification"
             cv = deep_search_citations.verify_citations(
                 returned_response, evidence_payload
             )
@@ -1974,7 +1980,7 @@ def aggregate_results(
         ),
         "chunks": chunk_metadata,
         "synthesis_failed": {
-            "stage": "synthesis",
+            "stage": failed_stage,
             "error_type": synthesis_error or "empty_response",
             "evidence_count": len(evidence_payload),
             "chunk_count": len(chunk_infos),

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -1591,6 +1591,11 @@ class FinalAnswerDict(TypedDict):
     # and quote-check counts from deep_search_citations.verify_citations.
     # Failure/empty branches omit it rather than fabricating a clean verdict.
     citation_verification: NotRequired[Dict[str, Any]]
+    #: Present only when the synthesis stage produced no report (task-17386):
+    #: the failure's class, and the pool size it failed on. A run carrying this
+    #: has no citation verdict, and without it such a run is indistinguishable
+    #: from one nobody scored.
+    synthesis_failed: NotRequired[Dict[str, Any]]
     # Present whenever relevance outcomes are known (task-16333):
     # {"relevant": int, "raw": int, "fallback": bool} -- fallback marks a
     # report built from gate-unverified evidence.
@@ -1890,6 +1895,7 @@ def aggregate_results(
 
     input_data = "Follow the above instructions."
 
+    synthesis_error: str | None = None
     try:
         logger.info("Generating the report")
         messages_payload = [
@@ -1948,15 +1954,31 @@ def aggregate_results(
             return success_answer
     except Exception as e:
         logger.error(f"Error aggregating results: {e}")
+        # task-17386: keep the CLASS of failure, not the message -- a timeout's
+        # text carries host:port, and this value travels into a run's artifacts.
+        synthesis_error = type(e).__name__
 
     logger.error("Could not create the report due to an error.")
+    # task-17386: a synthesis that never returns used to leave a generic string
+    # and no verdict, so the run "completed", the eval found no verification
+    # payload, and the sample vanished from the aggregate rather than counting
+    # as a failure. Measured: on a local model, synthesis of a 46-66 source pool
+    # ran 600-1200s against a 600s per-attempt provider timeout, so this is the
+    # normal shape of a large-pool run, not an exotic error.
+    reason = f" ({synthesis_error})" if synthesis_error else ""
     failure_answer: FinalAnswerDict = {
-        "text": "Could not create the report due to an error.",
+        "text": f"Could not create the report due to an error{reason}.",
         "evidence": evidence_payload,
         "confidence": _estimate_confidence(
             len(evidence_payload), len(chunk_infos), len(chunk_infos), has_llm=False
         ),
         "chunks": chunk_metadata,
+        "synthesis_failed": {
+            "stage": "synthesis",
+            "error_type": synthesis_error or "empty_response",
+            "evidence_count": len(evidence_payload),
+            "chunk_count": len(chunk_infos),
+        },
     }
     return failure_answer
 


### PR DESCRIPTION
Closes **TASK-17386**'s legibility and measurement criteria (#1, #2, #4). **AC #3 is deliberately left open** — see below.

Stacked on **#1774**, so its two commits appear here too; merging that first reduces this to the synthesis change and its records.

## The failure that hid itself

A run whose single synthesis call exceeded the provider timeout returned a generic `"Could not create the report due to an error"`, **completed normally**, and carried no citation verdict. The eval, finding no payload, left the sample out of the aggregate entirely.

That's the part worth dwelling on: metrics computed over surviving runs looked *better* precisely because the failures removed themselves from the sample. Arm H scored 2 of 3 questions and reported `cited_sentence_ratio` 1.00 — a number that would have been quietly averaged over the survivors of exactly this failure.

## Measured, not assumed (AC #2)

| arm | admitted (cumulative) | synthesis |
|---|---|---|
| B | 14 / 26 / 32 | 241s / 328s / 287s |
| G | 22 / 38 / 50 | 185s / 247s / 282s |
| H | 22 / 46 / 66 | 155s / **1200s FAILED** / 970s |

The two large numbers decode the mechanism: against a 600s per-attempt timeout with one retry, **1200s is two timeouts** (the log ends in `MaxRetryError`) and the 970s "success" is a first attempt timing out and the retry landing. Synthesis on a default multi-hop pool routinely exceeds the per-attempt budget — retries hide it sometimes and lose the whole run other times.

## What this changes

`aggregate_results` records the failure **class** — never its message, since a timeout's text carries `host:port` and this value travels into a run's artifacts — along with the pool size it failed on. The engine appends the warning *while the round's warning list is still being built*, so the reason reaches the run's warnings and bundle rather than only a summary written afterwards. `FinalAnswerDict` declares the field rather than growing an undocumented key.

## What this does NOT change (AC #3)

Making a large-pool synthesis actually *complete*. That needs a size-aware budget, and the per-call timeout isn't plumbable through `chat_api_call` — its signature is shared by ~9 providers, so threading one through is a change to the shared dispatcher, not to this pipeline. It belongs in its own task, and the task stays open rather than being marked Done on a partial fix.

The honest interim answer is documented beside the measurement: an install running default multi-hop against a local model needs a provider `api_timeout` well above the 600s these arms used — the 66-source pool took 970s of successful synthesis.

## Verification

- New engine test: a run whose synthesis failed records `synthesis_failed` in its verification summary **and** a warning naming the stage, pool size and failure class.
- An existing contract test pinned the failure answer's exact key set; updated to preserve its intent (typed shape, no `summary` key ever) while asserting the new reason.
- **227 passed** across `Tests/Research` and `Tests/Web_Scraping/test_deep_search_pipeline.py`; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes synthesis timeouts visible and counts runs that produced no report so they no longer vanish from aggregates. Also fixes stage attribution so post-synthesis verification errors are labeled “verification,” not “synthesis.”

- `WebSearch_APIs.aggregate_results` returns `synthesis_failed` with `stage`, `error_type`, `evidence_count`, and `chunk_count`, and appends the failure class to `text`; stage is tracked so verification defects are labeled correctly.
- `FinalAnswerDict` declares `synthesis_failed`.
- `local_research_engine` adds a warning during execution and writes `synthesis_failed` (and warnings) into `verification_summary.json`.
- `record_research_baseline`: runs without `citation_verification` return an `{"__unscored__": ...}` marker, and the final aggregate includes `unscored_runs.count` and `unscored_runs.reasons` so missing reports are counted, not dropped.
- Tests assert the new field and warning, correct stage labeling, and that aggregates state unscored runs; docs record synthesis wall clock vs. pool size. Connected to TASK-17386: closes AC #1, #2, and #4; AC #3 (size‑aware budget) remains open.

**Rollout**
- No code migration required. Callers may read `final_answer.synthesis_failed` and aggregate `unscored_runs` to detect failures explicitly.
- For local models with large evidence pools, set a higher provider `api_timeout` until a size‑aware synthesis budget is implemented.

<sup>Written for commit 865f47819e734376133669934150304b70e6e464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

