### PR TITLE
docs: withdraw TASK-17855's prompt-seam defect claim — the measurement was vacuous

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
+++ b/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
@@ -37,7 +37,15 @@ for prompts while the shipped app's plain mode does find them."*
 
 So `plain`'s `category.prompt.*` cells are **vacuous by construction**, and
 reading them as a retrieval failure — as the section below does — is the
-mistake. TASK-18255 is re-scoped accordingly.
+mistake.
+
+**Stated precisely, so this correction does not overclaim in the other
+direction:** what is established is that the measurement was vacuous, not
+that the seam works. Production wires the service; whether it then retrieves
+`prompt-vendor-chaser` is **untested here** — no arc has ever exercised the
+plain prompts sub-leg against a real `PromptScopeService`. The defect claim
+is withdrawn as unsupported, not disproven. Establishing which it is, is
+exactly what TASK-18255 now exists to do.
 
 **The rest of this report stands**: the 19-unreachable / 11-reachable split
 is a lexical property of the corpus and does not depend on any seam being

--- a/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
+++ b/Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md
@@ -22,7 +22,28 @@ semantic leg permanently.
 The 11 break down as one query with **all** content words present, and ten
 with partial overlap (from 1/8 up to 7/8).
 
-## The finding that changes the task's premise
+## CORRECTION (2026-08-18, before any work on TASK-18255)
+
+**The prompt-seam conclusion below is WRONG, and is retained only so the
+error stays legible.** The plain path returns zero rows for prompt queries
+because the EVAL HARNESS does not wire a prompts seam: its fake app sets
+`prompt_scope_service=None`, so `_search_prompts` returns `(False, [])` —
+the seam reporting itself **unavailable**, which is not the same as matching
+nothing. Production wires it (`app.py:5682`).
+
+The harness states this in its own comment, which I did not read before
+concluding: *"Leaving it None means the harness's plain column reports 0.000
+for prompts while the shipped app's plain mode does find them."*
+
+So `plain`'s `category.prompt.*` cells are **vacuous by construction**, and
+reading them as a retrieval failure — as the section below does — is the
+mistake. TASK-18255 is re-scoped accordingly.
+
+**The rest of this report stands**: the 19-unreachable / 11-reachable split
+is a lexical property of the corpus and does not depend on any seam being
+wired.
+
+## The finding that changes the task's premise (SUPERSEDED — see above)
 
 The task assumed the residual was a *recall* problem to be attacked by
 broadening. Half of that is right — the 19 unreachable ones are the semantic

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -209,13 +209,14 @@ cells):
 | `paraphrase` | 13 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only |
 | `vocabulary_mismatch` | 9 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only (see the caveat under Category meanings) |
 | `negation` | 3 | 0.000 | 0.000 | **0.000** | **full** — nothing retrieves these today |
-| `prompt` | 5 | 0.000 | 0.000 | **0.200** | 1 of 5. TASK-15400's construction flip took it; TASK-15700's merge fix + `and_then_prefix` flip held the cell at 0.200 while the MECHANISM under it moved (stopword trim → prefix fallback). The residual 4 are bounded by absent CONTENT words — see below |
+| `prompt` | 5 | 0.000 | 0.000 &nbsp;⚠️ | **0.200** | ⚠️ **the `plain` cell is VACUOUS, not measured** — the harness leaves `prompt_scope_service=None` so that seam reports itself unavailable (TASK-18255); read only the `semantic`/`hybrid` cells as retrieval. 1 of 5. TASK-15400's construction flip took it; TASK-15700's merge fix + `and_then_prefix` flip held the cell at 0.200 while the MECHANISM under it moved (stopword trim → prefix fallback). The residual 4 are bounded by absent CONTENT words — see below |
 | `scoped` | 7 | 0.000 | 1.000 | **1.000** | hybrid flipped from 0.000 in this arc (B1); MRR 0.163 is the remaining headroom, not recall |
 | **overall** | **46** | **0.804** | **0.293** | **0.848** | hybrid is **0.152** off the ceiling |
 
 **The remaining 0.000 rows are P2c's admission targets.** `negation` (all
-three modes) and `prompt` (still 0.000 in `semantic` and `plain`) are the
-cells with room to rise, and they are not the same kind of problem:
+three modes) and `prompt` (0.000 in `semantic`; `plain`'s 0.000 is **vacuous** — see the
+⚠️ note) are the cells with room to rise, and they are not the same kind of
+problem:
 
 - **`negation` 0.000 in all three modes is a genuine open capability gap.**
   Three fixtures, each describing the exception *without ever naming the
@@ -1272,11 +1273,24 @@ Two columns need context before you read the P/R/MRR/NDCG numbers as
 
   For media, notes and conversations the semantic leg covers all of this
   completely. Prompts have no semantic leg — B2 gave them an FTS sub-leg and
-  deliberately no vector index — so the `prompt` category still reads 0.000
-  in `semantic` and `plain`, and reads 0.200 in `hybrid` on the strength of
-  that single rescued query. Do not read a `prompt` 0.000 as a
-  prompts-retrieval defect, and do not read the other categories' hybrid
-  numbers as evidence that the keyword leg is contributing to them.
+  deliberately no vector index — so the `prompt` category reads 0.000 in
+  `semantic`, and reads 0.200 in `hybrid` on the strength of that single
+  rescued query. Do not read a `prompt` 0.000 as a prompts-retrieval defect,
+  and do not read the other categories' hybrid numbers as evidence that the
+  keyword leg is contributing to them.
+
+  **`plain`'s 0.000 has a DIFFERENT cause, and this paragraph used to give
+  the wrong one** (corrected 2026-08-18, TASK-18255). The missing vector
+  index cannot explain `plain`, which never consults a vector index at all.
+  `plain` fans out over the Library's own four seams, and the harness
+  **deliberately does not wire the prompts one** — its fake app sets
+  `prompt_scope_service=None`, so `_search_prompts` returns `(False, [])`:
+  the seam reporting itself UNAVAILABLE. The cell is therefore **vacuous by
+  construction**, not a measured zero, and production does wire the service
+  (`app.py:5682`). The warning above was right for the wrong reason in
+  `plain`'s case — and TASK-17855 nonetheless filed the defect this sentence
+  warns against, because a `0.000` renders identically whether it means "not
+  measured" or "measured and found nothing".
 - **Plain's MRR and NDCG track recall, not ranking.** The four-seam keyword
   path deliberately drops the FTS rank ("an FTS ranking artifact, not a
   retrieval similarity score" — every plain row carries `score=None`), and

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5225,3 +5225,16 @@ interpreted:
 - **Before filing a defect from an aggregate, reproduce it against
   production wiring.** One grep for the attribute in `app.py` would have
   ended this in under a minute.
+
+**The same seam collapses a THIRD state into that zero**, found by a reviewer
+on the correction PR: `_search_prompts` ends `except Exception: return True,
+[]`, so a seam that *threw* is reported as available-and-empty. Wiring the
+dependency therefore does not make the metric unambiguous — a zero still
+means no-match **or** threw. When a function's return type encodes status
+(`(bool, list)`), check what the exception path returns before trusting
+either value; a `warning` log is not a substitute, because nothing reads it.
+
+The general form: **any code path that converts a failure into a
+well-formed empty result destroys the distinction the caller needs.** Grep
+for `except` blocks that `return` an empty container whenever a measurement
+built on them surprises you.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5194,11 +5194,22 @@ It was wrong. The harness's fake app sets `prompt_scope_service=None`, so
 renders "not measured" and "measured, found nothing" as the same `0.000`,
 and I read the second.
 
-**Three written warnings sat in the tree, all unread**: the harness's own
+**Four written warnings sat in the tree, all unread**: the harness's own
 comment directly above the line (*"Leaving it None means the harness's plain
 column reports 0.000 for prompts while the shipped app's plain mode does
-find them"*), and the B2 plan twice (*"the Library four-seam path already
-searches prompts its own way — do not touch it"*).
+find them"*); the B2 plan twice (*"the Library four-seam path already
+searches prompts its own way — do not touch it"*); and — most pointedly —
+the eval README, which says in as many words: ***"Do not read a `prompt`
+0.000 as a prompts-retrieval defect."*** I filed that exact defect.
+
+That fourth one carries its own sub-lesson, because the README's *reason*
+was wrong even though its conclusion was right: it attributed `plain`'s
+0.000 to prompts having no vector index, and `plain` never consults a vector
+index. A warning with a wrong rationale is weak protection — the rationale
+is what a reader checks against their case, and mine visibly did not apply,
+which made the warning easy to step past. **When you write a "do not read X
+as Y" note, the reason has to be correct per-mode, or it invites exactly the
+misreading it forbids.**
 
 **This is the dual of the trap already recorded here.** The known family is
 *the intervention silently did not take* — the monkeypatch bound at import

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5178,3 +5178,50 @@ Three mechanics worth keeping:
    When a mounted test drives clicks or asserts geometry, subclass the
    harness with `CSS_PATH = BUNDLED_STYLESHEET` — and treat a red mounted
    test in a bare harness as unattributed until reproduced under the bundle.
+
+## A `0.000` from a seam the harness never wired reads exactly like a real negative (TASK-17855/18255, 2026-08-18)
+
+TASK-17855 censused the RAG eval harness's residual zero-row queries and
+reported a **production defect**: the Library's plain-mode prompts sub-leg
+returned zero rows for all five `prompt` golden queries, including one whose
+target contains *every* content word of the query, and `prompts_fts` indexes
+the matching column. Every term present, every term indexed, zero rows back
+— the conclusion looked forced.
+
+It was wrong. The harness's fake app sets `prompt_scope_service=None`, so
+`_search_prompts` returns `(False, [])` — a seam reporting itself
+**unavailable**. Production wires it (`app.py:5682`). The metrics table
+renders "not measured" and "measured, found nothing" as the same `0.000`,
+and I read the second.
+
+**Three written warnings sat in the tree, all unread**: the harness's own
+comment directly above the line (*"Leaving it None means the harness's plain
+column reports 0.000 for prompts while the shipped app's plain mode does
+find them"*), and the B2 plan twice (*"the Library four-seam path already
+searches prompts its own way — do not touch it"*).
+
+**This is the dual of the trap already recorded here.** The known family is
+*the intervention silently did not take* — the monkeypatch bound at import
+so both arms ran identical code; the probe asked for `body` when the field
+was `content` and reported `match=0` everywhere. The fix for those is a
+probe-proof line: make the probe prove it did work. **That fix cannot catch
+this one**, because the probe did run, did execute the real code path, and
+did read a real number. The instrument was honest; it simply could not see
+the thing.
+
+So the check is a different one, and it happens *before* the measurement is
+interpreted:
+
+- **A zero is a result only if the instrument was wired to produce a
+  non-zero.** Establish that first — census the seams, dependencies, and
+  fixtures the metric flows through, not just the rows it returned.
+- **Distinguish "unavailable" from "empty" at the source.** `(False, [])`
+  and `(True, [])` mean opposite things and collapse to the same aggregate
+  one layer up. When a seam can report unavailability, the harness should
+  surface that as a distinct cell value (or fail loudly), never as zero.
+- **Read the comments on the construction you are measuring through.** A
+  deliberately-stubbed dependency is usually documented at the stub, and
+  that comment is the cheapest possible refutation of a defect claim.
+- **Before filing a defect from an aggregate, reproduce it against
+  production wiring.** One grep for the attribute in `app.py` would have
+  ended this in under a minute.

--- a/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
+++ b/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
@@ -88,3 +88,19 @@ them — is buying with the wrong currency.
 Artifacts: `Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md` and
 `reachability_census.py` (runnable; prints its document count before any
 result).
+
+### CORRECTION (2026-08-18)
+
+**The prompt-seam finding above was wrong.** `plain` returns zero rows for
+prompt queries because the eval harness sets `prompt_scope_service=None`, so
+the seam reports itself UNAVAILABLE (`_search_prompts` → `(False, [])`) —
+not because it matched nothing. Production wires it (`app.py:5682`), and the
+harness comment says so explicitly: *"the shipped app's plain mode does find
+them."* I read the instrument's numbers without checking whether the
+instrument could see the thing.
+
+**What survives:** the 19-unreachable / 11-reachable split, a lexical
+property of the corpus, independent of any seam. **What does not:** the claim
+that the prompts sub-leg is defective, and the cost table's implication that
+fixing it would reach 5 queries. TASK-18255 is re-scoped from "fix the seam"
+to "wire the seam into the harness so the cells measure something".

--- a/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
+++ b/backlog/tasks/task-17855 - Investigate the remaining zero-row queries absent content words.md
@@ -99,6 +99,10 @@ harness comment says so explicitly: *"the shipped app's plain mode does find
 them."* I read the instrument's numbers without checking whether the
 instrument could see the thing.
 
+The defect claim is **withdrawn as unsupported, not disproven**: whether
+the sub-leg actually retrieves against a real `PromptScopeService` remains
+untested, and TASK-18255 exists to settle it.
+
 **What survives:** the 19-unreachable / 11-reachable split, a lexical
 property of the corpus, independent of any seam. **What does not:** the claim
 that the prompts sub-leg is defective, and the cost table's implication that

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-18255
 title: >-
-  The plain prompts sub-leg returns zero rows for queries whose target contains
-  the words
+  Wire a prompts seam into the eval harness so plain-mode prompt cells measure
+  something
 status: To Do
 assignee: []
 labels: [rag, retrieval]
@@ -12,44 +12,48 @@ priority: medium
 
 ## Description (the why)
 
-Found by TASK-17855's census of residual zero-row queries. On the gated
-fixture, the `prompt` category behaves like this:
+**CORRECTED 2026-08-18, before any work: this task was filed as a production
+defect and it is not one.** TASK-17855's census observed that the `plain`
+mode returns zero rows for all five `prompt` golden queries — including one
+whose target contains every content word — and concluded the Library's
+prompts sub-leg was broken. It is not.
 
-| mode | queries returning rows | queries finding the target |
-|---|---|---|
-| `plain` | **0 of 5** | 0 |
-| `semantic` | 5 of 5 | 0 |
-| `hybrid` | 5 of 5 | 1 |
+The cause is in the **instrument**, and the harness says so in its own
+comment (`Tests/RAG_Eval/harness/ingest.py`, the fake app's construction):
 
-**The plain path returns nothing at all for any prompt query** — and that is
-not explained by AND-strictness, which is what TASK-3997 and TASK-17755 were
-about. Four of the five queries have high lexical overlap with their target,
-and one has **every content word present**: `"saved prompt for chasing a
-supplier about a late order"` against `prompt-vendor-chaser`, whose name is
-*"Saved prompt: chasing a late order"* and whose body names the supplier, the
-order and the chase.
+> `prompt_scope_service=None` … *"Leaving it None means the harness's plain
+> column reports 0.000 for prompts while the shipped app's plain mode does
+> find them."*
 
-`prompts_fts` indexes five columns including `name`, so the words are
-indexed. A construction that reaches nothing when every term is present
-points at the sub-leg — its scoping, its query shape, or whether it runs at
-all on this path — rather than at how the MATCH expression is built.
+`_search_prompts` returns `(False, [])` when that attribute is absent — the
+seam reports itself **unavailable**, which is not the same as matching
+nothing. Production wires it (`app.py:5682`,
+`build_prompt_scope_service`). So the plain `category.prompt.*` cells are
+**vacuous by construction**, and TASK-17855's reading of them as a retrieval
+failure was wrong.
 
-This is a **defect candidate, not a recall-broadening candidate**, which
-matters: broadening was measured at a 34% MRR cost (TASK-3997), while fixing
-a seam that returns zero rows for exact-term queries has no precision cost by
-construction.
+**What remains is the work the harness comment defers**, and it is worth
+doing for the reason the wrong conclusion demonstrates: a 0.000 cell that
+means "not measured" is indistinguishable, to every reader, from one that
+means "measured and found nothing". This programme has now mis-read it once.
+
+The harness comment also names the cost, which is why it was deferred rather
+than smuggled in: the seam appends its rows to **every** plain fan-out, so
+wiring it moves plain-mode numbers for non-prompt queries too.
 
 ## Acceptance Criteria (the what)
 
-- [ ] The cause is named from evidence: whether the plain prompts sub-leg
-      runs, what MATCH expression it issues, and against which columns —
-      not inferred from the construction
-- [ ] `"saved prompt for chasing a supplier about a late order"` returns
-      `prompt-vendor-chaser` on the plain path, or the reason it cannot is
-      recorded with the same specificity
-- [ ] The other four prompt queries are reported with it, since they share
-      the seam and three of them also have partial overlap
-- [ ] The gated suite still reads `PASSED: No regression. 105 metric(s)`;
-      note that `plain`'s `category.prompt.*` cells are currently 0.000, so
-      a fix should MOVE them — if it does, that movement is the deliverable
-      and the baseline is re-stamped deliberately
+- [x] **The cause is named from evidence** (done at filing-correction time,
+      2026-08-18): the harness's fake app sets `prompt_scope_service=None`,
+      so `_search_prompts` returns `(False, [])` — seam UNAVAILABLE, not
+      seam matching nothing. Production wires it at `app.py:5682`.
+- [ ] The harness wires a real prompts seam, so `plain`'s
+      `category.prompt.*` cells measure retrieval rather than absence
+- [ ] The cost the harness comment predicts is measured, not assumed: the
+      seam appends rows to EVERY plain fan-out, so non-prompt plain cells
+      may move too — report which moved, by how much, before deciding
+- [ ] Whichever way the numbers go, the gate is re-stamped DELIBERATELY with
+      the reason recorded — this changes what the instrument can see, so a
+      moved cell is the deliverable rather than a regression
+- [ ] TASK-17855's report and this programme's README stop describing the
+      plain prompt cells as a retrieval result

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -13,13 +13,16 @@ priority: medium
 ## Description (the why)
 
 **CORRECTED 2026-08-18, before any work: this task was filed as a production
-defect and it is not one.** TASK-17855's census observed that the `plain`
-mode returns zero rows for all five `prompt` golden queries — including one
-whose target contains every content word — and concluded the Library's
-prompts sub-leg was broken. It is not.
+defect on evidence that cannot support the claim.** TASK-17855's census
+observed that the `plain` mode returns zero rows for all five `prompt`
+golden queries — including one whose target contains every content word —
+and concluded the Library's prompts sub-leg was broken. **That conclusion is
+withdrawn as unsupported.** Whether the sub-leg is defective is unknown and
+untested; what is established is only that the measurement could not have
+shown otherwise.
 
-The cause is in the **instrument**, and the harness says so in its own
-comment (`Tests/RAG_Eval/harness/ingest.py`, the fake app's construction):
+The cause of the zeros is in the **instrument**, and the harness says so in
+its own comment (`Tests/RAG_Eval/harness/ingest.py`, the fake app's construction):
 
 > `prompt_scope_service=None` … *"Leaving it None means the harness's plain
 > column reports 0.000 for prompts while the shipped app's plain mode does
@@ -31,6 +34,15 @@ nothing. Production wires it (`app.py:5682`,
 `build_prompt_scope_service`). So the plain `category.prompt.*` cells are
 **vacuous by construction**, and TASK-17855's reading of them as a retrieval
 failure was wrong.
+
+**A second collapse sits one branch further down, and it survives wiring the
+seam.** `_search_prompts` ends `except Exception: return True, []` — a seam
+that *threw* is reported as available-and-empty, indistinguishable in the
+metrics from one that searched and matched nothing. So "wire the service and
+watch the cell" is not on its own a sufficient test: a zero afterwards would
+still have three possible causes (no match / threw / genuinely absent). The
+`logger.warning("… prompts seam failed.")` line is the only tell, and the
+run must be checked for it.
 
 Note what this does and does not settle: the defect claim is **withdrawn as
 unsupported, not disproven.** No arc has exercised the plain prompts sub-leg
@@ -54,6 +66,20 @@ wiring it moves plain-mode numbers for non-prompt queries too.
       seam matching nothing. Production wires it at `app.py:5682`.
 - [ ] The harness wires a real prompts seam, so `plain`'s
       `category.prompt.*` cells measure retrieval rather than absence
+- [ ] **Reported PER QUERY, not as a category average.** All five prompt
+      goldens are listed with hit/miss individually — an aggregate cell of
+      0.200 means one of five succeeded and four still miss, which would let
+      this task close while the behaviour it exists to settle is still open.
+      `prompt-vendor-chaser` is named explicitly: its query contains every
+      content word of the target, so if any query retrieves, it must
+- [ ] **The run is checked for `"prompts seam failed."` in the log.** With
+      the service wired, an exception still returns `(True, [])`, so a zero
+      would remain ambiguous between no-match and threw. A clean run must
+      show the warning absent; if present, the exception is the finding
+- [ ] The `(False, [])` / `(True, [])` collapse is addressed at the metrics
+      layer or recorded as accepted: an unavailable seam should not render
+      as `0.000`, and this problem belongs to EVERY optional seam, not just
+      prompts (per the reviewer's suggestion on PR #1807)
 - [ ] The cost the harness comment predicts is measured, not assumed: the
       seam appends rows to EVERY plain fan-out, so non-prompt plain cells
       may move too — report which moved, by how much, before deciding

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -86,5 +86,10 @@ wiring it moves plain-mode numbers for non-prompt queries too.
 - [ ] Whichever way the numbers go, the gate is re-stamped DELIBERATELY with
       the reason recorded — this changes what the instrument can see, so a
       moved cell is the deliverable rather than a regression
-- [ ] TASK-17855's report and this programme's README stop describing the
-      plain prompt cells as a retrieval result
+- [x] TASK-17855's report and this programme's README stop describing the
+      plain prompt cells as a retrieval result (done in PR #1807: the report
+      carries a correction block, and `Tests/RAG_Eval/README.md` now flags
+      the `plain` cell as vacuous in the category table, the P2c-targets
+      paragraph, and the keyword-limits section — where the stated REASON was
+      also wrong, blaming the absent vector index for a mode that never uses
+      one)

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -32,6 +32,11 @@ nothing. Production wires it (`app.py:5682`,
 **vacuous by construction**, and TASK-17855's reading of them as a retrieval
 failure was wrong.
 
+Note what this does and does not settle: the defect claim is **withdrawn as
+unsupported, not disproven.** No arc has exercised the plain prompts sub-leg
+against a real `PromptScopeService`, so whether it retrieves is still an open
+question — which is a second, independent reason to wire the seam.
+
 **What remains is the work the harness comment defers**, and it is worth
 doing for the reason the wrong conclusion demonstrates: a 0.000 cell that
 means "not measured" is indistinguishable, to every reader, from one that


### PR DESCRIPTION
## What this corrects

TASK-17855 (merged in #1803) reported that the Library's **plain**-mode prompts sub-leg is defective, because the census showed zero rows for all five `prompt` golden queries — including `"saved prompt for chasing a supplier about a late order"`, whose target contains every content word and whose column `prompts_fts` indexes. I filed TASK-18255 to fix that defect.

**The measurement was vacuous.** The eval harness's fake app sets `prompt_scope_service=None` (`Tests/RAG_Eval/harness/ingest.py:540`), so `_search_prompts` returns `(False, [])` — the seam reporting itself **unavailable**, which is not the same value as the seam matching nothing. The metrics table renders both as `0.000`, and I read the second. Production wires the service at `app.py:5682` via `build_prompt_scope_service`.

The harness says this in a comment sitting directly above the line I was measuring through:

> *"Leaving it None means the harness's plain column reports 0.000 for prompts while the shipped app's plain mode does find them."*

The B2 plan says it twice more: *"the Library four-seam path already searches prompts its own way — do not touch it."* Three written warnings, none read.

## What this does and does not establish

**Withdrawn as unsupported, not disproven.** I have verified that the harness could not see prompts and that production wires the service. I have *not* verified that the sub-leg then retrieves — no arc has ever exercised the plain prompts path against a real `PromptScopeService`. Asserting "there is no defect" would replace one overclaim with its opposite. Whether it works is now an open question, and a second reason to do 18255.

**Survives untouched:** the 19-unreachable / 11-reachable split of the 30 residual zero-row queries. That is a lexical property of the corpus — no golden target contains the query's content words — and holds regardless of which seams are wired. Every conclusion 17855 drew from it is unaffected.

**Does not survive:** the defect claim, and the cost table's implication that repairing it would reach 5 queries.

## Changes

- `Docs/superpowers/qa/2026-08-18-residual-zero-row/report.md` — correction block heading the superseded section; the wrong reasoning is **kept and marked** rather than deleted, so the error stays legible
- `backlog/tasks/task-17855…` — matching correction in the notes
- `backlog/tasks/task-18255…` — **re-scoped** from "fix the seam" to "wire a prompts seam into the harness so the plain-mode prompt cells measure something", with the cost recorded as an explicit AC
- `backlog/docs/lessons-testing-evidence.md` — the incident, and why it is a **new species**

## Why the lesson is not a duplicate

The family already recorded in that file is *the intervention silently did not take* (a monkeypatch bound at import so both arms ran identical code; a probe that asked for `body` when the field was `content`). Its fix is a probe-proof line — make the probe prove it did work.

**That fix cannot catch this one.** The probe ran, executed the real code path, and read a real number. The instrument was honest; it simply was not wired to see the thing. So the check moves earlier: *a zero is a result only if the instrument was wired to produce a non-zero* — census the seams, not just the rows.

## Verification

Docs and task files only. No code, no test changes, gate untouched.

Refs TASK-17855, TASK-18255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)