### PR TITLE
test(console,settings): resolve both filed dev reds — stale pins, no defects (tasks 17656, 17660)

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -4017,6 +4017,15 @@ async def test_console_message_action_keyboard_focus_stays_inside_action_row():
         )
         await _wait_for_focus(console.app, pilot, copy_button)
 
+        # task-17656: idle Speak moved from the message header into the
+        # action row between Copy and Edit (8ae87242a) — the walk gains a
+        # stop, exactly as the row's on-screen guide lists it.
+        await pilot.press("tab")
+        speak_button = console.query_one(
+            f"#console-message-action-speak-{message.id}", Button
+        )
+        await _wait_for_focus(console.app, pilot, speak_button)
+
         await pilot.press("tab")
         edit_button = console.query_one(
             f"#console-message-action-edit-{message.id}", Button
@@ -4029,6 +4038,24 @@ async def test_console_message_action_keyboard_focus_stays_inside_action_row():
         )
         await _wait_for_focus(console.app, pilot, save_as_button)
 
+        # task-17656: walk the rest of the row full circle back to Delete —
+        # every stop of a completed assistant reply is Tab-reachable in
+        # visual order, and focus never escapes the row.
+        for action_id in (
+            "regenerate",
+            "continue",
+            "feedback-up",
+            "feedback-down",
+            "delete",
+        ):
+            await pilot.press("tab")
+            stop = console.query_one(
+                f"#console-message-action-{action_id}-{message.id}", Button
+            )
+            await _wait_for_focus(console.app, pilot, stop)
+
+        transcript.focus_action(message.id, "save-as")
+        await _wait_for_focus(console.app, pilot, save_as_button)
         await pilot.press("enter")
         await _wait_for_selector(host.screen_stack[-1], pilot, "#console-save-as-modal")
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -4016,7 +4016,23 @@ async def test_settings_console_paste_collapse_toggle_reflects_and_persists_conf
             return True
 
     monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
-    host = DestinationHarness(app, "settings")
+
+    # task-17660: this flow needs the REAL stylesheet. The bare harness
+    # loads no bundle, so `.settings-secondary-card { height: auto }` never
+    # applies and the card falls back to a container default that clamps it
+    # to a fraction of the pane — the checkbox lays out past the clamp,
+    # sibling detail rows paint over it, and pilot.click misses silently
+    # (returns False), so the draft never staged and Save truthfully said
+    # "no changes". The card grew past the clamp when Status row placement
+    # and Selection side chat landed; in the bundled app the card
+    # auto-grows and the control is reachable by scrolling, exactly as a
+    # user does below.
+    from Tests.UI.consolidated_css import BUNDLED_STYLESHEET
+
+    class _StyledDestinationHarness(DestinationHarness):
+        CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    host = _StyledDestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
         screen = _active_destination_screen(host)
@@ -4032,7 +4048,10 @@ async def test_settings_console_paste_collapse_toggle_reflects_and_persists_conf
 
         assert toggle.value is expected_checked
 
-        await pilot.click("#settings-console-collapse-large-pastes-toggle")
+        toggle.scroll_visible(animate=False)
+        await pilot.pause()
+        clicked = await pilot.click("#settings-console-collapse-large-pastes-toggle")
+        assert clicked, "checkbox click missed — widget not in view"
         await pilot.pause(0.1)
 
         assert app.app_config["console"]["collapse_large_pastes"] == initial_value

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5144,3 +5144,37 @@ arc's own freshly written pin `assert "outline:" not in focus` — written
 minutes earlier to mean "no focus outline". Ban the specific values
 (`outline: solid`, `outline: heavy`) and PIN the opt-out explicitly; a
 substring ban on the property name bans the cure along with the disease.
+
+## A bundle-less harness does not just hide styles — it changes LAYOUT MODE (task-17660, 2026-08-18)
+
+**What happened.** Two Settings toggle tests went red on dev and looked like a
+regression from recent merges. The real chain: the Console Behavior card's
+stylesheet rule is `height: auto`, but the test harness (`DestinationHarness`,
+a `ConsolidatedCSSApp` with no bundle) never loads it — so the card fell back
+to the container default and was CLAMPED to a fraction of the pane. When two
+new sections landed in the card (Status row placement, Selection side chat),
+its content grew past the clamp; the paste checkbox laid out beyond the card's
+box, sibling detail rows painted over its coordinates, and `pilot.click`
+missed silently — `clicked` came back `False`, nothing staged, and the Save
+button truthfully reported "no changes". A bundled probe against the same
+build showed the card auto-growing to its full height with the control
+reachable by ordinary scrolling: **no production defect existed**.
+
+Three mechanics worth keeping:
+
+1. **Missing CSS can flip a container from auto-sizing to fraction-sizing.**
+   That is a different failure class from "the margin/padding I assert on is
+   absent": the whole layout topology changes, children overflow their
+   parent's box, and hit-testing lands on unrelated widgets. A geometry or
+   interaction test whose subject sits deep in a card is meaningless without
+   the bundle.
+2. **`pilot.click` misses are silent unless you assert the return value.**
+   The click "succeeded" as far as the test flow was concerned and the
+   failure surfaced two steps later as a missing toast — assert `clicked` at
+   the click site so the failure names the real problem.
+3. This is the third distinct incident of the bundle-less-harness trap
+   (`ConsoleHarness` could not see the phantom chips margin in task-17650;
+   the composer padding in the same audit; now layout-mode clamping here).
+   When a mounted test drives clicks or asserts geometry, subclass the
+   harness with `CSS_PATH = BUNDLED_STYLESHEET` — and treat a red mounted
+   test in a bare harness as unattributed until reproduced under the bundle.

--- a/backlog/tasks/task-17656 - Console-message-action-focus-walk-red-on-dev-after-selection-feedback.md
+++ b/backlog/tasks/task-17656 - Console-message-action-focus-walk-red-on-dev-after-selection-feedback.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-17656
 title: 'Console: message-action focus-walk test red on dev after selection-feedback merge'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-17'
 labels:
   - console
@@ -22,6 +23,21 @@ Fix belongs with the selection-feedback feature: either the action-row focus ord
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The action-row keyboard focus walk is verified live: every action in a selected message's row is reachable by Tab in visual order, including the new feedback action
-- [ ] #2 The test is green on dev, updated to the intended contract (or the focus-order defect it caught is fixed)
+- [x] #1 The action-row keyboard focus walk is verified live: every action in a selected message's row is reachable by Tab in visual order, including the new feedback action
+- [x] #2 The test is green on dev, updated to the intended contract (or the focus-order defect it caught is fixed)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce; identify what added the stop between Copy and Edit.
+2. Walk the row live; decide regression vs stale pin; fix accordingly.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The filing's attribution was half right: the failure rode in with the selection-feedback merge train, but the mechanism was NOT the feedback action — commit `8ae87242a` ("move idle Speak into the selected-message action row", 2026-08-15, merged via that branch) deliberately moved Speak from the message header into the row between Copy and Edit, exactly where the on-screen guide has always listed it. Keyboard navigation was never broken; the walk test's expectations were stale. The walk gains the Speak stop, and — to honor AC#1 — now continues full circle through Regenerate, Continue, both feedback thumbs, and back to Delete, proving every stop of a completed assistant reply is Tab-reachable in visual order with focus contained, before re-focusing Save-as for the modal ending. Green with zero production changes.
+
+Files: `Tests/UI/test_console_native_chat_flow.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17660 - Settings-paste-collapse-toggle-tests-red-on-dev.md
+++ b/backlog/tasks/task-17660 - Settings-paste-collapse-toggle-tests-red-on-dev.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-17660
 title: 'Settings: paste-collapse toggle persistence tests red on dev'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-17'
 labels:
   - settings
@@ -22,6 +23,24 @@ Needs a bisect against recent Settings/Console-Behavior merges (the status-row t
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The failing parameterizations are green on dev, either by fixing the regression they caught or by updating the test to the intended contract (decided by reproducing the toggle flow live first)
-- [ ] #2 The task records which merge introduced the red
+- [x] #1 The failing parameterizations are green on dev, either by fixing the regression they caught or by updating the test to the intended contract (decided by reproducing the toggle flow live first)
+- [x] #2 The task records which merge introduced the red
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce; read the failure's visible-text dump (it showed "Save (s) — no changes": the checkbox click never staged a draft).
+2. Hit-test the click coordinates; trace the miss to its mechanism; verify against a bundled harness before attributing.
+3. Fix at the mechanism; record the generalizable trap in lessons-testing-evidence.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+No regression existed and no bisect was needed — the mechanism was the third instance of the bundle-less-harness trap, this time changing LAYOUT MODE: without the bundle, `.settings-secondary-card { height: auto }` never applies, the card is clamped to a container-default fraction of the pane, and when the card's content grew (Status row placement [task-17652] + Selection side chat [selection-feedback]) the paste checkbox laid out past the clamp with sibling detail rows painted over its coordinates — `pilot.click` missed silently (returned False), nothing staged, and Save truthfully reported "no changes". A bundled probe on the same build showed the card auto-growing (h=123) and the control clickable after ordinary scrolling: the real app was never broken.
+
+Fix: the test gets a bundle-loading harness subclass, scrolls the toggle into view the way a user does, and asserts the click's return value so a future miss fails AT the click. Both parameterizations green; full-repo lesson appended to lessons-testing-evidence.md ("a bundle-less harness does not just hide styles — it changes layout mode").
+
+Files: `Tests/UI/test_destination_shells.py`, `backlog/docs/lessons-testing-evidence.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17663 - Watchlists-destination-action-outcome-test-red-on-dev.md
+++ b/backlog/tasks/task-17663 - Watchlists-destination-action-outcome-test-red-on-dev.md
@@ -1,0 +1,25 @@
+---
+id: TASK-17663
+title: 'Watchlists: destination action-outcome test red on dev (collections param)'
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels:
+  - watchlists
+  - test-health
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_destination_shells.py::test_destination_action_buttons_explain_their_outcome[watchlists_collections]` fails on clean origin/dev — verified 2026-08-18 in a detached baseline worktree at `dd1a82146` (solo run, same failure on a task-17656/17660 branch that touches neither watchlists nor this test's fixtures). Found during task-17660's collateral run. Needs the usual decide-by-reproducing pass: either a watchlists collections action button stopped explaining its outcome (real copy/tooltip regression) or the pin is stale against an intended change from a recent watchlists/destination merge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The failing parameterization is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the surface live first)
+- [ ] #2 The task records which merge introduced the red
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Both dev reds filed during the bottom-stack programme are resolved, and **neither was a real defect** — both filings' original theories were wrong in instructive ways:

**task-17656 — action-row focus walk.** Filed as "the selection-feedback arc's Comment action changed the Tab-stop count." Half right: the failure rode in with that merge train, but the mechanism was `8ae87242a` — *"move idle Speak into the selected-message action row"* — which deliberately placed Speak between Copy and Edit, exactly where the row's on-screen guide has always listed it. Keyboard navigation was never broken; the walk test was stale. The walk gains the Speak stop and now runs **full circle** (Delete → wrap → Copy → Speak → Edit → Save-as → Regenerate → Continue → 👍 → 👎 → Delete), proving every action of a completed assistant reply is Tab-reachable in visual order with focus contained. Zero production changes.

**task-17660 — Settings paste-collapse toggle.** Filed as "needs a bisect across recent Settings merges." No bisect needed and no regression existed — this was the **third instance of the bundle-less-harness trap**, with a new twist recorded in `lessons-testing-evidence.md`: missing CSS doesn't just hide styles, it changes **layout mode**. Without the bundle, the card's `height: auto` never applies, the container-default clamp took over, and when the card's content grew (Status row placement, Selection side chat) the checkbox laid out past the clamp with sibling rows painted over it — `pilot.click` missed silently and Save truthfully said "no changes". A bundled probe on the same build showed the card auto-growing (h=123) and the control clickable after ordinary scrolling. The test now loads the bundle, scrolls like a user, and asserts the click's return value so a future miss fails at the click site.

Also files **task-17663**: a pre-existing watchlists red (`test_destination_action_buttons_explain_their_outcome[watchlists_collections]`) found in this branch's collateral run and baselined red on clean dev at `dd1a82146`.

Collateral: 413 passed across both full files (the one red being 17663's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves two dev test reds by updating stale assertions and running settings tests with the bundled stylesheet. Product behavior is unchanged; tests now reflect the intended UI and reliably catch regressions.

- Console action-row focus walk (task-17656): The test now includes the Speak action between Copy and Edit and walks the row full circle back to Delete, verifying Tab order and focus containment. No production changes.
- Settings paste-collapse toggle (task-17660): The test previously used a bundle-less `DestinationHarness`, which clamped the card and caused the checkbox click to miss. It now subclasses the harness to load `BUNDLED_STYLESHEET`, scrolls the control into view, and asserts the click return value. Adds a lesson to `backlog/docs/lessons-testing-evidence.md` about bundle-less harness pitfalls.
- Housekeeping: Adds task 17663 documenting a pre-existing watchlists test red found in collateral runs; not addressed here.

<sup>Written for commit e1f034cbd7b3e24ad47d3d6b203ce8e90034b9ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

