### PR TITLE
test(rag-eval): wire the harness prompts seam — pm-vendor-chaser retrieves; deliberate 10-cell re-stamp

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-prompts-seam/report.md
+++ b/Docs/superpowers/qa/2026-08-18-prompts-seam/report.md
@@ -1,0 +1,111 @@
+# TASK-18255 — wiring the harness prompts seam, and what it settled
+
+**The seam is wired. `pm-vendor-chaser` now retrieves. The gated baseline was
+re-stamped deliberately: 10 of 105 metrics moved, all up, all in `plain`.**
+
+Reproduce: `seam_effect.py` beside this file (`RAG_EVAL=1`).
+
+## What this settles, beyond the re-scoped task
+
+TASK-17855 reported a production defect: `plain` returned zero rows for all
+five `prompt` goldens, including `pm-vendor-chaser`, whose target contains
+every content word. PR #1807 withdrew that claim as **unsupported** — the
+harness set `prompt_scope_service=None`, so `_search_prompts` returned
+`(False, [])`, the seam reporting itself *unavailable* — while being careful
+not to assert the opposite, because nothing had exercised the sub-leg
+against a real `PromptScopeService`.
+
+**Now something has.** With the seam wired:
+
+```
+PROBE PROOF: app.prompt_scope_service = PromptScopeService
+PROBE PROOF: _search_prompts availability = True
+PROBE PROOF: smoke-query rows = 6
+```
+
+and `pm-vendor-chaser` **HITs**. The defect claim moves from *withdrawn as
+unsupported* to *disproven*: the sub-leg works, and the 0.000 was the
+instrument all along.
+
+## The five prompt goldens, per query
+
+An aggregate of 0.200 means one of five, which is exactly the kind of number
+that hides four misses — so the AC required per-query reporting:
+
+| query | result | rows | prompt rows | target |
+|---|---|---|---|---|
+| `pm-shift-summary` | MISS | 0 | 0 | `prompt-shift-summary` |
+| `pm-incident-timeline` | MISS | 0 | 0 | `prompt-incident-timeline` |
+| **`pm-vendor-chaser`** | **HIT** | 1 | 1 | `prompt-vendor-chaser` |
+| `pm-meeting-actions` | MISS | 0 | 0 | `prompt-meeting-actions` |
+| `pm-glossary` | MISS | 0 | 0 | `prompt-glossary-builder` |
+
+**1 of 5.** The four misses are consistent with TASK-17855's surviving
+finding: their targets do not contain the queries' content words, which no
+seam wiring can fix. `pm-vendor-chaser` was the one query whose target *did*,
+and it is the one that hits.
+
+## The predicted cost did not materialize
+
+The harness comment warned that wiring the seam "would move plain-mode
+numbers for NON-prompt queries too, since the seam appends its rows to every
+plain fan-out." Measured:
+
+**0 of 55 non-prompt queries have a prompt row in their fan-out.**
+
+The seam appends nothing where nothing matches, so the fan-out is unchanged
+for every non-prompt query. The warning was reasonable and turned out not to
+bind on this corpus — which is worth recording, because it was the stated
+reason the wiring was deferred.
+
+## The re-stamp: 10 of 105 metrics, all up, all in `plain`
+
+`[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of
+baseline.`
+
+| metric | before | after |
+|---|---|---|
+| `plain category.prompt.{precision,recall,mrr,ndcg,f1}` | 0.000 | **0.200** |
+| `plain overall.{precision,recall,mrr,ndcg,f1}` | 0.315–0.326 | **+0.022** |
+
+**No category other than `prompt` moved anywhere.** The `overall` movement is
+arithmetic: a category that was vacuously 0.000 now contributes a real value
+to the average. Every `semantic` and `hybrid` metric is unchanged at +0.000,
+which is the expected shape — `plain` is the only mode that uses the
+Library's four-seam fan-out.
+
+## Disclosure: the environment fingerprint moved, and why that is safe here
+
+The re-stamp changed one fingerprint field:
+
+```
+- "sentence_transformers": "5.7.0"
++ "sentence_transformers": "5.4.1"
+```
+
+The committed baselines were stamped on a machine with 5.7.0; this one has
+5.4.1. Nothing else in the fingerprint moved — python, platform, torch,
+transformers, chromadb and the embedding model are all unchanged.
+
+**The library difference is demonstrably retrieval-neutral on this corpus**:
+every one of the **70 metrics across `semantic` and `hybrid` is byte-identical**
+(+0.000). If the version difference affected embeddings, those two vector
+modes are where it would show, and it does not. So the 10 moved cells are
+attributable to the seam, not to the library.
+
+This is disclosed rather than hidden because a future arc reading these
+baselines needs to know the environment block moved and why. Re-stamping on a
+5.7.0 machine would restore it; the metric values should not change.
+
+## Residual, recorded not fixed: `(True, [])` still collapses
+
+`_search_prompts` ends `except Exception: return True, []`, so a seam that
+**threw** is still reported as available-and-empty — indistinguishable in the
+metrics from one that searched and matched nothing. This run logged the
+warning **0 times**, so these numbers are clean, and `seam_effect.py` checks
+for it and refuses a verdict if it fires.
+
+Fixing the collapse properly means giving the metrics layer a distinct
+"unavailable" value for every optional seam, not just prompts. That is a
+larger change than this task, and it is the shape of the defect that produced
+TASK-17855 in the first place — recorded here as the accepted residual.

--- a/Docs/superpowers/qa/2026-08-18-prompts-seam/report.md
+++ b/Docs/superpowers/qa/2026-08-18-prompts-seam/report.md
@@ -109,3 +109,24 @@ Fixing the collapse properly means giving the metrics layer a distinct
 "unavailable" value for every optional seam, not just prompts. That is a
 larger change than this task, and it is the shape of the defect that produced
 TASK-17855 in the first place — recorded here as the accepted residual.
+
+
+## What review changed (PR #1818)
+
+**The README contradicted itself.** I updated the category table's `prompt`
+row to 0.200 but left the prose two paragraphs below still calling `plain`'s
+cell vacuous, and left the `overall` row at its pre-re-stamp 0.293. Both
+fixed: `overall` now reads **0.337** from the re-stamped baseline, with the
+rise attributed, and the prose says `prompt` is 0.000 in `semantic` **only**
+(prompts have no vector index). A reader can no longer take two incompatible
+readings of the result this arc establishes.
+
+**The probe leaked the eval runtime.** `seam_effect.py` built an
+`EvalRuntime` — SQLite connections, a Chroma store, and the event loop its
+pools are bound to — and never closed it, while the scratch directory
+vanished underneath. Every harness caller in `test_harness_run.py` closes it;
+this probe forgot. Now closed in a `finally`, with the failure reported rather
+than swallowed.
+
+Verdict unchanged on a full re-run: seam available, `pm-vendor-chaser` hits,
+1 of 5, 0 of 55 non-prompt fan-outs affected, 0 seam failures logged.

--- a/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
+++ b/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
@@ -37,6 +37,10 @@ def main() -> int:
     Returns:
         0 on a complete run; 1 if any query errored or the seam logged a
         failure (either makes a zero unreadable).
+
+    Raises:
+        SystemExit: ``RAG_EVAL`` is not set to ``"1"``. This builds a real
+            index over the full fixture corpus, so it never runs by accident.
     """
     import tempfile
 
@@ -70,6 +74,7 @@ def main() -> int:
     )
 
     corpus, golden = load_fixtures()
+    rt = None
     try:
         with tempfile.TemporaryDirectory() as tmp:
             rt = build_eval_runtime(corpus, tmp)
@@ -114,6 +119,15 @@ def main() -> int:
                     any(s in set(docs) for s in q.relevant_slugs), len(rws), n_prompt
                 )
     finally:
+        # The runtime owns SQLite connections, a Chroma store and the event
+        # loop its pools are bound to; the scratch dir is about to vanish, so
+        # they must be released first. Every harness caller closes it -- this
+        # probe forgot to, which leaks handles into the rest of the process.
+        if rt is not None:
+            try:
+                rt.close()
+            except Exception as exc:                          # noqa: BLE001
+                print(f"NOTE: runtime.close() failed after the run: {exc!r}")
         logger.remove(sink_id)
 
     by_id = {q.id: q for q in golden}

--- a/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
+++ b/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
@@ -1,0 +1,152 @@
+"""TASK-18255: what does wiring the harness prompts seam actually change?
+
+Run::
+
+    RAG_EVAL=1 PYTHONPATH=$(pwd) <venv>/bin/python \
+        Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
+
+Reports, in `plain` (the only mode that uses the Library's four-seam fan-out):
+
+* whether `_search_prompts` reports itself AVAILABLE at all -- the distinction
+  the metrics table cannot show, and the one TASK-17855 misread;
+* per query, hit/miss for all five prompt goldens (an aggregate cell of 0.200
+  means one of five, which would hide four misses);
+* the COST the harness comment predicted: the seam appends rows to every
+  plain fan-out, so non-prompt queries can move too;
+* whether the run logged "prompts seam failed." -- with a service wired, an
+  exception still returns `(True, [])`, so a zero would otherwise be
+  ambiguous between no-match and threw.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+K = 10
+SEAM_FAILED_MARKER = "prompts seam failed."
+
+
+def main() -> int:
+    """Measure the seam's availability, per-query hits and fan-out cost.
+
+    Returns:
+        0 on a complete run; 1 if any query errored or the seam logged a
+        failure (either makes a zero unreadable).
+    """
+    import tempfile
+
+    if os.environ.get("RAG_EVAL") != "1":
+        raise SystemExit("refusing to run without RAG_EVAL=1 (this builds a real index)")
+
+    import tldw_chatbook
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        LibraryLocalRagSearchService,
+    )
+
+    from Tests.RAG_Eval.harness.canonicalize import rows_to_doc_ids, slug_lookup_from
+    from Tests.RAG_Eval.harness.goldenset import load_fixtures
+    from Tests.RAG_Eval.harness.ingest import build_eval_runtime
+    from Tests.RAG_Eval.harness.runner import (
+        SOURCE_TYPES,
+        _extract_rows,
+        build_query_scope,
+    )
+
+    print(f"PROVENANCE tldw_chatbook <- {tldw_chatbook.__file__}")
+    assert str(REPO) in tldw_chatbook.__file__, f"WRONG TREE: expected under {REPO}"
+
+    # Capture loguru so a seam exception cannot hide behind a warning nobody reads.
+    from loguru import logger
+
+    seam_failures: list[str] = []
+    sink_id = logger.add(
+        lambda m: seam_failures.append(str(m)) if SEAM_FAILED_MARKER in str(m) else None,
+        level="WARNING",
+    )
+
+    corpus, golden = load_fixtures()
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            rt = build_eval_runtime(corpus, tmp)
+
+            # 1. Is the seam AVAILABLE? `(False, [])` and `(True, [])` render
+            #    the same downstream; ask the seam directly.
+            seam = LibraryLocalRagSearchService(rt.app)
+            svc = getattr(rt.app, "prompt_scope_service", None)
+            print(f"\nPROBE PROOF: app.prompt_scope_service = {type(svc).__name__}")
+            available, rows = rt.run(seam._search_prompts("prompt", K))
+            print(f"PROBE PROOF: _search_prompts availability = {available} "
+                  f"(False means UNAVAILABLE, not 'matched nothing')")
+            print(f"PROBE PROOF: smoke-query rows = {len(rows)}")
+            if not available:
+                print("  SEAM UNAVAILABLE -- nothing below would be meaningful.")
+                return 1
+
+            lookup = slug_lookup_from(rt.slug_to_source)
+            cfg = rt.service.config.search
+            cfg.default_search_mode = "plain"
+
+            errors: list[str] = []
+            results: dict[str, tuple[bool, int, int]] = {}
+            for q in golden:
+                scope = build_query_scope(rt.slug_to_source, q)
+                try:
+                    res = rt.run(
+                        seam.search(q.query, SOURCE_TYPES, "rag", top_k=K, scope=scope)
+                    )
+                    rws, _b, err = _extract_rows(res)
+                except Exception as exc:                       # noqa: BLE001
+                    rws, err = [], f"{type(exc).__name__}: {exc}"
+                if err:
+                    errors.append(f"{q.id}: {err}")
+                    continue
+                docs = rows_to_doc_ids(rws, lookup)
+                n_prompt = sum(
+                    1 for r in rws
+                    if (r.get("provenance") or {}).get("source_type") == "prompt"
+                )
+                results[q.id] = (
+                    any(s in set(docs) for s in q.relevant_slugs), len(rws), n_prompt
+                )
+    finally:
+        logger.remove(sink_id)
+
+    by_id = {q.id: q for q in golden}
+    print(f"\nPROBE PROOF: queries measured = {len(results)}, errors = {len(errors)}")
+    for e in errors:
+        print(f"    !! {e}")
+    print(f"PROBE PROOF: '{SEAM_FAILED_MARKER}' logged = {len(seam_failures)} time(s)")
+    if errors or seam_failures:
+        print("NO VERDICT CLAIMED -- a zero here would be unreadable.")
+        return 1
+
+    print("\n=== the five prompt goldens, PER QUERY (an aggregate hides misses) ===")
+    prompts = [q for q in golden if q.category == "prompt"]
+    for q in prompts:
+        hit, n, n_p = results[q.id]
+        print(f"  {'HIT ' if hit else 'MISS'} {q.id:22s} rows={n:2d} prompt-rows={n_p:2d}"
+              f"  target={q.relevant_slugs[0]}")
+    hits = sum(1 for q in prompts if results[q.id][0])
+    print(f"  -> {hits}/{len(prompts)} (aggregate cell would read {hits/len(prompts):.3f})")
+
+    print("\n=== the COST the harness comment predicted ===")
+    others = [q for q in golden if q.category != "prompt"]
+    with_prompt_rows = [q.id for q in others if results[q.id][2] > 0]
+    print(f"  non-prompt queries whose plain fan-out now contains prompt rows: "
+          f"{len(with_prompt_rows)} of {len(others)}")
+    for qid in with_prompt_rows[:15]:
+        hit, n, n_p = results[qid]
+        print(f"      {qid:30s} [{by_id[qid].category:20s}] rows={n:2d} "
+              f"prompt-rows={n_p} hit={hit}")
+    print(f"  non-prompt queries currently HITTING: "
+          f"{sum(1 for q in others if results[q.id][0])} of {len(others)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -221,7 +221,7 @@ cells):
 | `paraphrase` | 13 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only |
 | `vocabulary_mismatch` | 9 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only (see the caveat under Category meanings) |
 | `negation` | 3 | 0.000 | 0.000 | **0.000** | **full** — nothing retrieves these today |
-| `prompt` | 5 | 0.000 | 0.000 &nbsp;⚠️ | **0.200** | ⚠️ **the `plain` cell is VACUOUS, not measured** — the harness leaves `prompt_scope_service=None` so that seam reports itself unavailable (TASK-18255); read only the `semantic`/`hybrid` cells as retrieval. 1 of 5. TASK-15400's construction flip took it; TASK-15700's merge fix + `and_then_prefix` flip held the cell at 0.200 while the MECHANISM under it moved (stopword trim → prefix fallback). The residual 4 are bounded by absent CONTENT words — see below |
+| `prompt` | 5 | 0.000 | **0.200** | **0.200** | `plain`'s cell was VACUOUS until TASK-18255 wired the harness prompts seam; it now MEASURES retrieval and reads 0.200 (`pm-vendor-chaser` hits, the other four are blocked by absent content words). 1 of 5. TASK-15400's construction flip took it; TASK-15700's merge fix + `and_then_prefix` flip held the cell at 0.200 while the MECHANISM under it moved (stopword trim → prefix fallback). The residual 4 are bounded by absent CONTENT words — see below |
 | `scoped` | 7 | 0.000 | 1.000 | **1.000** | hybrid flipped from 0.000 in this arc (B1); MRR 0.163 is the remaining headroom, not recall |
 | **overall** | **46** | **0.804** | **0.293** | **0.848** | hybrid is **0.152** off the ceiling |
 
@@ -1417,18 +1417,22 @@ Two columns need context before you read the P/R/MRR/NDCG numbers as
   and do not read the other categories' hybrid numbers as evidence that the
   keyword leg is contributing to them.
 
-  **`plain`'s 0.000 has a DIFFERENT cause, and this paragraph used to give
-  the wrong one** (corrected 2026-08-18, TASK-18255). The missing vector
-  index cannot explain `plain`, which never consults a vector index at all.
-  `plain` fans out over the Library's own four seams, and the harness
-  **deliberately does not wire the prompts one** — its fake app sets
-  `prompt_scope_service=None`, so `_search_prompts` returns `(False, [])`:
-  the seam reporting itself UNAVAILABLE. The cell is therefore **vacuous by
-  construction**, not a measured zero, and production does wire the service
-  (`app.py:5682`). The warning above was right for the wrong reason in
-  `plain`'s case — and TASK-17855 nonetheless filed the defect this sentence
-  warns against, because a `0.000` renders identically whether it means "not
-  measured" or "measured and found nothing".
+  **`plain`'s cell had a DIFFERENT cause, now FIXED** (TASK-18255). The
+  missing vector index never explained `plain`, which does not consult a
+  vector index at all — it fans out over the Library's own four seams, and
+  the harness did not wire the prompts one (`prompt_scope_service=None`, so
+  `_search_prompts` returned `(False, [])`: the seam reporting itself
+  UNAVAILABLE). The cell was **vacuous by construction**, not a measured
+  zero. TASK-17855 read it as a production retrieval defect — the exact
+  misreading the sentence above warns against — because a `0.000` renders
+  identically whether it means "not measured" or "measured and found
+  nothing".
+
+  **The seam is wired as of TASK-18255 and `plain`'s prompt cell now reads
+  0.200**: `pm-vendor-chaser` retrieves, which disproves the defect claim
+  rather than merely withdrawing it. The other four prompt goldens miss for
+  the reason TASK-17855 established and which survives — their targets do
+  not contain the queries' content words.
 - **Plain's MRR and NDCG track recall, not ranking.** The four-seam keyword
   path deliberately drops the FTS rank ("an FTS ranking artifact, not a
   retrieval similarity score" — every plain row carries `score=None`), and

--- a/Tests/RAG_Eval/README.md
+++ b/Tests/RAG_Eval/README.md
@@ -221,14 +221,14 @@ cells):
 | `paraphrase` | 13 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only |
 | `vocabulary_mismatch` | 9 | 1.000 | 0.000 | 1.000 | **none in the vector modes** — regression-only (see the caveat under Category meanings) |
 | `negation` | 3 | 0.000 | 0.000 | **0.000** | **full** — nothing retrieves these today |
-| `prompt` | 5 | 0.000 | **0.200** | **0.200** | `plain`'s cell was VACUOUS until TASK-18255 wired the harness prompts seam; it now MEASURES retrieval and reads 0.200 (`pm-vendor-chaser` hits, the other four are blocked by absent content words). 1 of 5. TASK-15400's construction flip took it; TASK-15700's merge fix + `and_then_prefix` flip held the cell at 0.200 while the MECHANISM under it moved (stopword trim → prefix fallback). The residual 4 are bounded by absent CONTENT words — see below |
+| `prompt` | 5 | 0.000 | **0.200** | **0.200** | 1 of 5 in both. `plain`'s cell was VACUOUS until TASK-18255 wired the harness prompts seam; it now MEASURES retrieval, and `pm-vendor-chaser` hits. `hybrid`'s 0.200 came from TASK-15400's construction flip; TASK-15700's merge fix + `and_then_prefix` held it there while the MECHANISM under it moved (stopword trim → prefix fallback). Both modes' residual 4 are bounded by absent CONTENT words — see below |
 | `scoped` | 7 | 0.000 | 1.000 | **1.000** | hybrid flipped from 0.000 in this arc (B1); MRR 0.163 is the remaining headroom, not recall |
-| **overall** | **46** | **0.804** | **0.293** | **0.848** | hybrid is **0.152** off the ceiling |
+| **overall** | **46** | **0.804** | **0.337** | **0.848** | hybrid is **0.152** off the ceiling; `plain` rose from 0.293 with TASK-18255's prompts-seam wiring (the prompt category stopped being vacuous) |
 
 **The remaining 0.000 rows are P2c's admission targets.** `negation` (all
-three modes) and `prompt` (0.000 in `semantic`; `plain`'s 0.000 is **vacuous** — see the
-⚠️ note) are the cells with room to rise, and they are not the same kind of
-problem:
+three modes) and `prompt` (0.000 in `semantic` only — prompts have no vector
+index; `plain` and `hybrid` both read 0.200) are the cells with room to rise,
+and they are not the same kind of problem:
 
 - **`negation` 0.000 in all three modes is a genuine open capability gap.**
   Three fixtures, each describing the exception *without ever naming the

--- a/Tests/RAG_Eval/baselines/hybrid.json
+++ b/Tests/RAG_Eval/baselines/hybrid.json
@@ -1,6 +1,6 @@
 {
   "baseline_id": "hybrid",
-  "created_at": "2026-08-12T23:01:15.693189+00:00",
+  "created_at": "2026-08-18T23:33:29.981252+00:00",
   "pipeline_config": {
     "mode": "hybrid",
     "k": 10,
@@ -64,10 +64,10 @@
     "report_only": {
       "latency": {
         "count": 60.0,
-        "mean_ms": 9.9,
-        "p95_ms": 16.0,
-        "max_ms": 17.1,
-        "total_s": 0.6
+        "mean_ms": 8.6,
+        "p95_ms": 12.9,
+        "max_ms": 13.5,
+        "total_s": 0.5
       },
       "mean_docs_at_k": 10.0,
       "num_queries": 46,

--- a/Tests/RAG_Eval/baselines/plain.json
+++ b/Tests/RAG_Eval/baselines/plain.json
@@ -1,6 +1,6 @@
 {
   "baseline_id": "plain",
-  "created_at": "2026-08-18T02:04:39.534789+00:00",
+  "created_at": "2026-08-18T23:33:29.980780+00:00",
   "pipeline_config": {
     "mode": "plain",
     "k": 10,
@@ -13,11 +13,11 @@
     ]
   },
   "metrics": {
-    "overall.precision": 0.32608695652173914,
-    "overall.recall": 0.31521739130434784,
-    "overall.mrr": 0.32608695652173914,
-    "overall.ndcg": 0.3176771128862056,
-    "overall.f1": 0.3188405797101449,
+    "overall.precision": 0.34782608695652173,
+    "overall.recall": 0.33695652173913043,
+    "overall.mrr": 0.34782608695652173,
+    "overall.ndcg": 0.33941624332098824,
+    "overall.f1": 0.34057971014492755,
     "category.keyword.precision": 0.9375,
     "category.keyword.recall": 0.90625,
     "category.keyword.mrr": 0.9375,
@@ -33,11 +33,11 @@
     "category.paraphrase.mrr": 0.0,
     "category.paraphrase.ndcg": 0.0,
     "category.paraphrase.f1": 0.0,
-    "category.prompt.precision": 0.0,
-    "category.prompt.recall": 0.0,
-    "category.prompt.mrr": 0.0,
-    "category.prompt.ndcg": 0.0,
-    "category.prompt.f1": 0.0,
+    "category.prompt.precision": 0.2,
+    "category.prompt.recall": 0.2,
+    "category.prompt.mrr": 0.2,
+    "category.prompt.ndcg": 0.2,
+    "category.prompt.f1": 0.2,
     "category.scoped.precision": 1.0,
     "category.scoped.recall": 1.0,
     "category.scoped.mrr": 1.0,
@@ -59,17 +59,17 @@
       "platform": "darwin"
     },
     "environment_info": {
-      "sentence_transformers": "5.7.0"
+      "sentence_transformers": "5.4.1"
     },
     "report_only": {
       "latency": {
         "count": 60.0,
-        "mean_ms": 18.4,
-        "p95_ms": 31.1,
-        "max_ms": 41.6,
-        "total_s": 1.1
+        "mean_ms": 17.3,
+        "p95_ms": 29.6,
+        "max_ms": 39.7,
+        "total_s": 1.0
       },
-      "mean_docs_at_k": 0.457,
+      "mean_docs_at_k": 0.478,
       "num_queries": 46,
       "num_golden_queries": 60,
       "num_negative": 7,

--- a/Tests/RAG_Eval/baselines/semantic.json
+++ b/Tests/RAG_Eval/baselines/semantic.json
@@ -1,6 +1,6 @@
 {
   "baseline_id": "semantic",
-  "created_at": "2026-08-12T23:01:15.691443+00:00",
+  "created_at": "2026-08-18T23:33:29.979956+00:00",
   "pipeline_config": {
     "mode": "semantic",
     "k": 10,
@@ -64,10 +64,10 @@
     "report_only": {
       "latency": {
         "count": 60.0,
-        "mean_ms": 8.4,
-        "p95_ms": 13.9,
-        "max_ms": 15.9,
-        "total_s": 0.5
+        "mean_ms": 6.8,
+        "p95_ms": 10.9,
+        "max_ms": 11.4,
+        "total_s": 0.4
       },
       "mean_docs_at_k": 9.652,
       "num_queries": 46,

--- a/Tests/RAG_Eval/harness/ingest.py
+++ b/Tests/RAG_Eval/harness/ingest.py
@@ -372,6 +372,10 @@ def build_eval_runtime(
     from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
     from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
     from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
+    from tldw_chatbook.Prompt_Management.prompt_scope_service import (
+        ServerPromptService,
+        build_prompt_scope_service,
+    )
     from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
     from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
     from tldw_chatbook.Notes.Notes_Library import NotesInteropService
@@ -523,21 +527,25 @@ def build_eval_runtime(
                 server_service=None,
             ),
             notes_user_id=NOTES_USER_ID,
-            # No prompts seam, deliberately, and this is now a REAL gap
-            # rather than a shape convenience — record it when reading the
-            # numbers. Prompts are written and indexed-in-FTS as of
-            # TASK-15020/B2, so hybrid retrieves them through the engine's
-            # keyword leg; PLAIN mode does not go through the engine at all,
-            # it fans out over the Library's own four seams, and the prompts
-            # one is this attribute. Leaving it None means the harness's
-            # plain column reports 0.000 for prompts while the shipped app's
-            # plain mode does find them. B2's deliverable is the ENGINE leg
-            # (the spec puts the four-seam path out of scope), so wiring a
-            # `PromptScopeService` here is left to the Library work rather
-            # than smuggled in — and would move plain-mode numbers for
-            # NON-prompt queries too, since the seam appends its rows to
-            # every plain fan-out.
-            prompt_scope_service=None,
+            # The prompts seam, wired (TASK-18255). It used to be `None`
+            # "deliberately", and that omission cost a wrong finding: the
+            # plain `category.prompt.*` cells read 0.000 because
+            # `_search_prompts` returns `(False, [])` — the seam reporting
+            # itself UNAVAILABLE — and TASK-17855 read that as a production
+            # retrieval defect. The metrics table renders "not measured" and
+            # "measured, found nothing" identically, so an unwired seam is
+            # indistinguishable from a broken one.
+            #
+            # `server_service` is passed EXPLICITLY as a client-less service
+            # rather than left to `app_config`: the default path runs
+            # `derive_configured_server_binding`, and a harness that consults
+            # ambient config could bind to the developer's own server — the
+            # same hazard the `*_db_path` overrides above exist to prevent.
+            # Local-only, no network, by construction.
+            prompt_scope_service=build_prompt_scope_service(
+                prompt_db=prompts_db,
+                server_service=ServerPromptService(client=None),
+            ),
             # An UNSTAMPED `_rag_service` wins outright in the seam's
             # resolver (`semantic_availability.current_app_rag_service`'s
             # direct-injection carve-out), so the seam retrieves through

--- a/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
+++ b/backlog/tasks/task-18255 - The plain prompts sub-leg returns zero rows for queries whose target contains the words.md
@@ -3,7 +3,7 @@ id: TASK-18255
 title: >-
   Wire a prompts seam into the eval harness so plain-mode prompt cells measure
   something
-status: To Do
+status: Done
 assignee: []
 labels: [rag, retrieval]
 dependencies: []
@@ -64,28 +64,38 @@ wiring it moves plain-mode numbers for non-prompt queries too.
       2026-08-18): the harness's fake app sets `prompt_scope_service=None`,
       so `_search_prompts` returns `(False, [])` — seam UNAVAILABLE, not
       seam matching nothing. Production wires it at `app.py:5682`.
-- [ ] The harness wires a real prompts seam, so `plain`'s
-      `category.prompt.*` cells measure retrieval rather than absence
-- [ ] **Reported PER QUERY, not as a category average.** All five prompt
-      goldens are listed with hit/miss individually — an aggregate cell of
-      0.200 means one of five succeeded and four still miss, which would let
-      this task close while the behaviour it exists to settle is still open.
-      `prompt-vendor-chaser` is named explicitly: its query contains every
-      content word of the target, so if any query retrieves, it must
-- [ ] **The run is checked for `"prompts seam failed."` in the log.** With
-      the service wired, an exception still returns `(True, [])`, so a zero
-      would remain ambiguous between no-match and threw. A clean run must
-      show the warning absent; if present, the exception is the finding
-- [ ] The `(False, [])` / `(True, [])` collapse is addressed at the metrics
-      layer or recorded as accepted: an unavailable seam should not render
-      as `0.000`, and this problem belongs to EVERY optional seam, not just
-      prompts (per the reviewer's suggestion on PR #1807)
-- [ ] The cost the harness comment predicts is measured, not assumed: the
-      seam appends rows to EVERY plain fan-out, so non-prompt plain cells
-      may move too — report which moved, by how much, before deciding
-- [ ] Whichever way the numbers go, the gate is re-stamped DELIBERATELY with
-      the reason recorded — this changes what the instrument can see, so a
-      moved cell is the deliverable rather than a regression
+- [x] Wired via `build_prompt_scope_service(prompt_db=prompts_db,
+      server_service=ServerPromptService(client=None))`. Availability proven
+      directly rather than inferred: `_search_prompts` returns `True` with 6
+      rows on a smoke query, not `(False, [])`.
+- [x] All five reported individually. **`pm-vendor-chaser` HITS** — the query
+      the AC named, and the one whose target contains every content word. The
+      other four MISS, consistent with TASK-17855's surviving finding (their
+      targets lack the content words). 1 of 5, which is the 0.200 aggregate
+      stated plainly rather than hidden behind it.
+- [x] A loguru sink captures the marker; it fired **0 times**.
+      `seam_effect.py` refuses a verdict if it ever fires, so this cannot
+      silently regress.
+- [x] **Recorded as accepted, with the reason.** Fixing it properly means a
+      distinct "unavailable" value at the metrics layer for every optional
+      seam — larger than this task, and exactly the defect shape that produced
+      TASK-17855. Documented as the residual in the report;
+      `_search_prompts`'s `except Exception: return True, []` still collapses
+      threw-vs-empty, which is why the log check above is mandatory.
+- [x] Measured, and **it did not materialize**: **0 of 55** non-prompt
+      queries have a prompt row in their fan-out, and no non-prompt CATEGORY
+      moved. The seam appends nothing where nothing matches. Worth recording,
+      since this predicted cost was the stated reason the wiring was deferred.
+- [x] Re-stamped deliberately. **10 of 105 metrics moved, all up, all in
+      `plain`**: the five `category.prompt.*` cells 0.000 -> 0.200 and the
+      five `plain overall.*` cells +0.022 (arithmetic — a vacuous category now
+      contributes). Gate reads `PASSED: No regression. 105 metric(s)`. Every
+      `semantic` and `hybrid` metric is +0.000.
+      **Disclosed:** the fingerprint's `sentence_transformers` moved 5.7.0 ->
+      5.4.1 (this machine's venv). Nothing else in it moved, and the change is
+      demonstrably retrieval-neutral here — all **70** semantic+hybrid metrics
+      are byte-identical, which is precisely where an embedding-library change
+      would show.
 - [x] TASK-17855's report and this programme's README stop describing the
       plain prompt cells as a retrieval result (done in PR #1807: the report
       carries a correction block, and `Tests/RAG_Eval/README.md` now flags
@@ -93,3 +103,45 @@ wiring it moves plain-mode numbers for non-prompt queries too.
       paragraph, and the keyword-limits section — where the stated REASON was
       also wrong, blaming the absent vector index for a mode that never uses
       one)
+
+
+## Implementation Notes
+
+**The seam is wired, and it settled the question the arc was named for.**
+
+One line of harness wiring (`build_prompt_scope_service`), passing
+`server_service=ServerPromptService(client=None)` **explicitly** rather than
+letting `app_config` resolve it — the default path runs
+`derive_configured_server_binding`, and a harness consulting ambient config
+could bind to the developer's own server, the same hazard the `*_db_path`
+overrides exist to prevent.
+
+**`pm-vendor-chaser` retrieves.** PR #1807 withdrew TASK-17855's defect claim
+as *unsupported* while explicitly declining to assert the opposite, because
+nothing had exercised the sub-leg against a real `PromptScopeService`. Now
+something has: the claim is **disproven**, not merely withdrawn. The other
+four prompt goldens still miss, for the reason 17855 established and which
+survives — absent content words.
+
+**The deferred cost did not bind.** The harness comment predicted the seam
+would move plain numbers for non-prompt queries too. Measured: 0 of 55. That
+prediction was the stated reason for deferring the wiring, so its falsity is
+worth the record.
+
+**Re-stamp:** 10 of 105 cells, all up, all `plain`. Disclosed separately: the
+`sentence_transformers` fingerprint moved 5.7.0 -> 5.4.1 on this machine, and
+its retrieval-neutrality is shown by 70 unchanged semantic+hybrid metrics
+rather than asserted.
+
+**Residual, accepted not fixed:** `_search_prompts`'s
+`except Exception: return True, []` still renders a *thrown* seam as
+available-and-empty. The run logged the failure marker 0 times and the probe
+refuses a verdict if it ever fires, so these numbers are clean — but the
+general fix (a distinct "unavailable" value for every optional seam) is
+larger than this task and is exactly the defect shape that produced
+TASK-17855.
+
+**Files:** `Tests/RAG_Eval/harness/ingest.py` (the wiring),
+`Tests/RAG_Eval/baselines/*.json` (deliberate re-stamp),
+`Tests/RAG_Eval/README.md`, `Docs/superpowers/qa/2026-08-18-prompts-seam/`
+(report + `seam_effect.py`). No production source changed.


### PR DESCRIPTION
## What this settles

TASK-17855 reported a **production defect**: `plain` returned zero rows for all five `prompt` goldens, including `pm-vendor-chaser`, whose target contains every content word. PR #1807 withdrew that claim as **unsupported** — the harness set `prompt_scope_service=None`, so `_search_prompts` returned `(False, [])`, the seam reporting itself *unavailable* — while carefully **declining to assert the opposite**, because nothing had ever exercised the sub-leg against a real `PromptScopeService`.

**Now something has.**

```
PROBE PROOF: app.prompt_scope_service = PromptScopeService
PROBE PROOF: _search_prompts availability = True
PROBE PROOF: smoke-query rows = 6
```

**`pm-vendor-chaser` HITS.** The defect claim moves from *withdrawn as unsupported* to **disproven**. The 0.000 was the instrument all along.

## The five prompt goldens, per query

An aggregate of 0.200 means one of five — exactly the number that hides four misses — so the AC required per-query reporting:

| query | result | target |
|---|---|---|
| `pm-shift-summary` | MISS | `prompt-shift-summary` |
| `pm-incident-timeline` | MISS | `prompt-incident-timeline` |
| **`pm-vendor-chaser`** | **HIT** | `prompt-vendor-chaser` |
| `pm-meeting-actions` | MISS | `prompt-meeting-actions` |
| `pm-glossary` | MISS | `prompt-glossary-builder` |

The four misses are consistent with TASK-17855's **surviving** finding: their targets don't contain the queries' content words, which no seam wiring can fix.

## The deferred cost did not bind

The harness comment predicted wiring "would move plain-mode numbers for NON-prompt queries too, since the seam appends its rows to every plain fan-out" — and that prediction was the stated reason the wiring was deferred.

**Measured: 0 of 55 non-prompt queries have a prompt row in their fan-out.** No non-prompt category moved.

## The re-stamp: 10 of 105, all up, all `plain`

`[rag-eval baselines] PASSED: No regression. 105 metric(s) within 0.05 of baseline.`

| metric | before | after |
|---|---|---|
| `plain category.prompt.*` (5) | 0.000 | **0.200** |
| `plain overall.*` (5) | 0.315–0.326 | **+0.022** |

The `overall` movement is arithmetic — a vacuous category now contributes to the average. **Every `semantic` and `hybrid` metric is +0.000.**

## Disclosure: one fingerprint field moved

```
- "sentence_transformers": "5.7.0"
+ "sentence_transformers": "5.4.1"
```

This machine's venv differs from whichever stamped the committed baselines. Nothing else in the fingerprint moved (python, platform, torch, transformers, chromadb, embedding model all unchanged).

**The difference is demonstrably retrieval-neutral here, not assumed to be:** all **70** metrics across `semantic` and `hybrid` are byte-identical. If the version affected embeddings, those two vector modes are exactly where it would show. Re-stamping on a 5.7.0 machine should restore the field without moving any value.

## Residual, accepted rather than fixed

`_search_prompts` ends `except Exception: return True, []`, so a seam that **threw** still reads as available-and-empty. This run logged the failure marker **0 times**, and `seam_effect.py` refuses a verdict if it ever fires — so these numbers are clean. But the general fix (a distinct "unavailable" value at the metrics layer for **every** optional seam) is larger than this task, and it is precisely the defect shape that produced TASK-17855.

## Verification

No production source changed. `Tests/RAG_Eval`: **358 passed, 14 skipped**. Gate re-verified green after the re-stamp.

Refs TASK-18255, TASK-17855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the eval harness prompts seam so `plain` prompt cells measure retrieval instead of rendering as unavailable. Re-stamps baselines; fixes README inconsistency and closes a probe runtime leak.

- Old vs new: `prompt_scope_service=None` made `_search_prompts` unavailable and `plain category.prompt.*` read 0.000; now wired via `build_prompt_scope_service(..., server_service=ServerPromptService(client=None))`. `pm-vendor-chaser` retrieves; `plain category.prompt.*` is 0.200 and `plain overall.*` rises by +0.022; `semantic`/`hybrid` unchanged.
- No spillover: 0/55 non-prompt queries gained prompt rows; no non-prompt category moved.
- Baselines: deliberate re-stamp of 10/105 cells (all `plain`). Fingerprint only changes `sentence_transformers` 5.7.0 -> 5.4.1; 70 `semantic`/`hybrid` metrics are byte-identical.
- Probe hardening: adds `Docs/superpowers/qa/.../seam_effect.py` to prove availability, require `RAG_EVAL=1`, capture the “prompts seam failed.” marker, and close `EvalRuntime` in `finally`.
- Docs: `Tests/RAG_Eval/README.md` is self-consistent (`prompt` is 0.200 in `plain` and `hybrid`, 0.000 in `semantic` only; `plain overall` reads 0.337 with attribution).
- Scope: harness-only change; no production code touched. Completes TASK-18255 and disproves TASK-17855.

<sup>Written for commit bf6c3384a1c91874f2d85c0545d0f15674dbd8ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

