### PR TITLE
fix(serve): route --serve host/port/title/debug through the python -m entry (task-18908)

### DIFF
--- a/Tests/UI/test_serve_main_args.py
+++ b/Tests/UI/test_serve_main_args.py
@@ -1,0 +1,57 @@
+"""task-18908: `python -m tldw_chatbook.app --serve --port N` must route
+host/port/title/debug into run_web_server instead of ignoring them."""
+
+from unittest.mock import patch
+
+from tldw_chatbook.app import _build_arg_parser
+
+
+def test_serve_flags_parse_on_shared_parser():
+    # Both entry points share _build_arg_parser; serve flags must exist.
+    args = _build_arg_parser().parse_args(
+        ["--serve", "--port", "8765", "--host", "0.0.0.0"]
+    )
+    assert args.serve is True
+    assert args.port == 8765
+    assert args.host == "0.0.0.0"
+
+
+def test_main_module_routes_serve_args(monkeypatch):
+    """The __main__ serve branch must pass parsed args to run_web_server.
+
+    Runs the module's __main__ block via runpy with the serve flags; the
+    real run_web_server is patched so the test asserts the routing, not a
+    real bind. runpy with run_name="__main__" executes the whole module
+    (imports, early logging) the same way `python -m` does.
+    """
+    import runpy
+    import sys
+
+    captured = {}
+
+    def _fake_run_web_server(host=None, port=None, title=None, debug=None):
+        # Stands in for the whole serve loop; recording the routed kwargs
+        # IS the assertion surface (a real bind is covered by the live
+        # check in the task's AC).
+        captured.update(host=host, port=port, title=title, debug=debug)
+
+    def _fake_check():
+        return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Web_Server.serve.run_web_server", _fake_run_web_server
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Web_Server.serve.check_web_server_available", _fake_check
+    )
+    monkeypatch.setattr(sys, "argv", ["tldw-cli", "--serve", "--port", "8765"])
+
+    try:
+        runpy.run_module(
+            "tldw_chatbook.app", run_name="__main__", alter_sys=True
+        )
+    except SystemExit as exc:
+        # The serve branch exits 0 after the (patched) server returns.
+        assert exc.code in (0, None)
+
+    assert captured.get("port") == 8765, captured

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -12894,6 +12894,27 @@ if __name__ == "__main__":
     # SystemExit would print usage and then launch the TUI anyway.
     _main_args = _build_arg_parser().parse_args()
 
+    # task-18908: --serve historically only worked via the console-script
+    # entry; this __main__ path parsed the flags and then ignored them,
+    # silently binding the config default port. Route them exactly like
+    # main_cli_runner does.
+    if _main_args.serve:
+        from .Web_Server.serve import check_web_server_available, run_web_server
+
+        if not check_web_server_available():
+            loguru_logger.error("Web server feature is not available!")
+            loguru_logger.error("Install with: pip install tldw_chatbook[web]")
+            raise SystemExit(1)
+
+        loguru_logger.info("Starting tldw_chatbook in web server mode")
+        run_web_server(
+            host=_main_args.host,
+            port=_main_args.port,
+            title=_main_args.web_title,
+            debug=_main_args.debug,
+        )
+        raise SystemExit(0)
+
     # Create instance with early logging flag
     app_instance = TldwCli()
     app_instance._cli_focus_override = bool(_main_args.focus)


### PR DESCRIPTION
## Summary

`python -m tldw_chatbook.app --serve --port N` parsed the flags and then ignored them — the `__main__` block never routed them into `run_web_server`, so serve mode always bound the config default (8000). The `tldw-serve` console-script entrypoint was correct; only the `python -m` path was broken.

Found during live verification of focus mode (PR #1829), where the phone-over-`--serve` flow needs a stable custom port.

- The `__main__` serve branch now routes `--host/--port/--web-title/--debug` into `run_web_server`, exactly mirroring `main_cli_runner`'s branch; exits 0 when the server stops, 1 when textual-serve is missing.
- No ADR required: bug fix, mechanical, preserves existing boundaries.

## Test plan

- [x] New `Tests/UI/test_serve_main_args.py`: shared-parser serve flags parse; the `__main__` module (via runpy, `run_web_server` patched) routes `--port 8765` into the call.
- [x] Live: `--serve --port 8765` binds 8765 (HTTP 200; log shows `Starting web server at http://localhost:8765`).
- [x] Regression: `--help` exits 0, bad flags exit 2 on both entrypoints (unchanged by PR #1829's argparse work); `TestFocusCliAndConfig` still green.
- [ ] CI

Task: `backlog/tasks/task-18908 - Fix-serve-port-being-ignored-by-the-python-m-entry-point.md`

🤖 Generated with [ZCode](https://github.com/ZCode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `python -m tldw_chatbook.app --serve` ignoring `--host/--port/--web-title/--debug`. Previously it parsed these flags but always bound the default port (8000); now `__main__` passes them to `run_web_server`, matching the `tldw-serve` console entry. Exits 0 when the server stops, 1 when the web server feature is missing. Satisfies Linear task-18908 (serve must honor a custom port for the phone-over-serve flow).

- Adds routing in `tldw_chatbook/app.py`; no parser changes.
- Adds `Tests/UI/test_serve_main_args.py` to verify shared flag parsing and `__main__` routing via `runpy`.
- `--help` and invalid-flag exit codes are unchanged (0 and 2). No migration required.

<sup>Written for commit 61533414bdd8d21841b0f9c95640b69e95fcf088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

