### PR TITLE
fix(llm): read Kobold and TabbyAPI config from sections that exist

### DIFF
--- a/Tests/LLM_Calls/test_kobold_tabby_config.py
+++ b/Tests/LLM_Calls/test_kobold_tabby_config.py
@@ -1,0 +1,203 @@
+"""Kobold and TabbyAPI summarizer configuration resolution (task-17383).
+
+NOTE ON SHAPE: both functions are GENERATOR functions -- a top-level `yield` in
+their streaming branches makes the whole function one -- so calling them returns
+a generator and the body runs only when it is iterated. That is a separate,
+larger defect (a non-streaming caller receives a generator where a summary
+belongs, and the deep-search pipeline would store it as evidence); it is filed
+on its own because fixing it re-attributes ~20 diagnostics to nested functions
+and rewrites a security-reviewed ledger. These tests therefore drive the
+functions the way they currently behave, and still prove the configuration
+resolution.
+
+Both indexed sections the loader has never built -- `api_keys`,
+`local_api_ip`, `models` -- so like llama.cpp before task-17382 they raised
+before contacting a server and returned an error STRING that callers could
+store as evidence. Both providers DO have complete modern `api_settings`
+entries and complete legacy sections; these tests pin that they read those.
+"""
+
+import pytest
+
+from tldw_chatbook.LLM_Calls import Local_Summarization_Lib as lib
+
+
+class FakeResponse:
+    """Shapes the SERVERS actually return, not the shape the code wants.
+
+    Kobold's native generate endpoint answers ``{"results": [{"text": ...}]}``;
+    TabbyAPI is OpenAI-compatible and answers with ``choices[].message``. A
+    single fake asserting one shape would have passed while the other provider
+    stayed broken -- the failure mode task-17382 was built on.
+    """
+
+    status_code = 200
+
+    def __init__(self, payload=None):
+        self.text = ""
+        self._payload = payload if payload is not None else {
+            # Kobold native generate
+            "results": [{"text": " SUMMARY "}],
+            # OpenAI-compatible envelope -- TabbyAPI validates every one of
+            # these keys before reading the content, so a fake carrying only
+            # "choices" passes nothing.
+            "id": "cmpl-test",
+            "created": 0,
+            "model": "test-model",
+            "object": "chat.completion",
+            "usage": {"completion_tokens": 3},
+            "choices": [{"message": {"role": "assistant", "content": " SUMMARY "}}],
+        }
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.fixture
+def captured_post(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            pass
+
+        def post(self, url, headers=None, json=None, stream=False, **_kw):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: FakeSession())
+    return captured
+
+
+def drain(result):
+    """Run a summarizer to completion and return its final value."""
+    if isinstance(result, str):
+        return result
+    chunks = []
+    while True:
+        try:
+            chunks.append(next(result))
+        except StopIteration as stop:
+            return stop.value if stop.value is not None else "".join(chunks)
+
+
+def settings(**overrides):
+    """A snapshot shaped like the real loader's: the modern per-provider table
+    and the legacy sections exist; `api_keys`/`local_api_ip`/`models` do NOT."""
+    base = {
+        "api_settings": {
+            "koboldcpp": {"api_url": "http://kobold.invalid/v1/chat/completions"},
+            "tabbyapi": {"api_url": "http://tabby.invalid/v1/chat/completions"},
+        },
+        "kobold_api": {
+            "api_ip": "http://legacy-kobold.invalid/api/v1/generate",
+            "api_key": "legacy-kobold-key",
+            "api_retries": 0,
+            "api_retry_delay": 0,
+            "streaming": False,
+            "temperature": 0.7,
+            "max_tokens": 64,
+        },
+        "tabby_api": {
+            "api_ip": "http://legacy-tabby.invalid/v1/chat/completions",
+            "api_key": "legacy-tabby-key",
+            "model": "legacy-model",
+            "api_retries": 0,
+            "api_retry_delay": 0,
+            "streaming": False,
+            "temperature": 0.7,
+            "max_tokens": 64,
+        },
+    }
+    for key, value in overrides.items():
+        base["api_settings"].setdefault(key, {}).update(value)
+    return base
+
+
+@pytest.mark.parametrize(
+    "summarize,expected_url",
+    [
+        (
+            lambda: lambda: lib.summarize_with_kobold("some text", None, "Summarize."),
+            "http://kobold.invalid/v1/chat/completions",
+        ),
+        (
+            lambda: lambda: lib.summarize_with_tabbyapi("some text", "Summarize."),
+            "http://tabby.invalid/v1/chat/completions",
+        ),
+    ],
+    ids=["kobold", "tabby"],
+)
+def test_summarizer_reaches_its_server_via_the_modern_entry(
+    monkeypatch, captured_post, summarize, expected_url
+):
+    """The whole defect: no KeyError, a real request, a real summary."""
+    monkeypatch.setattr(lib, "load_settings", lambda: settings())
+
+    result = drain(summarize()())
+
+    # Kobold strips its summary and TabbyAPI does not; that difference is not
+    # what this test is about.
+    assert result.strip() == "SUMMARY", result
+    assert captured_post["url"] == expected_url
+
+
+@pytest.mark.parametrize(
+    "summarize,expected_url",
+    [
+        (
+            lambda: lambda: lib.summarize_with_kobold("some text", None, "Summarize."),
+            "http://legacy-kobold.invalid/api/v1/generate",
+        ),
+        (
+            lambda: lambda: lib.summarize_with_tabbyapi("some text", "Summarize."),
+            "http://legacy-tabby.invalid/v1/chat/completions",
+        ),
+    ],
+    ids=["kobold", "tabby"],
+)
+def test_summarizer_falls_back_to_its_legacy_section(
+    monkeypatch, captured_post, summarize, expected_url
+):
+    conf = settings()
+    conf["api_settings"] = {"koboldcpp": {}, "tabbyapi": {}}
+    monkeypatch.setattr(lib, "load_settings", lambda: conf)
+
+    drain(summarize()())
+
+    assert captured_post["url"] == expected_url
+
+
+def test_tabby_reads_the_credential_env_var_the_config_names(
+    monkeypatch, captured_post
+):
+    """`api_key_env_var` is this repo's existing convention (the media and
+    settings windows both honour it), and it is tabbyapi's only credential
+    field in the modern table."""
+    conf = settings(tabbyapi={"api_key_env_var": "TABBY_TEST_KEY"})
+    conf["tabby_api"]["api_key"] = ""
+    monkeypatch.setattr(lib, "load_settings", lambda: conf)
+    monkeypatch.setenv("TABBY_TEST_KEY", "env-tabby-key")
+
+    drain(lib.summarize_with_tabbyapi("some text", "Summarize."))
+
+    assert "env-tabby-key" in str(captured_post["headers"])
+
+
+def test_missing_sections_do_not_raise(monkeypatch, captured_post):
+    """A config with neither modern nor legacy entries must fail legibly, not
+    with a KeyError that becomes an error string stored as evidence."""
+    monkeypatch.setattr(lib, "load_settings", lambda: {"api_settings": {}})
+
+    result = drain(lib.summarize_with_kobold("some text", None, "Summarize."))
+
+    from tldw_chatbook.Web_Scraping.WebSearch_APIs import _is_summary_failure
+
+    assert isinstance(result, str)
+    assert _is_summary_failure(result), result
+    assert "KeyError" not in result

--- a/Tests/LLM_Calls/test_kobold_tabby_config.py
+++ b/Tests/LLM_Calls/test_kobold_tabby_config.py
@@ -201,3 +201,104 @@ def test_missing_sections_do_not_raise(monkeypatch, captured_post):
     assert isinstance(result, str)
     assert _is_summary_failure(result), result
     assert "KeyError" not in result
+
+
+def test_kobold_streaming_uses_the_openai_compatible_endpoint(monkeypatch):
+    """Qodo (PR 1788): the streaming branch parses OpenAI SSE, but both the
+    modern api_url and the legacy api_ip point at Kobold's NATIVE generate
+    endpoint -- only `api_streaming_ip` is OpenAI-compatible. Preferring the
+    modern url sent streaming to the native endpoint and yielded nothing."""
+    conf = settings()
+    conf["api_settings"]["koboldcpp"]["api_url"] = "http://kobold.invalid/api/v1/generate"
+    conf["kobold_api"]["api_ip"] = "http://kobold.invalid/api/v1/generate"
+    conf["kobold_api"]["api_streaming_ip"] = "http://kobold.invalid/v1/chat/completions"
+    monkeypatch.setattr(lib, "load_settings", lambda: conf)
+
+    seen = {}
+
+    class StreamResponse:
+        status_code = 200
+        text = ""
+
+        def iter_lines(self):
+            yield b'data: {"choices":[{"delta":{"content":"chunk"}}]}'
+            yield b"data: [DONE]"
+
+        def json(self):
+            return {}
+
+        def raise_for_status(self):
+            return None
+
+    class StreamSession:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, url, **_kw):
+            seen["url"] = url
+            return StreamResponse()
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: StreamSession())
+
+    drain(lib.summarize_with_kobold("text", None, "Summarize.", streaming=True))
+
+    assert seen["url"] == "http://kobold.invalid/v1/chat/completions", seen
+
+
+def test_kobold_non_streaming_uses_the_native_endpoint(monkeypatch, captured_post):
+    """The complement: the non-streaming branch parses `results[].text`, so it
+    must go to the NATIVE generate endpoint. Shaped like the real config, where
+    both the modern api_url and the legacy api_ip are native."""
+    conf = settings()
+    conf["api_settings"]["koboldcpp"]["api_url"] = "http://kobold.invalid/api/v1/generate"
+    conf["kobold_api"]["api_ip"] = "http://kobold.invalid/api/v1/generate"
+    conf["kobold_api"]["api_streaming_ip"] = "http://kobold.invalid/v1/chat/completions"
+    monkeypatch.setattr(lib, "load_settings", lambda: conf)
+
+    drain(lib.summarize_with_kobold("text", None, "Summarize."))
+
+    assert captured_post["url"] == "http://kobold.invalid/api/v1/generate"
+
+
+def test_configuration_reaches_the_public_analyze_boundary(monkeypatch):
+    """Qodo (PR 1788): the other tests call the summarizers directly. This one
+    goes through `analyze`, the seam the deep-search pipeline actually uses, so
+    the resolution is verified where a caller meets it."""
+    from tldw_chatbook.LLM_Calls.Summarization_General_Lib import analyze
+
+    monkeypatch.setattr(lib, "load_settings", lambda: settings())
+    seen = {}
+
+    class Session:
+        def mount(self, *_a, **_k):
+            pass
+
+        def post(self, url, headers=None, json=None, stream=False, **_kw):
+            seen["url"] = url
+            return FakeResponse()
+
+    monkeypatch.setattr(lib.requests, "Session", lambda: Session())
+
+    result = drain(
+        analyze(
+            input_data="a chunk of packed evidence",
+            custom_prompt_arg="Summarize.",
+            api_name="tabbyapi",
+            api_key=None,
+            temp=0.3,
+            system_message=None,
+            streaming=False,
+        )
+    )
+
+    # The configuration resolution is what this asserts: the request went to
+    # the endpoint the modern table names, through the public seam.
+    assert seen["url"] == "http://tabby.invalid/v1/chat/completions", seen
+    # The VALUE a caller gets back is still unusable, and deliberately so: these
+    # functions are generators (task-17387), so `analyze` hands back something
+    # a non-streaming caller cannot treat as a summary. Pinned here rather than
+    # asserted away, so this test starts telling the truth about the return
+    # value the moment task-17387 lands.
+    assert result.strip() == "", (
+        "task-17387 fixed? then assert the summary here instead: " + repr(result)
+    )

--- a/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
+++ b/Tests/LLM_Calls/test_summarization_diagnostic_privacy.py
@@ -167,12 +167,14 @@ def _local_settings(*, llama_endpoint: str = "http://llama.invalid") -> dict[str
             "api_retries": 0,
             "api_retry_delay": 0,
         },
-        "api_keys": {"kobold": "fixed-kobold-key"},
-        "local_api_ip": {
-            "kobold": "http://kobold.invalid/generate",
-            "kobold_openai": "http://kobold.invalid/chat",
+        # Same for Kobold (task-17383): its own section is what exists.
+        "kobold_api": {
+            "api_key": "fixed-kobold-key",
+            "api_ip": "http://kobold.invalid/generate",
+            "api_streaming_ip": "http://kobold.invalid/chat",
+            "api_retries": 0,
+            "api_retry_delay": 0,
         },
-        "kobold_api": {"api_retries": 0, "api_retry_delay": 0},
     }
 
 
@@ -189,10 +191,16 @@ def _local_adapter_settings(
             "api_retries": 0,
             "api_retry_delay": 0,
         },
-        "api_keys": {"tabby": tabby_key},
-        "local_api_ip": {"tabby": "http://tabby.invalid/v1/chat/completions"},
-        "models": {"tabby": "fixed-tabby-model"},
-        "tabby_api": {"api_retries": 0, "api_retry_delay": 0},
+        # task-17383: `api_keys`, `local_api_ip` and `models` are names the
+        # loader has never built -- keying the fixture to them is what let the
+        # TabbyAPI summarizer pass here while failing on every real config.
+        "tabby_api": {
+            "api_key": tabby_key,
+            "api_ip": "http://tabby.invalid/v1/chat/completions",
+            "model": "fixed-tabby-model",
+            "api_retries": 0,
+            "api_retry_delay": 0,
+        },
     }
 
 
@@ -2744,7 +2752,10 @@ def test_local_core_kobold_missing_key_error_contract_is_unchanged(
         raise AssertionError("transport invoked before missing-key failure")
 
     settings = _local_settings()
-    settings["api_keys"]["kobold"] = None
+    # task-17383: the credential lives in the section the loader builds now;
+    # the intent is unchanged -- an ABSENT key still hits the historical
+    # TypeError contract, distinct from a configured-but-blank one.
+    settings["kobold_api"]["api_key"] = None
     monkeypatch.setattr(local_summarization, "load_settings", lambda: settings)
     monkeypatch.setattr(
         local_summarization.requests,

--- a/backlog/tasks/task-17383 - Kobold-and-TabbyAPI-summarizers-read-config-sections-that-do-not-exist.md
+++ b/backlog/tasks/task-17383 - Kobold-and-TabbyAPI-summarizers-read-config-sections-that-do-not-exist.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17383
 title: Kobold and TabbyAPI summarizers read config sections that do not exist
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-17 09:05'
 labels:
@@ -23,9 +23,9 @@ The evidence-contamination consequence is already closed for every provider: the
 <!-- AC:BEGIN -->
 - [ ] #1 A Kobold summarization request reaches its server instead of failing on a configuration lookup
 - [ ] #2 A TabbyAPI summarization request reaches its server instead of failing on a configuration lookup
-- [ ] #3 Each summarizer resolves its endpoint and credential from a source the loader actually populates, preferring the modern per-provider settings table like the chat handlers do
-- [ ] #4 The remaining local summarizers are audited for reads of absent sections or keys, and each is fixed or recorded as sound
-- [ ] #5 Tests cover the configuration resolution for both providers without contacting a network
+- [x] #3 Each summarizer resolves its endpoint and credential from a source the loader actually populates, preferring the modern per-provider settings table like the chat handlers do
+- [x] #4 The remaining local summarizers are audited for reads of absent sections or keys, and each is fixed or recorded as sound
+- [x] #5 Tests cover the configuration resolution for both providers without contacting a network
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -40,4 +40,41 @@ Evidence from the task-17382 investigation, before any fix here:
   (TabbyAPI) index the missing sections.
 - Same failure shape as task-17382: the read sits above the HTTP call, and the
   bottom `except` converts the KeyError into a returned error string.
+<!-- SECTION:NOTES:END -->
+
+## Implementation Notes (partial -- AC #1 and #2 blocked)
+
+<!-- SECTION:NOTES:BEGIN -->
+Both summarizers now resolve their endpoint, credential and model from tables
+the loader actually builds -- the modern `api_settings` entry first
+(`koboldcpp` / `tabbyapi`, both of which exist and carry `api_url`), then the
+legacy section (`kobold_api` / `tabby_api`, which carry `api_ip`, `api_key` and
+for Tabby `model`). Two shared helpers do the resolution by name rather than by
+index, so a missing section can never raise again.
+
+Credential resolution keeps a distinction the previous code had by accident and
+the contract tests pin deliberately: a key declared as an empty string is
+"configured but blank" (proceed with no Authorization header), while a key that
+is absent or declared null is "absent" (refuse). Collapsing the two turned a
+working blank-credential call into a failure, which those tests caught.
+`api_key_env_var` is honoured because tabbyapi's modern table carries only that
+field and two UI surfaces already read it -- following the repo's convention,
+not inventing one.
+
+AC #4, the audit: an AST pass over every `summarize_with_*` shows only these two
+read sections the loader never builds. `local_llm` has no direct config reads,
+`llama` was fixed in task-17382, and `oobabooga`, `vllm`, `ollama`,
+`custom_openai` and `custom_openai_2` all read sections that exist.
+
+**AC #1 and #2 remain open, blocked on task-17387.** Both functions are
+GENERATOR functions -- a top-level `yield` in their streaming branches -- so a
+call returns a generator and the body never runs; no request reaches either
+server regardless of configuration. A prototype fix worked but re-attributed
+roughly twenty diagnostics to nested functions and broke seven tests in the
+security-reviewed ledger suite, so it was reverted and filed separately rather
+than landed as a side effect of a configuration fix.
+
+Verified: the diagnostic privacy suite fails exactly the 3 manifest-boundary
+tests clean dev fails (3 failed / 254 passed on both sides), and 1106 tests pass
+across the LLM_Calls, pipeline and research suites.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17387 - Kobold-and-TabbyAPI-summarizers-are-generator-functions.md
+++ b/backlog/tasks/task-17387 - Kobold-and-TabbyAPI-summarizers-are-generator-functions.md
@@ -1,0 +1,53 @@
+---
+id: TASK-17387
+title: Kobold and TabbyAPI summarizers are generator functions
+status: To Do
+assignee: []
+created_date: '2026-08-18 04:30'
+labels:
+  - llm-calls
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two local summarizers can never return a summary. Their streaming branches yield from the function body rather than from a nested generator, which makes the entire function a generator function: calling it returns a generator object and runs none of the body, on every path including the non-streaming one. No request reaches the server unless the caller happens to iterate the result.
+
+The consequence for the deep-search pipeline is the same class of defect as the llama.cpp chain, one step worse. A caller that stores the result keeps a generator object where a summary belongs; the pipeline's failure detector inspects strings, so a generator passes it, and a generator is truthy, so the emptiness guard passes too. The object would be stored as a result's evidence content.
+
+Fixing this is a contract change with governed-artifact fallout, which is why it is separate from the configuration fix that preceded it: nesting the streaming bodies re-attributes roughly twenty diagnostics from the owning function to the nested one, and the summarization diagnostic ledger keys every entry on its enclosing function name. The ledger and the contract tests that consume these functions as generators both need deliberate review, not a mechanical update.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A non-streaming call to either summarizer executes its body and returns a string
+- [ ] #2 A streaming call still returns an iterator that yields the same chunks it does today
+- [ ] #3 No caller can receive an object that the deep-search failure detector silently accepts as a summary
+- [ ] #4 The diagnostic ledger's re-attribution is reviewed and updated deliberately, with the reason recorded
+- [ ] #5 The existing contract tests are updated to the corrected contract, each with its reason, or shown to be unaffected
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Evidence gathered during task-17383 (2026-08-18), before any fix:
+
+- An AST check over the module: `summarize_with_kobold` and
+  `summarize_with_tabbyapi` are the only two `summarize_with_*` functions that
+  are generators; the other seven are plain functions.
+- The top-level yields are in the streaming branches and error paths --
+  Kobold at the `if streaming:` body, TabbyAPI likewise plus its outer
+  `except`, which yields for streaming and returns for non-streaming.
+- Calling `summarize_with_tabbyapi(...)` directly with a stubbed transport
+  returns `<generator object ...>`; the transport is never invoked.
+- A prototype fix (nesting each streaming body in a `_stream_generator`, as
+  `summarize_with_llama` already does) worked and left both functions
+  non-generators, but broke 7 tests in
+  `Tests/LLM_Calls/test_summarization_diagnostic_privacy.py`: the ledger keys
+  entries as `(file, function, message, ordinal)`, so nesting re-attributes
+  every diagnostic inside the moved body. That prototype was reverted rather
+  than landed with a silently-rewritten ledger.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -551,10 +551,18 @@ def summarize_with_kobold(
                 else:
                     logging.warning("Kobold: No API key found in config file")
             # Get the Streaming API IP from the config
+            # Qodo (PR 1788): these two endpoints are NOT interchangeable.
+            # The streaming branch parses OpenAI-compatible SSE, and the
+            # OpenAI-compatible endpoint is the legacy `api_streaming_ip`
+            # (".../v1/chat/completions"), while BOTH `api_settings.koboldcpp.
+            # api_url` and the legacy `api_ip` point at Kobold's NATIVE
+            # ".../api/v1/generate". Preferring the modern url here sent
+            # streaming requests to the native endpoint and produced no
+            # summary, because the modern key is normally populated.
             kobold_openai_api_IP = (
-                kobold_modern.get("api_url")
-                or kobold_legacy.get("api_streaming_ip")
-                or kobold_legacy.get("api_ip")
+                kobold_legacy.get("api_streaming_ip")
+                or kobold_modern.get("api_streaming_url")
+                or kobold_modern.get("api_url")
             )
 
         if kobold_api_key is None:

--- a/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py
@@ -149,6 +149,76 @@ def summarize_with_local_llm(
 DEFAULT_SUMMARY_MAX_TOKENS = 4096
 
 
+def _resolve_local_provider_config(
+    loaded_config_data, modern_key: str, legacy_key: str
+) -> tuple[dict, dict]:
+    """Return ``(modern, legacy)`` config tables for a local provider.
+
+    task-17383: several summarizers indexed sections the loader has never built
+    (`api_keys`, `local_api_ip`, `models`), so they raised before contacting a
+    server and reported failure by RETURNING an error string -- which the
+    deep-search caller could store as a result's evidence. Resolved by name and
+    defensively here, never by index.
+
+    Args:
+        loaded_config_data: The loaded settings mapping (may be None).
+        modern_key: Provider key under ``api_settings`` (e.g. "koboldcpp").
+        legacy_key: Historical top-level section (e.g. "kobold_api").
+
+    Returns:
+        The two tables, each an empty dict when absent.
+    """
+    if not isinstance(loaded_config_data, dict):
+        return {}, {}
+    modern = (loaded_config_data.get("api_settings") or {}).get(modern_key) or {}
+    legacy = loaded_config_data.get(legacy_key) or {}
+    return (
+        modern if isinstance(modern, dict) else {},
+        legacy if isinstance(legacy, dict) else {},
+    )
+
+
+def _resolve_provider_credential(parameter_key, modern: dict, legacy: dict):
+    """Credential for a local provider: the caller's parameter, then the modern
+    table, then the legacy section, then the environment variable the config
+    NAMES (``api_key_env_var`` -- this repo's existing convention, honoured by
+    the media and settings windows; tabbyapi's modern table carries only that).
+
+    Args:
+        parameter_key: Key passed by the caller, if any.
+        modern: Modern per-provider table.
+        legacy: Legacy section.
+
+    Returns:
+        The resolved key, or None when nothing supplies one.
+    """
+    if parameter_key and str(parameter_key).strip():
+        return str(parameter_key).strip()
+    declared = False
+    for table in (modern, legacy):
+        if "api_key" not in table:
+            continue
+        candidate = table.get("api_key")
+        if candidate is None:
+            # Declared as null reads as ABSENT, not blank: these functions
+            # refuse a run with no credential at all while proceeding without
+            # an Authorization header for a configured empty string.
+            continue
+        declared = True
+        if str(candidate).strip():
+            return str(candidate).strip()
+    env_name = str(modern.get("api_key_env_var") or "").strip()
+    if env_name:
+        env_value = os.environ.get(env_name, "").strip()
+        if env_value:
+            return env_value
+    # "Configured but blank" is NOT the same as "absent": these summarizers
+    # proceed without an Authorization header for the former and refuse the
+    # latter, and their tests pin that distinction. Collapsing both to None
+    # turned a working blank-credential call into a failure.
+    return "" if declared else None
+
+
 def summarize_with_llama(
     input_data,
     custom_prompt,
@@ -457,6 +527,12 @@ def summarize_with_kobold(
     try:
         logging.debug("Kobold: Loading and validating configurations")
         loaded_config_data = load_settings()
+        # task-17383: this function indexed `api_keys` and `local_api_ip`,
+        # names the loader has never built, so it raised before reaching a
+        # server. Both a modern api_settings entry and a legacy section exist.
+        kobold_modern, kobold_legacy = _resolve_local_provider_config(
+            loaded_config_data, "koboldcpp", "kobold_api"
+        )
         if loaded_config_data is None:
             logging.error("Failed to load configuration data")
             kobold_api_key = None
@@ -467,13 +543,19 @@ def summarize_with_kobold(
                 logging.info("Kobold: Using API key provided as parameter")
             else:
                 # If no parameter is provided, use the key from the config
-                kobold_api_key = loaded_config_data["api_keys"].get("kobold")
+                kobold_api_key = _resolve_provider_credential(
+                    None, kobold_modern, kobold_legacy
+                )
                 if kobold_api_key:
                     logging.info("Kobold: Using API key from config file")
                 else:
                     logging.warning("Kobold: No API key found in config file")
             # Get the Streaming API IP from the config
-            kobold_openai_api_IP = loaded_config_data["local_api_ip"]["kobold_openai"]
+            kobold_openai_api_IP = (
+                kobold_modern.get("api_url")
+                or kobold_legacy.get("api_streaming_ip")
+                or kobold_legacy.get("api_ip")
+            )
 
         if kobold_api_key is None:
             raise TypeError("'NoneType' object is not subscriptable")
@@ -527,7 +609,12 @@ def summarize_with_kobold(
 
         logging.debug("Kobold Summarization: Submitting request to API endpoint")
         logging.info("Kobold Summarization: Submitting request to API endpoint")
-        kobold_api_ip = loaded_config_data["local_api_ip"]["kobold"]
+        kobold_api_ip = kobold_modern.get("api_url") or kobold_legacy.get("api_ip")
+        if not kobold_api_ip:
+            raise ValueError(
+                "Kobold Summarize: no API URL configured "
+                "(api_settings.koboldcpp.api_url or kobold_api.api_ip)"
+            )
 
         if streaming:
             logging.debug("Kobold Summarization: Streaming mode enabled")
@@ -536,8 +623,8 @@ def summarize_with_kobold(
                 session = requests.Session()
 
                 # Load config values
-                retry_count = loaded_config_data["kobold_api"]["api_retries"]
-                retry_delay = loaded_config_data["kobold_api"]["api_retry_delay"]
+                retry_count = kobold_legacy["api_retries"]
+                retry_delay = kobold_legacy["api_retry_delay"]
 
                 # Configure the retry strategy
                 retry_strategy = Retry(
@@ -613,8 +700,8 @@ def summarize_with_kobold(
                 session = requests.Session()
 
                 # Load config values
-                retry_count = loaded_config_data["kobold_api"]["api_retries"]
-                retry_delay = loaded_config_data["kobold_api"]["api_retry_delay"]
+                retry_count = kobold_legacy["api_retries"]
+                retry_delay = kobold_legacy["api_retry_delay"]
 
                 # Configure the retry strategy
                 retry_strategy = Retry(
@@ -945,6 +1032,11 @@ def summarize_with_tabbyapi(
     try:
         logging.debug("TabbyAPI: Loading and validating configurations")
         loaded_config_data = load_settings()
+        # task-17383: same defect -- `api_keys`, `local_api_ip` and `models`
+        # are names nothing produces.
+        tabby_modern, tabby_legacy = _resolve_local_provider_config(
+            loaded_config_data, "tabbyapi", "tabby_api"
+        )
         if loaded_config_data is None:
             logging.error("Failed to load configuration data")
             tabby_api_key = None
@@ -955,15 +1047,22 @@ def summarize_with_tabbyapi(
                 logging.info("TabbyAPI: Using API key provided as parameter")
             else:
                 # If no parameter is provided, use the key from the config
-                tabby_api_key = loaded_config_data["api_keys"].get("tabby")
+                tabby_api_key = _resolve_provider_credential(
+                    None, tabby_modern, tabby_legacy
+                )
                 if tabby_api_key:
                     logging.info("TabbyAPI: Using API key from config file")
                 else:
                     logging.warning("TabbyAPI: No API key found in config file")
 
         # Set API IP and model from config.txt
-        tabby_api_ip = loaded_config_data["local_api_ip"]["tabby"]
-        tabby_model = loaded_config_data["models"]["tabby"]
+        tabby_api_ip = tabby_modern.get("api_url") or tabby_legacy.get("api_ip")
+        if not tabby_api_ip:
+            raise ValueError(
+                "TabbyAPI Summarize: no API URL configured "
+                "(api_settings.tabbyapi.api_url or tabby_api.api_ip)"
+            )
+        tabby_model = tabby_modern.get("model") or tabby_legacy.get("model")
         if temp is None:
             temp = 0.7
 
@@ -1027,8 +1126,8 @@ def summarize_with_tabbyapi(
                 session = requests.Session()
 
                 # Load config values
-                retry_count = loaded_config_data["tabby_api"]["api_retries"]
-                retry_delay = loaded_config_data["tabby_api"]["api_retry_delay"]
+                retry_count = tabby_legacy["api_retries"]
+                retry_delay = tabby_legacy["api_retry_delay"]
 
                 # Configure the retry strategy
                 retry_strategy = Retry(
@@ -1095,8 +1194,8 @@ def summarize_with_tabbyapi(
                 session = requests.Session()
 
                 # Load config values
-                retry_count = loaded_config_data["tabby_api"]["api_retries"]
-                retry_delay = loaded_config_data["tabby_api"]["api_retry_delay"]
+                retry_count = tabby_legacy["api_retries"]
+                retry_delay = tabby_legacy["api_retry_delay"]
 
                 # Configure the retry strategy
                 retry_strategy = Retry(


### PR DESCRIPTION
Closes **TASK-17383**'s reachable criteria (#3, #4, #5). **AC #1 and #2 stay open**, blocked on a larger defect this work uncovered — filed as **TASK-17387**.

## The fix

Both summarizers indexed `api_keys`, `local_api_ip` and `models` — names the loader has **never** built — so like llama.cpp before TASK-17382 they raised before reaching a server and reported failure by *returning* an error string a caller could store as evidence. Both providers have complete modern `api_settings` entries **and** complete legacy sections; nothing was missing but the lookup.

Two shared helpers now resolve by name rather than by index.

**One subtlety worth calling out**, because the contract tests caught me: credential resolution preserves a distinction the old code had by accident — a key declared as an empty string is *configured but blank* (proceed with no `Authorization` header), while absent or null is *absent* (refuse). My first version collapsed both to `None`, which turned a working blank-credential call into a failure. `api_key_env_var` is honoured because tabbyapi's modern table carries only that field and two UI surfaces already read it — following the repo's convention rather than inventing one.

## The audit (AC #4)

By AST over every `summarize_with_*`:

| summarizer | verdict |
|---|---|
| `local_llm` | no direct config reads |
| `llama` | fixed in TASK-17382 |
| `oobabooga`, `vllm`, `ollama`, `custom_openai`, `custom_openai_2` | read sections that exist |
| **`kobold`, `tabbyapi`** | **read never-built sections — fixed here** |

## What I found and did NOT fix

Both functions are **generator functions** — a top-level `yield` in their streaming branches — so calling either returns a generator and runs *none* of the body. No request reaches either server regardless of configuration, and a caller storing the result keeps a generator object where a summary belongs. Worse for the pipeline: the failure detector inspects strings so a generator passes it, and a generator is truthy so the emptiness guard passes too — it would be stored as evidence.

I prototyped the fix (nest each streaming body in a `_stream_generator`, as `summarize_with_llama` already does). It worked, and it **broke seven tests in the security-reviewed diagnostic ledger suite**: the ledger keys entries on `(file, function, message, ordinal)`, so nesting re-attributes ~20 diagnostics to the nested function. I reverted it rather than land a silently-rewritten governed artifact inside a configuration fix, and filed **TASK-17387** with the evidence and the ledger consequence.

That's why AC #1 and #2 ("a request reaches its server") are honestly still open here.

## Verification

- The diagnostic privacy suite fails **exactly** the 3 manifest-boundary tests clean `dev` fails (3 failed / 254 passed on both sides) — no governed-artifact churn.
- **1106 passed** across `Tests/LLM_Calls`, the pipeline suite and `Tests/Research`; `ruff` clean.
- Six new tests drive both providers with each server's real response envelope (Kobold's native `results[].text`, TabbyAPI's full OpenAI envelope — it validates `id`/`created`/`model`/`object`/`usage` before reading content, so a fake carrying only `choices` proves nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads Kobold and TabbyAPI settings from real config sections and fixes Kobold streaming to use the OpenAI-compatible endpoint. Old behavior: both looked up `api_keys`/`local_api_ip`/`models` and returned an error string before any request; Kobold streaming hit the native generate URL and produced no chunks. New behavior: endpoints and credentials resolve from `api_settings.koboldcpp`/`api_settings.tabbyapi` with fallback to `kobold_api`/`tabby_api`; Kobold streaming prefers `kobold_api.api_streaming_ip` while non-streaming uses the native generate endpoint.

**Review notes**
- Config resolution: new helpers prefer modern tables, fall back to legacy; supports `api_key_env_var` for Tabby; preserves blank-vs-absent credential semantics; clear error when no API URL is configured; legacy retry settings are used.
- Endpoints: Kobold streaming sends to OpenAI-compatible SSE; non-streaming sends to native `.../api/v1/generate`.
- Tests/tasks: adds coverage for modern/legacy resolution, real response envelopes, streaming vs non-streaming, and an `analyze` integration; diagnostic-privacy fixtures rekeyed to `kobold_api`/`tabby_api`. Satisfies TASK-17383 AC #3–#5; AC #1–#2 remain open (blocked by TASK-17387: both functions are still generator functions).
- Migration: none for runtime configs using `api_settings` or `kobold_api`/`tabby_api`. Update any test fixtures keyed to `api_keys`/`local_api_ip`/`models`.

<sup>Written for commit e3ef9b126d79ee5450231420e3d92d496f09d343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

