### PR TITLE
fix(anthropic): TASK-18414 — Console cannot drive claude-opus-5; make the two model gates capability predicates

### DIFF
--- a/Docs/superpowers/plans/2026-08-18-task-18414-report.md
+++ b/Docs/superpowers/plans/2026-08-18-task-18414-report.md
@@ -1,0 +1,307 @@
+# TASK-18414 — Console could not drive `claude-opus-5`
+
+**Branch:** `fix/task-18414-anthropic-model-capabilities` (from `origin/dev` `7d87686a3`)
+**Status:** complete — all 7 acceptance criteria met, live-verified both ways.
+
+---
+
+## 1. What was broken
+
+Two per-model **provider API capabilities** were encoded as hand-maintained model-name
+checks inside the Anthropic request builder (`tldw_chatbook/LLM_Calls/LLM_API_Calls.py`):
+
+| Gate | Old implementation | Knew about |
+|---|---|---|
+| "omit `temperature`/`top_p`/`top_k`" | `_anthropic_is_sonnet_5()` | Claude Sonnet 5 only |
+| "don't send `budget_tokens`" | `_ANTHROPIC_ADAPTIVE_THINKING_MODEL_MARKERS` | opus-4-7, opus-4-8, sonnet-4-6 |
+
+Consequences, all confirmed live:
+
+* `claude-opus-5` failed **both** ways — `budget_tokens` when a thinking effort was set,
+  `temperature` when it was not. Every send was an HTTP 400.
+* `claude-fable-5` / `claude-mythos-5` were in the same position.
+* `claude-opus-4-8` / `claude-opus-4-7` were in the adaptive list, but with **no** effort
+  configured the mapper returns no thinking config — which reopened the sampling branch and
+  put `temperature` on a request those models reject.
+
+The underlying defect is structural: a fact about the provider's request surface was written
+as a string list in the request builder, so every new model release silently broke a provider
+the app claims to support.
+
+---
+
+## 2. The 400 bodies (Step 1 — captured before any fix)
+
+The filed task had a live-observed 400 but never captured the body, so *which* parameter the
+provider named was unestablished. Established here with the real key, issued directly against
+`https://api.anthropic.com/v1/messages` — a standalone `curl` that imports no `tldw_chatbook`
+module and touches no app config.
+
+### Rejections
+
+**A — `claude-opus-5` + `temperature`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB5qiXpMbYhtroLrCYVo"}
+```
+
+**B — `claude-opus-5` + `thinking={"type":"enabled","budget_tokens":1024}`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."},"request_id":"req_011CeB5rcDqa5SBWeXW26dDh"}
+```
+
+**C — `claude-opus-5` + `top_p`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`top_p` is deprecated for this model."},"request_id":"req_011CeB5rdL4jvWzKgXNNJbPA"}
+```
+
+**D — `claude-opus-5` + `top_k`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`top_k` is deprecated for this model."},"request_id":"req_011CeB5rePKA31M94KTCaNuv"}
+```
+
+**E — `claude-opus-4-8` + `temperature`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB5rffTYRBahFbgi4tmm"}
+```
+
+**F — `claude-opus-4-7` + `temperature`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB5rgfjSCcAxVBfE7u9p"}
+```
+
+**G — `claude-fable-5` + `temperature`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB5rhiEgz53Z37aZUQ1r"}
+```
+
+**O — `claude-sonnet-5` + `temperature`** → HTTP 400
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB5tYhK2Dgt6bwxGQWyy"}
+```
+
+Both shapes the code can emit for `claude-opus-5` are rejected, and the provider names the
+parameter each time. Note the two error messages are *different in kind*: the sampling
+rejection just says "deprecated", while the thinking rejection names the replacement
+(`thinking.type.adaptive` + `output_config.effort`) — which is exactly the shape the fix now
+emits.
+
+### Controls that must keep working (AC #6)
+
+**H — `claude-opus-4-6` + `temperature`** → **HTTP 200**
+
+```json
+{"model":"claude-opus-4-6","id":"msg_011CeB5sreXxJJxEXnpihr6H","type":"message","role":"assistant","content":[{"type":"text","text":"OK."}],"stop_reason":"end_turn",...}
+```
+
+**I — `claude-opus-4-6` + `thinking={"type":"enabled","budget_tokens":1024}`** → **HTTP 200**
+(response carries a real `thinking` block, so the legacy budget path is genuinely still live)
+
+**J — `claude-sonnet-4-5` + `temperature`** → **HTTP 200**
+**K — `claude-haiku-4-5` + `temperature` + `top_k`** → **HTTP 200**
+
+### Post-fix shapes (verified before writing them)
+
+**L — `claude-opus-5`, no `thinking` key, no sampling** → **HTTP 200**
+**M — `claude-opus-5` + `thinking={"type":"adaptive"}` + `output_config={"effort":"high"}`** → **HTTP 200**
+**N — `claude-opus-4-8`, no `thinking` key, no sampling** → **HTTP 200**
+
+### One finding that reshaped nothing but is worth recording
+
+**P — `claude-mythos-5`** → HTTP 404
+
+```json
+{"type":"error","error":{"type":"not_found_error","message":"model: claude-mythos-5"},"request_id":"req_011CeB5tZoYDsY6k4HCz4Zfx"}
+```
+
+Mythos 5 is Project Glasswing–only and this key has no access, so **its behaviour is the one
+row in the table that is documented rather than live-observed.** It is included in the
+capability set on the documented grounds that it shares Fable 5's request surface exactly; if
+that ever proves wrong, the cost is a 400 on a model this key cannot reach anyway.
+
+---
+
+## 3. Where the capability now lives, and why
+
+`tldw_chatbook/model_capabilities.py` — the module CLAUDE.md already names as the home for
+per-model capability facts. Two predicates over one family table:
+
+```python
+anthropic_model_rejects_sampling_params(model) -> bool
+anthropic_model_rejects_fixed_thinking_budget(model) -> bool
+```
+
+They are kept as **two named predicates** even though they currently select the same families
+(Anthropic removed both parameters in the same generation) because they are two questions
+about the request surface and a future model can answer them differently.
+
+### Why not the config-driven capability tables in that same module
+
+This was the obvious move and it is wrong, for two concrete reasons:
+
+1. **A direct mapping shadows every pattern, and `claude-sonnet-5` already has one.**
+   `get_model_capabilities()` checks `direct_mappings` first and returns early. `DEFAULT_MODEL_CAPABILITIES`
+   contains `"claude-sonnet-5": {"vision": True, "max_images": 5}`. A pattern-based
+   `rejects_sampling_params` would therefore have missed **exactly the one model that already
+   worked** — a silent regression, and one no test of the new models would have caught.
+2. **The tables are wholly replaceable from user config.** `ModelCapabilities.__init__` does
+   `config.get("models", DEFAULT_MODEL_CAPABILITIES.copy())` and
+   `config.get("patterns", DEFAULT_MODEL_PATTERNS.copy())` — a `[model_capabilities.models]`
+   section in a user's `config.toml` replaces the defaults outright. Vision support is a
+   reasonable thing for a user to override. "Does this provider reject this parameter" is not:
+   the only edit a user can make is one that reintroduces the 400.
+
+So the predicates are module-level pure functions with a hard-coded table, sitting in the
+capability module but outside the user-overridable tree. This is pinned by
+`test_predicates_survive_a_user_configured_capability_table`.
+
+### Family matching
+
+Model ids are parsed to `(tier, major, minor)` by one regex, then matched against the table,
+with `None` meaning "every minor in this major line":
+
+```python
+("fable", 5, None), ("mythos", 5, None), ("opus", 5, None),
+("opus", 4, 8),     ("opus", 4, 7),      ("sonnet", 5, None),
+```
+
+Matching uses `re.search`, so it resolves bare ids, dotted variants (`claude-opus-4.8`),
+dated and suffixed snapshots (`claude-opus-5-20260101`, `claude-opus-4-8-fast`,
+`claude-opus-5[1m]`, `claude-sonnet-5@20260101`) and provider-prefixed forms
+(`anthropic/claude-opus-5`, `us.anthropic.claude-opus-4-8`) alike.
+
+It does **not** over-match: `claude-opus-4-5-20251101` parses as `(opus, 4, 5)`,
+`claude-opus-4-20250514` as `(opus, 4, 20250514)` — neither is in the table. The
+`claude-3-5-sonnet-*` generation, where the tier follows the version rather than preceding
+it, does not parse at all and is therefore never matched.
+
+### The request builder
+
+* Sampling suppression now reads `model_rejects_sampling or thinking_config is not None`.
+  **Decoupling it from the thinking config is the whole of the AC #5 fix**: Opus 4.8/4.7 are
+  in the adaptive set but produce no thinking config without an effort, which used to reopen
+  the branch.
+* `_anthropic_uses_adaptive_thinking()` returns True for any model that rejects a fixed
+  budget, so opus-5 / fable-5 / mythos-5 no longer fall through to the legacy branch.
+  The hand-maintained marker list shrinks to `sonnet-4-6` alone — the one model that merely
+  *prefers* adaptive thinking rather than requiring it. That is the AC #7 outcome: the
+  requirement is a predicate; only the preference stays a name.
+* `_anthropic_is_sonnet_5()` survives, but only for Sonnet 5's thinking *shape*, and its
+  docstring now says so explicitly. It is no longer the answer to either capability question.
+
+---
+
+## 4. Evidence
+
+### Red → green (read counts)
+
+| Stage | Command | Result |
+|---|---|---|
+| Red (predicates present, builder untouched) | `pytest Tests/Chat/test_anthropic_model_capabilities.py -q -p no:randomly` | **12 failed, 56 passed** |
+| Green (after rewire) | same | **68 passed** |
+| Targeted gate | 12 files + `Tests/LLM_Calls/` | **1620 passed, 3 failed** |
+| Import sweep | `pytest Tests/ --collect-only -q` | **50634 tests collected**, 0 errors |
+
+The reds were for the right reason — the two shapes verbatim:
+
+```
+AssertionError: claude-opus-5 with {'thinking_effort': 'high'} sent a legacy thinking config: {'type': 'enabled', 'budget_tokens': 8192}
+assert ['temperature'] == []
+```
+
+The 3 gate failures are `Tests/LLM_Calls/test_summarization_diagnostic_privacy.py`'s
+manifest-boundary tests. **They are not this branch's.** Reproduced on a dedicated detached
+worktree of clean `origin/dev` with nothing applied: **3 failed, 254 passed** — the identical
+three. Filed as TASK-18801.
+
+### Mutation test of the core predicate
+
+| Mutation | Result |
+|---|---|
+| Narrow the family table to `("sonnet", 5, None)` only (reproduces the original bug) | **30 failed, 38 passed** — pins die |
+| Shift the boundary: `("opus", 4, 7)` → `("opus", 4, 6)` (over-match) | **9 failed, 59 passed** — pins die in *both* directions |
+
+The second mutation is the more informative one: it kills the under-match pins
+(`claude-opus-4-7`) **and** the AC #6 over-match pins (`test_legacy_models_still_receive_temperature[claude-opus-4-6]`,
+`test_legacy_model_still_receives_fixed_thinking_budget`). The suite constrains the family
+edge from both sides, not just "more models suppressed = better".
+
+Both mutations were reverted with `Edit`, and the restore proven with an empty
+`git diff HEAD -- tldw_chatbook/model_capabilities.py`, followed by a re-green at 68 passed.
+
+### Live verification
+
+tmux, scratch `TLDW_CONFIG_PATH` + scratch `HOME`/`XDG_*` (the real `~/.config/tldw_cli` and
+`~/.local/share/tldw_cli` were never read or written), real key, `[chat_defaults]` carrying the
+**shipped default sampling values** (`temperature = 0.6`, `top_p = 0.95`, `top_k = 50`) — i.e.
+exactly the configuration that produced the originally filed 400.
+
+| # | Branch | Model | Thinking effort | Result |
+|---|---|---|---|---|
+| 1 | fix | `claude-opus-5` | unset | **PASS** |
+| 2 | fix | `claude-opus-5` | `high` | **PASS** |
+| 3 | fix | `claude-opus-4-8` | unset | **PASS** |
+| 4 | fix | `claude-opus-4-6` | unset | **PASS** |
+| C1 | `origin/dev` | `claude-opus-5` | `high` | **FAIL (expected)** — HTTP 400 |
+| C2 | `origin/dev` | `claude-opus-5` | unset | **FAIL (expected)** — HTTP 400 |
+
+Pane evidence (`scratchpad/live/panes/`):
+
+* **1** — `│   Assistant                    │` / `│   TASK-18414 SCENARIO ONE OK   │`, status bar `Provider: Anthropic   Model: claude-opus-5`
+* **2** — `│   Assistant                    │` / `│   TASK-18414 SCENARIO TWO OK   │`, same status bar, `thinking_effort = "high"`
+* **3** — `│   TASK-18414 OPUS 48 OK        │`, status bar `Model: claude-opus-4-8`
+* **4** — `│   TASK-18414 OPUS 46 OK        │`, status bar `Model: claude-opus-4-6`
+* **C1/C2** — `│   Assistant  Failed │` and `Agent run failed: provider returned HTTP 400 (Provider error from anthropic: bad request. Status: 400. Selected model: claude-opus-5. …)`
+
+C1/C2 matter: they are the **same scratch profile and same config file** driven by clean
+`origin/dev`, and they reproduce the filed error text verbatim. That makes this an A/B on the
+fix rather than an assertion that it works.
+
+Across all four fixed-branch runs the app logs contain **0** occurrences of `Status: 400`.
+
+---
+
+## 5. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 Console turn on `claude-opus-5`, effort unset | met | Live scenario 1 |
+| #2 Console turn on `claude-opus-5`, effort set | met | Live scenario 2 |
+| #3 No sampling params to any rejecting model | met | `test_no_sampling_model_omits_sampling_when_effort_{unset,set}` × 6 families |
+| #4 No `budget_tokens` to any rejecting model | met | `test_no_sampling_model_never_sends_fixed_thinking_budget` (4 setting combos × 6 families) |
+| #5 opus-4-8 / 4-7 omit sampling with no effort | met | `test_opus_4_8_and_4_7_omit_sampling_with_no_effort` + live scenario 3 |
+| #6 Opus 4.6 and earlier unchanged, pinned | met | `test_legacy_models_still_receive_temperature` (8 models), `test_legacy_model_still_receives_fixed_thinking_budget`, live scenario 4; probes H/I/J/K show the API still accepts them |
+| #7 One capability predicate, not duplicated name checks | met | Both gates read from `model_capabilities`; the marker list shrinks to the single genuine preference (`sonnet-4-6`) |
+
+---
+
+## 6. Filed, not fixed
+
+* **TASK-18800** — Console thinking-effort `off` is not honored on Claude Opus 5 or Fable 5.
+  A third, genuinely different capability ("does this model think by default"), and it is
+  *not* uniform across the family: an explicit `thinking={"type":"disabled"}` is accepted on
+  Opus 5 only at effort `high` or below and is **rejected with a 400 on Fable 5**, which
+  requires the parameter to be omitted. Naively widening the existing Sonnet 5 branch would
+  introduce a new 400 — which is why it was left alone here rather than half-fixed.
+* **TASK-18801** — the three pre-existing manifest-boundary reds on `origin/dev`.
+
+---
+
+## 7. Notes for review
+
+* One dev test changed: `test_anthropic_sonnet_5_default_omits_thinking_effort_and_sampling`
+  asserted the retired Sonnet-5-specific warning string, and patched `logger.warning` with a
+  bare single-argument `list.append` — which raised `TypeError` once the warning became lazily
+  formatted with the model name. Updated to the new message and a tolerant capture; its
+  **payload assertions are untouched**, so it still guards the behaviour it was written for.
+* The new lazy `%s` warning is consistent with the existing style in that module and does not
+  trip `Tests/LLM_Calls/test_debug_log_fstring_hygiene.py`, which guards against unevaluated
+  `{}` placeholders rather than against lazy formatting.
+* No schema, UI or docs surface changed, so no `Docs/User_Guide/` page needed updating.

--- a/Tests/Chat/test_anthropic_model_capabilities.py
+++ b/Tests/Chat/test_anthropic_model_capabilities.py
@@ -1,0 +1,294 @@
+"""TASK-18414: per-model Anthropic request capabilities must be capability
+predicates, not hand-maintained name checks in the request builder.
+
+Every expectation below is pinned to a *live-observed* response from
+api.anthropic.com (captured 2026-08-18 with a real key, recorded verbatim in
+`Docs/superpowers/plans/2026-08-18-task-18414-report.md`):
+
+  claude-opus-5   + temperature -> 400 "`temperature` is deprecated for this model."
+  claude-opus-5   + top_p       -> 400 "`top_p` is deprecated for this model."
+  claude-opus-5   + top_k       -> 400 "`top_k` is deprecated for this model."
+  claude-opus-5   + budget      -> 400 '"thinking.type.enabled" is not supported
+                                        for this model. Use "thinking.type.adaptive"
+                                        and "output_config.effort" ...'
+  claude-opus-4-8 + temperature -> 400 (same message)
+  claude-opus-4-7 + temperature -> 400 (same message)
+  claude-fable-5  + temperature -> 400 (same message)
+  claude-sonnet-5 + temperature -> 400 (same message)
+  claude-opus-4-6 + temperature -> 200   <- must stay unchanged (AC #6)
+  claude-opus-4-6 + budget      -> 200   <- must stay unchanged (AC #6)
+  claude-sonnet-4-5 + temperature -> 200 <- must stay unchanged (AC #6)
+  claude-haiku-4-5  + temperature + top_k -> 200 <- must stay unchanged (AC #6)
+
+The harness mirrors `Tests/Chat/test_anthropic_native_tools.py`: patch
+`requests.Session.post`, drive the real dispatcher through `chat_api_call`, and
+inspect the JSON body actually put on the wire.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_fixed_thinking_budget,
+    anthropic_model_rejects_sampling_params,
+)
+
+SAMPLING_KEYS = ("temperature", "top_p", "top_k")
+
+# Families the live API rejects sampling parameters / a fixed thinking budget on.
+NO_SAMPLING_MODELS = [
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+]
+
+# Families that still accept both; behaviour here must not change (AC #6).
+LEGACY_SAMPLING_MODELS = [
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-1",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-opus-20240229",
+]
+
+
+def _anthropic_text_response():
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+def _sent_payload(mock_post, model, **extra):
+    """Drive the real dispatch path and return the JSON body actually posted."""
+    mock_response = Mock()
+    mock_response.json.return_value = _anthropic_text_response()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_post.return_value = mock_response
+
+    chat_api_call(
+        "anthropic",
+        messages_payload=[{"role": "user", "content": "hi"}],
+        api_key="test-key",
+        model=model,
+        streaming=False,
+        temp=0.7,
+        **extra,
+    )
+    return mock_post.call_args[1]["json"]
+
+
+# ---------------------------------------------------------------------------
+# (a) A no-sampling model with the thinking effort UNSET.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", NO_SAMPLING_MODELS)
+@patch("requests.Session.post")
+def test_no_sampling_model_omits_sampling_when_effort_unset(mock_post, model):
+    """AC #3 / #5: the sampling parameters the live API rejects are never sent,
+    including when no thinking effort is configured (the branch that reopened
+    the temperature path for Opus 4.8/4.7)."""
+    sent = _sent_payload(mock_post, model)
+    present = [key for key in SAMPLING_KEYS if key in sent]
+    assert present == [], f"{model} must not send {present}"
+
+
+# ---------------------------------------------------------------------------
+# (b) The same models with a thinking effort SET.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", NO_SAMPLING_MODELS)
+@patch("requests.Session.post")
+def test_no_sampling_model_omits_sampling_when_effort_set(mock_post, model):
+    """AC #3: an effort must not reopen the sampling branch either."""
+    sent = _sent_payload(mock_post, model, thinking_effort="high")
+    present = [key for key in SAMPLING_KEYS if key in sent]
+    assert present == [], f"{model} must not send {present}"
+
+
+@pytest.mark.parametrize("model", NO_SAMPLING_MODELS)
+@patch("requests.Session.post")
+def test_no_sampling_model_never_sends_fixed_thinking_budget(mock_post, model):
+    """AC #4: `thinking.type == "enabled"` with `budget_tokens` is rejected on
+    every one of these families -- with an effort set, with an explicit budget
+    set, and with neither."""
+    for extra in (
+        {"thinking_effort": "high"},
+        {"thinking_budget_tokens": 4096},
+        {"thinking_effort": "medium", "thinking_budget_tokens": 4096},
+        {},
+    ):
+        sent = _sent_payload(mock_post, model, **extra)
+        thinking = sent.get("thinking")
+        if thinking is not None:
+            assert thinking.get("type") != "enabled", (
+                f"{model} with {extra} sent a legacy thinking config: {thinking}"
+            )
+            assert "budget_tokens" not in thinking, (
+                f"{model} with {extra} sent budget_tokens: {thinking}"
+            )
+
+
+@patch("requests.Session.post")
+def test_opus_5_with_effort_sends_adaptive_thinking_and_effort(mock_post):
+    """AC #2 wire shape: live-verified as HTTP 200 (probe M in the report)."""
+    sent = _sent_payload(mock_post, "claude-opus-5", thinking_effort="high")
+    assert sent["thinking"] == {"type": "adaptive"}
+    assert sent["output_config"] == {"effort": "high"}
+
+
+@patch("requests.Session.post")
+def test_opus_5_with_effort_unset_sends_neither_thinking_nor_sampling(mock_post):
+    """AC #1 wire shape: live-verified as HTTP 200 (probe L in the report).
+    Opus 5 runs adaptive thinking by default when `thinking` is omitted."""
+    sent = _sent_payload(mock_post, "claude-opus-5")
+    assert "thinking" not in sent
+    assert not any(key in sent for key in SAMPLING_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# (c) Opus 4.8 / 4.7 specifically, with no effort configured.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", ["claude-opus-4-8", "claude-opus-4-7"])
+@patch("requests.Session.post")
+def test_opus_4_8_and_4_7_omit_sampling_with_no_effort(mock_post, model):
+    """AC #5: these are in the adaptive-thinking set, but with no effort the
+    mapper returns no thinking config -- which used to reopen the sampling
+    branch and put `temperature` on a request the API rejects."""
+    sent = _sent_payload(mock_post, model)
+    assert "thinking" not in sent, "no effort configured -> no thinking config"
+    present = [key for key in SAMPLING_KEYS if key in sent]
+    assert present == [], f"{model} must not send {present}"
+
+
+# ---------------------------------------------------------------------------
+# (d) Legacy models that must still receive temperature (AC #6).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", LEGACY_SAMPLING_MODELS)
+@patch("requests.Session.post")
+def test_legacy_models_still_receive_temperature(mock_post, model):
+    """AC #6 regression pin: Opus 4.6 and earlier, Sonnet 4.6/4.5 and Haiku
+    still accept sampling parameters live, so they must still get them."""
+    sent = _sent_payload(mock_post, model)
+    assert sent.get("temperature") == 0.7, f"{model} lost its temperature"
+
+
+@patch("requests.Session.post")
+def test_legacy_model_still_receives_fixed_thinking_budget(mock_post):
+    """AC #6 regression pin: `budget_tokens` is live-verified 200 on Opus 4.6."""
+    sent = _sent_payload(
+        mock_post, "claude-opus-4-6", thinking_effort="high", thinking_budget_tokens=4096
+    )
+    assert sent["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+    # thinking enabled -> sampling suppressed, as before this change.
+    assert not any(key in sent for key in SAMPLING_KEYS)
+
+
+@patch("requests.Session.post")
+def test_sonnet_4_6_still_uses_adaptive_without_a_capability_flag(mock_post):
+    """Sonnet 4.6 *prefers* adaptive thinking but does not reject a fixed
+    budget -- it stays on the preference marker list, not the capability set."""
+    assert anthropic_model_rejects_fixed_thinking_budget("claude-sonnet-4-6") is False
+    sent = _sent_payload(mock_post, "claude-sonnet-4-6", thinking_effort="high")
+    assert sent["thinking"] == {"type": "adaptive"}
+    assert sent["output_config"] == {"effort": "high"}
+
+
+# ---------------------------------------------------------------------------
+# The predicates themselves: family matching must be robust without
+# over-matching older families.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        # bare ids
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+        # dotted variants
+        "claude-opus-4.8",
+        "claude-opus-4.7",
+        # dated / suffixed variants
+        "claude-opus-5-20260101",
+        "claude-opus-4-8-20260101",
+        "claude-opus-4-8-fast",
+        "claude-opus-5[1m]",
+        # provider-prefixed forms the codebase passes through
+        "anthropic/claude-opus-5",
+        "anthropic.claude-opus-5",
+        "us.anthropic.claude-opus-4-8",
+        "claude-sonnet-5@20260101",
+        # case insensitivity
+        "Claude-Opus-5",
+    ],
+)
+def test_predicates_match_the_whole_family(model):
+    assert anthropic_model_rejects_sampling_params(model) is True, model
+    assert anthropic_model_rejects_fixed_thinking_budget(model) is True, model
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-opus-4-5-20251101",
+        "claude-opus-4-1",
+        "claude-opus-4-0",
+        "claude-opus-4-20250514",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-5-20250929",
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-opus-20240229",
+        "claude-3-haiku-20240307",
+        "anthropic/claude-opus-4-6",
+        "gpt-5.6",
+        "",
+        None,
+    ],
+)
+def test_predicates_do_not_over_match(model):
+    assert anthropic_model_rejects_sampling_params(model) is False, model
+    assert anthropic_model_rejects_fixed_thinking_budget(model) is False, model
+
+
+def test_predicates_survive_a_user_configured_capability_table():
+    """The direct-mapping / pattern tables in `model_capabilities` are wholly
+    replaceable from `config.toml`, and `claude-sonnet-5` already has a direct
+    mapping that would shadow any Anthropic pattern. A provider *request
+    validity* fact must therefore not be reachable from user config -- a user
+    edit could only turn it off and reintroduce the 400."""
+    from tldw_chatbook.model_capabilities import ModelCapabilities
+
+    caps = ModelCapabilities(config={"models": {}, "patterns": {}})
+    assert caps.get_model_capabilities("Anthropic", "claude-opus-5") is not None
+    # Predicates are unaffected by an emptied capability table.
+    assert anthropic_model_rejects_sampling_params("claude-opus-5") is True
+    assert anthropic_model_rejects_fixed_thinking_budget("claude-opus-5") is True

--- a/Tests/Chat/test_chat_functions.py
+++ b/Tests/Chat/test_chat_functions.py
@@ -1332,7 +1332,11 @@ class TestProviderRequestPayloads:
 
         captured = {}
         warnings = []
-        monkeypatch.setattr(LLM_API_Calls.logger, "warning", warnings.append)
+        monkeypatch.setattr(
+            LLM_API_Calls.logger,
+            "warning",
+            lambda message, *args, **kwargs: warnings.append(str(message) % args),
+        )
         monkeypatch.setattr(
             LLM_API_Calls,
             "load_settings",
@@ -1376,9 +1380,11 @@ class TestProviderRequestPayloads:
         assert "temperature" not in payload
         assert "top_p" not in payload
         assert "top_k" not in payload
+        # TASK-18414: the suppression is no longer a Sonnet-5 name check, so the
+        # warning names the model that rejects the parameters instead.
         assert warnings == [
-            "Anthropic: omitting temperature/top_p/top_k because Claude Sonnet 5 "
-            "requires default sampling."
+            "Anthropic: omitting temperature/top_p/top_k because model "
+            "claude-sonnet-5 rejects sampling parameters."
         ]
 
     @pytest.mark.parametrize("effort", ["low", "medium", "high", "xhigh", "max"])

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1110,3 +1110,34 @@ press-resolution with the automated widget test (a mounted-widget `press()`
 drives the same production seam) and use a documented keyboard path (here:
 quit-denies) to end the live round. Record which regions accepted synthetic
 mouse so the next rig starts there.
+
+## The Console's provider-error text replaces the provider's own 400 body — go direct with curl to get it back (TASK-18414, 2026-08-18)
+
+**What happened.** TASK-18414 was filed off a live-observed failure: a scratch-profile
+Console on `claude-opus-5` failed every send, and the preserved pane read
+
+    Agent run failed: provider returned HTTP 400 (Provider error from anthropic: bad
+    request. Status: 400. Selected model: claude-opus-5. The provider rejected this
+    request. Confirm the model is still available, or choose another model from the
+    model picker.)
+
+That message is entirely the app's own text. Anthropic had actually answered
+``` `temperature` is deprecated for this model. ``` — naming the offending parameter —
+and the mapping layer discarded it in favour of advice ("confirm the model is still
+available") that points at the wrong cause: the model was fine, the payload was not.
+So the filed task could say a 400 happened but not *which* of two candidate parameters
+caused it, and it explicitly left that as owed work. Recovering it took one `curl`.
+The second failure shape was more valuable still: for `budget_tokens` the provider
+replies ``` "thinking.type.enabled" is not supported for this model. Use
+"thinking.type.adaptive" and "output_config.effort" to control thinking behavior. ``` —
+i.e. the provider hands you the exact remediation, and the app throws it away.
+
+**What to do.** A provider 400 seen through this app is a *report that* a 400 happened,
+never *why*. Before theorising, re-issue the minimal failing request straight at the
+provider with `curl` and the repo-root key file, and paste the verbatim body into the
+task. Two cheap habits that paid off here: probe **every** shape the builder can emit
+(the two shapes had different causes and different fixes), and probe the **controls**
+that must keep working in the same batch — Opus 4.6, Sonnet 4.5 and Haiku 4.5 returning
+200 for the identical payload is what turned "don't break older models" from an
+intention into evidence. Keep this out of the app's config path entirely: a standalone
+`curl` imports no `tldw_chatbook` module and cannot touch the live config.

--- a/backlog/tasks/task-18414 - Console-cannot-drive-claude-opus-5-the-anthropic-handler-sends-temperature-to-models-that-reject-sampling-params-only-Sonnet-5-is-special-cased.md
+++ b/backlog/tasks/task-18414 - Console-cannot-drive-claude-opus-5-the-anthropic-handler-sends-temperature-to-models-that-reject-sampling-params-only-Sonnet-5-is-special-cased.md
@@ -3,10 +3,11 @@ id: TASK-18414
 title: >-
   Console cannot drive claude-opus-5: the anthropic handler sends temperature to
   models that reject sampling params (only Sonnet 5 is special-cased)
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-18 16:20'
-updated_date: '2026-08-18 18:51'
+updated_date: '2026-08-18 23:54'
 labels:
   - llm
   - console
@@ -45,11 +46,42 @@ Repro: scratch profile, `[chat_defaults] provider="anthropic" model="claude-opus
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A Console turn against claude-opus-5 completes successfully with thinking effort unset
-- [ ] #2 A Console turn against claude-opus-5 completes successfully with a thinking effort configured
-- [ ] #3 No request to a model that rejects sampling parameters includes temperature, top_p or top_k (covering the Fable 5, Mythos 5, Opus 5, Opus 4.8, Opus 4.7 and Sonnet 5 families)
-- [ ] #4 No request to a model that rejects a fixed thinking budget includes budget_tokens
-- [ ] #5 claude-opus-4-8 and claude-opus-4-7 omit sampling parameters even when no thinking effort is configured
-- [ ] #6 Models that still accept sampling parameters and budget_tokens (e.g. Opus 4.6 and earlier) are unchanged, pinned by a regression test
-- [ ] #7 The model-family decision is expressed once as a capability predicate rather than duplicated name checks in the request builder
+- [x] #1 A Console turn against claude-opus-5 completes successfully with thinking effort unset
+- [x] #2 A Console turn against claude-opus-5 completes successfully with a thinking effort configured
+- [x] #3 No request to a model that rejects sampling parameters includes temperature, top_p or top_k (covering the Fable 5, Mythos 5, Opus 5, Opus 4.8, Opus 4.7 and Sonnet 5 families)
+- [x] #4 No request to a model that rejects a fixed thinking budget includes budget_tokens
+- [x] #5 claude-opus-4-8 and claude-opus-4-7 omit sampling parameters even when no thinking effort is configured
+- [x] #6 Models that still accept sampling parameters and budget_tokens (e.g. Opus 4.6 and earlier) are unchanged, pinned by a regression test
+- [x] #7 The model-family decision is expressed once as a capability predicate rather than duplicated name checks in the request builder
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Capture the real 400 bodies from api.anthropic.com for every shape the builder can emit (temperature/top_p/top_k, budget_tokens) plus controls that must still succeed (Opus 4.6, Sonnet 4.5, Haiku 4.5).
+2. Write payload pins RED first: no-sampling model with effort unset / set, opus-4-8+4-7 with no effort, and a legacy model that must still receive temperature.
+3. Add two capability predicates to tldw_chatbook/model_capabilities.py (rejects sampling params / rejects a fixed thinking budget) over one Anthropic family table with a boundary-safe matcher covering bare, dotted, dated, suffixed and provider-prefixed ids.
+4. Rewire LLM_API_Calls.py: sampling suppression keys off the predicate (not thinking_config is None + a sonnet-5 name check); the adaptive-thinking branch fires for every model that rejects a fixed budget.
+5. Mutation-test the core predicate, run the targeted suites, then live-verify a real Console turn on claude-opus-5 with effort unset and with an effort set.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both model-gated questions in the Anthropic request builder are now capability predicates in `tldw_chatbook/model_capabilities.py` -- `anthropic_model_rejects_sampling_params` and `anthropic_model_rejects_fixed_thinking_budget` -- over one family table matched by (tier, major, minor).
+
+**Step 1 first: the 400 bodies were captured before any fix** (the task's open question). Direct curl against api.anthropic.com with the real key. Both shapes the code can emit for claude-opus-5 are rejected, and the provider names the parameter:
+- temperature/top_p/top_k -> 400 ```X` is deprecated for this model.`
+- thinking={type: enabled, budget_tokens: N} -> 400 `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`
+Same rejection confirmed on opus-4-8, opus-4-7, fable-5, sonnet-5. Controls confirmed still 200: opus-4-6 (temperature AND budget_tokens), sonnet-4-5, haiku-4-5. claude-mythos-5 returns 404 on this key (Project Glasswing only), so it is the one row documented rather than live-observed.
+
+**Approach.** The predicates deliberately sit outside the config-driven capability tables in that module, for two concrete reasons: (1) `get_model_capabilities` returns on a direct mapping before consulting patterns, and `claude-sonnet-5` already has one -- a pattern-based implementation would have missed exactly the one model that already worked; (2) those tables are wholly replaceable from config.toml, and the only edit a user can make to a request-validity fact is one that reintroduces the 400. Pinned by `test_predicates_survive_a_user_configured_capability_table`.
+
+**Trade-off.** `_anthropic_is_sonnet_5` was kept, narrowed to Sonnet 5's thinking *shape* only, rather than generalised. Widening its 'effort = off' branch to the whole family would introduce a NEW 400 on Fable 5, which rejects an explicit thinking={type: disabled} outright. That third capability is filed as TASK-18800, not half-fixed here.
+
+**Key fix detail.** AC #5 came from decoupling sampling suppression from `thinking_config is None`: Opus 4.8/4.7 are in the adaptive set but produce no thinking config when no effort is set, which reopened the temperature branch. The hand-maintained marker list shrank to `sonnet-4-6` alone -- the one model that merely prefers adaptive thinking rather than requiring it.
+
+**Evidence.** Red-first 12 failed/56 passed -> green 68 passed. Targeted gate 1620 passed, 3 failed (the 3 are test_summarization_diagnostic_privacy manifest-boundary tests, reproduced identically on a clean origin/dev worktree at 3 failed/254 passed -- filed as TASK-18801). Collect-only sweep 50634 tests, 0 errors. Mutation-tested the predicate twice: narrowing the table to sonnet-5 killed 30 pins, shifting the 4-7 boundary to 4-6 killed 9 in both directions (including the AC #6 over-match pins). Live: scratch tmux profile with the shipped default sampling values, real key -- claude-opus-5 completes a Console turn with effort unset and with effort=high, opus-4-8 and opus-4-6 also complete, and the same scratch config driven by clean origin/dev reproduces the filed HTTP 400 verbatim in both directions.
+
+**Files.** tldw_chatbook/model_capabilities.py (predicates), tldw_chatbook/LLM_Calls/LLM_API_Calls.py (both gates rewired), Tests/Chat/test_anthropic_model_capabilities.py (new, 68 pins), Tests/Chat/test_chat_functions.py (one dev test asserted the retired warning string and patched logger.warning with a single-arg list.append; message updated, payload assertions untouched), Docs/superpowers/plans/2026-08-18-task-18414-report.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18414 - Console-cannot-drive-claude-opus-5-the-anthropic-handler-sends-temperature-to-models-that-reject-sampling-params-only-Sonnet-5-is-special-cased.md
+++ b/backlog/tasks/task-18414 - Console-cannot-drive-claude-opus-5-the-anthropic-handler-sends-temperature-to-models-that-reject-sampling-params-only-Sonnet-5-is-special-cased.md
@@ -3,11 +3,11 @@ id: TASK-18414
 title: >-
   Console cannot drive claude-opus-5: the anthropic handler sends temperature to
   models that reject sampling params (only Sonnet 5 is special-cased)
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-18 16:20'
-updated_date: '2026-08-18 23:54'
+updated_date: '2026-08-18 23:59'
 labels:
   - llm
   - console

--- a/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
+++ b/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
@@ -1,0 +1,28 @@
+---
+id: TASK-18800
+title: Console thinking-effort 'off' is not honored on Claude Opus 5 or Fable 5
+status: To Do
+assignee: []
+created_date: '2026-08-18 23:52'
+labels:
+  - llm
+  - console
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Setting the Console thinking effort to 'off' does not turn thinking off for Claude Opus 5, Fable 5 or Mythos 5. On those models thinking is ON by default when the 'thinking' parameter is omitted, and the Anthropic request builder only emits an explicit thinking={"type": "disabled"} config for the Claude Sonnet 5 family (_anthropic_is_sonnet_5 in LLM_Calls/LLM_API_Calls.py). For every other model the 'off' branch returns no thinking config at all, which on Sonnet 4.5 and earlier genuinely means no thinking but on Opus 5 / Fable 5 silently leaves adaptive thinking running and billed.
+
+Found while fixing TASK-18414 and deliberately left out of scope there: that task's acceptance criteria cover only the two request-validity gates (sampling parameters and a fixed thinking budget), and its fix makes the 'off' path send a valid request either way. This is a third, separate capability -- 'does this model think by default, so that turning it off requires an explicit disabled config' -- and it is not uniform across the family: an explicit thinking={"type": "disabled"} is accepted on Opus 5 only at effort 'high' or lower and is rejected outright with a 400 on Fable 5 and Mythos 5, which require the parameter to be omitted instead. Naively widening the existing Sonnet 5 branch would therefore introduce a new 400 on Fable 5.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting thinking effort 'off' on Claude Opus 5 produces a request that actually disables thinking
+- [ ] #2 Selecting thinking effort 'off' on Claude Fable 5 or Mythos 5 does not produce an HTTP 400
+- [ ] #3 The by-default-thinking decision is a capability predicate alongside the two added in TASK-18414, not a new name check in the request builder
+- [ ] #4 Models where omitting the thinking parameter already means no thinking (Opus 4.8 and earlier, Sonnet 4.6 and earlier, Haiku) are unchanged, pinned by a regression test
+<!-- AC:END -->

--- a/backlog/tasks/task-18801 - Three-manifest-boundary-tests-in-test_summarization_diagnostic_privacy-are-red-on-origin-dev.md
+++ b/backlog/tasks/task-18801 - Three-manifest-boundary-tests-in-test_summarization_diagnostic_privacy-are-red-on-origin-dev.md
@@ -1,0 +1,39 @@
+---
+id: TASK-18801
+title: >-
+  Three manifest-boundary tests in test_summarization_diagnostic_privacy are red
+  on origin/dev
+status: To Do
+assignee: []
+created_date: '2026-08-18 23:52'
+labels:
+  - tests
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tests/LLM_Calls/test_summarization_diagnostic_privacy.py has three failing tests on a clean origin/dev checkout at 7d87686a3, unrelated to any feature branch:
+
+  test_manifest_boundary_changes_only_summarization_owner_diagnostics
+  test_manifest_boundary_rejects_owned_digest_schema_changes
+  test_manifest_boundary_rejects_unreconciled_owned_digest
+
+The first asserts that a normalized projection of the checked-in diagnostic inventory hashes to the SHA recorded in the review fixture, and it does not:
+
+  AssertionError: checked inventory changed outside the two summarization owners
+  assert 'b0187e7972ac...85edefc4ed7ee' == '8b0633e98e95...05bfd61aac9de'
+
+The other two fail as a consequence -- both call the first test as their control before applying their mutant.
+
+Reproduced on a dedicated detached worktree of origin/dev with nothing else applied: 3 failed, 254 passed. The same three, and only those three, appear when running the file from a feature branch, so branches touching tldw_chatbook/LLM_Calls/ currently inherit a red gate they did not cause. Either the checked-in inventory JSON or the fixture SHA needs regenerating and reconciling.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The three manifest-boundary tests pass on a clean origin/dev checkout
+- [ ] #2 Whichever of the checked-in inventory or the recorded fixture SHA is stale is identified and the fix explains which drifted and why
+- [ ] #3 Tests/LLM_Calls/test_summarization_diagnostic_privacy.py runs green as a whole
+<!-- AC:END -->

--- a/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
+++ b/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
@@ -1,0 +1,38 @@
+---
+id: TASK-18802
+title: >-
+  Summarization path sends sampling params that modern Anthropic and OpenAI
+  models reject
+status: To Do
+assignee: []
+created_date: '2026-08-18 23:55'
+labels:
+  - llm
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Summarization_General_Lib.py builds its own provider payloads and applies no per-model capability gate at all, so it reproduces exactly the defect TASK-18414 fixed on the chat path -- on a different, still-live code path.
+
+summarize_with_anthropic (around lines 1048-1061) unconditionally sends temperature, top_k and top_p alongside get_cli_setting('anthropic_api', 'model', ...). PROBE-VERIFIED: the exact payload that function builds, sent to api.anthropic.com with a real key, returns
+
+  HTTP 400 {"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},"request_id":"req_011CeB7m2VQbn2JXsd3LcQQy"}
+
+on claude-opus-5. The same holds for Fable 5, Mythos 5, Opus 4.8, Opus 4.7 and Sonnet 5 -- and the shipped [api_settings.anthropic] model default is now claude-sonnet-5, one of them. summarize_with_openai (around lines 870-880) has the same shape, unconditionally sending max_tokens and temperature with openai_api.model (CODE-READ, not probe-verified: expected to 400 on gpt-5 / o-series / gpt-5.6).
+
+This is reachable: analyze() in this module is imported by Web_Scraping/WebSearch_APIs.py, Web_Scraping/Article_Extractor_Lib.py, Local_Ingestion/{Book,Document,Image}_Processing_Lib.py and Local_Ingestion/XML_Ingestion.py, so ingestion and web-search summarization fail against the default configured model.
+
+Found by a deliberate sweep for the same pattern while fixing TASK-18414, which added anthropic_model_rejects_sampling_params to model_capabilities.py; this path simply never consults it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Summarizing with a modern Anthropic model (Opus 5, Fable 5, Opus 4.8, Opus 4.7, Sonnet 5) completes instead of returning HTTP 400
+- [ ] #2 Summarizing with an OpenAI reasoning model completes, with the correct token-cap parameter name
+- [ ] #3 The summarization path reuses the model_capabilities predicates rather than adding its own model-name checks
+- [ ] #4 Models that still accept these parameters are unchanged, pinned by a regression test
+<!-- AC:END -->

--- a/backlog/tasks/task-18803 - OpenAI-Moonshot-and-Z.ai-request-builders-gate-parameters-on-hand-maintained-model-name-checks.md
+++ b/backlog/tasks/task-18803 - OpenAI-Moonshot-and-Z.ai-request-builders-gate-parameters-on-hand-maintained-model-name-checks.md
@@ -1,0 +1,39 @@
+---
+id: TASK-18803
+title: >-
+  OpenAI, Moonshot and Z.ai request builders gate parameters on hand-maintained
+  model-name checks
+status: To Do
+assignee: []
+created_date: '2026-08-18 23:56'
+labels:
+  - llm
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-18414 replaced two hand-maintained Anthropic model-name lists with capability predicates in model_capabilities.py, after they went stale and made every send to claude-opus-5 an HTTP 400. A sweep of LLM_Calls/ found the same pattern still live for three other providers. All findings below are CODE-READ, not probe-verified -- each needs a reproduction before being fixed.
+
+1. LLM_API_Calls.py:245/248 -- _OPENAI_REASONING_MODEL_FAMILIES / _is_openai_reasoning_model, a hand-maintained tuple ('o1','o3','o4','gpt-5'), consumed at :681 to omit temperature and top_p. Structurally identical to the Anthropic list that was just removed; a miss is a 400. Its own docstring cites the same historical incident (task-404).
+
+2. LLM_API_Calls.py:218 -- _is_openai_gpt_5_6_model, matching exactly gpt-5.6 and gpt-5.6-*, deciding which key carries the token cap (max_output_tokens / max_completion_tokens / max_tokens) at :660, :695, :738. The sweep reports a live hole rather than only a future one: _openai_use_responses_api (:233) returns True only when a reasoning effort/summary/verbosity is set, so gpt-5, gpt-5.1, o3 and o4-mini with no reasoning effort configured are said to fall through to payload['max_tokens'] at :698, which OpenAI rejects in favour of max_completion_tokens. Reproduce this first -- it is the highest-value claim in the sweep and the repo has an openai-api-key.txt.
+
+3. moonshot.py:527 -- an inline startswith('moonshot-v1-') allowlist that only ADDS temperature/top_p/n/presence_penalty/frequency_penalty for that prefix, so on kimi-k3 or any future Kimi id the user's sampling settings are silently dropped rather than rejected. Lower urgency (silent, not a 400) but the same staleness mechanism.
+
+4. moonshot.py:516 and zai.py:292 -- reasoning_effort pinned to the single literals kimi-k3 and glm-5.2 respectively, each raising a client-side ChatBadRequestError for any other model. Worse than the Anthropic case in one respect: an exact-id pin rather than a family, so a kimi-k3-turbo or glm-5.3 release is rejected before a request is ever made.
+
+Adjacent, no name check at all: zai.py:269 puts thinking={'type':'enabled',...} into every payload unconditionally.
+
+model_capabilities.py now has the right shape to extend -- a prefix/suffix-tolerant family parser plus per-question predicates -- but nothing equivalent exists for OpenAI, Moonshot or Z.ai.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each claim above is reproduced (or disproved) against the real provider API and the finding recorded before any code changes
+- [ ] #2 Per-model request capabilities for these providers are expressed as predicates in model_capabilities.py rather than name checks in the request builders
+- [ ] #3 A new model release in a covered family does not require editing a marker list to avoid a 400
+- [ ] #4 Models currently working are unchanged, pinned by regression tests
+<!-- AC:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -59,6 +59,10 @@ from tldw_chatbook.LLM_Calls.moonshot import (
     chat_with_moonshot as _strict_chat_with_moonshot,
 )
 from tldw_chatbook.LLM_Calls.zai import chat_with_zai as _strict_chat_with_zai
+from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_fixed_thinking_budget,
+    anthropic_model_rejects_sampling_params,
+)
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.sensitive_llm_logging import (
     is_sensitive_llm_request,
@@ -195,11 +199,12 @@ _ANTHROPIC_THINKING_BUDGETS_BY_EFFORT = {
     "xhigh": 16384,
     "max": 32768,
 }
+# Models that merely *prefer* adaptive thinking. Models that outright REJECT a
+# fixed thinking budget are not listed here -- that is a provider request
+# capability and comes from
+# `model_capabilities.anthropic_model_rejects_fixed_thinking_budget`, so a new
+# release in those families never needs a marker added by hand (TASK-18414).
 _ANTHROPIC_ADAPTIVE_THINKING_MODEL_MARKERS = (
-    "opus-4-8",
-    "opus-4.8",
-    "opus-4-7",
-    "opus-4.7",
     "sonnet-4-6",
     "sonnet-4.6",
 )
@@ -365,6 +370,14 @@ def _responses_stream_to_chat_sse(response, *, model: str):
 
 
 def _anthropic_uses_adaptive_thinking(model: object) -> bool:
+    """Return whether ``model`` must be driven with adaptive thinking.
+
+    True either because the provider rejects a fixed thinking budget outright
+    (the capability predicate) or because the model merely prefers adaptive
+    thinking (the marker list).
+    """
+    if anthropic_model_rejects_fixed_thinking_budget(model):
+        return True
     model_name = str(model or "").lower()
     return any(
         marker in model_name for marker in _ANTHROPIC_ADAPTIVE_THINKING_MODEL_MARKERS
@@ -372,7 +385,14 @@ def _anthropic_uses_adaptive_thinking(model: object) -> bool:
 
 
 def _anthropic_is_sonnet_5(model: object) -> bool:
-    """Return whether model is the documented unprefixed Claude Sonnet 5 family."""
+    """Return whether model is the documented unprefixed Claude Sonnet 5 family.
+
+    This selects Sonnet 5's *thinking shape* (an explicit ``disabled`` config to
+    turn thinking off; bare ``output_config.effort`` with no ``thinking`` key
+    otherwise). It is deliberately not the answer to "does this model reject
+    sampling parameters / a fixed thinking budget" -- those are capability
+    predicates in ``model_capabilities`` (TASK-18414).
+    """
     model_name = str(model or "").lower()
     return model_name == "claude-sonnet-5" or model_name.startswith("claude-sonnet-5-")
 
@@ -1416,7 +1436,14 @@ def chat_with_anthropic(
             ]
         else:
             data["system"] = system_prompt  # unchanged for non-caching models
-    if thinking_config is None and not _anthropic_is_sonnet_5(current_model):
+    # Sampling parameters are suppressed for two independent reasons: the model
+    # rejects them outright (a provider capability -- 400 on Fable 5, Mythos 5,
+    # Opus 5, Opus 4.8, Opus 4.7 and Sonnet 5), or thinking is enabled for this
+    # request. The capability check must not be conditioned on the thinking
+    # config: Opus 4.8/4.7 produce no thinking config when no effort is
+    # configured, which used to reopen this branch (TASK-18414 AC #5).
+    model_rejects_sampling = anthropic_model_rejects_sampling_params(current_model)
+    if not model_rejects_sampling and thinking_config is None:
         if temp is not None:
             data["temperature"] = current_temp
             if current_top_p is not None:
@@ -1430,10 +1457,11 @@ def chat_with_anthropic(
         if current_top_k is not None:
             data["top_k"] = current_top_k
     elif any(value is not None for value in (temp, current_top_p, current_top_k)):
-        if _anthropic_is_sonnet_5(current_model):
+        if model_rejects_sampling:
             logger.warning(
-                "Anthropic: omitting temperature/top_p/top_k because Claude Sonnet 5 "
-                "requires default sampling."
+                "Anthropic: omitting temperature/top_p/top_k because model %s "
+                "rejects sampling parameters.",
+                current_model,
             )
         else:
             logger.warning(

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -127,6 +127,132 @@ DEFAULT_MODEL_CAPABILITIES = {
 #
 #######################################################################################################################
 #
+# Anthropic per-model request capabilities
+#
+# These answer two questions about what the *provider API* accepts, not what the
+# user prefers:
+#
+#   1. Does this model reject the sampling parameters (temperature/top_p/top_k)?
+#   2. Does this model reject a fixed thinking budget (thinking.budget_tokens)?
+#
+# Both were previously encoded as ad-hoc name checks inside the Anthropic request
+# builder, which knew only about Claude Sonnet 5 -- so every newer model release
+# silently broke the provider with an HTTP 400 (TASK-18414).
+#
+# Deliberately NOT part of the config-driven tables above. Those are wholly
+# replaceable from `config.toml` (`config.get("models", ...)` /
+# `config.get("patterns", ...)`), and a direct mapping shadows every pattern --
+# `claude-sonnet-5` already has one. A user edit to a request-*validity* fact
+# could therefore only reintroduce the 400 it exists to prevent.
+#
+# Families are matched by (tier, major, minor) so that bare ids, dotted variants,
+# dated/suffixed snapshots and provider-prefixed forms all resolve, without
+# over-matching the older families that still accept both parameters.
+_ANTHROPIC_FAMILY_RE = re.compile(
+    r"claude[-_.]?(?P<tier>opus|sonnet|haiku|fable|mythos)[-_.]?(?P<major>\d+)"
+    r"(?:[-_.](?P<minor>\d+))?",
+    re.IGNORECASE,
+)
+
+# A ``None`` minor means "every minor version in this major line".
+# Verified live against api.anthropic.com on 2026-08-18: each family below
+# returns 400 for `temperature`/`top_p`/`top_k` and for
+# `thinking={"type": "enabled", "budget_tokens": N}`, while Opus 4.6, Sonnet 4.5
+# and Haiku 4.5 return 200 for the same payloads.
+_ANTHROPIC_MODERN_REQUEST_FAMILIES = frozenset(
+    {
+        ("fable", 5, None),
+        ("mythos", 5, None),
+        ("opus", 5, None),
+        ("opus", 4, 8),
+        ("opus", 4, 7),
+        ("sonnet", 5, None),
+    }
+)
+
+
+def _anthropic_model_family(model: object) -> Optional[Tuple[str, int, Optional[int]]]:
+    """Parse an Anthropic model id into ``(tier, major, minor)``.
+
+    Args:
+        model: A model identifier in any form the codebase passes through --
+            bare (``claude-opus-5``), dotted (``claude-opus-4.8``), dated
+            (``claude-opus-4-5-20251101``), suffixed (``claude-opus-4-8-fast``)
+            or provider-prefixed (``anthropic/claude-opus-5``,
+            ``us.anthropic.claude-opus-4-8``).
+
+    Returns:
+        The parsed family tuple, or ``None`` when the id is not a recognisable
+        modern Anthropic model name (including the ``claude-3-5-sonnet-*``
+        generation, whose tier follows the version rather than preceding it).
+    """
+    if not isinstance(model, str):
+        return None
+    match = _ANTHROPIC_FAMILY_RE.search(model.strip())
+    if match is None:
+        return None
+    minor = match.group("minor")
+    return (
+        match.group("tier").lower(),
+        int(match.group("major")),
+        int(minor) if minor is not None else None,
+    )
+
+
+def _anthropic_is_modern_request_family(model: object) -> bool:
+    """Return whether ``model`` is in the modern Anthropic request family."""
+    family = _anthropic_model_family(model)
+    if family is None:
+        return False
+    tier, major, minor = family
+    return (tier, major, None) in _ANTHROPIC_MODERN_REQUEST_FAMILIES or (
+        tier,
+        major,
+        minor,
+    ) in _ANTHROPIC_MODERN_REQUEST_FAMILIES
+
+
+def anthropic_model_rejects_sampling_params(model: object) -> bool:
+    """Return whether ``model`` rejects ``temperature``/``top_p``/``top_k``.
+
+    Args:
+        model: An Anthropic model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when sending any sampling parameter would be answered with
+        ``400 invalid_request_error: `temperature` is deprecated for this
+        model.`` -- the Fable 5, Mythos 5, Opus 5, Opus 4.8, Opus 4.7 and
+        Sonnet 5 families. False for Opus 4.6 and earlier, Sonnet 4.6/4.5 and
+        Haiku, which still accept them.
+    """
+    return _anthropic_is_modern_request_family(model)
+
+
+def anthropic_model_rejects_fixed_thinking_budget(model: object) -> bool:
+    """Return whether ``model`` rejects ``thinking.budget_tokens``.
+
+    Args:
+        model: An Anthropic model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when ``thinking={"type": "enabled", "budget_tokens": N}`` would be
+        answered with ``400 invalid_request_error: "thinking.type.enabled" is
+        not supported for this model``; such a model must use adaptive thinking
+        plus ``output_config.effort`` instead.
+
+    Note:
+        This currently covers exactly the same families as
+        :func:`anthropic_model_rejects_sampling_params` -- Anthropic removed both
+        parameters in the same generation -- but they are separate questions
+        about the request surface and are kept as separate predicates so a future
+        model can answer them differently.
+    """
+    return _anthropic_is_modern_request_family(model)
+
+
+#
+#######################################################################################################################
+#
 # ModelCapabilities Class
 #
 class ModelCapabilities:


### PR DESCRIPTION
Closes TASK-18414.

Console could not complete a single turn against `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-7` or `claude-fable-5` — every send was an HTTP 400 — because two per-model **provider API capabilities** were encoded as hand-maintained model-name checks in the Anthropic request builder that knew only about Claude Sonnet 5.

## The 400 bodies (captured first, before any fix)

The filed task had a live-observed 400 but never captured the body, so *which* parameter the provider named was unestablished. Established with the real key, straight at `api.anthropic.com`:

| Probe | Result |
|---|---|
| `claude-opus-5` + `temperature` | 400 ``` `temperature` is deprecated for this model. ``` |
| `claude-opus-5` + `thinking={"type":"enabled","budget_tokens":N}` | 400 ``` "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior. ``` |
| `claude-opus-5` + `top_p` / `top_k` | 400 (same "deprecated" wording) |
| `opus-4-8`, `opus-4-7`, `fable-5`, `sonnet-5` + `temperature` | 400 |
| **`opus-4-6` + `temperature`, and + `budget_tokens`** | **200** |
| **`sonnet-4-5`, `haiku-4-5` + `temperature`** | **200** |
| `claude-opus-5` with the post-fix shapes (no sampling; adaptive+effort) | **200** |

`claude-mythos-5` returns 404 on this key (Project Glasswing only) — the one row documented rather than live-observed. Full verbatim bodies with request ids: `Docs/superpowers/plans/2026-08-18-task-18414-report.md`.

## The fix

Two predicates in `tldw_chatbook/model_capabilities.py` over one family table:

```python
anthropic_model_rejects_sampling_params(model)
anthropic_model_rejects_fixed_thinking_budget(model)
```

* Sampling suppression now reads `model_rejects_sampling or thinking_config is not None`. **Decoupling it from the thinking config is the whole of the AC #5 fix** — Opus 4.8/4.7 are in the adaptive set but produce no thinking config without an effort, which reopened the temperature branch.
* `_anthropic_uses_adaptive_thinking()` returns True for anything that rejects a fixed budget, so opus-5 / fable-5 / mythos-5 stop falling through to the legacy `budget_tokens` branch. The hand-maintained marker list shrinks to `sonnet-4-6` — the one model that merely *prefers* adaptive thinking rather than requiring it.
* `_anthropic_is_sonnet_5` survives, narrowed (and documented) as Sonnet 5's thinking *shape* only. It is no longer the answer to either capability question.

**Why the predicates sit outside the config-driven tables in that same module** — two concrete reasons, not style:
1. `get_model_capabilities()` returns on a direct mapping before consulting patterns, and `DEFAULT_MODEL_CAPABILITIES` already contains `claude-sonnet-5`. A pattern-based implementation would have missed **exactly the one model that already worked**.
2. Those tables are wholly replaceable from `config.toml`. Vision support is a reasonable user override; "does this provider reject this parameter" is not — the only edit a user can make is one that reintroduces the 400. Pinned by `test_predicates_survive_a_user_configured_capability_table`.

Family matching is `(tier, major, minor)` via one regex, so bare, dotted, dated, suffixed and provider-prefixed ids all resolve (`claude-opus-4.8`, `claude-opus-5-20260101`, `claude-opus-4-8-fast`, `anthropic/claude-opus-5`, `us.anthropic.claude-opus-4-8`) without over-matching `claude-opus-4-5-20251101` or the `claude-3-5-sonnet-*` generation.

## Evidence

* **Red → green:** 12 failed / 56 passed → **68 passed**. The reds were the two shapes verbatim (`{'type': 'enabled', 'budget_tokens': 8192}` and a bare `temperature` key).
* **Targeted gate:** **1620 passed, 3 failed**. The 3 are `test_summarization_diagnostic_privacy` manifest-boundary tests, reproduced identically on a clean detached `origin/dev` worktree (**3 failed, 254 passed**) — filed as TASK-18801, not caused here.
* **Collect-only sweep:** 50634 tests, 0 import errors.
* **Mutation-tested twice.** Narrowing the table to sonnet-5 (reproducing the original bug) killed 30 pins; shifting the `("opus", 4, 7)` boundary to `4, 6` killed 9 **in both directions** — the under-match pins *and* the AC #6 over-match pins. Reverted with `Edit`, restore proven by an empty `git diff HEAD`, re-green at 68.
* **Live A/B**, tmux + scratch `TLDW_CONFIG_PATH`/`HOME`/`XDG_*` (real `~/.config/tldw_cli` never touched), real key, **shipped default sampling values** — the exact configuration that produced the filed 400:

| Branch | Model | Effort | Result |
|---|---|---|---|
| fix | `claude-opus-5` | unset | **PASS** |
| fix | `claude-opus-5` | `high` | **PASS** |
| fix | `claude-opus-4-8` | unset | **PASS** |
| fix | `claude-opus-4-6` | unset | **PASS** |
| `origin/dev` | `claude-opus-5` | `high` | **HTTP 400** (expected) |
| `origin/dev` | `claude-opus-5` | unset | **HTTP 400** (expected) |

The two dev rows use the **same scratch profile and config file** and reproduce the filed error text verbatim, so this is an A/B on the fix rather than an assertion that it works. 0 occurrences of `Status: 400` across all four fixed-branch runs.

## All 7 ACs met

#1/#2 live scenarios · #3/#4 payload pins across 6 families · #5 `test_opus_4_8_and_4_7_omit_sampling_with_no_effort` + live · #6 8-model regression pin + live + probes H/I/J/K · #7 both gates read one predicate pair.

## Filed, not fixed

* **TASK-18800** — thinking-effort `off` is not honored on Opus 5 / Fable 5. A third, distinct capability, and *not* uniform: explicit `{"type":"disabled"}` is accepted on Opus 5 only at effort ≤ `high` and **400s on Fable 5**, so widening the Sonnet 5 branch would introduce a new 400. Left alone rather than half-fixed.
* **TASK-18801** — the 3 pre-existing `origin/dev` reds.
* **TASK-18802** — `Summarization_General_Lib` has no capability gate at all and still ships this exact defect on the ingestion/web-search path. **Probe-verified**: the payload `summarize_with_anthropic` builds returns 400 on `claude-opus-5`, and the shipped `[api_settings.anthropic]` default is `claude-sonnet-5` — also in the rejecting set.
* **TASK-18803** — the same pattern still live for OpenAI, Moonshot and Z.ai (code-read; gated on reproduction).

Also adds a `lessons-live-verification.md` entry: the Console's provider-error text **replaces** the provider's own 400 body, which is why this task was filed without knowing the cause — the discarded message named the parameter, and for the `budget_tokens` shape it named the remediation.

## Reviewer notes

One dev test changed: `test_anthropic_sonnet_5_default_omits_thinking_effort_and_sampling` asserted the retired Sonnet-5-specific warning string and patched `logger.warning` with a single-argument `list.append`, which raised `TypeError` once the warning became lazily formatted with the model name. Message updated, **payload assertions untouched**. The lazy `%s` form matches the existing style in that module and does not trip `test_debug_log_fstring_hygiene.py` (which guards unevaluated `{}` placeholders, not lazy formatting).

No schema, UI or docs surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic 400s by replacing Sonnet-5-only model checks with capability predicates. Previously we sent `temperature`/`top_p`/`top_k` and `thinking.budget_tokens` to models that reject them; now we suppress sampling and use adaptive thinking where required, while legacy models keep their old behavior.

- Introduces `anthropic_model_rejects_sampling_params` and `anthropic_model_rejects_fixed_thinking_budget` in `tldw_chatbook/model_capabilities.py`, matched via a robust family parser.
- Rewires `tldw_chatbook/LLM_Calls/LLM_API_Calls.py` to suppress sampling independent of thinking config and to prefer adaptive thinking when a fixed budget is rejected.
- Narrows `_anthropic_is_sonnet_5` to Sonnet 5’s thinking shape only; the hand-maintained marker list now only covers the Sonnet 4.6 preference.
- Adds `Tests/Chat/test_anthropic_model_capabilities.py`; adjusts one warning message capture in `Tests/Chat/test_chat_functions.py`.

**Review notes**

- Meets Linear TASK-18414 acceptance criteria; legacy models (e.g., Opus 4.6, Sonnet/Haiku 4.5) remain unchanged.
- No schema, UI, or config migrations.
- Follow-ups filed for thinking-off behavior and other providers; summarization path will adopt the same predicates separately.

<sup>Written for commit 5b826a0c8a1926f6fc79c64dd408666c052d7109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

