### PR TITLE
Address the Qodo findings this session merged without seeing

### DIFF
--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
@@ -74,9 +74,13 @@ from typing import Any
 HERE = Path(__file__).resolve().parent
 WORKTREE = HERE.parents[3]
 QUESTIONS_PATH = HERE / "questions.toml"
-API_KEY_PATH = Path(
-    "/Users/macbook-dev/Documents/GitHub/tldw_chatbook/anthropic-api-key.txt"
-)
+# Qodo PR-1712: an absolute machine-specific path is both a poor
+# secret-handling pattern and non-portable -- anyone re-running this probe on
+# another checkout gets a confusing FileNotFoundError rather than a usable
+# message. Resolution order: an explicit env var, then the git-excluded
+# repo-root file located RELATIVE to this script.
+API_KEY_ENV = "ANTHROPIC_API_KEY"
+API_KEY_PATH = Path(__file__).resolve().parents[3] / "anthropic-api-key.txt"
 
 #: Cheapest capable model with native tool-calls. Pricing (Anthropic first-party,
 #: cached 2026-06-24): $1.00 / MTok input, $5.00 / MTok output; cache writes
@@ -604,7 +608,14 @@ def main() -> int:
 
     api_key = ""
     if args.live:
-        api_key = API_KEY_PATH.read_text(encoding="utf-8").strip()
+        api_key = os.environ.get(API_KEY_ENV, "").strip()
+        if not api_key:
+            if not API_KEY_PATH.exists():
+                raise SystemExit(
+                    f"no credential: set ${API_KEY_ENV} or place a key at "
+                    f"{API_KEY_PATH}"
+                )
+            api_key = API_KEY_PATH.read_text(encoding="utf-8").strip()
         if not api_key:
             raise SystemExit("the repo-root API key file is empty")
 

--- a/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
+++ b/Docs/superpowers/qa/2026-08-15-rag-agentic-expansion/oracle_run.py
@@ -80,7 +80,10 @@ QUESTIONS_PATH = HERE / "questions.toml"
 # message. Resolution order: an explicit env var, then the git-excluded
 # repo-root file located RELATIVE to this script.
 API_KEY_ENV = "ANTHROPIC_API_KEY"
-API_KEY_PATH = Path(__file__).resolve().parents[3] / "anthropic-api-key.txt"
+# parents[4], not [3]: this file sits at
+# Docs/superpowers/qa/<arc>/oracle_run.py, so [3] is Docs/ (Qodo PR-1795
+# finding 5 -- an off-by-one in this PR's own fix, caught by review).
+API_KEY_PATH = Path(__file__).resolve().parents[4] / "anthropic-api-key.txt"
 
 #: Cheapest capable model with native tool-calls. Pricing (Anthropic first-party,
 #: cached 2026-06-24): $1.00 / MTok input, $5.00 / MTok output; cache writes

--- a/Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md
+++ b/Docs/superpowers/qa/2026-08-18-four-seam-and-strictness/report.md
@@ -32,7 +32,7 @@ Three constructions, same corpus, same queries, MRR over the 53 scored:
 | **`and_then_prefix`** (the engine's shipped shape) | **0.423** | 25/53 | AND primary; prefix **only** where the primary found nothing |
 
 **The naive fix is measurably worse.** Replacing AND with OR/prefix rescues
-every zero-row query and *halves* ranking quality — 20–30 loosely-matching
+every zero-row query and cuts ranking quality by a third (-34%) — 20–30 loosely-matching
 rows per query on a 172-document corpus bury the answers that AND was getting
 right. Recall bought at that price is not recall worth having.
 

--- a/Tests/Chat/test_chat_api_call_endpoint_redaction.py
+++ b/Tests/Chat/test_chat_api_call_endpoint_redaction.py
@@ -97,3 +97,52 @@ def test_the_metrics_label_carries_no_unrecognised_endpoint(monkeypatch):
     for labels in seen:
         for label_value in labels.values():
             assert not _leaks(label_value), labels
+
+
+def test_the_metrics_label_is_bounded_not_merely_redacted(monkeypatch):
+    """Qodo PR-1759: redacting the VALUE did not bound the CARDINALITY.
+
+    The first fix reused one marker for logs and metrics, and that marker
+    embeds `{len(text)} chars` -- useful in a log line, but it means N
+    unrecognised endpoints of N different lengths still mint N distinct
+    metric series. That is the exact hazard the fix's own comment named,
+    reintroduced by the marker it introduced.
+
+    The label must therefore come from a BOUNDED set: a registered endpoint
+    name, or one constant. Logs keep the length.
+    """
+    seen: list[str] = []
+
+    import tldw_chatbook.Chat.Chat_Functions as cf
+
+    def _capture(name, value=1, labels=None, **kwargs):
+        if labels and "api_endpoint" in labels:
+            seen.append(str(labels["api_endpoint"]))
+
+    monkeypatch.setattr(cf, "log_counter", _capture)
+
+    # Twelve unrecognised endpoints, every one a different length.
+    for n in range(3, 15):
+        with pytest.raises(Exception):
+            chat_api_call("x" * n, [{"role": "user", "content": "q"}])
+
+    assert len(seen) == 12, f"expected one label per call, got {len(seen)}"
+    assert len(set(seen)) == 1, (
+        f"unbounded metrics cardinality: {len(set(seen))} distinct labels "
+        f"for 12 unknown endpoints -- {sorted(set(seen))[:4]}"
+    )
+    assert not any(ch.isdigit() for ch in seen[0]), (
+        f"the label still carries a caller-controlled number: {seen[0]!r}"
+    )
+
+
+def test_the_log_line_keeps_the_length_for_debugging(loguru_caplog):
+    """Bounding the LABEL must not blind the LOG: the length is the one
+    detail that tells an operator what shape of value arrived."""
+    with pytest.raises(Exception):
+        chat_api_call("abcdefghij", [{"role": "user", "content": "q"}])
+
+    routing = [r.getMessage() for r in loguru_caplog.records
+               if "Routing to endpoint" in r.getMessage()]
+    assert routing, "expected a routing log line"
+    assert any("10 chars" in line for line in routing), routing[:2]

--- a/Tests/Chat/test_chat_api_call_endpoint_redaction.py
+++ b/Tests/Chat/test_chat_api_call_endpoint_redaction.py
@@ -110,6 +110,10 @@ def test_the_metrics_label_is_bounded_not_merely_redacted(monkeypatch):
 
     The label must therefore come from a BOUNDED set: a registered endpoint
     name, or one constant. Logs keep the length.
+
+    Args:
+        monkeypatch: Replaces `log_counter` so the emitted labels can be
+            captured without a metrics backend.
     """
     seen: list[str] = []
 
@@ -137,8 +141,14 @@ def test_the_metrics_label_is_bounded_not_merely_redacted(monkeypatch):
 
 
 def test_the_log_line_keeps_the_length_for_debugging(loguru_caplog):
-    """Bounding the LABEL must not blind the LOG: the length is the one
-    detail that tells an operator what shape of value arrived."""
+    """Bounding the LABEL must not blind the LOG.
+
+    The length is the one detail that tells an operator what shape of value
+    arrived, and it costs nothing in a log line.
+
+    Args:
+        loguru_caplog: The repo's loguru-to-caplog bridge fixture.
+    """
     with pytest.raises(Exception):
         chat_api_call("abcdefghij", [{"role": "user", "content": "q"}])
 

--- a/Tests/RAG_Search/test_pipeline_middleware_contract.py
+++ b/Tests/RAG_Search/test_pipeline_middleware_contract.py
@@ -34,14 +34,9 @@ a branch that exists but does nothing.
 """
 
 import ast
-import sys
+import tomllib
 from pathlib import Path
 from typing import Dict, Set
-
-if sys.version_info < (3, 11):  # pragma: no cover - repo requires >= 3.11
-    import tomli as tomllib
-else:
-    import tomllib
 
 import pytest
 
@@ -227,3 +222,51 @@ def test_the_guard_can_see_the_names_it_is_guarding():
     assert _handler_nodes(), "the _apply_*_middleware handlers were not found"
     assert any(_declared_by_phase().values()), "no pipeline declares middleware"
     assert any(_implemented_by_phase().values()), "no middleware branch was parsed"
+
+
+# ---------------------------------------------------------------------------
+# Qodo PR-1778: the deletion has to reach users who already have a config copy
+# ---------------------------------------------------------------------------
+
+
+def test_unimplemented_middleware_is_dropped_from_a_user_config(tmp_path):
+    """TASK-17600 deleted eight middleware promises from the BUNDLED toml, but
+    `PipelineLoader` copies that file to the user's config directory on first
+    run and prefers the copy forever after. Every existing installation
+    therefore keeps all eight stale declarations -- and now the branch that
+    at least recognised `result_reranking` is gone too.
+
+    The fix is a RUNTIME rule rather than a migration, for the reason
+    TASK-17365 chose a floor over rewriting saved profiles: a loader may
+    safely refuse to honour a name it cannot implement, but it should not
+    silently rewrite a file the user owns.
+    """
+    from tldw_chatbook.RAG_Search.pipeline_loader import PipelineLoader
+
+    stale = tmp_path / "rag_pipelines.toml"
+    stale.write_text(
+        """
+[pipelines.legacy]
+name = "Legacy"
+description = "a config copied before TASK-17600"
+type = "built-in"
+function = "search_plain"
+enabled = true
+
+[pipelines.legacy.middleware]
+before = ["query_expansion", "code_syntax_enhancer"]
+after = ["result_reranking", "citation_enhancement", "table_renderer"]
+""",
+        encoding="utf-8",
+    )
+
+    loader = PipelineLoader()
+    loader.load_pipeline_config(stale)
+
+    pipeline = loader.pipelines["legacy"]
+    # `PipelineConfig.middleware` is a dict of phase -> names, not an object.
+    before = list(pipeline.middleware.get("before") or [])
+    after = list(pipeline.middleware.get("after") or [])
+
+    assert before == ["query_expansion"], f"stale before-names survived: {before}"
+    assert after == ["citation_enhancement"], f"stale after-names survived: {after}"

--- a/Tests/RAG_Search/test_pipeline_middleware_contract.py
+++ b/Tests/RAG_Search/test_pipeline_middleware_contract.py
@@ -240,6 +240,9 @@ def test_unimplemented_middleware_is_dropped_from_a_user_config(tmp_path):
     TASK-17365 chose a floor over rewriting saved profiles: a loader may
     safely refuse to honour a name it cannot implement, but it should not
     silently rewrite a file the user owns.
+
+    Args:
+        tmp_path: Pytest-provided directory for the stale config fixture.
     """
     from tldw_chatbook.RAG_Search.pipeline_loader import PipelineLoader
 

--- a/backlog/tasks/task-16450 - Shielded-cancellation-loop-in-_execute_library_rag_search-never-uncancels.md
+++ b/backlog/tasks/task-16450 - Shielded-cancellation-loop-in-_execute_library_rag_search-never-uncancels.md
@@ -1,5 +1,5 @@
 ---
-id: task-16450
+id: TASK-16450
 title: Shielded-cancellation loop in _execute_library_rag_search never uncancels
 status: Done
 assignee: []

--- a/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
+++ b/backlog/tasks/task-17755 - Adopt and_then_prefix on the four-seam keyword path.md
@@ -1,5 +1,5 @@
 ---
-id: task-17755
+id: TASK-17755
 title: Adopt and_then_prefix on the four-seam keyword path
 status: Done
 assignee: []

--- a/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
+++ b/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
@@ -1,5 +1,5 @@
 ---
-id: task-17855
+id: TASK-17855
 title: Investigate the remaining zero-row queries — absent content words
 status: To Do
 assignee: []
@@ -35,7 +35,8 @@ publishable outcome and is sufficient to close this task.**
       the relevant document is reachable by ANY keyword construction over the
       terms the user typed, or only by semantic retrieval
 - [ ] At least one candidate is proposed with its measured or estimated
-      precision cost, judged against the finding that pure OR HALVED MRR —
+      precision cost, judged against the finding that pure OR cut MRR by a
+      THIRD (0.396 -> 0.261, -34%) —
       recall bought by broadening is not free and must be priced
 - [ ] A decision is recorded: pursue a specific candidate as its own arc, or
       record that keyword construction has reached its ceiling on this corpus

--- a/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
+++ b/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
@@ -1,5 +1,5 @@
 ---
-id: task-17955
+id: TASK-17955
 title: Four-seam merge is untiered now that the path has fallback forms
 status: To Do
 assignee: []

--- a/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
+++ b/backlog/tasks/task-18055 - send_to_agent missing from the skills shadow-name set.md
@@ -1,5 +1,5 @@
 ---
-id: task-18055
+id: TASK-18055
 title: send_to_agent missing from the skills shadow-name set
 status: Done
 assignee: []

--- a/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
+++ b/backlog/tasks/task-3997 - Investigate-four-seam-keyword-plain-search-is-AND-strict-returning-zero-rows-when-one-query-term-is-absent.md
@@ -54,7 +54,7 @@ set — on the current instrument the effect is two thirds of the query set.
 | `and_then_prefix` (the engine's shape) | **0.423** | 25 |
 
 The naive fix is **measurably worse**: OR rescues every zero-row query and
-halves ranking quality, because 20–30 loosely-matching rows on a 172-document
+cuts ranking quality by a THIRD (0.396 -> 0.261, a 34% reduction), because 20–30 loosely-matching rows on a 172-document
 corpus bury the answers AND was getting right. `and_then_prefix` beats both,
 and its shape is why — the 21 queries whose primary already returns a row are
 untouched by construction, so it can only change queries that currently return

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -834,6 +834,36 @@ def safe_endpoint_for_display(api_endpoint: Any) -> str:
     return f"<unrecognised endpoint, {len(text)} chars, redacted>"
 
 
+#: The one label an unrecognised endpoint may contribute to metrics.
+UNRECOGNISED_ENDPOINT_LABEL = "<unrecognised>"
+
+
+def safe_endpoint_for_metrics(api_endpoint: Any) -> str:
+    """Return a BOUNDED label for the endpoint dimension.
+
+    TASK-17165 redacted the endpoint's VALUE from logs, labels and errors,
+    and Qodo (PR #1759) caught what that left behind: the redaction marker
+    embeds ``{len(text)} chars``, so N unrecognised endpoints of N different
+    lengths still mint N distinct metric series. Redacting the value is not
+    the same as bounding the cardinality, and this label lands in exported
+    metrics where unbounded series cost memory and scrape size.
+
+    So metrics and diagnostics diverge deliberately: a registered endpoint
+    labels itself (a closed set, one series each), and everything else
+    collapses to a single constant. The length stays in the LOG line, where
+    it tells an operator what shape of value arrived and costs nothing.
+
+    Args:
+        api_endpoint: The raw endpoint argument, of any type.
+
+    Returns:
+        The lowercased endpoint when registered, else
+        ``UNRECOGNISED_ENDPOINT_LABEL``.
+    """
+    lowered = str(api_endpoint or "").lower()
+    return lowered if lowered in API_CALL_HANDLERS else UNRECOGNISED_ENDPOINT_LABEL
+
+
 def chat_api_call(
     api_endpoint: str,
     messages_payload: List[Dict[str, Any]],  # CHANGED from input_data, prompt
@@ -955,7 +985,12 @@ def chat_api_call(
     # metrics (where it is also an unbounded-cardinality hazard).
     endpoint_display = safe_endpoint_for_display(api_endpoint)
     logger.info(f"Chat API Call - Routing to endpoint: {endpoint_display}")
-    log_counter("chat_api_call_attempt", labels={"api_endpoint": endpoint_display})
+    # The LABEL is bounded (Qodo PR-1759); the log line above keeps the
+    # length. Redacting a value and bounding a dimension are different jobs.
+    log_counter(
+        "chat_api_call_attempt",
+        labels={"api_endpoint": safe_endpoint_for_metrics(api_endpoint)},
+    )
     start_time = time.time()
 
     handler = API_CALL_HANDLERS.get(endpoint_lower)

--- a/tldw_chatbook/RAG_Search/pipeline_loader.py
+++ b/tldw_chatbook/RAG_Search/pipeline_loader.py
@@ -52,6 +52,24 @@ class PipelineConfig:
     components: Optional[Dict[str, Dict[str, Any]]] = None
 
 
+#: Middleware ids `_apply_before_middleware` actually implements. A name not
+#: here is a PROMISE, not a stage: TASK-17600 deleted eight such names from the
+#: bundled TOML, and Qodo (PR #1778) caught that the deletion never reaches an
+#: installation that already has a user copy -- `load_pipeline_config` writes
+#: one on first run and prefers it forever after. So the filter is applied at
+#: LOAD, to whatever file is loaded, rather than only to the shipped file.
+#:
+#: Filtering rather than migrating is deliberate, and follows TASK-17365's
+#: floor-over-migration reasoning: a loader may refuse to honour a name it
+#: cannot implement, but it should not silently rewrite a file the user owns.
+IMPLEMENTED_BEFORE_MIDDLEWARE: frozenset[str] = frozenset(
+    {"query_expansion", "technical_term_detector"}
+)
+
+#: Middleware ids `_apply_after_middleware` actually implements.
+IMPLEMENTED_AFTER_MIDDLEWARE: frozenset[str] = frozenset({"citation_enhancement"})
+
+
 class PipelineLoader:
     """Loads and manages pipeline configurations from TOML files."""
 
@@ -68,6 +86,43 @@ class PipelineLoader:
             "perform_full_rag_pipeline": chat_rag_events.perform_full_rag_pipeline,
             "perform_hybrid_rag_search": chat_rag_events.perform_hybrid_rag_search,
         }
+
+    def _implemented_middleware(
+        self, pipeline_id: str, declared: Dict[str, Any]
+    ) -> Dict[str, List[str]]:
+        """Drop declared middleware names this loader cannot run.
+
+        Args:
+            pipeline_id: The pipeline the names were declared under.
+            declared: The raw ``middleware`` table from the config file.
+
+        Returns:
+            The same table with unimplemented names removed, phase by phase.
+        """
+        allowed = {
+            "before": IMPLEMENTED_BEFORE_MIDDLEWARE,
+            "after": IMPLEMENTED_AFTER_MIDDLEWARE,
+        }
+        kept: Dict[str, List[str]] = {}
+        for phase, names in (declared or {}).items():
+            if not isinstance(names, list):
+                kept[phase] = names
+                continue
+            permitted = allowed.get(phase)
+            if permitted is None:
+                kept[phase] = list(names)
+                continue
+            keep = [n for n in names if n in permitted]
+            dropped = [n for n in names if n not in permitted]
+            if dropped:
+                logger.warning(
+                    f"Pipeline {pipeline_id!r}: ignoring {phase} middleware with no "
+                    f"implementation: {', '.join(sorted(dropped))}. These names were "
+                    "removed from the shipped config (TASK-17600); a config copied "
+                    "before that still lists them."
+                )
+            kept[phase] = keep
+        return kept
 
     def load_pipeline_config(self, config_file: Optional[Path] = None) -> None:
         """Load pipeline configurations from TOML file."""
@@ -146,7 +201,9 @@ class PipelineLoader:
                         profile=pipeline_config.get("profile"),
                         tags=pipeline_config.get("tags", []),
                         parameters=pipeline_config.get("parameters", {}),
-                        middleware=pipeline_config.get("middleware", {}),
+                        middleware=self._implemented_middleware(
+                            pipeline_id, pipeline_config.get("middleware", {})
+                        ),
                         strategy=pipeline_config.get("strategy"),
                         components=pipeline_config.get("components"),
                     )

--- a/tldw_chatbook/RAG_Search/pipeline_loader.py
+++ b/tldw_chatbook/RAG_Search/pipeline_loader.py
@@ -106,7 +106,18 @@ class PipelineLoader:
         kept: Dict[str, List[str]] = {}
         for phase, names in (declared or {}).items():
             if not isinstance(names, list):
-                kept[phase] = names
+                # Qodo PR-1795 finding 1: preserving a malformed value let it
+                # reach PipelineConfig unchecked. A phase is a LIST of names or
+                # it is not a phase; anything else is dropped loudly rather
+                # than carried. (Validating the whole file through a Pydantic
+                # model is the broader fix and is deliberately not attempted
+                # here -- this loader has never used one, and widening a
+                # remediation PR into a schema migration is how a small fix
+                # acquires an unmeasured blast radius.)
+                logger.warning(
+                    f"Pipeline {pipeline_id!r}: ignoring {phase} middleware -- "
+                    f"expected a list of names, got {type(names).__name__}"
+                )
                 continue
             permitted = allowed.get(phase)
             if permitted is None:


### PR DESCRIPTION
An audit of all 16 PRs merged today, prompted by the question "were all Qodo comments addressed?". The answer was **no**, and the root cause is mine.

## The method failure

Qodo posts **two** comments per PR — a summary and a code review. My check read the **last** one and looked for a "Code Review by Qodo" heading; when the summary landed last, I concluded "no findings" and merged. I reported "Qodo endorsed with zero findings" on PRs that had findings.

| PR | Findings | Disposition |
|---|---|---|
| 1640 | 5 | 3 fixed pre-merge; 1 by documented decision; 1 → TASK-16450, fixed today |
| 1672 | 1 | ❌ → fixed here |
| 1712 | 3 | 1 fixed later via 16688; 1 fixed here; **1 rejected with evidence** |
| 1729 / 1738 / 1775 / 1789 / 1791 / 1794 | — | ✅ all addressed pre-merge |
| 1736 | 5 | ❌ → addressed here |
| 1751 | 3 | ✅ all |
| 1759 | 1 | ❌ **substantive** → fixed here |
| 1767 | 2 | ✅ later, as TASK-17265 + TASK-17365 |
| 1778 | 2 | ❌ **substantive** → fixed here |
| 1781 | 3 | 1 caught independently by 17755's review; 2 → fixed here |
| 1786 | 1 | ✅ filed as TASK-17955 |

## The two that mattered

**#1759 — redacting the value didn't bound the cardinality.** My redaction marker embeds `{len(text)} chars`, so N unrecognised endpoints of N different lengths still mint N distinct metric series — *the exact hazard that fix's own comment named*, reintroduced by the marker it introduced. Metrics and diagnostics now diverge on purpose: `safe_endpoint_for_metrics()` collapses anything unregistered to one constant, while the log line keeps the length, where it tells an operator what shape of value arrived and costs nothing. Pinned by twelve different-length unknown endpoints producing exactly one label.

**#1778 — the deletion never reached users.** TASK-17600 removed eight middleware promises from the *bundled* TOML, but `PipelineLoader` writes a user copy on first run and prefers it forever after. Existing installations kept all eight — and now the branch that at least *recognised* `result_reranking` is gone too. Fixed as a **load-time filter, not a migration**, following TASK-17365's floor-over-migration reasoning: a loader may refuse to honour a name it cannot implement, but it should not silently rewrite a file the user owns.

## Accuracy

**"Pure OR halves ranking quality" was wrong** — 0.396 → 0.261 is a **34% reduction**. That phrasing was overstating the evidence for a decision you took, and it appeared in TASK-3997, TASK-17855 and the QA report. All three corrected.

## Hygiene

Five task files I filed today used lowercase `id: task-N` against the repo's **2,148-to-5** uppercase convention — and all five outliers were mine. Canonicalised. Plus `oracle_run.py`'s hardcoded absolute API-key path is now env-first and repo-relative with a usable error message, and the `tomli`/`tomllib` compatibility block is gone (the repo requires 3.11+).

## Two findings checked and rejected, with evidence

- `oracle_run.py`'s argparse declares **only boolean flags**, so "CLI-provided paths reach `mkdir`/`write_text`" is false for that script.
- PR #1791's "`plant maintenance record` has industrial and botanical readings" was already refuted during that PR: exactly **one** corpus document mentions "plant", and it *is* the labelled relevant one.

Both were plausible, which is why they were checked rather than either accepted or dismissed.

## Verification

89 passed across the touched test files; ruff clean. The new tests are RED-first: the cardinality test fails on the old marker, and the user-config test fails without the load-time filter.

**Going forward** I check every Qodo comment for findings, not the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds chat API endpoint metrics and filters unimplemented RAG middleware at load so existing installs stop minting unbounded metrics series and carrying deleted stages. Resolves findings tied to TASK-17600 and TASK-17365, and corrects a misstatement in TASK-3997.

- Chat metrics: previously the redaction marker included input length, creating unbounded series; now `safe_endpoint_for_metrics()` emits the registered endpoint or "<unrecognised>", while logs keep length via `safe_endpoint_for_display()`. Adds tests proving one label across many unknown endpoints and length preserved in logs.
- Pipeline loader: previously removing names from the shipped TOML did not affect user‑copied configs and non‑list phase values passed through; now `_implemented_middleware()` drops unsupported names at load and ignores non‑list phase values with warnings. No migration or file rewrite required. Adds a test that stale names are filtered from a user config.
- QA/docs and hygiene: corrected “halves” to “-34%” MRR in the QA report and tasks; normalized task IDs to uppercase; `oracle_run.py` now prefers `$ANTHROPIC_API_KEY` then a repo‑root file and fixes an off‑by‑one in the parent path; removed `tomli` shim in favor of `tomllib`.

<sup>Written for commit 03cc2dcd83d05dad0f3d43ee768a907720984a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

