### PR TITLE
fix(watchlists): read pager buttons explain their outcome (task-17663)

### DIFF
--- a/backlog/tasks/task-17663 - Watchlists-destination-action-outcome-test-red-on-dev.md
+++ b/backlog/tasks/task-17663 - Watchlists-destination-action-outcome-test-red-on-dev.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-17663
 title: 'Watchlists: destination action-outcome test red on dev (collections param)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-18'
 labels:
   - watchlists
@@ -20,6 +21,21 @@ priority: medium
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The failing parameterization is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the surface live first)
-- [ ] #2 The task records which merge introduced the red
+- [x] #1 The failing parameterization is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the surface live first)
+- [x] #2 The task records which merge introduced the red
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce with detail; identify the tooltip-less buttons and the introducing commit.
+2. Decide regression vs stale pin; fix at the right layer; watchlists collateral sweep.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+This one WAS a real defect (unlike its siblings 17656/17660): the destination contract — every action button carries an outcome tooltip, pinned by `test_destination_action_buttons_explain_their_outcome` — was broken by `1a57986ee` ("feat(watchlists): add explicit read pager controls"), which shipped the `items-page-previous`/`items-page-next` pagination buttons tooltip-less. Two-line production fix in `UI/Watchlists_Modules/article_list.py`: outcome tooltips ("Load the previous/next page of items.") matching the module's existing copy voice, with a comment naming the contract and the introducing commit. The pin itself was the RED (born red on dev); green after the fix; the parameterized audit's one skip is the pre-existing, deliberately tracked Personas exclusion.
+
+Files: `tldw_chatbook/UI/Watchlists_Modules/article_list.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-17664 - Watchlists-bordered-compact-select-frame-test-red-on-dev.md
+++ b/backlog/tasks/task-17664 - Watchlists-bordered-compact-select-frame-test-red-on-dev.md
@@ -1,0 +1,27 @@
+---
+id: TASK-17664
+title: 'Watchlists: bordered compact-select frame test red on dev'
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels:
+  - watchlists
+  - test-health
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_watchlists_select_option_overlays.py::test_a_bordered_compact_select_keeps_its_frame_under_focus_and_hover` fails on clean origin/dev — verified 2026-08-18 solo in a detached baseline worktree at `2b11a709e`, identical failure on a task-17663 branch that touches only two watchlists pagination tooltips. Found during task-17663's collateral sweep; fourth pre-existing dev red surfaced by this programme's sweeps (after 17656, 17660, 17663), which suggests the merge velocity is outrunning per-PR test coverage of neighboring suites.
+
+Needs the usual decide-by-reproducing pass: either a bordered compact Select genuinely loses its frame under focus/hover (a real focus-visibility regression in a theme/CSS change) or the pin is stale against an intended styling change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The test is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the styling live first — never probe a colour mechanism colorlessly)
+- [ ] #2 The task records which merge introduced the red
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Watchlists_Modules/article_list.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/article_list.py
@@ -423,11 +423,15 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
             classes="watchlists-hint-line",
         )
         with Horizontal(id="items-pagination", classes="destination-filter-strip"):
+            # task-17663: every destination action button carries an outcome
+            # tooltip (pinned by test_destination_action_buttons_explain_
+            # their_outcome) — these two shipped without one in 1a57986ee.
             yield Button(
                 "Previous",
                 id="items-page-previous",
                 compact=True,
                 disabled=self.page_loading or not self.has_previous,
+                tooltip="Load the previous page of items.",
             )
             yield Static(f"Page {self.page_number}", id="items-page-label")
             yield Button(
@@ -435,6 +439,7 @@ class ArticleListPane(RecomposeCaptureGuard, Vertical):
                 id="items-page-next",
                 compact=True,
                 disabled=self.page_loading or not self.has_next,
+                tooltip="Load the next page of items.",
             )
 
     def _build_rows(self) -> list[ListItem]:


### PR DESCRIPTION
## Summary

The third filed dev red — and unlike its siblings (17656, 17660: both stale pins), **this one was a real defect**. `1a57986ee` ("feat(watchlists): add explicit read pager controls") shipped the `items-page-previous`/`items-page-next` pagination buttons without tooltips, breaking the destination contract that every action button explains its outcome — pinned by `test_destination_action_buttons_explain_their_outcome`, whose born-red parameterization WAS the reproduction. Two-line production fix: outcome tooltips in the module's existing copy voice, with a comment naming the contract and the introducing commit.

## Evidence

- The pin: red on clean dev before, all 10 parameterizations green after (the one skip is the pre-existing, deliberately tracked Personas exclusion).
- Watchlists collateral sweep: **295 passed**. The single red is a FOURTH pre-existing dev failure (`test_a_bordered_compact_select_keeps_its_frame_under_focus_and_hover`), baselined red on clean dev at `2b11a709e` and filed as **task-17664** — the fourth pre-existing red this programme's sweeps have surfaced, which is itself a signal about merge velocity vs. neighboring-suite coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the destination contract by adding outcome tooltips to the Watchlists read pager buttons. Previously, “Previous” and “Next” had no tooltips; now they say “Load the previous/next page of items.” so each action explains its outcome and the pinned test passes.

- Touches only `tldw_chatbook/UI/Watchlists_Modules/article_list.py`: adds tooltips and a comment noting the contract.
- No behavior change beyond tooltips; enable/disable logic and layout are unchanged.
- Test impact: the destination outcome test is green; watchlists sweep is green except an unrelated failure tracked as task-17664.

<sup>Written for commit 640b1f1423919c44715564e3cd1499509984495f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

