### PR TITLE
fix(console): re-key interrupt-bridge retained payloads by round with FIFO head (task-15661)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -117,7 +117,10 @@ scoped to the one run that raised it, so deciding one card never resolves or
 touches another's. Cancelling that sub-agent (see
 [Stopping & leaving](#stopping--leaving)) withdraws only its own still-pending
 cards; a sibling sub-agent's card, or the parent's, is left exactly as it
-was.
+was. Within one session, Console shows only one card at a time, oldest-armed
+first — a second round arming for the same session while another is still
+pending queues silently and mounts its own card only once the earlier round
+is decided.
 
 ### Interrupted provider tool runs — Resume, Take over, or Discard
 
@@ -1285,6 +1288,14 @@ advances to `· 5s` on the next poll
 live-walked in a terminal — the states and the elapsed are covered by that
 suite plus mutation testing; the rest of this page's content is unchanged
 from the prior stamp.*
+
+*The one-card-at-a-time-per-session sentence added @ HEAD — 2026-08-19
+(task-15661, PR0 parked-payload re-key: documentation-only for this page.
+A second same-session approval round used to evict the first's card from
+the pre-PR0 shared slot; the round-keyed FIFO map now leaves it mounted
+and queues the new round's card invisibly behind it until the head
+resolves. The rest of this page's content is unchanged from the prior
+stamp.)*
 
 *Headless-wake sections (auto-wake off-screen, wake at launch, headless
 approval, the kill switch) re-verified against dev @ 524194c15 —

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -584,7 +584,13 @@ Finally, rewrite `_remount_parked_skill_install`'s body to use the head:
 - [ ] **Step 4: Run the tests**
 
 Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py Tests/UI/test_skill_install_concurrent_confirms.py Tests/UI/test_console_skill_install_confirm.py -v`
-Expected: all PASS, including every pre-existing TASK-910 test.
+
+Expected: your new tests PASS and every pre-existing TASK-910 test PASSES, **except** these two, which already fail on `origin/dev` before any PR0 change and are NOT yours to fix:
+
+- `test_skill_install_concurrent_confirms.py::test_bare_shutdown_flag_alone_denies_a_real_session_round_within_one_poll_interval`
+- `test_skill_install_concurrent_confirms.py::test_shutdown_flag_alone_denies_both_unregistered_sessions_rounds_and_cleans_accounting`
+
+The baseline is exactly `2 failed, 26 passed` for `test_console_headless_approval.py` plus `test_skill_install_concurrent_confirms.py` together. A THIRD failure in that pair is a real regression. Do not "fix" the two known ones; if your change makes them pass, say so in your report rather than assuming it is unrelated luck.
 
 - [ ] **Step 5: Commit**
 

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -167,6 +167,13 @@ def test_the_queued_round_mounts_when_the_head_resolves(controller):
     assert _wait_until(lambda: len(_round_ids(controller)) == 2)
     round_2 = [r for r in _round_ids(controller) if r != round_1][0]
 
+    # Pre-condition: the head still owns the card. Without this, the test
+    # cannot tell FIFO promotion from the arm-time clobber it exists to
+    # catch -- round_2 would already be mounted and the post-assert below
+    # would pass for the wrong reason, on both sides of the fix.
+    time.sleep(0.1)
+    assert _mounted_round(controller) == round_1
+
     controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
     first.join(timeout=5)
 
@@ -197,7 +204,9 @@ def test_last_round_teardown_clears_the_card(controller):
 
 Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py -v`
 
-Expected: `test_arming_a_second_same_session_round_does_not_evict_the_first_card` FAILS — the second arm overwrites `_parked_approval_payloads[session_id]` and marshals its own payload, so `_mounted_round` is `round_2`. `test_the_queued_round_mounts_when_the_head_resolves` FAILS — nothing re-derives a head. `test_last_round_teardown_clears_the_card` may already PASS; that is expected and it guards against regressing the single-round case.
+Expected: BOTH `test_arming_a_second_same_session_round_does_not_evict_the_first_card` and `test_the_queued_round_mounts_when_the_head_resolves` FAIL, each on the assertion that the head still owns the card — the second arm overwrites `_parked_approval_payloads[session_id]` and marshals its own payload, so `_mounted_round` is `round_2`. `test_last_round_teardown_clears_the_card` may already PASS; that is expected and it guards against regressing the single-round case.
+
+A failure that is an import, fixture, or API error is NOT valid RED — fix the harness until each failure is a real assertion failure.
 
 - [ ] **Step 3: Commit the failing tests**
 

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -21,6 +21,7 @@
 - **Locate code by SYMBOL, never by line number.** This file changes fast; every `:NNNN` anchor in an earlier draft of this plan was stale within a day. Each step below names the enclosing method and quotes the code block to replace. Use `grep -n` on the quoted text.
 - This work is **task-15661**, already filed. It is cited in `remount_pending_approval_for_active_session`'s docstring and in the test that pins the defect. Do not open a new backlog task.
 - Branch from `origin/dev`. `origin/main` is over 10,000 commits behind and is not the trunk.
+- **Never read `tldw_chatbook/Chat/console_chat_controller.py` whole.** It is 12,482 lines / 608KB, and a single full read is large enough to kill an agent — it already killed one attempt at Task 2. Read it only in bounded windows (~120 lines) with explicit offset/limit, and locate sites with `grep -n` on the quoted code rather than by browsing.
 
 ---
 

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -390,6 +390,7 @@ Then in `_revoke_tool_approval_rounds`, replace the loop that pops the payload m
 ```
 
 The "is this the last armed round for the session" test existed only because the slot was shared. With per-round storage each revoked round drops exactly its own payload, so a still-armed sibling keeps its own.
+**Lock discipline — this bit the Task 2 implementer.** `self._approval_state_lock` is a plain non-reentrant `threading.Lock`, and `_unpark_round_payload` acquires it internally. The replacement loop must therefore sit OUTSIDE any enclosing `with self._approval_state_lock:` block. Placed inside one it self-deadlocks on every run cancellation. Check the indentation of the code you are replacing before you paste.
 
 - [ ] **Step 6: Re-key the three re-derive call sites**
 
@@ -758,7 +759,9 @@ The round registry keeps its own `_pending_skill_script_lock`; only the payload 
 
 Delete the whole `_clear_pending_skill_script_if_round_is_current` method — the third copy of the same order-dependent guard.
 
-In `_revoke_skill_script_rounds`, replace the conditional `self._parked_skill_script_payloads.pop(session_id, None)` and its "last armed for this session" guard with a per-round unpark, exactly as Task 2 Step 5 did for `_revoke_tool_approval_rounds`:
+In `_revoke_skill_script_rounds`, replace the conditional `self._parked_skill_script_payloads.pop(session_id, None)` and its "last armed for this session" guard with a per-round unpark, exactly as Task 2 Step 5 did for `_revoke_tool_approval_rounds`.
+
+**The same lock trap applies here.** `_unpark_round_payload` acquires the non-reentrant `_approval_state_lock` internally, so this loop must sit OUTSIDE any enclosing `with self._approval_state_lock:` block or it self-deadlocks on every run cancellation. Task 2's implementer hit exactly this and had to move the loop out of the lock:
 
 ```python
             for round_id_to_drop, session_id in revoked:

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -21,6 +21,7 @@
 - **Locate code by SYMBOL, never by line number.** This file changes fast; every `:NNNN` anchor in an earlier draft of this plan was stale within a day. Each step below names the enclosing method and quotes the code block to replace. Use `grep -n` on the quoted text.
 - This work is **task-15661**, already filed. It is cited in `remount_pending_approval_for_active_session`'s docstring and in the test that pins the defect. Do not open a new backlog task.
 - Branch from `origin/dev`. `origin/main` is over 10,000 commits behind and is not the trunk.
+- **Grep the WHOLE REPO for each map you re-key, not just the controller.** These maps are private but not local: a consumer outside `console_chat_controller.py` read `_parked_approval_payloads` by session key (`ChatScreen._current_park_round_ids`), and a second in-file caller of a deleted guard would have raised `AttributeError` on every cancellation. Before you finish a bridge, run `grep -rn "_parked_<bridge>_payloads" --include=*.py .` and account for every hit, production and test.
 - **Never read `tldw_chatbook/Chat/console_chat_controller.py` whole.** It is 12,482 lines / 608KB, and a single full read is large enough to kill an agent — it already killed one attempt at Task 2. Read it only in bounded windows (~120 lines) with explicit offset/limit, and locate sites with `grep -n` on the quoted code rather than by browsing.
 
 ---
@@ -600,7 +601,12 @@ Expected: your new tests PASS and every pre-existing TASK-910 test PASSES, **exc
 - `test_skill_install_concurrent_confirms.py::test_bare_shutdown_flag_alone_denies_a_real_session_round_within_one_poll_interval`
 - `test_skill_install_concurrent_confirms.py::test_shutdown_flag_alone_denies_both_unregistered_sessions_rounds_and_cleans_accounting`
 
-The baseline is exactly `2 failed, 26 passed` for `test_console_headless_approval.py` plus `test_skill_install_concurrent_confirms.py` together. A THIRD failure in that pair is a real regression. Do not "fix" the two known ones; if your change makes them pass, say so in your report rather than assuming it is unrelated luck.
+The baseline across the suites this plan touches is **4 known pre-existing failures**, all verified at the base commit in a detached worktree before any PR0 code change. The other two are in `Tests/UI/test_console_parallel_runs.py`:
+
+- `test_navigating_away_with_busy_fleet_confirms_and_records_teardown`
+- `test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coordinates`
+
+Any failure OUTSIDE these four is a real regression. Do not "fix" the two known ones; if your change makes them pass, say so in your report rather than assuming it is unrelated luck.
 
 - [ ] **Step 5: Commit**
 

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -18,6 +18,9 @@
 - FIFO head = oldest-armed round for the session. Python dicts preserve insertion order; do not add a separate ordering structure.
 - Insertion order is arm order only because every write goes through `_park_round_payload`. Never assign into these maps directly.
 - No behavior change is visible to users in this PR. Card content, timeouts, badges, and decisions are all unchanged for the single-round case.
+- **Locate code by SYMBOL, never by line number.** This file changes fast; every `:NNNN` anchor in an earlier draft of this plan was stale within a day. Each step below names the enclosing method and quotes the code block to replace. Use `grep -n` on the quoted text.
+- This work is **task-15661**, already filed. It is cited in `remount_pending_approval_for_active_session`'s docstring and in the test that pins the defect. Do not open a new backlog task.
+- Branch from `origin/dev`. `origin/main` is over 10,000 commits behind and is not the trunk.
 
 ---
 
@@ -208,7 +211,8 @@ git commit -m "test(console): pin same-session interrupt round clobbering (PR0)"
 ### Task 2: Shared park/head/unpark helpers and the approvals bridge
 
 **Files:**
-- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_approval_payloads` declaration (`:1594`), arming (`:4019`), teardown `finally` (`:4126-4137`), `_clear_pending_approval_if_round_is_current` (`:4187-4260`, deleted), re-derive call sites (`:3259`, `:3429`, `:3503`)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — the `_parked_approval_payloads` declaration; `request_mcp_approvals` (arming + teardown `finally`); `_clear_pending_approval_if_round_is_current` (deleted whole); `_revoke_tool_approval_rounds` (its pop); and FOUR re-derive sites: the three inline `self._parked_approval_payloads.get(...)` blocks in `new_session`, `switch_session`, and `close_session`, plus the public `remount_pending_approval_for_active_session`
+- Modify: `Tests/UI/test_console_headless_approval.py` — `test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts`
 - Test: `Tests/UI/test_console_parked_payload_rekey.py`
 
 **Interfaces:**
@@ -221,7 +225,7 @@ git commit -m "test(console): pin same-session interrupt round clobbering (PR0)"
 
 - [ ] **Step 1: Add the helpers**
 
-Add these four methods to `ConsoleChatController`, next to `_marshal_pending_approval` (`:4322`):
+Add these four methods to `ConsoleChatController`, immediately after the `_marshal_pending_approval` method:
 
 ```python
     # -- PR0: per-round retained payloads ------------------------------
@@ -305,7 +309,7 @@ Add these four methods to `ConsoleChatController`, next to `_marshal_pending_app
 
 - [ ] **Step 2: Re-key the declaration**
 
-Replace the `_parked_approval_payloads` declaration and its docstring (`:1585-1594`) with:
+Find the `self._parked_approval_payloads: dict[str, dict[str, Any]] = {}` assignment in `__init__` and replace it and its preceding `#:` comment block with:
 
 ```python
         #: PR0: retained payload per ROUND (was per session), keyed by
@@ -318,7 +322,7 @@ Replace the `_parked_approval_payloads` declaration and its docstring (`:1585-15
 
 - [ ] **Step 3: Re-key arming**
 
-In `request_mcp_approvals`, replace the retained-payload write (`:4017-4019`) and make the mount conditional on being the head. The `with self._approval_state_lock: self._parked_approval_payloads[session_id] = payload` block becomes:
+In `request_mcp_approvals`, find the retained-payload write — a `with self._approval_state_lock:` block whose body is `self._parked_approval_payloads[session_id] = payload` — and replace the whole block with:
 
 ```python
             is_head = self._park_round_payload(
@@ -326,7 +330,7 @@ In `request_mcp_approvals`, replace the retained-payload write (`:4017-4019`) an
             )
 ```
 
-Then change the mount branch (`:4022-4027`) from `self._marshal_pending_approval(payload)` to:
+Then, in the `try:` immediately below, change the `else:` arm that calls `self._marshal_pending_approval(payload)` to an `elif is_head:` arm:
 
 ```python
         try:
@@ -341,7 +345,7 @@ Then change the mount branch (`:4022-4027`) from `self._marshal_pending_approval
 
 - [ ] **Step 4: Re-key teardown**
 
-Replace the entire `finally` payload-pop block (`:4126-4137`, the `still_armed_same_session` computation and conditional pop) plus the `_clear_pending_approval_if_round_is_current` call with:
+In `request_mcp_approvals`' `finally`, replace everything from the `with self._approval_state_lock:` that pops `_pending_approval_rounds` through the `self._clear_pending_approval_if_round_is_current(round_id, session_id)` call — including the `still_armed_same_session` computation and its conditional `self._parked_approval_payloads.pop(session_id, None)` — with:
 
 ```python
             with self._approval_state_lock:
@@ -361,13 +365,24 @@ Replace the entire `finally` payload-pop block (`:4126-4137`, the `still_armed_s
                 )
 ```
 
-- [ ] **Step 5: Delete the superseded guard**
+- [ ] **Step 5: Delete the superseded guard and fix the revocation pop**
 
-Delete `_clear_pending_approval_if_round_is_current` entirely (`:4187` through the end of its body). Its two-part identity-plus-sibling check is subsumed by `_remount_head`.
+Delete the whole `_clear_pending_approval_if_round_is_current` method. Its two-part identity-plus-sibling check is subsumed by `_remount_head`.
+
+Then in `_revoke_tool_approval_rounds`, replace the loop that pops the payload map — the `for _round_id, session_id in revoked:` block containing `self._parked_approval_payloads.pop(session_id, None)` guarded by a `not any(... state.get("session_id") == session_id ...)` test — with a straight per-round unpark:
+
+```python
+            for round_id_to_drop, session_id in revoked:
+                self._unpark_round_payload(
+                    self._parked_approval_payloads, round_id_to_drop
+                )
+```
+
+The "is this the last armed round for the session" test existed only because the slot was shared. With per-round storage each revoked round drops exactly its own payload, so a still-armed sibling keeps its own.
 
 - [ ] **Step 6: Re-key the three re-derive call sites**
 
-At `:3259`, `:3429`, and `:3503`, replace each
+There are THREE inline sites, one each in `new_session`, `switch_session`, and `close_session`. Replace each
 
 ```python
             with self._approval_state_lock:
@@ -375,7 +390,7 @@ At `:3259`, `:3429`, and `:3503`, replace each
             self.set_pending_approval(parked_payload)
 ```
 
-with (adjusting the variable name to the local one at each site — `session.id` at `:3259`, `session_id` at `:3429`, `new_active_id` at `:3503`):
+with (the local variable differs per site: `session.id` in `new_session`, `session_id` in `switch_session`, `new_active_id` in `close_session`):
 
 ```python
             self.set_pending_approval(
@@ -385,21 +400,48 @@ with (adjusting the variable name to the local one at each site — `session.id`
 
 These three sites already run on the UI thread, so they call `_head_round_payload` directly rather than `_remount_head`.
 
+There is a FOURTH, public re-derive site: `remount_pending_approval_for_active_session`. Replace its `with self._approval_state_lock:` block (the one computing `still_armed` and then `payload`) with a head lookup, and delete the now-false "Known limitation" paragraph from its docstring:
+
+```python
+        payload = self._head_round_payload(
+            self._parked_approval_payloads, session_id
+        )
+        if payload is None:
+            return False
+        self.set_pending_approval(payload)
+        return True
+```
+
+The `still_armed` test is redundant now: a round's payload is unparked in its own teardown, so a payload present in the map belongs to a live round.
+
 - [ ] **Step 7: Run the new tests**
 
 Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py -v`
 Expected: all three PASS.
 
-- [ ] **Step 8: Run the existing approval suites for regressions**
+- [ ] **Step 8: Rewrite the test that pins the defect**
 
-Run: `.venv/bin/python -m pytest Tests/UI/test_console_mcp_approval.py Tests/UI/test_chat_task_cards_sync.py Tests/UI/test_console_parallel_runs.py -v`
-Expected: all PASS. Any failure here is a real regression — the pre-PR0 behavior these pin is what PR0 must preserve for the single-round case.
+`Tests/UI/test_console_headless_approval.py::test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts` deliberately asserts the BROKEN behaviour. Its own docstring says it is "pinned here so the limitation is a measured fact with a failing test the day someone fixes it, rather than folklore in a comment." Today is that day — this test MUST fail after Steps 2-6, and that failure is success.
 
-- [ ] **Step 9: Commit**
+Do not delete it: its `_detached_rig()` / `_leave()` harness covers the headless detached-attach path nothing else exercises. Rewrite it in place:
+
+- Rename it to `test_two_headless_rounds_each_mount_in_turn`.
+- Replace the docstring with a statement of the fixed contract, citing task-15661 as fixed rather than pinned.
+- Keep the setup verbatim through the `assert len(app.notifications) == 2` line — both rounds arming and both announcing is unchanged behaviour.
+- Replace the assertions that only one card can mount with: `remount_pending_approval_for_active_session()` mounts round A (the FIFO head, armed first); after round A resolves, a second call mounts round B.
+
+Also update `remount_pending_approval_for_active_session`'s docstring reference to this test name if it names it.
+
+- [ ] **Step 9: Run the existing approval suites for regressions**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_mcp_approval.py Tests/UI/test_chat_task_cards_sync.py Tests/UI/test_console_parallel_runs.py Tests/UI/test_console_headless_approval.py -v`
+Expected: all PASS, including the rewritten headless test. Any OTHER failure is a real regression — the pre-PR0 behaviour those pin is what PR0 must preserve for the single-round case.
+
+- [ ] **Step 10: Commit**
 
 ```bash
 git add tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_parked_payload_rekey.py
-git commit -m "fix(console): re-key approval retained payloads by round with FIFO head"
+git commit -m "fix(console): re-key approval retained payloads by round with FIFO head (task-15661)"
 ```
 
 ---
@@ -407,12 +449,12 @@ git commit -m "fix(console): re-key approval retained payloads by round with FIF
 ### Task 3: Skill-install bridge
 
 **Files:**
-- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_skill_install_payloads` (`:1620`), `request_skill_install_confirm` arming (`:5060`) and teardown (`:5077` onward), `_remount_parked_skill_install` (`:5187-5203`)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — the `_parked_skill_install_payloads` declaration; `request_skill_install_confirm` (arming + teardown `finally`); `_clear_pending_skill_install_if_round_is_current` (deleted whole); `_remount_parked_skill_install`
 - Test: `Tests/UI/test_console_parked_payload_rekey.py`
 
 **Interfaces:**
 - Consumes: `_park_round_payload`, `_head_round_payload`, `_unpark_round_payload`, `_remount_head` from Task 2.
-- Note: the skill-install payload built at `:5036-5041` already carries both `"request_id"` and `"session_id"`. The helpers key the STORE by round id (passed as an argument) and look up the head by the payload's `"session_id"`, so no production payload needs a new field.
+- Note: the skill-install payload built inside `request_skill_install_confirm` already carries both `"request_id"` and `"session_id"`. The helpers key the STORE by round id (passed as an argument) and look up the head by the payload's `"session_id"`, so no production payload needs a new field.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -475,7 +517,7 @@ Expected: FAIL — the second arm overwrites `_parked_skill_install_payloads[ses
 
 - [ ] **Step 3: Re-key declaration, arming, teardown, and re-derive**
 
-Replace the `_parked_skill_install_payloads` declaration comment at `:1616-1620` with:
+Find the `self._parked_skill_install_payloads: dict[str, dict[str, Any]] = {}` assignment in `__init__` and replace it and its preceding `#:` comment block with:
 
 ```python
         #: PR0: retained payload per ROUND (was per session), keyed by
@@ -484,7 +526,7 @@ Replace the `_parked_skill_install_payloads` declaration comment at `:1616-1620`
         self._parked_skill_install_payloads: dict[str, dict[str, Any]] = {}
 ```
 
-Replace the arming write at `:5058-5060`:
+In `request_skill_install_confirm`, replace the `with self._approval_state_lock:` block whose body is `self._parked_skill_install_payloads[session_id] = payload` with:
 
 ```python
             is_head = self._park_round_payload(
@@ -527,7 +569,9 @@ In the `finally`, delete the `still_armed_same_session` computation and its cond
 
 Note the round registry keeps its own `_pending_skill_install_lock`; only the payload map moves to the shared helpers under `_approval_state_lock`.
 
-Finally, rewrite `_remount_parked_skill_install` (`:5199-5203`) to use the head:
+Delete the whole `_clear_pending_skill_install_if_round_is_current` method — this bridge has its own copy of the same order-dependent guard, subsumed by `_remount_head` exactly as the approvals one was.
+
+Finally, rewrite `_remount_parked_skill_install`'s body to use the head:
 
 ```python
         if self.set_pending_skill_install is None:
@@ -554,7 +598,7 @@ git commit -m "fix(console): re-key skill-install retained payloads by round"
 ### Task 4: Skill-script bridge
 
 **Files:**
-- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_skill_script_payloads` (`:1645`), `request_skill_script_confirm` arming (`:5346-5366`) and its teardown `finally`, `_remount_parked_skill_script` (`:5480-5496`)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — the `_parked_skill_script_payloads` declaration; `request_skill_script_confirm` (arming + teardown `finally`); `_clear_pending_skill_script_if_round_is_current` (deleted whole); `_revoke_skill_script_rounds` (its pop); `_remount_parked_skill_script`
 - Test: `Tests/UI/test_console_parked_payload_rekey.py`
 
 **Interfaces:**
@@ -563,7 +607,7 @@ git commit -m "fix(console): re-key skill-install retained payloads by round"
   - `request_skill_script_confirm(self, payload: dict[str, Any], *, session_id: str | None = None) -> dict[str, bool]` — the first argument is a **dict**, not a string.
   - `resolve_pending_skill_script(self, allow: bool, remember: bool, request_id: str | None = None) -> None` — **three** parameters, and `request_id` is positional-or-keyword, not keyword-only.
   - `pending_skill_script_ids() -> list[str]` returns armed ids in insertion order.
-- The card payload is `card_payload` (a copy of the caller's dict plus `timeout_seconds`, `request_id`, `session_id`), built at `:5346-5349`. It already carries both ids the helpers need.
+- The card payload is `card_payload` (a copy of the caller's dict plus `timeout_seconds`, `request_id`, `session_id`). It already carries the ids the helpers need.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -632,7 +676,7 @@ Expected: FAIL — the second arm overwrites `_parked_skill_script_payloads[sess
 
 - [ ] **Step 3: Re-key the declaration**
 
-Replace the `_parked_skill_script_payloads` declaration comment at `:1642-1645` with:
+Find the `self._parked_skill_script_payloads: dict[str, dict[str, Any]] = {}` assignment in `__init__` and replace it and its preceding `#:` comment block with:
 
 ```python
         #: PR0: retained payload per ROUND (was per session), keyed by
@@ -643,7 +687,7 @@ Replace the `_parked_skill_script_payloads` declaration comment at `:1642-1645` 
 
 - [ ] **Step 4: Re-key arming**
 
-In `request_skill_script_confirm`, replace the retained-payload write (`:5359-5360`, the `with self._approval_state_lock: self._parked_skill_script_payloads[session_id] = card_payload` block) with:
+In `request_skill_script_confirm`, replace the `with self._approval_state_lock:` block whose body is `self._parked_skill_script_payloads[session_id] = card_payload` with:
 
 ```python
             is_head = self._park_round_payload(
@@ -688,9 +732,20 @@ In the same method's `finally`, delete the `still_armed_same_session` computatio
 
 The round registry keeps its own `_pending_skill_script_lock`; only the payload map moves to the shared helpers under `_approval_state_lock`.
 
-- [ ] **Step 6: Re-key the re-derive helper**
+- [ ] **Step 6: Delete the guard, fix the revocation pop, and re-key the re-derive helper**
 
-Replace the body of `_remount_parked_skill_script` (`:5492-5496`) with:
+Delete the whole `_clear_pending_skill_script_if_round_is_current` method — the third copy of the same order-dependent guard.
+
+In `_revoke_skill_script_rounds`, replace the conditional `self._parked_skill_script_payloads.pop(session_id, None)` and its "last armed for this session" guard with a per-round unpark, exactly as Task 2 Step 5 did for `_revoke_tool_approval_rounds`:
+
+```python
+            for round_id_to_drop, session_id in revoked:
+                self._unpark_round_payload(
+                    self._parked_skill_script_payloads, round_id_to_drop
+                )
+```
+
+Then replace the body of `_remount_parked_skill_script` with:
 
 ```python
         if self.set_pending_skill_script is None:
@@ -719,7 +774,7 @@ git commit -m "fix(console): re-key skill-script retained payloads by round"
 ### Task 5: Cross-bridge coverage and cleanup
 
 **Files:**
-- Modify: `tldw_chatbook/Chat/console_chat_controller.py:1646-1650` (orphaned comment)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (orphaned `#:` comment before the `run_state` property)
 - Test: `Tests/UI/test_console_parked_payload_rekey.py`
 
 **Interfaces:**
@@ -775,7 +830,7 @@ Expected: all PASS. If this one fails, a bridge is reading another bridge's map 
 
 - [ ] **Step 3: Delete the orphaned comment**
 
-`console_chat_controller.py:1646-1650` is a `#:` comment block describing "the currently-armed round's unique id" — a field that no longer exists; the next statement is the `run_state` property. Delete the comment block.
+In `__init__`, immediately before the `run_state` property, there is a dangling `#:` comment block describing "The currently-armed round's unique id" — it documents a field that no longer exists (the next statement is the `run_state` property, not an assignment). Locate it with `grep -n "currently-armed round's unique id"` and delete the comment block.
 
 - [ ] **Step 4: Run the full Console suite**
 
@@ -793,7 +848,10 @@ git commit -m "test(console): cross-bridge head independence; drop orphaned comm
 
 ## Done criteria
 
-- All three bridges key retained payloads by round id; no `_parked_*_payloads[session_id] = ...` write remains.
-- `_clear_pending_approval_if_round_is_current` is deleted.
+- All three bridges key retained payloads by round id. `grep -n "_parked_.*_payloads\[session_id\]"` returns nothing, and no `.pop(session_id` remains against any of the three maps.
+- All THREE order-dependent guards are deleted: `_clear_pending_approval_if_round_is_current`, `_clear_pending_skill_install_if_round_is_current`, `_clear_pending_skill_script_if_round_is_current`.
+- All FOUR approvals re-derive sites use the head, including the public `remount_pending_approval_for_active_session`, whose "Known limitation" docstring paragraph is gone.
+- Both revocation paths (`_revoke_tool_approval_rounds`, `_revoke_skill_script_rounds`) unpark per round.
+- `test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts` is rewritten to assert per-round mounting.
 - `Tests/UI/test_console_parked_payload_rekey.py` passes, and every pre-existing suite named in Tasks 2-4 still passes.
 - No user-visible change for the single-round case.

--- a/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
+++ b/Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md
@@ -1,0 +1,799 @@
+# Parked-Payload Re-Key (PR0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-key the three Console interrupt bridges' retained-payload maps from `session_id` to `round_id` with per-session FIFO, so concurrent same-session rounds stop clobbering each other.
+
+**Architecture:** All three bridges (MCP approvals, skill-install confirm, skill-script confirm) retain the payload their mounted card is re-derived from in a `dict[session_id, payload]` — one slot per session, last-armed-wins. Arming a second round for the same session overwrites the first's payload, so the first round's card vanishes and it hangs undecidable until its own timeout. This plan re-keys all three maps to `dict[round_id, payload]` and adds shared park/head/unpark helpers that pick the session's oldest-armed round as the mounted head. All three maps are already guarded by the single `_approval_state_lock`, so one helper set serves all three.
+
+**Tech Stack:** Python 3.11+, Textual 8.2.8, pytest, stdlib `threading` only. No new dependencies.
+
+**Spec:** `Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md` (§3 defect, §4 PR0)
+
+## Global Constraints
+
+- Run tests with the checked-out venv only: `.venv/bin/python -m pytest`. The venv is uv-managed and ships no `pip`.
+- All three retained-payload maps are guarded by `self._approval_state_lock`. Never introduce a second lock for them, and never hold that lock across a `call_from_thread`.
+- Any decision about what the mounted card should show MUST be computed on the UI thread, inside the callable passed to `call_from_thread` — never from a worker-thread snapshot. This is the invariant three prior fix rounds converged on.
+- FIFO head = oldest-armed round for the session. Python dicts preserve insertion order; do not add a separate ordering structure.
+- Insertion order is arm order only because every write goes through `_park_round_payload`. Never assign into these maps directly.
+- No behavior change is visible to users in this PR. Card content, timeouts, badges, and decisions are all unchanged for the single-round case.
+
+---
+
+### Task 1: Failing tests for the same-session defect
+
+**Files:**
+- Create: `Tests/UI/test_console_parked_payload_rekey.py`
+
+**Interfaces:**
+- Consumes: `ConsoleChatController.request_mcp_approvals(pending, *, session_id)`, `.resolve_pending_approval(decisions, *, round_id)`, `MCPPendingCall`.
+- Produces: the `FakeApp` / `_wait_until` / `_arm` harness that Tasks 3, 4, and 5 reuse.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""PR0: concurrent same-session interrupt rounds must not clobber each other.
+
+Mirrors ``Tests/UI/test_skill_install_concurrent_confirms.py`` (TASK-910) but
+targets the half that task left unfixed: the RETAINED PAYLOAD each bridge
+re-derives its mounted card from is keyed by ``session_id``, not ``round_id``,
+so arming a second round for the same session overwrites the first's payload.
+The code names this itself in ``request_mcp_approvals``' ``finally`` block:
+"per-round payload storage is a larger change out of scope here".
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class FakeApp:
+    """``call_from_thread`` stand-in: invokes the callback immediately."""
+
+    def call_from_thread(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+
+def _wait_until(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@pytest.fixture
+def controller():
+    """A controller with a fake UI wired and one ACTIVE session.
+
+    ``mounted`` records every payload the approval card was told to show,
+    including the ``None`` clears, so a test can assert on what the user
+    would actually be looking at after each transition.
+    """
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_approval = ctrl.mounted.append
+    ctrl.mcp_approval_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def _call(name):
+    return MCPPendingCall(
+        llm_name=name,
+        server_key="agent:builtin",
+        tool_name=name,
+        server_label="builtin",
+        arguments={},
+        reason="ask",
+    )
+
+
+def _arm(ctrl, name, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_mcp_approvals(
+            [_call(name)], session_id=session_id
+        )
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+def _round_ids(ctrl):
+    return list(ctrl._pending_approval_rounds)
+
+
+def _mounted_round(ctrl):
+    """The round id of the card currently shown, or None if cleared.
+
+    The approvals payload names its id `round_id`; both skill bridges name
+    theirs `request_id`. Every payload already carries one of the two, so
+    no production payload needs a duplicate field for this helper.
+    """
+    payload = ctrl.mounted[-1] if ctrl.mounted else None
+    if not payload:
+        return None
+    return payload.get("round_id") or payload.get("request_id")
+
+
+def test_arming_a_second_same_session_round_does_not_evict_the_first_card(
+    controller,
+):
+    """The head round keeps the card; a later sibling waits its turn."""
+    results = {}
+    first = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+    assert _wait_until(lambda: _mounted_round(controller) == round_1)
+
+    second = _arm(controller, "beta", controller.session_a, results, "beta")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 2)
+    time.sleep(0.1)  # let any errant mount land before asserting
+
+    assert _mounted_round(controller) == round_1, (
+        "arming a second same-session round must not evict the first's card"
+    )
+
+    for round_id in _round_ids(controller):
+        controller.resolve_pending_approval({"alpha": "approve_once", "beta": "approve_once"}, round_id=round_id)
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+
+def test_the_queued_round_mounts_when_the_head_resolves(controller):
+    """FIFO: resolving the head promotes the next same-session round."""
+    results = {}
+    first = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+
+    second = _arm(controller, "beta", controller.session_a, results, "beta")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 2)
+    round_2 = [r for r in _round_ids(controller) if r != round_1][0]
+
+    controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
+    first.join(timeout=5)
+
+    assert _wait_until(lambda: _mounted_round(controller) == round_2), (
+        "the queued round must mount once the head resolves"
+    )
+
+    controller.resolve_pending_approval({"beta": "approve_once"}, round_id=round_2)
+    second.join(timeout=5)
+
+
+def test_last_round_teardown_clears_the_card(controller):
+    """With no rounds left for the session, the card clears."""
+    results = {}
+    only = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+
+    controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
+    only.join(timeout=5)
+
+    assert _wait_until(lambda: _mounted_round(controller) is None), (
+        "the card must clear once the session has no armed rounds left"
+    )
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py -v`
+
+Expected: `test_arming_a_second_same_session_round_does_not_evict_the_first_card` FAILS — the second arm overwrites `_parked_approval_payloads[session_id]` and marshals its own payload, so `_mounted_round` is `round_2`. `test_the_queued_round_mounts_when_the_head_resolves` FAILS — nothing re-derives a head. `test_last_round_teardown_clears_the_card` may already PASS; that is expected and it guards against regressing the single-round case.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add Tests/UI/test_console_parked_payload_rekey.py
+git commit -m "test(console): pin same-session interrupt round clobbering (PR0)"
+```
+
+---
+
+### Task 2: Shared park/head/unpark helpers and the approvals bridge
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_approval_payloads` declaration (`:1594`), arming (`:4019`), teardown `finally` (`:4126-4137`), `_clear_pending_approval_if_round_is_current` (`:4187-4260`, deleted), re-derive call sites (`:3259`, `:3429`, `:3503`)
+- Test: `Tests/UI/test_console_parked_payload_rekey.py`
+
+**Interfaces:**
+- Produces, for Tasks 3 and 4:
+  - `_park_round_payload(self, store: dict[str, dict], round_id: str, payload: dict) -> bool` — stores the payload and returns whether this round is now its session's head.
+  - `_head_round_payload(self, store: dict[str, dict], session_id: str) -> dict | None` — the session's oldest-armed retained payload.
+  - `_unpark_round_payload(self, store: dict[str, dict], round_id: str) -> None`
+  - `_remount_head(self, store: dict[str, dict], setter, session_id: str) -> None` — worker-thread-safe UI re-derive.
+  - Every payload dict MUST carry both `"round_id"` and `"session_id"` keys.
+
+- [ ] **Step 1: Add the helpers**
+
+Add these four methods to `ConsoleChatController`, next to `_marshal_pending_approval` (`:4322`):
+
+```python
+    # -- PR0: per-round retained payloads ------------------------------
+    #
+    # All three bridges' retained-payload maps are keyed by ROUND id and
+    # guarded by `_approval_state_lock`. The mounted card is always the
+    # session's FIFO HEAD -- its oldest-armed round. Dict insertion order
+    # is arm order, which is why every write goes through
+    # `_park_round_payload` and nothing assigns into these maps directly.
+    #
+    # This replaces the pre-PR0 single-slot-per-session maps, whose
+    # last-armed-wins semantics let a second same-session round overwrite
+    # the first's payload and strand it until timeout.
+
+    @staticmethod
+    def _head_round_payload_locked(
+        store: dict[str, dict[str, Any]], session_id: str
+    ) -> dict[str, Any] | None:
+        """The session's oldest-armed payload. Caller holds the lock."""
+        for payload in store.values():
+            if payload.get("session_id") == session_id:
+                return payload
+        return None
+
+    def _park_round_payload(
+        self, store: dict[str, dict[str, Any]], round_id: str, payload: dict[str, Any]
+    ) -> bool:
+        """Retain ``payload``; return whether it is now its session's head.
+
+        A round that is NOT the head must not mount -- an older sibling is
+        still holding the card.
+        """
+        session_id = payload.get("session_id")
+        with self._approval_state_lock:
+            store[round_id] = payload
+            head = self._head_round_payload_locked(store, session_id)
+        return head is payload
+
+    def _head_round_payload(
+        self, store: dict[str, dict[str, Any]], session_id: str
+    ) -> dict[str, Any] | None:
+        """The payload whose card ``session_id`` should currently show."""
+        with self._approval_state_lock:
+            return self._head_round_payload_locked(store, session_id)
+
+    def _unpark_round_payload(
+        self, store: dict[str, dict[str, Any]], round_id: str
+    ) -> None:
+        """Drop one round's retained payload. Idempotent."""
+        with self._approval_state_lock:
+            store.pop(round_id, None)
+
+    def _remount_head(
+        self,
+        store: dict[str, dict[str, Any]],
+        setter: Callable[[dict[str, Any] | None], None] | None,
+        session_id: str | None,
+    ) -> None:
+        """WORKER THREAD: enqueue a head re-derive onto the UI thread.
+
+        Replaces the pre-PR0 two-part TOCTOU guard. That guard existed
+        because CLEARING the card was order-dependent -- whether to clear
+        depended on which sibling resolved first, and a worker-thread
+        snapshot of that answer could be stale by the time the UI thread
+        ran it. Re-deriving the head is order-INDEPENDENT: it is a pure
+        function of current state. The race-proofing principle is
+        unchanged -- the decision still runs inside the callable on the UI
+        thread, never from a snapshot -- but the decision itself is now one
+        lookup instead of an identity check plus a sibling check.
+        """
+        if self.app is None or setter is None or session_id is None:
+            return
+
+        def _apply() -> None:
+            if session_id != (self.store.active_session_id or ""):
+                return
+            setter(self._head_round_payload(store, session_id))
+
+        self.app.call_from_thread(_apply)
+```
+
+- [ ] **Step 2: Re-key the declaration**
+
+Replace the `_parked_approval_payloads` declaration and its docstring (`:1585-1594`) with:
+
+```python
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `round_id`. `switch_session` and every teardown re-derive the
+        #: mounted card from this map's FIFO head for the session, so a
+        #: second same-session round no longer evicts an older sibling's
+        #: card. Every payload carries its own `round_id` and `session_id`.
+        self._parked_approval_payloads: dict[str, dict[str, Any]] = {}
+```
+
+- [ ] **Step 3: Re-key arming**
+
+In `request_mcp_approvals`, replace the retained-payload write (`:4017-4019`) and make the mount conditional on being the head. The `with self._approval_state_lock: self._parked_approval_payloads[session_id] = payload` block becomes:
+
+```python
+            is_head = self._park_round_payload(
+                self._parked_approval_payloads, round_id, payload
+            )
+```
+
+Then change the mount branch (`:4022-4027`) from `self._marshal_pending_approval(payload)` to:
+
+```python
+        try:
+            if is_parked:
+                if self.app is not None and self.park_pending_approval is not None:
+                    self.app.call_from_thread(self.park_pending_approval, session_id)
+            elif is_head:
+                self._marshal_pending_approval(payload)
+```
+
+`is_head` is `False` for the legacy `session_id is None` callers, which never park and never queue; keep their existing unconditional mount by initialising `is_head = True` before the `if session_id is not None:` block.
+
+- [ ] **Step 4: Re-key teardown**
+
+Replace the entire `finally` payload-pop block (`:4126-4137`, the `still_armed_same_session` computation and conditional pop) plus the `_clear_pending_approval_if_round_is_current` call with:
+
+```python
+            with self._approval_state_lock:
+                self._pending_approval_rounds.pop(round_id, None)
+            self._unpark_round_payload(self._parked_approval_payloads, round_id)
+            if session_id is not None:
+                self.discard_pending_round(session_id, round_id)
+            try:
+                self._remount_head(
+                    self._parked_approval_payloads,
+                    self.set_pending_approval,
+                    session_id,
+                )
+            except Exception:  # noqa: BLE001 -- suppress teardown-time errors
+                logger.opt(exception=True).debug(
+                    "Failed to marshal approval remount during teardown"
+                )
+```
+
+- [ ] **Step 5: Delete the superseded guard**
+
+Delete `_clear_pending_approval_if_round_is_current` entirely (`:4187` through the end of its body). Its two-part identity-plus-sibling check is subsumed by `_remount_head`.
+
+- [ ] **Step 6: Re-key the three re-derive call sites**
+
+At `:3259`, `:3429`, and `:3503`, replace each
+
+```python
+            with self._approval_state_lock:
+                parked_payload = self._parked_approval_payloads.get(session_id)
+            self.set_pending_approval(parked_payload)
+```
+
+with (adjusting the variable name to the local one at each site — `session.id` at `:3259`, `session_id` at `:3429`, `new_active_id` at `:3503`):
+
+```python
+            self.set_pending_approval(
+                self._head_round_payload(self._parked_approval_payloads, session_id)
+            )
+```
+
+These three sites already run on the UI thread, so they call `_head_round_payload` directly rather than `_remount_head`.
+
+- [ ] **Step 7: Run the new tests**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py -v`
+Expected: all three PASS.
+
+- [ ] **Step 8: Run the existing approval suites for regressions**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_mcp_approval.py Tests/UI/test_chat_task_cards_sync.py Tests/UI/test_console_parallel_runs.py -v`
+Expected: all PASS. Any failure here is a real regression — the pre-PR0 behavior these pin is what PR0 must preserve for the single-round case.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_parked_payload_rekey.py
+git commit -m "fix(console): re-key approval retained payloads by round with FIFO head"
+```
+
+---
+
+### Task 3: Skill-install bridge
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_skill_install_payloads` (`:1620`), `request_skill_install_confirm` arming (`:5060`) and teardown (`:5077` onward), `_remount_parked_skill_install` (`:5187-5203`)
+- Test: `Tests/UI/test_console_parked_payload_rekey.py`
+
+**Interfaces:**
+- Consumes: `_park_round_payload`, `_head_round_payload`, `_unpark_round_payload`, `_remount_head` from Task 2.
+- Note: the skill-install payload built at `:5036-5041` already carries both `"request_id"` and `"session_id"`. The helpers key the STORE by round id (passed as an argument) and look up the head by the payload's `"session_id"`, so no production payload needs a new field.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/UI/test_console_parked_payload_rekey.py`:
+
+```python
+def _arm_install(ctrl, url, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_skill_install_confirm(url, session_id=session_id)
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.fixture
+def install_controller():
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_skill_install = ctrl.mounted.append
+    ctrl.skill_install_confirm_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def test_install_second_same_session_round_does_not_evict_the_first(
+    install_controller,
+):
+    ctrl = install_controller
+    results = {}
+    first = _arm_install(ctrl, "https://x/one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 1)
+    round_1 = ctrl.pending_skill_install_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_1)
+
+    second = _arm_install(ctrl, "https://x/two", ctrl.session_a, results, "two")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 2)
+    time.sleep(0.1)
+
+    assert _mounted_round(ctrl) == round_1, (
+        "a second same-session install confirm must not evict the first's card"
+    )
+
+    ctrl.resolve_pending_skill_install(True, request_id=round_1)
+    first.join(timeout=5)
+    round_2 = ctrl.pending_skill_install_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_2)
+
+    ctrl.resolve_pending_skill_install(True, request_id=round_2)
+    second.join(timeout=5)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py::test_install_second_same_session_round_does_not_evict_the_first -v`
+Expected: FAIL — the second arm overwrites `_parked_skill_install_payloads[session_id]` and marshals its own payload.
+
+- [ ] **Step 3: Re-key declaration, arming, teardown, and re-derive**
+
+Replace the `_parked_skill_install_payloads` declaration comment at `:1616-1620` with:
+
+```python
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `request_id`. The mounted card is the session's FIFO head, so a
+        #: second same-session confirm no longer evicts an older sibling.
+        self._parked_skill_install_payloads: dict[str, dict[str, Any]] = {}
+```
+
+Replace the arming write at `:5058-5060`:
+
+```python
+            is_head = self._park_round_payload(
+                self._parked_skill_install_payloads, request_id, payload
+            )
+```
+
+and make the mount conditional, exactly as Task 2 Step 3 did:
+
+```python
+        try:
+            if is_parked:
+                if self.app is not None and self.park_pending_approval is not None:
+                    self.app.call_from_thread(self.park_pending_approval, session_id)
+            elif is_head:
+                self._marshal_pending_skill_install(payload)
+```
+
+In the `finally`, delete the `still_armed_same_session` computation and its conditional pop, and replace with:
+
+```python
+            with self._pending_skill_install_lock:
+                self._pending_skill_install_rounds.pop(request_id, None)
+            self._unpark_round_payload(
+                self._parked_skill_install_payloads, request_id
+            )
+            if session_id is not None:
+                self.discard_pending_round(session_id, request_id)
+            try:
+                self._remount_head(
+                    self._parked_skill_install_payloads,
+                    self.set_pending_skill_install,
+                    session_id,
+                )
+            except Exception:  # noqa: BLE001 -- suppress teardown-time errors
+                logger.opt(exception=True).debug(
+                    "Failed to marshal skill-install remount during teardown"
+                )
+```
+
+Note the round registry keeps its own `_pending_skill_install_lock`; only the payload map moves to the shared helpers under `_approval_state_lock`.
+
+Finally, rewrite `_remount_parked_skill_install` (`:5199-5203`) to use the head:
+
+```python
+        if self.set_pending_skill_install is None:
+            return
+        self.set_pending_skill_install(
+            self._head_round_payload(self._parked_skill_install_payloads, session_id)
+        )
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py Tests/UI/test_skill_install_concurrent_confirms.py Tests/UI/test_console_skill_install_confirm.py -v`
+Expected: all PASS, including every pre-existing TASK-910 test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_parked_payload_rekey.py
+git commit -m "fix(console): re-key skill-install retained payloads by round"
+```
+
+---
+
+### Task 4: Skill-script bridge
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_parked_skill_script_payloads` (`:1645`), `request_skill_script_confirm` arming (`:5346-5366`) and its teardown `finally`, `_remount_parked_skill_script` (`:5480-5496`)
+- Test: `Tests/UI/test_console_parked_payload_rekey.py`
+
+**Interfaces:**
+- Consumes: `_park_round_payload`, `_head_round_payload`, `_unpark_round_payload`, `_remount_head` from Task 2.
+- Exact API for this bridge, verified against the source — it differs from skill-install in two ways that will break a copy-paste:
+  - `request_skill_script_confirm(self, payload: dict[str, Any], *, session_id: str | None = None) -> dict[str, bool]` — the first argument is a **dict**, not a string.
+  - `resolve_pending_skill_script(self, allow: bool, remember: bool, request_id: str | None = None) -> None` — **three** parameters, and `request_id` is positional-or-keyword, not keyword-only.
+  - `pending_skill_script_ids() -> list[str]` returns armed ids in insertion order.
+- The card payload is `card_payload` (a copy of the caller's dict plus `timeout_seconds`, `request_id`, `session_id`), built at `:5346-5349`. It already carries both ids the helpers need.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Tests/UI/test_console_parked_payload_rekey.py`:
+
+```python
+def _arm_script(ctrl, script, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_skill_script_confirm(
+            {"skill": "demo", "script": script}, session_id=session_id
+        )
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.fixture
+def script_controller():
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_skill_script = ctrl.mounted.append
+    ctrl.skill_script_confirm_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def test_script_second_same_session_round_does_not_evict_the_first(
+    script_controller,
+):
+    ctrl = script_controller
+    results = {}
+    first = _arm_script(ctrl, "echo one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_script_ids()) == 1)
+    round_1 = ctrl.pending_skill_script_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_1)
+
+    second = _arm_script(ctrl, "echo two", ctrl.session_a, results, "two")
+    assert _wait_until(lambda: len(ctrl.pending_skill_script_ids()) == 2)
+    time.sleep(0.1)
+
+    assert _mounted_round(ctrl) == round_1, (
+        "a second same-session script confirm must not evict the first's card"
+    )
+
+    # resolve_pending_skill_script takes (allow, remember, request_id).
+    ctrl.resolve_pending_skill_script(True, False, round_1)
+    first.join(timeout=5)
+
+    round_2 = ctrl.pending_skill_script_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_2), (
+        "the queued script confirm must mount once the head resolves"
+    )
+
+    ctrl.resolve_pending_skill_script(True, False, round_2)
+    second.join(timeout=5)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py::test_script_second_same_session_round_does_not_evict_the_first -v`
+Expected: FAIL — the second arm overwrites `_parked_skill_script_payloads[session_id]` and marshals its own `card_payload`, so `_mounted_round` is `round_2`.
+
+- [ ] **Step 3: Re-key the declaration**
+
+Replace the `_parked_skill_script_payloads` declaration comment at `:1642-1645` with:
+
+```python
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `request_id`. The mounted card is the session's FIFO head, so a
+        #: second same-session confirm no longer evicts an older sibling.
+        self._parked_skill_script_payloads: dict[str, dict[str, Any]] = {}
+```
+
+- [ ] **Step 4: Re-key arming**
+
+In `request_skill_script_confirm`, replace the retained-payload write (`:5359-5360`, the `with self._approval_state_lock: self._parked_skill_script_payloads[session_id] = card_payload` block) with:
+
+```python
+            is_head = self._park_round_payload(
+                self._parked_skill_script_payloads, request_id, card_payload
+            )
+```
+
+Initialise `is_head = True` immediately before the enclosing `if session_id is not None:` block, so the legacy no-session callers keep their unconditional mount. Then make the mount conditional:
+
+```python
+        try:
+            if is_parked:
+                if self.app is not None and self.park_pending_approval is not None:
+                    self.app.call_from_thread(self.park_pending_approval, session_id)
+            elif is_head:
+                self._marshal_pending_skill_script(card_payload)
+```
+
+- [ ] **Step 5: Re-key teardown**
+
+In the same method's `finally`, delete the `still_armed_same_session` computation and its conditional pop of `_parked_skill_script_payloads`, leaving:
+
+```python
+            with self._pending_skill_script_lock:
+                self._pending_skill_script_rounds.pop(request_id, None)
+            self._unpark_round_payload(
+                self._parked_skill_script_payloads, request_id
+            )
+            if session_id is not None:
+                self.discard_pending_round(session_id, request_id)
+            try:
+                self._remount_head(
+                    self._parked_skill_script_payloads,
+                    self.set_pending_skill_script,
+                    session_id,
+                )
+            except Exception:  # noqa: BLE001 -- suppress teardown-time errors
+                logger.opt(exception=True).debug(
+                    "Failed to marshal skill-script remount during teardown"
+                )
+```
+
+The round registry keeps its own `_pending_skill_script_lock`; only the payload map moves to the shared helpers under `_approval_state_lock`.
+
+- [ ] **Step 6: Re-key the re-derive helper**
+
+Replace the body of `_remount_parked_skill_script` (`:5492-5496`) with:
+
+```python
+        if self.set_pending_skill_script is None:
+            return
+        self.set_pending_skill_script(
+            self._head_round_payload(self._parked_skill_script_payloads, session_id)
+        )
+```
+
+It already runs on the UI thread, so it calls `_head_round_payload` directly rather than `_remount_head`.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py Tests/Chat/test_skill_script_concurrent_confirms.py -v`
+Expected: all PASS, including every pre-existing task-581 test.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_parked_payload_rekey.py
+git commit -m "fix(console): re-key skill-script retained payloads by round"
+```
+
+---
+
+### Task 5: Cross-bridge coverage and cleanup
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py:1646-1650` (orphaned comment)
+- Test: `Tests/UI/test_console_parked_payload_rekey.py`
+
+**Interfaces:**
+- Consumes: every fixture and helper from Tasks 1, 3, and 4.
+
+- [ ] **Step 1: Write the cross-bridge test**
+
+Append to `Tests/UI/test_console_parked_payload_rekey.py`:
+
+```python
+def test_bridges_do_not_share_a_head(controller):
+    """Each bridge keeps its own FIFO head for the same session.
+
+    An approval round and a skill-install round armed for one session are
+    independent surfaces -- neither may evict or promote the other.
+    """
+    ctrl = controller
+    approvals_mounted = ctrl.mounted
+    install_mounted = []
+    ctrl.set_pending_skill_install = install_mounted.append
+    ctrl.skill_install_confirm_timeout_seconds = lambda: 30.0
+
+    results = {}
+    approval = _arm(ctrl, "alpha", ctrl.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(ctrl)) == 1)
+    approval_round = _round_ids(ctrl)[0]
+
+    install = _arm_install(ctrl, "https://x/one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 1)
+    install_round = ctrl.pending_skill_install_ids()[0]
+
+    # The approvals payload names its id `round_id`; the install payload
+    # names its own `request_id`. Neither bridge renames the other's.
+    assert approvals_mounted[-1]["round_id"] == approval_round
+    assert install_mounted[-1]["request_id"] == install_round
+
+    ctrl.resolve_pending_approval({"alpha": "approve_once"}, round_id=approval_round)
+    approval.join(timeout=5)
+
+    assert _wait_until(lambda: approvals_mounted[-1] is None)
+    assert install_mounted[-1] is not None, (
+        "resolving an approval round must not clear the install card"
+    )
+
+    ctrl.resolve_pending_skill_install(True, request_id=install_round)
+    install.join(timeout=5)
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `.venv/bin/python -m pytest Tests/UI/test_console_parked_payload_rekey.py -v`
+Expected: all PASS. If this one fails, a bridge is reading another bridge's map — check the store argument at each `_park_round_payload` / `_remount_head` call site.
+
+- [ ] **Step 3: Delete the orphaned comment**
+
+`console_chat_controller.py:1646-1650` is a `#:` comment block describing "the currently-armed round's unique id" — a field that no longer exists; the next statement is the `run_state` property. Delete the comment block.
+
+- [ ] **Step 4: Run the full Console suite**
+
+Run: `.venv/bin/python -m pytest Tests/UI/ Tests/Chat/ -q`
+Expected: no new failures versus the pre-PR0 baseline. Record the baseline first on a clean checkout if you do not already have it — this repo carries known pre-existing failures, and a plain "N failed" number is not evidence by itself.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_parked_payload_rekey.py
+git commit -m "test(console): cross-bridge head independence; drop orphaned comment"
+```
+
+---
+
+## Done criteria
+
+- All three bridges key retained payloads by round id; no `_parked_*_payloads[session_id] = ...` write remains.
+- `_clear_pending_approval_if_round_is_current` is deleted.
+- `Tests/UI/test_console_parked_payload_rekey.py` passes, and every pre-existing suite named in Tasks 2-4 still passes.
+- No user-visible change for the single-round case.

--- a/Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md
+++ b/Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md
@@ -1,0 +1,368 @@
+# Console user-interaction and support features — program design
+
+Date: 2026-08-19
+Status: design approved; sub-project A specified, sub-project C requires its own design pass
+Related: ADR-032 (local agent tool permission boundary), TASK-13216, TASK-910, task-581
+
+## 1. Problem
+
+The Console agent runtime can act but cannot *ask*. An agent that hits a genuine
+fork — which provider, which file, which of three interpretations of an ambiguous
+request — has no way to put that question to the user. It must guess, or stop and
+emit prose the user may not be watching for.
+
+Separately, the agent can already track a task list, but the user effectively
+cannot see it: the list renders as a plain-text block appended to the transcript
+on every mutation, which scrolls away within a few turns.
+
+This program adds the agent↔user interaction surface the Console lacks, and
+unifies the four ad-hoc "agent needs you" cards that grew up around approvals.
+
+## 2. Ground truth — what already exists
+
+Roughly half of this is built. Establishing that first, because the naive reading
+of the request ("build a question tool and a task list") duplicates working code.
+
+### Task list — backend complete, no UI
+
+- `Agents/session_todo_store.py` — `SessionTodoStore`: stable IDs, compare-and-swap
+  versioning, 50-item cap, one-`in_progress` invariant, snapshot export/import.
+- `Agents/local_tool_provider.py` registers `todo_create` / `todo_update` /
+  `todo_get` / `todo_list`, governed by ADR-032. `todo_write` was replaced in
+  TASK-13216.
+- The only UI is `format_todo_marker` (`Chat/console_agent_bridge.py:733`) —
+  a display-only `☰ Tasks (n in progress):` block appended to the transcript.
+  Not interactive, not pinned, not re-derived after restart.
+- Per TASK-13216 AC#6, session-scoped-not-durable is a deliberate decision, not
+  an oversight. This program does not change it.
+
+### Agent asks the user — nothing, but the round-trip machinery exists
+
+There is no ask/elicitation seam. There is a complete blocking round-trip:
+
+- `ConsoleChatController.request_mcp_approvals` (`console_chat_controller.py:3810`)
+  is **owner-agnostic** despite its name — MCP tools and built-in agent tools
+  (`server_key="agent:builtin"`) both ride it.
+- Worker thread blocks → `call_from_thread` pushes into
+  `TaskResumeState.pending_approval` → `ChatTaskCards.sync_state` →
+  `ChatApprovalCard.set_batch` → `ApprovalDecided` → `resolve_pending_approval`
+  releases the thread.
+- With round-ID bookkeeping, park-if-background-session, fleet badge + toast,
+  1s deadline polling, and cancel-revocation.
+
+### Bounds that constrain any design here
+
+- `RunBudget.max_tool_call_seconds = 300.0` (`Agents/agent_models.py`) caps a
+  single tool call. Exceeding it means the wrapper reports "timed out" for a call
+  still live on an abandoned thread.
+- MCP approval timeout defaults to 120s, polled at `_MCP_APPROVAL_POLL_SECONDS = 1.0`.
+- `ChatApprovalCard` must stay synchronous end-to-end — `sync_state` cannot `await`.
+
+### Attention and progress — nothing
+
+No bell, no `notify`, no desktop notification anywhere in the app. The only
+attention affordance is the Console rail badge (`"1 appr"`), visible only on the
+Console with the rail open. Live progress amounts to one `"Working."` string in
+`console_status_chips.py:581`; step markers land only after a step completes.
+
+## 3. The defect this program inherits
+
+`_parked_approval_payloads` is keyed by **`session_id`**, not `round_id`
+(`console_chat_controller.py:4019`). The round *registry* is round-keyed and
+tracks siblings independently, but the retained payload — the sole source
+`switch_session` re-derives the mounted card from — is one slot per session with
+last-armed-wins semantics.
+
+Consequence: two same-session rounds mean the second overwrites the first. The
+first round's card vanishes and it hangs undecidable until its own timeout fails
+it closed.
+
+A two-part TOCTOU guard sits on top of this invariant
+(`console_chat_controller.py:4187-4247`), accumulated over three fix rounds — the
+original Qodo TOCTOU, then a fix-round-3 stranded-card regression from dropping
+the older-sibling check. That guard prevents a resolving round from *clearing* a
+sibling's card. It does not give an older sibling a turn on screen.
+
+**The same shape exists three times.** `_parked_skill_install_payloads`
+(`:1620`) and the skill-script equivalent are also session-keyed, each with its
+own re-derive path. TASK-910 and task-581 already converted the *event
+registries* of those two bridges from single global slots to per-round
+registries, for exactly this reason — but left the payload/mount half unfixed.
+
+So the re-key is a twice-landed pattern applied to the half that was skipped, not
+novel risk. `Tests/UI/test_skill_install_concurrent_confirms.py` already contains
+the same-session concurrency tests to mirror, along with a reusable
+`FakeApp`/`_wait_until` harness.
+
+## 4. Program decomposition
+
+| # | Sub-project | Delivers |
+|---|---|---|
+| **PR0** | Parked-payload re-key | Round-keyed retained payloads with per-session FIFO across all three bridges and their re-derive paths. Pure defect fix, no user-visible change. |
+
+**PR0 is three parallel edits, not one abstraction.** Each bridge owns an
+independent lock — `_approval_state_lock` (`:1331`),
+`_pending_skill_install_lock` (`:1613`), `_pending_skill_script_lock` (`:1641`) —
+so the re-key cannot share a critical section across them. Each bridge has its
+own retained-payload map (`:4019`, `:1620`, `:1645`) and its own three re-derive
+call sites (`:3265`/`:3440`/`:3509` for install, `:3266`/`:3441`/`:3510` for
+script, and the approvals equivalents). The edit is the same shape three times
+under three separate locks; attempting to unify the locking is a different and
+much riskier change that belongs to C, if anywhere.
+| **C** | Unified interrupt surface | One host and one card model for approvals, skill-install, skill-script, resume, and questions. |
+| **A** | `ask_user` | The tool, the question card as C's first renderer, typed-answer interception. |
+| **B** | Persistent task list | A pinned surface over the existing `SessionTodoStore`. |
+| **D** | Attention when away | Bell / notification / cross-screen badge when a run blocks on the user. |
+| **E** | Live progress | What the agent is doing now, elapsed time, visible cancel during long tool calls. |
+
+**Order: PR0 → C → A → B → D → E.**
+
+C moved ahead of A on evidence (§6): both reference implementations converged on
+a single unified interrupt surface rather than per-kind bespoke cards. Building
+A's card as the fifth bespoke card and rewriting it in C is waste.
+
+**C is not designed yet.** It was sequenced third when A was brainstormed, and
+moving it forward means it needs its own design cycle before implementation. A's
+design below is written against a card host that C must define.
+
+## 5. Sub-project A — `ask_user`
+
+### 5.1 Tool contract
+
+Registered in `Agents/local_tool_provider.py` beside `todo_*`, conditional on the
+controller supplying an ask callback. Absent in headless runs; absent from the
+MCP Hub. Same ADR-032 posture the `todo_*` tools hold.
+
+```
+ask_user(questions: [
+  { question: str,        # <= 500 chars
+    header: str,          # <= 12 chars, the UI chip
+    multiSelect: bool,
+    options: [ {label: str <= 100, description: str <= 300} ]   # 2-4
+  }
+])  # 1-4 questions
+
+-> {"answered": true,
+    "answers": [{"question": ..., "selected": [...], "other_text": str|null,
+                 "unanswered": bool}]}
+-> {"answered": false, "reason": "timeout" | "cancelled" | "busy"}
+```
+
+"Other" free-text is injected by the card, never declared in the schema — the
+model cannot suppress the user's escape hatch. Validation matches
+`SessionTodoStore` strictness: strict types, UTF-8, no blanks, control characters
+flattened for render. The payload is model-controlled text going straight to a
+renderer.
+
+**Depth 1, fail fast.** One live question round per session. A second `ask_user`
+— from a sibling fleet child or a second call in the same model turn — returns
+`{"answered": false, "reason": "busy"}` immediately. Depth is expressed by
+batching up to four questions into one call, not by queueing calls. This matches
+both reference implementations (§6) and avoids blocking a worker thread for the
+full budget only to report that nothing was ever shown.
+
+Approval and skill-confirm rounds do **not** fail fast — an agent cannot proceed
+without them, so they use PR0's FIFO. Only questions bounce.
+
+**A bounce must not become a retry loop.** A model that receives `busy` and
+immediately retries burns turns against `max_model_turns` (30) with no progress.
+The `busy` result therefore carries explicit instruction not to retry — proceed
+without the answer, or ask again in a later turn — and the run counts consecutive
+bounces, degrading to a hard refusal after the second so a determined retry loop
+terminates rather than consuming the turn budget.
+
+**Gating.** `[tools] ask_user_enabled`, **default ON**. This is a deliberate
+deviation from the repo convention that gates default off, and from Codex, which
+ships its equivalent experimental and off by default. The argument: every other
+gate defaults off because the tool touches user data, disk, or network.
+`ask_user` touches only the user's attention, and a tool whose entire purpose is
+to initiate contact cannot be discovered while invisible. Claude Code ships its
+equivalent always-on. As a `LocalToolSpec` rather than a `_GATEABLE_BUILTINS`
+row, it needs a hand-added entry in `all_tool_gates()` — the `web_deep_search`
+precedent.
+
+**Restraint guidance is part of the deliverable.** A model handed a new tool
+uses it; because the gate defaults ON, every user gets whatever the default
+behavior is. Both reference implementations spend most of their tool description
+on *when not to ask* — reserving it for decisions genuinely the user's to make,
+not for choices with a conventional default or facts discoverable from the code.
+This text ships as the tool description and is registered in the internal-prompts
+registry alongside the other agent prompts, not hardcoded at the call site.
+
+**Permission gate: exempt.** No `risk_tags`, never floored to `ask`. Raising an
+approval card to ask whether the agent may ask a question delivers two
+interruptions for one question.
+
+**Sub-agents may ask.** Any agent in the fleet can call `ask_user`; the card
+attributes the question to the asking agent. `run_context.current_run_id()` is
+already available inside local tool handlers; mapping a run id to a child's
+display label goes through the fleet coordinator.
+
+### 5.2 Round plumbing
+
+Extract the round lifecycle currently inlined in `request_mcp_approvals` — mint
+round id, register, mount-or-park, `event.wait(1.0)` to deadline, resolve, tear
+down — into a shared `_run_pending_round(...)`. `request_mcp_approvals` keeps its
+name and behavior; `request_user_questions(questions, *, session_id)` is a
+sibling calling the same helper with a different payload and resolver.
+
+- `_pending_approval_rounds` entries gain `kind: "approval" | "question"`. The
+  map name stays, for the same reason `request_mcp_approvals` keeps its legacy
+  name; renaming belongs to C.
+- `TaskResumeState` gains `pending_question`, routed to the question renderer.
+- Budget: **240s from request**, one deadline covering everything, under the 300s
+  ceiling with slack for 1s poll granularity and marshalling. Semantics are
+  *auto-continue*, matching Claude Code's naming: on expiry the agent proceeds
+  with `answered: false` rather than failing the run.
+- Because the ceiling is hard, we cannot offer Claude Code's `never` option. A
+  question that must not expire is not expressible here.
+
+### 5.3 Card and interaction
+
+Rendered through C's host. Built on Textual's own `RadioSet` / `SelectionList`
+per `multiSelect` rather than hand-rolled selection state, and synchronous
+end-to-end, reusing `ChatApprovalCard`'s collision-safe remount pattern.
+(Verified against the pinned Textual 8.2.8: `RadioSet`, `RadioButton`,
+`SelectionList`, `Checkbox`, and `Input` are all available.)
+
+Per question: header chip, question text, options with descriptions, and an
+always-present "Other" `Input`.
+
+- **Live countdown.** The card renders remaining time, as Codex does
+  (`auto-resolves in ...`). A silent deadline is user-hostile: a card waiting for
+  you looks identical to one about to expire.
+- **Partial submission allowed.** Unanswered questions submit as
+  `unanswered: true` rather than blocking the submit button. Both reference
+  implementations permit this; Codex renders `Submit with N unanswered`.
+- **No focus stealing.** The approvals chip exposes an explicit
+  `Enter -> review_approval` action to focus its card, which means these cards
+  deliberately do not grab focus. A question card that auto-focused would eat
+  keystrokes from a user mid-sentence. The chip must therefore also cover
+  question rounds so keyboard-only users can reach the card.
+- **Height must be bounded.** The approval card is `height: auto` at any row
+  count (`css/tldw_cli_modular.tcss:9433`, `:9448`) in a non-scrolling region
+  above the transcript, with live-repro'd `fr-inside-flex` ballooning scars at
+  `:9408` and `:9466`. Approval batches are small, so it never bit. Four
+  questions with four described options each plus four "Other" inputs is 30-40
+  rows and would consume the transcript. This card needs an explicit
+  `max-height` and internal `overflow-y: auto` — discipline no sibling card has —
+  and a geometry test alongside the existing
+  `test_batch_row_widgets_have_nonzero_geometry_and_do_not_overlap_under_bundled_css`.
+- **Esc is already bound.** `Binding("escape", "focus_console_composer_home")`
+  (`UI/Screens/chat_screen.py:1782`) already returns focus to the composer. No
+  new binding.
+
+### 5.4 Typed-answer interception
+
+The composer stays usable while a question card is up — matching approvals, which
+do not block sends (`_console_send_blocked_reason`, `chat_screen.py:17141`, gates
+only on empty RAG launches, readiness, and attachments). Locking the composer
+would be new, divergent behavior, and this codebase already carries a scar from
+an accidental composer lockout (`chat_screen.py:14294`).
+
+Instead: if the active session has a **mounted** question round, a send resolves
+that round — returning any selections already made plus the typed text — and
+appends the message to the transcript so the exchange reads naturally. It is not
+also dispatched as a user turn. Only a mounted card intercepts; a bounced or
+background round never touches the composer.
+
+Two cases the interception must handle explicitly:
+
+- **Slash commands are never swallowed.** Console has a command grammar and
+  popup surface; a command dispatches normally and leaves the round pending.
+- **Staged context refuses interception.** If attachments or staged RAG evidence
+  are present when the user sends, the send dispatches as a normal user turn and
+  the question round stays pending. Carrying staged context into a tool result is
+  meaningless, and silently discarding it would destroy work the user staged
+  deliberately. The user answers the question via the card.
+
+### 5.5 Edges
+
+| Case | Result |
+|---|---|
+| Deadline expires while mounted | `{"answered": false, "reason": "timeout"}` — auto-continue |
+| Second concurrent ask | `{"answered": false, "reason": "busy"}`, returned immediately |
+| Run cancelled / revoked | `{"answered": false, "reason": "cancelled"}`. Note `_revoke_run_approvals` stamps `"deny"` per name today; a question round needs its own resolution, not a verdict string |
+| Session switch | Card re-derives from PR0's round-keyed payload map |
+| App restart with question pending | Round is in-memory and lost, as approvals are today. The transcript marker is written **on resolve only**, so a question pending at kill time leaves nothing in scrollback |
+
+The resolve marker follows `format_todo_marker`'s conventions
+(`console_agent_bridge.py:733`): display-only, appended in-memory with
+`persist=False`, rendered markup-off, embedded newlines and terminal controls
+flattened, each line truncated. One header line naming the asking agent, then one
+line per question with its answer — or `(unanswered)`, `(timed out)`,
+`(cancelled)` as applicable.
+| Headless run | Tool never registered — no UI callback. Matches Codex, which refuses `request_user_input` in exec mode outright |
+
+### 5.6 Phasing
+
+1. **PR0** — re-key, all three bridges, mirroring the existing concurrency suite.
+2. **C** — unified interrupt surface (needs its own design first).
+3. **A.1** — tool, schema, gating, round plumbing.
+4. **A.2** — question card on C's host: countdown, partial submit, bounded height.
+5. **A.3** — typed-answer interception.
+
+## 6. Reference implementations
+
+Established by string analysis of the shipped `claude` and `codex` binaries on
+this machine. Strong evidence for feature existence and UI copy; weaker for exact
+control flow.
+
+|  | Claude Code | Codex |
+|---|---|---|
+| Tool | `AskUserQuestion`, 1-4 questions per call | `experimental_request_user_input`, config-gated under `[tools]` in `ConfigToml` |
+| Placement | inline in transcript flow | bottom pane — `tui/src/bottom_pane/request_user_input/{mod,render}.rs` |
+| Timeout | `askUserQuestionTimeout`, a policy/settings value labelled "Question auto-continue timeout", with a `never` option | live `auto-resolves in ...` countdown |
+| Partial answers | — | `Submit with N unanswered`, per-field `Answer required` |
+| Navigation | — | `<-/-> to navigate fields`, `ctrl+p / ctrl+n change field`, `Question X/Y`, `option X/Y`, `esc to cancel`, `to interrupt` |
+| Concurrency | — | single bottom-pane view host (`bottom_pane/mod.rs`); `mcp_server_elicitation.rs` and `request_user_input/` share that one slot |
+| Headless | — | refused: "request_user_input is not supported in exec mode for thread" |
+| Unified surface | — | one `tui/src/app/background_requests.rs` serves exec approval, file-change approval, permissions approval, MCP elicitation, and request_user_input |
+
+Conclusions drawn: neither system holds a deep queue (both use one display slot
+plus multi-question batching); timeout semantics are auto-continue, not failure;
+a visible countdown and partial submission are both established practice; and
+both converged on a unified interrupt surface, which is why C moved ahead of A.
+
+Where we knowingly diverge: our card sits in a top banner, which neither
+reference does, because in this codebase that slot already exists with working
+mount, sync, park, and visibility plumbing.
+
+## 7. Testing
+
+1. **Mirror `Tests/UI/test_skill_install_concurrent_confirms.py`** for PR0 across
+   all three bridges, reusing its `FakeApp`/`_wait_until` harness.
+2. Concurrent same-session rounds in every pairing — approval+approval,
+   approval+question, install+script — each decidable in FIFO order, none
+   stranded.
+3. Schema-bound validation at `SessionTodoStore` strictness.
+4. Every resolution path: answered, partial, timeout, busy, cancelled.
+5. Typed-answer interception resolves the round, does not double-send, and does
+   not swallow slash commands.
+6. Card geometry under bundled CSS: bounded height, internal scroll, no overlap
+   at four questions with four options each.
+7. Headless: tool absent from the catalog.
+8. A repeated `ask_user` against a live round bounces, and a persistent retry
+   loop terminates at the bounce ceiling rather than draining `max_model_turns`.
+9. PR0 regression coverage runs per bridge, under each bridge's own lock — a
+   passing approvals suite is not evidence for skill-install or skill-script.
+
+## 8. Decisions log
+
+| Decision | Choice | Note |
+|---|---|---|
+| Program scope | Full interaction family, five sub-projects | |
+| Tool shape | Full AskUserQuestion parity, minus `preview` | |
+| Placement | Existing `ChatTaskCards` slot | Diverges from both references |
+| Composer | Stays usable; typing answers the mounted question | Approvals do not lock the composer either |
+| Sub-agents | May ask | With depth-1 fail-fast |
+| Queue depth | Fail fast beyond 1 | Matches both references |
+| Round plumbing | Re-key parked payloads, all three bridges, own PR first | Fuller fix over entry-point serialization |
+| Gate default | ON | Deliberate deviation from repo convention and from Codex |
+| Sequencing | PR0 -> C -> A -> B -> D -> E | C pulled forward on reference evidence |
+
+## 9. Open items
+
+- **C needs its own design cycle** before implementation, now that it precedes A.
+- Backlog tasks are not yet filed. IDs must be assigned after a fresh sweep of
+  all worktrees and branches — this repo has had six ID collisions.

--- a/Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md
+++ b/Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md
@@ -98,7 +98,7 @@ the same-session concurrency tests to mirror, along with a reusable
 
 | # | Sub-project | Delivers |
 |---|---|---|
-| **PR0** | Parked-payload re-key | Round-keyed retained payloads with per-session FIFO across all three bridges and their re-derive paths. Pure defect fix, no user-visible change. |
+| **PR0** | Parked-payload re-key | Round-keyed retained payloads with per-session FIFO across all three bridges and their re-derive paths. Pure defect fix; no change to the single-round path. Concurrent same-session rounds now queue FIFO instead of clobbering. |
 
 **PR0 is three parallel edits, not one abstraction.** Each bridge owns an
 independent lock — `_approval_state_lock` (`:1331`),
@@ -366,3 +366,14 @@ mount, sync, park, and visibility plumbing.
 - **C needs its own design cycle** before implementation, now that it precedes A.
 - Backlog tasks are not yet filed. IDs must be assigned after a fresh sweep of
   all worktrees and branches — this repo has had six ID collisions.
+- **Known gap carried into C.** PR0's FIFO queue only orders cards for one
+  session; it does nothing for a non-head round on a session that isn't the
+  active one. A non-head round on the ACTIVE session is fully silent — no
+  card (gated by `is_head`) and no toast (it isn't parked). A non-head round
+  on a BACKGROUND session still toasts. Meanwhile the `Approvals: N pending`
+  chip (`ChatScreen._console_pending_approval_count`) is a single boolean
+  slot — "is a card mounted" — not a count of armed rounds, so it reads "1
+  pending" identically whether one round is queued or three; queue depth is
+  invisible today. This is strictly better than pre-PR0 (where the older
+  round was undecidable, full stop), but surfacing every queued round — not
+  just the head — is the natural job for C's unified interrupt surface.

--- a/Tests/Chat/test_console_viewless_hooks.py
+++ b/Tests/Chat/test_console_viewless_hooks.py
@@ -508,8 +508,11 @@ async def test_an_approval_round_armed_with_no_view_is_not_lost(tmp_path):
             "a round armed with no view is unregistered -- the next mount "
             "has nothing to claim and the card is silently swallowed"
         )
-        with controller._approval_state_lock:
-            parked = controller._parked_approval_payloads.get(session.id)
+        # PR0 (task-15661): keyed by ROUND now -- this session's retained
+        # payload is its FIFO head, not a `.get(session_id)`.
+        parked = controller._head_round_payload(
+            controller._parked_approval_payloads, session.id
+        )
         assert parked is not None and parked.get("calls"), (
             "the round's payload was not retained, so a mount could not "
             "re-derive the card even knowing the round exists"

--- a/Tests/Chat/test_skill_script_concurrent_confirms.py
+++ b/Tests/Chat/test_skill_script_concurrent_confirms.py
@@ -140,10 +140,9 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     guard.
 
     PR0 (task-15661) removes the shared slot entirely: the map is keyed by
-    ROUND, so each teardown drops exactly its own key and the guard --
-    along with `_clear_pending_skill_script_if_round_is_current`, which
-    this docstring used to reference through three review rounds of
-    symmetry notes -- is gone. The CONTRACT this test pins is unchanged
+    ROUND, so each teardown drops exactly its own key, and the
+    order-dependent guard is replaced by `_remount_head`'s FIFO-head
+    re-derive. The CONTRACT this test pins is unchanged
     and now holds by construction: the earlier round resolving first
     leaves the later round's payload intact, and the session's card
     re-derives to it. See the install bridge's identical update

--- a/Tests/Chat/test_skill_script_concurrent_confirms.py
+++ b/Tests/Chat/test_skill_script_concurrent_confirms.py
@@ -158,10 +158,10 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     Fix round 2 (review, Qodo PR #1041) note on symmetry: the same
     applies to the mounted-card CLEAR itself -- `request_skill_script_
     confirm`'s teardown now calls `_clear_pending_skill_script_if_round_
-    is_current` (byte-for-byte the same shape as `request_mcp_approvals`'
-    `_clear_pending_approval_if_round_is_current` and `request_skill_
-    install_confirm`'s `_clear_pending_skill_install_if_round_is_
-    current`), so the deterministic race proof (a newer same-session
+    is_current` (byte-for-byte the same shape as `request_skill_install_
+    confirm`'s `_clear_pending_skill_install_if_round_is_current`; the
+    MCP bridge's equivalent was retired by PR0's FIFO-head re-derive),
+    so the deterministic race proof (a newer same-session
     round arming while an older round's clear is still enqueued must not
     get wiped) is exercised directly for the MCP bridge
     (`test_console_mcp_approval.py::

--- a/Tests/Chat/test_skill_script_concurrent_confirms.py
+++ b/Tests/Chat/test_skill_script_concurrent_confirms.py
@@ -130,67 +130,25 @@ def test_teardown_of_one_round_leaves_the_other_armed(controller):
 def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resolve(
     controller,
 ):
-    """TASK-1050 (Defect A/B): unlike every test above (which arms with
-    `session_id=None`, so neither the badge nor a retained payload ever
-    comes into play), this arms TWO skill-script rounds for the SAME real
-    session. `_parked_skill_script_payloads` is keyed by session id
-    alone, so the second round's arm overwrites the first round's stored
-    payload under that key. The EARLIER round resolving first must not
-    clear the badge (the sibling round is still outstanding) nor discard
-    the NEWER round's still-armed payload; only resolving the LAST one
-    does either.
+    """One round's teardown must never discard a sibling's retained payload.
 
-    Fix round 1 (review) note on symmetry: the reverse-ordering case
-    (resolving the NEWER round first must leave the slot populated
-    rather than popped, since the guard is order-independent -- "no
-    armed round left for this session", not "is the stored payload still
-    mine") is exercised directly for the MCP bridge
-    (`test_console_mcp_approval.py::
-    test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated`)
-    and the skill-install bridge
-    (`test_skill_install_concurrent_confirms.py::
-    test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated`).
-    `request_skill_script_confirm`'s teardown guard is byte-for-byte the
-    same shape (`if not still_armed_same_session: pop`, no per-round
-    identity check), so it is symmetric by construction -- not
-    duplicated a third time here.
+    TASK-1050 (Defect A/B) originally: `_parked_skill_script_payloads` was
+    keyed by session id ALONE, so arming a SECOND round for the SAME
+    session overwrote the first's payload and an unconditional pop in
+    either teardown discarded the survivor's only copy. That was patched
+    with an order-dependent "only pop when this is the LAST armed round"
+    guard.
 
-    Fix round 2 (review, Qodo PR #1041) note on symmetry: the same
-    applies to the mounted-card CLEAR itself -- `request_skill_script_
-    confirm`'s teardown now calls `_clear_pending_skill_script_if_round_
-    is_current` (byte-for-byte the same shape as `request_skill_install_
-    confirm`'s `_clear_pending_skill_install_if_round_is_current`; the
-    MCP bridge's equivalent was retired by PR0's FIFO-head re-derive),
-    so the deterministic race proof (a newer same-session
-    round arming while an older round's clear is still enqueued must not
-    get wiped) is exercised directly for the MCP bridge
-    (`test_console_mcp_approval.py::
-    test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_round_arming_mid_teardown`)
-    and the skill-install bridge
-    (`test_skill_install_concurrent_confirms.py::
-    test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_round_arming_mid_teardown`)
-    rather than a third time here.
-
-    Fix round 3 (re-review) note on symmetry: the round-identity check
-    ALONE (fix round 2) only caught "payload overwritten by a newer arm"
-    -- it missed "a DIFFERENT, OLDER sibling round is still armed" when
-    the NEWEST round resolves FIRST, which trivially passes the identity
-    check (nothing has overwritten the slot since it armed) and cleared
-    the card anyway, stranding the older round card-less while the badge
-    stayed lit. `_clear_pending_skill_script_if_round_is_current`'s
-    teardown now ALSO re-reads `_pending_skill_script_rounds` live
-    (byte-for-byte the same two-part shape as the other two bridges'
-    fixes), so this is symmetric by construction too. The end-to-end,
-    card-clear-seam-asserting proof (using a recording list rather than a
-    discarding no-op, since a no-op cannot distinguish "clear was called"
-    from "clear was never called") is exercised directly for the MCP
-    bridge
-    (`test_console_mcp_approval.py::
-    test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated`)
-    and the skill-install bridge
-    (`test_skill_install_concurrent_confirms.py::
-    test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated`)
-    rather than a third time here."""
+    PR0 (task-15661) removes the shared slot entirely: the map is keyed by
+    ROUND, so each teardown drops exactly its own key and the guard --
+    along with `_clear_pending_skill_script_if_round_is_current`, which
+    this docstring used to reference through three review rounds of
+    symmetry notes -- is gone. The CONTRACT this test pins is unchanged
+    and now holds by construction: the earlier round resolving first
+    leaves the later round's payload intact, and the session's card
+    re-derives to it. See the install bridge's identical update
+    (`Tests/UI/test_skill_install_concurrent_confirms.py::
+    test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resolve`)."""
     session_id = controller.store.create_session(title="S").id
     controller.store.switch_session(session_id)
 
@@ -203,22 +161,38 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     t2 = _arm_for_session(controller, "skill-two", session_id, results, "two")
     assert _wait_until(lambda: len(controller.pending_skill_script_ids()) == 2)
     id2 = [i for i in controller.pending_skill_script_ids() if i != id1][0]
-    # Round 2 overwrote round 1's stored payload under the same session key.
-    assert controller._parked_skill_script_payloads[session_id]["request_id"] == id2
+    # PR0: round 2 keeps its OWN key rather than overwriting round 1's --
+    # round 1 is still the session's head and still owns the card.
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_script_payloads, session_id
+        )["request_id"]
+        == id1
+    ), "arming round 2 must not evict round 1's card"
 
     controller.resolve_pending_skill_script(False, False, request_id=id1)
     t1.join(timeout=5)
     assert results["one"] == {"allow": False, "remember": False}
     assert controller.run_marker_for(session_id) is ConsoleRunMarker.NEEDS_APPROVAL
     assert session_id in controller._pending_approvals
-    assert controller._parked_skill_script_payloads[session_id]["request_id"] == id2
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_script_payloads, session_id
+        )["request_id"]
+        == id2
+    ), "round 1 resolving must promote round 2, not discard it"
 
     controller.resolve_pending_skill_script(True, True, request_id=id2)
     t2.join(timeout=5)
     assert results["two"] == {"allow": True, "remember": True}
     assert controller.run_marker_for(session_id) is ConsoleRunMarker.NONE
     assert session_id not in controller._pending_approvals
-    assert session_id not in controller._parked_skill_script_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_script_payloads, session_id
+        )
+        is None
+    )
 
 
 def test_shutdown_denies_every_armed_round(controller):

--- a/Tests/UI/test_console_headless_approval.py
+++ b/Tests/UI/test_console_headless_approval.py
@@ -196,8 +196,14 @@ def _round_is_claimable(controller, session_id) -> bool:
     """
     if not _armed_round_ids(controller, session_id):
         return False
-    with controller._approval_state_lock:
-        return controller._parked_approval_payloads.get(session_id) is not None
+    # PR0 (task-15661): the map is keyed by ROUND now, so "this session has
+    # a retained payload" is a head lookup, not a `.get(session_id)`.
+    return (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_id
+        )
+        is not None
+    )
 
 
 async def _wait_for_round(controller, session_id, *, seconds: float = 3.0) -> bool:
@@ -506,26 +512,26 @@ async def test_attaching_a_view_with_no_armed_round_mounts_nothing():
 
 
 # ---------------------------------------------------------------------------
-# The two-round limitation -- asserted AGAINST, not around (task-15661)
+# Two same-session rounds each get their turn (task-15661, FIXED in PR0)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts():
-    """KNOWN LIMITATION, pinned: `_parked_approval_payloads` is per-SESSION.
+async def test_two_headless_rounds_each_mount_in_turn():
+    """`_parked_approval_payloads` is keyed by ROUND: no round is stranded.
 
-    Both rounds are independently registered (the badge and the verdicts
-    are round-keyed), and both stay claimable in the sense that neither is
-    denied -- but the retained payload slot holds only the LAST-armed
-    round, so an attach can only ever mount ONE card. That is
-    `console_chat_controller.py`'s own documented "accepted scope
-    limitation" on that slot, filed as task-15661.
+    Pre-PR0 this slot was per-SESSION and last-armed-wins, so of two rounds
+    armed while detached only the newest had a surviving payload and an
+    attach could mount only ONE card -- the older round stayed registered,
+    badge lit, with no way to answer it until its own timeout. That was
+    `console_chat_controller.py`'s documented "accepted scope limitation",
+    filed as task-15661, and this test pinned it as a measured fact.
 
-    **This task does NOT fix it.** Per-round payload storage changes the
-    card's mount/park contract for every caller (mounted rounds included),
-    which is a wider change than making the headless case surfaceable.
-    Pinned here so the limitation is a measured fact with a failing test
-    the day someone fixes it, rather than folklore in a comment.
+    task-15661 is now FIXED. Each round retains its own payload, and the
+    mounted card is the session's FIFO HEAD -- the oldest-armed round.
+    Attaching mounts round A; once A resolves, B is promoted and mounts in
+    its turn. Everything above the mount assertions is unchanged: both
+    rounds still register independently and both still announce.
     """
     runtime, controller, _store, session, app = _detached_rig()
     await _leave(runtime)
@@ -553,27 +559,47 @@ async def test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts():
     # Both announced: a sibling round must never silence a new one.
     assert len(app.notifications) == 2, app.notifications
 
+    round_b = [
+        r for r in _armed_round_ids(controller, session.id) if r != round_a
+    ][0]
+
+    # Attaching mounts the FIFO HEAD -- round A, armed FIRST. Pre-PR0 this
+    # was round B, because B's arm had overwritten A's payload.
     mounted: list[dict | None] = []
     runtime.attach_view(_View({"set_pending_approval": mounted.append}))
     assert mounted and mounted[-1] is not None, "attach mounted nothing at all"
     names = [c["llm_name"] for c in mounted[-1]["calls"]]
-    assert names == ["builtin__delete_note"], (
-        "THE LIMITATION: the single per-session payload slot means the "
-        f"LAST-armed round is the only one an attach can mount; got {names}"
+    assert names == ["builtin__write_file"], (
+        f"attach must mount the oldest-armed round's card; got {names}"
     )
-    assert mounted[-1]["round_id"] != round_a, (
-        "round A's payload was overwritten by B's -- that IS the limitation"
-    )
+    assert mounted[-1]["round_id"] == round_a
 
-    for round_id, name in (
-        (round_a, "builtin__write_file"),
-        (mounted[-1]["round_id"], "builtin__delete_note"),
-    ):
-        controller.resolve_pending_approval({name: "deny"}, round_id=round_id)
+    # Resolving the head promotes B. Round A's own teardown re-derives the
+    # card from the session's remaining head, so B mounts without anyone
+    # asking -- and a fresh remount (the attach path) agrees.
+    controller.resolve_pending_approval(
+        {"builtin__write_file": "deny"}, round_id=round_a
+    )
     thread_a.join(timeout=5)
+    assert await _settle(
+        lambda: bool(mounted) and (mounted[-1] or {}).get("round_id") == round_b,
+        seconds=3.0,
+    ), f"round B was never promoted after the head resolved: {mounted[-1]}"
+
+    mounted.clear()
+    assert controller.remount_pending_approval_for_active_session() is True
+    assert mounted[-1]["round_id"] == round_b
+    assert [c["llm_name"] for c in mounted[-1]["calls"]] == ["builtin__delete_note"]
+
+    controller.resolve_pending_approval(
+        {"builtin__delete_note": "deny"}, round_id=round_b
+    )
     thread_b.join(timeout=5)
     assert box_a["decisions"] == {"builtin__write_file": "deny"}
     assert box_b["decisions"] == {"builtin__delete_note": "deny"}
+
+    # Nothing left armed -> the card clears rather than showing a corpse.
+    assert await _settle(lambda: mounted[-1] is None, seconds=3.0), mounted[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -972,7 +998,9 @@ async def test_the_risk_floor_still_raises_a_card_in_a_headless_turn(
     with controller._approval_state_lock:
         state = controller._pending_approval_rounds[round_id]
     assert state["names"] == ("read_file",), state["names"]
-    payload = controller._parked_approval_payloads[session.id]
+    payload = controller._head_round_payload(
+        controller._parked_approval_payloads, session.id
+    )
     assert payload["calls"][0]["server_key"] == BUILTIN_TOOL_SERVER_KEY
     assert payload["calls"][0]["reason"] == "risk_floored"
 

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1521,7 +1521,9 @@ def test_mcp_round_and_skill_install_round_for_the_same_session_both_keep_the_ba
     time.sleep(0.1)
     assert background in controller._pending_approvals
     assert controller.run_marker_for(background) is ConsoleRunMarker.NEEDS_APPROVAL
-    mcp_round_id = controller._parked_approval_payloads[background]["round_id"]
+    mcp_round_id = controller._head_round_payload(
+        controller._parked_approval_payloads, background
+    )["round_id"]
     # (Minor, review) Data-level check: after just the MCP round has
     # parked, the round-keyed set for this session is EXACTLY the
     # singleton of its own round id -- locks in that arming never
@@ -1558,7 +1560,12 @@ def test_mcp_round_and_skill_install_round_for_the_same_session_both_keep_the_ba
     )
     # The MCP bridge's OWN payload map is cleared (it was the last MCP
     # round for this session).
-    assert background not in controller._parked_approval_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, background
+        )
+        is None
+    )
 
     # The skill-install round resolves LAST -- only now does the badge
     # fully clear.
@@ -1668,7 +1675,9 @@ def test_resolve_pending_approval_by_round_id_survives_a_mid_flight_session_swit
     worker_b = threading.Thread(target=_run_round_b)
     worker_b.start()
     time.sleep(0.1)
-    round_id_b = controller._parked_approval_payloads[session_b]["round_id"]
+    round_id_b = controller._head_round_payload(
+        controller._parked_approval_payloads, session_b
+    )["round_id"]
     assert round_id_b != round_id_a
 
     # The user clicked "Submit" on A's card, but before the resulting
@@ -1693,19 +1702,34 @@ def test_resolve_pending_approval_by_round_id_survives_a_mid_flight_session_swit
     assert result_b["decisions"] == {"mcp__b__tool": "deny"}
 
 
+def _other_round_id(controller, session_id: str, not_this_one: str) -> str:
+    """The session's OTHER retained round id (PR0: one key per round)."""
+    return [
+        payload["round_id"]
+        for payload in controller._session_round_payloads(
+            controller._parked_approval_payloads, session_id
+        )
+        if payload["round_id"] != not_this_one
+    ][0]
+
+
 def test_two_mcp_rounds_for_the_same_session_the_earlier_ones_teardown_does_not_evict_the_newer_ones_payload():
-    """TASK-1050 (Defect B): `_parked_approval_payloads` is keyed by
-    session id ALONE, not by round id -- arming a SECOND MCP round for
-    the SAME session overwrites the first round's retained payload under
-    that key. If the FIRST (now-superseded) round's teardown pops that
-    key unconditionally, it silently discards the SECOND round's own,
-    still-live payload -- a switch-away/back would then remount `None`
-    and the second round would sit unresolvable until its timeout. The
-    teardown must only pop when it is the LAST armed round for the
-    session (fix round 1, review: an earlier draft also popped whenever
-    the stored payload was still "its own" id, but that condition is
-    true exactly for the newest-armed round -- see the reverse-ordering
-    sibling test below for why that reintroduced the same eviction)."""
+    """One round's teardown must never discard a sibling's retained payload.
+
+    TASK-1050 (Defect B) originally: `_parked_approval_payloads` was keyed
+    by session id ALONE, so arming a SECOND round for the SAME session
+    overwrote the first's payload and an unconditional pop in either
+    teardown discarded the survivor's only copy -- a switch-away/back
+    remounted `None` and the survivor sat unresolvable until its timeout.
+    That was patched with an order-dependent "only pop when this is the
+    LAST armed round" guard.
+
+    PR0 (task-15661) removes the shared slot entirely: the map is keyed by
+    ROUND, so each teardown drops exactly its own key and the guard is
+    gone. The CONTRACT this test pins is unchanged and now holds by
+    construction rather than by a guard -- the earlier round resolving
+    first leaves the later round's payload intact, and the session's card
+    re-derives to it."""
     controller, store = _build_controller()
     session_a = store.create_session(title="A").id
     store.switch_session(session_a)
@@ -1724,7 +1748,9 @@ def test_two_mcp_rounds_for_the_same_session_the_earlier_ones_teardown_does_not_
     worker_1 = threading.Thread(target=_run_round_1)
     worker_1.start()
     time.sleep(0.1)
-    round_id_1 = controller._parked_approval_payloads[session_a]["round_id"]
+    round_id_1 = controller._head_round_payload(
+        controller._parked_approval_payloads, session_a
+    )["round_id"]
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
 
     def _run_round_2() -> None:
@@ -1735,9 +1761,16 @@ def test_two_mcp_rounds_for_the_same_session_the_earlier_ones_teardown_does_not_
     worker_2 = threading.Thread(target=_run_round_2)
     worker_2.start()
     time.sleep(0.1)
-    # Round 2 overwrote round 1's stored payload under the same session key.
-    round_id_2 = controller._parked_approval_payloads[session_a]["round_id"]
+    # PR0: round 2 keeps its OWN key rather than overwriting round 1's --
+    # round 1 is still the session's head and still owns the card.
+    round_id_2 = _other_round_id(controller, session_a, round_id_1)
     assert round_id_2 != round_id_1
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )["round_id"]
+        == round_id_1
+    ), "arming round 2 must not evict round 1's card"
 
     # Round 1 (the EARLIER, now-superseded round) resolves first -- its
     # teardown must not discard round 2's still-armed, newer payload, nor
@@ -1749,7 +1782,12 @@ def test_two_mcp_rounds_for_the_same_session_the_earlier_ones_teardown_does_not_
     assert result_1["decisions"] == {"mcp__one__tool": "deny"}
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
     assert session_a in controller._pending_approvals
-    assert controller._parked_approval_payloads[session_a]["round_id"] == round_id_2
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )["round_id"]
+        == round_id_2
+    ), "round 1 resolving must promote round 2, not discard it"
 
     # Round 2 (the LAST remaining round) resolves -- now everything clears.
     controller.resolve_pending_approval(
@@ -1759,47 +1797,37 @@ def test_two_mcp_rounds_for_the_same_session_the_earlier_ones_teardown_does_not_
     assert result_2["decisions"] == {"mcp__two__tool": "approve_once"}
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_approval_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )
+        is None
+    )
 
 
 def test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated():
-    """TASK-1050 fix round 1 (review): reverse-ordering counterpart to the
-    sibling test above. `_parked_approval_payloads` is a SINGLE
-    per-session slot always holding whichever round's payload was LAST
-    WRITTEN (arming overwrites it) -- so "the stored payload is still
-    this round's own id" is true exactly when THIS round is the
-    newest-armed one, which is also the common case where an OLDER
-    sibling round is still outstanding (arming a round re-mounts its
-    card, which typically gets decided before an already-waiting sibling
-    does -- this is the NATURAL live ordering, not an edge case). An
-    earlier draft of the Defect B fix popped the slot whenever that
-    condition held, which discarded the still-armed OLDER round's only
-    remaining payload the moment the NEWER round resolved first -- a
-    switch-away/back would then re-derive from the now-empty map and
-    mount `None`, leaving the older round unresolvable until its
-    timeout. The fix now pops ONLY when no armed round remains for the
-    session at all (order-independent), so resolving the newer round
-    first must leave the slot populated (remount still works) and the
-    badge up; only resolving the older (now last) round clears both.
+    """Reverse ordering: the newer round resolving first must not strand
+    the older one card-less with the badge still lit.
 
-    Fix round 3 (re-review) EXTENSION: pins the CARD-CLEAR seam itself,
-    not just the payload map -- the round-identity-guarded clear
-    (`_clear_pending_approval_if_round_is_current`) introduced in fix
-    round 2 initially checked ONLY "has a newer round overwritten the
-    payload slot", which is trivially false when round 2 (the newest)
-    resolves first, so it cleared the card anyway even though round 1
-    was still armed -- card gone, badge still lit, round 1 undecidable
-    through the UI until timeout. The ORIGINAL version of this test used
-    `controller.set_pending_approval = lambda payload: None` (a
-    discarding no-op), which could not have caught that regression: a
-    stray `set_pending_approval(None)` call is silently indistinguishable
-    from no call at all through a no-op. Now records every call via
-    `mounted.append` (mirrors every other test in this module) and
-    asserts directly on it at each step: no NEW clear call reaches the
-    seam while round 1 is still armed, and the OLDER round remains
-    resolvable (decidable) through its own `round_id` the whole time;
-    only once round 1 (the last remaining round) resolves does the clear
-    actually fire."""
+    This is the NATURAL live ordering, not an edge case -- pre-PR0, arming
+    a round re-mounted its card, so the newest round was typically decided
+    before an already-waiting sibling. Two successive TASK-1050 fix rounds
+    were needed to stop the newer round's teardown from popping the SHARED
+    per-session payload slot (fix round 1) and then from firing the
+    card-clear seam (fix round 3) while the older round was still armed.
+
+    PR0 (task-15661) makes both hazards structural non-events: each round
+    owns its own key, and the card is always the session's FIFO HEAD.
+    Round 1 is therefore the round that MOUNTS (round 2 queues silently
+    behind it), and round 2 resolving re-derives the head -- which is
+    still round 1's own payload, so the card the user is looking at does
+    not change and is certainly never cleared. That last point is what the
+    fix-round-3 assertion below now checks: it asserts on the card's
+    CONTENT rather than on whether the seam was called, because under
+    FIFO the seam legitimately fires (re-deriving to the same head) where
+    pre-PR0 it had to stay silent. Recording every call through
+    `mounted.append` (rather than a discarding no-op) is what makes that
+    distinction observable at all."""
     controller, store = _build_controller()
     session_a = store.create_session(title="A").id
     store.switch_session(session_a)
@@ -1830,18 +1858,18 @@ def test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leave
     worker_2 = threading.Thread(target=_run_round_2)
     worker_2.start()
     time.sleep(0.1)
+    # PR0: round 2 does NOT mount -- round 1 is the head and keeps the card.
     assert mounted[-1] is not None
-    round_id_2 = mounted[-1]["round_id"]
+    assert mounted[-1]["round_id"] == round_id_1, (
+        "arming round 2 must not evict the head round's card"
+    )
+    round_id_2 = _other_round_id(controller, session_a, round_id_1)
     assert round_id_2 != round_id_1
-    calls_after_both_armed = len(mounted)  # 2: round 1's mount, round 2's mount
 
-    # Round 2 (the NEWER, newest-armed round) resolves FIRST -- round 1 is
-    # still outstanding, so the badge must stay up, the parked slot must
-    # still hold a payload (not popped to `None`, even though it is --
-    # per the accepted single-slot scope -- round 2's own now-stale
-    # payload rather than round 1's), and -- the regression this test now
-    # pins -- the CARD-CLEAR seam must NOT be invoked at all: no new
-    # entry (`None` or otherwise) reaches `mounted`.
+    # Round 2 (the NEWER, queued round) resolves FIRST -- round 1 is still
+    # outstanding, so the badge must stay up, round 1 must keep its own
+    # retained payload, and the card the user is looking at must still be
+    # round 1's own (PR0: the head re-derive resolves back to it).
     controller.resolve_pending_approval(
         {"mcp__two__tool": "approve_once"}, round_id=round_id_2
     )
@@ -1849,15 +1877,15 @@ def test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leave
     assert result_2["decisions"] == {"mcp__two__tool": "approve_once"}
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
     assert session_a in controller._pending_approvals
-    assert session_a in controller._parked_approval_payloads, (
-        "the parked slot must still hold a payload -- popping it here "
+    assert round_id_1 in controller._parked_approval_payloads, (
+        "round 1 must keep its own retained payload -- dropping it here "
         "would strand the still-armed older round unresolvable on the "
         "next switch-away/back"
     )
-    assert len(mounted) == calls_after_both_armed, (
-        "round 2 resolving must NOT invoke the card-clear seam while "
-        "round 1 is still armed -- doing so strands round 1 card-less "
-        "with the badge still lit"
+    assert mounted[-1] is not None and mounted[-1]["round_id"] == round_id_1, (
+        "round 2 resolving must leave round 1's card on screen -- clearing "
+        "it (or swapping in anything else) strands round 1 card-less with "
+        f"the badge still lit; got {mounted[-1]}"
     )
 
     # Round 1 (the OLDER round) remains fully decidable through the UI
@@ -1870,9 +1898,13 @@ def test_two_mcp_rounds_for_the_same_session_resolving_the_newer_one_first_leave
     assert result_1["decisions"] == {"mcp__one__tool": "deny"}
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_approval_payloads
-    # Round 1 (now the LAST remaining round) resolving DOES fire the clear.
-    assert len(mounted) == calls_after_both_armed + 1
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )
+        is None
+    )
+    # Round 1 (now the LAST remaining round) resolving DOES clear the card.
     assert mounted[-1] is None
 
 
@@ -1925,9 +1957,13 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     BLOCKS mid-flight (right where the race window used to be); round 2
     arms and mounts for the SAME session while round 1's clear is still
     blocked; only then is round 1's clear released to actually run.
-    `_clear_pending_approval_if_round_is_current`'s round-identity check
-    (re-read live at that exact moment, never from a stale snapshot) must
-    make it a no-op, leaving round 2's freshly-mounted card intact."""
+    PR0 (task-15661) replaced that round-identity guard with a FIFO-head
+    re-derive (`_remount_head`), which closes the same race by the same
+    principle -- the decision is computed INSIDE the callable, on the UI
+    thread, never from a worker-thread snapshot -- and is order-
+    independent besides. Released here, round 1's deferred callable must
+    re-derive to round 2 (the session's head by then) and leave round 2's
+    freshly-mounted card intact."""
     controller, store = _build_controller()
     session_a = store.create_session(title="A").id
     store.switch_session(session_a)
@@ -1963,7 +1999,12 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     # entirely independent of whether its still-blocked UI-thread clear
     # has run yet.
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_approval_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )
+        is None
+    )
 
     # Round 2 arms for the SAME session WHILE round 1's clear is still
     # blocked -- it mounts its own card immediately (session_a is active).
@@ -2008,7 +2049,12 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     assert result_2["decisions"] == {"mcp__two__tool": "approve_once"}
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_approval_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )
+        is None
+    )
     assert mounted[-1] is None
 
 
@@ -2233,11 +2279,11 @@ def test_request_mcp_approvals_survives_marshal_failure_during_teardown():
                 # round_id off of.
                 calls.append(args[0] if args else None)
                 return fn(*args, **kwargs)
-            # TASK-1050 fix round 2: the teardown-time clear is now a
-            # zero-arg, round-identity-guarded wrapper closure
-            # (`_clear_pending_approval_if_round_is_current`) rather than
-            # a direct `call_from_thread(setter, None)` call, so it can no
-            # longer be identified by inspecting `args[0] is None`.
+            # TASK-1050 fix round 2 / PR0: the teardown-time card update
+            # is a zero-arg wrapper closure (`_remount_head`'s `_apply`)
+            # rather than a direct `call_from_thread(setter, None)` call,
+            # so it can no longer be identified by inspecting
+            # `args[0] is None`.
             # Simulate the app having stopped by the time this (second)
             # `call_from_thread` invocation happens, regardless of what
             # it was called with.
@@ -2746,7 +2792,12 @@ def test_revoking_a_run_unblocks_its_waiting_thread_and_clears_the_card():
     assert elapsed < 2.5
     assert mounted[-1] is None, "the revoked card was left on screen"
     assert session_id not in controller._pending_approvals
-    assert session_id not in controller._parked_approval_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_approval_payloads, session_id
+        )
+        is None
+    )
 
 
 def test_revoking_an_unknown_run_is_a_zero_return_noop():

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1534,9 +1534,9 @@ def test_mcp_round_and_skill_install_round_for_the_same_session_both_keep_the_ba
     install_worker = threading.Thread(target=_run_install)
     install_worker.start()
     time.sleep(0.1)
-    install_request_id = controller._parked_skill_install_payloads[background][
-        "request_id"
-    ]
+    install_request_id = controller._head_round_payload(
+        controller._parked_skill_install_payloads, background
+    )["request_id"]
     # Both rounds' ids are now tracked, still with no double-count.
     assert controller._pending_approvals[background] == {
         mcp_round_id,
@@ -1553,9 +1553,10 @@ def test_mcp_round_and_skill_install_round_for_the_same_session_both_keep_the_ba
     assert mcp_result["decisions"] == {"mcp__srv__tool": "deny"}
     assert controller.run_marker_for(background) is ConsoleRunMarker.NEEDS_APPROVAL
     assert background in controller._pending_approvals
-    assert background in controller._parked_skill_install_payloads
     assert (
-        controller._parked_skill_install_payloads[background]["request_id"]
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, background
+        )["request_id"]
         == install_request_id
     )
     # The MCP bridge's OWN payload map is cleared (it was the last MCP
@@ -1574,7 +1575,12 @@ def test_mcp_round_and_skill_install_round_for_the_same_session_both_keep_the_ba
     assert install_result["allowed"] is True
     assert controller.run_marker_for(background) is ConsoleRunMarker.NONE
     assert background not in controller._pending_approvals
-    assert background not in controller._parked_skill_install_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, background
+        )
+        is None
+    )
 
 
 def test_request_mcp_approvals_other_sessions_cancel_event_does_not_deny_this_round():

--- a/Tests/UI/test_console_mcp_approval.py
+++ b/Tests/UI/test_console_mcp_approval.py
@@ -1948,7 +1948,7 @@ class _DeferredClearApp:
         return fn(*args, **kwargs)
 
 
-def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_round_arming_mid_teardown():
+def test_teardown_clear_does_not_clobber_a_newer_same_session_round_arming_mid_teardown():
     """TASK-1050 fix round 2 (review, Qodo PR #1041, CRITICAL): `request_
     mcp_approvals`'s teardown used to decide whether to clear the mounted
     card via a boolean snapshot (`still_active`/`still_armed_same_
@@ -2030,9 +2030,9 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
 
     # NOW release round 1's blocked clear. A snapshot-guarded clear would
-    # unconditionally wipe round 2's just-mounted card here; the
-    # round-identity guard must instead see round 2 has since claimed the
-    # slot and no-op.
+    # unconditionally wipe round 2's just-mounted card here; `_remount_head`'s
+    # FIFO head re-derive must instead see round 2 is now the session's head
+    # and leave its card mounted.
     app.release_clear.set()
     worker_1.join(timeout=2.0)
     assert result_1["decisions"] == {"mcp__one__tool": "deny"}

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -1668,7 +1668,9 @@ async def test_background_skill_install_confirm_parks_badges_toasts_and_mounts_o
         assert console.query_one("#chat-skill-install-card").display
         assert len([n for n in notifications if "needs approval" in n]) == 1
 
-        request_id = controller._parked_skill_install_payloads[background]["request_id"]
+        request_id = controller._head_round_payload(
+            controller._parked_skill_install_payloads, background
+        )["request_id"]
         controller.resolve_pending_skill_install(True, request_id=request_id)
         allowed = await asyncio.wait_for(decision_task, timeout=2.0)
         assert allowed is True
@@ -1768,7 +1770,9 @@ async def test_skill_install_park_toast_survives_a_re_invocation_for_the_same_ro
         )
         await pilot.pause(0.3)
         assert len([n for n in notifications if "needs approval" in n]) == 1
-        request_id = controller._parked_skill_install_payloads[background]["request_id"]
+        request_id = controller._head_round_payload(
+            controller._parked_skill_install_payloads, background
+        )["request_id"]
 
         # Re-invoke the shared park seam for the SAME, still-outstanding
         # skill-install round.

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -728,7 +728,8 @@ async def test_park_toast_survives_a_post_teardown_re_invocation_for_the_same_ro
         # Tear down round-1 exactly like `request_mcp_approvals`'s own
         # `finally` does once it resolves: discard the round id, then pop
         # the retained payload (no sibling round left, so the pop fires
-        # -- mirrors the real "not still_armed_same_session" branch).
+        # -- mirrors the real teardown, where `_remount_head`'s FIFO-head
+        # re-derive finds no sibling payload left to re-mount).
         controller.discard_pending_round(background, "round-1")
         controller._parked_approval_payloads.pop("round-1", None)
         assert "round-1" not in controller._parked_approval_payloads

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -1730,7 +1730,9 @@ async def test_background_skill_script_confirm_parks_badges_toasts_and_mounts_on
         assert console.query_one("#chat-skill-script-card").display
         assert len([n for n in notifications if "needs approval" in n]) == 1
 
-        request_id = controller._parked_skill_script_payloads[background]["request_id"]
+        request_id = controller._head_round_payload(
+            controller._parked_skill_script_payloads, background
+        )["request_id"]
         controller.resolve_pending_skill_script(True, False, request_id=request_id)
         decision = await asyncio.wait_for(decision_task, timeout=2.0)
         assert decision == {"allow": True, "remember": False}
@@ -1814,7 +1816,9 @@ async def test_skill_script_park_toast_survives_a_re_invocation_for_the_same_rou
         )
         await pilot.pause(0.3)
         assert len([n for n in notifications if "needs approval" in n]) == 1
-        request_id = controller._parked_skill_script_payloads[background]["request_id"]
+        request_id = controller._head_round_payload(
+            controller._parked_skill_script_payloads, background
+        )["request_id"]
 
         # Re-invoke the shared park seam for the SAME, still-outstanding
         # skill-script round.

--- a/Tests/UI/test_console_parallel_runs.py
+++ b/Tests/UI/test_console_parallel_runs.py
@@ -472,7 +472,12 @@ async def test_background_approval_parks_with_badge_and_single_toast() -> None:
         # Seed the retained round payload `request_mcp_approvals` would
         # have stored before parking, then drive the UI-thread park seam
         # directly.
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["seeded-round"] = {
+            # PR0: the map is keyed by ROUND, and every payload carries its
+            # own `round_id`/`session_id` -- the invariant `_park_round_
+            # payload` maintains in production.
+            "round_id": "seeded-round",
+            "session_id": background,
             "calls": [
                 {
                     "llm_name": "mcp__srv__tool",
@@ -581,7 +586,9 @@ async def test_park_toast_survives_a_viewed_run_completion_re_invocation() -> No
 
         approval_toasts = [n for n in notifications if "needs approval" in n]
         assert len(approval_toasts) == 1
-        round_id = controller._parked_approval_payloads[background]["round_id"]
+        round_id = controller._head_round_payload(
+            controller._parked_approval_payloads, background
+        )["round_id"]
 
         # A's own real terminal transition -- A stays active/viewed
         # throughout, so `_set_run_state`'s non-active toast branch never
@@ -601,7 +608,12 @@ async def test_park_toast_survives_a_viewed_run_completion_re_invocation() -> No
         # SAME, still-outstanding round (round_id unchanged) -- the
         # hazard TASK-1141 guards against regardless of which real
         # trigger UAT actually hit.
-        assert controller._parked_approval_payloads[background]["round_id"] == round_id
+        assert (
+            controller._head_round_payload(
+                controller._parked_approval_payloads, background
+            )["round_id"]
+            == round_id
+        )
         console._park_console_approval(background)
         await pilot.pause(0.1)
 
@@ -641,7 +653,7 @@ async def test_park_toast_fires_again_for_a_genuinely_new_round_same_session() -
         app.notify = lambda message, **kwargs: notifications.append(str(message))
 
         controller.add_pending_round(background, "round-1")
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["round-1"] = {
             "round_id": "round-1",
             "session_id": background,
             "calls": [],
@@ -653,11 +665,11 @@ async def test_park_toast_fires_again_for_a_genuinely_new_round_same_session() -
 
         # Round 1 resolves and clears completely.
         controller.discard_pending_round(background, "round-1")
-        controller._parked_approval_payloads.pop(background, None)
+        controller._parked_approval_payloads.pop("round-1", None)
 
         # A genuinely new round (different id) parks for the same session.
         controller.add_pending_round(background, "round-2")
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["round-2"] = {
             "round_id": "round-2",
             "session_id": background,
             "calls": [],
@@ -703,7 +715,7 @@ async def test_park_toast_survives_a_post_teardown_re_invocation_for_the_same_ro
         app.notify = lambda message, **kwargs: notifications.append(str(message))
 
         controller.add_pending_round(background, "round-1")
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["round-1"] = {
             "round_id": "round-1",
             "session_id": background,
             "calls": [],
@@ -718,8 +730,8 @@ async def test_park_toast_survives_a_post_teardown_re_invocation_for_the_same_ro
         # the retained payload (no sibling round left, so the pop fires
         # -- mirrors the real "not still_armed_same_session" branch).
         controller.discard_pending_round(background, "round-1")
-        controller._parked_approval_payloads.pop(background, None)
-        assert background not in controller._parked_approval_payloads
+        controller._parked_approval_payloads.pop("round-1", None)
+        assert "round-1" not in controller._parked_approval_payloads
 
         # A stray re-invocation of the shared park seam landing AFTER
         # teardown -- the exact hazard the reviewer reproduced live.
@@ -755,7 +767,7 @@ async def test_park_toast_fires_once_for_a_new_round_arriving_after_teardown() -
         app.notify = lambda message, **kwargs: notifications.append(str(message))
 
         controller.add_pending_round(background, "round-1")
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["round-1"] = {
             "round_id": "round-1",
             "session_id": background,
             "calls": [],
@@ -766,12 +778,12 @@ async def test_park_toast_fires_once_for_a_new_round_arriving_after_teardown() -
         assert len([n for n in notifications if "needs approval" in n]) == 1
 
         controller.discard_pending_round(background, "round-1")
-        controller._parked_approval_payloads.pop(background, None)
+        controller._parked_approval_payloads.pop("round-1", None)
 
         # A genuinely NEW round (different id) parks for the same session
         # AFTER the previous one's full teardown.
         controller.add_pending_round(background, "round-2")
-        controller._parked_approval_payloads[background] = {
+        controller._parked_approval_payloads["round-2"] = {
             "round_id": "round-2",
             "session_id": background,
             "calls": [],
@@ -1525,7 +1537,9 @@ async def test_mounted_round_survives_switch_away_and_switch_back() -> None:
         # retained payload to re-derive from).
         assert console.query_one("#chat-approval-card").display
 
-        round_id = controller._parked_approval_payloads[session_a]["round_id"]
+        round_id = controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )["round_id"]
         controller.resolve_pending_approval(
             {"mcp__srv__tool": "approve_once"}, round_id=round_id
         )
@@ -1578,7 +1592,9 @@ async def test_new_session_clears_a_mounted_card_from_the_session_being_left() -
         await pilot.pause(0.2)
         assert console.query_one("#chat-approval-card").display
 
-        round_id = controller._parked_approval_payloads[session_a]["round_id"]
+        round_id = controller._head_round_payload(
+            controller._parked_approval_payloads, session_a
+        )["round_id"]
         controller.resolve_pending_approval(
             {"mcp__srv__tool": "deny"}, round_id=round_id
         )

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -129,6 +129,13 @@ def test_the_queued_round_mounts_when_the_head_resolves(controller):
     assert _wait_until(lambda: len(_round_ids(controller)) == 2)
     round_2 = [r for r in _round_ids(controller) if r != round_1][0]
 
+    # Pre-condition: the head still owns the card. Without this, the test
+    # cannot tell FIFO promotion from the arm-time clobber it exists to
+    # catch -- round_2 would already be mounted and the post-assert would
+    # pass for the wrong reason, on both sides of the fix.
+    time.sleep(0.1)  # let any errant mount land before asserting
+    assert _mounted_round(controller) == round_1
+
     controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
     first.join(timeout=5)
 

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -209,3 +209,58 @@ def test_install_second_same_session_round_does_not_evict_the_first(
 
     ctrl.resolve_pending_skill_install(True, request_id=round_2)
     second.join(timeout=5)
+
+
+def _arm_script(ctrl, script, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_skill_script_confirm(
+            {"skill": "demo", "script": script}, session_id=session_id
+        )
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.fixture
+def script_controller():
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_skill_script = ctrl.mounted.append
+    ctrl.skill_script_confirm_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def test_script_second_same_session_round_does_not_evict_the_first(
+    script_controller,
+):
+    ctrl = script_controller
+    results = {}
+    first = _arm_script(ctrl, "echo one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_script_ids()) == 1)
+    round_1 = ctrl.pending_skill_script_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_1)
+
+    second = _arm_script(ctrl, "echo two", ctrl.session_a, results, "two")
+    assert _wait_until(lambda: len(ctrl.pending_skill_script_ids()) == 2)
+    time.sleep(0.1)
+
+    assert _mounted_round(ctrl) == round_1, (
+        "a second same-session script confirm must not evict the first's card"
+    )
+
+    # resolve_pending_skill_script takes (allow, remember, request_id).
+    ctrl.resolve_pending_skill_script(True, False, round_1)
+    first.join(timeout=5)
+
+    round_2 = ctrl.pending_skill_script_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_2), (
+        "the queued script confirm must mount once the head resolves"
+    )
+
+    ctrl.resolve_pending_skill_script(True, False, round_2)
+    second.join(timeout=5)

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -303,3 +303,74 @@ def test_bridges_do_not_share_a_head(controller):
 
     ctrl.resolve_pending_skill_install(True, request_id=install_round)
     install.join(timeout=5)
+
+
+def test_promoted_round_mounts_with_remaining_time_not_original_timeout(controller):
+    """Qodo PR #1836 finding 1: a queued round's worker deadline starts at
+    ARM time, so mounting it at promotion with the arm-time
+    ``timeout_seconds`` overstates the decision window ("Auto-denies in
+    2:00" on a card that denies in seconds). The mounted payload must carry
+    the REMAINING time, derived from the round's monotonic deadline; the
+    retained payload itself stays unmutated (each later re-derive computes
+    its own snapshot).
+    """
+    results = {}
+    first = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+    assert _wait_until(lambda: _mounted_round(controller) == round_1)
+
+    second = _arm(controller, "beta", controller.session_a, results, "beta")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 2)
+    round_2 = [r for r in _round_ids(controller) if r != round_1][0]
+
+    controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
+    first.join(timeout=5)
+    assert _wait_until(lambda: _mounted_round(controller) == round_2)
+
+    promoted = controller.mounted[-1]
+    # The fixture arms 30.0s rounds; queue time has necessarily elapsed by
+    # promotion, so an accurate snapshot is strictly below the original.
+    assert 0.0 < promoted["timeout_seconds"] < 30.0, (
+        "a promoted round must mount with its REMAINING decision window, "
+        f"not the arm-time timeout (got {promoted['timeout_seconds']!r})"
+    )
+    with controller._approval_state_lock:
+        stored = controller._parked_approval_payloads[round_2]
+    assert stored["timeout_seconds"] == 30.0, (
+        "the retained payload must stay unmutated; only the mounted "
+        "snapshot carries the adjusted remaining time"
+    )
+
+    controller.resolve_pending_approval({"beta": "approve_once"}, round_id=round_2)
+    second.join(timeout=5)
+
+
+def test_legacy_round_teardown_clears_its_card_after_a_session_switch(controller):
+    """Qodo PR #1836 finding 2: a legacy ``session_id=None`` round mounts
+    unconditionally, but its teardown re-derived for the session that was
+    active AT ARM. If the active session changed in between, the re-derive
+    guard rejected the stale id and the legacy card stayed mounted
+    indefinitely -- where the deleted pre-PR0 guard cleared it
+    unconditionally. Teardown of a legacy round must re-derive for
+    whichever session is active WHEN THE CALLBACK RUNS.
+    """
+    results = {}
+    legacy = _arm(controller, "legacy", None, results, "legacy")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+    assert _wait_until(lambda: _mounted_round(controller) == round_1)
+
+    # Direct store switch: the end-state of the documented race, where the
+    # legacy mount's call_from_thread lands AFTER the switch already ran
+    # its own re-derive -- active session B, legacy card still on screen.
+    session_b = controller.store.create_session(title="B").id
+    controller.store.switch_session(session_b)
+
+    controller.resolve_pending_approval({"legacy": "approve_once"}, round_id=round_1)
+    legacy.join(timeout=5)
+
+    assert _wait_until(lambda: controller.mounted[-1] is None), (
+        "a legacy round's teardown must clear its card even after a "
+        "session switch -- the pre-PR0 unconditional clear's job"
+    )

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -1,0 +1,155 @@
+"""PR0: concurrent same-session interrupt rounds must not clobber each other.
+
+Mirrors ``Tests/UI/test_skill_install_concurrent_confirms.py`` (TASK-910) but
+targets the half that task left unfixed: the RETAINED PAYLOAD each bridge
+re-derives its mounted card from is keyed by ``session_id``, not ``round_id``,
+so arming a second round for the same session overwrites the first's payload.
+The code names this itself in ``request_mcp_approvals``' ``finally`` block:
+"per-round payload storage is a larger change out of scope here".
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+
+
+class FakeApp:
+    """``call_from_thread`` stand-in: invokes the callback immediately."""
+
+    def call_from_thread(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+
+def _wait_until(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@pytest.fixture
+def controller():
+    """A controller with a fake UI wired and one ACTIVE session.
+
+    ``mounted`` records every payload the approval card was told to show,
+    including the ``None`` clears, so a test can assert on what the user
+    would actually be looking at after each transition.
+    """
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_approval = ctrl.mounted.append
+    ctrl.mcp_approval_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def _call(name):
+    return MCPPendingCall(
+        llm_name=name,
+        server_key="agent:builtin",
+        tool_name=name,
+        server_label="builtin",
+        arguments={},
+        reason="ask",
+    )
+
+
+def _arm(ctrl, name, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_mcp_approvals(
+            [_call(name)], session_id=session_id
+        )
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+def _round_ids(ctrl):
+    return list(ctrl._pending_approval_rounds)
+
+
+def _mounted_round(ctrl):
+    """The round id of the card currently shown, or None if cleared.
+
+    The approvals payload names its id `round_id`; both skill bridges name
+    theirs `request_id`. Every payload already carries one of the two, so
+    no production payload needs a duplicate field for this helper.
+    """
+    payload = ctrl.mounted[-1] if ctrl.mounted else None
+    if not payload:
+        return None
+    return payload.get("round_id") or payload.get("request_id")
+
+
+def test_arming_a_second_same_session_round_does_not_evict_the_first_card(
+    controller,
+):
+    """The head round keeps the card; a later sibling waits its turn."""
+    results = {}
+    first = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+    assert _wait_until(lambda: _mounted_round(controller) == round_1)
+
+    second = _arm(controller, "beta", controller.session_a, results, "beta")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 2)
+    time.sleep(0.1)  # let any errant mount land before asserting
+
+    assert _mounted_round(controller) == round_1, (
+        "arming a second same-session round must not evict the first's card"
+    )
+
+    for round_id in _round_ids(controller):
+        controller.resolve_pending_approval({"alpha": "approve_once", "beta": "approve_once"}, round_id=round_id)
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+
+def test_the_queued_round_mounts_when_the_head_resolves(controller):
+    """FIFO: resolving the head promotes the next same-session round."""
+    results = {}
+    first = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+
+    second = _arm(controller, "beta", controller.session_a, results, "beta")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 2)
+    round_2 = [r for r in _round_ids(controller) if r != round_1][0]
+
+    controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
+    first.join(timeout=5)
+
+    assert _wait_until(lambda: _mounted_round(controller) == round_2), (
+        "the queued round must mount once the head resolves"
+    )
+
+    controller.resolve_pending_approval({"beta": "approve_once"}, round_id=round_2)
+    second.join(timeout=5)
+
+
+def test_last_round_teardown_clears_the_card(controller):
+    """With no rounds left for the session, the card clears."""
+    results = {}
+    only = _arm(controller, "alpha", controller.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(controller)) == 1)
+    round_1 = _round_ids(controller)[0]
+
+    controller.resolve_pending_approval({"alpha": "approve_once"}, round_id=round_1)
+    only.join(timeout=5)
+
+    assert _wait_until(lambda: _mounted_round(controller) is None), (
+        "the card must clear once the session has no armed rounds left"
+    )

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -290,6 +290,7 @@ def test_bridges_do_not_share_a_head(controller):
     # The approvals payload names its id `round_id`; the install payload
     # names its own `request_id`. Neither bridge renames the other's.
     assert approvals_mounted[-1]["round_id"] == approval_round
+    assert _wait_until(lambda: len(install_mounted) == 1)
     assert install_mounted[-1]["request_id"] == install_round
 
     ctrl.resolve_pending_approval({"alpha": "approve_once"}, round_id=approval_round)

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -160,3 +160,52 @@ def test_last_round_teardown_clears_the_card(controller):
     assert _wait_until(lambda: _mounted_round(controller) is None), (
         "the card must clear once the session has no armed rounds left"
     )
+
+
+def _arm_install(ctrl, url, session_id, results, key):
+    def worker():
+        results[key] = ctrl.request_skill_install_confirm(url, session_id=session_id)
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    return thread
+
+
+@pytest.fixture
+def install_controller():
+    store = ConsoleChatStore()
+    ctrl = ConsoleChatController(store=store, provider_gateway=object())
+    ctrl.app = FakeApp()
+    ctrl.mounted = []
+    ctrl.set_pending_skill_install = ctrl.mounted.append
+    ctrl.skill_install_confirm_timeout_seconds = lambda: 30.0
+    ctrl.session_a = store.create_session(title="A").id
+    store.switch_session(ctrl.session_a)
+    return ctrl
+
+
+def test_install_second_same_session_round_does_not_evict_the_first(
+    install_controller,
+):
+    ctrl = install_controller
+    results = {}
+    first = _arm_install(ctrl, "https://x/one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 1)
+    round_1 = ctrl.pending_skill_install_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_1)
+
+    second = _arm_install(ctrl, "https://x/two", ctrl.session_a, results, "two")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 2)
+    time.sleep(0.1)
+
+    assert _mounted_round(ctrl) == round_1, (
+        "a second same-session install confirm must not evict the first's card"
+    )
+
+    ctrl.resolve_pending_skill_install(True, request_id=round_1)
+    first.join(timeout=5)
+    round_2 = ctrl.pending_skill_install_ids()[0]
+    assert _wait_until(lambda: _mounted_round(ctrl) == round_2)
+
+    ctrl.resolve_pending_skill_install(True, request_id=round_2)
+    second.join(timeout=5)

--- a/Tests/UI/test_console_parked_payload_rekey.py
+++ b/Tests/UI/test_console_parked_payload_rekey.py
@@ -264,3 +264,41 @@ def test_script_second_same_session_round_does_not_evict_the_first(
 
     ctrl.resolve_pending_skill_script(True, False, round_2)
     second.join(timeout=5)
+
+
+def test_bridges_do_not_share_a_head(controller):
+    """Each bridge keeps its own FIFO head for the same session.
+
+    An approval round and a skill-install round armed for one session are
+    independent surfaces -- neither may evict or promote the other.
+    """
+    ctrl = controller
+    approvals_mounted = ctrl.mounted
+    install_mounted = []
+    ctrl.set_pending_skill_install = install_mounted.append
+    ctrl.skill_install_confirm_timeout_seconds = lambda: 30.0
+
+    results = {}
+    approval = _arm(ctrl, "alpha", ctrl.session_a, results, "alpha")
+    assert _wait_until(lambda: len(_round_ids(ctrl)) == 1)
+    approval_round = _round_ids(ctrl)[0]
+
+    install = _arm_install(ctrl, "https://x/one", ctrl.session_a, results, "one")
+    assert _wait_until(lambda: len(ctrl.pending_skill_install_ids()) == 1)
+    install_round = ctrl.pending_skill_install_ids()[0]
+
+    # The approvals payload names its id `round_id`; the install payload
+    # names its own `request_id`. Neither bridge renames the other's.
+    assert approvals_mounted[-1]["round_id"] == approval_round
+    assert install_mounted[-1]["request_id"] == install_round
+
+    ctrl.resolve_pending_approval({"alpha": "approve_once"}, round_id=approval_round)
+    approval.join(timeout=5)
+
+    assert _wait_until(lambda: approvals_mounted[-1] is None)
+    assert install_mounted[-1] is not None, (
+        "resolving an approval round must not clear the install card"
+    )
+
+    ctrl.resolve_pending_skill_install(True, request_id=install_round)
+    install.join(timeout=5)

--- a/Tests/UI/test_probe_headless_approval_behaviour.py
+++ b/Tests/UI/test_probe_headless_approval_behaviour.py
@@ -162,10 +162,10 @@ async def test_probe_headless_approval_round_wall_time(tmp_path):
             "registry: round still registered after the verdict = "
             f"{controller.has_pending_approval_round(session_id)}"
         )
-        findings.append(
-            "registry: parked payload retained = "
-            f"{controller._parked_approval_payloads.get(session_id) is not None}"
+        head = controller._head_round_payload(
+            controller._parked_approval_payloads, session_id
         )
+        findings.append(f"registry: parked payload retained = {head is not None}")
 
         gateway.release.set()
         await pilot.pause()

--- a/Tests/UI/test_skill_install_concurrent_confirms.py
+++ b/Tests/UI/test_skill_install_concurrent_confirms.py
@@ -154,13 +154,20 @@ def test_teardown_of_one_round_leaves_the_other_armed(controller):
 def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resolve(
     controller,
 ):
-    """TASK-1050 (Defect A/B): two install-confirm rounds for the SAME
-    session (unlike every test above, which uses two DIFFERENT sessions)
-    -- `_parked_skill_install_payloads` is keyed by session id alone, so
-    arming the second round overwrites the first's retained payload under
-    that key. Resolving the EARLIER round first must not clear the badge
-    (a sibling round is still outstanding) nor discard the NEWER round's
-    still-armed payload; only resolving the LAST one does either."""
+    """One round's teardown must never discard a sibling's retained payload.
+
+    TASK-1050 (Defect A/B) originally: `_parked_skill_install_payloads`
+    was keyed by session id ALONE, so arming a SECOND round for the SAME
+    session overwrote the first's payload and an unconditional pop in
+    either teardown discarded the survivor's only copy. That was patched
+    with an order-dependent "only pop when this is the LAST armed round"
+    guard.
+
+    PR0 (task-15661) removes the shared slot entirely: the map is keyed by
+    ROUND, so each teardown drops exactly its own key and the guard is
+    gone. The CONTRACT this test pins is unchanged and now holds by
+    construction -- the earlier round resolving first leaves the later
+    round's payload intact, and the session's card re-derives to it."""
     results = {}
     t1 = _arm(controller, "https://x/one", controller.session_a, results, "one")
     assert _wait_until(lambda: len(controller.pending_skill_install_ids()) == 1)
@@ -173,11 +180,14 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     t2 = _arm(controller, "https://x/two", controller.session_a, results, "two")
     assert _wait_until(lambda: len(controller.pending_skill_install_ids()) == 2)
     id2 = [i for i in controller.pending_skill_install_ids() if i != id1][0]
-    # Round 2 overwrote round 1's stored payload under the same session key.
+    # PR0: round 2 keeps its OWN key rather than overwriting round 1's --
+    # round 1 is still the session's head and still owns the card.
     assert (
-        controller._parked_skill_install_payloads[controller.session_a]["request_id"]
-        == id2
-    )
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_a
+        )["request_id"]
+        == id1
+    ), "arming round 2 must not evict round 1's card"
 
     # Round 1 (the EARLIER round) resolves first -- must not evict round
     # 2's still-armed payload nor clear the badge.
@@ -190,9 +200,11 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     )
     assert controller.session_a in controller._pending_approvals
     assert (
-        controller._parked_skill_install_payloads[controller.session_a]["request_id"]
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_a
+        )["request_id"]
         == id2
-    )
+    ), "round 1 resolving must promote round 2, not discard it"
 
     # Round 2 (the LAST remaining round) resolves -- now everything clears.
     controller.resolve_pending_skill_install(True, request_id=id2)
@@ -200,36 +212,38 @@ def test_two_rounds_for_the_same_session_keep_badge_and_payload_until_both_resol
     assert results["two"] is True
     assert controller.run_marker_for(controller.session_a) is ConsoleRunMarker.NONE
     assert controller.session_a not in controller._pending_approvals
-    assert controller.session_a not in controller._parked_skill_install_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_a
+        )
+        is None
+    )
 
 
 def test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_the_slot_populated(
     controller,
 ):
-    """TASK-1050 fix round 1 (review): reverse-ordering counterpart to the
-    sibling test above (mirrors `test_console_mcp_approval.py`'s identical
-    MCP-bridge test). `_parked_skill_install_payloads` is a SINGLE
-    per-session slot holding whichever round's payload was LAST WRITTEN,
-    so resolving the NEWER (newest-armed) round FIRST -- the natural live
-    ordering, since arming a round re-mounts its card, which typically
-    gets decided before an already-waiting sibling does -- must not pop
-    the slot while the OLDER round is still outstanding: the badge must
-    stay up and the slot must still hold a payload (remount still works,
-    even though it is round 2's own now-stale payload rather than round
-    1's -- the accepted single-slot scope). Only resolving the older,
-    now-last round clears both.
+    """Reverse ordering: the newer round resolving first must not strand
+    the older one card-less with the badge still lit.
 
-    Fix round 3 (re-review) EXTENSION: mirrors `test_console_mcp_
-    approval.py`'s identical extension -- pins the CARD-CLEAR seam
-    itself, not just the payload map. The `controller` fixture wires
-    `set_pending_skill_install` as a discarding no-op, which could not
-    have caught the fix-round-2 regression (a stray clear call is
-    silently indistinguishable from no call at all through a no-op), so
-    this test overrides it locally with a recording list and asserts
-    directly on it: no NEW clear call reaches the seam while round 1 is
-    still armed, and round 1 remains resolvable (decidable) through its
-    own `request_id` throughout; only once round 1 (the last remaining
-    round) resolves does the clear actually fire."""
+    This is the NATURAL live ordering, not an edge case -- pre-PR0, arming
+    a round re-mounted its card, so the newest round was typically decided
+    before an already-waiting sibling. Two successive TASK-1050 fix rounds
+    were needed to stop the newer round's teardown from popping the SHARED
+    per-session payload slot (fix round 1) and then from firing the
+    card-clear seam (fix round 3) while the older round was still armed.
+
+    PR0 (task-15661) makes both hazards structural non-events: each round
+    owns its own key, and the card is always the session's FIFO HEAD.
+    Round 1 is therefore the round that MOUNTS (round 2 queues silently
+    behind it), and round 2 resolving re-derives the head -- which is
+    still round 1's own payload, so the card the user is looking at does
+    not change and is certainly never cleared. Recording every call
+    through `mounted.append` (rather than a discarding no-op) is what
+    makes that observable at all -- under FIFO the re-derive seam
+    legitimately fires (re-deriving to the same head) where pre-PR0 it
+    had to stay silent, so this asserts on the card's CONTENT rather than
+    on whether the seam was called."""
     mounted: list[dict | None] = []
     controller.set_pending_skill_install = mounted.append
 
@@ -241,14 +255,17 @@ def test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_th
 
     t2 = _arm(controller, "https://x/two", controller.session_a, results, "two")
     assert _wait_until(lambda: len(controller.pending_skill_install_ids()) == 2)
-    id2 = [i for i in controller.pending_skill_install_ids() if i != id1][0]
+    # PR0: round 2 does NOT mount -- round 1 is the head and keeps the card.
     assert mounted[-1] is not None
-    calls_after_both_armed = len(mounted)  # 2: round 1's mount, round 2's mount
+    assert mounted[-1]["request_id"] == id1, (
+        "arming round 2 must not evict the head round's card"
+    )
+    id2 = [i for i in controller.pending_skill_install_ids() if i != id1][0]
 
-    # Round 2 (the NEWER round) resolves FIRST -- round 1 is still
-    # outstanding, so the badge must stay up, the slot must still hold a
-    # payload, and -- the regression this test now pins -- the
-    # CARD-CLEAR seam must NOT be invoked at all.
+    # Round 2 (the NEWER, queued round) resolves FIRST -- round 1 is still
+    # outstanding, so the badge must stay up, round 1 must keep its own
+    # retained payload, and the card the user is looking at must still be
+    # round 1's own (PR0: the head re-derive resolves back to it).
     controller.resolve_pending_skill_install(True, request_id=id2)
     t2.join(timeout=5)
     assert results["two"] is True
@@ -257,15 +274,15 @@ def test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_th
         is ConsoleRunMarker.NEEDS_APPROVAL
     )
     assert controller.session_a in controller._pending_approvals
-    assert controller.session_a in controller._parked_skill_install_payloads, (
-        "the parked slot must still hold a payload -- popping it here "
+    assert id1 in controller._parked_skill_install_payloads, (
+        "round 1 must keep its own retained payload -- dropping it here "
         "would strand the still-armed older round unresolvable on the "
         "next switch-away/back"
     )
-    assert len(mounted) == calls_after_both_armed, (
-        "round 2 resolving must NOT invoke the card-clear seam while "
-        "round 1 is still armed -- doing so strands round 1 card-less "
-        "with the badge still lit"
+    assert mounted[-1] is not None and mounted[-1]["request_id"] == id1, (
+        "round 2 resolving must leave round 1's card on screen -- clearing "
+        "it (or swapping in anything else) strands round 1 card-less with "
+        f"the badge still lit; got {mounted[-1]}"
     )
 
     # Round 1 (the OLDER round) remains fully decidable through the UI --
@@ -275,9 +292,13 @@ def test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_th
     assert results["one"] is False
     assert controller.run_marker_for(controller.session_a) is ConsoleRunMarker.NONE
     assert controller.session_a not in controller._pending_approvals
-    assert controller.session_a not in controller._parked_skill_install_payloads
-    # Round 1 (now the LAST remaining round) resolving DOES fire the clear.
-    assert len(mounted) == calls_after_both_armed + 1
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_a
+        )
+        is None
+    )
+    # Round 1 (now the LAST remaining round) resolving DOES clear the card.
     assert mounted[-1] is None
 
 
@@ -313,8 +334,16 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     deterministic (event/gate-controlled, never sleep-timed) proof: round
     1 resolves and its teardown's clear call BLOCKS mid-flight; round 2
     arms and mounts for the SAME session while round 1's clear is still
-    blocked; only then is round 1's clear released to actually run and
-    must no-op rather than wipe round 2's freshly-mounted card."""
+    blocked; only then is round 1's clear released to actually run.
+
+    PR0 (task-15661) replaced the round-identity guard with a FIFO-head
+    re-derive (`_remount_head`), which closes the same race by the same
+    principle -- the decision is computed INSIDE the callable, on the UI
+    thread, never from a worker-thread snapshot -- and is order-
+    independent besides. Released here, round 1's deferred callable must
+    re-derive to round 2 (the session's head by then, since round 1's own
+    entry is already popped) and leave round 2's freshly-mounted card
+    intact."""
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=object())
     session_a = store.create_session(title="A").id
@@ -343,7 +372,12 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
         "round 1's teardown never reached its clear call"
     )
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_skill_install_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, session_a
+        )
+        is None
+    )
 
     result_2: dict[str, bool] = {}
 
@@ -360,8 +394,9 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     assert request_id_2 != request_id_1
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NEEDS_APPROVAL
 
-    # Release round 1's blocked clear -- the round-identity guard must see
-    # round 2 has since claimed the slot and no-op.
+    # Release round 1's blocked clear -- the FIFO-head re-derive must land
+    # on round 2 (the only round left once round 1's own entry is popped),
+    # leaving its already-mounted card as-is rather than wiping it.
     app.release_clear.set()
     worker_1.join(timeout=2.0)
     assert result_1["allowed"] is False
@@ -376,7 +411,12 @@ def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_r
     assert result_2["allowed"] is True
     assert controller.run_marker_for(session_a) is ConsoleRunMarker.NONE
     assert session_a not in controller._pending_approvals
-    assert session_a not in controller._parked_skill_install_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, session_a
+        )
+        is None
+    )
     assert mounted[-1] is None
 
 
@@ -548,5 +588,15 @@ def test_shutdown_flag_alone_denies_both_unregistered_sessions_rounds_and_cleans
     assert controller.pending_skill_install_ids() == []
     assert controller.session_a not in controller._pending_approvals
     assert controller.session_b not in controller._pending_approvals
-    assert controller.session_a not in controller._parked_skill_install_payloads
-    assert controller.session_b not in controller._parked_skill_install_payloads
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_a
+        )
+        is None
+    )
+    assert (
+        controller._head_round_payload(
+            controller._parked_skill_install_payloads, controller.session_b
+        )
+        is None
+    )

--- a/Tests/UI/test_skill_install_concurrent_confirms.py
+++ b/Tests/UI/test_skill_install_concurrent_confirms.py
@@ -303,14 +303,14 @@ def test_two_rounds_for_the_same_session_resolving_the_newer_one_first_leaves_th
 
 
 class _DeferredClearApp:
-    """`call_from_thread` stand-in that BLOCKS the round-identity-guarded
-    clear closures until a test explicitly releases them, while every
+    """`call_from_thread` stand-in that BLOCKS the `_remount_head` re-derive
+    closures until a test explicitly releases them, while every
     OTHER `call_from_thread` use (mount, park) still runs immediately.
 
     Mirrors `test_console_mcp_approval.py`'s identical fake -- see
-    `_clear_pending_skill_install_if_round_is_current`'s docstring for
-    why the clear closures are always invoked with zero args/kwargs,
-    which is what identifies them here without any bridge-specific hook.
+    `_remount_head`'s docstring for why the re-derive closures are
+    always invoked with zero args/kwargs, which is what identifies them
+    here without any bridge-specific hook.
     """
 
     def __init__(self) -> None:
@@ -325,12 +325,12 @@ class _DeferredClearApp:
         return fn(*args, **kwargs)
 
 
-def test_teardown_clear_is_round_identity_guarded_against_a_newer_same_session_round_arming_mid_teardown():
+def test_teardown_clear_does_not_clobber_a_newer_same_session_round_arming_mid_teardown():
     """TASK-1050 fix round 2 (review, Qodo PR #1041): mirrors `test_
     console_mcp_approval.py`'s identical MCP-bridge test -- `request_
     skill_install_confirm`'s teardown has the exact same shape (a
     snapshot-guarded clear enqueued via `call_from_thread`), so it needs
-    the exact same round-identity-guarded fix and the exact same
+    the exact same FIFO-head re-derive fix and the exact same
     deterministic (event/gate-controlled, never sleep-timed) proof: round
     1 resolves and its teardown's clear call BLOCKS mid-flight; round 2
     arms and mounts for the SAME session while round 1's clear is still

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1741,11 +1741,6 @@ class ConsoleChatController:
         #: `request_id`. The mounted card is the session's FIFO head, so a
         #: second same-session confirm no longer evicts an older sibling.
         self._parked_skill_script_payloads: dict[str, dict[str, Any]] = {}
-        #: The currently-armed round's unique id (see `request_skill_script_
-        #: confirm` / `resolve_pending_skill_script`). A resolve carrying any
-        #: other id (including None) is dropped -- this is what stops a
-        #: late button press from a torn-down round 1 from authorizing
-        #: round 2's script. `None` whenever no round is armed.
 
     @property
     def run_state(self) -> ConsoleRunState:
@@ -5141,8 +5136,9 @@ class ConsoleChatController:
         rather than at its auto-deny deadline, (e) discarded from
         ``_pending_approvals`` so the session's NEEDS_APPROVAL badge
         clears once its last round is gone, and (f) taken off screen
-        through the SAME round-identity-guarded clear that round's own
-        teardown uses, so a sibling round's card is never clobbered.
+        through the SAME FIFO-head re-derive (``_remount_head``) that the
+        round's own teardown uses, so a sibling round's card is never
+        clobbered.
 
         Thread-safe. Each registry is swept under its own lock, and the
         two locks are taken SEQUENTIALLY, never nested. ``discard_pending_

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1712,12 +1712,9 @@ class ConsoleChatController:
         #: concurrent.
         self._pending_skill_install_rounds: dict[str, dict[str, Any]] = {}
         self._pending_skill_install_lock = threading.Lock()
-        #: TASK-910 (parked background skill confirms): retained payload for
-        #: a session-attributed `request_skill_install_confirm` round --
-        #: mounted or parked, exactly like `_parked_approval_payloads`.
-        #: `switch_session`/`new_session`/`close_session` re-derive the
-        #: mounted card from this map on every activation, never from
-        #: whatever the card happened to already be showing.
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `request_id`. The mounted card is the session's FIFO head, so a
+        #: second same-session confirm no longer evicts an older sibling.
         self._parked_skill_install_payloads: dict[str, dict[str, Any]] = {}
         #: UI-thread callback that pushes/clears the pending skill-SCRIPT
         #: confirm payload into the owning screen's task-resume state.
@@ -5385,6 +5382,9 @@ class ConsoleChatController:
         is_parked = session_id is not None and session_id != (
             self.store.active_session_id or ""
         )
+        # PR0: legacy `session_id is None` callers never park and never
+        # queue -- they keep the unconditional mount below.
+        is_head = True
         if session_id is not None:
             # TASK-1050 (Defect A): round-keyed, not a plain boolean -- see
             # `request_mcp_approvals`' identical `add_pending_round` call
@@ -5397,13 +5397,17 @@ class ConsoleChatController:
             # `request_mcp_approvals`' identical retention (Fix wave,
             # CRITICAL 1): a round that mounted immediately must still be
             # recoverable after a switch-away-and-back.
-            with self._approval_state_lock:
-                self._parked_skill_install_payloads[session_id] = payload
+            # PR0: keyed by ROUND, and the return says whether THIS round
+            # is its session's FIFO head. A non-head round must not mount:
+            # an older sibling is still holding the card.
+            is_head = self._park_round_payload(
+                self._parked_skill_install_payloads, request_id, payload
+            )
         try:
             if is_parked:
                 if self.app is not None and self.park_pending_approval is not None:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
-            else:
+            elif is_head:
                 self._marshal_pending_skill_install(payload)
             # ADR-067: mark the owning run as waiting on a human decision
             # (see `request_mcp_approvals`' identical wrap for the why).
@@ -5421,116 +5425,43 @@ class ConsoleChatController:
         finally:
             with self._pending_skill_install_lock:
                 self._pending_skill_install_rounds.pop(request_id, None)
-                still_armed_same_session = any(
-                    state.get("session_id") == owning_session_id
-                    for state in self._pending_skill_install_rounds.values()
-                )
+            # PR0: drop exactly THIS round's retained payload. Pre-PR0 the
+            # slot was shared per session, so the pop had to be guarded by
+            # an order-dependent "is this the last armed round for the
+            # session" test to avoid discarding a still-armed sibling's
+            # only copy. Per-round storage makes that guard meaningless --
+            # each round owns its own key.
+            self._unpark_round_payload(
+                self._parked_skill_install_payloads, request_id
+            )
             if session_id is not None:
-                # TASK-1050 (Defect B) fix round 1 (review): `_parked_
-                # skill_install_payloads` is a SINGLE per-session slot
-                # holding whichever round's payload was LAST WRITTEN
-                # (arming overwrites it) -- an unconditional pop here would
-                # let the EARLIER round's teardown discard the NEWER
-                # round's still-armed retained payload. The original fix
-                # also popped whenever the stored payload was still this
-                # round's own id ("nothing has overwritten it since"), but
-                # that is true exactly when THIS round is the newest-armed
-                # one -- which is also the common case where an OLDER
-                # sibling is still outstanding (arming re-mounts/re-parks a
-                # card, which typically gets decided before an
-                # already-waiting sibling does). Popping there discarded
-                # the still-armed OLDER round's only remaining payload
-                # (reviewer reproduced live). Only the order-independent
-                # "no armed round left for this session" test is safe: pop
-                # ONLY when this is the LAST armed round for the session.
-                # (Accepted scope limitation: last-armed-wins regardless of
-                # resolution order -- see `request_mcp_approvals`' mirror
-                # of this comment for the full rationale.)
-                with self._approval_state_lock:
-                    if not still_armed_same_session:
-                        self._parked_skill_install_payloads.pop(session_id, None)
                 # TASK-1050 (Defect A): discard ONLY this round's own id --
                 # the badge clears only once every bridge round for this
                 # session (this one included) has resolved.
                 self.discard_pending_round(session_id, request_id)
-            # TASK-1050 fix round 2 (review): mirrors `request_mcp_
-            # approvals`' identical fix -- a plain boolean snapshot
-            # (`still_active`/`still_armed_same_session`) computed before
-            # enqueueing the clear via `call_from_thread` leaves a race
-            # window where a NEWER same-session round can arm, mount its
-            # own card, and then get wiped by this round's now-stale
-            # clear. `_clear_pending_skill_install_if_round_is_current`
-            # defers the whole decision (round-identity check included)
-            # to the UI thread's own execution of the enqueued callable
-            # -- see `_clear_pending_skill_install_if_round_is_current`'s
-            # own docstring for the full race analysis. (The MCP bridge's
-            # equivalent guard is gone: PR0 re-keyed its payload map by
-            # round, so `_remount_head` re-derives the FIFO head instead
-            # of deciding whether to clear. This bridge is re-keyed in its
-            # own task.)
+            # PR0: re-derive the card from the session's remaining FIFO
+            # head rather than deciding whether to CLEAR it. This
+            # subsumes `_clear_pending_skill_install_if_round_is_current`'s
+            # two-part TOCTOU guard -- see `request_mcp_approvals`'
+            # identical `_remount_head` teardown call for the full race
+            # analysis.
+            # `owning_session_id`, not `session_id`: a legacy no-session
+            # caller retains no payload, so its head resolves to `None` and
+            # the card clears exactly as the pre-PR0 unconditional clear
+            # did -- `_remount_head` no-ops on a `None` session_id, which
+            # would otherwise leave a legacy caller's card stuck on screen
+            # (caught live by `test_console_skill_install_confirm.py::
+            # test_confirm_round_trip_allow`).
             try:
-                self._clear_pending_skill_install_if_round_is_current(
-                    request_id, session_id
+                self._remount_head(
+                    self._parked_skill_install_payloads,
+                    self.set_pending_skill_install,
+                    owning_session_id,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(
-                    "Failed to clear skill-install confirm during teardown"
+                    "Failed to marshal skill-install remount during teardown"
                 )
-
-    def _clear_pending_skill_install_if_round_is_current(
-        self, request_id: str | None, session_id: str | None
-    ) -> None:
-        """WORKER THREAD: enqueue a round-identity-guarded clear of the mounted skill-install card.
-
-        TASK-1050 fix round 2 (review): mirrors ``_clear_pending_
-        approval_if_round_is_current``'s identical race-proofing -- see
-        that method's docstring for the full analysis of why a boolean
-        snapshot computed before enqueueing (however late) cannot close
-        this race, only deferring the whole identity check to the UI
-        thread's own execution of the enqueued callable can.
-
-        Fix round 3 (re-review) regression fix: mirrors ``_clear_pending_
-        approval_if_round_is_current``'s identical two-part guard -- the
-        round-identity check alone only catches "payload overwritten by a
-        newer arm", not "a DIFFERENT, OLDER sibling round is still armed"
-        (true exactly when THIS round is the newest-armed one and
-        resolves FIRST, the natural live ordering). Also re-reads
-        ``_pending_skill_install_rounds`` live (under ``_pending_skill_
-        install_lock``, sequentially after -- never nested with --
-        ``_approval_state_lock``, matching this file's existing lock-
-        ordering discipline) filtered to this session; any hit there is
-        necessarily a still-armed sibling (this round's own entry is
-        already popped earlier in ``finally``), so the clear must no-op
-        exactly as it does on a failed identity check.
-
-        Args:
-            request_id: This round's own id. Only consulted when
-                ``session_id`` is not ``None``.
-            session_id: This round's owning session. ``None`` preserves
-                the pre-existing unconditional-clear behavior for legacy
-                no-session callers.
-        """
-        if self.app is None or self.set_pending_skill_install is None:
-            return
-
-        def _clear_if_still_current() -> None:
-            if session_id is not None:
-                with self._approval_state_lock:
-                    current = self._parked_skill_install_payloads.get(session_id)
-                if current is not None and current.get("request_id") != request_id:
-                    return
-                with self._pending_skill_install_lock:
-                    still_armed_same_session = any(
-                        state.get("session_id") == session_id
-                        for state in self._pending_skill_install_rounds.values()
-                    )
-                if still_armed_same_session:
-                    return
-                if session_id != (self.store.active_session_id or ""):
-                    return
-            self.set_pending_skill_install(None)
-
-        self.app.call_from_thread(_clear_if_still_current)
 
     def _remount_parked_skill_install(self, session_id: str) -> None:
         """Re-derive the mounted skill-install confirm card for ``session_id``.
@@ -5546,9 +5477,9 @@ class ConsoleChatController:
         """
         if self.set_pending_skill_install is None:
             return
-        with self._approval_state_lock:
-            parked_payload = self._parked_skill_install_payloads.get(session_id)
-        self.set_pending_skill_install(parked_payload)
+        self.set_pending_skill_install(
+            self._head_round_payload(self._parked_skill_install_payloads, session_id)
+        )
 
     def _marshal_pending_skill_install(self, payload: dict[str, Any] | None) -> None:
         """WORKER THREAD: hand a skill-install confirm payload to the UI thread.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1737,9 +1737,9 @@ class ConsoleChatController:
         #: both worker threads then blocked to their full deadline.
         self._pending_skill_script_rounds: dict[str, dict[str, Any]] = {}
         self._pending_skill_script_lock = threading.Lock()
-        #: TASK-910 (parked background skill confirms): retained payload for
-        #: a session-attributed `request_skill_script_confirm` round --
-        #: mirrors `_parked_skill_install_payloads` above.
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `request_id`. The mounted card is the session's FIFO head, so a
+        #: second same-session confirm no longer evicts an older sibling.
         self._parked_skill_script_payloads: dict[str, dict[str, Any]] = {}
         #: The currently-armed round's unique id (see `request_skill_script_
         #: confirm` / `resolve_pending_skill_script`). A resolve carrying any
@@ -5145,11 +5145,10 @@ class ConsoleChatController:
         teardown uses, so a sibling round's card is never clobbered.
 
         Thread-safe. Each registry is swept under its own lock, and the
-        two locks are taken SEQUENTIALLY, never nested -- the ordering
-        contract ``_clear_pending_skill_script_if_round_is_current``
-        already documents. ``discard_pending_round`` and both UI clears
-        take those (non-reentrant) locks themselves, so they are
-        deliberately called after every critical section is released.
+        two locks are taken SEQUENTIALLY, never nested. ``discard_pending_
+        round`` and both UI clears take those (non-reentrant) locks
+        themselves, so they are deliberately called after every critical
+        section is released.
 
         Args:
             run_id: The cancelled/abandoned run whose cards must die. A
@@ -5184,8 +5183,13 @@ class ConsoleChatController:
             if session_id is not None:
                 self.discard_pending_round(session_id, request_id)
             try:
-                self._clear_pending_skill_script_if_round_is_current(
-                    request_id, session_id
+                # PR0: re-derive from the session's remaining FIFO head --
+                # revoking one round of several must promote the next, not
+                # blank the session's card.
+                self._remount_head(
+                    self._parked_skill_script_payloads,
+                    self.set_pending_skill_script,
+                    session_id,
                 )
             except Exception:  # noqa: BLE001 -- as above.
                 logger.debug("Failed to clear skill-script confirm during revocation")
@@ -5243,9 +5247,8 @@ class ConsoleChatController:
         """Fail this run's ``run_skill_script`` confirms closed.
 
         Registry work only, under ``_pending_skill_script_lock`` and then
-        (sequentially, never nested -- see
-        ``_clear_pending_skill_script_if_round_is_current``)
-        ``_approval_state_lock`` for the retained-payload slot.
+        (sequentially, never nested) ``_approval_state_lock`` for the
+        retained-payload slot.
 
         Args:
             run_id: The cancelled/abandoned run.
@@ -5271,15 +5274,16 @@ class ConsoleChatController:
                 event = state.get("event")
                 if event is not None:
                     event.set()
-            still_armed = {
-                state.get("session_id")
-                for state in self._pending_skill_script_rounds.values()
-            }
-        if revoked:
-            with self._approval_state_lock:
-                for _request_id, session_id in revoked:
-                    if session_id is not None and session_id not in still_armed:
-                        self._parked_skill_script_payloads.pop(session_id, None)
+        # PR0: mirrors `request_skill_script_confirm`'s `finally` exactly --
+        # each round drops exactly its OWN retained payload, so a
+        # still-armed sibling keeps its own copy. The pre-PR0 "is this the
+        # last armed round for the session" test existed only because the
+        # slot was shared. Runs outside the critical section above because
+        # `_unpark_round_payload` takes the (non-reentrant) same lock.
+        for round_id_to_drop, session_id in revoked:
+            self._unpark_round_payload(
+                self._parked_skill_script_payloads, round_id_to_drop
+            )
         return revoked
 
     # -- Skill-install confirm bridge (task-5, parked TASK-910) --------------
@@ -5637,18 +5641,25 @@ class ConsoleChatController:
         is_parked = session_id is not None and session_id != (
             self.store.active_session_id or ""
         )
+        # PR0: legacy `session_id is None` callers never park and never
+        # queue -- they keep the unconditional mount below.
+        is_head = True
         if session_id is not None:
             # TASK-1050 (Defect A): round-keyed, not a plain boolean -- see
             # `request_mcp_approvals`' identical `add_pending_round` call
             # for the full rationale.
             self.add_pending_round(session_id, request_id)
-            with self._approval_state_lock:
-                self._parked_skill_script_payloads[session_id] = card_payload
+            # PR0: keyed by ROUND, and the return says whether THIS round
+            # is its session's FIFO head. A non-head round must not mount:
+            # an older sibling is still holding the card.
+            is_head = self._park_round_payload(
+                self._parked_skill_script_payloads, request_id, card_payload
+            )
         try:
             if is_parked:
                 if self.app is not None and self.park_pending_approval is not None:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
-            else:
+            elif is_head:
                 self._marshal_pending_skill_script(card_payload)
             # ADR-067: mark the owning run as waiting on a human decision
             # (see `request_mcp_approvals`' identical wrap for the why).
@@ -5683,95 +5694,41 @@ class ConsoleChatController:
         finally:
             with self._pending_skill_script_lock:
                 self._pending_skill_script_rounds.pop(request_id, None)
-                still_armed_same_session = any(
-                    state.get("session_id") == owning_session_id
-                    for state in self._pending_skill_script_rounds.values()
-                )
+            # PR0: drop exactly THIS round's retained payload. Pre-PR0 the
+            # slot was shared per session, so the pop had to be guarded by
+            # an order-dependent "is this the last armed round for the
+            # session" test to avoid discarding a still-armed sibling's
+            # only copy. Per-round storage makes that guard meaningless --
+            # each round owns its own key.
+            self._unpark_round_payload(
+                self._parked_skill_script_payloads, request_id
+            )
             if session_id is not None:
-                # TASK-1050 (Defect B) fix round 1 (review): mirrors
-                # `request_skill_install_confirm`'s identical guard --
-                # `_parked_skill_script_payloads` is a SINGLE per-session
-                # slot holding whichever round's payload was LAST WRITTEN.
-                # The original fix also popped whenever the stored payload
-                # was still this round's own id, but that is true exactly
-                # when THIS round is the newest-armed one -- which is also
-                # the common case where an OLDER sibling is still
-                # outstanding. Popping there discarded the still-armed
-                # OLDER round's only remaining payload (reviewer reproduced
-                # live). Only pop when this is the LAST armed round for the
-                # session -- see `request_mcp_approvals`' mirror of this
-                # comment for the full rationale and the accepted
-                # single-slot/last-armed-wins scope limitation.
-                with self._approval_state_lock:
-                    if not still_armed_same_session:
-                        self._parked_skill_script_payloads.pop(session_id, None)
                 # TASK-1050 (Defect A): discard ONLY this round's own id --
                 # the badge clears only once every bridge round for this
                 # session (this one included) has resolved.
                 self.discard_pending_round(session_id, request_id)
-            # TASK-1050 fix round 2 (review): mirrors `request_skill_
-            # install_confirm`'s identical fix -- see `_clear_pending_
-            # skill_script_if_round_is_current`'s docstring for the full
-            # race analysis a plain boolean snapshot (however late it is
-            # recomputed) cannot close. `request_mcp_approvals` no longer
-            # needs a clear guard at all: PR0 re-keyed its payload map by
-            # round, so it re-derives the FIFO head (`_remount_head`).
+            # PR0: re-derive the card from the session's remaining FIFO
+            # head rather than deciding whether to CLEAR it. This subsumes
+            # the pre-PR0 `_clear_pending_skill_script_if_round_is_current`
+            # guard's two-part TOCTOU check -- see `request_mcp_approvals`'
+            # identical `_remount_head` teardown call for the full race
+            # analysis.
+            # `owning_session_id`, not `session_id`: a legacy no-session
+            # caller retains no payload, so its head resolves to `None` and
+            # the card clears exactly as the pre-PR0 unconditional clear
+            # did -- `_remount_head` no-ops on a `None` session_id, which
+            # would otherwise leave a legacy caller's card stuck on screen.
             try:
-                self._clear_pending_skill_script_if_round_is_current(
-                    request_id, session_id
+                self._remount_head(
+                    self._parked_skill_script_payloads,
+                    self.set_pending_skill_script,
+                    owning_session_id,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(
-                    "Failed to clear skill-script confirm during teardown"
+                    "Failed to marshal skill-script remount during teardown"
                 )
-
-    def _clear_pending_skill_script_if_round_is_current(
-        self, request_id: str | None, session_id: str | None
-    ) -> None:
-        """WORKER THREAD: enqueue a round-identity-guarded clear of the mounted skill-script card.
-
-        TASK-1050 fix round 2 (review): mirrors ``_clear_pending_
-        approval_if_round_is_current``'s identical race-proofing -- see
-        that method's docstring for the full analysis.
-
-        Fix round 3 (re-review) regression fix: mirrors ``_clear_pending_
-        approval_if_round_is_current``'s/``_clear_pending_skill_install_
-        if_round_is_current``'s identical two-part guard -- also
-        re-reads ``_pending_skill_script_rounds`` live (under
-        ``_pending_skill_script_lock``, sequentially after -- never
-        nested with -- ``_approval_state_lock``) filtered to this
-        session, so a still-armed OLDER sibling round (true exactly when
-        THIS round is the newest-armed one and resolves FIRST) blocks the
-        clear just as surely as a failed identity check does.
-
-        Args:
-            request_id: This round's own id. Only consulted when
-                ``session_id`` is not ``None``.
-            session_id: This round's owning session. ``None`` preserves
-                the pre-existing unconditional-clear behavior for legacy
-                no-session callers.
-        """
-        if self.app is None or self.set_pending_skill_script is None:
-            return
-
-        def _clear_if_still_current() -> None:
-            if session_id is not None:
-                with self._approval_state_lock:
-                    current = self._parked_skill_script_payloads.get(session_id)
-                if current is not None and current.get("request_id") != request_id:
-                    return
-                with self._pending_skill_script_lock:
-                    still_armed_same_session = any(
-                        state.get("session_id") == session_id
-                        for state in self._pending_skill_script_rounds.values()
-                    )
-                if still_armed_same_session:
-                    return
-                if session_id != (self.store.active_session_id or ""):
-                    return
-            self.set_pending_skill_script(None)
-
-        self.app.call_from_thread(_clear_if_still_current)
 
     def _remount_parked_skill_script(self, session_id: str) -> None:
         """Re-derive the mounted skill-script confirm card for ``session_id``.
@@ -5782,14 +5739,19 @@ class ConsoleChatController:
         departing session had shown, all in one call. A no-op when no UI
         bridge is wired.
 
+        PR0: re-keyed by round, so this now re-derives the session's FIFO
+        head instead of a single per-session slot. It already runs on the
+        UI thread, so it calls `_head_round_payload` directly rather than
+        `_remount_head`.
+
         Args:
             session_id: The session now being activated/viewed.
         """
         if self.set_pending_skill_script is None:
             return
-        with self._approval_state_lock:
-            parked_payload = self._parked_skill_script_payloads.get(session_id)
-        self.set_pending_skill_script(parked_payload)
+        self.set_pending_skill_script(
+            self._head_round_payload(self._parked_skill_script_payloads, session_id)
+        )
 
     def _marshal_pending_skill_script(self, payload: dict[str, Any] | None) -> None:
         """WORKER THREAD: hand a skill-script confirm payload to the UI thread.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -4455,7 +4455,7 @@ class ConsoleChatController:
 
     @staticmethod
     def _head_round_payload_locked(
-        store: dict[str, dict[str, Any]], session_id: str
+        store: dict[str, dict[str, Any]], session_id: str | None
     ) -> dict[str, Any] | None:
         """The session's oldest-armed payload. Caller holds the lock."""
         for payload in store.values():
@@ -5233,7 +5233,7 @@ class ConsoleChatController:
         # round for the session" test existed only because the slot was
         # shared. Runs outside the critical section above because
         # `_unpark_round_payload` takes the (non-reentrant) same lock.
-        for round_id_to_drop, session_id in revoked:
+        for round_id_to_drop, _session_id in revoked:
             self._unpark_round_payload(
                 self._parked_approval_payloads, round_id_to_drop
             )
@@ -5276,7 +5276,7 @@ class ConsoleChatController:
         # last armed round for the session" test existed only because the
         # slot was shared. Runs outside the critical section above because
         # `_unpark_round_payload` takes the (non-reentrant) same lock.
-        for round_id_to_drop, session_id in revoked:
+        for round_id_to_drop, _session_id in revoked:
             self._unpark_round_payload(
                 self._parked_skill_script_payloads, round_id_to_drop
             )

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -1687,15 +1687,11 @@ class ConsoleChatController:
         #: whose id was stamped onto the card the user actually decided --
         #: never "whichever session happens to be active right now".
         self._pending_approval_rounds: dict[str, dict[str, Any]] = {}
-        #: Task 9: retained payload for a PARKED round (session_id !=
-        #: active_session_id at round-start), keyed by owning session id --
-        #: the exact dict ``request_mcp_approvals`` would otherwise have
-        #: pushed straight to ``set_pending_approval``. ``switch_session``
-        #: re-derives the mounted card from this map every time the user
-        #: visits (or re-visits) the session, per the spec's "card state
-        #: derives from the run's pending review state, not mounted-widget
-        #: lifetime" contract -- never mutated by mount/unmount itself, only
-        #: by the round's own start (park) and end (any resolution path).
+        #: PR0: retained payload per ROUND (was per session), keyed by
+        #: `round_id`. `switch_session` and every teardown re-derive the
+        #: mounted card from this map's FIFO head for the session, so a
+        #: second same-session round no longer evicts an older sibling's
+        #: card. Every payload carries its own `round_id` and `session_id`.
         self._parked_approval_payloads: dict[str, dict[str, Any]] = {}
         #: UI-thread callback that pushes/clears the pending skill-install
         #: confirm payload into the owning screen's task-resume state
@@ -3372,12 +3368,9 @@ class ConsoleChatController:
         # "card state derives from the run's pending review state" rule
         # every other activation path follows.
         if self.set_pending_approval is not None:
-            # F2b fix (Qodo wave): guard the read for consistency with
-            # every other `_parked_approval_payloads` access, even though
-            # a single `.get()` is not itself an iteration hazard.
-            with self._approval_state_lock:
-                parked_payload = self._parked_approval_payloads.get(session.id)
-            self.set_pending_approval(parked_payload)
+            self.set_pending_approval(
+                self._head_round_payload(self._parked_approval_payloads, session.id)
+            )
         # TASK-910: same re-derive for the skill-install/script cards -- a
         # brand-new session can never itself have a parked confirm, so this
         # always resolves to clearing whatever the session being left behind
@@ -3543,11 +3536,9 @@ class ConsoleChatController:
         # parking -- the round now stays alive until its own resolution
         # (decision, cancel, or timeout).
         if self.set_pending_approval is not None:
-            # F2b fix (Qodo wave): guard the read for consistency with
-            # every other `_parked_approval_payloads` access.
-            with self._approval_state_lock:
-                parked_payload = self._parked_approval_payloads.get(session_id)
-            self.set_pending_approval(parked_payload)
+            self.set_pending_approval(
+                self._head_round_payload(self._parked_approval_payloads, session_id)
+            )
         # TASK-910: skill-install/script confirms now get the SAME park/
         # re-derive treatment as MCP batch approvals above -- a context
         # change (switch away) no longer force-denies either bridge's
@@ -3650,11 +3641,11 @@ class ConsoleChatController:
         if new_active_id is not None and new_active_id != previous_active_id:
             self.mark_session_visited(new_active_id)
             if self.set_pending_approval is not None:
-                # F2b fix (Qodo wave): guard the read for consistency with
-                # every other `_parked_approval_payloads` access.
-                with self._approval_state_lock:
-                    parked_payload = self._parked_approval_payloads.get(new_active_id)
-                self.set_pending_approval(parked_payload)
+                self.set_pending_approval(
+                    self._head_round_payload(
+                        self._parked_approval_payloads, new_active_id
+                    )
+                )
             # TASK-910: same re-derive for the skill-install/script cards --
             # closing the ACTIVE session auto-activates a neighbor, which is
             # now the VIEWED session exactly as if `switch_session` had
@@ -4065,8 +4056,12 @@ class ConsoleChatController:
         Task 9: the retained ``payload`` goes into
         ``_parked_approval_payloads`` for ``switch_session`` to mount
         later, and ``park_pending_approval`` fires the fleet badge +
-        one-shot toast instead of touching the mounted-card slot). Either
-        way it then polls ``event.wait(1.0)`` re-checking this run's OWN
+        one-shot toast instead of touching the mounted-card slot). PR0
+        adds a third case: an ACTIVE-session round that is not its
+        session's FIFO head neither mounts nor parks -- an older sibling
+        still owns the card, and this round's payload is retained under
+        its own ``round_id`` until that sibling's teardown promotes it.
+        Either way it then polls ``event.wait(1.0)`` re-checking this run's OWN
         cancel signal (``_is_session_cancelled``) and -- only when a
         POSITIVE timeout is configured (ADR-067: the default is 0 = none)
         -- a deadline, every second until one of three things happens: the
@@ -4227,6 +4222,9 @@ class ConsoleChatController:
         is_parked = session_id is not None and session_id != (
             self.store.active_session_id or ""
         )
+        # PR0: legacy `session_id is None` callers never park and never
+        # queue -- they keep the unconditional mount below.
+        is_head = True
         if session_id is not None:
             # Register THIS round's own id directly here (worker thread,
             # plain-dict/set mutation -- same no-marshal convention as
@@ -4258,11 +4256,13 @@ class ConsoleChatController:
             # here too makes retention symmetric with that cleanup, per
             # spec §5 ("card state survives tab switches") for every round,
             # not only parked ones.
-            # F2b fix (Qodo wave): guard the store -- `switch_session`'s
-            # own re-derive read (`.get()`) runs on the UI thread and can
-            # race this worker-thread write.
-            with self._approval_state_lock:
-                self._parked_approval_payloads[session_id] = payload
+            # PR0: keyed by ROUND, and the return says whether THIS round
+            # is its session's FIFO head. A non-head round must not mount:
+            # an older sibling is still holding the card, and evicting it
+            # is exactly the task-15661 defect this replaced.
+            is_head = self._park_round_payload(
+                self._parked_approval_payloads, round_id, payload
+            )
 
         try:
             if self._approval_view_is_detached():
@@ -4276,7 +4276,7 @@ class ConsoleChatController:
             elif is_parked:
                 if self.app is not None and self.park_pending_approval is not None:
                     self.app.call_from_thread(self.park_pending_approval, session_id)
-            else:
+            elif is_head:
                 self._marshal_pending_approval(payload)
             # ADR-067: mark this run as waiting on a human decision for the
             # duration of the wait, so a per-call wrapper hosting this round
@@ -4355,187 +4355,51 @@ class ConsoleChatController:
             # a second source of truth.
             return {name: decisions.get(name, "deny") for name in unique_names}
         finally:
-            # F2b fix (Qodo wave): guard both pops -- `resolve_pending_
-            # approval`'s round_id lookup and `switch_session`'s re-derive
-            # read can each observe these maps from the UI thread while
+            # F2b fix (Qodo wave): guard the pop -- `resolve_pending_
+            # approval`'s round_id lookup and the `fleet_summary_counts`
+            # sync tick can each observe this map from the UI thread while
             # this worker thread tears the round down.
             with self._approval_state_lock:
                 self._pending_approval_rounds.pop(round_id, None)
-                # TASK-1050 (Defect B) fix round 1 (review): `_parked_
-                # approval_payloads` is a SINGLE per-session slot that
-                # always holds whichever round's payload was LAST WRITTEN
-                # (arming always overwrites it) -- mirrors `request_skill_
-                # install_confirm`'s/`request_skill_script_confirm`'s
-                # identical guard. The original fix also popped whenever
-                # the STORED payload was still this round's own id, on the
-                # theory that meant "nothing has overwritten it since" --
-                # but that condition is true exactly when THIS round is
-                # the newest-armed one, which is also the common case where
-                # an OLDER sibling round is still outstanding (arming a
-                # round re-mounts/re-parks its card, which typically gets
-                # decided before an already-waiting sibling does). Popping
-                # there discarded the still-armed OLDER round's only
-                # remaining payload, so a switch-away/back re-derive found
-                # nothing and mounted `None` -- the reviewer reproduced
-                # this live. Only the order-independent "no armed round
-                # left for this session" test is safe: pop ONLY when this
-                # is the LAST armed MCP round for the session. (Accepted
-                # scope limitation: because the slot is single-payload,
-                # last-armed-wins regardless of resolution order -- a
-                # remount after the newest round resolves first shows the
-                # newest round's now-stale payload, not the still-live
-                # older round's; per-round payload storage is a larger
-                # change out of scope here.)
-                still_armed_same_session = session_id is not None and any(
-                    state.get("session_id") == session_id
-                    for state in self._pending_approval_rounds.values()
-                )
-                if session_id is not None and not still_armed_same_session:
-                    self._parked_approval_payloads.pop(session_id, None)
+            # PR0: drop exactly THIS round's retained payload. Pre-PR0 the
+            # slot was shared per session, so the pop had to be guarded by
+            # an order-dependent "is this the last armed round for the
+            # session" test to avoid discarding a still-armed sibling's
+            # only copy. Per-round storage makes that guard meaningless --
+            # each round owns its own key -- and takes the accepted
+            # last-armed-wins limitation (task-15661) with it.
+            self._unpark_round_payload(self._parked_approval_payloads, round_id)
             if session_id is not None:
                 # TASK-1050 (Defect A): discard ONLY this round's own id --
                 # the badge clears only once every bridge round for this
                 # session (this one included) has resolved.
                 self.discard_pending_round(session_id, round_id)
-            # TASK-1050 fix round 2 (review): clearing the mounted card
-            # here used to be guarded by `still_active`/`still_armed_same_
-            # session` booleans computed BEFORE enqueueing the clear via
-            # `call_from_thread` -- a race window between that snapshot and
-            # the UI thread actually running the clear let a NEWER
-            # same-session round arm, mount its own card, and then get
-            # wiped by this round's now-stale clear. `_clear_pending_
-            # approval_if_round_is_current` closes this by deferring the
-            # ENTIRE decision (round-identity check included) to the UI
-            # thread's own execution of the enqueued callable -- see its
-            # docstring for the full race analysis.
+            # PR0: re-derive the card from the session's remaining FIFO
+            # head rather than deciding whether to CLEAR it. This
+            # subsumes `_clear_pending_approval_if_round_is_current`'s
+            # two-part TOCTOU guard: clearing was order-dependent, so the
+            # decision could go stale between a worker-thread snapshot and
+            # the UI thread running it; a head re-derive is a pure
+            # function of current state. The race-proofing principle is
+            # unchanged -- `_remount_head` still computes the answer
+            # INSIDE the callable that runs on the UI thread, never from a
+            # snapshot taken here.
+            # `owning_session_id`, not `session_id`: a legacy no-session
+            # caller retains no payload, so its head resolves to `None` and
+            # the card clears exactly as the pre-PR0 unconditional clear
+            # did -- unless a real session-attributed sibling is armed for
+            # the session it mounted over, in which case that sibling's
+            # card is (correctly) what stays up.
             try:
-                self._clear_pending_approval_if_round_is_current(round_id, session_id)
+                self._remount_head(
+                    self._parked_approval_payloads,
+                    self.set_pending_approval,
+                    owning_session_id,
+                )
             except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(
-                    "Failed to marshal approval clear during teardown"
+                    "Failed to marshal approval remount during teardown"
                 )
-
-    def _clear_pending_approval_if_round_is_current(
-        self, round_id: str | None, session_id: str | None
-    ) -> None:
-        """WORKER THREAD: enqueue a round-identity-guarded clear of the mounted MCP approval card.
-
-        TASK-1050 fix round 2 (review): `request_mcp_approvals`'s
-        `finally` used to decide whether to clear the mounted card via a
-        plain boolean snapshot (``still_active and not still_armed_same_
-        session``) computed BEFORE enqueueing ``self._marshal_pending_
-        approval(None)`` through ``call_from_thread``. A NEWER same-
-        session round could arm -- and, if this session is the one being
-        viewed, fully mount ITS OWN card via its own ``call_from_thread``
-        call -- in the window between that snapshot and the UI thread
-        actually running THIS round's clear, which would then wipe the
-        newer round's just-mounted card, stranding it until a manual
-        remount (switch away/back) or its own timeout. Recomputing the
-        same boolean any earlier -- e.g. right before enqueueing --
-        narrows that window but cannot close it: checking and enqueueing
-        are still two separate steps a concurrent round's own check-and-
-        enqueue can interleave with. The only race-proof fix is to defer
-        the ENTIRE decision to the single-threaded UI event loop's own
-        execution of the enqueued callable, which re-reads the CURRENT
-        authoritative state (never a snapshot) at the last possible
-        moment: once that callable starts running, Textual's
-        ``call_from_thread`` callables run to completion, one at a time,
-        on the UI thread, so no further worker-thread interleaving can
-        change the outcome mid-decision.
-
-        The check is TWO-PART, and BOTH parts must pass before clearing:
-
-        1. Round-IDENTITY based, not boolean: ``_parked_approval_payloads
-           [session_id]`` always holds whichever round's payload was LAST
-           WRITTEN (arming overwrites it -- mirrors the payload-pop
-           guard's own "last-armed-wins" contract in the ``finally``
-           block above). If it no longer names THIS round's own
-           ``round_id``, a newer round has already claimed the slot (and,
-           if ``session_id`` is the currently active session, already
-           marshaled its own mount), so this round's clear must no-op.
-           This closes the ORIGINAL Qodo TOCTOU (a newer round's own
-           mount getting wiped by an older round's stale clear).
-
-        2. Fix round 3 (re-review) regression fix: the identity check
-           ALONE only detects "payload overwritten by a newer arm" -- it
-           says nothing about whether a DIFFERENT, OLDER sibling round is
-           still armed. When the newest-armed round resolves FIRST (the
-           natural live ordering, per this file's own fix-round-1
-           docstrings: arming a round typically gets it decided before an
-           already-waiting older sibling does), the identity check
-           trivially PASSES (nothing has overwritten the slot since this
-           round armed) even though an older round is still pending --
-           the old snapshot-based ``still_armed_same_session`` guard this
-           closure replaced used to catch exactly this case; dropping it
-           entirely (rather than also re-checking it live) reintroduced a
-           stranded-card regression: the card cleared while the badge
-           stayed lit, leaving the older round undecidable through the
-           UI until its own timeout. Closed by ALSO re-reading (live,
-           under the same lock, at the same last-possible-moment as the
-           identity check -- never a pre-enqueue snapshot)
-           ``_pending_approval_rounds`` filtered to this session: if ANY
-           round remains registered there (this round's own entry is
-           already popped earlier in ``finally``, before this closure
-           even runs, so any hit here is necessarily a DIFFERENT,
-           still-armed sibling), the clear must no-op just as surely as a
-           failed identity check does.
-
-        Only once both checks pass does it fall through to the
-        ``still_active`` check -- also re-read live here, not from a
-        snapshot -- before actually clearing.
-
-        Args:
-            round_id: This round's own id. Only consulted when
-                ``session_id`` is not ``None`` (every session-attributed
-                round is 1:1 with a real round id).
-            session_id: This round's owning session. ``None`` preserves
-                the pre-existing unconditional-clear behavior for legacy
-                no-session callers -- there is no "newer round for this
-                session" concept without a session to key by.
-        """
-        if self.app is None or self.set_pending_approval is None:
-            return
-
-        def _clear_if_still_current() -> None:
-            if session_id is not None:
-                # F2b-style guard: this runs on the UI thread, but a
-                # worker thread can concurrently write `_parked_approval_
-                # payloads`/`_pending_approval_rounds` under this same
-                # lock (MCP's round registry shares `_approval_state_
-                # lock` with the payload map, so both reads happen in one
-                # atomic critical section).
-                with self._approval_state_lock:
-                    current = self._parked_approval_payloads.get(session_id)
-                    still_armed_same_session = any(
-                        state.get("session_id") == session_id
-                        for state in self._pending_approval_rounds.values()
-                    )
-                if current is not None and current.get("round_id") != round_id:
-                    # A newer round already claimed this session's
-                    # retained-payload slot -- whatever the mounted card
-                    # is currently showing (if this session is even the
-                    # one being viewed) belongs to THAT round, not this
-                    # one. Leave it alone.
-                    return
-                if still_armed_same_session:
-                    # A DIFFERENT round (necessarily -- this round's own
-                    # entry was already popped before this closure runs)
-                    # is still armed for this session. Clearing now would
-                    # strand it: card gone, badge still lit, undecidable
-                    # through the UI until its own timeout.
-                    return
-                if session_id != (self.store.active_session_id or ""):
-                    # Not (or no longer) the session being viewed --
-                    # nothing of THIS round's own was ever mounted here
-                    # (a parked round never marshals), or the user has
-                    # since switched away (`switch_session`'s own
-                    # explicit clear already handled the departing
-                    # card). Clearing here would blank whatever the
-                    # CURRENTLY active session's own card is showing.
-                    return
-            self.set_pending_approval(None)
-
-        self.app.call_from_thread(_clear_if_still_current)
 
     def _record_cancelled_approval_decisions(
         self,
@@ -4585,6 +4449,101 @@ class ConsoleChatController:
         if self.app is not None and self.set_pending_approval is not None:
             self.app.call_from_thread(self.set_pending_approval, payload)
 
+    # -- PR0: per-round retained payloads ------------------------------
+    #
+    # All three bridges' retained-payload maps are keyed by ROUND id and
+    # guarded by `_approval_state_lock`. The mounted card is always the
+    # session's FIFO HEAD -- its oldest-armed round. Dict insertion order
+    # is arm order, which is why every write goes through
+    # `_park_round_payload` and nothing assigns into these maps directly.
+    #
+    # This replaces the pre-PR0 single-slot-per-session maps, whose
+    # last-armed-wins semantics let a second same-session round overwrite
+    # the first's payload and strand it until timeout (task-15661).
+
+    @staticmethod
+    def _head_round_payload_locked(
+        store: dict[str, dict[str, Any]], session_id: str
+    ) -> dict[str, Any] | None:
+        """The session's oldest-armed payload. Caller holds the lock."""
+        for payload in store.values():
+            if payload.get("session_id") == session_id:
+                return payload
+        return None
+
+    def _park_round_payload(
+        self, store: dict[str, dict[str, Any]], round_id: str, payload: dict[str, Any]
+    ) -> bool:
+        """Retain ``payload``; return whether it is now its session's head.
+
+        A round that is NOT the head must not mount -- an older sibling is
+        still holding the card.
+        """
+        session_id = payload.get("session_id")
+        with self._approval_state_lock:
+            store[round_id] = payload
+            head = self._head_round_payload_locked(store, session_id)
+        return head is payload
+
+    def _head_round_payload(
+        self, store: dict[str, dict[str, Any]], session_id: str
+    ) -> dict[str, Any] | None:
+        """The payload whose card ``session_id`` should currently show."""
+        with self._approval_state_lock:
+            return self._head_round_payload_locked(store, session_id)
+
+    def _session_round_payloads(
+        self, store: dict[str, dict[str, Any]], session_id: str
+    ) -> list[dict[str, Any]]:
+        """Every payload ``store`` retains for ``session_id``, arm order first.
+
+        Key-shape agnostic on purpose: it matches on the payload's own
+        ``session_id``, so it reads a PR0 round-keyed map and a not-yet-
+        migrated session-keyed one identically (`ChatScreen._current_park_
+        round_ids` scans all three bridges' maps through it).
+        """
+        with self._approval_state_lock:
+            return [
+                payload
+                for payload in store.values()
+                if payload.get("session_id") == session_id
+            ]
+
+    def _unpark_round_payload(
+        self, store: dict[str, dict[str, Any]], round_id: str
+    ) -> None:
+        """Drop one round's retained payload. Idempotent."""
+        with self._approval_state_lock:
+            store.pop(round_id, None)
+
+    def _remount_head(
+        self,
+        store: dict[str, dict[str, Any]],
+        setter: Callable[[dict[str, Any] | None], None] | None,
+        session_id: str | None,
+    ) -> None:
+        """WORKER THREAD: enqueue a head re-derive onto the UI thread.
+
+        Replaces the pre-PR0 two-part TOCTOU guard. That guard existed
+        because CLEARING the card was order-dependent -- whether to clear
+        depended on which sibling resolved first, and a worker-thread
+        snapshot of that answer could be stale by the time the UI thread
+        ran it. Re-deriving the head is order-INDEPENDENT: it is a pure
+        function of current state. The race-proofing principle is
+        unchanged -- the decision still runs inside the callable on the UI
+        thread, never from a snapshot -- but the decision itself is now one
+        lookup instead of an identity check plus a sibling check.
+        """
+        if self.app is None or setter is None or session_id is None:
+            return
+
+        def _apply() -> None:
+            if session_id != (self.store.active_session_id or ""):
+                return
+            setter(self._head_round_payload(store, session_id))
+
+        self.app.call_from_thread(_apply)
+
     def remount_pending_approval_for_active_session(self) -> bool:
         """Mount the ACTIVE session's still-armed approval round, if any.
 
@@ -4598,13 +4557,12 @@ class ConsoleChatController:
         ``None`` here would clear a card on every new claim, and an attach
         is not a reason to hide anything.
 
-        **Known limitation, not fixed here:**
-        ``_parked_approval_payloads`` holds ONE payload per session
-        (last-armed wins -- see ``request_mcp_approvals``' ``finally``),
-        so with two rounds armed for one session only the newest can
-        mount. Filed as task-15661; pinned by
-        ``Tests/UI/test_console_headless_approval.py::
-        test_two_headless_rounds_share_one_payload_slot_and_only_one_mounts``.
+        PR0 (task-15661, fixed): ``_parked_approval_payloads`` is keyed by
+        ROUND now, so two rounds armed for one session each keep their own
+        payload. This mounts the session's FIFO HEAD -- the oldest-armed
+        round -- and each later sibling mounts in turn as the head ahead of
+        it resolves. Covered by ``Tests/UI/test_console_headless_approval.
+        py::test_two_headless_rounds_each_mount_in_turn``.
 
         Returns:
             True when a card was mounted.
@@ -4614,16 +4572,12 @@ class ConsoleChatController:
         session_id = self.store.active_session_id
         if not session_id:
             return False
-        with self._approval_state_lock:
-            still_armed = any(
-                state.get("session_id") == session_id
-                for state in self._pending_approval_rounds.values()
-            )
-            payload = (
-                self._parked_approval_payloads.get(session_id)
-                if still_armed
-                else None
-            )
+        # The pre-PR0 `still_armed` pre-test is redundant: a round unparks
+        # its own payload in its own teardown, so a payload present here
+        # necessarily belongs to a live round.
+        payload = self._head_round_payload(
+            self._parked_approval_payloads, session_id
+        )
         if payload is None:
             return False
         self.set_pending_approval(payload)
@@ -5218,10 +5172,17 @@ class ConsoleChatController:
             if session_id is not None:
                 self.discard_pending_round(session_id, round_id)
             try:
-                self._clear_pending_approval_if_round_is_current(round_id, session_id)
-            except Exception:  # noqa: BLE001 -- a UI clear must never
+                # PR0: re-derive from the session's remaining FIFO head --
+                # revoking one round of several must promote the next, not
+                # blank the session's card.
+                self._remount_head(
+                    self._parked_approval_payloads,
+                    self.set_pending_approval,
+                    session_id,
+                )
+            except Exception:  # noqa: BLE001 -- a UI remount must never
                 # break the cancellation path that called us.
-                logger.debug("Failed to marshal approval clear during revocation")
+                logger.debug("Failed to marshal approval remount during revocation")
         for request_id, session_id in script_revoked:
             if session_id is not None:
                 self.discard_pending_round(session_id, request_id)
@@ -5269,19 +5230,16 @@ class ConsoleChatController:
                     # Last, and only once the round is unreachable: the
                     # thread this releases returns the moment it wakes.
                     event.set()
-            # Mirrors `request_mcp_approvals`' `finally` exactly: the
-            # retained payload is a SINGLE per-session slot, so it may
-            # only be dropped once NO armed round is left for that
-            # session -- otherwise a still-armed sibling loses the only
-            # copy of its card and a switch away/back mounts nothing.
-            for _round_id, session_id in revoked:
-                if session_id is None:
-                    continue
-                if not any(
-                    state.get("session_id") == session_id
-                    for state in self._pending_approval_rounds.values()
-                ):
-                    self._parked_approval_payloads.pop(session_id, None)
+        # PR0: mirrors `request_mcp_approvals`' `finally` exactly -- each
+        # round drops exactly its OWN retained payload, so a still-armed
+        # sibling keeps its own copy. The pre-PR0 "is this the last armed
+        # round for the session" test existed only because the slot was
+        # shared. Runs outside the critical section above because
+        # `_unpark_round_payload` takes the (non-reentrant) same lock.
+        for round_id_to_drop, session_id in revoked:
+            self._unpark_round_payload(
+                self._parked_approval_payloads, round_id_to_drop
+            )
         return revoked
 
     def _revoke_skill_script_rounds(self, run_id: str) -> list[tuple[str, str | None]]:
@@ -5503,9 +5461,13 @@ class ConsoleChatController:
             # own card, and then get wiped by this round's now-stale
             # clear. `_clear_pending_skill_install_if_round_is_current`
             # defers the whole decision (round-identity check included)
-            # to the UI thread's own execution of the enqueued callable --
-            # see `_clear_pending_approval_if_round_is_current`'s
-            # docstring for the full race analysis.
+            # to the UI thread's own execution of the enqueued callable
+            # -- see `_clear_pending_skill_install_if_round_is_current`'s
+            # own docstring for the full race analysis. (The MCP bridge's
+            # equivalent guard is gone: PR0 re-keyed its payload map by
+            # round, so `_remount_head` re-derives the FIFO head instead
+            # of deciding whether to clear. This bridge is re-keyed in its
+            # own task.)
             try:
                 self._clear_pending_skill_install_if_round_is_current(
                     request_id, session_id
@@ -5816,11 +5778,13 @@ class ConsoleChatController:
                 # the badge clears only once every bridge round for this
                 # session (this one included) has resolved.
                 self.discard_pending_round(session_id, request_id)
-            # TASK-1050 fix round 2 (review): mirrors `request_mcp_
-            # approvals`'/`request_skill_install_confirm`'s identical
-            # fix -- see `_clear_pending_approval_if_round_is_current`'s
-            # docstring for the full race analysis a plain boolean
-            # snapshot (however late it is recomputed) cannot close.
+            # TASK-1050 fix round 2 (review): mirrors `request_skill_
+            # install_confirm`'s identical fix -- see `_clear_pending_
+            # skill_script_if_round_is_current`'s docstring for the full
+            # race analysis a plain boolean snapshot (however late it is
+            # recomputed) cannot close. `request_mcp_approvals` no longer
+            # needs a clear guard at all: PR0 re-keyed its payload map by
+            # round, so it re-derives the FIFO head (`_remount_head`).
             try:
                 self._clear_pending_skill_script_if_round_is_current(
                     request_id, session_id

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -4206,6 +4206,11 @@ class ConsoleChatController:
                 for call in pending
             ],
             "timeout_seconds": timeout_seconds,
+            # Qodo PR #1836 finding 1: the absolute deadline, so a mount
+            # that happens AFTER arm (promotion, switch-back, attach) can
+            # show the remaining window instead of the arm-time total --
+            # see `_head_round_payload`'s snapshot.
+            "deadline_monotonic": deadline,
         }
         # Task 9: park rather than mount when this round's session is a
         # DIFFERENT, background session -- `session_id is None` (a legacy
@@ -4383,10 +4388,15 @@ class ConsoleChatController:
             # the session it mounted over, in which case that sibling's
             # card is (correctly) what stays up.
             try:
+                # Qodo PR #1836 finding 2: a legacy no-session round's card
+                # mounted unconditionally and may sit over ANY session by
+                # now -- pass None so `_remount_head` re-derives for the
+                # session active when the callback runs, not the arm-time
+                # snapshot (whose mismatch would strand the card).
                 self._remount_head(
                     self._parked_approval_payloads,
                     self.set_pending_approval,
-                    owning_session_id,
+                    owning_session_id if session_id is not None else None,
                 )
             except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(
@@ -4480,9 +4490,33 @@ class ConsoleChatController:
     def _head_round_payload(
         self, store: dict[str, dict[str, Any]], session_id: str
     ) -> dict[str, Any] | None:
-        """The payload whose card ``session_id`` should currently show."""
+        """The payload whose card ``session_id`` should currently show.
+
+        Qodo PR #1836 finding 1: a round's auto-deny deadline starts at ARM
+        time, but a queued round can mount much later (promotion at the
+        head's resolve, a switch back to a parked session, a headless
+        attach). Handing the card the arm-time ``timeout_seconds`` then
+        overstates the decision window -- "Auto-denies in 2:00" on a card
+        whose worker denies in seconds. When the payload carries its
+        ``deadline_monotonic``, return a shallow SNAPSHOT whose
+        ``timeout_seconds`` is the remaining time at this call; the
+        retained payload is never mutated, so every later re-derive
+        computes its own fresh snapshot. A payload without a deadline
+        (ADR-067 arms none for ``timeout <= 0`` script confirms) passes
+        through untouched. ``_park_round_payload``'s ``head is payload``
+        identity check goes through ``_head_round_payload_locked`` and is
+        unaffected.
+        """
         with self._approval_state_lock:
-            return self._head_round_payload_locked(store, session_id)
+            payload = self._head_round_payload_locked(store, session_id)
+        if payload is None:
+            return None
+        deadline = payload.get("deadline_monotonic")
+        if not deadline:
+            return payload
+        snapshot = dict(payload)
+        snapshot["timeout_seconds"] = max(0.0, deadline - time.monotonic())
+        return snapshot
 
     def _session_round_payloads(
         self, store: dict[str, dict[str, Any]], session_id: str
@@ -4525,11 +4559,27 @@ class ConsoleChatController:
         unchanged -- the decision still runs inside the callable on the UI
         thread, never from a snapshot -- but the decision itself is now one
         lookup instead of an identity check plus a sibling check.
+
+        ``session_id=None`` means "the session being VIEWED when the
+        callback runs" (Qodo PR #1836 finding 2): a legacy no-session round
+        mounts unconditionally, so its card can be sitting over ANY session
+        by teardown time, and re-deriving for the arm-time snapshot id
+        no-ops on a mismatch -- stranding the card where the deleted
+        pre-PR0 guard cleared it unconditionally. Resolving the active
+        session inside ``_apply`` clears the stale legacy card AND restores
+        that session's own real head if it has one -- strictly better than
+        the old unconditional clear, which could wipe a real sibling's
+        card. Session-attributed rounds keep the exact-match guard so a
+        background teardown can never touch the viewed session's card.
         """
-        if self.app is None or setter is None or session_id is None:
+        if self.app is None or setter is None:
             return
 
         def _apply() -> None:
+            if session_id is None:
+                active = self.store.active_session_id or ""
+                setter(self._head_round_payload(store, active))
+                return
             if session_id != (self.store.active_session_id or ""):
                 return
             setter(self._head_round_payload(store, session_id))
@@ -5374,6 +5424,9 @@ class ConsoleChatController:
             "timeout_seconds": timeout_seconds,
             "request_id": request_id,
             "session_id": owning_session_id,
+            # Qodo PR #1836 finding 1 -- see `_head_round_payload`'s
+            # remaining-time snapshot. None when ADR-067 armed no deadline.
+            "deadline_monotonic": deadline,
         }
         # TASK-910: park rather than mount when this round's session is a
         # DIFFERENT, background session -- mirrors `request_mcp_approvals`'
@@ -5453,10 +5506,12 @@ class ConsoleChatController:
             # (caught live by `test_console_skill_install_confirm.py::
             # test_confirm_round_trip_allow`).
             try:
+                # Qodo PR #1836 finding 2 -- see the approvals teardown's
+                # identical legacy-round note.
                 self._remount_head(
                     self._parked_skill_install_payloads,
                     self.set_pending_skill_install,
-                    owning_session_id,
+                    owning_session_id if session_id is not None else None,
                 )
             except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(
@@ -5634,6 +5689,9 @@ class ConsoleChatController:
         card_payload["timeout_seconds"] = timeout_seconds
         card_payload["request_id"] = request_id
         card_payload["session_id"] = owning_session_id
+        # Qodo PR #1836 finding 1 -- see `_head_round_payload`'s
+        # remaining-time snapshot. None when ADR-067 armed no deadline.
+        card_payload["deadline_monotonic"] = deadline
         is_parked = session_id is not None and session_id != (
             self.store.active_session_id or ""
         )
@@ -5710,16 +5768,17 @@ class ConsoleChatController:
             # guard's two-part TOCTOU check -- see `request_mcp_approvals`'
             # identical `_remount_head` teardown call for the full race
             # analysis.
-            # `owning_session_id`, not `session_id`: a legacy no-session
-            # caller retains no payload, so its head resolves to `None` and
-            # the card clears exactly as the pre-PR0 unconditional clear
-            # did -- `_remount_head` no-ops on a `None` session_id, which
-            # would otherwise leave a legacy caller's card stuck on screen.
+            # Qodo PR #1836 finding 2: a legacy no-session round passes
+            # None, so `_remount_head` re-derives for the session active
+            # WHEN THE CALLBACK RUNS -- the arm-time `owning_session_id`
+            # snapshot could mismatch after a switch and strand the
+            # unconditionally-mounted legacy card. Session-attributed
+            # rounds keep the exact-match owning id.
             try:
                 self._remount_head(
                     self._parked_skill_script_payloads,
                     self.set_pending_skill_script,
-                    owning_session_id,
+                    owning_session_id if session_id is not None else None,
                 )
             except Exception:  # noqa: BLE001 -- suppress teardown-time errors
                 logger.opt(exception=True).debug(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -20665,21 +20665,24 @@ class ChatScreen(BaseAppScreen):
             ``session_id``.
         """
         ids: set[str] = set()
-        mcp_payload = controller._parked_approval_payloads.get(session_id)
-        if mcp_payload is not None:
-            round_id = mcp_payload.get("round_id")
-            if round_id:
-                ids.add(f"mcp:{round_id}")
-        install_payload = controller._parked_skill_install_payloads.get(session_id)
-        if install_payload is not None:
-            request_id = install_payload.get("request_id")
-            if request_id:
-                ids.add(f"install:{request_id}")
-        script_payload = controller._parked_skill_script_payloads.get(session_id)
-        if script_payload is not None:
-            request_id = script_payload.get("request_id")
-            if request_id:
-                ids.add(f"script:{request_id}")
+        for prefix, store, id_key in (
+            ("mcp", controller._parked_approval_payloads, "round_id"),
+            ("install", controller._parked_skill_install_payloads, "request_id"),
+            ("script", controller._parked_skill_script_payloads, "request_id"),
+        ):
+            # PR0 (task-15661): `_parked_approval_payloads` is keyed by
+            # ROUND now, so a session can retain SEVERAL payloads at once
+            # and a `.get(session_id)` would find none of them. Scanning by
+            # the payload's own `session_id` reads either key shape, which
+            # also means the two skill maps need no change here when they
+            # are re-keyed in turn. Returning EVERY live id (not just the
+            # session's mounted head) is what this method already promises
+            # and what the caller's dedupe needs: a genuinely new sibling
+            # round must still toast.
+            for payload in controller._session_round_payloads(store, session_id):
+                round_id = payload.get(id_key)
+                if round_id:
+                    ids.add(f"{prefix}:{round_id}")
         return frozenset(ids)
 
     def _notify_console_run_outcome(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -20674,8 +20674,8 @@ class ChatScreen(BaseAppScreen):
             # ROUND now, so a session can retain SEVERAL payloads at once
             # and a `.get(session_id)` would find none of them. Scanning by
             # the payload's own `session_id` reads either key shape, which
-            # also means the two skill maps need no change here when they
-            # are re-keyed in turn. Returning EVERY live id (not just the
+            # also means the two skill maps needed no change here when they
+            # were re-keyed. Returning EVERY live id (not just the
             # session's mounted head) is what this method already promises
             # and what the caller's dedupe needs: a genuinely new sibling
             # round must still toast.


### PR DESCRIPTION
## What

Re-keys the three Console interrupt bridges' retained-payload maps from `session_id` to `round_id`, with a per-session FIFO head, and deletes the three order-dependent TOCTOU guards that existed only to compensate for the old key shape.

Bridges: MCP tool approvals, skill-install confirm, skill-script confirm.

## Why

Each bridge retained the payload its card is re-derived from in a `dict[session_id, payload]` — one slot per session, last-armed-wins. Arming a second round for the same session **overwrote the first's payload**: the first round's card vanished from the screen and the round hung undecidable until its own timeout fired and failed it closed.

This was already known and filed as **task-15661**. The codebase documented it in two places — `request_mcp_approvals`' `finally` block ("Accepted scope limitation ... per-round payload storage is a larger change out of scope here") and `remount_pending_approval_for_active_session`'s docstring — and pinned it with a test whose docstring said it existed so there would be "a failing test the day someone fixes it, rather than folklore in a comment."

That test now asserts the fixed contract.

## How

Five generic helpers (`_park_round_payload`, `_head_round_payload`, `_unpark_round_payload`, `_remount_head`, `_head_round_payload_locked`), shared by all three bridges. The mounted card is always the session's FIFO head — its oldest-armed round. A later sibling queues instead of clobbering, and is promoted when the head resolves.

**Why the guards could be deleted rather than adapted.** Each `_clear_pending_*_if_round_is_current` had two parts: "has a newer round claimed the slot" and "is an older sibling still armed". Both existed *only* because a shared slot made *clearing* order-dependent — whether to clear depended on which sibling resolved first, and a worker-thread snapshot of that answer could be stale by the time the UI thread ran it. Re-deriving the head is order-**independent**: a pure function of current state. The failure mode is now unrepresentable rather than defended.

The race-proofing principle is preserved exactly — the decision still runs inside the callable passed to `call_from_thread`, never from a worker-thread snapshot. Only the decision itself got simpler.

## Scope beyond the obvious

- Four approvals re-derive sites, including the public `remount_pending_approval_for_active_session`
- Both revocation paths (`_revoke_tool_approval_rounds`, `_revoke_skill_script_rounds`)
- A consumer outside the controller: `ChatScreen._current_park_round_ids`
- The script guard had a second caller in `revoke_approval_rounds_for_run` — deleting it without that would have raised `AttributeError` on every cancellation carrying a live confirm

## Behaviour change

No change to the single-round path — card content, timeouts, badges, and decisions are all identical.

Concurrent same-session rounds now queue FIFO instead of clobbering. A non-head round on the **active** session is silent (no card, no toast) until promoted; a non-head round on a **background** session still toasts. That silent-queue gap is recorded in the design doc as a known item for the follow-on unified-interrupt-surface work.

## Testing

New `Tests/UI/test_console_parked_payload_rekey.py` — six tests, written RED before the fix, covering per-bridge FIFO behaviour and cross-bridge independence.

Pre-existing concurrency suites (task-581 / TASK-910) updated: their pinned assertions asserted the *old* single-slot semantics. Where a call-count proxy was used, it was replaced with a content assertion on which round is displayed — under FIFO the re-derive seam legitimately fires on every teardown, so counting calls would fail on correct behaviour.

`170 passed, 4 failed` across the eight suites this branch touches. All four failures are pre-existing on `dev` and were reproduced at the merge base in a separate worktree before any change here:

- `test_skill_install_concurrent_confirms.py::test_bare_shutdown_flag_alone_denies_a_real_session_round_within_one_poll_interval`
- `test_skill_install_concurrent_confirms.py::test_shutdown_flag_alone_denies_both_unregistered_sessions_rounds_and_cleans_accounting`
- `test_console_parallel_runs.py::test_navigating_away_with_busy_fleet_confirms_and_records_teardown`
- `test_console_parallel_runs.py::test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coordinates`

The full project suite was **not** run end to end.

## Net effect

Production is **−144 lines**. Three bespoke guard methods carrying three fix-rounds of accumulated docstrings are replaced by five short helpers no bridge can special-case.

## Design docs

Included in the branch: `Docs/superpowers/specs/2026-08-19-console-user-interaction-design.md` (this is PR0 of that program) and `Docs/superpowers/plans/2026-08-19-parked-payload-rekey.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-keys Console interrupt bridges’ retained-payload maps from per-session to per-round with a per-session FIFO head, so concurrent same-session rounds queue instead of clobbering (task-15661). Previously a second round overwrote the first and the first hung; now the oldest-armed mounts first and siblings promote on resolve. Mounted cards now show remaining timeout at mount/promotion, and legacy session_id=None cards clear correctly after session switches.

- Review notes
  - Applies to all three bridges: MCP tool approvals, skill-install confirm, skill-script confirm. Deletes the `_clear_pending_*_if_round_is_current` guards; replaces with shared helpers: `_park_round_payload`, `_head_round_payload`, `_unpark_round_payload`, `_remount_head` (decisions still run on the UI thread).
  - Timeout display: payloads carry `deadline_monotonic`; `_head_round_payload` returns a fresh remaining-time snapshot at each re-derive. No-deadline rounds are unchanged.
  - Legacy behavior: `_remount_head(None)` now resolves for the active session when the callback runs, clearing stale cards post-switch and restoring that session’s head; revoke paths benefit from the same cleanup.
  - Active vs background: non-head rounds on the active session are silent; non-head on background sessions still toast. Bridges keep independent heads (cross-bridge independence tested).
  - `ChatScreen._current_park_round_ids` now scans payloads by `session_id` and is key-shape agnostic. Tests updated; new `Tests/UI/test_console_parked_payload_rekey.py`. Known baseline: 4 pre-existing failures on `dev`.

- Required migration
  - Replace any `_parked_*_payloads[session_id]` lookups with `_head_round_payload(store, session_id)` or scan payloads by their `session_id`.
  - Do not count re-derive calls; assert mounted content and FIFO order instead.

<sup>Written for commit 10ed5f84f4e13bbabebd16661e635cef715e2ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

