### PR TITLE
fix(console): phone-width rail squeeze + visible hands-free toggle (task-18911 fixes 1-2)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -158,6 +158,8 @@ composer-level strip below shows once setup completes.
 | **Search Library** | Searches Library evidence before sending — see [Context & RAG](console/context-and-rag.md). |
 | **Save as Chatbook** (composer **Menu**) | Saves this run as a Chatbook — see [Artifacts](artifacts.md). |
 | **Help** | Opens the Console help panel (same as F1). |
+| **Speak replies** | Speaks new assistant replies in this conversation. |
+| **Hands-free** | Enters/exits the voice conversation loop (same as Ctrl+Shift+H) — the switch is the touch/soft-keyboard route into the mode. |
 
 ### Rails and handles
 

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -99,7 +99,10 @@ handle (or via the **Sources**/**Tools** chips) always works, at any width,
 and your stored open/closed preference is kept and restored at wider sizes;
 and below 84 columns the workspace switches to a single pane — both edge
 handles hide and the transcript takes the full width, so it stays usable
-even at 80x24 or 60x18.
+even at 80x24 or 60x18. An explicitly opened rail yields to this rule once
+the terminal cannot fit the rail plus a usable transcript (~70 columns for
+the Context rail, ~74 for the Inspector); the preference itself survives and
+the rail returns when the terminal widens again.
 
 ### Focus mode
 

--- a/Tests/Chat/test_console_rail_state.py
+++ b/Tests/Chat/test_console_rail_state.py
@@ -605,7 +605,7 @@ def test_console_rail_state_single_pane_below_84_columns():
     """TASK-2154.1 (LY-09): below 84 cols the workspace drops to one pane.
 
     TASK-2154.2 originally honored an explicitly opened rail even in
-    single-pane mode. task-18909 (2026-08-19 mobile audit) narrowed that:
+    single-pane mode. task-18911 (2026-08-19 mobile audit) narrowed that:
     below the width budget (single-pane floor + rail min-width) the collapse
     is a rendering override the explicit marker cannot buy past -- at 60
     cols an honored 30-col rail left a 14-col transcript. Above the budget
@@ -916,7 +916,7 @@ def test_build_console_rail_state_carries_section_flags():
     assert state.model_open is True
 
 
-# --- task-18909: width-budget rule (explicit toggles vs usable transcript) ---
+# --- task-18911: width-budget rule (explicit toggles vs usable transcript) ---
 
 
 def test_explicit_left_open_honored_when_width_affords_it():
@@ -933,7 +933,7 @@ def test_explicit_left_open_honored_when_width_affords_it():
 
 def test_explicit_left_open_collapsed_below_width_budget():
     """69 cols (inside the compact-collapse zone) with the explicit marker:
-    ADR-043 honored the open; task-18909 collapses it because 69 < 30+40 --
+    ADR-043 honored the open; task-18911 collapses it because 69 < 30+40 --
     rail + usable transcript does not fit. At 70+ the marker is honored
     again (the honored-at-budget test above pins that side)."""
     key = build_console_rail_preference_key(workspace_id="w", session_id="s")

--- a/Tests/Chat/test_console_rail_state.py
+++ b/Tests/Chat/test_console_rail_state.py
@@ -604,9 +604,12 @@ def test_console_rail_state_left_rail_not_collapsed_at_or_above_threshold():
 def test_console_rail_state_single_pane_below_84_columns():
     """TASK-2154.1 (LY-09): below 84 cols the workspace drops to one pane.
 
-    TASK-2154.2: the left force-collapse still applies to the never-toggled
-    default; an explicitly opened rail is honored even in single-pane mode
-    (handles stay hidden -- the rail's own collapse button is the way back).
+    TASK-2154.2 originally honored an explicitly opened rail even in
+    single-pane mode. task-18909 (2026-08-19 mobile audit) narrowed that:
+    below the width budget (single-pane floor + rail min-width) the collapse
+    is a rendering override the explicit marker cannot buy past -- at 60
+    cols an honored 30-col rail left a 14-col transcript. Above the budget
+    the marker is still honored (see the *_width_budget tests below).
     """
     key = build_console_rail_preference_key(
         workspace_id="workspace-1",
@@ -634,13 +637,13 @@ def test_console_rail_state_single_pane_below_84_columns():
     )
 
     assert explicit.single_pane is True
-    assert explicit.left_open is True
-    assert explicit.right_open is True
-    assert explicit.left_forced_collapsed is False
-    assert explicit.right_forced_collapsed is False
-    assert explicit.left_compact_override is True
-    assert explicit.right_compact_override is True
-    assert explicit.compact_override is True
+    assert explicit.left_open is False
+    assert explicit.right_open is False
+    assert explicit.left_forced_collapsed is True
+    assert explicit.right_forced_collapsed is True
+    assert explicit.left_compact_override is False
+    assert explicit.right_compact_override is False
+    assert explicit.compact_override is False
 
 
 def test_console_rail_state_no_responsive_overrides_without_width():
@@ -911,3 +914,72 @@ def test_build_console_rail_state_carries_section_flags():
     assert state.workspace_open is False
     assert state.conversations_open is True
     assert state.model_open is True
+
+
+# --- task-18909: width-budget rule (explicit toggles vs usable transcript) ---
+
+
+def test_explicit_left_open_honored_when_width_affords_it():
+    """30 + 40 = 70: exactly the left budget, explicit open is honored."""
+    key = build_console_rail_preference_key(workspace_id="w", session_id="s")
+    state = build_console_rail_state(
+        preference_key=key,
+        stored_preferences={"left_open": True, "left_open_explicit": True},
+        available_columns=70,
+    )
+    assert state.left_open is True
+    assert state.left_forced_collapsed is False
+
+
+def test_explicit_left_open_collapsed_below_width_budget():
+    """69 cols (inside the compact-collapse zone) with the explicit marker:
+    ADR-043 honored the open; task-18909 collapses it because 69 < 30+40 --
+    rail + usable transcript does not fit. At 70+ the marker is honored
+    again (the honored-at-budget test above pins that side)."""
+    key = build_console_rail_preference_key(workspace_id="w", session_id="s")
+    state = build_console_rail_state(
+        preference_key=key,
+        stored_preferences={"left_open": True, "left_open_explicit": True},
+        available_columns=69,
+    )
+    assert state.left_open is False
+    assert state.left_forced_collapsed is True
+    assert state.single_pane is True  # 69 < 84: single-pane floor applies too
+
+
+def test_explicit_right_open_collapsed_below_width_budget():
+    """73 cols: right rail open by explicit value, but 73 < 34+40 -- an
+    honored 34-col rail would leave a 39-col transcript."""
+    key = build_console_rail_preference_key(workspace_id="w", session_id="s")
+    state = build_console_rail_state(
+        preference_key=key,
+        stored_preferences={"right_open": True},
+        available_columns=73,
+    )
+    assert state.right_open is False
+    assert state.right_forced_collapsed is True
+
+
+def test_explicit_right_open_honored_at_budget():
+    key = build_console_rail_preference_key(workspace_id="w", session_id="s")
+    state = build_console_rail_state(
+        preference_key=key,
+        stored_preferences={"right_open": True},
+        available_columns=74,
+    )
+    assert state.right_open is True
+    assert state.right_forced_collapsed is False
+
+
+def test_phone_width_explicit_left_open_collapsed():
+    """The 2026-08-19 mobile-audit repro: phone width (48 cols) with the
+    explicit marker stored -- transcript must get the full width."""
+    key = build_console_rail_preference_key(workspace_id="w", session_id="s")
+    state = build_console_rail_state(
+        preference_key=key,
+        stored_preferences={"left_open": True, "left_open_explicit": True},
+        available_columns=48,
+    )
+    assert state.single_pane is True
+    assert state.left_open is False
+    assert state.left_forced_collapsed is True

--- a/Tests/UI/test_hands_free_toggle.py
+++ b/Tests/UI/test_hands_free_toggle.py
@@ -1,0 +1,40 @@
+"""Visible hands-free toggle (task-18911 fix 2).
+
+The Switch in the control bar's speech row is the soft-keyboard-only
+user's entry/exit for hands-free mode -- the mode was previously
+keybinding-only (ctrl+shift+h / escape).
+"""
+
+import pytest
+from textual.widgets import Switch
+
+from Tests.UI.app_factory import _build_test_app
+
+
+@pytest.mark.asyncio
+async def test_switch_renders_and_toggles_hands_free():
+    app = _build_test_app(configured_default="chat")
+    async with app.run_test(size=(120, 40)) as pilot:
+        for _ in range(200):
+            await pilot.pause(0.02)
+            if type(app.screen).__name__ == "ChatScreen":
+                break
+        await pilot.pause(0.5)
+        s = app.screen
+        sw = s.query_one("#console-hands-free-switch", Switch)
+        assert sw.value is False, "switch starts off when hands-free inactive"
+
+        sw.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.4)
+        # hands-free session should now be active (or at minimum the switch
+        # reflects the requested state)
+        assert sw.value is True, "switch flips on after activation"
+        active = s._console_hands_free is not None
+        assert active is True, "hands-free session started via switch"
+
+        # exit via the switch again
+        sw.focus()
+        await pilot.press("enter")
+        await pilot.pause(0.4)
+        assert s._console_hands_free is None, "hands-free session ended via switch"

--- a/backlog/decisions/043-console-rail-compact-collapse-yields-to-explicit-toggle.md
+++ b/backlog/decisions/043-console-rail-compact-collapse-yields-to-explicit-toggle.md
@@ -61,7 +61,7 @@ The rails detect "explicit" differently because their defaults differ. The right
 - [Persistent rails design spec](../../Docs/superpowers/specs/2026-05-24-console-persistent-rails-design.md)
 - Parent epic: backlog/tasks/task-2154; sibling: task-2154.1 (responsive fallback below ~100 cols)
 
-## Amendment (2026-08-19, task-18909 — width budget for honored explicit toggles)
+## Amendment (2026-08-19, task-18911 — width budget for honored explicit toggles)
 
 The 2026-08-19 mobile tappability audit found the explicit-toggle yield has
 no floor: with `left_open_explicit` stored, a 48-column phone viewport

--- a/backlog/decisions/043-console-rail-compact-collapse-yields-to-explicit-toggle.md
+++ b/backlog/decisions/043-console-rail-compact-collapse-yields-to-explicit-toggle.md
@@ -60,3 +60,27 @@ The rails detect "explicit" differently because their defaults differ. The right
 - [UX review findings LY-11/DS-06](../../Docs/superpowers/qa/console-ux-review-2026-08/console-ux-review.md)
 - [Persistent rails design spec](../../Docs/superpowers/specs/2026-05-24-console-persistent-rails-design.md)
 - Parent epic: backlog/tasks/task-2154; sibling: task-2154.1 (responsive fallback below ~100 cols)
+
+## Amendment (2026-08-19, task-18909 — width budget for honored explicit toggles)
+
+The 2026-08-19 mobile tappability audit found the explicit-toggle yield has
+no floor: with `left_open_explicit` stored, a 48-column phone viewport
+rendered the rail at its full 30-column minimum and squeezed the transcript
+to 14 columns — with both rail handles hidden in single-pane mode, the
+layout was effectively unusable.
+
+An explicit open is now honored only while the viewport can afford
+**rail minimum + a usable transcript floor (40 columns)**: left rail
+honored at ≥70 columns, right rail at ≥74 (`CONSOLE_RAIL_*_MIN_COLUMNS` +
+`CONSOLE_RAIL_MAIN_USABLE_COLUMNS` in `console_rail_state.py`). Below those
+budgets the compact-collapse is a rendering override the marker cannot buy
+past. The stored preference is still never rewritten — widening back past
+the budget restores the explicit rail unchanged.
+
+The floor is deliberately NOT the single-pane threshold (84): between the
+budget and 84+ columns a honored rail plus the waived-min transcript
+resolves fine (e.g. an explicit left rail at 90 columns leaves a 60-column
+transcript), so TASK-2154.2's behavior is preserved everywhere the layout
+actually works. Status chips opening the Inspector in single-pane mode
+(the designed narrow route) are unaffected: they act on live state, not the
+stored marker.

--- a/backlog/tasks/task-18911 - Mobile-tappability-audit-make-the-focused-Console-fully-usable-over-serve-on-a-phone.md
+++ b/backlog/tasks/task-18911 - Mobile-tappability-audit-make-the-focused-Console-fully-usable-over-serve-on-a-phone.md
@@ -1,0 +1,26 @@
+---
+id: TASK-18911
+title: >-
+  Mobile tappability audit: make the focused Console fully usable over --serve
+  on a phone
+status: To Do
+assignee: []
+created_date: '2026-08-19 22:50'
+labels:
+  - serve
+  - console
+  - mobile
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Focus mode (task-18812) made the Console chrome-free for phone use over --serve, but it is 'necessary but not sufficient' per ADR-071. This task is the sufficiency half: audit and fix the three spec items — (1) send/tool-approvals must be real tap targets, not key-only actions; (2) no hover-only information (hover reveals need tap equivalents); (3) soft-keyboard escape flows — the Console binds several Escape actions (exit hands-free, expand composer, focus composer) and phones have no Escape key, so critical flows need visible affordances. Scope: the three spec items plus whatever the first live phone-sized session over --serve surfaces; NOT a full mobile retrofit. Narrow-terminal CSS already handles layout (single pane <84 cols, footer width tiers).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Composer send is achievable purely by tap (button or equivalent),Tool approval/rejection flows are fully tappable,No information is reachable only via hover — every hover reveal has a tap path,Flows that depend on Escape (hands-free exit, composer expand, composer focus) have visible tap/keyboard alternatives on a phone,Verified live over --serve at a phone-sized viewport (e.g. 390x844),Focus-mode desktop behavior unchanged (existing test suites stay green)
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -40,6 +40,17 @@ CONSOLE_RAIL_LEFT_COMPACT_COLLAPSE_COLUMNS = 100
 # hide and the main column's min-width is waived so the transcript always
 # renders (covers the 80x24 and 60x18 review captures).
 CONSOLE_SINGLE_PANE_COLUMNS = 84
+#: task-18909: rail min-widths mirrored from ChatScreen's compose-time
+#: styles (left 30, right 34), plus the floor a transcript needs to stay
+#: usable. An explicitly-toggled-open rail is honored only while the
+#: viewport can afford rail + this floor; below that budget the rendering
+#: override wins no matter how the preference was set -- an honored rail at
+#: phone width squeezed the transcript to ~14 cols (2026-08-19 mobile
+#: audit). The floor is deliberately NOT the single-pane threshold: at
+#: 84+ cols a honored rail + waived-min transcript still resolves fine.
+CONSOLE_RAIL_LEFT_MIN_COLUMNS = 30
+CONSOLE_RAIL_RIGHT_MIN_COLUMNS = 34
+CONSOLE_RAIL_MAIN_USABLE_COLUMNS = 40
 #: Width band where the Console may automatically reveal Inspector when its
 #: standard-width readiness contract is satisfied. Exported so resize
 #: deduplication and the UI eligibility check share exact boundaries.
@@ -679,15 +690,32 @@ def build_console_rail_state(
     #   ``ChatScreen._set_console_rail_preference``) records it. Legacy
     #   payloads lack the marker and keep the force-collapse default.
     explicit_left_open = console_rail_left_open_explicit(stored_preferences)
+    # task-18909: an explicit toggle is honored only while the viewport can
+    # afford rail + a usable transcript (rail min + main floor). Below that
+    # budget the collapse is a rendering override the explicit marker
+    # cannot buy its way past -- the stored preference is untouched, so
+    # widening back past the budget restores the explicit rail.
+    left_width_budget = (
+        CONSOLE_RAIL_LEFT_MIN_COLUMNS + CONSOLE_RAIL_MAIN_USABLE_COLUMNS
+    )
+    right_width_budget = (
+        CONSOLE_RAIL_RIGHT_MIN_COLUMNS + CONSOLE_RAIL_MAIN_USABLE_COLUMNS
+    )
     right_forced_collapsed = (
         available_columns is not None
         and available_columns < CONSOLE_RAIL_RIGHT_COMPACT_COLLAPSE_COLUMNS
-        and not preferences.right_open
+        and (
+            not preferences.right_open
+            or available_columns < right_width_budget
+        )
     )
     left_forced_collapsed = (
         available_columns is not None
         and available_columns < CONSOLE_RAIL_LEFT_COMPACT_COLLAPSE_COLUMNS
-        and not explicit_left_open
+        and (
+            not explicit_left_open
+            or available_columns < left_width_budget
+        )
     )
     single_pane = (
         available_columns is not None

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -40,7 +40,7 @@ CONSOLE_RAIL_LEFT_COMPACT_COLLAPSE_COLUMNS = 100
 # hide and the main column's min-width is waived so the transcript always
 # renders (covers the 80x24 and 60x18 review captures).
 CONSOLE_SINGLE_PANE_COLUMNS = 84
-#: task-18909: rail min-widths mirrored from ChatScreen's compose-time
+#: task-18911: rail min-widths mirrored from ChatScreen's compose-time
 #: styles (left 30, right 34), plus the floor a transcript needs to stay
 #: usable. An explicitly-toggled-open rail is honored only while the
 #: viewport can afford rail + this floor; below that budget the rendering
@@ -690,7 +690,7 @@ def build_console_rail_state(
     #   ``ChatScreen._set_console_rail_preference``) records it. Legacy
     #   payloads lack the marker and keep the force-collapse default.
     explicit_left_open = console_rail_left_open_explicit(stored_preferences)
-    # task-18909: an explicit toggle is honored only while the viewport can
+    # task-18911: an explicit toggle is honored only while the viewport can
     # afford rail + a usable transcript (rail min + main floor). Below that
     # budget the collapse is a rendering override the explicit marker
     # cannot buy its way past -- the stored preference is untouched, so

--- a/tldw_chatbook/UI/Console_Modules/hands_free.py
+++ b/tldw_chatbook/UI/Console_Modules/hands_free.py
@@ -370,6 +370,24 @@ class ConsoleHandsFreeController:
         #: blocker`, the realtime engine's own loud-fallback check.
         self._console_hands_free_vad_degraded = False
 
+    def _sync_hands_free_switch(self, active: bool) -> None:
+        """Mirror hands-free session state onto the control bar's Switch.
+
+        task-18911 (fix 2): the Switch is the soft-keyboard-only user's
+        entry/exit for the mode; every session lifecycle change repaints it
+        so it never disagrees with reality. No-op when the control bar is
+        not mounted (pre-mount, mid-teardown).
+        """
+        try:
+            from ..Widgets.Console.console_control_bar import ConsoleControlBar
+
+            control_bar = self._screen.query_one(
+                "#console-control-bar", ConsoleControlBar
+            )
+        except Exception:
+            return
+        control_bar.sync_hands_free_state(active)
+
     @property
     def is_mounted(self) -> bool:
         """Whether the Console screen is currently mounted.
@@ -563,6 +581,7 @@ class ConsoleHandsFreeController:
         session = ConsoleHandsFreeSession(controller=controller, sequencer=sequencer)
         sequencer.on_drained = self._on_console_hands_free_sequencer_drained
         self._console_hands_free = session
+        self._sync_hands_free_switch(True)
         self._install_console_hands_free_store_tap()
         session.tick_timer = self.set_interval(0.1, self._tick_console_hands_free)
         controller.enter(capture_live=capture_live)
@@ -581,6 +600,7 @@ class ConsoleHandsFreeController:
         if session.tick_timer is not None:
             session.tick_timer.stop()
         self._console_hands_free = None
+        self._sync_hands_free_switch(False)
         composer = self._console_composer_or_none()
         if composer is not None:
             # Repaints over whatever hands-free's own `set_voice_status`

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -442,6 +442,7 @@ from ...Widgets.Console import (
     ConsoleWorkspaceContextTray,
 )
 from ...Widgets.Console.console_control_bar import (
+    ConsoleHandsFreeToggleRequested,
     ConsoleAutoSpeakChanged,
     ConsoleAutoSpeakRetryRequested,
     ConsoleAutoSpeakResumeRequested,
@@ -6731,6 +6732,17 @@ class ChatScreen(BaseAppScreen):
     # screen instance). See `hands_free.py`'s module docstring for the full
     # map of what moved and the two-engine boundary it draws.
     # ------------------------------------------------------------------
+
+    @on(ConsoleHandsFreeToggleRequested)
+    def on_console_hands_free_toggle_requested(
+        self, event: "ConsoleHandsFreeToggleRequested"
+    ) -> None:
+        """The visible Switch flipped (task-18911 fix 2): same path as the
+        keybinding. The switch is repainted by the session lifecycle sync,
+        not here -- entering can fail (e.g. mic unavailable), and the
+        control must reflect the session, not the wish."""
+        event.stop()
+        self._hands_free.action_toggle_console_hands_free()
 
     def action_toggle_console_hands_free(self) -> None:
         """`ctrl+shift+h`: enter the hands-free loop, or exit it if already

--- a/tldw_chatbook/Widgets/Console/console_control_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_control_bar.py
@@ -60,6 +60,18 @@ FALLBACK_ACTIONS = (
 )
 
 
+class ConsoleHandsFreeToggleRequested(Message):
+    """User flipped the visible hands-free Switch (task-18911 fix 2).
+
+    Emitted only for user gestures; programmatic ``sync_hands_free_state``
+    repaints silently so lifecycle sync never re-enters the toggle path.
+    """
+
+    def __init__(self, enabled: bool) -> None:
+        super().__init__()
+        self.enabled = enabled
+
+
 class ConsoleAutoSpeakChanged(Message):
     """User requested a durable Speak replies state change."""
 
@@ -284,6 +296,20 @@ class ConsoleControlBar(Vertical):
         resume = self.query_one("#console-auto-speak-resume", Button)
         resume.display = self.auto_speak_enabled and self.auto_speak_paused
 
+    def sync_hands_free_state(self, active: bool) -> None:
+        """Mirror the hands-free session state onto the visible Switch.
+
+        task-18911 (fix 2): called by ChatScreen whenever the session state
+        changes from any path (switch itself, keybinding, run end) so the
+        control never disagrees with reality. Silently no-ops pre-mount.
+        """
+        try:
+            switch = self.query_one("#console-hands-free-switch", Switch)
+        except Exception:
+            return
+        if switch.value is not active:
+            switch.value = active
+
     def compose(self) -> ComposeResult:
         with Horizontal(
             id="console-control-action-row", classes="console-control-action-row"
@@ -336,6 +362,36 @@ class ConsoleControlBar(Vertical):
                 auto_speak_switch.styles.padding = 0
                 auto_speak_switch.styles.border = ("none", "transparent")
                 yield auto_speak_switch
+            # task-18911 (fix 2): visible hands-free toggle. The mode was
+            # keybinding-only (ctrl+shift+h / escape), unreachable on a soft
+            # keyboard; this Switch mirrors the Speak-replies control beside it.
+            # ChatScreen keeps it in sync when the session exits by any path.
+            with Horizontal(id="console-hands-free-control") as hands_free_control:
+                hands_free_control.styles.width = "auto"
+                hands_free_control.styles.height = 1
+                hands_free_label = Static(
+                    "Hands-free",
+                    id="console-hands-free-label",
+                    markup=False,
+                )
+                hands_free_label.styles.width = "auto"
+                yield hands_free_label
+                hands_free_switch = Switch(
+                    False,
+                    name="Hands-free",
+                    id="console-hands-free-switch",
+                    tooltip=(
+                        "Voice conversation loop: speak prompts, hear replies "
+                        "(Ctrl+Shift+H)."
+                    ),
+                )
+                hands_free_switch.styles.width = "auto"
+                hands_free_switch.styles.height = 1
+                hands_free_switch.styles.min_height = 1
+                hands_free_switch.styles.max_height = 1
+                hands_free_switch.styles.padding = 0
+                hands_free_switch.styles.border = ("none", "transparent")
+                yield hands_free_switch
             retry = Button(
                 "Retry speech",
                 id="console-auto-speak-retry",
@@ -425,6 +481,12 @@ class ConsoleControlBar(Vertical):
             return
         event.stop()
         self.post_message(WorkbenchActionRequested(action_id))
+
+    @on(Switch.Changed, "#console-hands-free-switch")
+    def on_console_hands_free_switch_changed(self, event: Switch.Changed) -> None:
+        """Forward the gesture; the screen owns the hands-free session."""
+        event.stop()
+        self.post_message(ConsoleHandsFreeToggleRequested(event.value))
 
     @on(Switch.Changed, "#console-auto-speak")
     def on_console_auto_speak_changed(self, event: Switch.Changed) -> None:


### PR DESCRIPTION
## Summary

Two fixes from task-18911's mobile tappability audit (the phone-usability follow-up to focus mode, PR #1829).

**Fix 1 — phone-width rail squeeze (HIGH):** with `left_open_explicit` stored, a 48-column viewport rendered the Context rail at its 30-column minimum and squeezed the transcript to 14 columns — with both rail handles hidden in single-pane mode, the layout was effectively unusable. `build_console_rail_state` now honors an explicit rail open only while the viewport affords rail + a 40-column usable transcript (left ≥70 cols, right ≥74). Below the budget the compact-collapse override wins; the stored preference is untouched, so widening restores the explicit rail. The floor is deliberately *not* the single-pane threshold — an explicit rail at 90 columns still behaves exactly as TASK-2154.2 documented, and the status-chips-open path in single-pane mode is unaffected (it acts on live state, not the marker). Amends ADR-043 (amendment section added).

**Fix 2 — hands-free visible toggle (MED):** hands-free mode was keybinding-only (`ctrl+shift+h` in, `escape` out) — unreachable from a soft keyboard in either direction, the audit's sole no-Escape dead-end. The control bar's speech row (beside Speak replies) now carries a Hands-free `Switch` mirroring that control's pattern. The Switch is repainted by the session lifecycle, not the gesture handler — entering can fail (mic unavailable), and the control must reflect the session, not the wish. Keybindings unchanged.

Also: renumbered the mobile-audit task 18909→18911 (dev already had a 18909); rode along on this branch since its ID appears in the fixes' comments.

## Test plan

- [x] 5 new `test_console_rail_state.py` tests: budget boundaries both sides (left 69/70, right 73/74), phone-width collapse with marker present
- [x] Pinned 60-col single-pane test updated with rationale (explicit-open below budget now collapses)
- [x] New `Tests/UI/test_hands_free_toggle.py`: Switch renders, flipping starts/ends a real hands-free session
- [x] 145 passed across rail-state + hands-free + workbench-contract + inspector-compact-access suites
- [x] Live phone repro: transcript 14 → 44 columns at 48 cols with the explicit marker present
- [ ] CI

Task: `backlog/tasks/task-18911 - Mobile-tappability-audit-...md` (audit findings + both fixes documented)

🤖 Generated with [ZCode](https://github.com/ZCode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents phone-width rail squeeze and adds a visible hands‑free toggle per TASK‑18911. Old: explicit rail opens were honored at any width and hands‑free was keybinding‑only; new: explicit opens are honored only when width affords rail min + a 40‑col transcript (left ≥70, right ≥74), and a control‑bar `Switch` enters/exits hands‑free and mirrors session state; stored preferences and keybindings are unchanged.

- Console rails: `build_console_rail_state` now forces collapse when `available_columns` is below the budget (`CONSOLE_RAIL_LEFT_MIN_COLUMNS`/`CONSOLE_RAIL_RIGHT_MIN_COLUMNS` + `CONSOLE_RAIL_MAIN_USABLE_COLUMNS`); single‑pane threshold (84 cols) and chips‑open behavior are unchanged; preferences are never rewritten. ADR‑043 adds an amendment documenting the budget.
- UI wiring: `console_control_bar.py` adds a “Hands‑free” `Switch` and emits `ConsoleHandsFreeToggleRequested`; `chat_screen.py` handles the event via the existing toggle action; `hands_free.py` calls `sync_hands_free_state` to repaint the switch on session enter/teardown so it always reflects reality.
- Tests: boundary cases at 69/70 (left) and 73/74 (right) and a 48‑col phone repro in `Tests/Chat/test_console_rail_state.py`; a new UI test `Tests/UI/test_hands_free_toggle.py` asserts the switch renders and starts/ends a real session.
- Docs: `console.md` clarifies the width rule and documents the “Speak replies” and “Hands‑free” controls; backlog task and ADR updated.
- Migration/rollout: no migrations; verify at phone width and at budget edges. This satisfies TASK‑18911 acceptance criteria for a tappable hands‑free entry/exit and a usable transcript at phone widths.

<sup>Written for commit 482e8f2e51e589176095bf3e16effc8806205a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

