### PR TITLE
perf(console): cache readiness key-sets — 24k identity resolves per screen switch (TASK-18909)

### DIFF
--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -2282,3 +2282,41 @@ class TestConsoleSettingsWarnings:
         # mapping, so it must not warn as unconsumed.
         settings = self._settings(provider="openai", reasoning_effort="none")
         assert console_settings_warnings(settings) == []
+
+
+class TestReadinessKeySetCaching:
+    """TASK-18909: the readiness key-sets are pure functions of a constant.
+
+    A warm Console switch called `build_console_settings_readiness` ~400
+    times; each call re-resolved provider identity for all 29 handler keys
+    twice (supported + send-capable) -- 24k identity resolutions, the
+    largest app-side cost of the switch. The no-injection path must cache.
+    """
+
+    def test_default_key_sets_are_cached_objects(self):
+        # Same object returned when no keys are injected: the frozensets are
+        # rebuilt from a module constant, so repeated calls must not
+        # recompute (and callers may rely on the identity for cheap checks).
+        assert (
+            session_settings._supported_readiness_keys()
+            is session_settings._supported_readiness_keys()
+        )
+        assert (
+            session_settings._send_capable_readiness_keys()
+            is session_settings._send_capable_readiness_keys()
+        )
+
+    def test_injected_keys_are_not_served_from_cache(self):
+        # The test-injection seam (native_provider_keys) changes the result;
+        # it must never be served from the no-injection cache.
+        with_injection = session_settings._supported_readiness_keys({"openai"})
+        assert "openai" in with_injection
+        assert with_injection is not session_settings._supported_readiness_keys()
+
+    def test_cached_set_matches_uncached_derivation(self):
+        # The cached set equals a fresh derivation over the same constant.
+        fresh = session_settings.supported_console_provider_readiness_keys(
+            session_settings.CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+        )
+        assert session_settings._supported_readiness_keys() == fresh
+        assert session_settings._send_capable_readiness_keys() == fresh

--- a/backlog/tasks/task-18909 - Reduce-Console-screen-switch-mount-cost-1.55s-warm-on-fast-hardware.md
+++ b/backlog/tasks/task-18909 - Reduce-Console-screen-switch-mount-cost-1.55s-warm-on-fast-hardware.md
@@ -1,0 +1,31 @@
+---
+id: TASK-18909
+title: Reduce Console screen-switch mount cost (1.55s warm on fast hardware)
+status: To Do
+assignee: []
+created_date: '2026-08-19 16:31'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Measured 2026-08-19 at dev f6ae7d23e (TASK-18908 spike): switching to the Console/ChatScreen costs ~1.55s WARM on an M-series Mac with a scratch config, vs Home 0.76s / Settings 0.89s / Library 1.39s. Screens rebuild fully per switch by design (caching was root-caused to a freeze in July); the cost is construction+compose+CSS-apply of a 21k-line screen plus its Console module chain (transcript+bridge+controller+store grew +9.6k lines in the Aug 15-18 window). On constrained Windows hardware at 3-5x this is 5-8s — the residual of the reported incident. Profile a warm switch (Py-spy or cProfile around handle_screen_navigation) and land the top deferrable items (likely first-visit import already handled by preimport thread; suspect compose-time work that can move to post-first-paint workers).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Profile of a warm Console switch exists with named top costs,Top deferrable compose-time work moved off the first paint (or documented why each cannot be),Warm Console switch re-measured and reported in the task,Latency guardrail budgets updated if the improvement moves baseline
+<!-- AC:END -->
+
+
+## Implementation Notes
+
+- Profile (cProfile around a full warm navigation, dev `153a664ce`): the largest app-side cost was NOT screen composition but `build_console_settings_readiness` (~400 calls/switch) each rebuilding the supported + send-capable readiness frozensets by resolving provider identity for all 29 handler keys — 24,484 resolutions / 692k `normalize_provider_config_key` string ops per switch.
+- Fix: `functools.cache` on the no-injection path of `_supported_readiness_keys`/`_send_capable_readiness_keys` (pure functions of `CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS`); the `native_provider_keys` test-injection seam stays uncached. PR #1830.
+- Result: identity resolution absent from the profile, normalize calls −95%, wall 1.52s → 1.45s (~5%, honest small number).
+- "Why not more" (the AC's document-or-defer clause): after the fix, app code is ABSENT from the switch profile — the ~1.4s floor is Textual's mount/CSS/compositor machinery over a ~600-widget screen. The deferrable-work hypothesis was wrong: compose-time app work was already deferral-clean (July's task-15452 memo held). Reducing the floor further requires screen decomposition (splitting ChatScreen's widget tree or upstream Textual caching) — a deliberate architecture project, not a follow-up patch; no task filed because no measured app-side lever remains.
+- Guardrail budgets (PR #1827) unchanged: baseline moved ~5%, far inside the 10s budgets.
+- ADR: not required — a pure memoization change behind existing function signatures.

--- a/backlog/tasks/task-18909 - Reduce-Console-screen-switch-mount-cost-1.55s-warm-on-fast-hardware.md
+++ b/backlog/tasks/task-18909 - Reduce-Console-screen-switch-mount-cost-1.55s-warm-on-fast-hardware.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-18909
 title: Reduce Console screen-switch mount cost (1.55s warm on fast hardware)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-19 16:31'
+updated_date: '2026-08-19 19:31'
 labels: []
 dependencies: []
 priority: high
@@ -20,12 +21,13 @@ Measured 2026-08-19 at dev f6ae7d23e (TASK-18908 spike): switching to the Consol
 - [x] #1 Profile of a warm Console switch exists with named top costs,Top deferrable compose-time work moved off the first paint (or documented why each cannot be),Warm Console switch re-measured and reported in the task,Latency guardrail budgets updated if the improvement moves baseline
 <!-- AC:END -->
 
-
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 - Profile (cProfile around a full warm navigation, dev `153a664ce`): the largest app-side cost was NOT screen composition but `build_console_settings_readiness` (~400 calls/switch) each rebuilding the supported + send-capable readiness frozensets by resolving provider identity for all 29 handler keys — 24,484 resolutions / 692k `normalize_provider_config_key` string ops per switch.
 - Fix: `functools.cache` on the no-injection path of `_supported_readiness_keys`/`_send_capable_readiness_keys` (pure functions of `CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS`); the `native_provider_keys` test-injection seam stays uncached. PR #1830.
 - Result: identity resolution absent from the profile, normalize calls −95%, wall 1.52s → 1.45s (~5%, honest small number).
 - "Why not more" (the AC's document-or-defer clause): after the fix, app code is ABSENT from the switch profile — the ~1.4s floor is Textual's mount/CSS/compositor machinery over a ~600-widget screen. The deferrable-work hypothesis was wrong: compose-time app work was already deferral-clean (July's task-15452 memo held). Reducing the floor further requires screen decomposition (splitting ChatScreen's widget tree or upstream Textual caching) — a deliberate architecture project, not a follow-up patch; no task filed because no measured app-side lever remains.
 - Guardrail budgets (PR #1827) unchanged: baseline moved ~5%, far inside the 10s budgets.
 - ADR: not required — a pure memoization change behind existing function signatures.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 from dataclasses import dataclass, replace
@@ -123,9 +124,7 @@ _REASONING_EFFORT_MODEL_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
 # "none" and "high" are live-verified on dotted Qwens: "none" is consumed
 # via our enable_thinking=false mapping, and the template aliases "high" to
 # "xhigh" — neither must warn as unconsumed.
-_QWEN_DOTTED_EFFORT_VALUES = frozenset(
-    {"low", "medium", "high", "xhigh", "none"}
-)
+_QWEN_DOTTED_EFFORT_VALUES = frozenset({"low", "medium", "high", "xhigh", "none"})
 # local-llm sends compose llama.cpp-family wire fields (chat_template_kwargs
 # reasoning/enable_thinking + reasoning_budget_tokens), so its users need the
 # --jinja/b9982 requirements note too.
@@ -808,6 +807,24 @@ def build_console_settings_readiness(
     )
 
 
+def _default_supported_readiness_keys() -> frozenset[str]:
+    """Return the no-injection supported set, computed once.
+
+    TASK-18909: ``build_console_settings_readiness`` runs ~400 times during
+    one warm Console screen switch, and this set is a pure function of a
+    module constant -- recomputing it resolved provider identity for all
+    29 handler keys on every call (24k resolutions, the largest app-side
+    cost of the switch). Cached at first use; ``_supported_readiness_keys``
+    retains the test-injection seam uncached.
+    """
+    return supported_console_provider_readiness_keys(
+        CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    )
+
+
+_default_supported_readiness_keys = functools.cache(_default_supported_readiness_keys)
+
+
 def _supported_readiness_keys(
     native_provider_keys: set[str] | None = None,
 ) -> frozenset[str]:
@@ -816,38 +833,36 @@ def _supported_readiness_keys(
     ``native_provider_keys`` is retained for older tests/callers that injected a
     support set before generic Console provider support existed.
     """
-    supported_keys = supported_console_provider_readiness_keys(
-        CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    if native_provider_keys is None:
+        return _default_supported_readiness_keys()
+    supported_keys = _default_supported_readiness_keys()
+    injected_keys = frozenset(
+        resolve_console_provider_identity(
+            provider,
+            handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+        ).readiness_key
+        for provider in native_provider_keys
     )
-    if native_provider_keys is not None:
-        injected_keys = frozenset(
-            resolve_console_provider_identity(
-                provider,
-                handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
-            ).readiness_key
-            for provider in native_provider_keys
-        )
-        return supported_keys | injected_keys
-    return supported_keys
+    return supported_keys | injected_keys
 
 
 def _send_capable_readiness_keys(
     native_provider_keys: set[str] | None = None,
 ) -> frozenset[str]:
     """Return readiness keys that currently have a wired Console send path."""
-    send_capable_keys = supported_console_provider_readiness_keys(
-        CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    if native_provider_keys is None:
+        # Same constant inputs as the supported set (see
+        # `_default_supported_readiness_keys`); one shared cache serves both.
+        return _default_supported_readiness_keys()
+    send_capable_keys = _default_supported_readiness_keys()
+    injected_keys = frozenset(
+        resolve_console_provider_identity(
+            provider,
+            handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+        ).readiness_key
+        for provider in native_provider_keys
     )
-    if native_provider_keys is not None:
-        injected_keys = frozenset(
-            resolve_console_provider_identity(
-                provider,
-                handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
-            ).readiness_key
-            for provider in native_provider_keys
-        )
-        return send_capable_keys | injected_keys
-    return send_capable_keys
+    return send_capable_keys | injected_keys
 
 
 def build_console_settings_summary_state(
@@ -910,9 +925,7 @@ def build_console_settings_summary_state(
                     f"reasoning_budget_tokens={wire_fields['reasoning_budget_tokens']}"
                 )
             if "reasoning_effort" in wire_fields:
-                wire_parts.append(
-                    f"reasoning_effort={wire_fields['reasoning_effort']}"
-                )
+                wire_parts.append(f"reasoning_effort={wire_fields['reasoning_effort']}")
             sampling_parts.append("wire: " + "; ".join(wire_parts))
 
     character_label = sanitize_character_display_label(


### PR DESCRIPTION
## Why

TASK-18909 profiled the warm Console screen switch (the structural residual of the Aug-2026 lag incident, filed with a 1.55s baseline). cProfile around the full navigation showed the largest **app-side** cost was not the screen itself but a hidden recomputation: `build_console_settings_readiness` runs ~400 times per switch (control-bar syncs, setup card, recovery actions), and **each call rebuilt two frozensets by resolving provider identity for all 29 handler keys — 24,484 resolutions driving 692k `normalize_provider_config_key` string operations** per switch.

## The fix

The sets are pure functions of the module constant `CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS` when no keys are injected. The no-injection path now serves a single `functools.cache`'d frozenset, shared by both `_supported_readiness_keys` and `_send_capable_readiness_keys` (they derive identical sets from the same constant). The `native_provider_keys` test-injection seam stays uncached — injected results are never served from the cache.

## Measured results

| Metric | Before | After |
|---|---|---|
| `resolve_console_provider_identity` calls/switch | 24,484 | **0** (absent from profile) |
| `normalize_provider_config_key` calls/switch | 691,973 | 35,877 (−95%) |
| Warm switch wall (M-series Mac, n≈6-9) | 1.52s | 1.45s (~5%) |

**Honest number on the wall clock**: the ~1.4s floor is Textual's own mount/CSS machinery over a ~600-widget screen — after this fix, app code is absent from the switch profile entirely (the only remaining app entry is 36k cheap string normalizations, 0.02s). On the constrained Windows hardware from the incident (3–5× multiplier), the eliminated CPU work is proportionally larger. Pushing the floor lower requires screen decomposition — documented in the task closeout as out of scope.

## Tests

- 3 new pins in `TestReadinessKeySetCaching`: cached-object identity, injected keys never served from cache, cached set equals a fresh derivation
- `Tests/Chat/test_console_session_settings.py`: 117/117
- Console suites (session settings + agent bridge + provider gateway): 565/565
- ruff + format clean

TASK-18909 closeout notes (profile numbers, why-not-more analysis) in the task file. Follow-up TASK-18910 (boot CSS rebuild) is next, separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches default Console readiness key sets to eliminate ~24k provider-identity resolves per warm screen switch (TASK-18909). Previously each switch recomputed supported/send-capable frozensets for all 29 handler keys; now the no-injection path returns one cached frozenset shared by both helpers. Injected-key paths remain uncached.

- Adds `_default_supported_readiness_keys()` wrapped with `functools.cache`; `_supported_readiness_keys()` and `_send_capable_readiness_keys()` return it when `native_provider_keys` is None, otherwise union with injected identities.
- Tests pin cached-object identity, injection bypass, and equality with a fresh derivation; all Console suites pass. Adds TASK-18909 closeout notes with profile results and rationale.
- Impact: identity resolves per switch drop to 0; string normalizations −95%; warm switch wall 1.52s → 1.45s (~5%).

<sup>Written for commit 95872c3127c12eb40073ec0fbc7cdac1246b31ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

