### PR TITLE
fix(console): teardown cannot skip its cancellation signals (post-#1799 approval pins)

### DIFF
--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1193,8 +1193,11 @@ def test_request_mcp_approvals_cancellation_denies_undecided():
     `_stop_requested` flag to exercise that; F5 removed `_stop_requested`
     from the bridge's poll (a single session's Stop must not cross-cancel
     an unrelated session's approval round any more), so the equivalent
-    "global" signal is now the never-reset `_shutdown_requested` (set only
-    by `shutdown()`)."""
+    "global" signal is the production app-exit path `begin_shutdown()`, which
+    sets the visit Event AND cancels headless-bound rounds -- a raw
+    `_shutdown_requested.set()` poke stopped reaching never-visited
+    controllers' rounds when the Qodo-S2 fix (PR #1799) made those bind the
+    headless cancel signal. Drive the seam, not the flag."""
     controller, _ = _build_controller()
     received: list[dict | None] = []
     controller.app = _FakeApp()
@@ -1203,7 +1206,7 @@ def test_request_mcp_approvals_cancellation_denies_undecided():
 
     def _cancel_soon() -> None:
         time.sleep(0.05)
-        controller._shutdown_requested.set()
+        controller.begin_shutdown()
 
     canceller = threading.Thread(target=_cancel_soon)
     canceller.start()
@@ -1331,7 +1334,7 @@ def test_request_mcp_approvals_cancellation_records_denied_decision_to_execution
 
     def _cancel_soon() -> None:
         time.sleep(0.05)
-        controller._shutdown_requested.set()
+        controller.begin_shutdown()
 
     canceller = threading.Thread(target=_cancel_soon)
     canceller.start()
@@ -3116,7 +3119,7 @@ def test_shutdown_still_denies_a_survivors_round():
     )
     time.sleep(0.15)
 
-    controller._shutdown_requested.set()
+    controller.begin_shutdown()
     worker.join(timeout=3.0)
 
     assert not worker.is_alive(), "teardown left a survivor's round parked"

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -6079,9 +6079,19 @@ class ConsoleChatController:
 
         self._disposed = True
         self._visit_open = False
-        self.prompt_queue_coordinator.shutdown()
-        self._shutdown_requested.set()
-        self._cancel_headless_rounds()
+        # The queue tombstone keeps its contract of running BEFORE any
+        # teardown cancellation -- but it must never be able to SKIP that
+        # cancellation. Its shutdown asserts queue-owner-thread affinity
+        # (QueueThreadViolation from any other thread), and an exit path
+        # whose safety signals sit after a raise-capable call would leave
+        # every armed approval round waiting for a deadline instead of
+        # denying. Found via a test that drove begin_shutdown off-thread:
+        # the round timed out at 30s because the signals were never set.
+        try:
+            self.prompt_queue_coordinator.shutdown()
+        finally:
+            self._shutdown_requested.set()
+            self._cancel_headless_rounds()
 
     def _cancel_headless_rounds(self) -> None:
         """Deny every round armed while no Console visit was open.


### PR DESCRIPTION
## The three approval reds after #1799 — a test shortcut, and the real bug it was hiding

Task 5's attribution flagged 3 `test_console_mcp_approval.py` deny-on-cancellation tests red at `98a189015` (#1799, the Qodo S2 fix). The tests simulated teardown by poking `controller._shutdown_requested.set()` — the raw Event, bypassing every production entry point. S2 deliberately made a never-visited controller's rounds bind the headless cancel signal instead, so the poked flag stopped reaching them. Fourth instance of this programme's harness-shortcut trap; the tests now drive `begin_shutdown()`, the production app-exit seam their own docstrings name as the intent.

**Repointing them exposed a real production fragility.** `begin_shutdown` runs the queue tombstone first — per its documented ordering contract — but that call asserts queue-owner-thread affinity and raises `QueueThreadViolation` from any other thread, **before the cancellation signals are set**: every armed approval round would then wait out its deadline instead of denying. Latent today (the only production caller is on the owner thread), but an exit path whose safety signals sit after a raise-capable call is one refactor away from being live. The tombstone now runs inside try/finally: it keeps its runs-first contract and can never skip the signals. Mutation-checked — removing the `finally` kills exactly the two repointed tests, which now pin the hardening (an off-owner-thread `begin_shutdown` still denies).

Suite: 71→**74 passed, 0 failed**. Adjacent gates (headless approval, runtime lifetime, provenance) 107 green. This also clears the "new dev red routed to the owner" from Task 5's report — PR #1808 should be re-based on this before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures console teardown always triggers cancellation signals and updates tests to use the production shutdown path. Previously, `begin_shutdown` could raise before setting cancellation signals when called off the queue owner thread, leaving approval rounds to wait for timeouts; it now guarantees signals are set and rounds deny promptly.

- Wraps `prompt_queue_coordinator.shutdown()` in `begin_shutdown` with `try/finally` so `_shutdown_requested` and headless-round cancellation always run; preserves the “tombstone runs first” order.
- Replaces direct `_shutdown_requested.set()` with `begin_shutdown()` in three approval cancellation tests to drive the production seam and pin the behavior.
- Migration: if any tests or tooling set `_shutdown_requested` directly, switch to `begin_shutdown()` to simulate teardown.

<sup>Written for commit 93fa11accdfc4bbc54f96d4968c5538323df90e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

