### PR TITLE
Residual zero-row queries: 19 unreachable, 11 hiding a seam defect (TASK-17855)

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-residual-zero-row/reachability_census.py
+++ b/Docs/superpowers/qa/2026-08-18-residual-zero-row/reachability_census.py
@@ -1,0 +1,59 @@
+"""TASK-17855 AC#1: characterise the residual zero-row queries.
+
+The question is whether a keyword construction could EVER reach the target.
+A construction can only rearrange the terms the user typed, so the decisive
+test is lexical overlap: does the relevant document contain ANY content word
+from the query? If not, no AND/OR/prefix/stopword arrangement of those terms
+can retrieve it, and the residual is the semantic leg's job by construction.
+"""
+import re, tempfile, pathlib, collections
+from Tests.RAG_Eval.harness.goldenset import load_fixtures
+from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+from Tests.RAG_Eval.harness.runner import run_eval
+
+STOP = {"a","an","the","of","for","to","in","on","and","or","is","are","was","were",
+        "be","been","with","at","by","from","how","what","when","which","do","does",
+        "did","can","should","would","my","our","that","this","it","not","no","if",
+        "you","i","me","us","they","them","there","here","about","into","than","then"}
+
+corpus, golden = load_fixtures()
+docs = {d.slug: (d.title + "\n" + d.content).lower() for d in corpus}
+print("PROBE PROOF: docs with text:", sum(1 for v in docs.values() if len(v) > 50), "of", len(docs))
+
+tmp = pathlib.Path(tempfile.mkdtemp(prefix="zr17855-"))
+runtime = build_eval_runtime(corpus, tmp)
+try:
+    rep = run_eval(runtime, golden, k=10, modes=("plain",))
+    qs = rep.modes["plain"].queries
+finally:
+    runtime.close()
+
+def cw(q):
+    return [w for w in re.findall(r"[a-z0-9\-]+", q.lower()) if w not in STOP and len(w) > 2]
+
+zero_scored = [q for q in qs if q.rows_returned == 0 and (q.relevant_slugs or ())]
+print(f"residual zero-row queries WITH ground truth: {len(zero_scored)}")
+
+buckets = collections.Counter()
+detail = []
+for q in zero_scored:
+    words = cw(q.query)
+    targets = [docs.get(s, "") for s in (q.relevant_slugs or ())]
+    # how many query content words appear in ANY relevant document?
+    present = [w for w in words if any(w in t for t in targets)]
+    if not present:
+        bucket = "UNREACHABLE (no shared content word)"
+    elif len(present) == len(words):
+        bucket = "all words present (construction could reach it)"
+    else:
+        bucket = f"partial ({len(present)}/{len(words)} words present)"
+    buckets[bucket] += 1
+    detail.append((q.category, q.query[:44], len(words), len(present), bucket))
+
+print()
+for b, n in buckets.most_common():
+    print(f"  {n:3d}  {b}")
+print()
+for cat, qtext, nw, npres, b in sorted(detail):
+    if not b.startswith("UNREACHABLE"):
+        print(f"   REACHABLE? [{cat:20s}] {qtext!r}  {npres}/{nw} words present")

--- a/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
+++ b/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
@@ -1,0 +1,70 @@
+# Residual zero-row queries: what keyword construction can and cannot reach (TASK-17855)
+
+Date: 2026-08-18 · gated fixture (172 docs, 60 golden queries), plain path,
+current dev (post-TASK-17755). No network, no spend.
+Reproduce: `reachability_census.py` in this directory.
+
+## The test, and why it is decisive
+
+A construction can only rearrange the terms the user typed. So the question
+is lexical, not algorithmic: **does the relevant document contain ANY content
+word from the query?** If not, no AND / OR / prefix / stopword-trim
+arrangement of those terms can ever retrieve it, and the query belongs to the
+semantic leg permanently.
+
+## The census — 30 residual zero-row queries with ground truth
+
+| | queries |
+|---|---|
+| **UNREACHABLE** — target shares NO content word | **19** (63%) |
+| lexically reachable — some or all words present | **11** (37%) |
+
+The 11 break down as one query with **all** content words present, and ten
+with partial overlap (from 1/8 up to 7/8).
+
+## The finding that changes the task's premise
+
+The task assumed the residual was a *recall* problem to be attacked by
+broadening. Half of that is right — the 19 unreachable ones are the semantic
+leg's job by construction, and no keyword work will ever move them.
+
+But the reachable 11 are dominated by one category, and it is not behaving
+like a construction problem:
+
+| mode | `prompt` queries returning rows | finding the target |
+|---|---|---|
+| `plain` | **0 of 5** | 0 |
+| `semantic` | 5 of 5 | 0 |
+| `hybrid` | 5 of 5 | 1 |
+
+**The plain path returns nothing at all for any prompt query**, including
+`"saved prompt for chasing a supplier about a late order"` — whose target is
+named *"Saved prompt: chasing a late order"* and contains **every content
+word of the query**. `prompts_fts` indexes five columns including `name`, so
+the terms are indexed. A sub-leg that returns zero rows when every term is
+present is a **defect**, not a construction that needs widening.
+
+## Decision (AC#3)
+
+**Keyword construction has NOT reached its ceiling — but the remaining
+headroom is not in broadening, and pursuing broadening would paper over a
+defect.**
+
+- The **19 unreachable** queries are closed as the semantic leg's business.
+  No construction can reach them; this is recorded so no future arc
+  re-derives it.
+- The **11 reachable** queries are pursued as **TASK-18255**, a seam defect
+  in the plain prompts sub-leg — filed rather than fixed here, since this
+  task's scope is characterisation.
+- **Broadening is explicitly not recommended.** Its cost is measured:
+  TASK-3997 found pure OR/prefix cut MRR by 34% (0.396 → 0.261). Paying that
+  to reach queries whose target contains the words — when the seam should
+  already be reaching them — would be buying with the wrong currency.
+
+## AC#2's candidate, with its cost
+
+| candidate | reaches | precision cost |
+|---|---|---|
+| **fix the prompts sub-leg** (TASK-18255) | up to 5 of the 11 | **none by construction** — the terms are already present and indexed |
+| broaden the construction | some of the remaining 6 | **−34% MRR**, measured (TASK-3997) |
+| semantic/vocabulary work | the 19 unreachable | out of scope here; the only route for them |

--- a/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
+++ b/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-17855
 title: Investigate the remaining zero-row queries — absent content words
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18'
 labels: [rag, retrieval, investigation]
@@ -31,13 +31,60 @@ publishable outcome and is sufficient to close this task.**
 
 ## Acceptance Criteria (the what)
 
-- [ ] The 25 residual zero-row queries are characterised: for each, whether
+- [x] The 25 residual zero-row queries are characterised: for each, whether
       the relevant document is reachable by ANY keyword construction over the
       terms the user typed, or only by semantic retrieval
-- [ ] At least one candidate is proposed with its measured or estimated
+- [x] At least one candidate is proposed with its measured or estimated
       precision cost, judged against the finding that pure OR cut MRR by a
       THIRD (0.396 -> 0.261, -34%) —
       recall bought by broadening is not free and must be priced
-- [ ] A decision is recorded: pursue a specific candidate as its own arc, or
+- [x] A decision is recorded: pursue a specific candidate as its own arc, or
       record that keyword construction has reached its ceiling on this corpus
       and the remainder is the semantic leg's job
+
+## Outcome (2026-08-18): the residual splits in two, and neither half wants broadening
+
+**AC#1 — characterised, from the corpus.** 30 residual zero-row queries carry
+ground truth (the count moved from the filed 25 because TASK-17755 shipped
+`and_then_prefix` to this path in between; re-measured rather than inherited).
+The test is lexical, because a construction can only rearrange the terms the
+user typed: does the target contain ANY content word of the query?
+
+| | queries |
+|---|---|
+| **UNREACHABLE** — no shared content word | **19** (63%) |
+| lexically reachable | **11** (37%) |
+
+**AC#2 — the candidate, and it is not the one this task expected.** The
+reachable 11 are dominated by `prompt`, which is not behaving like a
+construction problem at all:
+
+| mode | prompt queries returning rows | finding the target |
+|---|---|---|
+| `plain` | **0 of 5** | 0 |
+| `semantic` | 5 of 5 | 0 |
+| `hybrid` | 5 of 5 | 1 |
+
+The plain path returns **nothing** for any prompt query — including one whose
+target contains **every content word** and whose name is indexed by
+`prompts_fts`. A sub-leg returning zero rows when every term is present is a
+defect, filed as **TASK-18255**.
+
+Costs, since AC#2 asks for them priced:
+
+| candidate | reaches | precision cost |
+|---|---|---|
+| fix the prompts sub-leg (TASK-18255) | up to 5 of the 11 | **none** — terms already present and indexed |
+| broaden the construction | some of the other 6 | **−34% MRR**, measured (TASK-3997) |
+| semantic/vocabulary work | the 19 unreachable | the only route for them |
+
+**AC#3 — the decision.** Keyword construction has **not** reached its ceiling,
+but the headroom is not in broadening. The 19 unreachable queries are closed
+as the semantic leg's business permanently. The reachable 11 go to TASK-18255.
+**Broadening is explicitly not recommended**: paying 34% MRR to reach queries
+whose target already contains the words — when the seam should be matching
+them — is buying with the wrong currency.
+
+Artifacts: `Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md` and
+`reachability_census.py` (runnable; prints its document count before any
+result).

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -1,0 +1,55 @@
+---
+id: TASK-18255
+title: >-
+  The plain prompts sub-leg returns zero rows for queries whose target contains
+  the words
+status: To Do
+assignee: []
+labels: [rag, retrieval]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+Found by TASK-17855's census of residual zero-row queries. On the gated
+fixture, the `prompt` category behaves like this:
+
+| mode | queries returning rows | queries finding the target |
+|---|---|---|
+| `plain` | **0 of 5** | 0 |
+| `semantic` | 5 of 5 | 0 |
+| `hybrid` | 5 of 5 | 1 |
+
+**The plain path returns nothing at all for any prompt query** — and that is
+not explained by AND-strictness, which is what TASK-3997 and TASK-17755 were
+about. Four of the five queries have high lexical overlap with their target,
+and one has **every content word present**: `"saved prompt for chasing a
+supplier about a late order"` against `prompt-vendor-chaser`, whose name is
+*"Saved prompt: chasing a late order"* and whose body names the supplier, the
+order and the chase.
+
+`prompts_fts` indexes five columns including `name`, so the words are
+indexed. A construction that reaches nothing when every term is present
+points at the sub-leg — its scoping, its query shape, or whether it runs at
+all on this path — rather than at how the MATCH expression is built.
+
+This is a **defect candidate, not a recall-broadening candidate**, which
+matters: broadening was measured at a 34% MRR cost (TASK-3997), while fixing
+a seam that returns zero rows for exact-term queries has no precision cost by
+construction.
+
+## Acceptance Criteria (the what)
+
+- [ ] The cause is named from evidence: whether the plain prompts sub-leg
+      runs, what MATCH expression it issues, and against which columns —
+      not inferred from the construction
+- [ ] `"saved prompt for chasing a supplier about a late order"` returns
+      `prompt-vendor-chaser` on the plain path, or the reason it cannot is
+      recorded with the same specificity
+- [ ] The other four prompt queries are reported with it, since they share
+      the seam and three of them also have partial overlap
+- [ ] The gated suite still reads `PASSED: No regression. 105 metric(s)`;
+      note that `plain`'s `category.prompt.*` cells are currently 0.000, so
+      a fix should MOVE them — if it does, that movement is the deliverable
+      and the baseline is re-stamped deliberately


### PR DESCRIPTION
The investigation this task asked for, and it lands somewhere the task didn't expect.

## The test, and why it's decisive

A construction can only rearrange the terms the user typed. So the question is lexical, not algorithmic: **does the target contain any content word from the query?** If not, no AND / OR / prefix / stopword-trim arrangement can ever retrieve it.

| | queries |
|---|---|
| **UNREACHABLE** — no shared content word | **19** (63%) |
| lexically reachable | **11** (37%) |

(30 residual queries carry ground truth, not the 25 in the filing — TASK-17755 shipped `and_then_prefix` to this path in between, so the census was re-measured rather than inherited.)

## The finding that changes the premise

The task assumed the residual was a *recall* problem to attack by broadening. Half of that holds — the 19 unreachable queries belong to the semantic leg permanently, and no keyword work will move them.

But the reachable 11 are dominated by one category that isn't behaving like a construction problem at all:

| mode | `prompt` queries returning rows | finding the target |
|---|---|---|
| `plain` | **0 of 5** | 0 |
| `semantic` | 5 of 5 | 0 |
| `hybrid` | 5 of 5 | 1 |

**The plain path returns nothing for any prompt query** — including `"saved prompt for chasing a supplier about a late order"`, whose target is named *"Saved prompt: chasing a late order"* and contains **every content word of the query**. `prompts_fts` indexes five columns including `name`, so those terms are indexed.

A sub-leg that returns zero rows when every term is present is a **defect**, not a construction that needs widening. Filed as **TASK-18255**.

## The decision (AC#3)

**Keyword construction has not reached its ceiling — but the headroom isn't in broadening, and chasing it there would paper over the defect.**

| candidate | reaches | precision cost |
|---|---|---|
| fix the prompts sub-leg (TASK-18255) | up to 5 of the 11 | **none** — terms already present and indexed |
| broaden the construction | some of the other 6 | **−34% MRR**, measured in TASK-3997 |
| semantic/vocabulary work | the 19 unreachable | the only route for them |

Paying 34% MRR to reach queries whose target already contains the words — when the seam should be matching them — is buying with the wrong currency.

## Artifacts

`Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md` plus a runnable `reachability_census.py` that prints how many documents it actually read before any result (the guard three probes in this programme have needed after silently reading empty text).

Refs TASK-17855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records a reachability census for residual zero‑row queries and files a prompts seam defect. 19/30 are unreachable by keywords; the 11 reachable are dominated by `prompt` queries where the plain path returns zero rows, shifting follow‑up from broadening (−34% MRR) to fixing the plain prompts sub‑leg.

- Adds `Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md` and a reproducible `reachability_census.py` for the gated fixture.
- Updates `backlog/tasks/task-17855` to Done with findings/decision; adds `backlog/tasks/task-18255` to fix the plain prompts sub‑leg returning zero rows despite full term overlap.
- No retrieval/query code changed; docs/backlog only. No rollout or migration required.

<sup>Written for commit 15b80483a7321ebc46184cc03d7b66ce047ff572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

