### PR TITLE
fix(watchlists): segment-level cost-bounded change percentage, single continuous semantic (task-16839)

### DIFF
--- a/Tests/Subscriptions/test_change_percentage_bounds.py
+++ b/Tests/Subscriptions/test_change_percentage_bounds.py
@@ -16,14 +16,17 @@ the two full raw texts, which has two entangled failure regimes:
 The shipped fix computes the ratio over ``_segment_for_diff`` segments -- the
 same sentence/line-sized basis the stored diff body, ``diff_summary`` and
 ``added_and_removed_text`` already use -- so the percentage now means "fraction
-of the page's diff segments that changed" and every consumer (the
-``change_threshold`` comparison, the withheld disposition, the reader's
-"N% changed" headline) reads one coherent story. Cost is bounded by
-construction: an O(n) multiset comparison takes over past explicit size/
-repetition bounds (see ``_segment_change_ratio``).
+of the page's segment content that appeared or disappeared" and every consumer
+(the ``change_threshold`` comparison, the withheld disposition, the reader's
+"N% changed" headline) reads one coherent story. The ratio is an O(n)
+order-insensitive multiset comparison at EVERY size (see
+``_segment_change_ratio``): the fix round retired an initial order-sensitive
+``SequenceMatcher`` tier after the independent review reproduced a sign-flip
+cliff at its 4,000-segment boundary for reorder-shaped edits.
 
-Both born-red pins below were run against the pre-fix implementation and
-failed for the advertised reason (degenerate value; blown wall-clock bound).
+The born-red pins below were each run against the implementation they indict
+and failed for the advertised reason (degenerate value; blown wall-clock
+bound; the reorder tier-cliff).
 """
 
 import random
@@ -31,7 +34,6 @@ import time
 
 import pytest
 
-from tldw_chatbook.Subscriptions import monitoring_engine
 from tldw_chatbook.Subscriptions.monitoring_engine import (
     ContentExtractor,
     _segment_for_diff,
@@ -127,6 +129,50 @@ def test_identical_and_disjoint_and_empty_extremes():
     )
 
 
+def _pure_reorder_pct(n_per_side: int) -> float:
+    """Change percentage for a page whose segments were shuffled, nothing else."""
+    sentences = [
+        f"unique sentence number {i} holding its own distinct words."
+        for i in range(n_per_side)
+    ]
+    old = " ".join(sentences)
+    assert len(_segment_for_diff(old)) == n_per_side, (
+        "the probe is only meaningful if each sentence is its own segment"
+    )
+    shuffled = sentences[:]
+    random.Random(99).shuffle(shuffled)
+    new = " ".join(shuffled)
+    return ContentExtractor.calculate_change_percentage(old, new)
+
+
+def test_pure_reorder_reports_zero_change_with_no_size_cliff():
+    """Born-red fix-round pin (task-16839 review, Finding 1).
+
+    At commit 6d22de89f a purely reordered page -- same segments, shuffled,
+    zero content change -- reported pct=0.9925 at 4,000 total segments (the
+    order-sensitive SequenceMatcher alignment tier) and pct=0.0000 at 4,002
+    (the order-insensitive multiset tier): one extra sentence per side flipped
+    "99% changed" to "0% changed" for functionally the same event. The fix
+    retired the alignment tier; the multiset ratio is the sole mechanism at
+    every size, so a pure reorder reports 0.0 everywhere -- the documented
+    semantic decision (see ``_segment_change_ratio``): a segment that merely
+    moved is not content change, and the diff body still shows the moves.
+    """
+    below = _pure_reorder_pct(2000)  # 4,000 total segments: the retired tier boundary
+    above = _pure_reorder_pct(2001)  # 4,002 total segments: just past it
+    assert abs(below - above) < 0.01, (
+        f"tier cliff: a pure reorder reports {below:.4f} at 4,000 total "
+        f"segments but {above:.4f} at 4,002 -- the two mechanisms disagree "
+        f"at their boundary"
+    )
+    for n_per_side in (12, 300, 2000, 2001, 6000):
+        pct = _pure_reorder_pct(n_per_side)
+        assert pct == 0.0, (
+            f"a purely reordered page must report 0.0 at any size "
+            f"(got {pct!r} at {n_per_side} segments/side)"
+        )
+
+
 def test_small_page_one_sentence_edit_is_one_segments_worth():
     """The percentage is segment-granular: 1 edited sentence of 11 is ~9%."""
     old = " ".join(
@@ -141,15 +187,12 @@ def test_small_page_one_sentence_edit_is_one_segments_worth():
     assert pct == pytest.approx(1 - (2 * 10 / 22), abs=1e-9)
 
 
-def test_multiset_regime_above_the_alignment_bound_keeps_sane_values():
-    """Past the alignment bound the O(n) multiset tier reports the same
-    magnitudes (it is order-insensitive there, by design and documented)."""
-    n = 3 * monitoring_engine._ALIGNMENT_MAX_TOTAL_SEGMENTS
-    old = _latin_page(n)
-    assert (
-        len(_segment_for_diff(old)) * 2
-        > monitoring_engine._ALIGNMENT_MAX_TOTAL_SEGMENTS
-    )
+def test_very_large_page_keeps_sane_values():
+    """A ~640 KB / 12,000-segment page reports the same magnitudes as a small
+    one -- the multiset ratio is one mechanism at every size, so there is no
+    tier boundary for the value to jump at (fix round, review Finding 1)."""
+    old = _latin_page(12_000)
+    assert len(_segment_for_diff(old)) == 12_000
     new = _edit_fraction(old, 0.05)
     pct = ContentExtractor.calculate_change_percentage(old, new)
     assert pct == pytest.approx(0.05, abs=0.02)
@@ -246,9 +289,11 @@ def test_repetitive_page_is_neither_junked_nor_quadratic():
     """A page of few distinct segments must not resurrect either regime.
 
     Segment-level autojunk would junk a segment repeated >1% of a >=200-segment
-    page (the old defect one level up), and an unjunked alignment over heavy
-    repetition is the quadratic shape -- the collision budget routes this to
-    the multiset tier instead: exact small value, bounded time.
+    page (the old defect one level up), and an unjunked SequenceMatcher
+    alignment over heavy repetition is the quadratic shape -- the multiset
+    ratio has neither mechanism: counting multiplicity is immune to
+    repetition, and its cost is O(n) by construction. Exact small value,
+    bounded time.
     """
     old = " ".join(f"entry number {i % 7} is listed here." for i in range(4000))
     new_sentences = old.split(". ")

--- a/Tests/Subscriptions/test_change_percentage_bounds.py
+++ b/Tests/Subscriptions/test_change_percentage_bounds.py
@@ -1,0 +1,264 @@
+"""`ContentExtractor.calculate_change_percentage`: sane values, bounded cost.
+
+TASK-16839, from the task-15764 review (finding 5). The old implementation ran a
+character-level ``difflib.SequenceMatcher.ratio()`` with ``autojunk=True`` over
+the two full raw texts, which has two entangled failure regimes:
+
+* **Degenerate values** — for large Latin pages every character clears
+  autojunk's 1%-popularity bar, the matcher junks its whole alphabet, and a
+  5%-edited page reported ~100% changed. The percentage was meaningless exactly
+  where it was cheap.
+* **Quadratic cost** — for a large character repertoire (CJK/unicode-heavy)
+  nothing is junked and ``ratio()`` goes quadratic: measured 4x per doubling,
+  ~1 s at 160 K chars, extrapolating to ~7 minutes at the 10 MB
+  ``MAX_FETCH_BYTES_PAGE`` cap, on a GIL-holding worker thread.
+
+The shipped fix computes the ratio over ``_segment_for_diff`` segments -- the
+same sentence/line-sized basis the stored diff body, ``diff_summary`` and
+``added_and_removed_text`` already use -- so the percentage now means "fraction
+of the page's diff segments that changed" and every consumer (the
+``change_threshold`` comparison, the withheld disposition, the reader's
+"N% changed" headline) reads one coherent story. Cost is bounded by
+construction: an O(n) multiset comparison takes over past explicit size/
+repetition bounds (see ``_segment_change_ratio``).
+
+Both born-red pins below were run against the pre-fix implementation and
+failed for the advertised reason (degenerate value; blown wall-clock bound).
+"""
+
+import random
+import time
+
+import pytest
+
+from tldw_chatbook.Subscriptions import monitoring_engine
+from tldw_chatbook.Subscriptions.monitoring_engine import (
+    ContentExtractor,
+    _segment_for_diff,
+)
+
+# --- deterministic content builders ------------------------------------------
+
+# Only very common characters (lowercase letters, space, period): at >=~20 KB
+# every one of them exceeds autojunk's 1%-of-sequence popularity bar, which is
+# precisely the shape that degenerated the old character-level matcher.
+_COMMON_WORDS = (
+    "the report section remains unchanged in this revision and the terms "
+    "stay exactly as they were with no further notice given here"
+).split()
+
+
+def _latin_page(n_sentences: int) -> str:
+    """One long extracted-text line of `n_sentences` common-word sentences."""
+    return " ".join(
+        " ".join(_COMMON_WORDS[(i + j) % len(_COMMON_WORDS)] for j in range(9)) + "."
+        for i in range(n_sentences)
+    )
+
+
+def _edit_fraction(text: str, fraction: float) -> str:
+    """Rewrite every ``1/fraction``-th sentence entirely (scattered edits)."""
+    sentences = text.split(". ")
+    step = max(1, round(1 / fraction))
+    for i in range(0, len(sentences), step):
+        sentences[i] = "completely rewritten clause about another topic entirely"
+    return ". ".join(sentences)
+
+
+def _cjk_page(n_sentences: int, chars_per_sentence: int = 40) -> str:
+    """Spaceless CJK-shaped prose: sentences end with 。and no whitespace.
+
+    Seeded-random draws over a 6,000-codepoint repertoire keep every character
+    rare AND aperiodic -- the regime where autojunk junked nothing and the old
+    matcher went cleanly quadratic. (A deterministic cycling generator was
+    tried first and did NOT reproduce the quadratic regime at the pre-fix
+    HEAD: periodic text lets the matcher find giant matches cheaply.)
+    """
+    rng = random.Random(1234)
+    out = []
+    for _ in range(n_sentences):
+        out.append(
+            "".join(
+                chr(0x4E00 + rng.randrange(6000)) for _ in range(chars_per_sentence - 1)
+            )
+        )
+    return "。".join(out) + "。"
+
+
+# --- value sanity (the degeneracy pin) ---------------------------------------
+
+
+def test_five_percent_edited_large_latin_page_reports_a_small_percentage():
+    """Born-red degeneracy pin (task-16839 AC#1).
+
+    At the pre-fix HEAD this exact input returned 0.471 ("47% changed") for a
+    page with 5% of its sentences rewritten -- and took ~39 s doing it: Latin
+    text this size junks nearly every character it is made of, so the matcher
+    had almost nothing left to align (the task-15764 review measured a full
+    1.0 on its shape). The segment-level basis reports the honest magnitude:
+    ~5% of the page's sentences changed.
+    """
+    old = _latin_page(2400)  # ~128 KB of extracted text
+    new = _edit_fraction(old, 0.05)
+    assert len(old) > 100_000, "the pin is about LARGE pages; keep it large"
+
+    pct = ContentExtractor.calculate_change_percentage(old, new)
+
+    assert pct == pytest.approx(0.05, abs=0.02), (
+        "a 5%-edited large Latin page must report ~5% changed, not the "
+        f"autojunk-degenerate ~100% (got {pct!r})"
+    )
+
+
+def test_identical_and_disjoint_and_empty_extremes():
+    page = _latin_page(300)
+    assert ContentExtractor.calculate_change_percentage(page, page) == 0.0
+    assert ContentExtractor.calculate_change_percentage("", "") == 0.0
+    assert ContentExtractor.calculate_change_percentage(page, "") == 1.0
+    assert ContentExtractor.calculate_change_percentage("", page) == 1.0
+
+    disjoint = " ".join(
+        f"totally different words about frogs and rivers number {i}."
+        for i in range(300)
+    )
+    pct = ContentExtractor.calculate_change_percentage(page, disjoint)
+    assert pct == pytest.approx(1.0, abs=0.01), (
+        f"two pages sharing no sentences must report ~100% changed (got {pct!r})"
+    )
+
+
+def test_small_page_one_sentence_edit_is_one_segments_worth():
+    """The percentage is segment-granular: 1 edited sentence of 11 is ~9%."""
+    old = " ".join(
+        f"clause {i} of the terms stays exactly as written." for i in range(10)
+    )
+    old += " the price is 42 credits per widget."
+    new = old.replace(
+        "the price is 42 credits per widget.",
+        "pricing moved to a metered plan billed hourly instead.",
+    )
+    pct = ContentExtractor.calculate_change_percentage(old, new)
+    assert pct == pytest.approx(1 - (2 * 10 / 22), abs=1e-9)
+
+
+def test_multiset_regime_above_the_alignment_bound_keeps_sane_values():
+    """Past the alignment bound the O(n) multiset tier reports the same
+    magnitudes (it is order-insensitive there, by design and documented)."""
+    n = 3 * monitoring_engine._ALIGNMENT_MAX_TOTAL_SEGMENTS
+    old = _latin_page(n)
+    assert (
+        len(_segment_for_diff(old)) * 2
+        > monitoring_engine._ALIGNMENT_MAX_TOTAL_SEGMENTS
+    )
+    new = _edit_fraction(old, 0.05)
+    pct = ContentExtractor.calculate_change_percentage(old, new)
+    assert pct == pytest.approx(0.05, abs=0.02)
+    assert ContentExtractor.calculate_change_percentage(old, old) == 0.0
+
+
+def test_cjk_prose_segments_on_sentence_enders_and_reports_small_edits():
+    """CJK prose (no whitespace, 。sentence enders) gets sentence segments.
+
+    Before task-16839 ``_SENTENCE_BOUNDARY`` required trailing whitespace, so
+    a whole CJK page was ONE unit fixed-sliced into 110-char segments whose
+    boundaries all shift under any insertion -- a one-sentence edit would have
+    re-sliced (and so "changed") half the page.
+    """
+    old = _cjk_page(400)
+    segments = _segment_for_diff(old)
+    assert len(segments) == 400, "each 。-ended sentence must be its own segment"
+
+    sentences = old.split("。")
+    sentences[200] = "完全不同的新句子在这里出现了"
+    new = "。".join(sentences)
+    pct = ContentExtractor.calculate_change_percentage(old, new)
+    assert pct == pytest.approx(2 / 800, abs=1e-9), (
+        f"one edited sentence of 400 must report ~0.25% (got {pct!r})"
+    )
+
+
+# --- bounded cost (the quadratic-regime pin) ---------------------------------
+
+# These are wall-clock regression bounds, deliberately LOOSE (an order of
+# magnitude over the measured times) so machine noise never flakes them: the
+# regression they guard is seconds-to-minutes, not milliseconds.
+
+
+def _timed_percentage(old: str, new: str) -> tuple[float, float]:
+    start = time.perf_counter()
+    pct = ContentExtractor.calculate_change_percentage(old, new)
+    return pct, time.perf_counter() - start
+
+
+def test_large_repertoire_page_is_not_quadratic():
+    """Born-red cost pin (task-16839 AC#2), loose wall-clock bound.
+
+    ~640 K chars over a 6,000-codepoint random repertoire: nothing is junked,
+    and the pre-fix character matcher was quadratic here (4x per doubling --
+    tens of seconds at this size, ~7 minutes at the 10 MB cap); the segment
+    basis is linear. The 2 s bound is an order of magnitude over the post-fix
+    measurement.
+    """
+    old = _cjk_page(16_000)  # 16000 sentences x 40 chars = 640K chars
+    sentences = old.split("。")
+    sentences[8000] = "改" * 39
+    new = "。".join(sentences)
+
+    pct, elapsed = _timed_percentage(old, new)
+
+    assert elapsed < 2.0, f"took {elapsed:.1f}s -- the quadratic regime is back"
+    assert 0.0 < pct < 0.01, f"one edited sentence of 16000 (got {pct!r})"
+
+
+def test_ten_megabyte_fetch_cap_is_bounded_latin_and_spaceless():
+    """AC#2: bounded at the 10 MB ``MAX_FETCH_BYTES_PAGE`` cap, for the
+    many-segments shape (Latin), the CJK-prose shape (~10 MB utf-8), and the
+    single-giant-unit shape (no sentence enders at all). At the pre-fix HEAD
+    the Latin shape alone was minutes. Measured (2026-08-16, this change):
+    all comfortably sub-second; 5 s is the loose regression bound."""
+    old = _latin_page(200_000)  # ~10.7 MB of text, ~200K segments
+    assert len(old) >= 10_000_000
+    new = _edit_fraction(old, 0.05)
+    pct, elapsed = _timed_percentage(old, new)
+    assert elapsed < 5.0, f"10MB Latin took {elapsed:.1f}s"
+    assert pct == pytest.approx(0.05, abs=0.02)
+
+    old_cjk = _cjk_page(85_000)  # 3.4M chars, ~10 MB utf-8
+    cjk_sentences = old_cjk.split("。")
+    del cjk_sentences[40_000:42_000]  # drop ~2.4% of the page
+    new_cjk = "。".join(cjk_sentences)
+    pct, elapsed = _timed_percentage(old_cjk, new_cjk)
+    assert elapsed < 5.0, f"10MB CJK prose took {elapsed:.1f}s"
+    assert pct == pytest.approx(2000 / 169_000, abs=0.005)
+
+    # No sentence enders anywhere: one giant unbreakable unit per side, the
+    # shape that made `textwrap.wrap` quadratic before this task fixed-sliced
+    # it. Boundaries shift under the deletion, so the value is coarse here
+    # (documented); the assertions are the bound and value validity.
+    blob_old = _cjk_page(85_000).replace("。", "")
+    blob_new = blob_old[:1_000_000] + blob_old[1_100_000:]
+    pct, elapsed = _timed_percentage(blob_old, blob_new)
+    assert elapsed < 5.0, f"10MB spaceless blob took {elapsed:.1f}s"
+    assert 0.0 < pct <= 1.0
+
+
+def test_repetitive_page_is_neither_junked_nor_quadratic():
+    """A page of few distinct segments must not resurrect either regime.
+
+    Segment-level autojunk would junk a segment repeated >1% of a >=200-segment
+    page (the old defect one level up), and an unjunked alignment over heavy
+    repetition is the quadratic shape -- the collision budget routes this to
+    the multiset tier instead: exact small value, bounded time.
+    """
+    old = " ".join(f"entry number {i % 7} is listed here." for i in range(4000))
+    new_sentences = old.split(". ")
+    new_sentences[2000] = "one genuinely new entry appears"
+    new = ". ".join(new_sentences)
+
+    pct, elapsed = _timed_percentage(old, new)
+
+    assert elapsed < 2.0, f"repetitive page took {elapsed:.1f}s"
+    assert 0.0 < pct < 0.01, (
+        f"one edited segment of 4000 must report ~0.025%, not junk-degenerate "
+        f"~100% (got {pct!r})"
+    )

--- a/Tests/Subscriptions/test_local_watchlists_service.py
+++ b/Tests/Subscriptions/test_local_watchlists_service.py
@@ -286,15 +286,17 @@ async def test_url_list_offloads_cpu_work_for_every_url_in_order(tmp_path, monke
         calls.append(("extract", marker, threading.get_ident()))
         return real_extract(html, ignore_selectors)
 
-    def recording_percentage(old_content, new_content):
+    # Both spies forward the pre-built segment lists `check_url` now passes
+    # (TASK-16839 fix round: one segmentation per side, shared across hops).
+    def recording_percentage(old_content, new_content, **kwargs):
         marker = f"{text_markers[old_content]}->{text_markers[new_content]}"
         calls.append(("percentage", marker, threading.get_ident()))
-        return real_percentage(old_content, new_content)
+        return real_percentage(old_content, new_content, **kwargs)
 
-    def recording_details(previous_text, current_text):
+    def recording_details(previous_text, current_text, **kwargs):
         marker = f"{text_markers[previous_text]}->{text_markers[current_text]}"
         calls.append(("details", marker, threading.get_ident()))
-        return real_details(previous_text, current_text)
+        return real_details(previous_text, current_text, **kwargs)
 
     monkeypatch.setattr(monitoring_engine, "guarded_fetch_httpx_async", serve)
     monkeypatch.setattr(

--- a/Tests/Subscriptions/test_url_monitor_off_loop.py
+++ b/Tests/Subscriptions/test_url_monitor_off_loop.py
@@ -162,11 +162,14 @@ def _spy_diff_work(monkeypatch) -> dict[str, list[int]]:
 
     real_percentage = ContentExtractor.calculate_change_percentage
 
-    def percentage_spy(old_content, new_content):
+    # `check_url`'s percentage hop passes pre-built segment lists (TASK-16839
+    # fix round: segments are shared with the details hop), so the spy must
+    # forward them.
+    def percentage_spy(old_content, new_content, **kwargs):
         threads.setdefault("calculate_change_percentage", []).append(
             threading.get_ident()
         )
-        return real_percentage(old_content, new_content)
+        return real_percentage(old_content, new_content, **kwargs)
 
     monkeypatch.setattr(
         ContentExtractor, "calculate_change_percentage", staticmethod(percentage_spy)
@@ -247,14 +250,15 @@ async def test_the_diff_work_runs_off_the_event_loop_thread(tmp_path, monkeypatc
     assert set(threads) == expected, (
         f"every difflib call must have happened (saw {sorted(threads)})"
     )
-    # 4 = 2 in the change-percentage hop (TASK-16839 rebased the percentage
-    # onto the same segment basis as the diff) + 2 in the details hop, where
-    # the Qodo segment-once rule still holds: `build_change_diff` and
-    # `added_and_removed_text` share one segmentation per side. A 5th call
-    # means that sharing broke.
-    assert len(threads["_segment_for_diff"]) == 4, (
-        "each hop segments each side exactly once (percentage hop + details "
-        "hop) -- an extra call means the segment-once sharing broke"
+    # 2 = one segmentation per side, total, for the whole changed path: the
+    # percentage hop builds both lists and passes them through to the details
+    # hop (TASK-16839 fix round, review finding 2 -- each hop previously
+    # segmented independently, paying the dominant cost twice for every
+    # significant change). A 3rd call means the cross-hop sharing broke.
+    assert len(threads["_segment_for_diff"]) == 2, (
+        "the changed path segments each side exactly once, shared across the "
+        "percentage and details hops -- an extra call means the segment-once "
+        "sharing broke"
     )
     loop_thread = threading.get_ident()
     for name, idents in threads.items():

--- a/Tests/Subscriptions/test_url_monitor_off_loop.py
+++ b/Tests/Subscriptions/test_url_monitor_off_loop.py
@@ -247,9 +247,14 @@ async def test_the_diff_work_runs_off_the_event_loop_thread(tmp_path, monkeypatc
     assert set(threads) == expected, (
         f"every difflib call must have happened (saw {sorted(threads)})"
     )
-    assert len(threads["_segment_for_diff"]) == 2, (
-        "each side is segmented once and shared (the Qodo segment-once rule) "
-        "-- a third call means the sharing broke in the move"
+    # 4 = 2 in the change-percentage hop (TASK-16839 rebased the percentage
+    # onto the same segment basis as the diff) + 2 in the details hop, where
+    # the Qodo segment-once rule still holds: `build_change_diff` and
+    # `added_and_removed_text` share one segmentation per side. A 5th call
+    # means that sharing broke.
+    assert len(threads["_segment_for_diff"]) == 4, (
+        "each hop segments each side exactly once (percentage hop + details "
+        "hop) -- an extra call means the segment-once sharing broke"
     )
     loop_thread = threading.get_ident()
     for name, idents in threads.items():

--- a/Tests/Subscriptions/test_watchlist_content_kind_producer.py
+++ b/Tests/Subscriptions/test_watchlist_content_kind_producer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -296,7 +297,11 @@ async def test_the_change_headline_carries_a_diff_summary_and_a_real_percentage(
 
     plain, _ansi = _rendered(item)
     assert f"{pct:.0f}% changed" in plain
-    assert "0% changed" not in plain, (
+    # `(?<!\d)` because a bare substring check matched the tail of any
+    # percentage ending in 0 -- TASK-16839's segment-level basis reports this
+    # fixture as "60% changed" (2 of its 3+2 sentence segments differ) and
+    # the old `"0% changed" not in plain` tripped on it.
+    assert not re.search(r"(?<!\d)0% changed", plain), (
         "a real change must never print as 0% -- the ratio/percent mismatch"
     )
     assert item["diff_summary"] in plain

--- a/Tests/Subscriptions/test_watchlist_noise_not_volume.py
+++ b/Tests/Subscriptions/test_watchlist_noise_not_volume.py
@@ -696,9 +696,9 @@ async def _direct_check(db, source_id: int) -> tuple[dict | None, dict]:
 def _long_page(tail: str) -> str:
     """~40 unchanging sentences plus one line carrying `tail`.
 
-    The point is the ratio: the whole page is ~2.5 kB, so editing `tail`
-    alone moves `SequenceMatcher`'s whole-page similarity by well under 1% --
-    two orders of magnitude below the old 0.1 default.
+    The point is the ratio: editing `tail` alone changes 1 of the page's 41
+    sentence segments (~2.4% on TASK-16839's segment basis; under 1% of
+    characters on the old basis) -- well below the old 0.1 default either way.
     """
     body = "".join(
         f"<p>Section {i} of the release notes is unchanged in this revision.</p>"
@@ -748,10 +748,14 @@ async def test_a_small_edit_to_a_long_page_fires_under_the_default(monkeypatch):
     assert any(line.startswith("+") and "4.5" in line for line in diff_lines)
     assert any(line.startswith("-") and "4.1" in line for line in diff_lines)
 
-    # The precondition that makes this test meaningful: the edit really is far
-    # below the retired 0.1 default, so the pass cannot come from a big change.
-    assert items[0]["change_percentage"] < 1.0, (
-        "the edit must be tiny (well under 1% of the page) or this test would "
+    # The precondition that makes this test meaningful: the edit really is
+    # below the retired 0.1 default, so the pass cannot come from a big
+    # change. TASK-16839 rebased the percentage from characters onto
+    # sentence-sized diff segments, so this one-sentence edit on a 41-segment
+    # page now reports ~2.4% (1 segment of 41) instead of ~0.1% of
+    # characters -- still well under the retired default's 10%.
+    assert items[0]["change_percentage"] < 10.0, (
+        "the edit must stay below the retired 0.1 default or this test would "
         f"pass under the old default too; got {items[0]['change_percentage']!r}"
     )
 

--- a/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
@@ -518,7 +518,10 @@ async def test_changed_item_cpu_work_runs_off_the_event_loop_without_changing_se
 
     assert len(calls["percentage"]) == 1
     assert calls["percentage"][0] != loop_thread
-    assert len(calls["segment"]) == 2
+    # 4 = 2 inside the percentage hop (TASK-16839: the percentage is computed
+    # on the same `_segment_for_diff` basis as the diff) + 2 in the details
+    # hop, which still segments once per side and shares (segment-once rule).
+    assert len(calls["segment"]) == 4
     assert len(calls["build"]) == 1
     assert len(calls["added_removed"]) == 1
     assert len(calls["classify"]) == 1

--- a/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
+++ b/Tests/Subscriptions/test_watchlists_db_instance_and_off_loop.py
@@ -518,10 +518,11 @@ async def test_changed_item_cpu_work_runs_off_the_event_loop_without_changing_se
 
     assert len(calls["percentage"]) == 1
     assert calls["percentage"][0] != loop_thread
-    # 4 = 2 inside the percentage hop (TASK-16839: the percentage is computed
-    # on the same `_segment_for_diff` basis as the diff) + 2 in the details
-    # hop, which still segments once per side and shares (segment-once rule).
-    assert len(calls["segment"]) == 4
+    # 2 = one segmentation per side for the whole changed path: the percentage
+    # hop builds both segment lists and `check_url` passes them through to the
+    # details hop (TASK-16839 fix round, review finding 2 -- previously each
+    # hop segmented independently, 4 calls, paying the dominant cost twice).
+    assert len(calls["segment"]) == 2
     assert len(calls["build"]) == 1
     assert len(calls["added_removed"]) == 1
     assert len(calls["classify"]) == 1
@@ -553,9 +554,11 @@ async def test_below_threshold_cpu_work_stops_before_significant_change_details(
 
     percentage_threads: list[int] = []
 
-    def recording_percentage(old_content, new_content):
+    # The percentage hop passes pre-built segment lists (TASK-16839 fix
+    # round: shared with the details hop), so the spy forwards them.
+    def recording_percentage(old_content, new_content, **kwargs):
         percentage_threads.append(threading.get_ident())
-        return real_percentage(old_content, new_content)
+        return real_percentage(old_content, new_content, **kwargs)
 
     grouped_calls: list[int] = []
 
@@ -650,12 +653,12 @@ async def test_cancelled_change_worker_does_not_resume_check_or_mutate_state(
     worker_finished = threading.Event()
     worker_threads: list[int] = []
 
-    def blocked_details(previous_text, current_text):
+    def blocked_details(previous_text, current_text, **kwargs):
         worker_threads.append(threading.get_ident())
         worker_entered.set()
         try:
             release_worker.wait()
-            return real_details(previous_text, current_text)
+            return real_details(previous_text, current_text, **kwargs)
         finally:
             worker_finished.set()
 
@@ -721,7 +724,7 @@ async def test_failing_change_worker_propagates_and_records_breaker_failure(
 
     worker_threads: list[int] = []
 
-    def failing_details(_previous_text, _current_text):
+    def failing_details(_previous_text, _current_text, **_kwargs):
         worker_threads.append(threading.get_ident())
         raise SignificantDetailsError("significant details failed")
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4413,10 +4413,14 @@ pct=0.47 for a 5%-edited page after ~39 s.) The off-loop move was thus MORE
 justified than the original numbers suggested, and the review's own stall probe
 corroborated the shape independently (164.7 ms -> 18.4 ms max stall on the same
 seam). Both regimes are historical as of task-16839: `calculate_change_percentage`
-now computes the ratio over `_segment_for_diff` segments (the same basis as the
-stored diff), autojunk off, with an O(n) multiset fallback past explicit
-size/repetition bounds -- measured ~5 ms at 160 KB Latin, ~650 ms worst shape at
-the 10 MB cap. Keep both halves of this incident: measure the whole operation,
+now computes an O(n) order-insensitive multiset ratio over `_segment_for_diff`
+segments (the same basis as the stored diff) at every size -- measured ~6 ms at
+160 KB Latin, ~430 ms worst shape at the 10 MB cap. (A first revision kept an
+order-sensitive `SequenceMatcher` tier below a 4,000-segment bound with the
+multiset ratio as fallback; the independent review reproduced a pure-reorder
+cliff at that boundary -- 99.25% vs 0.00% across one added sentence -- and the
+fix round retired the tier. See the boundary-probe lesson below.) Keep both
+halves of this incident: measure the whole operation,
 and expect your headline number to be re-run by a skeptic. The lesson: before
 implementing a perf task scoped by a list of call sites, run one measurement that
 would catch an omission -- a wall/stall probe around the whole operation, not
@@ -5310,3 +5314,24 @@ not None`, `not button.disabled`, label != "Checking"), never a mounted-state
 or pause proxy; settle `not disabled` before any programmatic `press()`. After
 the class fix: 10/10 full-file runs green (4 under the same 14-burner load)
 plus 5/5 standalone runs of the old reproducer.
+
+## A tiered design's boundary must be probed with a shape the tiers disagree on (task-16839 fix round, 2026-08-20)
+
+Task-16839's first revision computed its change ratio with an order-sensitive
+`SequenceMatcher` alignment up to 4,000 total segments and an order-insensitive
+multiset ratio past that bound. The implementer's boundary checking used
+scattered-edit shapes and saw a smooth 0.0500 -> 0.049975 step, which looked
+like continuity. The independent review probed the same boundary with a **pure
+reorder** -- the one shape on which the two mechanisms measure opposite things
+-- and got 0.9925 -> 0.0000: one added sentence per side flipped "99% changed"
+to "0% changed" for a page whose content had not changed at all. The smooth
+ordinary-shape probe had proven nothing, because on ordinary shapes the two
+tiers compute (nearly) the same number by construction; the boundary's real
+behaviour lives exactly where they disagree. Rule: when a function switches
+mechanisms on a size/cost threshold, first name the semantic axis on which the
+mechanisms differ (here: order-sensitivity), then build the boundary probe to
+maximise disagreement on that axis -- and if such a shape exists at all, the
+design has a cliff no threshold placement can fix; the durable resolution is
+one semantic at every size (the fix round retired the alignment tier and made
+the order-insensitive ratio the sole mechanism, with "a moved segment is not a
+change" as the documented decision), not a relocated boundary.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -4403,19 +4403,27 @@ the independent review (the implementer's 16.2 s / "99.8%" figure on a 160 KB La
 page pair did NOT reproduce -- Latin text at that size hits `autojunk`'s fast path,
 20-40 ms across four content shapes, and autojunk incidentally returns a
 meaningless `pct` for it, a separate pre-existing oddity): character-level
-`ratio()` goes quadratic only when the character repertoire is large enough that
-autojunk junks nothing (CJK / unicode-heavy pages) -- measured clean 4x per
+`ratio()` went quadratic only when the character repertoire was large enough that
+autojunk junked nothing (CJK / unicode-heavy pages) -- measured clean 4x per
 doubling, extrapolating to ~1 s at 160 K chars and **~7 minutes at the 10 MB
-fetch cap**. The off-loop move is thus MORE justified than the original numbers
-suggested, and the review's own stall probe corroborated the shape independently
-(164.7 ms -> 18.4 ms max stall on the same seam). Keep both halves of this
-incident: measure the whole operation, and expect your headline number to be
-re-run by a skeptic. The lesson: before implementing a perf task scoped by a list of
-call sites, run one measurement that would catch an omission -- a wall/stall probe
-around the whole operation, not around the listed calls. If the numbers do not drop
-when the listed sites move, the list was wrong, and the AC's own wording ("the
-difflib work") almost always licenses fixing the omission in the same change --
-record the addition explicitly rather than silently widening scope.
+fetch cap**. (The two regimes were not even cleanly separated: task-16839's
+born-red pin found a 128 KB Latin shape -- common letters junked, digits/capitals
+rare enough to survive as anchors -- that was degenerate AND quadratic at once,
+pct=0.47 for a 5%-edited page after ~39 s.) The off-loop move was thus MORE
+justified than the original numbers suggested, and the review's own stall probe
+corroborated the shape independently (164.7 ms -> 18.4 ms max stall on the same
+seam). Both regimes are historical as of task-16839: `calculate_change_percentage`
+now computes the ratio over `_segment_for_diff` segments (the same basis as the
+stored diff), autojunk off, with an O(n) multiset fallback past explicit
+size/repetition bounds -- measured ~5 ms at 160 KB Latin, ~650 ms worst shape at
+the 10 MB cap. Keep both halves of this incident: measure the whole operation,
+and expect your headline number to be re-run by a skeptic. The lesson: before
+implementing a perf task scoped by a list of call sites, run one measurement that
+would catch an omission -- a wall/stall probe around the whole operation, not
+around the listed calls. If the numbers do not drop when the listed sites move,
+the list was wrong, and the AC's own wording ("the difflib work") almost always
+licenses fixing the omission in the same change -- record the addition explicitly
+rather than silently widening scope.
 
 ## A version-stamp rollback fixture is a promise every future migration must keep — centralize it or it breaks serially (task-15765/task-16197, 2026-08-15)
 

--- a/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
+++ b/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
@@ -86,7 +86,9 @@ task changes the story it tells.
 `_segment_for_diff` segments -- the same sentence/line-sized basis the stored
 diff body, `diff_summary` and `added_and_removed_text` already use -- so the
 percentage, the diff and the added/removed haystacks all describe the change at
-one granularity. Two tiers in `_segment_change_ratio`: alignment
+one granularity. Two tiers in `_segment_change_ratio` (**superseded by the
+fix round below -- the alignment tier is retired; the multiset ratio is the
+sole mechanism at every size**): alignment
 (`SequenceMatcher` over segments, `autojunk=False` -- popularity junking IS the
 degeneracy mechanism, so it is off and cost is bounded explicitly instead) for
 pages up to `_ALIGNMENT_MAX_TOTAL_SEGMENTS`=4,000 segments with
@@ -157,3 +159,67 @@ known pre-existing dirt in the untouched FeedMonitor region).
 `test_url_monitor_off_loop.py`, `test_watchlists_db_instance_and_off_loop.py`,
 `test_watchlist_noise_not_volume.py`, `test_watchlist_content_kind_producer.py`
 (pin updates); `backlog/docs/lessons-testing-evidence.md` (AC#4 correction).
+
+### Fix round (2026-08-20, independent review FIX-FIRST verdict)
+
+**Finding 1 (blocking) -- ALIGNMENT/MULTISET tier cliff for reorders, FIXED
+by retiring the alignment tier.** The review reproduced a sign-flip
+discontinuity at the 4,000-total-segment boundary: a purely reordered page
+(same segments, shuffled, zero content change) reported pct=0.9925 at 4,000
+total segments (order-sensitive `SequenceMatcher` tier) and pct=0.0000 at
+4,002 (order-insensitive multiset tier) -- one extra sentence per side
+flipped "99% changed" to "0% changed". Born-red evidence: the new
+`test_pure_reorder_reports_zero_change_with_no_size_cliff` was run against
+6d22de89f and failed with exactly that signature ("a pure reorder reports
+0.9925 at 4,000 total segments but 0.0000 at 4,002"). Resolution: the
+**two-tier design described above is retired**; `_segment_change_ratio` is
+the O(n) order-insensitive multiset ratio at EVERY size, and both alignment
+constants are deleted. This is the only continuous option: any hard boundary
+between an order-sensitive and an order-insensitive mechanism flips on
+reorder-shaped edits wherever it is placed, and order-sensitivity at every
+size is the unaffordable quadratic this task retired. **Semantic decision,
+documented in `_segment_change_ratio`'s docstring: a segment that merely
+moved is not a content change -- a pure reorder reports 0.0 at any size.**
+Rationale: the consumers read the value as "how much content changed"; a
+re-sorted listing page is exactly the noise a raised threshold exists to
+withhold, and near-100% for zero content change is the misleading-percentage
+defect this task exists to eliminate. A pure reorder is still detected (hash
+differs) and at the default threshold 0.0 still produces an item, with the
+moves visible in the (position-aware) diff body. Behavior delta vs the
+reviewed commit: none for non-move edit shapes (multiset equals the
+alignment value there -- the review's own probe: 0.050000/0.049975 across
+the boundary for a scattered 5% edit); moves now consistently count 0
+instead of order-dependently 0-or-~1.
+
+**Finding 2 (non-blocking) -- doubled segmentation across `check_url`'s two
+hops, FIXED by sharing segments.** The percentage hop
+(`_change_percentage_with_segments`, new) segments each side once and
+returns the lists; `check_url` passes them to
+`_build_significant_change_details`, which (like `build_change_diff` and
+`added_and_removed_text` already did) accepts optional pre-built segments.
+`calculate_change_percentage` gained matching optional
+`old_segments`/`new_segments` kwargs; all default to None so every other
+caller is unchanged. Measured at the 10 MB cap: end-to-end changed-path CPU
+947 ms -> 528 ms (one `_segment_for_diff` pass over a 10 MB side is ~200 ms,
+paid 4x before, 2x now), outputs byte-identical across the two shapes.
+
+**Re-measured post-fix** (same M-series laptop): 160 KB Latin 5%-edit
+6.2 ms; at the 10 MB cap: Latin 431 ms, CJK prose 162 ms, spaceless blob
+166 ms -- worst measured shape at the cap is now 431 ms (the multiset-only
+path is faster than the reviewed two-tier's 647 ms; the 5 s in-test loose
+bound is unchanged). Pure-reorder probe: 0.0 at 12/300/2,000/2,001/6,000
+segments per side -- no cliff.
+
+**Test pin updates in this round**, each disclosed in-file: the two off-loop
+`_segment_for_diff` counts go 4 -> 2 (the cross-hop sharing is the fix;
+an extra call now means the sharing broke); the off-loop/service spies on
+`calculate_change_percentage` and `_build_significant_change_details`
+forward the new segment kwargs;
+`test_multiset_regime_above_the_alignment_bound_keeps_sane_values` is now
+`test_very_large_page_keeps_sane_values` (the bound it referenced no longer
+exists). `Tests/Subscriptions/`: 806 passed, 1 pre-existing skip.
+
+**Lessons**: corrected the 15764/16839 entry's mechanism sentence (multiset
+is now the sole tier) and added a new entry: a tiered design's boundary must
+be probed with a shape the tiers DISAGREE on -- the smooth scattered-edit
+step proved nothing because the tiers agree on that shape by construction.

--- a/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
+++ b/backlog/tasks/task-16839 - Fix-and-bound-calculate_change_percentage-quadratic-cost-and-autojunk-degenerate-ratios.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-16839
 title: 'Fix and bound calculate_change_percentage (quadratic cost and autojunk-degenerate ratios)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-16'
 labels:
   - bug
@@ -42,11 +43,117 @@ carries the old (wrong) mechanism claim for this function's cost — correct it 
 task changes the story it tells.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+1. Consumer census: the ratio feeds exactly (a) `check_url`'s `change_percentage <
+   threshold` withhold comparison (default threshold 0.0), (b) the withheld disposition
+   (`withheld_percentage`, x100), (c) the stored item's `change_percentage` (x100,
+   rendered `f"{pct:.0f}% changed"` by `content_pane.render_change` and echoed by
+   briefings/tool service). All consumers need a coarse, monotonic-ish 0..1 magnitude,
+   not char-exact ratios.
+2. Rebase the percentage on the SAME `_segment_for_diff` segmentation the stored diff,
+   `diff_summary` and `added_and_removed_text` already use, so all outputs of a change
+   tell one story: primary = `SequenceMatcher(None, old_segments, new_segments,
+   autojunk=False).ratio()` (autojunk over near-unique segments is the defect's
+   mechanism, so it is off and cost is bounded explicitly instead); fallback = a
+   segment multiset ratio (order-insensitive, O(n)) whenever the alignment tier's
+   measured cost model says alignment could be slow (total segments or
+   equal-segment collision count over a budget).
+3. Bound `_segment_for_diff` itself: `textwrap.wrap` is quadratic on a unit containing
+   a giant unbreakable run (a 10 MB single-line CJK page costs minutes) — detect
+   `[^\s-]{1001,}` and fixed-slice that unit instead.
+4. Born-red first: degeneracy pin (5%-edited large Latin page must report ~5%, not
+   ~100%) and a loose wall-clock cost pin at a large-repertoire input; then implement,
+   then measure at 160 KB Latin / 160 K-char CJK / the 10 MB cap.
+5. Re-run the threshold-consumer families (noise-not-volume, content-kind producer,
+   off-loop thread identity x2, local service); update the three pins the new basis
+   legitimately shifts, each with a disclosed reason.
+6. Correct the task-15764 lesson entry (its mechanism/number claims describe code this
+   task retires) and the stale module comments; ruff on touched files.
+
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A 5%-edited large Latin page reports a small change percentage, not 1.0 (regression test)
-- [ ] #2 Worst-case runtime at the 10 MB fetch cap is bounded to sub-second, measured and stated
-- [ ] #3 Existing change-classification behavior for ordinary pages is preserved or the delta is characterized (byte-diff over the 15764 semantic-identity cases or equivalent)
-- [ ] #4 The stale mechanism/number claims in the 15764 lesson entry are corrected to match the shipped behavior
+- [x] #1 A 5%-edited large Latin page reports a small change percentage, not 1.0 (regression test)
+- [x] #2 Worst-case runtime at the 10 MB fetch cap is bounded to sub-second, measured and stated
+- [x] #3 Existing change-classification behavior for ordinary pages is preserved or the delta is characterized (byte-diff over the 15764 semantic-identity cases or equivalent)
+- [x] #4 The stale mechanism/number claims in the 15764 lesson entry are corrected to match the shipped behavior
 <!-- AC:END -->
+
+## Implementation Notes
+
+**Design.** `calculate_change_percentage` now computes its 0..1 ratio over
+`_segment_for_diff` segments -- the same sentence/line-sized basis the stored
+diff body, `diff_summary` and `added_and_removed_text` already use -- so the
+percentage, the diff and the added/removed haystacks all describe the change at
+one granularity. Two tiers in `_segment_change_ratio`: alignment
+(`SequenceMatcher` over segments, `autojunk=False` -- popularity junking IS the
+degeneracy mechanism, so it is off and cost is bounded explicitly instead) for
+pages up to `_ALIGNMENT_MAX_TOTAL_SEGMENTS`=4,000 segments with
+`_ALIGNMENT_MAX_SEGMENT_COLLISIONS`=200K equal-segment pairs; past either
+bound, an O(n) multiset ratio (`2*matches/total`, order-insensitive --
+documented as the honest coarse answer for the noise-threshold consumer). Both
+bounds chosen from adversarial measurements (edit-every-2nd-segment: 119 ms at
+the 2,000/side boundary; repetitive pages route to multiset). Alternatives
+rejected: input truncation (silently zeroes edits past the cap), sampling
+(nondeterministic), keeping char-level for small pages (the autojunk cliff
+starts at a few KB, so "small" had no safe region).
+
+**Consumer evidence.** The ratio has exactly three consumers -- `check_url`'s
+threshold withhold (default 0.0), the withheld disposition, and the x100
+display value rendered `f"{pct:.0f}% changed"` -- all coarse-magnitude readers.
+
+**Cost, measured** (M-series laptop; was ~39 s at 128 KB Latin / quadratic 4x
+per doubling for CJK / ~7 min extrapolated at the cap): 160 KB Latin 5%-edit
+5.2 ms; 160 K-char CJK one-sentence edit 7.5 ms; at the 10 MB fetch cap: Latin
+647 ms, CJK prose 236 ms, spaceless blob 246 ms -- worst measured shape at the
+cap is 647 ms, stated bound sub-second, in-test regression bound 5 s (loose
+wall-clock, marked as such).
+
+**Value sanity**: identical 0.0; disjoint ~1.0; 5%-edited large Latin page
+0.0500 (was 0.47-1.0 degenerate); 1-of-41-sentence edit 2.4%; empty-vs-content
+1.0; whitespace-only difference 0.0 (agrees with the "no textual change after
+normalization" diff path).
+
+**Two supporting fixes in the same seam** (both disclosed): (a)
+`_SENTENCE_BOUNDARY` now also splits after CJK sentence enders (。．！？)
+without requiring whitespace -- previously an entire CJK page was ONE unit
+fixed-wrapped into 110-char slices whose boundaries all shift under any edit;
+(b) `_segment_for_diff` fixed-slices units containing a whitespace-free run
+>1,000 chars (`_UNWRAPPABLE_RUN`) because `textwrap.wrap` re-slices the whole
+remainder per emitted line (quadratic; minutes at 10 MB spaceless) -- for a
+fully unbreakable unit the slices are byte-identical to what wrap produced
+(verified empirically).
+
+**Threshold-consumer disposition.** End-to-end byte-diff vs origin/dev over the
+eleven 15764 semantic-identity cases (`semantic_delta_16839.py`, adapted from
+the review harness): 10/11 byte-identical in every non-percentage field
+(dispositions, diff bodies, summaries, rule-match text, snapshots); the one
+divergence is the intended CJK-boundary improvement (finer diff lines, same
+content). Percentages shift basis as characterized per case -- e.g. "oversized"
+(all 400 sentences replaced) 10.16%->100% (the old value was the degenerate
+lie), "withheld below threshold" 2.35%->2.50% still withheld. Three test pins
+updated with disclosed reasons: the noise-not-volume `< 1.0` precondition is
+now `< 10.0` (1 segment of 41 is 2.4%; still below the retired 0.1 default the
+pin exists to guard), the two off-loop `_segment_for_diff == 2` counts are 4
+(the percentage hop segments once per side too; the details hop still shares),
+and the content-kind producer's `"0% changed" not in` substring check gained
+`(?<!\d)` (it matched the tail of the new honest "60% changed").
+
+**Born-red evidence** (run at pre-fix HEAD): degeneracy pin FAILED with
+pct=0.471 for the 5%-edited page after ~39 s; cost pin FAILED with 7.2 s
+against the 2 s bound at 640 K chars (a first-draft deterministic-cycling CJK
+generator did NOT reproduce the quadratic regime -- periodic text aligns
+cheaply -- and was replaced with seeded-random draws; recorded in the test).
+
+**Tests**: new `Tests/Subscriptions/test_change_percentage_bounds.py` (8);
+`Tests/Subscriptions/` 805 passed / 1 pre-existing skip; wider watchlist suites
+(Tools/UI/Scheduling/DB) 334 passed. Ruff clean on touched files; no new
+format dirt (the one `ruff format` hunk left in `monitoring_engine.py` is the
+known pre-existing dirt in the untouched FeedMonitor region).
+
+**Files**: `tldw_chatbook/Subscriptions/monitoring_engine.py`;
+`Tests/Subscriptions/test_change_percentage_bounds.py` (new);
+`test_url_monitor_off_loop.py`, `test_watchlists_db_instance_and_off_loop.py`,
+`test_watchlist_noise_not_volume.py`, `test_watchlist_content_kind_producer.py`
+(pin updates); `backlog/docs/lessons-testing-evidence.md` (AC#4 correction).

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -15,6 +15,7 @@ import json
 import re
 import textwrap
 import time
+from collections import Counter
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse
@@ -253,24 +254,47 @@ class ContentExtractor:
 
     @staticmethod
     def calculate_change_percentage(old_content: str, new_content: str) -> float:
-        """
-        Calculate percentage of change between two texts.
+        """Estimate how much of a page's text changed, as a 0.0-1.0 ratio.
+
+        Computed over ``_segment_for_diff`` segments -- the same
+        sentence/line-sized units the stored diff body, ``diff_summary`` and
+        ``added_and_removed_text`` are built from -- so the ratio means "the
+        fraction of the page's diff segments that changed" and agrees in
+        granularity with everything else the reader sees about the change.
+        See ``_segment_change_ratio`` for the cost bounds.
+
+        TASK-16839. This was a character-level
+        ``SequenceMatcher(None, old, new).ratio()`` with default autojunk,
+        which had two entangled failure regimes over the unbounded inputs the
+        10 MB fetch cap admits: for large Latin pages autojunk junks the
+        entire alphabet and the value degenerates (a 5%-edited ~128 KB page
+        measured pct=0.47 -- the 15764 review measured a full 1.0 -- while
+        taking ~39 s), and for large character repertoires (CJK) nothing is
+        junked and ``ratio()`` is quadratic (4x per doubling; ~7 minutes at
+        the fetch cap, on a GIL-holding worker thread). Its consumers -- the
+        ``change_threshold`` withhold comparison (default 0.0), the withheld
+        disposition, and the reader's ``f"{pct:.0f}% changed"`` headline --
+        all need a coarse, monotonic-ish magnitude, not char-exact ratios.
 
         Args:
-            old_content: Previous content
-            new_content: New content
+            old_content: Previous extracted text.
+            new_content: New extracted text.
 
         Returns:
-            Change percentage (0.0 to 1.0)
+            Change ratio, 0.0 (identical) to 1.0 (nothing in common).
+            Identical texts return 0.0; a whitespace-only difference also
+            returns 0.0 (segmentation normalizes whitespace, deliberately
+            agreeing with the "no textual change after normalization" path
+            of ``build_change_diff``); one side empty returns 1.0.
         """
         if not old_content and not new_content:
             return 0.0
         if not old_content or not new_content:
             return 1.0
 
-        matcher = SequenceMatcher(None, old_content, new_content)
-        similarity = matcher.ratio()
-        return 1.0 - similarity
+        return _segment_change_ratio(
+            _segment_for_diff(old_content), _segment_for_diff(new_content)
+        )
 
 
 ########################################################################################################################
@@ -310,11 +334,31 @@ _HEADER_LINES = 2
 # `_segment_for_diff`, which splits on real line breaks when the text has any
 # and on sentence boundaries when it does not (sentences stay aligned under a
 # local edit in a way fixed-width chunking does not).
-_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+#
+# The second alternative splits AFTER a CJK sentence ender with no whitespace
+# requirement (TASK-16839): CJK prose ends sentences with 。！？ and contains
+# no spaces at all, so under the Latin-only rule an entire CJK page was ONE
+# unit that fell to fixed-width wrapping -- every boundary after an edit
+# shifted, which made the diff (and the change percentage now computed on the
+# same segments) treat half the page as changed for a one-sentence edit.
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+|(?<=[。．！？])")
 
 # A segment longer than this is wrapped at word boundaries, so no single diff
 # line is wider than the narrow reader pane can show without wrapping mid-word.
 _MAX_DIFF_SEGMENT_CHARS = 110
+
+# `textwrap.wrap` is quadratic in the length of a single unbreakable run:
+# `_handle_long_word` re-slices the whole remainder once per emitted line, so
+# one 3.4M-char spaceless unit (a 10 MB CJK page without sentence enders)
+# costs minutes (TASK-16839). A unit containing any whitespace-free run longer
+# than this is fixed-sliced to `_MAX_DIFF_SEGMENT_CHARS` instead -- O(n), and
+# for a fully unbreakable unit the slices are exactly what `break_long_words`
+# would have produced anyway. (Hyphens sometimes let textwrap break a
+# spaceless run cheaply, but only between word characters -- whitespace is
+# the only breaker this guard can trust.) Runs at or under this bound keep
+# textwrap's word-boundary aesthetics at a bounded cost: each run re-slices
+# at most ~1000 chars per emitted line.
+_UNWRAPPABLE_RUN = re.compile(r"\S{1001,}")
 
 # Bounds on the stored diff. The body goes into a TEXT column and into a pane
 # roughly nine rows tall, and the full page it was computed from is already
@@ -354,8 +398,12 @@ def _segment_for_diff(text: str) -> List[str]:
     Splits on real line breaks when ``text`` contains any, and on sentence
     boundaries when it does not -- which is the case for a whole page captured
     through ``extract_text_from_html``, since that collapses everything onto
-    one line. Segments longer than ``_MAX_DIFF_SEGMENT_CHARS`` are then wrapped
-    at word boundaries, and blank segments are dropped.
+    one line. Sentence boundaries include CJK enders with no trailing
+    whitespace (see ``_SENTENCE_BOUNDARY``). Segments longer than
+    ``_MAX_DIFF_SEGMENT_CHARS`` are then wrapped at word boundaries -- or
+    fixed-sliced when they contain a run textwrap could only break
+    quadratically (see ``_UNWRAPPABLE_RUN``) -- and blank segments are
+    dropped.
 
     (Fix round 1, Minor #4: this used to be described in terms of the
     subscription's ``extraction_method``, which it never reads -- the only
@@ -380,8 +428,83 @@ def _segment_for_diff(text: str) -> List[str]:
         if len(stripped) <= _MAX_DIFF_SEGMENT_CHARS:
             segments.append(stripped)
             continue
+        if _UNWRAPPABLE_RUN.search(stripped):
+            # Bounded fixed-width slicing for units textwrap cannot break at
+            # word boundaries anyway -- see `_UNWRAPPABLE_RUN` for why wrap
+            # is quadratic on these.
+            segments.extend(
+                piece
+                for start in range(0, len(stripped), _MAX_DIFF_SEGMENT_CHARS)
+                if (piece := stripped[start : start + _MAX_DIFF_SEGMENT_CHARS].strip())
+            )
+            continue
         segments.extend(textwrap.wrap(stripped, _MAX_DIFF_SEGMENT_CHARS) or [stripped])
     return segments
+
+
+# Cost bounds for `_segment_change_ratio`'s alignment tier (TASK-16839), both
+# chosen from adversarial measurements (worst shapes, M-series laptop):
+#
+# - `_ALIGNMENT_MAX_TOTAL_SEGMENTS`: `SequenceMatcher.get_matching_blocks`
+#   over two segment lists is quadratic-ish when small edits are scattered
+#   densely (an edit every 2nd segment measured 134 ms at 2,000 segments per
+#   side and 4x that at 4,000 per side). 4,000 total segments (~2,000 per
+#   side, roughly 200+ KB of extracted text per side) keeps that worst case
+#   near 100 ms while covering ordinary pages by a wide margin.
+# - `_ALIGNMENT_MAX_SEGMENT_COLLISIONS`: with repeated segments the matcher's
+#   inner loop walks every position of the element in the other side, so its
+#   per-sweep cost is the number of equal-segment pairs (sum over distinct
+#   segments of count_a * count_b) -- e.g. two sides of 2,000 identical
+#   segments are 4M pairs in a single sweep. 200K pairs measured ~40 ms.
+#
+# Past either bound the multiset tier takes over: O(n), order-insensitive.
+_ALIGNMENT_MAX_TOTAL_SEGMENTS = 4_000
+_ALIGNMENT_MAX_SEGMENT_COLLISIONS = 200_000
+
+
+def _segment_change_ratio(old_segments: List[str], new_segments: List[str]) -> float:
+    """Change ratio between two segment lists, with bounded worst-case cost.
+
+    Two tiers (TASK-16839):
+
+    * **Alignment** (ordinary pages): ``SequenceMatcher`` over the segment
+      lists with ``autojunk=False``. Segments are near-unique in real pages,
+      so this is effectively linear; autojunk is OFF because popularity
+      junking is exactly the mechanism that made the old character-level
+      ratio degenerate, and a repetitive page (few distinct segments) would
+      reproduce it one level up.
+    * **Multiset** (past the bounds above): the fraction of segments present
+      on both sides counting multiplicity -- ``2*matches/total``, the
+      ``quick_ratio`` formula over segments. O(n) and order-INSENSITIVE: a
+      huge page that merely reorders its segments reports ~0 change, which is
+      the honest coarse answer for a noise-threshold consumer.
+
+    Args:
+        old_segments: Previous text through ``_segment_for_diff``.
+        new_segments: Current text likewise.
+
+    Returns:
+        0.0 (identical) .. 1.0 (disjoint). Both sides empty is 0.0; exactly
+        one side empty is 1.0.
+    """
+    total = len(old_segments) + len(new_segments)
+    if not old_segments or not new_segments:
+        return 0.0 if total == 0 else 1.0
+
+    old_counts = Counter(old_segments)
+    new_counts = Counter(new_segments)
+    if total <= _ALIGNMENT_MAX_TOTAL_SEGMENTS:
+        collisions = sum(
+            count * new_counts.get(segment, 0) for segment, count in old_counts.items()
+        )
+        if collisions <= _ALIGNMENT_MAX_SEGMENT_COLLISIONS:
+            matcher = SequenceMatcher(None, old_segments, new_segments, autojunk=False)
+            return 1.0 - matcher.ratio()
+
+    matches = sum(
+        min(count, new_counts.get(segment, 0)) for segment, count in old_counts.items()
+    )
+    return 1.0 - (2.0 * matches / total)
 
 
 def build_change_diff(

--- a/tldw_chatbook/Subscriptions/monitoring_engine.py
+++ b/tldw_chatbook/Subscriptions/monitoring_engine.py
@@ -253,15 +253,23 @@ class ContentExtractor:
         return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
     @staticmethod
-    def calculate_change_percentage(old_content: str, new_content: str) -> float:
+    def calculate_change_percentage(
+        old_content: str,
+        new_content: str,
+        *,
+        old_segments: List[str] | None = None,
+        new_segments: List[str] | None = None,
+    ) -> float:
         """Estimate how much of a page's text changed, as a 0.0-1.0 ratio.
 
         Computed over ``_segment_for_diff`` segments -- the same
         sentence/line-sized units the stored diff body, ``diff_summary`` and
         ``added_and_removed_text`` are built from -- so the ratio means "the
-        fraction of the page's diff segments that changed" and agrees in
-        granularity with everything else the reader sees about the change.
-        See ``_segment_change_ratio`` for the cost bounds.
+        fraction of the page's segment content that appeared or disappeared"
+        and agrees in granularity with everything else the reader sees about
+        the change. The ratio is order-INSENSITIVE: a page that merely
+        reorders its segments reports 0.0 -- see ``_segment_change_ratio``
+        for that semantic decision and its rationale, and for the O(n) cost.
 
         TASK-16839. This was a character-level
         ``SequenceMatcher(None, old, new).ratio()`` with default autojunk,
@@ -279,6 +287,14 @@ class ContentExtractor:
         Args:
             old_content: Previous extracted text.
             new_content: New extracted text.
+            old_segments: ``old_content`` already run through
+                ``_segment_for_diff``. Optional: segmentation is ~95% of this
+                function's cost, so ``check_url`` segments each side once and
+                shares the lists between this ratio and the significant-change
+                details -- the same segment-once rule ``build_change_diff``
+                documents. Segmented here when omitted, so callers passing
+                only the texts are unchanged.
+            new_segments: ``new_content`` likewise.
 
         Returns:
             Change ratio, 0.0 (identical) to 1.0 (nothing in common).
@@ -292,9 +308,11 @@ class ContentExtractor:
         if not old_content or not new_content:
             return 1.0
 
-        return _segment_change_ratio(
-            _segment_for_diff(old_content), _segment_for_diff(new_content)
-        )
+        if old_segments is None:
+            old_segments = _segment_for_diff(old_content)
+        if new_segments is None:
+            new_segments = _segment_for_diff(new_content)
+        return _segment_change_ratio(old_segments, new_segments)
 
 
 ########################################################################################################################
@@ -442,50 +460,52 @@ def _segment_for_diff(text: str) -> List[str]:
     return segments
 
 
-# Cost bounds for `_segment_change_ratio`'s alignment tier (TASK-16839), both
-# chosen from adversarial measurements (worst shapes, M-series laptop):
-#
-# - `_ALIGNMENT_MAX_TOTAL_SEGMENTS`: `SequenceMatcher.get_matching_blocks`
-#   over two segment lists is quadratic-ish when small edits are scattered
-#   densely (an edit every 2nd segment measured 134 ms at 2,000 segments per
-#   side and 4x that at 4,000 per side). 4,000 total segments (~2,000 per
-#   side, roughly 200+ KB of extracted text per side) keeps that worst case
-#   near 100 ms while covering ordinary pages by a wide margin.
-# - `_ALIGNMENT_MAX_SEGMENT_COLLISIONS`: with repeated segments the matcher's
-#   inner loop walks every position of the element in the other side, so its
-#   per-sweep cost is the number of equal-segment pairs (sum over distinct
-#   segments of count_a * count_b) -- e.g. two sides of 2,000 identical
-#   segments are 4M pairs in a single sweep. 200K pairs measured ~40 ms.
-#
-# Past either bound the multiset tier takes over: O(n), order-insensitive.
-_ALIGNMENT_MAX_TOTAL_SEGMENTS = 4_000
-_ALIGNMENT_MAX_SEGMENT_COLLISIONS = 200_000
-
-
 def _segment_change_ratio(old_segments: List[str], new_segments: List[str]) -> float:
-    """Change ratio between two segment lists, with bounded worst-case cost.
+    """Order-insensitive change ratio between two segment lists. O(n), always.
 
-    Two tiers (TASK-16839):
+    The fraction of segment occurrences (counting multiplicity) present on
+    only one side: ``1 - 2*matches/total``, difflib's ``quick_ratio`` formula
+    over segments.
 
-    * **Alignment** (ordinary pages): ``SequenceMatcher`` over the segment
-      lists with ``autojunk=False``. Segments are near-unique in real pages,
-      so this is effectively linear; autojunk is OFF because popularity
-      junking is exactly the mechanism that made the old character-level
-      ratio degenerate, and a repetitive page (few distinct segments) would
-      reproduce it one level up.
-    * **Multiset** (past the bounds above): the fraction of segments present
-      on both sides counting multiplicity -- ``2*matches/total``, the
-      ``quick_ratio`` formula over segments. O(n) and order-INSENSITIVE: a
-      huge page that merely reorders its segments reports ~0 change, which is
-      the honest coarse answer for a noise-threshold consumer.
+    **Semantic decision (TASK-16839 fix round): a segment that merely MOVED
+    is not a change.** A purely reordered page -- same segments, shuffled --
+    reports 0.0 at every size. Rationale: this ratio's consumers (the
+    ``change_threshold`` withhold comparison, the withheld disposition, the
+    reader's "N% changed" headline) all read it as "how much of the page's
+    content changed", and a re-sorted listing page whose content is intact is
+    exactly the noise shape a raised threshold exists to withhold -- reporting
+    near-100% for zero content change is the misleading-percentage defect
+    this task exists to eliminate. Order is not lost to the reader: the
+    stored diff body is position-aware and shows moved blocks as ``-``/``+``
+    pairs, and a pure reorder is still *detected* (the content hash differs),
+    so at the default threshold 0.0 it still produces an item -- headlined
+    "0% changed", with the moves visible in the diff.
+
+    Why one mechanism at every size, rather than an order-sensitive alignment
+    below a cost bound: the reviewed revision ran a ``SequenceMatcher``
+    alignment up to 4,000 total segments with this multiset ratio as the
+    past-the-bound fallback, and the review reproduced the resulting cliff --
+    a pure reorder reported 0.9925 at 4,000 total segments and 0.0000 at
+    4,002, so one added sentence per side flipped "99% changed" to "0%
+    changed". Any hard boundary between an order-sensitive and an
+    order-insensitive tier flips like that on reorder-shaped edits, and
+    order-sensitivity at *every* size is the unaffordable-quadratic shape
+    this task retired -- so the order-insensitive ratio is the sole
+    mechanism, and the reported quantity is continuous in page size for a
+    fixed edit shape. For non-move edit shapes (in-place rewrites,
+    insertions, deletions) this agrees with what the alignment tier
+    reported anyway -- the review measured a scattered 5% edit at
+    0.050000/0.049975 across that boundary -- so ordinary pages are
+    unaffected by the tier's retirement; only moves are now consistently
+    "not a content change" instead of order-dependently either.
 
     Args:
         old_segments: Previous text through ``_segment_for_diff``.
         new_segments: Current text likewise.
 
     Returns:
-        0.0 (identical) .. 1.0 (disjoint). Both sides empty is 0.0; exactly
-        one side empty is 1.0.
+        0.0 (identical multisets) .. 1.0 (disjoint). Both sides empty is
+        0.0; exactly one side empty is 1.0.
     """
     total = len(old_segments) + len(new_segments)
     if not old_segments or not new_segments:
@@ -493,14 +513,6 @@ def _segment_change_ratio(old_segments: List[str], new_segments: List[str]) -> f
 
     old_counts = Counter(old_segments)
     new_counts = Counter(new_segments)
-    if total <= _ALIGNMENT_MAX_TOTAL_SEGMENTS:
-        collisions = sum(
-            count * new_counts.get(segment, 0) for segment, count in old_counts.items()
-        )
-        if collisions <= _ALIGNMENT_MAX_SEGMENT_COLLISIONS:
-            matcher = SequenceMatcher(None, old_segments, new_segments, autojunk=False)
-            return 1.0 - matcher.ratio()
-
     matches = sum(
         min(count, new_counts.get(segment, 0)) for segment, count in old_counts.items()
     )
@@ -692,12 +704,54 @@ def classify_change_type(previous_text: str, current_text: str) -> str:
     return "content"
 
 
-def _build_significant_change_details(
+def _change_percentage_with_segments(
     previous_text: str, current_text: str
-) -> tuple[str, str, str, str, str]:
-    """Build all significant-change diff details from one segmentation pass."""
+) -> tuple[float, List[str], List[str]]:
+    """Segment both sides once and compute the change ratio over the segments.
+
+    ``check_url``'s percentage hop. Segmentation is ~95% of the ratio's cost
+    (measured ~200 ms per side of a ~430 ms total at the 10 MB fetch cap;
+    the multiset ratio itself is cheap), so the segment lists are returned for the
+    details hop to reuse rather than re-segmenting -- extending the
+    segment-once rule ``build_change_diff`` documents across the two
+    ``asyncio.to_thread`` hops as well as within the second (TASK-16839 fix
+    round, review finding 2: a significant change previously paid full
+    segmentation twice end-to-end).
+    """
     old_segments = _segment_for_diff(previous_text)
     new_segments = _segment_for_diff(current_text)
+    percentage = ContentExtractor.calculate_change_percentage(
+        previous_text,
+        current_text,
+        old_segments=old_segments,
+        new_segments=new_segments,
+    )
+    return percentage, old_segments, new_segments
+
+
+def _build_significant_change_details(
+    previous_text: str,
+    current_text: str,
+    *,
+    old_segments: List[str] | None = None,
+    new_segments: List[str] | None = None,
+) -> tuple[str, str, str, str, str]:
+    """Build all significant-change diff details from one segmentation pass.
+
+    Args:
+        previous_text: The previous snapshot's ``extracted_content``.
+        current_text: The freshly fetched extracted text.
+        old_segments: ``previous_text`` already segmented; ``new_segments``
+            likewise. Optional: ``check_url`` passes the lists its percentage
+            hop already built (``_change_percentage_with_segments``), so a
+            significant change segments each side once end-to-end. Segmented
+            here when omitted, so direct callers are unchanged.
+        new_segments: See ``old_segments``.
+    """
+    if old_segments is None:
+        old_segments = _segment_for_diff(previous_text)
+    if new_segments is None:
+        new_segments = _segment_for_diff(current_text)
     diff_body, diff_summary = build_change_diff(
         previous_text,
         current_text,
@@ -1463,10 +1517,21 @@ class URLMonitor:
                 breaker.record_success()
                 return None, _disposition(DISPOSITION_UNCHANGED)
 
-            # Calculate change details
+            # Calculate change details. The percentage hop returns the segment
+            # lists it built alongside the ratio: segmentation dominates the
+            # ratio's cost, and the details hop below consumes the very same
+            # lists, so they are carried across the threshold check instead of
+            # being rebuilt (TASK-16839 fix round, review finding 2). The lists
+            # go out of scope with this call frame either way; holding them
+            # across one cheap comparison does not change peak memory, which
+            # the details hop's own segmentation already reached before.
             previous_text = previous["extracted_content"] or ""
-            change_percentage = await asyncio.to_thread(
-                ContentExtractor.calculate_change_percentage,
+            (
+                change_percentage,
+                old_segments,
+                new_segments,
+            ) = await asyncio.to_thread(
+                _change_percentage_with_segments,
                 previous_text,
                 current_content["text"],
             )
@@ -1516,6 +1581,8 @@ class URLMonitor:
                 _build_significant_change_details,
                 previous_text,
                 current_content["text"],
+                old_segments=old_segments,
+                new_segments=new_segments,
             )
             change_info = {
                 "type": "url_change",


### PR DESCRIPTION
## Summary
Closes task-16839: `calculate_change_percentage`'s quadratic cost and autojunk-degenerate ratios in `tldw_chatbook/Subscriptions/monitoring_engine.py`.

Two commits:
1. **Segment-level, cost-bounded ratio** — segment-basis comparison (`_segment_change_ratio`) with CJK sentence enders in `_SENTENCE_BOUNDARY` and fixed-slicing for >1,000-char whitespace-free runs, replacing the character-level SequenceMatcher whose autojunk produced degenerate ratios (born-red pin: pct=0.471 after ~37s on a 128KB Latin shape at base).
2. **Fix round (from independent review)** — the first revision's two-tier design (SequenceMatcher ≤4,000 segments, multiset above) had a sign-flip at the boundary for reorder-shaped edits: a purely reordered page reported **0.9925 at 4,000 segments and 0.0000 at 4,002**. Resolution: the alignment tier is retired; the O(n) order-insensitive multiset ratio is the sole mechanism at every size — the only structurally continuous option. Documented semantic decision: a moved segment is not a content change; a pure reorder reports 0.0 but is still detected (order-sensitive content hash), still surfaces at the default threshold, and moves remain visible in the diff body. Also fixes the doubled segmentation cost: segments are computed once and shared between the percentage and details hops (end-to-end changed-path CPU 947ms → 528ms at the 10MB cap, outputs byte-identical).

## Evidence
- Born-red both rounds: the degeneracy pin failed at base with the exact defect signature; the reorder-cliff pin failed at the first revision with the reviewer's exact `0.9925@4000 vs 0.0000@4002` signature.
- Cost at the 10MB cap: Latin 431ms / CJK 162ms / spaceless 166ms (vs 647ms worst for the reviewed two-tier; sub-second everywhere, off-loop).
- Post-rebase on current dev (`20caf3ecf`): Tests/Subscriptions/ **807 passed, 1 pre-existing skip**; task test file 9/9.

## Review
Independent review: initial **FIX-FIRST** (the reorder cliff — reproduced; plus the undisclosed double segmentation), then scoped re-review of the fix round: **APPROVE** — deletion completeness grep-verified; both load-bearing docstring claims traced in code (reorder still surfaces as an item; diff body shows moves); shared-segment seam traced desync-impossible; byte-identical outputs spot-checked on independently built shapes; cost re-measured (924→513ms, 1.80x); suite counts corroborated first-hand.

Lessons entry added: a tiered design's boundary must be probed with a shape the tiers *disagree* on — smooth ordinary-shape steps prove nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calculates change percentage over sentence/line segments using an O(n) order‑insensitive multiset ratio and shares segmentation across hops, replacing the character‑level `SequenceMatcher` that produced degenerate values and quadratic run times. Old: character-level `ratio()` with `autojunk` and per-hop segmentation; New: segment-level basis shared across hops; moves report 0% while still detected and shown in the diff.

- Connects to Linear task-16839. `calculate_change_percentage` now accepts optional `old_segments`/`new_segments`; `check_url` computes once via `_change_percentage_with_segments` and passes segments to `_build_significant_change_details`.
- Semantic decision: a moved segment is not a content change; pure reorders report 0% everywhere, remain detected by content hash, and moves are visible in the diff body.
- `_segment_for_diff` now splits on CJK sentence enders and fixed-slices units with >1,000-char whitespace-free runs to avoid `textwrap.wrap` quadratic behavior.
- Bounded cost at the 10 MB cap; measured worst shape ~0.43–0.65 s; new regression tests cover degenerate values, quadratic regime, and reorder cliff.
- Consumers unchanged beyond more honest percentages: identical 0%, empty-vs-content 100%, small edits track segment granularity; default threshold behavior is preserved.

<sup>Written for commit 26e83e6f180bd3cadfdb51a4821dc04131fa01d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

