### PR TITLE
feat: project-local .SKILLS/ discovery and prompt-driven skill import (TASK-17651)

### DIFF
--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -119,6 +119,15 @@ switching Console to it. **Escape cancels the dialog — nothing is created.**
 A name that collides with an existing workspace renders inline and keeps the
 dialog open.
 
+If a folder you add contains a `.SKILLS/` project skills folder, its row in
+the list gains a "— contains N project skill(s)" annotation. After Create
+finishes (the workspace is created either way), a separate import prompt
+offers to bring those skills into your skill library — see
+[Project skills](../library/skills.md#project-skills-skills) for the full
+convention and what "trust-pending" means for an imported skill. Declining
+here or at app startup is remembered per project, so you're not asked again
+until the project's skill set changes.
+
 The built-in Default workspace has no "Rename" or "Archive" buttons. If you
 archive the workspace you are in, the Console switches back to Default.
 
@@ -224,6 +233,10 @@ nothing is created, no matter what you had typed or added.
 - A brand-new conversation can't be starred until it has been sent or saved —
   the star's tooltip says "Send or save this conversation before starring."
 - The Default workspace can't be renamed or archived.
+- Launching the app from inside a project with a `.SKILLS/` folder can pop
+  its own import prompt on startup, separately from anything workspace- or
+  tab-related — see [Project skills](../library/skills.md#project-skills-skills).
+  Turn it off with `[skills] project_skills_prompt_enabled = false`.
 
 —
 *Verified against dev @ ff435772c — 2026-07-31*
@@ -233,3 +246,7 @@ name, optional validated folder bindings with Browse…, a "Switch to this
 workspace" checkbox default on, and Escape/Cancel creating nothing —
 instead of instant "Workspace N" creation; the walkthrough split into
 create-and-switch / create-without-switching / cancel tasks to match).*
+*Verified against feat/project-skills-import @ 964cb04df — 2026-08-18
+(task-17651: a bound folder containing `.SKILLS/` now annotates its row
+"— contains N project skill(s)" in the dialog, and a chained import prompt
+follows workspace creation).*

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -169,7 +169,7 @@ current as of that open, not a reading cached at some earlier repaint.
 
 | Action | What it does |
 |---|---|
-| **Create local workspace** | Opens the same "New Workspace" dialog Console and Settings use — a prefilled "Workspace N" name, optional folders to bind (validated as added, with a Browse… picker), and a "Switch to this workspace" checkbox (checked by default). Escape cancels with nothing created. Server sync and ACP handoff remain WIP. |
+| **Create local workspace** | Opens the same "New Workspace" dialog Console and Settings use — a prefilled "Workspace N" name, optional folders to bind (validated as added, with a Browse… picker), and a "Switch to this workspace" checkbox (checked by default). Escape cancels with nothing created. Server sync and ACP handoff remain WIP. A bound folder containing a `.SKILLS/` project skills folder is annotated "— contains N project skill(s)" and, after Create, offers a chained import prompt — see [Project skills](library/skills.md#project-skills-skills). |
 | **Import sources** | Shown only while you have no workspace-eligible sources: "Open Library Import/Export to add workspace-eligible sources." |
 | **Use in Console** | Stages a snapshot of your local Library sources ("Local Library Sources") into Console and takes you there. When it can't run yet, its tooltip says why — "Stage Library source context after Library finishes loading." or "Stage Library source context after adding notes, media, or conversations." |
 
@@ -409,3 +409,7 @@ Workspace" dialog — the same one Console and Settings use — instead of
 creating a zero-input workspace instantly; documented its name prefill,
 optional validated folder bindings, Browse… picker, and default-on
 "Switch to this workspace" checkbox).*
+*Verified against feat/project-skills-import @ 964cb04df — 2026-08-18
+(task-17651: a bound folder containing `.SKILLS/` now annotates its row
+"— contains N project skill(s)" and a chained import prompt follows
+Create).*

--- a/Docs/User_Guide/library/skills.md
+++ b/Docs/User_Guide/library/skills.md
@@ -100,8 +100,11 @@ Chatbook offers to import from `.SKILLS/` at two moments, never silently:
 The prompt lists each discovered skill with a checkbox — **new** entries
 checked by default, entries that match an **already installed** skill name
 left unchecked (an existing skill is never silently overwritten), and
-**invalid** entries (bad name, unparseable frontmatter) shown unselectable
-with a reason. **Import selected** runs the same importer as a manual
+**invalid** entries (a bad name, or a file that can't be read) shown
+unselectable with a reason. Unparseable frontmatter is not one of those
+reasons — a skill file whose frontmatter can't be parsed still imports
+fine, just with an empty description (matching how a manual import treats
+the same case). **Import selected** runs the same importer as a manual
 import; **Not now** declines for this launch only — you're asked again only
 if the project's skill set actually changes (a new or removed skill file
 changes its fingerprint); **Never for this folder** declines permanently for

--- a/Docs/User_Guide/library/skills.md
+++ b/Docs/User_Guide/library/skills.md
@@ -76,6 +76,51 @@ SKILL.md file), **Browse folder…** (pick a skill folder), **Import**, and
   "Unsupported file type.", "Skill import is unavailable.", and
   `Skipped — a skill named "name" already exists.`
 
+### Project skills (`.SKILLS/`)
+
+A project with a `.SKILLS/` (or `.skills/`) folder at its root can offer its
+skills for import automatically instead of one-at-a-time manual imports. The
+convention: each skill is either a subdirectory containing a top-level
+`SKILL.md` (skill name = the directory name) or a loose `*.md` file (name
+derived from the filename). Anything else in the folder — a subdirectory
+without `SKILL.md`, a non-markdown file — is listed as skipped with a
+reason, never silently ignored. A symlinked `.SKILLS/` directory, or a
+symlinked entry inside it, is refused.
+
+Chatbook offers to import from `.SKILLS/` at two moments, never silently:
+
+- **App startup**, when launched from inside such a project (or a
+  subdirectory of one — the search walks upward looking for `.SKILLS/`,
+  stopping at the first ancestor containing `.git`, at your home folder, or
+  at the filesystem root).
+- **After creating a workspace** bound to a folder that contains `.SKILLS/`
+  (the folder row in the "New Workspace" dialog shows "— contains N project
+  skill(s)" while you're adding it).
+
+The prompt lists each discovered skill with a checkbox — **new** entries
+checked by default, entries that match an **already installed** skill name
+left unchecked (an existing skill is never silently overwritten), and
+**invalid** entries (bad name, unparseable frontmatter) shown unselectable
+with a reason. **Import selected** runs the same importer as a manual
+import; **Not now** declines for this launch only — you're asked again only
+if the project's skill set actually changes (a new or removed skill file
+changes its fingerprint); **Never for this folder** declines permanently for
+that project. Declining or importing from either trigger (startup or
+workspace creation) is remembered for both.
+
+**Every import still lands trust-pending, exactly like a manual import** —
+the prompt states this up front ("Imported skills require a one-time trust
+review in Library ▸ Skills before they can run") because a project-imported
+skill is otherwise indistinguishable from any other skill in the list. The
+result view's **Review in Library ▸ Skills** button brings you straight
+here to review and approve them (see [Trust panel](#trust-panel) above).
+
+The whole feature can be turned off — no scanning, no prompts, at either
+trigger — with `[skills] project_skills_prompt_enabled = false` in
+`config.toml`; it defaults to on. This does not affect the manual
+**Import…** row above, which is always available regardless of this
+setting.
+
 ### Editor
 
 | Field / control | Notes |
@@ -185,8 +230,10 @@ through (Esc also cancels the passphrase dialogs).
   deep dive on how bundled scripts run and are sandboxed.
 - [Library](../library.md) — the surrounding screen; [Prompts](prompts.md)
   are the simpler cousin (inserted text, no trust or execution).
-- This panel owns no `config.toml` keys; trust lives in a local,
-  passphrase-protected store on this machine. Guide index:
+- Trust itself lives in a local, passphrase-protected store on this
+  machine, not in `config.toml`. The one config key this panel's flow does
+  read is `[skills] project_skills_prompt_enabled` (default `true`) —
+  see [Project skills](#project-skills-skills) above. Guide index:
   [index](../index.md).
 
 ## Quirks & troubleshooting
@@ -212,6 +259,14 @@ through (Esc also cancels the passphrase dialogs).
   re-check.
 - **Model override does nothing yet** — it is kept only so SKILL.md files
   round-trip without losing the field.
+- **Skills imported from a project's `.SKILLS/` folder are quarantined like
+  any other import** — a fresh `$mention` of one in Console is refused with
+  a pointer back here until you review and approve it; the import prompt's
+  header says this explicitly, but it's easy to miss.
+- **`.SKILLS/` scanning is opt-out, not opt-in** — set `[skills]
+  project_skills_prompt_enabled = false` in `config.toml` if you don't want
+  Chatbook checking project directories for skill folders at startup or on
+  workspace creation.
 
 —
 *Verified against dev @ bd05a692a — 2026-07-31*
@@ -222,3 +277,9 @@ chooser-strip pattern (press → Name / Status with ✓ on the active one,
 direct pick, Escape cancels); the editor's three two-state switches stay
 one-press toggles with their full option set now on the label —
 "User can invoke: ✓ yes ⇄ no" — so the option space is on screen.)*
+
+*Verified against feat/project-skills-import @ 964cb04df — 2026-08-18
+(task-17651: documented the new "Project skills (`.SKILLS/`)" convention —
+per-project discovery at startup and workspace creation, the fingerprint
+gated prompt ledger, the quarantine/trust-review expectation, and the
+`[skills] project_skills_prompt_enabled` kill-switch.)*

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -377,7 +377,11 @@ picker), and a "Switch to this workspace" checkbox, checked by default —
 here, unlike the old inline row, checking it activates the workspace
 immediately on Create. Escape cancels the dialog with nothing created.
 **Show archived** widens the list; each row shows the workspace's name and
-its bound-folder count ("N folders"); click a row to open its card.
+its bound-folder count ("N folders"); click a row to open its card. A
+folder you add that contains a `.SKILLS/` project skills folder is
+annotated "— contains N project skill(s)" in the list, and creation is
+followed by a chained import prompt for it — see
+[Project skills](library/skills.md#project-skills-skills).
 
 | Control | What it does |
 |---|---|
@@ -683,3 +687,8 @@ validated folder bindings, and a "Switch to this workspace" checkbox that
 here defaults to activating the workspace on Create, unlike the old
 inline flow; the walkthrough's step 5 updated to match; the rest of this
 page's content unchanged from the prior stamp).*
+*Verified against feat/project-skills-import @ 964cb04df — 2026-08-18
+(task-17651: a bound folder containing `.SKILLS/` now annotates its row
+"— contains N project skill(s)" in the creation dialog, followed by a
+chained import prompt after Create; the rest of this page's content
+unchanged from the prior stamp).*

--- a/Tests/Skills/test_project_skills_discovery.py
+++ b/Tests/Skills/test_project_skills_discovery.py
@@ -82,9 +82,21 @@ def test_fingerprint_changes_when_a_skill_is_added(tmp_path):
 
 
 def test_hostile_description_survives_as_plain_data(tmp_path):
-    _skill_dir(tmp_path, "alpha-skill", description="[red]evil[/red]")
+    _skill_dir(tmp_path, "alpha-skill", description='"[red]evil[/red]"')
     discovery = discover_project_skills(tmp_path)
     assert discovery.entries[0].description == "[red]evil[/red]"  # escaping is UI-side
+
+
+def test_unparseable_frontmatter_degrades_to_empty_description(tmp_path):
+    # Unquoted brackets break the front matter's YAML grammar; the importer's
+    # own _parse_front_matter degrades this to empty metadata (not an error),
+    # and discovery mirrors that -- still "ok", still importable, just no
+    # preview text.
+    _skill_dir(tmp_path, "alpha-skill", description="[red]evil[/red]")
+    discovery = discover_project_skills(tmp_path)
+    entry = discovery.entries[0]
+    assert entry.status == "ok"
+    assert entry.description == ""
 
 
 def test_ancestor_walk_finds_project_root(tmp_path):

--- a/Tests/Skills/test_project_skills_discovery.py
+++ b/Tests/Skills/test_project_skills_discovery.py
@@ -116,6 +116,48 @@ def test_entry_cap_reports_truncation(tmp_path):
     assert discovery.truncated == 3
 
 
+def test_scan_bound_caps_enumeration_and_skipped_list(tmp_path, monkeypatch):
+    """Finding 8 (Qodo review, PR #1810): unbounded materialize/sort +
+    unbounded skips. A ``.SKILLS/`` with hundreds of junk files must not
+    enumerate/sort/record everything -- the raw scan is capped at
+    ``MAX_SCANNED_CHILDREN`` and the ``skipped`` list stays bounded even
+    when far more than that many children exist, while the valid skills
+    within the scanned window are still found.
+    """
+    skills_dir = tmp_path / ".SKILLS"
+    _skill_dir(tmp_path, "a-alpha-skill")
+    (skills_dir / "a-beta-skill.md").write_text(
+        "---\ndescription: Loose one.\n---\nBody\n", encoding="utf-8"
+    )
+    for i in range(600):
+        (skills_dir / f"junk-{i:04d}.txt").write_text("junk", encoding="utf-8")
+
+    # Real filesystem iteration order (APFS/ext4 are hash-ordered, not
+    # creation-ordered) does not reliably put the "a-"-prefixed entries
+    # within the first MAX_SCANNED_CHILDREN raw children -- verified empty
+    # on this host. Force the .SKILLS/ raw iterdir() order deterministically
+    # (valid entries first) so the "found IF within the scanned window"
+    # case is actually exercised rather than left to chance.
+    real_iterdir = Path.iterdir
+
+    def fake_iterdir(self):
+        if self == skills_dir:
+            children = list(real_iterdir(self))
+            children.sort(key=lambda p: (not p.name.startswith("a-"), p.name))
+            return iter(children)
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+
+    discovery = discover_project_skills(tmp_path)
+
+    assert discovery is not None
+    names = {e.name for e in discovery.entries}
+    assert {"a-alpha-skill", "a-beta-skill"} <= names
+    assert len(discovery.skipped) <= 21  # bounded: no unbounded skip growth
+    assert discovery.truncated >= 1
+
+
 def test_fingerprint_changes_when_a_skill_is_added(tmp_path):
     _skill_dir(tmp_path, "alpha-skill")
     first = discover_project_skills(tmp_path).fingerprint

--- a/Tests/Skills/test_project_skills_discovery.py
+++ b/Tests/Skills/test_project_skills_discovery.py
@@ -1,0 +1,111 @@
+import os
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    MAX_DISCOVERED_ENTRIES,
+    discover_project_skills,
+    find_project_dir_with_skills,
+    find_project_skills_dir,
+)
+
+
+def _skill_dir(root, name, description="Does a thing."):
+    d = root / ".SKILLS" / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nBody\n",
+        encoding="utf-8",
+    )
+    return d
+
+
+def test_no_skills_dir_returns_none(tmp_path):
+    assert discover_project_skills(tmp_path) is None
+
+
+def test_discovers_directory_and_loose_file_skills(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    (tmp_path / ".SKILLS" / "beta-skill.md").write_text(
+        "---\ndescription: Loose one.\n---\nBody\n", encoding="utf-8"
+    )
+    discovery = discover_project_skills(tmp_path)
+    kinds = {(e.name, e.kind, e.status) for e in discovery.entries}
+    assert ("alpha-skill", "directory", "ok") in kinds
+    assert ("beta-skill", "file", "ok") in kinds
+    assert discovery.truncated == 0
+
+
+def test_subdir_without_skill_md_is_skipped_with_reason(tmp_path):
+    (tmp_path / ".SKILLS" / "not-a-skill").mkdir(parents=True)
+    discovery = discover_project_skills(tmp_path)
+    assert ("not-a-skill", "no SKILL.md") in discovery.skipped
+
+
+def test_invalid_name_flagged_not_failed(tmp_path):
+    _skill_dir(tmp_path, "My_Skill")
+    discovery = discover_project_skills(tmp_path)
+    entry = discovery.entries[0]
+    assert entry.status == "invalid"
+    assert "lowercase" in entry.reason
+
+
+def test_symlinked_skills_dir_refused(tmp_path):
+    real = tmp_path / "elsewhere"
+    real.mkdir()
+    os.symlink(real, tmp_path / ".SKILLS")
+    assert find_project_skills_dir(tmp_path) is None
+
+
+def test_symlinked_entry_skipped(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, tmp_path / ".SKILLS" / "sneaky")
+    discovery = discover_project_skills(tmp_path)
+    assert ("sneaky", "symlink") in discovery.skipped
+    assert [e.name for e in discovery.entries] == ["alpha-skill"]
+
+
+def test_entry_cap_reports_truncation(tmp_path):
+    for i in range(MAX_DISCOVERED_ENTRIES + 3):
+        _skill_dir(tmp_path, f"skill-{i:03d}")
+    discovery = discover_project_skills(tmp_path)
+    assert len(discovery.entries) == MAX_DISCOVERED_ENTRIES
+    assert discovery.truncated == 3
+
+
+def test_fingerprint_changes_when_a_skill_is_added(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill")
+    first = discover_project_skills(tmp_path).fingerprint
+    _skill_dir(tmp_path, "gamma-skill")
+    assert discover_project_skills(tmp_path).fingerprint != first
+
+
+def test_hostile_description_survives_as_plain_data(tmp_path):
+    _skill_dir(tmp_path, "alpha-skill", description="[red]evil[/red]")
+    discovery = discover_project_skills(tmp_path)
+    assert discovery.entries[0].description == "[red]evil[/red]"  # escaping is UI-side
+
+
+def test_ancestor_walk_finds_project_root(tmp_path):
+    _skill_dir(tmp_path / "repo", "alpha-skill")
+    (tmp_path / "repo" / ".git").mkdir()
+    sub = tmp_path / "repo" / "src" / "deep"
+    sub.mkdir(parents=True)
+    assert find_project_dir_with_skills(sub) == tmp_path / "repo"
+
+
+def test_ancestor_walk_stops_at_git_root_without_skills(tmp_path):
+    (tmp_path / "repo" / ".git").mkdir(parents=True)
+    sub = tmp_path / "repo" / "src"
+    sub.mkdir()
+    _skill_dir(tmp_path, "above-the-repo")  # must NOT be found past the .git root
+    assert find_project_dir_with_skills(sub) is None
+
+
+def test_ancestor_walk_stops_at_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    start = tmp_path / "sub"
+    start.mkdir()
+    _skill_dir(tmp_path, "in-home-itself")
+    assert find_project_dir_with_skills(start) is None

--- a/Tests/Skills/test_project_skills_discovery.py
+++ b/Tests/Skills/test_project_skills_discovery.py
@@ -81,6 +81,22 @@ def test_fingerprint_changes_when_a_skill_is_added(tmp_path):
     assert discover_project_skills(tmp_path).fingerprint != first
 
 
+def test_fingerprint_changes_when_skill_md_edited_in_place(tmp_path):
+    d = _skill_dir(tmp_path, "alpha-skill")
+    first = discover_project_skills(tmp_path).fingerprint
+    skill_md = d / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: alpha-skill\ndescription: Changed content.\n---\nNew body\n",
+        encoding="utf-8",
+    )
+    # Bump mtime_ns explicitly (rather than sleeping) so the assertion doesn't
+    # depend on filesystem mtime resolution catching a fast in-process edit.
+    st = skill_md.stat()
+    os.utime(skill_md, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+    second = discover_project_skills(tmp_path).fingerprint
+    assert second != first
+
+
 def test_hostile_description_survives_as_plain_data(tmp_path):
     _skill_dir(tmp_path, "alpha-skill", description='"[red]evil[/red]"')
     discovery = discover_project_skills(tmp_path)
@@ -120,4 +136,26 @@ def test_ancestor_walk_stops_at_home(monkeypatch, tmp_path):
     start = tmp_path / "sub"
     start.mkdir()
     _skill_dir(tmp_path, "in-home-itself")
+    assert find_project_dir_with_skills(start) is None
+
+
+def test_ancestor_walk_stops_at_home_reached_via_symlinked_ancestor(monkeypatch, tmp_path):
+    # The walk start is reached through a symlinked path component that
+    # resolves onto $HOME. The unresolved `current` never string-equals the
+    # resolved `home`, so a stop-check that compares unresolved `current`
+    # against resolved `home` never fires -- the walk sails past the $HOME
+    # boundary and can discover skills planted at (or beyond) home.
+    real_home = tmp_path / "real_home"
+    real_home.mkdir()
+    _skill_dir(real_home, "in-home-itself")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: real_home))
+
+    link_root = tmp_path / "link_root"
+    link_root.mkdir()
+    home_link = link_root / "home_link"
+    os.symlink(real_home, home_link)
+
+    start = home_link / "sub"
+    start.mkdir()
+
     assert find_project_dir_with_skills(start) is None

--- a/Tests/Skills/test_project_skills_discovery.py
+++ b/Tests/Skills/test_project_skills_discovery.py
@@ -49,6 +49,48 @@ def test_invalid_name_flagged_not_failed(tmp_path):
     assert "lowercase" in entry.reason
 
 
+def test_both_candidates_present_prefers_skills_upper_and_logs_ignored(
+    tmp_path, monkeypatch
+):
+    """Finding 5 (spec §5.1): when BOTH ``.SKILLS/`` and ``.skills/`` exist,
+    ``.SKILLS`` wins (existing behavior) and a debug/info log line records
+    that the second candidate was found but ignored -- silent precedence
+    is a footgun for a project that accidentally has both.
+
+    Can't create both as REAL directories: on this machine's (and most
+    macOS) default case-insensitive filesystem, ``.SKILLS`` and ``.skills``
+    collide onto the same inode -- ``mkdir`` of the second raises
+    ``FileExistsError``. A project on a case-sensitive filesystem (Linux,
+    or a case-sensitive APFS volume) genuinely can have both though, so
+    this fakes ``Path.is_dir``/``is_symlink`` for exactly the two
+    candidate names instead of depending on the test host's filesystem
+    case-sensitivity.
+    """
+    from tldw_chatbook.Skills_Interop import project_skills_discovery as _module
+
+    real_is_dir = Path.is_dir
+
+    def fake_is_dir(self):
+        if self.parent == tmp_path and self.name in (".SKILLS", ".skills"):
+            return True
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", fake_is_dir)
+    monkeypatch.setattr(Path, "is_symlink", lambda self: False)
+
+    messages: list[str] = []
+    sink_id = _module.logger.add(messages.append, level="DEBUG", format="{message}")
+    try:
+        result = find_project_skills_dir(tmp_path)
+    finally:
+        _module.logger.remove(sink_id)
+
+    assert result == tmp_path / ".SKILLS"
+    assert any(
+        ".skills" in message and str(tmp_path) in message for message in messages
+    )
+
+
 def test_symlinked_skills_dir_refused(tmp_path):
     real = tmp_path / "elsewhere"
     real.mkdir()

--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -43,6 +43,26 @@ class _HarnessApp(App[None]):
         self.push_screen(self._modal, _done)
 
 
+class _RecorderApp:
+    """Minimal app double (not a real Textual App): records
+    ``push_screen``/``run_worker`` calls without ever running an event
+    loop -- used for Finding 1/6 tests where ``maybe_offer_project_skills_
+    import`` must return BEFORE touching either, so there is nothing to
+    pump.
+    """
+
+    def __init__(self, skills_scope_service="sentinel"):
+        self.skills_scope_service = skills_scope_service
+        self.pushed: list = []
+        self.workers: list = []
+
+    def push_screen(self, screen, callback=None):
+        self.pushed.append(screen)
+
+    def run_worker(self, coro, **kwargs):
+        self.workers.append(coro)
+
+
 def _modal(tmp_path, installed=frozenset(), imported=None, fail=()):
     imported = imported if imported is not None else []
 
@@ -143,6 +163,60 @@ async def test_double_click_import_runs_importer_once_per_entry(tmp_path):
         await pilot.click("#project-skills-import")
         await pilot.pause(0.2)
     assert sorted(imported) == ["alpha-skill", "beta-skill"]
+
+
+@pytest.mark.asyncio
+async def test_never_during_inflight_import_is_inert(tmp_path):
+    """Finding 2: while an import is running (``_committed`` and no
+    outcomes yet), "Never for this folder" must be inert -- it must not
+    dismiss the modal mid-import -- and the flow must still land on the
+    results phase once the import finishes.
+    """
+    imported: list[str] = []
+
+    async def slow_importer(entry):
+        await asyncio.sleep(0.1)
+        imported.append(entry.name)
+
+    modal = ProjectSkillsImportModal(
+        discovery=_discovery(tmp_path),
+        installed_names=frozenset(),
+        importer=slow_importer,
+    )
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        # The slow importer is still in flight here (0.1s sleep, no pause
+        # duration given) -- Never must be a no-op, not a dismissal.
+        await pilot.click("#project-skills-never")
+        await pilot.pause()
+        assert app.result == "unset"  # still open -- no dismissal happened
+        assert app.screen is modal
+        await pilot.pause(0.2)  # let the slow importer finish
+        assert modal._outcomes is not None  # landed on the results phase
+    assert sorted(imported) == ["alpha-skill", "beta-skill"]
+
+
+@pytest.mark.asyncio
+async def test_escape_on_results_phase_dismisses_as_imported(tmp_path):
+    """Minor 6: escape on the RESULTS phase must dismiss like "Close"
+    (``("imported", outcomes)``), not like a cancel (``("not_now", None)``)
+    -- the import already ran; there is nothing left to cancel.
+    """
+    modal, _imported = _modal(tmp_path)
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        assert modal._outcomes is not None  # sanity: results phase reached
+        await pilot.press("escape")
+        await pilot.pause()
+    decision, outcomes = app.result
+    assert decision == "imported"
+    assert outcomes is not None and len(outcomes) == 2
 
 
 class _StubSkillsScopeService:
@@ -319,4 +393,70 @@ async def test_on_dismiss_bookkeeping_failure_still_clears_flag_and_does_not_rai
         # in the un-fixed `_on_dismiss` would have exited it here.
         assert not app._exit
 
+    assert getattr(app, "_project_skills_offer_active", False) is False
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: the create-path trigger must respect the SAME gating as the
+# startup path -- kill-switch, "Never", and fingerprint gating -- not just
+# scan-and-offer unconditionally. ``maybe_offer_project_skills_import`` is
+# the one entry point every call site (startup, Console/Settings/Library
+# create-modal chaining) routes through, so fixing gating there closes all
+# of them at once.
+# ---------------------------------------------------------------------------
+
+
+def test_never_for_folder_silences_create_trigger(tmp_path, monkeypatch):
+    """A "never" decision recorded for a discovery's root (e.g. via the
+    startup offer) must silence a LATER create-path offer for the same
+    folder too -- spec §5.3's "declining in one place silences the other".
+    """
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+    monkeypatch.setattr(_offer_module, "get_cli_setting", lambda *a, **k: True)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    ledger.record(discovery.root, "never", discovery.fingerprint)
+
+    app = _RecorderApp()
+    maybe_offer_project_skills_import(app, (discovery,))
+
+    assert app.pushed == []
+    assert app.workers == []
+    assert getattr(app, "_project_skills_offer_active", False) is False
+
+
+def test_kill_switch_suppresses_create_offer(tmp_path, monkeypatch):
+    """The ``[skills] project_skills_prompt_enabled`` kill-switch must be
+    consulted at the top of ``maybe_offer_project_skills_import`` itself --
+    not only by the startup path's own pre-filtering -- so every call site
+    that routes through this one helper is covered.
+    """
+    monkeypatch.setattr(_offer_module, "get_cli_setting", lambda *a, **k: False)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    app = _RecorderApp()
+
+    maybe_offer_project_skills_import(app, (discovery,))
+
+    assert app.pushed == []
+    assert app.workers == []
+    assert getattr(app, "_project_skills_offer_active", False) is False
+
+
+def test_missing_skills_scope_service_suppresses_offer(tmp_path, monkeypatch):
+    """Finding 6: without ``app.skills_scope_service`` an offer can only
+    fail (there is nothing to import into) -- suppress it entirely instead
+    of pushing a modal whose "Import selected" is guaranteed to error.
+    """
+    monkeypatch.setattr(_offer_module, "get_cli_setting", lambda *a, **k: True)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    app = _RecorderApp(skills_scope_service=None)
+
+    maybe_offer_project_skills_import(app, (discovery,))
+
+    assert app.pushed == []
+    assert app.workers == []
     assert getattr(app, "_project_skills_offer_active", False) is False

--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -1,0 +1,240 @@
+import asyncio
+
+import pytest
+from textual import on
+from textual.app import App
+from textual.widgets import Checkbox
+
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    discover_project_skills,
+)
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    ProjectSkillsPromptLedger,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.Widgets import project_skills_import_modal as _offer_module
+from tldw_chatbook.Widgets.project_skills_import_modal import (
+    ProjectSkillsImportModal,
+    maybe_offer_project_skills_import,
+)
+
+
+def _discovery(tmp_path, names=("alpha-skill", "beta-skill")):
+    for name in names:
+        d = tmp_path / ".SKILLS" / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\ndescription: [red]desc[/red] for {name}\n---\nBody\n",
+            encoding="utf-8",
+        )
+    return discover_project_skills(tmp_path)
+
+
+class _HarnessApp(App[None]):
+    def __init__(self, modal):
+        super().__init__()
+        self._modal = modal
+        self.result = "unset"
+
+    def on_mount(self) -> None:
+        def _done(result):
+            self.result = result
+
+        self.push_screen(self._modal, _done)
+
+
+def _modal(tmp_path, installed=frozenset(), imported=None, fail=()):
+    imported = imported if imported is not None else []
+
+    async def importer(entry):
+        if entry.name in fail:
+            raise ValueError("import exploded")
+        imported.append(entry.name)
+
+    return (
+        ProjectSkillsImportModal(
+            discovery=_discovery(tmp_path),
+            installed_names=installed,
+            importer=importer,
+        ),
+        imported,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_rows_checked_installed_rows_unchecked(tmp_path):
+    modal, _ = _modal(tmp_path, installed=frozenset({"beta-skill"}))
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        boxes = {
+            box.id: box.value for box in modal.query(Checkbox)
+        }
+        assert boxes["project-skill-row-0"] is True   # alpha-skill: new
+        assert boxes["project-skill-row-1"] is False  # beta-skill: installed
+
+
+@pytest.mark.asyncio
+async def test_escape_means_not_now(tmp_path):
+    modal, _ = _modal(tmp_path)
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.result == ("not_now", None)
+
+
+@pytest.mark.asyncio
+async def test_never_button(tmp_path):
+    modal, _ = _modal(tmp_path)
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-never")
+        await pilot.pause()
+    assert app.result == ("never", None)
+
+
+@pytest.mark.asyncio
+async def test_import_selected_runs_importer_and_reports(tmp_path):
+    modal, imported = _modal(tmp_path, fail=("beta-skill",))
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        # results phase: Close dismisses with outcomes
+        await pilot.click("#project-skills-close")
+        await pilot.pause()
+    assert imported == ["alpha-skill"]
+    decision, outcomes = app.result
+    assert decision == "imported"
+    assert ("alpha-skill", "imported") in outcomes
+    assert any(name == "beta-skill" and "exploded" in msg for name, msg in outcomes)
+
+
+@pytest.mark.asyncio
+async def test_double_click_import_runs_importer_once_per_entry(tmp_path):
+    """A rapid double-press of 'Import selected' must not double-run imports.
+
+    A slow (real-yielding) importer keeps the "Import selected" button
+    mounted across both clicks -- ``pilot.click`` only waits for the app's
+    message queue to idle, not for the background import worker to finish,
+    so a second real click can land on the SAME button while the first
+    import is still in flight. The modal's one-shot ``_committed`` guard is
+    what keeps that second click a no-op instead of a duplicate import run.
+    """
+    imported: list[str] = []
+
+    async def slow_importer(entry):
+        await asyncio.sleep(0.05)
+        imported.append(entry.name)
+
+    modal = ProjectSkillsImportModal(
+        discovery=_discovery(tmp_path),
+        installed_names=frozenset(),
+        importer=slow_importer,
+    )
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#project-skills-import")
+        await pilot.click("#project-skills-import")
+        await pilot.pause(0.2)
+    assert sorted(imported) == ["alpha-skill", "beta-skill"]
+
+
+class _StubSkillsScopeService:
+    """Records import calls; ``alpha-skill`` reports as already installed."""
+
+    def __init__(self):
+        self.import_calls: list[tuple] = []
+
+    async def get_context(self, *, mode=None):
+        del mode
+        return {
+            "available_skills": [{"name": "alpha-skill"}],
+            "blocked_skills": [],
+        }
+
+    async def import_skill_directory(self, path, *, mode, name, trust_approved):
+        self.import_calls.append(("directory", str(path), mode, name, trust_approved))
+
+    async def import_skill_file(
+        self, data, *, mode, filename, content_type, trust_approved
+    ):
+        self.import_calls.append(
+            ("file", data, mode, filename, content_type, trust_approved)
+        )
+
+
+class _OfferHarnessApp(App[None]):
+    def __init__(self, service, discoveries):
+        super().__init__()
+        self.skills_scope_service = service
+        self._discoveries = discoveries
+        self.navigated: list[str] = []
+
+    def on_mount(self) -> None:
+        maybe_offer_project_skills_import(self, self._discoveries)
+
+    @on(NavigateToScreen)
+    def _record_navigation(self, message: NavigateToScreen) -> None:
+        self.navigated.append(message.screen_name)
+
+
+@pytest.mark.asyncio
+async def test_maybe_offer_chains_installed_names_ledger_and_navigation(
+    tmp_path, monkeypatch
+):
+    """End-to-end exercise of the shared offer helper across two discoveries.
+
+    Covers everything the modal-only tests above don't: installed_names
+    built from ``app.skills_scope_service.get_context``, the injected
+    importer's exact ``import_skill_directory`` call shape, sequential
+    chaining (discovery B's modal only appears after A's dismisses), the
+    ledger decision mapping, and the "review" -> NavigateToScreen("skills")
+    post.
+    """
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    root_a = tmp_path / "repo-a"
+    root_b = tmp_path / "repo-b"
+    discovery_a = _discovery(root_a, names=("alpha-skill",))
+    discovery_b = _discovery(root_b, names=("beta-skill",))
+
+    service = _StubSkillsScopeService()
+    app = _OfferHarnessApp(service, (discovery_a, discovery_b))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        # First discovery: alpha-skill is reported "installed" by the stub
+        # context, so its row must render unchecked.
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+        boxes = {box.id: box.value for box in app.screen.query(Checkbox)}
+        assert boxes["project-skill-row-0"] is False
+        await pilot.click("#project-skills-never")
+        await pilot.pause()
+        await pilot.pause()
+
+        # Second discovery only appears after the first dismisses.
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        await pilot.click("#project-skills-review")
+        await pilot.pause()
+
+    assert service.import_calls == [
+        ("directory", str(root_b / ".SKILLS" / "beta-skill"), "local", "beta-skill", False)
+    ]
+    assert app.navigated == ["skills"]
+
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    assert ledger.decision_for(discovery_a.root) == ("never", discovery_a.fingerprint)
+    assert ledger.decision_for(discovery_b.root) == (
+        "imported",
+        discovery_b.fingerprint,
+    )

--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -279,3 +279,44 @@ async def test_maybe_offer_reentrancy_guard_blocks_concurrent_calls(
 
     ledger = ProjectSkillsPromptLedger(ledger_dir)
     assert ledger.decision_for(discovery.root) == ("never", discovery.fingerprint)
+
+
+@pytest.mark.asyncio
+async def test_on_dismiss_bookkeeping_failure_still_clears_flag_and_does_not_raise(
+    tmp_path, monkeypatch
+):
+    """A raising ledger write inside ``_on_dismiss`` must not crash the app.
+
+    ``_on_dismiss`` runs synchronously out of Textual's own dismiss
+    handling -- NOT a worker -- so an uncaught exception there reaches
+    ``App._handle_exception`` on the main thread and exits the app.
+    Monkeypatches the ledger-record call to raise and drives a real
+    dismissal through the pilot: the app must survive to the end of the
+    ``async with`` block, and the re-entrancy flag must still end False
+    (never stuck True) since this is the chain's last (only) discovery.
+    """
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("ledger exploded")
+
+    monkeypatch.setattr(_offer_module, "_record_project_skills_decision", _raise)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    service = _StubSkillsScopeService()
+    app = _OfferHarnessApp(service, (discovery,))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+
+        await pilot.click("#project-skills-not-now")
+        await pilot.pause()
+        await pilot.pause()
+
+        # The app is still alive and responsive -- an uncaught exception
+        # in the un-fixed `_on_dismiss` would have exited it here.
+        assert not app._exit
+
+    assert getattr(app, "_project_skills_offer_active", False) is False

--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+from types import SimpleNamespace
 
 import pytest
 from textual import on
@@ -15,6 +17,7 @@ from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.Widgets import project_skills_import_modal as _offer_module
 from tldw_chatbook.Widgets.project_skills_import_modal import (
     ProjectSkillsImportModal,
+    _project_skills_importer,
     maybe_offer_project_skills_import,
 )
 
@@ -397,6 +400,115 @@ async def test_on_dismiss_bookkeeping_failure_still_clears_flag_and_does_not_rai
 
 
 # ---------------------------------------------------------------------------
+# Finding 6 (Qodo review, PR #1810): a failed import's unchanged fingerprint
+# must not be recorded as "imported" in the ledger -- the .SKILLS/ folder on
+# disk is untouched by a failed import, so recording "imported" anyway would
+# make the ledger's unchanged-fingerprint check permanently suppress every
+# future offer for a root that never actually finished importing.
+# ---------------------------------------------------------------------------
+
+
+class _NoInstalledSkillsScopeService(_StubSkillsScopeService):
+    """Like ``_StubSkillsScopeService`` but reports nothing as installed --
+    so every row defaults checked and gets attempted on Import."""
+
+    async def get_context(self, *, mode=None):
+        del mode
+        return {"available_skills": [], "blocked_skills": []}
+
+
+class _PartialFailureSkillsScopeService(_NoInstalledSkillsScopeService):
+    """Fails ``import_skill_directory`` for one configured skill name;
+    every other entry imports normally."""
+
+    def __init__(self, fail_name: str):
+        super().__init__()
+        self._fail_name = fail_name
+
+    async def import_skill_directory(self, path, *, mode, name, trust_approved):
+        if name == self._fail_name:
+            raise RuntimeError("import exploded")
+        await super().import_skill_directory(
+            path, mode=mode, name=name, trust_approved=trust_approved
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_import_failure_leaves_ledger_untouched(tmp_path, monkeypatch):
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill", "beta-skill"))
+    service = _PartialFailureSkillsScopeService(fail_name="beta-skill")
+    app = _OfferHarnessApp(service, (discovery,))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        await pilot.click("#project-skills-close")
+        await pilot.pause()
+        await pilot.pause()
+
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    assert ledger.decision_for(discovery.root) is None
+
+
+@pytest.mark.asyncio
+async def test_fully_successful_import_records_imported_decision(
+    tmp_path, monkeypatch
+):
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    service = _NoInstalledSkillsScopeService()
+    app = _OfferHarnessApp(service, (discovery,))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        await pilot.click("#project-skills-close")
+        await pilot.pause()
+        await pilot.pause()
+
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    assert ledger.decision_for(discovery.root) == ("imported", discovery.fingerprint)
+
+
+@pytest.mark.asyncio
+async def test_zero_selected_import_records_nothing(tmp_path, monkeypatch):
+    """The "outcomes empty because the import never ran" half of Finding 6:
+    pressing Import with nothing checked must not record "imported" either
+    -- nothing actually happened, so the ledger must stay untouched."""
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    service = _NoInstalledSkillsScopeService()
+    app = _OfferHarnessApp(service, (discovery,))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+
+        app.screen.query_one("#project-skill-row-0", Checkbox).value = False
+        await pilot.click("#project-skills-import")
+        await pilot.pause()
+        await pilot.click("#project-skills-close")
+        await pilot.pause()
+        await pilot.pause()
+
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    assert ledger.decision_for(discovery.root) is None
+
+
+# ---------------------------------------------------------------------------
 # Finding 1: the create-path trigger must respect the SAME gating as the
 # startup path -- kill-switch, "Never", and fingerprint gating -- not just
 # scan-and-offer unconditionally. ``maybe_offer_project_skills_import`` is
@@ -460,3 +572,132 @@ def test_missing_skills_scope_service_suppresses_offer(tmp_path, monkeypatch):
     assert app.pushed == []
     assert app.workers == []
     assert getattr(app, "_project_skills_offer_active", False) is False
+
+
+# ---------------------------------------------------------------------------
+# Finding 7 (Qodo review, PR #1810): TOCTOU symlink swap between discovery
+# and import. Discovery accepts a loose ``.md`` file, but the import-time
+# read happens later (after the user reviews and presses "Import selected")
+# -- a hostile/racing actor can swap the accepted file for a symlink to any
+# readable file in between. The loose-file importer must re-validate
+# symlink/regular-file status immediately before reading, not trust
+# discovery's earlier check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loose_file_symlink_swap_before_import_is_refused(tmp_path):
+    skill_path = tmp_path / ".SKILLS" / "swapped-skill.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\ndescription: real.\n---\nBody\n", encoding="utf-8")
+    discovery = discover_project_skills(tmp_path)
+    assert discovery is not None
+    entry = next(e for e in discovery.entries if e.name == "swapped-skill")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET CONTENTS", encoding="utf-8")
+
+    # Swap the discovery-accepted regular file for a symlink pointing at an
+    # arbitrary (readable) file, simulating a race between discovery and
+    # the user pressing "Import selected".
+    skill_path.unlink()
+    os.symlink(secret, skill_path)
+
+    calls: list = []
+
+    class _Service:
+        async def import_skill_file(self, data, **kwargs):
+            calls.append(data)
+
+        async def import_skill_directory(self, *args, **kwargs):
+            raise AssertionError("directory import should not be reached")
+
+    app = SimpleNamespace(skills_scope_service=_Service())
+    importer = _project_skills_importer(app)
+
+    with pytest.raises(ValueError, match="skill file changed on disk"):
+        await importer(entry)
+
+    assert calls == []  # the symlink target must never reach the importer
+
+
+@pytest.mark.asyncio
+async def test_loose_file_unswapped_import_still_succeeds(tmp_path):
+    """Sanity companion to the swap test above: the re-validation added for
+    Finding 7 must not break the ordinary (unswapped) loose-file import
+    path."""
+    skill_path = tmp_path / ".SKILLS" / "steady-skill.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\ndescription: real.\n---\nBody\n", encoding="utf-8")
+    discovery = discover_project_skills(tmp_path)
+    assert discovery is not None
+    entry = next(e for e in discovery.entries if e.name == "steady-skill")
+
+    calls: list = []
+
+    class _Service:
+        async def import_skill_file(self, data, **kwargs):
+            calls.append((data, kwargs))
+
+    app = SimpleNamespace(skills_scope_service=_Service())
+    importer = _project_skills_importer(app)
+    await importer(entry)
+
+    assert len(calls) == 1
+    data, kwargs = calls[0]
+    assert data == skill_path.read_bytes()
+    assert kwargs["filename"] == "steady-skill.md"
+
+
+# ---------------------------------------------------------------------------
+# Finding 10 (Qodo review, PR #1810): the INITIAL ``run_worker`` call in
+# ``maybe_offer_project_skills_import`` was unguarded -- unlike the
+# continuation's own ``run_worker`` call in ``_on_dismiss``, a scheduling
+# failure here (e.g. the app's task runner rejecting the call) left
+# ``_project_skills_offer_active`` stuck True forever, permanently
+# silencing every future offer for the app's whole session.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingOnceRunWorkerApp(_RecorderApp):
+    """``run_worker`` raises on its first call only; succeeds after."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fail_next = True
+
+    def run_worker(self, coro, **kwargs):
+        if self._fail_next:
+            self._fail_next = False
+            # Deliberately does NOT close `coro` here -- closing it is the
+            # fix's own responsibility (Finding 10), not this double's; a
+            # correct fix closes it in its `except` branch so no
+            # "coroutine was never awaited" warning escapes this test.
+            raise RuntimeError("scheduling exploded")
+        return super().run_worker(coro, **kwargs)
+
+
+def test_initial_scheduling_failure_clears_flag_and_allows_retry(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_offer_module, "get_cli_setting", lambda *a, **k: True)
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: tmp_path / "data")
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    app = _RaisingOnceRunWorkerApp()
+
+    maybe_offer_project_skills_import(app, (discovery,))
+
+    # The failed scheduling attempt must not propagate, and must not leave
+    # the re-entrancy flag stuck True.
+    assert app.workers == []
+    assert getattr(app, "_project_skills_offer_active", False) is False
+
+    # A second call must not be blocked by a stuck flag -- it schedules
+    # normally now that run_worker no longer raises.
+    maybe_offer_project_skills_import(app, (discovery,))
+    assert len(app.workers) == 1
+    # `_RecorderApp.run_worker` only records the coroutine, it never
+    # awaits it (no event loop here) -- close it explicitly so pytest's
+    # gc-based leak detector doesn't flag it as never-awaited.
+    app.workers[0].close()

--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -238,3 +238,44 @@ async def test_maybe_offer_chains_installed_names_ledger_and_navigation(
         "imported",
         discovery_b.fingerprint,
     )
+
+
+@pytest.mark.asyncio
+async def test_maybe_offer_reentrancy_guard_blocks_concurrent_calls(
+    tmp_path, monkeypatch
+):
+    """Two back-to-back offer calls while the first modal is still open.
+
+    ``_OfferHarnessApp.on_mount`` fires the first (and only, in this test)
+    call automatically; a second call while that modal is up must be a
+    no-op -- no second modal stacked on top -- and the re-entrancy flag
+    must clear once the (single-discovery) chain's last modal dismisses.
+    """
+    ledger_dir = tmp_path / "data"
+    monkeypatch.setattr(_offer_module, "get_user_data_dir", lambda: ledger_dir)
+
+    discovery = _discovery(tmp_path, names=("alpha-skill",))
+    service = _StubSkillsScopeService()
+    app = _OfferHarnessApp(service, (discovery,))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        assert isinstance(app.screen, ProjectSkillsImportModal)
+        first_modal = app.screen
+        assert app._project_skills_offer_active is True
+
+        # Second call while the flow is still active: must be a no-op.
+        maybe_offer_project_skills_import(app, (discovery,))
+        await pilot.pause()
+        await pilot.pause()
+        assert app.screen is first_modal
+
+        await pilot.click("#project-skills-never")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert getattr(app, "_project_skills_offer_active", False) is False
+
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    assert ledger.decision_for(discovery.root) == ("never", discovery.fingerprint)

--- a/Tests/Skills/test_project_skills_prompt.py
+++ b/Tests/Skills/test_project_skills_prompt.py
@@ -1,0 +1,36 @@
+# Tests/Skills/test_project_skills_prompt.py
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    ProjectSkillsPromptLedger,
+    should_offer_project_skills_prompt,
+)
+
+
+def test_gating_truth_table():
+    assert should_offer_project_skills_prompt(False, None, "f1") is False
+    assert should_offer_project_skills_prompt(True, None, "f1") is True
+    assert should_offer_project_skills_prompt(True, ("never", "f0"), "f1") is False
+    assert should_offer_project_skills_prompt(True, ("declined", "f1"), "f1") is False
+    assert should_offer_project_skills_prompt(True, ("declined", "f0"), "f1") is True
+    assert should_offer_project_skills_prompt(True, ("imported", "f0"), "f1") is True
+
+
+def test_ledger_roundtrip_and_missing(tmp_path):
+    ledger = ProjectSkillsPromptLedger(tmp_path)
+    directory = Path("/some/project")
+    assert ledger.decision_for(directory) is None
+    ledger.record(directory, "declined", "f1")
+    assert ledger.decision_for(directory) == ("declined", "f1")
+    ledger.record(directory, "never", "f2")
+    assert ledger.decision_for(directory) == ("never", "f2")
+
+
+def test_ledger_survives_corrupt_file(tmp_path):
+    path = tmp_path / "skills" / "project_prompts.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    ledger = ProjectSkillsPromptLedger(tmp_path)
+    assert ledger.decision_for(Path("/x")) is None
+    ledger.record(Path("/x"), "imported", "f1")
+    assert ledger.decision_for(Path("/x")) == ("imported", "f1")

--- a/Tests/Skills/test_project_skills_prompt.py
+++ b/Tests/Skills/test_project_skills_prompt.py
@@ -34,3 +34,12 @@ def test_ledger_survives_corrupt_file(tmp_path):
     assert ledger.decision_for(Path("/x")) is None
     ledger.record(Path("/x"), "imported", "f1")
     assert ledger.decision_for(Path("/x")) == ("imported", "f1")
+
+
+def test_ledger_key_normalizes_path_spellings(tmp_path):
+    (tmp_path / "x").mkdir()
+    (tmp_path / "proj").mkdir()
+    ledger = ProjectSkillsPromptLedger(tmp_path)
+    unresolved = tmp_path / "x" / ".." / "proj"
+    ledger.record(unresolved, "imported", "f1")
+    assert ledger.decision_for(tmp_path / "proj") == ("imported", "f1")

--- a/Tests/Skills/test_project_skills_startup_gate.py
+++ b/Tests/Skills/test_project_skills_startup_gate.py
@@ -1,0 +1,36 @@
+# Tests/Skills/test_project_skills_startup_gate.py
+from pathlib import Path
+
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    startup_discovery_for,
+)
+
+
+def _skill(root):
+    d = root / ".SKILLS" / "alpha-skill"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+
+
+def test_startup_discovery_found(tmp_path):
+    _skill(tmp_path / "repo")
+    (tmp_path / "repo" / ".git").mkdir()
+    sub = tmp_path / "repo" / "src"
+    sub.mkdir()
+    discovery = startup_discovery_for(sub, enabled=True, ledger_dir=tmp_path / "data")
+    assert discovery is not None and discovery.entries
+
+
+def test_startup_discovery_disabled(tmp_path):
+    _skill(tmp_path)
+    assert startup_discovery_for(tmp_path, enabled=False, ledger_dir=tmp_path / "d") is None
+
+
+def test_startup_discovery_respects_never(tmp_path):
+    _skill(tmp_path)
+    from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+        ProjectSkillsPromptLedger,
+    )
+    ledger = ProjectSkillsPromptLedger(tmp_path / "data")
+    ledger.record(tmp_path.resolve(), "never", "anything")
+    assert startup_discovery_for(tmp_path, enabled=True, ledger_dir=tmp_path / "data") is None

--- a/Tests/Skills/test_project_skills_startup_gate.py
+++ b/Tests/Skills/test_project_skills_startup_gate.py
@@ -1,5 +1,6 @@
 # Tests/Skills/test_project_skills_startup_gate.py
 from pathlib import Path
+from types import SimpleNamespace
 
 from tldw_chatbook.Skills_Interop.project_skills_prompt import (
     startup_discovery_for,
@@ -34,3 +35,31 @@ def test_startup_discovery_respects_never(tmp_path):
     ledger = ProjectSkillsPromptLedger(tmp_path / "data")
     ledger.record(tmp_path.resolve(), "never", "anything")
     assert startup_discovery_for(tmp_path, enabled=True, ledger_dir=tmp_path / "data") is None
+
+
+def test_discover_project_skills_for_startup_never_raises(monkeypatch, tmp_path):
+    """The worker body must swallow ANY exception, not just OSError on cwd().
+
+    ``TldwCli._discover_project_skills_for_startup`` runs on a worker
+    thread with ``exit_on_error=False``, but that alone still surfaces an
+    unhandled exception as a logged worker error -- an entirely optional
+    startup nicety must degrade to a quiet no-op instead. Exercised by
+    monkeypatching ``startup_discovery_for`` at its home module (the
+    method imports it locally on every call, so patching the module
+    attribute is visible to that import) to raise, then calling the
+    method directly on a minimal stub object -- no real ``TldwCli``
+    instance needed since the exception fires before anything else on
+    ``self`` is touched.
+    """
+    import tldw_chatbook.Skills_Interop.project_skills_prompt as prompt_module
+    from tldw_chatbook.app import TldwCli
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(prompt_module, "startup_discovery_for", _raise)
+    monkeypatch.chdir(tmp_path)
+
+    stub = SimpleNamespace()
+    result = TldwCli._discover_project_skills_for_startup(stub)
+    assert result is None

--- a/Tests/UI/test_first_run_wizard_live_contract.py
+++ b/Tests/UI/test_first_run_wizard_live_contract.py
@@ -787,6 +787,37 @@ def test_started_flag_mirrors_only_after_success_and_logs_bounded_failure(
     assert "private-value" not in rendered_log
 
 
+def test_prompt_branch_returns_true_to_defer_lower_priority_startup_offers(
+    monkeypatch,
+):
+    """Finding 3 (final review 2026-08-17): the recovery-dialog "prompt"
+    branch must also return True from ``_maybe_offer_first_run_wizard`` --
+    app.py only defers the lower-priority project-.SKILLS import offer when
+    this method returns True (see the ``if not wizard_offered:`` call site),
+    so previously only the wizard's own "offer" branch stopped the skills
+    offer from stacking on top of a just-pushed screen; the "prompt" branch
+    (``SetupRecoveryDialog``) did not, letting the skills modal stack on
+    top of the recovery dialog.
+    """
+    from tldw_chatbook.app import TldwCli
+    import tldw_chatbook.UI.Wizards.first_run_setup_state as state_module
+
+    monkeypatch.setattr(
+        state_module, "setup_recovery_action", lambda app_config, environ: "prompt"
+    )
+
+    scheduled: list = []
+    fake = SimpleNamespace(app_config={}, _first_run_startup_action_scheduled=False)
+    fake.call_after_refresh = lambda cb: scheduled.append(cb)
+    fake._push_first_run_recovery_dialog = lambda: None
+
+    result = TldwCli._maybe_offer_first_run_wizard(fake)
+
+    assert result is True
+    assert fake._first_run_startup_action_scheduled is True
+    assert scheduled == [fake._push_first_run_recovery_dialog]
+
+
 @pytest.mark.asyncio
 async def test_resume_marks_attempt_before_pushing_restored_wizard(monkeypatch):
     from tldw_chatbook.app import TldwCli

--- a/Tests/Workspaces/test_console_workspace_create_handler.py
+++ b/Tests/Workspaces/test_console_workspace_create_handler.py
@@ -79,3 +79,23 @@ def test_failed_folders_surface_as_warnings(tmp_path):
     )
     ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
     assert any("Folder does not exist" in n for n in stub.notifications)
+
+
+def test_result_with_project_skills_offers_import(tmp_path, monkeypatch):
+    offered = []
+    import tldw_chatbook.UI.Console_Modules.workspace as ws_module
+
+    monkeypatch.setattr(
+        ws_module,
+        "maybe_offer_project_skills_import",
+        lambda app, discoveries: offered.append(discoveries),
+    )
+    stub = _Stub(_registry(tmp_path))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1",
+        name="Workspace 1",
+        make_active=False,
+        project_skills=("sentinel-discovery",),
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert offered == [("sentinel-discovery",)]

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -436,3 +436,40 @@ async def test_folder_with_skills_annotated_and_carried_on_result(tmp_path):
         await pilot.pause()
     assert len(app.result.project_skills) == 1
     assert app.result.project_skills[0].entries[0].name == "alpha-skill"
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_suppresses_folder_discovery_scan(tmp_path, monkeypatch):
+    """Finding 1: with the ``[skills] project_skills_prompt_enabled``
+    kill-switch off, ``_add_folder`` must not scan the bound folder for
+    project skills AT ALL -- "no scanning" must be literally true, not
+    merely "no offer" later. Monkeypatches ``discover_project_skills`` with
+    a recorder to prove the call never happens.
+    """
+    calls: list = []
+
+    def _recorder(root):
+        calls.append(root)
+        return None
+
+    monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "tldw_chatbook.Widgets.workspace_create_modal.discover_project_skills",
+        _recorder,
+    )
+
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    skill = project / ".SKILLS" / "alpha-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+
+    assert calls == []

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -414,3 +414,25 @@ async def test_escape_after_partial_create_returns_partial_result(tmp_path):
     created = inner.list_workspaces()
     assert len(created) == 1
     assert result.workspace_id == created[0].workspace_id
+
+
+@pytest.mark.asyncio
+async def test_folder_with_skills_annotated_and_carried_on_result(tmp_path):
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    skill = project / ".SKILLS" / "alpha-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        rows = [str(s.renderable) for s in modal.query(".workspace-create-folder-locator")]
+        assert any("1 project skill" in row for row in rows)
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    assert len(app.result.project_skills) == 1
+    assert app.result.project_skills[0].entries[0].name == "alpha-skill"

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 import pytest
@@ -473,3 +474,50 @@ async def test_kill_switch_suppresses_folder_discovery_scan(tmp_path, monkeypatc
         await pilot.pause()
 
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_removed_and_rescanned_folder_clears_stale_discovery(tmp_path):
+    """Finding 9 (Qodo review, PR #1810): a removed folder's stale
+    ``_folder_discoveries`` entry must not linger -- ``_remove_folder`` has
+    to pop it -- and a fresh ``_add_folder`` rescan that finds nothing
+    usable (e.g. the ``.SKILLS/`` dir was deleted since the last scan) must
+    CLEAR any previously-recorded entry for that same locator, not merely
+    leave the old one in place (assign-or-pop, not assign-only).
+    """
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    skill = project / ".SKILLS" / "alpha-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\ndescription: x\n---\nB\n", encoding="utf-8")
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        rows = [
+            str(s.renderable) for s in modal.query(".workspace-create-folder-locator")
+        ]
+        assert any("1 project skill" in row for row in rows)
+
+        # Remove the folder -- its discovery must be popped, not left stale.
+        modal.query_one("#workspace-create-folder-remove-0", Button).press()
+        await pilot.pause()
+        assert modal._folder_discoveries == {}
+
+        # Delete the .SKILLS/ dir, then re-add the SAME folder -- the fresh
+        # (empty) scan must not resurrect the stale annotation.
+        shutil.rmtree(project / ".SKILLS")
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+        rows = [
+            str(s.renderable) for s in modal.query(".workspace-create-folder-locator")
+        ]
+        assert not any("project skill" in row for row in rows)
+
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+    assert app.result.project_skills == ()

--- a/backlog/decisions/069-project-skills-folder-convention.md
+++ b/backlog/decisions/069-project-skills-folder-convention.md
@@ -1,0 +1,151 @@
+# ADR-069: Project-Local `.SKILLS/` Folder Convention
+
+Status: Accepted
+Date: 2026-08-18
+Related Task: [backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md](../tasks/task-17651%20-%20Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md)
+Supersedes: N/A
+
+## Decision
+
+A project may declare a `.SKILLS/` (or `.skills/`) directory at its root. Chatbook
+discovers it at two moments — app startup from inside the project, and workspace
+creation with a bound folder — and offers a **prompt-driven, never-silent** import into
+the existing local Skills store. Import always **copies** discovered skill content
+through the existing importer with `trust_approved=False`, landing the skills inside
+ADR-009's local trust boundary in the quarantined state; the folder itself is never
+executed from, watched, or treated as a live skill source. A per-project prompt ledger
+avoids re-nagging until the discovered skill set actually changes, and a config
+kill-switch (`[skills] project_skills_prompt_enabled`) disables the feature outright.
+
+## Context
+
+Users bring existing projects into Chatbook — a repo they already work in, with its own
+conventions and, increasingly, its own curated prompt/skill assets. Today the only way
+to get those into the app is a manual, one-directory-at-a-time import through Library ▸
+Skills. That is fine for a skill a user builds inside Chatbook, but it is friction for a
+user who already has a folder of skills sitting in their project and just wants the app
+to notice.
+
+The obvious per-skill layout choice follows the emerging "agent skill" convention
+already used elsewhere in this ecosystem: a per-skill subdirectory containing a
+top-level `SKILL.md`, imported via the existing `import_skill_directory`. A project may
+also have simpler loose `*.md` files not organized into subdirectories; those import via
+`import_skill_file`, one skill per file. Anything else in the folder (a subdirectory
+without `SKILL.md`, a non-markdown file) is reported as skipped with a reason rather
+than silently dropped, so a partially-matching folder doesn't read as broken or empty.
+
+The two discovery moments are the two points a user is most likely to be thinking about
+"this project's stuff": launching the app while sitting inside the project (or a
+subdirectory of it — the discovery walk goes upward looking for `.SKILLS/`, stopping at
+the first ancestor containing `.git`, at `$HOME`, or at the filesystem root, so a launch
+from a nested subdirectory still finds the project-root folder), and creating a
+Console/Settings/Library workspace explicitly bound to a folder that turns out to
+contain one. Both triggers write to the same ledger and read from the same discovery and
+gating logic, so declining (or importing) at one silences the other for that folder.
+
+## Import-copy, not live-load — relation to ADR-009
+
+ADR-009 established a passphrase-rooted, authenticated local trust boundary for
+Chatbook-managed skills: trust records, encrypted trusted snapshots, and a secure
+generation marker all live *inside* that boundary, and execution requires the file on
+disk to match what was trusted. A `.SKILLS/` folder living inside an arbitrary,
+externally-editable project directory is explicitly **outside** that boundary — it has
+no trust record, no generation marker, and can be modified by anything with filesystem
+access to the project (another process, a `git checkout`, a compromised dependency's
+postinstall script) without Chatbook ever seeing it.
+
+Two designs were on the table for getting a project's skills into a running session:
+
+1. **Live-load**: treat `.SKILLS/` as an additional skill source read at use time,
+   directly from the project folder.
+2. **Import-copy**: run discovered entries through the existing importer, which copies
+   their content into the Chatbook-managed local skills store.
+
+Live-load was rejected. It would mean skill content used to steer model behavior comes
+from a location ADR-009's trust and tamper-detection machinery does not cover at all —
+not "trust-blocked pending review" (a state ADR-009 already models and blocks execution
+for) but structurally unprotected, since the trust boundary has no jurisdiction over
+files it was never told to track. That reintroduces exactly the offline-tampering
+concern ADR-009 exists to close, for the one class of skill content most likely to come
+from a project the user did not author entirely themselves (cloned repos, downloaded
+templates, a colleague's shared project).
+
+Import-copy keeps this feature entirely inside ADR-009's existing model: an imported
+skill becomes an ordinary Chatbook-managed local skill, subject to the same trust
+records, the same encrypted snapshots, and — critically — the same **quarantine**.
+Imports from `.SKILLS/` are never auto-trusted; every import runs with
+`trust_approved=False`, identical to a manual Library import. A freshly imported skill
+is excluded from the Console skill picker and any `$mention` of it is refused with a
+pointer back to Library ▸ Skills, until a human reviews and approves it there. The
+import modal states this "one-time trust review" expectation up front, because without
+that framing the feature would read as broken (the skill appears to exist but silently
+refuses to run).
+
+The cost of import-copy is that the Chatbook-managed copy can drift from the project
+folder's copy once either changes — there is no live sync. That tradeoff is deliberate:
+a skill that could silently follow live edits to a project file is a skill an attacker
+(or an errant `git pull`) can silently rewrite underneath an already-trusted session.
+Requiring a fresh import (and fresh trust review) to pick up a changed version is the
+same friction ADR-009 already accepts for its "reviewed re-trust before a changed skill
+can run" rule — this decision extends it to the point of entry rather than carving out
+an exception.
+
+## Fingerprint ledger
+
+Nagging on every launch from inside a project that declined the offer once would be
+worse than not offering at all. A prompt ledger at `<user_data_dir>/skills/
+project_prompts.json` (same atomic-replace-on-write discipline as the skills index)
+records, per resolved project directory: the last decision (`imported` / `declined` /
+`never`) and a fingerprint — a stable hash over the sorted (name, size, mtime) of the
+recognized skill files at discovery time. The gating rule is: offer only if the feature
+is enabled, `.SKILLS/` is present, and either there is no ledger entry, or the recorded
+decision was not `never` **and** the current fingerprint differs from the recorded one.
+
+This makes "Not now" mean "ask me again if this project's skill set actually changes"
+rather than "ask me again next launch" — a project that hasn't been touched doesn't keep
+producing the same prompt, but one that grew two new skills usefully re-surfaces as
+exactly that. "Never for this folder" is permanent regardless of future fingerprint
+changes. Both triggers (startup, workspace creation) share this one ledger and one
+gating function, so a decision made from either surface is honored by the other.
+
+## Kill-switch
+
+`[skills] project_skills_prompt_enabled` (default `true`) disables the entire feature —
+no discovery-driven prompting at either trigger — for a user who does not want Chatbook
+scanning project directories for skill folders at all, without needing to hunt down and
+decline every project individually. It does not affect manual import through Library ▸
+Skills, which is unconditionally available regardless of this setting.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Live-load `.SKILLS/` as a skill source at use time | Puts trust-sensitive prompt content outside ADR-009's tamper-detection boundary entirely; see above. |
+| Silent auto-import on first launch | Contradicts ADR-009's "first enablement must be explicit" posture, extended here to "first *ingestion* must be explicit" — a folder full of skills silently entering the picker (even quarantined) is a surprise, not a convenience. |
+| Auto-trust imports from `.SKILLS/` because the user "already trusted the project" | Trusting a project directory (e.g. running its code, opening it in an editor) is not the same act as trusting arbitrary prompt content to steer the model; conflating them would let a compromised project skip the one review step ADR-009 relies on. |
+| One-time-only offer per project (no re-offer on change) | Silently stops covering new skills added to a project after the first decline, which is worse than a single well-gated re-prompt on genuine change. |
+| Merge multiple discovered `.SKILLS/` folders into a single combined offer | Rejected in favor of sequential, per-discovery modals — keeps each decision (and each ledger entry) tied to exactly one folder, avoiding a combined accept/decline that can't be attributed cleanly. |
+
+## Consequences
+
+Two new startup/workspace-creation code paths gain filesystem-scanning behavior
+(bounded: symlink refusal, 50-entry cap, 64 KiB per-file frontmatter read cap, top-level
+scan only) that must run off the main thread at startup so a slow or huge project
+directory cannot stall app launch.
+
+Every import from this path lands in the same quarantined state as a manual Library
+import — no new execution surface, no new trust-bypass path. The feature adds discovery
+and offer plumbing only; `execute_skill` and the Console `$mention` resolution path
+remain the sole authority on whether an imported skill may run, unchanged by this
+decision.
+
+The prompt ledger is advisory, not authoritative: a lost or corrupted ledger entry only
+costs the user one extra prompt, never a security regression, so ledger writes are
+best-effort and must never crash the app or block startup on failure.
+
+## Links
+
+- [ADR-009: Local Skill Trust Boundary](009-local-skill-trust-boundary.md)
+- [TASK-17651](../tasks/task-17651%20-%20Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md)
+- [Workspace create modal + project skills design spec](../../Docs/superpowers/specs/2026-08-17-workspace-create-modal-and-project-skills-design.md) §5
+- [Project skills import implementation plan](../../Docs/superpowers/plans/2026-08-17-project-skills-import.md)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -62,6 +62,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-063](063-hosted-provider-wire-and-durable-tool-continuation.md) | Accepted | Keep hosted Chat wire mechanics neutral and persist private provider continuation with message-owned sync, conflict, export, and model-specific replay semantics. |
 | [ADR-064](064-deepseek-dual-api-provider-boundary.md) | Accepted | Treat DeepSeek Chat Completions and Responses as two strict modes of one provider with stateless explicit history and durable reasoning/tool continuation. |
 | [ADR-065](065-active-ingest-source-admission-and-override.md) | Accepted | Refuse same-backend active-source ingest duplicates by default, with lexical identity, atomic folder admission, and an inline one-shot override. |
+| [ADR-069](069-project-skills-folder-convention.md) | Accepted | Discover project-local `.SKILLS/` folders at startup and workspace creation, offering prompt-driven, fingerprint-gated import that copies content into the ADR-009 trust boundary quarantined rather than live-loading it. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5249,3 +5249,20 @@ The general form: **any code path that converts a failure into a
 well-formed empty result destroys the distinction the caller needs.** Grep
 for `except` blocks that `return` an empty container whenever a measurement
 built on them surprises you.
+## A gate built in halves is no gate — and sound-looking test deviations can hide exactly that (TASK-17651, 2026-08-18)
+
+The `.SKILLS/` import feature had prompt-gating (kill-switch, permanent "Never",
+fingerprint re-offer) specified for BOTH its triggers. Task 2 built the gating
+functions; Task 4 wired them into the startup trigger; Task 5 wired the
+workspace-create trigger straight past them — every per-task review passed,
+because each task correctly built its own half. The final whole-branch review
+found the create trigger honored none of the gates, while a checked AC and
+three documents promised it did. Compounding it: the live-verification pass
+had deliberately used a FRESH fixture for the create-trigger scenario, with
+locally sound reasoning ("the 'Never' from the previous scenario would
+correctly suppress the offer") that ASSUMED the cross-trigger gate existed —
+the deviation dodged the exact broken case. Rules: (1) when a contract spans
+tasks, some review must check the CONNECTION, not the halves — that is what
+the whole-branch review is for; never skip it because per-task reviews were
+clean. (2) A test-plan deviation justified by assumed behavior of the thing
+under test is a red flag: the assumption is the test.

--- a/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+++ b/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
@@ -135,6 +135,32 @@ Deviations from the plan: none structural. The three same-day fix rounds
 above (Tasks 1, 2, 4) were caught by each task's own RED/GREEN discipline or
 immediate self-review, not by this close-out task.
 
+**Post-review gate connection (final review 2026-08-17, Finding 1):** the
+final whole-branch review found that AC#2's gating ("declining re-prompts
+only when the fingerprint changes; 'Never' is permanent; the kill-switch
+disables the feature") was consulted ONLY by the startup trigger
+(`startup_discovery_for`) -- the create-modal trigger's own path
+(`WorkspaceCreateModal._add_folder` -> `maybe_offer_project_skills_import`)
+scanned and offered unconditionally, bypassing the kill-switch, "Never",
+and fingerprint gating entirely, which violated spec §5.3's "declining in
+one place silences the other" and this AC. Fixed at the declared choke
+point: `maybe_offer_project_skills_import` (every call site routes through
+it) now checks the kill-switch first, filters every discovery through
+`should_offer_project_skills_prompt` + the ledger before offering anything,
+and suppresses when `app.skills_scope_service` is absent; `_add_folder`
+skips the scan entirely (not just the offer) when the kill-switch is off.
+New RED/GREEN pilot coverage: `test_never_for_folder_silences_create_
+trigger`, `test_kill_switch_suppresses_create_offer`,
+`test_kill_switch_suppresses_folder_discovery_scan`,
+`test_missing_skills_scope_service_suppresses_offer` (all in
+`Tests/Skills/test_project_skills_import_modal.py` /
+`Tests/Workspaces/test_workspace_create_modal.py`). AC#2 stays ticked with
+this fix in place; see `.superpowers/sdd/2026-08-17-project-skills-import/
+finalfix-report.md` for the full fix-wave record (also covers 6 other
+review findings: in-flight-import dismissal races, a recovery-dialog
+startup stacking bug, a docs inaccuracy about unparseable frontmatter, a
+missing precedence log line, and a coroutine-leak hardening fix).
+
 Modified/added files (cumulative, all 6 tasks): `tldw_chatbook/Skills_Interop/
 project_skills_discovery.py` (new), `project_skills_prompt.py` (new),
 `tldw_chatbook/Widgets/project_skills_import_modal.py` (new),

--- a/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+++ b/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
@@ -2,7 +2,7 @@
 id: TASK-17651
 title: >-
   Project skills (.SKILLS/) folder discovery and prompt-driven import
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-17 00:00'
 labels:

--- a/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+++ b/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
@@ -28,15 +28,127 @@ Plan: `Docs/superpowers/plans/2026-08-17-project-skills-import.md`.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Launching the app from a project (or subdirectory, up to the first .git ancestor) containing `.SKILLS/` offers an import prompt listing discovered skills; the first-run wizard suppresses it for that launch
-- [ ] Declining re-prompts only when the skill set's fingerprint changes; "Never for this folder" is permanent; `[skills] project_skills_prompt_enabled = false` disables the feature
-- [ ] Creating a workspace with a bound folder containing `.SKILLS/` chains the same offer after creation
-- [ ] Imports run through the existing importer with trust_approved=False (quarantined), never overwrite existing names silently, and the modal states the one-time trust review expectation with a route to Library ▸ Skills
-- [ ] Discovery refuses symlinked `.SKILLS/` dirs and entries, caps entries (50) and frontmatter reads (64 KiB), pre-flags invalid names, and renders repo-sourced text escaped
-- [ ] ADR for the convention added; config key documented; User Guide updated
+- [x] Launching the app from a project (or subdirectory, up to the first .git ancestor) containing `.SKILLS/` offers an import prompt listing discovered skills; the first-run wizard suppresses it for that launch
+- [x] Declining re-prompts only when the skill set's fingerprint changes; "Never for this folder" is permanent; `[skills] project_skills_prompt_enabled = false` disables the feature
+- [x] Creating a workspace with a bound folder containing `.SKILLS/` chains the same offer after creation
+- [x] Imports run through the existing importer with trust_approved=False (quarantined), never overwrite existing names silently, and the modal states the one-time trust review expectation with a route to Library ▸ Skills
+- [x] Discovery refuses symlinked `.SKILLS/` dirs and entries, caps entries (50) and frontmatter reads (64 KiB), pre-flags invalid names, and renders repo-sourced text escaped
+- [x] ADR for the convention added; config key documented; User Guide updated
 
 ## Implementation Plan (the how)
 
 Execute `Docs/superpowers/plans/2026-08-17-project-skills-import.md` (6 tasks:
 discovery → ledger → import modal → startup trigger → create-modal chaining →
 ADR/docs + live verification). Starts only after TASK-17650 is on dev.
+
+## Implementation Notes
+
+Shipped as 9 commits (`e511355df`..`964cb04df`, TASK-17651's 6 plan tasks
+plus 3 self-caught fix rounds):
+
+- **Task 1 (discovery)** — `tldw_chatbook/Skills_Interop/project_skills_discovery.py`:
+  pure `discover_project_skills(root)` — per-skill directories (`SKILL.md`)
+  and loose `*.md` files, symlink refusal on both the `.SKILLS/`/`.skills/`
+  dir and its entries, 50-entry / 64 KiB caps, invalid-name pre-flagging via
+  the importer's own name grammar, skipped-entry reasons, and a
+  sha256 fingerprint over the recognized skill files. Two same-day fix
+  rounds: `670250506` (description parsing didn't match the importer's own
+  frontmatter grammar) and `c950b271d` (the fingerprint originally stat'd
+  the containing directory, which doesn't change mtime on POSIX when a file
+  inside it is edited in place — switched to stat'ing the skill file itself;
+  also fixed the ancestor walk to resolve symlinked ancestors before the
+  `$HOME`/`.git`/fs-root stop checks).
+- **Task 2 (ledger)** — `tldw_chatbook/Skills_Interop/project_skills_prompt.py`:
+  `ProjectSkillsPromptLedger` at `<user_data_dir>/skills/project_prompts.json`,
+  resolved-path keys, `should_offer_project_skills_prompt` gating truth table
+  (no entry / declined+same fingerprint / declined+changed / never /
+  kill-switch). Writes use a writer-unique temp filename (pid + thread id) —
+  the two pre-existing sites with a fixed-temp-name equivalent
+  (`local_skills_service.py`, `skill_trust_store.py`) were deliberately left
+  alone and are now tracked as TASK-17963. Fix round `7005a09b9`: resolve
+  ledger keys consistently and make advisory writes crash-proof (swallow
+  `OSError`, never abort the caller).
+- **Task 3 (import modal)** — `tldw_chatbook/Widgets/project_skills_import_modal.py`:
+  `ProjectSkillsImportModal` (offer phase → results phase), verbatim
+  spec §5.5 trust line, escaped repo-sourced text, `trust_approved=False` on
+  every import, and the shared `maybe_offer_project_skills_import(app,
+  discoveries)` helper that sequentially chains multiple discoveries and
+  posts `NavigateToScreen("skills")` on Review.
+- **Task 4 (startup trigger)** — wired into `app.py`'s `_post_mount_setup`
+  next to the first-run wizard; wizard wins (skills offer defers to next
+  launch when the wizard fires this launch), worker-thread discovery so
+  startup stays unblocked. Fix round `971650bb5` (controller-completed after
+  the implementer died at session limit): the startup discovery worker
+  needed `exit_on_error=False` plus a full-body `try/except` so a discovery
+  crash can never take the app down, and a re-entrancy guard
+  (`_project_skills_offer_active`) so a second startup call while a modal
+  chain is already open can never stack a duplicate modal or leak the flag
+  on worker failure.
+- **Task 5 (create-modal chaining)** — `WorkspaceCreateModal._add_folder`
+  runs `discover_project_skills` synchronously per added folder (bounded
+  scan, consistent with the existing synchronous path-validation call in the
+  same handler) and annotates the row `"— contains N project skill(s)"`;
+  `WorkspaceCreateResult.project_skills` carries the discoveries for
+  successfully bound folders; all three creation surfaces (Console,
+  Settings, Library) call `maybe_offer_project_skills_import` after their
+  existing post-create sync.
+- **Task 6 (this task) — ADR, config docs, User Guide, live verification**:
+  - **ADR-069** (`backlog/decisions/069-project-skills-folder-convention.md`):
+    the `.SKILLS/`/`.skills/` convention, both triggers, the fingerprint
+    ledger, the kill-switch, and — the substantive decision — import-copy
+    (not live-load) as the only design that keeps imported content inside
+    ADR-009's trust boundary; live-load would put trust-sensitive prompt
+    content structurally outside it.
+  - **Config docs**: added a `[skills]` heading (none existed before) with
+    `# project_skills_prompt_enabled = true  # offer .SKILLS/ import at
+    startup; spec 2026-08-17` to `config.py`'s `CONFIG_TOML_CONTENT` docs
+    template, next to `[console]`'s `workspace_root` doc line (the brief's
+    cited `:2588` had drifted to `:2722` in this worktree's `config.py`;
+    verified by grepping the live symbol before editing).
+  - **User Guide**: `Docs/User_Guide/library/skills.md` gained a full
+    "Project skills (`.SKILLS/`)" subsection (convention, both triggers,
+    trust-review framing, kill-switch) plus two Quirks bullets and a
+    Related-docs correction (the page previously said it "owns no
+    `config.toml` keys" — no longer true); `Docs/User_Guide/console/
+    sessions-tabs-workspaces.md`, `settings.md`, and `library.md` (the three
+    workspace pages PR A's own docs commit touched) each gained the
+    folder-row annotation + chained-offer description and a fresh "Verified
+    against" stamp.
+  - **Live verification** (isolated `$HOME`/`TLDW_CONFIG_PATH` scratch
+    profile; real config confirmed byte-identical + same mtime before and
+    after): all 5 brief scenarios plus the kill-switch clause of AC#2,
+    driven end-to-end in a real launched TUI — see the full evidence log in
+    `.superpowers/sdd/2026-08-17-project-skills-import/task-6-report.md`.
+    One process-launch wrinkle worth recording: this venv's editable install
+    (`__editable__.tldw_chatbook-*.pth`) maps `tldw_chatbook` to a **stale,
+    different worktree** (`task-2512-mcp-unified`), so `python -m
+    tldw_chatbook.app` only resolves this worktree's code when its root is
+    either the process cwd or on `PYTHONPATH` — launching with cwd set to a
+    fixture project directory (as the scenarios require) needed an explicit
+    `PYTHONPATH=<this worktree>` alongside the isolated `HOME`, or every
+    launch would import the wrong branch's code with a
+    `ModuleNotFoundError` en route. Also found, live, a genuine (separately
+    filed, not blocking) grammar bug: the folder-row annotation reads "1
+    project skill(s)" for the singular case — TASK-17964.
+
+Deviations from the plan: none structural. The three same-day fix rounds
+above (Tasks 1, 2, 4) were caught by each task's own RED/GREEN discipline or
+immediate self-review, not by this close-out task.
+
+Modified/added files (cumulative, all 6 tasks): `tldw_chatbook/Skills_Interop/
+project_skills_discovery.py` (new), `project_skills_prompt.py` (new),
+`tldw_chatbook/Widgets/project_skills_import_modal.py` (new),
+`tldw_chatbook/Widgets/workspace_create_modal.py`, `tldw_chatbook/app.py`,
+`tldw_chatbook/UI/Console_Modules/workspace.py`,
+`tldw_chatbook/UI/Screens/{settings_screen,library_screen}.py`,
+`tldw_chatbook/config.py`, `backlog/decisions/069-project-skills-folder-
+convention.md` (new) + its README index row, `Docs/User_Guide/library/
+skills.md`, `Docs/User_Guide/console/sessions-tabs-workspaces.md`,
+`Docs/User_Guide/{settings,library}.md`, plus the `Tests/Skills/` and
+`Tests/Workspaces/` suites for each of Tasks 1-5.
+
+Follow-ups filed: TASK-17963 (fixed-temp-name write race, pre-existing sites
+in `local_skills_service.py`/`skill_trust_store.py`), TASK-17964 (offer-modal
+footer test coverage, Checkbox-escape assertion, the "1 project skill(s)"
+pluralization fix, a stale-discovery-after-remove/rescan fix, and an
+off-thread-discovery risk decision for `_add_folder`).

--- a/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+++ b/backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
@@ -2,7 +2,7 @@
 id: TASK-17651
 title: >-
   Project skills (.SKILLS/) folder discovery and prompt-driven import
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-17 00:00'
 labels:

--- a/backlog/tasks/task-17963 - Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
+++ b/backlog/tasks/task-17963 - Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
@@ -1,0 +1,70 @@
+---
+id: TASK-17963
+title: >-
+  Shared fixed-name temp files race across app instances in skills store and
+  trust store
+status: To Do
+assignee: []
+created_date: '2026-08-18 00:00'
+labels:
+  - skills
+  - reliability
+priority: medium
+dependencies:
+  - TASK-17651
+---
+
+## Description (the why)
+
+TASK-17651's live verification and its own new prompt ledger
+(`ProjectSkillsPromptLedger.record()` in
+`tldw_chatbook/Skills_Interop/project_skills_prompt.py`) had to route around a
+pre-existing atomic-write pattern used elsewhere in the skills subsystem: a
+fixed, non-writer-unique temp filename for the atomic write-then-`replace()`
+sequence. Two writes with the SAME fixed temp name racing across concurrent
+writers means one writer's `temp_path.replace(path)` can consume the other's
+still-being-written temp file out from under it (or the second writer's own
+open/write can clobber the first's in-flight temp file), raising
+`FileNotFoundError` or silently corrupting the write.
+
+Two pre-existing sites still have this pattern and were deliberately left
+untouched by TASK-17651 (out of that task's scope):
+
+- `tldw_chatbook/Skills_Interop/local_skills_service.py:303`
+  (`LocalSkillsService._save_index`, `temp_path =
+  self.index_path.with_suffix(".json.tmp")`) — called by every skill
+  create/import/edit/delete that touches the shared skills index, so two app
+  instances (or two concurrent async callers in the same instance) mutating
+  the skills store at close to the same moment can race on this one fixed
+  path. The same file's `_write_text_atomic`/`_write_bytes_atomic` (lines
+  ~316-329, `temp_path = path.with_name(f"{path.name}.tmp")`) have the
+  identical shape, scoped per target file rather than per store, but still
+  fixed-name and racy if two writers touch the same skill file concurrently.
+- `tldw_chatbook/Skills_Interop/skill_trust_store.py:599` and `:611`
+  (`_atomic_write_json`/`_atomic_write_bytes`, `temp_path =
+  path.with_name(f".{path.name}.tmp")`) — the trust store's core write
+  primitive, used for every trust mutation (bootstrap, approve, generation
+  marker updates, encrypted snapshots).
+
+This project's new ledger avoided the bug entirely by including the writer's
+PID and thread id in its temp filename
+(`project_prompts.json.<pid>.<tid>.tmp`) before the write-and-replace, per
+its own inline comment explaining why. The two sites above should get the
+same treatment.
+
+## Acceptance Criteria (the what)
+
+- [ ] `LocalSkillsService._save_index`'s temp file name includes a
+      writer-unique component (PID + thread id, or equivalent) so two
+      concurrent callers never share a temp path
+- [ ] `LocalSkillsService._write_text_atomic`/`_write_bytes_atomic` get the
+      same writer-unique temp naming
+- [ ] `skill_trust_store.py`'s `_atomic_write_json`/`_atomic_write_bytes` get
+      the same writer-unique temp naming, preserving the existing
+      `_validated_trust_file_path` containment check on the (now
+      writer-unique) temp path
+- [ ] A test reproduces the race for at least one of the two modules (two
+      concurrent writers to the same target path never raise
+      `FileNotFoundError` and the final file is one writer's complete,
+      valid content) and passes after the fix
+- [ ] Existing `Tests/Skills/` suite remains green

--- a/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
+++ b/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
@@ -79,3 +79,4 @@ verification in both the Name/folder Input fields and, in a new sighting, the
 "Search Library…"/"Filter skills…" inputs — not re-filed here since
 TASK-17961 already tracks the underlying rendering characteristic across
 surfaces).
+- [ ] Decide (timeout vs. accepted trade-off) the in-flight-import dismissal posture: post final-fix, Escape/Not now/Never are inert while an import runs, so a permanently-hung importer leaves no in-modal exit (final-review named risk (c), noted by the fix-wave re-review as inherent to not discarding partial imports silently)

--- a/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
+++ b/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
@@ -1,0 +1,81 @@
+---
+id: TASK-17964
+title: >-
+  Project-skills follow-ups: offer-modal footer tests, checkbox-escape
+  assertion, off-thread discovery in _add_folder
+status: To Do
+assignee: []
+created_date: '2026-08-18 00:00'
+labels:
+  - skills
+  - workspaces
+  - testing
+priority: low
+dependencies:
+  - TASK-17651
+---
+
+## Description (the why)
+
+TASK-17651's close-out review and live verification found a handful of
+small, non-blocking gaps left by the project-skills import feature (Tasks
+1-5 of `Docs/superpowers/plans/2026-08-17-project-skills-import.md`). None of
+these affect the shipped behavior's correctness for the common paths already
+covered by `Tests/Skills/test_project_skills_import_modal.py` and
+`Tests/Workspaces/test_workspace_create_modal.py`, but they are real,
+identified gaps worth closing.
+
+## Acceptance Criteria (the what)
+
+- [ ] `ProjectSkillsImportModal`'s offer-phase footer (`_offer_footer_lines`
+      in `tldw_chatbook/Widgets/project_skills_import_modal.py`) has test
+      coverage for both its branches: a discovery with `skipped` entries
+      renders `Skipped: <names>`, and a discovery with `truncated > 0`
+      renders `N more not shown` — neither branch is exercised by any
+      existing test today
+- [ ] A test asserts Checkbox-label escaping in the offer phase: a
+      malicious/markup-hostile skill `description` (e.g. containing
+      `[bold]`/`[/bold]` or other Rich markup) renders as literal text in
+      the Checkbox label, not interpreted markup — the discovery-layer
+      fixtures already used elsewhere in `Tests/Skills/` for
+      markup-hostile names/descriptions can be reused; today only the
+      `escape_markup()` call site in `_compose_offer_phase` defends this,
+      with no assertion pinning it
+- [ ] Fix the "1 project skill(s)" pluralization in
+      `tldw_chatbook/Widgets/workspace_create_modal.py` (`compose()`'s
+      folder-row label and `_add_folder`'s discovery-count usage) so a
+      single discovered skill reads "1 project skill" and multiple read "N
+      project skills" (live-verified as-is during TASK-17651's Step 4:
+      `... — contains 1 project skill(s)`, grammatically wrong for the
+      singular case)
+- [ ] Fix the stale `_folder_discoveries` entry: in
+      `WorkspaceCreateModal._add_folder`, a folder that is removed and later
+      re-added at a moment when its `.SKILLS/` folder no longer has entries
+      (deleted, emptied, or now-invalid between the two adds) keeps showing
+      the OLD discovery from the first add — the assignment
+      `if discovery is not None and discovery.entries:
+      self._folder_discoveries[resolved_locator] = discovery` only ever
+      sets, never clears, so a folder's entry outlives a rescan that finds
+      nothing. Either explicitly pop the stale entry when the rescan is
+      empty, or clear `_folder_discoveries[locator]` on `_remove_folder` (the
+      entry is currently left in the dict, unreachable via `self._folders`
+      but not deleted, when a folder is removed at all)
+- [ ] Decide (fix, or explicitly accept and document) whether
+      `discover_project_skills()` inside `_add_folder`'s synchronous button
+      handler should move off the main thread — it is a bounded scan (50
+      entries / 64 KiB reads, non-recursive) but still a blocking
+      filesystem walk on the UI thread, and a `.SKILLS/` folder that
+      resolves onto a slow or hung network mount would stall the whole
+      modal for as long as the OS filesystem call takes to time out or
+      return
+
+## Notes
+
+Source: TASK-17651 close-out (ADR/docs/live-verification task). Related:
+TASK-17961 (pre-existing, separately-tracked focused-widget rendering defect
+in the same `WorkspaceCreateModal`, reproduced again during this task's live
+verification in both the Name/folder Input fields and, in a new sighting, the
+`ProjectSkillsImportModal`'s offer-phase Checkboxes and Library's
+"Search Library…"/"Filter skills…" inputs — not re-filed here since
+TASK-17961 already tracks the underlying rendering characteristic across
+surfaces).

--- a/tldw_chatbook/Skills_Interop/project_skills_discovery.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_discovery.py
@@ -8,6 +8,7 @@ untrusted repos: symlink refusal, entry/read caps, top-level-only scan.
 from __future__ import annotations
 
 import hashlib
+import itertools
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -16,10 +17,43 @@ from loguru import logger
 _PROJECT_SKILLS_DIRNAMES = (".SKILLS", ".skills")
 MAX_DISCOVERED_ENTRIES = 50
 FRONTMATTER_READ_CAP_BYTES = 65536
+#: Raw-enumeration bound (Qodo finding 8, PR #1810): a ``.SKILLS/`` full of
+#: junk files must not be fully materialized and sorted just to discover it
+#: has nothing recognizable past this many children.
+MAX_SCANNED_CHILDREN = 500
+#: Cap on real (non-synthetic) rows recorded in ``skipped`` -- past this,
+#: overflow is folded into one synthetic ``"…"`` tail row instead of growing
+#: unboundedly (Qodo finding 8).
+MAX_RECORDED_SKIPPED = 20
 
 
 @dataclass(frozen=True)
 class ProjectSkillEntry:
+    """One recognized (or recognized-but-invalid) top-level child of a
+    ``.SKILLS``/``.skills`` folder.
+
+    Attributes:
+        name: The skill's would-be name -- the directory name for a
+            ``kind="directory"`` entry, or the file stem (``.md`` suffix
+            dropped) for a ``kind="file"`` entry. Normalized via the same
+            ``_normalize_skill_name`` the importer applies, so an
+            ``"ok"`` entry's name is already import-ready.
+        kind: ``"directory"`` (a subfolder with its own ``SKILL.md``) or
+            ``"file"`` (a loose top-level ``.md`` file).
+        path: Filesystem path to the entry itself -- the skill's own
+            directory for ``kind="directory"``, or the ``.md`` file for
+            ``kind="file"``.
+        description: The skill's frontmatter ``description``, truncated to
+            200 characters; empty when unavailable (unparseable frontmatter
+            degrades to empty, it is never treated as an error).
+        status: ``"ok"`` (importable) or ``"invalid"`` (recognized as a
+            skill-shaped entry but rejected, e.g. a bad name) -- distinct
+            from ``skipped`` on the discovery, which is for children that
+            were never even a skill candidate.
+        reason: Human-readable explanation when ``status == "invalid"``;
+            empty otherwise.
+    """
+
     name: str
     kind: str  # "directory" | "file"
     path: Path
@@ -30,6 +64,33 @@ class ProjectSkillEntry:
 
 @dataclass(frozen=True)
 class ProjectSkillsDiscovery:
+    """Result of scanning one project's ``.SKILLS``/``.skills`` folder.
+
+    Attributes:
+        root: The scanned project directory, resolved to an absolute path
+            (this is the ledger key ``ProjectSkillsPromptLedger`` records
+            decisions under).
+        skills_dir: The specific ``.SKILLS``/``.skills`` folder that was
+            scanned (see ``find_project_skills_dir``).
+        entries: Recognized top-level children, in name-sorted order, up to
+            ``MAX_DISCOVERED_ENTRIES``. Includes both ``"ok"`` and
+            ``"invalid"`` ``ProjectSkillEntry`` rows.
+        skipped: ``(entry name, reason)`` pairs for children that were
+            never even skill candidates (symlinks, a directory missing
+            ``SKILL.md``, an unrecognized file), bounded to
+            ``MAX_RECORDED_SKIPPED`` real rows plus at most one synthetic
+            ``("…", ...)`` summary row for whatever didn't fit.
+        truncated: Count of children not reflected in ``entries``/
+            ``skipped`` above their caps -- bumped once when the
+            recognized-entry cap (``MAX_DISCOVERED_ENTRIES``) is hit, and
+            again when the raw enumeration itself hit
+            ``MAX_SCANNED_CHILDREN`` before every child could even be
+            considered.
+        fingerprint: A hash over every recognized entry's backing file
+            (name + size + mtime), used to detect "this exact discovery has
+            already been shown" -- see ``should_offer_project_skills_prompt``.
+    """
+
     root: Path
     skills_dir: Path
     entries: tuple[ProjectSkillEntry, ...]
@@ -48,6 +109,14 @@ def find_project_skills_dir(root: Path) -> Path | None:
     a project with both is an easy-to-miss footgun (e.g. a rename that left
     the old casing behind), so which one silently wins should be visible
     somewhere other than "reading this function's check order".
+
+    Args:
+        root: Directory to check for a ``.SKILLS``/``.skills`` subfolder.
+
+    Returns:
+        The winning candidate's ``Path`` (unresolved, ``root / name``), or
+        ``None`` when neither name exists as a real, non-symlinked
+        directory, or checking either raises ``OSError``.
     """
     found: Path | None = None
     for name in _PROJECT_SKILLS_DIRNAMES:
@@ -81,6 +150,18 @@ def find_project_dir_with_skills(start: Path) -> Path | None:
     walks unresolved parents, but each stop-check resolves ``current``
     first, so a symlinked ancestor that points at (or through) ``$HOME``
     still stops the walk instead of silently crossing the boundary.
+
+    Args:
+        start: Directory to begin the upward walk from (typically the
+            app's cwd at startup).
+
+    Returns:
+        The first directory (``start`` itself, or an ancestor) containing
+        a recognizable ``.SKILLS``/``.skills`` folder per
+        ``find_project_skills_dir``, or ``None`` if none is found before
+        the walk hits ``$HOME``, the filesystem root, or a ``.git``
+        directory (the last directory checked, since a project root is
+        never expected to have its skills folder above it).
     """
     try:
         home = Path.home().resolve()
@@ -160,33 +241,105 @@ def _fingerprint(entries: list[ProjectSkillEntry]) -> str:
 
 
 def discover_project_skills(root: Path) -> ProjectSkillsDiscovery | None:
+    """Scan ``root``'s top-level ``.SKILLS``/``.skills`` folder, if any.
+
+    Pure and side-effect-free (spec §5.2): this only enumerates and reads
+    front matter, it never imports or executes anything. The scan is
+    top-level only -- a subdirectory is either a skill (contains a
+    non-symlinked ``SKILL.md``) or is skipped entirely, its own contents
+    never recursed into.
+
+    Hardened against an untrusted or hostile ``.SKILLS/``:
+
+    * Symlinked entries (and a directory whose ``SKILL.md`` is a symlink)
+      are refused outright -- recorded in ``skipped``, never followed.
+    * The raw ``iterdir()`` enumeration is capped at
+      ``MAX_SCANNED_CHILDREN`` (500): children beyond that bound are never
+      materialized, sorted, or examined at all, so a folder seeded with
+      thousands of junk files can't turn a discovery scan into an
+      unbounded directory walk. Within that cap, results stay
+      deterministic (sorted by name) exactly as for a normal-sized folder.
+    * Recognized skills are capped at ``MAX_DISCOVERED_ENTRIES`` (50);
+      further valid skills beyond the cap only bump ``truncated``.
+    * The ``skipped`` list itself stays bounded to
+      ``MAX_RECORDED_SKIPPED`` (20) real rows -- once exceeded (from
+      per-child skip reasons, an unscanned raw-enumeration remainder past
+      ``MAX_SCANNED_CHILDREN``, or both), one synthetic ``("…", ...)`` row
+      summarizes the rest instead of growing without bound.
+    * Each entry's frontmatter read is capped at
+      ``FRONTMATTER_READ_CAP_BYTES``.
+
+    Args:
+        root: Project directory to scan for a ``.SKILLS``/``.skills``
+            folder (see ``find_project_skills_dir``).
+
+    Returns:
+        A ``ProjectSkillsDiscovery`` describing what was found, or ``None``
+        when ``root`` has no recognizable project-skills folder, or that
+        folder's own top-level enumeration fails with an ``OSError``.
+    """
     skills_dir = find_project_skills_dir(root)
     if skills_dir is None:
         return None
     entries: list[ProjectSkillEntry] = []
     skipped: list[tuple[str, str]] = []
+    skipped_overflow = 0
     truncated = 0
     try:
-        children = sorted(skills_dir.iterdir(), key=lambda p: p.name)
+        # `+1` distinguishes "exactly the bound" from "more than the
+        # bound" without a second, unbounded iterdir() pass.
+        scanned = list(
+            itertools.islice(skills_dir.iterdir(), MAX_SCANNED_CHILDREN + 1)
+        )
     except OSError:
         return None
+    scan_bound_exceeded = len(scanned) > MAX_SCANNED_CHILDREN
+    if scan_bound_exceeded:
+        scanned = scanned[:MAX_SCANNED_CHILDREN]
+    # Sorting only the (bounded) taken slice preserves determinism for
+    # every normal-sized directory -- it's only a hostile/huge directory
+    # whose raw enumeration order (not sort order) decides which children
+    # even get considered.
+    children = sorted(scanned, key=lambda p: p.name)
+
+    def _skip(name: str, reason: str) -> None:
+        nonlocal skipped_overflow
+        if len(skipped) < MAX_RECORDED_SKIPPED:
+            skipped.append((name, reason))
+        else:
+            skipped_overflow += 1
+
     for child in children:
         if len(entries) >= MAX_DISCOVERED_ENTRIES:
             truncated += 1
             continue
         if child.is_symlink():
-            skipped.append((child.name, "symlink"))
+            _skip(child.name, "symlink")
             continue
         if child.is_dir():
             body = child / "SKILL.md"
             if body.is_symlink() or not body.is_file():
-                skipped.append((child.name, "no SKILL.md"))
+                _skip(child.name, "no SKILL.md")
                 continue
             entries.append(_entry_for(child.name, "directory", child, body))
         elif child.is_file() and child.suffix.lower() == ".md":
             entries.append(_entry_for(child.stem, "file", child, child))
         else:
-            skipped.append((child.name, "not a skill"))
+            _skip(child.name, "not a skill")
+
+    if scan_bound_exceeded:
+        truncated += 1
+    if skipped_overflow and scan_bound_exceeded:
+        skipped.append((
+            "…",
+            f"{skipped_overflow} more skipped; directory has more entries "
+            "than the scan bound",
+        ))
+    elif scan_bound_exceeded:
+        skipped.append(("…", "directory has more entries than the scan bound"))
+    elif skipped_overflow:
+        skipped.append(("…", f"{skipped_overflow} more skipped"))
+
     return ProjectSkillsDiscovery(
         root=root.resolve(),
         skills_dir=skills_dir,

--- a/tldw_chatbook/Skills_Interop/project_skills_discovery.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_discovery.py
@@ -1,0 +1,201 @@
+"""Pure discovery of a project-local .SKILLS/ folder (spec 2026-08-17 §5).
+
+No side effects, no execution, no trust decisions: this module only
+enumerates candidate skills so a prompt can offer them. Hardened against
+untrusted repos: symlink refusal, entry/read caps, top-level-only scan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROJECT_SKILLS_DIRNAMES = (".SKILLS", ".skills")
+MAX_DISCOVERED_ENTRIES = 50
+FRONTMATTER_READ_CAP_BYTES = 65536
+
+
+@dataclass(frozen=True)
+class ProjectSkillEntry:
+    name: str
+    kind: str  # "directory" | "file"
+    path: Path
+    description: str
+    status: str  # "ok" | "invalid"
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ProjectSkillsDiscovery:
+    root: Path
+    skills_dir: Path
+    entries: tuple[ProjectSkillEntry, ...]
+    skipped: tuple[tuple[str, str], ...]  # (entry name, reason)
+    truncated: int
+    fingerprint: str
+
+
+def find_project_skills_dir(root: Path) -> Path | None:
+    """First non-symlinked .SKILLS/.skills dir in root, deduped by resolved path."""
+    seen: set[Path] = set()
+    for name in _PROJECT_SKILLS_DIRNAMES:
+        candidate = root / name
+        try:
+            if candidate.is_symlink() or not candidate.is_dir():
+                continue
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        return candidate
+    return None
+
+
+def find_project_dir_with_skills(start: Path) -> Path | None:
+    """cwd plus bounded ancestor walk (spec §5.4, decision #7).
+
+    Checks each directory from ``start`` upward; a directory containing
+    ``.git`` is the last one checked (the project root); ``$HOME`` and the
+    filesystem root are never checked and end the walk.
+    """
+    try:
+        home = Path.home().resolve()
+    except OSError:
+        home = None
+    current = start
+    while True:
+        if current == home or current == Path(current.anchor):
+            return None
+        if find_project_skills_dir(current) is not None:
+            return current
+        if (current / ".git").exists():
+            return None
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _raw_description(head: str) -> str:
+    """Fallback description extraction for front matter that fails strict YAML.
+
+    ``LocalSkillsService._parse_front_matter`` parses the whole front-matter
+    block as YAML and silently returns no metadata on a ``YAMLError`` (e.g. a
+    description containing ``[bracketed]`` text, which YAML reads as a flow
+    sequence). That is the right behavior for real skill authoring, but a
+    discovery scan over an untrusted project must not let a merely-odd
+    description vanish into an empty string -- it should show up as plain
+    preview text (escaping is the UI's job, not this module's). This walks
+    the same front-matter block literally, line by line, with no YAML
+    parsing at all.
+    """
+    from tldw_chatbook.Skills_Interop.local_skills_service import (
+        _FRONT_MATTER_PATTERN,
+    )
+
+    match = _FRONT_MATTER_PATTERN.match(head)
+    if match is None:
+        return ""
+    for line in match.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped.lower().startswith("description:"):
+            continue
+        value = stripped.split(":", 1)[1].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            value = value[1:-1]
+        return value
+    return ""
+
+
+def _entry_for(name: str, kind: str, path: Path, body: Path) -> ProjectSkillEntry:
+    # Same normalization gate the importer applies -- pre-checking here turns
+    # a late import failure into a labeled row (spec §5.2).
+    from tldw_chatbook.tldw_api.skills_schemas import _normalize_skill_name
+
+    try:
+        normalized = _normalize_skill_name(name)
+    except Exception:
+        return ProjectSkillEntry(
+            name=name,
+            kind=kind,
+            path=path,
+            description="",
+            status="invalid",
+            reason="name must be lowercase-kebab",
+        )
+    from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+    try:
+        with body.open("r", encoding="utf-8", errors="replace") as handle:
+            head = handle.read(FRONTMATTER_READ_CAP_BYTES)
+    except OSError:
+        return ProjectSkillEntry(
+            name=normalized,
+            kind=kind,
+            path=path,
+            description="",
+            status="invalid",
+            reason="unreadable",
+        )
+    metadata, _ = LocalSkillsService._parse_front_matter(head)
+    description = str(metadata.get("description") or "")
+    if not description:
+        description = _raw_description(head)
+    description = description[:200]
+    return ProjectSkillEntry(
+        name=normalized, kind=kind, path=path, description=description, status="ok"
+    )
+
+
+def _fingerprint(entries: list[ProjectSkillEntry]) -> str:
+    digest = hashlib.sha256()
+    for entry in entries:
+        try:
+            stat = entry.path.stat()
+            digest.update(
+                f"{entry.name}|{stat.st_size}|{stat.st_mtime_ns}\n".encode()
+            )
+        except OSError:
+            digest.update(f"{entry.name}|?\n".encode())
+    return digest.hexdigest()
+
+
+def discover_project_skills(root: Path) -> ProjectSkillsDiscovery | None:
+    skills_dir = find_project_skills_dir(root)
+    if skills_dir is None:
+        return None
+    entries: list[ProjectSkillEntry] = []
+    skipped: list[tuple[str, str]] = []
+    truncated = 0
+    try:
+        children = sorted(skills_dir.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return None
+    for child in children:
+        if len(entries) >= MAX_DISCOVERED_ENTRIES:
+            truncated += 1
+            continue
+        if child.is_symlink():
+            skipped.append((child.name, "symlink"))
+            continue
+        if child.is_dir():
+            body = child / "SKILL.md"
+            if body.is_symlink() or not body.is_file():
+                skipped.append((child.name, "no SKILL.md"))
+                continue
+            entries.append(_entry_for(child.name, "directory", child, body))
+        elif child.is_file() and child.suffix.lower() == ".md":
+            entries.append(_entry_for(child.stem, "file", child, child))
+        else:
+            skipped.append((child.name, "not a skill"))
+    return ProjectSkillsDiscovery(
+        root=root.resolve(),
+        skills_dir=skills_dir,
+        entries=tuple(entries),
+        skipped=tuple(skipped),
+        truncated=truncated,
+        fingerprint=_fingerprint(entries),
+    )

--- a/tldw_chatbook/Skills_Interop/project_skills_discovery.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_discovery.py
@@ -11,6 +11,8 @@ import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 
+from loguru import logger
+
 _PROJECT_SKILLS_DIRNAMES = (".SKILLS", ".skills")
 MAX_DISCOVERED_ENTRIES = 50
 FRONTMATTER_READ_CAP_BYTES = 65536
@@ -41,8 +43,13 @@ def find_project_skills_dir(root: Path) -> Path | None:
 
     ``.SKILLS`` is preferred over ``.skills`` purely by check order: the
     names are tried in that order and the function returns on the first
-    candidate that exists, is a directory, and is not itself a symlink.
+    candidate that exists, is a directory, and is not itself a symlink. If
+    a lower-priority candidate ALSO exists, that is logged (spec §5.1) --
+    a project with both is an easy-to-miss footgun (e.g. a rename that left
+    the old casing behind), so which one silently wins should be visible
+    somewhere other than "reading this function's check order".
     """
+    found: Path | None = None
     for name in _PROJECT_SKILLS_DIRNAMES:
         candidate = root / name
         try:
@@ -50,8 +57,19 @@ def find_project_skills_dir(root: Path) -> Path | None:
                 continue
         except OSError:
             continue
-        return candidate
-    return None
+        if found is None:
+            found = candidate
+        else:
+            logger.debug(
+                "project-skills: both {} and {} exist in {}; using {}, "
+                "ignoring {}",
+                found.name,
+                candidate.name,
+                root,
+                found.name,
+                candidate.name,
+            )
+    return found
 
 
 def find_project_dir_with_skills(start: Path) -> Path | None:

--- a/tldw_chatbook/Skills_Interop/project_skills_discovery.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_discovery.py
@@ -37,19 +37,19 @@ class ProjectSkillsDiscovery:
 
 
 def find_project_skills_dir(root: Path) -> Path | None:
-    """First non-symlinked .SKILLS/.skills dir in root, deduped by resolved path."""
-    seen: set[Path] = set()
+    """First non-symlinked, existing .SKILLS/.skills dir in root.
+
+    ``.SKILLS`` is preferred over ``.skills`` purely by check order: the
+    names are tried in that order and the function returns on the first
+    candidate that exists, is a directory, and is not itself a symlink.
+    """
     for name in _PROJECT_SKILLS_DIRNAMES:
         candidate = root / name
         try:
             if candidate.is_symlink() or not candidate.is_dir():
                 continue
-            resolved = candidate.resolve()
         except OSError:
             continue
-        if resolved in seen:
-            continue
-        seen.add(resolved)
         return candidate
     return None
 
@@ -59,7 +59,10 @@ def find_project_dir_with_skills(start: Path) -> Path | None:
 
     Checks each directory from ``start`` upward; a directory containing
     ``.git`` is the last one checked (the project root); ``$HOME`` and the
-    filesystem root are never checked and end the walk.
+    filesystem root are never checked and end the walk. Traversal itself
+    walks unresolved parents, but each stop-check resolves ``current``
+    first, so a symlinked ancestor that points at (or through) ``$HOME``
+    still stops the walk instead of silently crossing the boundary.
     """
     try:
         home = Path.home().resolve()
@@ -67,7 +70,11 @@ def find_project_dir_with_skills(start: Path) -> Path | None:
         home = None
     current = start
     while True:
-        if current == home or current == Path(current.anchor):
+        try:
+            resolved_current = current.resolve()
+        except OSError:
+            return None
+        if resolved_current == home or resolved_current == Path(resolved_current.anchor):
             return None
         if find_project_skills_dir(current) is not None:
             return current
@@ -117,10 +124,15 @@ def _entry_for(name: str, kind: str, path: Path, body: Path) -> ProjectSkillEntr
 
 
 def _fingerprint(entries: list[ProjectSkillEntry]) -> str:
+    # Stat the recognized skill FILE (spec §5.2), not the containing
+    # directory: on POSIX a directory's mtime/size don't change when a file
+    # inside it is edited in place, so stat'ing entry.path for a directory
+    # kind would make in-place SKILL.md edits invisible to the fingerprint.
     digest = hashlib.sha256()
     for entry in entries:
+        body = entry.path / "SKILL.md" if entry.kind == "directory" else entry.path
         try:
-            stat = entry.path.stat()
+            stat = body.stat()
             digest.update(
                 f"{entry.name}|{stat.st_size}|{stat.st_mtime_ns}\n".encode()
             )

--- a/tldw_chatbook/Skills_Interop/project_skills_discovery.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_discovery.py
@@ -79,37 +79,6 @@ def find_project_dir_with_skills(start: Path) -> Path | None:
         current = parent
 
 
-def _raw_description(head: str) -> str:
-    """Fallback description extraction for front matter that fails strict YAML.
-
-    ``LocalSkillsService._parse_front_matter`` parses the whole front-matter
-    block as YAML and silently returns no metadata on a ``YAMLError`` (e.g. a
-    description containing ``[bracketed]`` text, which YAML reads as a flow
-    sequence). That is the right behavior for real skill authoring, but a
-    discovery scan over an untrusted project must not let a merely-odd
-    description vanish into an empty string -- it should show up as plain
-    preview text (escaping is the UI's job, not this module's). This walks
-    the same front-matter block literally, line by line, with no YAML
-    parsing at all.
-    """
-    from tldw_chatbook.Skills_Interop.local_skills_service import (
-        _FRONT_MATTER_PATTERN,
-    )
-
-    match = _FRONT_MATTER_PATTERN.match(head)
-    if match is None:
-        return ""
-    for line in match.group(1).splitlines():
-        stripped = line.strip()
-        if not stripped.lower().startswith("description:"):
-            continue
-        value = stripped.split(":", 1)[1].strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
-            value = value[1:-1]
-        return value
-    return ""
-
-
 def _entry_for(name: str, kind: str, path: Path, body: Path) -> ProjectSkillEntry:
     # Same normalization gate the importer applies -- pre-checking here turns
     # a late import failure into a labeled row (spec §5.2).
@@ -141,10 +110,7 @@ def _entry_for(name: str, kind: str, path: Path, body: Path) -> ProjectSkillEntr
             reason="unreadable",
         )
     metadata, _ = LocalSkillsService._parse_front_matter(head)
-    description = str(metadata.get("description") or "")
-    if not description:
-        description = _raw_description(head)
-    description = description[:200]
+    description = str(metadata.get("description") or "")[:200]
     return ProjectSkillEntry(
         name=normalized, kind=kind, path=path, description=description, status="ok"
     )

--- a/tldw_chatbook/Skills_Interop/project_skills_prompt.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_prompt.py
@@ -9,6 +9,12 @@ import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    ProjectSkillsDiscovery,
+    discover_project_skills,
+    find_project_dir_with_skills,
+)
+
 _LEDGER_FILENAME = "project_prompts.json"
 
 
@@ -84,3 +90,34 @@ def should_offer_project_skills_prompt(
     if decision == "never":
         return False
     return recorded_fingerprint != fingerprint
+
+
+def startup_discovery_for(
+    start: Path, *, enabled: bool, ledger_dir: Path
+) -> ProjectSkillsDiscovery | None:
+    """Pure gate deciding whether to offer a project's .SKILLS/ import at startup.
+
+    Combines Task 1's ancestor-walk discovery with the ledger gating above
+    into the one seam the app-startup worker calls, so ``app.py`` itself
+    stays a thin caller. Returns ``None`` (never offer) when: the kill
+    switch (``enabled``) is off; no project directory with a recognizable
+    ``.SKILLS``/``.skills`` folder is found walking up from ``start``; that
+    folder has no usable entries; or the ledger (built fresh from
+    ``ledger_dir``, keeping the ledger path defined in this one module)
+    says this exact fingerprint has already been shown and dismissed with
+    "never", or seen unchanged after "declined"/"imported".
+    """
+    if not enabled:
+        return None
+    project_dir = find_project_dir_with_skills(start)
+    if project_dir is None:
+        return None
+    discovery = discover_project_skills(project_dir)
+    if discovery is None or not discovery.entries:
+        return None
+    ledger = ProjectSkillsPromptLedger(ledger_dir)
+    if not should_offer_project_skills_prompt(
+        True, ledger.decision_for(discovery.root), discovery.fingerprint
+    ):
+        return None
+    return discovery

--- a/tldw_chatbook/Skills_Interop/project_skills_prompt.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_prompt.py
@@ -1,0 +1,60 @@
+# tldw_chatbook/Skills_Interop/project_skills_prompt.py
+"""Prompt ledger + gating for .SKILLS/ import offers (spec 2026-08-17 §5.3)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LEDGER_FILENAME = "project_prompts.json"
+
+
+class ProjectSkillsPromptLedger:
+    """Atomic-replace JSON ledger under <user_data_dir>/skills/."""
+
+    def __init__(self, user_data_dir: str | Path) -> None:
+        self._path = Path(user_data_dir) / "skills" / _LEDGER_FILENAME
+
+    def _load(self) -> dict:
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {"version": 1, "entries": {}}
+        if not isinstance(data, dict) or not isinstance(data.get("entries"), dict):
+            return {"version": 1, "entries": {}}
+        return data
+
+    def decision_for(self, directory: Path) -> tuple[str, str] | None:
+        entry = self._load()["entries"].get(str(directory))
+        if not isinstance(entry, dict):
+            return None
+        return str(entry.get("decision", "")), str(entry.get("fingerprint", ""))
+
+    def record(self, directory: Path, decision: str, fingerprint: str) -> None:
+        data = self._load()
+        data["entries"][str(directory)] = {
+            "decision": decision,
+            "fingerprint": fingerprint,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        temp = self._path.with_suffix(".tmp")
+        temp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        temp.replace(self._path)
+
+
+def should_offer_project_skills_prompt(
+    enabled: bool,
+    entry: tuple[str, str] | None,
+    fingerprint: str,
+) -> bool:
+    """Offer iff enabled AND (never seen OR changed-and-not-never) (spec §5.3)."""
+    if not enabled:
+        return False
+    if entry is None:
+        return True
+    decision, recorded_fingerprint = entry
+    if decision == "never":
+        return False
+    return recorded_fingerprint != fingerprint

--- a/tldw_chatbook/Skills_Interop/project_skills_prompt.py
+++ b/tldw_chatbook/Skills_Interop/project_skills_prompt.py
@@ -4,10 +4,17 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
 _LEDGER_FILENAME = "project_prompts.json"
+
+
+def _ledger_key(directory: str | Path) -> str:
+    """Normalize a directory to its resolved absolute form (spec §5.3)."""
+    return str(Path(directory).expanduser().resolve())
 
 
 class ProjectSkillsPromptLedger:
@@ -26,22 +33,41 @@ class ProjectSkillsPromptLedger:
         return data
 
     def decision_for(self, directory: Path) -> tuple[str, str] | None:
-        entry = self._load()["entries"].get(str(directory))
+        entry = self._load()["entries"].get(_ledger_key(directory))
         if not isinstance(entry, dict):
             return None
         return str(entry.get("decision", "")), str(entry.get("fingerprint", ""))
 
     def record(self, directory: Path, decision: str, fingerprint: str) -> None:
         data = self._load()
-        data["entries"][str(directory)] = {
+        data["entries"][_ledger_key(directory)] = {
             "decision": decision,
             "fingerprint": fingerprint,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        temp = self._path.with_suffix(".tmp")
-        temp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        temp.replace(self._path)
+        # Writer-unique temp name (pid + thread id) so two concurrent app
+        # instances/threads never race on the same temp file -- with a
+        # fixed name, one writer's `replace` can consume the other's temp
+        # file out from under it, raising FileNotFoundError. This ledger is
+        # advisory only (a lost record just causes one extra prompt later),
+        # so a write failure here must never crash the caller; best-effort
+        # write-and-replace, swallow OSError, clean up the temp file if it's
+        # still there. The two pre-existing sites with this same fixed-temp-
+        # name flaw (local_skills_service.py, skill_trust_store.py) are
+        # tracked separately -- not fixed here.
+        temp = self._path.with_name(
+            f"{self._path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        try:
+            temp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            temp.replace(self._path)
+        except OSError:
+            try:
+                temp.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return
 
 
 def should_offer_project_skills_prompt(

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -53,6 +53,7 @@ from ...Widgets.Console import (
     ConsoleWorkspaceSwitcherModal,
 )
 from ...Widgets.Console.console_scope_picker_modal import ConsoleScopePickerModal
+from ...Widgets.project_skills_import_modal import maybe_offer_project_skills_import
 from ...Workspaces import (
     CONSOLE_CONVERSATION_BROWSER_RESULT_LIMIT,
     ConsoleConversationBrowserInputRow,
@@ -1648,6 +1649,10 @@ class ConsoleWorkspaceController:
             self.app_instance.notify(
                 f"Created {result.name}.", severity="information"
             )
+            if result.project_skills:
+                maybe_offer_project_skills_import(
+                    self.app_instance, result.project_skills
+                )
             return
         try:
             registry_service.set_active_workspace(result.workspace_id)
@@ -1658,6 +1663,10 @@ class ConsoleWorkspaceController:
             self.app_instance.notify(
                 "Workspace created but could not be activated.", severity="error"
             )
+            if result.project_skills:
+                maybe_offer_project_skills_import(
+                    self.app_instance, result.project_skills
+                )
             return
         self._sync_console_chat_core_state()
         self._activate_console_session_for_workspace(result.workspace_id)
@@ -1671,6 +1680,10 @@ class ConsoleWorkspaceController:
             f"Created {result.name} and switched Console to it.",
             severity="information",
         )
+        if result.project_skills:
+            maybe_offer_project_skills_import(
+                self.app_instance, result.project_skills
+            )
 
     # -- Workspace RAG-scope picker ------------------------------------------
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -31753,6 +31753,14 @@ class LibraryScreen(BaseAppScreen):
                         f"Created local workspace {result.name}.",
                         severity="information",
                     )
+            if result.project_skills:
+                from tldw_chatbook.Widgets.project_skills_import_modal import (
+                    maybe_offer_project_skills_import,
+                )
+
+                maybe_offer_project_skills_import(
+                    self.app_instance, result.project_skills
+                )
 
         self.app.push_screen(
             WorkspaceCreateModal(registry_service=registry_service), _done

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -18123,6 +18123,12 @@ class SettingsScreen(BaseAppScreen):
                     status_parts.append(str(exc))
             self._settings_workspaces_result = "; ".join(status_parts)
             self._refresh_settings_workspaces_pane()
+            if result.project_skills:
+                from tldw_chatbook.Widgets.project_skills_import_modal import (
+                    maybe_offer_project_skills_import,
+                )
+
+                maybe_offer_project_skills_import(self.app, result.project_skills)
 
         self.app.push_screen(WorkspaceCreateModal(registry_service=registry), _done)
 

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
+import stat
 from collections.abc import Awaitable, Callable, Sequence
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -56,12 +59,19 @@ ImportOutcome = tuple[str, str]
 #: ``("imported" | "not_now" | "never" | "review", outcomes-or-None)``.
 ImportDecision = tuple[str, tuple[ImportOutcome, ...] | None]
 
-#: Decision -> ledger verb (spec §5.3/§5.5): review still counts as imported
-#: (the entries were already copied in; "review" only changes what happens
-#: after dismissal, not whether the import itself is recorded).
+#: Decision -> ledger verb for the two decisions whose mapping does NOT
+#: depend on per-entry outcomes (spec §5.3/§5.5). "imported"/"review" are
+#: handled separately in ``_record_project_skills_decision`` below: review
+#: still counts as imported when the import fully succeeded (the entries
+#: were already copied in; "review" only changes what happens after
+#: dismissal), but -- Qodo finding 6, PR #1810 -- NEITHER is recorded when
+#: any attempted entry failed, or none were attempted at all. A failed
+#: import leaves the ``.SKILLS/`` folder's fingerprint unchanged, so
+#: recording "imported" anyway would make the ledger's unchanged-
+#: fingerprint check (``should_offer_project_skills_prompt``) permanently
+#: suppress every future offer for a root that never actually finished
+#: importing.
 _LEDGER_DECISIONS = {
-    "imported": "imported",
-    "review": "imported",
     "not_now": "declined",
     "never": "never",
 }
@@ -361,6 +371,66 @@ async def _project_skills_installed_names(app: Any) -> frozenset[str]:
     return frozenset(names)
 
 
+def _read_loose_skill_file_sync(path: Path) -> bytes:
+    """Re-validate and read a loose-file skill body at import time.
+
+    Finding 7 (Qodo review, PR #1810): discovery accepts a loose ``.md``
+    file well before the user presses "Import selected" -- in between, a
+    hostile or racing actor can swap the accepted regular file for a
+    symlink pointing at any other readable file on disk. Reading via
+    ``entry.path.read_bytes()`` at import time would silently follow that
+    swap and ingest the symlink's target instead of the file the user
+    actually reviewed.
+
+    This re-checks symlink/regular-file status via ``os.lstat`` (which,
+    unlike ``stat``, does not itself follow a symlink) immediately before
+    reading, then opens with ``O_NOFOLLOW`` where the platform supports it
+    (macOS and Linux both do) so even a symlink planted in the TOCTOU
+    window between the ``lstat`` check and the ``open`` call is refused by
+    the kernel rather than followed.
+
+    Args:
+        path: The loose skill file's path, as recorded on the
+            ``ProjectSkillEntry`` at discovery time.
+
+    Returns:
+        The file's raw bytes.
+
+    Raises:
+        ValueError: The path is now a symlink, is no longer a regular
+            file, or otherwise could not be opened/read for import --
+            reported uniformly as "skill file changed on disk" so a caller
+            never has to distinguish a swap from an ordinary race with
+            deletion.
+    """
+    try:
+        info = os.lstat(path)
+    except OSError as exc:
+        raise ValueError("skill file changed on disk") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ValueError("skill file changed on disk")
+    o_nofollow = getattr(os, "O_NOFOLLOW", None)
+    if o_nofollow is None:
+        # Platform without O_NOFOLLOW: the lstat check above is the only
+        # protection against a same-window swap, but a regular open() is
+        # still correct for the (overwhelmingly common) unswapped case.
+        try:
+            return path.read_bytes()
+        except OSError as exc:
+            raise ValueError("skill file changed on disk") from exc
+    try:
+        fd = os.open(path, os.O_RDONLY | o_nofollow)
+    except OSError as exc:
+        # ELOOP (symlink) or ENOENT/others (deleted/replaced) alike: same
+        # clean, uniform error either way.
+        raise ValueError("skill file changed on disk") from exc
+    try:
+        with os.fdopen(fd, "rb") as handle:
+            return handle.read()
+    except OSError as exc:
+        raise ValueError("skill file changed on disk") from exc
+
+
 def _project_skills_importer(app: Any) -> Importer:
     """Build the injected importer from ``app.skills_scope_service``.
 
@@ -388,7 +458,7 @@ def _project_skills_importer(app: Any) -> Importer:
             return
         if not callable(import_skill_file):
             raise RuntimeError("Skill import is unavailable.")
-        data = await asyncio.to_thread(entry.path.read_bytes)
+        data = await asyncio.to_thread(_read_loose_skill_file_sync, entry.path)
         await import_skill_file(
             data,
             mode="local",
@@ -401,11 +471,44 @@ def _project_skills_importer(app: Any) -> Importer:
 
 
 def _record_project_skills_decision(
-    discovery: ProjectSkillsDiscovery, decision: str
+    discovery: ProjectSkillsDiscovery,
+    decision: str,
+    outcomes: tuple[ImportOutcome, ...] | None,
 ) -> None:
-    ledger_decision = _LEDGER_DECISIONS.get(decision)
-    if ledger_decision is None:
-        return
+    """Record one discovery's dismissal in the prompt ledger, or suppress it.
+
+    Finding 6 (Qodo review, PR #1810): "imported"/"review" are recorded as
+    ``"imported"`` ONLY when every attempted entry actually succeeded
+    (``outcome == "imported"`` for all of them). When any attempted entry
+    failed, or nothing was attempted at all (``outcomes`` empty or
+    ``None`` -- e.g. the user pressed Import with nothing checked),
+    NOTHING is recorded for this root: the ``.SKILLS/`` folder's
+    fingerprint is unchanged by a failed/no-op import, so recording
+    ``"imported"`` anyway would make the ledger's unchanged-fingerprint
+    check permanently suppress every future offer even though nothing
+    actually succeeded. Leaving prior ledger state untouched means the
+    next trigger re-offers -- entries that DID succeed naturally render
+    "(already installed)" on that re-offer.
+
+    "not_now"/"never" are unaffected by ``outcomes`` -- see
+    ``_LEDGER_DECISIONS``.
+
+    Args:
+        discovery: The discovery being dismissed.
+        decision: One of ``"imported"``, ``"review"``, ``"not_now"``,
+            ``"never"``.
+        outcomes: The per-entry ``(name, "imported" | error text)`` results
+            from the modal's import run, or ``None`` when no import ran
+            (declined/never decisions).
+    """
+    if decision in ("imported", "review"):
+        if not outcomes or any(message != "imported" for _name, message in outcomes):
+            return
+        ledger_decision = "imported"
+    else:
+        ledger_decision = _LEDGER_DECISIONS.get(decision)
+        if ledger_decision is None:
+            return
     ledger = ProjectSkillsPromptLedger(get_user_data_dir())
     ledger.record(discovery.root, ledger_decision, discovery.fingerprint)
 
@@ -425,7 +528,7 @@ async def _offer_next_project_skills_discovery(
     def _on_dismiss(result: ImportDecision) -> None:
         try:
             decision, _outcomes = result
-            _record_project_skills_decision(discovery, decision)
+            _record_project_skills_decision(discovery, decision, _outcomes)
             if decision == "review":
                 app.post_message(NavigateToScreen("skills"))
         except Exception:
@@ -519,11 +622,19 @@ def maybe_offer_project_skills_import(
     For any survivors: builds ``installed_names``/an ``importer`` from the
     live ``app.skills_scope_service``, then pushes one modal per discovery
     -- the next discovery's modal is only pushed once the current one
-    dismisses. Every dismissal is recorded in the prompt ledger
-    (``ProjectSkillsPromptLedger``, keyed by ``discovery.root``), and a
-    "review" decision also posts a navigation request to the Skills screen.
-    (The startup path's own pre-filtering in ``startup_discovery_for``
-    becomes redundant with this, but idempotent -- harmless double gating.)
+    dismisses. Every dismissal is passed through
+    ``_record_project_skills_decision`` (``ProjectSkillsPromptLedger``,
+    keyed by ``discovery.root``): "not_now"/"never" record
+    "declined"/"never" unconditionally, but "imported"/"review" record
+    "imported" ONLY when every attempted entry actually succeeded --
+    otherwise (any entry failed, or nothing was attempted) NOTHING is
+    recorded, leaving prior ledger state untouched so the next trigger
+    re-offers (Qodo finding 6, PR #1810: a failed import's unchanged
+    ``.SKILLS/`` fingerprint must not permanently suppress retries). A
+    "review" decision also posts a navigation request to the Skills
+    screen. (The startup path's own pre-filtering in
+    ``startup_discovery_for`` becomes redundant with this, but idempotent
+    -- harmless double gating.)
 
     Re-entrancy: while one offer flow is already running for ``app``
     (tracked via ``app._project_skills_offer_active``, set here when the
@@ -534,10 +645,14 @@ def maybe_offer_project_skills_import(
     silence the feature for the rest of the session -- because every path
     that can end the flow clears it: the chain worker's own failure
     (``_run_project_skills_offer_chain``'s ``except``), a failure
-    scheduling the next discovery's worker, and (via a ``finally``, so it
-    runs even if the ledger write or the review-navigation post above it
-    raised) the dismissal callback's terminal step when the last discovery
-    in the chain dismisses.
+    scheduling the next discovery's worker, a failure scheduling this
+    INITIAL worker (Qodo finding 10, PR #1810: mirrors the continuation's
+    own guard -- the coroutine is created up front so a raising
+    ``run_worker`` can still be closed explicitly instead of leaking a
+    never-awaited coroutine), and (via a ``finally``, so it runs even if
+    the ledger write or the review-navigation post above it raised) the
+    dismissal callback's terminal step when the last discovery in the
+    chain dismisses.
 
     Args:
         app: The running ``TldwCli`` app (or a test double exposing
@@ -572,7 +687,18 @@ def maybe_offer_project_skills_import(
     if not gated_discoveries:
         return
     app._project_skills_offer_active = True
-    app.run_worker(
-        _run_project_skills_offer_chain(app, gated_discoveries),
-        exclusive=False,
-    )
+    # The coroutine is created before `run_worker` sees it (same shape as
+    # the continuation's own guard in `_on_dismiss`): a `run_worker`
+    # failure here must not leave `_project_skills_offer_active` stuck
+    # True forever (Finding 10, Qodo review 2026-08-17) -- close the
+    # never-started coroutine explicitly instead of letting Python
+    # warn-and-leak an orphaned one, clear the flag, and never propagate.
+    coroutine = _run_project_skills_offer_chain(app, gated_discoveries)
+    try:
+        app.run_worker(coroutine, exclusive=False)
+    except Exception:
+        coroutine.close()
+        app._project_skills_offer_active = False
+        logger.opt(exception=True).debug(
+            "project-skills offer chain failed to start"
+        )

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -27,13 +27,14 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Static
 
-from tldw_chatbook.config import get_user_data_dir
+from tldw_chatbook.config import get_cli_setting, get_user_data_dir
 from tldw_chatbook.Skills_Interop.project_skills_discovery import (
     ProjectSkillEntry,
     ProjectSkillsDiscovery,
 )
 from tldw_chatbook.Skills_Interop.project_skills_prompt import (
     ProjectSkillsPromptLedger,
+    should_offer_project_skills_prompt,
 )
 from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
@@ -229,10 +230,31 @@ class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision
             )
             yield Button("Close", id="project-skills-close", compact=True)
 
+    def _import_in_flight(self) -> bool:
+        """True only while a committed import hasn't produced outcomes yet.
+
+        Finding 2 (final review 2026-08-17): the offer-phase buttons stay
+        mounted while ``_run_import`` is running (the modal only recomposes
+        into the results phase once ``self._outcomes`` is set), so a click
+        can still land on "Never"/"Not now", or Escape can still fire,
+        while an import the user already committed to is mid-flight. All
+        three must be inert then -- dismissing (or re-running) would either
+        discard a partial import silently or race the in-flight worker.
+        """
+        return self._committed and self._outcomes is None
+
     async def _perform_safe_cancel(self, *, source: str) -> None:
-        # Escape / backdrop-click / "Not now" all route here, and must all
-        # dismiss with the same ("not_now", None) decision tuple.
+        # Escape / backdrop-click / "Not now" all route here.
         del source
+        if self._import_in_flight():
+            return
+        if self._outcomes is not None:
+            # Results phase (minor 6): escape/backdrop must dismiss exactly
+            # like "Close" -- the import already ran, there is nothing left
+            # to cancel, and mislabeling it "not_now" would make the
+            # already-completed import look declined to the ledger.
+            self.dismiss_safe_once(("imported", self._outcomes))
+            return
         self.dismiss_safe_once(("not_now", None))
 
     @on(Button.Pressed, "#project-skills-not-now")
@@ -243,6 +265,8 @@ class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision
     @on(Button.Pressed, "#project-skills-never")
     def _never(self, event: Button.Pressed) -> None:
         event.stop()
+        if self._import_in_flight():
+            return
         self.dismiss_safe_once(("never", None))
 
     def _selected_entries(self) -> tuple[ProjectSkillEntry, ...]:
@@ -261,6 +285,19 @@ class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision
         if self._committed:
             return
         self._committed = True
+        # Belt-and-suspenders alongside the `_import_in_flight()` guards
+        # above: visibly disable the offer-phase buttons too, so a
+        # still-mounted "Never"/"Not now" doesn't even look clickable while
+        # the import it would discard is running.
+        for button_id in (
+            "#project-skills-import",
+            "#project-skills-not-now",
+            "#project-skills-never",
+        ):
+            try:
+                self.query_one(button_id, Button).disabled = True
+            except Exception:  # noqa: BLE001 - purely cosmetic, never fatal
+                pass
         selected = self._selected_entries()
         self.run_worker(self._run_import(selected), exclusive=True)
 
@@ -417,12 +454,17 @@ async def _offer_next_project_skills_discovery(
             if not remaining:
                 app._project_skills_offer_active = False
             else:
+                # The coroutine is created before `run_worker` sees it (it
+                # has to be -- it's the call's own argument), but a
+                # `run_worker` failure must not leak it as a never-awaited
+                # coroutine (Finding 7, final review 2026-08-17): keep the
+                # reference so the except branch can close it explicitly
+                # instead of letting Python warn-and-leak an orphaned one.
+                continuation = _run_project_skills_offer_chain(app, remaining)
                 try:
-                    app.run_worker(
-                        _run_project_skills_offer_chain(app, remaining),
-                        exclusive=False,
-                    )
+                    app.run_worker(continuation, exclusive=False)
                 except Exception:
+                    continuation.close()
                     app._project_skills_offer_active = False
                     logger.opt(exception=True).debug(
                         "project-skills offer chain continuation failed to start"
@@ -453,13 +495,35 @@ def maybe_offer_project_skills_import(
 ) -> None:
     """Offer imports for each discovery in turn (spec §5.5).
 
-    The one entry point other call sites use (startup, workspace-create
-    chaining). Builds ``installed_names``/an ``importer`` from the live
-    ``app.skills_scope_service``, then pushes one modal per discovery --
-    the next discovery's modal is only pushed once the current one
+    The one entry point EVERY call site uses -- startup and every
+    workspace-create surface (Console, Settings, Library) -- and therefore
+    the one choke point where gating lives (final review 2026-08-17,
+    Finding 1). Previously only the startup path pre-filtered discoveries
+    through the kill-switch/ledger before calling here, so a "Never for
+    this folder" or a disabled kill-switch recorded via one trigger did not
+    silence the other, violating spec §5.3's "declining in one place
+    silences the other". This function now applies the SAME gating no
+    matter which trigger calls it:
+
+    1. The ``[skills] project_skills_prompt_enabled`` kill-switch is
+       checked first -- off means no offer, full stop.
+    2. Without a usable ``app.skills_scope_service`` an offer can only
+       fail (Finding 6): suppressed rather than pushing a modal whose
+       "Import selected" is guaranteed to error.
+    3. Each discovery is re-checked against the prompt ledger
+       (``should_offer_project_skills_prompt`` -- never-seen, or
+       changed-and-not-"never"); a discovery already declined "never", or
+       unchanged since it was last shown, is dropped. If none remain,
+       nothing is offered.
+
+    For any survivors: builds ``installed_names``/an ``importer`` from the
+    live ``app.skills_scope_service``, then pushes one modal per discovery
+    -- the next discovery's modal is only pushed once the current one
     dismisses. Every dismissal is recorded in the prompt ledger
     (``ProjectSkillsPromptLedger``, keyed by ``discovery.root``), and a
     "review" decision also posts a navigation request to the Skills screen.
+    (The startup path's own pre-filtering in ``startup_discovery_for``
+    becomes redundant with this, but idempotent -- harmless double gating.)
 
     Re-entrancy: while one offer flow is already running for ``app``
     (tracked via ``app._project_skills_offer_active``, set here when the
@@ -481,13 +545,34 @@ def maybe_offer_project_skills_import(
             ``run_worker``).
         discoveries: Discoveries to offer, one modal at a time.
     """
+    if not get_cli_setting("skills", "project_skills_prompt_enabled", True):
+        logger.debug(
+            "project-skills offer suppressed: "
+            "[skills] project_skills_prompt_enabled is off"
+        )
+        return
     if getattr(app, "_project_skills_offer_active", False):
         return
     discoveries = tuple(discoveries)
     if not discoveries:
         return
+    if getattr(app, "skills_scope_service", None) is None:
+        logger.debug(
+            "project-skills offer suppressed: app.skills_scope_service is unavailable"
+        )
+        return
+    ledger = ProjectSkillsPromptLedger(get_user_data_dir())
+    gated_discoveries = tuple(
+        discovery
+        for discovery in discoveries
+        if should_offer_project_skills_prompt(
+            True, ledger.decision_for(discovery.root), discovery.fingerprint
+        )
+    )
+    if not gated_discoveries:
+        return
     app._project_skills_offer_active = True
     app.run_worker(
-        _run_project_skills_offer_chain(app, discoveries),
+        _run_project_skills_offer_chain(app, gated_discoveries),
         exclusive=False,
     )

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -386,23 +386,47 @@ async def _offer_next_project_skills_discovery(
     )
 
     def _on_dismiss(result: ImportDecision) -> None:
-        decision, _outcomes = result
-        _record_project_skills_decision(discovery, decision)
-        if decision == "review":
-            app.post_message(NavigateToScreen("skills"))
-        # Continue the SAME already-active chain directly rather than
-        # routing back through the public entry point below -- the
-        # re-entrancy guard there would see ``_project_skills_offer_active``
-        # still True (it stays True for the whole chain, cleared only at
-        # the terminal step here) and mistake this continuation for a
-        # second concurrent caller, dropping it.
-        if not remaining:
-            app._project_skills_offer_active = False
-            return
-        app.run_worker(
-            _run_project_skills_offer_chain(app, remaining),
-            exclusive=False,
-        )
+        try:
+            decision, _outcomes = result
+            _record_project_skills_decision(discovery, decision)
+            if decision == "review":
+                app.post_message(NavigateToScreen("skills"))
+        except Exception:
+            # The ledger write and the review-navigation post are both
+            # best-effort: this callback runs synchronously out of
+            # Textual's own dismiss handling (NOT a worker), so an
+            # uncaught exception here would reach App._handle_exception on
+            # the main thread and exit the whole app over what is, at
+            # worst, a lost ledger record or a missed navigation hint.
+            logger.opt(exception=True).debug(
+                "project-skills dismissal bookkeeping failed"
+            )
+        finally:
+            # The "last discovery -> clear flag" vs "recurse to next"
+            # decision lives in `finally`, not the `try` above, so the
+            # re-entrancy flag can NEVER stay stuck True -- it clears (or
+            # the chain continues) even when the bookkeeping above raised.
+            #
+            # Continuing here calls `_run_project_skills_offer_chain`
+            # directly rather than routing back through the public entry
+            # point below -- that guard would see
+            # ``_project_skills_offer_active`` still True (it stays True
+            # for the whole chain, cleared only at this terminal step) and
+            # mistake this continuation for a second concurrent caller,
+            # dropping it.
+            if not remaining:
+                app._project_skills_offer_active = False
+            else:
+                try:
+                    app.run_worker(
+                        _run_project_skills_offer_chain(app, remaining),
+                        exclusive=False,
+                    )
+                except Exception:
+                    app._project_skills_offer_active = False
+                    logger.opt(exception=True).debug(
+                        "project-skills offer chain continuation failed to start"
+                    )
 
     app.push_screen(modal, _on_dismiss)
 
@@ -439,10 +463,17 @@ def maybe_offer_project_skills_import(
 
     Re-entrancy: while one offer flow is already running for ``app``
     (tracked via ``app._project_skills_offer_active``, set here when the
-    flow starts and cleared when the chain's last modal dismisses or the
-    worker fails), a second call is a no-op. This stops two independent
+    flow starts), a second call is a no-op. This stops two independent
     callers -- e.g. the startup offer and a workspace-create offer -- from
-    both trying to push a modal for the same app at once.
+    both trying to push a modal for the same app at once. The flag is
+    guaranteed to clear -- it can never stay stuck True and permanently
+    silence the feature for the rest of the session -- because every path
+    that can end the flow clears it: the chain worker's own failure
+    (``_run_project_skills_offer_chain``'s ``except``), a failure
+    scheduling the next discovery's worker, and (via a ``finally``, so it
+    runs even if the ledger write or the review-navigation post above it
+    raised) the dismissal callback's terminal step when the last discovery
+    in the chain dismisses.
 
     Args:
         app: The running ``TldwCli`` app (or a test double exposing

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -390,9 +390,38 @@ async def _offer_next_project_skills_discovery(
         _record_project_skills_decision(discovery, decision)
         if decision == "review":
             app.post_message(NavigateToScreen("skills"))
-        maybe_offer_project_skills_import(app, remaining)
+        # Continue the SAME already-active chain directly rather than
+        # routing back through the public entry point below -- the
+        # re-entrancy guard there would see ``_project_skills_offer_active``
+        # still True (it stays True for the whole chain, cleared only at
+        # the terminal step here) and mistake this continuation for a
+        # second concurrent caller, dropping it.
+        if not remaining:
+            app._project_skills_offer_active = False
+            return
+        app.run_worker(
+            _run_project_skills_offer_chain(app, remaining),
+            exclusive=False,
+        )
 
     app.push_screen(modal, _on_dismiss)
+
+
+async def _run_project_skills_offer_chain(
+    app: Any, discoveries: tuple[ProjectSkillsDiscovery, ...]
+) -> None:
+    """Worker body for one offer flow; clears the re-entrancy flag on failure.
+
+    An exception here (e.g. ``push_screen`` raising) would otherwise leave
+    ``_project_skills_offer_active`` stuck True forever, permanently
+    blocking every future offer for this app -- this is the "on worker
+    failure" half of the re-entrancy guard's clear condition.
+    """
+    try:
+        await _offer_next_project_skills_discovery(app, discoveries)
+    except Exception:
+        app._project_skills_offer_active = False
+        logger.opt(exception=True).debug("project-skills offer chain failed")
 
 
 def maybe_offer_project_skills_import(
@@ -408,16 +437,26 @@ def maybe_offer_project_skills_import(
     (``ProjectSkillsPromptLedger``, keyed by ``discovery.root``), and a
     "review" decision also posts a navigation request to the Skills screen.
 
+    Re-entrancy: while one offer flow is already running for ``app``
+    (tracked via ``app._project_skills_offer_active``, set here when the
+    flow starts and cleared when the chain's last modal dismisses or the
+    worker fails), a second call is a no-op. This stops two independent
+    callers -- e.g. the startup offer and a workspace-create offer -- from
+    both trying to push a modal for the same app at once.
+
     Args:
         app: The running ``TldwCli`` app (or a test double exposing
             ``skills_scope_service``, ``push_screen``, ``post_message``, and
             ``run_worker``).
         discoveries: Discoveries to offer, one modal at a time.
     """
+    if getattr(app, "_project_skills_offer_active", False):
+        return
     discoveries = tuple(discoveries)
     if not discoveries:
         return
+    app._project_skills_offer_active = True
     app.run_worker(
-        _offer_next_project_skills_discovery(app, discoveries),
+        _run_project_skills_offer_chain(app, discoveries),
         exclusive=False,
     )

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -1,0 +1,423 @@
+"""Project-skills import modal + shared offer helper (spec 2026-08-17 §5.5).
+
+``ProjectSkillsImportModal`` presents one project's ``.SKILLS/`` discovery
+(Task 1) and lets the user pick which entries to import; import execution
+itself is injected (``importer``) so this module never talks to a skills
+store directly -- the modal only decides WHAT to import and reports WHAT
+happened.
+
+``maybe_offer_project_skills_import`` is the one entry point other modules
+call: it wires the injected importer/``installed_names`` from the live
+``app.skills_scope_service``, chains one modal per discovery, and records
+each dismissal in the prompt ledger (Task 2).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+from loguru import logger
+from rich.markup import escape as escape_markup
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Static
+
+from tldw_chatbook.config import get_user_data_dir
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    ProjectSkillEntry,
+    ProjectSkillsDiscovery,
+)
+from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+    ProjectSkillsPromptLedger,
+)
+from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+#: Verbatim trust-expectation line, spec 2026-08-17 §5.5.
+_TRUST_LINE = (
+    "Imported skills require a one-time trust review in Library ▸ Skills "
+    "before they can run."
+)
+#: Bootstrap-aware trust framing shown on the post-import results phase.
+_POST_IMPORT_TRUST_LINE = (
+    "Set up skill trust if this is your first skill, then approve each one."
+)
+
+#: ``async (entry) -> None``; raises on failure (caught + reported per-entry).
+Importer = Callable[[ProjectSkillEntry], Awaitable[None]]
+#: ``(name, "imported" | error text)``.
+ImportOutcome = tuple[str, str]
+#: ``("imported" | "not_now" | "never" | "review", outcomes-or-None)``.
+ImportDecision = tuple[str, tuple[ImportOutcome, ...] | None]
+
+#: Decision -> ledger verb (spec §5.3/§5.5): review still counts as imported
+#: (the entries were already copied in; "review" only changes what happens
+#: after dismissal, not whether the import itself is recorded).
+_LEDGER_DECISIONS = {
+    "imported": "imported",
+    "review": "imported",
+    "not_now": "declined",
+    "never": "never",
+}
+
+
+class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision]):
+    """Offer to import a discovered project's ``.SKILLS/`` folder.
+
+    Args:
+        discovery: The project-skills discovery to offer.
+        installed_names: Skill names already installed locally -- their rows
+            render unchecked and labeled "(already installed)".
+        importer: Injected ``async (entry) -> None`` that performs one
+            entry's import, raising on failure. Never called directly by
+            this modal for anything except an "Import selected" press.
+    """
+
+    DEFAULT_CSS = """
+    ProjectSkillsImportModal {
+        align: center middle;
+    }
+
+    #project-skills-modal {
+        width: 76;
+        height: auto;
+        max-height: 34;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #project-skills-provenance {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    #project-skills-trust-line {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    #project-skills-post-trust-line {
+        color: $text-muted;
+        margin: 0 0 1 0;
+    }
+
+    #project-skills-rows {
+        height: auto;
+        max-height: 18;
+        margin: 0 0 1 0;
+    }
+
+    #project-skills-results {
+        height: auto;
+        max-height: 18;
+        margin: 0 0 1 0;
+    }
+
+    #project-skills-footer {
+        color: $text-muted;
+        height: auto;
+    }
+
+    #project-skills-actions {
+        height: auto;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+    """
+
+    SAFE_MODAL_CONTENT = "#project-skills-modal"
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
+    AUTO_FOCUS = "#project-skills-import"
+
+    def __init__(
+        self,
+        *,
+        discovery: ProjectSkillsDiscovery,
+        installed_names: frozenset[str],
+        importer: Importer,
+    ) -> None:
+        super().__init__()
+        self._discovery = discovery
+        self._installed_names = installed_names
+        self._importer = importer
+        # One-shot guard: a double "Import selected" press (rapid double
+        # click, or Enter-Enter on the focused button) must run the injected
+        # importer at most once per entry -- see WorkspaceCreateModal's
+        # ``_committed`` precedent for this exact shape.
+        self._committed = False
+        self._outcomes: tuple[ImportOutcome, ...] | None = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="project-skills-modal"):
+            yield Static(
+                "Project skills found", classes="console-modal-header", markup=False
+            )
+            if self._outcomes is None:
+                yield from self._compose_offer_phase()
+            else:
+                yield from self._compose_results_phase()
+
+    def _compose_offer_phase(self) -> ComposeResult:
+        yield Static(
+            f"Found in {self._discovery.skills_dir}",
+            id="project-skills-provenance",
+            markup=False,
+        )
+        yield Static(_TRUST_LINE, id="project-skills-trust-line", markup=False)
+        with Vertical(id="project-skills-rows"):
+            for index, entry in enumerate(self._discovery.entries):
+                if entry.status == "ok":
+                    installed = entry.name in self._installed_names
+                    label = f"{entry.name} — {entry.description}"
+                    if installed:
+                        label += " (already installed)"
+                    # Checkbox labels render markup; every piece of that
+                    # label is a repo-sourced string (name/description), so
+                    # it must be escaped before Textual interprets it.
+                    yield Checkbox(
+                        escape_markup(label),
+                        not installed,
+                        id=f"project-skill-row-{index}",
+                    )
+                else:
+                    yield Static(
+                        f"{entry.name} — invalid: {entry.reason}",
+                        markup=False,
+                    )
+        footer_lines = self._offer_footer_lines()
+        if footer_lines:
+            yield Static(
+                "\n".join(footer_lines), id="project-skills-footer", markup=False
+            )
+        with Horizontal(id="project-skills-actions"):
+            yield Button("Import selected", id="project-skills-import", compact=True)
+            yield Button("Not now", id="project-skills-not-now", compact=True)
+            yield Button(
+                "Never for this folder", id="project-skills-never", compact=True
+            )
+
+    def _offer_footer_lines(self) -> list[str]:
+        lines: list[str] = []
+        if self._discovery.skipped:
+            names = ", ".join(name for name, _reason in self._discovery.skipped)
+            lines.append(f"Skipped: {names}")
+        if self._discovery.truncated:
+            lines.append(f"{self._discovery.truncated} more not shown")
+        return lines
+
+    def _compose_results_phase(self) -> ComposeResult:
+        assert self._outcomes is not None
+        with Vertical(id="project-skills-results"):
+            for name, message in self._outcomes:
+                yield Static(f"{name}: {message}", markup=False)
+        yield Static(
+            _POST_IMPORT_TRUST_LINE,
+            id="project-skills-post-trust-line",
+            markup=False,
+        )
+        with Horizontal(id="project-skills-actions"):
+            yield Button(
+                "Review in Library ▸ Skills",
+                id="project-skills-review",
+                compact=True,
+            )
+            yield Button("Close", id="project-skills-close", compact=True)
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        # Escape / backdrop-click / "Not now" all route here, and must all
+        # dismiss with the same ("not_now", None) decision tuple.
+        del source
+        self.dismiss_safe_once(("not_now", None))
+
+    @on(Button.Pressed, "#project-skills-not-now")
+    async def _not_now(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="button")
+
+    @on(Button.Pressed, "#project-skills-never")
+    def _never(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss_safe_once(("never", None))
+
+    def _selected_entries(self) -> tuple[ProjectSkillEntry, ...]:
+        selected: list[ProjectSkillEntry] = []
+        for index, entry in enumerate(self._discovery.entries):
+            if entry.status != "ok":
+                continue
+            checkbox = self.query_one(f"#project-skill-row-{index}", Checkbox)
+            if checkbox.value:
+                selected.append(entry)
+        return tuple(selected)
+
+    @on(Button.Pressed, "#project-skills-import")
+    def _import_selected(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._committed:
+            return
+        self._committed = True
+        selected = self._selected_entries()
+        self.run_worker(self._run_import(selected), exclusive=True)
+
+    async def _run_import(self, entries: tuple[ProjectSkillEntry, ...]) -> None:
+        outcomes: list[ImportOutcome] = []
+        for entry in entries:
+            try:
+                await self._importer(entry)
+            except Exception as exc:  # noqa: BLE001 - reported per-entry, not raised
+                outcomes.append((entry.name, str(exc)))
+            else:
+                outcomes.append((entry.name, "imported"))
+        self._outcomes = tuple(outcomes)
+        if self.is_mounted:
+            self.refresh(recompose=True)
+
+    @on(Button.Pressed, "#project-skills-review")
+    def _review(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._outcomes is None:
+            return
+        self.dismiss_safe_once(("review", self._outcomes))
+
+    @on(Button.Pressed, "#project-skills-close")
+    def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._outcomes is None:
+            return
+        self.dismiss_safe_once(("imported", self._outcomes))
+
+
+async def _project_skills_installed_names(app: Any) -> frozenset[str]:
+    """Best-effort local skill-name set from ``app.skills_scope_service``.
+
+    Degrades to an empty set (every row renders as "new") on any lookup
+    failure -- an offer to import must never crash because the installed-
+    names lookup failed.
+    """
+    service = getattr(app, "skills_scope_service", None)
+    get_context = getattr(service, "get_context", None)
+    if not callable(get_context):
+        return frozenset()
+    try:
+        payload = get_context(mode="local")
+        if inspect.isawaitable(payload):
+            payload = await payload
+    except Exception:
+        logger.opt(exception=True).debug(
+            "project-skills installed-name lookup failed"
+        )
+        return frozenset()
+    if not isinstance(payload, dict):
+        return frozenset()
+    names: set[str] = set()
+    for key in ("available_skills", "blocked_skills"):
+        for item in payload.get(key) or ():
+            if isinstance(item, dict):
+                name = item.get("name")
+                if name:
+                    names.add(str(name))
+    return frozenset(names)
+
+
+def _project_skills_importer(app: Any) -> Importer:
+    """Build the injected importer from ``app.skills_scope_service``.
+
+    Mirrors the exact call shapes the Library skills-import flow uses
+    (``library_screen.py``'s ``_run_library_skills_import``/
+    ``_import_library_skill_from_loose_file``): a directory entry imports
+    via ``import_skill_directory`` (preserving the whole tree faithfully),
+    a loose ``.md`` file entry imports via ``import_skill_file``. Both land
+    TRUST-PENDING (``trust_approved=False``).
+    """
+    service = getattr(app, "skills_scope_service", None)
+    import_skill_directory = getattr(service, "import_skill_directory", None)
+    import_skill_file = getattr(service, "import_skill_file", None)
+
+    async def _importer(entry: ProjectSkillEntry) -> None:
+        if entry.kind == "directory":
+            if not callable(import_skill_directory):
+                raise RuntimeError("Skill import is unavailable.")
+            await import_skill_directory(
+                entry.path,
+                mode="local",
+                name=entry.name,
+                trust_approved=False,
+            )
+            return
+        if not callable(import_skill_file):
+            raise RuntimeError("Skill import is unavailable.")
+        data = await asyncio.to_thread(entry.path.read_bytes)
+        await import_skill_file(
+            data,
+            mode="local",
+            filename=entry.path.name,
+            content_type="text/markdown",
+            trust_approved=False,
+        )
+
+    return _importer
+
+
+def _record_project_skills_decision(
+    discovery: ProjectSkillsDiscovery, decision: str
+) -> None:
+    ledger_decision = _LEDGER_DECISIONS.get(decision)
+    if ledger_decision is None:
+        return
+    ledger = ProjectSkillsPromptLedger(get_user_data_dir())
+    ledger.record(discovery.root, ledger_decision, discovery.fingerprint)
+
+
+async def _offer_next_project_skills_discovery(
+    app: Any, discoveries: tuple[ProjectSkillsDiscovery, ...]
+) -> None:
+    discovery, remaining = discoveries[0], discoveries[1:]
+    installed_names = await _project_skills_installed_names(app)
+    importer = _project_skills_importer(app)
+    modal = ProjectSkillsImportModal(
+        discovery=discovery,
+        installed_names=installed_names,
+        importer=importer,
+    )
+
+    def _on_dismiss(result: ImportDecision) -> None:
+        decision, _outcomes = result
+        _record_project_skills_decision(discovery, decision)
+        if decision == "review":
+            app.post_message(NavigateToScreen("skills"))
+        maybe_offer_project_skills_import(app, remaining)
+
+    app.push_screen(modal, _on_dismiss)
+
+
+def maybe_offer_project_skills_import(
+    app: Any, discoveries: Sequence[ProjectSkillsDiscovery]
+) -> None:
+    """Offer imports for each discovery in turn (spec §5.5).
+
+    The one entry point other call sites use (startup, workspace-create
+    chaining). Builds ``installed_names``/an ``importer`` from the live
+    ``app.skills_scope_service``, then pushes one modal per discovery --
+    the next discovery's modal is only pushed once the current one
+    dismisses. Every dismissal is recorded in the prompt ledger
+    (``ProjectSkillsPromptLedger``, keyed by ``discovery.root``), and a
+    "review" decision also posts a navigation request to the Skills screen.
+
+    Args:
+        app: The running ``TldwCli`` app (or a test double exposing
+            ``skills_scope_service``, ``push_screen``, ``post_message``, and
+            ``run_worker``).
+        discoveries: Discoveries to offer, one modal at a time.
+    """
+    discoveries = tuple(discoveries)
+    if not discoveries:
+        return
+    app.run_worker(
+        _offer_next_project_skills_discovery(app, discoveries),
+        exclusive=False,
+    )

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -322,10 +322,18 @@ class WorkspaceCreateModal(
         self._folders.append(resolved_locator)
         # Pure filesystem scan (no side effects, no trust decisions) so the
         # row can flag "contains N project skill(s)" up front; only stored
-        # when there's something to offer later (spec §5.5).
-        discovery = discover_project_skills(resolved)
-        if discovery is not None and discovery.entries:
-            self._folder_discoveries[resolved_locator] = discovery
+        # when there's something to offer later (spec §5.5). Skipped
+        # entirely when the kill-switch is off (Finding 1, final review
+        # 2026-08-17): the feature's "no scanning" promise must be
+        # literally true, not merely "no offer" once the flag was already
+        # set. Imported locally (like app.py's startup discovery worker
+        # does) rather than at module import time.
+        from tldw_chatbook.config import get_cli_setting
+
+        if get_cli_setting("skills", "project_skills_prompt_enabled", True):
+            discovery = discover_project_skills(resolved)
+            if discovery is not None and discovery.entries:
+                self._folder_discoveries[resolved_locator] = discovery
         self._error = ""
         self._stash_form_state()
         self._folder_path_value = ""  # the just-consumed path is cleared

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -334,6 +334,12 @@ class WorkspaceCreateModal(
             discovery = discover_project_skills(resolved)
             if discovery is not None and discovery.entries:
                 self._folder_discoveries[resolved_locator] = discovery
+            else:
+                # Finding 9 (Qodo review, PR #1810): a re-add of the same
+                # locator (e.g. after Remove) must not resurrect a stale
+                # discovery from an earlier scan when the fresh one finds
+                # nothing usable -- assign-or-pop, not assign-only.
+                self._folder_discoveries.pop(resolved_locator, None)
         self._error = ""
         self._stash_form_state()
         self._folder_path_value = ""  # the just-consumed path is cleared
@@ -348,7 +354,14 @@ class WorkspaceCreateModal(
         except ValueError:
             return
         if 0 <= index < len(self._folders):
+            locator = self._folders[index]
             del self._folders[index]
+            # Finding 9 (Qodo review, PR #1810): a removed folder's stale
+            # discovery must not linger -- otherwise re-adding a DIFFERENT
+            # folder that happens to resolve to the same locator later (or
+            # a subsequent buggy rescan) could read an annotation for a
+            # folder that is no longer bound at all.
+            self._folder_discoveries.pop(locator, None)
             self._error = ""
             self._stash_form_state()
             self.refresh(recompose=True)

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -16,6 +16,10 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Static
 
+from tldw_chatbook.Skills_Interop.project_skills_discovery import (
+    ProjectSkillsDiscovery,
+    discover_project_skills,
+)
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
 from tldw_chatbook.Utils.input_validation import sanitize_string
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
@@ -46,9 +50,10 @@ class WorkspaceCreateResult:
     bound_folders: tuple[str, ...] = ()
     failed_folders: tuple[tuple[str, str], ...] = ()  # (path, error message)
     make_active: bool = True
-    #: ProjectSkillsDiscovery entries for bound folders containing .SKILLS/.
-    #: Stays empty until project-skills discovery ships (spec §5.5 / PR B).
-    project_skills: tuple = ()
+    #: One ProjectSkillsDiscovery per bound folder whose root contains a
+    #: non-empty .SKILLS/ (spec §5.5 create-modal chaining). Empty when no
+    #: bound folder had project skills, or none were bound at all.
+    project_skills: tuple[ProjectSkillsDiscovery, ...] = ()
 
 
 class WorkspaceCreateModal(
@@ -116,6 +121,12 @@ class WorkspaceCreateModal(
         super().__init__()
         self._registry = registry_service
         self._folders: list[str] = []
+        #: Folder locator -> its project-skills discovery, populated only
+        #: for folders whose root contains a non-empty .SKILLS/ (spec §5.5
+        #: create-modal chaining). Keyed by the same resolved-locator string
+        #: stored in ``self._folders`` so `_create()` can filter by
+        #: ``bound_folders`` without a second discovery pass.
+        self._folder_discoveries: dict[str, ProjectSkillsDiscovery] = {}
         self._error = ""
         # Finding 1: one-shot guard against a double-submit (rapid
         # Enter-Enter, or a double-click race on Create) running
@@ -183,9 +194,17 @@ class WorkspaceCreateModal(
                 )
             with Vertical(id="workspace-create-folder-list"):
                 for index, folder in enumerate(self._folders):
+                    discovery = self._folder_discoveries.get(folder)
+                    if discovery is not None and discovery.entries:
+                        label = (
+                            f"{folder} — contains "
+                            f"{len(discovery.entries)} project skill(s)"
+                        )
+                    else:
+                        label = folder
                     with Horizontal(classes="workspace-create-folder-item"):
                         yield Static(
-                            folder,
+                            label,
                             classes="workspace-create-folder-locator",
                             markup=False,
                         )
@@ -231,7 +250,24 @@ class WorkspaceCreateModal(
                     for folder in self._folders
                 ),
                 make_active=self._make_active_result,
+                project_skills=self._project_skills_for(self._bound_folders),
             )
+        )
+
+    def _project_skills_for(self, folders: tuple[str, ...]) -> tuple:
+        """Discoveries for bound folders whose root carries a .SKILLS/ dir.
+
+        Args:
+            folders: Locator strings of successfully bound folders.
+
+        Returns:
+            The ``ProjectSkillsDiscovery`` entries recorded at Add time for
+            those folders, in binding order (spec 2026-08-17 §5.5).
+        """
+        return tuple(
+            self._folder_discoveries[folder]
+            for folder in folders
+            if folder in self._folder_discoveries
         )
 
     @on(Button.Pressed, "#workspace-create-browse")
@@ -282,7 +318,14 @@ class WorkspaceCreateModal(
         except WorkspaceRegistryServiceError as exc:
             self._set_error(str(exc))
             return
-        self._folders.append(str(resolved))
+        resolved_locator = str(resolved)
+        self._folders.append(resolved_locator)
+        # Pure filesystem scan (no side effects, no trust decisions) so the
+        # row can flag "contains N project skill(s)" up front; only stored
+        # when there's something to offer later (spec §5.5).
+        discovery = discover_project_skills(resolved)
+        if discovery is not None and discovery.entries:
+            self._folder_discoveries[resolved_locator] = discovery
         self._error = ""
         self._stash_form_state()
         self._folder_path_value = ""  # the just-consumed path is cleared
@@ -371,6 +414,7 @@ class WorkspaceCreateModal(
                 bound_folders=all_bound,
                 failed_folders=(),
                 make_active=self._make_active_result,
+                project_skills=self._project_skills_for(all_bound),
             )
         )
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10281,37 +10281,61 @@ class TldwCli(
         )
 
     def _maybe_offer_project_skills_import(self) -> None:
-        """Offer to import a project's .SKILLS/ folder (spec 2026-08-17 §5.4)."""
+        """Offer to import a project's .SKILLS/ folder (spec 2026-08-17 §5.4).
+
+        ``exit_on_error=False`` matches the repo's own precedent for an
+        optional, best-effort worker (``action_quit``'s ``_confirm_and_quit``,
+        the screen-navigation dispatch worker): Textual's default
+        (``exit_on_error=True``) makes ANY unhandled exception in the worker
+        exit the whole app, which an optional startup nicety must never do.
+        The worker body below additionally never lets an exception reach the
+        worker at all -- this is belt AND suspenders.
+        """
         try:
             self.run_worker(
                 self._discover_project_skills_for_startup,
                 thread=True,
                 exclusive=True,
                 group="project-skills-discovery",
+                exit_on_error=False,
             )
         except Exception:
             logger.opt(exception=True).debug("project-skills startup offer failed")
 
     def _discover_project_skills_for_startup(self) -> None:
-        from tldw_chatbook.config import get_cli_setting, get_user_data_dir
-        from tldw_chatbook.Skills_Interop.project_skills_prompt import (
-            startup_discovery_for,
-        )
+        """Worker body: every line here must be exception-safe.
 
+        This runs on a worker thread with ``exit_on_error=False`` set above,
+        but that alone still leaves an unhandled exception logged as a
+        worker error and the offer silently dropped with a stack trace in
+        the logs -- an entirely optional startup nicety earns a clean,
+        quiet no-op instead. ``get_cli_setting``/``get_user_data_dir`` (I/O,
+        config parsing), ``startup_discovery_for`` (filesystem walk), and
+        ``call_from_thread`` (can raise if the app is already shutting down
+        mid-walk) are all covered by the one try/except below.
+        """
         try:
-            cwd = Path.cwd().resolve()
-        except OSError:
-            return  # launch directory deleted out from under the process
-        discovery = startup_discovery_for(
-            cwd,
-            enabled=bool(
-                get_cli_setting("skills", "project_skills_prompt_enabled", True)
-            ),
-            ledger_dir=get_user_data_dir(),
-        )
-        if discovery is None:
-            return
-        self.call_from_thread(self._push_project_skills_import_modal, discovery)
+            from tldw_chatbook.config import get_cli_setting, get_user_data_dir
+            from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+                startup_discovery_for,
+            )
+
+            try:
+                cwd = Path.cwd().resolve()
+            except OSError:
+                return  # launch directory deleted out from under the process
+            discovery = startup_discovery_for(
+                cwd,
+                enabled=bool(
+                    get_cli_setting("skills", "project_skills_prompt_enabled", True)
+                ),
+                ledger_dir=get_user_data_dir(),
+            )
+            if discovery is None:
+                return
+            self.call_from_thread(self._push_project_skills_import_modal, discovery)
+        except Exception:
+            logger.opt(exception=True).debug("project-skills startup discovery failed")
 
     def _push_project_skills_import_modal(self, discovery) -> None:
         from tldw_chatbook.Widgets.project_skills_import_modal import (

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10174,14 +10174,19 @@ class TldwCli(
         """Offer the setup wizard once; otherwise nudge unfinished setups.
 
         Returns:
-            True iff the wizard was pushed this launch (the ``"offer"``
-            branch); False for every other outcome (already scheduled,
-            the recovery-dialog "prompt" branch, the resume-toast "none"
-            branch -- which still runs and notifies -- or a caught
+            True iff the wizard OR the recovery dialog was pushed this
+            launch (the ``"offer"`` and ``"prompt"`` branches); False for
+            every other outcome (already scheduled, the resume-toast
+            "none" branch -- which still runs and notifies -- or a caught
             exception). Callers use this to decide whether a lower-
             priority startup offer (e.g. the project-.SKILLS import
             prompt, spec 2026-08-17 §5.4) should defer to next launch
-            instead of competing with the wizard for the user's attention.
+            instead of competing with the wizard OR the recovery dialog
+            for the user's attention -- both branches push a screen onto
+            the stack, so both must suppress the lower-priority offer
+            (final review 2026-08-17, Finding 3: the "prompt" branch used
+            to return False here, letting the skills-import modal stack
+            on top of a just-pushed ``SetupRecoveryDialog``).
         """
         if getattr(self, "_first_run_startup_action_scheduled", False):
             return False
@@ -10199,6 +10204,7 @@ class TldwCli(
             elif action == "prompt":
                 self._first_run_startup_action_scheduled = True
                 self.call_after_refresh(self._push_first_run_recovery_dialog)
+                return True
             elif action == "none" and should_show_resume_toast(
                 self.app_config, os.environ
             ):

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10170,10 +10170,21 @@ class TldwCli(
 
         await forward_model_catalog_refreshed(self, event)
 
-    def _maybe_offer_first_run_wizard(self) -> None:
-        """Offer the setup wizard once; otherwise nudge unfinished setups."""
+    def _maybe_offer_first_run_wizard(self) -> bool:
+        """Offer the setup wizard once; otherwise nudge unfinished setups.
+
+        Returns:
+            True iff the wizard was pushed this launch (the ``"offer"``
+            branch); False for every other outcome (already scheduled,
+            the recovery-dialog "prompt" branch, the resume-toast "none"
+            branch -- which still runs and notifies -- or a caught
+            exception). Callers use this to decide whether a lower-
+            priority startup offer (e.g. the project-.SKILLS import
+            prompt, spec 2026-08-17 §5.4) should defer to next launch
+            instead of competing with the wizard for the user's attention.
+        """
         if getattr(self, "_first_run_startup_action_scheduled", False):
-            return
+            return False
         try:
             from tldw_chatbook.UI.Wizards.first_run_setup_state import (
                 setup_recovery_action,
@@ -10184,6 +10195,7 @@ class TldwCli(
             if action == "offer":
                 self._first_run_startup_action_scheduled = True
                 self.call_after_refresh(self._push_first_run_wizard)
+                return True
             elif action == "prompt":
                 self._first_run_startup_action_scheduled = True
                 self.call_after_refresh(self._push_first_run_recovery_dialog)
@@ -10202,6 +10214,7 @@ class TldwCli(
                 "First-run startup action failed (error_type={})",
                 type(exc).__name__,
             )
+        return False
 
     def _maybe_warn_config_load_failure(self) -> None:
         """Warn (never block) when boot's config load fell back to defaults.
@@ -10266,6 +10279,46 @@ class TldwCli(
         self.push_screen(
             FirstRunSetupWizard(self), self._handle_first_run_wizard_result
         )
+
+    def _maybe_offer_project_skills_import(self) -> None:
+        """Offer to import a project's .SKILLS/ folder (spec 2026-08-17 §5.4)."""
+        try:
+            self.run_worker(
+                self._discover_project_skills_for_startup,
+                thread=True,
+                exclusive=True,
+                group="project-skills-discovery",
+            )
+        except Exception:
+            logger.opt(exception=True).debug("project-skills startup offer failed")
+
+    def _discover_project_skills_for_startup(self) -> None:
+        from tldw_chatbook.config import get_cli_setting, get_user_data_dir
+        from tldw_chatbook.Skills_Interop.project_skills_prompt import (
+            startup_discovery_for,
+        )
+
+        try:
+            cwd = Path.cwd().resolve()
+        except OSError:
+            return  # launch directory deleted out from under the process
+        discovery = startup_discovery_for(
+            cwd,
+            enabled=bool(
+                get_cli_setting("skills", "project_skills_prompt_enabled", True)
+            ),
+            ledger_dir=get_user_data_dir(),
+        )
+        if discovery is None:
+            return
+        self.call_from_thread(self._push_project_skills_import_modal, discovery)
+
+    def _push_project_skills_import_modal(self, discovery) -> None:
+        from tldw_chatbook.Widgets.project_skills_import_modal import (
+            maybe_offer_project_skills_import,
+        )
+
+        maybe_offer_project_skills_import(self, (discovery,))
 
     def _push_first_run_recovery_dialog(self) -> None:
         from tldw_chatbook.UI.Wizards.first_run_recovery_dialog import (
@@ -10524,11 +10577,14 @@ class TldwCli(
             f"Screen navigation: Pushed initial {screen_class.__name__}"
             f" (target={resolved_screen_name})"
         )
-        self._maybe_offer_first_run_wizard()
+        wizard_offered = self._maybe_offer_first_run_wizard()
         try:
             self._maybe_warn_second_instance()
         except Exception as e:
             logger.error(f"Second-instance warning failed: {e}")
+        if not wizard_offered:
+            # Spec 2026-08-17 §5.4: wizard wins; .SKILLS offer defers to next launch.
+            self._maybe_offer_project_skills_import()
         try:
             self._maybe_warn_config_load_failure()
         except Exception as e:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2766,6 +2766,9 @@ scope = "transcript"  # transcript, workbench
 intensity = "low"  # low, medium, high
 fps = 6  # 1-12
 
+[skills]
+# project_skills_prompt_enabled = true  # offer .SKILLS/ import at startup; spec 2026-08-17
+
 [appearance]
 density = "normal"  # compact, normal, or comfortable default control density
 animations_enabled = true  # Enable optional UI animations where supported


### PR DESCRIPTION
## Summary

**Stacked on #1809** (`feat/workspace-create-modal`) — re-target to `dev` after that PR lands.

Introduces a project-local `.SKILLS/` convention (per-skill dirs with `SKILL.md`, plus loose `*.md`) with a prompt-driven, never-silent import offer at two triggers: app startup in (or under, up to the first `.git` ancestor) a directory containing one, and after creating a workspace bound to one.

- **Discovery** (`Skills_Interop/project_skills_discovery.py`): pure, hardened — symlink refusal at every level, 50-entry/64 KiB caps, top-level-only scan, invalid-name pre-flagging via the importer's own grammar, content fingerprint over the skill files.
- **Prompt ledger** (`project_skills_prompt.py`): resolved-path keys, crash-proof advisory writes; "Not now" re-offers only when the skill set's fingerprint changes; "Never for this folder" is permanent; kill-switch `[skills] project_skills_prompt_enabled` — all gates enforced at the single offer choke point, so both triggers honor them identically (a gap the final review caught and closed, with live re-verification).
- **Import modal**: quarantine-preserving (`trust_approved=False` structurally; the modal states the one-time trust review requirement and routes to Library ▸ Skills); new-checked / installed-unchecked / invalid-unselectable rows; all repo-sourced text escaped; safe-dismiss + in-flight-import guards; sequential chaining with a re-entrancy flag.
- **Startup trigger**: wizard/recovery-dialog defer; crash-proof worker (`exit_on_error=False` + full-body guard) — the feature can never break startup.
- **Docs**: ADR-069, config template key, User Guide (skills + workspaces pages).

## Verification

CI is intentionally cancelled on this repo — verified locally: `Tests/Skills/` + `Tests/Workspaces/` (686 passed), 49.9k-test collect sweep; live TUI passes on isolated profiles covering all five spec scenarios plus the kill-switch, and a targeted re-check of "Never"→create and kill-switch→create after the final-review fix. Whole-branch final review + verified fix wave.

## Notes for the reviewer

- Follow-ups filed: TASK-17963 (pre-existing fixed-temp-name write race in the skills store + trust store — this PR's new ledger avoids it locally), TASK-17964 (offer-modal test gaps, off-thread discovery decision, hung-import dismissal posture, pluralization).
- Backlog IDs 17651/17963/17964 and ADR-069 swept against origin/dev + all worktrees; re-verify at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project-local `.SKILLS/` discovery with a prompt-driven import at startup and after workspace creation, implementing TASK-17651. Previously there was no project import; now Chatbook detects `.SKILLS/` and offers to copy skills into the library, never silently; imports are trust-pending, and failed/partial imports no longer suppress future offers.

- Hardened discovery (`tldw_chatbook/Skills_Interop/project_skills_discovery.py`): top-level-only scan, symlink refusal, caps of 50 entries/64 KiB frontmatter, 500 child raw-enumeration bound, bounded “skipped” rows, content fingerprinting; `.SKILLS` preferred over `.skills`.
- Single offer choke point (`maybe_offer_project_skills_import`): enforces `[skills] project_skills_prompt_enabled` and a per-project ledger at `<user_data_dir>/skills/project_prompts.json`; "Never" is permanent; "Not now" re-offers only on fingerprint change; records "imported"/"review" only if all attempted entries succeed so failures remain retryable; initial scheduling guarded.
- Startup integration: `startup_discovery_for(...)` walks to the first `.git` ancestor; the first-run wizard — including the recovery “prompt” branch — defers the skills offer by returning True; the worker cannot crash startup; re-entrancy and scheduling are guarded.
- Import modal (`tldw_chatbook/Widgets/project_skills_import_modal.py`): imports through the existing path with `trust_approved=False`; revalidates loose-file symlinks with `os.lstat`/`O_NOFOLLOW`; escapes repo text; disables offer controls while importing; Esc on results acts as Close; suppresses offers if `skills_scope_service` is unavailable; chains multiple discoveries.
- Workspace flow: bound folders that contain `.SKILLS/` are annotated “— contains N project skill(s)” and produce discoveries that trigger the same post-create offer; stale per-folder discoveries are cleared on remove and when rescans find nothing; wiring added in Console, Library, and Settings.
- Docs and tests: ADR-069 and User Guide updated; tests cover discovery bounds, ledger gating and retry semantics, startup deferral, modal behavior, and workspace annotations.

**Rollout/Migration**
- No migration required; behavior changes only when a bound folder contains `.SKILLS/`.
- To disable all project-skill offers, set `[skills] project_skills_prompt_enabled = false`. Decisions persist in `<user_data_dir>/skills/project_prompts.json`.

<sup>Written for commit 429fa976ddd70891de969e80b823ebbfd0ae67be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

