### PR TITLE
feat(research): durable, resumable research runs (lease, budget restore, evidence)

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -236,24 +236,93 @@ PR #863 bot wave: Qodo 5 findings — #4 (:8405 BLANK compose crash) + #5 (:1099
 MERGED: PR #863 → dev, merge 7d8820bf1, 2026-07-25 (user approved screens + merge: "aapproved"). Qodo wave: 4 fixed (2 RED-first sentinel bugs) + 1 declined w/ precedent, all threads answered. Post-merge dup-check: 541/565-567 clean; pre-existing pileup grew (505-532, ~28 exact-basename collisions) → task-544 scope note. Memory updated. ===== 541 SDD RUN COMPLETE =====
 FOLLOW-UP STREAM COMPLETE 2026-07-25: 495 → PR #874 (imported-profile query keys, fingerprint-invariant, 541 RAG green); 482 → PR #876 (validate_chroma_persist_directory shared by 2 client sites + 2 producers, fault-injection verified); 544 → PR #877 (28 dup groups resolved, movers → 585-619, zero dups; #846 body prose stale re TASK-507→594); 565/566/567 → PR #882 (5 commits incl. 2 review catches: provider blank-select test + stray RAG-check toast). ALL FOUR PRs OPEN, HELD FOR USER APPROVAL. Reviews: every task Approved; RED evidence independently reproduced by reviewers on all 4 cycles.
 
-===== 2026-08-18 SDD RUN: phase-5 keyboard selection (task-18156) =====
-Plan: Docs/superpowers/plans/2026-08-18-console-keyboard-selection.md
-Branch: feat/console-keyboard-selection off origin/dev (spec d0cf92a0f, plan 9617f6c62)
-INCIDENT task 1: haiku implementer split work across checkouts despite cwd guard — module+task committed HERE (47dfe2937, a15054f09) but tests committed to MAIN checkout's feat/model-catalog-consent-gate (stray 4511614b2, removed via mixed reset + untracked-file delete; main restored to 34831c776). Tests salvaged and re-applied here by controller. GREEN evidence was real but ran in the wrong tree.
-Task 1: complete (commits 47dfe2937+3b97a1e43+3439c9a72, review clean after task-file fix; Minor noted: offset_for_cell doesn't reuse _clamp — deliberate restraint)
-Task 2: complete (commits 39cdbbdf3+3acb7696e, review clean after 1 Important fix: nav-key fall-through desync — consumed as no-ops; plan Task-3 rule corrected 67dbfb658; Minor noted: dead ConsoleToolDiffRow eligibility arm)
-Task 3: complete (commit 3ad8f8957, review clean; Minor for final review: h's candidate lacks len(text) upper clamp — one-liner, non-crashing, all other motions self-heal)
-INCIDENT task 4: NEVER git stash push/pop bare in this repo — the stash stack is SHARED across worktrees and holds other sessions' entries; a defensive pop applied a foreign 'WIP on dev' stash into this worktree (16 files, conflict in css bundle). Restored surgically; foreign entry left in list. Use patch files for baseline comparison instead.
-Task 4: complete (commit 11f920acc, review clean; Minors for final review: _RecordingPromptQueue hardcodes idle presentation ignoring kwargs; enter-outside-mode test proves only menu absence)
-Task 6: complete (commit a4286a199, controller-inline, gates green)
-Task 6: review clean (Minors for final review: stale _GeometryOwnerApp docstring '5 rows'; ANSI-disabled-border CSS list lacks create-note id (unreachable today); import order; no pilot test drives keyboard->CreateNote — covered live instead)
-FINAL REVIEW: READY FOR PR; 1 Important + 4 record fixes applied (b05c89a2b); follow-ups filed task-18315
-===== 18156 SDD RUN COMPLETE: PR #1813 MERGED to dev 908a3fbb3 (2026-08-18); Qodo round: 2 bugs fixed RED-first + 2 hardening + 2 docstrings, 4 stale re-anchors answered with line evidence; follow-ups task-18315 (3 open ACs)
+---
 
-===== 2026-08-18 SDD RUN 2: note-management riders =====
-Plan: Docs/superpowers/plans/2026-08-18-console-note-management.md
-Branch: feat/console-note-management off origin/dev 908a3fbb3 (plan 1aa7908e3)
-RUN2 Task 1: complete (commits 228637c2b+31c0eb9c6+d63167607, review clean after task-id fix; Minor: worktree venv lacks ruff module — used sibling binary)
-RUN2 Task 2: complete (commit 3706dcbc4, review clean, no findings; escape-hatch equality assertion FORCES Task 3 to move the modal into a TASK*_MODAL_CONTRACTS tuple)
-RUN2 Task 3: complete (screen wiring + unmocked round trips; modal moved into TASK2_MODAL_CONTRACTS not TASK3 -- its cancel dismisses False, which only Task2's blanket assertion accepts; guard field extended honestly for its real 2-stage mid-edit-escape behavior rather than defaulted to "none"; 1 pre-existing baseline failure confirmed unaffected via HEAD-content swap-back, not stash)
-RUN2 Task 3 review fix: complete -- Important (no inflight latch, could stack two modals w/ independent DB closures on rapid double-trigger; ported _console_selection_feedback_inflight precedent verbatim, RED-verified via HEAD-content swap-back) + Minor (_on_edit row indexing consistency) fixed; 146 passed, same 1 pre-existing baseline failure
+# TASK-18060 durable research jobs (core) — ledger
+Plan: Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md
+Spec: Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
+Branch: feat/durable-research-jobs off docs/synthesis-budget-spec
+Worktree: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/research-shipped-decomp
+Pre-flight: plan's Task 2 tests used time.sleep() to age a lease; replaced with
+zero-second leases (deterministic) before dispatch.
+Task 1: complete (commits a845d99..eb600e0, review clean after 1 fix round)
+  - Critical found+fixed: _now()/_timestamp_after() format divergence (Z vs +00:00,
+    dropped fractional field) made a live lease compare as expired -> double-claim.
+    Fixed via shared _format_timestamp(timespec="microseconds"); regression test
+    verified to fail if reverted.
+  - Minor (for final review triage): task-1-report narrative overstates its test
+    command's scope (pytest dedupes file+parent-dir to the file); mixed
+    LocalResearchService._format_timestamp vs self._format_timestamp call style.
+Task 2: complete (commits 362b7af..53d9f45, review clean after 1 fix round)
+  - Plan defect found by implementer: brief's claim_run incremented lease_attempts
+    only when reclaiming, so the brief's OWN budget test could never pass.
+  - Critical found by reviewer: the implementer's fix (count every claim) let
+    healthy claim->release cycles burn the crash budget and strand a run that
+    never crashed -- and Task 3's engine releases on EVERY invocation, so a
+    paused/resumed run would strand at max_attempts=3. Fixed by resetting
+    lease_attempts on clean release; budget now means consecutive abandonments.
+    Reviewer reverted the fix line and confirmed the new test fails without it.
+Task 3: implemented inline (subagent hit an API session limit after the red
+  tests). Commit below; awaiting review.
+  - Keep-alive mutation-checked: disabling it fails the long-silent-phase test,
+    which passed trivially pre-implementation (no lease means none to lose).
+  - _LeaseLost returns the run rather than fail_run: the taking-over executor
+    owns the terminal state.
+  commit 194077034
+Task 4: complete inline (commit 17c49cc4d). Mutation-checked; first version of
+  the engine test passed either way and was replaced with a pre-seeded-ledger
+  test that fails under from_limits.
+Task 5: complete inline (commit below). Persistence + cap only.
+  GAP: reading the pool back to skip a completed round is NOT implemented, so
+  TASK-18060 AC #3 remains open. Plan's Task 5 steps stop at persistence.
+  commit 0b563724c
+Tasks 3-5: reviewed together (first outside eye; they were authored inline during
+  a subagent capacity limit). Two Criticals found, both real:
+  - keep-alive starved: production search_fn is a blocking `def`, so the asyncio
+    renewal task never ran during collection and the lease could lapse. Fixed by
+    offloading sync pipeline seams via asyncio.to_thread; test verified RED->GREEN.
+  - 6 persisting writes unfenced including complete_run (a displaced executor
+    could mark a run completed). All fenced.
+  Plus: from_snapshot preferred stale limits (same bug class as Qodo PR 1766);
+  cap measured with a different serializer than the one that persists.
+  Re-review approved; threading workaround verified NOT to hide a production
+  hazard (production is file-backed, per-call connections; real pipeline
+  callables never touch the service; to_thread copies contextvars).
+  Commits: 194077034, 17c49cc4d, 0b563724c, 2fcfc3522
+OPEN: AC #3 (read the evidence pool back to skip a completed round) unimplemented.
+Final whole-branch review + 2 fix rounds: complete. Commits 2fcfc35, ecb65f4, 281f96c.
+  - Critical (regression I introduced): exhausted retry budget left a run
+    permanently unclaimable instead of failed. Fixed: LeaseBudgetExhausted ->
+    fail_run with a truthful message.
+  - Critical (introduced by THAT fix): the budget check fired on a LIVE lease,
+    so a newcomer failed a run a healthy executor was running. Fixed: a claim
+    counts as a reclaim only when the stored lease has expired, using one `now`
+    for both the guard and the UPDATE.
+  - 3x "test passed for the wrong reason" this run: my engine ledger test called
+    the function under test; the theft test stole a live lease and had its
+    AssertionError swallowed by a broad except; the repair fixed the steal but
+    not the masking. Final form asserts from top-level code on an independent
+    DB read.
+FOLLOW-UPS (named, not fixed): AC #3 read-back unimplemented; fence coverage is
+  2 of 11 individually; the except-ResearchLimitExceeded half untested; evidence
+  written before the doc-budget trim; engine-instance lease state unsafe if a
+  scheduler reuses one engine; ~120s decline window after SIGKILL.
+External review (Qodo, PR #1822) after 5 internal rounds found 6 MORE real bugs:
+  terminal runs resurrectable (claim checked lease expiry, not run status);
+  run-state writes (progress/phase/checkpoint/pause/cancel) unfenced; an expired
+  lease could renew itself; the fence is check-then-act (fixed by making
+  complete_run/fail_run lease-conditional in SQL, so a displaced executor's last
+  word is a no-op); external-db mode raised on every claim; the evidence cap was
+  checked but not enforced. Fixed in eaac7c8da (212 tests).
+  Finding 5 (unversioned ALTER) adjudicated and DECLINED: this service has no
+  migration framework at all, so adding one is a subsystem, not a fix.
+INCIDENTS during that fix round, both disclosed by the fixer:
+  - a mutation script's `git checkout -- <file>` reverted the whole uncommitted
+    source; recovered by re-applying edits. Independently re-verified after:
+    212 + 208 tests pass, ruff clean, all six fixes present in committed code.
+  - a stale stash conflict on THIS ledger was resolved with `git checkout --ours`,
+    which discarded the run's ledger appends. Recovered from stash@{0}.
+STATE: PR #1822 open, NOT merged, holding at the user's instruction.
+FOLLOW-UP found, not fixed: get_run's external-db branch raises TypeError instead
+  of returning None when db.get_run returns None; _claim_run_external now depends
+  on it.

--- a/Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md
+++ b/Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md
@@ -1,0 +1,829 @@
+# Durable Research Jobs — Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a research run survivable — exactly one executor at a time, a budget that is not re-granted on resume, and phases that do not redo paid work.
+
+**Architecture:** A lease (owner + fencing token + expiry) lives on the `research_runs` row. `LocalResearchService` gains atomic claim/renew/release operations; stale-lease reclaim happens inside claim, on a retry budget. `LocalResearchEngine` claims before executing, runs a keep-alive timer for as long as a phase is in flight, checks the fence before persisting writes, restores its ledger from the last snapshot, and resumes from the last completed phase using a persisted evidence pool.
+
+**Tech Stack:** Python 3.11+, SQLite (`sqlite3`, WAL), pytest, asyncio.
+
+## Global Constraints
+
+- SQLite only, through `LocalResearchService._connect()`; parameterized queries only.
+- New columns must be added idempotently — the schema uses `CREATE TABLE IF NOT EXISTS`, so an existing database never re-runs the DDL. Guard every `ALTER TABLE` with a `PRAGMA table_info` check.
+- Tests use a real in-memory SQLite service (`LocalResearchService(":memory:")`), never a mock DB.
+- No test contacts a network.
+- Run tests with `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest` from the worktree root.
+- Scope: this plan is the durability core only. Scheduler auto-resume and completion surfacing are separate plans.
+
+---
+
+### Task 1: Lease columns and atomic claim
+
+**Files:**
+- Modify: `tldw_chatbook/Research_Interop/local_research_service.py` (schema block at ~185, new methods after `_update_run_state` at ~585)
+- Test: `Tests/Research/test_research_run_lease.py` (create)
+
+**Interfaces:**
+- Consumes: `LocalResearchService._connect()`, `LocalResearchService._require_one(table, id, label)`, `LocalResearchService._now()`
+- Produces:
+  - `LocalResearchService.claim_run(run_id: str, *, worker_id: str, lease_seconds: float) -> str | None` — returns a new `lease_id` on success, `None` when another live lease holds the run
+  - `research_runs` columns: `lease_owner TEXT`, `lease_id TEXT`, `leased_until TEXT`, `lease_attempts INTEGER NOT NULL DEFAULT 0`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Tests/Research/test_research_run_lease.py
+"""Run leases (task-18060): exactly one executor may hold a run."""
+
+from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+
+def _service() -> LocalResearchService:
+    return LocalResearchService(":memory:")
+
+
+def test_first_claim_succeeds_and_returns_a_lease_id():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    lease_id = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert isinstance(lease_id, str) and lease_id
+
+
+def test_second_claim_is_refused_while_the_lease_is_live():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60) is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_run_lease.py -q`
+Expected: FAIL with `AttributeError: 'LocalResearchService' object has no attribute 'claim_run'`
+
+- [ ] **Step 3: Add the columns idempotently**
+
+In `local_research_service.py`, immediately after the block that executes the `CREATE TABLE`/`CREATE INDEX` DDL, add:
+
+```python
+    #: Columns added after the original schema shipped. CREATE TABLE IF NOT
+    #: EXISTS never revisits an existing database, so each one is applied by
+    #: an idempotent ALTER guarded on PRAGMA table_info (task-18060).
+    _RUN_COLUMN_ADDITIONS = (
+        ("lease_owner", "TEXT"),
+        ("lease_id", "TEXT"),
+        ("leased_until", "TEXT"),
+        ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
+    )
+
+    def _ensure_run_lease_columns(self, conn: sqlite3.Connection) -> None:
+        """Add lease columns to research_runs when they are absent.
+
+        Args:
+            conn: An open connection inside the caller's transaction.
+        """
+        existing = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(research_runs)").fetchall()
+        }
+        for column, declaration in self._RUN_COLUMN_ADDITIONS:
+            if column not in existing:
+                conn.execute(
+                    f"ALTER TABLE research_runs ADD COLUMN {column} {declaration}"
+                )
+```
+
+Call it from the same place the DDL runs, immediately after the `executescript`/`execute` of the schema, passing the same `conn`.
+
+- [ ] **Step 4: Implement the claim**
+
+Add after `_update_run_state`:
+
+```python
+    def claim_run(
+        self, run_id: str, *, worker_id: str, lease_seconds: float
+    ) -> str | None:
+        """Take the execution lease on a run, or decline it.
+
+        The claim is atomic: the UPDATE only matches when no live lease
+        exists, so two racing executors cannot both succeed (task-18060).
+
+        Args:
+            run_id: The run to claim.
+            worker_id: Identifies the claiming executor.
+            lease_seconds: How long the lease is valid without renewal.
+
+        Returns:
+            A new lease id when the claim succeeded, otherwise None.
+        """
+        self._require_one("research_runs", run_id, "research run")
+        lease_id = uuid.uuid4().hex
+        now = self._now()
+        expires = self._timestamp_after(lease_seconds)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET lease_owner = ?, lease_id = ?, leased_until = ?,
+                       updated_at = ?
+                 WHERE id = ?
+                   AND (leased_until IS NULL OR leased_until <= ?)
+                """,
+                (worker_id, lease_id, expires, now, run_id, now),
+            )
+            if cursor.rowcount != 1:
+                return None
+        return lease_id
+```
+
+Add the timestamp helper beside `_now`:
+
+```python
+    def _timestamp_after(self, seconds: float) -> str:
+        """An ISO timestamp ``seconds`` in the future, in the same format as
+        ``_now`` so string comparison orders correctly."""
+        return (
+            datetime.now(timezone.utc) + timedelta(seconds=max(0.0, float(seconds)))
+        ).isoformat()
+```
+
+Ensure `import uuid` and `from datetime import datetime, timedelta, timezone` are present at the top of the module.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_run_lease.py -q`
+Expected: PASS, 2 passed
+
+- [ ] **Step 6: Run the existing research suite for regressions**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research -q`
+Expected: PASS, no new failures
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Research_Interop/local_research_service.py Tests/Research/test_research_run_lease.py
+git commit -m "feat(research): lease a run to exactly one executor (TASK-18060)"
+```
+
+---
+
+### Task 2: Renewal, release, fencing, and stale reclaim on a retry budget
+
+**Files:**
+- Modify: `tldw_chatbook/Research_Interop/local_research_service.py`
+- Test: `Tests/Research/test_research_run_lease.py`
+
+**Interfaces:**
+- Consumes: `claim_run` from Task 1; the `lease_owner`/`lease_id`/`leased_until`/`lease_attempts` columns
+- Produces:
+  - `renew_lease(run_id: str, *, lease_id: str, lease_seconds: float) -> bool`
+  - `release_lease(run_id: str, *, lease_id: str) -> bool`
+  - `holds_lease(run_id: str, *, lease_id: str) -> bool`
+  - `claim_run` gains `max_attempts: int = 3`; a reclaim increments `lease_attempts` and refuses past the budget
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to Tests/Research/test_research_run_lease.py
+import time
+
+
+def test_a_stale_lease_can_be_taken_over():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0.01)
+    time.sleep(0.05)
+
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+
+
+def test_a_displaced_worker_cannot_renew_or_release():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0.01)
+    time.sleep(0.05)
+    service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+
+    assert service.renew_lease(run["id"], lease_id=stale, lease_seconds=60) is False
+    assert service.release_lease(run["id"], lease_id=stale) is False
+    assert service.holds_lease(run["id"], lease_id=stale) is False
+
+
+def test_reclaim_stops_at_the_retry_budget():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    for _ in range(3):
+        assert service.claim_run(
+            run["id"], worker_id="w", lease_seconds=0.01, max_attempts=3
+        )
+        time.sleep(0.05)
+
+    assert service.claim_run(
+        run["id"], worker_id="w", lease_seconds=0.01, max_attempts=3
+    ) is None
+
+
+def test_release_frees_the_run_for_the_next_executor():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    lease = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert service.release_lease(run["id"], lease_id=lease) is True
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_run_lease.py -q`
+Expected: FAIL — `renew_lease` undefined, and `claim_run` takes no `max_attempts`
+
+- [ ] **Step 3: Implement renewal, release, fence check, and the attempt budget**
+
+Replace `claim_run`'s signature and body with:
+
+```python
+    def claim_run(
+        self,
+        run_id: str,
+        *,
+        worker_id: str,
+        lease_seconds: float,
+        max_attempts: int = 3,
+    ) -> str | None:
+        """Take the execution lease on a run, or decline it.
+
+        The claim is atomic: the UPDATE matches only when no live lease
+        exists, so two racing executors cannot both succeed. Taking over an
+        EXPIRED lease counts against ``max_attempts`` -- a run whose executor
+        keeps dying is broken rather than slow, and must stop being retried
+        (task-18060, following the server job manager's retry budget).
+
+        Args:
+            run_id: The run to claim.
+            worker_id: Identifies the claiming executor.
+            lease_seconds: How long the lease is valid without renewal.
+            max_attempts: How many times a run may be reclaimed after an
+                expired lease before claims are refused.
+
+        Returns:
+            A new lease id when the claim succeeded, otherwise None.
+        """
+        row = self._require_one("research_runs", run_id, "research run")
+        previous = row["leased_until"] if "leased_until" in row.keys() else None
+        attempts = int(row["lease_attempts"] or 0) if "lease_attempts" in row.keys() else 0
+        reclaiming = previous is not None
+        if reclaiming and attempts >= int(max_attempts):
+            return None
+        lease_id = uuid.uuid4().hex
+        now = self._now()
+        expires = self._timestamp_after(lease_seconds)
+        next_attempts = attempts + 1 if reclaiming else attempts
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET lease_owner = ?, lease_id = ?, leased_until = ?,
+                       lease_attempts = ?, updated_at = ?
+                 WHERE id = ?
+                   AND (leased_until IS NULL OR leased_until <= ?)
+                """,
+                (worker_id, lease_id, expires, next_attempts, now, run_id, now),
+            )
+            if cursor.rowcount != 1:
+                return None
+        return lease_id
+
+    def renew_lease(
+        self, run_id: str, *, lease_id: str, lease_seconds: float
+    ) -> bool:
+        """Extend a lease the caller still holds.
+
+        The lease id is a fencing token: a worker that stalled past its lease
+        and was taken over still matches on worker id, so matching on the id
+        alone would let it act on a run it no longer owns (task-18060).
+
+        Args:
+            run_id: The leased run.
+            lease_id: The token returned by ``claim_run``.
+            lease_seconds: How much longer the lease should be valid.
+
+        Returns:
+            True when the lease was extended, False when it was lost.
+        """
+        expires = self._timestamp_after(lease_seconds)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET leased_until = ?, updated_at = ?
+                 WHERE id = ? AND lease_id = ?
+                """,
+                (expires, self._now(), run_id, lease_id),
+            )
+            return cursor.rowcount == 1
+
+    def release_lease(self, run_id: str, *, lease_id: str) -> bool:
+        """Drop a lease the caller holds so another executor may claim it.
+
+        Args:
+            run_id: The leased run.
+            lease_id: The token returned by ``claim_run``.
+
+        Returns:
+            True when the lease was released, False when it was already lost.
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET lease_owner = NULL, lease_id = NULL, leased_until = NULL,
+                       updated_at = ?
+                 WHERE id = ? AND lease_id = ?
+                """,
+                (self._now(), run_id, lease_id),
+            )
+            return cursor.rowcount == 1
+
+    def holds_lease(self, run_id: str, *, lease_id: str) -> bool:
+        """Whether ``lease_id`` is still the live lease on the run.
+
+        Args:
+            run_id: The run to check.
+            lease_id: The token returned by ``claim_run``.
+
+        Returns:
+            True when the token matches an unexpired lease.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT lease_id, leased_until FROM research_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None or row["lease_id"] != lease_id:
+            return False
+        return str(row["leased_until"] or "") > self._now()
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_run_lease.py -q`
+Expected: PASS, 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Research_Interop/local_research_service.py Tests/Research/test_research_run_lease.py
+git commit -m "feat(research): lease renewal, fencing and a reclaim budget (TASK-18060)"
+```
+
+---
+
+### Task 3: The engine claims, keeps alive, and fences its writes
+
+**Files:**
+- Modify: `tldw_chatbook/Research_Interop/local_research_engine.py` (`execute_run` at ~398, `_save_ledger`, `service.save_artifact` call sites)
+- Test: `Tests/Research/test_local_research_engine.py`
+
+**Interfaces:**
+- Consumes: `claim_run`, `renew_lease`, `release_lease`, `holds_lease` from Tasks 1-2
+- Produces:
+  - `LocalResearchEngine.worker_id: str` (per-instance identity)
+  - `LocalResearchEngine._lease_id: str | None` set for the duration of `execute_run`
+  - `LocalResearchEngine._require_lease() -> None`, raising `_LeaseLost` when the fence fails
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to Tests/Research/test_local_research_engine.py
+
+
+def test_a_second_engine_declines_a_leased_run():
+    """task-18060: two executors must not run one run. The window's
+    exclusive-worker guard is per-session and cannot see a second process."""
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    first = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    second = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    service.claim_run(run["id"], worker_id=first.worker_id, lease_seconds=60)
+    final = asyncio.run(second.execute_run(run["id"]))
+
+    assert final["status"] != "completed"
+    assert "lease" in str(final.get("progress_message") or "").lower()
+
+
+def test_a_long_silent_phase_keeps_its_lease():
+    """The synthesis phase emits no progress for its whole duration, so a
+    lease renewed only by progress events would expire inside it."""
+    service = _make_service()
+    search_fn, _analyze, _calls = _make_pipeline("q")
+
+    async def slow_analyze(wsr, sqd, params, cancel_event=None):
+        await asyncio.sleep(0.3)
+        return {
+            "final_answer": {"text": "Answer citing [1].", "evidence": [],
+                             "confidence": 0.5, "chunks": []},
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=slow_analyze
+    )
+    engine.lease_seconds = 0.1
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed", final.get("progress_message")
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_local_research_engine.py -q -k "declines_a_leased_run or long_silent_phase"`
+Expected: FAIL — `LocalResearchEngine` has no attribute `worker_id`
+
+- [ ] **Step 3: Implement claim, keep-alive and fence**
+
+In `local_research_engine.py`, add near `_RunPaused`:
+
+```python
+class _LeaseLost(Exception):
+    """Internal control-flow signal: this executor no longer owns the run."""
+```
+
+In `LocalResearchEngine.__init__`, after `self.service = local_service`:
+
+```python
+        #: Identity of this executor for leasing (task-18060).
+        self.worker_id = f"engine-{uuid.uuid4().hex[:12]}"
+        #: How long a lease is granted for, and how often it is renewed. The
+        #: keep-alive is a TIMER, not a progress hook: the synthesis phase
+        #: emits nothing for its whole duration, so a lease renewed only by
+        #: progress would expire inside the most expensive phase.
+        self.lease_seconds = 120.0
+        self.keepalive_seconds = 30.0
+        self._lease_id: str | None = None
+```
+
+Add `import uuid` to the module imports.
+
+Add the fence and keep-alive helpers beside `_get_run`:
+
+```python
+    def _require_lease(self) -> None:
+        """Raise when this executor no longer owns the run.
+
+        Checked before every persisting write, not only at completion: a
+        displaced executor blocked in a long provider call still returns, and
+        would otherwise write artifacts and settle budget on its way out
+        (task-18060).
+        """
+        if self._lease_id is None:
+            return
+        if not self.service.holds_lease(self._run_id or "", lease_id=self._lease_id):
+            raise _LeaseLost("execution lease lost")
+
+    async def _keepalive(self, run_id: str) -> None:
+        """Renew the lease on a timer for as long as a phase is in flight."""
+        while True:
+            await asyncio.sleep(max(0.01, float(self.keepalive_seconds)))
+            if self._lease_id is None:
+                return
+            if not self.service.renew_lease(
+                run_id, lease_id=self._lease_id, lease_seconds=self.lease_seconds
+            ):
+                return
+```
+
+Add `import asyncio` if absent, and set `self._run_id: str | None = None` in `__init__`.
+
+In `execute_run`, immediately after `run = self._get_run(run_id)` and the terminal-status check, add:
+
+```python
+        self._run_id = run_id
+        self._lease_id = self.service.claim_run(
+            run_id, worker_id=self.worker_id, lease_seconds=self.lease_seconds
+        )
+        if self._lease_id is None:
+            logger.info(f"Research run {run_id} is leased by another executor")
+            return self.service.update_run_progress(
+                run_id,
+                progress_message="another executor holds this run's lease",
+                event="lease_declined",
+            )
+        keepalive = asyncio.create_task(self._keepalive(run_id))
+```
+
+Wrap the existing `try:` body so the keep-alive and lease are always cleaned up, and translate a lost lease into a terminal state:
+
+```python
+        except _LeaseLost:
+            logger.warning(f"Research run {run_id} lease lost mid-flight")
+            return self._get_run(run_id)
+        finally:
+            keepalive.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await keepalive
+            if self._lease_id is not None:
+                self.service.release_lease(run_id, lease_id=self._lease_id)
+                self._lease_id = None
+            self._run_id = None
+```
+
+Add `import contextlib` if absent. Call `self._require_lease()` as the first statement of `_save_ledger`, and immediately before each `self.service.save_artifact(...)` call inside `_execute_phases`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_local_research_engine.py -q`
+Expected: PASS, all engine tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Research_Interop/local_research_engine.py Tests/Research/test_local_research_engine.py
+git commit -m "feat(research): claim, keep alive, and fence engine writes (TASK-18060)"
+```
+
+---
+
+### Task 4: Resume restores the spent budget
+
+**Files:**
+- Modify: `tldw_chatbook/Research_Interop/research_budget.py` (add `from_snapshot`), `tldw_chatbook/Research_Interop/local_research_engine.py` (`execute_run` ledger construction)
+- Test: `Tests/Research/test_research_budget.py`, `Tests/Research/test_local_research_engine.py`
+
+**Interfaces:**
+- Consumes: `BudgetLedger.snapshot()` (existing), `LocalResearchService.get_artifact(run_id, name)` (existing)
+- Produces: `BudgetLedger.from_snapshot(snapshot: Mapping[str, Any] | None, limits: Mapping[str, Any] | None) -> BudgetLedger`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to Tests/Research/test_research_budget.py
+
+
+def test_from_snapshot_restores_spend_rather_than_regranting_it():
+    """task-18060: execute_run rebuilt the ledger from limits on every entry
+    and never read budget_ledger.json back, so a resumed run was granted its
+    full budget again. With resume routine rather than exceptional, that is a
+    budget leak."""
+    from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
+
+    original = BudgetLedger.from_limits({"max_searches": 10})
+    original.reserve_searches(4)
+    original.settle_searches(4)
+    snapshot = original.snapshot()
+
+    restored = BudgetLedger.from_snapshot(snapshot, {"max_searches": 10})
+
+    assert restored.remaining_searches() == 6
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_budget.py -q -k from_snapshot`
+Expected: FAIL with `AttributeError: type object 'BudgetLedger' has no attribute 'from_snapshot'`
+
+- [ ] **Step 3: Implement `from_snapshot`**
+
+In `research_budget.py`, beside `from_limits`:
+
+```python
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: Mapping[str, Any] | None,
+        limits: Mapping[str, Any] | None,
+    ) -> "BudgetLedger":
+        """Rebuild a ledger that has already spent part of its budget.
+
+        Args:
+            snapshot: A prior ``snapshot()`` payload, or None for a fresh run.
+            limits: The run's limits, used when the snapshot has none.
+
+        Returns:
+            A ledger whose used counters continue from the snapshot.
+        """
+        ledger = cls(dict((snapshot or {}).get("limits") or limits or {}))
+        if not snapshot:
+            return ledger
+        ledger.searches_used = int(snapshot.get("searches_used") or 0)
+        ledger.searches_overshoot = int(snapshot.get("searches_overshoot") or 0)
+        ledger.docs_used = int(snapshot.get("docs_used") or 0)
+        ledger.tokens_settled = int(snapshot.get("tokens_settled") or 0)
+        return ledger
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_research_budget.py -q -k from_snapshot`
+Expected: PASS
+
+- [ ] **Step 5: Use it in the engine**
+
+In `execute_run`, replace `ledger = BudgetLedger.from_limits(limits)` with:
+
+```python
+        # task-18060: a resumed run continues its budget rather than being
+        # granted it again. The snapshot is the ledger written by the previous
+        # executor; its absence means this run has never executed.
+        previous_ledger = (
+            self.service.get_artifact(run_id, "budget_ledger.json") or {}
+        ).get("content")
+        ledger = BudgetLedger.from_snapshot(previous_ledger, limits)
+```
+
+- [ ] **Step 6: Write the engine-level test**
+
+```python
+# append to Tests/Research/test_local_research_engine.py
+
+
+def test_a_resumed_run_does_not_get_its_budget_back():
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_searches": 10}
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+
+    snapshot = (service.get_artifact(run["id"], "budget_ledger.json") or {}).get(
+        "content"
+    ) or {}
+
+    assert int(snapshot.get("searches_used") or 0) > 0
+    restored = BudgetLedger.from_snapshot(snapshot, {"max_searches": 10})
+    assert restored.remaining_searches() < 10
+```
+
+Add `from tldw_chatbook.Research_Interop.research_budget import BudgetLedger` to that test module's imports if absent.
+
+- [ ] **Step 7: Run the suites**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research -q`
+Expected: PASS, no new failures
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Research_Interop/research_budget.py tldw_chatbook/Research_Interop/local_research_engine.py Tests/Research/test_research_budget.py Tests/Research/test_local_research_engine.py
+git commit -m "feat(research): resume restores spent budget instead of re-granting it (TASK-18060)"
+```
+
+---
+
+### Task 5: Persist the round's evidence and resume from it
+
+**Files:**
+- Modify: `tldw_chatbook/Research_Interop/local_research_engine.py` (`_execute_phases` collection loop)
+- Test: `Tests/Research/test_local_research_engine.py`
+
+**Interfaces:**
+- Consumes: `self.service.save_artifact`, `self.service.get_artifact`, `self._require_lease()` from Task 3
+- Produces: artifact `evidence_pool.json` — `{"iteration": int, "results": list[dict], "truncated": bool, "cap_bytes": int}`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to Tests/Research/test_local_research_engine.py
+
+
+def test_a_resumed_run_reuses_persisted_evidence_instead_of_researching():
+    """task-18060: collection_summary.json persists counts and sub-questions
+    but not the evidence, so a resumed run re-searched everything it had
+    already paid for."""
+    service = _make_service()
+    search_fn, analyze_fn, calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+    searches_first_pass = calls["search"]
+
+    pool = (service.get_artifact(run["id"], "evidence_pool.json") or {}).get("content")
+
+    assert pool and pool["results"], "the round's evidence must be persisted"
+    assert searches_first_pass == 1
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_local_research_engine.py -q -k reuses_persisted_evidence`
+Expected: FAIL — `pool` is None, because no such artifact is written
+
+- [ ] **Step 3: Persist the pool under a stated cap**
+
+In `_execute_phases`, immediately after `merged_warnings.extend(round_warnings)` in the collection loop, add:
+
+```python
+            # task-18060: the pool itself is persisted so a resumed run does
+            # not re-search what it already paid for. Bounded explicitly --
+            # 66 sources of scraped text is roughly 0.7-3 MB per round, so
+            # beyond the cap the entries persist without their content and the
+            # artifact records that it happened.
+            self._require_lease()
+            self.service.save_artifact(
+                run_id,
+                artifact_name="evidence_pool.json",
+                content_type="application/json",
+                content=self._bounded_evidence(merged_results, iteration),
+            )
+```
+
+Add the helper beside `_save_ledger`:
+
+```python
+    #: Bytes of evidence persisted per run before content is dropped.
+    EVIDENCE_POOL_CAP_BYTES = 8 * 1024 * 1024
+
+    def _bounded_evidence(
+        self, results: list[dict[str, Any]], iteration: int
+    ) -> dict[str, Any]:
+        """Shape the round's evidence for persistence, under a byte cap.
+
+        Args:
+            results: The round's merged evidence records.
+            iteration: The round these belong to.
+
+        Returns:
+            A payload carrying the evidence, and whether content was dropped.
+        """
+        kept: list[dict[str, Any]] = []
+        used = 0
+        truncated = False
+        for record in results:
+            entry = dict(record)
+            size = len(json.dumps(entry, default=str))
+            if used + size > self.EVIDENCE_POOL_CAP_BYTES:
+                entry.pop("content", None)
+                entry.pop("original_content", None)
+                truncated = True
+                size = len(json.dumps(entry, default=str))
+            used += size
+            kept.append(entry)
+        return {
+            "iteration": iteration,
+            "results": kept,
+            "truncated": truncated,
+            "cap_bytes": self.EVIDENCE_POOL_CAP_BYTES,
+        }
+```
+
+`json` is already imported in this module.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research/test_local_research_engine.py -q -k reuses_persisted_evidence`
+Expected: PASS
+
+- [ ] **Step 5: Write the truncation test**
+
+```python
+# append to Tests/Research/test_local_research_engine.py
+
+
+def test_evidence_beyond_the_cap_persists_without_content():
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    engine.EVIDENCE_POOL_CAP_BYTES = 200
+    bulky = [
+        {"url": f"https://e.example/{n}", "content": "x" * 500,
+         "original_content": "y" * 500}
+        for n in range(4)
+    ]
+
+    payload = engine._bounded_evidence(bulky, iteration=1)
+
+    assert payload["truncated"] is True
+    assert any("content" not in entry for entry in payload["results"])
+    assert payload["cap_bytes"] == 200
+```
+
+- [ ] **Step 6: Run the full research suite**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Research -q`
+Expected: PASS, no new failures
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Research_Interop/local_research_engine.py Tests/Research/test_local_research_engine.py
+git commit -m "feat(research): persist the round's evidence under a stated cap (TASK-18060)"
+```
+
+---
+
+## Follow-on plans (not this document)
+
+- **Scheduler integration:** a `research_run` task type whose handler claims and executes, skips `awaiting_*` runs, and is deleted when the run reaches a terminal state. Depends on Tasks 1-3.
+- **Surfacing:** a handoff target for window-launched runs with an idempotent delivery marker, and `artifact_source`/`artifact_kind` metadata so reports reach the artifacts screen, with the matching `Docs/User_Guide/` update.

--- a/Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md
+++ b/Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md
@@ -191,14 +191,16 @@ git commit -m "feat(research): lease a run to exactly one executor (TASK-18060)"
 
 ```python
 # append to Tests/Research/test_research_run_lease.py
-import time
+# NOTE: a lease of 0 seconds expires the instant it is granted, so these tests
+# exercise takeover deterministically. Do NOT use time.sleep() to age a lease:
+# a wall-clock dependency makes the suite flaky on a loaded machine, and the
+# behaviour under test is the comparison against `leased_until`, not duration.
 
 
 def test_a_stale_lease_can_be_taken_over():
     service = _service()
     run = service.launch_run(query="q", autonomy_mode="autonomous")
-    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0.01)
-    time.sleep(0.05)
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
 
     assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
 
@@ -206,8 +208,7 @@ def test_a_stale_lease_can_be_taken_over():
 def test_a_displaced_worker_cannot_renew_or_release():
     service = _service()
     run = service.launch_run(query="q", autonomy_mode="autonomous")
-    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0.01)
-    time.sleep(0.05)
+    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
     service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
 
     assert service.renew_lease(run["id"], lease_id=stale, lease_seconds=60) is False
@@ -220,12 +221,11 @@ def test_reclaim_stops_at_the_retry_budget():
     run = service.launch_run(query="q", autonomy_mode="autonomous")
     for _ in range(3):
         assert service.claim_run(
-            run["id"], worker_id="w", lease_seconds=0.01, max_attempts=3
+            run["id"], worker_id="w", lease_seconds=0, max_attempts=3
         )
-        time.sleep(0.05)
 
     assert service.claim_run(
-        run["id"], worker_id="w", lease_seconds=0.01, max_attempts=3
+        run["id"], worker_id="w", lease_seconds=0, max_attempts=3
     ) is None
 
 

--- a/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
+++ b/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
@@ -1,0 +1,133 @@
+# Durable, resumable research jobs — design
+
+Date: 2026-08-18 · Task: TASK-18060 · Closes: TASK-17386 AC #3
+
+## Problem
+
+A research run whose evidence pool is large enough loses its report to a
+provider timeout during synthesis. TASK-17386 made that failure legible and
+counted; it did not make the run finish.
+
+The first design for this attacked the clock: derive a size-aware timeout so a
+big synthesis fits. Reviewing it produced a better framing. A research run is
+not something a user watches — its result is an artifact and a message in the
+conversation that asked for it. Once the run is a durable job, taking twenty
+minutes is not a failure, and almost all of the timeout machinery becomes
+unnecessary. What matters instead is that the job SURVIVES, RESUMES without
+redoing paid work, and SURFACES when it finishes.
+
+Measured on the repositories lane (local Qwen3.8-27B), which justifies the
+generous bounds below:
+
+| admitted pool | synthesis wall clock |
+|---|---|
+| 14 / 26 / 32 | 241s / 328s / 287s |
+| 46 | FAILED — two 600s attempts, `MaxRetryError` |
+| 66 | 970s (a timed-out attempt plus a landing retry) |
+
+## What this promises, and what it does not
+
+The scheduler loop runs INSIDE the app process (`app.py` starts it with
+`run_worker`). So this design makes a run survive an app exit and continue on
+the next launch. It does NOT run research while the app is closed, and the spec
+says so plainly because "background job" invites that expectation.
+
+Resume granularity is the PHASE. A synthesis interrupted at 900 of 970 seconds
+restarts that synthesis; the collection and judgement before it are not redone.
+Synthesis is the most expensive single phase, so this is the design's main
+residual cost, stated rather than implied.
+
+## Design
+
+### 1. Exactly one executor per run
+
+Today `execute_run` refuses only terminal runs, and the window's guard
+(`run_worker(exclusive=True, group=...)`) is per-session. Adding a scheduler
+that can invoke the same run makes concurrent execution possible: duplicate
+searches, duplicate spend, racing writes on one row.
+
+A run therefore carries a lease: an owner token and a heartbeat updated as
+phases progress. An executor claims the run atomically or declines it; a lease
+whose heartbeat has gone stale beyond a threshold may be taken over, so a
+process that died does not strand its run forever. This is a precondition for
+everything else here, not a refinement of it.
+
+### 2. Resume restores the budget, not just the position
+
+`execute_run` rebuilds the ledger with `BudgetLedger.from_limits(limits)` on
+every entry, and `budget_ledger.json` is written but never read back. With
+resume becoming routine rather than exceptional, a run resumed three times
+would be granted its full search and token budget three times. Resume restores
+the ledger from its artifact, and only falls back to `from_limits` for a run
+that has never executed.
+
+### 3. Phase state durable enough to resume
+
+`collection_summary.json` persists counts, sub-questions and warnings — not the
+collected evidence — so a resumed run re-searches everything. Each round's
+evidence pool becomes an artifact.
+
+Bounded explicitly, because "bounded" without a number is how the previous
+draft of this spec hid its worst case: 66 sources at roughly 10-50 KB of
+scraped text each is 0.7-3 MB per round, up to about 6 MB per run. The design
+persists evidence WITH content up to a per-run cap (default 8 MB), and beyond
+that cap persists references only, recording in the artifact that it did so. A
+resumed run rehydrates what it can and re-fetches the remainder, so the cap
+trades a bounded amount of network for a bounded amount of storage instead of
+letting either grow with the pool.
+
+### 4. Scheduler integration
+
+Execution is driven by a scheduler task (`task_type="research_run"`) whose
+handler claims the run and invokes the engine. The handler skips runs in an
+`awaiting_*` control state: a checkpointed run parked for review would
+otherwise be re-entered on every tick, re-park immediately, and emit an event
+each time.
+
+### 5. Surfacing
+
+- Window-launched runs gain a handoff target, so they alert the originating
+  conversation the way Console `/research` already does; `chat_handoff` appears
+  zero times in `Research_Window.py` today.
+- Research reports gain the `artifact_source` / `artifact_kind` metadata the
+  artifacts screen filters on. That screen currently requires
+  `artifact_source == "console"`, so widening it is a screen change and carries
+  the matching `Docs/User_Guide/` update.
+
+### 6. Bounds
+
+What remains of the timeout work: a generous per-attempt synthesis ceiling, a
+phase-2 deadline that cannot pre-empt it, and no default runtime cap. No
+calibrated curve, no multiplier, no instrumentation step — being slow stops
+being a failure once the result is a job. The measurements above set the
+ceiling; a user-set `max_runtime_seconds` still refuses before spending when it
+cannot cover the work, recording that through the `synthesis_failed` channel
+shipped in TASK-17386.
+
+## Out of scope
+
+`_default_gap_fn` and `answer_follow_up` share the timeout exposure and are
+recorded as a follow-up. Running research while the application is closed would
+require an out-of-process scheduler and is a different piece of work.
+
+## Testing
+
+- Two executors race one run: exactly one claims it, the other declines, and no
+  phase runs twice.
+- A stale lease is taken over; a live one is not.
+- A resumed run restores its spent budget rather than being re-granted it.
+- A resumed run does not re-search a completed round, and rehydrates evidence
+  from the artifact.
+- Evidence beyond the cap persists as references, and the artifact records the
+  truncation.
+- The handler skips `awaiting_*` runs without emitting events.
+- A window-launched run alerts its originating conversation.
+- A research report appears in the artifacts screen's listing.
+- No test contacts a network.
+
+## Success criteria
+
+A research run interrupted by an app exit resumes on the next launch without
+redoing its searches or re-granting its budget, finishes a synthesis that takes
+longer than any single provider timeout, and announces itself in the
+conversation that asked for it and in the artifacts screen.

--- a/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
+++ b/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
@@ -46,11 +46,38 @@ Today `execute_run` refuses only terminal runs, and the window's guard
 that can invoke the same run makes concurrent execution possible: duplicate
 searches, duplicate spend, racing writes on one row.
 
-A run therefore carries a lease: an owner token and a heartbeat updated as
-phases progress. An executor claims the run atomically or declines it; a lease
-whose heartbeat has gone stale beyond a threshold may be taken over, so a
-process that died does not strand its run forever. This is a precondition for
-everything else here, not a refinement of it.
+A run therefore carries a lease. The shape is taken from the server's job
+manager (`tldw_Server_API/app/core/Jobs/`, dev), which has solved this already;
+four of its decisions are adopted deliberately rather than re-derived:
+
+- **A lease id as well as a worker id.** The server's `jobs` table carries
+  `worker_id`, `lease_id`, `leased_until`, `acquired_at`, and
+  `renew_job_lease` can enforce that BOTH the worker and the lease id match
+  before a renewal or completion is accepted. A worker id alone is not enough:
+  a process that stalled past its lease, had its run taken over, and then woke
+  up would still match on worker id and could complete a run it no longer owns.
+  The lease id is the fencing token that makes takeover safe.
+- **Stale leases are reclaimed at acquisition, not by a reaper.** The server
+  requeues or terminally fails expired `processing` jobs as the first step of
+  `acquire_next_job`, "according to their retry budget". Folding recovery into
+  the acquire path means there is no separate sweeper to schedule, and no
+  window where a dead run is invisible.
+- **A retry budget decides requeue versus terminal failure.** `max_retries` and
+  `retry_count` on the row, with `available_at` carrying the backoff, so a run
+  that keeps dying is eventually failed rather than retried forever. A research
+  run that crashes its executor three times is a broken run, not a slow one.
+- **The heartbeat carries progress.** `renew_job_lease` takes
+  `progress_percent` and `progress_message`, so one call both proves liveness
+  and updates what the user sees. The engine already emits phase progress; that
+  emission becomes the heartbeat rather than a second mechanism beside it.
+
+What is NOT adopted: the server's multi-tenant machinery — domains, queues,
+fair-share scheduling, priority bands, quarantine for poison messages, the
+archive table. A single-user SQLite app with one research queue needs a lease
+and a retry budget, not a scheduler-of-schedulers. Its lease cap
+(`JOBS_LEASE_MAX_SECONDS`, 3600s) is worth noting though, because a synthesis
+measured at 970s sits inside it but a pathological one would not: the lease
+must be renewable mid-phase, not sized to cover a whole phase in one grant.
 
 ### 2. Resume restores the budget, not just the position
 

--- a/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
+++ b/Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md
@@ -66,10 +66,44 @@ four of its decisions are adopted deliberately rather than re-derived:
   `retry_count` on the row, with `available_at` carrying the backoff, so a run
   that keeps dying is eventually failed rather than retried forever. A research
   run that crashes its executor three times is a broken run, not a slow one.
-- **The heartbeat carries progress.** `renew_job_lease` takes
-  `progress_percent` and `progress_message`, so one call both proves liveness
-  and updates what the user sees. The engine already emits phase progress; that
-  emission becomes the heartbeat rather than a second mechanism beside it.
+- **The heartbeat may carry progress, but must not depend on it.** The
+  server's `renew_job_lease` takes `progress_percent` and `progress_message`,
+  and it is tempting to conclude that our existing phase-progress emission can
+  double as the heartbeat. It cannot, and the reason is specific to this
+  workload: between the "Synthesizing findings" update and the `analyze_fn`
+  call there are ZERO further emissions for the whole ~970s synthesis. A lease
+  renewed only by progress events would expire inside the longest phase, the
+  run would be taken over, and the most expensive phase would execute twice
+  while the first executor was still paying for it. The renewal is therefore an
+  explicit keep-alive on a timer for as long as a phase is in flight; progress
+  rides along when there is progress to report.
+
+**Fencing must guard writes, not just completion.** A displaced executor
+blocked in a long provider call will still return, still write artifacts, and
+still settle its ledger. Checking the lease only when finishing the run leaves
+every write in between unguarded, so the fence is checked before each
+persisting write.
+
+**Completion side effects are made idempotent.** `chat_handoff` inserts a
+message into the originating conversation; a takeover race would announce the
+same report twice. The run records that the handoff was delivered, and the
+insert is skipped when it already was.
+
+**One retry budget, owned by the run.** The scheduler has its own retry and
+backoff for failed tasks, and the run now has a retry budget of its own.
+Undefined precedence is how two counters drift apart, so the run's budget is
+authoritative: the scheduler task retries only its own dispatch, never the
+research work.
+
+**The scheduler task is cleaned up.** A one-time task per run is deleted when
+the run reaches a terminal state or is cancelled, so tasks do not accumulate
+behind completed work.
+
+**Why not the existing local jobs table.** `Library_Ingest_Jobs_DB` already
+carries a `retry_count` and a queued/failed/cancelled model, but no lease
+columns and a lifecycle shaped for file ingestion. Research runs keep their own
+table and gain lease columns there rather than being forced into it; the two
+converge only if a third consumer appears.
 
 What is NOT adopted: the server's multi-tenant machinery — domains, queues,
 fair-share scheduling, priority bands, quarantine for poison messages, the
@@ -141,6 +175,12 @@ require an out-of-process scheduler and is a different piece of work.
 
 - Two executors race one run: exactly one claims it, the other declines, and no
   phase runs twice.
+- A phase that emits no progress for longer than the lease keeps its lease: the
+  keep-alive renews on its own timer, and the run is not taken over mid-phase.
+- A displaced executor cannot write artifacts or settle its ledger after losing
+  its lease, not merely cannot complete the run.
+- A run announced once stays announced once across a takeover.
+- A terminal or cancelled run leaves no scheduler task behind.
 - A stale lease is taken over; a live one is not.
 - A resumed run restores its spent budget rather than being re-granted it.
 - A resumed run does not re-search a completed round, and rehydrates evidence
@@ -156,5 +196,6 @@ require an out-of-process scheduler and is a different piece of work.
 
 A research run interrupted by an app exit resumes on the next launch without
 redoing its searches or re-granting its budget, finishes a synthesis that takes
-longer than any single provider timeout, and announces itself in the
+longer than the DEFAULT provider timeout (a synthesis exceeding the configured
+ceiling still fails, and says so), and announces itself exactly once in the
 conversation that asked for it and in the artifacts screen.

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -9,6 +9,7 @@ artifact/event storage run real.
 
 import asyncio
 import concurrent.futures
+import json
 from unittest.mock import patch
 
 import pytest
@@ -1588,6 +1589,45 @@ def test_a_run_whose_lease_retry_budget_is_exhausted_is_failed():
     assert "lease" in message.lower() or "executor" in message.lower(), message
 
 
+def test_a_run_cancelled_between_the_engines_terminal_check_and_its_claim_is_not_executed():
+    """task-3 report finding 1: ``claim_run`` restricted acquisition by
+    lease expiry only, never by run status, while ``execute_run``'s own
+    terminal check (the ``ValueError`` guard at the top of ``execute_run``)
+    runs BEFORE the claim. A cancellation landing in that exact gap --
+    after the check reads "running", before ``claim_run``'s atomic UPDATE
+    -- let a terminal run be claimed and executed (resurrected) anyway.
+
+    Reproduces the race directly at its source: ``service.claim_run`` is
+    monkeypatched to cancel the run (simulating a concurrent caller racing
+    in right where the finding describes) immediately before delegating to
+    the real ``claim_run`` -- so by the time the atomic UPDATE runs, the
+    run really is terminal, and the fix (the status condition living in
+    that same UPDATE) must refuse the claim.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, calls = _make_pipeline("q")
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    original_claim_run = service.claim_run
+
+    def racing_claim_run(run_id, **kwargs):
+        service.cancel_run(run_id)
+        return original_claim_run(run_id, **kwargs)
+
+    service.claim_run = racing_claim_run
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "cancelled", (
+        "the run must stay exactly as the racing cancellation left it, "
+        "never resurrected back to a running/completed pipeline execution"
+    )
+    assert calls == {"search": 0, "analyze": 0}, (
+        f"a terminal run must never reach the pipeline: {calls}"
+    )
+
+
 def test_a_lease_stolen_during_synthesis_blocks_packaging_writes_and_completion():
     """task-18060 review finding 2: regression guard for the nine
     `_require_lease()` fences threaded through `_execute_phases`. Steals the
@@ -1739,6 +1779,72 @@ def test_the_last_lease_fence_blocks_completion_after_the_final_write():
     assert final["status"] != "completed"
     names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
     assert "bundle.json" in names  # the write that triggered the steal did land
+
+
+def test_a_displaced_executor_cannot_advance_the_runs_phase_to_synthesizing():
+    """task-3 report finding 2: the engine fenced artifact writes but not
+    run-state writes -- progress and phase updates, checkpoint creation,
+    and pause/cancel resolution were not fenced at all, so a displaced
+    executor could still advance a run's ``phase`` field (and its
+    progress/control_state) on a run it no longer owns.
+
+    Isolates the ONE fence guarding the "synthesizing" phase-advance write
+    specifically: the lease is stolen as a side effect of
+    ``_check_control("synthesizing")`` itself (a synchronous call with no
+    ``await`` point before the phase-advance write that immediately
+    follows it in ``_execute_phases``), so no OTHER fence gets a chance to
+    catch the theft first -- the same isolation technique the sibling
+    lease-theft tests above use for artifact writes, applied here to a
+    run-state write instead.
+
+    Mutation-verified (task report): deleting the ``_require_lease()`` call
+    immediately before the "synthesizing" ``update_run_progress`` in
+    ``_execute_phases`` turns this test red (the phase advances to
+    "synthesizing" and synthesis runs); restoring it turns it green.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, calls = _make_pipeline("q")
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    theft_box: dict[str, str | None] = {}
+    original_check_control = engine._check_control
+
+    def stealing_check_control(run_id, next_phase):
+        if next_phase == "synthesizing":
+            # Same technique as the sibling theft tests: release the
+            # engine's own still-live lease, then have a third party claim
+            # it -- deterministic, no real elapsed time needed.
+            released = service.release_lease(run_id, lease_id=engine._lease_id)
+            assert released is True, "the engine must still hold its own lease at this point"
+            stolen = service.claim_run(run_id, worker_id="rescuer", lease_seconds=60)
+            theft_box["lease_id"] = stolen
+            assert stolen is not None, "the steal itself must succeed for this test to mean anything"
+        return original_check_control(run_id, next_phase)
+
+    engine._check_control = stealing_check_control
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    # Checked from the test's own top-level code, not inside the patched
+    # seam, for the same reason the sibling theft tests do this: it cannot
+    # be short-circuited by execute_run swallowing an in-seam assertion
+    # into some other non-"completed" terminal status.
+    assert theft_box.get("lease_id"), "the rescuer's claim_run must have returned a lease id"
+    assert service.holds_lease(run["id"], lease_id=theft_box["lease_id"]) is True, (
+        "the rescuer must still hold the run's lease after the displaced "
+        "executor's execute_run returns"
+    )
+    assert calls["search"] == 1, "round 1's collecting phase ran legitimately, under a valid lease"
+    assert calls["analyze"] == 0, "synthesis must never run once the phase-advance write is blocked"
+
+    current = service.get_run(run["id"])
+    assert current["phase"] == "collecting", (
+        "the displaced executor must not have advanced the phase past its "
+        f"last legitimately-written value; got {current['phase']!r}"
+    )
+    assert final["status"] != "completed"
 
 
 def test_lease_lost_while_handling_a_pipeline_error_returns_quietly():
@@ -2090,3 +2196,67 @@ def test_a_pool_within_the_cap_keeps_every_body():
     assert payload["truncated"] is False
     assert payload["results"][0]["content"] == "short"
     assert payload["iteration"] == 2
+
+
+def test_a_single_entry_larger_than_the_cap_is_dropped_not_persisted_oversized():
+    """task-3 report finding 7: ``_bounded_evidence`` stripped bodies once
+    the running total passed the cap, but still appended EVERY entry and
+    kept accumulating ``used`` past the cap -- so the persisted artifact
+    could exceed ``EVIDENCE_POOL_CAP_BYTES``, and a single entry whose
+    reference-only (stripped) size alone exceeds the cap could blow it by
+    itself with no way for a reader to tell.
+
+    An entry that still does not fit even stripped of its body is dropped
+    from the persisted pool entirely (documented decision: its reference is
+    lost for this round, and ``dropped_count`` records how many entries
+    this happened to) -- the sum of what IS kept must never exceed the cap.
+    """
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    engine.EVIDENCE_POOL_CAP_BYTES = 50
+    # The URL alone (stripped of content/original_content) already exceeds
+    # a 50-byte cap.
+    huge_reference_entry = {
+        "url": "https://e.example/" + ("z" * 200),
+        "content": "x" * 10,
+    }
+
+    payload = engine._bounded_evidence([huge_reference_entry], iteration=1)
+
+    total_kept_bytes = sum(
+        len(json.dumps(entry, sort_keys=True)) for entry in payload["results"]
+    )
+    assert total_kept_bytes <= engine.EVIDENCE_POOL_CAP_BYTES
+    assert payload["results"] == []
+    assert payload["truncated"] is True
+    assert payload["dropped_count"] == 1
+
+
+def test_bounded_evidence_never_exceeds_the_cap_with_a_mix_of_sizes():
+    """A mix of entries that fit, entries that need stripping, and one
+    entry too big even stripped -- the cumulative kept size must stay
+    within the cap throughout, not just for the single-entry case above."""
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    engine.EVIDENCE_POOL_CAP_BYTES = 150
+    entries = [
+        {"url": "https://e.example/1", "content": "short"},  # fits whole
+        {  # needs stripping to fit
+            "url": "https://e.example/2",
+            "content": "x" * 300,
+            "original_content": "y" * 300,
+        },
+        {  # too big even stripped -- must be dropped
+            "url": "https://e.example/3/" + ("z" * 300),
+            "content": "x" * 10,
+        },
+    ]
+
+    payload = engine._bounded_evidence(entries, iteration=1)
+
+    total_kept_bytes = sum(
+        len(json.dumps(entry, sort_keys=True)) for entry in payload["results"]
+    )
+    assert total_kept_bytes <= engine.EVIDENCE_POOL_CAP_BYTES
+    assert payload["dropped_count"] >= 1
+    assert payload["truncated"] is True

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1592,3 +1592,63 @@ def test_the_engine_continues_a_pre_existing_ledger():
     ).get("content") or {}
 
     assert int(snapshot.get("searches_used") or 0) > 5, snapshot
+
+
+# --- the round's evidence is persisted (task-18060) ----------------------------
+# collection_summary.json persists counts, sub-questions and warnings -- not the
+# evidence -- so a resumed run re-searched everything it had already paid for.
+
+
+def test_the_rounds_evidence_pool_is_persisted():
+    service = _make_service()
+    search_fn, analyze_fn, calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    pool = (service.get_artifact(run["id"], "evidence_pool.json") or {}).get("content")
+
+    assert pool, "the round's evidence must be persisted"
+    assert pool["results"], pool
+    assert pool["iteration"] == 1
+    assert calls["search"] == 1
+
+
+def test_evidence_beyond_the_cap_persists_without_content():
+    """Bounded explicitly: 66 sources of scraped text is roughly 0.7-3 MB per
+    round, so beyond the cap entries keep their references and lose their bodies,
+    and the artifact records that it happened."""
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    engine.EVIDENCE_POOL_CAP_BYTES = 200
+    bulky = [
+        {
+            "url": f"https://e.example/{n}",
+            "content": "x" * 500,
+            "original_content": "y" * 500,
+        }
+        for n in range(4)
+    ]
+
+    payload = engine._bounded_evidence(bulky, iteration=1)
+
+    assert payload["truncated"] is True
+    assert any("content" not in entry for entry in payload["results"])
+    assert payload["cap_bytes"] == 200
+    # References survive truncation -- a resumed run can re-fetch from them.
+    assert all(entry["url"] for entry in payload["results"])
+
+
+def test_a_pool_within_the_cap_keeps_every_body():
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    small = [{"url": "https://e.example/1", "content": "short"}]
+
+    payload = engine._bounded_evidence(small, iteration=2)
+
+    assert payload["truncated"] is False
+    assert payload["results"][0]["content"] == "short"
+    assert payload["iteration"] == 2

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -9,6 +9,7 @@ artifact/event storage run real.
 
 import asyncio
 import concurrent.futures
+from unittest.mock import patch
 
 import pytest
 
@@ -1534,9 +1535,17 @@ def test_a_failed_synthesis_is_recorded_on_the_run():
 
 def test_a_second_engine_declines_a_leased_run():
     """task-18060: two executors must not run one run. The window's
-    exclusive-worker guard is per-session and cannot see a second process."""
+    exclusive-worker guard is per-session and cannot see a second process.
+
+    Review finding 6: the original version of this test asserted only
+    `status != "completed"` and captured `_calls` without ever checking it
+    -- it would have passed even if the declined executor had gone ahead
+    and run a phase anyway (e.g. if the None-return short-circuit were
+    accidentally removed further down the call stack). Assert directly
+    that the declined executor performed no work.
+    """
     service = _make_service()
-    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    search_fn, analyze_fn, calls = _make_pipeline("q")
     first = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
     second = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
     run = service.launch_run(query="q", autonomy_mode="autonomous")
@@ -1545,7 +1554,292 @@ def test_a_second_engine_declines_a_leased_run():
     final = asyncio.run(second.execute_run(run["id"]))
 
     assert final["status"] != "completed"
+    assert final["status"] != "failed"  # declined =/= failed: the run is left alone
     assert "lease" in str(final.get("progress_message") or "").lower()
+    assert calls == {"search": 0, "analyze": 0}, calls
+
+
+def test_a_run_whose_lease_retry_budget_is_exhausted_is_failed():
+    """task-18060 review finding 1: before the fix, exhausting the reclaim
+    budget made claim_run return None -- exactly like "another executor
+    holds it live" -- so execute_run wrote a lease_declined progress event
+    and left the run status=running forever, permanently unclaimable
+    (a REGRESSION: before this branch such a run could simply be
+    re-executed). A budget-exhausted run must instead be failed, since its
+    executor keeps dying rather than merely losing a race.
+    """
+    service = _make_service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    # Simulate a dead executor: claimed and abandoned (never released) three
+    # times in a row, each with an already-expired lease so the next claim
+    # can reclaim it deterministically (no time.sleep(), same technique as
+    # test_reclaim_stops_at_the_retry_budget in test_research_run_lease.py).
+    for _ in range(3):
+        assert service.claim_run(
+            run["id"], worker_id="dead-executor", lease_seconds=0, max_attempts=3
+        )
+
+    engine = LocalResearchEngine(service)  # never reaches the pipeline
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "failed"
+    message = str(final.get("progress_message") or "")
+    assert "lease" in message.lower() or "executor" in message.lower(), message
+
+
+def test_a_lease_stolen_during_synthesis_blocks_packaging_writes_and_completion():
+    """task-18060 review finding 2: regression guard for the nine
+    `_require_lease()` fences threaded through `_execute_phases`. Steals the
+    run out from under the executing engine from INSIDE a fake pipeline seam
+    (`analyze_fn`, which the engine awaits directly on the loop thread, so
+    the steal needs no cross-thread plumbing) once collecting has already
+    written its artifacts under a still-valid lease. Every packaging write
+    that follows the theft must be blocked, and the run must never be
+    marked completed.
+
+    Mutation-verified (task report): deleting the `_require_lease()` call
+    at the top of `_save_ledger` (the first fence reached after this test's
+    theft point, called again at the top of the packaging section) turns
+    this test red; restoring it turns it green again.
+    """
+    service = _make_service()
+    search_fn, _default_analyze, _calls = _make_pipeline("q")
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    async def stealing_analyze_fn(wsr, sqd, params, cancel_event=None):
+        # A live (unexpired) lease cannot be reclaimed by another claim_run
+        # call -- that non-double-claim guarantee is the whole point of the
+        # atomic UPDATE. Releasing it first (using the lease id the engine
+        # itself is holding, right now, mid-flight) is what actually
+        # simulates "a second executor now owns this run", deterministically
+        # and without a real sleep.
+        released = service.release_lease(run["id"], lease_id=engine._lease_id)
+        assert released is True, "the engine must still hold its own lease at this point"
+        stolen = service.claim_run(run["id"], worker_id="rescuer", lease_seconds=60)
+        assert stolen is not None, "the steal itself must succeed for this test to mean anything"
+        return {
+            "final_answer": {"text": "Answer[1].", "evidence": [], "confidence": 0.5, "chunks": []},
+            "relevant_results": {},
+            "web_search_results_dict": wsr,
+        }
+
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=stealing_analyze_fn)
+
+    complete_calls = {"n": 0}
+    original_complete_run = service.complete_run
+
+    def spy_complete_run(*args, **kwargs):
+        complete_calls["n"] += 1
+        return original_complete_run(*args, **kwargs)
+
+    service.complete_run = spy_complete_run
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] != "completed"
+    assert complete_calls["n"] == 0, "the displaced executor must never call complete_run"
+    names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
+    # Round-1 collecting wrote its artifacts before the theft (partial-
+    # artifact contract) -- packaging must not have written anything after it.
+    assert "plan.json" in names
+    assert "collection_summary.json" in names
+    for packaging_artifact in ("report_v1.md", "sources.json", "verification_summary.json", "bundle.json"):
+        assert packaging_artifact not in names, f"{packaging_artifact} must not exist: {names}"
+
+
+def test_the_last_lease_fence_blocks_completion_after_the_final_write():
+    """task-18060 review finding 2 (mutation-check companion): isolates the
+    VERY LAST `_require_lease()` call -- immediately before `complete_run`
+    -- from every fence before it, by stealing the lease as a side effect of
+    the LAST artifact write (`bundle.json`) rather than from inside a
+    pipeline seam. Every earlier fence has already passed by the time the
+    theft happens, so only that one final fence stands between the theft and
+    a wrongly "completed" run.
+
+    Mutation-verified (task report): deleting the `_require_lease()` call
+    immediately preceding `self.service.complete_run(...)` turns this test
+    red (the run gets marked completed on a stolen lease); restoring it
+    turns it green again.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    original_save_artifact = service.save_artifact
+
+    def stealing_save_artifact(run_id, *, artifact_name, content_type, content):
+        result = original_save_artifact(
+            run_id, artifact_name=artifact_name, content_type=content_type, content=content
+        )
+        if artifact_name == "bundle.json":
+            # The very last write before complete_run -- steal right after
+            # it succeeds, so everything up to and including it has already
+            # legitimately happened under this engine's own lease. A live
+            # lease can't be reclaimed directly (that's the whole point of
+            # claim_run's atomicity), so release it first using the id the
+            # engine itself is still holding.
+            released = service.release_lease(run_id, lease_id=engine._lease_id)
+            assert released is True
+            stolen = service.claim_run(run_id, worker_id="rescuer", lease_seconds=60)
+            assert stolen is not None
+        return result
+
+    service.save_artifact = stealing_save_artifact
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] != "completed"
+    names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
+    assert "bundle.json" in names  # the write that triggered the steal did land
+
+
+def test_lease_lost_while_handling_a_pipeline_error_returns_quietly():
+    """task-18060 review finding 3: `_save_ledger` is fenced, and it is
+    called from INSIDE the `except ResearchLimitExceeded` and
+    `except Exception` handlers in execute_run. A `_LeaseLost` raised from
+    inside an except body is NOT caught by that same try's sibling
+    `except _LeaseLost` clause (Python only matches a raise against a NEW
+    try), so before the fix it propagated out of execute_run entirely --
+    callers saw "Local research engine error: execution lease lost" instead
+    of the quiet return every other fenced write produces, contradicting
+    execute_run's own docstring (which promises only ValueError).
+
+    The lease is left to expire naturally (a real elapsed-time wait,
+    deterministic because the wait comfortably exceeds `lease_seconds`) and
+    reclaimed from inside `search_fn` on the loop's own thread (routed
+    through `_run_on_loop`, matching this suite's established pattern for
+    touching the thread-affine `:memory:` connection from an offloaded,
+    synchronous search_fn) -- then search_fn raises, landing in
+    `except Exception`, exactly where finding 3 lives.
+    """
+    service = _make_service()
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+    loop_box: dict[str, asyncio.AbstractEventLoop] = {}
+
+    import time as time_module
+
+    def search_fn(q, params):
+        time_module.sleep(0.3)  # comfortably past lease_seconds=0.1 below
+        stolen = _run_on_loop(
+            loop_box["loop"],
+            lambda: service.claim_run(run["id"], worker_id="rescuer", lease_seconds=60),
+        )
+        assert stolen is not None
+        raise RuntimeError("pipeline exploded")
+
+    engine = LocalResearchEngine(service, search_fn=search_fn)
+    engine.lease_seconds = 0.1
+    engine.keepalive_seconds = 999  # never renews inside the test window
+
+    fail_calls = {"n": 0}
+    original_fail_run = service.fail_run
+
+    def spy_fail_run(*args, **kwargs):
+        fail_calls["n"] += 1
+        return original_fail_run(*args, **kwargs)
+
+    service.fail_run = spy_fail_run
+
+    async def _run():
+        loop_box["loop"] = asyncio.get_running_loop()
+        return await engine.execute_run(run["id"])  # must not raise _LeaseLost
+
+    final = asyncio.run(_run())
+
+    assert fail_calls["n"] == 0, "a displaced executor must not fail a run it no longer owns"
+    assert final["status"] != "failed"
+
+
+def test_a_resumed_run_continues_its_runtime_budget():
+    """task-18060 review finding 4: snapshot() records runtime_elapsed_s but
+    from_snapshot dropped it, so `_start_monotonic` reset on every resume
+    and a resumed run was granted its whole max_runtime_seconds again -- the
+    same leak already fixed for searches, docs, and tokens. A run resumed
+    with prior elapsed time already past the budget must fail immediately
+    rather than get a fresh clock.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q",
+        autonomy_mode="autonomous",
+        limits_json={"max_runtime_seconds": 5, "max_iterations": 1},
+    )
+    service.save_artifact(
+        run["id"],
+        artifact_name="budget_ledger.json",
+        content_type="application/json",
+        content={
+            "limits": {"max_runtime_seconds": 5},
+            "searches_used": 0,
+            "searches_overshoot": 0,
+            "docs_used": 0,
+            "tokens_settled": 0,
+            "runtime_elapsed_s": 999.0,  # already blew the budget in a "previous" execution
+        },
+    )
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "failed"
+    assert "research_limit_exceeded:max_runtime_seconds" in final["progress_message"]
+    assert calls == {"search": 0, "analyze": 0}, "must fail at entry, before any pipeline call"
+
+
+def test_default_gap_fn_offloads_its_blocking_llm_call():
+    """task-18060 review finding 5: `_default_gap_fn` is `async def`, so
+    `_offload_pipeline_call` routes it INLINE when it is invoked as the
+    engine's gap_fn -- but it used to call `chat_api_call` synchronously,
+    directly on the loop thread, inside that coroutine. A gap-analysis call
+    longer than `lease_seconds` would starve the keep-alive and lapse the
+    lease, exactly the bug finding 1 of task-18060's original review fixed
+    for `search_fn`. The blocking call must be offloaded the same way.
+    """
+    import time as time_module
+
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+
+    def blocking_chat_api_call(**kwargs):
+        time_module.sleep(0.3)
+        return "[]"
+
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    engine.search_params = {"final_answer_llm": "fake-llm"}
+    engine.lease_seconds = 0.1
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    renewals = {"count": 0}
+    original_renew_lease = service.renew_lease
+
+    def spy_renew_lease(*args, **kwargs):
+        renewals["count"] += 1
+        return original_renew_lease(*args, **kwargs)
+
+    service.renew_lease = spy_renew_lease
+
+    with patch(
+        "tldw_chatbook.Chat.Chat_Functions.chat_api_call",
+        side_effect=blocking_chat_api_call,
+    ):
+        final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert renewals["count"] > 0, (
+        "the keep-alive never ran while the blocking gap-analysis LLM call was in flight"
+    )
+    assert final["status"] == "completed", final.get("progress_message")
 
 
 def test_a_long_silent_phase_keeps_its_lease():

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1556,8 +1556,43 @@ def test_a_second_engine_declines_a_leased_run():
 
     assert final["status"] != "completed"
     assert final["status"] != "failed"  # declined =/= failed: the run is left alone
-    assert "lease" in str(final.get("progress_message") or "").lower()
+    assert "lease_declined" in _events(service, run["id"])
     assert calls == {"search": 0, "analyze": 0}, calls
+
+
+def test_a_declined_executor_does_not_write_run_state():
+    """PR-1822 review follow-up: the declined executor's lease_declined
+    handling used ``update_run_progress`` -- an unfenced run-state write by
+    a NON-lease-holder that bumped the run's version and stomped the live
+    executor's progress message mid-collection, contradicting the
+    single-writer principle every fenced write in the engine enforces.
+
+    The decline is still observable: as an append-only event
+    (``lease_declined``) in the run's event stream, which any observer may
+    append to, and which overwrites nothing.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    holder = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    declined = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    assert service.claim_run(
+        run["id"], worker_id=holder.worker_id, lease_seconds=60
+    )
+    # The live executor's in-flight progress message must survive.
+    service.update_run_progress(
+        run["id"], progress_message="Collecting sources (iteration 1)"
+    )
+    before = service.get_run(run["id"])
+    assert before["progress_message"] == "Collecting sources (iteration 1)"
+
+    asyncio.run(declined.execute_run(run["id"]))
+
+    after = service.get_run(run["id"])
+    assert after["progress_message"] == "Collecting sources (iteration 1)", after
+    assert after["version"] == before["version"], after
+    assert "lease_declined" in _events(service, run["id"])
 
 
 def test_a_run_whose_lease_retry_budget_is_exhausted_is_failed():
@@ -2078,6 +2113,111 @@ def test_a_blocking_sync_search_fn_does_not_starve_the_keepalive():
     assert final["status"] == "completed", final.get("progress_message")
 
 
+def test_a_failing_renewal_does_not_break_execute_run_or_strand_the_lease():
+    """task-3 review follow-up (keepalive containment): ``renew_lease`` can
+    raise for reasons that are NOT lease loss -- e.g. a transient
+    ``sqlite3.OperationalError: database is locked`` while another process
+    writes the same DB file. The keep-alive task had no exception handling,
+    so the exception surfaced at ``await keepalive`` inside ``execute_run``'s
+    ``finally`` block, which (a) escaped ``execute_run`` entirely (breaking
+    its documented ValueError-only contract) and (b) skipped
+    ``release_lease``, stranding the lease in the DB with the run left
+    status=running and no fail_run recorded -- nobody owned the failure.
+
+    A renewal ERROR must be treated like a lost lease from the keep-alive's
+    perspective (stop renewing, warn) -- the next fence the engine hits
+    decides what the run's real state is -- and it must never hijack the
+    ``finally`` block's release.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+
+    async def slow_analyze(wsr, sqd, params, cancel_event=None):
+        await asyncio.sleep(0.15)
+        return {
+            "final_answer": {"text": "Answer citing [1].", "evidence": [],
+                             "confidence": 0.5, "chunks": []},
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=slow_analyze
+    )
+    engine.lease_seconds = 5.0
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    def exploding_renew(run_id, *, lease_id, lease_seconds):
+        raise RuntimeError("database is locked")
+
+    service.renew_lease = exploding_renew
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    # The run completed on its own merits; the renewal error neither failed
+    # it nor escaped execute_run.
+    assert final["status"] == "completed", final.get("progress_message")
+    # The finally block ran to completion: the lease was released and the
+    # engine's lease state cleaned up.
+    row = service.get_run(run["id"])
+    assert engine._lease_id is None
+    assert row["lease_id"] is None, row
+    assert row["lease_owner"] is None, row
+    assert engine._active_ledger is None
+
+
+def test_execute_run_releases_the_lease_even_when_a_phase_raises():
+    """task-3 review follow-up (finally hardening): with the keep-alive's
+    exception contained, the only remaining way to strand a lease is a
+    failure INSIDE the finally block itself. ``await keepalive`` must not
+    raise the keep-alive's stored exception back into cleanup: retrieval
+    via ``exception()`` (or a broad suppress) keeps release_lease
+    unconditional.
+
+    Reproduces by making the keep-alive DIE (so its exception is stored on
+    the task) while the run itself proceeds fine.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+
+    async def slow_analyze(wsr, sqd, params, cancel_event=None):
+        await asyncio.sleep(0.15)
+        return {
+            "final_answer": {"text": "Answer citing [1].", "evidence": [],
+                             "confidence": 0.5, "chunks": []},
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=slow_analyze
+    )
+    engine.lease_seconds = 5.0
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    # Kill the keep-alive with a non-CancelledError exception, mimicking
+    # any unhandled failure inside the task body.
+    import asyncio as asyncio_module
+
+    async def dying_keepalive(run_id):
+        await asyncio_module.sleep(0.05)
+        raise RuntimeError("keepalive exploded")
+
+    engine._keepalive = dying_keepalive  # type: ignore[method-assign]
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed", final.get("progress_message")
+    row = service.get_run(run["id"])
+    assert engine._lease_id is None
+    assert row["lease_id"] is None, row
+    assert row["lease_owner"] is None, row
+
+
 def test_a_resumed_run_does_not_get_its_search_budget_back():
     """task-18060: the engine rebuilt the ledger from limits on every entry, so
     a run resumed three times was granted its budget three times."""
@@ -2260,3 +2400,36 @@ def test_bounded_evidence_never_exceeds_the_cap_with_a_mix_of_sizes():
     assert total_kept_bytes <= engine.EVIDENCE_POOL_CAP_BYTES
     assert payload["dropped_count"] >= 1
     assert payload["truncated"] is True
+
+
+def test_a_non_serializable_entry_is_dropped_not_raised():
+    """PR-1822 review follow-up: an entry carrying a non-JSON-native value
+    (e.g. a datetime leaked from a provider adapter) raised TypeError
+    inside ``_bounded_evidence``'s measurement, failing the WHOLE run via
+    the generic exception handler instead of degrading the artifact. The
+    docstring's graceful-truncation contract requires the entry be dropped
+    and counted, like an oversized one -- the previous fix moved the crash
+    from save_artifact into the measurement, it did not remove it.
+    """
+    import datetime as datetime_module
+
+    service = _make_service()
+    engine = LocalResearchEngine(service)
+    entries = [
+        {"url": "https://e.example/1", "content": "fine"},
+        {  # datetime is not JSON-native
+            "url": "https://e.example/2",
+            "content": "fine too",
+            "published": datetime_module.datetime(2026, 8, 18),
+        },
+        {"url": "https://e.example/3", "content": "also fine"},
+    ]
+
+    payload = engine._bounded_evidence(entries, iteration=1)
+
+    assert [e["url"] for e in payload["results"]] == [
+        "https://e.example/1",
+        "https://e.example/3",
+    ]
+    assert payload["dropped_count"] == 1
+    assert payload["truncated"] is False

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -8,6 +8,7 @@ artifact/event storage run real.
 """
 
 import asyncio
+import concurrent.futures
 
 import pytest
 
@@ -18,6 +19,30 @@ from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
 
 def _make_service() -> LocalResearchService:
     return LocalResearchService(":memory:")
+
+
+def _run_on_loop(loop: "asyncio.AbstractEventLoop", fn):
+    """Run a sync callable on ``loop``'s own thread and block the CALLING
+    thread until it completes.
+
+    The engine now offloads a synchronous search_fn to a worker thread
+    (finding 1: this stops it from starving the lease keep-alive). A fake
+    search_fn that pokes the real, thread-affine ``:memory:`` SQLite
+    connection to simulate a concurrent user action (pause/cancel) can no
+    longer do so directly from that worker thread -- it must hand the call
+    back to the loop's own thread, which is where the connection was
+    created.
+    """
+    future: "concurrent.futures.Future" = concurrent.futures.Future()
+
+    def _call() -> None:
+        try:
+            future.set_result(fn())
+        except BaseException as exc:  # noqa: BLE001 - propagated via the future
+            future.set_exception(exc)
+
+    loop.call_soon_threadsafe(_call)
+    return future.result(timeout=5)
 
 
 def _make_pipeline(question: str):
@@ -169,9 +194,12 @@ def test_engine_fails_run_and_keeps_partial_artifacts_on_pipeline_error():
 def test_engine_pause_between_phases_leaves_run_resumable():
     service = _make_service()
     run = service.launch_run(query="Pause me mid-run", autonomy_mode="autonomous")
+    loop_box: dict[str, asyncio.AbstractEventLoop] = {}
 
     def search_fn(q, params):
-        service.pause_run(run["id"])  # user pauses while collecting runs
+        # user pauses while collecting runs -- run_on_loop hands the DB
+        # write back to the loop's own thread (see _run_on_loop docstring).
+        _run_on_loop(loop_box["loop"], lambda: service.pause_run(run["id"]))
         return ({"results": [{"title": "T", "url": "https://t.example/"}], "warnings": []},
                 {"sub_questions": [], "main_goal": q})
 
@@ -183,7 +211,12 @@ def test_engine_pause_between_phases_leaves_run_resumable():
                 "relevant_results": {}, "web_search_results_dict": wsr}
 
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
-    final = asyncio.run(engine.execute_run(run["id"]))
+
+    async def _run():
+        loop_box["loop"] = asyncio.get_running_loop()
+        return await engine.execute_run(run["id"])
+
+    final = asyncio.run(_run())
 
     assert final["control_state"] == "paused"
     assert final["status"] == "running"  # non-terminal: resumable
@@ -194,9 +227,11 @@ def test_engine_pause_between_phases_leaves_run_resumable():
 def test_engine_cancel_between_phases_resolves_cancelled_once():
     service = _make_service()
     run = service.launch_run(query="Cancel me mid-run", autonomy_mode="autonomous")
+    loop_box: dict[str, asyncio.AbstractEventLoop] = {}
 
     def search_fn(q, params):
-        service.cancel_run(run["id"])  # user cancels while collecting runs
+        # user cancels while collecting runs -- see _run_on_loop docstring.
+        _run_on_loop(loop_box["loop"], lambda: service.cancel_run(run["id"]))
         return ({"results": [{"title": "T", "url": "https://t.example/"}], "warnings": []},
                 {"sub_questions": [], "main_goal": q})
 
@@ -204,7 +239,12 @@ def test_engine_cancel_between_phases_resolves_cancelled_once():
         raise AssertionError("analyze must not run after cancellation")
 
     engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
-    final = asyncio.run(engine.execute_run(run["id"]))
+
+    async def _run():
+        loop_box["loop"] = asyncio.get_running_loop()
+        return await engine.execute_run(run["id"])
+
+    final = asyncio.run(_run())
 
     assert final["status"] == "cancelled"
     assert _events(service, run["id"]).count("cancelled") == 1
@@ -1531,6 +1571,68 @@ def test_a_long_silent_phase_keeps_its_lease():
 
     final = asyncio.run(engine.execute_run(run["id"]))
 
+    assert final["status"] == "completed", final.get("progress_message")
+
+
+def test_a_blocking_sync_search_fn_does_not_starve_the_keepalive():
+    """task-18060 review finding 1: in production search_fn resolves to a
+    plain `def` running a sequential loop of blocking HTTP calls
+    (generate_and_search). _collect_round used to await it inline, so the
+    call monopolized the single-threaded event loop for its whole duration
+    -- the _keepalive task (an asyncio.sleep-based timer) never got a
+    chance to run a single tick until the blocking call returned, by which
+    point (with a lease shorter than the block) the lease had already
+    expired unrenewed. That reopens the double-execution race the lease
+    exists to prevent.
+
+    A synchronous, BLOCKING fake search_fn (time.sleep, not asyncio.sleep)
+    is the one legitimate use of a real sleep in this suite, since blocking
+    the interpreter is exactly the behaviour under test -- an async fake
+    would not reproduce the bug at all (awaiting a real coroutine always
+    yields control back to the loop, which is why
+    test_a_long_silent_phase_keeps_its_lease above can use asyncio.sleep
+    for the analyze_fn side and still pass unmodified).
+    """
+    import time as time_module
+
+    service = _make_service()
+    _search_fn, analyze_fn, _calls = _make_pipeline("q")
+
+    def blocking_search_fn(q, params):
+        time_module.sleep(0.3)
+        return (
+            {
+                "results": [{"title": "One", "url": "https://one.example/"}],
+                "warnings": [],
+            },
+            {"sub_questions": [], "main_goal": q},
+        )
+
+    engine = LocalResearchEngine(
+        service, search_fn=blocking_search_fn, analyze_fn=analyze_fn
+    )
+    # Short enough that the lease WILL lapse across the 0.3s blocking call
+    # unless the keep-alive actually gets to run concurrently with it.
+    engine.lease_seconds = 0.1
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(
+        query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
+    )
+
+    renewals = {"count": 0}
+    original_renew_lease = service.renew_lease
+
+    def spy_renew_lease(*args, **kwargs):
+        renewals["count"] += 1
+        return original_renew_lease(*args, **kwargs)
+
+    service.renew_lease = spy_renew_lease
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert renewals["count"] > 0, (
+        "the keep-alive never ran while the blocking search was in flight"
+    )
     assert final["status"] == "completed", final.get("progress_message")
 
 

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1490,3 +1490,45 @@ def test_a_failed_synthesis_is_recorded_on_the_run():
     assert content.get("synthesis_failed", {}).get("error_type") == "ReadTimeoutError"
     warnings = " ".join(str(w) for w in (content.get("warnings") or []))
     assert "synthesis produced no report" in warnings, content.get("warnings")
+
+
+def test_a_second_engine_declines_a_leased_run():
+    """task-18060: two executors must not run one run. The window's
+    exclusive-worker guard is per-session and cannot see a second process."""
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    first = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    second = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    service.claim_run(run["id"], worker_id=first.worker_id, lease_seconds=60)
+    final = asyncio.run(second.execute_run(run["id"]))
+
+    assert final["status"] != "completed"
+    assert "lease" in str(final.get("progress_message") or "").lower()
+
+
+def test_a_long_silent_phase_keeps_its_lease():
+    """The synthesis phase emits no progress for its whole duration, so a
+    lease renewed only by progress events would expire inside it."""
+    service = _make_service()
+    search_fn, _analyze, _calls = _make_pipeline("q")
+
+    async def slow_analyze(wsr, sqd, params, cancel_event=None):
+        await asyncio.sleep(0.3)
+        return {
+            "final_answer": {"text": "Answer citing [1].", "evidence": [],
+                             "confidence": 0.5, "chunks": []},
+            "relevant_results": {},
+        }
+
+    engine = LocalResearchEngine(
+        service, search_fn=search_fn, analyze_fn=slow_analyze
+    )
+    engine.lease_seconds = 0.1
+    engine.keepalive_seconds = 0.02
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    final = asyncio.run(engine.execute_run(run["id"]))
+
+    assert final["status"] == "completed", final.get("progress_message")

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1608,6 +1608,17 @@ def test_a_lease_stolen_during_synthesis_blocks_packaging_writes_and_completion(
     run = service.launch_run(
         query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
     )
+    # task-3 report finding 2: `stolen` used to live only inside the seam's
+    # local scope, so an in-seam `assert stolen is not None` failing (e.g. if
+    # the theft silently did nothing) raised an AssertionError that propagated
+    # into execute_run's `except Exception` handler -- which still reaches a
+    # non-"completed" terminal status either way (see the outer assertion
+    # below), so every "shipped" assertion kept passing even with a no-op
+    # theft. Stashing the rescuer's lease id in this outer box lets the test
+    # verify, from OUTSIDE execute_run's exception handling, that a real
+    # third party actually holds the run's lease afterward -- an assertion
+    # that cannot be swallowed by any path through execute_run.
+    theft_box: dict[str, str | None] = {}
 
     async def stealing_analyze_fn(wsr, sqd, params, cancel_event=None):
         # A live (unexpired) lease cannot be reclaimed by another claim_run
@@ -1619,6 +1630,7 @@ def test_a_lease_stolen_during_synthesis_blocks_packaging_writes_and_completion(
         released = service.release_lease(run["id"], lease_id=engine._lease_id)
         assert released is True, "the engine must still hold its own lease at this point"
         stolen = service.claim_run(run["id"], worker_id="rescuer", lease_seconds=60)
+        theft_box["lease_id"] = stolen
         assert stolen is not None, "the steal itself must succeed for this test to mean anything"
         return {
             "final_answer": {"text": "Answer[1].", "evidence": [], "confidence": 0.5, "chunks": []},
@@ -1639,6 +1651,20 @@ def test_a_lease_stolen_during_synthesis_blocks_packaging_writes_and_completion(
 
     final = asyncio.run(engine.execute_run(run["id"]))
 
+    # The positive outcome: a real rescuer must actually hold the run's
+    # lease now. This is checked here, in the test's own top-level code --
+    # not inside the seam -- so it cannot be short-circuited by execute_run
+    # swallowing the in-seam assertion into some other non-"completed"
+    # terminal status (fail_run's "failed", or a quiet _LeaseLost return
+    # that leaves status at its launch-time "running"). Both of those satisfy
+    # a bare `!= "completed"`, which is why that check alone masked a no-op
+    # theft; this one cannot be satisfied unless the rescuer's claim really
+    # landed.
+    assert theft_box.get("lease_id"), "the rescuer's claim_run must have returned a lease id"
+    assert service.holds_lease(run["id"], lease_id=theft_box["lease_id"]) is True, (
+        "the rescuer must still hold the run's lease after the displaced "
+        "executor's execute_run returns"
+    )
     assert final["status"] != "completed"
     assert complete_calls["n"] == 0, "the displaced executor must never call complete_run"
     names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
@@ -1671,6 +1697,13 @@ def test_the_last_lease_fence_blocks_completion_after_the_final_write():
         query="q", autonomy_mode="autonomous", limits_json={"max_iterations": 1}
     )
 
+    # task-3 report finding 2: see the sibling theft test above for why this
+    # must be checked from OUTSIDE the seam -- an in-seam `assert stolen is
+    # not None` failing still lands execute_run at a non-"completed" terminal
+    # status either way (fail_run's "failed", or a quiet _LeaseLost return),
+    # so a bare `!= "completed"` check kept passing even for a no-op theft.
+    theft_box: dict[str, str | None] = {}
+
     original_save_artifact = service.save_artifact
 
     def stealing_save_artifact(run_id, *, artifact_name, content_type, content):
@@ -1687,6 +1720,7 @@ def test_the_last_lease_fence_blocks_completion_after_the_final_write():
             released = service.release_lease(run_id, lease_id=engine._lease_id)
             assert released is True
             stolen = service.claim_run(run_id, worker_id="rescuer", lease_seconds=60)
+            theft_box["lease_id"] = stolen
             assert stolen is not None
         return result
 
@@ -1694,6 +1728,14 @@ def test_the_last_lease_fence_blocks_completion_after_the_final_write():
 
     final = asyncio.run(engine.execute_run(run["id"]))
 
+    # The positive outcome, asserted from the test's own top-level code so it
+    # cannot be short-circuited by execute_run swallowing the in-seam
+    # assertion: a real rescuer must actually hold the run's lease now.
+    assert theft_box.get("lease_id"), "the rescuer's claim_run must have returned a lease id"
+    assert service.holds_lease(run["id"], lease_id=theft_box["lease_id"]) is True, (
+        "the rescuer must still hold the run's lease after the displaced "
+        "executor's execute_run returns"
+    )
     assert final["status"] != "completed"
     names = {a["artifact_name"] for a in service.get_bundle(run["id"])["artifacts"]}
     assert "bundle.json" in names  # the write that triggered the steal did land

--- a/Tests/Research/test_local_research_engine.py
+++ b/Tests/Research/test_local_research_engine.py
@@ -1532,3 +1532,63 @@ def test_a_long_silent_phase_keeps_its_lease():
     final = asyncio.run(engine.execute_run(run["id"]))
 
     assert final["status"] == "completed", final.get("progress_message")
+
+
+def test_a_resumed_run_does_not_get_its_search_budget_back():
+    """task-18060: the engine rebuilt the ledger from limits on every entry, so
+    a run resumed three times was granted its budget three times."""
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q",
+        autonomy_mode="autonomous",
+        limits_json={"max_searches": 10, "max_iterations": 1},
+    )
+    asyncio.run(engine.execute_run(run["id"]))
+
+    snapshot = (
+        service.get_artifact(run["id"], "budget_ledger.json") or {}
+    ).get("content") or {}
+
+    assert int(snapshot.get("searches_used") or 0) > 0, snapshot
+
+
+def test_the_engine_continues_a_pre_existing_ledger():
+    """The decisive test: pre-seed spend, then run. If the engine rebuilds from
+    limits it starts at zero and the final snapshot shows only this run's spend;
+    if it restores, the snapshot continues from the seeded total.
+
+    Written this way because the obvious version -- call from_snapshot in the
+    test and assert it reduces the budget -- passes whether or not the ENGINE
+    uses it. Verified by mutation: reverting the engine to from_limits fails
+    this test and nothing else.
+    """
+    service = _make_service()
+    search_fn, analyze_fn, _calls = _make_pipeline("q")
+    engine = LocalResearchEngine(service, search_fn=search_fn, analyze_fn=analyze_fn)
+    run = service.launch_run(
+        query="q",
+        autonomy_mode="autonomous",
+        limits_json={"max_searches": 10, "max_iterations": 1},
+    )
+    service.save_artifact(
+        run["id"],
+        artifact_name="budget_ledger.json",
+        content_type="application/json",
+        content={
+            "limits": {"max_searches": 10},
+            "searches_used": 5,
+            "searches_overshoot": 0,
+            "docs_used": 0,
+            "tokens_settled": 0,
+        },
+    )
+
+    asyncio.run(engine.execute_run(run["id"]))
+
+    snapshot = (
+        service.get_artifact(run["id"], "budget_ledger.json") or {}
+    ).get("content") or {}
+
+    assert int(snapshot.get("searches_used") or 0) > 5, snapshot

--- a/Tests/Research/test_local_research_service.py
+++ b/Tests/Research/test_local_research_service.py
@@ -326,3 +326,42 @@ def test_update_run_progress_external_db_wraps_in_transaction():
     assert updated["progress_percent"] == 45.0
     assert updated["version"] == 2
     external.close()
+
+
+def test_lease_operations_in_external_db_mode_do_not_raise():
+    """task-3 report finding 6: every lease operation called ``_connect()``
+    unconditionally, which raises ``RuntimeError`` in external-db mode
+    (``self.db is not None``, ``self.db_path is None``) -- so since
+    ``execute_run`` now always claims a lease, external-db mode was broken
+    outright. ``self.db`` has no lease columns and no lease API of its own
+    (the ``FakeExternalResearchDB`` double above matches that: only
+    ``transaction``/``get_run``/``close``), so a real, persisted,
+    cross-process lease cannot be implemented against it -- the service
+    degrades to an in-memory, per-instance lease instead of raising.
+    """
+    external = FakeExternalResearchDB()
+    now = "2026-08-16T00:00:00Z"
+    external.conn.execute(
+        "INSERT INTO research_runs (id, query, created_at, updated_at) "
+        "VALUES ('ext-run', 'External question', ?, ?)",
+        (now, now),
+    )
+    service = LocalResearchService(external)  # db object -> external mode
+
+    lease_id = service.claim_run("ext-run", worker_id="engine-a", lease_seconds=60)
+    assert lease_id is not None
+    assert service.holds_lease("ext-run", lease_id=lease_id) is True
+
+    # A second claim while the first is live must decline, not raise --
+    # "still functions single-executor" per the finding's fix direction.
+    declined = service.claim_run("ext-run", worker_id="engine-b", lease_seconds=60)
+    assert declined is None
+
+    assert service.renew_lease("ext-run", lease_id=lease_id, lease_seconds=60) is True
+    assert service.release_lease("ext-run", lease_id=lease_id) is True
+    assert service.holds_lease("ext-run", lease_id=lease_id) is False
+
+    # Released -- a new claim must now succeed.
+    second_lease = service.claim_run("ext-run", worker_id="engine-b", lease_seconds=60)
+    assert second_lease is not None
+    external.close()

--- a/Tests/Research/test_local_research_service.py
+++ b/Tests/Research/test_local_research_service.py
@@ -365,3 +365,131 @@ def test_lease_operations_in_external_db_mode_do_not_raise():
     second_lease = service.claim_run("ext-run", worker_id="engine-b", lease_seconds=60)
     assert second_lease is not None
     external.close()
+
+
+# --- versioned schema migration (Qodo PR-1822 finding 7) -------------------
+
+#: The research_runs shape as it shipped BEFORE the lease columns existed:
+#: what a genuinely pre-existing on-disk database carries.
+_PRE_LEASE_RUNS_DDL = """
+CREATE TABLE research_runs (
+    id TEXT PRIMARY KEY,
+    session_id TEXT,
+    query TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'running',
+    phase TEXT NOT NULL DEFAULT 'local_planning',
+    control_state TEXT NOT NULL DEFAULT 'running',
+    progress_percent REAL,
+    progress_message TEXT,
+    source_policy TEXT NOT NULL DEFAULT 'balanced',
+    autonomy_mode TEXT NOT NULL DEFAULT 'checkpointed',
+    limits_json TEXT NOT NULL DEFAULT '{}',
+    provider_overrides_json TEXT NOT NULL DEFAULT '{}',
+    chat_handoff_json TEXT NOT NULL DEFAULT '{}',
+    follow_up_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deleted INTEGER NOT NULL DEFAULT 0,
+    client_id TEXT NOT NULL DEFAULT 'local',
+    version INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY(session_id) REFERENCES research_sessions(id)
+);
+"""
+
+
+def _make_pre_lease_database(tmp_path) -> "object":
+    """A database in the pre-lease v0 shape: research_runs without the
+    lease columns, one surviving run row, ``user_version`` 0."""
+    db_path = tmp_path / "research.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_PRE_LEASE_RUNS_DDL)
+    conn.execute(
+        "INSERT INTO research_runs (id, query, created_at, updated_at) "
+        "VALUES ('legacy-run', 'A question paid for before leases', "
+        "'2026-08-01T00:00:00.000000Z', '2026-08-01T00:00:00.000000Z')"
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _columns(conn, table):
+    return {
+        str(row["name"])
+        for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+
+
+def test_a_pre_lease_database_upgrades_through_a_versioned_migration(tmp_path):
+    """Qodo PR-1822 finding 7: the lease columns were added by bare,
+    unversioned ALTERs at startup. The upgrade path must instead go
+    through a versioned migration that stamps ``PRAGMA user_version`` --
+    auditable, ordered, and refusing to run backwards -- like TTS's
+    ``migrations/`` and the repo's numbered SQL migrations. A pre-lease
+    database's data must survive the upgrade.
+    """
+    db_path = _make_pre_lease_database(tmp_path)
+    service = LocalResearchService(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        columns = _columns(conn, "research_runs")
+        assert {"lease_owner", "lease_id", "leased_until", "lease_attempts"} <= columns
+        row = conn.execute(
+            "SELECT query, status FROM research_runs WHERE id = 'legacy-run'"
+        ).fetchone()
+        assert row["query"] == "A question paid for before leases"
+        assert row["status"] == "running"
+    finally:
+        conn.close()
+
+    # The upgraded database is fully operational, not just column-complete.
+    lease = service.claim_run("legacy-run", worker_id="engine-a", lease_seconds=60)
+    assert lease is not None
+    assert service.release_lease("legacy-run", lease_id=lease) is True
+
+
+def test_a_fresh_database_is_stamped_with_the_schema_version(tmp_path):
+    """Fresh databases must carry the same versioned stamp -- not a
+    versionless shape that the next migration then cannot find."""
+    LocalResearchService(tmp_path / "research.db")
+
+    conn = sqlite3.connect(tmp_path / "research.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert {"lease_owner", "lease_id", "leased_until", "lease_attempts"} <= _columns(
+            conn, "research_runs"
+        )
+    finally:
+        conn.close()
+
+
+def test_reopening_an_upgraded_database_is_an_idempotent_noop(tmp_path):
+    """Re-constructing the service (next app launch) must neither re-ALTER
+    nor drift the version -- the migration runs once per database."""
+    db_path = _make_pre_lease_database(tmp_path)
+    LocalResearchService(db_path)
+    LocalResearchService(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_a_database_from_a_future_schema_version_is_refused(tmp_path):
+    """A database stamped by a NEWER service must not be silently
+    downgraded or half-used by older code: refuse loudly so the user
+    knows they need to update rather than risk corrupting data."""
+    db_path = _make_pre_lease_database(tmp_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA user_version = 99")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="newer"):
+        LocalResearchService(db_path)

--- a/Tests/Research/test_research_budget.py
+++ b/Tests/Research/test_research_budget.py
@@ -186,3 +186,50 @@ def test_release_searches_returns_unused_reservations():
     ledger.settle_searches(1)
 
     assert ledger.remaining_searches() == 2
+
+
+# --- resume restores spend rather than re-granting it (task-18060) -------------
+
+
+def test_from_snapshot_restores_spend_rather_than_regranting_it():
+    """execute_run rebuilt the ledger from limits on every entry and never read
+    budget_ledger.json back, so a resumed run was granted its full budget
+    again. With resume routine rather than exceptional, that is a budget leak."""
+    from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
+
+    original = BudgetLedger.from_limits({"max_searches": 10})
+    original.reserve_searches(4)
+    original.settle_searches(4)
+    snapshot = original.snapshot()
+
+    restored = BudgetLedger.from_snapshot(snapshot, {"max_searches": 10})
+
+    assert restored.remaining_searches() == 6
+
+
+def test_from_snapshot_without_a_snapshot_is_a_fresh_ledger():
+    """A run that has never executed has no snapshot; it must start whole."""
+    from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
+
+    restored = BudgetLedger.from_snapshot(None, {"max_searches": 10})
+
+    assert restored.remaining_searches() == 10
+
+
+def test_from_snapshot_restores_docs_and_tokens_too():
+    """Searches are not the only spendable budget; a partial restore would
+    silently re-grant whichever counter it forgot."""
+    from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
+
+    original = BudgetLedger.from_limits(
+        {"max_searches": 10, "max_fetched_docs": 8, "max_tokens": 1000}
+    )
+    original.settle_docs(3)
+    original.settle_tokens(250, exact=True)
+    snapshot = original.snapshot()
+
+    restored = BudgetLedger.from_snapshot(snapshot, None)
+
+    assert restored.docs_used == 3
+    assert restored.tokens_settled == 250
+    assert restored.max_fetched_docs == 8

--- a/Tests/Research/test_research_budget.py
+++ b/Tests/Research/test_research_budget.py
@@ -216,6 +216,23 @@ def test_from_snapshot_without_a_snapshot_is_a_fresh_ledger():
     assert restored.remaining_searches() == 10
 
 
+def test_from_snapshot_prefers_current_limits_over_stale_snapshot_limits():
+    """A plan-review checkpoint can patch a run's limits AFTER it has
+    already executed once and written a snapshot under the OLD limits. The
+    current value must win -- a snapshot's stale limits overriding a fresh
+    patch is the same bug class the Qodo PR 1766 fix addressed for
+    max_iterations in local_research_engine.py."""
+    from tldw_chatbook.Research_Interop.research_budget import BudgetLedger
+
+    original = BudgetLedger.from_limits({"max_searches": 3})
+    snapshot = original.snapshot()  # snapshot carries the STALE limit (3)
+
+    restored = BudgetLedger.from_snapshot(snapshot, {"max_searches": 20})
+
+    assert restored.max_searches == 20
+    assert restored.remaining_searches() == 20
+
+
 def test_from_snapshot_restores_docs_and_tokens_too():
     """Searches are not the only spendable budget; a partial restore would
     silently re-grant whichever counter it forgot."""

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -1,0 +1,24 @@
+"""Run leases (task-18060): exactly one executor may hold a run."""
+
+from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+
+def _service() -> LocalResearchService:
+    return LocalResearchService(":memory:")
+
+
+def test_first_claim_succeeds_and_returns_a_lease_id():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    lease_id = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert isinstance(lease_id, str) and lease_id
+
+
+def test_second_claim_is_refused_while_the_lease_is_live():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60) is None

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -194,3 +194,51 @@ def test_a_clean_release_resets_the_retry_budget():
         run["id"], worker_id="rescuer", lease_seconds=60, max_attempts=3
     )
     assert rescue is not None
+
+
+def test_a_live_lease_at_the_retry_budget_declines_instead_of_raising():
+    """task-3 report finding 1: ``claim_run`` treated ANY previous lease --
+    live or expired -- as a "reclaim" for budget-check purposes, keyed only
+    on ``previous is not None``. So once ``lease_attempts`` reached
+    ``max_attempts``, a second executor merely racing a perfectly healthy,
+    still-live lease got ``LeaseBudgetExhausted`` instead of a routine
+    decline. The engine's caller responds to that exception by calling
+    ``fail_run`` (see ``local_research_engine.py`` around the
+    ``LeaseBudgetExhausted`` handler), so a run whose executor was actively
+    working got failed out from under it with a false "claimed and
+    abandoned N time(s)" message.
+
+    Reproduces the reviewer's repro: two abandonments (expired leases, never
+    released) spend two of the three attempts, then a THIRD, healthy claim
+    takes the run and its lease is still live. A concurrent claim against
+    that live lease must be declined (return None, raise nothing) -- the
+    budget check only applies to RECLAIMING an EXPIRED lease.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    # Two abandonments: claimed with an already-expired lease, never released.
+    for _ in range(2):
+        assert service.claim_run(
+            run["id"], worker_id="dead-executor", lease_seconds=0, max_attempts=3
+        )
+
+    # A healthy third claim: attempt 3 of 3, but its lease is LIVE, not
+    # abandoned.
+    holder_lease = service.claim_run(
+        run["id"], worker_id="healthy-executor", lease_seconds=60, max_attempts=3
+    )
+    assert holder_lease is not None
+
+    # A racing second executor must be declined, not told the budget is
+    # exhausted.
+    racer_result = service.claim_run(
+        run["id"], worker_id="racer", lease_seconds=60, max_attempts=3
+    )
+    assert racer_result is None
+
+    # The run itself must be untouched: not failed, and still held by its
+    # legitimate, healthy holder.
+    run_row = service.get_run(run["id"])
+    assert run_row["status"] != "failed"
+    assert service.holds_lease(run["id"], lease_id=holder_lease) is True

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -196,6 +196,48 @@ def test_a_clean_release_resets_the_retry_budget():
     assert rescue is not None
 
 
+def test_releasing_an_expired_lease_does_not_reset_the_retry_budget():
+    """PR-1822 review follow-up: ``release_lease`` matched on ``lease_id``
+    only, with no liveness check, so it reset ``lease_attempts`` to 0 for an
+    EXPIRED lease too. An executor that stalls past expiry, notices, and
+    exits through its finally block therefore "cleanly released" a lease it
+    no longer held -- and a systematically stalling-but-alive executor could
+    loop claim -> expire -> release forever without ever spending the crash
+    budget, defeating the "fail a run whose executor keeps dying" contract
+    (AC #1b).
+
+    Only a release while the lease is still LIVE counts as clean. Releasing
+    an expired lease must still free the run for the next claimant but must
+    keep the abandonment on the books.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    # Two stalls: claimed, lease allowed to expire, executor wakes and
+    # releases what it no longer holds.
+    for _ in range(2):
+        lease = service.claim_run(
+            run["id"], worker_id="stalling", lease_seconds=0, max_attempts=3
+        )
+        assert lease is not None
+        # Zero-second lease: already expired at the moment of release.
+        assert service.release_lease(run["id"], lease_id=lease) is True
+
+    # The run is claimable again (the release DID clear the lease)...
+    third = service.claim_run(
+        run["id"], worker_id="stalling", lease_seconds=0, max_attempts=3
+    )
+    assert third is not None
+    assert service.release_lease(run["id"], lease_id=third) is True
+
+    # ...but the third stall must now exhaust the budget: three
+    # abandonments, none of them clean.
+    with pytest.raises(LeaseBudgetExhausted):
+        service.claim_run(
+            run["id"], worker_id="rescuer", lease_seconds=60, max_attempts=3
+        )
+
+
 def test_a_live_lease_at_the_retry_budget_declines_instead_of_raising():
     """task-3 report finding 1: ``claim_run`` treated ANY previous lease --
     live or expired -- as a "reclaim" for budget-check purposes, keyed only

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -148,3 +148,36 @@ def test_release_frees_the_run_for_the_next_executor():
 
     assert service.release_lease(run["id"], lease_id=lease) is True
     assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+
+
+def test_a_clean_release_resets_the_retry_budget():
+    """Regression guard for task-18060 finding 1: a healthy claim->release
+    cycle must NOT burn the crash-retry budget. Without resetting
+    lease_attempts on release, several healthy cycles would exhaust
+    max_attempts on their own, and the genuine crash recovery below would
+    be refused even though the run was never actually abandoned more than
+    once.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    # Several healthy claim -> release cycles by well-behaved executors.
+    for _ in range(3):
+        lease = service.claim_run(
+            run["id"], worker_id="w", lease_seconds=60, max_attempts=3
+        )
+        assert lease is not None
+        assert service.release_lease(run["id"], lease_id=lease) is True
+
+    # A genuine crash: claimed but never released, lease left to expire.
+    abandoned = service.claim_run(
+        run["id"], worker_id="w", lease_seconds=0, max_attempts=3
+    )
+    assert abandoned is not None
+
+    # The rescue claim must still succeed -- the prior clean releases must
+    # not have consumed the budget that this single abandonment is spending.
+    rescue = service.claim_run(
+        run["id"], worker_id="rescuer", lease_seconds=60, max_attempts=3
+    )
+    assert rescue is not None

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -242,3 +242,119 @@ def test_a_live_lease_at_the_retry_budget_declines_instead_of_raising():
     run_row = service.get_run(run["id"])
     assert run_row["status"] != "failed"
     assert service.holds_lease(run["id"], lease_id=holder_lease) is True
+
+
+# --- task-3 report (fourth fix-up): terminal-claim race, self-renewing
+# expired leases, and lease-conditional terminal writes -------------------
+
+
+def test_claim_run_refuses_a_cancelled_run():
+    """task-3 report finding 1: ``claim_run`` restricted acquisition by
+    lease expiry only, never by run status, while ``execute_run``'s own
+    terminal check happens BEFORE the claim. A cancellation landing between
+    that check and the claim let a terminal run be claimed and executed
+    (resurrected) anyway. The status condition now lives in the SAME atomic
+    UPDATE as the lease-expiry check, so a cancelled run can never be
+    claimed, first claim or not.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    service.cancel_run(run["id"])
+
+    assert service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60) is None
+
+
+def test_claim_run_refuses_a_completed_run_even_with_an_expired_lease():
+    """A run that finished (and thus never released, but no longer needs
+    to be) must not be reclaimable just because its lease looks expired."""
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+
+    service.complete_run(run["id"])
+
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60) is None
+
+
+def test_renew_lease_after_expiry_returns_false_even_without_takeover():
+    """task-3 report finding 3: ``renew_lease`` matched on ``run_id`` and
+    ``lease_id`` only, so a worker whose lease already expired could extend
+    it as long as nobody had taken over YET -- a stalled worker resurrecting
+    a claim it had already lost, contradicting takeover. The lease must
+    still be LIVE for a renewal to land, independent of whether a second
+    claimant has shown up.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    lease = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+    assert lease is not None
+
+    # No takeover has happened -- the lease is simply expired.
+    assert service.renew_lease(run["id"], lease_id=lease, lease_seconds=60) is False
+    # holds_lease agrees: an expired lease is not "held" either.
+    assert service.holds_lease(run["id"], lease_id=lease) is False
+
+
+def test_complete_run_with_a_stale_lease_id_is_a_noop():
+    """task-3 report finding 4: a standalone ``holds_lease()`` check
+    followed by an unconditional write is check-then-act -- a takeover
+    between the two still lets the stale write land. ``complete_run``'s own
+    UPDATE now matches ``lease_id`` at the SQL level, so a displaced
+    executor's completion is a no-op instead of a race.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+    rescuer = service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+    assert rescuer is not None
+
+    result = service.complete_run(run["id"], lease_id=stale)
+
+    assert result["status"] != "completed"
+    current = service.get_run(run["id"])
+    assert current["status"] != "completed"
+    assert service.holds_lease(run["id"], lease_id=rescuer) is True
+
+
+def test_fail_run_with_a_stale_lease_id_is_a_noop():
+    """Same contract as complete_run's sibling test, for fail_run."""
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+    rescuer = service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+    assert rescuer is not None
+
+    result = service.fail_run(run["id"], error_msg="boom", lease_id=stale)
+
+    assert result["status"] != "failed"
+    current = service.get_run(run["id"])
+    assert current["status"] != "failed"
+    assert service.holds_lease(run["id"], lease_id=rescuer) is True
+
+
+def test_complete_run_with_a_matching_lease_id_still_lands():
+    """The lease-conditional UPDATE must not become a no-op for the
+    legitimate holder -- only a mismatched (or absent-but-expected) lease
+    id blocks the write."""
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    lease = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+    assert lease is not None
+
+    result = service.complete_run(run["id"], lease_id=lease)
+
+    assert result["status"] == "completed"
+
+
+def test_complete_run_without_a_lease_id_is_unconditional_as_before():
+    """A caller that never held a lease (the LeaseBudgetExhausted path, or
+    any pre-existing caller outside the leased-execution flow) omits
+    ``lease_id`` -- the write must remain unconditional, matching behavior
+    before task-3's fourth fix-up."""
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    result = service.complete_run(run["id"])
+
+    assert result["status"] == "completed"

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -101,3 +101,50 @@ def test_format_timestamp_is_stable_at_a_whole_second_boundary():
     assert _TIMESTAMP_RE.match(fractional_str)
     # Chronological order must equal string order.
     assert whole_str < fractional_str
+
+
+# NOTE: a lease of 0 seconds expires the instant it is granted, so these tests
+# exercise takeover deterministically. Do NOT use time.sleep() to age a lease:
+# a wall-clock dependency makes the suite flaky on a loaded machine, and the
+# behaviour under test is the comparison against `leased_until`, not duration.
+
+
+def test_a_stale_lease_can_be_taken_over():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+
+
+def test_a_displaced_worker_cannot_renew_or_release():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    stale = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+    service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+
+    assert service.renew_lease(run["id"], lease_id=stale, lease_seconds=60) is False
+    assert service.release_lease(run["id"], lease_id=stale) is False
+    assert service.holds_lease(run["id"], lease_id=stale) is False
+
+
+def test_reclaim_stops_at_the_retry_budget():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    for _ in range(3):
+        assert service.claim_run(
+            run["id"], worker_id="w", lease_seconds=0, max_attempts=3
+        )
+
+    assert service.claim_run(
+        run["id"], worker_id="w", lease_seconds=0, max_attempts=3
+    ) is None
+
+
+def test_release_frees_the_run_for_the_next_executor():
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+    lease = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
+
+    assert service.release_lease(run["id"], lease_id=lease) is True
+    assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -3,7 +3,12 @@
 import re
 from datetime import datetime, timezone
 
-from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+import pytest
+
+from tldw_chatbook.Research_Interop.local_research_service import (
+    LeaseBudgetExhausted,
+    LocalResearchService,
+)
 
 # _now()/_timestamp_after() must always render this exact shape: fixed
 # microsecond precision (never omitted) and a trailing "Z". See
@@ -129,6 +134,12 @@ def test_a_displaced_worker_cannot_renew_or_release():
 
 
 def test_reclaim_stops_at_the_retry_budget():
+    """Review finding 1: once the retry budget is spent, claim_run raises
+    LeaseBudgetExhausted rather than returning None -- overloading None to
+    mean both "someone else holds it live" and "the budget is spent" left
+    callers unable to tell the two apart, and the caller MUST respond to
+    them differently (see the engine-level tests in
+    test_local_research_engine.py for the two different responses)."""
     service = _service()
     run = service.launch_run(query="q", autonomy_mode="autonomous")
     for _ in range(3):
@@ -136,9 +147,11 @@ def test_reclaim_stops_at_the_retry_budget():
             run["id"], worker_id="w", lease_seconds=0, max_attempts=3
         )
 
-    assert service.claim_run(
-        run["id"], worker_id="w", lease_seconds=0, max_attempts=3
-    ) is None
+    with pytest.raises(LeaseBudgetExhausted) as excinfo:
+        service.claim_run(run["id"], worker_id="w", lease_seconds=0, max_attempts=3)
+    assert excinfo.value.run_id == run["id"]
+    assert excinfo.value.attempts == 3
+    assert excinfo.value.max_attempts == 3
 
 
 def test_release_frees_the_run_for_the_next_executor():

--- a/Tests/Research/test_research_run_lease.py
+++ b/Tests/Research/test_research_run_lease.py
@@ -1,6 +1,14 @@
 """Run leases (task-18060): exactly one executor may hold a run."""
 
+import re
+from datetime import datetime, timezone
+
 from tldw_chatbook.Research_Interop.local_research_service import LocalResearchService
+
+# _now()/_timestamp_after() must always render this exact shape: fixed
+# microsecond precision (never omitted) and a trailing "Z". See
+# _format_timestamp's docstring for why the precision can't be optional.
+_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
 
 
 def _service() -> LocalResearchService:
@@ -22,3 +30,74 @@ def test_second_claim_is_refused_while_the_lease_is_live():
     service.claim_run(run["id"], worker_id="worker-a", lease_seconds=60)
 
     assert service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60) is None
+
+
+def test_zero_lease_seconds_produces_an_already_expired_lease():
+    """A zero lease_seconds must yield a lease a subsequent claim can take
+    over immediately -- deterministically, with no time.sleep(). What's
+    under test is the string comparison in claim_run's UPDATE guard, not
+    elapsed wall-clock time, so no real waiting is needed or wanted.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    first = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=0)
+    assert isinstance(first, str) and first
+
+    second = service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+    assert isinstance(second, str) and second
+    assert second != first
+
+
+def test_negative_lease_seconds_produces_an_already_expired_lease():
+    """A negative lease_seconds clamps to "expires now" rather than being
+    treated literally (which would try to lease *before* it was granted);
+    a subsequent claim must still be able to take over immediately.
+    """
+    service = _service()
+    run = service.launch_run(query="q", autonomy_mode="autonomous")
+
+    first = service.claim_run(run["id"], worker_id="worker-a", lease_seconds=-5)
+    assert isinstance(first, str) and first
+
+    second = service.claim_run(run["id"], worker_id="worker-b", lease_seconds=60)
+    assert isinstance(second, str) and second
+
+
+def test_now_and_timestamp_after_produce_mutually_comparable_strings():
+    """Regression guard for task-18060 finding 1: whatever ``_now()`` and
+    ``_timestamp_after()`` produce must be directly comparable as plain
+    strings, since claim_run's atomicity is a single string comparison in
+    a SQL WHERE clause, not a parsed-datetime comparison.
+    """
+    service = _service()
+    now = service._now()
+    zero_offset = service._timestamp_after(0)
+    later = service._timestamp_after(60)
+
+    assert _TIMESTAMP_RE.match(now)
+    assert _TIMESTAMP_RE.match(zero_offset)
+    assert _TIMESTAMP_RE.match(later)
+    assert now <= zero_offset <= later
+
+
+def test_format_timestamp_is_stable_at_a_whole_second_boundary():
+    """Pins the exact bug the reviewer found: plain ``datetime.isoformat()``
+    drops the fractional-seconds field when microsecond == 0, and ``"."``
+    (0x2E) sorts below ``"Z"`` (0x5A). Before the fix, a whole-second
+    timestamp with no fractional part would sort *below* an earlier
+    timestamp that still had trailing digits, silently reordering leases.
+    ``_format_timestamp`` must pin microsecond precision so this can't
+    recur regardless of how ``_now``/``_timestamp_after`` are called.
+    """
+    whole_second = datetime(2026, 8, 18, 8, 31, 1, 0, tzinfo=timezone.utc)
+    fractional = datetime(2026, 8, 18, 8, 31, 1, 123456, tzinfo=timezone.utc)
+
+    whole_str = LocalResearchService._format_timestamp(whole_second)
+    fractional_str = LocalResearchService._format_timestamp(fractional)
+
+    assert whole_str == "2026-08-18T08:31:01.000000Z"
+    assert _TIMESTAMP_RE.match(whole_str)
+    assert _TIMESTAMP_RE.match(fractional_str)
+    # Chronological order must equal string order.
+    assert whole_str < fractional_str

--- a/backlog/decisions/070-research-run-lease-and-durability.md
+++ b/backlog/decisions/070-research-run-lease-and-durability.md
@@ -97,13 +97,22 @@ re-searched everything it had already paid for.
    external object has no lease columns or API; external mode degrades to a
    documented, per-instance in-memory exclusion instead of failing
    outright.
+- **Keep the unversioned startup ALTERs** (first adjudication of Qodo
+   finding 7): reversed on merge review — the repo carries versioned-
+   migration conventions the service can adopt directly, so the columns
+   moved into `Research_Interop/migrations/` rather than staying outside
+   the auditable path.
 
 ## Consequences
 
 - Schema: four added columns on `research_runs` (`lease_owner`, `lease_id`,
-  `leased_until`, `lease_attempts`), applied by idempotent
-  `PRAGMA table_info`-guarded `ALTER`s (the service has no migration
-  framework; introducing one was adjudicated out of scope for this change).
+  `leased_until`, `lease_attempts`), applied by the versioned migration
+  `Research_Interop/migrations/v0_to_v1_run_lease_columns.py` (stamps
+  `PRAGMA user_version = 1`; interim databases created by the unversioned
+  ALTER path upgrade without re-ALTERing, and newer-stamped databases are
+  refused). Originally landed as idempotent startup ALTERs; rehomed into a
+  versioned migration on review (Qodo PR-1822 finding 7) to match the
+  repo's migration conventions (`TTS/migrations/`, `DB/migrations/`).
 - Callers of `claim_run` must handle `LeaseBudgetExhausted` separately from
   a `None` return.
 - External-DB mode leases are single-process only; cross-process exclusion

--- a/backlog/decisions/070-research-run-lease-and-durability.md
+++ b/backlog/decisions/070-research-run-lease-and-durability.md
@@ -1,0 +1,113 @@
+# ADR-070: Research run lease, fencing, and durable budget/evidence
+
+- **Status:** Accepted
+- **Date:** 2026-08-18
+- **Task:** task-18060 (Make research runs durable, resumable jobs)
+- **Related:** ADR-068 (local research execution engine — this layers
+  durability onto its engine); tldw_server `app/core/Jobs/` (the lease model
+  adopted); `Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md`
+  (design); PR #1822 review (the live/expired release semantics and
+  keep-alive containment decisions below)
+
+## Context
+
+ADR-068's engine executes a run inside one app session with no execution
+ownership: `execute_run` refuses only terminal runs, and the window's
+exclusive-worker guard is per-session. Two processes (or a future scheduler)
+could execute the same run concurrently — duplicate searches, duplicate
+spend, and racing terminal writes. Resume also re-granted the whole budget
+(the ledger was rebuilt from limits while `budget_ledger.json` was written
+and never read), and an interrupted run left no evidence behind, so a resume
+re-searched everything it had already paid for.
+
+## Decision
+
+1. **A lease with a fencing token, owned by the service layer.**
+   `LocalResearchService.claim_run` takes the execution lease in one atomic
+   `UPDATE` (`leased_until IS NULL OR expired`, plus `status NOT IN
+   terminal`); `renew_lease` / `release_lease` / terminal writes authorise
+   on `lease_id` — not `worker_id` — so a stalled worker that was taken over
+   cannot act on a run it no longer owns. Lease timestamps all flow through
+   one formatter (`_format_timestamp`, microsecond precision, `Z` suffix)
+   because the expiry comparison is a string compare and divergent formats
+   once let a live lease compare as expired.
+
+2. **A crash-retry budget of *consecutive abandonments*.** Each successful
+   claim increments `lease_attempts`; reclaiming an EXPIRED lease enforces
+   `max_attempts` and signals exhaustion by raising `LeaseBudgetExhausted`
+   (the caller fails the run) — distinct from `None` (another executor
+   holds a live lease; leave the run alone). A **live** release resets the
+   counter; a release of an **already-expired** lease is an abandonment
+   being acknowledged, not a clean hand-off — it leaves the lease record in
+   place so the next claim counts it (PR #1822 review: otherwise a
+   stalling-but-alive executor could loop claim → expire → release forever
+   without ever spending the budget).
+
+3. **A keep-alive on a timer, not a progress hook.** The synthesis phase
+   emits no progress for its whole duration (~970s measured), so renewal is
+   an `asyncio` timer task for as long as a phase is in flight. Blocking
+   pipeline seams (`search_fn`, `paper_search_fn`, the gap-analysis LLM
+   call) are offloaded via `asyncio.to_thread` so the timer actually runs.
+   A renewal that *raises* (e.g. transient SQLITE_BUSY) is contained inside
+   the keep-alive — treated as lost, never allowed to surface in
+   `execute_run`'s `finally` block where it would skip `release_lease`.
+
+4. **A fence before every persisting write.** `_require_lease()` guards
+   each artifact write, run-state write, and checkpoint creation; terminal
+   writes (`complete_run`/`fail_run`) additionally carry `lease_id` so the
+   UPDATE itself is lease-conditional (no check-then-act gap). A displaced
+   executor's terminal write is a no-op that returns the current truth.
+   Engine lease state is per-`execute_run`; every current caller builds a
+   fresh engine per run, and a shared-engine caller would silently disable
+   the fence — called out as a constraint on future scheduler design.
+
+5. **Resume restores spent budget across all four axes** (searches, docs,
+   tokens, elapsed runtime) via `BudgetLedger.from_snapshot`, with current
+   limits preferred over the snapshot's (an approved plan-review patch must
+   not be silently reverted). Reservations are deliberately not restored —
+   they belonged to calls that died with their executor.
+
+6. **Each round's evidence pool is an artifact under a stated 8 MB cap**
+   (`evidence_pool.json`), degrading to references-only past the cap;
+   entries that fit even without bodies only when dropped are dropped and
+   counted, and so are entries that cannot be serialized at all (a
+   non-JSON-native value degrades the artifact, never fails the run).
+
+7. **Observers append events; only the lease holder writes run state.** A
+   declined executor records `lease_declined` via
+   `record_run_event` (append-only) rather than `update_run_progress`,
+   which would stomp the live executor's progress and version mid-flight.
+
+## Alternatives considered
+
+- **Derive a size-aware synthesis timeout instead** (the superseded
+  task-17386 framing): rejected — a durable run is not watched live, so
+  outliving a provider timeout is acceptable once work survives and is not
+  duplicated; almost all timeout machinery became unnecessary.
+- **A separate reaper/sweeper for dead leases** (server-style): rejected —
+  stale-lease reclaim is folded into `claim_run`'s atomic UPDATE, so there
+  is no extra scheduled component and no window where a dead run is
+  invisible.
+- **Reuse `Library_Ingest_Jobs_DB`**: rejected — it has a retry counter but
+  no lease columns and a lifecycle shaped for file ingestion.
+- **Heartbeat on progress events**: rejected — see Decision 3; the longest
+  phase emits nothing, so the lease must be renewed by time, not by
+  activity.
+- **Persisted leases for external-db mode**: rejected as infeasible — the
+   external object has no lease columns or API; external mode degrades to a
+   documented, per-instance in-memory exclusion instead of failing
+   outright.
+
+## Consequences
+
+- Schema: four added columns on `research_runs` (`lease_owner`, `lease_id`,
+  `leased_until`, `lease_attempts`), applied by idempotent
+  `PRAGMA table_info`-guarded `ALTER`s (the service has no migration
+  framework; introducing one was adjudicated out of scope for this change).
+- Callers of `claim_run` must handle `LeaseBudgetExhausted` separately from
+  a `None` return.
+- External-DB mode leases are single-process only; cross-process exclusion
+  exists only in SQLite-backed mode.
+- A SIGKILLed executor's run stays declined for up to `lease_seconds`
+  before takeover. Evidence read-back (skipping a completed round on
+  resume) and scheduler auto-resume remain open (task-18060 ACs #3, #5–#11).

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -1,0 +1,56 @@
+---
+id: TASK-18060
+title: Make research runs durable, resumable jobs
+status: To Do
+assignee: []
+created_date: '2026-08-18 05:10'
+updated_date: '2026-08-18 05:40'
+labels:
+  - research
+  - scheduling
+  - llm-calls
+dependencies:
+  - task-17386
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A research run that takes longer than a provider's timeout cannot finish, and a run interrupted by an app exit is stranded: nothing resumes it, and the resume path that does exist restarts the phase machine from the beginning, discarding every search already paid for. Large pools are now the normal case rather than the exception, so both of these moved from rare to routine.
+
+Treating the run as a durable job rather than a synchronous call resolves the timeout problem without finely tuned clocks: a run whose result is an artifact and a message in the conversation that requested it can afford to take twenty minutes. What it cannot afford is to lose its work, to be executed twice, or to finish silently. Those become the substance of this task, and the timeout work reduces to generous bounds.
+
+This supersedes the earlier framing of the same criterion, which set out to derive a size-aware synthesis budget. The measurements from that work still stand and justify the bounds here; the derivation machinery it proposed does not survive the change of framing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Exactly one executor can run a given research run at a time, and a run whose executor died can be taken over rather than stranded
+- [ ] #2 A resumed run restores the budget it already spent instead of being granted it again
+- [ ] #3 A resumed run continues from its last completed phase without repeating searches it already paid for
+- [ ] #4 Persisted evidence is bounded by a stated cap, and an artifact that exceeded it records that it did
+- [ ] #5 A run interrupted by an application exit continues on the next launch without user intervention
+- [ ] #6 A run parked for checkpoint review is not re-entered by the scheduler on every tick
+- [ ] #7 A completed run announces itself in the conversation that requested it, however it was launched
+- [ ] #8 A completed run's report is reachable from the artifacts screen
+- [ ] #9 A synthesis that takes longer than any single provider timeout completes, and a user-set runtime limit that cannot cover the work refuses before spending
+- [ ] #10 The documentation states that runs resume at next launch and do not progress while the application is closed
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+The design, the measurements behind it, and the alternatives rejected are in
+`Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md`.
+
+1. Lease a run to exactly one executor, with a heartbeat and stale-lease
+   takeover. Everything else depends on this, so it lands first.
+2. Restore the budget ledger from its artifact on resume.
+3. Persist each round's evidence pool under a stated cap, and resume from it.
+4. Drive execution through a scheduler task whose handler claims the run and
+   skips runs awaiting review.
+5. Surface completion: a handoff target for window-launched runs, and the
+   metadata the artifacts screen filters on, with its user-guide page updated.
+6. Set the generous bounds and document what "resumes at next launch" means.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -27,6 +27,8 @@ This supersedes the earlier framing of the same criterion, which set out to deri
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Exactly one executor can run a given research run at a time, and a run whose executor died can be taken over rather than stranded
+- [ ] #1a A worker that wakes after its lease was taken over cannot complete or renew the run it lost
+- [ ] #1b A run whose executor keeps dying is failed on a retry budget rather than retried forever
 - [ ] #2 A resumed run restores the budget it already spent instead of being granted it again
 - [ ] #3 A resumed run continues from its last completed phase without repeating searches it already paid for
 - [ ] #4 Persisted evidence is bounded by a stated cap, and an artifact that exceeded it records that it did
@@ -44,8 +46,12 @@ This supersedes the earlier framing of the same criterion, which set out to deri
 The design, the measurements behind it, and the alternatives rejected are in
 `Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md`.
 
-1. Lease a run to exactly one executor, with a heartbeat and stale-lease
-   takeover. Everything else depends on this, so it lands first.
+1. Lease a run to exactly one executor, following the server's job manager
+   (`tldw_Server_API/app/core/Jobs/`, dev): a lease id alongside the worker id
+   as a fencing token, stale-lease reclaim folded into acquisition rather than
+   a separate reaper, a retry budget deciding requeue versus terminal failure,
+   and the existing phase-progress emission doubling as the heartbeat.
+   Everything else depends on this, so it lands first.
 2. Restore the budget ledger from its artifact on resume.
 3. Persist each round's evidence pool under a stated cap, and resume from it.
 4. Drive execution through a scheduler task whose handler claims the run and

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -29,15 +29,18 @@ This supersedes the earlier framing of the same criterion, which set out to deri
 - [ ] #1 Exactly one executor can run a given research run at a time, and a run whose executor died can be taken over rather than stranded
 - [ ] #1a A worker that wakes after its lease was taken over cannot complete or renew the run it lost
 - [ ] #1b A run whose executor keeps dying is failed on a retry budget rather than retried forever
+- [ ] #1c A phase that reports no progress for longer than the lease is not taken over
+- [ ] #1d An executor that lost its lease cannot write artifacts or settle budget, not merely cannot finish the run
 - [ ] #2 A resumed run restores the budget it already spent instead of being granted it again
 - [ ] #3 A resumed run continues from its last completed phase without repeating searches it already paid for
 - [ ] #4 Persisted evidence is bounded by a stated cap, and an artifact that exceeded it records that it did
 - [ ] #5 A run interrupted by an application exit continues on the next launch without user intervention
 - [ ] #6 A run parked for checkpoint review is not re-entered by the scheduler on every tick
-- [ ] #7 A completed run announces itself in the conversation that requested it, however it was launched
+- [ ] #7 A completed run announces itself EXACTLY ONCE in the conversation that requested it, however it was launched and however many times it was taken over
 - [ ] #8 A completed run's report is reachable from the artifacts screen
 - [ ] #9 A synthesis that takes longer than any single provider timeout completes, and a user-set runtime limit that cannot cover the work refuses before spending
 - [ ] #10 The documentation states that runs resume at next launch and do not progress while the application is closed
+- [ ] #11 A terminal or cancelled run leaves no scheduler task behind
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -46,6 +46,14 @@ This supersedes the earlier framing of the same criterion, which set out to deri
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/070-research-run-lease-and-durability.md
+Reason: the lease adds DB schema columns (lease_owner/lease_id/leased_until/
+lease_attempts) and a cross-module execution-ownership contract (claim/renew/
+release/fence) -- storage and service-contract decisions per the ADR policy.
+Recorded retroactively with PR #1822's post-review fixes; the branch itself
+landed without one, which the review flagged.
+
 The design, the measurements behind it, and the alternatives rejected are in
 `Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md`.
 
@@ -103,4 +111,29 @@ only because every caller builds a fresh engine per run -- a scheduler reusing
 one engine would silently disable the fence; and a run killed by SIGKILL is
 declined for up to `lease_seconds` before takeover, with a message that blames
 another executor.
+
+**PR #1822 external review (post-branch, fixed in the review round):** four
+defects found by an independent review, each fixed test-first:
+
+- A `renew_lease` that RAISES (e.g. transient SQLITE_BUSY) surfaced at
+  `await keepalive` inside `execute_run`'s `finally`, escaping the engine AND
+  skipping `release_lease` (stranding the lease; the run left running with no
+  fail_run). Renewal errors are now contained in the keep-alive (treated as
+  lost) and the finally's await suppresses both CancelledError and any stored
+  exception, so release is unconditional.
+- `release_lease` matched `lease_id` only, resetting the crash budget for an
+  already-EXPIRED lease: a stalling-but-alive executor could loop
+  claim -> expire -> release forever without spending the budget (defeating
+  AC #1b). Only a LIVE release is a clean hand-off; an expired release leaves
+  the record so the next claim counts the abandonment.
+- The DECLINED executor wrote run state (`update_run_progress`) on a run it
+  did not own, stomping the live executor's progress message and version
+  mid-flight. Decline is now an append-only `lease_declined` event via the
+  new `record_run_event` (observers append events; only the lease holder
+  writes run state).
+- A non-JSON-native value in an evidence entry raised TypeError inside
+  `_bounded_evidence`'s measurement and failed the whole run; it is now
+  dropped and counted like an oversized entry (the artifact degrades, the
+  run does not fail).
+- ADR-070 records the lease/durability contract (linked above).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-18060
 title: Make research runs durable, resumable jobs
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-18 05:10'
 updated_date: '2026-08-18 05:40'
@@ -26,14 +26,14 @@ This supersedes the earlier framing of the same criterion, which set out to deri
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Exactly one executor can run a given research run at a time, and a run whose executor died can be taken over rather than stranded
-- [ ] #1a A worker that wakes after its lease was taken over cannot complete or renew the run it lost
-- [ ] #1b A run whose executor keeps dying is failed on a retry budget rather than retried forever
-- [ ] #1c A phase that reports no progress for longer than the lease is not taken over
-- [ ] #1d An executor that lost its lease cannot write artifacts or settle budget, not merely cannot finish the run
-- [ ] #2 A resumed run restores the budget it already spent instead of being granted it again
+- [x] #1 Exactly one executor can run a given research run at a time, and a run whose executor died can be taken over rather than stranded
+- [x] #1a A worker that wakes after its lease was taken over cannot complete or renew the run it lost
+- [x] #1b A run whose executor keeps dying is failed on a retry budget rather than retried forever
+- [x] #1c A phase that reports no progress for longer than the lease is not taken over
+- [x] #1d An executor that lost its lease cannot write artifacts or settle budget, not merely cannot finish the run
+- [x] #2 A resumed run restores the budget it already spent instead of being granted it again
 - [ ] #3 A resumed run continues from its last completed phase without repeating searches it already paid for
-- [ ] #4 Persisted evidence is bounded by a stated cap, and an artifact that exceeded it records that it did
+- [x] #4 Persisted evidence is bounded by a stated cap, and an artifact that exceeded it records that it did
 - [ ] #5 A run interrupted by an application exit continues on the next launch without user intervention
 - [ ] #6 A run parked for checkpoint review is not re-entered by the scheduler on every tick
 - [ ] #7 A completed run announces itself EXACTLY ONCE in the conversation that requested it, however it was launched and however many times it was taken over
@@ -63,3 +63,44 @@ The design, the measurements behind it, and the alternatives rejected are in
    metadata the artifacts screen filters on, with its user-guide page updated.
 6. Set the generous bounds and document what "resumes at next launch" means.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes (durability core landed; the rest is named, not done)
+
+<!-- SECTION:NOTES:BEGIN -->
+The durability core is implemented: a lease with a fencing token and a reclaim
+budget, a keep-alive that survives blocking pipeline calls, a fence before every
+persisting write, budget restored across all four axes on resume, and each
+round's evidence persisted under a stated cap.
+
+**Met:** #1, #1a, #1b, #1c, #1d, #2, #4.
+**Not met and deliberately so:** #3 (reading the evidence pool back to skip a
+completed round -- the artifact that makes it possible is written, the read-back
+is not), #5-#11 (scheduler auto-resume and completion surfacing, which the plan
+scoped to follow-on work).
+
+What the review gates caught, recorded because the pattern generalises:
+
+- A timestamp format divergence made a LIVE lease compare as expired -- the
+  double-claim the lease exists to prevent.
+- A retry budget that counted healthy claim/release cycles stranded runs that
+  had never crashed.
+- The keep-alive was an asyncio task behind a blocking call, so it never ran
+  during collection; the design was right and the execution model defeated it.
+- Six persisting writes were unfenced, including the one that marks a run
+  completed.
+- An exhausted budget left a run permanently unclaimable rather than failed --
+  a regression against pre-branch behaviour -- and the fix for THAT then failed
+  runs whose executors were healthy.
+- Three times a test passed for the wrong reason, twice by asserting the absence
+  of a bad outcome rather than the presence of the good one.
+
+**Named follow-ups, not fixed here:** fence coverage is 2 of 11 when each fence
+is removed individually; the `except ResearchLimitExceeded` half of the
+lease-lost guard is untested; `evidence_pool.json` is written before the
+doc-budget trim, so it holds entries the run excluded (harmless until AC #3
+reads it back); `_lease_id`/`_run_id` are engine-instance state, which is safe
+only because every caller builds a fresh engine per run -- a scheduler reusing
+one engine would silently disable the fence; and a run killed by SIGKILL is
+declined for up to `lease_seconds` before takeover, with a message that blames
+another executor.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-18060 - Make-research-runs-durable-resumable-jobs.md
@@ -136,4 +136,18 @@ defects found by an independent review, each fixed test-first:
   dropped and counted like an oversized entry (the artifact degrades, the
   run does not fail).
 - ADR-070 records the lease/durability contract (linked above).
+
+**Qodo PR-1822 finding 7 (unversioned lease migration): fixed, reversing the
+earlier decline.** The branch had landed the lease columns as bare startup
+ALTERs and the first adjudication declined rehoming them ("no migration
+infrastructure in this service"). On merge review the repo DOES carry a
+versioned-migration convention (``TTS/migrations/`` Python steps stamped via
+``PRAGMA user_version``; numbered SQL under ``DB/migrations/``), so the
+service now has ``Research_Interop/migrations/``: v0->v1 adds the lease
+columns and stamps ``user_version = 1``, fresh and pre-existing databases
+pass through the same path, interim unversioned databases (columns present,
+version 0) upgrade without re-ALTERing, and a database stamped by a newer
+build is refused rather than silently downgraded. Four tests cover the
+upgrade, the fresh stamp, idempotent reopen, and the future-version refusal.
+ADR-070's "no migration framework" consequence entry is superseded by this.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -241,6 +241,35 @@ class LocalResearchEngine:
             return await value
         return value
 
+    def _offload_pipeline_call(
+        self, fn: "Callable[..., Any]", *args: Any, **kwargs: Any
+    ) -> Any:
+        """Invoke a pipeline seam without blocking the event loop.
+
+        The production ``search_fn``/``paper_search_fn`` default to a plain
+        ``def`` performing a sequential loop of blocking HTTP calls
+        (``generate_and_search``, and any non-async academic provider). If
+        that were called inline on the event loop, the call would monopolize
+        it for its whole duration, starving the ``_keepalive`` timer -- a
+        lease that expires mid-call re-opens the double-execution race the
+        lease exists to prevent (task-18060 review finding 1). A coroutine
+        function carries no such risk and is invoked exactly as before.
+
+        Args:
+            fn: The pipeline callable to invoke (``search_fn`` or
+                ``paper_search_fn``).
+            *args: Positional arguments for ``fn``.
+            **kwargs: Keyword arguments for ``fn``.
+
+        Returns:
+            An awaitable: ``fn``'s own coroutine when ``fn`` is a coroutine
+            function, otherwise an ``asyncio.to_thread`` coroutine that runs
+            it on a worker thread.
+        """
+        if inspect.iscoroutinefunction(fn):
+            return fn(*args, **kwargs)
+        return asyncio.to_thread(fn, *args, **kwargs)
+
     async def _llm_bounded_call(self, make_call: "Callable[[], Any]") -> Any:
         """Run one LLM-bearing call inside a usage scope and settle the
         recorded tokens into the ledger (task-16329). The token budget is
@@ -575,7 +604,9 @@ class LocalResearchEngine:
                 params["search_default_max_queries"] = cap
                 ledger.reserve_searches(cap)
                 reserved_for_call = cap
-            outcome = await self._llm_bounded_call(lambda: self.search_fn(query, params))
+            outcome = await self._llm_bounded_call(
+                lambda: self._offload_pipeline_call(self.search_fn, query, params)
+            )
             if isinstance(outcome, tuple) and len(outcome) == 2:
                 wsr, sqd = outcome
             else:
@@ -703,12 +734,19 @@ class LocalResearchEngine:
         truncated = False
         for record in results:
             entry = dict(record)
-            size = len(json.dumps(entry, default=str))
+            # Sized with the SAME json.dumps() arguments save_artifact uses
+            # to actually persist this payload (sort_keys=True, no
+            # default=str). A mismatch here previously let a non-JSON-native
+            # value pass this check under-sized (default=str silently
+            # stringified it) only to raise inside save_artifact's own dump,
+            # failing the whole run instead of this method's own graceful
+            # truncation.
+            size = len(json.dumps(entry, sort_keys=True))
             if used + size > self.EVIDENCE_POOL_CAP_BYTES:
                 entry.pop("content", None)
                 entry.pop("original_content", None)
                 truncated = True
-                size = len(json.dumps(entry, default=str))
+                size = len(json.dumps(entry, sort_keys=True))
             used += size
             kept.append(entry)
         return {
@@ -767,6 +805,7 @@ class LocalResearchEngine:
                 progress_percent=_PROGRESS_PLANNING,
                 progress_message="Planning research",
             )
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="plan.json",
@@ -864,11 +903,13 @@ class LocalResearchEngine:
                         attempted_extras += 1
                     try:
                         if providers_filter is not None and accepts_providers:
-                            papers = await self._maybe_await(
-                                self.paper_search_fn(query, providers=providers_filter)
+                            papers = await self._offload_pipeline_call(
+                                self.paper_search_fn, query, providers=providers_filter
                             )
                         else:
-                            papers = await self._maybe_await(self.paper_search_fn(query))
+                            papers = await self._offload_pipeline_call(
+                                self.paper_search_fn, query
+                            )
                     except Exception as exc:  # noqa: BLE001 - lane degrades
                         merged_warnings.append(f"academic search failed: {exc}")
                         continue
@@ -1074,12 +1115,14 @@ class LocalResearchEngine:
             report_lines.append("## Remaining gaps")
             report_lines.extend(f"- {gap}" for gap in remaining_gaps)
         report_markdown = "\n".join(report_lines)
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="report_v1.md",
             content_type="text/markdown",
             content=report_markdown,
         )
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="sources.json",
@@ -1104,6 +1147,7 @@ class LocalResearchEngine:
             verification_summary["citation_verification"] = final_answer[
                 "citation_verification"
             ]
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="verification_summary.json",
@@ -1139,6 +1183,7 @@ class LocalResearchEngine:
             "iterations": iteration,
             "remaining_gaps": remaining_gaps,
         }
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="bundle.json",
@@ -1146,6 +1191,11 @@ class LocalResearchEngine:
             content=bundle_content,
         )
 
+        # A displaced executor reaching this point would otherwise stomp the
+        # new owner's terminal state by marking the run "completed" out from
+        # under it -- fenced immediately before, not just before the
+        # artifact writes that precede it.
+        self._require_lease()
         completed = self.service.complete_run(
             run_id,
             progress_message=f"Completed with {len(evidence)} source(s)",

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -371,6 +371,15 @@ class LocalResearchEngine:
     async def _keepalive(self, run_id: str) -> None:
         """Renew the lease on a timer for as long as a phase is in flight.
 
+        A renewal that RAISES (e.g. a transient ``sqlite3.OperationalError``
+        while another process writes the DB) is not lease loss, but it is
+        also not survivable here: an unhandled exception in this task would
+        surface at ``await keepalive`` inside ``execute_run``'s ``finally``
+        block, skipping ``release_lease`` (stranding the lease) and escaping
+        the engine entirely. It is contained the same way a lost lease is:
+        stop renewing and warn; the next fence the engine hits decides what
+        the run's real state is.
+
         Args:
             run_id: The leased run.
         """
@@ -379,9 +388,17 @@ class LocalResearchEngine:
             lease_id = self._lease_id
             if lease_id is None:
                 return
-            if not self.service.renew_lease(
-                run_id, lease_id=lease_id, lease_seconds=self.lease_seconds
-            ):
+            try:
+                renewed = self.service.renew_lease(
+                    run_id, lease_id=lease_id, lease_seconds=self.lease_seconds
+                )
+            except Exception as exc:  # noqa: BLE001 - never hijack execute_run
+                logger.warning(
+                    f"Research run {run_id} lease renewal errored "
+                    f"(treated as lost): {exc}"
+                )
+                return
+            if not renewed:
                 return
 
     def _get_run(self, run_id: str) -> dict[str, Any]:
@@ -583,11 +600,13 @@ class LocalResearchEngine:
         if self._lease_id is None:
             self._run_id = None
             logger.info(f"Research run {run_id} is leased by another executor")
-            return self.service.update_run_progress(
-                run_id,
-                progress_message="another executor holds this run's lease",
-                event="lease_declined",
-            )
+            # An event, never a run-state write: this executor holds no
+            # lease, and update_run_progress would stomp the live
+            # executor's progress message and version mid-flight
+            # (PR-1822 review follow-up). The returned record is the
+            # holder's current truth.
+            self.service.record_run_event(run_id, "lease_declined")
+            return self._get_run(run_id)
         keepalive = asyncio.create_task(self._keepalive(run_id))
 
         try:
@@ -643,7 +662,11 @@ class LocalResearchEngine:
             )
         finally:
             keepalive.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            # CancelledError (normal teardown) AND any stored exception from
+            # the keep-alive task must both be contained here: either raising
+            # into this finally block would skip release_lease below and
+            # strand the lease.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await keepalive
             if self._lease_id is not None:
                 # Releasing on every invocation is safe: a clean release resets
@@ -845,8 +868,17 @@ class LocalResearchEngine:
             # value pass this check under-sized (default=str silently
             # stringified it) only to raise inside save_artifact's own dump,
             # failing the whole run instead of this method's own graceful
-            # truncation.
-            size = len(json.dumps(entry, sort_keys=True))
+            # truncation. An entry that cannot be measured at all (a
+            # non-JSON-native value) is dropped and counted like an
+            # oversized one rather than raising here -- a run's evidence
+            # artifact must degrade, never fail the run (PR-1822 review
+            # follow-up: the earlier fix moved this crash from save_artifact
+            # into the measurement; it did not remove it).
+            try:
+                size = len(json.dumps(entry, sort_keys=True))
+            except (TypeError, ValueError):
+                dropped += 1
+                continue
             if used + size > self.EVIDENCE_POOL_CAP_BYTES:
                 entry.pop("content", None)
                 entry.pop("original_content", None)

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -19,9 +19,12 @@ lazy-import pattern so the module import stays cheap.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import inspect
 import json
 import re
+import uuid
 from typing import Any, Awaitable, Callable
 
 from loguru import logger
@@ -86,6 +89,16 @@ AnalyzeFn = Callable[..., Awaitable[Any]]
 GapFn = Callable[[dict[str, Any]], Awaitable[list[str]]]
 
 
+class _LeaseLost(Exception):
+    """Internal control-flow signal: this executor no longer owns the run.
+
+    Raised by the fence before a persisting write. A displaced executor that
+    is still inside a long provider call returns normally, so without the
+    fence it would write artifacts and settle budget for a run another
+    executor now owns (task-18060).
+    """
+
+
 class _RunPaused(Exception):
     """Internal control-flow signal: the run was paused between phases."""
 
@@ -120,6 +133,18 @@ class LocalResearchEngine:
         completion_handoff: "Callable[[dict[str, Any]], Any] | None" = None,
     ) -> None:
         self.service = local_service
+        #: Identity of this executor, and its lease state for the duration of
+        #: execute_run (task-18060).
+        self.worker_id = f"engine-{uuid.uuid4().hex[:12]}"
+        #: How long a lease is granted for, and how often it is renewed. The
+        #: keep-alive is a TIMER rather than a progress hook: the synthesis
+        #: phase emits no progress for its whole duration (measured ~970s), so
+        #: a lease renewed only by progress events would expire inside the most
+        #: expensive phase and invite a second executor into it.
+        self.lease_seconds = 120.0
+        self.keepalive_seconds = 30.0
+        self._lease_id: str | None = None
+        self._run_id: str | None = None
         self.search_fn = search_fn or self._default_search_fn
         # task-17371: the pipeline's own required params are pre-flighted
         # before a run spends anything -- but ONLY when the real pipeline is
@@ -285,6 +310,33 @@ class LocalResearchEngine:
             "that does not need them)."
         )
 
+    def _require_lease(self) -> None:
+        """Refuse to persist anything if this executor lost its lease.
+
+        Raises:
+            _LeaseLost: When another executor now holds the run.
+        """
+        if self._lease_id is None or self._run_id is None:
+            return
+        if not self.service.holds_lease(self._run_id, lease_id=self._lease_id):
+            raise _LeaseLost("execution lease lost")
+
+    async def _keepalive(self, run_id: str) -> None:
+        """Renew the lease on a timer for as long as a phase is in flight.
+
+        Args:
+            run_id: The leased run.
+        """
+        while True:
+            await asyncio.sleep(max(0.01, float(self.keepalive_seconds)))
+            lease_id = self._lease_id
+            if lease_id is None:
+                return
+            if not self.service.renew_lease(
+                run_id, lease_id=lease_id, lease_seconds=self.lease_seconds
+            ):
+                return
+
     def _get_run(self, run_id: str) -> dict[str, Any]:
         run = self.service.get_run(run_id)
         if run is None:
@@ -417,6 +469,23 @@ class LocalResearchEngine:
         self._active_policy = policy
         self._active_academic_providers = overrides.get("academic_providers")
 
+        # task-18060: exactly one executor may run a run. The window's
+        # exclusive-worker guard is per-session and cannot see another process,
+        # so the lease is what actually prevents duplicate searches and spend.
+        self._run_id = run_id
+        self._lease_id = self.service.claim_run(
+            run_id, worker_id=self.worker_id, lease_seconds=self.lease_seconds
+        )
+        if self._lease_id is None:
+            self._run_id = None
+            logger.info(f"Research run {run_id} is leased by another executor")
+            return self.service.update_run_progress(
+                run_id,
+                progress_message="another executor holds this run's lease",
+                event="lease_declined",
+            )
+        keepalive = asyncio.create_task(self._keepalive(run_id))
+
         try:
             if self._uses_default_search_fn:
                 self._require_pipeline_params(run_params)
@@ -438,11 +507,27 @@ class LocalResearchEngine:
             logger.warning(f"Research run {run_id} stopped by budget: {exceeded}")
             self._save_ledger(run_id, ledger)
             return self.service.fail_run(run_id, error_msg=str(exceeded))
+        except _LeaseLost:
+            # Deliberately NOT fail_run: another executor owns this run now and
+            # is responsible for its terminal state. Writing one here would be
+            # the displaced executor overwriting the live one's work.
+            logger.warning(f"Research run {run_id} lease lost mid-flight")
+            return self._get_run(run_id)
         except Exception as exc:
             logger.opt(exception=True).error(f"Research run {run_id} failed: {exc}")
             self._save_ledger(run_id, ledger)
             return self.service.fail_run(run_id, error_msg=str(exc))
         finally:
+            keepalive.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await keepalive
+            if self._lease_id is not None:
+                # Releasing on every invocation is safe: a clean release resets
+                # the reclaim budget, so a paused-and-resumed run does not
+                # spend its crash allowance (task-18060).
+                self.service.release_lease(run_id, lease_id=self._lease_id)
+                self._lease_id = None
+            self._run_id = None
             self._active_ledger = None
             self._active_run_params = None
             self._active_policy = None
@@ -584,6 +669,7 @@ class LocalResearchEngine:
         return queries, reserved_extras
 
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:
+        self._require_lease()
         self.service.save_artifact(
             run_id,
             artifact_name="budget_ledger.json",
@@ -764,6 +850,7 @@ class LocalResearchEngine:
             # Record what was collected BEFORE enforcement: the collection
             # happened, and a budget stop on processing must preserve the
             # evidence of it (partial-artifact contract, task-16323).
+            self._require_lease()
             self.service.save_artifact(
                 run_id,
                 artifact_name="plan.json",
@@ -775,6 +862,7 @@ class LocalResearchEngine:
                     "iterations": iteration,
                 },
             )
+            self._require_lease()
             self.service.save_artifact(
                 run_id,
                 artifact_name="collection_summary.json",
@@ -968,6 +1056,7 @@ class LocalResearchEngine:
         )
         if claims:
             supported = sum(1 for c in claims if c.get("status") == "supported")
+            self._require_lease()
             self.service.save_artifact(
                 run_id,
                 artifact_name="claims.json",

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -29,14 +29,20 @@ from typing import Any, Awaitable, Callable
 
 from loguru import logger
 
-from .local_research_service import LeaseBudgetExhausted, LocalResearchService
+from .local_research_service import (
+    LeaseBudgetExhausted,
+    LocalResearchService,
+    TERMINAL_RUN_STATUSES,
+)
 from ..Chat.usage_recorder import usage_scope
 from .academic_providers import papers_to_evidence
 from .research_budget import BudgetLedger, ResearchLimitExceeded
 
 __all__ = ["LocalResearchEngine", "TERMINAL_RUN_STATUSES"]
 
-TERMINAL_RUN_STATUSES = {"completed", "failed", "cancelled"}
+# Re-exported for backward compatibility -- local_research_service.py is now
+# the single source of truth (task-3 review finding 1), since claim_run
+# needs this set and the service must not import the engine to get it.
 
 # Progress anchors mirror the server's phase progress map
 # (tldw_server app/core/Research/jobs.py :33-38).
@@ -405,12 +411,18 @@ class LocalResearchEngine:
     def _check_control(self, run_id: str, next_phase: str) -> dict[str, Any]:
         """Honor pause/cancel BEFORE entering ``next_phase`` (ADR-068).
 
+        Both resolutions are run-state writes and are fenced the same way
+        artifact writes are (task-3 review finding 2): a displaced executor
+        must not be the one recording "paused" or resolving "cancelled" for
+        a run it no longer owns.
+
         Returns the still-current run record when execution may proceed.
         """
         run = self._get_run(run_id)
         control = str(run.get("control_state") or "")
         status = str(run.get("status") or "")
         if control in {"paused", "pause_requested"} and status not in TERMINAL_RUN_STATUSES:
+            self._require_lease()
             self.service.update_run_progress(
                 run_id,
                 progress_message=f"Engine paused before {next_phase}",
@@ -420,6 +432,7 @@ class LocalResearchEngine:
             raise _RunPaused(run)
         if control in {"cancelled", "cancel_requested"} or status == "cancelled":
             if status != "cancelled":
+                self._require_lease()
                 run = self.service.cancel_run(run_id)
             raise _RunCancelled(run)
         return run
@@ -467,10 +480,18 @@ class LocalResearchEngine:
         self, run_id: str, checkpoint_type: str, proposed_payload: dict[str, Any]
     ) -> None:
         """Create the pending checkpoint and park the run in a non-terminal
-        awaiting state (task-16482). Raises _RunAwaitingReview."""
+        awaiting state (task-16482). Raises _RunAwaitingReview.
+
+        Both writes are fenced (task-3 review finding 2): a displaced
+        executor must not be the one creating a checkpoint or parking the
+        run in an awaiting-review state on behalf of a run it no longer
+        owns.
+        """
+        self._require_lease()
         checkpoint = self.service.create_checkpoint(
             run_id, checkpoint_type=checkpoint_type, proposed_payload=proposed_payload
         )
+        self._require_lease()
         updated = self.service.update_run_progress(
             run_id,
             control_state=f"awaiting_{checkpoint_type}",
@@ -598,9 +619,12 @@ class LocalResearchEngine:
             # quiet return every other fenced write produces.
             try:
                 self._save_ledger(run_id, ledger)
+                self._require_lease()
             except _LeaseLost:
                 return self._quiet_lease_lost_return(run_id)
-            return self.service.fail_run(run_id, error_msg=str(exceeded))
+            return self.service.fail_run(
+                run_id, error_msg=str(exceeded), lease_id=self._lease_id
+            )
         except _LeaseLost:
             # Deliberately NOT fail_run: another executor owns this run now and
             # is responsible for its terminal state. Writing one here would be
@@ -611,9 +635,12 @@ class LocalResearchEngine:
             # See the ResearchLimitExceeded branch above: same leak, same fix.
             try:
                 self._save_ledger(run_id, ledger)
+                self._require_lease()
             except _LeaseLost:
                 return self._quiet_lease_lost_return(run_id)
-            return self.service.fail_run(run_id, error_msg=str(exc))
+            return self.service.fail_run(
+                run_id, error_msg=str(exc), lease_id=self._lease_id
+            )
         finally:
             keepalive.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -784,16 +811,32 @@ class LocalResearchEngine:
         pool. The payload records that this happened; a reader cannot otherwise
         tell a truncated pool from a small one.
 
+        The cap is enforced on what is actually kept, not merely checked
+        before stripping a body (task-3 review finding 7): an entry is only
+        appended once it is known to fit -- full, or stripped -- within
+        what remains of the cap. An entry that still does not fit even
+        stripped of its body (e.g. a single pathological entry whose
+        references alone exceed the whole cap) is DROPPED from the
+        persisted pool entirely rather than being appended anyway; its
+        reference is lost for this round (a resumed run would need to
+        re-search rather than re-fetch it), and ``dropped_count`` records
+        how many entries this happened to so a reader can tell a
+        fully-represented pool from one that shed evidence outright, not
+        just one that lost bodies.
+
         Args:
             results: The round's merged evidence records.
             iteration: The round these belong to.
 
         Returns:
-            ``{iteration, results, truncated, cap_bytes}``.
+            ``{iteration, results, truncated, cap_bytes, dropped_count}``.
+            The sum of ``results``' own serialized sizes never exceeds
+            ``cap_bytes``.
         """
         kept: list[dict[str, Any]] = []
         used = 0
         truncated = False
+        dropped = 0
         for record in results:
             entry = dict(record)
             # Sized with the SAME json.dumps() arguments save_artifact uses
@@ -809,6 +852,12 @@ class LocalResearchEngine:
                 entry.pop("original_content", None)
                 truncated = True
                 size = len(json.dumps(entry, sort_keys=True))
+                if used + size > self.EVIDENCE_POOL_CAP_BYTES:
+                    # Even reference-only, this entry alone cannot fit in
+                    # what remains of the cap -- drop it rather than
+                    # persist a pool larger than cap_bytes promises.
+                    dropped += 1
+                    continue
             used += size
             kept.append(entry)
         return {
@@ -816,6 +865,7 @@ class LocalResearchEngine:
             "results": kept,
             "truncated": truncated,
             "cap_bytes": self.EVIDENCE_POOL_CAP_BYTES,
+            "dropped_count": dropped,
         }
 
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:
@@ -849,6 +899,9 @@ class LocalResearchEngine:
         ledger.check_runtime()  # zero/degenerate runtime budgets stop here
 
         # Draft runs (window "Create Run" flow) normalize to running here.
+        # Both branches are run-state writes, fenced the same way artifact
+        # writes are (task-3 review finding 2).
+        self._require_lease()
         if str(run.get("status") or "") != "running" or str(
             run.get("control_state") or ""
         ) != "running":
@@ -915,6 +968,7 @@ class LocalResearchEngine:
         while True:
             iteration += 1
             round_queries = [question] if iteration == 1 else list(remaining_gaps)
+            self._require_lease()
             self.service.update_run_progress(
                 run_id,
                 phase="collecting",
@@ -1089,6 +1143,7 @@ class LocalResearchEngine:
 
             self._check_control(run_id, "synthesizing")
             ledger.check_runtime()
+            self._require_lease()
             run = self.service.update_run_progress(
                 run_id,
                 phase="synthesizing",
@@ -1135,6 +1190,7 @@ class LocalResearchEngine:
                 )
                 or []
             )
+            self._require_lease()
             self.service.update_run_progress(
                 run_id,
                 progress_message=f"Iteration {iteration} complete ({len(gaps)} gap(s))",
@@ -1151,6 +1207,7 @@ class LocalResearchEngine:
         # Persist the ledger AFTER the last settlement of the run (synthesis
         # + gap analysis) so the artifact reflects final usage.
         self._save_ledger(run_id, ledger)
+        self._require_lease()
         run = self.service.update_run_progress(
             run_id,
             phase="packaging",
@@ -1256,11 +1313,16 @@ class LocalResearchEngine:
         # A displaced executor reaching this point would otherwise stomp the
         # new owner's terminal state by marking the run "completed" out from
         # under it -- fenced immediately before, not just before the
-        # artifact writes that precede it.
+        # artifact writes that precede it. self._require_lease() is the
+        # cheap early-out; passing lease_id makes the write itself
+        # lease-conditional at the SQL level too, closing the remaining
+        # check-then-act gap between that early-out and the write landing
+        # (task-3 review finding 4).
         self._require_lease()
         completed = self.service.complete_run(
             run_id,
             progress_message=f"Completed with {len(evidence)} source(s)",
+            lease_id=self._lease_id,
         )
         chat_handoff = run.get("chat_handoff")
         if (

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -674,6 +674,50 @@ class LocalResearchEngine:
             queries.append(str(facet).strip())
         return queries, reserved_extras
 
+    #: Bytes of evidence persisted per round before bodies are dropped
+    #: (task-18060). Sized against the measured worst case: 66 admitted sources
+    #: of scraped text is roughly 0.7-3 MB, so a normal round fits whole and a
+    #: pathological one degrades to references rather than growing without
+    #: bound inside SQLite.
+    EVIDENCE_POOL_CAP_BYTES = 8 * 1024 * 1024
+
+    def _bounded_evidence(
+        self, results: list[dict[str, Any]], iteration: int
+    ) -> dict[str, Any]:
+        """Shape a round's evidence for persistence, under a byte cap.
+
+        Entries past the cap keep their references and lose their bodies, so a
+        resumed run can re-fetch them rather than the artifact growing with the
+        pool. The payload records that this happened; a reader cannot otherwise
+        tell a truncated pool from a small one.
+
+        Args:
+            results: The round's merged evidence records.
+            iteration: The round these belong to.
+
+        Returns:
+            ``{iteration, results, truncated, cap_bytes}``.
+        """
+        kept: list[dict[str, Any]] = []
+        used = 0
+        truncated = False
+        for record in results:
+            entry = dict(record)
+            size = len(json.dumps(entry, default=str))
+            if used + size > self.EVIDENCE_POOL_CAP_BYTES:
+                entry.pop("content", None)
+                entry.pop("original_content", None)
+                truncated = True
+                size = len(json.dumps(entry, default=str))
+            used += size
+            kept.append(entry)
+        return {
+            "iteration": iteration,
+            "results": kept,
+            "truncated": truncated,
+            "cap_bytes": self.EVIDENCE_POOL_CAP_BYTES,
+        }
+
     def _save_ledger(self, run_id: str, ledger: BudgetLedger) -> None:
         self._require_lease()
         self.service.save_artifact(
@@ -879,6 +923,18 @@ class LocalResearchEngine:
                     "sub_questions": all_sub_questions,
                     "warnings": merged_warnings,
                 },
+            )
+            # task-18060: the summary above records COUNTS; the pool itself is
+            # persisted here so a resumed run has the evidence it already paid
+            # for. Written after the doc-budget settle below would lose the
+            # entries that settle trims, so it is written before it and the
+            # trim is reflected in the summary's own count.
+            self._require_lease()
+            self.service.save_artifact(
+                run_id,
+                artifact_name="evidence_pool.json",
+                content_type="application/json",
+                content=self._bounded_evidence(merged_results, iteration),
             )
             # Settle the fetched-doc batch at the remaining doc budget
             # BEFORE synthesis processes it (allot raises on an exhausted

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -447,7 +447,13 @@ class LocalResearchEngine:
         plan_patch_limits = self._approved_patch(run_id, "plan_review").get("limits")
         if isinstance(plan_patch_limits, dict) and plan_patch_limits:
             limits = {**limits, **plan_patch_limits}
-        ledger = BudgetLedger.from_limits(limits)
+        # task-18060: a resumed run continues its budget rather than being
+        # granted it again. The snapshot is the ledger the previous executor
+        # wrote; its absence means this run has never executed.
+        previous_ledger = (
+            self.service.get_artifact(run_id, "budget_ledger.json") or {}
+        ).get("content")
+        ledger = BudgetLedger.from_snapshot(previous_ledger, limits)
         self._active_ledger = ledger
         # task-16791: per-run routing/overrides (server parity). The run's
         # provider_overrides merge OVER the engine's construction params.

--- a/tldw_chatbook/Research_Interop/local_research_engine.py
+++ b/tldw_chatbook/Research_Interop/local_research_engine.py
@@ -29,7 +29,7 @@ from typing import Any, Awaitable, Callable
 
 from loguru import logger
 
-from .local_research_service import LocalResearchService
+from .local_research_service import LeaseBudgetExhausted, LocalResearchService
 from ..Chat.usage_recorder import usage_scope
 from .academic_providers import papers_to_evidence
 from .research_budget import BudgetLedger, ResearchLimitExceeded
@@ -193,11 +193,21 @@ class LocalResearchEngine:
         Uses the synthesis LLM when one is configured; returns no gaps
         otherwise. Failure here must never break the run -- an unparseable
         gap analysis reads as "no gaps" with a warning, not a failed report.
+
+        The LLM call itself is a plain, blocking ``chat_api_call`` (review
+        finding 5): being ``async def`` makes ``_offload_pipeline_call``
+        route THIS function inline (a coroutine function carries no
+        blocking-call risk by itself), but the call it makes on the loop
+        thread is exactly the risk that offload exists to avoid -- a gap
+        analysis longer than ``lease_seconds`` would starve the keep-alive
+        and lapse the lease, same as an un-offloaded ``search_fn`` would.
+        So the blocking call is wrapped and offloaded the same way the
+        other pipeline seams are.
         """
         llm = str(self.search_params.get("final_answer_llm") or "").strip()
         if not llm:
             return []
-        from ..Chat.Chat_Functions import chat_api_call
+        from ..Chat.Chat_Functions import chat_api_call, chat_reply_text
 
         prompt = (
             "You are reviewing a research synthesis for completeness. Given "
@@ -211,10 +221,9 @@ class LocalResearchEngine:
             f"Sub-questions asked: {context.get('sub_questions')}\n"
             f"Synthesized answer:\n{context.get('answer_text')}"
         )
-        try:
-            from ..Chat.Chat_Functions import chat_reply_text
 
-            response = chat_reply_text(
+        def _call_llm() -> str:
+            return chat_reply_text(
                 chat_api_call(
                     api_endpoint=llm,
                     messages_payload=[{"role": "user", "content": prompt}],
@@ -229,6 +238,9 @@ class LocalResearchEngine:
                     topp=None,
                 )
             )
+
+        try:
+            response = await self._offload_pipeline_call(_call_llm)
             parsed = json.loads(str(response or "[]"))
             if isinstance(parsed, list):
                 return [str(q) for q in parsed if str(q).strip()][:5]
@@ -372,6 +384,24 @@ class LocalResearchEngine:
             raise ValueError("research run not found")
         return run
 
+    def _quiet_lease_lost_return(self, run_id: str) -> dict[str, Any]:
+        """The shared quiet return for every ``_LeaseLost`` landing spot.
+
+        Deliberately NOT ``fail_run``: another executor owns this run now
+        and is responsible for its terminal state. Writing one here would
+        be the displaced executor overwriting the live one's work
+        (task-18060 review finding 3).
+
+        Args:
+            run_id: The run this executor was displaced from.
+
+        Returns:
+            The run's current record, as last written by whoever holds it
+            now.
+        """
+        logger.warning(f"Research run {run_id} lease lost mid-flight")
+        return self._get_run(run_id)
+
     def _check_control(self, run_id: str, next_phase: str) -> dict[str, Any]:
         """Honor pause/cancel BEFORE entering ``next_phase`` (ADR-068).
 
@@ -508,9 +538,27 @@ class LocalResearchEngine:
         # exclusive-worker guard is per-session and cannot see another process,
         # so the lease is what actually prevents duplicate searches and spend.
         self._run_id = run_id
-        self._lease_id = self.service.claim_run(
-            run_id, worker_id=self.worker_id, lease_seconds=self.lease_seconds
-        )
+        try:
+            self._lease_id = self.service.claim_run(
+                run_id, worker_id=self.worker_id, lease_seconds=self.lease_seconds
+            )
+        except LeaseBudgetExhausted as exhausted:
+            # task-18060 review finding 1: exhausting the reclaim budget
+            # means this run's executor keeps dying, not that a healthy
+            # executor is merely racing another for it -- distinct from the
+            # None branch below, which MUST leave the run alone for
+            # whichever executor holds the live lease. Left unhandled, the
+            # run would stay status=running forever, permanently unclaimable.
+            self._run_id = None
+            logger.warning(f"Research run {run_id} failed: {exhausted}")
+            return self.service.fail_run(
+                run_id,
+                error_msg=(
+                    "repeated executor failures: this run's lease was "
+                    f"claimed and abandoned {exhausted.attempts} time(s) "
+                    "without completing (lease retry budget exhausted)"
+                ),
+            )
         if self._lease_id is None:
             self._run_id = None
             logger.info(f"Research run {run_id} is leased by another executor")
@@ -540,17 +588,31 @@ class LocalResearchEngine:
             # resolve through the service's terminal failure transition --
             # partial artifacts saved by earlier phases are preserved.
             logger.warning(f"Research run {run_id} stopped by budget: {exceeded}")
-            self._save_ledger(run_id, ledger)
+            # task-18060 review finding 3: _save_ledger is itself fenced, and
+            # a _LeaseLost it raises here is NOT caught by the sibling
+            # `except _LeaseLost` below -- Python only matches a raise inside
+            # an except body against a NEW try, never a sibling clause of the
+            # same try it was raised from. Uncaught, it would escape
+            # execute_run entirely (contradicting the docstring, which
+            # promises only ValueError) instead of resolving to the same
+            # quiet return every other fenced write produces.
+            try:
+                self._save_ledger(run_id, ledger)
+            except _LeaseLost:
+                return self._quiet_lease_lost_return(run_id)
             return self.service.fail_run(run_id, error_msg=str(exceeded))
         except _LeaseLost:
             # Deliberately NOT fail_run: another executor owns this run now and
             # is responsible for its terminal state. Writing one here would be
             # the displaced executor overwriting the live one's work.
-            logger.warning(f"Research run {run_id} lease lost mid-flight")
-            return self._get_run(run_id)
+            return self._quiet_lease_lost_return(run_id)
         except Exception as exc:
             logger.opt(exception=True).error(f"Research run {run_id} failed: {exc}")
-            self._save_ledger(run_id, ledger)
+            # See the ResearchLimitExceeded branch above: same leak, same fix.
+            try:
+                self._save_ledger(run_id, ledger)
+            except _LeaseLost:
+                return self._quiet_lease_lost_return(run_id)
             return self.service.fail_run(run_id, error_msg=str(exc))
         finally:
             keepalive.cancel()

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -76,8 +76,42 @@ class LocalResearchService:
             self._memory_conn = None
 
     @staticmethod
+    def _format_timestamp(moment: datetime) -> str:
+        """Render a UTC ``datetime`` in the one format lease timestamps use.
+
+        ``claim_run``'s atomicity depends on a plain string comparison
+        between the persisted ``leased_until`` and "now" (task-18060), so
+        every timestamp that can appear on either side of that comparison
+        MUST be produced by this method. ``timespec="microseconds"`` pins
+        the fractional-seconds field so it is never dropped when the
+        microsecond value happens to be zero -- plain ``isoformat()``
+        omits it in that case, which otherwise makes a whole-second
+        timestamp sort *below* one with a non-zero fraction (``'.'`` sorts
+        below alphanumerics) and lets a live lease be claimed twice.
+
+        Args:
+            moment: A timezone-aware datetime. Converted to UTC before
+                formatting.
+
+        Returns:
+            An ISO-8601 string with microsecond precision and a trailing
+            ``Z``, e.g. ``"2026-08-18T08:31:01.000000Z"``.
+        """
+        return (
+            moment.astimezone(timezone.utc)
+            .isoformat(timespec="microseconds")
+            .replace("+00:00", "Z")
+        )
+
+    @staticmethod
     def _now() -> str:
-        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        """Current UTC time in the shared lease-comparable timestamp format.
+
+        Returns:
+            An ISO-8601 UTC timestamp string produced by
+            ``_format_timestamp``.
+        """
+        return LocalResearchService._format_timestamp(datetime.now(timezone.utc))
 
     @staticmethod
     def _new_id() -> str:
@@ -631,10 +665,23 @@ class LocalResearchService:
 
     def _timestamp_after(self, seconds: float) -> str:
         """An ISO timestamp ``seconds`` in the future, in the same format as
-        ``_now`` so string comparison orders correctly."""
-        return (
-            datetime.now(timezone.utc) + timedelta(seconds=max(0.0, float(seconds)))
-        ).isoformat()
+        ``_now`` so string comparison orders correctly.
+
+        Args:
+            seconds: Offset from the current time, in seconds. Negative
+                values clamp to 0 so a non-positive lease duration yields
+                an already-expired timestamp rather than one in the past
+                relative to itself.
+
+        Returns:
+            An ISO-8601 UTC timestamp string produced by
+            ``_format_timestamp``, guaranteed to compare correctly against
+            ``_now()``'s output.
+        """
+        moment = datetime.now(timezone.utc) + timedelta(
+            seconds=max(0.0, float(seconds))
+        )
+        return self._format_timestamp(moment)
 
     def claim_run(
         self, run_id: str, *, worker_id: str, lease_seconds: float

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -700,7 +700,11 @@ class LocalResearchService:
         EXPIRED lease -- a run's very first claim always succeeds. A run
         whose executor keeps dying is broken rather than slow, and must
         stop being retried once the budget is spent (task-18060, following
-        the server job manager's retry budget).
+        the server job manager's retry budget). A clean ``release_lease``
+        resets the counter to 0, since a run that was voluntarily released
+        was not abandoned -- so the budget tracks CONSECUTIVE abandonments
+        (crashes that leave the lease to expire), not the run's lifetime
+        claim count.
 
         Args:
             run_id: The run to claim.
@@ -782,7 +786,7 @@ class LocalResearchService:
                 """
                 UPDATE research_runs
                    SET lease_owner = NULL, lease_id = NULL, leased_until = NULL,
-                       updated_at = ?
+                       lease_attempts = 0, updated_at = ?
                  WHERE id = ? AND lease_id = ?
                 """,
                 (self._now(), run_id, lease_id),

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -743,6 +743,15 @@ class LocalResearchService:
         CONSECUTIVE abandonments (crashes that leave the lease to expire),
         not the run's lifetime claim count.
 
+        Whether a claim is a "reclaim" for budget purposes depends on the
+        previous lease being EXPIRED, not merely present: a healthy
+        executor's still-live lease must never trip the budget check for a
+        second, merely-racing claimant -- that claimant is simply declined
+        below by the atomic UPDATE's WHERE clause. Reusing the same ``now``
+        snapshot for both the reclaim check and the UPDATE's own
+        ``leased_until <= ?`` comparison guarantees the two judgments of
+        "is this lease live" cannot disagree with each other.
+
         Args:
             run_id: The run to claim.
             worker_id: Identifies the claiming executor.
@@ -763,13 +772,13 @@ class LocalResearchService:
         row = self._require_one("research_runs", run_id, "research run")
         previous = row["leased_until"] if "leased_until" in row.keys() else None
         attempts = int(row["lease_attempts"] or 0) if "lease_attempts" in row.keys() else 0
-        reclaiming = previous is not None
+        now = self._now()
+        reclaiming = previous is not None and str(previous) <= now
         if reclaiming and attempts >= int(max_attempts):
             raise LeaseBudgetExhausted(
                 run_id, attempts=attempts, max_attempts=int(max_attempts)
             )
         lease_id = uuid.uuid4().hex
-        now = self._now()
         expires = self._timestamp_after(lease_seconds)
         next_attempts = attempts + 1
         with self._connect() as conn:

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -684,39 +684,129 @@ class LocalResearchService:
         return self._format_timestamp(moment)
 
     def claim_run(
-        self, run_id: str, *, worker_id: str, lease_seconds: float
+        self,
+        run_id: str,
+        *,
+        worker_id: str,
+        lease_seconds: float,
+        max_attempts: int = 3,
     ) -> str | None:
         """Take the execution lease on a run, or decline it.
 
-        The claim is atomic: the UPDATE only matches when no live lease
-        exists, so two racing executors cannot both succeed (task-18060).
+        The claim is atomic: the UPDATE matches only when no live lease
+        exists, so two racing executors cannot both succeed. Every
+        successful claim counts against ``max_attempts`` (the run's total
+        attempt budget), but the budget is only ENFORCED when reclaiming an
+        EXPIRED lease -- a run's very first claim always succeeds. A run
+        whose executor keeps dying is broken rather than slow, and must
+        stop being retried once the budget is spent (task-18060, following
+        the server job manager's retry budget).
 
         Args:
             run_id: The run to claim.
             worker_id: Identifies the claiming executor.
             lease_seconds: How long the lease is valid without renewal.
+            max_attempts: How many times, in total, a run may be claimed
+                (its first claim plus subsequent reclaims of an expired
+                lease) before further reclaims are refused.
 
         Returns:
             A new lease id when the claim succeeded, otherwise None.
         """
-        self._require_one("research_runs", run_id, "research run")
+        row = self._require_one("research_runs", run_id, "research run")
+        previous = row["leased_until"] if "leased_until" in row.keys() else None
+        attempts = int(row["lease_attempts"] or 0) if "lease_attempts" in row.keys() else 0
+        reclaiming = previous is not None
+        if reclaiming and attempts >= int(max_attempts):
+            return None
         lease_id = uuid.uuid4().hex
         now = self._now()
         expires = self._timestamp_after(lease_seconds)
+        next_attempts = attempts + 1
         with self._connect() as conn:
             cursor = conn.execute(
                 """
                 UPDATE research_runs
                    SET lease_owner = ?, lease_id = ?, leased_until = ?,
-                       updated_at = ?
+                       lease_attempts = ?, updated_at = ?
                  WHERE id = ?
                    AND (leased_until IS NULL OR leased_until <= ?)
                 """,
-                (worker_id, lease_id, expires, now, run_id, now),
+                (worker_id, lease_id, expires, next_attempts, now, run_id, now),
             )
             if cursor.rowcount != 1:
                 return None
         return lease_id
+
+    def renew_lease(
+        self, run_id: str, *, lease_id: str, lease_seconds: float
+    ) -> bool:
+        """Extend a lease the caller still holds.
+
+        The lease id is a fencing token: a worker that stalled past its lease
+        and was taken over still matches on worker id, so matching on the id
+        alone would let it act on a run it no longer owns (task-18060).
+
+        Args:
+            run_id: The leased run.
+            lease_id: The token returned by ``claim_run``.
+            lease_seconds: How much longer the lease should be valid.
+
+        Returns:
+            True when the lease was extended, False when it was lost.
+        """
+        expires = self._timestamp_after(lease_seconds)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET leased_until = ?, updated_at = ?
+                 WHERE id = ? AND lease_id = ?
+                """,
+                (expires, self._now(), run_id, lease_id),
+            )
+            return cursor.rowcount == 1
+
+    def release_lease(self, run_id: str, *, lease_id: str) -> bool:
+        """Drop a lease the caller holds so another executor may claim it.
+
+        Args:
+            run_id: The leased run.
+            lease_id: The token returned by ``claim_run``.
+
+        Returns:
+            True when the lease was released, False when it was already lost.
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET lease_owner = NULL, lease_id = NULL, leased_until = NULL,
+                       updated_at = ?
+                 WHERE id = ? AND lease_id = ?
+                """,
+                (self._now(), run_id, lease_id),
+            )
+            return cursor.rowcount == 1
+
+    def holds_lease(self, run_id: str, *, lease_id: str) -> bool:
+        """Whether ``lease_id`` is still the live lease on the run.
+
+        Args:
+            run_id: The run to check.
+            lease_id: The token returned by ``claim_run``.
+
+        Returns:
+            True when the token matches an unexpired lease.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT lease_id, leased_until FROM research_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None or row["lease_id"] != lease_id:
+            return False
+        return str(row["leased_until"] or "") > self._now()
 
     def pause_run(self, run_id: str) -> dict[str, Any]:
         if self._uses_external_db:

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -990,16 +990,42 @@ class LocalResearchService:
     def release_lease(self, run_id: str, *, lease_id: str) -> bool:
         """Drop a lease the caller holds so another executor may claim it.
 
+        Only a release while the lease is still LIVE is a clean hand-off:
+        it clears the lease columns and resets the crash-retry budget
+        (PR-1822 review follow-up). Releasing a lease that had already
+        EXPIRED is an abandonment being acknowledged after the fact, not a
+        clean hand-off -- matching ``lease_id`` alone let a systematically
+        stalling-but-alive executor loop claim -> expire -> release forever
+        without ever spending the budget, defeating the "fail a run whose
+        executor keeps dying" contract (AC #1b). An expired release
+        therefore leaves the lease record exactly as a crashed executor
+        would (expired, still on the books): the next claim is a RECLAIM,
+        the budget check applies, and the run stays free for the next
+        claimant either way -- an expired lease is already claimable.
+
         Args:
             run_id: The leased run.
             lease_id: The token returned by ``claim_run``.
 
         Returns:
-            True when the lease was released, False when it was already lost.
+            True when the lease was the caller's to release (live: cleared;
+            expired: left in place as an abandonment), False when it was
+            already lost to a takeover.
         """
         if self._uses_external_db:
             return self._release_lease_external(run_id, lease_id=lease_id)
+        now = self._now()
         with self._connect() as conn:
+            row = conn.execute(
+                "SELECT leased_until FROM research_runs WHERE id = ? AND lease_id = ?",
+                (run_id, lease_id),
+            ).fetchone()
+            if row is None:
+                return False
+            if str(row["leased_until"] or "") <= now:
+                # Already expired: leave the record so the next claim counts
+                # this as the abandonment it was.
+                return True
             cursor = conn.execute(
                 """
                 UPDATE research_runs
@@ -1007,16 +1033,21 @@ class LocalResearchService:
                        lease_attempts = 0, updated_at = ?
                  WHERE id = ? AND lease_id = ?
                 """,
-                (self._now(), run_id, lease_id),
+                (now, run_id, lease_id),
             )
             return cursor.rowcount == 1
 
     def _release_lease_external(self, run_id: str, *, lease_id: str) -> bool:
         """``release_lease``'s degraded, in-memory counterpart for
-        external-db mode (task-3 review finding 6)."""
+        external-db mode (task-3 review finding 6). Mirrors the SQLite
+        path's live/expired split: a live release deletes the entry (the
+        next claim starts fresh); an expired release leaves it so the next
+        claim counts the abandonment against the retry budget."""
         state = self._external_leases.get(run_id)
         if state is None or state["lease_id"] != lease_id:
             return False
+        if str(state["leased_until"]) <= self._now():
+            return True
         del self._external_leases[run_id]
         return True
 
@@ -1551,6 +1582,30 @@ class LocalResearchService:
         if run is None:
             raise ValueError("research run not found")
         return {"run": run, "artifacts": self.list_artifacts(run_id)}
+
+    def record_run_event(
+        self, run_id: str, event: str, data: dict[str, Any] | None = None
+    ) -> None:
+        """Append an event to the run's stream WITHOUT touching run state.
+
+        PR-1822 review follow-up: ``update_run_progress`` writes both an
+        event and the run row, so it is reserved for the lease holder (a
+        non-holder's call stomps the live executor's progress message and
+        bumps the version mid-flight). The event log is append-only and
+        overwrites nothing, so an observer -- e.g. an executor that was
+        DECLINED a lease -- may record what it observed without violating
+        the single-writer principle.
+
+        Args:
+            run_id: The run the event concerns.
+            event: Event name.
+            data: Optional event payload.
+        """
+        if self._uses_external_db:
+            return
+        self._require_one("research_runs", run_id, "research run")
+        with self._connect() as conn:
+            self._record_event(conn, run_id, event, data)
 
     def list_run_events(
         self, run_id: str, *, after_id: int = 0

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -17,7 +17,15 @@ from .research_normalizers import (
     normalize_research_record,
 )
 
-__all__ = ["LocalResearchService", "LeaseBudgetExhausted"]
+__all__ = ["LocalResearchService", "LeaseBudgetExhausted", "TERMINAL_RUN_STATUSES"]
+
+#: Statuses from which a run cannot be claimed or further executed. The
+#: single source of truth: ``local_research_engine.py`` imports this rather
+#: than keeping its own copy, so the two modules cannot drift apart (task-3
+#: review finding 1). Defined here, not in the engine, so this service has
+#: no dependency on the engine module -- ``claim_run`` needs the set and the
+#: service must not import the engine to get it.
+TERMINAL_RUN_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
 
 class LeaseBudgetExhausted(Exception):
@@ -71,6 +79,19 @@ class LocalResearchService:
             notification_dispatcher or notification_dispatch_service
         )
         self.notification_app = notification_app
+        #: Degraded, per-instance lease bookkeeping used only in external-db
+        #: mode (task-3 review finding 6): ``self.db`` is an arbitrary
+        #: external object with no lease columns and no lease API of its
+        #: own (nothing in production constructs the service this way
+        #: today), so a real, persisted, cross-process lease cannot be
+        #: implemented against it. Rather than raise (breaking
+        #: ``execute_run``'s now-unconditional claim outright) this map
+        #: gives external-db mode a real, in-memory single-executor
+        #: exclusion for the lifetime of THIS service instance -- it stops
+        #: two engines sharing one instance from double-executing a run,
+        #: but confers no protection across process or instance boundaries.
+        #: ``run_id -> {"lease_id", "worker_id", "leased_until", "attempts"}``.
+        self._external_leases: dict[str, dict[str, Any]] = {}
         if self.db_path is not None:
             self._init_schema()
 
@@ -675,23 +696,61 @@ class LocalResearchService:
         )
 
     def _update_run_state(
-        self, run_id: str, event: str, **fields: Any
+        self,
+        run_id: str,
+        event: str,
+        *,
+        lease_id: str | None = None,
+        **fields: Any,
     ) -> dict[str, Any]:
+        """Apply a run-state transition, optionally lease-conditional.
+
+        When ``lease_id`` is given, the UPDATE's WHERE clause matches it
+        directly (single atomic statement -- not a separate check followed
+        by an unconditional write), so a displaced executor whose lease no
+        longer matches gets a no-op instead of a race with whoever holds
+        the run now (task-3 review finding 4: this closes the
+        check-then-act gap a standalone ``holds_lease()`` pre-check leaves
+        between the check and the write).
+
+        Args:
+            run_id: The run to transition.
+            event: Event name recorded when the write lands.
+            lease_id: When provided, the write only lands if this still
+                matches the run's current ``lease_id``. Omit (the default)
+                for callers that transition run state independent of lease
+                ownership (``pause_run``/``resume_run``/``cancel_run``, and
+                any ``complete_run``/``fail_run`` call made on a path that
+                never held a lease).
+            **fields: Columns to set.
+
+        Returns:
+            The run's record: updated when the write landed, or the
+            CURRENT unmodified record when a ``lease_id`` was given and did
+            not match (a losing write) -- mirroring
+            ``_quiet_lease_lost_return``'s "return the truth, not a lie"
+            contract elsewhere in the lease design.
+        """
         row = self._require_one("research_runs", run_id, "research run")
         updates = dict(fields)
         updates["updated_at"] = self._now()
         updates["version"] = int(row["version"]) + 1
         assignments = ", ".join(f"{key} = ?" for key in updates)
+        sql = f"UPDATE research_runs SET {assignments} WHERE id = ?"
+        params: list[Any] = [*updates.values(), run_id]
+        if lease_id is not None:
+            sql += " AND lease_id = ?"
+            params.append(lease_id)
         with self._connect() as conn:
-            conn.execute(
-                f"UPDATE research_runs SET {assignments} WHERE id = ?",
-                (*updates.values(), run_id),
-            )
-            self._record_event(conn, run_id, event)
+            cursor = conn.execute(sql, params)
+            landed = cursor.rowcount == 1
+            if landed:
+                self._record_event(conn, run_id, event)
         updated = self._normalize_run(
             self._require_one("research_runs", run_id, "research run")
         )
-        self._dispatch_terminal_run_notification(updated)
+        if landed:
+            self._dispatch_terminal_run_notification(updated)
         return updated
 
     def _timestamp_after(self, seconds: float) -> str:
@@ -752,6 +811,15 @@ class LocalResearchService:
         ``leased_until <= ?`` comparison guarantees the two judgments of
         "is this lease live" cannot disagree with each other.
 
+        A run in a ``TERMINAL_RUN_STATUSES`` status can never be claimed
+        (task-3 review finding 1): the caller's own terminal check (e.g.
+        ``execute_run``'s pre-flight ``ValueError``) runs BEFORE this call,
+        so a cancellation or completion landing in the gap between that
+        check and this one would otherwise let a finished run be claimed
+        and re-executed. The status condition lives in the SAME atomic
+        UPDATE as the lease-expiry check, so the win/lose decision and the
+        terminal check cannot themselves race apart.
+
         Args:
             run_id: The run to claim.
             worker_id: Identifies the claiming executor.
@@ -761,15 +829,31 @@ class LocalResearchService:
                 lease) before further reclaims are refused.
 
         Returns:
-            A new lease id when the claim succeeded, otherwise None (another
-            executor currently holds a live lease).
+            A new lease id when the claim succeeded, otherwise None (either
+            another executor currently holds a live lease, or the run is
+            already terminal).
 
         Raises:
             LeaseBudgetExhausted: When reclaiming an EXPIRED lease would
                 exceed ``max_attempts`` -- the caller must fail the run
                 rather than treat this like a routine claim refusal.
         """
+        if self._uses_external_db:
+            return self._claim_run_external(
+                run_id,
+                worker_id=worker_id,
+                lease_seconds=lease_seconds,
+                max_attempts=max_attempts,
+            )
         row = self._require_one("research_runs", run_id, "research run")
+        if str(row["status"] or "") in TERMINAL_RUN_STATUSES:
+            # Nothing to reclaim and nothing to budget-check -- a terminal
+            # run is simply unclaimable, full stop. The atomic UPDATE below
+            # enforces this for real; this is only the cheap early-out so a
+            # terminal run never even reaches the retry-budget check (which
+            # would otherwise misfire "exhausted" on a run that was never
+            # abandoned, just finished).
+            return None
         previous = row["leased_until"] if "leased_until" in row.keys() else None
         attempts = int(row["lease_attempts"] or 0) if "lease_attempts" in row.keys() else 0
         now = self._now()
@@ -781,19 +865,70 @@ class LocalResearchService:
         lease_id = uuid.uuid4().hex
         expires = self._timestamp_after(lease_seconds)
         next_attempts = attempts + 1
+        status_placeholders = ", ".join("?" for _ in TERMINAL_RUN_STATUSES)
         with self._connect() as conn:
             cursor = conn.execute(
-                """
+                f"""
                 UPDATE research_runs
                    SET lease_owner = ?, lease_id = ?, leased_until = ?,
                        lease_attempts = ?, updated_at = ?
                  WHERE id = ?
                    AND (leased_until IS NULL OR leased_until <= ?)
+                   AND status NOT IN ({status_placeholders})
                 """,
-                (worker_id, lease_id, expires, next_attempts, now, run_id, now),
+                (
+                    worker_id,
+                    lease_id,
+                    expires,
+                    next_attempts,
+                    now,
+                    run_id,
+                    now,
+                    *sorted(TERMINAL_RUN_STATUSES),
+                ),
             )
             if cursor.rowcount != 1:
                 return None
+        return lease_id
+
+    def _claim_run_external(
+        self,
+        run_id: str,
+        *,
+        worker_id: str,
+        lease_seconds: float,
+        max_attempts: int,
+    ) -> str | None:
+        """``claim_run``'s degraded, in-memory counterpart for external-db
+        mode (task-3 review finding 6). See ``self._external_leases``'s
+        docstring in ``__init__`` for why this cannot be a real, persisted
+        lease. Mirrors ``claim_run``'s semantics (terminal refusal, live-
+        lease decline, expired-lease reclaim budget) against the in-memory
+        map instead of a SQL UPDATE.
+        """
+        run = self.get_run(run_id)
+        if run is None:
+            raise ValueError("research run not found")
+        if str(run.get("status") or "") in TERMINAL_RUN_STATUSES:
+            return None
+        now = self._now()
+        state = self._external_leases.get(run_id)
+        attempts = int(state["attempts"]) if state is not None else 0
+        live = state is not None and str(state["leased_until"]) > now
+        if live:
+            return None
+        reclaiming = state is not None
+        if reclaiming and attempts >= int(max_attempts):
+            raise LeaseBudgetExhausted(
+                run_id, attempts=attempts, max_attempts=int(max_attempts)
+            )
+        lease_id = uuid.uuid4().hex
+        self._external_leases[run_id] = {
+            "lease_id": lease_id,
+            "worker_id": worker_id,
+            "leased_until": self._timestamp_after(lease_seconds),
+            "attempts": attempts + 1,
+        }
         return lease_id
 
     def renew_lease(
@@ -805,25 +940,52 @@ class LocalResearchService:
         and was taken over still matches on worker id, so matching on the id
         alone would let it act on a run it no longer owns (task-18060).
 
+        The lease must also still be LIVE (task-3 review finding 3): matching
+        on ``lease_id`` alone lets a worker whose lease already expired
+        extend it again as long as nobody has taken over YET, contradicting
+        takeover -- a stalled worker could resurrect a claim it had already
+        lost. ``now`` is computed once and reused for both the UPDATE's
+        expiry comparison and ``updated_at``, the same pattern ``claim_run``
+        uses for its own comparisons.
+
         Args:
             run_id: The leased run.
             lease_id: The token returned by ``claim_run``.
             lease_seconds: How much longer the lease should be valid.
 
         Returns:
-            True when the lease was extended, False when it was lost.
+            True when the lease was extended, False when it was lost (wrong
+            id, or the lease had already expired).
         """
+        if self._uses_external_db:
+            return self._renew_lease_external(
+                run_id, lease_id=lease_id, lease_seconds=lease_seconds
+            )
+        now = self._now()
         expires = self._timestamp_after(lease_seconds)
         with self._connect() as conn:
             cursor = conn.execute(
                 """
                 UPDATE research_runs
                    SET leased_until = ?, updated_at = ?
-                 WHERE id = ? AND lease_id = ?
+                 WHERE id = ? AND lease_id = ? AND leased_until > ?
                 """,
-                (expires, self._now(), run_id, lease_id),
+                (expires, now, run_id, lease_id, now),
             )
             return cursor.rowcount == 1
+
+    def _renew_lease_external(
+        self, run_id: str, *, lease_id: str, lease_seconds: float
+    ) -> bool:
+        """``renew_lease``'s degraded, in-memory counterpart for
+        external-db mode (task-3 review finding 6)."""
+        state = self._external_leases.get(run_id)
+        if state is None or state["lease_id"] != lease_id:
+            return False
+        if str(state["leased_until"]) <= self._now():
+            return False
+        state["leased_until"] = self._timestamp_after(lease_seconds)
+        return True
 
     def release_lease(self, run_id: str, *, lease_id: str) -> bool:
         """Drop a lease the caller holds so another executor may claim it.
@@ -835,6 +997,8 @@ class LocalResearchService:
         Returns:
             True when the lease was released, False when it was already lost.
         """
+        if self._uses_external_db:
+            return self._release_lease_external(run_id, lease_id=lease_id)
         with self._connect() as conn:
             cursor = conn.execute(
                 """
@@ -847,6 +1011,15 @@ class LocalResearchService:
             )
             return cursor.rowcount == 1
 
+    def _release_lease_external(self, run_id: str, *, lease_id: str) -> bool:
+        """``release_lease``'s degraded, in-memory counterpart for
+        external-db mode (task-3 review finding 6)."""
+        state = self._external_leases.get(run_id)
+        if state is None or state["lease_id"] != lease_id:
+            return False
+        del self._external_leases[run_id]
+        return True
+
     def holds_lease(self, run_id: str, *, lease_id: str) -> bool:
         """Whether ``lease_id`` is still the live lease on the run.
 
@@ -857,6 +1030,8 @@ class LocalResearchService:
         Returns:
             True when the token matches an unexpired lease.
         """
+        if self._uses_external_db:
+            return self._holds_lease_external(run_id, lease_id=lease_id)
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT lease_id, leased_until FROM research_runs WHERE id = ?",
@@ -865,6 +1040,14 @@ class LocalResearchService:
         if row is None or row["lease_id"] != lease_id:
             return False
         return str(row["leased_until"] or "") > self._now()
+
+    def _holds_lease_external(self, run_id: str, *, lease_id: str) -> bool:
+        """``holds_lease``'s degraded, in-memory counterpart for
+        external-db mode (task-3 review finding 6)."""
+        state = self._external_leases.get(run_id)
+        if state is None or state["lease_id"] != lease_id:
+            return False
+        return str(state["leased_until"]) > self._now()
 
     def pause_run(self, run_id: str) -> dict[str, Any]:
         if self._uses_external_db:
@@ -894,8 +1077,31 @@ class LocalResearchService:
         )
 
     def complete_run(
-        self, run_id: str, *, progress_message: str | None = None
+        self,
+        run_id: str,
+        *,
+        progress_message: str | None = None,
+        lease_id: str | None = None,
     ) -> dict[str, Any]:
+        """Resolve a run to its terminal "completed" state.
+
+        Args:
+            run_id: The run to complete.
+            progress_message: Optional final status message.
+            lease_id: When provided (SQLite-backed mode only -- external-db
+                mode has no lease concept and ignores this), the write only
+                lands if this still matches the run's current lease
+                (task-3 review finding 4). The engine passes its own lease
+                id on every call it makes while holding one; a caller on a
+                path that never held a lease omits it, so its write is
+                unconditional.
+
+        Returns:
+            The run's record: "completed" when the write landed, or the
+            CURRENT unmodified record when a ``lease_id`` was given and no
+            longer matched (a displaced executor's write is a no-op, never
+            an overwrite of whoever holds the run now).
+        """
         if self._uses_external_db:
             record = self._as_local_run(
                 self.db.update_run_state(
@@ -917,9 +1123,37 @@ class LocalResearchService:
         }
         if progress_message is not None:
             fields["progress_message"] = progress_message
-        return self._update_run_state(run_id, "completed", **fields)
+        return self._update_run_state(
+            run_id, "completed", lease_id=lease_id, **fields
+        )
 
-    def fail_run(self, run_id: str, *, error_msg: str | None = None) -> dict[str, Any]:
+    def fail_run(
+        self,
+        run_id: str,
+        *,
+        error_msg: str | None = None,
+        lease_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a run to its terminal "failed" state.
+
+        Args:
+            run_id: The run to fail.
+            error_msg: Optional failure message.
+            lease_id: When provided (SQLite-backed mode only -- external-db
+                mode has no lease concept and ignores this), the write only
+                lands if this still matches the run's current lease
+                (task-3 review finding 4). The engine passes its own lease
+                id on every call it makes while holding one; a caller on a
+                path that never held a lease (e.g. a spent retry budget,
+                where ``claim_run`` raised before any lease was granted)
+                omits it, so its write is unconditional.
+
+        Returns:
+            The run's record: "failed" when the write landed, or the
+            CURRENT unmodified record when a ``lease_id`` was given and no
+            longer matched (a displaced executor's write is a no-op, never
+            an overwrite of whoever holds the run now).
+        """
         if self._uses_external_db:
             record = self._as_local_run(
                 self.db.update_run_state(
@@ -939,7 +1173,7 @@ class LocalResearchService:
         }
         if error_msg is not None:
             fields["progress_message"] = error_msg
-        return self._update_run_state(run_id, "failed", **fields)
+        return self._update_run_state(run_id, "failed", lease_id=lease_id, **fields)
 
     # Hardcoded assignment fragments for update_run_progress's external-DB
     # branch (task-16814): the ONLY source of SQL text for those columns.

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -17,6 +17,37 @@ from .research_normalizers import (
     normalize_research_record,
 )
 
+__all__ = ["LocalResearchService", "LeaseBudgetExhausted"]
+
+
+class LeaseBudgetExhausted(Exception):
+    """Raised by ``claim_run`` when a run's crash-retry budget is spent.
+
+    Reclaiming an EXPIRED lease counts against ``max_attempts``. This is
+    distinct from a normal claim refusal (another executor holds a LIVE
+    lease, signalled by ``claim_run`` returning ``None``): once the retry
+    budget itself is spent, the run's executor keeps dying rather than
+    merely losing a race, and the caller must fail the run instead of
+    leaving it ``status=running`` forever and unclaimable by anyone
+    (task-18060 review finding 1).
+
+    Attributes:
+        run_id: The run whose retry budget is exhausted.
+        attempts: How many times the run's lease was claimed and then
+            abandoned (left to expire unrenewed and unreleased) before this
+            attempt.
+        max_attempts: The configured budget that was reached.
+    """
+
+    def __init__(self, run_id: str, *, attempts: int, max_attempts: int) -> None:
+        super().__init__(
+            f"research run {run_id} exhausted its lease retry budget "
+            f"({attempts} of {max_attempts} allowed attempts)"
+        )
+        self.run_id = run_id
+        self.attempts = attempts
+        self.max_attempts = max_attempts
+
 
 class LocalResearchService:
     """Local-first persistence for research sessions, runs, events, and artifacts."""
@@ -694,17 +725,23 @@ class LocalResearchService:
         """Take the execution lease on a run, or decline it.
 
         The claim is atomic: the UPDATE matches only when no live lease
-        exists, so two racing executors cannot both succeed. Every
+        exists, so two racing executors cannot both succeed -- that WIN/LOSE
+        decision between racing claimants is exactly what the single UPDATE
+        below decides, and a losing race still returns None. Every
         successful claim counts against ``max_attempts`` (the run's total
         attempt budget), but the budget is only ENFORCED when reclaiming an
         EXPIRED lease -- a run's very first claim always succeeds. A run
         whose executor keeps dying is broken rather than slow, and must
         stop being retried once the budget is spent (task-18060, following
-        the server job manager's retry budget). A clean ``release_lease``
-        resets the counter to 0, since a run that was voluntarily released
-        was not abandoned -- so the budget tracks CONSECUTIVE abandonments
-        (crashes that leave the lease to expire), not the run's lifetime
-        claim count.
+        the server job manager's retry budget) -- signalled by raising
+        ``LeaseBudgetExhausted`` rather than returning None, so a caller
+        cannot mistake "the budget is spent" for "someone else holds it
+        live" (review finding 1: those two cases need different responses --
+        the first must fail the run, the second must leave it alone). A
+        clean ``release_lease`` resets the counter to 0, since a run that
+        was voluntarily released was not abandoned -- so the budget tracks
+        CONSECUTIVE abandonments (crashes that leave the lease to expire),
+        not the run's lifetime claim count.
 
         Args:
             run_id: The run to claim.
@@ -715,14 +752,22 @@ class LocalResearchService:
                 lease) before further reclaims are refused.
 
         Returns:
-            A new lease id when the claim succeeded, otherwise None.
+            A new lease id when the claim succeeded, otherwise None (another
+            executor currently holds a live lease).
+
+        Raises:
+            LeaseBudgetExhausted: When reclaiming an EXPIRED lease would
+                exceed ``max_attempts`` -- the caller must fail the run
+                rather than treat this like a routine claim refusal.
         """
         row = self._require_one("research_runs", run_id, "research run")
         previous = row["leased_until"] if "leased_until" in row.keys() else None
         attempts = int(row["lease_attempts"] or 0) if "lease_attempts" in row.keys() else 0
         reclaiming = previous is not None
         if reclaiming and attempts >= int(max_attempts):
-            return None
+            raise LeaseBudgetExhausted(
+                run_id, attempts=attempts, max_attempts=int(max_attempts)
+            )
         lease_id = uuid.uuid4().hex
         now = self._now()
         expires = self._timestamp_after(lease_seconds)

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -239,6 +239,33 @@ class LocalResearchService:
                 );
                 """
             )
+            self._ensure_run_lease_columns(conn)
+
+    #: Columns added after the original schema shipped. CREATE TABLE IF NOT
+    #: EXISTS never revisits an existing database, so each one is applied by
+    #: an idempotent ALTER guarded on PRAGMA table_info (task-18060).
+    _RUN_COLUMN_ADDITIONS = (
+        ("lease_owner", "TEXT"),
+        ("lease_id", "TEXT"),
+        ("leased_until", "TEXT"),
+        ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
+    )
+
+    def _ensure_run_lease_columns(self, conn: sqlite3.Connection) -> None:
+        """Add lease columns to research_runs when they are absent.
+
+        Args:
+            conn: An open connection inside the caller's transaction.
+        """
+        existing = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(research_runs)").fetchall()
+        }
+        for column, declaration in self._RUN_COLUMN_ADDITIONS:
+            if column not in existing:
+                conn.execute(
+                    f"ALTER TABLE research_runs ADD COLUMN {column} {declaration}"
+                )
 
     def _fetch_one(self, table: str, item_id: str) -> dict[str, Any] | None:
         with self._connect() as conn:
@@ -601,6 +628,48 @@ class LocalResearchService:
         )
         self._dispatch_terminal_run_notification(updated)
         return updated
+
+    def _timestamp_after(self, seconds: float) -> str:
+        """An ISO timestamp ``seconds`` in the future, in the same format as
+        ``_now`` so string comparison orders correctly."""
+        return (
+            datetime.now(timezone.utc) + timedelta(seconds=max(0.0, float(seconds)))
+        ).isoformat()
+
+    def claim_run(
+        self, run_id: str, *, worker_id: str, lease_seconds: float
+    ) -> str | None:
+        """Take the execution lease on a run, or decline it.
+
+        The claim is atomic: the UPDATE only matches when no live lease
+        exists, so two racing executors cannot both succeed (task-18060).
+
+        Args:
+            run_id: The run to claim.
+            worker_id: Identifies the claiming executor.
+            lease_seconds: How long the lease is valid without renewal.
+
+        Returns:
+            A new lease id when the claim succeeded, otherwise None.
+        """
+        self._require_one("research_runs", run_id, "research run")
+        lease_id = uuid.uuid4().hex
+        now = self._now()
+        expires = self._timestamp_after(lease_seconds)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE research_runs
+                   SET lease_owner = ?, lease_id = ?, leased_until = ?,
+                       updated_at = ?
+                 WHERE id = ?
+                   AND (leased_until IS NULL OR leased_until <= ?)
+                """,
+                (worker_id, lease_id, expires, now, run_id, now),
+            )
+            if cursor.rowcount != 1:
+                return None
+        return lease_id
 
     def pause_run(self, run_id: str) -> dict[str, Any]:
         if self._uses_external_db:

--- a/tldw_chatbook/Research_Interop/local_research_service.py
+++ b/tldw_chatbook/Research_Interop/local_research_service.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable
 
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 
+from .migrations import MIGRATIONS
 from .research_normalizers import (
     ResearchRecord,
     ResearchRecordList,
@@ -325,33 +326,40 @@ class LocalResearchService:
                 );
                 """
             )
-            self._ensure_run_lease_columns(conn)
+            # The base script above ships the v0 shape (CREATE TABLE IF NOT
+            # EXISTS never revisits an existing database); the versioned
+            # migrations below take it from there (Qodo PR-1822 finding 7).
+            self._apply_migrations(conn)
 
-    #: Columns added after the original schema shipped. CREATE TABLE IF NOT
-    #: EXISTS never revisits an existing database, so each one is applied by
-    #: an idempotent ALTER guarded on PRAGMA table_info (task-18060).
-    _RUN_COLUMN_ADDITIONS = (
-        ("lease_owner", "TEXT"),
-        ("lease_id", "TEXT"),
-        ("leased_until", "TEXT"),
-        ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
-    )
+    def _apply_migrations(self, conn: sqlite3.Connection) -> None:
+        """Upgrade the database to the newest known schema version.
 
-    def _ensure_run_lease_columns(self, conn: sqlite3.Connection) -> None:
-        """Add lease columns to research_runs when they are absent.
+        Each migration in ``migrations.MIGRATIONS`` whose target version
+        exceeds the database's current ``PRAGMA user_version`` is applied
+        in order, inside one transaction per step (the guard inside each
+        migration makes re-runs no-ops). A database stamped by a NEWER
+        service is refused rather than silently downgraded or half-used.
 
         Args:
-            conn: An open connection inside the caller's transaction.
+            conn: An open connection.
+
+        Raises:
+            RuntimeError: If the database's schema version is newer than
+                this code knows about.
         """
-        existing = {
-            str(row["name"])
-            for row in conn.execute("PRAGMA table_info(research_runs)").fetchall()
-        }
-        for column, declaration in self._RUN_COLUMN_ADDITIONS:
-            if column not in existing:
-                conn.execute(
-                    f"ALTER TABLE research_runs ADD COLUMN {column} {declaration}"
-                )
+        current = int(
+            conn.execute("PRAGMA user_version").fetchone()[0] or 0
+        )
+        newest = MIGRATIONS[-1][0] if MIGRATIONS else current
+        if current > newest:
+            raise RuntimeError(
+                f"research database schema version {current} is newer than "
+                f"this build supports ({newest}); update the application "
+                "before opening this database"
+            )
+        for target_version, apply_step in MIGRATIONS:
+            if target_version > current:
+                apply_step(conn)
 
     def _fetch_one(self, table: str, item_id: str) -> dict[str, Any] | None:
         with self._connect() as conn:

--- a/tldw_chatbook/Research_Interop/migrations/__init__.py
+++ b/tldw_chatbook/Research_Interop/migrations/__init__.py
@@ -1,0 +1,24 @@
+"""Versioned schema migrations for the local research database.
+
+Each module in this package upgrades the database from one
+``PRAGMA user_version`` to the next and stamps the target version.
+``LocalResearchService._init_schema`` applies them in order on open;
+databases stamped by a newer service are refused rather than silently
+downgraded (Qodo PR-1822 finding 7 -- the lease columns originally landed
+as bare, unversioned startup ALTERs).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Callable
+
+from . import v0_to_v1_run_lease_columns
+
+#: Every migration, ordered by target version. A database at version N is
+#: upgraded by applying each step whose target exceeds N, in order.
+MIGRATIONS: tuple[tuple[int, Callable[[sqlite3.Connection], None]], ...] = (
+    (v0_to_v1_run_lease_columns.TARGET_VERSION, v0_to_v1_run_lease_columns.apply),
+)
+
+__all__ = ["MIGRATIONS"]

--- a/tldw_chatbook/Research_Interop/migrations/v0_to_v1_run_lease_columns.py
+++ b/tldw_chatbook/Research_Interop/migrations/v0_to_v1_run_lease_columns.py
@@ -1,0 +1,47 @@
+"""Migration v0 -> v1: add the run-lease columns to ``research_runs``.
+
+The columns themselves pre-date this migration (task-18060 landed them as
+idempotent startup ALTERs); this migration rehomes them in the versioned
+path Qodo PR-1822 finding 7 asked for, so the change is auditable and
+ordered like ``TTS/migrations/`` and the numbered SQL migrations under
+``DB/migrations/``.
+
+The ALTERs stay guarded on ``PRAGMA table_info`` inside the migration: a
+database created by the interim unversioned code already has the columns
+while still reading ``user_version = 0``, and upgrading it must stamp the
+version without re-adding anything.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+TARGET_VERSION = 1
+
+#: Columns this migration adds to research_runs. Single source of truth:
+#: the base CREATE TABLE in local_research_service.py ships the PRE-v1
+#: shape, so both fresh and pre-existing databases pass through here.
+LEASE_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("lease_owner", "TEXT"),
+    ("lease_id", "TEXT"),
+    ("leased_until", "TEXT"),
+    ("lease_attempts", "INTEGER NOT NULL DEFAULT 0"),
+)
+
+
+def apply(conn: sqlite3.Connection) -> None:
+    """Upgrade the database to schema version 1.
+
+    Args:
+        conn: An open connection; the caller owns the transaction.
+    """
+    existing = {
+        str(row["name"])
+        for row in conn.execute("PRAGMA table_info(research_runs)").fetchall()
+    }
+    for column, declaration in LEASE_COLUMNS:
+        if column not in existing:
+            conn.execute(
+                f"ALTER TABLE research_runs ADD COLUMN {column} {declaration}"
+            )
+    conn.execute(f"PRAGMA user_version = {TARGET_VERSION}")

--- a/tldw_chatbook/Research_Interop/research_budget.py
+++ b/tldw_chatbook/Research_Interop/research_budget.py
@@ -97,13 +97,21 @@ class BudgetLedger:
         Args:
             snapshot: A prior ``snapshot()`` payload, or None for a run that
                 has never executed.
-            limits: The run's limits, used when the snapshot carries none.
+            limits: The run's CURRENT effective limits (any approved
+                plan-review patch already merged over the run's stored
+                limits); these win over the snapshot's own ``limits`` when
+                provided, since a snapshot written before a plan-review
+                patch would otherwise resurrect the stale, pre-patch values
+                (same bug class as the Qodo PR 1766 fix a few lines above
+                this one in ``local_research_engine.py``, for
+                ``max_iterations``). Falls back to the snapshot's limits
+                only when this argument is empty/None.
 
         Returns:
             A ledger whose used counters continue from the snapshot.
         """
         snapshot = snapshot or {}
-        ledger = cls(dict(snapshot.get("limits") or limits or {}))
+        ledger = cls(dict(limits or snapshot.get("limits") or {}))
         ledger.searches_used = int(snapshot.get("searches_used") or 0)
         ledger.searches_overshoot = int(snapshot.get("searches_overshoot") or 0)
         ledger.docs_used = int(snapshot.get("docs_used") or 0)

--- a/tldw_chatbook/Research_Interop/research_budget.py
+++ b/tldw_chatbook/Research_Interop/research_budget.py
@@ -77,6 +77,47 @@ class BudgetLedger:
     def from_limits(cls, limits: Mapping[str, Any] | None) -> "BudgetLedger":
         return cls(limits)
 
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: Mapping[str, Any] | None,
+        limits: Mapping[str, Any] | None,
+    ) -> "BudgetLedger":
+        """Rebuild a ledger that has already spent part of its budget.
+
+        task-18060: ``execute_run`` used to rebuild from limits on every entry
+        while writing ``budget_ledger.json`` and never reading it back, so a
+        resumed run was granted its whole budget again. Resume is routine once
+        runs survive an app exit, which turns that into a leak.
+
+        Reservations are deliberately NOT restored. A reservation belongs to an
+        in-flight call that died with its executor; carrying it forward would
+        hold budget nothing is going to spend.
+
+        Args:
+            snapshot: A prior ``snapshot()`` payload, or None for a run that
+                has never executed.
+            limits: The run's limits, used when the snapshot carries none.
+
+        Returns:
+            A ledger whose used counters continue from the snapshot.
+        """
+        snapshot = snapshot or {}
+        ledger = cls(dict(snapshot.get("limits") or limits or {}))
+        ledger.searches_used = int(snapshot.get("searches_used") or 0)
+        ledger.searches_overshoot = int(snapshot.get("searches_overshoot") or 0)
+        ledger.docs_used = int(snapshot.get("docs_used") or 0)
+        ledger.tokens_settled = int(snapshot.get("tokens_settled") or 0)
+        # A snapshot records whether any settled usage was estimated rather than
+        # provider-reported, not the exact-token count itself; restoring the
+        # settled total as fully exact would erase that distinction, so an
+        # estimated snapshot restores as estimated.
+        if snapshot.get("tokens_estimated"):
+            ledger.tokens_settled_exact = 0
+        else:
+            ledger.tokens_settled_exact = ledger.tokens_settled
+        return ledger
+
     # -- searches ---------------------------------------------------------
 
     def remaining_searches(self) -> int | None:

--- a/tldw_chatbook/Research_Interop/research_budget.py
+++ b/tldw_chatbook/Research_Interop/research_budget.py
@@ -108,7 +108,8 @@ class BudgetLedger:
                 only when this argument is empty/None.
 
         Returns:
-            A ledger whose used counters continue from the snapshot.
+            A ledger whose used counters -- and elapsed runtime -- continue
+            from the snapshot.
         """
         snapshot = snapshot or {}
         ledger = cls(dict(limits or snapshot.get("limits") or {}))
@@ -124,6 +125,18 @@ class BudgetLedger:
             ledger.tokens_settled_exact = 0
         else:
             ledger.tokens_settled_exact = ledger.tokens_settled
+        # task-18060 review finding 4: the same leak already fixed above for
+        # searches/docs/tokens also applied to runtime -- elapsed_seconds()
+        # is derived from _start_monotonic, which the constructor stamps at
+        # "now", so a resumed run was silently re-granted its whole
+        # max_runtime_seconds. Back-dating _start_monotonic by the
+        # snapshot's own elapsed time makes elapsed_seconds() continue
+        # rather than restart.
+        try:
+            previous_elapsed = float(snapshot.get("runtime_elapsed_s") or 0.0)
+        except (TypeError, ValueError):
+            previous_elapsed = 0.0
+        ledger._start_monotonic = time.monotonic() - max(0.0, previous_elapsed)
         return ledger
 
     # -- searches ---------------------------------------------------------


### PR DESCRIPTION
Implements the durability core of **TASK-18060**, from the design in `Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md` and the plan in `Docs/superpowers/plans/2026-08-18-durable-research-jobs-core.md`. Executed as five plan tasks with a review gate on each and a whole-branch review at the end.

## What landed

- **A lease with a fencing token.** `claim_run` is a single atomic `UPDATE`; `lease_id` (not `worker_id`) authorises renewal, release and the fence, so a stalled worker that was taken over cannot act on a run it no longer owns.
- **A reclaim budget** that means *consecutive abandonments* — a clean release resets it — and that **fails** a run whose executor keeps dying rather than leaving it stuck.
- **A keep-alive on a timer**, not a progress hook: the synthesis phase emits nothing for ~970s, so a progress-driven lease would expire inside the most expensive phase. Blocking pipeline seams are offloaded via `asyncio.to_thread` so the renewal task can actually run.
- **A fence before every persisting write**, including `complete_run` — a displaced executor cannot stomp the new owner's terminal state.
- **Budget restored on resume** across searches, docs, tokens *and* runtime. Previously the ledger was rebuilt from limits on every entry while `budget_ledger.json` was written and never read.
- **Each round's evidence persisted** under a stated 8 MB cap, degrading to references with the truncation recorded.

## What did NOT land, deliberately

**AC #3 — reading the evidence pool back to skip a completed round — is not implemented.** The artifact that makes it possible is written; the read-back is not. A resumed run therefore still re-searches. The plan's Task 5 title promised this and its steps did not deliver it; that is a defect in my plan, recorded rather than papered over.

Scheduler auto-resume and completion surfacing (ACs #5–#11) are follow-on plans by design.

## What the review gates caught

Recorded because it is the honest picture of how this was built, not a victory lap:

| Found | By |
|---|---|
| Timestamp format divergence made a **live** lease compare as expired — the exact double-claim leasing prevents | Task 1 review |
| A retry budget that counted healthy claim/release cycles **stranded runs that never crashed** | Task 2 review |
| The keep-alive was an asyncio task behind a **blocking** call, so it never ran during collection | Tasks 3–5 review |
| **Six** persisting writes unfenced, including the one marking a run completed | Tasks 3–5 review |
| An exhausted budget left a run **permanently unclaimable** instead of failed — a regression against pre-branch behaviour | whole-branch review |
| The fix for *that* then **failed runs whose executors were healthy** | final review |

Three times a test passed for the wrong reason — twice by asserting the absence of a bad outcome instead of the presence of the good one. Each was caught by mutation: remove the mechanism, confirm the test goes red.

## Named follow-ups (not fixed here)

- fence coverage is **2 of 11** when fences are removed individually
- the `except ResearchLimitExceeded` half of the lease-lost guard is untested
- `evidence_pool.json` is written before the doc-budget trim, so it holds entries the run excluded — harmless until AC #3 reads it back
- `_lease_id`/`_run_id` are engine-instance state; safe only because every caller builds a fresh engine per run, and a scheduler reusing one engine would silently disable the fence
- a SIGKILLed run is declined for up to `lease_seconds` with a message blaming another executor

## Verification

- `Tests/Research` **200 passed**; `Tests/UI/test_research_screen.py` + `Tests/Helper_Scripts` **127 passed**; `ruff` clean on every touched file.
- Existing `_RunAwaitingReview` / `_RunPaused` / `_RunCancelled` / `ResearchLimitExceeded` paths verified unchanged.
- Guards mutation-checked individually: the timestamp formatter, the budget reset, the keep-alive, the ledger restore, the runtime restore, the gap-analysis offload, the evidence artifact, and the two theft tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Durable, resumable research runs with single-owner leases, keep-alive, budget restore, and per‑round evidence, now backed by a versioned migration for lease columns. This closes the durability core for TASK-18060 and makes the lease schema auditable and safe to roll out.

- Local service and engine
  - `LocalResearchService`: `claim_run` refuses terminal runs; declines a live lease vs raising `LeaseBudgetExhausted` only when the reclaim budget is spent; `renew_lease` updates only while live; `release_lease` resets attempts only on a live release; terminal writes accept `lease_id` for atomic fencing; `record_run_event` logs `lease_declined`; `TERMINAL_RUN_STATUSES` is the source of truth; external‑DB mode degrades leases to per‑process memory.
  - `LocalResearchEngine`: claims before work, renews via timer (renewal errors contained), always releases in `finally`, fences all state/artifact writes, passes `lease_id` on terminal writes, offloads blocking seams via `asyncio.to_thread`, and exits cleanly on lease loss.
  - `BudgetLedger`: `from_snapshot` restores searches/docs/tokens/runtime spend and prefers current limits over stale snapshots.
  - Evidence: persists each round under an 8 MB cap; truncates bodies, drops oversized or non‑JSON entries, and records flags; written before doc‑budget trim.
  - Schema: new `tldw_chatbook/Research_Interop/migrations` with v0→v1 adding lease columns and stamping `PRAGMA user_version = 1`; applied on open; databases stamped by a newer version are refused.

- Rollout and migration
  - Callers of `claim_run` must handle `LeaseBudgetExhausted` separately from None.
  - Observers must not call `update_run_progress` after a declined claim; append a `lease_declined` event via `record_run_event`.
  - External‑DB mode leases are single‑process only; do not rely on cross‑process enforcement.
  - DB migration runs automatically on open; no manual steps. Newer‑version databases are refused with a clear error.
  - Resumed runs still re‑search for now; scheduler auto‑resume and evidence read‑back follow in upcoming work.

<sup>Written for commit 83bd131c814270514514ceccd0253f8437077e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

