### PR TITLE
fix(tokens): estimate list-shaped message content instead of crashing (TASK-17610)

### DIFF
--- a/Tests/Chat/test_console_diff_feedback_delivery.py
+++ b/Tests/Chat/test_console_diff_feedback_delivery.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import tldw_chatbook.Agents.agent_service as agent_service_module
 from tldw_chatbook.Agents.agent_service import AgentService
 from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
@@ -349,17 +348,11 @@ def test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosur
 
     vision_message = {"role": "user", "content": [{"type": "text", "text": "hi"}]}
     captured: dict = {}
-    # Unrelated pre-existing gap, worked around here rather than fixed
-    # (out of this task's scope): the fake gateway reports no usage, so
-    # the "no usage" fallback estimates tokens by iterating message
-    # content as characters -- which raises on LIST content. Forcing a
-    # usage value skips that estimate path so this test can isolate the
-    # attach-loop behavior under test instead of tripping an unrelated
-    # token-counter limitation.
-    with (
-        patch.object(AgentService, "run_turn", _spy_run_turn(captured)),
-        patch.object(agent_service_module, "_usage_total_tokens", lambda resp: 5),
-    ):
+    # TASK-17610: this test used to force a usage value to dodge the
+    # no-usage token-estimate path, which crashed on LIST content. The
+    # estimator now normalizes part-list content, so the real fallback
+    # path runs here unpatched.
+    with patch.object(AgentService, "run_turn", _spy_run_turn(captured)):
         run_id, outcome = bridge.run_reply(
             **_run_kwargs(session, aid, agent_messages=[vision_message])
         )

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -277,3 +277,60 @@ def test_unknown_provider_and_model_falls_back_to_16k_window():
     from tldw_chatbook.Utils.token_counter import get_model_token_limit
 
     assert get_model_token_limit("some-unknown-model", "some-unknown-provider") == 16384
+
+
+# TASK-17610: list-shaped (vision/attachment) message content must never
+# crash the estimator. Found live during TASK-16800's delivery tests: a
+# user message whose content is the multimodal part-list shape reached
+# `_chars_estimate`, which iterated the LIST and called ord() on dict
+# items. The fix normalizes content at the `estimate_tokens` boundary:
+# text parts are counted normally; each non-text part contributes the
+# documented fixed estimate.
+
+
+def test_estimate_tokens_handles_vision_shaped_list_content():
+    """A text + image part list returns a sane count instead of raising."""
+    from tldw_chatbook.Utils.token_counter import (
+        NON_TEXT_PART_TOKEN_ESTIMATE,
+        estimate_tokens,
+    )
+
+    parts = [
+        {"type": "text", "text": "please look at this screenshot"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    text_only = estimate_tokens("please look at this screenshot", provider="openai")
+    combined = estimate_tokens(parts, provider="openai")
+    assert combined == text_only + NON_TEXT_PART_TOKEN_ESTIMATE
+    assert combined > 0
+
+
+def test_estimate_tokens_list_of_only_non_text_parts():
+    """An image-only message still yields the fixed per-part contribution."""
+    from tldw_chatbook.Utils.token_counter import (
+        NON_TEXT_PART_TOKEN_ESTIMATE,
+        estimate_tokens,
+    )
+
+    parts = [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,BBBB"}},
+    ]
+    assert estimate_tokens(parts) == 2 * NON_TEXT_PART_TOKEN_ESTIMATE
+
+
+def test_count_tokens_messages_survives_list_content_message():
+    """The message-level counter accepts a vision-shaped message end to end."""
+    from tldw_chatbook.Utils.token_counter import count_tokens_messages
+
+    messages = [
+        {"role": "system", "content": "be helpful"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA"}},
+            ],
+        },
+    ]
+    assert count_tokens_messages(messages) > 0

--- a/Tests/Chat/test_token_counter.py
+++ b/Tests/Chat/test_token_counter.py
@@ -334,3 +334,13 @@ def test_count_tokens_messages_survives_list_content_message():
         },
     ]
     assert count_tokens_messages(messages) > 0
+
+
+def test_non_text_part_estimate_matches_the_budget_per_image_charge():
+    """Qodo PR #1783: the generic estimator and budget enforcement must
+    charge images identically — a lower estimator figure would let
+    image-heavy no-usage turns slip past max_total_tokens."""
+    from tldw_chatbook.Chat.console_history_budget import DEFAULT_PER_IMAGE_TOKENS
+    from tldw_chatbook.Utils.token_counter import NON_TEXT_PART_TOKEN_ESTIMATE
+
+    assert DEFAULT_PER_IMAGE_TOKENS == NON_TEXT_PART_TOKEN_ESTIMATE

--- a/backlog/tasks/task-17610 - token_counter-char-fallback-crashes-on-list-shaped-message-content.md
+++ b/backlog/tasks/task-17610 - token_counter-char-fallback-crashes-on-list-shaped-message-content.md
@@ -1,10 +1,14 @@
 ---
 id: TASK-17610
-title: 'token_counter char-fallback crashes on list-shaped message content'
-status: To Do
-assignee: []
+title: token_counter char-fallback crashes on list-shaped message content
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-17 17:19'
-labels: [bug, tokens]
+updated_date: '2026-08-18 02:04'
+labels:
+  - bug
+  - tokens
 dependencies: []
 priority: medium
 ---
@@ -31,9 +35,20 @@ attach-loop behavior the test is actually about.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
 <!-- AC:BEGIN -->
-- [ ] #1 The char-based fallback estimator in `Utils/token_counter.py` handles list-shaped message content without raising: text parts are counted normally, non-text parts (e.g. image/attachment blocks) contribute a fixed, documented estimate instead of crashing.
-- [ ] #2 The monkeypatch workaround in `Tests/Chat/test_console_diff_feedback_delivery.py::test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosure` is removed -- the test exercises the real no-usage fallback path.
-- [ ] #3 A regression test in `Tests/Utils/` (or the existing token_counter test module) calls the fallback estimator directly on a vision-shaped message (list content with at least one text and one non-text part) and asserts it returns a sane token count instead of raising.
+- [x] #1 The char-based fallback estimator in `Utils/token_counter.py` handles list-shaped message content without raising: text parts are counted normally, non-text parts (e.g. image/attachment blocks) contribute a fixed, documented estimate instead of crashing.
+- [x] #2 The monkeypatch workaround in `Tests/Chat/test_console_diff_feedback_delivery.py::test_list_content_user_message_leaves_notes_pending_and_appends_no_disclosure` is removed -- the test exercises the real no-usage fallback path.
+- [x] #3 A regression test in `Tests/Utils/` (or the existing token_counter test module) calls the fallback estimator directly on a vision-shaped message (list content with at least one text and one non-text part) and asserts it returns a sane token count instead of raising.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Red: regression test on vision-shaped list content through the fallback estimator\n2. Fix: content-normalization in the char estimator (text parts counted, non-text fixed contribution)\n3. Remove the delivery test's monkeypatch workaround\n4. Green: token_counter + delivery suites; PR
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed at the estimate_tokens boundary: new _flatten_message_content normalizes any content shape (str passthrough; part-list -> concatenated text parts + count of non-text parts; other shapes -> str()); each non-text part contributes NON_TEXT_PART_TOKEN_ESTIMATE = 85 (documented: the published GPT-4V low-detail image cost, used as a conservative floor consistent with the estimator's contract). This also fixes the tiktoken path, which would have crashed identically on list content. Three regression tests added to Tests/Chat/test_token_counter.py (vision-shaped text+image list, image-only list, count_tokens_messages end-to-end) — all proven red pre-fix (TypeError/ImportError). The monkeypatch workaround in test_console_diff_feedback_delivery.py's list-content test removed along with its now-orphaned agent_service_module import — the test exercises the real no-usage fallback path unpatched and passes. Regression net: token_counter 34 passed, delivery 14, cost-tracker/history-budget/session-settings/bridge 365 — all green.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_history_budget.py
+++ b/tldw_chatbook/Chat/console_history_budget.py
@@ -22,12 +22,16 @@ from tldw_chatbook.Chat.provider_continuation import (
 )
 
 from tldw_chatbook.Utils.token_counter import (
+    NON_TEXT_PART_TOKEN_ESTIMATE,
     count_tokens_messages,
     get_model_token_limit,
 )
 
 DEFAULT_RESPONSE_RESERVATION = 1024
-DEFAULT_PER_IMAGE_TOKENS = 1024
+# One shared per-image charge with the generic estimator (TASK-17610 /
+# Qodo PR #1783): a lower estimator figure would let image-heavy no-usage
+# turns slip past budget enforcement that charges images at this rate.
+DEFAULT_PER_IMAGE_TOKENS = NON_TEXT_PART_TOKEN_ESTIMATE
 _MIN_SAFETY_MARGIN = 512
 
 

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -89,6 +89,13 @@ TOKENS_PER_CHAR_ESTIMATES = {
 CJK_TOKENS_PER_CHAR = 1.0  # each CJK code point is >= ~1 token
 ESTIMATE_HEADROOM = 1.2  # documented headroom so estimates lean high (safe)
 
+#: Fixed contribution for a non-text part of a multimodal message (an image /
+#: attachment block in the OpenAI part-list shape). 85 is the published
+#: low-detail image cost for GPT-4V-family models — a deliberate floor, not a
+#: per-provider truth; the estimator's contract everywhere else is likewise a
+#: conservative estimate, never an exact count (TASK-17610).
+NON_TEXT_PART_TOKEN_ESTIMATE = 85
+
 _CJK_RANGES = (
     (0x3000, 0x303F),  # CJK Symbols and Punctuation (。、「」etc.)
     (0x3040, 0x30FF),  # Hiragana + Katakana
@@ -136,22 +143,67 @@ def _chars_estimate(text: str, provider: str) -> int:
     )
 
 
-def estimate_tokens(text: str, model: str = "gpt-3.5-turbo", provider: str = "") -> int:
-    """Estimate the token count of a text string with one consistent strategy.
+def _flatten_message_content(content: Any) -> "tuple[str, int]":
+    """Normalize message ``content`` into countable text + non-text part count.
+
+    Message content is usually a plain string, but multimodal/attachment turns
+    carry the OpenAI part-list shape (``[{"type": "text", "text": ...},
+    {"type": "image_url", ...}]``). Iterating that list as if it were a string
+    crashed the char estimator (``ord()`` on dict items — TASK-17610).
+
+    Args:
+        content: A message's ``content`` value in any shape.
+
+    Returns:
+        ``(text, non_text_parts)`` — the concatenated text of every string
+        part (dict parts contribute their ``"text"`` value when it is a
+        string), and the count of parts that carry no countable text (each
+        later contributes :data:`NON_TEXT_PART_TOKEN_ESTIMATE`).
+    """
+    if isinstance(content, str):
+        return content, 0
+    if isinstance(content, list):
+        texts: list[str] = []
+        non_text = 0
+        for part in content:
+            if isinstance(part, str):
+                texts.append(part)
+            elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                texts.append(part["text"])
+            else:
+                non_text += 1
+        return "\n".join(texts), non_text
+    # Any other shape (None, dict, number): count its string form — same
+    # conservative-floor posture as the rest of the estimator.
+    return ("" if content is None else str(content)), 0
+
+
+def estimate_tokens(text: Any, model: str = "gpt-3.5-turbo", provider: str = "") -> int:
+    """Estimate the token count of message content with one consistent strategy.
 
     Tiers: a custom tokenizer (only when one is actually installed), else
     tiktoken (when available), else a conservative chars-based floor. Never uses
-    a whitespace word count.
+    a whitespace word count. Non-string content (the multimodal part-list
+    shape) is normalized first: text parts are estimated normally and each
+    non-text part contributes :data:`NON_TEXT_PART_TOKEN_ESTIMATE`.
 
     Args:
-        text: The text to estimate.
+        text: The text (or part-list content) to estimate.
         model: Model name (selects the tiktoken encoding / custom tokenizer).
         provider: Provider name (case-insensitive); selects the chars-path ratio
             and the custom tokenizer's provider patterns.
 
     Returns:
-        Estimated token count (0 for empty text).
+        Estimated token count (0 for empty content).
     """
+    non_text_parts = 0
+    if not isinstance(text, str):
+        text, non_text_parts = _flatten_message_content(text)
+        if non_text_parts:
+            return (
+                estimate_tokens(text, model, provider)
+                + non_text_parts * NON_TEXT_PART_TOKEN_ESTIMATE
+            )
     if not text:
         return 0
     if CUSTOM_TOKENIZERS_AVAILABLE and custom_tokenizers_available():

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -90,11 +90,14 @@ CJK_TOKENS_PER_CHAR = 1.0  # each CJK code point is >= ~1 token
 ESTIMATE_HEADROOM = 1.2  # documented headroom so estimates lean high (safe)
 
 #: Fixed contribution for a non-text part of a multimodal message (an image /
-#: attachment block in the OpenAI part-list shape). 85 is the published
-#: low-detail image cost for GPT-4V-family models — a deliberate floor, not a
-#: per-provider truth; the estimator's contract everywhere else is likewise a
-#: conservative estimate, never an exact count (TASK-17610).
-NON_TEXT_PART_TOKEN_ESTIMATE = 85
+#: attachment block in the OpenAI part-list shape). 1024 matches the repo's
+#: existing per-image budget charge (``console_history_budget``'s
+#: ``DEFAULT_PER_IMAGE_TOKENS`` aliases THIS constant so the two can never
+#: drift) — using a lower figure here would let image-heavy no-usage turns
+#: slip past ``max_total_tokens`` enforcement (Qodo, PR #1783). Deliberately
+#: conservative, consistent with the estimator's floor-not-exact contract
+#: (TASK-17610).
+NON_TEXT_PART_TOKEN_ESTIMATE = 1024
 
 _CJK_RANGES = (
     (0x3000, 0x303F),  # CJK Symbols and Punctuation (。、「」etc.)


### PR DESCRIPTION
## Summary

Closes TASK-17610 — a pre-existing bug found during the V1.5 annotate-loop work (#1779): a vision/attachment-shaped user message (`content` = OpenAI part-list) crashed `Utils/token_counter.py`'s char-based fallback whenever no provider usage was reported — `_chars_estimate` iterated the *list* as characters and called `ord()` on dict items.

**Fix (at the `estimate_tokens` boundary, so the tiktoken path is covered too):** new `_flatten_message_content` normalizes any content shape — string passthrough; part-lists yield their concatenated text parts plus a count of non-text parts; anything else falls back to its string form. Each non-text part contributes `NON_TEXT_PART_TOKEN_ESTIMATE = 85` (the published GPT-4V low-detail image cost, documented as a conservative floor consistent with the estimator's contract).

**Workaround removed (AC#2):** the delivery suite's list-content test no longer monkeypatches `_usage_total_tokens` — it exercises the real no-usage fallback path unpatched and passes; the orphaned module import went with it.

## Testing

- 3 new regression tests in `Tests/Chat/test_token_counter.py` (text+image list, image-only list, `count_tokens_messages` end-to-end), all proven red pre-fix (`TypeError`).
- Consumer regression net green: token_counter 34, diff-feedback delivery 14, cost-tracker + history-budget + session-settings + agent-bridge 365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents token estimation from crashing on multimodal list-shaped message content when usage is missing. Previously the char-based fallback iterated list items and raised; now `estimate_tokens` normalizes content and charges non-text parts at 1024 tokens each, aligned with budget enforcement (TASK-17610).

- Adds `\_flatten_message_content`: strings passthrough; part-lists become concatenated text plus a count of non-text parts; other shapes fall back to `str(...)`.
- Sets `NON_TEXT_PART_TOKEN_ESTIMATE = 1024`; `console_history_budget.DEFAULT_PER_IMAGE_TOKENS` now aliases it, with a parity test to prevent drift.
- Normalizes at the `estimate_tokens` boundary so both custom-tokenizer and `tiktoken` paths handle list content.
- Removes the delivery test monkeypatch and its orphaned import; the real no-usage fallback now runs unpatched.
- Adds regression tests for text+image lists, image-only lists, message-level counting, and budget/estimator parity.
- Behavior change: multimodal messages now return a nonzero estimate that includes the fixed per-part cost; expect higher totals versus prior crash/zero paths.

<sup>Written for commit 9085a8a1afa108d8701677de5da638bb953305fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

