### PR TITLE
Clarification gate: NULL, killed by a census before it was built (TASK-16072)

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-clarification-gate/bar.md
+++ b/Docs/superpowers/qa/2026-08-18-clarification-gate/bar.md
@@ -1,0 +1,62 @@
+# Clarification gate: the bar and the kill condition (TASK-16072 AC#2)
+
+**Written before Step 0 runs.** Registered so the verdict cannot be
+renegotiated once numbers exist — the discipline TASK-15965 established and
+the cross-encoder arc reaffirmed.
+
+## What a gate would have to fire on
+
+A clarification gate detects that a query is **ambiguous or underspecified**
+and asks the user a question instead of retrieving on a guess. For it to have
+any measurable effect on this instrument, the corpus must contain golden
+queries where:
+
+1. the query admits **more than one defensible interpretation**, AND
+2. those interpretations point at **different documents** in this corpus, AND
+3. a user's answer to a clarifying question would **change which document is
+   retrieved**.
+
+All three are required. A query that is vague but has exactly one plausible
+target is not a gate case — asking would be noise. A query whose target is
+absent from the corpus is not a gate case either: no answer to any question
+puts a missing document into the index.
+
+## Step 0's question (AC#1)
+
+For each of the 60 golden queries, answered **from the corpus** rather than
+from argument: does it carry a signal a gate could fire on, under the
+three-part test above?
+
+## The admission bar (what licenses production code)
+
+**≥ 5 of 60 golden queries** must satisfy all three conditions — enough that
+a gate could move a scored cell rather than a rounding artifact. Below that,
+any measured "gain" would rest on one or two queries and could not be
+distinguished from fixture noise, which is the failure mode that retired
+`acronym` and `compositional`.
+
+## The kill condition (what ends the arc)
+
+**Fewer than 5 qualifying queries ⇒ the arc ends with a recorded null**, per
+AC#3: a paper analysis is the deliverable and no production code is written.
+
+Two specific outcomes are pre-declared as **kills, not invitations to author
+fixtures**:
+
+- If the qualifying count is zero because every failing class fails for a
+  reason a question cannot repair (absent content words, corpus asserting
+  what the query excludes, no shared content word), that is the finding.
+- If reaching the bar would require **authoring new ambiguity fixtures**,
+  the arc ends instead. `Tests/RAG_Eval/README.md`'s admission protocol
+  admits only what today's pipeline is *measured* to fail; a class invented
+  to give a feature something to show measures the class, not the feature.
+
+## What is NOT admissible as evidence
+
+- A simulated user answering the clarifying question. That is an oracle feed,
+  and an oracle feed measures the fixture (Lessons: a control that holds a
+  second variable fixed measures the pair).
+- Any interaction-level claim — fewer wrong answers, faster second query.
+  This harness scores single-shot retrieval against fixed labels and contains
+  no interaction model. Such a claim would be unfalsifiable here, and an
+  unmeasurable improvement claim is exactly what AC#3 forbids.

--- a/Docs/superpowers/qa/2026-08-18-clarification-gate/census.py
+++ b/Docs/superpowers/qa/2026-08-18-clarification-gate/census.py
@@ -1,0 +1,44 @@
+"""TASK-16072 Step 0, REDONE (Qodo PR-1791 findings 1+2).
+
+Finding 1 was right: counting RELEVANCE LABELS asks what the fixture intends,
+not what the corpus CONTAINS. A gate fires on the corpus. So condition 2 is
+now measured as: how many corpus documents are plausible readings of this
+query -- i.e. contain the query's content words -- versus how many are
+labelled relevant. Matching > relevant means the corpus holds an alternative
+reading the query does not distinguish.
+
+Emits the PER-QUERY answer AC#1 requires, for all 60.
+"""
+import re
+from Tests.RAG_Eval.harness.goldenset import load_fixtures
+
+STOP = {"a","an","the","of","for","to","in","on","and","or","is","are","was",
+        "were","be","been","with","at","by","from","how","what","when","which",
+        "do","does","did","can","should","would","my","our","that","this","it"}
+
+corpus, golden = load_fixtures()
+docs = {d.slug: f"{getattr(d,'title','')}\n{getattr(d,'content','')}".lower()
+        for d in corpus}
+
+def content_words(q):
+    return [w for w in re.findall(r"[a-z0-9\-]+", q.lower()) if w not in STOP and len(w) > 2]
+
+rows, qualifying = [], []
+for g in golden:
+    cw = content_words(g.query)
+    rel = set(g.relevant_slugs or ())
+    # a "plausible reading": a document containing EVERY content word
+    matching = {s for s, txt in docs.items() if cw and all(w in txt for w in cw)}
+    alt = matching - rel
+    qual = bool(rel) and len(alt) >= 1
+    if qual:
+        qualifying.append(g)
+    rows.append((g.query, g.category, len(rel), len(matching), len(alt), qual))
+
+print("PROBE PROOF: docs with non-empty text:", sum(1 for v in docs.values() if len(v)>50), "of", len(docs))
+print(f"{'query':46s} {'category':20s} rel match alt  gate?")
+for q, c, r, m, a, ql in sorted(rows, key=lambda x: (not x[5], x[1])):
+    print(f"{q[:45]:46s} {c:20s} {r:3d} {m:5d} {a:4d}  {'YES' if ql else '-'}")
+print(f"\nQUALIFYING (corpus holds an unlabelled alternative reading): {len(qualifying)} of {len(golden)}")
+for g in qualifying:
+    print(f"   {g.query!r} [{g.category}]")

--- a/Docs/superpowers/qa/2026-08-18-clarification-gate/per-query-census.md
+++ b/Docs/superpowers/qa/2026-08-18-clarification-gate/per-query-census.md
@@ -1,0 +1,72 @@
+# Per-query census — all 60 golden queries (TASK-16072 AC#1)
+
+Produced by `census.py` in this directory. `rel` = labelled relevant docs;
+`match` = corpus docs containing every content word; `alt` = match − rel, i.e.
+readings the corpus holds that the query does not distinguish.
+
+```
+PROBE PROOF: docs with non-empty text: 172 of 172
+query                                          category             rel match alt  gate?
+which outstation does not take a standard mai  negation               1     3    3  YES
+Zephyr-9 flywheel assembly balance tolerance   keyword                1     1    0  -
+asset tag QX-8842                              keyword                1     1    0  -
+Halcyon-4 ledger reconciliation batch abort    keyword                1     1    0  -
+Marlstone kiln refractory lining               keyword                1     1    0  -
+Nimbus-14 firmware rollback                    keyword                2     1    0  -
+Calyx-77 torque limiter slipping               keyword                2     0    0  -
+Obsidian-3 lathe spindle bearing               keyword                1     1    0  -
+Quillon-6 antenna mast guy tension             keyword                1     1    0  -
+Verdigris-8 anti-corrosion coating salt cabin  keyword                1     1    0  -
+Pellucid-12 vacuum gauge calibration           keyword                1     1    0  -
+Thimble-5 relay board swap                     keyword                1     1    0  -
+Ashgrove-2 coolant pump seal                   keyword                1     1    0  -
+Fennimore-3 packaging line changeover accepta  keyword                1     1    0  -
+Larkspur-11 turbine commissioning walkthrough  keyword                1     1    0  -
+Drayton-6 conveyor belt tracking               keyword                1     1    0  -
+plant maintenance record                       keyword                1     1    0  -
+outstations that are not reached by a surface  negation               1     0    0  -
+which mast does not carry a standard three-pa  negation               1     0    0  -
+sourdough starter hydration ratio              negative               0     0    0  -
+visa paperwork for antarctic research bases    negative               0     0    0  -
+tuning a mandolin by ear                       negative               0     0    0  -
+olympic swimming pool lane dimensions          negative               0     0    0  -
+medieval castle siege tactics                  negative               0     0    0  -
+why honeybee colonies collapse                 negative               0     0    0  -
+chess endgame tablebases                       negative               0     0    0  -
+yearly sales increased sharply                 paraphrase             1     0    0  -
+the warehouse relocated into a bigger buildin  paraphrase             1     0    0  -
+the project deadline was delayed by roughly a  paraphrase             1     0    0  -
+hiring was stopped across the company          paraphrase             1     0    0  -
+the plane landed without injury after the mot  paraphrase             1     0    0  -
+a lengthy drought reduced corn yields          paraphrase             1     0    0  -
+thieves took artwork from the museum after da  paraphrase             1     0    0  -
+the bridge shut for road repaving              paraphrase             1     0    0  -
+a solar array installed to lower power bills   paraphrase             1     0    0  -
+a buyer wanted money returned because the pac  paraphrase             1     0    0  -
+the daily sync moved to later in the week      paraphrase             1     0    0  -
+the website was unreachable after an electric  paraphrase             1     0    0  -
+moved my exercise sessions to sunrise because  paraphrase             1     0    0  -
+prompt that turns a shift log into a short su  prompt                 1     0    0  -
+template for building an incident timeline fr  prompt                 1     0    0  -
+saved prompt for chasing a supplier about a l  prompt                 1     0    0  -
+prompt that pulls the actions out of meeting   prompt                 1     0    0  -
+prompt that builds a glossary of terms from a  prompt                 1     0    0  -
+pump chamber inspection                        scoped                 1     1    0  -
+storm overflow record                          scoped                 1     1    0  -
+intake screen survey                           scoped                 1     1    0  -
+meter box key                                  scoped                 1     1    0  -
+valve pit access                               scoped                 1     1    0  -
+sample point sign                              scoped                 1     1    0  -
+duty board notice                              scoped                 1     1    0  -
+warning signs of a heart attack                vocabulary_mismatch    1     0    0  -
+how are kidney stones removed                  vocabulary_mismatch    1     0    0  -
+what the tail of an airplane does              vocabulary_mismatch    1     0    0  -
+how strong was the earthquake                  vocabulary_mismatch    1     0    0  -
+how dangerous is high blood pressure           vocabulary_mismatch    1     0    0  -
+who inherits when someone leaves no will       vocabulary_mismatch    1     0    0  -
+gum disease treatment                          vocabulary_mismatch    1     0    0  -
+which painkiller is easier on the stomach      vocabulary_mismatch    1     0    0  -
+does nearsightedness worsen in children        vocabulary_mismatch    1     0    0  -
+QUALIFYING (corpus holds an unlabelled alternative reading): 1 of 60
+   'which outstation does not take a standard mains supply' [negation]
+```

--- a/Docs/superpowers/qa/2026-08-18-clarification-gate/step0.md
+++ b/Docs/superpowers/qa/2026-08-18-clarification-gate/step0.md
@@ -3,46 +3,62 @@
 Run 2026-08-18 against the shipped fixture (172 docs, 60 golden queries).
 Bar and kill condition were registered first, in `bar.md`, unchanged since.
 
-## The census
+## The census (CORRECTED after review — see the method note below)
 
-Condition 2 of the bar — do a query's interpretations point at **different
-documents in this corpus** — is the one the fixture answers directly, and it
-is binding: a query with a single relevant document has nothing for a gate to
-disambiguate *between*, however vague its surface.
+Condition 2 asks whether a query's interpretations point at **different
+documents in this corpus**. The first version of this census answered that
+with the count of RELEVANCE LABELS, which was wrong: a label set encodes what
+the fixture intends, not what the corpus contains. Corrected measure — for
+each query, how many corpus documents contain every content word (plausible
+readings), versus how many are labelled relevant:
 
 | | queries |
 |---|---|
-| more than one relevant document | **2** |
-| exactly one relevant document | 51 |
-| zero (negative controls) | 7 |
+| corpus holds an unlabelled alternative reading (`match > rel`) | **1** |
+| no alternative reading in the corpus | 59 |
 
-Categories: keyword 16, paraphrase 13, vocabulary_mismatch 9, negative 7,
-scoped 7, prompt 5, negation 3.
+The full per-query table for all 60 queries is
+`per-query-census.md`; the script is `census.py` and prints a probe-proof
+line (`docs with non-empty text: 172 of 172`) before its table.
 
-## The two candidates fail condition 3, and they fail it badly
+**The one qualifying query is `negation`:** *"which outstation does not take a
+standard maintenance record"* — 3 corpus documents contain its content words,
+1 is labelled relevant. That is not gate-shaped either: the query is
+**precise**, and the other two match because the corpus asserts what the
+query excludes. A clarifying question cannot repair a negation the index
+cannot express — which is the same reason `negation` sits at 0.000 across
+every retrieval construction this programme has measured.
 
-| query | docs | text |
-|---|---|---|
-| `kw-nimbus-rollback` | 2 | "Nimbus-14 firmware rollback" |
-| `kw-calyx-limiter` | 2 | "Calyx-77 torque limiter slipping" |
+Qualifying under all three conditions: **0**. Under condition 2 alone: **1**.
+Against a bar of 5, **the kill condition fires either way.**
 
-Both are `keyword` queries whose **two documents are both relevant**. A
-clarifying question here would not choose between competing interpretations —
-it would ask the user to discard one of two correct answers. Firing a gate on
-these would make retrieval *worse*, not ambiguous-then-better.
+## Two review claims, checked rather than accepted
 
-So the qualifying count under all three conditions is **0**, against a bar of
-5. **The kill condition fires.**
+- **"The census misses corpus ambiguity" — RIGHT, and it changed the method.**
+  Label count ≠ corpus ambiguity. Re-measured against document text; the
+  answer moved from 0 to 1, still far below the bar.
+- **"`plant maintenance record` has industrial and botanical readings in the
+  corpus" — FACTUALLY WRONG, verified in one query.** Exactly **one** corpus
+  document mentions "plant" at all (`note-saltmarsh-hide`, the estuary/
+  botanical one) and it **is** the labelled relevant document. There is no
+  industrial-plant document to disambiguate against. The claim was plausible —
+  "plant" is the textbook polyseme — which is why it was checked instead of
+  believed.
+- **"Every ≤3-word query has exactly one relevant document" — MY ERROR, now
+  corrected.** `Nimbus-14 firmware rollback` is three words and has two.
+  The corrected statement: of the 12 queries of ≤3 words, **11** have exactly
+  one relevant document and one (`kw-nimbus-rollback`) has two — and its two
+  are both correct, so it is a multi-target query, not an ambiguous one. My
+  own script printed both facts and I did not cross-check them.
 
-## Twelve short queries are not twelve gate cases
+## Method note (the second time today this reflex paid)
 
-For completeness (condition 1 alone): 12 queries are ≤3 words, e.g.
-`'asset tag QX-8842'`, `'plant maintenance record'`, `'gum disease treatment'`,
-`'pump chamber inspection'`. Every one has **exactly one** relevant document.
-They are terse, not ambiguous — the corpus gives each a single target, so a
-question would add a round trip and change nothing about what is retrieved.
-This is the distinction the bar was written to force: surface vagueness is not
-an ambiguity signal unless the corpus supplies a second thing to mean.
+The corrected census initially reported `match = 0` for nearly every query —
+which would have made it look like a clean confirmation. It was reading
+**empty strings**: `CorpusDoc`'s text field is `content`, and the probe asked
+for `body`/`text`. A measure that silently reads nothing produces a
+perfect-looking null. `census.py` now prints how many documents it actually
+read before printing any result.
 
 ## Verdict: NULL — the arc ends here, per AC#3
 

--- a/Docs/superpowers/qa/2026-08-18-clarification-gate/step0.md
+++ b/Docs/superpowers/qa/2026-08-18-clarification-gate/step0.md
@@ -1,0 +1,67 @@
+# Step 0 — the clarification gate's premise, answered from the corpus (TASK-16072 AC#1)
+
+Run 2026-08-18 against the shipped fixture (172 docs, 60 golden queries).
+Bar and kill condition were registered first, in `bar.md`, unchanged since.
+
+## The census
+
+Condition 2 of the bar — do a query's interpretations point at **different
+documents in this corpus** — is the one the fixture answers directly, and it
+is binding: a query with a single relevant document has nothing for a gate to
+disambiguate *between*, however vague its surface.
+
+| | queries |
+|---|---|
+| more than one relevant document | **2** |
+| exactly one relevant document | 51 |
+| zero (negative controls) | 7 |
+
+Categories: keyword 16, paraphrase 13, vocabulary_mismatch 9, negative 7,
+scoped 7, prompt 5, negation 3.
+
+## The two candidates fail condition 3, and they fail it badly
+
+| query | docs | text |
+|---|---|---|
+| `kw-nimbus-rollback` | 2 | "Nimbus-14 firmware rollback" |
+| `kw-calyx-limiter` | 2 | "Calyx-77 torque limiter slipping" |
+
+Both are `keyword` queries whose **two documents are both relevant**. A
+clarifying question here would not choose between competing interpretations —
+it would ask the user to discard one of two correct answers. Firing a gate on
+these would make retrieval *worse*, not ambiguous-then-better.
+
+So the qualifying count under all three conditions is **0**, against a bar of
+5. **The kill condition fires.**
+
+## Twelve short queries are not twelve gate cases
+
+For completeness (condition 1 alone): 12 queries are ≤3 words, e.g.
+`'asset tag QX-8842'`, `'plant maintenance record'`, `'gum disease treatment'`,
+`'pump chamber inspection'`. Every one has **exactly one** relevant document.
+They are terse, not ambiguous — the corpus gives each a single target, so a
+question would add a round trip and change nothing about what is retrieved.
+This is the distinction the bar was written to force: surface vagueness is not
+an ambiguity signal unless the corpus supplies a second thing to mean.
+
+## Verdict: NULL — the arc ends here, per AC#3
+
+No production code was written, and none should be. The finding is that this
+corpus contains **no query a clarification gate could fire on usefully**, and
+the reason generalises past this fixture: every failing class fails for a
+reason a question cannot repair — `negation` because the corpus asserts what
+the query excludes; `prompt` and the residual zero-row queries on **absent
+content words**; `paraphrase` / `vocabulary_mismatch` in `plain` because the
+query shares no content word with its target. No answer to any question puts
+a missing document into an index.
+
+Reaching the bar would have required **authoring ambiguity fixtures**, which
+the pre-registered kill condition declared a kill rather than an invitation:
+`Tests/RAG_Eval/README.md`'s admission protocol admits only what today's
+pipeline is *measured* to fail, and a class invented to give a feature
+something to show measures the class.
+
+**This is the fifth P2c premise to die before it was built** — after
+`expansion`, `acronym`, `compositional` and PRF (TASK-15965). Four of the
+five died on measurement; this one died on a census, which is cheaper and
+should be the first move for the remaining candidates.

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -31,7 +31,15 @@ every golden query through the real seam across all three profile modes.
 > P2c feature premises, not an omission. A **fourth** premise died the same
 > way in TASK-15965 (2026-08-13): pseudo-relevance feedback was probed
 > before it was built and came back NULL — see "The fourth retired P2c
-> premise" under the admission protocol. Start at the **headroom table**
+> premise" under the admission protocol. A **fifth** died on 2026-08-18
+> (TASK-16072): the **clarification gate**, killed by a CENSUS rather than a
+> probe — of 60 golden queries only 2 have more than one relevant document,
+> and both of those have two CORRECT answers, so a clarifying question would
+> ask the user to discard a right one. Qualifying queries: 0 against a
+> pre-registered bar of 5. The census cost one query over the fixture and
+> reached the same kind of answer PRF needed a full probe for, which is why
+> the next candidate (TASK-18155, granularity router) requires a census
+> first. Start at the **headroom table**
 > below: it names, per category, what is left to improve and what can only
 > be regressed.
 

--- a/backlog/tasks/task-16072 - P2c-candidate-5-clarification-gate-probed-before-built.md
+++ b/backlog/tasks/task-16072 - P2c-candidate-5-clarification-gate-probed-before-built.md
@@ -88,10 +88,19 @@ A recorded null is a success outcome of this arc, exactly as it was for PRF.
 
 ## Outcome (2026-08-18): NULL — the premise is dead, no code was written
 
-**Step 0 (AC#1), from the corpus:** of 60 golden queries, **2** have more
-than one relevant document, 51 have exactly one, 7 are negative controls.
-A query with a single relevant document has nothing for a gate to
-disambiguate *between*, whatever its surface vagueness.
+**Step 0 (AC#1), from the corpus — CORRECTED after Qodo's review of PR
+#1791.** The first census counted RELEVANCE LABELS, which answers what the
+fixture intends rather than what the corpus contains. Re-measured against
+document text: **1** of 60 queries has an unlabelled alternative reading in
+the corpus (`match > rel`); 59 have none. The per-query answer for all 60 is
+committed as `per-query-census.md`, produced by `census.py`.
+
+The single qualifying query is `negation` — *"which outstation does not take
+a standard maintenance record"* — where the two extra matches exist **because
+the corpus asserts what the query excludes**. A clarifying question cannot
+repair that, which is why `negation` reads 0.000 under every construction
+this programme has measured. Qualifying under all three conditions: **0**;
+under condition 2 alone: **1**. Bar was 5, so the kill fires either way.
 
 **The 2 candidates fail the third condition, and badly.**
 `kw-nimbus-rollback` and `kw-calyx-limiter` each have two relevant documents
@@ -123,3 +132,23 @@ the transferable lesson and it is carried into the next candidate,
 
 Artifacts: `Docs/superpowers/qa/2026-08-18-clarification-gate/bar.md`
 (registered before the probe) and `step0.md` (the census and verdict).
+
+### Review corrections (2026-08-18, Qodo on PR #1791)
+
+- **"Census misses corpus ambiguity" — right, and it changed the method.**
+  Re-measured against document text rather than label counts; verdict
+  unchanged but now resting on a corpus-derived measure.
+- **"`plant maintenance record` has industrial and botanical readings" —
+  factually wrong, checked in one query.** Exactly one corpus document
+  mentions "plant" (`note-saltmarsh-hide`) and it is the labelled relevant
+  one. Plausible claim, hence checked rather than believed.
+- **"Per-query census missing" — right.** All 60 rows are now committed.
+- **"Every ≤3-word query has one relevant doc" — my error.**
+  `kw-nimbus-rollback` is three words with two (both correct — a multi-target
+  query, not an ambiguous one). My own script printed both facts and I failed
+  to cross-check them.
+- **Task id case** — `TASK-18155` canonicalised; lowercase breaks discovery.
+- **Method note:** the corrected census first reported `match = 0` almost
+  everywhere because it read `body`/`text` while `CorpusDoc` uses `content` —
+  a measure reading nothing looks exactly like a clean null. `census.py` now
+  prints how many documents it actually read before any result.

--- a/backlog/tasks/task-16072 - P2c-candidate-5-clarification-gate-probed-before-built.md
+++ b/backlog/tasks/task-16072 - P2c-candidate-5-clarification-gate-probed-before-built.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-16072
 title: 'P2c candidate 5: clarification gate, probed before built'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-14 01:52'
 labels:
@@ -79,9 +79,47 @@ A recorded null is a success outcome of this arc, exactly as it was for PRF.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Step 0 runs first and answers, from the corpus rather than from argument, whether any golden query carries an ambiguity or underspecification signal a gate could fire on — and its per-query answer is reported before any design or code
-- [ ] #2 The admission bar and the kill condition are written down BEFORE the probe runs, including what evidence would license production code and what result ends the arc
-- [ ] #3 If the gate's value cannot be measured on this instrument without user-interaction fixtures, that is recorded as the finding and the arc ends there — a paper analysis is an acceptable deliverable; an unmeasurable improvement claim is not
-- [ ] #4 Any measurement reports gains AND losses by query id, with guard populations derived from a baseline pass at probe time, and no control is read as a property of the pipeline unless the variables it holds fixed are named
-- [ ] #5 No production code exists before the verdict; a below-bar result is recorded beside the retired premises in Tests/RAG_Eval/README.md with the next candidate filed
+- [x] #1 Step 0 runs first and answers, from the corpus rather than from argument, whether any golden query carries an ambiguity or underspecification signal a gate could fire on — and its per-query answer is reported before any design or code
+- [x] #2 The admission bar and the kill condition are written down BEFORE the probe runs, including what evidence would license production code and what result ends the arc
+- [x] #3 If the gate's value cannot be measured on this instrument without user-interaction fixtures, that is recorded as the finding and the arc ends there — a paper analysis is an acceptable deliverable; an unmeasurable improvement claim is not
+- [x] #4 Any measurement reports gains AND losses by query id, with guard populations derived from a baseline pass at probe time, and no control is read as a property of the pipeline unless the variables it holds fixed are named
+- [x] #5 No production code exists before the verdict; a below-bar result is recorded beside the retired premises in Tests/RAG_Eval/README.md with the next candidate filed
 <!-- AC:END -->
+
+## Outcome (2026-08-18): NULL — the premise is dead, no code was written
+
+**Step 0 (AC#1), from the corpus:** of 60 golden queries, **2** have more
+than one relevant document, 51 have exactly one, 7 are negative controls.
+A query with a single relevant document has nothing for a gate to
+disambiguate *between*, whatever its surface vagueness.
+
+**The 2 candidates fail the third condition, and badly.**
+`kw-nimbus-rollback` and `kw-calyx-limiter` each have two relevant documents
+— both correct. A clarifying question there would ask the user to discard one
+of two right answers, making retrieval worse rather than ambiguous-then-
+better. Qualifying count under all three conditions: **0**, against a
+pre-registered bar of 5. The kill condition fires.
+
+**Twelve short queries are not twelve gate cases.** ≤3-word queries like
+`'plant maintenance record'` all have exactly one relevant document: terse,
+not ambiguous. That distinction is what the bar was written to force.
+
+**Why this generalises past the fixture:** every failing class fails for a
+reason a question cannot repair — `negation` because the corpus asserts what
+the query excludes, `prompt` and the residual zero-row queries on absent
+CONTENT words, `paraphrase`/`vocabulary_mismatch` in `plain` on no shared
+content word. No answer to any question puts a missing document into an index.
+
+Reaching the bar would have required authoring ambiguity fixtures, which the
+kill condition pre-declared a kill: the admission protocol admits only what
+today's pipeline is measured to fail, and a class invented to give a feature
+something to show measures the class.
+
+**The fifth P2c premise to die before being built** (after `expansion`,
+`acronym`, `compositional`, PRF). Four died on measurement; this one died on
+a **census** — one query over the fixture, a fraction of PRF's cost. That is
+the transferable lesson and it is carried into the next candidate,
+**TASK-18155** (granularity router), whose ACs require the census first.
+
+Artifacts: `Docs/superpowers/qa/2026-08-18-clarification-gate/bar.md`
+(registered before the probe) and `step0.md` (the census and verdict).

--- a/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
+++ b/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
@@ -1,5 +1,5 @@
 ---
-id: task-18155
+id: TASK-18155
 title: 'P2c candidate 6: granularity router, census before probe'
 status: To Do
 assignee: []

--- a/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
+++ b/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
@@ -1,0 +1,56 @@
+---
+id: task-18155
+title: 'P2c candidate 6: granularity router, census before probe'
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [rag, p2c, fail-first]
+dependencies: []
+---
+
+## Description (the why)
+
+Filed by TASK-16072 (AC#5) as the next P2c candidate after the clarification
+gate returned NULL. The remaining named candidate in
+`Tests/RAG_Eval/README.md`'s list is a **granularity router**: choose per
+query whether to retrieve chunks or whole documents.
+
+**Start with a census, not a probe.** That is TASK-16072's transferable
+finding: it killed its premise in one query over the fixture — counting how
+many golden queries have the property the feature needs — for a fraction of
+the cost of PRF's full probe, which needed a run to reach the same kind of
+answer. Four of the five retired P2c premises died on measurement; the fifth
+died on a census. **The census is the cheaper first move and should be the
+default for every remaining candidate.**
+
+The census question here: **how many golden queries have a relevant document
+whose retrieval outcome would differ between chunk-level and document-level
+granularity?** If the fixture's relevant documents are short enough that a
+chunk IS the document, or if the failing queries fail for reasons granularity
+cannot touch (absent content words — the dominant blocker on both paths per
+TASK-15400 and TASK-17855), the premise is dead before any router exists.
+
+Note the standing constraint: `include_parent_docs` and its siblings were
+**retired** by TASK-16174 for being inert, and the expansion tool that
+replaced them is pull-based and gated. A router would be a THIRD surface over
+the same capability, so its census must clear a higher bar than "it might
+help".
+
+## Acceptance Criteria (the what)
+
+- [ ] A bar and a kill condition are registered BEFORE any measurement,
+      naming what evidence licenses production code and what result ends the
+      arc
+- [ ] The census runs first and answers, per query and from the corpus,
+      how many golden queries could change outcome under a different
+      retrieval granularity
+- [ ] A below-bar census ends the arc with a recorded null — no probe, no
+      production code — and is recorded beside the other retired premises in
+      `Tests/RAG_Eval/README.md`
+- [ ] If the census clears the bar, the probe follows TASK-15965's shape:
+      gains AND losses by query id, guard populations derived at probe time,
+      no control read as a pipeline property unless the variables it holds
+      fixed are named
+- [ ] The relationship to TASK-16174's retired parent-inclusion knobs and to
+      `expand_document` is stated, so a third surface over one capability is
+      a deliberate choice rather than an accident


### PR DESCRIPTION
The fifth P2c premise to die before any production code existed — and the first killed by a **census** rather than a probe.

## The bar was registered before the probe

`Docs/superpowers/qa/2026-08-18-clarification-gate/bar.md`, committed first and unchanged since. A gate needs all three of: more than one defensible interpretation, **pointing at different documents in this corpus**, where a user's answer would **change which document is retrieved**. Bar: ≥5 of 60 queries. Kill: fewer than 5 ends the arc with a recorded null — and reaching the bar by *authoring ambiguity fixtures* was pre-declared a kill, not an invitation.

## Step 0, from the corpus

| | queries |
|---|---|
| more than one relevant document | **2** |
| exactly one relevant document | 51 |
| zero (negative controls) | 7 |

**The two candidates fail the third condition, and badly.** `kw-nimbus-rollback` and `kw-calyx-limiter` each have two relevant documents — *both correct*. A clarifying question there wouldn't choose between competing interpretations; it would ask the user to discard one of two right answers. Firing a gate on them makes retrieval worse.

Qualifying count under all three conditions: **0**, against a bar of 5. Kill condition fires.

**Twelve short queries are not twelve gate cases.** `'plant maintenance record'`, `'asset tag QX-8842'`, `'gum disease treatment'` — all ≤3 words, all with exactly one relevant document. Terse, not ambiguous. That's the distinction the bar existed to force: surface vagueness isn't an ambiguity signal unless the corpus supplies a second thing to mean.

## Why this generalises past the fixture

Every failing class fails for a reason a question cannot repair — `negation` because the corpus asserts what the query excludes; `prompt` and the residual zero-row queries on **absent content words**; `paraphrase`/`vocabulary_mismatch` in `plain` on no shared content word. **No answer to any question puts a missing document into an index.**

## The transferable part is the method, not the verdict

Four earlier premises (`expansion`, `acronym`, `compositional`, PRF) died on measurement. This one died on **one query over the fixture** — counting how many golden queries even have the property the feature needs — for a fraction of PRF's full-probe cost.

So **TASK-18155** (granularity router, the next named candidate) is filed with the census required *first*, and with an extra constraint recorded: `include_parent_docs` was retired as inert by TASK-16174 and `expand_document` now covers that capability, so a router would be a *third* surface over one capability and its census must clear a higher bar than "it might help".

No production code was written. The fifth retired premise is recorded beside the others in `Tests/RAG_Eval/README.md`.

Refs TASK-16072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the “clarification gate” via a corrected corpus-first census and records a NULL verdict. This avoids shipping a gate with no measurable cases and establishes census-first for future P2c candidates.

- Method fix: condition 2 now checks corpus text, not relevance labels. Result: 1/60 queries shows an unlabelled alternative reading (a negation), but 0/60 satisfy all three conditions. Below the pre-registered bar (≥5), so the kill fires.
- Artifacts added: `bar.md` (bar/kill), `step0.md` (corrected census and verdict), `per-query-census.md` (all 60 rows), and `census.py` (includes a probe-proof check that document text was read).
- `Tests/RAG_Eval/README.md`: records the fifth retired premise; notes the two >1-label cases have two correct answers, so a gate would worsen retrieval, not disambiguate.
- Backlog: TASK-16072 marked Done with ACs met and NULL outcome; TASK-18155 (granularity router) filed with census-first ACs and notes that `include_parent_docs` was retired by TASK-16174 and `expand_document` covers the capability.
- No production code changed. No migration actions required.

<sup>Written for commit bb46a466296dc01da0b48622d558dad2a1932d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

