### PR TITLE
docs(backlog): file TASK-18413 — duplicate task ids 17650/17651 red the CI guard on dev

### DIFF
--- a/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
+++ b/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
@@ -1,0 +1,71 @@
+---
+id: TASK-18413
+title: Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev
+status: To Do
+assignee: []
+created_date: '2026-08-18'
+labels: [backlog-hygiene, ci]
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+**`No duplicate backlog task IDs` is RED on `origin/dev` and fails on every
+PR opened against it**, including PRs that touch no task file at all (found
+on PR #1812, which only modified an existing task).
+
+Two programmes minted the same two ids **fourteen minutes apart** on
+2026-08-17, and both merged:
+
+| id | filed 18:00:58 (`68b6e3a87`) | filed 18:14:57 (`979a6914a`) |
+|---|---|---|
+| `task-17650` | Console — delete the zero-information rows in the bottom stack | Shared workspace creation modal |
+| `task-17651` | Console — flatten the composer to a one-row dense form field | Project skills `.SKILLS/` discovery and import |
+
+All four are `Done`. The guard caught it only after both had landed, which is
+the known failure mode: the CLI assigns from the **local** max, so two
+worktrees that never see each other mint the same number.
+
+The harm is not only the red check. **A reference to "TASK-17651" is now
+ambiguous** — and both meanings are actively cited in the tree, including in
+production source comments.
+
+## Why this was filed rather than fixed
+
+Renumbering is the obvious repair, but it is **not** a mechanical rename, and
+a wrong reference is worse than a red check. Measured on dev at the time of
+filing: **79 references** to the two ids across the repo, of which roughly 25
+mean the later-filed (workspace/skills) pair. They span:
+
+- a **merged ADR** — `backlog/decisions/069-project-skills-folder-convention.md`
+  (two links, one URL-encoded to the filename)
+- **three User Guide pages** — `settings.md`, `library.md`, `library/skills.md`
+- **two lessons entries** in `backlog/docs/lessons-testing-evidence.md`
+- **four sibling task files** — 17961, 17962, 17963, 17964 (frontmatter
+  `dependencies:` **and** prose)
+- **production source comments** and `DESIGN.md` — these mean the *Console*
+  pair, so they must NOT be touched
+- **two test files** whose intent is genuinely ambiguous from the comment text
+  alone (`test_non_obscuring_focus_contract.py:895`,
+  `test_workbench_visual_snapshots.py:164`)
+
+That last category is the reason this needs a human decision: the two ids
+cannot be separated by pattern matching, only by reading each site for which
+programme it means.
+
+## Acceptance Criteria (the what)
+
+- [ ] The later-filed pair (workspace modal, project skills) is renumbered to
+      fresh ids taken by **leapfrog** from the max across ALL remotes and
+      worktrees, not from the local max — the practice that caused this
+- [ ] Every reference is re-pointed **by meaning, not by pattern**: each of
+      the ~25 workspace/skills sites is read and updated; the Console sites
+      (production comments, `DESIGN.md`, tasks 17652/17654/17655/17657/17662)
+      are left untouched
+- [ ] The two ambiguous test-file comments are resolved by reading the tests,
+      and which programme each meant is recorded
+- [ ] ADR-069's links resolve, including the URL-encoded filename form
+- [ ] `No duplicate backlog task IDs` passes on a PR into `dev`
+- [ ] The frontmatter `id:` field and the filename agree for every renamed
+      file (the guard checks both independently)

--- a/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
+++ b/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
@@ -36,86 +36,48 @@ production source comments.
 Renumbering is the obvious repair, but it is **not** a mechanical rename, and
 a wrong reference is worse than a red check.
 
-**The inventory below is GENERATED, not curated — because my first,
-hand-filtered one was wrong.** I separated the two meanings with a keyword
-grep (excluding anything matching `console`), and that filter silently hid
+**The inventory below is GENERATED, and it took two tries — both failures are
+the trap the repair will face.** First I separated the two meanings with a
+keyword grep excluding anything matching `console`, which silently dropped
 `Docs/User_Guide/console/sessions-tabs-workspaces.md` — a *workspaces* page
-whose path merely contains the word — plus `task-18310`. A reviewer caught
-it. **Any repair must start from a generated file list**, because the very
-heuristic that looks like it separates the two meanings is the thing that
-drops sites.
+whose path merely contains that word — and `task-18310`. A reviewer caught
+it. Then, regenerating, I split grep's output on whitespace; **these task
+filenames contain spaces** (`task-17650 - Console-….md`), so 33 paths
+shattered into 75 fragments. Both times the instrument, not the repo, was
+wrong.
 
-**75 files reference the two ids:**
+So: **generate the list, split on newlines, and assert every entry ends in a
+real extension** before trusting a count.
+
+**33 files reference the two ids:**
 
 ```
--
--
--
--
--
--
--
--
--
--
--
--
--
--
--
-17650
-17651
-CI
-Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
-Console-delete-the-zero-information-rows-in-the-bottom-stack.md
-Console-design-pass-inline-REPL-prompt-north-star.md
-Console-flatten-the-composer-to-a-one-row-dense-form-field.md
-Console-message-action-focus-walk-red-on-dev-after-selection-feedback.md
-Console-one-row-breathing-room-below-the-composer.md
-Console-raise-the-composer-draft-cap-from-4-to-8-rows.md
-Console-status-chips-placement-setting-and-persistent-collapse.md
 DESIGN.md
 Docs/User_Guide/console/sessions-tabs-workspaces.md
 Docs/User_Guide/library.md
 Docs/User_Guide/library/skills.md
 Docs/User_Guide/settings.md
-Duplicate
-Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md
-IDs
-Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
-Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
-Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
-Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
 Tests/UI/test_console_composer_collapse.py
 Tests/UI/test_console_internals_decomposition.py
 Tests/UI/test_console_status_row_collapse.py
 Tests/UI/test_non_obscuring_focus_contract.py
 Tests/UI/test_workbench_visual_snapshots.py
-Workspace-create-modal-follow-up-tests-and-typed-seams.md
-and
-backlog
 backlog/decisions/069-project-skills-folder-convention.md
 backlog/docs/lessons-testing-evidence.md
-backlog/tasks/task-17650
-backlog/tasks/task-17650
-backlog/tasks/task-17651
-backlog/tasks/task-17651
-backlog/tasks/task-17652
-backlog/tasks/task-17654
-backlog/tasks/task-17655
-backlog/tasks/task-17656
-backlog/tasks/task-17657
-backlog/tasks/task-17961
-backlog/tasks/task-17962
-backlog/tasks/task-17963
-backlog/tasks/task-17964
-backlog/tasks/task-18310
-dev.md
-guard
-on
-red
-task
-the
+backlog/tasks/task-17650 - Console-delete-the-zero-information-rows-in-the-bottom-stack.md
+backlog/tasks/task-17650 - Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
+backlog/tasks/task-17651 - Console-flatten-the-composer-to-a-one-row-dense-form-field.md
+backlog/tasks/task-17651 - Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+backlog/tasks/task-17652 - Console-status-chips-placement-setting-and-persistent-collapse.md
+backlog/tasks/task-17654 - Console-raise-the-composer-draft-cap-from-4-to-8-rows.md
+backlog/tasks/task-17655 - Console-design-pass-inline-REPL-prompt-north-star.md
+backlog/tasks/task-17656 - Console-message-action-focus-walk-red-on-dev-after-selection-feedback.md
+backlog/tasks/task-17657 - Console-one-row-breathing-room-below-the-composer.md
+backlog/tasks/task-17961 - Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md
+backlog/tasks/task-17962 - Workspace-create-modal-follow-up-tests-and-typed-seams.md
+backlog/tasks/task-17963 - Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
+backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
+backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
 tldw_chatbook/UI/Console_Modules/frame.py
 tldw_chatbook/UI/Console_Modules/provider_continuation_recovery.py
 tldw_chatbook/UI/Console_Modules/transcript.py

--- a/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
+++ b/backlog/tasks/task-18413 - Duplicate backlog task IDs 17650 and 17651 red the CI guard on dev.md
@@ -34,37 +34,133 @@ production source comments.
 ## Why this was filed rather than fixed
 
 Renumbering is the obvious repair, but it is **not** a mechanical rename, and
-a wrong reference is worse than a red check. Measured on dev at the time of
-filing: **79 references** to the two ids across the repo, of which roughly 25
-mean the later-filed (workspace/skills) pair. They span:
+a wrong reference is worse than a red check.
 
-- a **merged ADR** — `backlog/decisions/069-project-skills-folder-convention.md`
-  (two links, one URL-encoded to the filename)
-- **three User Guide pages** — `settings.md`, `library.md`, `library/skills.md`
-- **two lessons entries** in `backlog/docs/lessons-testing-evidence.md`
-- **four sibling task files** — 17961, 17962, 17963, 17964 (frontmatter
-  `dependencies:` **and** prose)
-- **production source comments** and `DESIGN.md` — these mean the *Console*
-  pair, so they must NOT be touched
-- **two test files** whose intent is genuinely ambiguous from the comment text
-  alone (`test_non_obscuring_focus_contract.py:895`,
-  `test_workbench_visual_snapshots.py:164`)
+**The inventory below is GENERATED, not curated — because my first,
+hand-filtered one was wrong.** I separated the two meanings with a keyword
+grep (excluding anything matching `console`), and that filter silently hid
+`Docs/User_Guide/console/sessions-tabs-workspaces.md` — a *workspaces* page
+whose path merely contains the word — plus `task-18310`. A reviewer caught
+it. **Any repair must start from a generated file list**, because the very
+heuristic that looks like it separates the two meanings is the thing that
+drops sites.
 
-That last category is the reason this needs a human decision: the two ids
-cannot be separated by pattern matching, only by reading each site for which
-programme it means.
+**75 files reference the two ids:**
+
+```
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+17650
+17651
+CI
+Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
+Console-delete-the-zero-information-rows-in-the-bottom-stack.md
+Console-design-pass-inline-REPL-prompt-north-star.md
+Console-flatten-the-composer-to-a-one-row-dense-form-field.md
+Console-message-action-focus-walk-red-on-dev-after-selection-feedback.md
+Console-one-row-breathing-room-below-the-composer.md
+Console-raise-the-composer-draft-cap-from-4-to-8-rows.md
+Console-status-chips-placement-setting-and-persistent-collapse.md
+DESIGN.md
+Docs/User_Guide/console/sessions-tabs-workspaces.md
+Docs/User_Guide/library.md
+Docs/User_Guide/library/skills.md
+Docs/User_Guide/settings.md
+Duplicate
+Focused-compact-Input-Checkbox-content-invisible-in-WorkspaceCreateModal.md
+IDs
+Project-skills-SKILLS-folder-discovery-and-prompt-driven-import.md
+Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
+Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
+Shared-workspace-creation-modal-across-Console-Settings-and-Library.md
+Tests/UI/test_console_composer_collapse.py
+Tests/UI/test_console_internals_decomposition.py
+Tests/UI/test_console_status_row_collapse.py
+Tests/UI/test_non_obscuring_focus_contract.py
+Tests/UI/test_workbench_visual_snapshots.py
+Workspace-create-modal-follow-up-tests-and-typed-seams.md
+and
+backlog
+backlog/decisions/069-project-skills-folder-convention.md
+backlog/docs/lessons-testing-evidence.md
+backlog/tasks/task-17650
+backlog/tasks/task-17650
+backlog/tasks/task-17651
+backlog/tasks/task-17651
+backlog/tasks/task-17652
+backlog/tasks/task-17654
+backlog/tasks/task-17655
+backlog/tasks/task-17656
+backlog/tasks/task-17657
+backlog/tasks/task-17961
+backlog/tasks/task-17962
+backlog/tasks/task-17963
+backlog/tasks/task-17964
+backlog/tasks/task-18310
+dev.md
+guard
+on
+red
+task
+the
+tldw_chatbook/UI/Console_Modules/frame.py
+tldw_chatbook/UI/Console_Modules/provider_continuation_recovery.py
+tldw_chatbook/UI/Console_Modules/transcript.py
+tldw_chatbook/UI/Screens/chat_screen.py
+tldw_chatbook/Widgets/Console/console_composer_bar.py
+tldw_chatbook/css/components/_agentic_terminal.tcss
+tldw_chatbook/css/tldw_cli_modular.tcss
+```
+
+Reading them by meaning:
+
+- **Must NOT be touched** (they mean the *Console* pair): the production
+  source comments (`chat_screen.py`, `Console_Modules/frame.py`,
+  `transcript.py`, `provider_continuation_recovery.py`,
+  `console_composer_bar.py`), both `.tcss` files, `DESIGN.md`, and tasks
+  17652 / 17654 / 17655 / 17656 / 17657.
+- **Must be re-pointed** (they mean the later-filed *workspace / project
+  skills* pair): the merged **ADR-069** (two links, one URL-encoded to the
+  filename), **four** User Guide pages (`settings.md`, `library.md`,
+  `library/skills.md`, **`console/sessions-tabs-workspaces.md`**), two
+  entries in `lessons-testing-evidence.md`, and tasks 17961, 17962, 17963,
+  17964, **18310** — in frontmatter `dependencies:` **and** prose.
+- **Ambiguous from the comment text alone**, needs the test read:
+  `test_non_obscuring_focus_contract.py`, `test_workbench_visual_snapshots.py`,
+  `test_console_composer_collapse.py`, `test_console_internals_decomposition.py`,
+  `test_console_status_row_collapse.py`.
+
+That last category is why this needs a human: the two ids cannot be
+separated by pattern matching, only by reading each site for which programme
+it means.
 
 ## Acceptance Criteria (the what)
 
 - [ ] The later-filed pair (workspace modal, project skills) is renumbered to
       fresh ids taken by **leapfrog** from the max across ALL remotes and
       worktrees, not from the local max — the practice that caused this
-- [ ] Every reference is re-pointed **by meaning, not by pattern**: each of
-      the ~25 workspace/skills sites is read and updated; the Console sites
-      (production comments, `DESIGN.md`, tasks 17652/17654/17655/17657/17662)
-      are left untouched
-- [ ] The two ambiguous test-file comments are resolved by reading the tests,
-      and which programme each meant is recorded
+- [ ] The repair starts from a **generated** file list (the grep in this
+      task), never a hand-curated one — a keyword filter already dropped two
+      sites when this task was first written
+- [ ] Every reference is re-pointed **by meaning, not by pattern**: each
+      workspace/skills site is read and updated; the Console sites
+      (production comments, both `.tcss` files, `DESIGN.md`, tasks
+      17652/17654/17655/17656/17657) are left untouched
+- [ ] The five ambiguous test files are resolved by reading the tests, and
+      which programme each meant is recorded
 - [ ] ADR-069's links resolve, including the URL-encoded filename form
 - [ ] `No duplicate backlog task IDs` passes on a PR into `dev`
 - [ ] The frontmatter `id:` field and the filename agree for every renamed


### PR DESCRIPTION
## The problem

**`No duplicate backlog task IDs` is red on `origin/dev`** and fails on every PR opened against it — including PRs that touch no task file at all. I hit it on #1812, which only modified an existing task.

Two programmes minted the same two ids **fourteen minutes apart** on 2026-08-17, and both merged:

| id | 18:00:58 (`68b6e3a87`) | 18:14:57 (`979a6914a`) |
|---|---|---|
| `task-17650` | Console — delete zero-information rows in the bottom stack | Shared workspace creation modal |
| `task-17651` | Console — flatten the composer to a one-row dense form field | Project skills `.SKILLS/` discovery and import |

All four are `Done`. The guard only catches this *after* both land, which is the known mechanism: the CLI assigns from the **local** max, so two worktrees that never see each other mint the same number.

The harm isn't only the red check — **a reference to "TASK-17651" is now ambiguous**, and both meanings are actively cited in the tree, including in production source comments.

## Why I filed this instead of fixing it

Renumbering looks mechanical and isn't. On dev there are **79 references** to the two ids, ~25 of which mean the later-filed workspace/skills pair. They span:

- a **merged ADR** (`069-project-skills-folder-convention.md`, including a URL-encoded filename link)
- **three User Guide pages**
- **two lessons entries**
- **four sibling task files** — frontmatter `dependencies:` *and* prose
- **production source comments** + `DESIGN.md` that mean the *Console* pair and must not be touched
- **two test files** whose intent is genuinely ambiguous from the comment text alone

The two ids cannot be separated by pattern matching — only by reading each site for which programme it means. A careless `sed` here corrupts the project record across two completed programmes, which is worse than a red check. That's an owner call on sequencing and on which pair gets renumbered, so this PR files the analysis and leaves the repair.

## What this PR contains

One task file. No code, no renames, no reference edits.

The id `18413` was taken by **leapfrog from the max across all remotes and worktrees** (18313), not from the local max — the practice that caused the collision in the first place.

## Note on this PR's own CI

The duplicate-id check will fail here too, for the reason this task describes. It is pre-existing on `dev` and unrelated to this change.

Refs TASK-18413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents duplicate backlog task IDs 17650/17651 that keep the “No duplicate backlog task IDs” CI check red on dev, and adds a validated inventory plus acceptance criteria for a safe renumbering.

- Adds one backlog task file only; no code changes or renames. Uses `TASK-18413`, leapfrogged from the global max to avoid collisions.
- Includes a generated, validated 33‑file inventory of references; records pitfalls that hid or corrupted paths (keyword path filters; whitespace‑based splitting) and prescribes newline split + file‑extension assertions.
- Acceptance criteria: renumber the later‑filed workspace/skills pair with leapfrog IDs; update references by meaning (not pattern); resolve five ambiguous tests; verify ADR‑069 links (including URL‑encoded form); ensure `id` and filename agree post‑rename.
- CI remains red on this PR due to the pre‑existing duplicate IDs on `dev`; follow‑up is the renumbering and reference updates until the guard passes.

<sup>Written for commit 13c111e4addce4fbe61d69cad88d60276c6e51a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

