### PR TITLE
feat(console): transient strips sit above the status line (task-17661)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -51,8 +51,15 @@ Top to bottom:
   **Approvals**, and **Artifacts**, the **"Live work sources"** card
   (ask Library sources before sending), and the **Session Settings**
   summary.
+- **Staged-evidence strip** — appears at the top of the control deck,
+  directly under the conversation pane and above the status chip strip,
+  only while Library RAG evidence is staged (or briefly after a send
+  consumes it); lists what's staged with an **Un-stage** button — see
+  [Context & RAG](console/context-and-rag.md). The prompt-queue shelf
+  occupies the same slot while prompts are queued.
 - **Status chip strip** — one row of chips directly below the
-  conversation pane, above the composer: **Provider**, **Model**,
+  conversation pane (and below any staged-evidence or prompt-queue
+  strip), above the composer: **Provider**, **Model**,
   **Assistant**, **Library search**, **Sources**, **Tools**,
   **Approvals**, and — once retrieval is narrowed — **Scope**. (Settings ▸
   Console Behavior ▸ **Status row placement** can move this row below the
@@ -66,10 +73,6 @@ Top to bottom:
   pending approval card, and **Scope** opens the scope picker. The **Tools**
   chip only appears once tools are counted for the session (after your
   first send) — before that it stays hidden rather than guessing.
-- **Staged-evidence strip** — appears directly above the composer only
-  while Library RAG evidence is staged (or briefly after a
-  send consumes it); lists what's staged with an **Un-stage** button — see
-  [Context & RAG](console/context-and-rag.md).
 - **Composer row** — a slim one-row bar (it grows with your draft, up to
   eight rows, and shrinks back as the draft empties) marked by a one-column edge on its left that brightens and
   thickens while the composer has focus — the "Composer ▾" collapse toggle, the draft area
@@ -450,4 +453,8 @@ prompt-queue shelf and staged evidence sit immediately above that gap;
 compact mode drops both rows. Verified
 against TASK-17654 — 2026-08-17 (headless probe at 150×44): the draft
 now grows to eight rows (was four), head-elided with "... " while
-windowed, and returns to one row as the draft empties.*
+windowed, and returns to one row as the draft empties. Verified against
+TASK-17661 — 2026-08-18 (painted probe with staged sources): the
+staged-evidence strip and prompt-queue shelf now sit at the top of the
+control deck, above the status row, keeping the composer's surroundings
+quiet.*

--- a/Tests/UI/test_console_prompt_queue.py
+++ b/Tests/UI/test_console_prompt_queue.py
@@ -228,14 +228,16 @@ async def test_mounted_shelf_and_neighboring_composer_fit_terminal(size) -> None
 
         assert region.display
         assert region.region.height == 1
-        # task-17659: the shelf is the composer's nearest neighbor above —
-        # immediately above its MARGIN box (the breathing-room row, when the
-        # stylesheet provides one; this harness loads no bundle, and compact
-        # sizes drop the margin). The painted gap itself is pinned by the
-        # bundled single-separator contract in test_console_composer_collapse.
+        # task-17661: ALL transient strips sit at the top of the control
+        # deck, above the status line — the shelf's nearest lower neighbor
+        # in the default (chips-above) placement is the status row, and the
+        # composer keeps its quiet gap below the chips. DOM-order geometry,
+        # exact in any harness.
+        chips = console.query_one("#console-status-chips")
+        assert region.region.y + region.region.height == chips.region.y
         assert (
-            region.region.y + region.region.height
-            == composer.region.y - composer.styles.margin.top
+            chips.region.y + chips.region.height
+            <= composer.region.y - composer.styles.margin.top
         )
         assert manage.region.right <= region.region.right
         assert pause.region.right <= region.region.right

--- a/backlog/tasks/task-17661 - Console-transient-strips-sit-above-the-status-line.md
+++ b/backlog/tasks/task-17661 - Console-transient-strips-sit-above-the-status-line.md
@@ -1,0 +1,51 @@
+---
+id: TASK-17661
+title: 'Console: transient strips (staged evidence, prompt queue) sit above the status line'
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-18'
+labels:
+  - console
+  - ux
+dependencies:
+  - task-17659
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Owner request 2026-08-18: the attachments bar — the staged-evidence strip that appears when context is attached from Library — and, per the follow-up clarification, ALL transient strips (staged evidence AND the prompt-queue shelf) should sit ABOVE the status line rather than directly above the composer, so the area around the composer stays visually quiet. New deck order in the default placement: workspace grid → staged evidence → prompt queue → status row → gap → composer → gap → footer.
+
+This overrules the TASK-17659 shelf-adjacency contract (queue glued to the composer's margin): the shelf's nearest lower neighbor is now the status row. In below-placement mode the strips are already first in the deck; the rule "strips at the top of the control deck" holds in both modes. The status-row position mover simplifies: it anchors on the composer alone instead of the strip cluster.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 With the prompt-queue shelf visible in the default placement, the deck renders grid → shelf → status row → gap → composer, pinned by mounted geometry assertions
+- [x] #2 The staged-evidence strip occupies the same top-of-deck slot (verified on the running screen with a visible state)
+- [x] #3 The status-row placement setting still works in both modes (mover re-anchored on the composer; order and popup contract tests green in both placements)
+- [x] #4 The command popup still never paints over any visible strip or the status row
+- [x] #5 User Guide Console page updated
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: flip the shelf-adjacency pin — queue's lower neighbor becomes the status row (DOM-order geometry, harness-proof); watched fail.
+2. Compose reorder: staged strip + queue yield BEFORE the chips in above mode (strips are already first in below mode).
+3. Simplify `apply_status_chips_position`: anchor on the composer alone with exact-adjacency guards (the strip anchor is obsolete).
+4. Sweep, painted probe with a visible staged state, docs.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Compose-order move plus a simplification: the transient strips (staged evidence, prompt queue) now always open the control deck, so the status-row mover anchors on the composer with exact-adjacency guards instead of the staged-strip anchor — the loose ordering guards became normalization-correct equality checks in the same change. The TASK-17659 shelf-glued-to-composer contract is deliberately overruled (owner call): the shelf's lower neighbor is the status row, and the composer keeps its quiet gaps. Popup clearance needed no change (its min() loop is position-agnostic across all three strips).
+
+Evidence: RED-first on the flipped shelf pin; 648 passed on the 16-file deck sweep; painted probe with staged sources at 150x44 renders grid border / "Staged for the next send · 2 sources" + rows / status row / blank / composer / blank / footer.
+
+Files: `tldw_chatbook/UI/Screens/chat_screen.py`, `tldw_chatbook/UI/Console_Modules/status_row.py`, `Tests/UI/test_console_prompt_queue.py`, `Docs/User_Guide/console.md`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/status_row.py
+++ b/tldw_chatbook/UI/Console_Modules/status_row.py
@@ -77,13 +77,13 @@ def poke_console_setting(app_config: Any, key: str, value: Any) -> None:
 
 
 def apply_status_chips_position(screen: Any) -> bool:
-    """Move the mounted chips strip to the configured side of the composer cluster.
+    """Move the mounted chips strip to the configured side of the composer.
 
-    "Above" means directly under the workspace grid — above the
-    staged-evidence strip, the prompt-queue shelf, and the composer — so
-    the shelf-adjacency contract (queue hugs the composer) holds in both
-    modes. Never raises: a screen mid-teardown or a strip not yet mounted
-    is a no-op, not an error.
+    "Above" means directly above the composer's top gap — BELOW the
+    transient strips (staged evidence, prompt queue), which sit at the top
+    of the control deck at all times (task-17661). "Below" restores the
+    TASK-15704 bottom row. Never raises: a screen mid-teardown or a strip
+    not yet mounted is a no-op, not an error.
 
     Args:
         screen: The mounted ChatScreen (anything exposing ``query_one`` and
@@ -94,12 +94,11 @@ def apply_status_chips_position(screen: Any) -> bool:
     """
     try:
         chips = screen.query_one("#console-status-chips")
-        cluster_top = screen.query_one("#console-staged-evidence-strip")
         composer = screen.query_one("#console-native-composer")
     except Exception:
         return False
     parent = chips.parent
-    if parent is None or parent is not cluster_top.parent or parent is not composer.parent:
+    if parent is None or parent is not composer.parent:
         return False
     position = resolve_status_chips_position(
         getattr(getattr(screen, "app_instance", None), "app_config", None)
@@ -107,12 +106,13 @@ def apply_status_chips_position(screen: Any) -> bool:
     children: list["Widget"] = list(parent.children)
     try:
         chips_index = children.index(chips)
+        composer_index = children.index(composer)
         if position == STATUS_CHIPS_POSITION_ABOVE:
-            if chips_index < children.index(cluster_top):
+            if chips_index == composer_index - 1:
                 return False
-            parent.move_child(chips, before=cluster_top)
+            parent.move_child(chips, before=composer)
         else:
-            if chips_index > children.index(composer):
+            if chips_index == composer_index + 1:
                 return False
             parent.move_child(chips, after=composer)
     except Exception:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -14137,11 +14137,11 @@ class ChatScreen(BaseAppScreen):
                 id="console-status-chips",
                 classes="ds-panel",
             )
-            if status_chips_position == STATUS_CHIPS_POSITION_ABOVE:
-                yield status_chips
-            # RAG-40: staged evidence belongs on the MAIN surface, directly
-            # above the composer it is about to be prepended to -- not only
-            # in an Inspector rail the staging path never opens.
+            # RAG-40: staged evidence belongs on the MAIN surface -- not only
+            # in an Inspector rail the staging path never opens. task-17661:
+            # ALL transient strips (staged evidence, prompt queue) sit at the
+            # TOP of the control deck, above the status line, so the area
+            # around the composer stays visually quiet.
             yield ConsoleStagedEvidenceStrip(
                 self._build_console_staged_evidence_strip_state(pending_launch),
                 id="console-staged-evidence-strip",
@@ -14170,6 +14170,8 @@ class ChatScreen(BaseAppScreen):
                     )
                 ),
             )
+            if status_chips_position == STATUS_CHIPS_POSITION_ABOVE:
+                yield status_chips
             composer = ConsoleComposerBar(
                 id="console-native-composer",
                 classes="ds-panel",


### PR DESCRIPTION
## Summary

Owner call (2026-08-18): the attachments bar — the staged-evidence strip that appears when context is attached from Library — and, per the follow-up clarification, **all transient strips** (staged evidence and the prompt-queue shelf) now open the control deck **above the status line**, instead of sitting glued to the composer. The area around the composer stays visually quiet: with sources staged, the deck renders grid border → `Staged for the next send · 2 sources` + rows → status row → blank → composer → blank → footer (painted probe at 150×44).

This deliberately overrules the task-17659 shelf-adjacency contract (queue glued to the composer's margin): the shelf's lower neighbor is now the status row. The status-row placement mover **simplifies** as a result — it anchors on the composer alone, and its loose ordering guards became exact-adjacency equality checks that also normalize any stale order. The command popup's clearance loop needed no change (its `min()` over all three strips is position-agnostic).

## Evidence

- RED-first on the flipped shelf pin (DOM-order geometry, exact in any harness).
- **648 passed** on the 16-file deck sweep pre-rebase; **811 passed** post-rebase onto the Qodo audit batch, with the single red being the known pre-existing dev failure filed as task-17656 (selection-feedback focus walk).
- Both status-row placements re-verified; User Guide layout tour reordered and stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move all transient console strips (staged-evidence and prompt-queue) to the top of the control deck above the status row, instead of glued to the composer, to keep the composer area quiet. Previously the prompt-queue shelf sat immediately above the composer (task-17659); now both strips render above the status chips in “chips above” mode and remain first in “chips below” mode. The status-row mover now anchors on the composer; command-popup clearance is unchanged. Satisfies TASK-17661.

**Review notes**
- Compose order: in `tldw_chatbook/UI/Screens/chat_screen.py`, transient strips are yielded before the status chips; when chips are “above,” chips render after strips and before the composer.
- Positioning logic: in `tldw_chatbook/UI/Console_Modules/status_row.py`, `apply_status_chips_position` anchors on the composer with exact-adjacency checks (above = move chips before composer; below = after composer); independent of strip presence.
- Tests/docs: updated geometry assertions in `Tests/UI/test_console_prompt_queue.py`; Console User Guide reordered to reflect the new deck; acceptance task added.
- Required action: update any tests/selectors that assumed the prompt-queue shelf was the composer’s nearest neighbor. The shelf’s lower neighbor is now the status row.

<sup>Written for commit 1301f02ceb9e746aa56ebe76bfb56f02e854ca42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

