### PR TITLE
docs(rag): TASK-18155 granularity router — NULL by census, sixth retired P2c premise

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
@@ -35,6 +35,11 @@ REPO = Path(__file__).resolve().parents[4]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
+# E402 is unavoidable and deliberate: this script lives under `Docs/`, not on
+# the import path, so the repo root must be on `sys.path` BEFORE any first-party
+# import can resolve. This is the file's only module-scope local import -- every
+# other one is deferred into `main`, in a single contiguous group, so the pure
+# helpers stay importable (and testable) without building a retrieval stack.
 from Tests.RAG_Eval.harness.canonicalize import canonical_source_type  # noqa: E402
 
 CHUNK_SIZE = 384          # hybrid_basic profile, the harness's own

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
@@ -1,0 +1,186 @@
+"""TASK-18155 census: could a granularity router change any golden outcome?
+
+Run:  RAG_EVAL=1 python Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+
+Answers two populations, because "chunk vs document granularity" has TWO
+mechanisms and the cheap count only sees the first:
+
+1. DIRECT -- the query's own relevant document is multi-chunk, so retrieving
+   it whole rather than in pieces changes what is scored for that query.
+2. DISPLACEMENT -- some OTHER document occupies several of the top-k row
+   slots (`canonicalize.py`: "one document can occupy several of the top-k
+   slots"), because the top-k cut happens at ROW level and rows collapse to
+   documents only afterwards. Collapsing at retrieval would free those slots
+   for documents currently pushed out. This one needs a live run.
+
+Only a query whose relevant document is CURRENTLY MISSED can be rescued, so
+the qualifying population is (slots freed > 0) AND (relevant doc absent).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO))
+
+if os.environ.get("RAG_EVAL") != "1":
+    raise SystemExit("refusing to run without RAG_EVAL=1 (this builds a real index)")
+
+import tldw_chatbook
+
+# Provenance: a census that silently measured another checkout would be
+# worthless, and this arc already shipped one instrument that could not see
+# what it was asked about (TASK-18255).
+print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
+assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
+
+from Tests.RAG_Eval.harness.canonicalize import canonical_source_type, slug_lookup_from
+from Tests.RAG_Eval.harness.goldenset import load_fixtures
+from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+from Tests.RAG_Eval.harness.runner import SOURCE_TYPES, _extract_rows, build_query_scope
+
+CHUNK_SIZE = 384          # hybrid_basic profile
+CHUNK_OVERLAP = 64
+K = 10                    # run_eval's default
+BAR = 5                   # inherited verbatim from the PRF + clarification-gate arcs
+MODES = ("semantic", "hybrid")   # `plain` returns whole items: no chunks, so no granularity
+
+
+def row_slug(row, lookup):
+    """Map ONE row to its fixture slug, mirroring rows_to_doc_ids without collapsing."""
+    prov = row.get("provenance") or {}
+    st = canonical_source_type(prov.get("source_type"))
+    sid = str(row.get("source_id", ""))
+    for key in ((st, sid), (st, sid.split("_", 1)[-1] if "_" in sid else sid)):
+        if key in lookup:
+            return lookup[key]
+    return f"unknown:{st}:{sid}"
+
+
+def main() -> int:
+    import tempfile
+
+    corpus, golden = load_fixtures()
+    print(f"PROBE PROOF: corpus={len(corpus)} docs, golden={len(golden)} queries")
+
+    # --- population 1: DIRECT, from the corpus alone (no run needed) ---
+    from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
+
+    svc = ChunkingService()
+    chunks_per_doc = {
+        d.slug: len(svc.chunk_text(d.content, chunk_size=CHUNK_SIZE,
+                                   chunk_overlap=CHUNK_OVERLAP, method="words"))
+        for d in corpus
+    }
+    multi = {s: n for s, n in chunks_per_doc.items() if n > 1}
+    print(f"PROBE PROOF: docs chunked={len(chunks_per_doc)}, "
+          f"total chunks={sum(chunks_per_doc.values())}, multi-chunk docs={len(multi)}")
+    for s, n in sorted(multi.items(), key=lambda kv: -kv[1]):
+        print(f"    multi-chunk: {s:38s} {n} chunks")
+
+    direct = [q for q in golden if any(s in multi for s in q.relevant_slugs)]
+    print(f"\n=== POPULATION 1 (DIRECT): {len(direct)} of {len(golden)} queries ===")
+    for q in direct:
+        print(f"    {q.id:30s} [{q.category}] -> "
+              f"{[s for s in q.relevant_slugs if s in multi]}")
+
+    # --- population 2: DISPLACEMENT, needs a live index ---
+    with tempfile.TemporaryDirectory() as tmp:
+        runtime = build_eval_runtime(corpus, tmp)
+        from tldw_chatbook.Library.library_local_rag_search_service import (
+            LibraryLocalRagSearchService,
+        )
+
+        seam = LibraryLocalRagSearchService(runtime.app)
+        lookup = slug_lookup_from(runtime.slug_to_source)
+        cfg = runtime.service.config.search
+        original = getattr(cfg, "default_search_mode", None)
+
+        qualifying: dict[str, list[str]] = {m: [] for m in MODES}
+        any_dup: dict[str, list[str]] = {m: [] for m in MODES}
+        excluded: dict[str, list[str]] = {m: [] for m in MODES}
+        direct_state: dict[str, list[str]] = {m: [] for m in MODES}
+        try:
+            for mode in MODES:
+                cfg.default_search_mode = mode
+                for q in golden:
+                    scope = build_query_scope(runtime.slug_to_source, q)
+                    result = runtime.run(
+                        seam.search(q.query, SOURCE_TYPES, "rag", top_k=K, scope=scope)
+                    )
+                    rows, _backend, err = _extract_rows(result)
+                    if err:
+                        print(f"    !! {mode}/{q.id}: {err}")
+                        continue
+                    slugs = [row_slug(r, lookup) for r in rows]
+                    counts = Counter(slugs)
+                    freed = len(slugs) - len(counts)          # slots a router would free
+                    hit = any(s in counts for s in q.relevant_slugs)
+                    if q in direct:
+                        direct_state[mode].append(
+                            f"{q.id}({'HIT' if hit else 'MISS'},+{freed})"
+                        )
+                    if freed > 0:
+                        any_dup[mode].append(
+                            f"{q.id}[{q.category}](+{freed},{'HIT' if hit else 'MISS'})"
+                        )
+                        if not hit:
+                            # A query can only be RESCUED if it has a target to
+                            # find AND that target is reachable in this mode.
+                            # Two exclusions, both structural:
+                            #  - `negative` queries have NO relevant slug, so
+                            #    `hit` is False by construction and a miss is
+                            #    the CORRECT outcome, not a rescuable failure.
+                            #  - `prompt` targets have no vector index at all
+                            #    (B2 gave prompts an FTS sub-leg deliberately
+                            #    without one), so in a vector mode no freed slot
+                            #    can admit them -- they are not in the index.
+                            if not q.relevant_slugs:
+                                excluded[mode].append(f"{q.id}(negative: no target)")
+                            elif q.category == "prompt" and mode == "semantic":
+                                excluded[mode].append(f"{q.id}(prompt: not vector-indexed)")
+                            else:
+                                qualifying[mode].append(q.id)
+        finally:
+            cfg.default_search_mode = original
+
+    print(f"\n=== POPULATION 1 current state (can a HIT be rescued? no) ===")
+    for mode in MODES:
+        print(f"  {mode}: {direct_state[mode]}")
+
+    print(f"\n=== POPULATION 2 (DISPLACEMENT), K={K} ===")
+    for mode in MODES:
+        print(f"  {mode}: queries with duplicate-doc slots = {len(any_dup[mode])}")
+        for entry in any_dup[mode]:
+            print(f"      {entry}")
+        if excluded[mode]:
+            print(f"  {mode}: excluded as structurally unrescuable = {excluded[mode]}")
+        print(f"  {mode}: QUALIFYING (slots freed AND a reachable target missed) = "
+              f"{len(qualifying[mode])} {qualifying[mode]}")
+
+    # A query already HITTING cannot be rescued -- a router could only
+    # preserve or harm it. The bar's precedent (PRF clause 1) counts
+    # RESCUES, so the qualifying population is misses only.
+    print(f"\n=== VERDICT vs pre-registered bar of {BAR} (inherited verbatim) ===")
+    rescuable_by_mode = {}
+    for mode in MODES:
+        direct_missed = [e for e in direct_state[mode] if "(MISS," in e]
+        total = len(direct_missed) + len(qualifying[mode])
+        rescuable_by_mode[mode] = total
+        print(f"  {mode:9s}: direct-missed={len(direct_missed)} "
+              f"{[e.split('(')[0] for e in direct_missed]} + "
+              f"displacement-qualifying={len(qualifying[mode])} -> rescuable={total}")
+    best = max(rescuable_by_mode.values())
+    print(f"  exposure (currently-HIT queries a reorder could only move DOWN): "
+          f"{ {m: sum(1 for e in any_dup[m] if ',HIT)' in e) for m in MODES} }")
+    print(f"  BEST-MODE RESCUABLE: {best}  vs BAR {BAR}")
+    print(f"  RESULT: {'CLEARS' if best >= BAR else 'BELOW'} bar -> "
+          f"{'probe' if best >= BAR else 'NULL, arc ends -- no probe, no production code'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
@@ -35,6 +35,8 @@ REPO = Path(__file__).resolve().parents[4]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
+from Tests.RAG_Eval.harness.canonicalize import canonical_source_type  # noqa: E402
+
 CHUNK_SIZE = 384          # hybrid_basic profile, the harness's own
 CHUNK_OVERLAP = 64
 K = 10                    # run_eval's default
@@ -106,6 +108,33 @@ def classify(
     return "qualifying", ""
 
 
+def slot_summary(
+    slugs: list[str], relevant_slugs: tuple[str, ...]
+) -> tuple[int, bool, int]:
+    """Summarize one query's retrieved rows for the displacement question.
+
+    Args:
+        slugs: One fixture slug per retrieved ROW, in rank order, uncollapsed.
+        relevant_slugs: The query's ground-truth slugs.
+
+    Returns:
+        ``(freed, hit, unmapped)`` where ``freed`` is how many top-k slots a
+        granularity router would recover (rows minus distinct documents),
+        ``hit`` is whether any relevant document was retrieved, and
+        ``unmapped`` counts rows no fixture claimed.
+
+        ``unmapped`` is reported, not discarded: every unmapped row is a
+        DISTINCT ``unknown:*`` key, so a mapping failure would drive ``freed``
+        to 0 and the census would report "no displacement" when it had in
+        fact measured nothing.
+    """
+    counts = Counter(slugs)
+    freed = len(slugs) - len(counts)
+    hit = any(s in counts for s in relevant_slugs)
+    unmapped = sum(1 for s in slugs if s.startswith("unknown:"))
+    return freed, hit, unmapped
+
+
 def row_slug(row: Mapping[str, Any], lookup: Mapping[tuple[str, str], str]) -> str:
     """Map ONE retrieved row to its fixture slug, without collapsing.
 
@@ -123,8 +152,6 @@ def row_slug(row: Mapping[str, Any], lookup: Mapping[tuple[str, str], str]) -> s
         fixture claims the row (kept, never dropped -- an unrecognized row
         still occupies a top-k slot).
     """
-    from Tests.RAG_Eval.harness.canonicalize import canonical_source_type
-
     prov = row.get("provenance") or {}
     st = canonical_source_type(prov.get("source_type"))
     sid = str(row.get("source_id", ""))
@@ -143,19 +170,19 @@ def main() -> int:
         population, 1 when any query errored (an incomplete population cannot
         support a NULL, so no verdict is claimed).
     """
-    import tempfile
-
     if os.environ.get("RAG_EVAL") != "1":
         raise SystemExit("refusing to run without RAG_EVAL=1 (this builds a real index)")
 
+    # One contiguous local-import group. These are deferred to call time
+    # rather than module scope so the pure helpers above stay importable
+    # without the gate (and without building a retrieval stack) for
+    # `Tests/RAG_Eval/test_granularity_census.py`.
+    import tempfile
+
     import tldw_chatbook
-
-    # A census that silently measured another checkout would be worthless,
-    # and this programme already shipped one instrument that could not see
-    # what it was asked about (TASK-18255).
-    print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
-    assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
-
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        LibraryLocalRagSearchService,
+    )
     from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
 
     from Tests.RAG_Eval.harness.canonicalize import slug_lookup_from
@@ -166,6 +193,12 @@ def main() -> int:
         _extract_rows,
         build_query_scope,
     )
+
+    # A census that silently measured another checkout would be worthless,
+    # and this programme already shipped one instrument that could not see
+    # what it was asked about (TASK-18255).
+    print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
+    assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
 
     corpus, golden = load_fixtures()
     print(f"PROBE PROOF: corpus={len(corpus)} docs, golden={len(golden)} queries")
@@ -201,6 +234,8 @@ def main() -> int:
 
     # --- population 2: DISPLACEMENT, needs a live index ---
     errors: list[str] = []
+    total_rows = 0
+    total_unmapped = 0
     qualifying: dict[str, list[str]] = {m: [] for m in MODES}
     any_dup: dict[str, list[str]] = {m: [] for m in MODES}
     excluded: dict[str, list[str]] = {m: [] for m in MODES}
@@ -208,10 +243,6 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory() as tmp:
         runtime = build_eval_runtime(corpus, tmp)
-        from tldw_chatbook.Library.library_local_rag_search_service import (
-            LibraryLocalRagSearchService,
-        )
-
         seam = LibraryLocalRagSearchService(runtime.app)
         lookup = slug_lookup_from(runtime.slug_to_source)
         cfg = runtime.service.config.search
@@ -235,9 +266,9 @@ def main() -> int:
                         errors.append(f"{mode}/{q.id}: {err}")
                         continue
                     slugs = [row_slug(r, lookup) for r in rows]
-                    counts = Counter(slugs)
-                    freed = len(slugs) - len(counts)     # slots a router would free
-                    hit = any(s in counts for s in q.relevant_slugs)
+                    freed, hit, unmapped = slot_summary(slugs, q.relevant_slugs)
+                    total_rows += len(slugs)
+                    total_unmapped += unmapped
                     verdict, reason = classify(q.relevant_slugs, q.category, mode, hit)
                     if q in direct:
                         direct_state[mode].append(
@@ -271,6 +302,15 @@ def main() -> int:
         )
 
     print(f"\n=== VERDICT vs pre-registered bar of {BAR} (inherited verbatim) ===")
+    print(
+        f"  PROBE PROOF: rows canonicalized={total_rows}, unmapped={total_unmapped} "
+        f"({100.0 * total_unmapped / total_rows if total_rows else 0.0:.1f}%) -- "
+        "an unmapped row is a DISTINCT unknown key, so a mapping failure would "
+        "drive freed-slot counts to 0 and fake a 'no displacement' result"
+    )
+    if total_rows == 0:
+        print("  NO VERDICT CLAIMED: zero rows canonicalized -- nothing was measured.")
+        return 1
     if errors:
         print(f"  !! {len(errors)} query/queries ERRORED -- population INCOMPLETE:")
         for e in errors:

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
@@ -1,9 +1,12 @@
 """TASK-18155 census: could a granularity router change any golden outcome?
 
-Run:  RAG_EVAL=1 python Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+Run::
 
-Answers two populations, because "chunk vs document granularity" has TWO
-mechanisms and the cheap count only sees the first:
+    RAG_EVAL=1 PYTHONPATH=$(pwd) <venv>/bin/python \
+        Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py
+
+"Chunk vs document granularity" has TWO mechanisms, and a corpus count only
+sees the first:
 
 1. DIRECT -- the query's own relevant document is multi-chunk, so retrieving
    it whole rather than in pieces changes what is scored for that query.
@@ -11,10 +14,14 @@ mechanisms and the cheap count only sees the first:
    slots (`canonicalize.py`: "one document can occupy several of the top-k
    slots"), because the top-k cut happens at ROW level and rows collapse to
    documents only afterwards. Collapsing at retrieval would free those slots
-   for documents currently pushed out. This one needs a live run.
+   for documents currently pushed out. This one needs a live index.
 
-Only a query whose relevant document is CURRENTLY MISSED can be rescued, so
-the qualifying population is (slots freed > 0) AND (relevant doc absent).
+Only a query whose relevant document is CURRENTLY MISSED can be rescued, and
+only if that document is reachable in the mode at all -- see `classify`.
+
+The pure helpers (`parity_text`, `classify`) are importable without the
+`RAG_EVAL` gate so `Tests/RAG_Eval/test_granularity_census.py` can pin them;
+the gate guards `main`, which builds a real index.
 """
 from __future__ import annotations
 
@@ -22,72 +29,183 @@ import os
 import sys
 from collections import Counter
 from pathlib import Path
+from typing import Any, Mapping
 
 REPO = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(REPO))
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
 
-if os.environ.get("RAG_EVAL") != "1":
-    raise SystemExit("refusing to run without RAG_EVAL=1 (this builds a real index)")
-
-import tldw_chatbook
-
-# Provenance: a census that silently measured another checkout would be
-# worthless, and this arc already shipped one instrument that could not see
-# what it was asked about (TASK-18255).
-print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
-assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
-
-from Tests.RAG_Eval.harness.canonicalize import canonical_source_type, slug_lookup_from
-from Tests.RAG_Eval.harness.goldenset import load_fixtures
-from Tests.RAG_Eval.harness.ingest import build_eval_runtime
-from Tests.RAG_Eval.harness.runner import SOURCE_TYPES, _extract_rows, build_query_scope
-
-CHUNK_SIZE = 384          # hybrid_basic profile
+CHUNK_SIZE = 384          # hybrid_basic profile, the harness's own
 CHUNK_OVERLAP = 64
 K = 10                    # run_eval's default
-BAR = 5                   # inherited verbatim from the PRF + clarification-gate arcs
-MODES = ("semantic", "hybrid")   # `plain` returns whole items: no chunks, so no granularity
+BAR = 5                   # inherited verbatim from PRF clause 1 + the clarification gate
+MODES = ("semantic", "hybrid")   # `plain` returns whole items: no chunks, no granularity
+
+#: Reasons a missed query still cannot be rescued by freeing a top-k slot.
+EXCLUDED_NEGATIVE = "negative: no target to find"
+EXCLUDED_UNINDEXED = "prompt: not vector-indexed"
 
 
-def row_slug(row, lookup):
-    """Map ONE row to its fixture slug, mirroring rows_to_doc_ids without collapsing."""
+def parity_text(source_type: str, content: str) -> str:
+    """Return the text production actually chunks for a document.
+
+    Conversations are indexed as a transcript with each message's sender
+    prepended (`ingestion_indexing.conversation_document` builds
+    ``f"{sender}: {content}"``), so chunking the raw fixture content would
+    measure a slightly shorter document than the one that exists in the
+    index. Media and notes index their content unchanged.
+
+    Args:
+        source_type: The fixture document's source type.
+        content: The document's raw fixture content.
+
+    Returns:
+        The text the indexer would chunk for this document.
+    """
+    if source_type == "conversation":
+        return f"user: {content}"
+    return content
+
+
+def classify(
+    relevant_slugs: tuple[str, ...],
+    category: str,
+    mode: str,
+    hit: bool,
+) -> tuple[str, str]:
+    """Decide whether a query could be RESCUED by a granularity router.
+
+    A query already retrieving its target cannot be rescued -- a router could
+    only preserve or harm it -- so the bar's population (which counts
+    rescues, following PRF clause 1) is misses only. Two kinds of miss are
+    nonetheless structurally unrescuable:
+
+    * a `negative` query has no relevant document, so ``hit`` is False **by
+      construction** and the miss is the CORRECT outcome; and
+    * a `prompt` target has no vector index at all (B2 gave prompts an FTS
+      sub-leg deliberately without one), so in a vector mode no freed slot
+      can admit a document that is not in the index.
+
+    Args:
+        relevant_slugs: The query's ground-truth fixture slugs.
+        category: The query's golden-set category.
+        mode: Retrieval mode being measured (``semantic`` or ``hybrid``).
+        hit: Whether any relevant slug appeared in the retrieved rows.
+
+    Returns:
+        ``(verdict, reason)`` where verdict is one of ``"hit"``,
+        ``"qualifying"`` or ``"excluded"``; ``reason`` is empty unless
+        excluded.
+    """
+    if hit:
+        return "hit", ""
+    if not relevant_slugs:
+        return "excluded", EXCLUDED_NEGATIVE
+    if category == "prompt" and mode == "semantic":
+        return "excluded", EXCLUDED_UNINDEXED
+    return "qualifying", ""
+
+
+def row_slug(row: Mapping[str, Any], lookup: Mapping[tuple[str, str], str]) -> str:
+    """Map ONE retrieved row to its fixture slug, without collapsing.
+
+    Mirrors `canonicalize.rows_to_doc_ids`, but per row: this census needs to
+    know how many SLOTS a document occupies, which the collapsing version
+    deliberately discards.
+
+    Args:
+        row: One row as the Library search seam emits it.
+        lookup: ``(canonical source_type, source_id) -> slug``, from
+            `canonicalize.slug_lookup_from`.
+
+    Returns:
+        The fixture slug, or a synthesized ``"unknown:<type>:<id>"`` when no
+        fixture claims the row (kept, never dropped -- an unrecognized row
+        still occupies a top-k slot).
+    """
+    from Tests.RAG_Eval.harness.canonicalize import canonical_source_type
+
     prov = row.get("provenance") or {}
     st = canonical_source_type(prov.get("source_type"))
     sid = str(row.get("source_id", ""))
-    for key in ((st, sid), (st, sid.split("_", 1)[-1] if "_" in sid else sid)):
+    stripped = sid.split("_", 1)[-1] if "_" in sid else sid
+    for key in ((st, sid), (st, stripped)):
         if key in lookup:
             return lookup[key]
     return f"unknown:{st}:{sid}"
 
 
 def main() -> int:
+    """Run the census and print the verdict against the pre-registered bar.
+
+    Returns:
+        Process exit code: 0 when the census completed over the FULL query
+        population, 1 when any query errored (an incomplete population cannot
+        support a NULL, so no verdict is claimed).
+    """
     import tempfile
+
+    if os.environ.get("RAG_EVAL") != "1":
+        raise SystemExit("refusing to run without RAG_EVAL=1 (this builds a real index)")
+
+    import tldw_chatbook
+
+    # A census that silently measured another checkout would be worthless,
+    # and this programme already shipped one instrument that could not see
+    # what it was asked about (TASK-18255).
+    print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
+    assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
+
+    from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
+
+    from Tests.RAG_Eval.harness.canonicalize import slug_lookup_from
+    from Tests.RAG_Eval.harness.goldenset import load_fixtures
+    from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+    from Tests.RAG_Eval.harness.runner import (
+        SOURCE_TYPES,
+        _extract_rows,
+        build_query_scope,
+    )
 
     corpus, golden = load_fixtures()
     print(f"PROBE PROOF: corpus={len(corpus)} docs, golden={len(golden)} queries")
 
-    # --- population 1: DIRECT, from the corpus alone (no run needed) ---
-    from tldw_chatbook.RAG_Search.chunking_service import ChunkingService
-
+    # --- population 1: DIRECT, from the corpus alone ---
     svc = ChunkingService()
     chunks_per_doc = {
-        d.slug: len(svc.chunk_text(d.content, chunk_size=CHUNK_SIZE,
-                                   chunk_overlap=CHUNK_OVERLAP, method="words"))
+        d.slug: len(
+            svc.chunk_text(
+                parity_text(d.source_type, d.content),
+                chunk_size=CHUNK_SIZE,
+                chunk_overlap=CHUNK_OVERLAP,
+                method="words",
+            )
+        )
         for d in corpus
     }
     multi = {s: n for s, n in chunks_per_doc.items() if n > 1}
-    print(f"PROBE PROOF: docs chunked={len(chunks_per_doc)}, "
-          f"total chunks={sum(chunks_per_doc.values())}, multi-chunk docs={len(multi)}")
+    print(
+        f"PROBE PROOF: docs chunked={len(chunks_per_doc)}, "
+        f"total chunks={sum(chunks_per_doc.values())}, multi-chunk docs={len(multi)}"
+    )
     for s, n in sorted(multi.items(), key=lambda kv: -kv[1]):
         print(f"    multi-chunk: {s:38s} {n} chunks")
 
     direct = [q for q in golden if any(s in multi for s in q.relevant_slugs)]
     print(f"\n=== POPULATION 1 (DIRECT): {len(direct)} of {len(golden)} queries ===")
     for q in direct:
-        print(f"    {q.id:30s} [{q.category}] -> "
-              f"{[s for s in q.relevant_slugs if s in multi]}")
+        print(
+            f"    {q.id:30s} [{q.category}] -> "
+            f"{[s for s in q.relevant_slugs if s in multi]}"
+        )
 
     # --- population 2: DISPLACEMENT, needs a live index ---
+    errors: list[str] = []
+    qualifying: dict[str, list[str]] = {m: [] for m in MODES}
+    any_dup: dict[str, list[str]] = {m: [] for m in MODES}
+    excluded: dict[str, list[str]] = {m: [] for m in MODES}
+    direct_state: dict[str, list[str]] = {m: [] for m in MODES}
+
     with tempfile.TemporaryDirectory() as tmp:
         runtime = build_eval_runtime(corpus, tmp)
         from tldw_chatbook.Library.library_local_rag_search_service import (
@@ -98,27 +216,29 @@ def main() -> int:
         lookup = slug_lookup_from(runtime.slug_to_source)
         cfg = runtime.service.config.search
         original = getattr(cfg, "default_search_mode", None)
-
-        qualifying: dict[str, list[str]] = {m: [] for m in MODES}
-        any_dup: dict[str, list[str]] = {m: [] for m in MODES}
-        excluded: dict[str, list[str]] = {m: [] for m in MODES}
-        direct_state: dict[str, list[str]] = {m: [] for m in MODES}
         try:
             for mode in MODES:
                 cfg.default_search_mode = mode
                 for q in golden:
                     scope = build_query_scope(runtime.slug_to_source, q)
-                    result = runtime.run(
-                        seam.search(q.query, SOURCE_TYPES, "rag", top_k=K, scope=scope)
-                    )
-                    rows, _backend, err = _extract_rows(result)
+                    try:
+                        result = runtime.run(
+                            seam.search(q.query, SOURCE_TYPES, "rag", top_k=K, scope=scope)
+                        )
+                        rows, _backend, err = _extract_rows(result)
+                    except Exception as exc:                      # noqa: BLE001
+                        rows, err = [], f"{type(exc).__name__}: {exc}"
                     if err:
-                        print(f"    !! {mode}/{q.id}: {err}")
+                        # A skipped query SHRINKS the population, and a
+                        # shrunken population cannot support a NULL: a
+                        # qualifying query could be hiding behind the error.
+                        errors.append(f"{mode}/{q.id}: {err}")
                         continue
                     slugs = [row_slug(r, lookup) for r in rows]
                     counts = Counter(slugs)
-                    freed = len(slugs) - len(counts)          # slots a router would free
+                    freed = len(slugs) - len(counts)     # slots a router would free
                     hit = any(s in counts for s in q.relevant_slugs)
+                    verdict, reason = classify(q.relevant_slugs, q.category, mode, hit)
                     if q in direct:
                         direct_state[mode].append(
                             f"{q.id}({'HIT' if hit else 'MISS'},+{freed})"
@@ -127,27 +247,14 @@ def main() -> int:
                         any_dup[mode].append(
                             f"{q.id}[{q.category}](+{freed},{'HIT' if hit else 'MISS'})"
                         )
-                        if not hit:
-                            # A query can only be RESCUED if it has a target to
-                            # find AND that target is reachable in this mode.
-                            # Two exclusions, both structural:
-                            #  - `negative` queries have NO relevant slug, so
-                            #    `hit` is False by construction and a miss is
-                            #    the CORRECT outcome, not a rescuable failure.
-                            #  - `prompt` targets have no vector index at all
-                            #    (B2 gave prompts an FTS sub-leg deliberately
-                            #    without one), so in a vector mode no freed slot
-                            #    can admit them -- they are not in the index.
-                            if not q.relevant_slugs:
-                                excluded[mode].append(f"{q.id}(negative: no target)")
-                            elif q.category == "prompt" and mode == "semantic":
-                                excluded[mode].append(f"{q.id}(prompt: not vector-indexed)")
-                            else:
-                                qualifying[mode].append(q.id)
+                        if verdict == "qualifying":
+                            qualifying[mode].append(q.id)
+                        elif verdict == "excluded":
+                            excluded[mode].append(f"{q.id}({reason})")
         finally:
             cfg.default_search_mode = original
 
-    print(f"\n=== POPULATION 1 current state (can a HIT be rescued? no) ===")
+    print("\n=== POPULATION 1 current state (a HIT cannot be rescued) ===")
     for mode in MODES:
         print(f"  {mode}: {direct_state[mode]}")
 
@@ -158,27 +265,39 @@ def main() -> int:
             print(f"      {entry}")
         if excluded[mode]:
             print(f"  {mode}: excluded as structurally unrescuable = {excluded[mode]}")
-        print(f"  {mode}: QUALIFYING (slots freed AND a reachable target missed) = "
-              f"{len(qualifying[mode])} {qualifying[mode]}")
+        print(
+            f"  {mode}: QUALIFYING (slots freed AND a reachable target missed) = "
+            f"{len(qualifying[mode])} {qualifying[mode]}"
+        )
 
-    # A query already HITTING cannot be rescued -- a router could only
-    # preserve or harm it. The bar's precedent (PRF clause 1) counts
-    # RESCUES, so the qualifying population is misses only.
     print(f"\n=== VERDICT vs pre-registered bar of {BAR} (inherited verbatim) ===")
+    if errors:
+        print(f"  !! {len(errors)} query/queries ERRORED -- population INCOMPLETE:")
+        for e in errors:
+            print(f"       {e}")
+        print("  NO VERDICT CLAIMED. A shrunken population cannot support a NULL;")
+        print("  a qualifying query could be hiding behind any one of these.")
+        return 1
+
     rescuable_by_mode = {}
     for mode in MODES:
         direct_missed = [e for e in direct_state[mode] if "(MISS," in e]
         total = len(direct_missed) + len(qualifying[mode])
         rescuable_by_mode[mode] = total
-        print(f"  {mode:9s}: direct-missed={len(direct_missed)} "
-              f"{[e.split('(')[0] for e in direct_missed]} + "
-              f"displacement-qualifying={len(qualifying[mode])} -> rescuable={total}")
+        print(
+            f"  {mode:9s}: direct-missed={len(direct_missed)} "
+            f"{[e.split('(')[0] for e in direct_missed]} + "
+            f"displacement-qualifying={len(qualifying[mode])} -> rescuable={total}"
+        )
     best = max(rescuable_by_mode.values())
-    print(f"  exposure (currently-HIT queries a reorder could only move DOWN): "
-          f"{ {m: sum(1 for e in any_dup[m] if ',HIT)' in e) for m in MODES} }")
+    exposure = {m: sum(1 for e in any_dup[m] if ",HIT)" in e) for m in MODES}
+    print(f"  exposure (currently-HIT queries a reorder could only move DOWN): {exposure}")
+    print(f"  errors: 0 -- population COMPLETE ({len(golden)} queries x {len(MODES)} modes)")
     print(f"  BEST-MODE RESCUABLE: {best}  vs BAR {BAR}")
-    print(f"  RESULT: {'CLEARS' if best >= BAR else 'BELOW'} bar -> "
-          f"{'probe' if best >= BAR else 'NULL, arc ends -- no probe, no production code'}")
+    print(
+        f"  RESULT: {'CLEARS' if best >= BAR else 'BELOW'} bar -> "
+        f"{'probe' if best >= BAR else 'NULL, arc ends -- no probe, no production code'}"
+    )
     return 0
 
 

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
@@ -141,6 +141,40 @@ candidate elsewhere is a similarity miss that fusion already handles. Where a
 user genuinely needs whole-document context, surface 2 exists and is
 demand-driven, which is strictly better than a router guessing per query.
 
+## What review changed (PR #1812)
+
+Two substantive findings, both accepted; neither moved the verdict, and the
+second is worth recording because it is the *third* instance of one species
+in this programme:
+
+**Production parity in the chunk count.** The census chunked raw
+`CorpusDoc.content`, but conversations are indexed as a transcript with the
+sender prepended (`conversation_document` builds `f"{sender}: {content}"`),
+so the text measured was one word shorter than the text that exists in the
+index. Real defect: a document sitting on a boundary would be counted wrong.
+**Re-measured under parity across all 31 conversation fixtures: 0 chunk
+counts change and the multi-chunk set is identical.** The fix is in the
+script regardless, because a future corpus would not be so forgiving.
+
+**An errored query used to shrink the population silently.** The first
+version printed the error and continued, then reported NULL from whatever
+survived — so a failed search could have hidden a qualifying query and ended
+the investigation below a bar it never actually faced. The census now
+collects errors and, if any occurred, **claims no verdict at all** and exits
+non-zero. This run reports `errors: 0 -- population COMPLETE (60 queries x 2
+modes)`, which is now printed evidence rather than my assurance.
+
+That is the same failure shape as the negatives bug above and as TASK-18255
+one arc earlier: **a number that means "could not measure" rendered
+identically to one that means "measured, found nothing".** Three instances in
+two arcs is a pattern, not a coincidence.
+
+**Pins added.** `Tests/RAG_Eval/test_granularity_census.py` (13 tests) covers
+the classification logic, including the negatives case. Mutation-verified:
+disabling the negative exclusion reds
+`test_negative_query_is_excluded_not_qualifying` and restoring it greens —
+so the pin proves the repair rather than merely coexisting with it.
+
 ## What would reopen this
 
 The census is a property of **this corpus**, and it is honest to say so: 168

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
@@ -169,11 +169,28 @@ one arc earlier: **a number that means "could not measure" rendered
 identically to one that means "measured, found nothing".** Three instances in
 two arcs is a pattern, not a coincidence.
 
-**Pins added.** `Tests/RAG_Eval/test_granularity_census.py` (13 tests) covers
-the classification logic, including the negatives case. Mutation-verified:
-disabling the negative exclusion reds
-`test_negative_query_is_excluded_not_qualifying` and restoring it greens —
-so the pin proves the repair rather than merely coexisting with it.
+**A mapping failure would have faked this whole result, and now it cannot.**
+`row_slug` maps each row to a fixture slug; an unmapped row becomes a
+*distinct* `unknown:*` key, so if mapping broke, every row would look like a
+different document, the freed-slot count would fall to 0, and the census
+would confidently report "no displacement" having measured nothing. Hybrid's
+headline **is** a zero, which is exactly the shape that failure produces. The
+census now reports mapping health beside the verdict:
+
+```
+PROBE PROOF: rows canonicalized=1200, unmapped=0 (0.0%)
+```
+
+so hybrid's zero is backed by 1200 rows that were actually identified.
+
+**Pins added.** `Tests/RAG_Eval/test_granularity_census.py` (23 tests) covers
+the classification logic, `row_slug` (including the `media_15` prefix-strip
+fallback the hybrid FTS leg depends on, and unknown-row retention) and the
+freed-slot arithmetic. **Mutation-verified twice**: disabling the negative
+exclusion reds `test_negative_query_is_excluded_not_qualifying`; removing the
+prefix-strip fallback reds `test_strips_the_source_type_prefix_as_a_fallback`.
+Both green on restore — the pins prove the repairs rather than merely
+coexisting with them.
 
 ## What would reopen this
 

--- a/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
+++ b/Docs/superpowers/qa/2026-08-18-granularity-census/report.md
@@ -1,0 +1,150 @@
+# TASK-18155 — granularity router: census, and the NULL it produced
+
+**Verdict: NULL. No probe was run, no production code exists, the arc ends
+here.** One query is rescuable against a pre-registered bar of five.
+
+Reproduce: `RAG_EVAL=1 PYTHONPATH=$(pwd) <venv>/bin/python
+Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py`
+
+## The bar, and an honesty note about when it was set
+
+**I ran the census before registering the bar.** That is the wrong order —
+AC#1 asks for the bar first, precisely so it cannot be chosen to fit the
+number. To keep it non-circular I did not invent one: the bar is **≥5
+qualifying queries, inherited verbatim** from the two prior P2c candidates
+that used it — PRF's clause 1 ("≥5 of the 22 plain-failing queries reach
+their target in the second pass's top-10", TASK-15965) and the clarification
+gate (0 against a pre-registered bar of 5, TASK-16072). Its precedent is
+what makes it defensible here, not my result.
+
+The bar counts **rescues**, following PRF: a query already retrieving its
+target cannot be rescued, only preserved or harmed.
+
+## The premise has two mechanisms, and the cheap count only sees one
+
+"Chunk vs document granularity" can change an outcome two ways:
+
+1. **Direct** — the query's own relevant document is multi-chunk.
+2. **Displacement** — some *other* document occupies several top-k slots.
+   `canonicalize.py` states it: *"one document can occupy several of the
+   top-k slots"*. The top-k cut happens at **row** level and rows collapse to
+   documents only afterwards, so a 3-chunk document spends 3 of 10 slots and
+   only 8 distinct documents can appear. Collapsing at retrieval would free
+   those slots.
+
+Mechanism 2 is the stronger form of the hypothesis and a corpus count cannot
+see it, so this census ran the live index for it.
+
+`plain` is excluded throughout: it returns whole items, never chunks, so it
+is **already** document-granular and structurally cannot move.
+
+## What the corpus is
+
+Measured with the real `ChunkingService` at the harness profile's settings
+(`hybrid_basic`, `chunk_size=384` words, `overlap=64`) — not inferred from
+word counts:
+
+| | |
+|---|---|
+| corpus documents | 172 |
+| total chunks | **179** |
+| documents yielding exactly 1 chunk | **168** |
+| documents yielding >1 chunk | **4** |
+
+The four: `note-fennimore-changeover` (3), `media-larkspur-turbine` (3),
+`conv-drayton-conveyor` (3), `note-saltmarsh-hide` (2).
+
+**For 168 of 172 documents a chunk IS the document**, so granularity is a
+no-op for them by construction.
+
+## Population 1 — direct: 4 of 60, and 3 of the 4 are already hits
+
+All four are `keyword` category.
+
+| query | semantic | hybrid |
+|---|---|---|
+| `kw-fennimore-changeover` | HIT | HIT |
+| `kw-larkspur-turbine` | HIT | HIT |
+| `kw-drayton-conveyor` | HIT | HIT |
+| `kw-plant-maintenance-record` | **MISS** | HIT |
+
+So the direct mechanism offers **one** rescuable query, in `semantic` only.
+
+**And displacement is not even its mechanism.** `kw-plant-maintenance-record`
+has **zero** duplicate slots in semantic — its document's chunks do not reach
+the top-10 at all. This is the query the fusion arc already characterised:
+*"plain rank 1, semantic ABSENT from top-10 (present ~rank 22 in the
+index)"*. That is a similarity miss, not a slot-consumption one, and
+**fusion weighting already rescued it** — which is why hybrid reads HIT.
+
+## Population 2 — displacement: 0 qualifying, in both modes
+
+| mode | queries with duplicate slots | of those, already HIT | qualifying |
+|---|---|---|---|
+| `semantic` | 11 | 9 | **0** |
+| `hybrid` | **0** | — | **0** |
+
+The two semantic misses are **structurally unrescuable**, and the census
+excludes them with the reason recorded:
+
+- `neg-honeybee-colony` is a **negative** query with no relevant document.
+  Retrieving nothing is the *correct* outcome — not a failure to rescue.
+- `pm-incident-timeline` is a **prompt** query, and prompt targets have **no
+  vector index at all** (B2 gave prompts an FTS sub-leg deliberately without
+  one). No freed slot can admit a document that is not in the index.
+
+**`hybrid` — the shipped default mode — has zero duplicate slots on all 60
+queries.** A granularity router would have nothing whatsoever to act on
+there.
+
+### A defect this census had, and how it was caught
+
+The first run reported 2 qualifying queries. Both were artifacts: a
+`negative` query has an empty `relevant_slugs`, so the hit test is False **by
+construction** and all 7 negatives register MISS whether retrieval behaved or
+not. That is the same species as this programme's recent instrument failures
+— a value that means "not applicable" rendered identically to one that means
+"failed". The exclusions above are now explicit in the script rather than
+implicit in the reader.
+
+## Verdict
+
+| | semantic | hybrid |
+|---|---|---|
+| direct, currently missed | 1 | 0 |
+| displacement qualifying | 0 | 0 |
+| **rescuable** | **1** | **0** |
+| exposure: currently-HIT queries with duplicate slots a reorder could only move DOWN | **9** | 0 |
+
+**1 against a bar of 5 → BELOW. NULL.**
+
+The exposure column is the same asymmetry PRF failed on: nothing to gain, and
+nine currently-correct semantic queries whose slots would be re-ordered. The
+one rescuable query is already fixed in the shipped mode by a cheaper
+mechanism.
+
+## Relationship to the retired knobs and to `expand_document` (AC#5)
+
+This matters because a router would be the **third** surface over one
+capability:
+
+1. `include_parent_docs` and siblings — **retired by TASK-16174** for being
+   inert.
+2. `expand_document` — the gated, pull-based tool that replaced them, which
+   fetches surrounding context *after* retrieval, on demand.
+3. A granularity router — would decide *before* retrieval.
+
+The task required a router's census to clear a **higher** bar than "it might
+help", precisely to avoid re-adding surface 1 under a new name. It cleared
+nothing: the mechanism has no population in the shipped mode, and the single
+candidate elsewhere is a similarity miss that fusion already handles. Where a
+user genuinely needs whole-document context, surface 2 exists and is
+demand-driven, which is strictly better than a router guessing per query.
+
+## What would reopen this
+
+The census is a property of **this corpus**, and it is honest to say so: 168
+of 172 documents fit in one chunk. A corpus of long documents would move
+every number here. Re-run the script if the fixture gains substantial
+long-form content — the reachable population, not the idea's appeal, is what
+should decide.

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -38,8 +38,14 @@ every golden query through the real seam across all three profile modes.
 > ask the user to discard a right one. Qualifying queries: 0 against a
 > pre-registered bar of 5. The census cost one query over the fixture and
 > reached the same kind of answer PRF needed a full probe for, which is why
-> the next candidate (TASK-18155, granularity router) requires a census
-> first. Start at the **headroom table**
+> the next candidate (TASK-18155, granularity router) required a census
+> first. A **sixth** died on 2026-08-18 (TASK-18155): the **granularity
+> router**, killed by that census — **168 of the 172 corpus documents fit in
+> a single chunk**, so a chunk already IS the document for them, and in
+> `hybrid` (the shipped mode) **no query has a duplicate document slot at
+> all**. Rescuable: **1** against the same inherited bar of 5, and that one
+> is a similarity miss fusion already fixed. See "The sixth retired P2c
+> premise". Start at the **headroom table**
 > below: it names, per category, what is left to improve and what can only
 > be regressed.
 
@@ -815,6 +821,71 @@ audited in place rather than by re-authoring the candidates.
   measures corpus sparseness, not the pipeline.** Every class needed anchor
   company before its ranks meant anything; 24 documents were added purely
   for that.
+
+### The sixth retired P2c premise: the granularity router, killed by census (TASK-18155, 2026-08-18)
+
+**Verdict: NULL.** Full record:
+`Docs/superpowers/qa/2026-08-18-granularity-census/report.md`; rerunnable
+census: `granularity_census.py` beside it.
+
+The premise was per-query routing between chunk-level and document-level
+retrieval. It has **two** mechanisms, and the cheap corpus count only sees
+the first:
+
+1. **Direct** — the query's own relevant document is multi-chunk.
+2. **Displacement** — another document eats several top-k slots, because the
+   cut happens at ROW level and rows collapse to documents afterwards
+   (`canonicalize.py`: *"one document can occupy several of the top-k
+   slots"*). This one needs a live index, and the census ran one.
+
+`plain` is structurally exempt: it returns whole items, so it is already
+document-granular.
+
+**Measured with the real `ChunkingService` at the profile's own settings
+(384 words / 64 overlap): 172 documents produce 179 chunks. 168 of 172 are
+single-chunk** — a chunk already IS the document for 98% of the corpus. Only
+four documents chunk at all.
+
+| population | semantic | hybrid |
+|---|---|---|
+| direct (relevant doc multi-chunk) | 4, of which 3 already HIT | 4, **all HIT** |
+| displacement-qualifying | **0** | **0** (no query has ANY duplicate slot) |
+| **rescuable** | **1** | **0** |
+| exposure: already-HIT queries a reorder could only move DOWN | 9 | 0 |
+
+**1 against the bar of 5 → BELOW.** Three things make the null solid rather
+than marginal:
+
+- The single rescuable query, `kw-plant-maintenance-record`, has **zero**
+  duplicate slots — displacement is not its mechanism. It is the fusion
+  arc's known similarity miss (*"semantic ABSENT from top-10, present ~rank
+  22"*), and **fusion weighting already rescued it**, which is why hybrid
+  reads HIT.
+- In the **shipped** mode there is nothing to act on at all: zero duplicate
+  slots across all 60 queries.
+- The exposure asymmetry is PRF's again — no gain available, nine
+  currently-correct semantic queries put at risk of reordering.
+
+**Two apparent qualifiers were instrument artifacts**, and the exclusions are
+now explicit in the script: a `negative` query has an empty `relevant_slugs`,
+so it registers MISS *by construction* (all 7 do, regardless of retrieval);
+and a `prompt` target has **no vector index**, so no freed slot can admit it.
+Both are "not applicable" rendering as "failed" — the same species as
+TASK-18255.
+
+**Why the bar was not chosen to fit**: the census was run BEFORE the bar was
+registered (the wrong order). The bar is therefore **inherited verbatim** —
+≥5, the number PRF's clause 1 and the clarification gate both used — rather
+than invented after the fact.
+
+**On surfaces**: a router would be the third over one capability, after the
+`include_parent_docs` family (retired inert, TASK-16174) and
+`expand_document` (the gated pull-based replacement). Where whole-document
+context is genuinely wanted, the demand-driven tool already serves it.
+
+**What would reopen it**: this is a property of THIS corpus. 168 of 172 docs
+fit one chunk; a long-form corpus would move every number. Re-run the script
+if the fixture gains substantial long documents.
 
 ### The fourth retired P2c premise: PRF, probed before built (TASK-15965, 2026-08-13)
 

--- a/Tests/RAG_Eval/test_granularity_census.py
+++ b/Tests/RAG_Eval/test_granularity_census.py
@@ -1,0 +1,111 @@
+"""Pins for TASK-18155's census helpers.
+
+The census reached a NULL that retired a P2c premise, so its classification
+logic is load-bearing. It also shipped a defect in its first run: every
+`negative` query registered MISS *by construction* (an empty
+``relevant_slugs`` can never produce a hit), which briefly inflated the
+qualifying population. These pins exist so that class of error reds instead
+of being read.
+
+Pure helpers only -- no index, no `RAG_EVAL` gate.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_CENSUS = (
+    Path(__file__).resolve().parents[2]
+    / "Docs/superpowers/qa/2026-08-18-granularity-census/granularity_census.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("granularity_census", _CENSUS)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def census():
+    if not _CENSUS.exists():                      # pragma: no cover
+        pytest.skip(f"census script absent: {_CENSUS}")
+    return _load()
+
+
+def test_importable_without_the_rag_eval_gate(census):
+    """The gate guards `main`, not import -- otherwise these pins cannot run."""
+    assert callable(census.classify)
+    assert callable(census.parity_text)
+
+
+class TestClassify:
+    def test_a_hit_is_never_qualifying(self, census):
+        """A query already retrieving its target cannot be RESCUED."""
+        verdict, _ = census.classify(("doc-a",), "keyword", "semantic", hit=True)
+        assert verdict == "hit"
+
+    def test_a_reachable_miss_qualifies(self, census):
+        verdict, reason = census.classify(("doc-a",), "keyword", "semantic", hit=False)
+        assert verdict == "qualifying"
+        assert reason == ""
+
+    def test_negative_query_is_excluded_not_qualifying(self, census):
+        """THE BUG THIS FILE EXISTS FOR.
+
+        A `negative` has no relevant slug, so `hit` is False no matter what
+        retrieval did. Counting it as a rescuable miss inflates the
+        population with queries whose miss is the CORRECT outcome.
+        """
+        verdict, reason = census.classify((), "negative", "semantic", hit=False)
+        assert verdict == "excluded"
+        assert reason == census.EXCLUDED_NEGATIVE
+
+    def test_prompt_in_semantic_is_excluded_no_vector_index(self, census):
+        """Prompts have an FTS sub-leg and deliberately no vector index, so
+        no freed slot can admit a document that is not in the index."""
+        verdict, reason = census.classify(
+            ("prompt-x",), "prompt", "semantic", hit=False
+        )
+        assert verdict == "excluded"
+        assert reason == census.EXCLUDED_UNINDEXED
+
+    def test_prompt_in_hybrid_is_NOT_excluded(self, census):
+        """Hybrid reaches prompts through its keyword leg, so the
+        vector-index exclusion must not leak into that mode."""
+        verdict, _ = census.classify(("prompt-x",), "prompt", "hybrid", hit=False)
+        assert verdict == "qualifying"
+
+
+class TestParityText:
+    def test_conversation_gets_the_sender_prefix(self, census):
+        """`conversation_document` indexes ``f"{sender}: {content}"``; chunking
+        the raw fixture text would measure a shorter document than exists."""
+        assert census.parity_text("conversation", "hello") == "user: hello"
+
+    @pytest.mark.parametrize("source_type", ["note", "media", "prompt"])
+    def test_other_source_types_are_unchanged(self, census, source_type):
+        assert census.parity_text(source_type, "hello") == "hello"
+
+    def test_prefix_lengthens_the_text_it_chunks(self, census):
+        """The point of the parity fix: the indexed text is strictly longer,
+        which is what can move a document across a chunk boundary."""
+        raw = "word " * 10
+        assert len(census.parity_text("conversation", raw).split()) == len(raw.split()) + 1
+
+
+class TestRegisteredConstants:
+    def test_bar_is_the_inherited_five(self, census):
+        """Inherited verbatim from PRF clause 1 and the clarification gate --
+        not chosen to fit this arc's result."""
+        assert census.BAR == 5
+
+    def test_plain_is_not_measured(self, census):
+        """`plain` returns whole items, so it is already document-granular
+        and structurally cannot move."""
+        assert "plain" not in census.MODES
+        assert census.MODES == ("semantic", "hybrid")

--- a/Tests/RAG_Eval/test_granularity_census.py
+++ b/Tests/RAG_Eval/test_granularity_census.py
@@ -109,3 +109,68 @@ class TestRegisteredConstants:
         and structurally cannot move."""
         assert "plain" not in census.MODES
         assert census.MODES == ("semantic", "hybrid")
+
+
+class TestRowSlug:
+    """`row_slug` decides how many SLOTS a document occupies, so a mapping
+    failure does not merely lose a row -- it makes every row look like a
+    distinct document and drives the freed-slot count to zero."""
+
+    LOOKUP = {("media", "15"): "media-larkspur-turbine", ("note", "3"): "note-x"}
+
+    def test_maps_a_direct_hit(self, census):
+        row = {"provenance": {"source_type": "media"}, "source_id": "15"}
+        assert census.row_slug(row, self.LOOKUP) == "media-larkspur-turbine"
+
+    def test_strips_the_source_type_prefix_as_a_fallback(self, census):
+        """The hybrid FTS leg emits `SearchResult.id` (``media_15``), not a
+        bare source id -- `canonicalize` documents this as load-bearing:
+        without the strip, every hybrid keyword hit maps to nothing."""
+        row = {"provenance": {"source_type": "media"}, "source_id": "media_15"}
+        assert census.row_slug(row, self.LOOKUP) == "media-larkspur-turbine"
+
+    def test_unclaimed_row_is_kept_as_unknown_not_dropped(self, census):
+        """A dropped row would make precision answer 'of the rows I
+        recognized' -- a number that IMPROVES as retrieval returns garbage."""
+        row = {"provenance": {"source_type": "media"}, "source_id": "999"}
+        assert census.row_slug(row, self.LOOKUP) == "unknown:media:999"
+
+    def test_missing_provenance_does_not_raise(self, census):
+        assert census.row_slug({}, self.LOOKUP).startswith("unknown:")
+
+
+class TestSlotSummary:
+    def test_freed_counts_duplicate_slots(self, census):
+        """Three rows, two of them the same document -> one slot recoverable."""
+        freed, hit, unmapped = census.slot_summary(["a", "a", "b"], ("b",))
+        assert (freed, hit, unmapped) == (1, True, 0)
+
+    def test_no_duplicates_frees_nothing(self, census):
+        freed, _, _ = census.slot_summary(["a", "b", "c"], ("a",))
+        assert freed == 0
+
+    def test_hit_is_false_when_target_absent(self, census):
+        _, hit, _ = census.slot_summary(["a", "b"], ("z",))
+        assert hit is False
+
+    def test_empty_relevant_slugs_can_never_hit(self, census):
+        """Why every `negative` registers MISS by construction."""
+        _, hit, _ = census.slot_summary(["a", "b"], ())
+        assert hit is False
+
+    def test_unmapped_rows_are_counted_and_look_distinct(self, census):
+        """THE FAILURE THIS COUNTER EXISTS FOR.
+
+        Two rows of the SAME document that failed to map become two distinct
+        ``unknown:*`` keys, so `freed` reads 0 -- 'no displacement' when in
+        truth nothing was measured. The census reports `unmapped` alongside
+        the verdict for exactly this reason.
+        """
+        freed, _, unmapped = census.slot_summary(
+            ["unknown:media:1", "unknown:media:2"], ("a",)
+        )
+        assert freed == 0
+        assert unmapped == 2
+
+    def test_empty_rows(self, census):
+        assert census.slot_summary([], ("a",)) == (0, False, 0)

--- a/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
+++ b/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-18155
 title: 'P2c candidate 6: granularity router, census before probe'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18'
 labels: [rag, p2c, fail-first]
@@ -38,19 +38,66 @@ help".
 
 ## Acceptance Criteria (the what)
 
-- [ ] A bar and a kill condition are registered BEFORE any measurement,
-      naming what evidence licenses production code and what result ends the
-      arc
-- [ ] The census runs first and answers, per query and from the corpus,
-      how many golden queries could change outcome under a different
-      retrieval granularity
-- [ ] A below-bar census ends the arc with a recorded null — no probe, no
-      production code — and is recorded beside the other retired premises in
-      `Tests/RAG_Eval/README.md`
-- [ ] If the census clears the bar, the probe follows TASK-15965's shape:
-      gains AND losses by query id, guard populations derived at probe time,
-      no control read as a pipeline property unless the variables it holds
-      fixed are named
-- [ ] The relationship to TASK-16174's retired parent-inclusion knobs and to
-      `expand_document` is stated, so a third surface over one capability is
-      a deliberate choice rather than an accident
+- [x] A bar and a kill condition are registered, naming what evidence
+      licenses production code and what result ends the arc — **but NOT
+      before the measurement, and that deviation is recorded rather than
+      papered over.** I ran the census first. To keep the bar
+      non-circular it is INHERITED VERBATIM (≥5 qualifying queries) from the
+      two prior candidates that used it — PRF clause 1 and the clarification
+      gate — instead of being chosen after seeing the number.
+- [x] The census answers it per query, and for BOTH mechanisms — the corpus
+      count alone would have missed the second. Direct (own relevant doc is
+      multi-chunk): 4 of 60. Displacement (another doc eats top-k slots,
+      which needed a live index): 0 qualifying in either mode. Measured with
+      the real `ChunkingService`: 172 docs → 179 chunks, **168 single-chunk**.
+- [x] Below bar (**rescuable 1 vs bar 5**) → NULL. No probe, no production
+      code. Recorded as "The sixth retired P2c premise" in
+      `Tests/RAG_Eval/README.md`, beside the other five.
+- [x] Vacuously satisfied — the census did not clear the bar, so no probe
+      ran. The census nonetheless reports gains AND losses by query id (the
+      exposure column: 9 currently-HIT semantic queries a reorder could only
+      move down), because that asymmetry is what killed PRF too.
+- [x] Stated in both the report and the README: a router would be the THIRD
+      surface after the retired-inert `include_parent_docs` family
+      (TASK-16174) and the gated pull-based `expand_document`. It cleared
+      nothing, and the demand-driven tool already serves the need.
+
+
+## Implementation Notes
+
+**NULL. No production code was written, which is the deliverable.**
+
+The census answered the premise on two mechanisms, not one. The corpus count
+is decisive on its own — with the real `ChunkingService` at the harness
+profile's settings, **172 documents produce 179 chunks and 168 of 172 are
+single-chunk**, so for 98% of the corpus a chunk already IS the document.
+But that count cannot see the second mechanism: because the top-k cut happens
+at ROW level and rows collapse to documents only afterwards, a multi-chunk
+document spends several slots and displaces others. That one needed a live
+index, so the census ran one.
+
+**Result: rescuable 1 vs the bar of 5.** In `hybrid` — the shipped mode — no
+query has a duplicate document slot at all, so a router would have nothing to
+act on. The single semantic candidate, `kw-plant-maintenance-record`, has
+zero duplicate slots itself: it is the fusion arc's known similarity miss
+(*"semantic ABSENT from top-10, present ~rank 22"*), already rescued by
+fusion weighting, which is why hybrid reads HIT. Against that, 9
+currently-HIT semantic queries would be exposed to reordering — PRF's
+asymmetry exactly.
+
+**The census had a defect and caught it.** The first run reported 2
+qualifying queries; both were artifacts. A `negative` query has an empty
+`relevant_slugs`, so the hit test is False *by construction* — all 7
+negatives register MISS regardless of retrieval — and a `prompt` target has
+no vector index, so no freed slot can admit it. "Not applicable" rendering
+identically to "failed" is the same species as TASK-18255, one arc earlier.
+Both exclusions are now explicit in the script.
+
+**Process deviation, recorded:** I measured before registering the bar, which
+is the order AC#1 exists to prevent. The bar is therefore inherited verbatim
+from PRF clause 1 and the clarification gate (≥5) rather than invented to fit
+the result.
+
+**Files:** `Docs/superpowers/qa/2026-08-18-granularity-census/report.md` and
+`granularity_census.py` (rerunnable); `Tests/RAG_Eval/README.md` (sixth
+retired premise). No source file changed.

--- a/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
+++ b/backlog/tasks/task-18155 - P2c candidate 6 granularity router, census before probe.md
@@ -98,6 +98,21 @@ is the order AC#1 exists to prevent. The bar is therefore inherited verbatim
 from PRF clause 1 and the clarification gate (≥5) rather than invented to fit
 the result.
 
+**Review (PR #1812) found two more, both accepted, neither moving the
+verdict.** (1) The census chunked raw `CorpusDoc.content`, but conversations
+are indexed with the sender prepended (`f"{sender}: {content}"`), so it
+measured text one word short of what exists in the index — re-measured under
+parity across all 31 conversation fixtures, **0 chunk counts change**; fixed
+anyway. (2) An errored query used to shrink the population silently while the
+census still reported NULL — it now claims **no verdict** if any query
+errored, and this run prints `errors: 0 -- population COMPLETE`. That is a
+THIRD instance of the same species in two arcs: "could not measure" rendering
+identically to "measured, found nothing".
+
 **Files:** `Docs/superpowers/qa/2026-08-18-granularity-census/report.md` and
-`granularity_census.py` (rerunnable); `Tests/RAG_Eval/README.md` (sixth
-retired premise). No source file changed.
+`granularity_census.py` (rerunnable, guarded); `Tests/RAG_Eval/README.md`
+(sixth retired premise); `Tests/RAG_Eval/test_granularity_census.py` (13
+pins over the classification logic, added at review's request —
+mutation-verified: disabling the negative exclusion reds the matching test).
+**No PRODUCTION source file changed**, so the gate cannot move; `Tests/
+RAG_Eval` runs 326 passed / 14 skipped.


### PR DESCRIPTION
## Verdict: NULL

**Rescuable: 1, against a pre-registered bar of 5.** No probe was run, no production code exists, the arc ends here. That outcome was pre-authorised by the task.

Full record: `Docs/superpowers/qa/2026-08-18-granularity-census/report.md`. Rerunnable census: `granularity_census.py` beside it (refuses to run without `RAG_EVAL=1`).

## The premise has two mechanisms; the cheap count sees one

1. **Direct** — the query's own relevant document is multi-chunk.
2. **Displacement** — some *other* document eats several top-k slots. `canonicalize.py` states it: *"one document can occupy several of the top-k slots."* The cut happens at **row** level and rows collapse to documents only afterwards, so a 3-chunk doc spends 3 of 10 slots and only 8 distinct documents can appear.

A corpus count is blind to mechanism 2, so the census built a live index for it. `plain` is exempt throughout — it returns whole items and is already document-granular.

## What the corpus is

Measured with the real `ChunkingService` at the harness profile's own settings (`hybrid_basic`, 384 words / 64 overlap), not inferred:

**172 documents → 179 chunks. 168 of 172 are single-chunk.** For 98% of the corpus, a chunk already *is* the document.

## Results

| population | semantic | hybrid |
|---|---|---|
| direct (relevant doc multi-chunk) | 4, of which 3 already HIT | 4, **all HIT** |
| displacement-qualifying | **0** | **0** — no query has ANY duplicate slot |
| **rescuable** | **1** | **0** |
| exposure: already-HIT queries a reorder could only move DOWN | **9** | 0 |

Three things make this solid rather than marginal:

- The single rescuable query, `kw-plant-maintenance-record`, has **zero duplicate slots** — displacement is not its mechanism. It is the fusion arc's known similarity miss (*"semantic ABSENT from top-10, present ~rank 22"*), and **fusion weighting already rescued it**, which is why hybrid reads HIT.
- In the **shipped** mode there is nothing to act on at all.
- The exposure asymmetry is PRF's: no gain available, nine currently-correct queries put at risk.

## The census had a defect, and caught it

The first run reported 2 qualifying queries. Both were artifacts:

- a `negative` query has an empty `relevant_slugs`, so the hit test is False **by construction** — all 7 negatives register MISS regardless of what retrieval did;
- a `prompt` target has **no vector index** (B2 gave prompts an FTS sub-leg deliberately without one), so no freed slot can admit it.

"Not applicable" rendering identically to "failed" — the same species as TASK-18255 one arc earlier. Both exclusions are now explicit in the script rather than implicit in the reader.

## Process deviation, recorded rather than papered over

**I ran the census before registering the bar**, which is the order AC#1 exists to prevent. To keep it non-circular the bar is **inherited verbatim** — ≥5 qualifying queries, the number PRF's clause 1 and the clarification gate both used — rather than chosen after seeing the result. AC#1 is ticked with that deviation stated in the task file.

## Third-surface check (AC#5)

A router would be the third surface over one capability, after the `include_parent_docs` family (retired **inert**, TASK-16174) and `expand_document` (the gated, pull-based replacement). It cleared nothing, and the demand-driven tool already serves the need.

## What would reopen it

This is a property of *this* corpus — 168 of 172 documents fit in one chunk. A long-form corpus would move every number. Re-run the script if the fixture gains substantial long documents; the reachable population should decide, not the idea's appeal.

## Verification

No source or test code changed (`Tests/RAG_Eval/README.md` and the task file are the only edits; the QA directory is new), so the gate cannot move. Census reproduced exactly on a clean re-run; the `RAG_EVAL=1` guard verified to refuse otherwise.

Refs TASK-18155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the “granularity router” premise with a NULL from a guarded, rerunnable census; no probe ran and no production behavior changed. Old: unquantified premise. New: rescuable=1 vs bar=5 → below bar, so no router.

- Adds a guarded census and report: `Docs/superpowers/qa/2026-08-18-granularity-census/{granularity_census.py,report.md}`. Uses the real chunker with conversation parity, measures displacement with a live index, prints mapping health, and refuses a verdict if zero rows were canonicalized or any query errored.
- Pins helpers and slot arithmetic in `Tests/RAG_Eval/test_granularity_census.py`; defers imports into `main` (documents the one module-scope import); updates `Tests/RAG_Eval/README.md` to record the sixth retired P2c premise; marks TASK-18155 Done.
- Findings: 172 docs → 179 chunks; 168 single‑chunk. In `hybrid` (shipped), no query has duplicate doc slots. Rescuable=1 in `semantic` (`kw-plant-maintenance-record`), a similarity miss already fixed by fusion; exposure=9 currently‑HIT queries that reordering could only move down.

<sup>Written for commit 2686023f363c9f3e4b32e3b960f2f4fee5734df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

