### PR TITLE
fix(library): a failed seam must not read as a seam that found nothing

### DIFF
--- a/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
+++ b/Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py
@@ -50,6 +50,7 @@ def main() -> int:
     import tldw_chatbook
     from tldw_chatbook.Library.library_local_rag_search_service import (
         LibraryLocalRagSearchService,
+        SeamState,
     )
 
     from Tests.RAG_Eval.harness.canonicalize import rows_to_doc_ids, slug_lookup_from
@@ -84,11 +85,13 @@ def main() -> int:
             seam = LibraryLocalRagSearchService(rt.app)
             svc = getattr(rt.app, "prompt_scope_service", None)
             print(f"\nPROBE PROOF: app.prompt_scope_service = {type(svc).__name__}")
-            available, rows = rt.run(seam._search_prompts("prompt", K))
-            print(f"PROBE PROOF: _search_prompts availability = {available} "
-                  f"(False means UNAVAILABLE, not 'matched nothing')")
+            state, rows = rt.run(seam._search_prompts("prompt", K))
+            print(f"PROBE PROOF: _search_prompts state = {state} "
+                  f"(UNAVAILABLE/FAILED both mean the rows are meaningless)")
             print(f"PROBE PROOF: smoke-query rows = {len(rows)}")
-            if not available:
+            # TASK-18903: `if not state` would be ALWAYS FALSE -- every Enum
+            # member is truthy. Compare with `is`, or this guard goes inert.
+            if state is not SeamState.AVAILABLE:
                 print("  SEAM UNAVAILABLE -- nothing below would be meaningful.")
                 return 1
 

--- a/Docs/superpowers/specs/2026-08-18-seam-availability-design.md
+++ b/Docs/superpowers/specs/2026-08-18-seam-availability-design.md
@@ -1,0 +1,242 @@
+# TASK-18903 — a seam that failed must not read as a seam that found nothing
+
+## The defect, measured
+
+Every one of the Library's four keyword seams ends:
+
+```python
+except Exception:
+    logger.opt(exception=True).warning("Library keyword search: <seam> failed.")
+    return True, []
+```
+
+`True` means **available**. So a seam whose backend threw reports itself
+healthy and empty. The merge site gates on `any(available)`, then discards
+per-seam availability.
+
+**Measured on dev (`692ed00d9`), all four backends raising:**
+
+```
+notes          -> available=True  rows=0   <-- claims AVAILABLE while broken
+media          -> available=True  rows=0
+conversations  -> available=True  rows=0
+prompts        -> available=True  rows=0
+
+caller receives: {"results": [], "runtime_backend": "local-fts"}
+```
+
+**A total backend failure is presented to the user as a successful search
+that matched nothing.** No status, no recovery state, no indication anything
+went wrong. The only trace is a log line nothing reads.
+
+This is not only an instrument problem. It is the same collapse that produced
+TASK-17855 (a wrong production-defect filing), TASK-18255, and two bugs inside
+this programme's own censuses — but here it is **user-facing**.
+
+## Why the obvious one-line fix is not enough
+
+Changing `return True, []` to `return False, []` makes the all-fail case
+report "blocked", which is right. But it leaves the **partial** case silently
+wrong: if notes succeeds and prompts throws, the user gets notes results and
+no indication that prompts was never searched. Silence still reads as absence.
+
+## Design: three states, surfaced twice
+
+**1. Replace the boolean with an explicit state.** The seams return
+`(SeamState, rows)` where `SeamState` is `AVAILABLE` / `UNAVAILABLE` /
+`FAILED`:
+
+| state | meaning | today |
+|---|---|---|
+| `AVAILABLE` | the seam ran and its rows are its answer | `True` |
+| `UNAVAILABLE` | not configured — `service is None` | `False` |
+| `FAILED` | configured, ran, and **threw** | **`True` — the bug** |
+
+**2. The merge site distinguishes total from partial.**
+
+- No seam `AVAILABLE` and at least one `FAILED` → **`status="blocked"`** with
+  a recovery state naming the failure. Today: a silent empty result.
+- No seam `AVAILABLE`, none `FAILED` (all `UNAVAILABLE`) → `status="blocked"`
+  with the existing no-backend recovery state. **Unchanged.**
+- Some `AVAILABLE`, some `FAILED` → results are returned **and** the failed
+  seams are recorded in `diagnostics` under a new keyed slot, so the caller
+  can say "showing media results; notes and prompts failed" rather than
+  implying the corpus was searched.
+
+`diagnostics` is already a `dict[str, Any]` threaded through every outcome
+with keyed slots (`SCOPE_DIAGNOSTICS_KEY`, `LIBRARY_RAG_ROUTE_NOTES_KEY`), so
+this follows the established pattern rather than inventing a channel.
+
+**3. Nothing else changes.** Row shape, the rank-fair merge (TASK-16071),
+scope handling, and the `_empty_scoped_seam` sentinel (which is deliberately
+`AVAILABLE`-with-no-rows, and stays that way) are untouched.
+
+## Scope
+
+**In:** `library_local_rag_search_service.py` — the four seams, the merge-site
+gate, one new diagnostics slot; tests pinning each state and each combination.
+
+**Out:** the UI copy that would render the partial-failure diagnostic (a
+follow-up once the data exists); the RAG-eval metrics layer (it consumes rows,
+not seam state — it benefits indirectly because a future census can finally
+see the difference); the engine's own hybrid keyword leg.
+
+## Acceptance criteria
+
+- [ ] A seam whose backend throws reports `FAILED`, not available
+- [ ] **All seams failing yields `blocked` with a recovery state, never a
+      zero-row success** — pinned by a test that reds on today's code
+- [ ] All seams merely unconfigured still yields the existing no-backend
+      blocked outcome, byte-identical
+- [ ] A partial failure returns the surviving seams' results **and** names the
+      failed seams in `diagnostics`
+- [ ] Every existing caller of the seams still type-checks and behaves
+      identically for the `AVAILABLE` path — this must not become a
+      three-state refactor that changes healthy behaviour
+- [ ] `Tests/Library` stays green; the RAG-eval gate reads
+      `PASSED: No regression. 105 metric(s)` (this touches no retrieval logic,
+      so any movement is a defect in the change)
+
+## Risks, all checked against dev rather than guessed
+
+**1. The change could introduce the very collapse it fixes.** An `Enum`
+member is **truthy**, including `UNAVAILABLE` and `FAILED`:
+
+```
+bool(SeamState.UNAVAILABLE) = True
+```
+
+The existing gate reads `if not any(available for available, _rows in ...)`.
+Swap the boolean for an enum and that line silently becomes *never blocked* —
+a working guard turning inert with no error, which is precisely this
+programme's recurring defect. **Mitigation:** the all-unavailable case gets
+its own test *before* the type changes, so it reds if the gate goes inert;
+the gate is rewritten to an explicit `is SeamState.AVAILABLE` comparison.
+
+**2. Callers: checked, and the seams are module-private.** Every hit outside
+`library_local_rag_search_service.py` is a comment or a differently-named
+method (`_search_conversations_sync` in CCP, `_tool_search_notes` in the MCP
+delegate). Two tests unpack the tuple
+(`Tests/Library/test_library_keyword_and_then_prefix.py`) and both discard the
+flag, so they are unaffected.
+
+**3. One committed QA script would go silently inert.**
+`Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py` (merged in
+TASK-18255) does `if not available:` to refuse a verdict on an unavailable
+seam. Under an enum that check becomes always-False — the guard dies quietly.
+It must be updated in the same change.
+
+**4. `_empty_scoped_seam` returns `(True, [])` deliberately** — scope excluded
+the seam, which is a genuine "searched, nothing in scope" answer. It maps to
+`AVAILABLE`, never `FAILED`, or scoped searches start reporting failures.
+
+**5. Hot path.** These seams run on every Library search. The change is
+state-only: no added awaits, no extra queries, no row-shape change.
+
+
+---
+
+# Design review (2026-08-18, before implementation)
+
+Six findings. Two change the design.
+
+## R1 — SEVERITY: the defect creates a hallucination surface (worse than specced)
+
+Traced end to end on dev `692ed00d9`:
+
+1. all four seams throw → each returns `(True, [])`
+2. `any(available)` passes the gate
+3. rows empty, unscoped → returns a plain `{"results": [], …}` dict
+4. `_outcome_from_service_result`: `if not rows: status="empty"`
+5. `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES = frozenset({"ready", "empty"})`
+6. `library_screen.py:30880` — `if outcome.status not in …: return` — **so
+   "empty" PROCEEDS**
+
+**A total backend outage therefore reaches the RAG answer path, which
+generates an answer with zero retrieved context and presents it as
+Library-grounded.** The failure is not merely "user told nothing matched"; it
+is "user given a confident answer built on nothing". This raises the priority
+of the fix and is the strongest argument for the total-failure status being
+NON-answerable.
+
+## R2 — DESIGN CHANGE: a new status is probably redundant; `failed` exists
+
+`run_library_rag_search`'s except branch already returns:
+
+```python
+return LibraryRagSearchOutcome(
+    status="failed",
+    recovery_state=_retrieval_failed_recovery_state(),
+)
+```
+
+It already means "retrieval did not happen", already has a recovery state,
+and is already fail-closed (absent from the answerable allowlist).
+
+**DECIDED (owner, 2026-08-18): reuse `failed`.** Recommendation was to reuse
+`failed` rather than mint a second failure status, and that is the ruling. Two statuses that both mean "retrieval did not happen" is an
+ambiguity every future reader must resolve, and the only difference would be
+recovery-state copy — which `recovery_state` already carries independently of
+`status`. If a distinct status is still wanted, it must be added to no
+allowlist and its copy must explain the difference from `failed`, or the
+distinction decays into folklore.
+
+## R3 — IMPROVEMENT: mirror the semantic leg; do not invent a scheme
+
+The semantic leg **already implements this exact design**:
+`SEMANTIC_DIAGNOSTICS_KEY` carries `{"status", "message"}` with
+`SEMANTIC_STATUS_UNAVAILABLE` / `SEMANTIC_STATUS_EMPTY_INDEX`, and
+`chat_rag_events.py` notifies the user — with the **same partial/total split
+this task needs**:
+
+```python
+if results:
+    notification = f"RAG context is keyword-only (FTS): {message}"
+else:
+    notification = f"Semantic retrieval returned no context: {message}"
+```
+
+The keyword-seam diagnostic should mirror that shape and that handler, and
+follow the append-to-a-LIST convention the scope slot already uses (a recorded
+task-9 review finding: assignment lets one entry silently overwrite another).
+
+## R4 — SCOPE CHANGE: the UI notice belongs IN this task, not after it
+
+My original scope deferred the rendering. Given R3, the notify site already
+exists and extending it is small — and shipping a diagnostics slot that
+nothing reads is the "declared but inert" trap this repo has hit before
+(TASK-16174's retired knobs, the eight unimplemented middleware names).
+**Pulled into scope.**
+
+## R5 — the change can introduce the very collapse it fixes
+
+`Enum` members are truthy, so `if not any(available for …)` silently becomes
+*never blocked*. Pin the all-unavailable case BEFORE the type changes;
+rewrite the gate to an explicit `is` comparison. (Already in Risks.)
+
+## R6 — pin the inside/outside-`try` asymmetry
+
+An exception **inside** a seam's `try` is swallowed to `(True, [])`; one
+**outside** it propagates through `asyncio.gather` (no `return_exceptions`)
+and becomes `status="failed"`. The fix makes both paths report failure, but
+the asymmetry should be pinned so it cannot silently return.
+
+## Revised acceptance criteria (superseding the list above where they differ)
+
+- [ ] A seam whose backend throws reports `FAILED`, not available
+- [ ] **Total failure is NON-answerable**: the outcome's status is excluded
+      from `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES`, pinned by a test that
+      asserts the answer path does not run — this is R1, the real defect
+- [ ] All seams merely unconfigured still yields the existing no-backend
+      blocked outcome, byte-identical
+- [ ] Partial failure returns surviving results AND records the failed seams
+      under a keyed diagnostics slot, appended to a list, mirroring
+      `SCOPE_DIAGNOSTICS_KEY`/`SEMANTIC_DIAGNOSTICS_KEY`
+- [ ] **The user is notified** on both partial and total failure, mirroring the
+      semantic leg's existing copy split
+- [ ] `_empty_scoped_seam` maps to `AVAILABLE`; scoped searches report no
+      failures
+- [ ] `seam_effect.py`'s `if not available:` guard is updated — under an enum
+      it would go silently inert
+- [ ] `Tests/Library` green; RAG-eval gate `PASSED: No regression. 105
+      metric(s)`

--- a/Tests/Agents/test_library_tool_provider.py
+++ b/Tests/Agents/test_library_tool_provider.py
@@ -936,3 +936,77 @@ def test_sealed_payload_survives_fallbacks():
     assert [row.get("doc_id") for row in payload["results"]] == (
         [None] * 5 + [f"note_n{index}" for index in range(5, 10)]
     )
+
+
+# --------------------------------------------------------------------------
+# TASK-18903 (PR #1823 review finding 3): partial seam failures must reach
+# the agent. The panel tells the user which seams failed; the tool used to
+# serialize only the surviving rows and report success, so the agent could
+# not distinguish an incomplete corpus search from a complete one.
+# --------------------------------------------------------------------------
+
+
+def _seam_failure_diagnostics(*seams: str) -> dict:
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        KEYWORD_SEAM_DIAGNOSTICS_KEY,
+        SEAM_STATUS_FAILED,
+    )
+
+    return {
+        KEYWORD_SEAM_DIAGNOSTICS_KEY: [
+            {
+                "status": SEAM_STATUS_FAILED,
+                "seam": seam,
+                "message": f"The {seam} seam failed and returned no rows.",
+            }
+            for seam in seams
+        ]
+    }
+
+
+def test_rag_invoke_partial_seam_failure_names_the_failed_seams():
+    service = FakeRagService(
+        result={
+            "results": [_rag_row(1)],
+            "diagnostics": _seam_failure_diagnostics("prompts", "conversations"),
+        }
+    )
+    provider = LibraryRagToolProvider(service)
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    assert result.ok is True
+    payload = json.loads(result.content)
+    assert payload["returned"] == 1, "surviving rows must still be returned"
+    assert payload["failed_seams"] == ["conversations", "prompts"]
+    assert "Incomplete search" in payload["note"]
+    assert "conversations, prompts" in payload["note"]
+
+
+def test_rag_invoke_healthy_search_has_no_failure_fields():
+    service = FakeRagService(result={"results": [_rag_row(1)]})
+    provider = LibraryRagToolProvider(service)
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    payload = json.loads(result.content)
+    assert "failed_seams" not in payload
+    assert "note" not in payload
+
+
+def test_rag_invoke_zero_survivors_with_failures_is_still_marked_incomplete():
+    """`empty` + failed seams is the most dangerous shape: without the field
+    the agent reads it as 'the corpus has nothing'."""
+    service = FakeRagService(
+        result={
+            "results": [],
+            "diagnostics": _seam_failure_diagnostics("notes"),
+        }
+    )
+    provider = LibraryRagToolProvider(service)
+
+    result = provider.invoke(f"library:{RAG_TOOL_NAME}", {"query": "q"})
+
+    payload = json.loads(result.content)
+    assert payload["status"] == "empty"
+    assert payload["failed_seams"] == ["notes"]

--- a/Tests/Library/test_library_keyword_and_then_prefix.py
+++ b/Tests/Library/test_library_keyword_and_then_prefix.py
@@ -66,6 +66,7 @@ from tldw_chatbook.Library.library_fts_query import (
     build_prefix_match_query,
 )
 from tldw_chatbook.Library.library_local_rag_search_service import (
+    SeamState,
     LibraryLocalRagSearchService,
 )
 from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
@@ -297,9 +298,12 @@ async def test_a_sub_leg_whose_primary_returns_rows_never_builds_the_prefix_form
     app = seams().app
     service = LibraryLocalRagSearchService(app)
 
-    available, rows = await service._search_notes(SPLIT_QUERY, 5, _USER_ID)
+    state, rows = await service._search_notes(SPLIT_QUERY, 5, _USER_ID)
 
-    assert available is True
+    # TASK-18903: the boolean became `SeamState`; same assertion, new
+    # vocabulary. Compared with `is` -- every Enum member is truthy, so a
+    # truthiness check here would pass for FAILED too.
+    assert state is SeamState.AVAILABLE
     assert len(rows) == 1, f"expected the notes primary to hit: {rows!r}"
     assert prefix_spy == [], (
         "the prefix form was built for a sub-leg whose primary returned "
@@ -403,9 +407,12 @@ async def test_a_zero_row_sub_leg_is_rescued_by_the_prefix_form(
         "prompts": lambda: service._search_prompts(SPLIT_QUERY, 5),
     }[seam]
 
-    available, rows = await call()
+    state, rows = await call()
 
-    assert available is True
+    # TASK-18903: the boolean became `SeamState`; same assertion, new
+    # vocabulary. Compared with `is` -- every Enum member is truthy, so a
+    # truthiness check here would pass for FAILED too.
+    assert state is SeamState.AVAILABLE
     assert _types(rows) == [source_type], (
         f"the {seam} seam was not rescued: {rows!r}"
     )

--- a/Tests/Library/test_library_local_rag_search_service.py
+++ b/Tests/Library/test_library_local_rag_search_service.py
@@ -553,18 +553,33 @@ async def test_erroring_notes_seam_contributes_zero_rows_without_raising(
     assert all(row["provenance"]["source_type"] != "note" for row in result["results"])
 
 
-# An erroring seam that is the ONLY queried seam is still "available" (attribute
-# present), so the result is empty results, not a blocked outcome.
+# An erroring seam that is the ONLY queried seam must NOT report `blocked`:
+# the seam is configured, so "configure retrieval" is the wrong advice. That
+# intent is preserved. What changed (TASK-18903) is the rest of the sentence.
+#
+# This test used to assert the search returned a plain dict with zero results
+# -- i.e. a SUCCESSFUL search that matched nothing. It reasoned that an
+# erroring seam "is still available (attribute present)", which is exactly the
+# conflation that task removed: a seam that RAN AND THREW contributed nothing,
+# and its empty rows mean nothing. Worse, empty rows normalize to
+# `status="empty"`, which IS in `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES`, so
+# the old behaviour let a total outage reach the RAG answer path and answer
+# from no context at all.
+#
+# Now: `failed` -- not `blocked` (the original intent), and not a silent
+# success (the defect).
 @pytest.mark.asyncio
-async def test_erroring_only_seam_returns_empty_results_not_blocked():
+async def test_erroring_only_seam_reports_failed_not_blocked_and_not_empty_success():
     notes_service = FakeNotesScopeService(error=RuntimeError("notes index unavailable"))
     app = SimpleNamespace(notes_scope_service=notes_service)
     service = LibraryLocalRagSearchService(app)
 
     result = await service.search("credential", ("notes",), "search", top_k=5)
 
-    assert not isinstance(result, LibraryRagSearchOutcome)
-    assert result["results"] == []
+    assert isinstance(result, LibraryRagSearchOutcome)
+    assert result.status == "failed", "a thrown seam is not a zero-row success"
+    assert result.status != "blocked", "the seam IS configured; setup advice is wrong"
+    assert result.recovery_state is not None
 
 
 # Unknown scope types are ignored quietly rather than raising or matching a seam.

--- a/Tests/Library/test_library_seam_availability.py
+++ b/Tests/Library/test_library_seam_availability.py
@@ -236,3 +236,75 @@ class TestUserVisibleNotice:
         )
         notes = diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or []
         assert not any("failed" in str(n) for n in notes)
+
+
+class TestItActuallyPaints:
+    """The diagnostics slot and the route note are only worth having if they
+    reach the screen. These assert the rendered WIDGET TEXT, not the state --
+    a diagnostics key nothing paints is the 'declared but inert' trap.
+
+    Verified against the built widgets on 2026-08-18; both failure shapes put
+    the failure in front of the user.
+    """
+
+    @staticmethod
+    def _children(status: str, *, with_recovery: bool = True):
+        """Build the panel's children for one failure shape.
+
+        `with_recovery` mirrors the service: a TOTAL failure carries a
+        recovery state, a PARTIAL one does not (results came back normally,
+        one seam merely contributed nothing). Passing the total-failure
+        recovery copy into the partial case would render a service-error
+        widget that the real partial path never produces.
+        """
+        from tldw_chatbook.Library.library_local_rag_search_service import (
+            ROUTE_NOTE_SEAMS_FAILED_TEMPLATE,
+            _seams_failed_recovery_state,
+        )
+        from tldw_chatbook.Library.library_rag_state import (
+            LIBRARY_RAG_ROUTE_NOTES_KEY,
+            LibraryRagPanelState,
+        )
+        from tldw_chatbook.Widgets.Library import library_rag_results_body_children
+
+        recovery = _seams_failed_recovery_state(["notes", "prompts"])
+        state = LibraryRagPanelState.from_values(
+            source_counts={"notes": 1, "prompts": 1},
+            query="q",
+            retrieval_status=status,
+            provider_name="openai",
+            diagnostics={
+                LIBRARY_RAG_ROUTE_NOTES_KEY: [
+                    ROUTE_NOTE_SEAMS_FAILED_TEMPLATE.format(seams="notes, prompts")
+                ]
+            },
+            recovery_copy=recovery.disabled_tooltip if with_recovery else "",
+            recovery_selector=recovery.stable_selector if with_recovery else "",
+        )
+        return library_rag_results_body_children(state)
+
+    def test_total_failure_names_the_failed_seams_on_screen(self):
+        children = self._children("failed")
+        note = next(c for c in children if c.id == "library-rag-coverage-note")
+        assert str(note.renderable) == "Notes, prompts failed — results exclude them."
+
+    def test_total_failure_also_shows_the_retry_recovery_copy(self):
+        """`failed` must not render ONLY the quiet note -- the user needs the
+        actionable half too."""
+        children = self._children("failed")
+        error = next(c for c in children if c.id == "library-rag-service-error")
+        text = str(error.renderable)
+        assert "every configured seam" in text
+        assert "notes, prompts" in text
+        assert "Retry" in text
+
+    def test_partial_failure_names_the_seams_above_the_no_match_copy(self):
+        """Zero rows is exactly when this matters most: without the note, "No
+        evidence matched" reads as a verdict on sources that were never
+        successfully searched."""
+        children = self._children("empty", with_recovery=False)
+        assert children[0].id == "library-rag-coverage-note"
+        assert str(children[0].renderable) == (
+            "Notes, prompts failed — results exclude them."
+        )
+        assert children[1].id == "library-rag-empty-state"

--- a/Tests/Library/test_library_seam_availability.py
+++ b/Tests/Library/test_library_seam_availability.py
@@ -26,7 +26,7 @@ from tldw_chatbook.Library.library_local_rag_search_service import (
 ALL_TYPES = ("notes", "media", "conversations", "prompts")
 
 
-class _Exploding:
+class ExplodingBackend:
     """Any awaited method raises -- a configured backend that is broken."""
 
     def __init__(self, label: str) -> None:
@@ -39,7 +39,7 @@ class _Exploding:
         return boom
 
 
-class _ExplodingSync:
+class ExplodingSyncBackend:
     """Sync-method backend (chachanotes_db) that raises."""
 
     def __init__(self, label: str) -> None:
@@ -54,24 +54,24 @@ class _ExplodingSync:
 
 def _all_broken_app() -> SimpleNamespace:
     return SimpleNamespace(
-        notes_scope_service=_Exploding("notes"),
-        media_reading_scope_service=_Exploding("media"),
-        chachanotes_db=_ExplodingSync("chachanotes"),
-        prompt_scope_service=_Exploding("prompts"),
+        notes_scope_service=ExplodingBackend("notes"),
+        media_reading_scope_service=ExplodingBackend("media"),
+        chachanotes_db=ExplodingSyncBackend("chachanotes"),
+        prompt_scope_service=ExplodingBackend("prompts"),
         notes_user_id="u",
     )
 
 
 class TestSeamStates:
     @pytest.mark.asyncio
-    async def test_unconfigured_seam_is_UNAVAILABLE(self):
+    async def test_unconfigured_seam_is_unavailable(self):
         service = LibraryLocalRagSearchService(SimpleNamespace())
         state, rows = await service._search_prompts("q", 5)
         assert state is SeamState.UNAVAILABLE
         assert rows == []
 
     @pytest.mark.asyncio
-    async def test_throwing_seam_is_FAILED_not_available(self):
+    async def test_throwing_seam_is_failed_not_available(self):
         """THE BUG. A configured backend that raises used to return
         `(True, [])` -- claiming health while broken."""
         service = LibraryLocalRagSearchService(_all_broken_app())
@@ -99,7 +99,7 @@ class TestTotalFailure:
         assert outcome.status == "failed"
 
     @pytest.mark.asyncio
-    async def test_total_failure_is_NOT_answerable(self):
+    async def test_total_failure_is_not_answerable(self):
         """R1: `empty` is in LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES, so the
         old behaviour let a total outage reach the answer path and generate an
         answer from no context at all."""
@@ -137,7 +137,7 @@ class TestPartialFailure:
         """Silence must not read as absence: the caller gets what worked AND
         is told what did not run."""
 
-        class _Notes:
+        class FakeNotesBackend:
             async def search_notes(self, **_k):
                 return [
                     {
@@ -149,8 +149,8 @@ class TestPartialFailure:
                 ]
 
         app = SimpleNamespace(
-            notes_scope_service=_Notes(),
-            prompt_scope_service=_Exploding("prompts"),
+            notes_scope_service=FakeNotesBackend(),
+            prompt_scope_service=ExplodingBackend("prompts"),
             notes_user_id="u",
         )
         outcome = await LibraryLocalRagSearchService(app).search(
@@ -170,11 +170,11 @@ class TestPartialFailure:
 
     @pytest.mark.asyncio
     async def test_healthy_search_records_no_failure_entries(self):
-        class _Notes:
+        class FakeNotesBackend:
             async def search_notes(self, **_k):
                 return []
 
-        app = SimpleNamespace(notes_scope_service=_Notes(), notes_user_id="u")
+        app = SimpleNamespace(notes_scope_service=FakeNotesBackend(), notes_user_id="u")
         outcome = await LibraryLocalRagSearchService(app).search(
             "q", ("notes",), "search", top_k=5
         )
@@ -194,7 +194,7 @@ class TestUserVisibleNotice:
             LIBRARY_RAG_ROUTE_NOTES_KEY,
         )
 
-        class _Notes:
+        class FakeNotesBackend:
             async def search_notes(self, **_k):
                 return [
                     {"id": 1, "title": "t", "content": "c",
@@ -202,8 +202,8 @@ class TestUserVisibleNotice:
                 ]
 
         app = SimpleNamespace(
-            notes_scope_service=_Notes(),
-            prompt_scope_service=_Exploding("prompts"),
+            notes_scope_service=FakeNotesBackend(),
+            prompt_scope_service=ExplodingBackend("prompts"),
             notes_user_id="u",
         )
         outcome = await LibraryLocalRagSearchService(app).search(
@@ -223,11 +223,11 @@ class TestUserVisibleNotice:
             LIBRARY_RAG_ROUTE_NOTES_KEY,
         )
 
-        class _Notes:
+        class FakeNotesBackend:
             async def search_notes(self, **_k):
                 return []
 
-        app = SimpleNamespace(notes_scope_service=_Notes(), notes_user_id="u")
+        app = SimpleNamespace(notes_scope_service=FakeNotesBackend(), notes_user_id="u")
         outcome = await LibraryLocalRagSearchService(app).search(
             "q", ("notes",), "search", top_k=5
         )

--- a/Tests/Library/test_library_seam_availability.py
+++ b/Tests/Library/test_library_seam_availability.py
@@ -1,0 +1,238 @@
+"""TASK-18903: a seam that FAILED must not read as a seam that found nothing.
+
+Every keyword seam used to end `except Exception: return True, []` -- `True`
+meaning AVAILABLE. The merge site gates on "any seam available", so a total
+backend failure passed the gate, produced zero rows, and normalized to
+`status="empty"` -- which is in `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES`,
+so the RAG answer path then generated an answer with NO retrieved context and
+presented it as Library-grounded.
+
+These pins cover the three states and, most importantly, that a total failure
+is not answerable.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Library.library_local_rag_search_service import (
+    KEYWORD_SEAM_DIAGNOSTICS_KEY,
+    SEAM_STATUS_FAILED,
+    LibraryLocalRagSearchService,
+    SeamState,
+)
+
+ALL_TYPES = ("notes", "media", "conversations", "prompts")
+
+
+class _Exploding:
+    """Any awaited method raises -- a configured backend that is broken."""
+
+    def __init__(self, label: str) -> None:
+        self._label = label
+
+    def __getattr__(self, name):
+        async def boom(*_a, **_k):
+            raise RuntimeError(f"{self._label} backend down ({name})")
+
+        return boom
+
+
+class _ExplodingSync:
+    """Sync-method backend (chachanotes_db) that raises."""
+
+    def __init__(self, label: str) -> None:
+        self._label = label
+
+    def __getattr__(self, name):
+        def boom(*_a, **_k):
+            raise RuntimeError(f"{self._label} backend down ({name})")
+
+        return boom
+
+
+def _all_broken_app() -> SimpleNamespace:
+    return SimpleNamespace(
+        notes_scope_service=_Exploding("notes"),
+        media_reading_scope_service=_Exploding("media"),
+        chachanotes_db=_ExplodingSync("chachanotes"),
+        prompt_scope_service=_Exploding("prompts"),
+        notes_user_id="u",
+    )
+
+
+class TestSeamStates:
+    @pytest.mark.asyncio
+    async def test_unconfigured_seam_is_UNAVAILABLE(self):
+        service = LibraryLocalRagSearchService(SimpleNamespace())
+        state, rows = await service._search_prompts("q", 5)
+        assert state is SeamState.UNAVAILABLE
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_throwing_seam_is_FAILED_not_available(self):
+        """THE BUG. A configured backend that raises used to return
+        `(True, [])` -- claiming health while broken."""
+        service = LibraryLocalRagSearchService(_all_broken_app())
+        for coro in (
+            service._search_notes("q", 5, "u"),
+            service._search_media("q", 5),
+            service._search_conversations("q", 5),
+            service._search_prompts("q", 5),
+        ):
+            state, rows = await coro
+            assert state is SeamState.FAILED, "a thrown seam must not report available"
+            assert rows == []
+
+
+class TestTotalFailure:
+    @pytest.mark.asyncio
+    async def test_total_failure_is_not_a_zero_row_success(self):
+        """The headline. Before: a plain dict with results=[] -- a successful
+        search that matched nothing."""
+        service = LibraryLocalRagSearchService(_all_broken_app())
+        outcome = await service.search("q", ALL_TYPES, "search", top_k=5)
+        assert not isinstance(outcome, dict), (
+            "a total backend failure must not present as a successful search"
+        )
+        assert outcome.status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_total_failure_is_NOT_answerable(self):
+        """R1: `empty` is in LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES, so the
+        old behaviour let a total outage reach the answer path and generate an
+        answer from no context at all."""
+        from tldw_chatbook.UI.Screens.library_screen import (
+            LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES,
+        )
+
+        service = LibraryLocalRagSearchService(_all_broken_app())
+        outcome = await service.search("q", ALL_TYPES, "search", top_k=5)
+        assert outcome.status not in LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES
+
+    @pytest.mark.asyncio
+    async def test_total_failure_carries_a_recovery_state_naming_the_seams(self):
+        service = LibraryLocalRagSearchService(_all_broken_app())
+        outcome = await service.search("q", ALL_TYPES, "search", top_k=5)
+        assert outcome.recovery_state is not None
+        assert outcome.recovery_state.status_label
+
+
+class TestAllUnavailableUnchanged:
+    @pytest.mark.asyncio
+    async def test_no_configured_seam_still_blocks(self):
+        """Byte-identical to today: nothing configured is `blocked`, not
+        `failed`. This pin also catches the enum-truthiness trap -- an `Enum`
+        member is truthy, so a gate left as `if not any(state ...)` would go
+        silently inert and stop blocking."""
+        service = LibraryLocalRagSearchService(SimpleNamespace())
+        outcome = await service.search("q", ALL_TYPES, "search", top_k=5)
+        assert outcome.status == "blocked"
+
+
+class TestPartialFailure:
+    @pytest.mark.asyncio
+    async def test_partial_failure_returns_survivors_and_records_the_failures(self):
+        """Silence must not read as absence: the caller gets what worked AND
+        is told what did not run."""
+
+        class _Notes:
+            async def search_notes(self, **_k):
+                return [
+                    {
+                        "id": 1,
+                        "title": "t",
+                        "content": "c",
+                        "last_modified": "2026-01-01",
+                    }
+                ]
+
+        app = SimpleNamespace(
+            notes_scope_service=_Notes(),
+            prompt_scope_service=_Exploding("prompts"),
+            notes_user_id="u",
+        )
+        outcome = await LibraryLocalRagSearchService(app).search(
+            "c", ("notes", "prompts"), "search", top_k=5
+        )
+        # survivors still returned
+        rows = outcome["results"] if isinstance(outcome, dict) else outcome.results
+        assert rows, "a surviving seam's rows must still be returned"
+        diagnostics = (
+            outcome["diagnostics"] if isinstance(outcome, dict) else outcome.diagnostics
+        )
+        entries = diagnostics.get(KEYWORD_SEAM_DIAGNOSTICS_KEY) or []
+        assert any(
+            e.get("status") == SEAM_STATUS_FAILED and e.get("seam") == "prompts"
+            for e in entries
+        ), f"the failed seam must be recorded; got {entries!r}"
+
+    @pytest.mark.asyncio
+    async def test_healthy_search_records_no_failure_entries(self):
+        class _Notes:
+            async def search_notes(self, **_k):
+                return []
+
+        app = SimpleNamespace(notes_scope_service=_Notes(), notes_user_id="u")
+        outcome = await LibraryLocalRagSearchService(app).search(
+            "q", ("notes",), "search", top_k=5
+        )
+        diagnostics = (
+            outcome["diagnostics"] if isinstance(outcome, dict) else outcome.diagnostics
+        )
+        assert not (diagnostics.get(KEYWORD_SEAM_DIAGNOSTICS_KEY) or [])
+
+
+class TestUserVisibleNotice:
+    @pytest.mark.asyncio
+    async def test_partial_failure_emits_a_rendered_route_note(self):
+        """The structured slot is for machines; this sentence is what the user
+        reads. Without it we would ship a diagnostics key nothing renders --
+        the 'declared but inert' trap this repo has hit before."""
+        from tldw_chatbook.Library.library_rag_state import (
+            LIBRARY_RAG_ROUTE_NOTES_KEY,
+        )
+
+        class _Notes:
+            async def search_notes(self, **_k):
+                return [
+                    {"id": 1, "title": "t", "content": "c",
+                     "last_modified": "2026-01-01"}
+                ]
+
+        app = SimpleNamespace(
+            notes_scope_service=_Notes(),
+            prompt_scope_service=_Exploding("prompts"),
+            notes_user_id="u",
+        )
+        outcome = await LibraryLocalRagSearchService(app).search(
+            "c", ("notes", "prompts"), "search", top_k=5
+        )
+        diagnostics = (
+            outcome["diagnostics"] if isinstance(outcome, dict) else outcome.diagnostics
+        )
+        notes = diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or []
+        assert any("prompts" in str(n) and "failed" in str(n) for n in notes), (
+            f"the user must be told which seam failed; got {notes!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_healthy_search_emits_no_failure_route_note(self):
+        from tldw_chatbook.Library.library_rag_state import (
+            LIBRARY_RAG_ROUTE_NOTES_KEY,
+        )
+
+        class _Notes:
+            async def search_notes(self, **_k):
+                return []
+
+        app = SimpleNamespace(notes_scope_service=_Notes(), notes_user_id="u")
+        outcome = await LibraryLocalRagSearchService(app).search(
+            "q", ("notes",), "search", top_k=5
+        )
+        diagnostics = (
+            outcome["diagnostics"] if isinstance(outcome, dict) else outcome.diagnostics
+        )
+        notes = diagnostics.get(LIBRARY_RAG_ROUTE_NOTES_KEY) or []
+        assert not any("failed" in str(n) for n in notes)

--- a/backlog/tasks/task-18903 - A failed Library seam must not read as a seam that found nothing.md
+++ b/backlog/tasks/task-18903 - A failed Library seam must not read as a seam that found nothing.md
@@ -1,0 +1,91 @@
+---
+id: TASK-18903
+title: A failed Library seam must not read as a seam that found nothing
+status: Done
+assignee: []
+created_date: '2026-08-18'
+labels: [library, rag, correctness]
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+Every Library keyword seam ended `except Exception: return True, []` — `True`
+meaning **available**. A seam whose backend threw reported itself healthy and
+empty, and the merge site (which gates on "any seam available") could not tell
+the difference.
+
+**Traced end to end, the consequence was not merely cosmetic:**
+
+1. all four seams throw → each returns `(True, [])`
+2. `any(available)` passes the gate
+3. zero rows, unscoped → a plain `{"results": [], …}` dict
+4. `_outcome_from_service_result`: `if not rows: status="empty"`
+5. `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES = frozenset({"ready", "empty"})`
+6. so the RAG answer path **ran** — generating an answer from **no retrieved
+   context** and presenting it as Library-grounded
+
+A total backend outage produced a confident, ungrounded answer.
+
+This is the same collapse that produced TASK-17855's wrong defect filing and
+TASK-18255 — a value meaning "could not measure" rendering identically to
+"measured, found nothing" — but reaching the user rather than the instrument.
+
+## Acceptance Criteria (the what)
+
+- [x] A seam whose backend throws reports `FAILED`, not available
+- [x] **Total failure is NON-answerable**: status `failed`, excluded from
+      `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES`, pinned by a test
+- [x] All seams merely unconfigured still yields `blocked` — unchanged
+- [x] Partial failure returns surviving results AND records the failed seams
+      in diagnostics, appended to a list
+- [x] The user is told which seams failed, through the existing rendered
+      route-notes channel
+- [x] `_empty_scoped_seam` maps to `AVAILABLE`
+- [x] `seam_effect.py`'s `if not available:` guard updated — under an enum it
+      would go silently inert
+- [x] `Tests/Library` green (2031 passed); RAG-eval gate `PASSED: No
+      regression. 105 metric(s)` with every cell at +0.000
+
+## Implementation Notes
+
+**`failed` is REUSED, not newly minted** (owner ruling). Design review found
+`run_library_rag_search` already returns `status="failed"` with a recovery
+state for a raised search; it already means "retrieval did not happen" and is
+already absent from every answerable allowlist. A second failure status would
+have been two vocabularies for one condition.
+
+**Two channels, mirroring existing precedent rather than inventing one.**
+Structured state goes to `KEYWORD_SEAM_DIAGNOSTICS_KEY` as a LIST of
+`{"status", "seam", "message"}` — appended, never assigned, for the same
+reason the scope slot is (task-9 review finding: two failures in one call must
+not overwrite each other). The human sentence goes through the existing
+`LIBRARY_RAG_ROUTE_NOTES_KEY`, which the panel already renders, and whose own
+docstring makes this task's argument: *"zero rows is exactly when it matters
+most"*.
+
+**Born-red on BEHAVIOUR, not ImportError.** Per
+`lessons-testing-evidence.md`, an ImportError red is not born-red evidence, so
+the enum and constants landed first with today's semantics preserved; the
+tests then failed 5/8 on behaviour, and the fix turned them green.
+
+**Mutation-verified twice.** Restoring `return SeamState.AVAILABLE, []` on the
+exception path reds 4 tests including both headline pins. Reverting the gate
+to `if not any(state ...)` — the enum-truthiness trap, since every `Enum`
+member is truthy — reds `test_no_configured_seam_still_blocks`, which exists
+precisely to catch that.
+
+**One existing test pinned the defect** and was rewritten, not deleted:
+`test_erroring_only_seam_returns_empty_results_not_blocked` asserted a plain
+dict with zero results, reasoning that an erroring seam "is still available
+(attribute present)". Its real intent — don't show *setup* advice for a
+configured seam — is preserved by returning `failed` rather than `blocked`;
+only the part encoding the bug changed. Four assertions in
+`test_library_keyword_and_then_prefix.py` moved from `available is True` to
+`state is SeamState.AVAILABLE` (my design review wrongly claimed they
+discarded the flag — they assert on it).
+
+**Files:** `library_local_rag_search_service.py` (enum, four seams, gate,
+recovery state, route note), `Tests/Library/test_library_seam_availability.py`
+(new, 10 pins), two existing test files, `seam_effect.py`, the design spec.

--- a/tldw_chatbook/Agents/library_rag_tool_provider.py
+++ b/tldw_chatbook/Agents/library_rag_tool_provider.py
@@ -35,6 +35,10 @@ from tldw_chatbook.Library.library_expand_policy import (
     EXPANDABLE_SOURCE_TYPES,
     expand_hint,
 )
+from tldw_chatbook.Library.library_local_rag_search_service import (
+    KEYWORD_SEAM_DIAGNOSTICS_KEY,
+    SEAM_STATUS_FAILED,
+)
 from tldw_chatbook.Library.library_rag_service import (
     LibraryRagSearchRequest,
     run_library_rag_search,
@@ -339,6 +343,32 @@ class LibraryRagToolProvider:
             "returned": len(rows),
             "results": rows,
         }
+        # PARTIAL seam failures survive outcome normalization in
+        # `diagnostics` (TASK-18903), and dropping them here would tell the
+        # agent an incomplete corpus search was a complete one -- the exact
+        # collapse that task removed from the user-facing panel. Surfaced as
+        # a dedicated key (at most four short seam names, so the bounding
+        # loop below is unaffected) plus the same sentence the panel renders.
+        failed_seams = sorted(
+            {
+                str(entry.get("seam"))
+                for entry in (
+                    (getattr(outcome, "diagnostics", None) or {}).get(
+                        KEYWORD_SEAM_DIAGNOSTICS_KEY
+                    )
+                    or ()
+                )
+                if isinstance(entry, Mapping)
+                and entry.get("status") == SEAM_STATUS_FAILED
+                and entry.get("seam")
+            }
+        )
+        if failed_seams:
+            payload["failed_seams"] = failed_seams
+            payload["note"] = (
+                f"Incomplete search: the {', '.join(failed_seams)} "
+                "seam(s) failed and contributed no rows."
+            )
         # Bound the sealed payload: drop trailing rows first, then shrink the
         # lone remaining row in a fixed order. Every iteration removes at
         # least one character or the row itself, so hostile metadata cannot

--- a/tldw_chatbook/Library/library_local_rag_search_service.py
+++ b/tldw_chatbook/Library/library_local_rag_search_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import replace
 from typing import Any, Hashable, Optional
@@ -32,6 +33,40 @@ from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_ROUTE_NOTES_KEY,
     LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
 )
+
+#: Diagnostics slot for per-seam keyword outcomes (TASK-18903). Mirrors
+#: ``SCOPE_DIAGNOSTICS_KEY``/``SEMANTIC_DIAGNOSTICS_KEY``: a LIST of
+#: ``{"status", "seam", "message"}`` entries, APPENDED never assigned, so two
+#: failing seams in one call cannot overwrite each other (the task-9 review
+#: finding that shaped the scope slot applies identically here).
+KEYWORD_SEAM_DIAGNOSTICS_KEY = "keyword_seams"
+
+#: Status value used inside that slot.
+SEAM_STATUS_FAILED = "failed"
+
+
+class SeamState(Enum):
+    """Outcome of one keyword seam.
+
+    The boolean this replaces could not tell "not configured" from "ran and
+    threw": both flowed on as *some* value alongside an empty row list, and a
+    thrown seam reported itself AVAILABLE. That collapse let a total backend
+    outage present as a successful search with zero results (TASK-18903), and
+    it is the same shape that produced TASK-17855's wrong defect filing and
+    TASK-18255.
+
+    NOTE for anyone reading the gate: every ``Enum`` member is TRUTHY,
+    including ``UNAVAILABLE`` and ``FAILED``. A guard written as
+    ``if not state`` is always False and silently inert -- compare with ``is``.
+    """
+
+    #: Configured, ran, and its rows are its answer (possibly none).
+    AVAILABLE = "available"
+    #: Not configured in this runtime -- nothing was searched.
+    UNAVAILABLE = "unavailable"
+    #: Configured, ran, and RAISED. Its empty rows mean nothing.
+    FAILED = "failed"
+
 
 # Single source of truth for the pipeline diagnostics "scope" slot key
 # (task-4/Backend A); reused here so the Library service's own
@@ -103,6 +138,11 @@ ROUTE_NOTE_HYBRID_NO_KEYWORD_SOURCES = (
     "no keyword leg for the selected sources — semantic only"
 )
 ROUTE_NOTE_SEMANTIC_LEG_EMPTY = "semantic leg empty — keyword-only results"
+# (TASK-18903) A seam that RAN AND THREW contributed nothing, and its silence
+# must not read as "that source has nothing". This is the same principle the
+# routing disclosures already encode -- and, as their own docstring says, zero
+# rows is exactly when it matters most.
+ROUTE_NOTE_SEAMS_FAILED_TEMPLATE = "{seams} failed — results exclude them"
 # Mirrors `library_rag_state`'s `_OPEN_SOURCE_TYPE_MAP` canonicalization:
 # raw provenance `source_type` values -> the scope-toggle identifiers used
 # by `LibraryRagScopeState`/the Search canvas's per-source toggles.
@@ -448,7 +488,50 @@ class LibraryLocalRagSearchService:
         gathered = await asyncio.gather(*coroutines.values())
         outcomes = dict(zip(coroutines.keys(), gathered))
 
-        if not any(available for available, _rows in outcomes.values()):
+        # Record every seam that RAN AND THREW, so a partial failure cannot
+        # read as "the corpus has nothing" one layer up. Appended to a list
+        # for the same reason the scope slot is (task-9 review finding): two
+        # seams can fail in one call and neither may overwrite the other.
+        failed_seams = sorted(
+            name for name, (state, _rows) in outcomes.items()
+            if state is SeamState.FAILED
+        )
+        for name in failed_seams:
+            diagnostics.setdefault(KEYWORD_SEAM_DIAGNOSTICS_KEY, []).append(
+                {
+                    "status": SEAM_STATUS_FAILED,
+                    "seam": name,
+                    "message": f"The {name} seam failed and returned no rows.",
+                }
+            )
+        if failed_seams:
+            # The human-readable half, through the channel the panel already
+            # renders. The structured slot above is for machines (and for the
+            # eval harness, which until TASK-18255 could not tell an unwired
+            # seam from an empty one); this sentence is what the user reads.
+            diagnostics.setdefault(LIBRARY_RAG_ROUTE_NOTES_KEY, []).append(
+                ROUTE_NOTE_SEAMS_FAILED_TEMPLATE.format(
+                    seams=", ".join(failed_seams)
+                )
+            )
+
+        if not any(state is SeamState.AVAILABLE for state, _rows in outcomes.values()):
+            # NOT the same condition, and the difference is the whole task.
+            # Nothing CONFIGURED is "blocked" -- a setup problem the user can
+            # act on. Everything configured having THROWN is a retrieval
+            # FAILURE, and it must never present as a zero-row success:
+            # `_outcome_from_service_result` maps empty rows to `status=
+            # "empty"`, which is in `LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES`,
+            # so the RAG answer path would run and answer from NO context at
+            # all. `failed` is deliberately reused rather than a new status --
+            # `run_library_rag_search` already returns it for a raised search,
+            # and it is already absent from every answerable allowlist.
+            if failed_seams:
+                return LibraryRagSearchOutcome(
+                    status="failed",
+                    recovery_state=_seams_failed_recovery_state(failed_seams),
+                    diagnostics=diagnostics,
+                )
             return LibraryRagSearchOutcome(
                 status="blocked",
                 recovery_state=_no_backend_recovery_state(),
@@ -573,11 +656,11 @@ class LibraryLocalRagSearchService:
         user_id: str,
         *,
         id_allowlist: Optional[Sequence[str]] = None,
-    ) -> tuple[bool, list[dict[str, Any]]]:
-        """Search the notes seam. Returns (seam_available, rows)."""
+    ) -> tuple[SeamState, list[dict[str, Any]]]:
+        """Search the notes seam. Returns (state, rows)."""
         service = getattr(self._app, "notes_scope_service", None)
         if service is None:
-            return False, []
+            return SeamState.UNAVAILABLE, []
         # Forward the allowlist only when provided so an unscoped call
         # keeps the exact legacy call shape (byte-identical, spec D2).
         allowlist_kwargs = (
@@ -605,12 +688,12 @@ class LibraryLocalRagSearchService:
             ]
 
         try:
-            return True, await _rows_with_prefix_fallback(query, run_match)
+            return SeamState.AVAILABLE, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: notes seam failed."
             )
-            return True, []
+            return SeamState.FAILED, []
 
     async def _search_media(
         self,
@@ -618,11 +701,11 @@ class LibraryLocalRagSearchService:
         top_k: int,
         *,
         id_allowlist: Optional[Sequence[str]] = None,
-    ) -> tuple[bool, list[dict[str, Any]]]:
-        """Search the media seam. Returns (seam_available, rows)."""
+    ) -> tuple[SeamState, list[dict[str, Any]]]:
+        """Search the media seam. Returns (state, rows)."""
         service = getattr(self._app, "media_reading_scope_service", None)
         if service is None:
-            return False, []
+            return SeamState.UNAVAILABLE, []
         # Forward the allowlist only when provided so an unscoped call
         # keeps the exact legacy call shape (byte-identical, spec D2).
         allowlist_kwargs = (
@@ -642,22 +725,22 @@ class LibraryLocalRagSearchService:
             return [_media_row(item) for item in items if isinstance(item, Mapping)]
 
         try:
-            return True, await _rows_with_prefix_fallback(query, run_match)
+            return SeamState.AVAILABLE, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: media seam failed."
             )
-            return True, []
+            return SeamState.FAILED, []
 
     async def _search_conversations(
         self,
         query: str,
         top_k: int,
-    ) -> tuple[bool, list[dict[str, Any]]]:
-        """Search the conversations seam. Returns (seam_available, rows)."""
+    ) -> tuple[SeamState, list[dict[str, Any]]]:
+        """Search the conversations seam. Returns (state, rows)."""
         db = getattr(self._app, "chachanotes_db", None)
         if db is None:
-            return False, []
+            return SeamState.UNAVAILABLE, []
 
         async def run_match(fts_query: str) -> list[dict[str, Any]]:
             if getattr(db, "is_memory_db", False):
@@ -676,22 +759,22 @@ class LibraryLocalRagSearchService:
             ]
 
         try:
-            return True, await _rows_with_prefix_fallback(query, run_match)
+            return SeamState.AVAILABLE, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: conversations seam failed."
             )
-            return True, []
+            return SeamState.FAILED, []
 
     async def _search_prompts(
         self,
         query: str,
         top_k: int,
-    ) -> tuple[bool, list[dict[str, Any]]]:
-        """Search the prompts seam. Returns (seam_available, rows)."""
+    ) -> tuple[SeamState, list[dict[str, Any]]]:
+        """Search the prompts seam. Returns (state, rows)."""
         service = getattr(self._app, "prompt_scope_service", None)
         if service is None:
-            return False, []
+            return SeamState.UNAVAILABLE, []
 
         async def run_match(fts_match_query: str) -> list[dict[str, Any]]:
             # Pre-built MATCH string, same as the notes/media/conversations
@@ -710,12 +793,12 @@ class LibraryLocalRagSearchService:
             ]
 
         try:
-            return True, await _rows_with_prefix_fallback(query, run_match)
+            return SeamState.AVAILABLE, await _rows_with_prefix_fallback(query, run_match)
         except Exception:
             logger.opt(exception=True).warning(
                 "Library keyword search: prompts seam failed."
             )
-            return True, []
+            return SeamState.FAILED, []
 
     async def _search_semantic(
         self,
@@ -1548,7 +1631,7 @@ def _raw_semantic_score(item: Any) -> float:
     return _coerce_score(value) or float("-inf")
 
 
-async def _empty_scoped_seam() -> tuple[bool, list[dict[str, Any]]]:
+async def _empty_scoped_seam() -> tuple[SeamState, list[dict[str, Any]]]:
     """Stand-in for a keyword seam whose source type is scoped to zero ids.
 
     The seam itself is available (the app has it configured) -- scope just
@@ -1556,7 +1639,7 @@ async def _empty_scoped_seam() -> tuple[bool, list[dict[str, Any]]]:
     than ``(False, [])`` (unavailable), keeping ``_search_keyword``'s
     any-seam-available gate accurate when other seams still have results.
     """
-    return True, []
+    return SeamState.AVAILABLE, []
 
 
 #: This service's own keyword-source-type vocabulary ("media", "notes", ...)
@@ -1599,6 +1682,38 @@ def _scope_item_count(
             continue
         total += len(scope.allowlist.get(scope_key, ()))
     return total
+
+
+def _seams_failed_recovery_state(
+    failed_seams: Sequence[str],
+) -> DestinationRecoveryState:
+    """Recovery state for "every configured seam ran and threw".
+
+    Distinct from `_no_backend_recovery_state` on purpose: nothing configured
+    is a SETUP problem ("configure retrieval"), whereas everything configured
+    failing is an OPERATIONAL one ("retry, check indexing"). Naming the seams
+    matters because the useful next action differs per backend.
+
+    Args:
+        failed_seams: Seam names that ran and raised, already sorted.
+
+    Returns:
+        The recovery state for a total keyword-retrieval failure.
+    """
+    named = ", ".join(failed_seams) if failed_seams else "every"
+    return DestinationRecoveryState(
+        status_label="Retrieval failed",
+        unavailable_what="Library Search/RAG retrieval",
+        why=f"Every configured Library seam failed ({named})",
+        next_action="Retry the query or check Library indexing",
+        recovery_action="Retry",
+        authority_owner="Library retrieval service",
+        stable_selector=LIBRARY_RAG_SERVICE_ERROR_SELECTOR,
+        disabled_tooltip=(
+            f"Library retrieval failed in every configured seam ({named}). "
+            "Retry the query or check Library indexing."
+        ),
+    )
 
 
 def _no_backend_recovery_state() -> DestinationRecoveryState:


### PR DESCRIPTION
> Branch name says `18804`; the task is **TASK-18903** (branch was cut before the id was settled). Cosmetic only.

## The defect reaches the user, not just the instrument

Every Library keyword seam ended `except Exception: return True, []` — `True` meaning **available**. A seam whose backend threw reported itself healthy and empty.

Traced end to end on dev:

```
all four seams throw → each returns (True, [])
  → any(available) passes the gate
  → zero rows → status="empty"
  → LIBRARY_RAG_ANSWERABLE_RETRIEVAL_STATUSES = {"ready", "empty"}
  → THE RAG ANSWER PATH RAN
```

**A total backend outage generated an answer from no retrieved context and presented it as Library-grounded.** Not "told nothing matched" — *given a confident, ungrounded answer*.

This is the same collapse behind TASK-17855's wrong defect filing and TASK-18255 — "could not measure" rendering identically to "measured, found nothing" — but reaching the user.

## The fix

Seams return `SeamState` — `AVAILABLE` / `UNAVAILABLE` / `FAILED`. The gate then separates two conditions that were one:

| condition | outcome | why |
|---|---|---|
| nothing configured | `blocked` **(unchanged)** | a setup problem: "configure retrieval" |
| everything configured **threw** | **`failed`** | an operational one: "retry, check indexing" — and **non-answerable** |
| some worked, some threw | results **+ diagnostics + a user-visible note** | silence must not read as absence |

**`failed` is reused, not newly minted.** Design review found `run_library_rag_search` already returns it for a raised search, already meaning "retrieval did not happen" and already absent from every answerable allowlist. A second failure status would have been two vocabularies for one condition.

**Both report channels follow existing precedent rather than inventing one:** structured state in `KEYWORD_SEAM_DIAGNOSTICS_KEY` (a **list**, appended never assigned — the task-9 finding that shaped the scope slot), and the human sentence through `LIBRARY_RAG_ROUTE_NOTES_KEY`, which the panel already renders and whose own docstring makes this task's argument: *"zero rows is exactly when it matters most"*.

## Evidence

**Born-red on behaviour, not ImportError.** Per `lessons-testing-evidence.md`, an ImportError red isn't born-red evidence — so the enum and constants landed first with today's semantics preserved, the tests failed **5 of 8 on behaviour**, and the fix greened them.

**Mutation-verified twice:**
- restoring `return SeamState.AVAILABLE, []` on the throw path → reds 4 tests, including both headline pins
- reverting the gate to `if not any(state ...)` — the enum-truthiness trap, since **every `Enum` member is truthy** → reds `test_no_configured_seam_still_blocks`, which exists precisely to catch that

**One existing test pinned the defect and was rewritten, not deleted.** `test_erroring_only_seam_returns_empty_results_not_blocked` asserted a plain dict with zero results, reasoning an erroring seam "is still available (attribute present)". Its real intent — no *setup* advice for a configured seam — survives as `failed` rather than `blocked`; only the part encoding the bug changed.

Four assertions in `test_library_keyword_and_then_prefix.py` moved from `available is True` to `state is SeamState.AVAILABLE`. My own design review claimed those tests "discard the flag" — they assert on it, and I was wrong.

## Verification

- `Tests/Library`: **2031 passed, 2 skipped**
- RAG-eval gate: `PASSED: No regression. 105 metric(s)` — **every cell +0.000, no baseline file modified** (this touches no retrieval logic, so any movement would be a defect in the change)
- New: `Tests/Library/test_library_seam_availability.py`, 10 pins

Refs TASK-18903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Library keyword seam failures from presenting as “empty” searches that let the RAG answer path run with no context. Old: exceptions were swallowed and seams returned `(True, [])`, normalizing total outages to `status="empty"`. New: seams return `SeamState`; an all-failed search yields `status="failed"` (non-answerable), and partial failures are recorded and surfaced.

- Seams now return `(SeamState, rows)` with `AVAILABLE`/`UNAVAILABLE`/`FAILED`; the gate checks `state is SeamState.AVAILABLE`. `_empty_scoped_seam` stays `AVAILABLE`.
- Outcomes: all configured seams failed → `LibraryRagSearchOutcome(status="failed", recovery_state=_seams_failed_recovery_state(...))`; all unconfigured → `blocked` (unchanged). Partial failure returns surviving rows, adds diagnostics under `KEYWORD_SEAM_DIAGNOSTICS_KEY`, and adds a route note via `LIBRARY_RAG_ROUTE_NOTES_KEY`; the UI renders the coverage note and the service-error widget on total failure.
- Agents: `LibraryRagToolProvider` now includes `failed_seams` and a one-line `note` in success payloads when any seam failed, so agents can detect incomplete corpus results.
- Migration: compare identity (`state is SeamState.AVAILABLE`); `Enum` members are truthy. Updated `Docs/superpowers/qa/2026-08-18-prompts-seam/seam_effect.py`. Payload changes are additive.
- Tests: added `Tests/Library/test_library_seam_availability.py` and agent pins; updated existing tests and UI render pins. Suites: Library 2034 passed (2 skipped), Agents 59 passed. RAG-eval unchanged (105 metrics). Addresses TASK-18903.

<sup>Written for commit e45d512330c316f09a7d8b2f24a11f0a89fc42aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

