### PR TITLE
Four-seam keyword: adopt and_then_prefix (TASK-17755)

### DIFF
--- a/Tests/Library/test_library_keyword_and_then_prefix.py
+++ b/Tests/Library/test_library_keyword_and_then_prefix.py
@@ -1,0 +1,565 @@
+"""The four-seam keyword path runs ``and_then_prefix`` (TASK-17755).
+
+TASK-3997 measured what the Library's plain Search path's AND-strictness
+costs on the gated corpus (172 docs, 53 ground-truthed golden queries) and
+the owner ruled on 2026-08-18:
+
+| construction | MRR | zero-row queries |
+|---|---|---|
+| AND-strict (shipped until now) | 0.396 | 32 of 53 |
+| pure prefix OR | 0.261 | 0 |
+| **and_then_prefix** | **0.423** | 25 |
+
+The naive fix -- replace AND with OR/prefix outright -- was measured *worse*
+than the status quo, because 20-30 loosely-matching rows per query on a
+172-document corpus bury the answers AND was already getting right.
+``and_then_prefix`` beats both, and the reason is structural rather than
+statistical: **a sub-leg whose AND primary returned rows never runs the
+widening form at all**, so the only results it can change are the ones that
+were empty. That property is what makes this a low-risk change, and it is
+the first thing pinned below -- pinned by asserting the prefix form is never
+*built*, not merely that the rows happen to come out the same. A test that
+only compares output cannot tell "the fallback correctly did not fire" from
+"the fallback fired and happened to return the same rows".
+
+The five pins:
+
+(a) **sub-leg byte-identity** -- a seam whose primary returns rows returns
+    exactly the rows it returned before, and the prefix form is never built;
+(b) **query-level byte-identity** -- a four-seam query where every seam's
+    primary returns rows is untouched, prefix form never built, no extra
+    query issued to any seam;
+(c) **the zero-row rescue** -- a seam whose primary returns nothing runs the
+    prefix form and comes back with rows;
+(d) **per-sub-leg independence** -- one query, one seam whose primary hits
+    and three whose primaries miss: the hitter keeps its AND rows untouched
+    while the other three are rescued. The decision is per sub-leg, exactly
+    as the engine makes it (`RAGService._fts_rows_with_fallback`), never
+    per query;
+(e) **the merge contract survives** -- TASK-16071's rank-fair round-robin
+    (`interleave_rankings` keyed on `_keyword_row_identity`) still holds
+    with fallback rows in the mix: every seam's rows are present, nothing is
+    truncated, and position-then-seam-order still decides.
+
+Real databases throughout, for the reason TASK-16071's suite gives: the
+behaviour under test is what four independently-capped seams do when merged,
+and no double reproduces that. The vocabulary is chosen so the AND primary's
+own plural/singular widening cannot reach the rescue documents -- "tension"
+does not widen to "tensioner" -- which is what makes a prefix rescue
+distinguishable from the widening the path already had.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Callable
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+from tldw_chatbook.Library import library_local_rag_search_service as seam_module
+from tldw_chatbook.Library.library_fts_query import (
+    build_fts_match_query,
+    build_prefix_match_query,
+)
+from tldw_chatbook.Library.library_local_rag_search_service import (
+    LibraryLocalRagSearchService,
+)
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
+from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+from tldw_chatbook.Notes.notes_scope_service import NotesScopeService
+from tldw_chatbook.Prompt_Management.prompt_scope_service import (
+    LocalPromptService,
+    PromptScopeService,
+)
+
+#: A term every seeded document carries, so a one-term query reaches all four
+#: seams' primaries at once (pins a and b).
+SHARED = "kestrel"
+
+#: Present verbatim in the NOTES document only.
+EXACT = "tension"
+
+#: Present in the media/conversations/prompts documents only. It begins with
+#: `EXACT`, so a PREFIX form reaches it -- while `build_fts_match_query`'s
+#: plural/singular widening ("tension" -> "tensions") provably cannot. That
+#: gap is the whole experiment: a rescue here is a rescue by the new form,
+#: not by widening the path already shipped.
+PREFIXED = "tensioner"
+
+#: Notes' primary hits, the other three seams' primaries return zero.
+SPLIT_QUERY = f"{SHARED} {EXACT}"
+
+#: Every seam's primary hits: the untouched-by-construction case.
+ALL_PRIMARY_QUERY = SHARED
+
+ALL_SOURCES = ("notes", "media", "conversations", "prompts")
+NOTE, MEDIA, CONVERSATION, PROMPT = "note", "media", "conversation", "prompt"
+
+_USER_ID = "prefix-fallback-user"
+_CLIENT_ID = "prefix-fallback-client"
+
+def _notes_body(marker: str) -> str:
+    """A notes body carrying `EXACT` verbatim -- reachable by the AND primary."""
+    return (
+        f"Inspection record {marker}: the {SHARED} gauge logs {EXACT} "
+        f"across the mast."
+    )
+
+
+def _prefixed_body(marker: str) -> str:
+    """A body carrying only `PREFIXED` -- reachable ONLY by the prefix form.
+
+    The `marker` is not decoration: the media writer rejects a second
+    document with identical content as a duplicate ("Overwrite not
+    enabled"), so seeding several rows per seam requires distinct bodies.
+    """
+    return (
+        f"Inspection record {marker}: the {SHARED} bracket carries a "
+        f"{PREFIXED} and a shim."
+    )
+
+
+@dataclass
+class Seams:
+    """A live four-seam app double over four real, seeded databases."""
+
+    app: SimpleNamespace
+
+
+@pytest.fixture
+def seams(tmp_path) -> Callable[..., Seams]:
+    """Seed the four seams with per-seam bodies and return the app double.
+
+    Distinct from `test_library_keyword_cross_seam.py`'s `four_seams`, which
+    gives every seam the same body on purpose (its subject is the merge, so
+    every seam must match every query). This one's subject is *divergence*
+    between seams under one query, so the bodies have to differ.
+    """
+    closers: list[Callable[[], None]] = []
+
+    def build(*, notes: int = 1, media: int = 1, conversations: int = 1,
+              prompts: int = 1) -> Seams:
+        notes_dir = tmp_path / "prefix_notes"
+        notes_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        chachanotes_db = CharactersRAGDB(
+            tmp_path / "prefix_chachanotes.db", client_id=_CLIENT_ID
+        )
+        closers.append(chachanotes_db.close_connection)
+        media_db = MediaDatabase(tmp_path / "prefix_media.db", client_id=_CLIENT_ID)
+        closers.append(media_db.close_connection)
+        prompts_db = PromptsDatabase(
+            tmp_path / "prefix_prompts.db", client_id=_CLIENT_ID
+        )
+        closers.append(prompts_db.close_connection)
+        notes_service = NotesInteropService(
+            base_db_directory=notes_dir,
+            api_client_id=_CLIENT_ID,
+            global_db_to_use=chachanotes_db,
+        )
+        closers.append(
+            lambda: [
+                db.close_connection()
+                for db in notes_service._db_instances.values()
+                if db is not chachanotes_db
+            ]
+        )
+
+        for index in range(notes):
+            assert notes_service.add_note(
+                _USER_ID, f"Record N{index}", _notes_body(f"N{index}")
+            ), f"note {index} write failed"
+        for index in range(media):
+            media_id, _uuid, message = media_db.add_media_with_keywords(
+                title=f"Record M{index}",
+                media_type="document",
+                content=_prefixed_body(f"M{index}"),
+            )
+            assert media_id is not None, f"media {index} write failed: {message}"
+        for index in range(conversations):
+            conversation_id = chachanotes_db.add_conversation(
+                {"title": f"Record C{index}"}
+            )
+            assert conversation_id, f"conversation {index} write failed"
+            chachanotes_db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "user",
+                    "content": _prefixed_body(f"C{index}"),
+                    "timestamp": "2026-01-01T00:00:00Z",
+                }
+            )
+        for index in range(prompts):
+            prompt_id, _uuid, message = prompts_db.add_prompt(
+                name=f"Record P{index}",
+                author="tester",
+                details=None,
+                system_prompt=_prefixed_body(f"P{index}"),
+            )
+            assert prompt_id is not None, f"prompt {index} write failed: {message}"
+
+        return Seams(
+            app=SimpleNamespace(
+                notes_scope_service=NotesScopeService(
+                    local_notes_service=notes_service, server_service=None
+                ),
+                notes_user_id=_USER_ID,
+                media_reading_scope_service=MediaReadingScopeService(
+                    LocalMediaReadingService(media_db), None
+                ),
+                chachanotes_db=chachanotes_db,
+                prompt_scope_service=PromptScopeService(
+                    local_service=LocalPromptService(prompts_db),
+                    server_service=None,
+                ),
+            )
+        )
+
+    try:
+        yield build
+    finally:
+        for close in reversed(closers):
+            close()
+
+
+@pytest.fixture
+def prefix_spy(monkeypatch):
+    """Count every construction of the PREFIX form, at the CONSUMER namespace.
+
+    Patched on `library_local_rag_search_service`, never on the defining
+    module. TASK-3997's own A/B run was invalidated exactly once by getting
+    this wrong: the seam does `from ... import build_prefix_match_query`,
+    which binds the name at import time, so patching the definition site
+    changes nothing and the "intervention" silently does nothing -- which
+    produces a perfect-looking null rather than an error.
+
+    Guarded against that here: the fixture asserts the name it is replacing
+    is actually the one the seam module holds, so a future refactor that
+    stops importing it this way fails loudly instead of neutering the spy.
+    """
+    assert seam_module.build_prefix_match_query is build_prefix_match_query, (
+        "the seam module no longer holds the imported prefix builder; this "
+        "spy would patch a name nothing calls"
+    )
+
+    calls: list[str] = []
+
+    def spy(query: str) -> str:
+        calls.append(query)
+        return build_prefix_match_query(query)
+
+    monkeypatch.setattr(seam_module, "build_prefix_match_query", spy)
+    return calls
+
+
+async def _search(app, query: str, sources=ALL_SOURCES, *, top_k: int = 5):
+    """Run the production keyword path and return its merged rows."""
+    result = await LibraryLocalRagSearchService(app).search(
+        query, tuple(sources), "search", top_k=top_k
+    )
+    assert isinstance(result, dict), f"expected rows, got outcome: {result!r}"
+    return list(result["results"])
+
+
+def _keys(rows) -> list:
+    """Each row's identity, read through the merge's OWN key function.
+
+    `_keyword_row_identity`, not a hand-rolled `(type, id)` tuple: pin (e)
+    is a claim about what `interleave_rankings` dedups on, and restating the
+    key here would let the two drift while the pin kept passing.
+    """
+    return [seam_module._keyword_row_identity(row) for row in rows]
+
+
+def _types(rows) -> list[str]:
+    return [row["provenance"]["source_type"] for row in rows]
+
+
+# --- (a) sub-leg byte-identity: the property that makes this low-risk -------
+
+
+@pytest.mark.asyncio
+async def test_a_sub_leg_whose_primary_returns_rows_never_builds_the_prefix_form(
+    seams, prefix_spy
+):
+    """AC#2 at the sub-leg. The rescue path is not merely unused -- unbuilt.
+
+    Asserting on the ROWS alone would pass just as happily if the fallback
+    had run and returned the same document, which is the failure mode that
+    would make this change risky without anyone noticing. So the assertion
+    is on the construction counter.
+    """
+    app = seams().app
+    service = LibraryLocalRagSearchService(app)
+
+    available, rows = await service._search_notes(SPLIT_QUERY, 5, _USER_ID)
+
+    assert available is True
+    assert len(rows) == 1, f"expected the notes primary to hit: {rows!r}"
+    assert prefix_spy == [], (
+        "the prefix form was built for a sub-leg whose primary returned "
+        f"rows: {prefix_spy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_hitting_sub_legs_rows_are_byte_identical_to_the_and_only_answer(
+    seams,
+):
+    """The rows themselves, compared against the AND expression run directly.
+
+    The reference is read UPSTREAM of the seam method -- straight from the
+    notes service with `build_fts_match_query`'s expression -- rather than
+    from a second `_search_notes` call, so the comparison cannot pass
+    against itself the way a same-path reference would.
+    """
+    app = seams().app
+    service = LibraryLocalRagSearchService(app)
+
+    _available, rows = await service._search_notes(SPLIT_QUERY, 5, _USER_ID)
+    reference = await app.notes_scope_service.search_notes(
+        scope="local_note",
+        query=SPLIT_QUERY,
+        limit=5,
+        user_id=_USER_ID,
+        fts_match_query=build_fts_match_query(SPLIT_QUERY),
+    )
+
+    assert _keys(rows) == [
+        seam_module._keyword_row_identity(seam_module._note_row(item))
+        for item in reference
+    ]
+
+
+# --- (b) query-level byte-identity: no fallback, no extra query -------------
+
+
+@pytest.mark.asyncio
+async def test_a_query_every_seam_matches_is_untouched_by_the_construction(
+    seams, prefix_spy
+):
+    """AC#2 at the query. All four primaries hit; nothing widens."""
+    app = seams().app
+
+    rows = await _search(app, ALL_PRIMARY_QUERY)
+
+    assert sorted(_types(rows)) == sorted(
+        [NOTE, MEDIA, CONVERSATION, PROMPT]
+    ), f"every seam should have contributed its primary row: {_types(rows)!r}"
+    assert prefix_spy == [], (
+        f"a fallback was built for an all-primary query: {prefix_spy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_all_primary_query_issues_exactly_one_match_per_seam(seams):
+    """"No extra query" is a claim about the DATABASE, so count DB calls.
+
+    Wraps the notes seam's own service call. A fallback that never fires
+    still costs nothing only if the second MATCH is never issued.
+    """
+    app = seams().app
+    real_search = app.notes_scope_service.search_notes
+    issued: list[str] = []
+
+    async def counting_search(**kwargs):
+        issued.append(kwargs.get("fts_match_query"))
+        return await real_search(**kwargs)
+
+    app.notes_scope_service.search_notes = counting_search
+
+    _available, rows = await LibraryLocalRagSearchService(app)._search_notes(
+        ALL_PRIMARY_QUERY, 5, _USER_ID
+    )
+
+    assert rows, "the primary was supposed to hit"
+    assert issued == [build_fts_match_query(ALL_PRIMARY_QUERY)], (
+        f"expected exactly the AND primary and nothing else: {issued!r}"
+    )
+
+
+# --- (c) the zero-row rescue ------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "seam, source_type",
+    [("media", MEDIA), ("conversations", CONVERSATION), ("prompts", PROMPT)],
+)
+async def test_a_zero_row_sub_leg_is_rescued_by_the_prefix_form(
+    seams, prefix_spy, seam, source_type
+):
+    """AC#1/AC#3. The document is unreachable under AND and reachable now."""
+    app = seams().app
+    service = LibraryLocalRagSearchService(app)
+    call = {
+        "media": lambda: service._search_media(SPLIT_QUERY, 5),
+        "conversations": lambda: service._search_conversations(SPLIT_QUERY, 5),
+        "prompts": lambda: service._search_prompts(SPLIT_QUERY, 5),
+    }[seam]
+
+    available, rows = await call()
+
+    assert available is True
+    assert _types(rows) == [source_type], (
+        f"the {seam} seam was not rescued: {rows!r}"
+    )
+    assert prefix_spy == [SPLIT_QUERY], (
+        f"expected exactly one prefix build for the empty sub-leg: {prefix_spy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_query_no_form_can_match_still_returns_nothing(seams, prefix_spy):
+    """The rescue is a widening, not a guarantee of rows.
+
+    The fallback runs (the primary was empty) and honestly finds nothing --
+    the arm that proves the pin above is measuring a real match rather than
+    an unconditional "return something".
+    """
+    app = seams().app
+
+    rows = await _search(app, "wombat")
+
+    assert rows == []
+    assert prefix_spy, "the fallback should have been attempted"
+
+
+@pytest.mark.asyncio
+async def test_an_all_function_word_query_never_runs_an_unbounded_prefix(seams):
+    """Trimming to nothing means no rows, never `"the"*` over the corpus.
+
+    A stopword prefix matches "the", "then", "there", "their", "these" --
+    nearly a whole corpus -- and the prefix form ANDs its terms, so one such
+    term drags the whole expression toward matching everything. The shared
+    builder answers "" for that case and the seam must skip the query
+    entirely rather than widen to it.
+    """
+    app = seams().app
+    real_search = app.notes_scope_service.search_notes
+    issued: list[str] = []
+
+    async def counting_search(**kwargs):
+        issued.append(kwargs.get("fts_match_query"))
+        return await real_search(**kwargs)
+
+    app.notes_scope_service.search_notes = counting_search
+
+    _available, rows = await LibraryLocalRagSearchService(app)._search_notes(
+        "of the", 5, _USER_ID
+    )
+
+    assert rows == []
+    assert issued == [build_fts_match_query("of the")], (
+        f"a second, unbounded MATCH was issued: {issued!r}"
+    )
+
+
+# --- (d) the decision is per sub-leg, not per query -------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_query_mixes_a_primary_sub_leg_with_three_rescued_ones(
+    seams, prefix_spy
+):
+    """AC#1's "per sub-leg" clause, and AC#4's divergence, in one query.
+
+    `SPLIT_QUERY` hits the notes seam's AND primary and misses the other
+    three. Per-QUERY fallback would either leave all four alone (no rescue)
+    or widen all four (the notes row displaced by loose matches). Per-SUB-
+    LEG gives the only correct answer: notes untouched, three rescued.
+    """
+    app = seams().app
+
+    rows = await _search(app, SPLIT_QUERY)
+
+    assert sorted(_types(rows)) == sorted(
+        [NOTE, MEDIA, CONVERSATION, PROMPT]
+    ), f"expected one row per seam: {_types(rows)!r}"
+    assert len(prefix_spy) == 3, (
+        "expected exactly three prefix builds -- one per zero-row sub-leg, "
+        f"none for the hitter: {prefix_spy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_rescued_seam_does_not_change_another_seams_rows(seams):
+    """Independence, checked against the seam's own solo answer.
+
+    The notes rows from the four-seam call must equal the notes rows from a
+    notes-only call: three other seams falling back around it changes
+    nothing about what notes returns.
+    """
+    app = seams().app
+
+    four_seam_rows = await _search(app, SPLIT_QUERY)
+    notes_only_rows = await _search(app, SPLIT_QUERY, sources=("notes",))
+
+    notes_from_four = [
+        key for row, key in zip(four_seam_rows, _keys(four_seam_rows))
+        if row["provenance"]["source_type"] == NOTE
+    ]
+    assert notes_from_four == _keys(notes_only_rows)
+
+
+# --- (e) the TASK-16071 merge contract, with fallback rows present ----------
+
+
+@pytest.mark.asyncio
+async def test_the_rank_fair_merge_still_holds_when_seams_mix_forms(seams):
+    """TASK-16071's contract survives the new construction.
+
+    Three seams' rows now arrive from a *fallback* form while one arrives
+    from the primary. The merge is `interleave_rankings` keyed on
+    `_keyword_row_identity` and knows nothing about forms, so what must
+    still hold is exactly what held before: every seam represented, nothing
+    truncated, and `_KNOWN_KEYWORD_SOURCE_TYPES` order breaking the tie at
+    equal rank.
+
+    NOTE for whoever changes this next: the Library merge is deliberately
+    UNTIERED, unlike the engine's (TASK-15700). This test pins the untiered
+    order that TASK-3997 measured `and_then_prefix` at. If tiering is ever
+    adopted here -- putting whole primary-form sub-legs ahead of fallback
+    ones -- this expectation changes and the change must be re-measured, not
+    just re-stamped.
+    """
+    app = seams(notes=3, media=3, conversations=3, prompts=3).app
+
+    rows = await _search(app, SPLIT_QUERY, top_k=3)
+
+    assert len(rows) == 12, f"no seam's rows may be dropped: {_types(rows)!r}"
+    assert _types(rows)[:4] == [NOTE, MEDIA, CONVERSATION, PROMPT], (
+        f"position 0 of each seam must come first, in seam order: {_types(rows)!r}"
+    )
+    assert len(set(_keys(rows))) == 12, f"the dedup key collided: {_keys(rows)!r}"
+
+
+@pytest.mark.asyncio
+async def test_rescued_rows_carry_the_same_row_shape_as_primary_rows(seams):
+    """A fallback row is a row: same builder, same provenance, same identity.
+
+    Cheap to get wrong (a second code path that hand-builds rows), and it
+    would break `_keyword_row_identity` and every downstream consumer
+    silently -- the merge would still "work", on garbage keys.
+    """
+    app = seams().app
+    service = LibraryLocalRagSearchService(app)
+
+    _a, primary_rows = await service._search_notes(SPLIT_QUERY, 5, _USER_ID)
+    _b, rescued_rows = await service._search_media(SPLIT_QUERY, 5)
+
+    assert primary_rows and rescued_rows
+    assert set(primary_rows[0]) == set(rescued_rows[0]), (
+        "the rescued row has a different key set than a primary row: "
+        f"{sorted(set(primary_rows[0]) ^ set(rescued_rows[0]))!r}"
+    )
+    assert rescued_rows[0]["provenance"]["source_type"] == MEDIA
+    assert rescued_rows[0]["score"] is None, (
+        "rescued rows must keep the path's no-score contract, which the "
+        "rank-fair merge depends on"
+    )

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -18,7 +18,14 @@ every golden query through the real seam across all three profile modes.
 > P2ab; TASK-15400's construction flip took it the rest of the way), and the
 > baselines were re-stamped once, deliberately, at the end of each arc that
 > moved a cell — TASK-15700 (2026-08-13) moved the default a second time and
-> moved **none**, so it re-stamped nothing and said so. Two candidate
+> moved **none**, so it re-stamped nothing and said so. **TASK-17755
+> (2026-08-18) re-stamped `plain.json` and only `plain.json`**: adopting the
+> engine's `and_then_prefix` construction on the Library's four-seam keyword
+> path took plain overall MRR/precision 0.304 → 0.326 and the `keyword`
+> category 0.875 → 0.938 (all ten plain cells up; `mean_docs_at_k`
+> 0.304 → 0.457), while every `semantic` and `hybrid` cell held at +0.000 —
+> that mode split is the evidence the change is confined to the path it
+> claims. Two candidate
 > classes (`compositional`, `acronym`) proved **unfailable** on this corpus
 > and model and were not authored — that is recorded evidence against two
 > P2c feature premises, not an omission. A **fourth** premise died the same

--- a/Tests/RAG_Eval/baselines/plain.json
+++ b/Tests/RAG_Eval/baselines/plain.json
@@ -1,6 +1,6 @@
 {
   "baseline_id": "plain",
-  "created_at": "2026-08-12T23:01:15.692447+00:00",
+  "created_at": "2026-08-18T02:04:39.534789+00:00",
   "pipeline_config": {
     "mode": "plain",
     "k": 10,
@@ -13,16 +13,16 @@
     ]
   },
   "metrics": {
-    "overall.precision": 0.30434782608695654,
-    "overall.recall": 0.29347826086956524,
-    "overall.mrr": 0.30434782608695654,
-    "overall.ndcg": 0.295937982451423,
-    "overall.f1": 0.2971014492753623,
-    "category.keyword.precision": 0.875,
-    "category.keyword.recall": 0.84375,
-    "category.keyword.mrr": 0.875,
-    "category.keyword.ndcg": 0.8508216995478411,
-    "category.keyword.f1": 0.8541666666666666,
+    "overall.precision": 0.32608695652173914,
+    "overall.recall": 0.31521739130434784,
+    "overall.mrr": 0.32608695652173914,
+    "overall.ndcg": 0.3176771128862056,
+    "overall.f1": 0.3188405797101449,
+    "category.keyword.precision": 0.9375,
+    "category.keyword.recall": 0.90625,
+    "category.keyword.mrr": 0.9375,
+    "category.keyword.ndcg": 0.9133216995478411,
+    "category.keyword.f1": 0.9166666666666666,
     "category.negation.precision": 0.0,
     "category.negation.recall": 0.0,
     "category.negation.mrr": 0.0,
@@ -59,17 +59,17 @@
       "platform": "darwin"
     },
     "environment_info": {
-      "sentence_transformers": "5.4.1"
+      "sentence_transformers": "5.7.0"
     },
     "report_only": {
       "latency": {
         "count": 60.0,
-        "mean_ms": 14.2,
-        "p95_ms": 24.8,
-        "max_ms": 33.4,
-        "total_s": 0.8
+        "mean_ms": 18.4,
+        "p95_ms": 31.1,
+        "max_ms": 41.6,
+        "total_s": 1.1
       },
-      "mean_docs_at_k": 0.304,
+      "mean_docs_at_k": 0.457,
       "num_queries": 46,
       "num_golden_queries": 60,
       "num_negative": 7,

--- a/Tests/RAG_Eval/test_cross_encoder_probe_run.py
+++ b/Tests/RAG_Eval/test_cross_encoder_probe_run.py
@@ -106,9 +106,11 @@ EXPECTED_BACKEND = {
 }
 
 #: Arm A covers `plain` as a GUARD, not as a measurement: the census says it
-#: is the identity there, and the plan makes any movement in a plain cell a
-#: STOP rather than a result. Arm B does not -- a mode that cannot fill two
-#: slots at k=10 has nothing to promote from rank 11-20 either.
+#: is the identity there for all but one query (TASK-17755's prefix fallback
+#: took plain from 0 reorderable to 1), and the plan makes any movement in a
+#: plain cell a STOP rather than a result. Arm B does not -- a mode that
+#: still cannot fill two slots at k=10 in 59 of 60 queries has nothing to
+#: promote from rank 11-20 either.
 ARM_A_MODES: tuple[str, ...] = ("semantic", "plain", "hybrid")
 ARM_B_MODES: tuple[str, ...] = VERDICT_MODES
 
@@ -477,7 +479,10 @@ def test_the_cross_encoder_probe_over_the_real_fixtures(tmp_path, capsys, monkey
     The assertions pin **the instrument, never the outcome**: that the model
     ran, that the census is the one the verdict rests on, that every pass
     routed to the mode it claims, that arm A's before-column is the shipped
-    measurement, and that `plain` did not move. An assertion that reranking
+    measurement, and that no `plain` METRIC moved (TASK-17755 made plain
+    reorderable for exactly one query, so the row-order half of that pin is
+    now a census-consistency check rather than a flat zero). An assertion
+    that reranking
     HELPS would turn the arc's pre-authorised NULL into a red test, which is
     the opposite of what this probe is for.
     """
@@ -682,23 +687,64 @@ def test_the_cross_encoder_probe_over_the_real_fixtures(tmp_path, capsys, monkey
                 "measured nothing and its null is uninterpretable"
             )
     plain_census = census_by_key[("plain", ARM_A_DEPTH)]
-    assert plain_census.reorderable == 0, (
+    # RE-DERIVED 2026-08-18 (TASK-17755), which is what this assertion's own
+    # message demanded when it tripped. TASK-16071 and TASK-16965 both
+    # measured 0 here, and the reason was structural: the four-seam plain
+    # path ANDed every query term, so it returned either nothing (39 of 60)
+    # or exactly one row (21) and NEVER two. TASK-17755 gave that path the
+    # engine's `and_then_prefix` construction -- a per-sub-leg prefix
+    # fallback for a seam whose AND primary found nothing -- and the census
+    # moved to 37 zero-row / 22 one-row / 1 reorderable. That is the change
+    # working: two queries that returned nothing now return something, and
+    # one of them returns two rows.
+    #
+    # Still an EXACT equality, not a relaxed bound: the premise it guards
+    # ("a plain null is uninterpretable if plain could be reordered") is now
+    # true for 59 of 60 queries instead of 60, and the one exception is
+    # covered by MEASUREMENT rather than by census -- `row_order_changes`
+    # below asserts the reranker in fact left it alone. If that ratio drifts
+    # again, this trips again, on purpose.
+    assert plain_census.reorderable == 1, (
         f"plain now has {plain_census.reorderable} reorderable queries "
-        "(TASK-16071 and this arc's census both measured 0). The premise "
-        "that plain is the identity under a reranker no longer holds — STOP "
-        "and re-derive the census before reading any verdict above."
+        "(TASK-17755's census measured 1; TASK-16071 and TASK-16965 measured "
+        "0 before the `and_then_prefix` adoption). The premise that plain is "
+        "near-identity under a reranker has shifted again — STOP and "
+        "re-derive the census before reading any verdict above."
     )
-    assert plain_arm.row_order_changes == 0, (
-        "reranking MOVED a plain row. Per the plan that is a STOP-and-report, "
-        "not a result."
+    assert plain_arm.queries_reordered <= plain_census.reorderable, (
+        "reranking permuted a plain query the census says has fewer than two "
+        f"rows ({plain_arm.queries_reordered} queries reordered vs "
+        f"{plain_census.reorderable} reorderable). That is impossible for a "
+        "reranker and means the probe is wrong -- STOP-and-report, not a "
+        "result."
     )
+    # WHAT THIS PIN USED TO SAY, and why it does not any more (TASK-17755).
+    # It read `plain_arm.row_order_changes == 0`, and that held for a
+    # structural reason rather than a behavioural one: the plain path's
+    # AND-strict construction never returned two rows for any golden query,
+    # so no reranker could permute anything. TASK-17755's `and_then_prefix`
+    # adoption rescued two zero-row queries, one of them with several rows,
+    # and the cross-encoder duly permuted that one window (measured: 5 row
+    # positions, 1 query, 28 plain rows scored, 0 failed).
+    #
+    # The arc's actual CONCLUSION is untouched, and the loop below is where
+    # it lives: every plain metric still moves by exactly +0.000 -- the
+    # order-sensitive MRR and NDCG included, not just the set-valued
+    # P/R/F1 -- so reranking remains the identity on plain where it counts.
+    # What was lost is only the census's structural PROOF of that for one
+    # query out of sixty; it is now covered by measurement instead. The
+    # assertion above keeps the part that is still structural: a reranker
+    # cannot reorder a window it was never given, so more reordered queries
+    # than reorderable ones would indict the probe.
     for move in metric_moves(
         plain_arm.before, plain_arm.after, ("mrr", "ndcg", "precision", "recall", "f1")
     ):
         assert move.delta == 0.0, (
-            f"plain/{move.metric} moved by {move.delta:+.6f}; reranking is "
-            "provably the identity on plain by census, so a moved plain cell "
-            "means the probe is wrong, not that reranking works"
+            f"plain/{move.metric} moved by {move.delta:+.6f}. Reranking is "
+            "the identity on plain for 59 of 60 golden queries by census and "
+            "was MEASURED to be the identity on the 60th (TASK-17755), so a "
+            "moved plain cell means the probe is wrong, not that reranking "
+            "works"
         )
 
     assert isinstance(arc_verdict, Verdict), (

--- a/Tests/RAG_Search/test_fts5_match_forms_shared.py
+++ b/Tests/RAG_Search/test_fts5_match_forms_shared.py
@@ -1,0 +1,280 @@
+"""The engine and the Library share ONE prefix form and ONE word list.
+
+TASK-17755 gave the Library's four-seam plain-Search path the
+``and_then_prefix`` construction the engine's keyword leg has run since
+TASK-15700. Both now need the PREFIX form and the function-word list it
+trims with, and the obvious way to get there -- paste the 67-word frozenset
+and the ``"tok"*`` builder into the Library module -- is the failure this
+file exists to prevent.
+
+It is not a hypothetical. The reason TASK-17755 was worth doing at all is
+that the Library SCREEN runs both paths: its **Search** tab is the four-seam
+one and its **RAG Answer** tab is the engine, and TASK-3997 documented a
+user getting two different matching rules on one screen (an inflection miss
+answered in one tab and returned nothing in the other). Two copies of the
+widening form would re-open exactly that gap the first time either copy was
+edited, and it would present as a retrieval bug with no obvious cause --
+both code paths look correct in isolation.
+
+So: one definition in `Utils/fts5_match_forms.py`, imported by both. These
+pins fail if a future edit re-introduces a second copy, and -- because
+identity is asserted, not just equality -- they fail while the two copies
+still agree, which is the only moment at which the problem is cheap to fix.
+
+The third pin is the one that would matter if the extraction were done
+carelessly: the engine's expression must be BYTE-IDENTICAL to what it built
+inline before, since `and_then_prefix` is the shipped default and TASK-15700
+measured it in that exact form.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+from tldw_chatbook.Library.library_fts_query import (
+    build_fts_match_query,
+    build_prefix_match_query,
+)
+from tldw_chatbook.Library.library_local_rag_search_service import (
+    LibraryLocalRagSearchService,
+)
+from tldw_chatbook.Prompt_Management.prompt_scope_service import (
+    LocalPromptService,
+    PromptScopeService,
+)
+from tldw_chatbook.RAG_Search.simplified import rag_service as engine_module
+from tldw_chatbook.RAG_Search.simplified.rag_service import (
+    FTS_MATCH_CONSTRUCTION_AND_THEN_PREFIX,
+    RAGConfig,
+    RAGService,
+)
+from tldw_chatbook.Utils.fts5_match_forms import (
+    FTS5_STOPWORDS,
+    build_prefix_match_expression,
+    fts5_query_tokens,
+)
+
+#: Queries chosen to exercise every branch the two paths could diverge on:
+#: a plain multi-token query, function words in the middle and at both ends,
+#: a query that is nothing BUT function words, punctuation-only tokens,
+#: multi-run tokens, case, and FTS5 operator syntax typed as user text.
+QUERIES = [
+    "feedback loop",
+    "the tension in the guy wire",
+    "of the",
+    "!!! ???",
+    "read-only Obsidian-3 vault",
+    "Wombat WOMBAT wombat,",
+    "search OR delete NOT keep",
+    'a "quoted" phrase',
+    "single",
+    "",
+]
+
+
+def _engine_service() -> RAGService:
+    """A RAGService under the shipped ``and_then_prefix`` construction."""
+    cfg = RAGConfig()
+    cfg.embedding.model = "mock"
+    cfg.embedding.device = "cpu"
+    cfg.vector_store.type = "memory"
+    cfg.vector_store.persist_directory = None
+    cfg.search.enable_cache = False
+    cfg.search.fts_match_construction = FTS_MATCH_CONSTRUCTION_AND_THEN_PREFIX
+    return RAGService(cfg)
+
+
+def test_the_stopword_list_is_one_object_not_two_that_agree():
+    """Identity, not equality -- equality passes right up until it doesn't."""
+    assert engine_module._FTS5_STOPWORDS is FTS5_STOPWORDS, (
+        "the engine has its own copy of the function-word list again; the "
+        "Library's prefix fallback and the engine's will drift apart"
+    )
+    assert len(FTS5_STOPWORDS) == 67, (
+        "the list changed size; it is fixed and small on purpose -- a large "
+        "list starts deleting the content words TASK-15400's census "
+        "measured as the real blockers"
+    )
+    assert all(word == word.lower() for word in FTS5_STOPWORDS)
+
+
+def test_the_engine_and_the_library_build_the_same_prefix_form():
+    """The two paths' widening expressions are the same string, per query."""
+    service = _engine_service()
+
+    for query in QUERIES:
+        _primary, engine_fallback = service._fts5_match_expressions(query)
+        library_fallback = build_prefix_match_query(query)
+        # The engine reports "no widening available" as None and the
+        # Library as "" -- both mean "skip the query", and neither path
+        # ever runs the expression. Normalize before comparing so the pin
+        # is about the FORM, not about two callers' empty conventions.
+        assert (engine_fallback or "") == library_fallback, (
+            f"{query!r}: engine built {engine_fallback!r}, Library built "
+            f"{library_fallback!r}"
+        )
+
+
+def test_the_extracted_builder_is_byte_identical_to_the_inline_construction():
+    """The engine's shipped default must not have moved during extraction.
+
+    Reproduces the exact expression TASK-15700's inline code built --
+    content tokens, quoted, star OUTSIDE the quotes, space-joined -- from
+    the engine's own tokenizer and stopword predicate, and compares it to
+    what the shared builder now returns.
+    """
+    service = _engine_service()
+
+    for query in QUERIES:
+        tokens = service._fts5_query_tokens(query)
+        quoted = [
+            service._quote_fts5_token(token)
+            for token in tokens
+            if not service._is_fts5_stopword(token)
+        ]
+        inline = " ".join(f"{token}*" for token in quoted)
+
+        assert build_prefix_match_expression(tokens) == inline, query
+
+
+def test_the_prefix_form_never_stars_a_function_word():
+    """The property the whole trim exists for.
+
+    ``"the"*`` matches "the", "then", "there", "their", "these" -- nearly a
+    whole corpus -- and the prefix form ANDs its terms, so one untrimmed
+    function word drags the whole expression toward matching everything the
+    other terms allow.
+    """
+    expression = build_prefix_match_query("the tension in the guy wire")
+
+    assert expression == '"tension"* "guy"* "wire"*', expression
+    for word in ("the", "in"):
+        assert f'"{word}"*' not in expression
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        'wombat" OR nonsense:"',
+        "wombat NEAR/2 badger",
+        "title:secret",
+        "wombat) OR (badger",
+        '"',
+        "*",
+        "^wombat",
+    ],
+)
+def test_the_library_prefix_form_is_safe_against_a_real_fts5_table(hostile):
+    """User text cannot become operator syntax in the widening form either.
+
+    The AND primary's injection safety is pinned in the Library's own suite;
+    the fallback is a second expression reaching the same tables, and an
+    escape that only covers the primary covers the path that runs when a
+    search finds nothing -- i.e. exactly when a user retypes and escalates.
+    Run against a real FTS5 table because the property being asserted is
+    "SQLite parses this without error", which only SQLite can answer.
+    """
+    connection = sqlite3.connect(":memory:")
+    try:
+        connection.execute("CREATE VIRTUAL TABLE docs USING fts5(body)")
+        connection.execute("INSERT INTO docs (body) VALUES ('wombat badger')")
+        for expression in (
+            build_fts_match_query(hostile),
+            build_prefix_match_query(hostile),
+        ):
+            if not expression:
+                continue
+            connection.execute(
+                "SELECT rowid FROM docs WHERE docs MATCH ?", (expression,)
+            ).fetchall()
+    finally:
+        connection.close()
+
+
+#: The document TASK-3997's divergence example is built on: it carries
+#: "guy" and "tensioner", so the query "guy tension" is an INFLECTION MISS
+#: for the AND primary (whose widening reaches "tensions", never
+#: "tensioner") and a hit for the prefix form.
+_INFLECTION_DOC = "The mast guy tensioner was re-seated during the shift."
+_INFLECTION_QUERY = "guy tension"
+
+
+def test_plain_search_and_rag_answer_answer_the_same_inflection_miss(tmp_path):
+    """AC#4: the Library screen stops having two matching rules.
+
+    This is the argument from TASK-3997 that is not about metrics. The
+    Library's **Search** tab is the four-seam keyword path and its **RAG
+    Answer** tab is the engine's keyword leg. Until TASK-17755 the engine
+    ran `and_then_prefix` and the four-seam path ran a strict AND, so one
+    screen answered an inflection miss in one tab and returned nothing in
+    the other -- with no way for a user to tell why.
+
+    Both paths are pointed at ONE seeded prompts database here, because the
+    claim is about the same corpus and the same query. Anything less (two
+    corpora, or comparing expressions rather than rows) would leave the
+    divergence provable only in the direction it was already known.
+    """
+    db_path = tmp_path / "divergence_prompts.db"
+    db = PromptsDatabase(db_path, client_id="test_shared_match_forms")
+    try:
+        prompt_id, _uuid, message = db.add_prompt(
+            name="Guy wire handover",
+            author=None,
+            details=None,
+            system_prompt=_INFLECTION_DOC,
+        )
+        assert prompt_id is not None, f"seed failed: {message}"
+
+        # The premise: the AND primary genuinely cannot reach this document.
+        # Stated as the expression, so a future change to the plural widener
+        # that DID reach "tensioner" would red here rather than turning the
+        # rest of this test into a tautology.
+        assert build_fts_match_query(_INFLECTION_QUERY) == (
+            '("guy" OR "guys" OR "guies") AND ("tension" OR "tensions")'
+        ), "the widener changed; re-derive whether this is still a miss"
+
+        engine = _engine_service()
+        engine.config.search.prompts_db_path = db_path
+        engine_rows = asyncio.run(
+            engine._keyword_search(
+                _INFLECTION_QUERY, top_k=5, keyword_source_types={"prompt"}
+            )
+        )
+
+        library = LibraryLocalRagSearchService(
+            SimpleNamespace(
+                prompt_scope_service=PromptScopeService(
+                    local_service=LocalPromptService(db), server_service=None
+                )
+            )
+        )
+        available, library_rows = asyncio.run(
+            library._search_prompts(_INFLECTION_QUERY, 5)
+        )
+
+        assert available is True
+        assert [row.metadata["doc_title"] for row in engine_rows] == [
+            "Guy wire handover"
+        ], "RAG Answer's keyword leg lost the document it used to find"
+        assert [row["title"] for row in library_rows] == ["Guy wire handover"], (
+            "plain Search still returns nothing for a query RAG Answer "
+            "answers -- the TASK-3997 divergence is not closed"
+        )
+    finally:
+        db.close_connection()
+
+
+def test_the_shared_tokenizer_drops_tokens_fts5_could_never_match():
+    """A pure-punctuation token would AND an unmatchable term into the form.
+
+    ``"!!!"*`` matches nothing, and the prefix form ANDs its terms, so
+    carrying it would turn a rescue into a guaranteed zero-row query -- the
+    fallback silently doing nothing, which is worse than not having one.
+    """
+    assert fts5_query_tokens("wombat !!! badger") == ["wombat", "badger"]
+    assert build_prefix_match_query("wombat !!! badger") == '"wombat"* "badger"*'

--- a/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
+++ b/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
@@ -1,7 +1,7 @@
 ---
 id: task-17755
 title: Adopt and_then_prefix on the four-seam keyword path
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18'
 labels: [rag, retrieval]
@@ -39,18 +39,104 @@ other).
 
 ## Acceptance Criteria (the what)
 
-- [ ] The four-seam keyword path applies an `and_then_prefix` construction:
+- [x] The four-seam keyword path applies an `and_then_prefix` construction:
       the existing AND-of-variant-groups stays the primary, and a per-token
       prefix form runs **only** for a sub-leg whose primary returned zero rows
-- [ ] A query whose AND primary returns rows produces byte-identical results
+- [x] A query whose AND primary returns rows produces byte-identical results
       to today — pinned by a test, since this is the property that makes the
       change low-risk
-- [ ] The zero-row rescue is demonstrated on the golden set, and the measured
+- [x] The zero-row rescue is demonstrated on the golden set, and the measured
       MRR does not fall below the AND-strict baseline (0.396 on the corpus in
       TASK-3997's report)
-- [ ] Plain Search and RAG Answer answer the same inflection-miss query on the
+- [x] Plain Search and RAG Answer answer the same inflection-miss query on the
       same corpus — the divergence TASK-3997 documented is gone
-- [ ] The gated retrieval suite reads `PASSED: No regression. 105 metric(s)`;
+- [x] The gated retrieval suite reads `PASSED: No regression. 105 metric(s)`;
       note that its `plain` cells CAN legitimately move here, unlike in
       reranking arcs — if they do, the move is the deliverable and the
       baselines are re-stamped deliberately with the reason recorded
+
+## Implementation Plan (the how)
+
+1. Extract the engine's PREFIX form and function-word list into one shared,
+   dependency-free module rather than copying either.
+2. Give `library_fts_query` a `build_prefix_match_query` adapter over it.
+3. Write the zero-row fallback ONCE and route all four seams through it.
+4. RED-first tests: never-built on a hitting sub-leg, rescue on an empty one,
+   per-sub-leg independence, merge contract, cross-path agreement.
+5. Run the gate; re-stamp only the baselines that actually moved.
+
+## Implementation Notes
+
+**What shipped.** The Library's four-seam plain-Search path now runs
+`and_then_prefix`: `build_fts_match_query`'s AND-of-variant-groups stays the
+primary, and a per-token PREFIX form (`"tok"*`, function words trimmed) runs
+only for a sub-leg whose own primary returned zero rows. The decision is per
+sub-leg, matching `RAGService._fts_rows_with_fallback` — one search can carry
+AND rows from notes and prefix rows from media, which is the point.
+
+**Reuse, not duplication.** The prefix builder and the 67-word function-word
+list were *moved* to a new pure module, `Utils/fts5_match_forms.py`, and both
+consumers import it: `rag_service._FTS5_STOPWORDS` is now that same object
+(the name is kept because the engine's tests and the RAG_Eval probes read it),
+and its inline prefix construction is now a call to the shared builder. It
+lives under `Utils/` because that package's `__init__` is empty, so the pure
+`library_fts_query` module stays cheap to import — `RAG_Search/__init__` pulls
+the whole simplified engine. `Tests/RAG_Search/test_fts5_match_forms_shared.py`
+asserts the stopword list is one OBJECT, not two that agree, so a
+re-introduced copy reds while the copies still match.
+
+**The fallback is written once** (`_rows_with_prefix_fallback`), taking a
+"run this MATCH and give me rows" callable; the four seams supply only their
+own service call. Each seam's `try/except` now wraps the whole helper, so the
+error contract (`(True, [])` plus one log) is unchanged and no new failure
+mode is added.
+
+**Low-risk property, pinned by construction not by output.** The prefix form
+is built lazily, after the primary comes back empty, so a hitting sub-leg
+never constructs it — the tests count constructions and DB calls rather than
+comparing rows, because a row comparison cannot tell "the fallback correctly
+did not fire" from "it fired and returned the same thing".
+
+**Deliberately NOT tiered.** TASK-16071's merge comment said the TASK-15700
+tier design would apply here if this path ever gained fallback forms. It now
+has them, and the merge is still untiered on purpose: `and_then_prefix` was
+*measured* untiered (TASK-3997), and tiering would ship an unmeasured
+ordering. The comment at the merge site now records that as a live decision
+with a re-measure requirement, and the new suite pins the untiered order so
+it cannot change silently.
+
+**Measured effect (gated harness, 172 docs / 60 golden queries).** Only
+`plain` cells moved, all up; every `semantic` and `hybrid` cell held at
++0.000:
+
+| cell | before | after |
+|---|---|---|
+| plain overall mrr / precision | 0.304 | 0.326 |
+| plain overall ndcg | 0.296 | 0.318 |
+| plain overall f1 | 0.297 | 0.319 |
+| plain overall recall | 0.293 | 0.315 |
+| plain category.keyword.* | 0.844–0.875 | 0.906–0.938 |
+| plain mean_docs_at_k | 0.304 | 0.457 |
+
+Census: zero-row golden queries 39 → 37, one-row 21 → 22, ≥2 rows 0 → 1.
+`plain.json` re-stamped deliberately; `semantic.json`/`hybrid.json` restored
+untouched because no metric in them moved.
+
+**One collateral premise had to be re-derived.** `test_cross_encoder_probe_run`
+asserted `plain_census.reorderable == 0` and `row_order_changes == 0` — both
+resting on the structural fact that AND-strictness never returned two rows, so
+a reranker could not permute anything. One rescued query now returns several
+rows and the cross-encoder duly permuted it (5 positions, 1 query). The arc's
+actual conclusion survives intact: **every plain metric still moves by exactly
++0.000, MRR and NDCG included.** The census pin is re-stamped to the new
+measured `== 1` (still an exact equality) and the row-order pin now asserts
+`queries_reordered <= reorderable`, which keeps the part that is still
+structural — a reranker cannot reorder a window it was never given.
+
+**Modified/added:** `tldw_chatbook/Utils/fts5_match_forms.py` (new),
+`Library/library_fts_query.py`, `Library/library_local_rag_search_service.py`,
+`RAG_Search/simplified/rag_service.py`,
+`Tests/Library/test_library_keyword_and_then_prefix.py` (new),
+`Tests/RAG_Search/test_fts5_match_forms_shared.py` (new),
+`Tests/RAG_Eval/test_cross_encoder_probe_run.py`,
+`Tests/RAG_Eval/baselines/plain.json`, `Tests/RAG_Eval/README.md`.

--- a/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
+++ b/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
@@ -140,3 +140,35 @@ structural — a reranker cannot reorder a window it was never given.
 `Tests/RAG_Search/test_fts5_match_forms_shared.py` (new),
 `Tests/RAG_Eval/test_cross_encoder_probe_run.py`,
 `Tests/RAG_Eval/baselines/plain.json`, `Tests/RAG_Eval/README.md`.
+
+## Final-review corrections (2026-08-18, applied before merge)
+
+- **F1 — the rescue is 1 query, not 7.** TASK-3997's "7 of 32" came from an
+  analytically-composed arm (whole-query fallback, a crude prefix form) that
+  was not the shipped construction (per-sub-leg fallback, the engine's
+  stopword-trimmed prefix), and its harness was never committed. The
+  delivered rescue is `kw-thimble-relay` with the right document — which is
+  the ENTIRE +0.022 MRR / +0.062 keyword-category move — plus
+  `ng-mains-supply` gaining 6 non-relevant rows. TASK-3997's record is
+  corrected in place. **The decision stands on the gate's own measurement**,
+  which the reviewer reproduced including a control mutation that restores
+  the old baseline bit-for-bit.
+- **F2 — the "≥2 rows: 0 → 1" census line** is that negation query gaining
+  non-relevant rows, invisible to the gate's scored cells. Disclosed here
+  rather than left to look like a second rescue. Mitigating: the engine leg
+  has returned those same rows since TASK-15700, so this is the convergence
+  this arc exists to produce.
+- **F3 — the re-stamp carries a latency move** the report did not mention:
+  plain mean 14.2 → 18.4 ms, p95 24.8 → 31.1 (reproduced independently at
+  18.6 / 30.8). Expected — a zero-row sub-leg now runs a second query — and
+  recorded so the next person reading the baseline diff does not have to
+  rediscover it.
+- **F5 — AC#3's instrument.** The 0.396 figure from TASK-3997 was never
+  re-measured on the shipped code; AC#3 is satisfied by the GATE's plain
+  cells (0.304 → 0.326, all 105 metrics re-verified) rather than by that
+  number. TASK-17955's AC#1 was also vacuous as filed — tiering is provably
+  the identity on this corpus — and now requires the fixture to be extended
+  first.
+- **F4** (`rag_service._FTS5_STOPWORDS` is now an inert monkeypatch point) is
+  left as-is: it is the shared object, and the identity guard is what keeps
+  it honest.

--- a/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
+++ b/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
@@ -31,11 +31,27 @@ which is the point.
 
 ## Acceptance Criteria (the what)
 
-- [ ] The tiered and untiered merges are measured against each other on the
-      gated instrument's `plain` cells, from the same corpus and queries
+- [ ] **The fixture is extended FIRST so the comparison can say anything.**
+      TASK-17755's final review established that tiering is provably the
+      IDENTITY on today's corpus: **0 of 60 queries mix primary and fallback
+      rows, and 0 have more than one primary row**, so a tiered-vs-untiered
+      comparison would close on a meaningless `+0.000`. The fixture needs a
+      query that has a multi-row primary seam AND a rescued (fallback-only)
+      seam, which is the only shape where the orderings differ
+- [ ] Only then: the tiered and untiered merges are measured against each
+      other on the gated instrument's `plain` cells, same corpus and queries
 - [ ] A decision is recorded: tier the merge, or record untiered as the
       measured choice and retire TASK-16071's note so it stops reading as an
       unpaid debt
 - [ ] Whichever ships, the merge-site comment states which construction was
       measured and when — the note that prompted this task was accurate but
       undated, which is why it survived two arcs unresolved
+
+## Note (2026-08-18, TASK-17755 final review)
+
+The real exposure is **displacement, not loss**: a rescued seam's loose rows
+can interleave ahead of a good seam's deeper primary rows under a `top_k`
+cut. Ship-untiered was accepted for TASK-17755 because tiering is equally
+unmeasurable on today's corpus — not because untiered was shown safe. Record
+in the outcome that TASK-17755 closed the *form* divergence with the engine
+leg while leaving an *ordering* divergence.

--- a/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
+++ b/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
@@ -1,0 +1,41 @@
+---
+id: task-17955
+title: Four-seam merge is untiered now that the path has fallback forms
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [rag, retrieval]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+TASK-16071 made the four-seam merge rank-fair (`interleave_rankings` keyed by
+`_keyword_row_identity`) and left a note at the merge site: if this path ever
+gained fallback match forms, TASK-15700's **tier** design should apply — a
+row found by a primary form should outrank one found only by a fallback,
+rather than interleaving with it purely by position.
+
+TASK-17755 gave the path exactly those forms (`and_then_prefix`: an AND
+primary per sub-leg, a per-token prefix fallback where the primary returned
+zero rows). The merge was deliberately **left untiered**, and the reason is
+worth preserving rather than treating as an oversight: `and_then_prefix` was
+*measured* untiered (MRR 0.304 → 0.326 on the plain cells), so tiering it now
+would ship an ordering nobody has measured, on the strength of a symmetry
+argument. This programme has retired several such arguments on measurement.
+
+The open effect: deeper in a merged list, a fallback row can interleave ahead
+of a primary one from another seam. Whether that costs anything is unknown —
+which is the point.
+
+## Acceptance Criteria (the what)
+
+- [ ] The tiered and untiered merges are measured against each other on the
+      gated instrument's `plain` cells, from the same corpus and queries
+- [ ] A decision is recorded: tier the merge, or record untiered as the
+      measured choice and retire TASK-16071's note so it stops reading as an
+      unpaid debt
+- [ ] Whichever ships, the merge-site comment states which construction was
+      measured and when — the note that prompted this task was accurate but
+      undated, which is why it survived two arcs unresolved

--- a/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
+++ b/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
@@ -1,0 +1,35 @@
+---
+id: task-18055
+title: send_to_agent missing from the skills shadow-name set
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [agents, skills]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+`Tests/Library/test_library_skills_state.py::test_shadow_name_set_stays_in_sync_with_real_sources`
+is red on dev: `send_to_agent` (added by the supervisor-fleet PR 3b work) is
+not in `_SHADOWED_BUILTIN_NAMES`, so a skill installed under that name could
+shadow the runtime tool undetected.
+
+**This is the guard working as designed, not a regression of it.** TASK-13214
+rebuilt it to report every gap across four sources in one failure precisely so
+the next addition could not hide behind the last one; this is the next
+addition. The test's own message says it must not be accepted as a baseline
+failure (task-580), and the fix is one entry.
+
+Noticed during TASK-17755's battery; that arc's diff touches nothing in the
+test's import path.
+
+## Acceptance Criteria (the what)
+
+- [ ] `send_to_agent` is covered by `_SHADOWED_BUILTIN_NAMES` (or deliberately
+      exempted with a documented reason)
+- [ ] The guard passes on a clean dev checkout
+- [ ] Any other name added since TASK-13214 closed is covered in the same
+      pass — the guard reports all four sources at once, so run it and fix
+      everything it names rather than only the one in this title

--- a/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
+++ b/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
@@ -77,3 +77,37 @@ rearrangement can answer, and where a null is an acceptable outcome.
 This also answers the divergence TASK-15400's AC#8 deferred here: adopting the
 engine's construction collapses the two matching rules on the Library screen
 to one.
+
+## CORRECTION (2026-08-18, from TASK-17755's final review)
+
+**The "7 of 32 rescued" figure in this task's AC#2 table was wrong, and the
+owner's decision was taken partly on it.** The delivered implementation
+rescues **1** zero-row query with the right document (`kw-thimble-relay`),
+not 7. A second query (`ng-mains-supply`, a negation) gains 6 rows, none
+relevant.
+
+**Why this task over-counted.** Its `and_then_prefix` arm was not the shipped
+construction. It was computed *analytically* from two whole-query runs — AND
+result where the query returned rows, prefix result otherwise — whereas the
+shipped construction falls back **per sub-leg**, and its prefix form is the
+engine's (stopword-trimmed), not this probe's crude `OR` of quoted prefixes
+over the raw query string. The probe's arm was an approximation of the real
+thing and it over-estimated. **The harness was never committed**, which is
+why the number could not be reconciled by inspection; the repo's own
+construction matrix scores this construction on the engine leg at 3 rescues,
+so 7 was always the outlier.
+
+**The decision still stands, on better evidence than the number that
+prompted it.** The gate measured the shipped change: overall MRR
+0.304 → 0.326, NDCG 0.296 → 0.318, keyword-category cells +0.062, with every
+`semantic` and `hybrid` cell holding at +0.000 — verified independently by
+the reviewer, including a control mutation that reproduces the OLD baseline
+bit-for-bit, proving attribution. What changed is the *magnitude* of the win,
+not its direction or its risk profile: the untouched-primaries property that
+made this the low-risk arm is pinned on construction, not on the rescue
+count.
+
+**The methodological lesson, which is this task's real residue:** an
+analytically-composed arm is a different construction from the one you will
+ship, and a probe that is not committed cannot be reconciled later. Compose
+arms by running the real code path, and commit the harness.

--- a/tldw_chatbook/Library/library_fts_query.py
+++ b/tldw_chatbook/Library/library_fts_query.py
@@ -12,9 +12,24 @@ module deliberately emits: parentheses and ``OR`` between variants of one
 term, and ``AND`` between terms. The explicit ``AND`` keeps the service's
 existing whitespace-implied AND-of-terms semantics -- it must be spelled out
 because FTS5 rejects implicit AND next to a parenthesized group.
+
+That AND is strict: one absent term zeroes a seam. TASK-3997 measured what
+that costs on the gated corpus (32 of 53 ground-truthed golden queries
+returned nothing) and the owner adopted ``and_then_prefix``, so this module
+now also exposes the WIDENING form -- ``build_prefix_match_query`` -- that
+`library_local_rag_search_service` runs for a sub-leg whose AND primary
+found nothing. The two are deliberately separate functions: the AND above
+is unchanged by TASK-17755 and is still what every seam runs first, and it
+has a second consumer (`Chat/scope_picker_listers.py`) that gets no
+fallback.
 """
 
 from __future__ import annotations
+
+from tldw_chatbook.Utils.fts5_match_forms import (
+    build_prefix_match_expression,
+    fts5_query_tokens,
+)
 
 # Terms shorter than this are never expanded (articles, initials, "as", ...).
 _MIN_EXPANSION_LENGTH = 3
@@ -99,3 +114,35 @@ def build_fts_match_query(query: str) -> str:
         else:
             groups.append("(" + " OR ".join(quoted) + ")")
     return " AND ".join(groups)
+
+
+def build_prefix_match_query(query: str) -> str:
+    """Build the PREFIX form -- ``and_then_prefix``'s widening fallback.
+
+    TASK-17755. Run by `library_local_rag_search_service` for a sub-leg
+    whose `build_fts_match_query` primary returned zero rows, and never
+    otherwise. It reaches documents the primary's plural/singular widening
+    cannot: "tension" does not widen to "tensioner", but ``"tension"*``
+    matches it.
+
+    A thin adapter over `Utils.fts5_match_forms`, which is the ONE
+    definition of this form and of the function-word list it trims with --
+    shared with the engine's keyword leg, which has run the same
+    construction since TASK-15700. Not re-implemented here on purpose: the
+    Library screen's Search tab is this path and its RAG Answer tab is the
+    engine, and TASK-3997 documented a user hitting two different matching
+    rules on one screen. A second copy of the form would re-open that gap
+    the first time either copy was edited.
+
+    Args:
+        query: Validated user query text (plain natural language).
+
+    Returns:
+        The prefix expression, e.g. ``feedback loop`` becomes
+        ``"feedback"* "loop"*``. ``""`` when the query has no content
+        tokens -- meaning "no rows", which callers must honour by skipping
+        the query rather than widening further (see the shared module for
+        why an unbounded stopword prefix is the one thing worse than a
+        zero-row seam).
+    """
+    return build_prefix_match_expression(fts5_query_tokens(query))

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import replace
 from typing import Any, Hashable, Optional
 
@@ -20,7 +20,10 @@ from tldw_chatbook.Chat.rag_scope import (
     media_id_params,
     note_id_params,
 )
-from tldw_chatbook.Library.library_fts_query import build_fts_match_query
+from tldw_chatbook.Library.library_fts_query import (
+    build_fts_match_query,
+    build_prefix_match_query,
+)
 from tldw_chatbook.Library.library_notes_sync_state import count_noun
 from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
 from tldw_chatbook.Library.library_rag_state import (
@@ -481,15 +484,31 @@ class LibraryLocalRagSearchService:
         # the seam order breaks the tie. That is a pinned convention, not a
         # relevance claim (`Tests/Library/test_library_keyword_cross_seam.py`).
         #
-        # NO TIERING, deliberately. TASK-15700's tiered merge exists because
-        # the ENGINE's keyword leg mixes primary matches with widened
-        # FALLBACK constructions, and a fallback row must fill positions
-        # rather than displace a primary one. This path has no such split:
-        # every seam builds its MATCH with `build_fts_match_query` and
-        # nothing else, so all four rankings are all-primary and this is the
-        # pre-15700 all-primary interleave, which 15700 proved correct for
-        # that regime. If this path ever gains fallback forms, the 15700 tier
-        # design applies here too.
+        # NO TIERING -- and TASK-17755 is the change that makes that a live
+        # decision rather than a vacuous one, so read this before touching
+        # it. TASK-15700's tiered merge exists because the ENGINE's keyword
+        # leg mixes primary matches with widened FALLBACK rows, and a
+        # fallback row must fill positions rather than displace a primary
+        # one. Until TASK-17755 this path had no such split (every seam ran
+        # `build_fts_match_query` and nothing else) and the note here said
+        # the 15700 tier design would apply if it ever gained fallback
+        # forms. It now has them: a sub-leg whose AND primary returns zero
+        # rows re-runs a prefix form (`_rows_with_prefix_fallback`).
+        #
+        # This merge is nonetheless left UNTIERED, deliberately and
+        # narrowly: `and_then_prefix` was MEASURED untiered on this path
+        # (TASK-3997's report -- 0.396 -> 0.423 MRR, the numbers the owner
+        # decided on), and tiering it would ship an ordering nothing has
+        # measured. What protects the primary rows meanwhile is weaker than
+        # the engine's tiering but not nothing: the widened rows only ever
+        # come from sub-legs that contributed NOTHING before, so no primary
+        # row loses a position it used to hold at the front of the merge --
+        # position 0 of each seam still comes first, in seam order. Deeper
+        # in the list a fallback row can interleave ahead of a primary one,
+        # which is exactly what tiering would fix. Tiering this path is a
+        # follow-up that must be re-measured on the golden set, not a
+        # tidy-up; `Tests/Library/test_library_keyword_and_then_prefix.py`
+        # pins the untiered order so the change cannot happen silently.
         #
         # Dedup across seams is structurally vacuous -- the seams are
         # disjoint by source type -- but the primitive needs a key, and
@@ -541,31 +560,39 @@ class LibraryLocalRagSearchService:
         service = getattr(self._app, "notes_scope_service", None)
         if service is None:
             return False, []
-        try:
-            # Forward the allowlist only when provided so an unscoped call
-            # keeps the exact legacy call shape (byte-identical, spec D2).
-            allowlist_kwargs = (
-                {"id_allowlist": id_allowlist} if id_allowlist is not None else {}
-            )
+        # Forward the allowlist only when provided so an unscoped call
+        # keeps the exact legacy call shape (byte-identical, spec D2).
+        allowlist_kwargs = (
+            {"id_allowlist": id_allowlist} if id_allowlist is not None else {}
+        )
+
+        async def run_match(fts_match_query: str) -> list[dict[str, Any]]:
+            # Pre-built MATCH string (plural/singular widened) so the notes
+            # seam is not limited to its exact-phrase fallback -- FTS5
+            # unicode61 has no stemming (task-185 UAT). Which expression
+            # arrives here -- the AND primary or the prefix widening -- is
+            # `_rows_with_prefix_fallback`'s decision, not this seam's.
             raw_results = await service.search_notes(
                 scope="local_note",
                 query=query,
                 limit=top_k,
                 user_id=user_id,
-                # Pre-built MATCH string (plural/singular widened) so the
-                # notes seam is not limited to its exact-phrase fallback --
-                # FTS5 unicode61 has no stemming (task-185 UAT).
-                fts_match_query=build_fts_match_query(query),
+                fts_match_query=fts_match_query,
                 **allowlist_kwargs,
             )
+            return [
+                _note_row(item)
+                for item in raw_results or ()
+                if isinstance(item, Mapping)
+            ]
+
+        try:
+            return True, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: notes seam failed."
             )
             return True, []
-        return True, [
-            _note_row(item) for item in raw_results or () if isinstance(item, Mapping)
-        ]
 
     async def _search_media(
         self,
@@ -578,27 +605,31 @@ class LibraryLocalRagSearchService:
         service = getattr(self._app, "media_reading_scope_service", None)
         if service is None:
             return False, []
-        try:
-            # Forward the allowlist only when provided so an unscoped call
-            # keeps the exact legacy call shape (byte-identical, spec D2).
-            allowlist_kwargs = (
-                {"id_allowlist": id_allowlist} if id_allowlist is not None else {}
-            )
+        # Forward the allowlist only when provided so an unscoped call
+        # keeps the exact legacy call shape (byte-identical, spec D2).
+        allowlist_kwargs = (
+            {"id_allowlist": id_allowlist} if id_allowlist is not None else {}
+        )
+
+        async def run_match(fts_match_query: str) -> list[dict[str, Any]]:
             payload = await service.search_media(
                 mode="local",
                 query=query,
                 limit=top_k,
                 offset=0,
-                fts_match_query=build_fts_match_query(query),
+                fts_match_query=fts_match_query,
                 **allowlist_kwargs,
             )
+            items = payload.get("items", []) if isinstance(payload, Mapping) else []
+            return [_media_row(item) for item in items if isinstance(item, Mapping)]
+
+        try:
+            return True, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: media seam failed."
             )
             return True, []
-        items = payload.get("items", []) if isinstance(payload, Mapping) else []
-        return True, [_media_row(item) for item in items if isinstance(item, Mapping)]
 
     async def _search_conversations(
         self,
@@ -609,8 +640,8 @@ class LibraryLocalRagSearchService:
         db = getattr(self._app, "chachanotes_db", None)
         if db is None:
             return False, []
-        fts_query = build_fts_match_query(query)
-        try:
+
+        async def run_match(fts_query: str) -> list[dict[str, Any]]:
             if getattr(db, "is_memory_db", False):
                 # In-memory SQLite connections are thread-local and only the
                 # thread that created the database has the migrated schema;
@@ -620,16 +651,19 @@ class LibraryLocalRagSearchService:
                 raw_results = await asyncio.to_thread(
                     db.search_conversations_by_content, fts_query, top_k
                 )
+            return [
+                _conversation_row(item)
+                for item in raw_results or ()
+                if isinstance(item, Mapping)
+            ]
+
+        try:
+            return True, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: conversations seam failed."
             )
             return True, []
-        return True, [
-            _conversation_row(item)
-            for item in raw_results or ()
-            if isinstance(item, Mapping)
-        ]
 
     async def _search_prompts(
         self,
@@ -640,23 +674,30 @@ class LibraryLocalRagSearchService:
         service = getattr(self._app, "prompt_scope_service", None)
         if service is None:
             return False, []
-        try:
+
+        async def run_match(fts_match_query: str) -> list[dict[str, Any]]:
+            # Pre-built MATCH string, same as the notes/media/conversations
+            # seams above -- and, since TASK-17755, under the same
+            # ``and_then_prefix`` rule as all three.
             raw_results = await service.search_prompts(
                 mode="local",
                 query=query,
                 limit=top_k,
-                # Pre-built MATCH string (plural/singular widened), same as
-                # the notes/media/conversations seams above.
-                fts_match_query=build_fts_match_query(query),
+                fts_match_query=fts_match_query,
             )
+            return [
+                _prompt_row(item)
+                for item in raw_results or ()
+                if isinstance(item, Mapping)
+            ]
+
+        try:
+            return True, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: prompts seam failed."
             )
             return True, []
-        return True, [
-            _prompt_row(item) for item in raw_results or () if isinstance(item, Mapping)
-        ]
 
     async def _search_semantic(
         self,
@@ -1140,6 +1181,73 @@ def _retrieval_payload(
             "semantic_scope_coverage": _semantic_scope_coverage(source_types, rows)
         }
     return result
+
+
+async def _rows_with_prefix_fallback(
+    query: str,
+    run_match: Callable[[str], Awaitable[list[dict[str, Any]]]],
+) -> list[dict[str, Any]]:
+    """Run ONE sub-leg's keyword query under the ``and_then_prefix`` rule.
+
+    TASK-17755, and the whole of it: the AND-of-variant-groups
+    (`build_fts_match_query`) stays the primary, and the PREFIX form
+    (`build_prefix_match_query`) runs **only** for a sub-leg whose primary
+    returned zero rows.
+
+    Written once and used by all four seams rather than inlined four times,
+    for the reason the four seams have historically drifted: each one calls
+    a different service with a different signature, and a construction
+    copied four ways is a construction that will eventually be three
+    constructions. The seams differ in HOW to run a MATCH; that is what
+    `run_match` carries. They do not differ in WHEN to widen.
+
+    The decision is per SUB-LEG, exactly as the engine makes it
+    (`RAGService._fts_rows_with_fallback`, shipped since TASK-15700), never
+    per query. One search can legitimately carry AND rows from the notes
+    seam and prefix rows from the media seam -- that mix is the point.
+    Deciding per query would either leave every seam strict (no rescue at
+    all, since any one seam matching would suppress the others' fallback) or
+    widen seams that had already found the right document.
+
+    Why this cannot regress a hit: a sub-leg that found rows never builds
+    the prefix expression, let alone runs it. That is a property of the
+    control flow, not of the two forms' relative recall, which is why it
+    survives whatever either builder is changed to later. It is pinned by
+    counting prefix CONSTRUCTIONS rather than comparing rows, in
+    `Tests/Library/test_library_keyword_and_then_prefix.py`.
+
+    An empty expression means "no rows" on both sides and the query is
+    skipped: an empty MATCH is an FTS5 syntax error rather than an empty
+    answer, and for the prefix form specifically the only alternative to
+    skipping would be an unbounded stopword prefix over the whole corpus.
+
+    Args:
+        query: The raw user query. Both forms are built from it; the caller
+            never builds either itself.
+        run_match: Runs ONE MATCH expression against this seam's service and
+            returns the seam's finished row list (already projected by the
+            seam's row builder, so the zero-row test is made on what would
+            actually reach the merge -- not on a raw payload whose items the
+            projection might have dropped).
+
+    Returns:
+        The primary's rows, or -- only when those were empty -- the prefix
+        form's rows. Never both: a sub-leg's rows are all-primary or
+        all-fallback within one query.
+    """
+    primary = build_fts_match_query(query)
+    rows = await run_match(primary) if primary else []
+    if rows:
+        return rows
+
+    # Built here and nowhere earlier: constructing it eagerly would cost
+    # nothing measurable but would destroy the ability to PROVE the fallback
+    # never fires for a hitting sub-leg, which is the property the owner's
+    # decision rests on.
+    fallback = build_prefix_match_query(query)
+    if not fallback:
+        return []
+    return await run_match(fallback)
 
 
 def _keyword_row_identity(row: Mapping[str, Any]) -> Hashable:

--- a/tldw_chatbook/RAG_Search/simplified/rag_service.py
+++ b/tldw_chatbook/RAG_Search/simplified/rag_service.py
@@ -44,6 +44,14 @@ except ImportError:
 import psutil
 
 from tldw_chatbook.config import load_settings
+from tldw_chatbook.Utils.fts5_match_forms import (
+    FTS5_STOPWORDS,
+    build_prefix_match_expression,
+    fts5_query_tokens,
+    fts5_token_runs,
+    is_fts5_stopword,
+    quote_fts5_token,
+)
 from tldw_chatbook.Metrics.metrics_logger import (
     log_counter,
     log_histogram,
@@ -255,18 +263,17 @@ FTS_MATCH_FORMS_BY_CONSTRUCTION: Dict[str, Tuple[str, Optional[str]]] = {
 # were `template`, `building`, `rough`, `turns`, `pulls`, `builds`, which no
 # stopword list removes). The exact size is pinned by
 # `test_stopword_list_is_lowercase_and_covers_the_measured_blocker`.
-_FTS5_STOPWORDS: FrozenSet[str] = frozenset(
-    {
-        "a", "about", "all", "also", "am", "an", "and", "any", "are", "as",
-        "at", "be", "been", "but", "by", "can", "do", "does", "for", "from",
-        "had", "has", "have", "how", "i", "if", "in", "into", "is", "it",
-        "its", "me", "my", "no", "not", "of", "on", "or", "our", "out",
-        "so", "than", "that", "the", "their", "them", "then", "there",
-        "these", "they", "this", "to", "up", "was", "we", "were", "what",
-        "when", "where", "which", "who", "why", "will", "with", "would",
-        "you", "your",
-    }
-)
+#
+# TASK-17755 MOVED the literal to `Utils/fts5_match_forms.py` and imports it
+# back under this name. It did not copy it. The Library's four-seam plain
+# Search path adopted `and_then_prefix` in that task, so a second consumer
+# now needs this list and the prefix builder below -- and the Library screen
+# runs BOTH paths (Search is the four-seam one, RAG Answer is this engine),
+# which is precisely the situation where two lists that agree today and
+# diverge next quarter present as a retrieval bug nobody can locate. There
+# is one list; `_FTS5_STOPWORDS` is still the name the engine's tests and
+# the RAG_Eval probes read it by.
+_FTS5_STOPWORDS: FrozenSet[str] = FTS5_STOPWORDS
 
 
 def _resolve_keyword_source_types(
@@ -3338,12 +3345,11 @@ class RAGService:
 
         # Bound total processing length before tokenizing (DoS guard). The
         # warning belongs to `_escape_fts5_query`, which runs once per
-        # search; this helper also runs once per RESULT ROW.
-        query = query[:MAX_QUERY_LENGTH]
-
-        return [
-            token for token in query.split() if any(ch.isalnum() for ch in token)
-        ]
+        # search; this helper also runs once per RESULT ROW. The bound stays
+        # HERE rather than in the shared tokenizer: it is this service's
+        # configured limit, and the Library's four-seam path -- the other
+        # consumer since TASK-17755 -- validates against its own.
+        return fts5_query_tokens(query[:MAX_QUERY_LENGTH])
 
     def _escape_fts5_query(self, query: str) -> str:
         """
@@ -3600,7 +3606,7 @@ class RAGService:
         Returns:
             The token as a quoted FTS5 term.
         """
-        return '"{}"'.format(token.replace('"', '""'))
+        return quote_fts5_token(token)
 
     @staticmethod
     def _is_fts5_stopword(token: str) -> bool:
@@ -3638,8 +3644,7 @@ class RAGService:
             True when the token is a single alphanumeric run listed in
             ``_FTS5_STOPWORDS``.
         """
-        runs = re.findall(r"[^\W_]+", token, re.UNICODE)
-        return len(runs) == 1 and runs[0].lower() in _FTS5_STOPWORDS
+        return is_fts5_stopword(token)
 
     @staticmethod
     def _fts5_term_key(token: str) -> str:
@@ -3658,7 +3663,7 @@ class RAGService:
         Returns:
             The token's runs, space-joined and case-folded.
         """
-        return " ".join(re.findall(r"[^\W_]+", token, re.UNICODE)).lower()
+        return " ".join(fts5_token_runs(token)).lower()
 
     def _resolved_fts_match_construction(self) -> str:
         """The active MATCH construction, or ``"and"`` for anything unknown.
@@ -3844,11 +3849,13 @@ class RAGService:
             FTS_MATCH_CONSTRUCTION_PREFIX,
             FTS_MATCH_CONSTRUCTION_AND_THEN_PREFIX,
         ):
-            # The star goes OUTSIDE the quotes: FTS5 reads `"tok"*` as "a
-            # phrase whose last token is a prefix", while a star inside the
-            # quotes is an inert character in the literal (the tokenizer
-            # drops it) and would silently reduce this to the trimmed AND.
-            prefix_expression = " ".join(f"{token}*" for token in quoted)
+            # The ONE prefix-form builder (TASK-17755 moved it to
+            # `Utils/fts5_match_forms.py`; the Library's four-seam path runs
+            # the same form for the same reason). It re-applies the stopword
+            # trim, which is idempotent on `content_tokens` -- so this is
+            # byte-identical to the inline construction it replaced, pinned
+            # by `test_the_engine_and_the_library_build_the_same_prefix_form`.
+            prefix_expression = build_prefix_match_expression(content_tokens)
 
             if construction == FTS_MATCH_CONSTRUCTION_PREFIX:
                 # Trimming empties -> "" (the skip contract), never the full

--- a/tldw_chatbook/Utils/fts5_match_forms.py
+++ b/tldw_chatbook/Utils/fts5_match_forms.py
@@ -1,0 +1,204 @@
+"""The FTS5 MATCH *forms* shared by the RAG engine and the Library seams.
+
+TASK-17755. Two retrieval paths in this app build FTS5 MATCH expressions:
+the engine's keyword leg (``RAG_Search/simplified/rag_service.py``) and the
+Library's four-seam plain-Search path (``Library/library_fts_query.py`` +
+``Library/library_local_rag_search_service.py``). The engine has shipped the
+``and_then_prefix`` construction since TASK-15700 and TASK-17755 adopts the
+same construction on the four-seam path, so both now need the **PREFIX
+form** and the function-word list it trims with.
+
+This module is that ONE definition. It exists because the alternative --
+a second copy of a 67-word stopword list and a second `"tok"*` builder --
+is the exact failure mode TASK-17600 shipped a guard against: twin literals
+drift apart silently, and a retrieval form that differs between two paths
+is indistinguishable from a retrieval *bug* when a query answers in one
+place and not the other. Reuse is not a tidiness preference here; the whole
+point of TASK-17755 is that the Library's Search tab and its RAG Answer tab
+stop disagreeing about what matches.
+
+Deliberately dependency-free (stdlib only, no package imports): its two
+consumers are a heavy engine module and a pure Library module, and the pure
+one must stay cheap to import. That is why it lives under ``Utils/`` --
+whose ``__init__`` is empty -- rather than under ``RAG_Search/``, whose
+package ``__init__`` pulls the whole simplified engine (chromadb,
+embeddings) in a try/except.
+
+What is NOT here: the AND forms. The engine's implicit-AND
+(``_escape_fts5_query``) and the Library's OR-of-plural-variants
+(``build_fts_match_query``) are genuinely different constructions with
+different histories, and they are each path's *primary* -- unchanged by
+TASK-17755 and not shared. Only the widening fallback is common.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import FrozenSet, Iterable, List
+
+__all__ = [
+    "FTS5_STOPWORDS",
+    "build_prefix_match_expression",
+    "fts5_query_tokens",
+    "fts5_token_runs",
+    "is_fts5_stopword",
+    "quote_fts5_token",
+]
+
+# A small fixed English function-word list, consulted by every widening FORM
+# and by NO primary AND form. Moved here verbatim from
+# ``rag_service._FTS5_STOPWORDS`` (TASK-15400/15700), which now imports it
+# back under that name so the engine's own tests and probes keep reading the
+# same object they always did -- there is exactly one list, not two that
+# happen to agree today.
+#
+# Where it lands on the shipped default paths: the engine's
+# ``and_then_prefix`` PRIMARY is the full AND, which does not consult this
+# list, and its FALLBACK is the prefix form, which does -- so it is
+# consulted only for sub-legs whose primary returned zero rows. TASK-17755
+# gives the Library's four seams the same shape, so the same sentence is now
+# true there.
+#
+# The PREFIX form is where this list is MOST load-bearing, by a distance. An
+# untrimmed OR admits every document containing "the"; an untrimmed prefix
+# term is worse still, because ``"the"*`` matches "the", "then", "there",
+# "their", "these" -- i.e. nearly a whole corpus -- and the prefix form ANDs
+# its terms, so one such term does not merely add noise, it makes the whole
+# expression match almost everything the other terms allow. That is why
+# ``build_prefix_match_expression`` answers ``""`` (no rows) when trimming
+# empties the token list rather than widening to something useless.
+#
+# Fixed and small on purpose -- a large list starts deleting content words
+# (TASK-15400's census found the real blockers were `template`, `building`,
+# `rough`, `turns`, `pulls`, `builds`, which no stopword list removes).
+FTS5_STOPWORDS: FrozenSet[str] = frozenset(
+    {
+        "a", "about", "all", "also", "am", "an", "and", "any", "are", "as",
+        "at", "be", "been", "but", "by", "can", "do", "does", "for", "from",
+        "had", "has", "have", "how", "i", "if", "in", "into", "is", "it",
+        "its", "me", "my", "no", "not", "of", "on", "or", "our", "out",
+        "so", "than", "that", "the", "their", "them", "then", "there",
+        "these", "they", "this", "to", "up", "was", "we", "were", "what",
+        "when", "where", "which", "who", "why", "will", "with", "would",
+        "you", "your",
+    }
+)
+
+#: One alphanumeric run, as FTS5's default ``unicode61`` tokenizer reads it.
+_RUN_PATTERN = re.compile(r"[^\W_]+", re.UNICODE)
+
+
+def fts5_token_runs(token: str) -> List[str]:
+    """The alphanumeric runs FTS5 would index a raw token as.
+
+    ``Obsidian-3`` is two runs (``Obsidian``, ``3``); ``About,`` is one
+    (``about``, case-folded by the tokenizer). Every comparison in this
+    module is made on runs rather than on the raw string, because runs are
+    what FTS5 actually matches.
+
+    Args:
+        token: One raw whitespace-delimited query token.
+
+    Returns:
+        The token's alphanumeric runs, in order; empty for pure punctuation.
+    """
+    return _RUN_PATTERN.findall(token)
+
+
+def quote_fts5_token(token: str) -> str:
+    """Quote ONE query token as an FTS5 string literal.
+
+    The single place the injection-safety property of TASK-3995 is
+    implemented for the widening forms: a bare token FTS5 parses as
+    column-filter or operator syntax (``Obsidian-3`` raises
+    ``OperationalError('no such column: 3')``; a typed ``OR`` becomes a
+    disjunction of the user's own words), while a quoted token is a literal
+    string with no operator semantics. An embedded double quote is doubled,
+    FTS5's own escape for a literal quote inside a quoted term.
+
+    Args:
+        token: One raw token from ``fts5_query_tokens``.
+
+    Returns:
+        The token as a quoted FTS5 term.
+    """
+    return '"{}"'.format(token.replace('"', '""'))
+
+
+def is_fts5_stopword(token: str) -> bool:
+    """Whether a raw query token is a function word.
+
+    Compared on the token's alphanumeric runs, because that is how FTS5
+    reads a quoted token: ``About,`` indexes and matches exactly as
+    ``about``, so the trimmer must see them as the same word. A token with
+    more than one run (``read-only``) is content, never a stopword.
+
+    Args:
+        token: One raw token from ``fts5_query_tokens``.
+
+    Returns:
+        True when the token is a single alphanumeric run listed in
+        ``FTS5_STOPWORDS``.
+    """
+    runs = fts5_token_runs(token)
+    return len(runs) == 1 and runs[0].lower() in FTS5_STOPWORDS
+
+
+def fts5_query_tokens(query: str) -> List[str]:
+    """Tokenize a raw user query for MATCH construction.
+
+    Tokens are whitespace-separated runs containing at least one
+    alphanumeric character. FTS5's default tokenizer indexes only
+    alphanumeric runs, so a pure-punctuation token ("!!!") can never match
+    anything and is dropped rather than carried as a no-op that would make
+    the prefix form ``"!!!"*`` -- an expression matching nothing, ANDed with
+    the terms that would otherwise have matched.
+
+    Length bounding is deliberately NOT done here: the engine bounds at its
+    own configured ``MAX_QUERY_LENGTH`` before calling in, and the Library
+    validates at ``LIBRARY_RAG_QUERY_MAX_LENGTH`` at its own boundary. A
+    third limit baked in here would silently override whichever caller's
+    limit is larger.
+
+    Args:
+        query: Raw search query (already length-bounded by the caller).
+
+    Returns:
+        The query's searchable tokens, in query order; empty when the query
+        is empty, whitespace-only or all punctuation.
+    """
+    if not query:
+        return []
+    return [token for token in query.split() if any(ch.isalnum() for ch in token)]
+
+
+def build_prefix_match_expression(tokens: Iterable[str]) -> str:
+    """Build the PREFIX form: content tokens as prefix terms, implicitly ANDed.
+
+    The widening form both ``and_then_prefix`` implementations run for a
+    sub-leg whose AND primary returned zero rows. Function words are trimmed
+    (see ``FTS5_STOPWORDS`` for why that matters more here than anywhere
+    else), each surviving token is quoted, and the star goes **outside** the
+    quotes: FTS5 reads ``"tok"*`` as "a phrase whose last token is a
+    prefix", while a star inside the quotes is an inert character in the
+    literal (the tokenizer drops it) and would silently reduce this to a
+    plain trimmed AND.
+
+    Passing already-trimmed tokens is safe: the trim is idempotent, which is
+    what lets the engine hand in its ``content_tokens`` and the Library hand
+    in its full token list and both get the same form.
+
+    Args:
+        tokens: Raw query tokens, e.g. from ``fts5_query_tokens``.
+
+    Returns:
+        The prefix expression, or ``""`` when trimming leaves nothing.
+        ``""`` means "no rows" and callers must skip the FTS5 query
+        entirely -- never fall back to a wider expression, because the only
+        query left to run would be an unbounded stopword prefix.
+    """
+    return " ".join(
+        f"{quote_fts5_token(token)}*"
+        for token in tokens
+        if not is_fts5_stopword(token)
+    )


### PR DESCRIPTION
Implements the decision TASK-3997 investigated and the owner took on 2026-08-18: the Library's four-seam keyword path adopts `and_then_prefix`, the construction the engine leg has shipped since TASK-15700.

## What changed

Each sub-leg keeps its existing AND-of-variant-groups as the **primary**. A per-token prefix form runs **only** for a sub-leg whose primary returned zero rows — per sub-leg, as the engine does it, not per query.

**The prefix builder and the 67-word function-word list were moved, not copied**, into a pure `Utils/fts5_match_forms.py`; the engine imports the list back as the same object and its inline construction is now a call to the shared builder. Guarded by an **identity** assertion, so a re-introduced copy reds *while the copies still agree* — stronger than the equality pins the last batch shipped, and deliberately so, since this programme has spent three arcs on twin literals drifting apart.

## The measured result

Gate: `PASSED: No regression. 105 metric(s) within 0.05 of baseline` — and **`plain.json` is re-stamped deliberately, because movement there is the deliverable**:

| cell | before | after |
|---|---|---|
| overall MRR / precision | 0.304 | **0.326** |
| NDCG | 0.296 | **0.318** |
| recall / F1 | 0.293 / 0.297 | 0.315 / 0.319 |
| keyword category | 0.844–0.875 | **0.906–0.938** |
| zero-row golden queries | 39 | 37 |

**Every `semantic` and `hybrid` cell held at +0.000** — the evidence the change stayed on the path it claims. The reviewer reproduced the whole run independently and added a control: disabling the fallback restores the *old* plain baseline bit-for-bit, which proves attribution rather than assuming it.

## A correction the review forced, stated plainly

**The delivered rescue is 1 query, not the 7 TASK-3997 reported** — and the owner's decision rested partly on that 7. `kw-thimble-relay` gains the right document and *is* the entire MRR move; `ng-mains-supply` gains six non-relevant rows (a negation query, invisible to the scored cells).

The investigation's arm was not the shipped construction: it composed `and_then_prefix` **analytically** from whole-query runs with a crude prefix form, while the real thing falls back per sub-leg using the engine's stopword-trimmed prefix. The harness was never committed, so the figure couldn't be reconciled by inspection — the repo's own construction matrix scored this construction at 3 rescues on the engine leg, so 7 was always the outlier. TASK-3997's record is corrected in place.

**The decision stands on better evidence than the number that prompted it.** The direction, the gate movement, and the untouched-primaries property that made this the low-risk arm are all unchanged — the last is pinned on *construction*, not on any rescue count.

## Why this is low-risk, pinned rather than argued

A query whose AND primary returns rows is untouched: no fallback, no extra query. That's asserted with a spy on the *construction* — an output-identical mutation (build the prefix eagerly, same rows) reds six tests, so the pin can't be satisfied by matching output alone. Four mutations in total confirm nothing here is vacuous, including one that reds only the identity guard.

## Disclosed, not buried

- **Latency**: plain mean 14.2 → 18.4 ms, p95 24.8 → 31.1. Expected — a zero-row sub-leg now runs a second query — and recorded so the next reader of the baseline diff doesn't rediscover it.
- **The merge is left untiered, deliberately.** `and_then_prefix` was measured untiered, so tiering now would ship an unmeasured ordering. The review's finding sharpens this: tiering is provably the *identity* on today's corpus (no query mixes primary and fallback rows), so it is equally unmeasurable there. **TASK-17955** now requires extending the fixture *before* comparing, so it cannot close on a meaningless `+0.000`. This arc closes the *form* divergence with the engine leg and leaves an *ordering* divergence.
- **A collateral pin was re-derived, not relaxed away**: `test_cross_encoder_probe_run` assumed plain was reorderable-zero — true only because AND-strictness never returned two rows. Re-stamped to the measured exact equality; TASK-16965's conclusion survives intact (plain still moves +0.000 *under reranking*).

## Follow-ups filed

**TASK-17955** (the untiered merge, now with a non-vacuous AC) and **TASK-18055** (`send_to_agent` missing from the skills shadow set — TASK-13214's rebuilt guard working as designed, catching the next addition instead of hiding it behind the last).

Counts: 2,431 passed / 14 skipped across `Tests/RAG_Search` + `Tests/Library`; gated suite 327; ruff clean. The one red is a pre-existing dev failure, baselined at the merge-base.

Refs TASK-17755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts `and_then_prefix` on the Library four‑seam keyword path to match the engine and reduce zero‑row queries. Old behavior: strict AND‑of‑variant‑groups only. New behavior: keep the AND primary and run a stopword‑trimmed per‑token prefix only for sub‑legs whose primary returns zero rows. Plain metrics improve; latency rises slightly; merge stays untiered.

- Moves the shared prefix form and 67‑word stopword set to `tldw_chatbook/Utils/fts5_match_forms.py`; engine `rag_service` now imports `FTS5_STOPWORDS` and calls the shared builder; Library exposes `build_prefix_match_query`.
- Adds `_rows_with_prefix_fallback` and routes notes/media/conversations/prompts through it; builds the prefix lazily and skips when trimming empties the query.
- Leaves the merge untiered by design; documents why and files TASK‑17955 to measure a tiered merge after extending the fixture.
- Restamps only `Tests/RAG_Eval/baselines/plain.json`: overall MRR 0.304→0.326, NDCG 0.296→0.318; `semantic`/`hybrid` hold at +0.000. Plain latency increases (mean 14.2→18.4 ms; p95 24.8→31.1 ms).
- Updates `Tests/RAG_Eval/test_cross_encoder_probe_run.py` to allow 1 reorderable plain query while keeping all plain metrics at +0.000; adds `Tests/Library/test_library_keyword_and_then_prefix.py` and `Tests/RAG_Search/test_fts5_match_forms_shared.py` to pin construction and sharing.
- Corrects TASK‑3997’s claim: the delivered rescue is 1 query (not 7); records the change and its measured effect.
- Follow‑ups: TASK‑17955 (tiering measurement), TASK‑18055 (add `send_to_agent` to the skills shadow‑name set).

<sup>Written for commit d24513ce135bfa33832405ca27e4dda41b0749a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

