### PR TITLE
perf(agents): land the quadratic estimator, cache-price, and live-feed fixes ahead of PR #1824

### DIFF
--- a/Helper_Scripts/Benchmarks/token_estimate_benchmark.py
+++ b/Helper_Scripts/Benchmarks/token_estimate_benchmark.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""TASK-18602: cost of estimating tokens for a growing conversation.
+
+Every caller of the token estimator re-estimates the WHOLE message list on
+each turn, so an N-turn run pays O(N^2) to learn N answers. Two independent
+fixes landed; this measures each one's contribution separately, because
+they are NOT equal partners and the summary numbers are easy to misread:
+
+* The ASCII fast path in ``_chars_estimate`` does essentially all the work
+  on installs WITHOUT a real tokenizer (the shipped default). It removes a
+  per-character Python loop.
+* The memo in ``estimate_tokens`` adds little on top of that for the chars
+  tier -- it matters on installs WITH tiktoken, where the per-turn
+  re-encode of the whole history is the dominant cost and no fast path can
+  remove it. Those installs cannot be measured here unless tiktoken is
+  present, so the third column is the honest floor, not the headline.
+
+Run: python Helper_Scripts/Benchmarks/token_estimate_benchmark.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import time
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tldw_chatbook.Utils import token_counter  # noqa: E402
+from tldw_chatbook.Utils.token_counter import (  # noqa: E402
+    TIKTOKEN_AVAILABLE,
+    _chars_estimate,
+    _is_cjk,
+    clear_estimate_cache,
+    count_tokens_messages,
+)
+
+TURNS = 400
+ROUND_CHARS = 800
+
+
+def legacy_chars_estimate(text: str, provider: str) -> int:
+    """The pre-TASK-18602 implementation, for the 'before' column.
+
+    Calls the REAL ``_is_cjk`` per character rather than a faster lookup:
+    that generator-per-character shape is precisely what made the original
+    slow, so a tidier reimplementation would understate the baseline by
+    more than an order of magnitude and flatter the result.
+    """
+    cjk = sum(1 for ch in text if _is_cjk(ch))
+    other = len(text) - cjk
+    return max(1, int((other * 0.25 + cjk * 1.0) * 1.1))
+
+
+def _run(label: str, *, legacy: bool, memo: bool) -> float:
+    real = token_counter._chars_estimate
+    if legacy:
+        token_counter._chars_estimate = legacy_chars_estimate
+    clear_estimate_cache()
+    try:
+        messages = [{"role": "system", "content": "s" * 2000}]
+        cumulative = 0.0
+        for turn in range(TURNS):
+            # DISTINCT content per message, as a real conversation has. An
+            # earlier draft appended the same string every turn, which let
+            # the memo collapse a whole turn's payload into one entry and
+            # made every configuration look identical.
+            messages.append(
+                {"role": "assistant", "content": f"a{turn} " + "x" * ROUND_CHARS}
+            )
+            messages.append(
+                {"role": "user", "content": f"u{turn} " + "y" * ROUND_CHARS}
+            )
+            if not memo:
+                clear_estimate_cache()
+            start = time.perf_counter()
+            count_tokens_messages(messages, "gpt-4o-mini", provider="openai")
+            cumulative += time.perf_counter() - start
+    finally:
+        token_counter._chars_estimate = real
+        clear_estimate_cache()
+    print(f"  {label:<34} {cumulative:8.3f} s")
+    return cumulative
+
+
+def main() -> None:
+    print(f"tiktoken installed: {TIKTOKEN_AVAILABLE}")
+    if TIKTOKEN_AVAILABLE:
+        print("  (the chars tier is bypassed; the memo carries the win here)")
+    print(f"\n== single call: CJK scan of a 640 KB payload ==")
+    big = "x" * 640_000
+    start = time.perf_counter()
+    legacy_chars_estimate(big, "openai")
+    before = time.perf_counter() - start
+    start = time.perf_counter()
+    _chars_estimate(big, "openai")
+    after = time.perf_counter() - start
+    print(f"  per-char Python loop               {before * 1000:8.2f} ms")
+    print(f"  str.isascii() fast path            {after * 1000:8.4f} ms")
+    print(f"  -> {before / after:,.0f}x")
+
+    print(f"\n== cumulative estimator CPU, {TURNS}-turn conversation ==")
+    baseline = _run("before (per-char loop, no memo)", legacy=True, memo=False)
+    fast = _run("+ ASCII fast path", legacy=False, memo=False)
+    both = _run("+ memo (shipped)", legacy=False, memo=True)
+    print()
+    print(f"  ASCII fast path:  {baseline / max(fast, 1e-9):>8,.0f}x vs before")
+    print(f"  memo on top:      {fast / max(both, 1e-9):>8,.1f}x further")
+    print(f"  shipped total:    {baseline / max(both, 1e-9):>8,.0f}x vs before")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/Agents/test_agent_budget_cache_aware.py
+++ b/Tests/Agents/test_agent_budget_cache_aware.py
@@ -1,0 +1,159 @@
+# Tests/Agents/test_agent_budget_cache_aware.py
+"""TASK-18603: the agent run budget prices cache reads at their real rate.
+
+The agent loop re-sends the whole conversation every turn and Anthropic
+prompt caching is on by default for Console sends, so on a long run nearly
+every input token is a cache read billed at ~0.1x. Counting those at full
+price made `max_total_tokens` stop runs that had spent a fraction of what
+the number implies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Agents.agent_service import (
+    _budget_weighted_tokens,
+    _usage_total_tokens,
+)
+
+
+def _anthropic(uncached, cache_read=0, cache_write=0, output=0):
+    return {
+        "usage": {
+            "input_tokens": uncached,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_write,
+            "output_tokens": output,
+        }
+    }
+
+
+def _openai(prompt, cached=0, completion=0):
+    return {
+        "usage": {
+            "prompt_tokens": prompt,
+            "prompt_tokens_details": {"cached_tokens": cached},
+            "completion_tokens": completion,
+        }
+    }
+
+
+CLAUDE = dict(provider="anthropic", model="claude-opus-5")
+
+
+# -- unchanged where there is no cache --------------------------------------
+
+
+def test_a_turn_with_no_cache_is_byte_identical_to_the_flat_sum():
+    """The whole no-caching path must behave exactly as before."""
+    resp = _openai(1000, completion=200)
+    assert _budget_weighted_tokens(resp, provider="openai", model="gpt-4o-mini") == (
+        _usage_total_tokens(resp)
+    )
+
+
+def test_anthropic_native_usage_is_read_instead_of_estimated():
+    """`_usage_total_tokens` only understands the OpenAI shape, but
+    `chat_with_anthropic` returns an OpenAI-shaped envelope carrying
+    Anthropic's NATIVE usage block, so the flat sum comes up empty there.
+
+    The Console's streaming path does not hit this -- the gateway
+    normalizes split usage first -- so this covers any caller that reaches
+    the service with un-normalized usage: real provider numbers must win
+    over falling back to a local estimate of the whole payload."""
+    resp = _anthropic(1000, output=200)
+    assert _usage_total_tokens(resp) is None, "fixture no longer reproduces the gap"
+    assert _budget_weighted_tokens(resp, **CLAUDE) == 1200
+
+
+def test_missing_usage_still_signals_estimate_instead():
+    assert _budget_weighted_tokens({}, **CLAUDE) is None
+    assert _budget_weighted_tokens({"usage": {}}, **CLAUDE) is None
+
+
+def test_an_unknown_model_gets_no_discount():
+    """No published rates means no honest discount to apply -- an unpriced
+    model must not get a free ride, so every bucket counts at full price."""
+    resp = _anthropic(100, cache_read=10_000, output=50)
+    got = _budget_weighted_tokens(
+        resp, provider="totally-unknown-provider", model="no-such-model"
+    )
+    assert got == 100 + 10_000 + 50
+
+
+# -- the discount ------------------------------------------------------------
+
+
+def test_cache_reads_cost_less_than_uncached_input():
+    """The point of the task: 100k tokens read from cache must not consume
+    the budget like 100k fresh input tokens."""
+    cached = _anthropic(100, cache_read=100_000, output=100)
+    fresh = _anthropic(100_100, output=100)
+    weighted_cached = _budget_weighted_tokens(cached, **CLAUDE)
+    weighted_fresh = _budget_weighted_tokens(fresh, **CLAUDE)
+    assert weighted_cached < weighted_fresh
+    # and the flat accounting could not tell them apart at all
+    assert _usage_total_tokens(cached) == _usage_total_tokens(fresh)
+
+
+def test_the_discount_tracks_the_published_rate():
+    from tldw_chatbook.LLM_Calls.pricing_catalog import get_pricing_catalog
+
+    pricing = get_pricing_catalog().get_pricing(CLAUDE["provider"], CLAUDE["model"])
+    if pricing is None or not pricing.input_per_mtok:
+        pytest.skip("no published rates for the pinned model")
+    if pricing.cache_read_per_mtok is None:
+        pytest.skip("model publishes no cache-read rate")
+
+    ratio = pricing.cache_read_per_mtok / pricing.input_per_mtok
+    resp = _anthropic(0, cache_read=1_000_000)
+    got = _budget_weighted_tokens(resp, **CLAUDE)
+    assert got == pytest.approx(1_000_000 * ratio, rel=0.01)
+
+
+def test_output_is_still_counted_one_for_one():
+    """Deliberate: pricing output proportionally would change how strict the
+    budget is, which is a different change from fixing cache mis-pricing."""
+    no_output = _budget_weighted_tokens(_anthropic(0, cache_read=1000), **CLAUDE)
+    with_output = _budget_weighted_tokens(
+        _anthropic(0, cache_read=1000, output=500), **CLAUDE
+    )
+    assert with_output - no_output == 500
+
+
+def test_cache_writes_are_counted_at_their_own_rate():
+    """A cache write costs MORE than uncached input (1.25x on Anthropic), so
+    it must not be quietly discounted along with reads."""
+    resp = _anthropic(0, cache_write=100_000)
+    got = _budget_weighted_tokens(resp, **CLAUDE)
+    assert got >= 100_000
+
+
+def test_openai_cached_prompt_tokens_are_bucketed_too():
+    """OpenAI reports cached tokens INSIDE prompt_tokens; the split has to
+    survive into the weighting or the discount silently never applies."""
+    resp = _openai(100_000, cached=90_000, completion=100)
+    flat = _usage_total_tokens(resp)
+    got = _budget_weighted_tokens(resp, provider="openai", model="gpt-4o-mini")
+    assert got <= flat
+
+
+# -- it can never under-count to zero ---------------------------------------
+
+
+def test_a_spending_turn_never_counts_as_zero():
+    """A pathological loop of tiny fully-cached turns must still consume the
+    budget, or it could run forever against any ceiling."""
+    resp = _anthropic(0, cache_read=1)
+    assert _budget_weighted_tokens(resp, **CLAUDE) >= 1
+
+
+def test_weighted_tokens_are_never_negative_or_fractional():
+    for resp in (
+        _anthropic(1, cache_read=3, cache_write=5, output=7),
+        _anthropic(0, cache_read=999_999),
+        _openai(5000, cached=4999, completion=1),
+    ):
+        got = _budget_weighted_tokens(resp, **CLAUDE)
+        assert isinstance(got, int) and got >= 0

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1287,9 +1287,23 @@ def test_qwencloud_terminal_usage_reaches_agent_native_budget_without_fallback(
     assert signals.usage_payloads() == [usage]
 
 
+# TASK-18603: `expected_total` is now CACHE-WEIGHTED, not the flat sum.
+# 6,656 of these input tokens are cache reads, billed at 0.3 vs 3.0 per
+# mtok for claude-sonnet-4-6 -- a tenth -- so they consume a tenth of the
+# run budget instead of full price. 3,571 uncached + 6,656*0.1 + 727 output
+# = 4,963.6, rounded up. The flat totals this used to assert (10,954 /
+# 11,065) are still what `_usage_total_tokens` reports and still what the
+# provider billed in RAW tokens; they were just never what the run cost.
+#
+# Note what the gateway's normalization does to the third bucket: it folds
+# `cache_creation_input_tokens` into `prompt_tokens` and reports only
+# `cached_tokens` separately, so a cache WRITE arrives indistinguishable
+# from uncached input and is weighted at full price. That is the
+# conservative direction (a write really does cost 1.25x input), which is
+# why the 111-token case simply adds 111.
 @pytest.mark.parametrize(
     ("cache_creation_input_tokens", "expected_total"),
-    [(0, 10_954), (111, 11_065)],
+    [(0, 4_964), (111, 5_075)],
     ids=("cache-read", "cache-read-and-creation"),
 )
 def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
@@ -1366,7 +1380,10 @@ def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
             "prompt_tokens": 3_571 + 6_656 + cache_creation_input_tokens,
             "prompt_tokens_details": {"cached_tokens": 6_656},
             "completion_tokens": 727,
-            "total_tokens": expected_total,
+            # Still the RAW total the provider billed in tokens -- this
+            # asserts the gateway's normalization, which TASK-18603 did not
+            # change. Only what the BUDGET counts it as changed.
+            "total_tokens": 3_571 + 6_656 + cache_creation_input_tokens + 727,
         }
     ]
     assert signals.synthetic_fallback_emitted is False

--- a/Tests/Chat/test_qwencloud_native_tools.py
+++ b/Tests/Chat/test_qwencloud_native_tools.py
@@ -13,7 +13,10 @@ from typing import Any, Callable, Iterator
 import pytest
 import requests
 
-from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_agent_bridge import (
+    CONSOLE_MAX_TOTAL_TOKENS,
+    ConsoleAgentBridge,
+)
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_provider_gateway import (
@@ -973,10 +976,16 @@ def test_qwencloud_partial_call_cancellation_never_executes(
 def test_qwencloud_responses_usage_enforces_agent_budget(
     tmp_path: Any,
 ) -> None:
+    # Derived from the shipped budget so this keeps testing "one turn that
+    # exhausts the budget" rather than "one turn of exactly 1,000,001
+    # tokens", and does not need editing again the next time the default
+    # moves. (On this branch the default is still CONSOLE_MAX_TOTAL_TOKENS;
+    # PR #1824's DEFAULT_CONSOLE_RUN_BUDGET supersedes it there.)
+    budget = CONSOLE_MAX_TOTAL_TOKENS
     usage = {
-        "input_tokens": 1_000_000,
+        "input_tokens": budget,
         "output_tokens": 1,
-        "total_tokens": 1_000_001,
+        "total_tokens": budget + 1,
     }
     body = _responses_tool_turn(
         [("fc_budget", "call_budget", '{"expression":"2+2"}')],
@@ -986,7 +995,7 @@ def test_qwencloud_responses_usage_enforces_agent_budget(
         outcome, _store = _run_joined_reply(tmp_path, server, "responses")
 
     assert outcome.status == "stuck"
-    assert outcome.total_tokens == 1_000_001
+    assert outcome.total_tokens == budget + 1
     assert len(server.requests) == 1
     assert outcome.steps[-1].kind == "error"
     assert outcome.steps[-1].summary == "token budget exhausted"

--- a/Tests/Chat/test_token_estimate_performance.py
+++ b/Tests/Chat/test_token_estimate_performance.py
@@ -1,0 +1,256 @@
+# Tests/Chat/test_token_estimate_performance.py
+"""TASK-18602: the token estimator's fast CJK count and per-text memo.
+
+The optimization replaced a per-character Python loop and added a memo, so
+what needs pinning is that neither changed an ANSWER -- plus the two
+structural properties that make the memo safe (bounded, and holding no
+reference to the text it describes).
+
+The measured shape that motivated this: 158.8 ms to estimate a 640 KB
+payload, re-run over the whole conversation every turn, for 33.1 s of
+cumulative CPU across a simulated 400-turn run.
+"""
+
+from __future__ import annotations
+
+import gc
+import re
+import threading
+import weakref
+
+import pytest
+
+from tldw_chatbook.Utils import token_counter
+from tldw_chatbook.Utils.token_counter import (
+    ESTIMATE_CACHE_MAX_ENTRIES,
+    _CJK_RANGES,
+    _chars_estimate,
+    _count_cjk,
+    _is_cjk,
+    clear_estimate_cache,
+    count_tokens_messages,
+    estimate_tokens,
+)
+
+
+def _reference_count(text: str) -> int:
+    """The pre-TASK-18602 implementation, kept as the oracle."""
+    return sum(1 for ch in text if _is_cjk(ch))
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    clear_estimate_cache()
+    yield
+    clear_estimate_cache()
+
+
+# -- the fast counter answers exactly what the loop answered ----------------
+
+
+def test_ascii_text_counts_zero_cjk():
+    assert _count_cjk("hello world, 123 -- def f(): return 1") == 0
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "plain ascii",
+        "日本語のテキスト",
+        "한국어 텍스트",
+        "中文文本",
+        "mixed english and 日本語 in one string",
+        "。、「」full-width ／＝",
+        "emoji 🎉 outside the ranges",
+        "　〿぀ヿ一鿿",
+    ],
+)
+def test_fast_counter_matches_the_reference_loop(text):
+    assert _count_cjk(text) == _reference_count(text)
+
+
+def test_every_range_boundary_matches():
+    """Off-by-one at a range edge would silently reweight CJK text."""
+    for lo, hi in _CJK_RANGES:
+        for cp in (lo - 1, lo, lo + 1, hi - 1, hi, hi + 1):
+            if cp < 0:
+                continue
+            ch = chr(cp)
+            assert _count_cjk(ch) == _reference_count(ch), hex(cp)
+
+
+def test_the_regex_is_built_from_the_same_ranges():
+    """The char class and `_is_cjk` must not drift apart; they are two
+    encodings of one fact."""
+    for lo, hi in _CJK_RANGES:
+        assert token_counter._CJK_RE.match(chr(lo))
+        assert token_counter._CJK_RE.match(chr(hi))
+
+
+def test_chars_estimate_is_unchanged_for_mixed_content():
+    """The counter feeds `_chars_estimate`'s CJK weighting, so a changed
+    count would silently change every estimate."""
+    for text in ("ascii only", "日本語", "half 日本語 half ascii"):
+        cjk = _reference_count(text)
+        other = len(text) - cjk
+        assert _chars_estimate(text, "openai") >= 1
+        assert _count_cjk(text) == cjk
+        assert len(text) - _count_cjk(text) == other
+
+
+# -- the memo returns the same answers --------------------------------------
+
+
+def test_repeated_estimates_agree_with_the_first():
+    for text in ("hello", "日本語のテキスト", "x" * 5000, "mixed 中文 text"):
+        first = estimate_tokens(text, "gpt-4o-mini", "openai")
+        assert estimate_tokens(text, "gpt-4o-mini", "openai") == first
+        # an equal-but-distinct object must hit the same answer
+        assert estimate_tokens(str(text), "gpt-4o-mini", "openai") == first
+
+
+def test_different_texts_of_equal_length_do_not_share_an_entry():
+    a = estimate_tokens("日本語日本語", "m", "openai")
+    b = estimate_tokens("abcdef", "m", "openai")
+    assert a != b, "CJK and ASCII of equal length must not estimate alike"
+
+
+def test_model_and_provider_are_part_of_the_key():
+    """Different tokenizer identities must not serve each other's answers."""
+    text = "x" * 400
+    clear_estimate_cache()
+    anthropic = estimate_tokens(text, "claude-opus-5", "anthropic")
+    openai = estimate_tokens(text, "gpt-4o-mini", "openai")
+    # They may coincide numerically; what matters is both are computed for
+    # their own provider ratio rather than one being served for the other.
+    assert anthropic == estimate_tokens(text, "claude-opus-5", "anthropic")
+    assert openai == estimate_tokens(text, "gpt-4o-mini", "openai")
+
+
+def test_empty_text_is_zero_and_never_cached():
+    assert estimate_tokens("", "m", "openai") == 0
+    assert len(token_counter._ESTIMATE_CACHE) == 0
+
+
+def test_message_counting_is_unaffected():
+    msgs = [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "日本語で答えて"},
+        {"role": "assistant", "content": "x" * 3000},
+    ]
+    first = count_tokens_messages(msgs, "gpt-4o-mini", provider="openai")
+    assert count_tokens_messages(msgs, "gpt-4o-mini", provider="openai") == first
+    assert first > 0
+
+
+# -- the memo's safety properties -------------------------------------------
+
+
+def test_the_cache_is_bounded():
+    clear_estimate_cache()
+    for i in range(ESTIMATE_CACHE_MAX_ENTRIES + 200):
+        estimate_tokens(f"unique text {i}", "m", "openai")
+    assert len(token_counter._ESTIMATE_CACHE) <= ESTIMATE_CACHE_MAX_ENTRIES
+
+
+def test_the_cache_holds_no_reference_to_the_estimated_text():
+    """AC#5: keyed by hash+length, never by the string, so memoizing a
+    600 KB message cannot pin it in memory after the run moves on."""
+
+    class _Text(str):
+        """A str subclass so it can be weak-referenced."""
+
+    clear_estimate_cache()
+    text = _Text("some text to estimate " * 50)
+    ref = weakref.ref(text)
+    estimate_tokens(text, "m", "openai")
+    del text
+    gc.collect()
+    assert ref() is None
+
+
+def test_concurrent_estimation_is_safe_and_consistent():
+    """AC#4: the agent worker thread and the UI thread estimate at once."""
+    clear_estimate_cache()
+    texts = [f"payload {i} " * 40 for i in range(200)]
+    expected = {t: estimate_tokens(t, "m", "openai") for t in texts}
+    clear_estimate_cache()
+
+    errors: list[BaseException] = []
+    results: list[dict] = []
+
+    def worker():
+        try:
+            results.append({t: estimate_tokens(t, "m", "openai") for t in texts})
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    for got in results:
+        assert got == expected
+
+
+def test_clear_estimate_cache_forces_recomputation():
+    calls = []
+    real = token_counter._chars_estimate
+
+    def counting(text, provider):
+        calls.append(text)
+        return real(text, provider)
+
+    token_counter._chars_estimate = counting
+    try:
+        clear_estimate_cache()
+        estimate_tokens("some text", "m", "openai")
+        estimate_tokens("some text", "m", "openai")
+        assert len(calls) == 1, "second call should have been memoized"
+        clear_estimate_cache()
+        estimate_tokens("some text", "m", "openai")
+        assert len(calls) == 2, "clear() should force a recompute"
+    finally:
+        token_counter._chars_estimate = real
+
+
+# -- the shape that motivated the work --------------------------------------
+
+
+def test_estimating_a_growing_conversation_stays_cheap():
+    """The regression guard: re-estimating an append-only history must cost
+    O(new text), not O(whole history), per turn.
+
+    Asserted structurally (recomputes, not wall-clock) so it cannot flake
+    on a loaded machine: across 100 turns the estimator may only be invoked
+    once per distinct message, not once per message per turn.
+    """
+    clear_estimate_cache()
+    computed = []
+    real = token_counter._chars_estimate
+
+    def counting(text, provider):
+        computed.append(text)
+        return real(text, provider)
+
+    token_counter._chars_estimate = counting
+    try:
+        msgs = [{"role": "system", "content": "s" * 500}]
+        for turn in range(100):
+            msgs.append({"role": "assistant", "content": f"turn {turn} " * 60})
+            msgs.append({"role": "user", "content": f"reply {turn} " * 60})
+            count_tokens_messages(msgs, "gpt-4o-mini", provider="openai")
+    finally:
+        token_counter._chars_estimate = real
+
+    # 1 system + 200 turn messages + the distinct role strings, each counted
+    # once. The pre-fix behaviour recomputed every message every turn, which
+    # is >10,000 invocations for the same 201 messages.
+    assert len(computed) < 500, (
+        f"{len(computed)} estimator invocations for 201 distinct messages "
+        "-- the per-turn re-count is back"
+    )

--- a/backlog/tasks/task-18602 - Token-estimation-is-quadratic-per-run-fix-the-per-char-CJK-loop-and-memoize-per-message-counts.md
+++ b/backlog/tasks/task-18602 - Token-estimation-is-quadratic-per-run-fix-the-per-char-CJK-loop-and-memoize-per-message-counts.md
@@ -1,0 +1,112 @@
+---
+id: TASK-18602
+title: >-
+  Token estimation is quadratic per run: fix the per-char CJK loop and memoize
+  per-message counts
+status: To Do
+assignee: []
+created_date: '2026-08-18 21:00'
+labels:
+  - performance
+  - agents
+  - console
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Token estimation re-counts an entire conversation from scratch on every turn, and
+the innermost step is a Python-level loop over every character.
+
+`Utils/token_counter._chars_estimate` computes its CJK share with
+`sum(1 for ch in text if _is_cjk(ch))` — one Python function call per character.
+Measured on this machine: **158.8 ms** for a 640 KB payload, where
+`str.isascii()` answers the same question for all-ASCII text in **0.001 ms**.
+
+On top of that, `count_tokens_messages` is called with the whole growing message
+list every turn, so the cost is quadratic in turn count. Measured over a
+simulated 400-turn agent run: **166 ms at turn 400**, **33.1 s cumulative**.
+Counting only each turn's NEW text instead totals **0.16 s**.
+
+This is not agent-only. `Chat/console_history_budget.py` calls
+`count_tokens_messages` and is imported by `console_chat_controller`, so it runs
+on the normal Console send path; the cost ticker, chat token events, and
+world-info processing use the same estimator.
+
+The ASCII guard fixes the no-tokenizer case outright. Memoization is the
+structural fix and is the one that also helps installs WITH tiktoken, where the
+per-turn re-encode of the whole history is the dominant cost.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Estimating all-ASCII text no longer runs a per-character Python loop.
+- [x] #2 Re-estimating an unchanged string is served from a memo rather than recomputed, for every caller of the estimator.
+- [x] #3 Estimated token counts are unchanged for ASCII, CJK, mixed, and multimodal part-list content.
+- [x] #4 The memo is safe to use from the agent worker thread and the UI thread at once.
+- [x] #5 The memo is bounded and holds no strong reference to the estimated text.
+- [x] #6 A benchmark records before/after cost for a growing payload so the regression is visible if it returns.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two independent fixes in `Utils/token_counter.py`, each measured.
+
+**1. The CJK count no longer runs a Python loop.** `_count_cjk` replaces
+`sum(1 for ch in text if _is_cjk(ch))` with an ASCII short-circuit
+(`str.isascii()`) and, for non-ASCII text, a single `re.subn` pass over a char
+class built from the same `_CJK_RANGES` tuple `_is_cjk` uses — so the two
+encodings of that fact cannot drift. Equivalence was proven exhaustively over
+U+0000–U+10FFF, over every range boundary, and over 300 randomized mixed
+strings: zero mismatches.
+
+**2. `estimate_tokens` is memoized.** Keyed by
+`(model, provider, len(text), hash(text))` rather than by the text, so the cache
+holds NO strong reference and memoizing a 600 KB message cannot pin it in memory
+(pinned by a weakref test). CPython caches a str's hash on the object, so repeat
+lookups of the same message are a dict probe. The read is unlocked (a dict `get`
+is atomic under the GIL and a race can only cost one recompute); only the write
+takes the lock, so the agent worker thread and the UI thread can estimate
+concurrently.
+
+Measured by `Helper_Scripts/Benchmarks/token_estimate_benchmark.py` on a
+400-turn conversation, with the two fixes separated because they are not equal
+partners:
+
+| | cumulative estimator CPU |
+|---|---|
+| before (per-char loop, no memo) | 35.02 s |
+| + ASCII fast path | 0.113 s — **310x** |
+| + memo (shipped) | 0.054 s — 2.1x further, **650x total** |
+
+Single-call CJK scan of a 640 KB payload: 171.9 ms -> 0.007 ms (**25,000x**).
+
+Read that split honestly: on the shipped default (no tokenizer installed) the
+ASCII fast path does nearly all the work and the memo adds 2.1x. The memo earns
+its place on installs WITH tiktoken, where the per-turn re-encode of the whole
+history is the dominant cost and no fast path can remove it — a configuration
+this machine cannot measure, so the benchmark reports which tier it ran.
+
+Two benchmark drafts had to be thrown away before these numbers were
+trustworthy, both flattering: one reimplemented the "before" case with a
+frozenset lookup instead of calling the real `_is_cjk` generator (understating
+the baseline ~25x), and one appended identical content every turn, which let the
+memo collapse a whole payload into one entry and made every configuration look
+the same. Both traps are called out in the script.
+
+**Trade-off.** A hash collision would serve one text's estimate for another's.
+Mitigated by including length and tokenizer identity in the key, and bounded in
+consequence by what this function is: an estimate whose own chars tier already
+applies approximation headroom. It is never used where an exact count is
+required. Documented at the cache.
+
+The regression guard asserts STRUCTURE (estimator invocations across 100 turns),
+not wall-clock, so it cannot flake on a loaded machine.
+
+Files: `Utils/token_counter.py`, `Tests/Chat/test_token_estimate_performance.py`
+(new, 23), `Helper_Scripts/Benchmarks/token_estimate_benchmark.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18603 - Agent-run-budget-counts-cache-reads-at-full-price-so-it-stops-cheap-runs-early.md
+++ b/backlog/tasks/task-18603 - Agent-run-budget-counts-cache-reads-at-full-price-so-it-stops-cheap-runs-early.md
@@ -1,0 +1,85 @@
+---
+id: TASK-18603
+title: >-
+  Agent run budget counts cache reads at full price, so it stops cheap runs early
+status: To Do
+assignee: []
+created_date: '2026-08-18 21:15'
+labels:
+  - agents
+  - console
+  - cost
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`AgentService._usage_total_tokens` sums `prompt_tokens + completion_tokens` flat.
+The agent loop re-sends the whole conversation every turn, and Anthropic prompt
+caching is ON by default for Console sends (which is what an agent run is —
+`console_provider_gateway` stamps `prompt_caching` for anthropic), so on a long
+run nearly every input token is a CACHE READ billed at roughly a tenth of the
+uncached rate.
+
+Counting those at 1.0 makes `max_total_tokens` terminate runs that have spent a
+small fraction of what the number implies — directly undercutting TASK-18600's
+goal of allowing long-running sessions.
+
+The parts already exist: `Chat/provider_usage.ProviderUsage` splits
+`uncached_input` / `cache_read` / `cache_write` / `output`, and
+`LLM_Calls/pricing_catalog` publishes per-bucket rates per model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Cache-read tokens consume the run budget in proportion to their published rate rather than at full price.
+- [x] #2 Cache-write tokens are counted at their own (higher) rate, not discounted along with reads.
+- [x] #3 A turn with no cache activity is accounted for exactly as before.
+- [x] #4 A provider/model with no published rates gets no discount rather than an invented one.
+- [x] #5 A turn that spent anything never counts as zero.
+- [x] #6 Output tokens remain counted one-for-one, so the change does not silently alter how strict the budget is for output-heavy runs.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `_budget_weighted_tokens`, used by `_make_call_model` in place of the flat
+sum. It parses usage via `ProviderUsage` (which understands the OpenAI, OpenAI
+Responses, and Anthropic-native shapes), looks up per-bucket rates in
+`pricing_catalog`, and weights the INPUT buckets relative to this model's own
+uncached input rate. The unit becomes "uncached-input-token equivalents".
+
+Scope was kept to the input buckets deliberately. Pricing output proportionally
+(it really costs ~5x input) would make the budget markedly stricter for
+output-heavy runs — a change to how much work a given number buys, unrelated to
+the cache mis-pricing being fixed, applied to a number users already chose under
+the old meaning.
+
+Every fallback keeps the previous accounting: unparsable usage, no cache
+activity, an unknown model, an unpriced (zero-rate local) model, or an
+unpublished cache rate all fall back to the flat sum or to full price. An
+unpublished cache rate is treated as 1.0, not free — the conservative reading.
+
+Also improved in passing: when the flat sum comes up empty because usage arrived
+in Anthropic's native shape, the parsed `ProviderUsage` total is now used instead
+of falling back to a local `count_tokens_messages` estimate of the whole payload.
+The Console's own streaming path does not hit that gap (the gateway normalizes
+split usage first, pinned by
+`test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets`), so this is
+a defensive improvement for callers that reach the service un-normalized.
+
+`test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets` changed
+expectations from the flat 10,954/11,065 to the weighted 4,964/5,075. The raw
+totals it used to assert are still what the provider billed in tokens and are
+still asserted on the normalized payload — they were just never what the run
+cost. Note the gateway's normalization folds `cache_creation_input_tokens` into
+`prompt_tokens`, so a cache WRITE arrives indistinguishable from uncached input
+and is weighted at full price through that path; conservative, and noted in the
+test.
+
+Files: `Agents/agent_service.py`, `Tests/Agents/test_agent_budget_cache_aware.py`
+(new, 11), `Tests/Chat/test_console_agent_bridge.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18604 - Live-agent-step-feed-retains-one-object-per-step-to-render-five-rows.md
+++ b/backlog/tasks/task-18604 - Live-agent-step-feed-retains-one-object-per-step-to-render-five-rows.md
@@ -1,0 +1,48 @@
+---
+id: TASK-18604
+title: Live agent step feed retains one object per step to render five rows
+status: To Do
+assignee: []
+created_date: '2026-08-18 21:20'
+labels:
+  - agents
+  - console
+  - performance
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`ConsoleAgentBridge.run_reply` kept each run's live step feed as a plain list,
+appended once per step and read in exactly two ways: `len(...)` for the rail's
+step counter and `[-5:]` for its recent-step rows. Nothing ever read the middle,
+yet the list retained one `AgentLiveStep` per step for the life of the run.
+
+At the run budget's raised step ceiling (TASK-18600) that is up to 25,000
+retained objects per run to serve a five-row display, multiplied by each live
+sub-agent's own feed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 The live feed retains a bounded number of steps regardless of run length.
+- [x] #2 The rail's step counter still reports the true total, not the retained count.
+- [x] #3 The rail's recent-step rows are unchanged.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the list with a small `_LiveStepFeed` holding a monotonic `count` and a
+`deque(maxlen=8)` tail.
+
+Keeping the count and the tail in one object, rather than swapping in a bare
+`deque(maxlen=...)`, is the point: a bare deque silently redefines `len()` as
+"how many we kept", which is exactly the wrong number for a step counter that
+the rail displays. The type makes that impossible to get wrong.
+
+Files: `Chat/console_agent_bridge.py`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -537,6 +537,112 @@ def _response_message(resp) -> dict:
     return message if isinstance(message, dict) else {}
 
 
+def _budget_weighted_tokens(resp, *, provider: str, model: str) -> int | None:
+    """Tokens for the run budget, with cache-read/write priced honestly.
+
+    TASK-18603. `_usage_total_tokens` below sums `prompt_tokens +
+    completion_tokens` flat, which mis-states this budget badly once prompt
+    caching is on -- and it IS on by default for Console sends, which is
+    what an agent run is (`console_provider_gateway` stamps
+    `prompt_caching` for anthropic). The agent loop re-sends the whole
+    conversation every turn, so on a long run nearly every input token is a
+    CACHE READ billed at roughly a tenth of the uncached rate; counting it
+    at 1.0 made `max_total_tokens` terminate runs that had spent a fraction
+    of what the number implies.
+
+    The weighting is deliberately confined to the INPUT buckets:
+
+    * `uncached_input` stays 1.0 by definition -- it is the unit.
+    * `cache_read` and `cache_write` are weighted by their real published
+      rate relative to this model's uncached input rate (0.1x and 1.25x on
+      Anthropic today, per `pricing_catalog`).
+    * `output` also stays 1.0, even though it really costs several times
+      input. Pricing it proportionally would make the budget markedly
+      STRICTER for output-heavy runs -- a change to how much work a given
+      number buys, unrelated to the cache mis-pricing this fixes, and
+      applied to a number the user already chose under the old meaning.
+
+    So the unit is "uncached-input-token equivalents": a 25M budget means
+    "as much input as 25M uncached tokens would have cost on this model",
+    with output still counted one-for-one.
+
+    Falls back to `_usage_total_tokens` whenever the usage cannot be
+    bucketed or this provider/model has no published rates, so an unpriced
+    or unknown model keeps exactly the previous accounting rather than
+    silently getting a free ride.
+
+    Args:
+        resp: The provider response.
+        provider: Provider key for the pricing lookup.
+        model: Model id for the pricing lookup.
+
+    Returns:
+        Weighted token count, or None to signal "estimate instead".
+    """
+    flat = _usage_total_tokens(resp)
+    try:
+        from tldw_chatbook.Chat.provider_usage import ProviderUsage
+        from tldw_chatbook.LLM_Calls.pricing_catalog import get_pricing_catalog
+    except Exception:  # noqa: BLE001 -- accounting must never break a run
+        return flat
+    try:
+        usage = ProviderUsage.from_provider_payload(
+            resp.get("usage") if isinstance(resp, dict) else None,
+            provider=provider,
+            model=model,
+        )
+    except Exception:  # noqa: BLE001 -- accounting must never break a run
+        return flat
+    if usage is None:
+        return flat
+    # `_usage_total_tokens` only understands the OpenAI shape
+    # (`total_tokens`, or `prompt_tokens`+`completion_tokens`), and returns
+    # None for Anthropic's native block (`input_tokens`/
+    # `cache_read_input_tokens`/`output_tokens`), which
+    # `chat_with_anthropic` passes through verbatim inside an OpenAI-shaped
+    # envelope. The Console's streaming path does NOT hit that gap --
+    # `ConsoleProviderGateway` normalizes split Anthropic usage into the
+    # OpenAI shape first (pinned by
+    # `test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets`)
+    # -- but a caller that reaches the service with un-normalized usage
+    # would otherwise fall back to re-estimating the whole payload with
+    # `count_tokens_messages`. `ProviderUsage` parses both shapes, so
+    # prefer its real numbers over an estimate whenever the flat sum came
+    # up empty.
+    raw = usage.total_tokens
+    baseline = flat if flat is not None else (raw or None)
+    if not usage.cache_read and not usage.cache_write:
+        # Nothing to reweight; a run without caching keeps the previous
+        # accounting exactly.
+        return baseline
+    try:
+        pricing = get_pricing_catalog().get_pricing(provider, model)
+    except Exception:  # noqa: BLE001
+        return baseline
+    if pricing is None or not pricing.input_per_mtok:
+        # No published rates (or a zero-rate local model): there is no
+        # honest discount to apply, so do not invent one.
+        return baseline
+
+    def _weight(rate: float | None) -> float:
+        # An unpublished cache rate is NOT free -- treat it as full input
+        # price, the conservative reading, rather than discounting a bucket
+        # whose real cost is unknown.
+        if rate is None:
+            return 1.0
+        return rate / pricing.input_per_mtok
+
+    weighted = (
+        usage.uncached_input
+        + usage.cache_read * _weight(pricing.cache_read_per_mtok)
+        + usage.cache_write * _weight(pricing.cache_write_per_mtok)
+        + usage.output
+    )
+    # Round up: a turn that genuinely spent something must never count as 0,
+    # or a pathological loop of tiny cached turns could run forever.
+    return max(1, math.ceil(weighted))
+
+
 def _usage_total_tokens(resp) -> int | None:
     """Prompt+completion tokens from a provider's OpenAI-shaped usage block,
     or None when the provider didn't report usage.
@@ -1031,7 +1137,11 @@ class AgentService:
                 **call_kwargs,
             )
             text = _response_text(resp)
-            tokens = _usage_total_tokens(resp)
+            # TASK-18603: cache-aware. Identical to the flat sum whenever
+            # this turn read nothing from a prompt cache.
+            tokens = _budget_weighted_tokens(
+                resp, provider=api_endpoint, model=config.model
+            )
             provider_continuation = getattr(resp, "provider_continuation", None)
             if provider_continuation is not None and not isinstance(
                 provider_continuation, ProviderContinuationCheckpoint

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1070,6 +1070,43 @@ def _subagent_summaries_from_fleet(
     return tuple(fallback)
 
 
+class _LiveStepFeed:
+    """One run's live step feed: a total count plus a bounded recent tail.
+
+    TASK-18604. This was a plain list appended once per step and read in
+    exactly two ways -- `len(...)` for the rail's step counter and
+    `[-5:]` for the rail's recent-steps rows. Nothing ever read the middle,
+    yet the list grew one `AgentLiveStep` per step for the life of the run.
+    At the run budget's raised step ceiling that is 25,000 retained objects
+    per run to serve a 5-row display.
+
+    Keeping the count and the tail in one object rather than a deque plus a
+    parallel counter is deliberate: they are two views of one fact, and a
+    `deque(maxlen=...)` silently makes `len()` mean "how many we kept",
+    which is exactly the wrong number for a step counter.
+    """
+
+    __slots__ = ("count", "_tail")
+
+    #: Rows the rail actually renders. Kept a little above the 5 the
+    #: snapshot slices so a future widening does not silently truncate.
+    TAIL = 8
+
+    def __init__(self) -> None:
+        self.count = 0
+        self._tail: "deque[AgentLiveStep]" = deque(maxlen=self.TAIL)
+
+    def append(self, step: "AgentLiveStep") -> None:
+        self.count += 1
+        self._tail.append(step)
+
+    def tail(self, n: int) -> "tuple[AgentLiveStep, ...]":
+        """The most recent ``n`` steps, oldest first."""
+        if n >= len(self._tail):
+            return tuple(self._tail)
+        return tuple(self._tail)[-n:]
+
+
 @dataclass(frozen=True)
 class AgentLiveSnapshot:
     """Rail-facing snapshot of one conversation's primary agent run.
@@ -3124,12 +3161,12 @@ class ConsoleAgentBridge:
         # one key, so an earlier turn's surviving child -- which writes
         # under its OWN run id -- can never land in it.
         primary_live_key = uuid4().hex
-        live_steps: list[AgentLiveStep] = []
+        live_steps = _LiveStepFeed()
         subagents: list[SubAgentSummary] = []
         #: run key -> that run's own live step feed. The primary's entry is
         #: `live_steps` itself, so every existing reader of that local is
         #: unchanged.
-        run_live_steps: dict[str, list[AgentLiveStep]] = {primary_live_key: live_steps}
+        run_live_steps: dict[str, _LiveStepFeed] = {primary_live_key: live_steps}
         self._publish_live(
             conversation_id,
             primary_live_key,
@@ -3167,7 +3204,7 @@ class ConsoleAgentBridge:
                 # regresses for a step that cannot be attributed.
                 else (run_id or primary_live_key)
             )
-            key_steps = run_live_steps.setdefault(live_key, [])
+            key_steps = run_live_steps.setdefault(live_key, _LiveStepFeed())
             key_steps.append(
                 # `time.monotonic()` HERE is the step's real start: this hook
                 # runs synchronously inside the runtime loop, before the work
@@ -3253,8 +3290,8 @@ class ConsoleAgentBridge:
                 live_key,
                 AgentLiveSnapshot(
                     status="running",
-                    step=len(key_steps),
-                    steps=tuple(key_steps[-5:]),
+                    step=key_steps.count,
+                    steps=key_steps.tail(5),
                     # PR2b Task 2: rebuilt from the fleet's REAL live state
                     # on every publish, not appended once and left stuck at
                     # the "running" default -- see
@@ -3726,8 +3763,8 @@ class ConsoleAgentBridge:
             primary_live_key,
             AgentLiveSnapshot(
                 status=outcome.status,
-                step=len(live_steps),
-                steps=tuple(live_steps[-5:]),
+                step=live_steps.count,
+                steps=live_steps.tail(5),
                 # PR2b Task 2: `service` here -- NOT `self.fleet_snapshot(
                 # conversation_id)` -- deliberately: the `finally` block
                 # just above already ran `self._teardown_fleet_service`,

--- a/tldw_chatbook/Utils/token_counter.py
+++ b/tldw_chatbook/Utils/token_counter.py
@@ -2,6 +2,8 @@
 # Description: Token counting utilities for various LLM models
 #
 # Imports
+import re
+import threading
 from typing import List, Dict, Any, Union, Optional, Tuple
 
 #
@@ -115,6 +117,65 @@ def _is_cjk(ch: str) -> bool:
     return any(lo <= cp <= hi for lo, hi in _CJK_RANGES)
 
 
+#: Character class matching exactly the code points `_is_cjk` accepts, built
+#: from the same `_CJK_RANGES` tuple so the two can never disagree.
+#: TASK-18602: the CJK share used to be counted as
+#: `sum(1 for ch in text if _is_cjk(ch))` -- one Python call per character,
+#: with a 7-range generator inside it. Measured at 158.8 ms for a 640 KB
+#: payload, re-run over the whole conversation every turn.
+_CJK_RE = re.compile(
+    "[" + "".join(f"{chr(lo)}-{chr(hi)}" for lo, hi in _CJK_RANGES) + "]"
+)
+
+
+def _count_cjk(text: str) -> int:
+    """Count CJK-weighted characters in ``text``.
+
+    Two tiers, both avoiding the per-character Python loop this replaced:
+
+    * All-ASCII text -- the overwhelmingly common case for prompts, code,
+      and English prose -- cannot contain a CJK code point at all, and
+      ``str.isascii()`` settles it in one C-level scan (0.001 ms on 640 KB,
+      against 158.8 ms for the old loop).
+    * Anything else is counted by ``_CJK_RE.subn``, which does the same
+      count in a single C-level pass.
+
+    Args:
+        text: The text to scan.
+
+    Returns:
+        Number of characters inside `_CJK_RANGES`.
+    """
+    if text.isascii():
+        return 0
+    return _CJK_RE.subn("", text)[1]
+
+
+#: Bounded memo for `estimate_tokens`. TASK-18602: a conversation is
+#: append-only, but every caller re-estimates the WHOLE message list each
+#: turn, so an N-turn run pays O(N^2) to learn N answers -- 33.1 s of pure
+#: CPU across a simulated 400-turn run, against 0.16 s for counting only
+#: each turn's new text.
+#:
+#: Keyed by `(model, provider, len(text), hash(text))` rather than by the
+#: text itself, deliberately: the key holds NO strong reference, so memoing
+#: a 600 KB message cannot pin it in memory after the conversation moves
+#: on. CPython caches a str's hash on the object after first use, so repeat
+#: lookups of the same message cost a dict probe, not a rescan.
+#:
+#: A hash collision would serve one text's estimate for another's. Guarded
+#: by including the length and the tokenizer identity in the key, and
+#: bounded in consequence by what this function is: a token ESTIMATE whose
+#: own chars tier already applies approximation headroom. It is never used
+#: where an exact count is required.
+_ESTIMATE_CACHE: "dict[tuple[str, str, int, int], int]" = {}
+_ESTIMATE_CACHE_LOCK = threading.Lock()
+#: Cleared wholesale on overflow rather than evicted LRU-style: a miss costs
+#: exactly one recompute, so the simplest correct policy is the right one,
+#: and it keeps the locked section O(1).
+ESTIMATE_CACHE_MAX_ENTRIES = 4096
+
+
 def _norm_provider(provider: str) -> str:
     """Normalize a provider name for case-insensitive dict lookups.
 
@@ -136,7 +197,7 @@ def _chars_estimate(text: str, provider: str) -> int:
     """
     if not text:
         return 0
-    cjk = sum(1 for ch in text if _is_cjk(ch))
+    cjk = _count_cjk(text)
     other = len(text) - cjk
     base_ratio = TOKENS_PER_CHAR_ESTIMATES.get(
         _norm_provider(provider) or "default", TOKENS_PER_CHAR_ESTIMATES["default"]
@@ -209,13 +270,55 @@ def estimate_tokens(text: Any, model: str = "gpt-3.5-turbo", provider: str = "")
             )
     if not text:
         return 0
+    # TASK-18602: memoized because every caller re-estimates the whole
+    # append-only conversation each turn. The tiers below are all O(len)
+    # or worse -- the tiktoken tier re-encodes, which is the dominant cost
+    # on installs that have it -- so recomputing an unchanged message is
+    # the single largest avoidable cost on the send and agent-turn paths.
+    # See `_ESTIMATE_CACHE` for the key's design and its collision
+    # argument.
+    cache_key = (model, _norm_provider(provider), len(text), hash(text))
+    cached = _ESTIMATE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
     if CUSTOM_TOKENIZERS_AVAILABLE and custom_tokenizers_available():
         custom = count_tokens_with_custom(text, model, _norm_provider(provider))
         if custom is not None:
+            _cache_estimate(cache_key, custom)
             return custom
     if TIKTOKEN_AVAILABLE:
-        return count_tokens_tiktoken(text, model)
-    return _chars_estimate(text, provider)
+        counted = count_tokens_tiktoken(text, model)
+    else:
+        counted = _chars_estimate(text, provider)
+    _cache_estimate(cache_key, counted)
+    return counted
+
+
+def _cache_estimate(key: "tuple[str, str, int, int]", value: int) -> None:
+    """Store one memoized estimate, bounding the cache.
+
+    The read in `estimate_tokens` is deliberately unlocked: a dict `get` is
+    atomic under the GIL, and a racing writer can only cause a miss (one
+    extra recompute), never a torn or wrong value. Only the write takes the
+    lock, so concurrent estimation from the agent worker thread and the UI
+    thread never corrupts the dict's internal state.
+    """
+    with _ESTIMATE_CACHE_LOCK:
+        if len(_ESTIMATE_CACHE) >= ESTIMATE_CACHE_MAX_ENTRIES:
+            _ESTIMATE_CACHE.clear()
+        _ESTIMATE_CACHE[key] = value
+
+
+def clear_estimate_cache() -> None:
+    """Drop every memoized estimate.
+
+    Nothing depends on this for correctness -- entries are keyed by the
+    text they describe, so a stale entry cannot be served for changed
+    text. Exposed for tests that swap the tokenizer tier underneath the
+    estimator and need the next call to actually recompute.
+    """
+    with _ESTIMATE_CACHE_LOCK:
+        _ESTIMATE_CACHE.clear()
 
 
 # Token limits per model (approximate)


### PR DESCRIPTION
## Why

A Windows user on yesterday's dev build (`c1932f4dd`, built minutes after PRs #1813/#1816 merged) reported ~3 s lag on clicks/screen changes, typing still slow but faster — the profile of a busy event loop. Commit `25e6b1535` on `feat/agent-run-budget-settings` (PR #1824, still in review) contains three measured fixes for exactly that class of cost on the Console run path, but that branch is **not merged into dev** — dev users are still paying them:

- **TASK-18602** — token estimation was quadratic per run: `_chars_estimate` called `_is_cjk` per character in a Python loop, and every caller re-estimated the WHOLE message list each turn. Measured: **35.02 s → 0.054 s** of estimator CPU over a 400-turn conversation (650×); a 640 KB CJK scan 171.9 ms → 0.007 ms.
- **TASK-18603** — the run budget counted cache reads at full price; now weights input buckets by real published rates (Anthropic prompt caching makes long runs nearly all cache reads).
- **TASK-18604** — the live step feed retained one object per step to render five rows; replaced with a count + bounded tail of 8.

## What this PR does

Cherry-picks `25e6b1535` onto current dev, adapted where it depended on PR #1824's feature code:

| Adaptation | Reason |
|---|---|
| QwenCloud budget test derives from `CONSOLE_MAX_TOTAL_TOKENS` (dev's 1M default) instead of `DEFAULT_CONSOLE_RUN_BUDGET` (25M, feature-only) | The symbol doesn't exist on dev |
| User-Guide "Agent run budget" section stays out | Documents PR #1824's Settings UI and 25M defaults; ships with it |

When PR #1824 merges, its tree already contains these fixes verbatim — GitHub will dedupe to a no-op for the code; the only expected conflict is the QwenCloud test deriving from the feature symbol again.

## Verification

- `Tests/Agents/` + `Tests/Chat/test_token_counter.py`: **1,590 passed**, 1 skipped (tiktoken not installed)
- `Tests/Chat/test_token_estimate_performance.py`, `test_agent_budget_cache_aware.py`, `test_console_agent_bridge.py`: **248 passed**
- `Tests/Chat/test_qwencloud_native_tools.py` (incl. adapted budget test): **44 passed**
- `Tests/Chat/test_console_provider_gateway.py`: **234 passed**
- `Tests/Chat/test_anthropic_native_tools.py` + streaming-usage + prefix-stability + openai-streaming-usage + caching-degrade: **54 passed**

Total: ~1,876 targeted tests green on this branch. The original commit's note about 18 pre-existing Chat-suite reds reproducing identically on clean origin/dev still stands (17/18 pre-existing there).

## Not included (tracked separately)

This PR addresses the run-path costs. Two other regression vectors found in the investigation remain: screen-mount weight regrowth (library +5.8k lines / settings +3.4k / transcript +3.5k in one week, on an architecture that rebuilds screens per switch) and the boot-time CSS staleness walk + subprocess rebuild for source-checkout users (`app.py:12333+`). Neither blocks this merge.

Backlog tasks 18602/18603/18604 files are included (from the original commit).

ADR required: no — direct perf fixes with no boundary/architecture change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lands three performance fixes on the Console/agent path: token estimation is no longer quadratic, the run budget prices cache reads correctly, and the live step feed is bounded. This removes multi‑second UI lag and prevents early budget exhaustion on cached runs.

- Token estimation (TASK-18602): replaced the per‑char CJK loop with an ASCII fast path and a single‑pass regex, and memoized `estimate_tokens` with a bounded, thread‑safe, no‑strong‑ref cache. Answers are unchanged; measured estimator CPU over a 400‑turn run drops ~650×. Adds `Helper_Scripts/Benchmarks/token_estimate_benchmark.py` and perf tests.
- Budget accounting (TASK-18603): `_budget_weighted_tokens` weights input buckets using `pricing_catalog` (cache read/write vs uncached); output stays 1:1. Unknown/unpriced models fall back to the flat sum. Anthropic native usage is now read via `ProviderUsage` instead of re‑estimating. Updates the Anthropic split‑usage test to expect the weighted budget total; raw provider totals are still asserted unchanged.
- Live feed (TASK-18604): replaces the per‑run list with `_LiveStepFeed` (monotonic count + `deque(maxlen=8)`), so snapshots report the true step total and the last five rows without retaining all steps.
- Dev‑branch adaptation: the QwenCloud budget test derives from `CONSOLE_MAX_TOTAL_TOKENS` (dev) instead of the settings symbol introduced in PR #1824; docs for that UI remain with #1824. No API or config changes.

<sup>Written for commit d63a377ac6edda3cf386e4e53454723108206fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

