### PR TITLE
Sync cache API keys on the same dimensions as the async one (TASK-15701)

### DIFF
--- a/Tests/RAG/simplified/test_simple_cache_sync_key_dimensions.py
+++ b/Tests/RAG/simplified/test_simple_cache_sync_key_dimensions.py
@@ -1,0 +1,83 @@
+"""TASK-15701: the SYNC cache API must key on the same search-defining
+dimensions the async one does.
+
+`_make_key` takes eight inputs, three of which describe *what search was
+actually run* — `keyword_source_types` (which sub-legs the keyword leg
+queried), `hybrid_fusion` (alpha / rrf_k / pool) and `fts_match_construction`
+(how the FTS MATCH expression was built). The async path passes all three;
+the sync `get`/`put` did not accept them at all, so they rendered the legacy
+key.
+
+The failure that matters is not a missed hit (harmless) but a **wrong hit**:
+two searches differing only in an omitted dimension collide, and the second
+is served the first one's rows. Before TASK-15400 the legacy key was
+accidentally truthful — `and` was both the legacy value and the shipped
+default. The default has since moved twice (`and_stopword_trim`, then
+`and_then_prefix`), so an omitted part now asserts a construction that did
+not run.
+"""
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.RAG_Search.simplified.simple_cache import SimpleRAGCache
+
+
+def _cache() -> SimpleRAGCache:
+    return SimpleRAGCache(max_size=32, ttl_seconds=300, enabled=True)
+
+
+@pytest.mark.parametrize(
+    "dimension,first,second",
+    [
+        ("fts_match_construction", "and", "and_then_prefix"),
+        ("keyword_source_types", ("notes",), ("notes", "media")),
+        ("hybrid_fusion", (0.7, 5, 2), (0.3, 60, 4)),
+    ],
+)
+def test_sync_round_trips_differing_in_one_dimension_do_not_collide(
+    dimension, first, second
+):
+    """AC#2: a search that differs ONLY in one search-defining dimension must
+    not be served the other's rows.
+
+    Args:
+        dimension: The `_make_key` parameter under test.
+        first: The value stored under.
+        second: A different value that must not hit the first entry.
+    """
+    cache = _cache()
+    rows_a = [{"id": "a"}]
+
+    cache.put("q", "hybrid", 10, rows_a, "ctx-a", **{dimension: first})
+    hit_same = cache.get("q", "hybrid", 10, **{dimension: first})
+    hit_other = cache.get("q", "hybrid", 10, **{dimension: second})
+
+    assert hit_same is not None, "the identical search must still hit"
+    assert hit_same[0] == rows_a
+    assert hit_other is None, (
+        f"WRONG HIT: a search differing in {dimension} was served the other "
+        f"search's rows ({first!r} vs {second!r})"
+    )
+
+
+def test_sync_and_async_render_the_same_key_for_the_same_search():
+    """AC#3: the two paths must agree, shown rather than asserted separately.
+
+    A sync `put` followed by an async `get_async` for the same search is the
+    only check that cannot pass while the two key renderings differ.
+    """
+    cache = _cache()
+    rows = [{"id": "shared"}]
+    kwargs = dict(
+        keyword_source_types=("notes", "media"),
+        hybrid_fusion=(0.7, 5, 2),
+        fts_match_construction="and_then_prefix",
+    )
+
+    cache.put("q", "hybrid", 10, rows, "ctx", **kwargs)
+    hit = asyncio.run(cache.get_async("q", "hybrid", 10, **kwargs))
+
+    assert hit is not None, "the async path did not find what the sync path stored"
+    assert hit[0] == rows

--- a/backlog/tasks/task-15701 - SimpleRAGCache-sync-get-put-render-a-key-that-ignores-three-search-defining-dimensions.md
+++ b/backlog/tasks/task-15701 - SimpleRAGCache-sync-get-put-render-a-key-that-ignores-three-search-defining-dimensions.md
@@ -3,7 +3,7 @@ id: TASK-15701
 title: >-
   SimpleRAGCache sync get/put render a key that ignores three search-defining
   dimensions
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-12 23:05'
 labels:
@@ -63,10 +63,10 @@ cold misses after the upgrade.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The synchronous `get`/`put` either accept and forward all three search-defining dimensions to `_make_key`, or are removed / made private if the async path is genuinely the only supported entry point — the decision is stated in the module docstring with its reason
-- [ ] #2 A test fails on today's behaviour: two sync `put`/`get` round trips that differ ONLY in `fts_match_construction` (and, separately, only in `keyword_source_types`, and only in `hybrid_fusion`) must not collide on one key
-- [ ] #3 If the sync API is kept, the async and sync paths are shown to render the SAME key for the same search, rather than each being asserted separately
-- [ ] #4 The "no production caller" claim is re-verified at the time of the fix and recorded, so a future reader knows whether this was still latent when it was closed
+- [x] #1 The synchronous `get`/`put` either accept and forward all three search-defining dimensions to `_make_key`, or are removed / made private if the async path is genuinely the only supported entry point — the decision is stated in the module docstring with its reason
+- [x] #2 A test fails on today's behaviour: two sync `put`/`get` round trips that differ ONLY in `fts_match_construction` (and, separately, only in `keyword_source_types`, and only in `hybrid_fusion`) must not collide on one key
+- [x] #3 If the sync API is kept, the async and sync paths are shown to render the SAME key for the same search, rather than each being asserted separately
+- [x] #4 The "no production caller" claim is re-verified at the time of the fix and recorded, so a future reader knows whether this was still latent when it was closed
 <!-- AC:END -->
 
 ## Related
@@ -78,3 +78,37 @@ cold misses after the upgrade.
   async path and point here.
 - **TASK-4110** — the precedent: fusion parameters absent from a cache key
   would have flattened that arc's sweep silently.
+
+## Implementation Notes
+
+**AC#1 — the sync API is KEPT and corrected, not removed.** It now accepts
+and forwards all three search-defining dimensions, so it renders the same key
+as the async path. The reason is stated in `get`'s docstring: the sync
+methods are the cache's ergonomic **test** surface — 58 call sites across
+five test modules — while production reads and writes go through the async
+path only. Removing a correct-but-unused API to fix a key bug would have
+traded a latent trap for 58 rewrites and no behavioural gain.
+
+**AC#4 — the "no production caller" claim re-verified at fix time
+(2026-08-18) and it still holds.** The only `SimpleRAGCache` traffic in
+`tldw_chatbook/` is `rag_service.py:1301` (`get_async`), `:1395`
+(`put_async`) and `:4229` (`get_metrics`). The `_global_cache` singleton has
+no consumer outside `simple_cache.py` itself. So this was closed while still
+latent, which is the state the task was filed to preserve.
+
+**AC#2 — three RED-first collision tests**, one per omitted dimension
+(`fts_match_construction`, `keyword_source_types`, `hybrid_fusion`),
+parametrized so each names the dimension it protects. Each asserts the
+*wrong-hit* failure specifically: the identical search must still hit, and
+the differing one must not be served the first search's rows. A missed hit
+would be harmless; being served another search's results is not.
+
+**AC#3 — shown, not asserted separately:** a sync `put` followed by an async
+`get_async` for the same search. That round trip cannot pass while the two
+paths render different keys, which is exactly what asserting each path's key
+in isolation would have failed to catch.
+
+`Tests/RAG/simplified/` + the three sibling suites: 354 passed. The one red
+(`test_config.py::test_config_loading_from_file`) is pre-existing on clean
+dev — baselined in a throwaway worktree at `e49c5dba8` before being called
+unrelated.

--- a/tldw_chatbook/RAG_Search/simplified/simple_cache.py
+++ b/tldw_chatbook/RAG_Search/simplified/simple_cache.py
@@ -610,23 +610,21 @@ class SimpleRAGCache:
                 a cache entry. Defaults to ``None`` (no change for existing
                 callers).
             keyword_source_types: Optional keyword-leg source-type selection;
-                also part of the key. The synchronous ``get``/``put`` twins
-                do not take it: no caller can hand them one, so they key
-                without it. Across a MIXED sync/async workload that can only
-                produce a miss (the two paths render different keys). It is
-                NOT safe between two SYNC calls: two sync searches differing
-                only in a dimension the sync key omits render the SAME key,
-                so the second is served the first's rows -- a wrong hit.
-                Latent only because no production code calls the sync API
-                (re-verified at the close of TASK-15400); **TASK-15701**
-                owns closing it.
+                also part of the key. **TASK-15701 closed the sync-twin gap
+                this argument used to describe**: ``get``/``put`` now accept
+                and forward this dimension too, so both paths render the same
+                key and two sync searches differing only in it can no longer
+                collide. (The historical hazard, for anyone reading a git
+                blame: the sync twins could not take it, so two sync searches
+                differing only in an omitted dimension rendered the SAME key
+                and the second was served the first's rows -- a wrong hit,
+                latent only because no production code called the sync API.)
             hybrid_fusion: The resolved ``(alpha, rrf_k, pool_multiplier)``
                 for a hybrid search; see ``_make_key`` for why this must be
-                part of the key. Same sync-twin exclusion rationale as
-                ``keyword_source_types`` above.
+                part of the key. Carried by both paths since TASK-15701.
             fts_match_construction: The keyword leg's MATCH construction
-                (hybrid/keyword searches); see ``_make_key``. Same sync-twin
-                exclusion rationale.
+                (hybrid/keyword searches); see ``_make_key``. Carried by both
+                paths since TASK-15701.
         """
         if not self.enabled:
             return

--- a/tldw_chatbook/RAG_Search/simplified/simple_cache.py
+++ b/tldw_chatbook/RAG_Search/simplified/simple_cache.py
@@ -436,12 +436,38 @@ class SimpleRAGCache:
         top_k: int,
         filters: Optional[Dict[str, Any]] = None,
         metadata_allowlist: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        keyword_source_types: Optional[Collection[str]] = None,
+        hybrid_fusion: Optional[Tuple[float, int, int]] = None,
+        fts_match_construction: Optional[str] = None,
     ) -> Optional[Tuple[List[Any], str]]:
         """
         Thread-safe synchronous cache get.
 
         This method is safe to call from any context and will not cause deadlocks.
         For better performance in async contexts, use get_async() directly.
+
+        TASK-15701: the three search-defining dimensions below are accepted
+        and forwarded so this path renders the SAME key as `get_async`. They
+        were previously absent from the signature entirely, which made the
+        sync key a legacy, construction-less one -- harmless while `and` was
+        both the legacy value and the shipped default, and a WRONG-HIT risk
+        once the default moved (twice). The API was kept rather than removed
+        because it is the cache's ergonomic test surface (58 call sites);
+        production reads and writes go through the async path only, re-verified
+        at fix time.
+
+        Args:
+            query: The search query.
+            search_type: Which retrieval mode ran.
+            top_k: The result window.
+            filters: Optional metadata filters.
+            metadata_allowlist: Optional per-source-type allowlist.
+            keyword_source_types: Which sub-legs the keyword leg queried.
+            hybrid_fusion: (alpha, rrf_k, pool) for the fusion step.
+            fts_match_construction: How the FTS MATCH expression was built.
+
+        Returns:
+            The cached (results, context) pair, or None on a miss.
         """
         if not self.enabled:
             return None
@@ -461,6 +487,9 @@ class SimpleRAGCache:
                     top_k,
                     filters,
                     metadata_allowlist,
+                    keyword_source_types,
+                    hybrid_fusion,
+                    fts_match_construction,
                 )
                 return future.result(
                     timeout=1.0
@@ -468,7 +497,14 @@ class SimpleRAGCache:
         except RuntimeError:
             # No running loop, safe to run directly
             return self._sync_get_impl(
-                query, search_type, top_k, filters, metadata_allowlist
+                query,
+                search_type,
+                top_k,
+                filters,
+                metadata_allowlist,
+                keyword_source_types,
+                hybrid_fusion,
+                fts_match_construction,
             )
 
     def _sync_get_impl(
@@ -478,6 +514,9 @@ class SimpleRAGCache:
         top_k: int,
         filters: Optional[Dict[str, Any]],
         metadata_allowlist: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        keyword_source_types: Optional[Collection[str]] = None,
+        hybrid_fusion: Optional[Tuple[float, int, int]] = None,
+        fts_match_construction: Optional[str] = None,
     ) -> Optional[Tuple[List[Any], str]]:
         """Internal synchronous implementation using threading lock."""
         with self._lock:
@@ -489,7 +528,16 @@ class SimpleRAGCache:
                 self._prune_expired_sync()
                 self._last_prune_time = current_time
 
-            key = self._make_key(query, search_type, top_k, filters, metadata_allowlist)
+            key = self._make_key(
+                query,
+                search_type,
+                top_k,
+                filters,
+                metadata_allowlist,
+                keyword_source_types,
+                hybrid_fusion,
+                fts_match_construction,
+            )
             log_counter("cache_request", labels={"type": search_type})
 
             if key not in self._cache:
@@ -676,12 +724,32 @@ class SimpleRAGCache:
         context: str,
         filters: Optional[Dict[str, Any]] = None,
         metadata_allowlist: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        keyword_source_types: Optional[Collection[str]] = None,
+        hybrid_fusion: Optional[Tuple[float, int, int]] = None,
+        fts_match_construction: Optional[str] = None,
     ) -> None:
         """
         Thread-safe synchronous cache put.
 
         This method is safe to call from any context and will not cause deadlocks.
         For better performance in async contexts, use put_async() directly.
+
+        TASK-15701: forwards the same three search-defining dimensions as
+        `put_async`, so an entry cannot be STORED under a key asserting a
+        construction that did not produce it. See `get` for why the sync API
+        was kept rather than removed.
+
+        Args:
+            query: The search query.
+            search_type: Which retrieval mode ran.
+            top_k: The result window.
+            results: The rows to cache.
+            context: The rendered context string.
+            filters: Optional metadata filters.
+            metadata_allowlist: Optional per-source-type allowlist.
+            keyword_source_types: Which sub-legs the keyword leg queried.
+            hybrid_fusion: (alpha, rrf_k, pool) for the fusion step.
+            fts_match_construction: How the FTS MATCH expression was built.
         """
         if not self.enabled:
             return
@@ -703,12 +771,24 @@ class SimpleRAGCache:
                     context,
                     filters,
                     metadata_allowlist,
+                    keyword_source_types,
+                    hybrid_fusion,
+                    fts_match_construction,
                 )
                 future.result(timeout=1.0)  # 1 second timeout for cache operations
         except RuntimeError:
             # No running loop, safe to run directly
             self._sync_put_impl(
-                query, search_type, top_k, results, context, filters, metadata_allowlist
+                query,
+                search_type,
+                top_k,
+                results,
+                context,
+                filters,
+                metadata_allowlist,
+                keyword_source_types,
+                hybrid_fusion,
+                fts_match_construction,
             )
 
     def _sync_put_impl(
@@ -720,10 +800,22 @@ class SimpleRAGCache:
         context: str,
         filters: Optional[Dict[str, Any]],
         metadata_allowlist: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+        keyword_source_types: Optional[Collection[str]] = None,
+        hybrid_fusion: Optional[Tuple[float, int, int]] = None,
+        fts_match_construction: Optional[str] = None,
     ) -> None:
         """Internal synchronous implementation using threading lock."""
         with self._lock:
-            key = self._make_key(query, search_type, top_k, filters, metadata_allowlist)
+            key = self._make_key(
+                query,
+                search_type,
+                top_k,
+                filters,
+                metadata_allowlist,
+                keyword_source_types,
+                hybrid_fusion,
+                fts_match_construction,
+            )
 
             # Create cache entry
             entry = CacheEntry(key=key, value=(results, context), timestamp=time.time())


### PR DESCRIPTION
`SimpleRAGCache.get`/`put` did not accept `keyword_source_types`, `hybrid_fusion` or `fts_match_construction` **at all**, so they rendered a legacy key that omitted three dimensions describing *what search actually ran*.

## Why it matters, and why it got worse

The failure mode is not a missed hit — that's harmless. It's a **wrong hit**: two searches differing only in an omitted dimension collide, and the second is served the first one's rows. A Notes-only keyword search and an all-sources one collide; so do two searches at different fusion weights.

It was *accidentally* safe before TASK-15400, because `and` was both the legacy value and the shipped default — an omitted key part described the search truthfully. The default has since moved twice (`and_stopword_trim`, then `and_then_prefix`), so a sync-path entry would now be stored under a key asserting a construction that did not produce it.

## Kept and corrected, not removed (AC#1)

Both arms were open. The sync methods are the cache's **ergonomic test surface** — 58 call sites across five modules — while production reads and writes go through the async path only. Removing a correct-but-unused API to fix a key bug would have traded a latent trap for 58 rewrites and no behavioural gain. The decision and its reason are in `get`'s docstring, as the AC required.

## Still latent at close (AC#4, re-verified today)

The only `SimpleRAGCache` traffic in `tldw_chatbook/` is `rag_service.py:1301` (`get_async`), `:1395` (`put_async`) and `:4229` (`get_metrics`); the `_global_cache` singleton has no consumer outside its own module. Recorded so a future reader knows this closed **before** anything wired to it — which is the state the task was filed to preserve.

## The tests (AC#2, AC#3)

Three parametrized collision tests, one per omitted dimension, each asserting the wrong-hit case specifically: the identical search must still hit, and the differing one must **not** be served the first search's rows.

AC#3 is *shown* rather than asserted separately — a sync `put` followed by an async `get_async` for the same search. That round trip cannot pass while the two paths render different keys, which is precisely what checking each path's key in isolation would have missed.

All four were RED before the change.

## Verification

354 passed across `Tests/RAG/simplified/` and the three sibling suites that exercise the sync API; ruff clean. The one red (`test_config.py::test_config_loading_from_file`) is pre-existing — baselined in a throwaway worktree at clean dev `e49c5dba8` before being called unrelated.

Refs TASK-15701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `SimpleRAGCache.get`/`put` now key on the same search-defining dimensions as the async API (`keyword_source_types`, `hybrid_fusion`, `fts_match_construction`), preventing wrong-hit collisions. Previously, the sync path used a legacy key that omitted these, so two searches differing only in those dimensions could return the wrong rows. Side effect: legacy sync-written entries won’t be hit and will age out via TTL. No migration required; new parameters are optional.

**Reviewer focus**
- Code: `tldw_chatbook/RAG_Search/simplified/simple_cache.py` expands sync `get`/`put` signatures and forwards new args to `_make_key` to render identical keys as async. Behavior change is limited to the sync path; sync API kept for test ergonomics, while production uses async only (re-verified).
- Tests: `Tests/RAG/simplified/test_simple_cache_sync_key_dimensions.py` adds three collision tests (one per dimension) and a sync-put/async-get parity test.
- Docs: `put_async` and sync method docstrings updated to reflect parity and note the historical hazard now closed.

<sup>Written for commit 46c7d27316608a17e43c1974116490f27dacea35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

