### PR TITLE
feat: shared workspace creation modal across Console, Settings, and Library (TASK-17650)

### DIFF
--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -108,8 +108,10 @@ Workspaces and Library use. It opens with a **name** prefilled "Workspace N"
 (edit or keep it), an optional **folder** field with a **Browse…** button
 (opens a directory picker) and an **Add folder** button — each folder is
 validated as you add it (must be a real, existing directory; not your home
-folder or filesystem root; not nested inside/around a folder already in the
-list) and rejections render inline without closing the dialog. Folders bind
+folder or filesystem root; not this app's own data, configuration, or
+credential directories — or a folder that contains or sits inside one; not
+nested inside/around a folder already in the list) and rejections render
+inline without closing the dialog. Folders bind
 **read-only** (change that later in Settings ▸ Workspaces). A **"Switch to
 this workspace"** checkbox, checked by default, controls whether Create also
 activates the workspace; unchecking it creates the workspace without

--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -98,10 +98,24 @@ highlighted result when it is an open tab. Esc cancels.
 | Control | What it does |
 |---|---|
 | "Switch" / Alt+W | Opens "Change Workspace" — "Switching changes Console context only; Library and Notes stay globally visible." Click a workspace to activate it; the active one is marked "(current)" and the built-in one is listed as "Default (everyday chats)" |
-| "New" | Creates a workspace (named "Workspace 1", "Workspace 2", …) and switches to it |
+| "New" | Opens the "New Workspace" dialog — see below |
 | "Rename" (in the switcher) | Opens "Rename Workspace" — edit the name, then "Save" |
 | "Archive" (in the switcher) | Opens "Archive workspace?" — "Its conversations stay saved and remain visible in Library; the workspace disappears from the switcher and the Console browser." Confirm with "Archive" |
 | "RAG Scope" | Narrows retrieval to this workspace — see [Context & RAG](context-and-rag.md) |
+
+**The "New Workspace" dialog** is the same creation dialog Settings ▸
+Workspaces and Library use. It opens with a **name** prefilled "Workspace N"
+(edit or keep it), an optional **folder** field with a **Browse…** button
+(opens a directory picker) and an **Add folder** button — each folder is
+validated as you add it (must be a real, existing directory; not your home
+folder or filesystem root; not nested inside/around a folder already in the
+list) and rejections render inline without closing the dialog. Folders bind
+**read-only** (change that later in Settings ▸ Workspaces). A **"Switch to
+this workspace"** checkbox, checked by default, controls whether Create also
+activates the workspace; unchecking it creates the workspace without
+switching Console to it. **Escape cancels the dialog — nothing is created.**
+A name that collides with an existing workspace renders inline and keeps the
+dialog open.
 
 The built-in Default workspace has no "Rename" or "Archive" buttons. If you
 archive the workspace you are in, the Console switches back to Default.
@@ -146,12 +160,28 @@ single summary line quoted in the layout tour instead.
 
 **Create and switch to a new workspace**
 
-1. In the "Session" block, click "New" — a "Workspace N" is created and
-   becomes active; new chats now land in it.
-2. To go back, press Alt+W (or click "Switch") and pick
+1. In the "Session" block, click "New" — the "New Workspace" dialog opens
+   with a prefilled "Workspace N" name.
+2. Optional: edit the name, and add a project folder (type a path or click
+   "Browse…", then "Add folder") so agents have file access there.
+3. Leave "Switch to this workspace" checked and click "Create" — the
+   workspace is created and becomes active; new chats now land in it. A
+   toast confirms the switch even if the Session block is scrolled out of
+   view.
+4. To go back, press Alt+W (or click "Switch") and pick
    "Default (everyday chats)".
-3. Optional: in the same switcher, use "Rename" to give the new workspace a
-   real name.
+
+**Create a workspace without switching to it**
+
+1. Click "New", fill in the dialog as above, and uncheck "Switch to this
+   workspace" before pressing "Create".
+2. The workspace is created (with any folders bound) but Console stays on
+   its current workspace; a "Created \<name\>." toast confirms it.
+
+**Cancel a workspace creation**
+
+Press Escape (or click "Cancel") anywhere in the "New Workspace" dialog —
+nothing is created, no matter what you had typed or added.
 
 ## Keyboard & commands
 
@@ -195,3 +225,9 @@ single summary line quoted in the layout tour instead.
 
 —
 *Verified against dev @ ff435772c — 2026-07-31*
+*Verified against feat/workspace-create-modal @ 64a07a3d7 — 2026-08-17
+(task-17650: "New" now opens the shared "New Workspace" dialog — prefilled
+name, optional validated folder bindings with Browse…, a "Switch to this
+workspace" checkbox default on, and Escape/Cancel creating nothing —
+instead of instant "Workspace N" creation; the walkthrough split into
+create-and-switch / create-without-switching / cancel tasks to match).*

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -169,7 +169,7 @@ current as of that open, not a reading cached at some earlier repaint.
 
 | Action | What it does |
 |---|---|
-| **Create local workspace** | "Create a local-only workspace and make it active. Server sync and ACP handoff remain WIP." |
+| **Create local workspace** | Opens the same "New Workspace" dialog Console and Settings use — a prefilled "Workspace N" name, optional folders to bind (validated as added, with a Browse… picker), and a "Switch to this workspace" checkbox (checked by default). Escape cancels with nothing created. Server sync and ACP handoff remain WIP. |
 | **Import sources** | Shown only while you have no workspace-eligible sources: "Open Library Import/Export to add workspace-eligible sources." |
 | **Use in Console** | Stages a snapshot of your local Library sources ("Local Library Sources") into Console and takes you there. When it can't run yet, its tooltip says why — "Stage Library source context after Library finishes loading." or "Stage Library source context after adding notes, media, or conversations." |
 
@@ -403,3 +403,9 @@ anything you've saved" step above to match B3's already-shipped
 behavior — the Search / RAG canvas's per-source count follows Settings ▸
 RAG's Default results, 15 on the shipped default profile, not a fixed 5;
 no code changed here).*
+*Verified against feat/workspace-create-modal @ 64a07a3d7 — 2026-08-17
+(task-17650: **Create local workspace** now opens the shared "New
+Workspace" dialog — the same one Console and Settings use — instead of
+creating a zero-input workspace instantly; documented its name prefill,
+optional validated folder bindings, Browse… picker, and default-on
+"Switch to this workspace" checkbox).*

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -368,8 +368,16 @@ reconnected." Two things to internalise:
 ### Data & Privacy — Workspaces
 
 No draft — every action applies as you make it, and each is reversible
-("unarchive, rename again, or set active"). Type a name and press **Create**;
-**Show archived** widens the list; click a workspace to open its card.
+("unarchive, rename again, or set active"). **Create workspace…** opens the
+same creation dialog Console and Library use (see
+[Console sessions, tabs & workspaces](console/sessions-tabs-workspaces.md#workspaces)
+for the full walkthrough): a name prefilled "Workspace N", an optional list
+of folders to bind (validated as each is added; **Browse…** opens a directory
+picker), and a "Switch to this workspace" checkbox, checked by default —
+here, unlike the old inline row, checking it activates the workspace
+immediately on Create. Escape cancels the dialog with nothing created.
+**Show archived** widens the list; each row shows the workspace's name and
+its bound-folder count ("N folders"); click a row to open its card.
 
 | Control | What it does |
 |---|---|
@@ -531,11 +539,14 @@ a note on what would have to exist before Settings could own a default.
    saved paths." Move the file yourself, then restart: until you do, the app
    keeps using the old one, which is what **Active files (resolved this
    session)** is showing you.
-5. **Create a workspace and give an agent a folder.** Open **Workspaces**, type
-   a name, press **Create**. Select the new workspace, press **Set active**,
-   then under **Folders (agent file-tool access)** enter a folder path and press
-   **Add folder** — it is bound read-only. Press **Allow write** on that row if
-   the agent needs to write. Every step applies immediately; nothing to save.
+5. **Create a workspace and give an agent a folder.** Open **Workspaces** and
+   press **Create workspace…**. In the dialog, keep the prefilled name (or
+   type your own), enter a folder path and press **Add folder** — it is
+   validated and bound read-only — then leave "Switch to this workspace"
+   checked and press **Create**; the new workspace is created, bound, and
+   activated in one step. Click the new workspace's row to open its card,
+   then press **Allow write** on the folder's row if the agent needs to
+   write. Every step applies immediately; nothing to save.
 6. **Repair a configuration you broke.** Open **Diagnostics** and press
    **Validate Config** — the error names the problem, with secrets redacted. Fix
    it in the guided pages if you can. If not, open **Advanced Config**, press
@@ -664,3 +675,11 @@ unchanged from the prior stamp).*
 2026-08-17 (mounted-settings test drives the toggle both ways and reads
 the live config; headless Console probes verified both placements render;
 the rest of this page's content unchanged from the prior stamp).*
+*Verified against feat/workspace-create-modal @ 64a07a3d7 — 2026-08-17
+(task-17650: Data & Privacy ▸ Workspaces' inline "type a name, press
+Create" row is retired — **Create workspace…** now opens the same shared
+creation dialog Console and Library use, with a prefilled name, optional
+validated folder bindings, and a "Switch to this workspace" checkbox that
+here defaults to activating the workspace on Create, unlike the old
+inline flow; the walkthrough's step 5 updated to match; the rest of this
+page's content unchanged from the prior stamp).*

--- a/Docs/superpowers/plans/2026-08-17-project-skills-import.md
+++ b/Docs/superpowers/plans/2026-08-17-project-skills-import.md
@@ -1,0 +1,800 @@
+# Project Skills (.SKILLS/) Discovery + Import (PR B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A directory containing `.SKILLS/` triggers a prompt-driven (never silent) offer to import its skills — at app startup and after workspace creation with a bound folder containing one.
+
+**Architecture:** A pure discovery module scans one `.SKILLS/` directory under strict caps and symlink refusal; a JSON prompt ledger with content fingerprints gates re-prompting; a `ModalScreen` presents the offer and runs imports through the existing quarantine-preserving importer (`trust_approved=False` always). Startup hooks into `app.py`'s `_post_mount_setup` beside the first-run wizard; the create-modal chaining reads discoveries off `WorkspaceCreateResult`.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, pytest + Textual pilot; no new dependencies.
+
+**Spec:** `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md` (§5, §6, §7, §8, §9 PR B)
+
+**Depends on:** PR A merged (`tldw_chatbook/Widgets/workspace_create_modal.py` with `WorkspaceCreateResult.project_skills` and the three surface handlers).
+
+## Global Constraints
+
+- Work in a worktree under `<repo>/.worktrees/` branched off `origin/dev` (PR A must be on dev first). Push after every task.
+- pytest is venv-only: `.venv/bin/pytest …`.
+- **Security posture (spec §3, §5.2):** never execute or trust anything at discovery time; all imports pass `trust_approved=False`; refuse symlinked `.SKILLS/` dirs and symlinked entries; caps: max 50 entries, 64 KiB frontmatter read; every repo-sourced string renders with `markup=False`.
+- Convention: `.SKILLS/` preferred, `.skills/` accepted, deduplicated by resolved path.
+- Config kill-switch: `[skills] project_skills_prompt_enabled` (default `true`) read via `get_cli_setting("skills", "project_skills_prompt_enabled", True)`.
+- Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- File one backlog task for PR B before starting (ID sweep per `backlog/docs/lessons-backlog-hygiene.md`).
+
+---
+
+### Task 1: Pure discovery module
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/project_skills_discovery.py`
+- Test: `Tests/Skills/test_project_skills_discovery.py` (new)
+
+**Interfaces:**
+- Consumes: `_normalize_skill_name` from `tldw_chatbook.tldw_api.skills_schemas`; `LocalSkillsService._parse_front_matter` (static, `Skills_Interop/local_skills_service.py:330`).
+- Produces (used by Tasks 2-5): `ProjectSkillEntry` (`name, kind: "directory"|"file", path: Path, description: str, status: "ok"|"invalid", reason: str`), `ProjectSkillsDiscovery` (`root, skills_dir, entries, skipped, truncated, fingerprint`), `find_project_skills_dir(root: Path) -> Path | None`, `find_project_dir_with_skills(start: Path) -> Path | None`, `discover_project_skills(root: Path) -> ProjectSkillsDiscovery | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Skills/test_project_skills_discovery.py
+import os
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    MAX_DISCOVERED_ENTRIES,
+    discover_project_skills,
+    find_project_dir_with_skills,
+    find_project_skills_dir,
+)
+
+
+def _skill_dir(root, name, description="Does a thing."):
+    d = root / ".SKILLS" / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nBody\n",
+        encoding="utf-8",
+    )
+    return d
+
+
+def test_no_skills_dir_returns_none(tmp_path):
+    assert discover_project_skills(tmp_path) is None
+
+
+def test_discovers_directory_and_loose_file_skills(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    (tmp_path / ".SKILLS" / "beta-skill.md").write_text(
+        "---\ndescription: Loose one.\n---\nBody\n", encoding="utf-8"
+    )
+    discovery = discover_project_skills(tmp_path)
+    kinds = {(e.name, e.kind, e.status) for e in discovery.entries}
+    assert ("alpha-skill", "directory", "ok") in kinds
+    assert ("beta-skill", "file", "ok") in kinds
+    assert discovery.truncated == 0
+
+
+def test_subdir_without_skill_md_is_skipped_with_reason(tmp_path):
+    (tmp_path / ".SKILLS" / "not-a-skill").mkdir(parents=True)
+    discovery = discover_project_skills(tmp_path)
+    assert ("not-a-skill", "no SKILL.md") in discovery.skipped
+
+
+def test_invalid_name_flagged_not_failed(tmp_path):
+    _skill_dir(tmp_path, "My_Skill")
+    discovery = discover_project_skills(tmp_path)
+    entry = discovery.entries[0]
+    assert entry.status == "invalid"
+    assert "lowercase" in entry.reason
+
+
+def test_symlinked_skills_dir_refused(tmp_path):
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    os.symlink(real, tmp_path / ".SKILLS")
+    assert find_project_skills_dir(tmp_path) is None
+
+
+def test_symlinked_entry_skipped(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, tmp_path / ".SKILLS" / "sneaky")
+    discovery = discover_project_skills(tmp_path)
+    assert ("sneaky", "symlink") in discovery.skipped
+    assert [e.name for e in discovery.entries] == ["alpha-skill"]
+
+
+def test_entry_cap_reports_truncation(tmp_path):
+    for i in range(MAX_DISCOVERED_ENTRIES + 3):
+        _skill_dir(tmp_path, f"skill-{i:03d}")
+    discovery = discover_project_skills(tmp_path)
+    assert len(discovery.entries) == MAX_DISCOVERED_ENTRIES
+    assert discovery.truncated == 3
+
+
+def test_fingerprint_changes_when_a_skill_is_added(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    first = discover_project_skills(tmp_path).fingerprint
+    _skill_dir(tmp_path, "gamma-skill")
+    assert discover_project_skills(tmp_path).fingerprint != first
+
+
+def test_hostile_description_survives_as_plain_data(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill", description="[red]evil[/red]")
+    discovery = discover_project_skills(tmp_path)
+    assert discovery.entries[0].description == "[red]evil[/red]"  # escaping is UI-side
+
+
+def test_ancestor_walk_finds_project_root(tmp_path):
+    _skill_dir(tmp_path / "repo", "alpha-skill")
+    (tmp_path / "repo" / ".git").mkdir()
+    sub = tmp_path / "repo" / "src" / "deep"
+    sub.mkdir(parents=True)
+    assert find_project_dir_with_skills(sub) == tmp_path / "repo"
+
+
+def test_ancestor_walk_stops_at_git_root_without_skills(tmp_path):
+    (tmp_path / "repo" / ".git").mkdir(parents=True)
+    sub = tmp_path / "repo" / "src"
+    sub.mkdir()
+    _skill_dir(tmp_path, "above-the-repo")  # must NOT be found past the .git root
+    assert find_project_dir_with_skills(sub) is None
+
+
+def test_ancestor_walk_stops_at_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    start = tmp_path / "sub"
+    start.mkdir()
+    _skill_dir(tmp_path, "in-home-itself")
+    assert find_project_dir_with_skills(start) is None
+```
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/pytest Tests/Skills/test_project_skills_discovery.py -v` — ImportError.
+
+- [ ] **Step 3: Implement**
+
+```python
+# tldw_chatbook/Skills_Interop/project_skills_discovery.py
+"""Pure discovery of a project-local .SKILLS/ folder (spec 2026-08-17 §5).
+
+No side effects, no execution, no trust decisions: this module only
+enumerates candidate skills so a prompt can offer them. Hardened against
+untrusted repos: symlink refusal, entry/read caps, top-level-only scan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROJECT_SKILLS_DIRNAMES = (".SKILLS", ".skills")
+MAX_DISCOVERED_ENTRIES = 50
+FRONTMATTER_READ_CAP_BYTES = 65536
+
+
+@dataclass(frozen=True)
+class ProjectSkillEntry:
+    name: str
+    kind: str  # "directory" | "file"
+    path: Path
+    description: str
+    status: str  # "ok" | "invalid"
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ProjectSkillsDiscovery:
+    root: Path
+    skills_dir: Path
+    entries: tuple[ProjectSkillEntry, ...]
+    skipped: tuple[tuple[str, str], ...]  # (entry name, reason)
+    truncated: int
+    fingerprint: str
+
+
+def find_project_skills_dir(root: Path) -> Path | None:
+    """First non-symlinked .SKILLS/.skills dir in root, deduped by resolved path."""
+    seen: set[Path] = set()
+    for name in _PROJECT_SKILLS_DIRNAMES:
+        candidate = root / name
+        try:
+            if candidate.is_symlink() or not candidate.is_dir():
+                continue
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        return candidate
+    return None
+
+
+def find_project_dir_with_skills(start: Path) -> Path | None:
+    """cwd plus bounded ancestor walk (spec §5.4, decision #7).
+
+    Checks each directory from ``start`` upward; a directory containing
+    ``.git`` is the last one checked (the project root); ``$HOME`` and the
+    filesystem root are never checked and end the walk.
+    """
+    try:
+        home = Path.home().resolve()
+    except OSError:
+        home = None
+    current = start
+    while True:
+        if current == home or current == Path(current.anchor):
+            return None
+        if find_project_skills_dir(current) is not None:
+            return current
+        if (current / ".git").exists():
+            return None
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _entry_for(name: str, kind: str, path: Path, body: Path) -> ProjectSkillEntry:
+    # Same normalization gate the importer applies -- pre-checking here turns
+    # a late import failure into a labeled row (spec §5.2).
+    from tldw_chatbook.tldw_api.skills_schemas import _normalize_skill_name
+
+    try:
+        normalized = _normalize_skill_name(name)
+    except Exception:
+        return ProjectSkillEntry(
+            name=name,
+            kind=kind,
+            path=path,
+            description="",
+            status="invalid",
+            reason="name must be lowercase-kebab",
+        )
+    from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+    try:
+        with body.open("r", encoding="utf-8", errors="replace") as handle:
+            head = handle.read(FRONTMATTER_READ_CAP_BYTES)
+    except OSError:
+        return ProjectSkillEntry(
+            name=normalized,
+            kind=kind,
+            path=path,
+            description="",
+            status="invalid",
+            reason="unreadable",
+        )
+    metadata, _ = LocalSkillsService._parse_front_matter(head)
+    description = str(metadata.get("description") or "")[:200]
+    return ProjectSkillEntry(
+        name=normalized, kind=kind, path=path, description=description, status="ok"
+    )
+
+
+def _fingerprint(entries: list[ProjectSkillEntry]) -> str:
+    digest = hashlib.sha256()
+    for entry in entries:
+        try:
+            stat = entry.path.stat()
+            digest.update(
+                f"{entry.name}|{stat.st_size}|{stat.st_mtime_ns}\n".encode()
+            )
+        except OSError:
+            digest.update(f"{entry.name}|?\n".encode())
+    return digest.hexdigest()
+
+
+def discover_project_skills(root: Path) -> ProjectSkillsDiscovery | None:
+    skills_dir = find_project_skills_dir(root)
+    if skills_dir is None:
+        return None
+    entries: list[ProjectSkillEntry] = []
+    skipped: list[tuple[str, str]] = []
+    truncated = 0
+    try:
+        children = sorted(skills_dir.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return None
+    for child in children:
+        if len(entries) >= MAX_DISCOVERED_ENTRIES:
+            truncated += 1
+            continue
+        if child.is_symlink():
+            skipped.append((child.name, "symlink"))
+            continue
+        if child.is_dir():
+            body = child / "SKILL.md"
+            if body.is_symlink() or not body.is_file():
+                skipped.append((child.name, "no SKILL.md"))
+                continue
+            entries.append(_entry_for(child.name, "directory", child, body))
+        elif child.is_file() and child.suffix.lower() == ".md":
+            entries.append(_entry_for(child.stem, "file", child, child))
+        else:
+            skipped.append((child.name, "not a skill"))
+    return ProjectSkillsDiscovery(
+        root=root.resolve(),
+        skills_dir=skills_dir,
+        entries=tuple(entries),
+        skipped=tuple(skipped),
+        truncated=truncated,
+        fingerprint=_fingerprint(entries),
+    )
+```
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Skills/test_project_skills_discovery.py -v` — all PASS.
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(skills): pure .SKILLS/ project skills discovery"` (+ trailer).
+
+---
+
+### Task 2: Prompt ledger + gating
+
+**Files:**
+- Create: `tldw_chatbook/Skills_Interop/project_skills_prompt.py`
+- Test: `Tests/Skills/test_project_skills_prompt.py` (new)
+
+**Interfaces:**
+- Produces: `ProjectSkillsPromptLedger(user_data_dir)` with `decision_for(directory: Path) -> tuple[str, str] | None` (decision, fingerprint) and `record(directory: Path, decision: str, fingerprint: str) -> None`; `should_offer_project_skills_prompt(enabled: bool, entry: tuple[str, str] | None, fingerprint: str) -> bool`. Decisions: `"imported" | "declined" | "never"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Skills/test_project_skills_prompt.py
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    ProjectSkillsPromptLedger,
+    should_offer_project_skills_prompt,
+)
+
+
+def test_gating_truth_table():
+    assert should_offer_project_skills_prompt(False, None, "f1") is False
+    assert should_offer_project_skills_prompt(True, None, "f1") is True
+    assert should_offer_project_skills_prompt(True, ("never", "f0"), "f1") is False
+    assert should_offer_project_skills_prompt(True, ("declined", "f1"), "f1") is False
+    assert should_offer_project_skills_prompt(True, ("declined", "f0"), "f1") is True
+    assert should_offer_project_skills_prompt(True, ("imported", "f0"), "f1") is True
+
+
+def test_ledger_roundtrip_and_missing(tmp_path):
+    ledger = ProjectSkillsPromptLedger(tmp_path)
+    directory = Path("/some/project")
+    assert ledger.decision_for(directory) is None
+    ledger.record(directory, "declined", "f1")
+    assert ledger.decision_for(directory) == ("declined", "f1")
+    ledger.record(directory, "never", "f2")
+    assert ledger.decision_for(directory) == ("never", "f2")
+
+
+def test_ledger_survives_corrupt_file(tmp_path):
+    path = tmp_path / "skills" / "project_prompts.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    ledger = ProjectSkillsPromptLedger(tmp_path)
+    assert ledger.decision_for(Path("/x")) is None
+    ledger.record(Path("/x"), "imported", "f1")
+    assert ledger.decision_for(Path("/x")) == ("imported", "f1")
+```
+
+- [ ] **Step 2: Run to verify failure** — ImportError expected.
+- [ ] **Step 3: Implement**
+
+```python
+# tldw_chatbook/Skills_Interop/project_skills_prompt.py
+"""Prompt ledger + gating for .SKILLS/ import offers (spec 2026-08-17 §5.3)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LEDGER_FILENAME = "project_prompts.json"
+
+
+class ProjectSkillsPromptLedger:
+    """Atomic-replace JSON ledger under <user_data_dir>/skills/."""
+
+    def __init__(self, user_data_dir: str | Path) -> None:
+        self._path = Path(user_data_dir) / "skills" / _LEDGER_FILENAME
+
+    def _load(self) -> dict:
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {"version": 1, "entries": {}}
+        if not isinstance(data, dict) or not isinstance(data.get("entries"), dict):
+            return {"version": 1, "entries": {}}
+        return data
+
+    def decision_for(self, directory: Path) -> tuple[str, str] | None:
+        entry = self._load()["entries"].get(str(directory))
+        if not isinstance(entry, dict):
+            return None
+        return str(entry.get("decision", "")), str(entry.get("fingerprint", ""))
+
+    def record(self, directory: Path, decision: str, fingerprint: str) -> None:
+        data = self._load()
+        data["entries"][str(directory)] = {
+            "decision": decision,
+            "fingerprint": fingerprint,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        temp = self._path.with_suffix(".tmp")
+        temp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        temp.replace(self._path)
+
+
+def should_offer_project_skills_prompt(
+    enabled: bool,
+    entry: tuple[str, str] | None,
+    fingerprint: str,
+) -> bool:
+    """Offer iff enabled AND (never seen OR changed-and-not-never) (spec §5.3)."""
+    if not enabled:
+        return False
+    if entry is None:
+        return True
+    decision, recorded_fingerprint = entry
+    if decision == "never":
+        return False
+    return recorded_fingerprint != fingerprint
+```
+
+- [ ] **Step 4: Run** — all PASS. **Step 5: Commit** — `git add -A && git commit -m "feat(skills): project-skills prompt ledger with fingerprint gating"` (+ trailer).
+
+---
+
+### Task 3: Import modal + shared offer helper
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/project_skills_import_modal.py`
+- Test: `Tests/Skills/test_project_skills_import_modal.py` (new)
+
+**Interfaces:**
+- Consumes: `ProjectSkillsDiscovery` (Task 1), `ProjectSkillsPromptLedger` (Task 2).
+- Produces: `ProjectSkillsImportModal(ModalScreen)` with `__init__(self, *, discovery, installed_names: frozenset[str], importer)` where `importer` is `async (entry) -> None` (raises on failure); dismisses with `("imported", outcomes) | ("not_now", None) | ("never", None) | ("review", outcomes)` where `outcomes: tuple[tuple[str, str], ...]` of (name, "imported" | error text). Also `maybe_offer_project_skills_import(app, discoveries)` — the one entry point Tasks 4-5 call; it builds `installed_names` + `importer` from `app.skills_scope_service`, chains modals sequentially (one per discovery), writes the ledger on each dismissal (`imported`/`review` → "imported", `not_now` → "declined", `never` → "never"), and posts `NavigateToScreen("skills")` on `review`.
+
+- [ ] **Step 1: Write the failing tests.** Import execution is injected, so tests use a recording fake importer — no skills store needed:
+
+```python
+# Tests/Skills/test_project_skills_import_modal.py
+import pytest
+from textual.app import App
+from textual.widgets import Checkbox
+
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    discover_project_skills,
+)
+from tldw_chatbook.Widgets.project_skills_import_modal import (
+    ProjectSkillsImportModal,
+)
+
+
+def _discovery(tmp_path, names=("alpha-skill", "beta-skill")):
+    for name in names:
+        d = tmp_path / ".SKILLS" / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\ndescription: [red]desc[/red] for {name}\n---\nBody\n",
+            encoding="utf-8",
+        )
+    return discover_project_skills(tmp_path)
+
+
+class _HarnessApp(App[None]):
+    def __init__(self, modal):
+        super().__init__()
+        self._modal = modal
+        self.result = "unset"
+
+    def on_mount(self) -> None:
+        def _done(result):
+            self.result = result
+
+        self.push_screen(self._modal, _done)
+
+
+def _modal(tmp_path, installed=frozenset(), imported=None, fail=()):
+    imported = imported if imported is not None else []
+
+    async def importer(entry):
+        if entry.name in fail:
+            raise ValueError("import exploded")
+        imported.append(entry.name)
+
+    return (
+        ProjectSkillsImportModal(
+            discovery=_discovery(tmp_path),
+            installed_names=installed,
+            importer=importer,
+        ),
+        imported,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_rows_checked_installed_rows_unchecked(tmp_path):
+    modal, _ = _modal(tmp_path, installed=frozenset({"beta-skill"}))
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        boxes = {
+            box.id: box.value for box in modal.query(Checkbox)
+        }
+        assert boxes["project-skill-row-0"] is True   # alpha-skill: new
+        assert boxes["project-skill-row-1"] is False  # beta-skill: installed
+
+
+@pytest.mark.asyncio
+async def test_escape_means_not_now(tmp_path):
+    modal, _ = _modal(tmp_path)
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.result == ("not_now", None)
+
+
+@pytest.mark.asyncio
+async def test_never_button(tmp_path):
+    modal, _ = _modal(tmp_path)
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-never")
+        await pilot.pause()
+    assert app.result == ("never", None)
+
+
+@pytest.mark.asyncio
+async def test_import_selected_runs_importer_and_reports(tmp_path):
+    modal, imported = _modal(tmp_path, fail=("beta-skill",))
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        # results phase: Close dismisses with outcomes
+        await pilot.click("#project-skills-close")
+        await pilot.pause()
+    assert imported == ["alpha-skill"]
+    decision, outcomes = app.result
+    assert decision == "imported"
+    assert ("alpha-skill", "imported") in outcomes
+    assert any(name == "beta-skill" and "exploded" in msg for name, msg in outcomes)
+```
+
+- [ ] **Step 2: Run to verify failure** — ImportError.
+
+- [ ] **Step 3: Implement.** Modal shape (follow `ConsoleWorkspaceSwitcherModal`'s DEFAULT_CSS/BINDINGS/escape pattern):
+  - Header `Static`s (`markup=False`): title "Project skills found"; provenance `f"Found in {discovery.skills_dir}"`; the trust framing verbatim from spec §5.5: *"Imported skills require a one-time trust review in Library ▸ Skills before they can run."*
+  - One row per entry: `status == "ok"` and not installed → `Checkbox(f"{name} — {description}", True, id=f"project-skill-row-{i}")`; installed → same, `False`, label suffix " (already installed)"; `invalid` → `Static(f"{name} — invalid: {reason}", markup=False)`. All checkbox labels built from repo strings must be passed through `rich.markup.escape()` (Checkbox labels render markup; Statics use `markup=False`).
+  - Footer lines for `discovery.skipped` and `f"{discovery.truncated} more not shown"` when nonzero.
+  - Buttons: `#project-skills-import` ("Import selected"), `#project-skills-not-now` ("Not now"), `#project-skills-never` ("Never for this folder"). `escape` → `dismiss(("not_now", None))`.
+  - Import press: gather selected entries, run `self.run_worker(self._run_import(selected), exclusive=True)`; `_run_import` awaits `self._importer(entry)` per entry collecting `(name, "imported")` / `(name, str(exc))`, then swaps the modal body to a results phase (recompose on an internal `_outcomes` attribute): per-outcome `Static`s, the bootstrap-aware trust line ("Set up skill trust if this is your first skill, then approve each one."), and buttons `#project-skills-review` ("Review in Library ▸ Skills") → `dismiss(("review", outcomes))` and `#project-skills-close` ("Close") → `dismiss(("imported", outcomes))`.
+  - `maybe_offer_project_skills_import(app, discoveries)` in the same module: builds `installed_names` from `app.skills_scope_service` (mirror the name-listing call `library_screen.py:3855` uses), an `importer` that mirrors the exact call shapes at `library_screen.py:9721-9811` (`import_skill_directory(entry.path, mode="local", name=entry.name, trust_approved=False)` for directories; the file-import call for loose files), and chains: push the modal for `discoveries[0]` with a callback that records the ledger decision (`ProjectSkillsPromptLedger(get_user_data_dir())`, keyed by `discovery.root`, with `discovery.fingerprint`), posts `NavigateToScreen("skills")` on `review`, then recurses on the remaining discoveries.
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Skills/test_project_skills_import_modal.py -v` — all PASS.
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(skills): project-skills import modal with quarantine-preserving importer"` (+ trailer).
+
+---
+
+### Task 4: Startup trigger in app.py
+
+**Files:**
+- Modify: `tldw_chatbook/app.py:7725-7744` (`_maybe_offer_first_run_wizard` — return bool) and `:7878-7882` (`_post_mount_setup` call site)
+- Test: `Tests/Skills/test_project_skills_startup_gate.py` (new — pure pieces only; app-level behavior is covered by Task 6's live pass)
+
+**Interfaces:**
+- Consumes: Tasks 1-3 modules; `get_cli_setting`, `get_user_data_dir` from `tldw_chatbook.config`.
+- Produces: `TldwCli._maybe_offer_project_skills_import()`; `_maybe_offer_first_run_wizard() -> bool` (True iff the wizard was pushed this launch).
+
+- [ ] **Step 1: Write the failing test** for the seam that decides whether startup offers — extract it as a pure function in `project_skills_prompt.py` so app.py stays thin:
+
+```python
+# Tests/Skills/test_project_skills_startup_gate.py
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    startup_discovery_for,
+)
+
+
+def _skill(root):
+    d = root / ".SKILLS" / "alpha-skill"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+
+
+def test_startup_discovery_found(tmp_path):
+    _skill(tmp_path / "repo")
+    (tmp_path / "repo" / ".git").mkdir()
+    sub = tmp_path / "repo" / "src"
+    sub.mkdir()
+    discovery = startup_discovery_for(sub, enabled=True, ledger_dir=tmp_path / "data")
+    assert discovery is not None and discovery.entries
+
+
+def test_startup_discovery_disabled(tmp_path):
+    _skill(tmp_path)
+    assert startup_discovery_for(tmp_path, enabled=False, ledger_dir=tmp_path / "d") is None
+
+
+def test_startup_discovery_respects_never(tmp_path):
+    _skill(tmp_path)
+    from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+        ProjectSkillsPromptLedger,
+    )
+    ledger = ProjectSkillsPromptLedger(tmp_path / "data")
+    ledger.record(tmp_path.resolve(), "never", "anything")
+    assert startup_discovery_for(tmp_path, enabled=True, ledger_dir=tmp_path / "data") is None
+```
+
+- [ ] **Step 2: Run to verify failure**, then implement `startup_discovery_for(start: Path, *, enabled: bool, ledger_dir: Path) -> ProjectSkillsDiscovery | None` in `project_skills_prompt.py`: return None unless enabled; `find_project_dir_with_skills(start)`; `discover_project_skills(project_dir)`; None if no entries; None unless `should_offer_project_skills_prompt(True, ledger.decision_for(discovery.root), discovery.fingerprint)`.
+
+- [ ] **Step 3: Wire app.py.** `_maybe_offer_first_run_wizard` returns True on the `should_offer_wizard` branch, False otherwise (update its docstring). At the `:7878` call site:
+
+```python
+        wizard_offered = self._maybe_offer_first_run_wizard()
+        try:
+            self._maybe_warn_second_instance()
+        except Exception as e:
+            logger.error(f"Second-instance warning failed: {e}")
+        if not wizard_offered:
+            # Spec 2026-08-17 §5.4: wizard wins; .SKILLS offer defers to next launch.
+            self._maybe_offer_project_skills_import()
+```
+
+New methods on `TldwCli` (place after `_push_first_run_wizard`):
+
+```python
+    def _maybe_offer_project_skills_import(self) -> None:
+        """Offer to import a project's .SKILLS/ folder (spec 2026-08-17 §5.4)."""
+        try:
+            self.run_worker(
+                self._discover_project_skills_for_startup,
+                thread=True,
+                exclusive=True,
+                group="project-skills-discovery",
+            )
+        except Exception:
+            logger.opt(exception=True).debug("project-skills startup offer failed")
+
+    def _discover_project_skills_for_startup(self) -> None:
+        from tldw_chatbook.config import get_cli_setting, get_user_data_dir
+        from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+            startup_discovery_for,
+        )
+
+        try:
+            cwd = Path.cwd().resolve()
+        except OSError:
+            return  # launch directory deleted out from under the process
+        discovery = startup_discovery_for(
+            cwd,
+            enabled=bool(
+                get_cli_setting("skills", "project_skills_prompt_enabled", True)
+            ),
+            ledger_dir=get_user_data_dir(),
+        )
+        if discovery is None:
+            return
+        self.call_from_thread(self._push_project_skills_import_modal, discovery)
+
+    def _push_project_skills_import_modal(self, discovery) -> None:
+        from tldw_chatbook.Widgets.project_skills_import_modal import (
+            maybe_offer_project_skills_import,
+        )
+
+        maybe_offer_project_skills_import(self, (discovery,))
+```
+
+(`startup_discovery_for` takes `ledger_dir=get_user_data_dir()` and builds the ledger itself, so the ledger path stays defined in exactly one module.)
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Skills/test_project_skills_startup_gate.py Tests/Skills/test_project_skills_prompt.py -v`; then `.venv/bin/pytest Tests/ --collect-only -q | tail -3` to prove app.py still imports.
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(app): offer project .SKILLS import at startup behind wizard + ledger gates"` (+ trailer).
+
+---
+
+### Task 5: Create-modal chaining
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/workspace_create_modal.py` (`_add_folder`, `_create`, folder-row compose)
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py` (`_handle_workspace_create_result`), `tldw_chatbook/UI/Screens/settings_screen.py` (`handle_workspace_create._done`), `tldw_chatbook/UI/Screens/library_screen.py` (`create_local_workspace._done`)
+- Test: extend `Tests/Workspaces/test_workspace_create_modal.py` and `Tests/Workspaces/test_console_workspace_create_handler.py`
+
+**Interfaces:**
+- Consumes: `discover_project_skills` (Task 1), `maybe_offer_project_skills_import` (Task 3).
+- Produces: `WorkspaceCreateResult.project_skills: tuple[ProjectSkillsDiscovery, ...]` now populated for bound folders whose root contains `.SKILLS/`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to Tests/Workspaces/test_workspace_create_modal.py
+@pytest.mark.asyncio
+async def test_folder_with_skills_annotated_and_carried_on_result(tmp_path):
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    skill = project / ".SKILLS" / "alpha-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        rows = [str(s.renderable) for s in modal.query(".workspace-create-folder-locator")]
+        assert any("1 project skill" in row for row in rows)
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    assert len(app.result.project_skills) == 1
+    assert app.result.project_skills[0].entries[0].name == "alpha-skill"
+```
+
+and in the console handler test file, assert the handler calls the offer helper:
+
+```python
+def test_result_with_project_skills_offers_import(tmp_path, monkeypatch):
+    offered = []
+    import tldw_chatbook.UI.Console_Modules.workspace as ws_module
+
+    monkeypatch.setattr(
+        ws_module,
+        "maybe_offer_project_skills_import",
+        lambda app, discoveries: offered.append(discoveries),
+    )
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1",
+        name="Workspace 1",
+        make_active=False,
+        project_skills=("sentinel-discovery",),
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert offered == [("sentinel-discovery",)]
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement.**
+  - In `_add_folder`, after appending the folder: run `discover_project_skills(Path(resolved))`; keep a parallel `self._folder_discoveries: dict[str, ProjectSkillsDiscovery]`; the folder row Static label becomes `f"{folder} — contains {n} project skill(s)"` when a discovery with entries exists.
+  - In `_create`, set `project_skills=tuple(self._folder_discoveries[f] for f in bound if f in self._folder_discoveries)`.
+  - In each of the three surface callbacks, after their existing post-create work add (module-level import so tests can monkeypatch it):
+
+```python
+        if result.project_skills:
+            maybe_offer_project_skills_import(
+                self.app_instance if hasattr(self, "app_instance") else self.app,
+                result.project_skills,
+            )
+```
+
+  (Console/Settings/Library each pass their app handle the way the surrounding code already does — `self.app_instance` in the Console controller and Library, `self.app` where the Settings callback uses it.)
+
+- [ ] **Step 4: Run** — both extended test files + `.venv/bin/pytest Tests/Workspaces/ Tests/Skills/ -q`. All PASS.
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(workspaces): chain project-skills import offer after workspace creation"` (+ trailer).
+
+---
+
+### Task 6: ADR, config docs, User Guide, live verification, close-out
+
+**Files:**
+- Create: `backlog/decisions/0NN-project-skills-folder-convention.md` (`ls backlog/decisions/` for the next free number)
+- Modify: `tldw_chatbook/config.py` (`:2588` comment block region — document the new key beside `workspace_root`'s doc line)
+- Modify: `Docs/User_Guide/` skills + workspaces pages (locate via `grep -rln -i "skills" Docs/User_Guide/`)
+
+- [ ] **Step 1: ADR.** Contents per spec §8: the `.SKILLS/`/`.skills/` layout (per-skill dirs with SKILL.md + loose `*.md`), both triggers, import-copy-not-live-load rationale, quarantine posture and its relation to ADR-009 (import-copy stays inside the boundary; live-load would not), the fingerprint ledger, and the `[skills] project_skills_prompt_enabled` kill-switch.
+- [ ] **Step 2: Config docs.** Add `# project_skills_prompt_enabled = true  # offer .SKILLS/ import at startup; spec 2026-08-17` to the commented `[skills]`-area of the config template/docs near `config.py:2588`.
+- [ ] **Step 3: User Guide.** Document the `.SKILLS/` convention on the skills page (layout, both prompts, "one-time trust review" expectation, kill-switch) and the create-modal chaining on the workspaces page; refresh "Verified against" stamps.
+- [ ] **Step 4: Live verification** per the `verify` skill and `lessons-live-verification.md`: launch the TUI from a fixture project containing `.SKILLS/` (2 valid skills, 1 invalid name, 1 loose file) — confirm the startup modal, import 2, confirm they appear in Library ▸ Skills as trust-pending and are refused in Console with the Library pointer; relaunch to confirm no re-prompt; add a skill and relaunch to confirm the changed-fingerprint re-offer; create a workspace bound to the fixture to confirm the chained offer; confirm "Never" then relaunch.
+- [ ] **Step 5: Gate + close-out** — `.venv/bin/pytest Tests/Skills/ Tests/Workspaces/ -q` plus `--collect-only` sweep; backlog task ACs checked, Implementation Notes added, status Done; commit docs (+ trailer); push and open the PR B branch PR.

--- a/Docs/superpowers/plans/2026-08-17-workspace-create-modal.md
+++ b/Docs/superpowers/plans/2026-08-17-workspace-create-modal.md
@@ -1,0 +1,921 @@
+# Workspace Create Modal (PR A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace zero-input workspace creation on all three surfaces (Console rail, Settings ▸ Workspaces, Library) with one shared modal that collects a name + optional folder bindings and explains what a workspace does.
+
+**Architecture:** A `ModalScreen[WorkspaceCreateResult | None]` owns the service calls (`create_workspace` + `add_folder_binding`) so errors render inline; each surface keeps its own dismissal callback for post-create UI sync. A pure path validator is extracted from `add_folder_binding` so folders are vetted as they are added, before Create.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, SQLite (`WorkspaceDB`), pytest + Textual pilot.
+
+**Spec:** `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md` (§4, §6, §7, §9 PR A)
+
+## Global Constraints
+
+- Work in a worktree under `<repo>/.worktrees/` branched off `origin/dev` (NEVER `/tmp`; see memory rules). Push after every task.
+- pytest is venv-only: run `.venv/bin/pytest …` (if pytest is missing: `VIRTUAL_ENV=.venv uv pip install -e ".[dev]"`). `timeout` command is unavailable in this environment.
+- Modal styling via `DEFAULT_CSS` on the widget (house pattern: `ConsoleWorkspaceSwitcherModal`); never hand-edit the CSS bundle.
+- All user-visible strings that echo user/filesystem input render with `markup=False`.
+- Folder bindings are added read-only (`allow_write=False`) — ADR-028; rw stays a Settings action.
+- Escape always dismisses with `None`; nothing is created on cancel.
+- Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- File one backlog task for PR A before starting (sweep IDs against origin/dev + all remotes/worktrees per `backlog/docs/lessons-backlog-hygiene.md`); set In Progress with this plan as the Implementation Plan.
+
+---
+
+### Task 1: Extract pure folder-path validator
+
+**Files:**
+- Modify: `tldw_chatbook/Workspaces/registry_service.py:659-726` (`add_folder_binding`)
+- Test: `Tests/Workspaces/test_folder_binding_validator.py` (new)
+
+**Interfaces:**
+- Consumes: existing `find_root_binding_conflict`, `WorkspaceRegistryServiceError` in the same module.
+- Produces: module-level `validate_folder_binding_path(path: str | Path, existing_locators: Sequence[str] = ()) -> Path` — raises `WorkspaceRegistryServiceError` with the exact messages `add_folder_binding` raises today; returns the resolved path. Task 2/3 import it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Workspaces/test_folder_binding_validator.py
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+    validate_folder_binding_path,
+)
+
+
+def test_valid_directory_resolves(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    assert validate_folder_binding_path(project) == project.resolve()
+
+
+def test_missing_directory_rejected(tmp_path):
+    with pytest.raises(WorkspaceRegistryServiceError, match="does not exist"):
+        validate_folder_binding_path(tmp_path / "nope")
+
+
+def test_filesystem_root_rejected():
+    with pytest.raises(WorkspaceRegistryServiceError, match="filesystem root"):
+        validate_folder_binding_path(Path("/"))
+
+
+def test_home_directory_rejected():
+    with pytest.raises(WorkspaceRegistryServiceError, match="home directory"):
+        validate_folder_binding_path(Path.home())
+
+
+def test_duplicate_locator_rejected(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    with pytest.raises(WorkspaceRegistryServiceError, match="already bound"):
+        validate_folder_binding_path(project, [str(project.resolve())])
+
+
+def test_nested_inside_existing_rejected(tmp_path):
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    with pytest.raises(WorkspaceRegistryServiceError, match="inside the already-bound"):
+        validate_folder_binding_path(child, [str(parent.resolve())])
+
+
+def test_existing_inside_candidate_rejected(tmp_path):
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    with pytest.raises(WorkspaceRegistryServiceError, match="remove it first"):
+        validate_folder_binding_path(parent, [str(child.resolve())])
+
+
+def test_sensitive_conflict_rejected(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    import tldw_chatbook.Workspaces.registry_service as rs
+
+    monkeypatch.setattr(
+        rs, "find_root_binding_conflict", lambda p: Path("/protected")
+    )
+    with pytest.raises(WorkspaceRegistryServiceError, match="protected path"):
+        validate_folder_binding_path(project)
+
+
+def test_add_folder_binding_still_enforces(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="validator-tests")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="workspace-local-1", name="Workspace 1")
+    project = tmp_path / "project"
+    project.mkdir()
+    binding = service.add_folder_binding("workspace-local-1", project)
+    assert binding.locator == str(project.resolve())
+    with pytest.raises(WorkspaceRegistryServiceError, match="already bound"):
+        service.add_folder_binding("workspace-local-1", project)
+```
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/pytest Tests/Workspaces/test_folder_binding_validator.py -v` — expect ImportError: `validate_folder_binding_path` not defined.
+
+- [ ] **Step 3: Implement.** In `registry_service.py`, add `Sequence` to the module's existing typing/collections.abc imports. Directly above `class LocalWorkspaceRegistryService`, add the function by MOVING the checks from `add_folder_binding:675-726` verbatim (keep the TASK-857 comment with them):
+
+```python
+def validate_folder_binding_path(
+    path: str | Path,
+    existing_locators: Sequence[str] = (),
+) -> Path:
+    """Resolve and vet a candidate folder-binding path (spec 2026-08-17 §4.2).
+
+    Pure with respect to the registry: consults only the filesystem and the
+    sensitive-path denylist, so creation UIs can vet folders before any
+    workspace exists. Raises WorkspaceRegistryServiceError with the same
+    user-facing messages ``add_folder_binding`` raised before extraction.
+    """
+    candidate = Path(path).expanduser()
+    try:
+        resolved = candidate.resolve()
+    except OSError as exc:
+        raise WorkspaceRegistryServiceError(
+            f"Folder path could not be resolved: {candidate}"
+        ) from exc
+    if not resolved.is_dir():
+        raise WorkspaceRegistryServiceError(
+            f"Folder does not exist or is not a directory: {resolved}"
+        )
+    if resolved == Path(resolved.anchor):
+        raise WorkspaceRegistryServiceError(
+            "The filesystem root cannot be bound to a workspace."
+        )
+    if resolved == Path.home().resolve():
+        raise WorkspaceRegistryServiceError(
+            "Your home directory itself cannot be bound; choose a "
+            "project folder inside it."
+        )
+    conflict = find_root_binding_conflict(resolved)
+    if conflict is not None:
+        raise WorkspaceRegistryServiceError(
+            f"'{resolved}' cannot be bound: it is, or contains, the "
+            f"protected path '{conflict}'. Choose a folder that does "
+            f"not overlap this application's own data, configuration, "
+            f"or credential directories."
+        )
+    for locator in existing_locators:
+        existing_path = Path(locator)
+        if resolved == existing_path:
+            raise WorkspaceRegistryServiceError(
+                f"{resolved} is already bound to this workspace."
+            )
+        if existing_path in resolved.parents:
+            raise WorkspaceRegistryServiceError(
+                f"{resolved} is inside the already-bound folder "
+                f"{existing_path}."
+            )
+        if resolved in existing_path.parents:
+            raise WorkspaceRegistryServiceError(
+                f"The already-bound folder {existing_path} is inside "
+                f"{resolved}; remove it first."
+            )
+    return resolved
+```
+
+Then `add_folder_binding` replaces lines 675-726 with:
+
+```python
+        resolved = validate_folder_binding_path(
+            path,
+            [b.locator for b in self.list_folder_bindings(workspace_id)],
+        )
+```
+
+- [ ] **Step 4: Run new tests + existing regressions** — `.venv/bin/pytest Tests/Workspaces/test_folder_binding_validator.py Tests/Workspaces/test_workspace_folder_bindings.py Tests/Workspaces/test_workspace_registry_service.py -v` — all PASS (read the passed count; "no tests ran" is a FAILED gate).
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "refactor(workspaces): extract pure folder-binding path validator"` (+ trailer).
+
+---
+
+### Task 2: Modal skeleton + Browse-from-modal spike
+
+The spec (§4.4) requires proving fspicker-over-modal FIRST — no site has ever pushed `SelectDirectory` from inside a `ModalScreen`.
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/workspace_create_modal.py`
+- Test: `Tests/Workspaces/test_workspace_create_modal.py` (new)
+
+**Interfaces:**
+- Consumes: `SelectDirectory` from `tldw_chatbook.Third_Party.textual_fspicker`; `LocalWorkspaceRegistryService`, `next_local_workspace_identity` from `tldw_chatbook.Workspaces.registry_service`.
+- Produces: `WorkspaceCreateResult` dataclass and `WorkspaceCreateModal(ModalScreen[WorkspaceCreateResult | None])` with `__init__(self, *, registry_service)`. Widget ids Task 3 extends: `#workspace-create-name`, `#workspace-create-folder-path`, `#workspace-create-browse`, `#workspace-create-cancel`.
+
+- [ ] **Step 1: Write the failing spike test**
+
+```python
+# Tests/Workspaces/test_workspace_create_modal.py
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.widgets import Input
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Widgets.workspace_create_modal import (
+    WorkspaceCreateModal,
+    WorkspaceCreateResult,
+)
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+def _registry(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="create-modal-tests")
+    return LocalWorkspaceRegistryService(db)
+
+
+class _HarnessApp(App[None]):
+    def __init__(self, registry):
+        super().__init__()
+        self._registry = registry
+        self.result = "unset"
+
+    def on_mount(self) -> None:
+        def _done(result):
+            self.result = result
+
+        self.push_screen(
+            WorkspaceCreateModal(registry_service=self._registry), _done
+        )
+
+
+@pytest.mark.asyncio
+async def test_browse_pushes_picker_and_fills_path(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+        await pilot.click("#workspace-create-browse")
+        await pilot.pause()
+        assert isinstance(app.screen, SelectDirectory)
+        project = tmp_path / "project"
+        project.mkdir()
+        app.screen.dismiss(project)
+        await pilot.pause()
+        assert app.screen is modal  # focus/stack returned to the modal
+        assert (
+            modal.query_one("#workspace-create-folder-path", Input).value
+            == str(project)
+        )
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_with_none(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.result is None
+```
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/pytest Tests/Workspaces/test_workspace_create_modal.py -v` — expect ImportError (module missing).
+
+- [ ] **Step 3: Implement the skeleton**
+
+```python
+# tldw_chatbook/Widgets/workspace_create_modal.py
+"""Shared workspace creation modal (spec 2026-08-17 §4).
+
+Used by the Console rail, Settings ▸ Workspaces, and Library. The modal
+owns the create/bind service calls so failures render inline; surfaces
+own post-create UI sync via their dismissal callbacks (§4.3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, Static
+
+from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+    next_local_workspace_identity,
+    validate_folder_binding_path,
+)
+
+_WORKSPACE_EXPLAINER = (
+    "A workspace scopes the Console to one project. Conversations started "
+    "in it are grouped together, agents' project file access comes only "
+    "from the folders you bind here (read-only unless you grant write in "
+    "Settings), and retrieval can be narrowed to the workspace's items via "
+    "its RAG Scope. Binding your project's folder is what makes a "
+    "workspace more than a label — without one, agents have no file "
+    "access. You can add or change folders later in Settings ▸ Workspaces."
+)
+
+
+@dataclass(frozen=True)
+class WorkspaceCreateResult:
+    """Outcome of a completed create dialog (spec §4.3)."""
+
+    workspace_id: str
+    name: str
+    bound_folders: tuple[str, ...] = ()
+    failed_folders: tuple[tuple[str, str], ...] = ()  # (path, error message)
+    make_active: bool = True
+    #: ProjectSkillsDiscovery entries for bound folders containing .SKILLS/.
+    #: Stays empty until project-skills discovery ships (spec §5.5 / PR B).
+    project_skills: tuple = ()
+
+
+class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
+    """Collect a workspace name + optional folder bindings."""
+
+    DEFAULT_CSS = """
+    WorkspaceCreateModal {
+        align: center middle;
+    }
+
+    #workspace-create-modal {
+        width: 72;
+        height: auto;
+        max-height: 32;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #workspace-create-explainer {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    #workspace-create-error {
+        color: $error;
+        height: auto;
+    }
+
+    #workspace-create-folder-row {
+        height: 3;
+        min-height: 3;
+    }
+
+    #workspace-create-folder-path {
+        width: 1fr;
+    }
+
+    #workspace-create-actions {
+        height: 3;
+        min-height: 3;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss", "Cancel")]
+    AUTO_FOCUS = "#workspace-create-name"
+
+    def __init__(self, *, registry_service: LocalWorkspaceRegistryService) -> None:
+        super().__init__()
+        self._registry = registry_service
+        self._folders: list[str] = []
+        self._error = ""
+
+    def compose(self) -> ComposeResult:
+        _, suggested_name = next_local_workspace_identity(self._registry)
+        with Vertical(id="workspace-create-modal"):
+            yield Static("New Workspace", classes="console-modal-header")
+            yield Static(
+                _WORKSPACE_EXPLAINER, id="workspace-create-explainer", markup=False
+            )
+            yield Input(
+                value=suggested_name,
+                id="workspace-create-name",
+                placeholder="Workspace name",
+            )
+            with Horizontal(id="workspace-create-folder-row"):
+                yield Input(
+                    id="workspace-create-folder-path",
+                    placeholder="~/path/to/project (optional)",
+                )
+                yield Button("Browse…", id="workspace-create-browse", compact=True)
+            with Horizontal(id="workspace-create-actions"):
+                yield Button("Cancel", id="workspace-create-cancel", compact=True)
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#workspace-create-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#workspace-create-browse")
+    def _browse(self, event: Button.Pressed) -> None:
+        event.stop()
+
+        def _picked(selected: Path | None) -> None:
+            if selected is not None:
+                self.query_one(
+                    "#workspace-create-folder-path", Input
+                ).value = str(selected)
+
+        self.app.push_screen(
+            SelectDirectory(title="Bind Project Folder"), _picked
+        )
+```
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Workspaces/test_workspace_create_modal.py -v` — both PASS. **If the browse round-trip fails structurally** (stack/focus does not return), STOP: implement the fallback from spec §4.4 (modal dismisses to the picker and is re-pushed prefilled, following `tldw_chatbook/Widgets/document_generation_modal.py:301`'s chaining shape) and record the deviation in the task file.
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(workspaces): create-modal skeleton with browse-from-modal spike"` (+ trailer).
+
+---
+
+### Task 3: Full modal — folder list, validation, create + bind, result
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/workspace_create_modal.py`
+- Test: `Tests/Workspaces/test_workspace_create_modal.py`
+
+**Interfaces:**
+- Produces (used by Tasks 4-6): completed dialog dismisses with `WorkspaceCreateResult`; new ids `#workspace-create-folder-add`, `#workspace-create-folder-remove-{i}`, `#workspace-create-make-active`, `#workspace-create-confirm`, `#workspace-create-error`.
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+@pytest.mark.asyncio
+async def test_invalid_folder_shows_inline_error(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "does not exist" in str(error.renderable)
+        assert app.result == "unset"  # still open
+
+
+@pytest.mark.asyncio
+async def test_create_with_folder_returns_result_and_binds(tmp_path):
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    assert result.name == "Video Tool"
+    assert result.bound_folders == (str(project.resolve()),)
+    assert result.failed_folders == ()
+    assert result.make_active is True
+    stored = registry.get_workspace(result.workspace_id)
+    assert stored is not None and stored.name == "Video Tool"
+    locators = [b.locator for b in registry.list_folder_bindings(result.workspace_id)]
+    assert locators == [str(project.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_name_error_keeps_modal_open(tmp_path):
+    registry = _registry(tmp_path)
+    registry.create_workspace(workspace_id="workspace-local-9", name="Video Tool")
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "already exists" in str(error.renderable)
+        assert app.result == "unset"
+
+
+@pytest.mark.asyncio
+async def test_make_active_checkbox_carried_on_result(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-make-active", Checkbox).value = False
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    assert app.result.make_active is False
+```
+
+(add `from textual.widgets import Checkbox, Static` to the test imports)
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/pytest Tests/Workspaces/test_workspace_create_modal.py -v` — new tests FAIL (missing ids).
+
+- [ ] **Step 3: Implement.** Extend `compose()` between the folder row and actions:
+
+```python
+            with Vertical(id="workspace-create-folder-list"):
+                for index, folder in enumerate(self._folders):
+                    with Horizontal(classes="workspace-create-folder-item"):
+                        yield Static(folder, classes="workspace-create-folder-locator", markup=False)
+                        yield Button(
+                            "Remove",
+                            id=f"workspace-create-folder-remove-{index}",
+                            compact=True,
+                        )
+            yield Static(self._error, id="workspace-create-error", markup=False)
+            yield Checkbox(
+                "Switch to this workspace", True, id="workspace-create-make-active"
+            )
+```
+
+and add `Button("Add folder", id="workspace-create-folder-add", compact=True)` inside `#workspace-create-folder-row` after Browse, plus `Button("Create", id="workspace-create-confirm", compact=True)` in the actions row. Add handlers:
+
+```python
+    def _set_error(self, message: str) -> None:
+        self._error = message
+        self.query_one("#workspace-create-error", Static).update(message)
+
+    @on(Button.Pressed, "#workspace-create-folder-add")
+    def _add_folder(self, event: Button.Pressed) -> None:
+        event.stop()
+        raw = self.query_one("#workspace-create-folder-path", Input).value.strip()
+        if not raw:
+            return
+        try:
+            resolved = validate_folder_binding_path(raw, self._folders)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_error(str(exc))
+            return
+        self._folders.append(str(resolved))
+        self._error = ""
+        self.query_one("#workspace-create-folder-path", Input).value = ""
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#workspace-create-folder-list Button")
+    def _remove_folder(self, event: Button.Pressed) -> None:
+        event.stop()
+        button_id = event.button.id or ""
+        try:
+            index = int(button_id.rsplit("-", 1)[-1])
+        except ValueError:
+            return
+        if 0 <= index < len(self._folders):
+            del self._folders[index]
+            self.refresh(recompose=True)
+
+    @on(Input.Submitted, "#workspace-create-name")
+    def _name_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._create()
+
+    @on(Button.Pressed, "#workspace-create-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._create()
+
+    def _create(self) -> None:
+        name = self.query_one("#workspace-create-name", Input).value.strip()
+        workspace_id, generated_name = next_local_workspace_identity(self._registry)
+        try:
+            self._registry.create_workspace(
+                workspace_id=workspace_id,
+                name=name or generated_name,
+                description="Created from the workspace setup dialog.",
+            )
+        except WorkspaceRegistryServiceError as exc:
+            self._set_error(str(exc))
+            return
+        bound: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for folder in self._folders:
+            try:
+                self._registry.add_folder_binding(workspace_id, folder)
+                bound.append(folder)
+            except WorkspaceRegistryServiceError as exc:
+                failed.append((folder, str(exc)))
+        self.dismiss(
+            WorkspaceCreateResult(
+                workspace_id=workspace_id,
+                name=name or generated_name,
+                bound_folders=tuple(bound),
+                failed_folders=tuple(failed),
+                make_active=self.query_one(
+                    "#workspace-create-make-active", Checkbox
+                ).value,
+            )
+        )
+```
+
+Note: `compose()` re-reads `self._error`/`self._folders` on recompose, so `refresh(recompose=True)` keeps rows and error in sync. The prefilled name must be captured once in `__init__` (`self._suggested_name`) and reused by `compose()` — otherwise recompose after add-folder would clobber a user-edited name. Store the name Input's current value into an attribute in `_add_folder`/`_remove_folder` before `refresh(recompose=True)` and restore it in `compose()`.
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Workspaces/test_workspace_create_modal.py -v` — all PASS (including the Task 2 tests).
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(workspaces): full create modal with folder validation and result"` (+ trailer).
+
+---
+
+### Task 4: Console wiring
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py:837-883` (`ConsoleWorkspaceController._create_console_workspace`)
+- Test: `Tests/Workspaces/test_console_workspace_create_handler.py` (new)
+
+**Interfaces:**
+- Consumes: `WorkspaceCreateModal`, `WorkspaceCreateResult` from Task 3.
+- Produces: `ConsoleWorkspaceController._handle_workspace_create_result(result: WorkspaceCreateResult | None) -> None` (PR B appends one line to it).
+
+- [ ] **Step 1: Write the failing test.** The controller methods are testable unbound against a stub exposing only the seams they touch:
+
+```python
+# Tests/Workspaces/test_console_workspace_create_handler.py
+from types import SimpleNamespace
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
+from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateResult
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+class _Stub:
+    def __init__(self, registry):
+        self.notifications = []
+        self.calls = []
+        self.app_instance = SimpleNamespace(
+            workspace_registry_service=registry,
+            notify=lambda message, **kw: self.notifications.append(message),
+        )
+
+    def _sync_console_chat_core_state(self):
+        self.calls.append("core")
+
+    def _activate_console_session_for_workspace(self, workspace_id):
+        self.calls.append(f"activate:{workspace_id}")
+
+    def _sync_console_workspace_context(self):
+        self.calls.append("context")
+
+    def _sync_native_console_chat_ui(self):
+        return "ui-sync-sentinel"
+
+    def run_worker(self, work, **kw):
+        self.calls.append(f"worker:{work}")
+
+
+def _registry(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="console-handler-tests")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="workspace-local-1", name="Workspace 1")
+    return service
+
+
+def test_make_active_runs_full_console_sequence(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1", name="Workspace 1", make_active=True
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert stub.calls == [
+        "core",
+        "activate:workspace-local-1",
+        "context",
+        "worker:ui-sync-sentinel",
+    ]
+    assert any("switched Console" in n for n in stub.notifications)
+
+
+def test_not_active_only_resyncs_context(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1", name="Workspace 1", make_active=False
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert stub.calls == ["context"]
+    assert any("Created Workspace 1." in n for n in stub.notifications)
+
+
+def test_none_result_is_a_noop(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, None)
+    assert stub.calls == [] and stub.notifications == []
+
+
+def test_failed_folders_surface_as_warnings(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1",
+        name="Workspace 1",
+        failed_folders=(("/gone", "Folder does not exist"),),
+        make_active=False,
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert any("Folder does not exist" in n for n in stub.notifications)
+```
+
+- [ ] **Step 2: Run to verify failure** — `.venv/bin/pytest Tests/Workspaces/test_console_workspace_create_handler.py -v` — AttributeError, method missing.
+
+- [ ] **Step 3: Implement.** Replace the body of `_create_console_workspace` (keep the registry-None guard verbatim) and add the handler:
+
+```python
+    def _create_console_workspace(self) -> None:
+        """Open the shared create dialog (spec 2026-08-17 §4.3)."""
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            self.app_instance.notify(
+                "Workspace service is not ready.", severity="warning"
+            )
+            return
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+        self.push_screen(
+            WorkspaceCreateModal(registry_service=registry_service),
+            self._handle_workspace_create_result,
+        )
+
+    def _handle_workspace_create_result(self, result) -> None:
+        """Console-side post-create sync; the modal already created/bound."""
+        if result is None:
+            return
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            return
+        for _folder, message in result.failed_folders:
+            self.app_instance.notify(message, severity="warning")
+        if not result.make_active:
+            self._sync_console_workspace_context()
+            self.app_instance.notify(
+                f"Created {result.name}.", severity="information"
+            )
+            return
+        try:
+            registry_service.set_active_workspace(result.workspace_id)
+        except WorkspaceRegistryServiceError:
+            logger.opt(exception=True).warning(
+                "Unable to activate new Console workspace"
+            )
+            self.app_instance.notify(
+                "Workspace created but could not be activated.", severity="error"
+            )
+            return
+        self._sync_console_chat_core_state()
+        self._activate_console_session_for_workspace(result.workspace_id)
+        self._sync_console_workspace_context()
+        self.run_worker(
+            self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
+        )
+        # TASK-713: the whole sequence is invisible when the Workspace status
+        # row is scrolled out of view -- keep the toast even with the modal.
+        self.app_instance.notify(
+            f"Created {result.name} and switched Console to it.",
+            severity="information",
+        )
+```
+
+`next_local_workspace_identity` may now be unused in this file — remove the import if so.
+
+- [ ] **Step 4: Run** — `.venv/bin/pytest Tests/Workspaces/test_console_workspace_create_handler.py -v` plus `.venv/bin/pytest Tests/Workspaces/ Tests/UI/test_console_native_chat_flow.py -x -q` for regressions (any test asserting the old zero-input flow must be updated to drive the modal).
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(console): route New workspace through the shared create modal"` (+ trailer).
+
+---
+
+### Task 5: Settings wiring
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py:11886-11892` (render) and `:14414-14437` (`handle_workspace_create`)
+- Test: existing Settings workspaces tests (locate: `grep -rln "settings-workspace-create" Tests/`)
+
+- [ ] **Step 1: Find and update affected tests first.** `grep -rn "settings-workspace-create-name" tldw_chatbook Tests` — every hit outside the two regions above must be updated: tests that typed a name into the inline input now drive the modal (push via button, fill `#workspace-create-name`, click `#workspace-create-confirm`). Write the updated tests before changing the screen; run them; they FAIL against the old inline flow only where behavior genuinely changed (e.g. asserting the input exists).
+
+- [ ] **Step 2: Implement.** In `_render_workspaces_detail`, replace the `Horizontal` create row (lines 11886-11892) with:
+
+```python
+        yield Button(
+            "Create workspace…", id="settings-workspace-create", compact=True
+        )
+```
+
+Replace `handle_workspace_create` with:
+
+```python
+    @on(Button.Pressed, "#settings-workspace-create")
+    def handle_workspace_create(self, event: Button.Pressed) -> None:
+        """Open the shared create dialog (spec 2026-08-17 §4.3)."""
+        event.stop()
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None:
+            return
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+        def _done(result) -> None:
+            if result is None:
+                return
+            status_parts = [message for _folder, message in result.failed_folders]
+            if result.make_active:
+                try:
+                    registry.set_active_workspace(result.workspace_id)
+                except WorkspaceRegistryServiceError as exc:
+                    status_parts.append(str(exc))
+            self._settings_workspaces_result = "; ".join(status_parts)
+            self._refresh_settings_workspaces_pane()
+
+        self.app.push_screen(WorkspaceCreateModal(registry_service=registry), _done)
+```
+
+- [ ] **Step 3: Run** — the updated Settings tests from Step 1 plus `.venv/bin/pytest Tests/Workspaces/ -q`. All PASS.
+
+- [ ] **Step 4: Commit** — `git add -A && git commit -m "feat(settings): workspace creation opens the shared create modal"` (+ trailer).
+
+---
+
+### Task 6: Library wiring
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:19853-19901` (`create_local_workspace`)
+- Test: existing Library workspace tests (locate: `grep -rln "library-create-local-workspace" Tests/`), updated the same way as Task 5 Step 1.
+
+- [ ] **Step 1: Update affected tests first** (same discipline as Task 5 Step 1, id `#library-create-local-workspace`).
+
+- [ ] **Step 2: Implement.** Replace the handler body after the registry-None guard (keep the guard verbatim) with:
+
+```python
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+        def _done(result) -> None:
+            if result is None:
+                return
+            notify = getattr(self.app_instance, "notify", None)
+            for _folder, message in result.failed_folders:
+                if callable(notify):
+                    notify(message, severity="warning")
+            if result.make_active:
+                try:
+                    registry_service.set_active_workspace(result.workspace_id)
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Failed to activate new Library workspace"
+                    )
+                    if callable(notify):
+                        notify(
+                            "Workspace created but could not be activated.",
+                            severity="error",
+                        )
+                    return
+            self._invalidate_library_workspace_depth_state()
+            # TASK-716: preserve the rail's scroll offset across the rebuild.
+            self._preserve_library_rail_scroll()
+            self.refresh(recompose=True)
+            if callable(notify):
+                if result.make_active:
+                    # TASK-713: activation retargets Console from another screen.
+                    notify(
+                        f"Created local workspace {result.name} and made it "
+                        "active; Console now targets it.",
+                        severity="information",
+                    )
+                else:
+                    notify(
+                        f"Created local workspace {result.name}.",
+                        severity="information",
+                    )
+
+        self.app.push_screen(
+            WorkspaceCreateModal(registry_service=registry_service), _done
+        )
+```
+
+- [ ] **Step 3: Run** — updated Library tests + `.venv/bin/pytest Tests/Workspaces/ -q`. All PASS.
+
+- [ ] **Step 4: Commit** — `git add -A && git commit -m "feat(library): workspace creation opens the shared create modal"` (+ trailer).
+
+---
+
+### Task 7: Docs, supersession note, live verification, close-out
+
+**Files:**
+- Modify: `Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md` (§1)
+- Modify: matching `Docs/User_Guide/` pages (locate: `grep -rln -i "workspace" Docs/User_Guide/`)
+- Commit: `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md` (still uncommitted)
+
+- [ ] **Step 1: Supersession note.** At the top of the 2026-07-26 spec's §1, add: *"Superseded in part (2026-08-17): workspace creation on every surface now runs through the shared creation modal — see `2026-08-17-workspace-create-modal-and-project-skills-design.md` §4. The management-home split below otherwise stands."*
+- [ ] **Step 2: User Guide.** Update every page found by the grep that documents workspace creation (Console, Settings, Library) to describe the modal (name prefill, optional folders, read-only default, Switch checkbox) and refresh each page's "Verified against" stamp.
+- [ ] **Step 3: Live verification** per the `verify` project skill: launch the TUI, create a workspace from all three surfaces (one with a folder, one cancelled with escape, one with "Switch" unchecked), confirm the Console rail/session behavior and Settings folder list. Evidence per `backlog/docs/lessons-live-verification.md`.
+- [ ] **Step 4: Full targeted gate** — `.venv/bin/pytest Tests/Workspaces/ -q` plus every test file touched in Tasks 4-6; then a `--collect-only` sweep over `Tests/` to catch import breakage.
+- [ ] **Step 5: Close out** — check off the backlog task's ACs, add Implementation Notes, `backlog task edit <id> -s Done`; commit docs + spec: `git add -A && git commit -m "docs(workspaces): create-modal user guide + spec + supersession note"` (+ trailer); push and open the PR A branch PR.

--- a/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
+++ b/Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md
@@ -10,6 +10,11 @@ ADR-027).
 
 ## 1. Goal and decisions (locked with the user)
 
+> **Superseded in part (2026-08-17):** workspace creation on every surface now
+> runs through the shared creation modal — see
+> `2026-08-17-workspace-create-modal-and-project-skills-design.md` §4. The
+> management-home split below otherwise stands.
+
 A dedicated **Settings ▸ Workspaces** category that hosts workspace
 management outright — create, rename, archive/unarchive, set active — and
 lets users modify existing workspaces by **adding/removing folders**.

--- a/Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md
+++ b/Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md
@@ -1,0 +1,298 @@
+# Workspace Create Modal + Project Skills (.SKILLS/) Discovery — Design
+
+- **Date:** 2026-08-17
+- **Status:** Proposed (awaiting owner review)
+- **Supersedes (partially):** `2026-07-26-settings-workspaces-category-design.md` §1 — that spec locked
+  "Library keeps create as an in-context quick action" with zero-input creation. This design replaces
+  instant creation on **all three** surfaces (Console rail, Settings ▸ Workspaces, Library) with a
+  shared creation modal. Everything else in that spec (Settings as management home, folder-binding
+  editor, Alt+W switcher scope) stands.
+- **Related ADRs:** ADR-028 (folder bindings are file-tool access roots, ro default, Default
+  workspace stays tool-less), ADR-009 (local skill trust boundary). This design adds a new ADR for
+  the project-skills folder convention (see §8).
+- **Related backlog:** task-713 (silent workspace creation), task-714 (forced "Workspace N" names) —
+  both partially addressed by Feature 1.
+
+## 1. Problem
+
+Workspace creation today collects nothing: Console's `New` button and Library's create button
+auto-name "Workspace N" with zero input (`UI/Console_Modules/workspace.py:837`,
+`UI/Screens/library_screen.py:19853`); Settings collects an optional name only
+(`UI/Screens/settings_screen.py:14415`). Folder binding — the thing that makes a workspace *do*
+anything for agents — is a separate, post-creation, Settings-only, type-the-path-by-hand action.
+Users are left with a new entry and no idea what it changes.
+
+Separately, a user resuming work on an existing project has no way to bring that project's skills
+into the app short of importing them one directory at a time through Library ▸ Skills. There is no
+project-local skills convention and no cwd awareness at startup.
+
+## 2. Goals
+
+1. Creating a workspace from any surface prompts for a **name** and optional **folder path(s)** in a
+   modal that explains, truthfully, what a workspace is and why a folder is being requested.
+2. A directory containing a **`.SKILLS/`** folder (per-skill subdirectories with `SKILL.md`, or
+   loose `*.md` skill files) triggers a **prompt-driven, never silent** offer to import those skills:
+   on app startup in that directory, and when a workspace is created with that directory bound.
+
+## 3. Non-goals
+
+- **Live-loading** skills from `.SKILLS/` without importing (would cross the ADR-009 trust
+  boundary and requires per-workspace skill scoping that does not exist). Possible later phase.
+- **Bulk trust approval.** Imported skills land quarantined exactly as today; trusting stays the
+  per-skill Review → Approve → passphrase flow. One-click-trusting a freshly cloned repo's skills is
+  what the boundary exists to prevent.
+- Recognizing `.claude/skills/` / `.agents/skills/` layouts (same shape, large ecosystem) — tempting
+  follow-up task, not v1.
+- Changing what folder bindings mean (ADR-028 semantics untouched), the Alt+W switcher, or the
+  Settings folder-binding editor.
+
+## 4. Feature 1 — shared workspace creation modal
+
+### 4.1 Component
+
+New `tldw_chatbook/Widgets/workspace_create_modal.py`:
+`WorkspaceCreateModal(ModalScreen[WorkspaceCreateResult | None])`, patterned on
+`ConsoleWorkspaceRenameModal` (escape binding, Save/Cancel, `Input.Submitted`). Layout top to
+bottom:
+
+1. **Educational header** (Static, ~4 sentences). Draft copy — must stay truthful to shipped
+   behavior:
+   > *A workspace scopes the Console to one project. Conversations started in it are grouped
+   > together, agents' project file access comes only from the folders you bind here (read-only
+   > unless you grant write in Settings), and retrieval can be narrowed to the workspace's items
+   > via its RAG Scope.
+   > Binding your project's folder is what makes a workspace more than a label — without one, agents
+   > have no file access. You can add or change folders later in Settings ▸ Workspaces.*
+
+   Note the precision: folder bindings drive **file-tool access roots** (ADR-028); RAG scoping is
+   driven by the separate per-workspace item picker (live and enforced —
+   `Chat/rag_scope.py:219` → allowlists in `RAG_Search/pipeline_functions_simple.py`). The copy
+   must not imply binding a folder scopes RAG.
+2. **Name input**, prefilled from `next_local_workspace_identity(registry)`
+   (`Workspaces/registry_service.py:1185`) so completion stays Enter-cheap. The workspace **id** is
+   always the generated one regardless of the typed name (matches Settings today).
+3. **Folder list**: path `Input` + **Browse…** `Button` (pushes the existing
+   `Third_Party/textual_fspicker/SelectDirectory`) + **Add** — added folders render as removable
+   rows. Multiple folders supported (schema is N bindings). Folders are **optional**; leaving the
+   list empty is valid and the header copy states what is lost.
+4. **"Switch to this workspace"** checkbox, **default checked** — makes activation behavior uniform
+   across surfaces (today Console/Library activate, Settings silently doesn't).
+5. **Create / Cancel** buttons. `escape` = Cancel = dismiss with `None`, nothing created.
+
+### 4.2 Validation (before Create, not after)
+
+Extract a **pure path validator** from `add_folder_binding`
+(`Workspaces/registry_service.py:659-726`) — e.g.
+`validate_folder_binding_path(path, existing_locators) -> Path` raising a typed error — covering:
+expanduser/resolve, must be an existing real directory, not filesystem root, not `$HOME`, sensitive-
+path denylist (`find_root_binding_conflict`), and duplicate/nested/parent overlap **among the
+modal's own entries** (a new workspace has no prior bindings, so intra-modal overlap is the only
+conflict class). `add_folder_binding` is refactored to call the same validator so the rules cannot
+drift. The modal runs it **as each folder is added**, surfacing rejection inline immediately.
+
+Name collisions: `workspace_records` has a unique index on `lower(name)` (non-archived). A collision
+on Create renders inline in the modal (modal stays open); optionally pre-checked against
+`list_workspaces` on blur.
+
+### 4.3 Ownership split: modal creates, surfaces sync
+
+The modal receives the registry service and **owns the service calls** on Create:
+`create_workspace(...)` then `add_folder_binding(...)` per folder (pre-validated; residual TOCTOU
+failures render inline as per-folder warnings — the workspace still exists, matching a partial
+result in `WorkspaceCreateResult`). Create-level failure keeps the modal open with an inline error.
+
+`WorkspaceCreateResult` carries: `workspace_id`, `name`, `bound_folders`, `failed_folders`,
+`make_active`, and `project_skills` (see §5.5). Each surface keeps its **own** dismissal callback
+for post-create UI sync:
+
+- **Console** (`UI/Console_Modules/workspace.py:837` `_create_console_workspace` becomes
+  push-modal + result handler): when `make_active` is set, replicates today's exact sequence —
+  `set_active_workspace` →
+  `_sync_console_chat_core_state()` → `_activate_console_session_for_workspace(workspace_id)` →
+  `_sync_console_workspace_context()` → `run_worker(_sync_native_console_chat_ui(),
+  exclusive=True, group="console-sync")` → the toast. When `make_active` is unchecked, only
+  `_sync_console_workspace_context()` runs, with a "Created <name>." toast and no session switch.
+  The toast **stays** despite the modal in both cases: task-713's comment marks it load-bearing
+  when the status row is scrolled out of view.
+- **Settings** (`settings_screen.py`): the inline name-input + Create row
+  (`:11886-11893`, handler `:14415`) is **replaced** by a single "Create workspace…" button that
+  pushes the modal; on result, honor `make_active` then refresh via the existing
+  `mutate_reactive(SettingsScreen.active_category)` recompose.
+- **Library** (`library_screen.py:19853`): same button → modal; existing activate/recompose/toast
+  behavior preserved, honoring `make_active`.
+
+All three surfaces then run the shared project-skills chaining helper (§5.5).
+
+### 4.4 Implementation risk — spike first
+
+Pushing a screen from inside a `ModalScreen` is established (6 sites, e.g.
+`briefing_preset_modal.py:610`, which documents the snapshot-before-await discipline), but **no
+site has ever pushed the fspicker from a modal** — every `SelectDirectory` push is from a full
+screen. The Browse-from-modal interaction (focus return, callback delivery, escape handling) is the
+first thing implementation verifies, before the rest of the modal is built. Fallback if it
+misbehaves: modal temporarily dismisses to a picker and re-pushes itself prefilled (the
+`document_generation_modal.py:301` chaining shape).
+
+## 5. Feature 2 — `.SKILLS/` discovery and prompt-driven import
+
+### 5.1 Convention
+
+A project-local skills folder is a directory named `.SKILLS/` (or `.skills/`; if a case-sensitive
+filesystem somehow has both, `.SKILLS/` wins and the other is ignored with a log line) at a
+project root, containing:
+
+- **per-skill subdirectories** with a top-level `SKILL.md` → imported via
+  `import_skill_directory` (skill name = directory name), and/or
+- **loose `*.md` files** → imported via `import_skill_file` (name derived from filename).
+
+Entries that match neither (subdir without `SKILL.md`, non-markdown files) are reported as skipped
+with a reason, never silently ignored.
+
+### 5.2 Discovery module (pure)
+
+New `tldw_chatbook/Skills_Interop/project_skills_discovery.py`:
+`discover_project_skills(root: Path) -> ProjectSkillsDiscovery` — no side effects, no execution.
+Hardening (untrusted repo input):
+
+- Refuse a **symlinked** `.SKILLS/` directory and skip symlinked entries (mirrors
+  `_iter_bundle_files` discipline in `local_skills_service.py`).
+- Caps before any parse: max 50 entries enumerated (remainder reported as "N more not
+  shown"), max 64 KiB read per `SKILL.md`/`*.md` for frontmatter, top level only — no
+  recursive scan below the per-skill dirs at discovery time (the importer walks them later under
+  its own caps).
+- Frontmatter via the existing `_parse_front_matter`/`yaml.safe_load` grammar; a file that fails to
+  parse is listed as "invalid" rather than aborting discovery.
+- Derived skill names are pre-checked against the skills name grammar
+  (`local_skills_service.py:82`); an entry whose directory/file name cannot normalize to a valid
+  name (e.g. `My_Skill/`) is listed as "invalid — name must be lowercase-kebab" at discovery time
+  instead of failing later inside the importer.
+- `.SKILLS/` and `.skills/` candidates are deduplicated by resolved path (on case-insensitive
+  filesystems both names match the same directory).
+- Fingerprint: stable hash over sorted (entry name, size, mtime) of the recognized skill files —
+  used by the ledger (§5.3).
+- **Names/descriptions are untrusted display text**: rendered with Rich markup escaped everywhere
+  they appear (modal rows, toasts, logs), so a hostile `description` cannot inject console markup.
+
+### 5.3 Prompt ledger (nag-avoidance)
+
+`<user_data_dir>/skills/project_prompts.json` (same atomic-replace pattern as the skills index):
+`{version: 1, entries: {<resolved dir>: {decision: "imported"|"declined"|"never", fingerprint,
+timestamp}}}`. Pure gating function, mirroring `first_run_setup_state.should_offer_wizard`:
+
+> offer ⇔ prompt enabled **and** `.SKILLS/` present **and** (no entry, **or** decision ≠ "never"
+> **and** fingerprint changed since the recorded one).
+
+So "Not now" suppresses re-prompting until the skill set actually changes (which then usefully
+reads as "2 new skills appeared in this project"); "Never for this folder" is permanent; a global
+kill-switch `[skills] project_skills_prompt_enabled = true` is declared in `config.py` defaults.
+Both triggers (§5.4) write the same ledger, so declining in one place silences the other.
+
+### 5.4 Triggers
+
+**Startup:** new `_maybe_offer_project_skills_import()` in `app.py`'s `_post_mount_setup`, next to
+`_maybe_offer_first_run_wizard()` (`app.py:7878`). Rules:
+
+- If the first-run wizard was offered this launch, **skip** (defer to next launch) — no modal
+  stacking at startup.
+- `Path.cwd()` guarded (the launch directory can be deleted out from under the process); resolved
+  before ledger lookup. If cwd has no `.SKILLS/`, a **bounded upward walk** checks each ancestor,
+  stopping after the first one containing `.git` (the project root) or on reaching `$HOME` or the
+  filesystem root — so launching from a project *subdirectory* still finds the project's skills.
+  The ledger is keyed by the directory where `.SKILLS/` was found. Launches from unrelated
+  directories are covered by the second trigger.
+- Discovery runs in a worker thread (startup path stays unblocked), then
+  `call_from_thread`/`call_after_refresh` pushes the import modal, matching the wizard's push
+  pattern.
+
+**Workspace creation:** after `WorkspaceCreateModal` dismisses successfully, the surface's result
+handler checks `result.project_skills` (the modal runs discovery on each folder as it is added — a
+row in the folder list gains a "contains N project skills" annotation) and, after post-create sync
+completes, pushes the import modal via a shared helper
+`maybe_offer_project_skills_import(app, discoveries)` used by all three surfaces. When several
+bound folders each carry a `.SKILLS/` directory (rare), import modals are offered **sequentially,
+one per discovery**, each writing its own ledger entry — no merged multi-source modal. The workspace is
+created regardless of what the user chooses here — skills are a **global** store; the workspace
+trigger is a discovery moment, not a linkage (no workspace↔skill coupling exists or is added).
+
+### 5.5 Import modal
+
+New `tldw_chatbook/Widgets/project_skills_import_modal.py` (`ModalScreen`):
+
+- **Header** states provenance ("found in `<dir>/.SKILLS/`") and sets the trust expectation up
+  front: *imported skills require a one-time trust review in Library ▸ Skills before they can
+  run.* This is load-bearing: quarantined skills are excluded from the Console skill picker
+  entirely and `$mentions` are refused (`console_chat_controller.py:5692`), so without this framing
+  the feature reads as broken.
+- **Rows**: checkbox + name + status — `new` (checked by default), `already installed` (unchecked;
+  never silently overwritten), `invalid` (unselectable, with reason). Skipped-entry and
+  "N more not shown" lines included. All repo-sourced text escaped.
+- **Buttons**: **Import selected** / **Not now** / **Never for this folder**. Escape = Not now.
+- On import: iterate `import_skill_directory` / `import_skill_file` with
+  `trust_approved=False` (unchanged security posture); collect per-skill outcomes; result view
+  lists them with a **"Review in Library ▸ Skills"** button navigating via the existing `skills`
+  Library sub-route (`UI/Navigation/shell_destinations.py:65`), plus Close. If the trust store was
+  never bootstrapped, Library's adaptive trust header already routes through setup first — the
+  result-view copy mentions this ("set up skill trust, then approve") rather than assuming a
+  passphrase exists. Ledger updated with the decision + current fingerprint.
+
+## 6. Error handling summary
+
+- Modal-time validation failures (path, name) render inline; the modal never dismisses on error.
+- Post-validation binding failures: workspace exists, failed folders listed inline as warnings and
+  carried in the result (`failed_folders`) so surfaces can toast.
+- Registry unavailable: Console's `New` is already disabled by `display_state`; Settings/Library
+  buttons render the existing inline status error instead of pushing the modal.
+- Discovery/import failures per-skill, never aborting the batch; import errors reuse the Library
+  import flow's error surfaces.
+- RAG-scope fails-closed behavior, trust flow, and folder-root call-time re-validation are all
+  untouched.
+
+## 7. Testing
+
+- **Pure units** (no Textual): the extracted folder-path validator (each rejection class +
+  intra-modal overlap); `discover_project_skills` against fixtures — happy layouts, loose files,
+  symlinked `.SKILLS/`, symlinked entries, junk entries, oversized frontmatter, markup-hostile
+  names, fingerprint stability; ledger gating function truth table (no entry / declined+same /
+  declined+changed / never / kill-switch).
+- **Pilot tests** (Textual): create modal — prefilled name Enter-Enter fast path, escape creates
+  nothing, invalid path inline error, duplicate name inline error, Browse round-trip (the §4.4
+  spike graduates into this test), result plumbed to each surface's handler; import modal —
+  selection defaults, Never writes ledger, statuses render escaped.
+- **Integration**: startup gating (wizard-offered ⇒ skipped; ledger honored), Console post-create
+  sequence still activates session + resyncs rail (assert against the same seams the existing
+  workspace tests use).
+- Per repo rules: targeted test selection, real in-memory SQLite for registry tests, and a live
+  `verify`-skill pass on the three surfaces before PR.
+
+## 8. Documentation / decision records
+
+- **New ADR**: project-skills folder convention — layout, both triggers, import-copy (not
+  live-load) rationale, quarantine posture, relation to ADR-009's boundary (import-copy stays
+  inside it; live-load would not).
+- **Supersession note** added to `2026-07-26-settings-workspaces-category-design.md` §1 pointing
+  here.
+- **User Guide** pages for Console (workspace section), Settings ▸ Workspaces, and Library ▸ Skills
+  updated (CLAUDE.md rule), including the `.SKILLS/` convention as user-facing documentation.
+
+## 9. Phasing
+
+Two independently valuable PR-sized stages, foundations first:
+
+1. **PR A — creation modal**: validator extraction + `WorkspaceCreateModal` + three-surface wiring
+   (includes the §4.4 spike). Ships alone; addresses task-713/714 concerns.
+2. **PR B — project skills**: discovery module + ledger + import modal + startup trigger +
+   create-modal chaining (the only touch on PR A is reading `project_skills` off the result).
+
+Backlog tasks to be filed per repo hygiene (IDs swept against origin/dev + all remotes/worktrees).
+
+## 10. Decisions taken (owner may override)
+
+| # | Decision | Default taken |
+|---|----------|---------------|
+| 1 | Folder at creation | Optional, encouraged by copy — organizational-only workspaces stay legal |
+| 2 | Activation | Uniform "Switch to this workspace" checkbox, default on |
+| 3 | `.SKILLS/` handling | Import-copy through existing importer; quarantined; no bulk trust |
+| 4 | Existing skill names | Skipped by default, shown as "already installed", explicit overwrite only |
+| 5 | Convention names | `.SKILLS/` and `.skills/`; `.claude/skills/` deferred to a follow-up task |
+| 6 | Escape semantics | Cancel — nothing created/imported; "Not now" for the import prompt |
+| 7 | Startup detection scope | cwd plus a bounded walk up to the first `.git` ancestor (covers subdirectory launches); stops at `$HOME`/root |

--- a/Tests/UI/test_console_new_workspace.py
+++ b/Tests/UI/test_console_new_workspace.py
@@ -9,11 +9,19 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
 from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
 
 
 @pytest.mark.asyncio
 async def test_console_new_workspace_creates_and_activates() -> None:
-    """Pressing [New] in the Session rail creates and activates a local workspace."""
+    """Pressing [New] in the Session rail opens the shared create modal;
+    confirming it creates and activates a local workspace.
+
+    The PR that introduced WorkspaceCreateModal changed this button from an
+    instant-create action to opening the shared dialog first (spec
+    2026-08-17 Sec4.3) -- see Tests/UI/test_settings_workspaces_category.py's
+    create flow for the same pattern.
+    """
     app = _build_test_app()
     registry_service = app.workspace_registry_service
     host = ConsoleHarness(app)
@@ -25,8 +33,20 @@ async def test_console_new_workspace_creates_and_activates() -> None:
         new_button = console.query_one("#console-new-workspace", Button)
         assert new_button.disabled is False
         new_button.press()
-        await pilot.pause(0.2)
-        assert len(registry_service.list_workspaces()) == before + 1
+        await pilot.pause()
+
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, WorkspaceCreateModal)
+
+        modal.query_one("#workspace-create-confirm", Button).press()
+
+        created = ()
+        for _ in range(200):
+            created = registry_service.list_workspaces()
+            if len(created) == before + 1:
+                break
+            await pilot.pause(0.01)
+        assert len(created) == before + 1
         active = registry_service.get_active_workspace()
         assert active is not None
         assert active.workspace_id.startswith("workspace-local-")
@@ -35,7 +55,11 @@ async def test_console_new_workspace_creates_and_activates() -> None:
 @pytest.mark.asyncio
 async def test_console_new_workspace_announces_creation() -> None:
     """TASK-713: creating a workspace must not be silent - the user should be
-    told what was created and that Console switched to it."""
+    told what was created and that Console switched to it.
+
+    Drives the shared create modal (opened by [New]) to completion first --
+    see test_console_new_workspace_creates_and_activates's docstring.
+    """
     app = _build_test_app()
     host = ConsoleHarness(app)
 
@@ -47,9 +71,23 @@ async def test_console_new_workspace_announces_creation() -> None:
             (str(message), kwargs)
         )
         console.query_one("#console-new-workspace", Button).press()
-        await pilot.pause(0.2)
+        await pilot.pause()
 
-        active = app.workspace_registry_service.get_active_workspace()
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, WorkspaceCreateModal)
+
+        modal.query_one("#workspace-create-confirm", Button).press()
+
+        active = None
+        for _ in range(200):
+            active = app.workspace_registry_service.get_active_workspace()
+            messages = [message for message, _ in notifications]
+            if active is not None and any(
+                "switched" in message.lower() for message in messages
+            ):
+                break
+            await pilot.pause(0.01)
+
         assert active is not None
         messages = [message for message, _ in notifications]
         assert any(

--- a/Tests/UI/test_post_release_workspaces_library_depth.py
+++ b/Tests/UI/test_post_release_workspaces_library_depth.py
@@ -251,6 +251,12 @@ async def test_library_workspaces_can_create_and_select_local_workspace() -> Non
         await _wait_for_selector(screen, pilot, "#library-create-local-workspace")
 
         screen.query_one("#library-create-local-workspace", Button).press()
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
         await _wait_for_selector(screen, pilot, "#library-workspaces-active-workspace")
 
         active_workspace = app.workspace_registry_service.get_active_workspace()
@@ -301,6 +307,12 @@ async def test_library_workspaces_create_local_workspace_mouse_clicks() -> None:
         await pilot.pause()
 
         await pilot.click("#library-create-local-workspace")
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
         await _wait_for_selector(screen, pilot, "#library-workspaces-active-workspace")
 
         active_workspace = app.workspace_registry_service.get_active_workspace()
@@ -343,6 +355,12 @@ async def test_library_workspaces_create_skips_archived_local_workspace_identity
         await _wait_for_selector(screen, pilot, "#library-create-local-workspace")
 
         screen.query_one("#library-create-local-workspace", Button).press()
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
         await _wait_for_selector(screen, pilot, "#library-workspaces-active-workspace")
 
         active_workspace = service.get_active_workspace()
@@ -518,6 +536,11 @@ async def test_library_create_workspace_notification_names_console_retarget() ->
         notifications: list[str] = []
         app.notify = lambda message, **kwargs: notifications.append(str(message))
         screen.query_one("#library-create-local-workspace", Button).press()
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
         await pilot.pause(0.3)
 
         assert any(
@@ -571,6 +594,11 @@ async def test_create_workspace_preserves_rail_scroll() -> None:
         assert scrolled_to > 0
 
         screen.query_one("#library-create-local-workspace", Button).press()
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
         await pilot.pause(0.6)
 
         rail = screen.query_one("#library-rail")

--- a/Tests/UI/test_post_release_workspaces_library_depth.py
+++ b/Tests/UI/test_post_release_workspaces_library_depth.py
@@ -550,6 +550,70 @@ async def test_library_create_workspace_notification_names_console_retarget() ->
 
 
 @pytest.mark.asyncio
+async def test_create_workspace_recomposes_after_activation_failure() -> None:
+    """Finding 2: activation failure must not skip the depth-state
+    invalidation, rail-scroll preservation, or recompose seam -- the
+    workspace WAS created (it just could not be switched to), so the rail
+    must still be rebuilt to show it exists.
+
+    Pinned by monkeypatching the real registry service's
+    set_active_workspace to raise, then spying on
+    LibraryScreen._invalidate_library_workspace_depth_state to prove the
+    seam is (or is not) reached.
+    """
+    app = _build_test_app()
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(140, 40)) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_shell_ready(screen, pilot)
+        await _open_library_details(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-create-local-workspace")
+
+        def _boom(workspace_id: str) -> None:
+            raise RuntimeError("simulated activation failure")
+
+        app.workspace_registry_service.set_active_workspace = _boom
+
+        invalidate_calls: list[bool] = []
+        original_invalidate = screen._invalidate_library_workspace_depth_state
+
+        def _tracking_invalidate() -> None:
+            invalidate_calls.append(True)
+            original_invalidate()
+
+        screen._invalidate_library_workspace_depth_state = _tracking_invalidate
+
+        notifications: list[str] = []
+        app.notify = lambda message, **kwargs: notifications.append(str(message))
+
+        screen.query_one("#library-create-local-workspace", Button).press()
+        await pilot.pause()
+        modal = host.screen
+        assert modal is not screen
+        await _wait_for_selector(modal, pilot, "#workspace-create-confirm")
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause(0.3)
+
+        # The workspace was created despite the activation failure.
+        created = [
+            workspace
+            for workspace in app.workspace_registry_service.list_workspaces()
+            if workspace.name == "Workspace 1"
+        ]
+        assert created, "workspace creation itself must have succeeded"
+
+        assert invalidate_calls, (
+            "activation failure must not skip the depth-state invalidation "
+            "and recompose seam -- the created workspace must still show "
+            "up in the rail"
+        )
+        assert any(
+            "could not be activated" in message for message in notifications
+        ), f"expected an activation-failure notice, got {notifications!r}"
+
+
+@pytest.mark.asyncio
 async def test_blocked_use_in_console_press_explains_inline() -> None:
     """TASK-716: pressing the blocked action must surface the reason as a
     warning toast - previously the button was disabled, Pressed never fired,

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -72,12 +72,21 @@ async def test_create_rename_archive_unarchive_flow() -> None:
             await _wait_for_selector(
                 screen,
                 pilot,
-                "#settings-workspace-create-name",
+                "#settings-workspace-create",
             )
 
-            # Create with a free-form name.
-            screen.query_one("#settings-workspace-create-name", Input).value = "Client X"
+            # Create with a free-form name via the shared create modal.
             screen.query_one("#settings-workspace-create", Button).press()
+            await pilot.pause()
+            modal = app.screen
+            assert modal is not screen
+            await _wait_for_selector(modal, pilot, "#workspace-create-name")
+            modal.query_one("#workspace-create-name", Input).value = "Client X"
+            # Leave inactive so the rename/duplicate-name/set-active steps
+            # below still exercise the Settings-side "Set active" button.
+            modal.query_one("#workspace-create-make-active", Checkbox).value = False
+            modal.query_one("#workspace-create-confirm", Button).press()
+            await pilot.pause()
             created = []
             for _ in range(200):
                 created = [

--- a/Tests/Workspaces/test_console_workspace_create_handler.py
+++ b/Tests/Workspaces/test_console_workspace_create_handler.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
+from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateResult
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+class _Stub:
+    def __init__(self, registry):
+        self.notifications = []
+        self.calls = []
+        self.app_instance = SimpleNamespace(
+            workspace_registry_service=registry,
+            notify=lambda message, **kw: self.notifications.append(message),
+        )
+
+    def _sync_console_chat_core_state(self):
+        self.calls.append("core")
+
+    def _activate_console_session_for_workspace(self, workspace_id):
+        self.calls.append(f"activate:{workspace_id}")
+
+    def _sync_console_workspace_context(self):
+        self.calls.append("context")
+
+    def _sync_native_console_chat_ui(self):
+        return "ui-sync-sentinel"
+
+    def run_worker(self, work, **kw):
+        self.calls.append(f"worker:{work}")
+
+
+def _registry(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="console-handler-tests")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="workspace-local-1", name="Workspace 1")
+    return service
+
+
+def test_make_active_runs_full_console_sequence(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1", name="Workspace 1", make_active=True
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert stub.calls == [
+        "core",
+        "activate:workspace-local-1",
+        "context",
+        "worker:ui-sync-sentinel",
+    ]
+    assert any("switched Console" in n for n in stub.notifications)
+
+
+def test_not_active_only_resyncs_context(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1", name="Workspace 1", make_active=False
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert stub.calls == ["context"]
+    assert any("Created Workspace 1." in n for n in stub.notifications)
+
+
+def test_none_result_is_a_noop(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, None)
+    assert stub.calls == [] and stub.notifications == []
+
+
+def test_failed_folders_surface_as_warnings(tmp_path):
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1",
+        name="Workspace 1",
+        failed_folders=(("/gone", "Folder does not exist"),),
+        make_active=False,
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert any("Folder does not exist" in n for n in stub.notifications)

--- a/Tests/Workspaces/test_folder_binding_validator.py
+++ b/Tests/Workspaces/test_folder_binding_validator.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+    validate_folder_binding_path,
+)
+
+
+def test_valid_directory_resolves(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    assert validate_folder_binding_path(project) == project.resolve()
+
+
+def test_missing_directory_rejected(tmp_path):
+    with pytest.raises(WorkspaceRegistryServiceError, match="does not exist"):
+        validate_folder_binding_path(tmp_path / "nope")
+
+
+def test_filesystem_root_rejected():
+    with pytest.raises(WorkspaceRegistryServiceError, match="filesystem root"):
+        validate_folder_binding_path(Path("/"))
+
+
+def test_home_directory_rejected():
+    with pytest.raises(WorkspaceRegistryServiceError, match="home directory"):
+        validate_folder_binding_path(Path.home())
+
+
+def test_duplicate_locator_rejected(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    with pytest.raises(WorkspaceRegistryServiceError, match="already bound"):
+        validate_folder_binding_path(project, [str(project.resolve())])
+
+
+def test_nested_inside_existing_rejected(tmp_path):
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    with pytest.raises(WorkspaceRegistryServiceError, match="inside the already-bound"):
+        validate_folder_binding_path(child, [str(parent.resolve())])
+
+
+def test_existing_inside_candidate_rejected(tmp_path):
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    with pytest.raises(WorkspaceRegistryServiceError, match="remove it first"):
+        validate_folder_binding_path(parent, [str(child.resolve())])
+
+
+def test_sensitive_conflict_rejected(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    import tldw_chatbook.Workspaces.registry_service as rs
+
+    monkeypatch.setattr(
+        rs, "find_root_binding_conflict", lambda p: Path("/protected")
+    )
+    with pytest.raises(WorkspaceRegistryServiceError, match="protected path"):
+        validate_folder_binding_path(project)
+
+
+def test_add_folder_binding_still_enforces(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="validator-tests")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="workspace-local-1", name="Workspace 1")
+    project = tmp_path / "project"
+    project.mkdir()
+    binding = service.add_folder_binding("workspace-local-1", project)
+    assert binding.locator == str(project.resolve())
+    with pytest.raises(WorkspaceRegistryServiceError, match="already bound"):
+        service.add_folder_binding("workspace-local-1", project)

--- a/Tests/Workspaces/test_folder_binding_validator.py
+++ b/Tests/Workspaces/test_folder_binding_validator.py
@@ -81,14 +81,15 @@ def test_add_folder_binding_still_enforces(tmp_path):
 def test_add_folder_binding_path_validation_before_db_lookup(tmp_path):
     """Verify path validation happens before list_folder_bindings is called.
 
-    Regression test: ensures that add_folder_binding validates the path
-    before looking up existing bindings, preserving the original evaluation
-    order. If the order was wrong, an invalid path with an invalid workspace_id
-    would raise ValueError instead of WorkspaceRegistryServiceError.
+    Regression test (evaluation-order guard): with broken ordering, the call
+    list_folder_bindings("") would raise ValueError("workspace_id is required")
+    before path validation could reject the bad path. With correct ordering,
+    _validate_folder_path_rules runs first and raises WorkspaceRegistryServiceError
+    about the missing directory.
     """
     db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="validator-tests")
     service = LocalWorkspaceRegistryService(db)
-    # Don't create the workspace - test that path validation happens first
     bad_path = tmp_path / "does_not_exist"
+    # Empty workspace_id would fail in list_folder_bindings if called first
     with pytest.raises(WorkspaceRegistryServiceError, match="does not exist"):
-        service.add_folder_binding("invalid-workspace-id", bad_path)
+        service.add_folder_binding("", bad_path)

--- a/Tests/Workspaces/test_folder_binding_validator.py
+++ b/Tests/Workspaces/test_folder_binding_validator.py
@@ -76,3 +76,19 @@ def test_add_folder_binding_still_enforces(tmp_path):
     assert binding.locator == str(project.resolve())
     with pytest.raises(WorkspaceRegistryServiceError, match="already bound"):
         service.add_folder_binding("workspace-local-1", project)
+
+
+def test_add_folder_binding_path_validation_before_db_lookup(tmp_path):
+    """Verify path validation happens before list_folder_bindings is called.
+
+    Regression test: ensures that add_folder_binding validates the path
+    before looking up existing bindings, preserving the original evaluation
+    order. If the order was wrong, an invalid path with an invalid workspace_id
+    would raise ValueError instead of WorkspaceRegistryServiceError.
+    """
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="validator-tests")
+    service = LocalWorkspaceRegistryService(db)
+    # Don't create the workspace - test that path validation happens first
+    bad_path = tmp_path / "does_not_exist"
+    with pytest.raises(WorkspaceRegistryServiceError, match="does not exist"):
+        service.add_folder_binding("invalid-workspace-id", bad_path)

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from textual.app import App
-from textual.widgets import Input
+from textual.widgets import Checkbox, Input, Static
 
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
@@ -67,3 +67,74 @@ async def test_escape_dismisses_with_none(tmp_path):
         await pilot.press("escape")
         await pilot.pause()
         assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_folder_shows_inline_error(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "does not exist" in str(error.renderable)
+        assert app.result == "unset"  # still open
+
+
+@pytest.mark.asyncio
+async def test_create_with_folder_returns_result_and_binds(tmp_path):
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    assert result.name == "Video Tool"
+    assert result.bound_folders == (str(project.resolve()),)
+    assert result.failed_folders == ()
+    assert result.make_active is True
+    stored = registry.get_workspace(result.workspace_id)
+    assert stored is not None and stored.name == "Video Tool"
+    locators = [b.locator for b in registry.list_folder_bindings(result.workspace_id)]
+    assert locators == [str(project.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_name_error_keeps_modal_open(tmp_path):
+    registry = _registry(tmp_path)
+    registry.create_workspace(workspace_id="workspace-local-9", name="Video Tool")
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "already exists" in str(error.renderable)
+        assert app.result == "unset"
+
+
+@pytest.mark.asyncio
+async def test_make_active_checkbox_carried_on_result(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-make-active", Checkbox).value = False
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    assert app.result.make_active is False

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -10,12 +10,47 @@ from tldw_chatbook.Widgets.workspace_create_modal import (
     WorkspaceCreateModal,
     WorkspaceCreateResult,
 )
-from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+)
 
 
 def _registry(tmp_path):
     db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="create-modal-tests")
     return LocalWorkspaceRegistryService(db)
+
+
+class _RaisingListWorkspacesRegistry:
+    """Wraps a real registry but fails ``list_workspaces()`` (Qodo finding
+    6a): simulates a registry read failure surfacing during modal
+    construction, before the modal is even pushed/mounted."""
+
+    def __init__(self, inner: LocalWorkspaceRegistryService) -> None:
+        self._inner = inner
+
+    def list_workspaces(self, *args, **kwargs):
+        raise WorkspaceRegistryServiceError("registry read failed")
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+class _FlakyBindRegistry:
+    """Wraps a real registry; ``add_folder_binding()`` fails until armed to
+    succeed (Qodo finding 7's retry-capable binding-failure behavior)."""
+
+    def __init__(self, inner: LocalWorkspaceRegistryService) -> None:
+        self._inner = inner
+        self.should_fail = True
+
+    def add_folder_binding(self, workspace_id, path, **kwargs):
+        if self.should_fail:
+            raise WorkspaceRegistryServiceError("Folder does not exist")
+        return self._inner.add_folder_binding(workspace_id, path, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
 
 
 class _HarnessApp(App[None]):
@@ -225,3 +260,157 @@ async def test_remove_folder_clears_stale_error(tmp_path):
         await pilot.pause()
         error = modal.query_one("#workspace-create-error", Static)
         assert str(error.renderable) == ""
+
+
+@pytest.mark.asyncio
+async def test_overlong_name_shows_inline_error_and_creates_nothing(tmp_path):
+    """Finding 2: a name sanitize_string(raw, 100) would truncate/strip must
+    be rejected inline at the boundary rather than silently mangled into the
+    registry."""
+    registry = _registry(tmp_path)
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "x" * 300
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+        assert app.screen is modal
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "too long" in str(error.renderable)
+        assert app.result == "unset"
+    assert registry.list_workspaces() == ()
+
+
+@pytest.mark.asyncio
+async def test_registry_read_failure_still_mounts_usable_modal(tmp_path):
+    """Finding 6a: next_local_workspace_identity() raising during __init__
+    (list_workspaces() failing) must not crash the modal before it can even
+    mount -- it falls back to an empty suggested name and shows an inline
+    error so the user can still type a name and retry."""
+    stub = _RaisingListWorkspacesRegistry(_registry(tmp_path))
+    app = _HarnessApp(stub)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+        name_input = modal.query_one("#workspace-create-name", Input)
+        assert name_input.value == ""
+        assert name_input.placeholder == "Workspace name"
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "registry could not be read" in str(error.renderable)
+
+
+@pytest.mark.asyncio
+async def test_identity_failure_at_create_resets_committed_for_retry(
+    tmp_path, monkeypatch
+):
+    """Finding 6b: next_local_workspace_identity() raising inside _create()
+    used to run AFTER _committed was set True and OUTSIDE the try/except
+    that resets it, permanently locking the Create button for the session.
+    It must now reset _committed so a subsequent Create succeeds."""
+    import tldw_chatbook.Widgets.workspace_create_modal as wcm_module
+
+    registry = _registry(tmp_path)
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+
+        def _raise(_registry_service):
+            raise WorkspaceRegistryServiceError("boom")
+
+        monkeypatch.setattr(wcm_module, "next_local_workspace_identity", _raise)
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+        assert app.screen is modal
+        assert app.result == "unset"
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "boom" in str(error.renderable)
+
+        monkeypatch.undo()
+        # NOTE: a second pilot.click() on the *same* button in quick
+        # succession is silently dropped by Textual's own ~0.2s "-active"
+        # press-effect debounce (see test_add_folder_empty_input_clears_
+        # stale_error above) -- use Button.press() to bypass it.
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
+    assert isinstance(app.result, WorkspaceCreateResult)
+    assert len(registry.list_workspaces()) == 1
+
+
+@pytest.mark.asyncio
+async def test_folder_binding_failure_keeps_modal_open_and_retries(tmp_path):
+    """Finding 7: a per-folder add_folder_binding() failure must not
+    dismiss the modal or lose the already-created workspace -- it renders
+    the failure inline, and a subsequent Create press retries only the
+    remaining folder(s) without creating a second workspace."""
+    inner = _registry(tmp_path)
+    stub = _FlakyBindRegistry(inner)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(stub)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+
+        assert app.screen is modal
+        assert app.result == "unset"
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "Folder does not exist" in str(error.renderable)
+        assert len(inner.list_workspaces()) == 1
+
+        stub.should_fail = False
+        # NOTE: a second pilot.click() on the *same* button in quick
+        # succession is silently dropped by Textual's own ~0.2s "-active"
+        # press-effect debounce (see test_add_folder_empty_input_clears_
+        # stale_error above) -- use Button.press() to bypass it.
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
+
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    created = inner.list_workspaces()
+    assert len(created) == 1
+    assert result.workspace_id == created[0].workspace_id
+    assert result.bound_folders == (str(project.resolve()),)
+    assert result.failed_folders == ()
+
+
+@pytest.mark.asyncio
+async def test_escape_after_partial_create_returns_partial_result(tmp_path):
+    """Finding 7: cancel after a partial create is a fact, not something
+    Cancel/Escape can undo -- it must deliver the partial result instead of
+    None so callers still sync their workspace list."""
+    inner = _registry(tmp_path)
+    stub = _FlakyBindRegistry(inner)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(stub)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+        assert app.result == "unset"
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    assert result.name == "Video Tool"
+    created = inner.list_workspaces()
+    assert len(created) == 1
+    assert result.workspace_id == created[0].workspace_id

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from textual.app import App
-from textual.widgets import Checkbox, Input, Static
+from textual.widgets import Button, Checkbox, Input, Static
 
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
@@ -138,3 +138,90 @@ async def test_make_active_checkbox_carried_on_result(tmp_path):
         await pilot.click("#workspace-create-confirm")
         await pilot.pause()
     assert app.result.make_active is False
+
+
+@pytest.mark.asyncio
+async def test_double_submit_creates_exactly_one_workspace_no_crash(tmp_path):
+    """Finding 1: rapid Enter-Enter (or a double-click race on Create) must
+    not create a duplicate workspace, and must not raise ScreenStackError
+    from a second dismiss landing after the modal has already popped.
+
+    Leaving the name Input blank exercises the real race: each call falls
+    back to a freshly-computed auto-generated name ("Workspace 1", then
+    "Workspace 2"), so the registry's duplicate-name rejection does not
+    incidentally save the unguarded code from creating two workspaces.
+    """
+    registry = _registry(tmp_path)
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+        modal.query_one("#workspace-create-name", Input).value = ""
+        # Simulates the second queued Enter/click landing before the screen
+        # has actually popped off the stack.
+        modal._create()
+        modal._create()
+        await pilot.pause()
+    assert isinstance(app.result, WorkspaceCreateResult)
+    workspaces = registry.list_workspaces()
+    assert len(workspaces) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_folder_empty_input_clears_stale_error(tmp_path):
+    """Finding 5: an invalid-folder error must not linger once the field is
+    cleared and Add is pressed again on blank input.
+
+    Uses Button.press() rather than pilot.click() for the second press:
+    Textual's own Button._on_click() skips press() while the button still
+    carries its ~0.2s "-active" press-effect class, so two pilot.click()s on
+    the same button in quick succession silently drop the second one -- an
+    unrelated Textual debounce, not the seam this test is pinning.
+    """
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        modal.query_one("#workspace-create-folder-add", Button).press()
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "does not exist" in str(error.renderable)
+
+        modal.query_one("#workspace-create-folder-path", Input).value = ""
+        modal.query_one("#workspace-create-folder-add", Button).press()
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert str(error.renderable) == ""
+
+
+@pytest.mark.asyncio
+async def test_remove_folder_clears_stale_error(tmp_path):
+    """Finding 5: removing a bound folder must not leave a prior invalid-
+    folder error rendered."""
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        modal.query_one("#workspace-create-folder-add", Button).press()
+        await pilot.pause()
+
+        modal.query_one("#workspace-create-folder-path", Input).value = str(
+            tmp_path / "missing"
+        )
+        modal.query_one("#workspace-create-folder-add", Button).press()
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert "does not exist" in str(error.renderable)
+
+        modal.query_one("#workspace-create-folder-remove-0", Button).press()
+        await pilot.pause()
+        error = modal.query_one("#workspace-create-error", Static)
+        assert str(error.renderable) == ""

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+from textual.app import App
+from textual.widgets import Input
+
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Widgets.workspace_create_modal import (
+    WorkspaceCreateModal,
+    WorkspaceCreateResult,
+)
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+def _registry(tmp_path):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="create-modal-tests")
+    return LocalWorkspaceRegistryService(db)
+
+
+class _HarnessApp(App[None]):
+    def __init__(self, registry):
+        super().__init__()
+        # NOTE: `App.__init__` already defines `self._registry` (a WeakSet of
+        # mounted DOM nodes, consulted at shutdown in `_close_all`). Naming
+        # this `_registry` clobbers that internal attribute and breaks
+        # teardown with `TypeError: '...' object is not iterable`, so the
+        # harness's own workspace registry gets a non-colliding name.
+        self._workspace_registry = registry
+        self.result = "unset"
+
+    def on_mount(self) -> None:
+        def _done(result):
+            self.result = result
+
+        self.push_screen(
+            WorkspaceCreateModal(registry_service=self._workspace_registry), _done
+        )
+
+
+@pytest.mark.asyncio
+async def test_browse_pushes_picker_and_fills_path(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+        await pilot.click("#workspace-create-browse")
+        await pilot.pause()
+        assert isinstance(app.screen, SelectDirectory)
+        project = tmp_path / "project"
+        project.mkdir()
+        app.screen.dismiss(project)
+        await pilot.pause()
+        assert app.screen is modal  # focus/stack returned to the modal
+        assert (
+            modal.query_one("#workspace-create-folder-path", Input).value
+            == str(project)
+        )
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_with_none(tmp_path):
+    app = _HarnessApp(_registry(tmp_path))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.result is None

--- a/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
+++ b/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
@@ -27,15 +27,104 @@ Plan: `Docs/superpowers/plans/2026-08-17-workspace-create-modal.md`.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Creating a workspace from Console rail, Settings ▸ Workspaces, or Library opens the shared modal; escape cancels with nothing created
-- [ ] Folder paths are validated inline as they are added (missing/home/root/sensitive/nested-overlap rejected before Create), via a validator shared with `add_folder_binding`
-- [ ] Name collisions render inline and keep the modal open
-- [ ] Console make_active path reproduces the full session-activation sequence including the TASK-713 toast; unchecked path only resyncs context
-- [ ] Folders bind read-only per ADR-028
-- [ ] User Guide pages updated and the 2026-07-26 settings-workspaces spec carries a supersession note
+- [x] Creating a workspace from Console rail, Settings ▸ Workspaces, or Library opens the shared modal; escape cancels with nothing created
+- [x] Folder paths are validated inline as they are added (missing/home/root/sensitive/nested-overlap rejected before Create), via a validator shared with `add_folder_binding`
+- [x] Name collisions render inline and keep the modal open
+- [x] Console make_active path reproduces the full session-activation sequence including the TASK-713 toast; unchecked path only resyncs context
+- [x] Folders bind read-only per ADR-028
+- [x] User Guide pages updated and the 2026-07-26 settings-workspaces spec carries a supersession note
 
 ## Implementation Plan (the how)
 
 Execute `Docs/superpowers/plans/2026-08-17-workspace-create-modal.md` (7 tasks:
 validator extraction → browse-from-modal spike → full modal → Console/Settings/
 Library wiring → docs + live verification).
+
+## Implementation Notes
+
+**Approach.** Seven tasks executed per the plan: extracted a pure
+`validate_folder_binding_path` from `add_folder_binding` (Task 1); spiked
+pushing `SelectDirectory` from a `ModalScreen` (Task 2); built the full
+`WorkspaceCreateModal` — name prefill via `next_local_workspace_identity`,
+optional multi-folder list with inline per-add validation, a
+"Switch to this workspace" checkbox default-on, Create/Cancel with
+escape-cancels-with-nothing-created (Task 3); wired Console's rail `New`,
+Settings ▸ Workspaces' new "Create workspace…" button (replacing the old
+inline name-input row), and Library's "Create local workspace" button, each
+keeping its own post-create sync callback (Task 4-6); this task closed out
+docs, the supersession note, and live verification (Task 7).
+
+**Live verification (Task 7, isolated scratch profile — real config/data dirs
+confirmed untouched before/after).** Console: created "PROJECT-ALPHA" with a
+bound folder and "Switch" checked → toast "Created PROJECT-ALPHA and switched
+Console to it.", rail switched, a `PROJECT-ALPHA Chat` tab opened
+(TASK-713 toast + full activation sequence confirmed). Escape on a fresh
+modal → dismissed with nothing created (rail unchanged). Console again with
+"Switch" unchecked → toast "Created Workspace 2." only, rail stayed on
+PROJECT-ALPHA (unchecked path correctly skips activation). Settings ▸
+Workspaces: list refreshed live to show both new workspaces with correct
+folder counts ("PROJECT-ALPHA (active) - 1 folders", "Workspace 2 - 0
+folders"). Library: "Create local workspace" opened the identical shared
+modal; default Create → toast "Created local workspace Workspace 3 and made
+it active; Console now targets it.", and Console's rail reflected
+"Workspace 3" as active on next visit — confirming all three surfaces drive
+the same modal and stay in sync.
+
+**Read-only folders (AC5).** `WorkspaceCreateModal._create()` calls
+`add_folder_binding(workspace_id, folder)` with no `allow_write` argument,
+and `add_folder_binding`'s signature defaults `allow_write: bool = False`
+(`registry_service.py:788`) — confirmed by source read plus the full green
+`Tests/Workspaces/` suite (253 passed) rather than by toggling "Allow write"
+live in Settings.
+
+**Name-collision + inline-validation ACs.** Live-confirmed the happy path
+(valid folder add, duplicate-name path not separately driven live); AC
+coverage for name collisions and inline rejection classes is carried by
+`Tests/Workspaces/test_workspace_create_modal.py`
+(`test_duplicate_name_error_keeps_modal_open`,
+`test_invalid_folder_shows_inline_error`, plus the Task 1 validator unit
+tests), all green in the Task 7 gate run.
+
+**Deviations / findings, not part of this task's AC scope:**
+- **Validator-split ruling (Task 1-2, pre-existing before this close-out):**
+  `add_folder_binding` now calls the shared `validate_folder_binding_path`
+  so the modal and the direct-add path can never drift on rejection rules.
+- **Settings activation-default change (spec decision #2):** unlike the
+  retired inline-name-input flow (which never activated), Settings-created
+  workspaces now activate by default via the modal's checkbox — documented
+  in `Docs/User_Guide/settings.md`'s refreshed Workspaces section and
+  walkthrough step 5.
+- **Live-verification-only defect found and filed separately, not fixed
+  here (out of this task's AC scope):** the Name Input, folder-path Input,
+  and "Switch to this workspace" Checkbox each render as an empty bordered
+  box (zero content rows) while they hold keyboard focus — value/label
+  invisible until focus moves away; the underlying value is unaffected
+  (confirmed via blur-to-reveal and via the unchecked-checkbox path's
+  correct functional result above). A similarly-shaped collapsed-content
+  row was also seen on the pre-existing, unrelated "Show archived" Checkbox
+  in Settings ▸ Workspaces, suggesting a broader pre-existing rendering
+  interaction rather than something newly introduced only by this modal.
+  Filed as `task-17961` for root-cause and fix; not blocking here because
+  every functional outcome (values persist, Create/Cancel/toast semantics)
+  was independently confirmed correct despite the cosmetic bug. This also
+  explains a gap in the shipped Pilot coverage: `test_workspace_create_modal
+  .py::test_make_active_checkbox_carried_on_result` asserts via
+  `checkbox.value = False` rather than a real keypress/click, so it could
+  not have caught a focused-widget rendering defect (the exact blind-spot
+  shape documented in `backlog/docs/lessons-live-verification.md`'s
+  TASK-13154.1 entry).
+
+**Files touched this task (Task 7 only; Tasks 1-6 shipped the feature
+itself):**
+- `Docs/superpowers/specs/2026-07-26-settings-workspaces-category-design.md`
+  (supersession note, §1)
+- `Docs/User_Guide/settings.md` (Workspaces section + walkthrough step 5 +
+  Verified-against stamp)
+- `Docs/User_Guide/console/sessions-tabs-workspaces.md` (Workspaces table +
+  three Common-tasks walkthroughs + Verified-against stamp)
+- `Docs/User_Guide/library.md` ("Create local workspace" row + Verified-
+  against stamp)
+- `backlog/tasks/task-17961 - Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md`
+  (new — the rendering defect found during live verification)
+- This file (ACs ticked, Implementation Notes added; `status:` left
+  untouched per instruction)

--- a/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
+++ b/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
@@ -2,7 +2,7 @@
 id: TASK-17650
 title: >-
   Shared workspace creation modal across Console, Settings, and Library
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-17 00:00'
 labels:

--- a/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
+++ b/backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
@@ -1,0 +1,41 @@
+---
+id: TASK-17650
+title: >-
+  Shared workspace creation modal across Console, Settings, and Library
+status: In Progress
+assignee: []
+created_date: '2026-08-17 00:00'
+labels:
+  - workspaces
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+Workspace creation today collects nothing (Console/Library) or a name only
+(Settings), and folder binding — the thing that makes a workspace do anything
+for agents — is a separate post-creation Settings-only action. Users are left
+with a new "Workspace N" entry and no idea what it changes (task-713/task-714
+complaints). Replace instant creation on all three surfaces with one shared
+modal that collects a name + optional folder bindings and explains, truthfully,
+what a workspace does.
+
+Spec: `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md` §4.
+Plan: `Docs/superpowers/plans/2026-08-17-workspace-create-modal.md`.
+
+## Acceptance Criteria (the what)
+
+- [ ] Creating a workspace from Console rail, Settings ▸ Workspaces, or Library opens the shared modal; escape cancels with nothing created
+- [ ] Folder paths are validated inline as they are added (missing/home/root/sensitive/nested-overlap rejected before Create), via a validator shared with `add_folder_binding`
+- [ ] Name collisions render inline and keep the modal open
+- [ ] Console make_active path reproduces the full session-activation sequence including the TASK-713 toast; unchecked path only resyncs context
+- [ ] Folders bind read-only per ADR-028
+- [ ] User Guide pages updated and the 2026-07-26 settings-workspaces spec carries a supersession note
+
+## Implementation Plan (the how)
+
+Execute `Docs/superpowers/plans/2026-08-17-workspace-create-modal.md` (7 tasks:
+validator extraction → browse-from-modal spike → full modal → Console/Settings/
+Library wiring → docs + live verification).

--- a/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+++ b/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
@@ -1,0 +1,42 @@
+---
+id: TASK-17651
+title: >-
+  Project skills (.SKILLS/) folder discovery and prompt-driven import
+status: To Do
+assignee: []
+created_date: '2026-08-17 00:00'
+labels:
+  - skills
+  - workspaces
+  - ux
+priority: high
+dependencies:
+  - TASK-17650
+---
+
+## Description (the why)
+
+A user resuming work on an existing project has no way to bring that project's
+skills into the app short of importing them one directory at a time through
+Library ▸ Skills. Introduce a project-local `.SKILLS/` convention: on app
+startup in (or under) a directory containing one, and after creating a
+workspace bound to such a directory, offer a prompt-driven (never silent)
+import. Imports stay quarantined behind the ADR-009 trust boundary.
+
+Spec: `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md` §5.
+Plan: `Docs/superpowers/plans/2026-08-17-project-skills-import.md`.
+
+## Acceptance Criteria (the what)
+
+- [ ] Launching the app from a project (or subdirectory, up to the first .git ancestor) containing `.SKILLS/` offers an import prompt listing discovered skills; the first-run wizard suppresses it for that launch
+- [ ] Declining re-prompts only when the skill set's fingerprint changes; "Never for this folder" is permanent; `[skills] project_skills_prompt_enabled = false` disables the feature
+- [ ] Creating a workspace with a bound folder containing `.SKILLS/` chains the same offer after creation
+- [ ] Imports run through the existing importer with trust_approved=False (quarantined), never overwrite existing names silently, and the modal states the one-time trust review expectation with a route to Library ▸ Skills
+- [ ] Discovery refuses symlinked `.SKILLS/` dirs and entries, caps entries (50) and frontmatter reads (64 KiB), pre-flags invalid names, and renders repo-sourced text escaped
+- [ ] ADR for the convention added; config key documented; User Guide updated
+
+## Implementation Plan (the how)
+
+Execute `Docs/superpowers/plans/2026-08-17-project-skills-import.md` (6 tasks:
+discovery → ledger → import modal → startup trigger → create-modal chaining →
+ADR/docs + live verification). Starts only after TASK-17650 is on dev.

--- a/backlog/tasks/task-17961 - Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md
+++ b/backlog/tasks/task-17961 - Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md
@@ -1,0 +1,29 @@
+---
+id: TASK-17961
+title: >-
+  Focused compact Input/Checkbox content invisible in
+  WorkspaceCreateModal
+status: To Do
+assignee: []
+created_date: '2026-08-18 03:09'
+labels:
+  - workspaces
+  - ui
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live-verifying task-17650 (shared workspace creation modal) found that the Name Input, folder-path Input, and the "Switch to this workspace" Checkbox in tldw_chatbook/Widgets/workspace_create_modal.py all render as an empty bordered box -- top and bottom border rows with zero content rows, hiding the value/label entirely -- whenever that specific widget has keyboard focus. Blurred, each renders correctly as a single-line compact row with its value/placeholder visible. The underlying data is unaffected (confirmed: typed values persist across focus changes, folder Add/Remove works, and Create/Cancel/toast behavior is functionally correct end to end), so this is a pure rendering defect, but a severe one: a user tabbing through the form or actively typing into the Name or folder-path field sees nothing on screen while doing so. A structurally similar collapsed-content-row appearance was also observed on the pre-existing, unrelated "Show archived" Checkbox in Settings ▸ Workspaces (which does not use compact=True), suggesting the root cause may be a broader pre-existing Textual/CSS rendering characteristic (possibly version 8.2.8's interaction between a widget's compact/tall border styles and its :focus state) rather than something newly introduced only by this modal -- needs root-causing across both cases before concluding scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reproduce headlessly (Pilot test or compositor render_strips check) that a focused compact Input/Checkbox in WorkspaceCreateModal shows its label/value
+- [ ] #2 Root-cause whether this is scoped to WorkspaceCreateModal's CSS or a broader Textual/app-CSS interaction also affecting Settings' non-compact Show archived checkbox
+- [ ] #3 Fix the rendering so a focused field/checkbox in the modal always shows its current value or label
+- [ ] #4 Add a regression test asserting focused-state content is visible via Screen._compositor.render_strips(), not terminal-capture text alone
+<!-- AC:END -->

--- a/backlog/tasks/task-17962 - Workspace-create-modal-follow-up-tests-and-typed-seams.md
+++ b/backlog/tasks/task-17962 - Workspace-create-modal-follow-up-tests-and-typed-seams.md
@@ -1,0 +1,37 @@
+---
+id: TASK-17962
+title: >-
+  Workspace create modal: follow-up tests and typed seams
+status: To Do
+assignee: []
+created_date: '2026-08-17 21:00'
+labels:
+  - workspaces
+  - testing
+priority: medium
+dependencies:
+  - TASK-17650
+---
+
+## Description (the why)
+
+The TASK-17650 final whole-branch review closed with a set of deliberately
+deferred coverage and typing gaps (its Recommendations §3). They are known,
+ledgered, and none blocks the shipped behavior — but PR B (TASK-17651) reads
+more fields off `WorkspaceCreateResult`, so these seams should be pinned and
+typed before that work builds on them.
+
+## Acceptance Criteria (the what)
+
+- [ ] Activation-failure path (`set_active_workspace` raising after a successful create) has a seam test on each surface: Console handler, Settings `_done`, Library `_done` (Library's reorder is already pinned; Console/Settings are not)
+- [ ] The Enter-submit fast path (`Input.Submitted` on `#workspace-create-name` → `_create`) has a pilot test using a real keypress (not a direct method call), per the task-17961 blind-spot lesson
+- [ ] A test produces `failed_folders` through the real TOCTOU path (folder deleted between Add and Create), not a synthetic result object
+- [ ] `_remove_folder` and unchecked-checkbox-survives-recompose have pilot coverage
+- [ ] The three `_done`/handler callbacks and `WorkspaceCreateResult.project_skills` carry real type annotations (`WorkspaceCreateResult | None`; a typed tuple for `project_skills`)
+- [ ] Decide (and implement or explicitly reject) restoring per-surface `description` provenance ("Created from Console/Settings/Library") lost to the uniform modal description
+
+## Notes
+
+Source: final review of `feat/workspace-create-modal` (see
+`Docs/superpowers/plans/2026-08-17-workspace-create-modal.md` and the spec's
+§7). Related open defect: TASK-17961 (focused compact-widget rendering).

--- a/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
+++ b/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
@@ -1,0 +1,36 @@
+---
+id: TASK-18310
+title: >-
+  Centralized workspace activation seam for cross-screen Console runtime sync
+status: To Do
+assignee: []
+created_date: '2026-08-18 15:30'
+labels:
+  - workspaces
+  - console
+priority: medium
+dependencies: []
+---
+
+## Description (the why)
+
+Activating a workspace from OUTSIDE Console (Library's "Create local workspace"
+— shipped long before the create modal — and now Settings via the shared modal,
+PR #1809) updates only the registry (`set_active_workspace`) and toasts
+"Console now targets it". Console's deeper runtime state (chat store context,
+active session, native UI) is only synchronized by Console-internal paths
+(`_activate_console_session_for_workspace` at switch/create/archive). The rail
+reflects the registry on the next Console visit (live-verified in TASK-17650),
+but no resume-time seam activates the matching session the way an in-Console
+switch does. Qodo flagged this on PR #1809 (finding 5); it is a pre-existing
+design gap shared by the Library path, not a regression of the modal work —
+resolving it properly means one centralized activation seam that any screen can
+invoke (or a Console resume-time reconcile), instead of duplicating Console's
+fragile sequence per caller.
+
+## Acceptance Criteria (the what)
+
+- [ ] Activating a workspace from Settings or Library leaves Console — on next visit — in the same runtime state as an in-Console switch to that workspace (session activated or created, store context set, rail synced)
+- [ ] The mechanism is a single shared seam (or resume-time reconcile), not per-surface copies of Console's activation sequence
+- [ ] In-Console switch/create behavior is unchanged (order-pinned tests stay green)
+- [ ] Covered by a test that activates from a non-Console surface and asserts the Console-side session state after resume

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -73,7 +73,6 @@ from ...Workspaces.display_state import (
 from ...Workspaces.registry_service import (
     WorkspaceNotFound,
     WorkspaceRegistryServiceError,
-    next_local_workspace_identity,
 )
 from ..character_display_text import sanitize_character_display_label
 
@@ -1617,7 +1616,7 @@ class ConsoleWorkspaceController:
         )
 
     def _create_console_workspace(self) -> None:
-        """Create a new local workspace and activate it."""
+        """Open the shared create dialog (spec 2026-08-17 §4.3)."""
         registry_service = getattr(
             self.app_instance, "workspace_registry_service", None
         )
@@ -1626,41 +1625,50 @@ class ConsoleWorkspaceController:
                 "Workspace service is not ready.", severity="warning"
             )
             return
-        try:
-            workspace_id, workspace_name = next_local_workspace_identity(
-                registry_service
-            )
-            registry_service.create_workspace(
-                workspace_id=workspace_id,
-                name=workspace_name,
-                description="Local workspace created from Console.",
-            )
-            registry_service.set_active_workspace(workspace_id)
-        except WorkspaceRegistryServiceError:
-            logger.opt(exception=True).warning("Unable to create Console workspace")
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+        self.push_screen(
+            WorkspaceCreateModal(registry_service=registry_service),
+            self._handle_workspace_create_result,
+        )
+
+    def _handle_workspace_create_result(self, result) -> None:
+        """Console-side post-create sync; the modal already created/bound."""
+        if result is None:
+            return
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            return
+        for _folder, message in result.failed_folders:
+            self.app_instance.notify(message, severity="warning")
+        if not result.make_active:
+            self._sync_console_workspace_context()
             self.app_instance.notify(
-                "Workspace could not be created.", severity="error"
+                f"Created {result.name}.", severity="information"
             )
             return
-        except Exception:
+        try:
+            registry_service.set_active_workspace(result.workspace_id)
+        except WorkspaceRegistryServiceError:
             logger.opt(exception=True).warning(
-                "Unexpected error creating Console workspace"
+                "Unable to activate new Console workspace"
             )
             self.app_instance.notify(
-                "Workspace could not be created.", severity="error"
+                "Workspace created but could not be activated.", severity="error"
             )
             return
         self._sync_console_chat_core_state()
-        self._activate_console_session_for_workspace(workspace_id)
+        self._activate_console_session_for_workspace(result.workspace_id)
         self._sync_console_workspace_context()
         self.run_worker(
             self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
         )
-        # TASK-713: creation also activates the workspace and opens a tab;
-        # without a notification the whole sequence is invisible when the
-        # Workspace status row is scrolled out of view.
+        # TASK-713: the whole sequence is invisible when the Workspace status
+        # row is scrolled out of view -- keep the toast even with the modal.
         self.app_instance.notify(
-            f"Created {workspace_name} and switched Console to it.",
+            f"Created {result.name} and switched Console to it.",
             severity="information",
         )
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -31730,6 +31730,12 @@ class LibraryScreen(BaseAppScreen):
             for _folder, message in result.failed_folders:
                 if callable(notify):
                     notify(message, severity="warning")
+            # Finding 2: the workspace record was already created by the
+            # modal regardless of what happens below, so the rail must
+            # always be rebuilt to show it -- activation failure only
+            # changes which toast fires, it must not skip the
+            # invalidate/scroll-preserve/recompose seam entirely.
+            activation_failed = False
             if result.make_active:
                 try:
                     registry_service.set_active_workspace(result.workspace_id)
@@ -31737,18 +31743,18 @@ class LibraryScreen(BaseAppScreen):
                     logger.opt(exception=True).warning(
                         "Failed to activate new Library workspace"
                     )
-                    if callable(notify):
-                        notify(
-                            "Workspace created but could not be activated.",
-                            severity="error",
-                        )
-                    return
+                    activation_failed = True
             self._invalidate_library_workspace_depth_state()
             # TASK-716: preserve the rail's scroll offset across the rebuild.
             self._preserve_library_rail_scroll()
             self.refresh(recompose=True)
             if callable(notify):
-                if result.make_active:
+                if activation_failed:
+                    notify(
+                        "Workspace created but could not be activated.",
+                        severity="error",
+                    )
+                elif result.make_active:
                     # TASK-713: activation retargets Console from another screen.
                     notify(
                         f"Created local workspace {result.name} and made it "

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -31721,39 +31721,49 @@ class LibraryScreen(BaseAppScreen):
             if callable(notify):
                 notify("Workspace registry is not ready.", severity="warning")
             return
-        try:
-            workspace_id, workspace_name = self._next_local_workspace_identity()
-            registry_service.create_workspace(
-                workspace_id=workspace_id,
-                name=workspace_name,
-                description="Local workspace created from Library.",
-            )
-            registry_service.set_active_workspace(workspace_id)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Failed to create local Library workspace"
-            )
-            notify = getattr(self.app_instance, "notify", None)
-            if callable(notify):
-                notify("Local workspace could not be created.", severity="error")
-            return
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
 
-        self._invalidate_library_workspace_depth_state()
-        # TASK-716: the whole-screen recompose replaces the rail and resets
-        # its scroll to the top, hiding the Details disclosure (and the
-        # updated Active row) the user was just working in. Preserve the
-        # rail's scroll offset across the rebuild.
-        self._preserve_library_rail_scroll()
-        self.refresh(recompose=True)
-        notify = getattr(self.app_instance, "notify", None)
-        if callable(notify):
-            # TASK-713: creation also makes the workspace active, which
-            # retargets Console's context from another screen - say so.
-            notify(
-                f"Created local workspace {workspace_name} and made it active; "
-                "Console now targets it.",
-                severity="information",
-            )
+        def _done(result) -> None:
+            if result is None:
+                return
+            notify = getattr(self.app_instance, "notify", None)
+            for _folder, message in result.failed_folders:
+                if callable(notify):
+                    notify(message, severity="warning")
+            if result.make_active:
+                try:
+                    registry_service.set_active_workspace(result.workspace_id)
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Failed to activate new Library workspace"
+                    )
+                    if callable(notify):
+                        notify(
+                            "Workspace created but could not be activated.",
+                            severity="error",
+                        )
+                    return
+            self._invalidate_library_workspace_depth_state()
+            # TASK-716: preserve the rail's scroll offset across the rebuild.
+            self._preserve_library_rail_scroll()
+            self.refresh(recompose=True)
+            if callable(notify):
+                if result.make_active:
+                    # TASK-713: activation retargets Console from another screen.
+                    notify(
+                        f"Created local workspace {result.name} and made it "
+                        "active; Console now targets it.",
+                        severity="information",
+                    )
+                else:
+                    notify(
+                        f"Created local workspace {result.name}.",
+                        severity="information",
+                    )
+
+        self.app.push_screen(
+            WorkspaceCreateModal(registry_service=registry_service), _done
+        )
 
     def _preserve_library_rail_scroll(self) -> None:
         """Restore the rail's scroll offset after the next recompose.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -356,7 +356,6 @@ from ...Workspaces import (
     build_library_workspace_depth_state,
     library_item_context_handoff,
 )
-from ...Workspaces.registry_service import next_local_workspace_identity
 from ...Widgets.destination_rail import (
     RAIL_SECTION_TOGGLE_PREFIX,
     DestinationRailSectionHeader,
@@ -8797,18 +8796,6 @@ class LibraryScreen(BaseAppScreen):
 
     def _invalidate_library_workspace_depth_state(self) -> None:
         self._library_workspace_depth_state_cache = None
-
-    def _next_local_workspace_identity(self) -> tuple[str, str]:
-        """Return a collision-free local workspace id and display name."""
-        registry_service = getattr(
-            self.app_instance, "workspace_registry_service", None
-        )
-        if registry_service is None:
-            # Preserve the original behavior when the registry is unavailable by
-            # falling back to a deterministic identity that mirrors the shared
-            # helper's first candidate.
-            return "workspace-local-1", "Workspace 1"
-        return next_local_workspace_identity(registry_service)
 
     def _library_workspace_depth_state(
         self,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -103,7 +103,6 @@ from ...Workspaces.registry_service import (
     DEFAULT_WORKSPACE_ID,
     LocalWorkspaceRegistryService,
     WorkspaceRegistryServiceError,
-    next_local_workspace_identity,
 )
 from ...Widgets.confirmation_dialog import ConfirmationDialog
 from ...Widgets.destination_workbench import DestinationModeStrip
@@ -14493,13 +14492,9 @@ class SettingsScreen(BaseAppScreen):
         show_archived = bool(self._settings_show_archived_workspaces)
         active = registry.get_active_workspace()
         active_id = active.workspace_id if active is not None else None
-        with Horizontal(classes="settings-input-row"):
-            yield Input(
-                placeholder="New workspace name",
-                id="settings-workspace-create-name",
-                classes="settings-compact-input",
-            )
-            yield Button("Create", id="settings-workspace-create", compact=True)
+        yield Button(
+            "Create workspace…", id="settings-workspace-create", compact=True
+        )
         yield Checkbox(
             "Show archived", show_archived, id="settings-workspaces-show-archived"
         )
@@ -18106,28 +18101,26 @@ class SettingsScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#settings-workspace-create")
     def handle_workspace_create(self, event: Button.Pressed) -> None:
-        """Create a workspace from the typed name, or a generated one when
-        left blank -- the id always comes from `next_local_workspace_identity`
-        (task 9)."""
+        """Open the shared create dialog (spec 2026-08-17 §4.3)."""
         event.stop()
         registry = getattr(self.app_instance, "workspace_registry_service", None)
         if registry is None:
             return
-        try:
-            name_input = self.query_one("#settings-workspace-create-name", Input)
-        except QueryError:
-            return
-        typed_name = name_input.value.strip()
-        workspace_id, generated_name = next_local_workspace_identity(registry)
-        try:
-            registry.create_workspace(
-                workspace_id=workspace_id, name=typed_name or generated_name
-            )
-        except WorkspaceRegistryServiceError as exc:
-            self._set_settings_workspaces_result(str(exc))
-            return
-        self._settings_workspaces_result = ""
-        self._refresh_settings_workspaces_pane()
+        from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+        def _done(result) -> None:
+            if result is None:
+                return
+            status_parts = [message for _folder, message in result.failed_folders]
+            if result.make_active:
+                try:
+                    registry.set_active_workspace(result.workspace_id)
+                except WorkspaceRegistryServiceError as exc:
+                    status_parts.append(str(exc))
+            self._settings_workspaces_result = "; ".join(status_parts)
+            self._refresh_settings_workspaces_pane()
+
+        self.app.push_screen(WorkspaceCreateModal(registry_service=registry), _done)
 
     @on(Button.Pressed, "#settings-workspace-rename-apply")
     def handle_workspace_rename_apply(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -18101,7 +18101,11 @@ class SettingsScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#settings-workspace-create")
     def handle_workspace_create(self, event: Button.Pressed) -> None:
-        """Open the shared create dialog (spec 2026-08-17 §4.3)."""
+        """Open the shared create dialog (spec 2026-08-17 §4.3).
+
+        Args:
+            event: The Create-workspace button press event.
+        """
         event.stop()
         registry = getattr(self.app_instance, "workspace_registry_service", None)
         if registry is None:

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -17,6 +17,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Static
 
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 from tldw_chatbook.Workspaces.registry_service import (
     LocalWorkspaceRegistryService,
     WorkspaceRegistryServiceError,
@@ -49,7 +50,9 @@ class WorkspaceCreateResult:
     project_skills: tuple = ()
 
 
-class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
+class WorkspaceCreateModal(
+    SafeModalDismissMixin, ModalScreen["WorkspaceCreateResult | None"]
+):
     """Collect a workspace name + optional folder bindings."""
 
     DEFAULT_CSS = """
@@ -104,7 +107,8 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
     }
     """
 
-    BINDINGS = [("escape", "dismiss", "Cancel")]
+    SAFE_MODAL_CONTENT = "#workspace-create-modal"
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
     AUTO_FOCUS = "#workspace-create-name"
 
     def __init__(self, *, registry_service: LocalWorkspaceRegistryService) -> None:
@@ -112,6 +116,11 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
         self._registry = registry_service
         self._folders: list[str] = []
         self._error = ""
+        # Finding 1: one-shot guard against a double-submit (rapid
+        # Enter-Enter, or a double-click race on Create) running
+        # create_workspace()/add_folder_binding() twice before the modal
+        # actually pops off the screen stack.
+        self._committed = False
         # Captured once so recompose()s triggered by add/remove-folder don't
         # clobber a user-edited name back to the original suggestion.
         _, self._suggested_name = next_local_workspace_identity(self._registry)
@@ -166,13 +175,10 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
                 yield Button("Cancel", id="workspace-create-cancel", compact=True)
                 yield Button("Create", id="workspace-create-confirm", compact=True)
 
-    def action_dismiss(self) -> None:
-        self.dismiss(None)
-
     @on(Button.Pressed, "#workspace-create-cancel")
-    def _cancel(self, event: Button.Pressed) -> None:
+    async def _cancel(self, event: Button.Pressed) -> None:
         event.stop()
-        self.dismiss(None)
+        await self.request_safe_cancel(source="button")
 
     @on(Button.Pressed, "#workspace-create-browse")
     def _browse(self, event: Button.Pressed) -> None:
@@ -215,6 +221,7 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
         event.stop()
         raw = self.query_one("#workspace-create-folder-path", Input).value.strip()
         if not raw:
+            self._set_error("")
             return
         try:
             resolved = validate_folder_binding_path(raw, self._folders)
@@ -237,6 +244,7 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
             return
         if 0 <= index < len(self._folders):
             del self._folders[index]
+            self._error = ""
             self._stash_form_state()
             self.refresh(recompose=True)
 
@@ -251,6 +259,15 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
         self._create()
 
     def _create(self) -> None:
+        # Finding 1: guard against a double-submit (rapid Enter-Enter on the
+        # name Input, or a double-click on Create) re-running the side
+        # effects below before the modal has actually popped off the screen
+        # stack -- without this, a second queued call would create another
+        # workspace (auto-generated names don't collide across calls) and
+        # then crash with ScreenStackError trying to dismiss twice.
+        if self._committed:
+            return
+        self._committed = True
         name = self.query_one("#workspace-create-name", Input).value.strip()
         workspace_id, generated_name = next_local_workspace_identity(self._registry)
         try:
@@ -260,6 +277,9 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
                 description="Created from the workspace setup dialog.",
             )
         except WorkspaceRegistryServiceError as exc:
+            # Nothing was committed -- let the user fix the name/folder and
+            # retry rather than permanently locking the dialog.
+            self._committed = False
             self._set_error(str(exc))
             return
         bound: list[str] = []
@@ -270,7 +290,7 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
                 bound.append(folder)
             except WorkspaceRegistryServiceError as exc:
                 failed.append((folder, str(exc)))
-        self.dismiss(
+        self.dismiss_safe_once(
             WorkspaceCreateResult(
                 workspace_id=workspace_id,
                 name=name or generated_name,

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -1,0 +1,146 @@
+"""Shared workspace creation modal (spec 2026-08-17 §4).
+
+Used by the Console rail, Settings ▸ Workspaces, and Library. The modal
+owns the create/bind service calls so failures render inline; surfaces
+own post-create UI sync via their dismissal callbacks (§4.3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, Static
+
+from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+    next_local_workspace_identity,
+    validate_folder_binding_path,
+)
+
+_WORKSPACE_EXPLAINER = (
+    "A workspace scopes the Console to one project. Conversations started "
+    "in it are grouped together, agents' project file access comes only "
+    "from the folders you bind here (read-only unless you grant write in "
+    "Settings), and retrieval can be narrowed to the workspace's items via "
+    "its RAG Scope. Binding your project's folder is what makes a "
+    "workspace more than a label — without one, agents have no file "
+    "access. You can add or change folders later in Settings ▸ Workspaces."
+)
+
+
+@dataclass(frozen=True)
+class WorkspaceCreateResult:
+    """Outcome of a completed create dialog (spec §4.3)."""
+
+    workspace_id: str
+    name: str
+    bound_folders: tuple[str, ...] = ()
+    failed_folders: tuple[tuple[str, str], ...] = ()  # (path, error message)
+    make_active: bool = True
+    #: ProjectSkillsDiscovery entries for bound folders containing .SKILLS/.
+    #: Stays empty until project-skills discovery ships (spec §5.5 / PR B).
+    project_skills: tuple = ()
+
+
+class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
+    """Collect a workspace name + optional folder bindings."""
+
+    DEFAULT_CSS = """
+    WorkspaceCreateModal {
+        align: center middle;
+    }
+
+    #workspace-create-modal {
+        width: 72;
+        height: auto;
+        max-height: 32;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #workspace-create-explainer {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    #workspace-create-error {
+        color: $error;
+        height: auto;
+    }
+
+    #workspace-create-folder-row {
+        height: 3;
+        min-height: 3;
+    }
+
+    #workspace-create-folder-path {
+        width: 1fr;
+    }
+
+    #workspace-create-actions {
+        height: 3;
+        min-height: 3;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+    """
+
+    BINDINGS = [("escape", "dismiss", "Cancel")]
+    AUTO_FOCUS = "#workspace-create-name"
+
+    def __init__(self, *, registry_service: LocalWorkspaceRegistryService) -> None:
+        super().__init__()
+        self._registry = registry_service
+        self._folders: list[str] = []
+        self._error = ""
+
+    def compose(self) -> ComposeResult:
+        _, suggested_name = next_local_workspace_identity(self._registry)
+        with Vertical(id="workspace-create-modal"):
+            yield Static("New Workspace", classes="console-modal-header")
+            yield Static(
+                _WORKSPACE_EXPLAINER, id="workspace-create-explainer", markup=False
+            )
+            yield Input(
+                value=suggested_name,
+                id="workspace-create-name",
+                placeholder="Workspace name",
+            )
+            with Horizontal(id="workspace-create-folder-row"):
+                yield Input(
+                    id="workspace-create-folder-path",
+                    placeholder="~/path/to/project (optional)",
+                )
+                yield Button("Browse…", id="workspace-create-browse", compact=True)
+            with Horizontal(id="workspace-create-actions"):
+                yield Button("Cancel", id="workspace-create-cancel", compact=True)
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#workspace-create-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#workspace-create-browse")
+    def _browse(self, event: Button.Pressed) -> None:
+        event.stop()
+
+        def _picked(selected: Path | None) -> None:
+            if selected is not None:
+                self.query_one(
+                    "#workspace-create-folder-path", Input
+                ).value = str(selected)
+
+        self.app.push_screen(
+            SelectDirectory(title="Bind Project Folder"), _picked
+        )

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -17,6 +17,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Static
 
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Utils.input_validation import sanitize_string
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 from tldw_chatbook.Workspaces.registry_service import (
     LocalWorkspaceRegistryService,
@@ -121,14 +122,43 @@ class WorkspaceCreateModal(
         # create_workspace()/add_folder_binding() twice before the modal
         # actually pops off the screen stack.
         self._committed = False
+        # Finding 7: once a workspace has actually been created, a Create
+        # press retries only the remaining folder bindings -- the
+        # name/sanitize/create_workspace logic below is skipped entirely.
+        self._created_workspace_id: str | None = None
+        self._created_workspace_name: str = ""
+        self._make_active_result: bool = True
+        self._bound_folders: tuple[str, ...] = ()
+        # (path -> message) for whatever is still failing after the most
+        # recent bind attempt; used to build the partial result if the user
+        # cancels instead of retrying.
+        self._failed_folder_messages: dict[str, str] = {}
         # Captured once so recompose()s triggered by add/remove-folder don't
         # clobber a user-edited name back to the original suggestion.
-        _, self._suggested_name = next_local_workspace_identity(self._registry)
+        try:
+            _, self._suggested_name = next_local_workspace_identity(self._registry)
+        except WorkspaceRegistryServiceError:
+            # Finding 6a: a raise here (list_workspaces() failing) must not
+            # crash the modal before it can even mount -- fall back to an
+            # empty suggestion and surface the failure inline so the user
+            # can still type a name and retry.
+            self._suggested_name = ""
+            self._error = (
+                "Workspace registry could not be read — you can still type "
+                "a name and retry."
+            )
         self._name_value = self._suggested_name
         self._folder_path_value = ""
         self._make_active_value = True
 
     def compose(self) -> ComposeResult:
+        """Build the name/folder-binding form and its action buttons.
+
+        Returns:
+            The modal's widget tree: header, explainer, name input, folder
+            add/list controls, inline error area, make-active checkbox, and
+            the Cancel/Create action row.
+        """
         with Vertical(id="workspace-create-modal"):
             yield Static("New Workspace", classes="console-modal-header")
             yield Static(
@@ -179,6 +209,30 @@ class WorkspaceCreateModal(
     async def _cancel(self, event: Button.Pressed) -> None:
         event.stop()
         await self.request_safe_cancel(source="button")
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        """Route Cancel/Escape/backdrop to a partial result once created.
+
+        Finding 7: a workspace that already exists (folder-binding retry in
+        progress) is a fact, not something Cancel can undo -- deliver the
+        current state as a result instead of ``None`` so callers still sync
+        their workspace list/active-workspace UI.
+        """
+        if self._created_workspace_id is None:
+            await super()._perform_safe_cancel(source=source)
+            return
+        self.dismiss_safe_once(
+            WorkspaceCreateResult(
+                workspace_id=self._created_workspace_id,
+                name=self._created_workspace_name,
+                bound_folders=self._bound_folders,
+                failed_folders=tuple(
+                    (folder, self._failed_folder_messages.get(folder, ""))
+                    for folder in self._folders
+                ),
+                make_active=self._make_active_result,
+            )
+        )
 
     @on(Button.Pressed, "#workspace-create-browse")
     def _browse(self, event: Button.Pressed) -> None:
@@ -258,6 +312,68 @@ class WorkspaceCreateModal(
         event.stop()
         self._create()
 
+    def _bind_folders(
+        self, workspace_id: str, folders: list[str]
+    ) -> tuple[list[str], list[tuple[str, str]]]:
+        """Attempt to bind each folder, collecting per-folder failures.
+
+        Args:
+            workspace_id: The workspace to bind folders onto.
+            folders: Folder locators to attempt to bind, in order.
+
+        Returns:
+            A ``(bound, failed)`` pair: successfully bound folder paths, and
+            ``(path, error message)`` pairs for the ones that failed.
+        """
+        bound: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for folder in folders:
+            try:
+                self._registry.add_folder_binding(workspace_id, folder)
+                bound.append(folder)
+            except WorkspaceRegistryServiceError as exc:
+                failed.append((folder, str(exc)))
+        return bound, failed
+
+    def _finish_or_retry_bindings(
+        self, newly_bound: list[str], failed: list[tuple[str, str]]
+    ) -> None:
+        """Dismiss on full success, otherwise leave the modal open to retry.
+
+        Finding 7: a per-folder binding failure must not discard the
+        already-created workspace or the successful bindings -- it renders
+        the failures inline, narrows ``self._folders`` to just the
+        remainder, and resets ``_committed`` so a subsequent Create press
+        retries only what is still outstanding.
+
+        Args:
+            newly_bound: Folders that just succeeded in this attempt.
+            failed: ``(path, error message)`` pairs that just failed.
+        """
+        all_bound = tuple(self._bound_folders) + tuple(newly_bound)
+        if failed:
+            self._bound_folders = all_bound
+            self._folders = [folder for folder, _message in failed]
+            self._failed_folder_messages = dict(failed)
+            self._error = "\n".join(
+                f"{folder}: {message}" for folder, message in failed
+            )
+            self._committed = False
+            self._stash_form_state()
+            self.refresh(recompose=True)
+            return
+        self._bound_folders = all_bound
+        self._failed_folder_messages = {}
+        self.dismiss_safe_once(
+            WorkspaceCreateResult(
+                workspace_id=self._created_workspace_id,
+                name=self._created_workspace_name,
+                bound_folders=all_bound,
+                failed_folders=(),
+                make_active=self._make_active_result,
+            )
+        )
+
     def _create(self) -> None:
         # Finding 1: guard against a double-submit (rapid Enter-Enter on the
         # name Input, or a double-click on Create) re-running the side
@@ -268,9 +384,39 @@ class WorkspaceCreateModal(
         if self._committed:
             return
         self._committed = True
-        name = self.query_one("#workspace-create-name", Input).value.strip()
-        workspace_id, generated_name = next_local_workspace_identity(self._registry)
+
+        if self._created_workspace_id is not None:
+            # Finding 7 retry path: the workspace already exists -- only
+            # re-attempt the folders that are still outstanding. Name/
+            # sanitize/create_workspace logic below is intentionally skipped.
+            bound, failed = self._bind_folders(
+                self._created_workspace_id, list(self._folders)
+            )
+            self._finish_or_retry_bindings(bound, failed)
+            return
+
+        # Finding 2: validate the name at the boundary before it reaches the
+        # registry. Control characters or an overlong name are rejected
+        # inline rather than silently truncated/stripped into the DB; a
+        # blank name still falls back to the generated suggestion below.
+        raw_name = self.query_one("#workspace-create-name", Input).value.strip()
+        sanitized_name = sanitize_string(raw_name, 100).strip()
+        if raw_name and (sanitized_name != raw_name or not sanitized_name):
+            self._committed = False
+            self._set_error(
+                "Workspace name is too long or contains unsupported characters."
+            )
+            return
+        name = sanitized_name
+
+        # Finding 6b: identity generation (next_local_workspace_identity)
+        # can also raise WorkspaceRegistryServiceError -- it must be inside
+        # this try so a raise resets _committed instead of permanently
+        # locking the Create button for the rest of the session.
         try:
+            workspace_id, generated_name = next_local_workspace_identity(
+                self._registry
+            )
             self._registry.create_workspace(
                 workspace_id=workspace_id,
                 name=name or generated_name,
@@ -282,22 +428,12 @@ class WorkspaceCreateModal(
             self._committed = False
             self._set_error(str(exc))
             return
-        bound: list[str] = []
-        failed: list[tuple[str, str]] = []
-        for folder in self._folders:
-            try:
-                self._registry.add_folder_binding(workspace_id, folder)
-                bound.append(folder)
-            except WorkspaceRegistryServiceError as exc:
-                failed.append((folder, str(exc)))
-        self.dismiss_safe_once(
-            WorkspaceCreateResult(
-                workspace_id=workspace_id,
-                name=name or generated_name,
-                bound_folders=tuple(bound),
-                failed_folders=tuple(failed),
-                make_active=self.query_one(
-                    "#workspace-create-make-active", Checkbox
-                ).value,
-            )
-        )
+
+        self._created_workspace_id = workspace_id
+        self._created_workspace_name = name or generated_name
+        self._make_active_result = self.query_one(
+            "#workspace-create-make-active", Checkbox
+        ).value
+
+        bound, failed = self._bind_folders(workspace_id, list(self._folders))
+        self._finish_or_retry_bindings(bound, failed)

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -77,8 +77,7 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
     }
 
     #workspace-create-folder-row {
-        height: 3;
-        min-height: 3;
+        height: auto;
     }
 
     #workspace-create-folder-path {
@@ -86,10 +85,22 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
     }
 
     #workspace-create-actions {
-        height: 3;
-        min-height: 3;
+        height: auto;
         margin: 1 0 0 0;
         align-horizontal: right;
+    }
+
+    #workspace-create-folder-list {
+        height: auto;
+    }
+
+    .workspace-create-folder-item {
+        height: auto;
+    }
+
+    .workspace-create-folder-locator {
+        width: 1fr;
+        content-align: left middle;
     }
     """
 
@@ -101,27 +112,59 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
         self._registry = registry_service
         self._folders: list[str] = []
         self._error = ""
+        # Captured once so recompose()s triggered by add/remove-folder don't
+        # clobber a user-edited name back to the original suggestion.
+        _, self._suggested_name = next_local_workspace_identity(self._registry)
+        self._name_value = self._suggested_name
+        self._folder_path_value = ""
+        self._make_active_value = True
 
     def compose(self) -> ComposeResult:
-        _, suggested_name = next_local_workspace_identity(self._registry)
         with Vertical(id="workspace-create-modal"):
             yield Static("New Workspace", classes="console-modal-header")
             yield Static(
                 _WORKSPACE_EXPLAINER, id="workspace-create-explainer", markup=False
             )
             yield Input(
-                value=suggested_name,
+                value=self._name_value,
                 id="workspace-create-name",
                 placeholder="Workspace name",
+                compact=True,
             )
             with Horizontal(id="workspace-create-folder-row"):
                 yield Input(
+                    value=self._folder_path_value,
                     id="workspace-create-folder-path",
                     placeholder="~/path/to/project (optional)",
+                    compact=True,
                 )
                 yield Button("Browse…", id="workspace-create-browse", compact=True)
+                yield Button(
+                    "Add folder", id="workspace-create-folder-add", compact=True
+                )
+            with Vertical(id="workspace-create-folder-list"):
+                for index, folder in enumerate(self._folders):
+                    with Horizontal(classes="workspace-create-folder-item"):
+                        yield Static(
+                            folder,
+                            classes="workspace-create-folder-locator",
+                            markup=False,
+                        )
+                        yield Button(
+                            "Remove",
+                            id=f"workspace-create-folder-remove-{index}",
+                            compact=True,
+                        )
+            yield Static(self._error, id="workspace-create-error", markup=False)
+            yield Checkbox(
+                "Switch to this workspace",
+                self._make_active_value,
+                id="workspace-create-make-active",
+                compact=True,
+            )
             with Horizontal(id="workspace-create-actions"):
                 yield Button("Cancel", id="workspace-create-cancel", compact=True)
+                yield Button("Create", id="workspace-create-confirm", compact=True)
 
     def action_dismiss(self) -> None:
         self.dismiss(None)
@@ -143,4 +186,98 @@ class WorkspaceCreateModal(ModalScreen["WorkspaceCreateResult | None"]):
 
         self.app.push_screen(
             SelectDirectory(title="Bind Project Folder"), _picked
+        )
+
+    def _stash_form_state(self) -> None:
+        """Capture live Input/Checkbox values before a recompose discards them.
+
+        `refresh(recompose=True)` tears down and rebuilds every child widget
+        from `compose()`, which re-reads `self._name_value`,
+        `self._folder_path_value`, and `self._make_active_value`. Without
+        capturing the live values here first, a folder add/remove would
+        silently reset a user-edited name back to the original suggestion
+        (and an unchecked "make active" box back to checked).
+        """
+        self._name_value = self.query_one("#workspace-create-name", Input).value
+        self._folder_path_value = self.query_one(
+            "#workspace-create-folder-path", Input
+        ).value
+        self._make_active_value = self.query_one(
+            "#workspace-create-make-active", Checkbox
+        ).value
+
+    def _set_error(self, message: str) -> None:
+        self._error = message
+        self.query_one("#workspace-create-error", Static).update(message)
+
+    @on(Button.Pressed, "#workspace-create-folder-add")
+    def _add_folder(self, event: Button.Pressed) -> None:
+        event.stop()
+        raw = self.query_one("#workspace-create-folder-path", Input).value.strip()
+        if not raw:
+            return
+        try:
+            resolved = validate_folder_binding_path(raw, self._folders)
+        except WorkspaceRegistryServiceError as exc:
+            self._set_error(str(exc))
+            return
+        self._folders.append(str(resolved))
+        self._error = ""
+        self._stash_form_state()
+        self._folder_path_value = ""  # the just-consumed path is cleared
+        self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#workspace-create-folder-list Button")
+    def _remove_folder(self, event: Button.Pressed) -> None:
+        event.stop()
+        button_id = event.button.id or ""
+        try:
+            index = int(button_id.rsplit("-", 1)[-1])
+        except ValueError:
+            return
+        if 0 <= index < len(self._folders):
+            del self._folders[index]
+            self._stash_form_state()
+            self.refresh(recompose=True)
+
+    @on(Input.Submitted, "#workspace-create-name")
+    def _name_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._create()
+
+    @on(Button.Pressed, "#workspace-create-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._create()
+
+    def _create(self) -> None:
+        name = self.query_one("#workspace-create-name", Input).value.strip()
+        workspace_id, generated_name = next_local_workspace_identity(self._registry)
+        try:
+            self._registry.create_workspace(
+                workspace_id=workspace_id,
+                name=name or generated_name,
+                description="Created from the workspace setup dialog.",
+            )
+        except WorkspaceRegistryServiceError as exc:
+            self._set_error(str(exc))
+            return
+        bound: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for folder in self._folders:
+            try:
+                self._registry.add_folder_binding(workspace_id, folder)
+                bound.append(folder)
+            except WorkspaceRegistryServiceError as exc:
+                failed.append((folder, str(exc)))
+        self.dismiss(
+            WorkspaceCreateResult(
+                workspace_id=workspace_id,
+                name=name or generated_name,
+                bound_folders=tuple(bound),
+                failed_folders=tuple(failed),
+                make_active=self.query_one(
+                    "#workspace-create-make-active", Checkbox
+                ).value,
+            )
         )

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 import json
 from pathlib import Path
 import sqlite3
@@ -79,6 +79,72 @@ class BindingNotFound(WorkspaceRegistryServiceError):
     def __init__(self, binding_id: str) -> None:
         super().__init__(f"Runtime binding not found: {binding_id}")
         self.binding_id = binding_id
+
+
+def validate_folder_binding_path(
+    path: str | Path,
+    existing_locators: Sequence[str] = (),
+) -> Path:
+    """Resolve and vet a candidate folder-binding path (spec 2026-08-17 §4.2).
+
+    Pure with respect to the registry: consults only the filesystem and the
+    sensitive-path denylist, so creation UIs can vet folders before any
+    workspace exists. Raises WorkspaceRegistryServiceError with the same
+    user-facing messages ``add_folder_binding`` raised before extraction.
+    """
+    candidate = Path(path).expanduser()
+    try:
+        resolved = candidate.resolve()
+    except OSError as exc:
+        raise WorkspaceRegistryServiceError(
+            f"Folder path could not be resolved: {candidate}"
+        ) from exc
+    if not resolved.is_dir():
+        raise WorkspaceRegistryServiceError(
+            f"Folder does not exist or is not a directory: {resolved}"
+        )
+    if resolved == Path(resolved.anchor):
+        raise WorkspaceRegistryServiceError(
+            "The filesystem root cannot be bound to a workspace."
+        )
+    if resolved == Path.home().resolve():
+        raise WorkspaceRegistryServiceError(
+            "Your home directory itself cannot be bound; choose a "
+            "project folder inside it."
+        )
+    # TASK-857: the sensitive-path denylist used to only be consulted
+    # at file-tool READ/WRITE time, never here at the binding gate --
+    # so binding e.g. ~/.config/tldw_cli (this app's own config,
+    # API keys included), get_user_data_dir() (every app database), or
+    # ~/.ssh as a workspace folder root all passed this check, widening
+    # what the agent file tools can reach up to the edge of whatever
+    # the denylist enumerates. See ``find_root_binding_conflict`` for
+    # the exact "is, or contains, or is contained by" rule.
+    conflict = find_root_binding_conflict(resolved)
+    if conflict is not None:
+        raise WorkspaceRegistryServiceError(
+            f"'{resolved}' cannot be bound: it is, or contains, the "
+            f"protected path '{conflict}'. Choose a folder that does "
+            f"not overlap this application's own data, configuration, "
+            f"or credential directories."
+        )
+    for locator in existing_locators:
+        existing_path = Path(locator)
+        if resolved == existing_path:
+            raise WorkspaceRegistryServiceError(
+                f"{resolved} is already bound to this workspace."
+            )
+        if existing_path in resolved.parents:
+            raise WorkspaceRegistryServiceError(
+                f"{resolved} is inside the already-bound folder "
+                f"{existing_path}."
+            )
+        if resolved in existing_path.parents:
+            raise WorkspaceRegistryServiceError(
+                f"The already-bound folder {existing_path} is inside "
+                f"{resolved}; remove it first."
+            )
+    return resolved
 
 
 class LocalWorkspaceRegistryService:
@@ -693,58 +759,10 @@ class LocalWorkspaceRegistryService:
         (TASK-857). Default-workspace and unknown-workspace rejection is
         delegated to ``save_runtime_binding``.
         """
-        candidate = Path(path).expanduser()
-        try:
-            resolved = candidate.resolve()
-        except OSError as exc:
-            raise WorkspaceRegistryServiceError(
-                f"Folder path could not be resolved: {candidate}"
-            ) from exc
-        if not resolved.is_dir():
-            raise WorkspaceRegistryServiceError(
-                f"Folder does not exist or is not a directory: {resolved}"
-            )
-        if resolved == Path(resolved.anchor):
-            raise WorkspaceRegistryServiceError(
-                "The filesystem root cannot be bound to a workspace."
-            )
-        if resolved == Path.home().resolve():
-            raise WorkspaceRegistryServiceError(
-                "Your home directory itself cannot be bound; choose a "
-                "project folder inside it."
-            )
-        # TASK-857: the sensitive-path denylist used to only be consulted
-        # at file-tool READ/WRITE time, never here at the binding gate --
-        # so binding e.g. ~/.config/tldw_cli (this app's own config,
-        # API keys included), get_user_data_dir() (every app database), or
-        # ~/.ssh as a workspace folder root all passed this check, widening
-        # what the agent file tools can reach up to the edge of whatever
-        # the denylist enumerates. See ``find_root_binding_conflict`` for
-        # the exact "is, or contains, or is contained by" rule.
-        conflict = find_root_binding_conflict(resolved)
-        if conflict is not None:
-            raise WorkspaceRegistryServiceError(
-                f"'{resolved}' cannot be bound: it is, or contains, the "
-                f"protected path '{conflict}'. Choose a folder that does "
-                f"not overlap this application's own data, configuration, "
-                f"or credential directories."
-            )
-        for existing in self.list_folder_bindings(workspace_id):
-            existing_path = Path(existing.locator)
-            if resolved == existing_path:
-                raise WorkspaceRegistryServiceError(
-                    f"{resolved} is already bound to this workspace."
-                )
-            if existing_path in resolved.parents:
-                raise WorkspaceRegistryServiceError(
-                    f"{resolved} is inside the already-bound folder "
-                    f"{existing_path}."
-                )
-            if resolved in existing_path.parents:
-                raise WorkspaceRegistryServiceError(
-                    f"The already-bound folder {existing_path} is inside "
-                    f"{resolved}; remove it first."
-                )
+        resolved = validate_folder_binding_path(
+            path,
+            [b.locator for b in self.list_folder_bindings(workspace_id)],
+        )
         binding = WorkspaceRuntimeBinding(
             workspace_id=workspace_id,
             binding_id=f"folder-{uuid4().hex[:12]}",

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -81,16 +81,12 @@ class BindingNotFound(WorkspaceRegistryServiceError):
         self.binding_id = binding_id
 
 
-def validate_folder_binding_path(
-    path: str | Path,
-    existing_locators: Sequence[str] = (),
-) -> Path:
-    """Resolve and vet a candidate folder-binding path (spec 2026-08-17 §4.2).
+def _validate_folder_path_rules(path: str | Path) -> Path:
+    """Validate filesystem and sensitive-path rules for a candidate folder.
 
-    Pure with respect to the registry: consults only the filesystem and the
-    sensitive-path denylist, so creation UIs can vet folders before any
-    workspace exists. Raises WorkspaceRegistryServiceError with the same
-    user-facing messages ``add_folder_binding`` raised before extraction.
+    Private helper; does not check existing bindings. Resolves and vets the
+    path itself: existence, root/home rejection, and sensitive-path denylist.
+    Raises WorkspaceRegistryServiceError on failure.
     """
     candidate = Path(path).expanduser()
     try:
@@ -128,6 +124,19 @@ def validate_folder_binding_path(
             f"not overlap this application's own data, configuration, "
             f"or credential directories."
         )
+    return resolved
+
+
+def _validate_folder_overlap(
+    resolved: Path,
+    existing_locators: Sequence[str],
+) -> None:
+    """Validate that a folder does not duplicate or nest existing bindings.
+
+    Private helper; assumes path has already passed filesystem/sensitive checks.
+    Raises WorkspaceRegistryServiceError if the path duplicates or nests
+    any existing binding, or if any existing binding nests within the path.
+    """
     for locator in existing_locators:
         existing_path = Path(locator)
         if resolved == existing_path:
@@ -144,6 +153,34 @@ def validate_folder_binding_path(
                 f"The already-bound folder {existing_path} is inside "
                 f"{resolved}; remove it first."
             )
+
+
+def validate_folder_binding_path(
+    path: str | Path,
+    existing_locators: Sequence[str] = (),
+) -> Path:
+    """Resolve and vet a candidate folder-binding path (spec 2026-08-17 §4.2).
+
+    Pure with respect to the registry: consults only the filesystem and the
+    sensitive-path denylist, so creation UIs can vet folders before any
+    workspace exists. Raises WorkspaceRegistryServiceError with the same
+    user-facing messages ``add_folder_binding`` raised before extraction.
+
+    Args:
+        path: Candidate folder path (str or Path; supports ~ expansion).
+        existing_locators: Already-bound folder paths to check against for
+            duplicates and nesting conflicts. Defaults to empty sequence.
+
+    Returns:
+        The resolved, canonical folder path as a Path object.
+
+    Raises:
+        WorkspaceRegistryServiceError: If the path does not exist, is not a
+            directory, is the filesystem root, is the home directory, overlaps
+            a sensitive path, or duplicates/nests any existing binding.
+    """
+    resolved = _validate_folder_path_rules(path)
+    _validate_folder_overlap(resolved, existing_locators)
     return resolved
 
 
@@ -759,8 +796,9 @@ class LocalWorkspaceRegistryService:
         (TASK-857). Default-workspace and unknown-workspace rejection is
         delegated to ``save_runtime_binding``.
         """
-        resolved = validate_folder_binding_path(
-            path,
+        resolved = _validate_folder_path_rules(path)
+        _validate_folder_overlap(
+            resolved,
             [b.locator for b in self.list_folder_bindings(workspace_id)],
         )
         binding = WorkspaceRuntimeBinding(


### PR DESCRIPTION
## Summary

Replaces zero-input workspace creation on all three surfaces (Console rail **New**, Settings ▸ Workspaces, Library) with one shared `WorkspaceCreateModal` that collects a name (prefilled with the next free "Workspace N") and optional read-only folder bindings, with truthful educational copy about what a workspace actually does (agent file access roots, conversation grouping, RAG scope). Escape cancels with nothing created. A "Switch to this workspace" checkbox (default on) makes activation behavior uniform — note this changes Settings, whose old inline flow never activated.

- Pure `validate_folder_binding_path` extracted from `add_folder_binding` (original evaluation order preserved; RED-proven regression pin) so the modal vets folders inline before Create with the exact same rules.
- Modal owns create+bind (errors render inline, modal stays open); each surface keeps its own post-create sync — Console's full TASK-713 activation sequence is pinned by an order-asserting test.
- `SafeModalDismissMixin` + one-shot guard (double-submit cannot create a duplicate workspace).
- Docs: User Guide pages updated (settings/console/library) with refreshed stamps; the 2026-07-26 settings-workspaces spec §1 carries a supersession note. Spec + plans: `Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md`.

## Verification

CI is intentionally cancelled on this repo — verified locally: `Tests/Workspaces/` + settings/library UI files (282 passed) and a 49.8k-test `--collect-only` sweep; live TUI pass on an isolated profile covering all three surfaces (create-with-folder, escape-creates-nothing, switch-unchecked). Whole-branch final review + verified fix wave.

## Notes for the reviewer

- TASK-17961 (filed): compact Inputs/Checkbox render blank while focused — pre-existing rendering interaction, functionally harmless; the non-compact mitigation provably doesn't fit 80×24, so it's an explicit ship/hold call.
- Follow-up batch filed as TASK-17962. Backlog IDs 17650/17961/17962 swept against origin/dev + all worktrees; re-verify at merge per repo hygiene.
- Stacked PR: `feat/project-skills-import` builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies workspace creation across Console, Settings, and Library behind one modal and standardizes activation. Previously Console/Library auto‑created “Workspace N” and switched; Settings added an inactive row. Now all three open the same dialog; Escape cancels; a default‑on “Switch to this workspace” checkbox controls activation. Implements TASK‑17650.

- Adds `WorkspaceCreateModal` that owns create+bind, renders errors inline, supports nested `SelectDirectory`, uses safe cancel/dismiss, and guards double submit; addresses review feedback with name‑boundary validation, identity‑generation failure recovery, and inline binding‑failure retry.
- Extracts pure `validate_folder_binding_path` for inline folder vetting (original evaluation order preserved plus a sensitive‑path denylist); adds regression tests.
- Routes Console/Settings/Library through the modal; updates Console tests; Library recomposes even if activation fails; removes dead Library helper.
- Docs update the User Guide and add a spec supersession note.
- Known issue: compact Input/Checkbox content can be invisible while focused in the modal; cosmetic only (TASK‑17961). Follow‑up on cross‑screen activation sync is tracked in TASK‑18310.

<sup>Written for commit cb7e7efdd19881bbc5e2cb7c0a54965ef20112a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

