### PR TITLE
fix(summarization): gate sampling params and token cap on model capabilities (TASK-18802)

### DIFF
--- a/Docs/superpowers/plans/2026-08-20-task-18802-report.md
+++ b/Docs/superpowers/plans/2026-08-20-task-18802-report.md
@@ -1,0 +1,228 @@
+# TASK-18802 — Summarization path sent sampling params modern models reject
+
+**Branch:** `fix/task-18802-summarization-model-gates` (from `origin/dev` `ff6b29235`)
+**Status:** complete — all 4 acceptance criteria met, live-verified both ways.
+
+---
+
+## 1. What was broken
+
+`tldw_chatbook/LLM_Calls/Summarization_General_Lib.py` builds its own provider
+payloads and applied no per-model capability gate — the same defect TASK-18414
+fixed on the chat path, alive on the path that `analyze()` serves for
+ingestion (`Local_Ingestion/*`) and web-search summarization
+(`Web_Scraping/*`):
+
+| Function | Unconditional payload | Consequence |
+|---|---|---|
+| `summarize_with_anthropic` | `temperature`, `top_k`, `top_p` | HTTP 400 on Fable 5 / Mythos 5 / Opus 5 / Opus 4.8 / Opus 4.7 / **Sonnet 5 — the shipped `[api_settings.anthropic]` default** (probe-verified in the filing: `req_011CeB7m2VQbn2JXsd3LcQQy`) |
+| `summarize_with_openai` | `max_tokens: 4096`, `temperature` | HTTP 400 on gpt-5 / gpt-5.6 / o3 / o4-mini (was code-read only; probe-verified here — §2) |
+
+## 2. Step 1 probes — captured before any code change
+
+Standalone `curl` against `https://api.openai.com/v1/chat/completions` with the
+**exact payload shape `summarize_with_openai` builds** (system + user message,
+`max_tokens: 4096`, `temperature: 0.7`, `stream: false`). No `tldw_chatbook`
+module imported.
+
+**P1 — `gpt-5`, exact shape** → HTTP 400 (the token cap is named first):
+
+```json
+{"error": {"code": "unsupported_parameter", "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", "param": "max_tokens", "type": "invalid_request_error"}}
+```
+
+**P3 — `gpt-5`, `temperature: 0.7` only** → HTTP 400:
+
+```json
+{"error": {"code": "unsupported_value", "message": "Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.", "param": "temperature", "type": "invalid_request_error"}}
+```
+
+**P8 — `gpt-5`, `temperature: 1` only** → HTTP 200 — the sampling rejection is
+*value*-level (non-default), unlike Anthropic's parameter-level rejection.
+Omitting the parameter is correct either way.
+
+**P5 / P6 / P11 — `gpt-5.6`, `o4-mini`, `o3`, exact shape** → HTTP 400, same
+`unsupported_parameter` body as P1. **P13 — `gpt-5.6` + `temperature: 0.7`**
+→ HTTP 400, same `unsupported_value` body as P3.
+
+**P4 / P9 / P10 — post-fix shape** (`max_completion_tokens: 4096`, no
+sampling) → HTTP 200 on `gpt-5` (`chatcmpl-EEyVqbObmis1VBHXSitpSz9aLoylo`),
+`gpt-5.6` (served as `gpt-5.6-sol`), `o4-mini`.
+
+**P7 / P12 — controls `gpt-4o`, `gpt-4.1`, exact old shape** → HTTP 200
+unchanged (`chatcmpl-EEyW094AYOXfAFNSVi8aRVGHo3Mru`,
+`chatcmpl-EEyWiN2mGffqVanPxqauMZ7H5bLk1`).
+
+Reality matched the task's expectation exactly; nothing was reshaped. The o1
+family was not probed (no access needed; it shares the o-series surface and is
+already encoded in the chat path's task-404 marker list) and is documented
+rather than live-observed.
+
+### Anthropic discovery probes (during Step 3, reported here for completeness)
+
+The live legacy control exposed a **second, pre-existing defect**, out of this
+task's scope (see §7):
+
+**A — `claude-haiku-4-5` + the exact legacy trio `temperature=0.1, top_k=0,
+top_p=1.0`** → HTTP 400:
+
+```json
+{"error": {"message": "`temperature` and `top_p` cannot both be specified for this model. Please use only one.", "type": "invalid_request_error"}, "request_id": "req_011CeEDXPHNyF7apkaZepbTN", "type": "error"}
+```
+
+**E — `claude-sonnet-4-5`, same trio** → HTTP 400 identical
+(`req_011CeEDXa9V99yBoHN5vcjDG`). **B/C — `temperature` alone, or
+`temperature`+`top_k`** → HTTP 200. **D — `claude-3-haiku-20240307`** (the
+function's own fallback default) → HTTP 404 `not_found_error` — retired
+(`req_011CeEDXZ8iS29MZCgyySwQa`).
+
+## 3. The fix
+
+* **Anthropic** — `summarize_with_anthropic` gates `temperature`/`top_k`/`top_p`
+  on the existing `anthropic_model_rejects_sampling_params` predicate
+  (TASK-18414; AC #3 — reuse, no new name check). The function sends no
+  thinking/budget shape, so `anthropic_model_rejects_fixed_thinking_budget`
+  has nothing to gate — checked explicitly, noted in a comment.
+* **OpenAI** — two new immutable predicates in
+  `tldw_chatbook/model_capabilities.py`:
+  `openai_model_rejects_sampling_params` and
+  `openai_model_requires_max_completion_tokens`, over one family table
+  `{("gpt", 5), ("o", 1), ("o", 3), ("o", 4)}`. Same design rules as 18414:
+  module-level pure functions **outside** the config-driven, user-overridable
+  capability tables; boundary-safe `(series, major)` matching that resolves
+  dotted minors (`gpt-5.6`), dated snapshots (`gpt-5-2025-08-07`,
+  `o3-2025-04-16`), suffixes (`gpt-5.6-terra`, `o4-mini`) and provider
+  prefixes (`openai/gpt-5`), and never parses `gpt-4o`, `gpt-4.1`,
+  `gpt-oss-120b`, `o365-copilot` or `olmo-7b` into a family. Kept as two
+  named predicates because they are two questions about the request surface.
+  `summarize_with_openai` consults both: `max_completion_tokens` for the
+  modern families, `temperature` omitted for them; everything else unchanged.
+* **No new logging calls** in `Summarization_General_Lib.py` — the
+  diagnostic-privacy manifest (`test_summarization_diagnostic_privacy.py`)
+  hard-codes this module's diagnostic counts (281), and the fix does not
+  disturb them (suite green, §5).
+
+### Scope decision: chat path NOT widened
+
+`chat_with_openai` (LLM_Calls/LLM_API_Calls.py :695-698) has the code-read
+`max_tokens` hole for gpt-5/o-series with no reasoning effort configured. Its
+fix is not one adjacent predicate call — it interacts with
+`_is_openai_gpt_5_6_model`, the Responses-API branch and that file's own test
+surface — so per TASK-18803's own AC #1 (reproduce first, per finding) the
+probe evidence was filed into 18803 rather than widening this PR.
+
+## 4. Sweep of the other `summarize_with_*` functions
+
+Same unconditional-params shape found (line numbers on this branch):
+`summarize_with_cohere` :1307 (`temperature`), `summarize_with_groq` :1555
+(`temperature`), `summarize_with_openrouter` :1779/:1868 (`temperature`;
+proxies OpenAI/Anthropic models, so routed modern models may inherit the exact
+400s fixed here), `summarize_with_huggingface` :1967-1969
+(`max_tokens` + `temperature`), `summarize_with_deepseek` :2159
+(`temperature`), `summarize_with_mistral` :2342-2344 (`temperature` AND
+`top_p` together, plus `max_tokens`). `summarize_with_google` sends none
+(commented out). Filed as **TASK-19021** (one follow-up, probe-first); only
+Anthropic + OpenAI fixed here, per the ACs.
+
+## 5. Evidence
+
+### Red → green (read counts)
+
+| Stage | Command | Result |
+|---|---|---|
+| Red (predicates present, builders untouched) | `pytest Tests/test_probe_import_provenance.py Tests/LLM_Calls/test_summarization_model_capabilities.py -q -p no:randomly` | **17 failed, 37 passed** |
+| Green (after rewire) | same | **54 passed** |
+| Targeted gate | `Tests/LLM_Calls/` + `Tests/test_model_capabilities.py` + `Tests/Chat/test_anthropic_model_capabilities.py` + `Tests/Chat/test_openai_reasoning_sampling_params.py` + `Tests/Internal_Prompts/test_summarization_migration.py` + provenance probe | **1048 passed, 0 failed** |
+| Consumers | `Tests/test_config_model_catalog_defaults.py`, `Tests/Chat/test_openai_streaming_usage.py` | **11 passed** |
+| Import sweep | `pytest Tests/ --collect-only -q` | **50946 collected, 0 errors** |
+
+The reds were for the right reason — verbatim:
+
+```
+AssertionError: claude-sonnet-5 rejects sampling params but the summarization payload still carries ['temperature', 'top_k', 'top_p']
+AssertionError: gpt-5 rejects 'max_tokens' (400 unsupported_parameter) but the summarization payload still carries it
+```
+
+Note: the three manifest-boundary reds TASK-18414 filed as TASK-18801 did
+**not** reproduce on this branch's base — the whole diagnostic-privacy suite
+is green here.
+
+### Mutation tests
+
+| Mutation | Result |
+|---|---|
+| A — invert the predicate consultation in both builders (reproduces the original bug) | **17 failed, 36 passed** — every rejecting-model pin dies |
+| B — narrow `_OPENAI_MODERN_REQUEST_FAMILIES` by dropping `("gpt", 5)` | **17 failed, 36 passed** — gpt-family payload + predicate pins die |
+| C — widen the table by adding `("gpt", 4)` | **5 failed, 48 passed** — the AC #4 over-match pins die (`gpt-4.1`, `gpt-4-turbo` payload + predicate pins); `gpt-4o` pins survive because `4o` still doesn't parse, demonstrating the boundary-safe parse |
+
+All three restored with `Edit`, proven by `git diff` containing zero MUTATION
+markers, re-green at 54 passed.
+
+### Live verification (AC #1 and #2)
+
+Seam-level, via pytest with `@pytest.mark.allow_network` in a throwaway
+uncommitted test driving the **production** `analyze()` →
+`_dispatch_to_api` → `summarize_with_*` chain — no payload reimplementation;
+the only patch was the configured model id, on the same `get_cli_setting`
+seam the functions already read. Chosen over a tmux UI pass because the
+defect and its ACs live entirely below the UI (ingestion/web-search call
+`analyze()` directly), and the seam-level call exercises the exact production
+payload builder; `Tests/conftest.py`'s bootstrap scratch `TLDW_CONFIG_PATH`
+kept the runs off the real profile. Import provenance pinned by
+`Tests/test_probe_import_provenance.py` in the same runs.
+
+| # | Checkout | Provider / model | Result |
+|---|---|---|---|
+| 1 | fix | anthropic / `claude-sonnet-5` (shipped default) | **PASS** — `'**Summary**\n\n- A **fox** jumps over a **lazy dog** while clocks strike an unusual thirteen on a cold April day.'` |
+| 2 | fix | openai / `gpt-5` | **PASS** — `"**Fox, dog, April, and thirteen o'clock**\n- A **fox** jumps over a **lazy dog** on a bright, cold **April** day as clocks strike **thirteen** (**TASK-18802 LIVE CHECK**)."` |
+| 3 | fix | openai / `gpt-4o` (legacy control) | **PASS** — `'A fox leaps over a dog on an unusual April day marked by clocks striking thirteen.'` |
+| 4 | fix | anthropic / `claude-haiku-4-5` (legacy) | in-band failure, **identical to dev** — the pre-existing §2 combo defect; proves legacy payloads untouched |
+| C1 | clean `origin/dev` `64ce7ab39` (detached control worktree) | anthropic / `claude-sonnet-5` | **FAIL (expected)** — `ERROR Summarization_General_Lib.py:1165 Failed to process summary; status_code=400` → `'Error: Summarization failed unexpectedly.'` |
+| C2 | control worktree | openai / `gpt-5` | **FAIL (expected)** — `'Error: OpenAI API request failed: 400 Client Error: Bad Request for url: https://api.openai.com/v1/chat/completions'` |
+| C3 | control worktree | anthropic / `claude-haiku-4-5` | same in-band failure as row 4 — legacy behavior identical on both checkouts |
+
+C1/C2 are the same harness on an unmodified origin/dev checkout (provenance
+probe printed the control worktree's path), making this an A/B on the fix.
+The control worktree and the throwaway live test were removed afterwards.
+
+## 6. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 Modern Anthropic model completes | met | Live row 1 (claude-sonnet-5, the shipped default) vs C1; payload pins × 5 families |
+| #2 OpenAI reasoning model completes with the correct token-cap name | met | Live row 2 vs C2; probes P4/P9/P10; `max_completion_tokens` pins × 6 ids |
+| #3 Reuses model_capabilities predicates, no own name checks | met | Anthropic half consults the 18414 predicate; OpenAI half consults the two new predicates in the same module; grep of the diff shows no model-name literal in the builders |
+| #4 Accepting models unchanged, pinned | met | `test_anthropic_legacy_model_still_sends_sampling_params` × 4, `test_openai_legacy_model_payload_unchanged` × 4, mutation C kills them; live rows 3/4 = C3 |
+
+## 7. Filed / updated, not fixed
+
+* **TASK-19020** — the legacy Anthropic payload sends `temperature` AND
+  `top_p` together, which every currently-served Claude 4.x rejects
+  (probes A/E in §2), and the fallback default `claude-3-haiku-20240307` is
+  retired (probe D). Discovered by running the *legacy* leg of the live pass;
+  fixing it would change exactly the payloads AC #4 requires unchanged, so it
+  is a separate capability question (filed with the probe bodies). First
+  filing collided — the CLI assigned task-18912, which already exists under
+  two other titles on other branches; renumbered to 19020 after a
+  ghost-check across all refs and worktrees.
+* **TASK-19021** — the six remaining `summarize_with_*` providers (§4).
+* **TASK-18803** — updated from "CODE-READ, not probe-verified" with the §2
+  OpenAI probe bodies: the API side of its findings 1–2 is now established;
+  the chat-path builder reproduction and the Moonshot/Z.ai claims remain owed.
+
+## 8. Notes for review
+
+* The predicates deliberately mirror the chat path's
+  `_OPENAI_REASONING_MODEL_FAMILIES` semantics but live in
+  `model_capabilities.py`; TASK-18803 can later rewire the chat path onto
+  them, shrinking that hand-maintained tuple the way 18414 shrank the
+  Anthropic markers.
+* No logging added or removed in `Summarization_General_Lib.py` — the
+  diagnostic-privacy manifest pins this module's diagnostic counts, and the
+  full suite (including the manifest-boundary tests) is green on this branch.
+* No UI surface changed; no `Docs/User_Guide/` page cites this module's
+  payload shapes, so none needed a stamp.
+* Lessons entry added to `backlog/docs/lessons-live-verification.md`: the
+  live pass's *unchanged-behavior* control leg is what surfaced TASK-19020 —
+  a green "legacy unchanged" pin can faithfully pin behavior that is itself
+  broken.

--- a/Tests/LLM_Calls/test_summarization_model_capabilities.py
+++ b/Tests/LLM_Calls/test_summarization_model_capabilities.py
@@ -1,0 +1,253 @@
+"""Payload pins for TASK-18802: the summarization path must consult the
+per-model request-capability predicates instead of unconditionally sending
+sampling parameters and the classic ``max_tokens`` cap.
+
+Provider facts pinned here were probe-verified against the real APIs:
+
+* Anthropic (TASK-18414 probes, req_011CeB5qiXpMbYhtroLrCYVo et al.):
+  ``temperature``/``top_p``/``top_k`` return HTTP 400 on the Fable 5,
+  Mythos 5, Opus 5, Opus 4.8, Opus 4.7 and Sonnet 5 families; Opus 4.6,
+  Sonnet 4.5 and Haiku 4.5 still accept them.
+* OpenAI (TASK-18802 probes, 2026-08-20): ``max_tokens`` returns
+  ``400 unsupported_parameter`` ("Use 'max_completion_tokens' instead") and
+  ``temperature: 0.7`` returns ``400 unsupported_value`` on gpt-5, gpt-5.6,
+  o3 and o4-mini; gpt-4o and gpt-4.1 accept the old shape unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.LLM_Calls import Summarization_General_Lib as sgl
+from tldw_chatbook.model_capabilities import (
+    ModelCapabilities,
+    openai_model_rejects_sampling_params,
+    openai_model_requires_max_completion_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenAIResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    def json(self) -> dict:
+        return {"choices": [{"message": {"content": "openai summary"}}]}
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class _FakeAnthropicResponse:
+    status_code = 200
+
+    def json(self) -> dict:
+        return {"content": [{"type": "text", "text": "anthropic summary"}]}
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+def _install_model_setting(monkeypatch: pytest.MonkeyPatch, section: str, model: str) -> None:
+    """Route the module's config lookups: the model under test, defaults otherwise."""
+
+    def fake_get_cli_setting(sec: str, key: str, default: object = None) -> object:
+        if sec == section and key == "model":
+            return model
+        return default
+
+    monkeypatch.setattr(sgl, "get_cli_setting", fake_get_cli_setting)
+
+
+def _capture_openai_payload(monkeypatch: pytest.MonkeyPatch, model: str) -> dict:
+    _install_model_setting(monkeypatch, "openai_api", model)
+    captured: dict = {}
+
+    def fake_session_post(self, url, headers=None, json=None, stream=False, timeout=None, **kwargs):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeOpenAIResponse()
+
+    monkeypatch.setattr(sgl.requests.Session, "post", fake_session_post)
+    result = sgl.summarize_with_openai("test-key", "some input text", "Summarize this.")
+    assert result == "openai summary", result
+    assert "json" in captured, "summarize_with_openai never posted a request"
+    return captured["json"]
+
+
+def _capture_anthropic_payload(monkeypatch: pytest.MonkeyPatch, model: str) -> dict:
+    _install_model_setting(monkeypatch, "anthropic_api", model)
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, stream=False, **kwargs):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeAnthropicResponse()
+
+    monkeypatch.setattr(sgl.requests, "post", fake_post)
+    result = sgl.summarize_with_anthropic("test-key", "some input text", "Summarize this.")
+    assert result == "anthropic summary", result
+    assert "json" in captured, "summarize_with_anthropic never posted a request"
+    return captured["json"]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic payload pins (AC #1 / #3 / #4)
+# ---------------------------------------------------------------------------
+
+_ANTHROPIC_REJECTING_MODELS = [
+    "claude-sonnet-5",  # the shipped [api_settings.anthropic] default
+    "claude-opus-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+]
+
+_ANTHROPIC_LEGACY_MODELS = [
+    "claude-3-haiku-20240307",  # the function's own fallback default
+    "claude-opus-4-6",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+]
+
+
+@pytest.mark.parametrize("model", _ANTHROPIC_REJECTING_MODELS)
+def test_anthropic_rejecting_model_omits_sampling_params(monkeypatch, model):
+    payload = _capture_anthropic_payload(monkeypatch, model)
+    offending = [k for k in ("temperature", "top_k", "top_p") if k in payload]
+    assert offending == [], (
+        f"{model} rejects sampling params but the summarization payload "
+        f"still carries {offending}"
+    )
+    # The rest of the request survives the gate.
+    assert payload["model"] == model
+    assert payload["max_tokens"] == 4096
+    assert payload["messages"], payload
+
+
+@pytest.mark.parametrize("model", _ANTHROPIC_LEGACY_MODELS)
+def test_anthropic_legacy_model_still_sends_sampling_params(monkeypatch, model):
+    payload = _capture_anthropic_payload(monkeypatch, model)
+    assert payload["temperature"] == pytest.approx(0.1)
+    assert payload["top_k"] == 0
+    assert payload["top_p"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI payload pins (AC #2 / #3 / #4)
+# ---------------------------------------------------------------------------
+
+_OPENAI_MODERN_MODELS = [
+    "gpt-5",
+    "gpt-5.6",
+    "gpt-5.6-terra",  # the shipped chat-path default id shape
+    "gpt-5-2025-08-07",
+    "o3",
+    "o4-mini",
+]
+
+_OPENAI_LEGACY_MODELS = [
+    "gpt-4o",  # the function's own fallback default
+    "gpt-4.1",
+    "gpt-4-turbo",
+    "gpt-3.5-turbo",
+]
+
+
+@pytest.mark.parametrize("model", _OPENAI_MODERN_MODELS)
+def test_openai_modern_model_omits_temperature(monkeypatch, model):
+    payload = _capture_openai_payload(monkeypatch, model)
+    assert "temperature" not in payload, (
+        f"{model} rejects non-default temperature but the summarization "
+        f"payload still carries temperature={payload.get('temperature')!r}"
+    )
+
+
+@pytest.mark.parametrize("model", _OPENAI_MODERN_MODELS)
+def test_openai_modern_model_uses_max_completion_tokens(monkeypatch, model):
+    payload = _capture_openai_payload(monkeypatch, model)
+    assert "max_tokens" not in payload, (
+        f"{model} rejects 'max_tokens' (400 unsupported_parameter) but the "
+        f"summarization payload still carries it"
+    )
+    assert payload.get("max_completion_tokens") == 4096, payload
+
+
+@pytest.mark.parametrize("model", _OPENAI_LEGACY_MODELS)
+def test_openai_legacy_model_payload_unchanged(monkeypatch, model):
+    payload = _capture_openai_payload(monkeypatch, model)
+    assert payload["temperature"] == pytest.approx(0.7)
+    assert payload["max_tokens"] == 4096
+    assert "max_completion_tokens" not in payload
+
+
+# ---------------------------------------------------------------------------
+# OpenAI predicate unit pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5",
+        "gpt-5.6",
+        "gpt-5.1",
+        "gpt-5.6-terra",
+        "gpt-5-2025-08-07",
+        "GPT-5",
+        "openai/gpt-5",
+        "openai/gpt-5.6-terra",
+        "o1",
+        "o1-mini",
+        "o3",
+        "o3-2025-04-16",
+        "o4-mini",
+        "o4-mini-2025-04-16",
+    ],
+)
+def test_openai_predicates_cover_modern_family_variants(model):
+    assert openai_model_rejects_sampling_params(model) is True
+    assert openai_model_requires_max_completion_tokens(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4.1",
+        "gpt-4.1-mini-2025-04-14",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo",
+        "gpt-oss-120b",
+        "o365-copilot",  # 'o' + digits, but not an o-series family
+        "olmo-7b",
+        "chatgpt-4o-latest",
+        "",
+        None,
+        42,
+    ],
+)
+def test_openai_predicates_never_match_legacy_or_lookalikes(model):
+    assert openai_model_rejects_sampling_params(model) is False
+    assert openai_model_requires_max_completion_tokens(model) is False
+
+
+def test_openai_predicates_survive_a_user_configured_capability_table():
+    """The predicates are request-validity facts and must not be reachable
+    from the user-overridable capability tables (same design rule the
+    Anthropic predicates pinned in TASK-18414)."""
+    ModelCapabilities(
+        config={
+            "models": {"gpt-5": {"vision": True, "rejects_sampling_params": False}},
+            "patterns": {},
+        }
+    )
+    assert openai_model_rejects_sampling_params("gpt-5") is True
+    assert openai_model_requires_max_completion_tokens("gpt-5") is True

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1141,3 +1141,28 @@ that must keep working in the same batch — Opus 4.6, Sonnet 4.5 and Haiku 4.5 
 200 for the identical payload is what turned "don't break older models" from an
 intention into evidence. Keep this out of the app's config path entirely: a standalone
 `curl` imports no `tldw_chatbook` module and cannot touch the live config.
+
+---
+
+## An "unchanged behavior" AC can faithfully pin behavior that is already broken — run the control leg live
+
+**TASK-18802, 2026-08-20.** The summarization fix gated sampling params on the
+modern-Anthropic predicate and pinned AC #4 ("models that still accept these
+parameters are unchanged") with payload tests: legacy models keep receiving
+`temperature=0.1, top_k=0, top_p=1.0` byte-for-byte. Those pins were green,
+mutation-hardened — and pinning a payload that no served model accepts. Only
+running the *legacy* leg of the live pass (claude-haiku-4-5, expected to just
+work) surfaced it: HTTP 400 ``` `temperature` and `top_p` cannot both be
+specified for this model. Please use only one. ``` (req_011CeEDXPHNyF7apkaZepbTN).
+Follow-up probes showed every currently-served Claude 4.x rejects the
+temperature+top_p combination, and the function's own fallback default
+(`claude-3-haiku-20240307`) now 404s as retired — so the "preserved" legacy
+path had no live model it worked on. Filed as TASK-19020 rather than silently
+widening the fix, since changing those payloads is exactly what the AC forbade.
+
+**What to do.** When an AC says "X is unchanged", the payload pin proves only
+*unchanged*, not *working*. Give the control leg one live request in the same
+pass as the fixed leg — it is one extra call, and it is the only thing that can
+distinguish "preserved" from "preserved a fossil". If the control fails live,
+probe the minimal shapes standalone, and file the discovery against its own
+task instead of mutating the payloads your current AC pins.

--- a/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
+++ b/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
@@ -3,11 +3,11 @@ id: TASK-18802
 title: >-
   Summarization path sends sampling params that modern Anthropic and OpenAI
   models reject
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-18 23:55'
-updated_date: '2026-08-20 14:58'
+updated_date: '2026-08-20 15:18'
 labels:
   - llm
   - bug
@@ -33,10 +33,10 @@ Found by a deliberate sweep for the same pattern while fixing TASK-18414, which 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Summarizing with a modern Anthropic model (Opus 5, Fable 5, Opus 4.8, Opus 4.7, Sonnet 5) completes instead of returning HTTP 400
-- [ ] #2 Summarizing with an OpenAI reasoning model completes, with the correct token-cap parameter name
-- [ ] #3 The summarization path reuses the model_capabilities predicates rather than adding its own model-name checks
-- [ ] #4 Models that still accept these parameters are unchanged, pinned by a regression test
+- [x] #1 Summarizing with a modern Anthropic model (Opus 5, Fable 5, Opus 4.8, Opus 4.7, Sonnet 5) completes instead of returning HTTP 400
+- [x] #2 Summarizing with an OpenAI reasoning model completes, with the correct token-cap parameter name
+- [x] #3 The summarization path reuses the model_capabilities predicates rather than adding its own model-name checks
+- [x] #4 Models that still accept these parameters are unchanged, pinned by a regression test
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,3 +44,19 @@ Found by a deliberate sweep for the same pattern while fixing TASK-18414, which 
 <!-- SECTION:PLAN:BEGIN -->
 1. Probe api.openai.com with the exact summarize_with_openai payload shape (temperature+max_tokens) against modern reasoning-family models (gpt-5, gpt-5.6, o4-mini) and a legacy control (gpt-4o); capture verbatim 400 bodies; establish which params are rejected and the correct token-cap name\n2. Add immutable OpenAI predicates to model_capabilities.py (outside config-driven tables), family-matched per 18414 design\n3. Write RED payload pins for summarize_with_anthropic and summarize_with_openai (rejecting models omit params, legacy models unchanged)\n4. Rewire summarize_with_anthropic to consult anthropic_model_rejects_sampling_params; rewire summarize_with_openai to consult the new predicates\n5. Mutation-test predicate consultation; targeted suites\n6. Live-verify AC#1/#2 through the production payload builder with real keys + dev control on clean origin/dev\n7. Sweep other summarize_with_* functions, file follow-up; update 18803 with probe evidence
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both halves fixed by consulting capability predicates in model_capabilities.py; no new model-name checks and no new logging calls (the diagnostic-privacy manifest hard-codes this module's diagnostic counts).
+
+**Anthropic.** summarize_with_anthropic now gates temperature/top_k/top_p on the existing anthropic_model_rejects_sampling_params (TASK-18414); the function sends no thinking config, so the fixed-budget predicate has nothing to gate. Legacy models keep the exact prior payload (AC #4 pins).
+
+**OpenAI, probe-first.** Standalone curl with the exact payload shape this function builds established: gpt-5/gpt-5.6/o3/o4-mini 400 on max_tokens (unsupported_parameter -> 'Use max_completion_tokens instead') and on temperature=0.7 (unsupported_value; temperature=1 accepted); max_completion_tokens + no sampling -> 200; gpt-4o/gpt-4.1 accept the old shape unchanged. Two new immutable predicates (openai_model_rejects_sampling_params, openai_model_requires_max_completion_tokens) over one (series, major) family table {(gpt,5),(o,1),(o,3),(o,4)}, boundary-safe (o365-copilot, olmo-7b, gpt-4o, gpt-oss never parse), outside the user-overridable capability tables per the 18414 design. summarize_with_openai consults both.
+
+**Evidence.** Red-first 17 failed/37 passed -> 54 passed. Mutation-tested three ways: inverted consultation in the builders (17 pins die), narrowed table dropping (gpt,5) (17 die), widened table adding (gpt,4) (5 die incl. legacy over-match pins -- two-sided). Targeted gate 1048 passed 0 failed (whole Tests/LLM_Calls incl. the diagnostic-privacy manifest suite, model_capabilities consumers); collect-only 50946, 0 errors. Live via pytest driving the production analyze() seam with real keys (scratch bootstrap config): claude-sonnet-5 (the shipped default) and gpt-5 both return real summaries; gpt-4o unchanged; clean-origin/dev control worktree reproduces the 400 both ways (anthropic 'Failed to process summary; status_code=400', openai 'Error: OpenAI API request failed: 400 Client Error').
+
+**Discovered, filed, not fixed:** TASK-19020 -- the legacy Anthropic payload sends temperature AND top_p together, which every served Claude 4.x rejects (probe req_011CeEDXPHNyF7apkaZepbTN), and the fallback default claude-3-haiku-20240307 is retired (404). TASK-19021 -- same unconditional-params shape in the six remaining summarize_with_* providers. TASK-18803 updated with the OpenAI probe bodies.
+
+Files: tldw_chatbook/model_capabilities.py, tldw_chatbook/LLM_Calls/Summarization_General_Lib.py, Tests/LLM_Calls/test_summarization_model_capabilities.py (54 pins), Docs/superpowers/plans/2026-08-20-task-18802-report.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
+++ b/backlog/tasks/task-18802 - Summarization-path-sends-sampling-params-that-modern-Anthropic-and-OpenAI-models-reject.md
@@ -3,9 +3,11 @@ id: TASK-18802
 title: >-
   Summarization path sends sampling params that modern Anthropic and OpenAI
   models reject
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-18 23:55'
+updated_date: '2026-08-20 14:58'
 labels:
   - llm
   - bug
@@ -36,3 +38,9 @@ Found by a deliberate sweep for the same pattern while fixing TASK-18414, which 
 - [ ] #3 The summarization path reuses the model_capabilities predicates rather than adding its own model-name checks
 - [ ] #4 Models that still accept these parameters are unchanged, pinned by a regression test
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Probe api.openai.com with the exact summarize_with_openai payload shape (temperature+max_tokens) against modern reasoning-family models (gpt-5, gpt-5.6, o4-mini) and a legacy control (gpt-4o); capture verbatim 400 bodies; establish which params are rejected and the correct token-cap name\n2. Add immutable OpenAI predicates to model_capabilities.py (outside config-driven tables), family-matched per 18414 design\n3. Write RED payload pins for summarize_with_anthropic and summarize_with_openai (rejecting models omit params, legacy models unchanged)\n4. Rewire summarize_with_anthropic to consult anthropic_model_rejects_sampling_params; rewire summarize_with_openai to consult the new predicates\n5. Mutation-test predicate consultation; targeted suites\n6. Live-verify AC#1/#2 through the production payload builder with real keys + dev control on clean origin/dev\n7. Sweep other summarize_with_* functions, file follow-up; update 18803 with probe evidence
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-18803 - OpenAI-Moonshot-and-Z.ai-request-builders-gate-parameters-on-hand-maintained-model-name-checks.md
+++ b/backlog/tasks/task-18803 - OpenAI-Moonshot-and-Z.ai-request-builders-gate-parameters-on-hand-maintained-model-name-checks.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-18 23:56'
+updated_date: '2026-08-20 15:16'
 labels:
   - llm
 dependencies: []
@@ -37,3 +38,9 @@ model_capabilities.py now has the right shape to extend -- a prefix/suffix-toler
 - [ ] #3 A new model release in a covered family does not require editing a marker list to avoid a 400
 - [ ] #4 Models currently working are unchanged, pinned by regression tests
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PARTIAL EVIDENCE from TASK-18802 (2026-08-20, real key, standalone curl against api.openai.com/v1/chat/completions -- no tldw imports): the API-side behavior behind findings 1 and 2 is now PROBE-VERIFIED. (a) max_tokens is rejected on gpt-5, gpt-5.6, o3 and o4-mini: HTTP 400 {"error":{"code":"unsupported_parameter","message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","param":"max_tokens","type":"invalid_request_error"}}. (b) Non-default temperature is rejected on gpt-5 and gpt-5.6: HTTP 400 {"error":{"code":"unsupported_value","message":"Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.","param":"temperature","type":"invalid_request_error"}}; temperature=1 (the default) IS accepted (HTTP 200), so the rejection is value-level, not parameter-level. (c) max_completion_tokens with no sampling params returns 200 on gpt-5 (chatcmpl-EEyVqbObmis1VBHXSitpSz9aLoylo), gpt-5.6 (served as gpt-5.6-sol) and o4-mini. (d) Controls gpt-4o and gpt-4.1 return 200 with temperature=0.7 + max_tokens unchanged. Still owed by this task: reproducing that chat_with_openai's builder actually emits max_tokens for gpt-5/o-series with no reasoning effort configured (LLM_API_Calls.py :695-698 branch -- code-read only), plus the Moonshot and Z.ai claims. Reusable plumbing now exists: TASK-18802 added openai_model_rejects_sampling_params and openai_model_requires_max_completion_tokens to model_capabilities.py (immutable, outside the config-driven tables) and wired them into the summarization path; this task can consult the same predicates for the chat path.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
+++ b/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19020
+title: >-
+  Summarization Anthropic legacy payload sends temperature and top_p together,
+  which every served Claude 4.x rejects; fallback default model is retired
+status: To Do
+assignee: []
+created_date: '2026-08-20 15:15'
+labels:
+  - llm
+  - bug
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during TASK-18802 live verification. summarize_with_anthropic's legacy-model payload (unchanged by 18802, which only gates the families that reject sampling params outright) sends temperature, top_k AND top_p together. PROBE-VERIFIED against api.anthropic.com on 2026-08-20: claude-haiku-4-5 and claude-sonnet-4-5 with that exact trio return HTTP 400 {"type":"invalid_request_error","message":"`temperature` and `top_p` cannot both be specified for this model. Please use only one."} (req_011CeEDXPHNyF7apkaZepbTN, req_011CeEDXa9V99yBoHN5vcjDG), while temperature alone and temperature+top_k both return 200 (req_011CeEDXQwqi7yXoozbdrXFX, req_011CeEDXVk4nXXCoBGdf9mFm). Separately, the function's own fallback default get_cli_setting('anthropic_api','model','claude-3-haiku-20240307') names a RETIRED model: the same probe run returns HTTP 404 not_found_error (req_011CeEDXZ8iS29MZCgyySwQa). Net effect: with an Anthropic model configured that still accepts sampling params (Haiku 4.5, Sonnet 4.5, Opus 4.6), or with no model configured at all, summarization still fails after 18802. Chat path is NOT affected (chat_with_anthropic sends at most one of temperature/top_p). Fix should probe-verify which families reject the combination, express it as a model_capabilities predicate per the 18414/18802 design, and refresh the stale default model id.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Summarizing with claude-haiku-4-5 or claude-sonnet-4-5 completes instead of returning HTTP 400
+- [ ] #2 The combination rule is expressed via model_capabilities rather than a name check in the request builder
+- [ ] #3 The summarization path's fallback default Anthropic model is a currently-served model
+- [ ] #4 Models unaffected by the combination rule are unchanged, pinned by a regression test
+<!-- AC:END -->

--- a/backlog/tasks/task-19021 - Remaining-summarize_with_-providers-send-unconditional-sampling-params-with-no-capability-gate.md
+++ b/backlog/tasks/task-19021 - Remaining-summarize_with_-providers-send-unconditional-sampling-params-with-no-capability-gate.md
@@ -1,0 +1,26 @@
+---
+id: TASK-19021
+title: >-
+  Remaining summarize_with_* providers send unconditional sampling params with
+  no capability gate
+status: To Do
+assignee: []
+created_date: '2026-08-20 15:16'
+labels:
+  - llm
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-18802 fixed the Anthropic and OpenAI halves of the summarization path and swept the rest of Summarization_General_Lib.py for the same unconditional-params shape. CODE-READ, not probe-verified -- each needs a reproduction before being fixed. Sites (line numbers as of the 18802 branch): summarize_with_cohere :1307 temperature; summarize_with_groq :1555 temperature; summarize_with_openrouter :1779 and :1868 temperature (openrouter proxies OpenAI/Anthropic models, so a routed gpt-5 or claude-sonnet-5 may inherit exactly the 400s 18802 fixed -- worth probing first); summarize_with_huggingface :1967-1969 max_tokens + temperature; summarize_with_deepseek :2159 temperature; summarize_with_mistral :2342-2344 temperature AND top_p together plus max_tokens (the both-at-once shape that 400s on Anthropic Claude 4.x per TASK-19020 -- check whether Mistral restricts the combination). summarize_with_google sends none (commented out) and is unaffected. None of these providers' modern-model behavior has been probed; if a provider rejects nothing, record that and close. Follow the model_capabilities predicate design from TASK-18414/18802 for any that reproduce.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each provider's modern-model behavior toward its unconditional params is probed and recorded before any code change
+- [ ] #2 Any provider that reproduces a rejection consults a model_capabilities predicate instead of sending the param unconditionally
+- [ ] #3 Providers whose models accept the params are left unchanged
+<!-- AC:END -->

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -46,6 +46,11 @@ from tldw_chatbook.Logging_Config import logging
 from tldw_chatbook.config import get_cli_setting
 from tldw_chatbook.Internal_Prompts import get_internal_prompt
 from tldw_chatbook.Utils.persistent_diagnostics import safe_metadata_token
+from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_sampling_params,
+    openai_model_rejects_sampling_params,
+    openai_model_requires_max_completion_tokens,
+)
 
 try:
     from tldw_chatbook.Chunking.Chunk_Lib import improved_chunking_process
@@ -873,11 +878,21 @@ def summarize_with_openai(
                 {"role": "system", "content": system_message},
                 {"role": "user", "content": openai_prompt},
             ],
-            # FIXME - Set a Max tokens value in config file for each API
-            "max_tokens": 4096,
-            "temperature": temp,
             "stream": streaming,
         }
+        # TASK-18802: per-model request capabilities. Reasoning-family models
+        # (o-series, gpt-5) reject the classic `max_tokens` cap with
+        # 400 unsupported_parameter ("Use 'max_completion_tokens' instead")
+        # and reject non-default `temperature` with 400 unsupported_value, so
+        # both are gated on the model_capabilities predicates instead of being
+        # sent unconditionally.
+        # FIXME - Set a Max tokens value in config file for each API
+        if openai_model_requires_max_completion_tokens(openai_model):
+            payload["max_completion_tokens"] = 4096
+        else:
+            payload["max_tokens"] = 4096
+        if not openai_model_rejects_sampling_params(openai_model):
+            payload["temperature"] = temp
 
         # --- Retry Logic --- (Copied from original, seems reasonable)
         session = requests.Session()
@@ -1050,15 +1065,22 @@ def summarize_with_anthropic(
             "max_tokens": 4096,  # max possible tokens to return
             "messages": [user_message],
             "stop_sequences": ["\n\nHuman:"],
-            "temperature": temp,
-            "top_k": 0,
-            "top_p": 1.0,
             "metadata": {
                 "user_id": "example_user_id",
             },
             "stream": streaming,
             "system": system_message,
         }
+        # TASK-18802: the Fable 5 / Mythos 5 / Opus 5 / Opus 4.8 / Opus 4.7 /
+        # Sonnet 5 families reject temperature/top_p/top_k with HTTP 400
+        # ("`temperature` is deprecated for this model."), so sampling params
+        # are gated on the same model_capabilities predicate the chat path
+        # consults (TASK-18414). This function sends no thinking config, so
+        # the fixed-thinking-budget predicate has nothing to gate here.
+        if not anthropic_model_rejects_sampling_params(model):
+            data["temperature"] = temp
+            data["top_k"] = 0
+            data["top_p"] = 1.0
 
         for attempt in range(max_retries):
             try:

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -253,6 +253,134 @@ def anthropic_model_rejects_fixed_thinking_budget(model: object) -> bool:
 #
 #######################################################################################################################
 #
+# OpenAI per-model request capabilities
+#
+# Same design as the Anthropic predicates above (TASK-18414), for the same two
+# reasons: these are facts about what api.openai.com *accepts*, not user
+# preferences, so they live outside the config-driven tables; and a direct
+# mapping in those tables shadows every pattern, so a pattern row could never
+# be trusted to fire.
+#
+# Probe-verified against api.openai.com on 2026-08-20 (TASK-18802) with the
+# exact payload shape the summarization path builds:
+#
+#   * gpt-5, gpt-5.6, o3, o4-mini + ``max_tokens`` -> 400
+#     ``unsupported_parameter: 'max_tokens' is not supported with this model.
+#     Use 'max_completion_tokens' instead.``
+#   * gpt-5, gpt-5.6 + ``temperature: 0.7`` -> 400
+#     ``unsupported_value: 'temperature' does not support 0.7 with this model.
+#     Only the default (1) value is supported.``
+#   * gpt-5, gpt-5.6, o4-mini + ``max_completion_tokens`` and no sampling
+#     params -> 200
+#   * Controls: gpt-4o and gpt-4.1 return 200 with ``temperature: 0.7`` +
+#     ``max_tokens`` unchanged.
+#
+# The o1 family was not probed (no access on the project key) and is included
+# on the documented grounds already encoded in the chat path's reasoning-model
+# marker list (task-404): it shares the o-series request surface.
+#
+# Families are matched as (series, major) so dated snapshots
+# (``gpt-5-2025-08-07``, ``o3-2025-04-16``), dotted minors (``gpt-5.6``,
+# ``gpt-5.1``), suffixed variants (``gpt-5.6-terra``, ``o4-mini``) and
+# provider-prefixed forms (``openai/gpt-5``) all resolve, without matching the
+# legacy families that still accept both parameters (``gpt-4o``, ``gpt-4.1``,
+# ``gpt-4-turbo``, ``gpt-3.5-turbo``) or non-OpenAI lookalikes
+# (``o365-copilot``, ``olmo-7b``, ``gpt-oss-120b``).
+_OPENAI_O_SERIES_RE = re.compile(r"^o(?P<major>\d)(?=$|[-_.@\[])")
+_OPENAI_GPT_SERIES_RE = re.compile(r"^gpt[-_.](?P<major>\d+)(?=$|[-_.@\[])")
+
+# (series, major) pairs whose chat-completions surface rejects the classic
+# ``max_tokens`` cap and non-default sampling parameters.
+_OPENAI_MODERN_REQUEST_FAMILIES = frozenset(
+    {
+        ("gpt", 5),
+        ("o", 1),
+        ("o", 3),
+        ("o", 4),
+    }
+)
+
+
+def _openai_model_family(model: object) -> Optional[Tuple[str, int]]:
+    """Parse an OpenAI model id into ``(series, major)``.
+
+    Args:
+        model: A model identifier in any form the codebase passes through --
+            bare (``gpt-5``, ``o3``), dotted (``gpt-5.6``), dated
+            (``gpt-5-2025-08-07``, ``o3-2025-04-16``), suffixed
+            (``gpt-5.6-terra``, ``o4-mini``) or provider-prefixed
+            (``openai/gpt-5``).
+
+    Returns:
+        ``("gpt", major)`` or ``("o", major)``, or ``None`` when the id is not
+        a recognisable OpenAI series name. The o-series major is a single
+        digit and the gpt major must sit at a token boundary, so
+        ``o365-copilot``, ``olmo-7b`` and ``gpt-4o`` never parse into a
+        family.
+    """
+    if not isinstance(model, str):
+        return None
+    normalized = model.strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    for pattern, series in (
+        (_OPENAI_O_SERIES_RE, "o"),
+        (_OPENAI_GPT_SERIES_RE, "gpt"),
+    ):
+        match = pattern.match(normalized)
+        if match is not None:
+            return (series, int(match.group("major")))
+    return None
+
+
+def _openai_is_modern_request_family(model: object) -> bool:
+    """Return whether ``model`` is in the modern OpenAI request family."""
+    family = _openai_model_family(model)
+    if family is None:
+        return False
+    return family in _OPENAI_MODERN_REQUEST_FAMILIES
+
+
+def openai_model_rejects_sampling_params(model: object) -> bool:
+    """Return whether ``model`` rejects non-default ``temperature``/``top_p``.
+
+    Args:
+        model: An OpenAI model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when sending a non-default sampling value would be answered with
+        ``400 unsupported_value: 'temperature' does not support 0.7 with this
+        model. Only the default (1) value is supported.`` -- the o-series and
+        gpt-5 reasoning families. False for gpt-4o, gpt-4.1 and earlier, which
+        still accept them.
+    """
+    return _openai_is_modern_request_family(model)
+
+
+def openai_model_requires_max_completion_tokens(model: object) -> bool:
+    """Return whether ``model`` requires ``max_completion_tokens``.
+
+    Args:
+        model: An OpenAI model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when sending the classic ``max_tokens`` cap would be answered
+        with ``400 unsupported_parameter: 'max_tokens' is not supported with
+        this model. Use 'max_completion_tokens' instead.``
+
+    Note:
+        This currently covers the same families as
+        :func:`openai_model_rejects_sampling_params` -- OpenAI changed both
+        rules with the reasoning generation -- but they are separate questions
+        about the request surface and are kept as separate predicates so a
+        future model can answer them differently.
+    """
+    return _openai_is_modern_request_family(model)
+
+
+#
+#######################################################################################################################
+#
 # ModelCapabilities Class
 #
 class ModelCapabilities:


### PR DESCRIPTION
## Summary

`Summarization_General_Lib.py` built its own Anthropic/OpenAI payloads with no per-model capability gate — the defect TASK-18414 fixed on the chat path, alive on the path ingestion and web-search summarization actually reach (`analyze()` → `_dispatch_to_api`). Every summarization against the **shipped default `[api_settings.anthropic] model = claude-sonnet-5`** was an HTTP 400, and every modern OpenAI reasoning model 400'd on `max_tokens` + `temperature`.

- **Anthropic**: `summarize_with_anthropic` now consults the existing `anthropic_model_rejects_sampling_params` predicate (TASK-18414) and omits `temperature`/`top_k`/`top_p` for the Fable 5 / Mythos 5 / Opus 5 / Opus 4.8 / Opus 4.7 / Sonnet 5 families. It sends no thinking config, so the fixed-budget predicate has nothing to gate.
- **OpenAI**: two new immutable predicates in `model_capabilities.py` (`openai_model_rejects_sampling_params`, `openai_model_requires_max_completion_tokens`), probe-verified against api.openai.com with the exact payload shape this function builds: gpt-5 / gpt-5.6 / o3 / o4-mini 400 on `max_tokens` (`unsupported_parameter` → use `max_completion_tokens`) and on `temperature: 0.7` (`unsupported_value`); gpt-4o / gpt-4.1 accept the old shape unchanged. Same design rules as 18414 — outside the config-driven user-overridable tables, boundary-safe `(series, major)` family matching (`gpt-4o`, `o365-copilot`, `olmo-7b`, `gpt-oss` never parse).
- No logging calls added or removed — the diagnostic-privacy manifest pins this module's diagnostic counts; that suite is green.

## Evidence

- **Red-first**: 17 failed / 37 passed → **54 passed** (`Tests/LLM_Calls/test_summarization_model_capabilities.py`).
- **Mutation-tested three ways**: inverted predicate consultation (17 pins die), narrowed family table (17 die), widened table (5 die incl. the legacy over-match pins — two-sided).
- **Targeted gate**: 1048 passed, 0 failed (all of `Tests/LLM_Calls/` incl. the diagnostic-privacy manifest suite, plus every `model_capabilities` consumer); collect-only sweep 50,946 tests, 0 errors.
- **Live A/B through the production `analyze()` seam with real keys**: fix branch — `claude-sonnet-5` and `gpt-5` return real summaries, `gpt-4o` unchanged; clean `origin/dev` control worktree — same calls fail with `status_code=400` (Anthropic) and `400 Client Error` (OpenAI).

## Filed, not fixed

- **TASK-19020** — discovered by the live legacy control: the unchanged legacy Anthropic payload sends `temperature` AND `top_p` together, which every served Claude 4.x rejects, and the fallback default `claude-3-haiku-20240307` is retired (404). Changing those payloads is exactly what AC #4 forbids here.
- **TASK-19021** — the six remaining `summarize_with_*` providers share the unconditional-params shape (probe-first follow-up).
- **TASK-18803** — updated with the verbatim OpenAI probe bodies (its findings 1–2 API side now established; the chat-path builder fix stays in its scope).

Full report: `Docs/superpowers/plans/2026-08-20-task-18802-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 400s in summarization by gating Anthropic/OpenAI request payloads on model capabilities. Previously we always sent sampling params and `max_tokens`; now we omit `temperature`/`top_p`/`top_k` for rejecting models and use `max_completion_tokens` for modern OpenAI reasoning families, while legacy-accepting models keep their old payload. Satisfies TASK-18802.

- `tldw_chatbook/LLM_Calls/Summarization_General_Lib.py`: consults `anthropic_model_rejects_sampling_params`, `openai_model_rejects_sampling_params`, and `openai_model_requires_max_completion_tokens`; no logging changes.
- `tldw_chatbook/model_capabilities.py`: adds immutable OpenAI predicates with boundary-safe `(series, major)` parsing; kept outside user-overridable tables.
- Tests: adds `Tests/LLM_Calls/test_summarization_model_capabilities.py` to pin rejecting-model behavior and legacy payload stability.
- Follow-ups: TASK-19020 (legacy Anthropic payload sends `temperature`+`top_p`, and fallback model is retired) and TASK-19021 (other `summarize_with_*` providers) filed; TASK-18803 updated with OpenAI probe evidence.

<sup>Written for commit 7f1cae460275834adc6d06babb140d4cd90a7706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

