### PR TITLE
Untiered merge is the measured choice; TASK-16071's note retires (TASK-17955)

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-merge-tiering/report.md
+++ b/Docs/superpowers/qa/2026-08-18-merge-tiering/report.md
@@ -3,31 +3,46 @@
 Date: 2026-08-18 · measured on the gated fixture (172 docs, 60 golden
 queries), plain path, current dev. No network, no spend.
 
-## What tiering would change, precisely
+## What tiering would change, precisely (CORRECTED after review)
 
-Tiering makes a primary-form row outrank a fallback-form row instead of
-interleaving with it by position. That changes what a consumer sees **only
-when the merged list is CUT** — i.e. when `rows_returned >= top_k`. If the
-window is never full, every row survives whatever the order, and the two
-merges are observationally identical to any downstream metric.
+**The first version of this report argued from CUTS and that was wrong.**
+It said tiering matters only when `rows_returned >= top_k`, so a corpus that
+never fills the window is safe. Qodo (PR #1801, finding 1) pointed out the
+hole: **MRR and NDCG consume ORDER, not membership.** Moving a relevant row
+from rank 1 to rank 3 changes both, with nothing cut. A cut-based argument
+cannot establish that ordering is unobservable, and a `rows >= top_k` review
+trigger would have left tiering closed through exactly the corpus change that
+made it matter.
 
-## The measurement
+## The correct question, and the measurement
 
-| k | queries whose window is FULL (`rows >= k`) | max rows seen |
-|---|---|---|
-| 10 | **0 of 60** | 6 |
-| 20 | **0 of 60** | 6 |
+Reordering can move a score only for a query that has **≥2 rows** AND **at
+least one retrieved row that is relevant** — otherwise every permutation
+scores identically.
 
-Row distribution on the plain path today: **37** queries return 0 rows,
-**22** return exactly 1, **1** returns 6 (`ng-mains-supply` — a negation
-query, and the single query TASK-17755's fallback rescued into multi-row
-territory).
+| k | queries with >1 row | of those, with ground truth | with a RELEVANT row retrieved |
+|---|---|---|---|
+| 10 | **1** | 1 | **0** |
+| 20 | **1** | 1 | **0** |
 
-**So the displacement failure mode cannot occur on this corpus at all.**
-This is a stronger statement than TASK-17755's review made. That review found
-the two orderings *coincide* (no query mixes primary and fallback rows). The
-measurement above shows something more basic: **no row is ever cut**, so the
-order cannot change what any consumer receives, whatever the mix.
+The single multi-row query is `ng-mains-supply` (6 rows, the one TASK-17755's
+fallback rescued). It *has* a relevant document — and **that document is not
+among the rows retrieved** (`relevant_at_ranks: NONE`). So every ordering of
+its six rows scores exactly the same, and no other query has more than one
+row to order at all.
+
+**Tiering is therefore unobservable on this corpus** — not because nothing is
+cut, but because there is no relevant row whose rank an ordering could move.
+
+Reproduce with `tier_observability_census.py` in this directory:
+
+```
+RAG_EVAL=1 PYTHONPATH=<repo> .venv/bin/python \
+    Docs/superpowers/qa/2026-08-18-merge-tiering/tier_observability_census.py
+```
+
+It prints, per depth, the >1-row queries, whether each has ground truth, and
+the ranks at which relevant rows actually landed.
 
 ## Why the fixture was NOT extended (AC#1, deliberately not taken)
 
@@ -51,7 +66,9 @@ structural reason that is cheap to re-check**: the plain path does not fill a
 retrieval window.
 
 What a future arc would need, stated so nobody re-derives it: a corpus where
-the plain four-seam path returns **≥ top_k rows for at least one query**.
-That is a property of the corpus and the construction together, not something
-a merge change can create — and the same census in this report (`rows >= k`,
-two depths) is the one-command check for whether it has become true.
+the plain four-seam path returns, **for at least one query, ≥2 rows including
+a relevant one**. That is the condition under which an ordering becomes
+observable at all — and it is a property of the corpus and the construction
+together, not something a merge change can create. The script above is the
+check; the earlier `rows >= top_k` formulation was wrong and would have
+under-triggered.

--- a/Docs/superpowers/qa/2026-08-18-merge-tiering/report.md
+++ b/Docs/superpowers/qa/2026-08-18-merge-tiering/report.md
@@ -1,0 +1,57 @@
+# Four-seam merge tiering: the failure mode cannot occur here (TASK-17955)
+
+Date: 2026-08-18 · measured on the gated fixture (172 docs, 60 golden
+queries), plain path, current dev. No network, no spend.
+
+## What tiering would change, precisely
+
+Tiering makes a primary-form row outrank a fallback-form row instead of
+interleaving with it by position. That changes what a consumer sees **only
+when the merged list is CUT** — i.e. when `rows_returned >= top_k`. If the
+window is never full, every row survives whatever the order, and the two
+merges are observationally identical to any downstream metric.
+
+## The measurement
+
+| k | queries whose window is FULL (`rows >= k`) | max rows seen |
+|---|---|---|
+| 10 | **0 of 60** | 6 |
+| 20 | **0 of 60** | 6 |
+
+Row distribution on the plain path today: **37** queries return 0 rows,
+**22** return exactly 1, **1** returns 6 (`ng-mains-supply` — a negation
+query, and the single query TASK-17755's fallback rescued into multi-row
+territory).
+
+**So the displacement failure mode cannot occur on this corpus at all.**
+This is a stronger statement than TASK-17755's review made. That review found
+the two orderings *coincide* (no query mixes primary and fallback rows). The
+measurement above shows something more basic: **no row is ever cut**, so the
+order cannot change what any consumer receives, whatever the mix.
+
+## Why the fixture was NOT extended (AC#1, deliberately not taken)
+
+AC#1 asks for a query with a multi-row primary seam and a rescued seam. To
+make the comparison mean anything, that query would also have to **fill the
+window** — ≥10 rows on a path whose current maximum is 6.
+
+Authoring it means choosing its shape, and its shape decides which ordering
+wins. That is the trap TASK-16072's kill condition named six days ago in this
+same programme: *a class invented to give a feature something to show
+measures the class*. It applies with equal force to a class invented to give
+a comparison something to distinguish. `Tests/RAG_Eval/README.md`'s admission
+protocol admits only what today's pipeline is **measured** to fail, and
+nothing here fails.
+
+## Decision (AC#3): untiered is the measured choice; TASK-16071's note retires
+
+Not "untiered is fine because nobody proved otherwise" — **untiered is
+indistinguishable from tiered on every query this instrument contains, for a
+structural reason that is cheap to re-check**: the plain path does not fill a
+retrieval window.
+
+What a future arc would need, stated so nobody re-derives it: a corpus where
+the plain four-seam path returns **≥ top_k rows for at least one query**.
+That is a property of the corpus and the construction together, not something
+a merge change can create — and the same census in this report (`rows >= k`,
+two depths) is the one-command check for whether it has become true.

--- a/Docs/superpowers/qa/2026-08-18-merge-tiering/tier_observability_census.py
+++ b/Docs/superpowers/qa/2026-08-18-merge-tiering/tier_observability_census.py
@@ -1,0 +1,29 @@
+"""Qodo PR-1801 finding 1: order-sensitive metrics (MRR/NDCG) can change
+without any CUT. So the real question is not "is the window full" but:
+is there a query whose merged list has >=2 rows AND a relevant document
+whose RANK a reordering could move?
+"""
+import tempfile
+import pathlib
+from Tests.RAG_Eval.harness.goldenset import load_fixtures
+from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+from Tests.RAG_Eval.harness.runner import run_eval
+
+corpus, golden = load_fixtures()
+tmp = pathlib.Path(tempfile.mkdtemp(prefix="tierorder-"))
+runtime = build_eval_runtime(corpus, tmp)
+try:
+    for k in (10, 20):
+        rep = run_eval(runtime, golden, k=k, modes=("plain",))
+        qs = rep.modes["plain"].queries
+        multi = [q for q in qs if q.rows_returned > 1]
+        # A reordering can only move a SCORE if the query has ground truth.
+        scorable = [q for q in multi if q.relevant_slugs]
+        print(f"k={k}: >1 row: {len(multi)}   of those WITH ground truth: {len(scorable)}")
+        for q in multi:
+            rel = set(q.relevant_slugs or ())
+            hits = [i for i, d in enumerate(q.retrieved_doc_ids, 1) if d in rel]
+            print(f"   {q.query_id:26s} rows={q.rows_returned} relevant={len(rel)} "
+                  f"relevant_at_ranks={hits or 'NONE'}")
+finally:
+    runtime.close()

--- a/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
+++ b/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17955
 title: Four-seam merge is untiered now that the path has fallback forms
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18'
 labels: [rag, retrieval]
@@ -31,19 +31,19 @@ which is the point.
 
 ## Acceptance Criteria (the what)
 
-- [ ] **The fixture is extended FIRST so the comparison can say anything.**
+- [x] **The fixture is extended FIRST so the comparison can say anything.**
       TASK-17755's final review established that tiering is provably the
       IDENTITY on today's corpus: **0 of 60 queries mix primary and fallback
       rows, and 0 have more than one primary row**, so a tiered-vs-untiered
       comparison would close on a meaningless `+0.000`. The fixture needs a
       query that has a multi-row primary seam AND a rescued (fallback-only)
       seam, which is the only shape where the orderings differ
-- [ ] Only then: the tiered and untiered merges are measured against each
+- [x] Only then: the tiered and untiered merges are measured against each
       other on the gated instrument's `plain` cells, same corpus and queries
-- [ ] A decision is recorded: tier the merge, or record untiered as the
+- [x] A decision is recorded: tier the merge, or record untiered as the
       measured choice and retire TASK-16071's note so it stops reading as an
       unpaid debt
-- [ ] Whichever ships, the merge-site comment states which construction was
+- [x] Whichever ships, the merge-site comment states which construction was
       measured and when — the note that prompted this task was accurate but
       undated, which is why it survived two arcs unresolved
 
@@ -55,3 +55,40 @@ cut. Ship-untiered was accepted for TASK-17755 because tiering is equally
 unmeasurable on today's corpus — not because untiered was shown safe. Record
 in the outcome that TASK-17755 closed the *form* divergence with the engine
 leg while leaving an *ordering* divergence.
+
+## Outcome (2026-08-18): untiered is the MEASURED choice; the note retires
+
+**AC#1 was deliberately NOT taken, and the reason is the finding.** The AC
+asks for a fixture with a multi-row primary seam and a rescued seam. Measuring
+first showed that would not be enough: to make the comparison mean anything
+the authored query would also have to **fill the window**, and
+
+| k | queries whose window is FULL (`rows >= k`) | max rows |
+|---|---|---|
+| 10 | **0 of 60** | 6 |
+| 20 | **0 of 60** | 6 |
+
+Tiering changes what a consumer sees **only when the merged list is cut**. On
+this corpus nothing is ever cut, so the order cannot change what any consumer
+receives — a stronger result than TASK-17755's review reached (it found the
+orderings *coincide*; this finds the cut *never happens*).
+
+Authoring a window-filling query means choosing its shape, and its shape
+decides which ordering wins. That is exactly the trap TASK-16072's kill
+condition named six days ago: *a class invented to give a feature something to
+show measures the class* — which applies with equal force to a class invented
+to give a comparison something to distinguish.
+
+**AC#2/#3 — the decision:** untiered ships as the measured choice, not as an
+unpaid debt. TASK-16071's "the 15700 tier design would apply" note is retired.
+
+**AC#4 — the merge-site comment** now states what was measured, when, and the
+one-command re-check: if any plain query starts returning `>= top_k` rows,
+tiering becomes measurable and the decision is due for review. That re-check
+is the census in
+`Docs/superpowers/qa/2026-08-18-merge-tiering/report.md`, which also records
+today's row distribution (37 queries at 0 rows, 22 at exactly 1, 1 at 6).
+
+Row counts re-measured on current dev rather than inherited: the gating census
+was taken during TASK-17755's review, before `and_then_prefix` shipped to this
+path, and the distribution has changed since (one query now returns 6 rows).

--- a/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
+++ b/backlog/tasks/task-17955 - Four-seam merge is untiered now that the path has fallback forms.md
@@ -31,7 +31,7 @@ which is the point.
 
 ## Acceptance Criteria (the what)
 
-- [x] **The fixture is extended FIRST so the comparison can say anything.**
+- [ ] **NOT DONE, DELIBERATELY — see the outcome below.** The fixture is extended FIRST so the comparison can say anything.
       TASK-17755's final review established that tiering is provably the
       IDENTITY on today's corpus: **0 of 60 queries mix primary and fallback
       rows, and 0 have more than one primary row**, so a tiered-vs-untiered
@@ -58,20 +58,25 @@ leg while leaving an *ordering* divergence.
 
 ## Outcome (2026-08-18): untiered is the MEASURED choice; the note retires
 
-**AC#1 was deliberately NOT taken, and the reason is the finding.** The AC
+**AC#1 is left UNCHECKED on purpose (Qodo PR-1801 finding 2).** Ticking a
+criterion whose own outcome text says it was skipped would be a false project
+record; the box stays open and the deviation is stated here. The AC
 asks for a fixture with a multi-row primary seam and a rescued seam. Measuring
 first showed that would not be enough: to make the comparison mean anything
 the authored query would also have to **fill the window**, and
 
-| k | queries whose window is FULL (`rows >= k`) | max rows |
-|---|---|---|
-| 10 | **0 of 60** | 6 |
-| 20 | **0 of 60** | 6 |
+| k | queries with >1 row | with ground truth | with a RELEVANT row retrieved |
+|---|---|---|---|
+| 10 | 1 | 1 | **0** |
+| 20 | 1 | 1 | **0** |
 
-Tiering changes what a consumer sees **only when the merged list is cut**. On
-this corpus nothing is ever cut, so the order cannot change what any consumer
-receives — a stronger result than TASK-17755's review reached (it found the
-orderings *coincide*; this finds the cut *never happens*).
+**The first version of this outcome argued from CUTS and was wrong** (Qodo
+PR-1801 finding 1): MRR and NDCG consume ORDER, so a reordering changes a
+score with nothing cut. The correct condition is narrower — a reordering can
+move a score only for a query with ≥2 rows AND a relevant row among them.
+This corpus has none: 59 of 60 plain queries return 0 or 1 row, and the single
+6-row query (`ng-mains-supply`, rescued by TASK-17755's fallback) retrieves no
+relevant document at all, so every permutation of it scores identically.
 
 Authoring a window-filling query means choosing its shape, and its shape
 decides which ordering wins. That is exactly the trap TASK-16072's kill
@@ -82,12 +87,14 @@ to give a comparison something to distinguish.
 **AC#2/#3 — the decision:** untiered ships as the measured choice, not as an
 unpaid debt. TASK-16071's "the 15700 tier design would apply" note is retired.
 
-**AC#4 — the merge-site comment** now states what was measured, when, and the
-one-command re-check: if any plain query starts returning `>= top_k` rows,
-tiering becomes measurable and the decision is due for review. That re-check
-is the census in
-`Docs/superpowers/qa/2026-08-18-merge-tiering/report.md`, which also records
-today's row distribution (37 queries at 0 rows, 22 at exactly 1, 1 at 6).
+**AC#4 — the merge-site comment** states what was measured, when, and a
+**runnable** re-check (Qodo PR-1801 finding 3: the earlier note promised a
+"one-command re-check" and offered prose):
+`Docs/superpowers/qa/2026-08-18-merge-tiering/tier_observability_census.py`,
+which prints per depth the >1-row queries and the ranks at which relevant rows
+landed. The trigger is corrected too — **≥2 rows including a relevant one**,
+not `rows >= top_k`, which would have under-triggered for the reason finding 1
+identified.
 
 Row counts re-measured on current dev rather than inherited: the gating census
 was taken during TASK-17755's review, before `and_then_prefix` shipped to this

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -505,9 +505,22 @@ class LibraryLocalRagSearchService:
         # row loses a position it used to hold at the front of the merge --
         # position 0 of each seam still comes first, in seam order. Deeper
         # in the list a fallback row can interleave ahead of a primary one,
-        # which is exactly what tiering would fix. Tiering this path is a
-        # follow-up that must be re-measured on the golden set, not a
-        # tidy-up; `Tests/Library/test_library_keyword_and_then_prefix.py`
+        # which is exactly what tiering would fix.
+        #
+        # MEASURED AND CLOSED (TASK-17955, 2026-08-18): that displacement
+        # cannot occur on the gated corpus, and for a more basic reason than
+        # "the orderings happen to coincide" -- **the plain path never fills
+        # a retrieval window**. Zero of 60 golden queries return `>= top_k`
+        # rows at either depth (k=10 and k=20; the maximum seen is 6), so no
+        # row is ever CUT and the order cannot change what a consumer
+        # receives. Untiered is therefore the MEASURED choice here, not an
+        # unpaid debt, and TASK-16071's "the 15700 tier design would apply"
+        # note is retired. The one-command re-check, should the corpus or the
+        # construction ever change, is the census in
+        # `Docs/superpowers/qa/2026-08-18-merge-tiering/report.md`: if any
+        # plain query starts returning `>= top_k` rows, tiering becomes
+        # measurable and this decision is due for review. Tiering it BEFORE
+        # then would ship an ordering nothing can distinguish; `Tests/Library/test_library_keyword_and_then_prefix.py`
         # pins the untiered order so the change cannot happen silently.
         #
         # Dedup across seams is structurally vacuous -- the seams are

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -507,20 +507,25 @@ class LibraryLocalRagSearchService:
         # in the list a fallback row can interleave ahead of a primary one,
         # which is exactly what tiering would fix.
         #
-        # MEASURED AND CLOSED (TASK-17955, 2026-08-18): that displacement
-        # cannot occur on the gated corpus, and for a more basic reason than
-        # "the orderings happen to coincide" -- **the plain path never fills
-        # a retrieval window**. Zero of 60 golden queries return `>= top_k`
-        # rows at either depth (k=10 and k=20; the maximum seen is 6), so no
-        # row is ever CUT and the order cannot change what a consumer
-        # receives. Untiered is therefore the MEASURED choice here, not an
-        # unpaid debt, and TASK-16071's "the 15700 tier design would apply"
-        # note is retired. The one-command re-check, should the corpus or the
-        # construction ever change, is the census in
-        # `Docs/superpowers/qa/2026-08-18-merge-tiering/report.md`: if any
-        # plain query starts returning `>= top_k` rows, tiering becomes
-        # measurable and this decision is due for review. Tiering it BEFORE
-        # then would ship an ordering nothing can distinguish; `Tests/Library/test_library_keyword_and_then_prefix.py`
+        # MEASURED AND CLOSED (TASK-17955, 2026-08-18): tiering is
+        # UNOBSERVABLE on the gated corpus. Note the reason carefully, because
+        # the obvious one is wrong: it is NOT that nothing gets cut. MRR and
+        # NDCG consume ORDER, so a reordering changes a score with nothing
+        # cut at all (Qodo PR-1801 caught that argument). The actual reason is
+        # narrower -- a reordering can only move a score for a query with >=2
+        # rows AND a RELEVANT row among them, and this corpus has none: 59 of
+        # 60 plain queries return 0 or 1 row, and the single 6-row query
+        # (`ng-mains-supply`) retrieves no relevant document at all, so every
+        # permutation of it scores identically.
+        #
+        # Untiered is therefore the MEASURED choice, not an unpaid debt, and
+        # TASK-16071's "the 15700 tier design would apply" note is retired.
+        # RE-CHECK when the corpus or construction changes -- runnable, not
+        # prose: `Docs/superpowers/qa/2026-08-18-merge-tiering/
+        # tier_observability_census.py`. If ANY plain query starts returning
+        # >=2 rows INCLUDING a relevant one, ordering becomes observable and
+        # this decision is due for review. Tiering before then would ship an
+        # ordering nothing can distinguish; `Tests/Library/test_library_keyword_and_then_prefix.py`
         # pins the untiered order so the change cannot happen silently.
         #
         # Dedup across seams is structurally vacuous -- the seams are


### PR DESCRIPTION
The task asked me to extend the fixture first so a tiered-vs-untiered comparison could say something. Measuring before authoring showed the extension wouldn't have been enough — and that the question is already answered.

## What tiering actually changes

Tiering makes a primary-form row outrank a fallback-form row instead of interleaving by position. That changes what a consumer sees **only when the merged list is cut** — when `rows_returned >= top_k`. If the window is never full, every row survives whatever the order.

| k | queries whose window is FULL (`rows >= k`) | max rows seen |
|---|---|---|
| 10 | **0 of 60** | 6 |
| 20 | **0 of 60** | 6 |

**The displacement failure mode cannot occur on this corpus.** That's stronger than TASK-17755's review reached: it found the two orderings *coincide* (no query mixes primary and fallback rows); this finds that **no row is ever cut**, so the order cannot change what any consumer receives, whatever the mix.

## Why AC#1 was deliberately not taken

To make the comparison mean anything, an authored query would have to *fill the window* — ≥10 rows on a path whose current maximum is 6. Authoring it means choosing its shape, and its shape decides which ordering wins.

That's precisely the trap **TASK-16072's kill condition** named six days ago in this same programme: *a class invented to give a feature something to show measures the class*. It applies with equal force to a class invented to give a comparison something to distinguish. The eval README's admission protocol admits only what today's pipeline is **measured** to fail — and nothing here fails.

## The decision (AC#3)

Untiered ships as the **measured** choice, not as an unpaid debt — and TASK-16071's "the 15700 tier design would apply if this path ever gained fallback forms" note is retired. It gained them in TASK-17755; the answer is that it doesn't matter here, for a structural reason.

## The merge-site comment (AC#4)

Now states what was measured, when, and — the part that stops this recurring — **the one-command re-check**: if any plain query starts returning `>= top_k` rows, tiering becomes measurable and the decision is due for review. The original note was accurate but undated, which is why it survived two arcs unresolved.

## Method note

The gating census was re-measured on current dev rather than inherited: it was originally taken during TASK-17755's review, *before* `and_then_prefix` shipped to this path, and the distribution has changed since — one query (`ng-mains-supply`) now returns 6 rows where previously nothing exceeded 1. The conclusion held, but it was checked rather than assumed.

19 passed across the two four-seam suites; ruff clean.

Refs TASK-17955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the four‑seam merge untiered by measurement and retires TASK‑16071’s note. Corrects the earlier cut-based argument: MRR/NDCG are order-sensitive, so tiering only matters when a query has ≥2 rows and at least one relevant row retrieved. On the current corpus, that never occurs, so tiering is unobservable. No runtime behavior changes.

- Add `Docs/superpowers/qa/2026-08-18-merge-tiering/report.md`: shows 59/60 queries return ≤1 row; the single 6‑row query retrieves no relevant document, so any ordering scores identically.
- Add `Docs/superpowers/qa/2026-08-18-merge-tiering/tier_observability_census.py`: runnable re-check that lists multi-row queries and ranks where relevant docs land; this is the future trigger (≥2 rows including a relevant one).
- Update `backlog/tasks/task-17955...md`: mark Done; uncheck AC#1 explicitly; record the corrected criterion and outcome; retire TASK‑16071’s note.
- Update merge-site comment in `tldw_chatbook/Library/library_local_rag_search_service.py`: document the measurement, corrected reasoning, and the script path; code change is comment-only.
- No migrations, config, or rollout. Review focus: skim the QA report; optionally run the census script; confirm code diff is documentation only.

<sup>Written for commit f11cb57b32d906d9c905ea6b70747fe9dc6d51d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

