### PR TITLE
Cover send_to_agent in the shadow-name set (TASK-18055)

### DIFF
--- a/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
+++ b/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
@@ -1,7 +1,7 @@
 ---
 id: task-18055
 title: send_to_agent missing from the skills shadow-name set
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18'
 labels: [agents, skills]
@@ -27,9 +27,26 @@ test's import path.
 
 ## Acceptance Criteria (the what)
 
-- [ ] `send_to_agent` is covered by `_SHADOWED_BUILTIN_NAMES` (or deliberately
+- [x] `send_to_agent` is covered by `_SHADOWED_BUILTIN_NAMES` (or deliberately
       exempted with a documented reason)
-- [ ] The guard passes on a clean dev checkout
-- [ ] Any other name added since TASK-13214 closed is covered in the same
+- [x] The guard passes on a clean dev checkout
+- [x] Any other name added since TASK-13214 closed is covered in the same
       pass — the guard reports all four sources at once, so run it and fix
       everything it names rather than only the one in this title
+
+## Implementation Notes
+
+`send_to_agent` added to `_SHADOWED_BUILTIN_NAMES` with the reason in place.
+`Tests/Library/` is now **2016 passed / 4 skipped / 0 failed** — the standing
+dev red is gone.
+
+**AC#3 is satisfied by the guard's own shape rather than by a second sweep.**
+TASK-13214 rebuilt it to collect all four sources and assert ONCE, so its
+failure message enumerates every gap simultaneously; this run named exactly
+one (`RUNTIME_TOOL_NAMES: ['send_to_agent']`), which IS the answer to "is
+anything else missing". Under the pre-13214 shape that question would have
+needed a manual sweep, because the in-order asserts short-circuited and each
+new name hid behind the last — which is how `generate-video`/`stream-video`
+masked `research`, which masked this one, across three sightings.
+
+This is the guard working as designed on its first post-repair catch.

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -58,6 +58,11 @@ _SHADOWED_BUILTIN_NAMES = frozenset(
         # The run_skill_script runtime tool (same drift-guard rationale as
         # skill_file/install_skill above).
         "run_skill_script",
+        # The fleet's send_to_agent runtime tool (supervisor-fleet PR 3b) --
+        # caught by the four-source guard TASK-13214 rebuilt, which is what
+        # it was rebuilt FOR: the previous shape short-circuited on the first
+        # failing subset, so each new name hid behind the last one.
+        "send_to_agent",
         # The /research Console command (task-16481) -- the drift guard's
         # third sighting (TASK-13214): it was MASKED behind the video-command
         # gap until the guard learned to report all sources at once.


### PR DESCRIPTION
One entry, and a standing dev red is gone: `Tests/Library/` goes from 2015 passed / 1 failed to **2016 passed / 0 failed**.

## What happened

The supervisor-fleet work added a `send_to_agent` runtime tool without adding it to `_SHADOWED_BUILTIN_NAMES`, so a skill installed under that name could shadow the runtime tool undetected. The drift guard caught it:

```
Shadow-guard drift -- ALL gaps across ALL sources (nothing masked):
{'RUNTIME_TOOL_NAMES': ['send_to_agent']}
```

## This is the guard working as designed — its first post-repair catch

TASK-13214 rebuilt this guard six days ago because the previous shape asserted three subsets **in order** and short-circuited on the first failure, so each new name hid behind the last: `generate-video`/`stream-video` masked `research`, which masked whatever came next, across three separate sightings over ten days.

The rebuilt guard collects four sources and asserts **once**. That's why AC#3 ("cover anything else added since 13214 closed") needed no separate sweep — the failure message enumerates every gap simultaneously, and it named exactly one. Under the old shape, answering that question meant fixing one name and re-running to see what appeared next.

Refs TASK-18055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `send_to_agent` to the skills shadow-name set to prevent skills from shadowing the runtime tool; the shadow-guard now passes and the Library tests are green. Previously, the missing entry allowed a skill named `send_to_agent` to shadow the runtime tool and triggered a drift failure.

**Review notes / impact**
- Adds `send_to_agent` to `_SHADOWED_BUILTIN_NAMES` in `tldw_chatbook/Library/library_skills_state.py` with rationale; satisfies TASK-18055 and aligns with the post-13214 guard.
- Behavior change: skills named `send_to_agent` are now blocked by the guard. Required action: rename any skill using this name.
- Tests: `Tests/Library/` is 2016 passed / 4 skipped / 0 failed; the standing dev red is resolved.

<sup>Written for commit 48fd9c623048feb5f8687009342cebe1cdb1ebe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

