### PR TITLE
test(settings): repoint the compact-select frame pin at a living exemplar (task-17664)

### DIFF
--- a/Tests/UI/test_watchlists_select_option_overlays.py
+++ b/Tests/UI/test_watchlists_select_option_overlays.py
@@ -378,17 +378,31 @@ async def test_a_bordered_compact_select_keeps_its_frame_under_focus_and_hover()
     Nothing in the existing suite saw it (`test_settings_provider_test_draft.py`
     stayed green), so it is pinned here, on the painted rows, in all three
     states.
+
+    task-17664: the original exemplar died by design — 484c74af2 replaced
+    the visible provider Select with the search + picker flow and kept
+    `#settings-provider-value` only as a hidden manual-entry compat control
+    (`settings-provider-manual-hidden`, zero-size), which made this pin
+    IndexError on an empty paint. The contract outlives the exemplar
+    (~21 bordered compact Selects remain), so it is pinned on the Console
+    Behavior compaction-mode Select instead, scrolled into view first the
+    way a user reaches it.
     """
     app = _build_test_app()
     host = StyledSettingsDestinationHarness(app, "settings")
     async with host.run_test(size=(180, 50)) as pilot:
-        await _open_settings_category(pilot, "#settings-category-providers-models")
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
         screen = pilot.app.screen
-        await _wait_for_selector(screen, pilot, "#settings-provider-value", timeout=5.0)
-        select = screen.query_one("#settings-provider-value", Select)
+        await _wait_for_selector(
+            screen, pilot, "#settings-console-context-compaction-mode", timeout=5.0
+        )
+        select = screen.query_one("#settings-console-context-compaction-mode", Select)
         assert "-textual-compact" in select.classes, (
             "precondition: this control is the compact-AND-bordered shape"
         )
+        select.scroll_visible(animate=False)
+        await pilot.pause()
+        await pilot.pause()
 
         def _frame() -> tuple[str, str]:
             rows = _painted_rows(screen, select.region)
@@ -407,7 +421,7 @@ async def test_a_bordered_compact_select_keeps_its_frame_under_focus_and_hover()
             f"painted {_painted_rows(screen, select.region)!r}"
         )
 
-        await pilot.hover("#settings-provider-value")
+        await pilot.hover("#settings-console-context-compaction-mode")
         await pilot.pause()
         assert _frame() == (rest_top, rest_bottom), (
             "and on hover -- a frame that appears and disappears under the "

--- a/backlog/tasks/task-17664 - Watchlists-bordered-compact-select-frame-test-red-on-dev.md
+++ b/backlog/tasks/task-17664 - Watchlists-bordered-compact-select-frame-test-red-on-dev.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-17664
 title: 'Watchlists: bordered compact-select frame test red on dev'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-18'
 labels:
   - watchlists
@@ -22,6 +23,23 @@ Needs the usual decide-by-reproducing pass: either a bordered compact Select gen
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The test is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the styling live first — never probe a colour mechanism colorlessly)
-- [ ] #2 The task records which merge introduced the red
+- [x] #1 The test is green on dev, with the regression fixed or the pin updated to the intended contract (decided by reproducing the styling live first — never probe a colour mechanism colorlessly)
+- [x] #2 The task records which merge introduced the red
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce with detail (the failure was an IndexError on an EMPTY paint, not a styling assert).
+2. Trace the exemplar's zero-size region to its cause; verify the contract on a living exemplar; repoint the pin.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Stale exemplar, live contract. The pin (bordered compact Selects keep their painted frame at rest/focus/hover — the review-wave Critical 1 regression guard) exercised `#settings-provider-value`, and `484c74af2` ("feat: organize provider settings by user task", merged via PR #1630, 2026-08-13) replaced that visible Select with the search + OptionList picker flow, keeping the id only as a HIDDEN manual-entry compat control (`settings-provider-manual-hidden`, zero-size row) — so `_painted_rows` returned an empty list and the rest-read IndexErrored before any styling assertion ran. Not a focus-visibility regression.
+
+The contract outlives the exemplar (~21 bordered compact Selects remain per the original docstring), so the pin now runs on `#settings-console-context-compaction-mode` (probed first: `-textual-compact` + `settings-compact-select`, paints a full frame at rest), scrolled into view the way a user reaches it, with the three-state assertions unchanged — the guarded regression (a blanket compact opt-out stripping frames on focus/hover) would still turn it red. Docstring records the swap. 11/11 green on the overlays file.
+
+Files: `Tests/UI/test_watchlists_select_option_overlays.py`.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

The fourth filed dev red resolves as a **stale exemplar, live contract** — and the failure mode was instructive: not a styling assert going red, but an `IndexError` on an **empty paint**, because the pin's exemplar `#settings-provider-value` no longer paints at all. `484c74af2` ("organize provider settings by user task", merged via PR #1630 on 2026-08-13) replaced the visible provider Select with the search + OptionList picker flow and kept the old id only as a hidden, zero-size manual-entry compat control (`settings-provider-manual-hidden`). No focus-visibility regression exists.

The contract the pin guards — the review-wave Critical 1 regression, where a blanket compact opt-out stripped frames from all ~21 bordered compact Selects on focus/hover — outlives the exemplar. The pin now runs on `#settings-console-context-compaction-mode` (probed first: compact + bordered, paints a full `┌─┐/└─┘` frame at rest), scrolled into view the way a user reaches it, with the rest/focus/hover assertions unchanged — the guarded regression would still turn it red. The docstring records the swap and the original measurements.

## Evidence

- Zero-size probe: the old exemplar's row region is `(0,0,0,0)` by design; the new exemplar paints its frame at rest and keeps it under focus and hover.
- **11/11** green on the overlays file; ruff clean.

With this, all four dev reds surfaced by the bottom-stack programme's sweeps are resolved: two stale pins (17656, 17664), one bundle-less-harness layout trap (17660), one real a11y contract gap fixed in production (17663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repoints the bordered-compact Select frame test to a living control to restore the regression guard and remove an IndexError. The pin previously used `#settings-provider-value` (now a hidden zero-size compat control); it now targets `#settings-console-context-compaction-mode`, scrolled into view, with rest/focus/hover assertions unchanged.

**Reviewer notes**
- Replaces waits/queries/hover from `#settings-provider-value` to `#settings-console-context-compaction-mode`; asserts compact + bordered precondition and scrolls into view for deterministic paint.
- Keeps frame-capture and three-state checks intact, eliminating the empty-paint failure.
- Updates `backlog/tasks/task-17664...` to Done with root cause and implementation notes; acceptance criteria met.
- Test-only change; no product behavior impact.

<sup>Written for commit ac7c0f2127f8e3d09dc3c491eaf32ab809418064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

