### PR TITLE
chore(backlog): file second-wave close-out follow-ups (input-latency programme)

### DIFF
--- a/backlog/tasks/task-19041 - Study-wire-or-retire-the-remaining-17-undispatched-pane-buttons-post-16845-census.md
+++ b/backlog/tasks/task-19041 - Study-wire-or-retire-the-remaining-17-undispatched-pane-buttons-post-16845-census.md
@@ -1,0 +1,54 @@
+---
+id: TASK-19041
+title: >-
+  Study: wire or retire the remaining 17 undispatched pane buttons
+  (post-16845 census)
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - ui
+  - dead-code
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16845 removed four undispatched Study buttons (add-child / create-course /
+generate-guide / add-milestone) plus the Course form, and explicitly deferred the
+rest of the surface as "materially larger" (see its Implementation Notes'
+out-of-scope list). Fresh census at dev `1bf7f234e`: `UI/Study_Window.py` composes
+48 buttons (42 literal ids + 6 f-string `review-rating-*`), of which 24 distinct
+ids reach a handler (21 `@on(Button.Pressed, ...)` targets incl. the six rating
+ids, plus `on_button_pressed`'s `study-back-to-workspace-button`,
+`study-switch-global-button`, and the seven `view-*` sidebar ids). That leaves
+**18 composed button instances across 17 distinct ids with no dispatch anywhere**
+(whole-tree grep per id returns only `Study_Window.py` and tests):
+
+`add-sibling-btn`, `delete-node-btn`, `edit-node-btn`, `import-notes-btn`,
+`export-md-btn` (composed TWICE — Mindmaps pane :451 and Course pane :512, a
+duplicate-id wrinkle of its own), `generate-mindmap-btn`, `add-module-btn`,
+`export-pdf-btn`, `export-scorm-btn`, `add-concept-btn`,
+`generate-questions-btn`, `save-guide-btn`, `mark-complete-btn`,
+`set-dependencies-btn`, `import-course-btn`, `export-path-btn`,
+`generate-suggestions-btn`.
+
+`on_button_pressed` early-returns for every one of them, so each press is a
+silent no-op — the exact UX shape 16195's review called worse than "does
+nothing" implies. 16845's per-pane evidence already established the backing is
+placeholder-grade (write-only or nonexistent schema; static trees nothing
+populates), so per the owner's stability ruling the default expectation is
+honest removal / honest empty state per pane, not speculative wiring to
+write-only sinks. No existing backlog task covers these ids (grepped
+backlog/tasks at dev).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No composed Study control silently swallows a press: each of the 17 ids either reaches a real handler or is removed with per-affordance evidence (16195/16845 pattern, including controls that exist solely to feed a removed button)
+- [ ] #2 Wire-vs-remove is decided per pane on schema/service evidence, preferring durable removal or an honest empty state over wiring to write-only sinks (owner ruling: stability over quick wins)
+- [ ] #3 The duplicate `export-md-btn` id no longer composes twice
+- [ ] #4 Study suites stay green and pinning tests forbid removed affordances from returning
+<!-- AC:END -->

--- a/backlog/tasks/task-19042 - Wire-or-retire-the-orphaned-mindmap-subsystem-and-list-VisualIdentity_DB-in-CLAUDE-md.md
+++ b/backlog/tasks/task-19042 - Wire-or-retire-the-orphaned-mindmap-subsystem-and-list-VisualIdentity_DB-in-CLAUDE-md.md
@@ -1,0 +1,57 @@
+---
+id: TASK-19042
+title: >-
+  Wire-or-retire the orphaned mindmap subsystem (Tools/Mind_Map +
+  MindmapViewer + write-only tables); list VisualIdentity_DB in CLAUDE.md
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - cleanup
+  - dead-code
+  - docs
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The wave-2 close-out queue carried "mindmap viewer unmounted+stubbed;
+`DB/Mindmap_DB.py` missing while CLAUDE.md claims it exists". Half of that is
+already resolved on dev: TASK-15481 deleted `DB/Mindmap_DB.py` (it called a
+nonexistent `self.get_connection()`), and commit `004872669` dropped the retired
+DB modules from CLAUDE.md's Data Layer list. What remains at dev `1bf7f234e` is
+the rest of the subsystem, verified orphaned:
+
+- `Tools/Mind_Map/` — 7 modules, 2,803 LOC (model, renderer, integration,
+  exporter, mermaid parser, jsoncanvas handler, an `anytree-demo.py` script) —
+  imported by nothing in production except `UI/Widgets/MindmapViewer.py`.
+- `UI/Widgets/MindmapViewer.py` — exported behind a guarded import in
+  `UI/Widgets/__init__.py` but **never constructed anywhere** (whole-tree grep
+  for `MindmapViewer(` hits only the class definition).
+- Support plumbing with no production caller: `Utils/widget_helpers.py::
+  alert_mindmap_not_available`, the `optional_deps.py` "mindmap" feature key
+  (anytree).
+- ChaChaNotes `mindmaps`/`mindmap_nodes` tables are write-only:
+  `create_mindmap`/`add_mindmap_node` exist, zero read methods (16845's
+  per-button evidence) — nothing written could ever be displayed.
+- Tests keeping the corpse exercised: `Tests/test_jsoncanvas_handler.py`,
+  `Tests/UI/test_mindmap_viewer_tooltips.py`.
+
+(The Study screen's dead mindmap-pane buttons are TASK-19041's census; this
+task is the subsystem behind them.)
+
+CLAUDE.md residual: a fresh diff of the Data Layer DB list against
+`ls tldw_chatbook/DB/` shows exactly one discrepancy — `VisualIdentity_DB.py`
+(live since the v39 visual-identity schema) is absent from the list. Every
+other listed module exists; no other live DB module is unlisted.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The mindmap subsystem is either reachable end-to-end (viewer mounted from a live screen with a real DB read path) or retired — code, guarded exports, optional-dep/helper plumbing, and its tests handled together with git-log provenance recorded; per the owner ruling, prefer durable retirement over speculative wiring
+- [ ] #2 The write-only `mindmaps`/`mindmap_nodes` DB surface is resolved intentionally: gains a read path if wired, or its write-only accessors are retired (any table drop only via a proper schema migration)
+- [ ] #3 CLAUDE.md's Data Layer DB list matches `ls tldw_chatbook/DB/` — `VisualIdentity_DB.py` listed, no other discrepancy
+- [ ] #4 Targeted suites green; grep shows no remaining production references to retired names
+<!-- AC:END -->

--- a/backlog/tasks/task-19043 - Remove-the-orphaned-export_current_audio-pair-left-by-the-16837-TTS-export-retirement.md
+++ b/backlog/tasks/task-19043 - Remove-the-orphaned-export_current_audio-pair-left-by-the-16837-TTS-export-retirement.md
@@ -1,0 +1,45 @@
+---
+id: TASK-19043
+title: >-
+  Remove the orphaned export_current_audio pair left by the 16837 TTS export
+  retirement
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - cleanup
+  - dead-code
+  - tts
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16837 (PR #1742) retired the never-dispatched `TTSExportEvent` path and
+pinned it out (`Tests/TTS/test_tts_improvements.py::
+test_per_message_export_surface_stays_retired`). That pin's docstring claims
+"the user-reachable audio export lives on the S/TT/S playground path
+(`STTSEventHandler.export_current_audio`)" — verified stale at dev `1bf7f234e`:
+the playground actually exports via `UI/Speech/speech_playback_mixin.py::
+_export_audio`/`_handle_audio_export` (`#audio-export-btn`, FileSave + direct
+copy), which never touches the handler.
+
+The surviving pair is orphaned: `app.py::export_current_audio` (:11413) has
+zero callers anywhere in the tree, and it is the only production caller of
+`Event_Handlers/STTS_Events/stts_events.py::STTSEventHandler.
+export_current_audio` (:2786). Outside those two definitions, the only
+references are `Tests/TTS/test_stts_export_security.py` (drives the handler
+directly to prove destination-path validation) and the stale pin docstring.
+Whole-tree grep for `export_current_audio` confirms — no dynamic dispatch,
+no UI call site.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The dead pair (`app.py` wrapper + `STTSEventHandler.export_current_audio`) is removed — or wired to a live surface only if one genuinely needs it (none found; owner ruling prefers durable removal over speculative wiring)
+- [ ] #2 The 16837 pin's docstring no longer asserts the stale reachability claim
+- [ ] #3 `test_stts_export_security.py`'s destination-path-validation coverage is handled intentionally: retired with the code or re-pointed at the live playground export path's validation — not silently dropped
+- [ ] #4 TTS suites green; whole-tree grep for the removed names returns nothing
+<!-- AC:END -->

--- a/backlog/tasks/task-19044 - Packaging-migration-probe-pins-_CURRENT_SCHEMA_VERSION-39-red-at-dev-constant-is-40.md
+++ b/backlog/tasks/task-19044 - Packaging-migration-probe-pins-_CURRENT_SCHEMA_VERSION-39-red-at-dev-constant-is-40.md
@@ -1,0 +1,43 @@
+---
+id: TASK-19044
+title: >-
+  Packaging migration probe pins _CURRENT_SCHEMA_VERSION == 39 — red at dev
+  (constant is 40)
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - test-health
+  - db
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16840's investigation flagged two schema-version equality pins that were
+already red at the wave's base `cef56efaf` (constant 39, tests asserting 38):
+`Tests/DB/test_chachanotes_trajectory_metadata_migration.py:44` and `:220`.
+Those two were fixed on dev by commit `46945ebbe` (v39→v40,
+`transcript_annotations`), which converted them to
+`== CharactersRAGDB._CURRENT_SCHEMA_VERSION`.
+
+But the same commit bumped the constant to 40 and left a third literal pin
+behind: `Tests/Packaging/test_installed_distribution.py:807`
+(`INSTALLED_MIGRATION_PROBE`) reads the constant into
+`current_schema_version` and then asserts `current_schema_version == 39` —
+red whenever the integration-marked packaging suite runs at dev `1bf7f234e`
+(the constant is 40). History shows the literal being hand-bumped each time
+(37→39 at `4a2d48046`) and missed on this bump — the exact
+equality-pin-on-a-moving-constant fragility the trajectory fix just removed.
+The probe's real job (monkeypatch to v35, reopen, prove the installed
+migration chain reaches the current version) does not need the literal at all.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The installed-migration probe passes at current dev with no hand-maintained schema-version literal remaining in the file (owner ruling: durable over re-pinning the new number)
+- [ ] #2 The probe still proves what the literal stood in for: a v35 database migrates to whatever `_CURRENT_SCHEMA_VERSION` is, under the installed distribution
+- [ ] #3 The affected packaging test is demonstrated green at dev (run evidence, not collection)
+<!-- AC:END -->

--- a/backlog/tasks/task-19045 - Pin-the-ChaChaNotes-index-set-84-of-94-named-indexes-are-unreferenced-by-any-test.md
+++ b/backlog/tasks/task-19045 - Pin-the-ChaChaNotes-index-set-84-of-94-named-indexes-are-unreferenced-by-any-test.md
@@ -1,0 +1,49 @@
+---
+id: TASK-19045
+title: >-
+  Pin the ChaChaNotes index set: 84 of 94 named indexes are unreferenced by
+  any test
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - test-health
+  - db
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16840's close-out review constructed and disclosed a MUT-INDEX escape:
+delete a `CREATE INDEX` from a ChaChaNotes migration step and nothing turns
+red. The 16840 sweep cannot catch it by design — it compares a
+chain-migrated DB against a fresh bootstrap, and both sides run the same
+migration code, so a deterministic chain mutation is the identity on the
+comparison (16840's own MUT-A honesty note in its Implementation Notes). No
+absolute index census exists anywhere in Tests/.
+
+Fresh census at dev `1bf7f234e` (live `CharactersRAGDB(":memory:")`,
+`sqlite_master type='index'` minus autoindexes, isolated config): **94 named
+indexes; only 10 of their names appear anywhere in Tests/; 84 are
+unreferenced** — among them hot-path indexes like
+`idx_messages_conversation_id_id`, `idx_msgs_conv_ts`,
+`idx_conversations_workspace_id`, and the UNIQUE ledger-ordering
+`idx_message_trajectory_conv_seq`. (16840's review counted 18-of-28 on the
+narrower chain-created subset; the full gap is wider.) A dropped or renamed
+index ships as a silent performance regression, and a lost UNIQUE index as a
+silent integrity regression.
+
+Precedent to mirror: `TestChachanotesValidTablesMatchesLiveSchema`
+(`Tests/DB/test_sql_validation.py`, TASK-864 heritage) already does exactly
+this census-against-live-schema pattern for tables.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A schema-census test asserts the full expected index-name set against a live, fully-migrated ChaChaNotes DB — red on any missing, renamed, or unexpected index
+- [ ] #2 UNIQUE-ness is pinned for indexes where it is load-bearing (at minimum the trajectory `conv_seq` ledger index)
+- [ ] #3 Mutation evidence: removing one `CREATE INDEX` from a migration step turns the census red (Edit-based restore, per repo lessons)
+- [ ] #4 The expected set lives in one maintained place with drift guidance mirroring the VALID_TABLES pattern
+<!-- AC:END -->

--- a/backlog/tasks/task-19046 - Wire-or-retire-CollectionsTagWindow-unmounted-since-Aug-2025-its-keyword-event-loop-is-dead.md
+++ b/backlog/tasks/task-19046 - Wire-or-retire-CollectionsTagWindow-unmounted-since-Aug-2025-its-keyword-event-loop-is-dead.md
@@ -1,0 +1,46 @@
+---
+id: TASK-19046
+title: >-
+  Wire-or-retire CollectionsTagWindow — unmounted since Aug 2025, its whole
+  keyword-event loop is dead
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - ui
+  - dead-code
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Review-confirmed during the wave-2 close-out and re-verified at dev
+`1bf7f234e`: `Widgets/collections_tag_window.py::CollectionsTagWindow` (:128,
+the media-DB keyword/tag manager) is constructed nowhere in production — a
+definitive whole-tree grep finds only the class definition, lazy imports
+inside `Event_Handlers/collections_tag_events.py` handlers, and tests. Its
+mount was lost at commit `de367762a` (2025-08-02).
+
+The entire loop behind it is therefore unreachable: the
+KeywordRename/Merge/Delete events are posted only from inside the widget
+itself (:523/:529/:542), so `app.py`'s dispatch (:11953-11960) and every
+`collections_tag_events` handler can never fire — and those handlers
+`query_one(CollectionsTagWindow)`, which would raise on the unmounted widget
+even if an event somehow arrived. TASK-15471's collections keyword-delete
+threading repair (Done) landed on this dead path — corpse-groundwork, exactly
+the shape this queue item predicted.
+
+Tests keeping the corpse green: `Tests/UI/test_bulk_selection_tooltips.py`,
+`Tests/UI/test_tag_action_recovery_tooltips.py`, the CollectionsTagWindow
+slice of `Tests/Widgets/test_reactive_default_aliasing.py`, and
+`Tests/Event_Handlers/test_collections_tag_events.py`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CollectionsTagWindow is either mounted and reachable from a live screen (with the event loop verified end-to-end) or retired — widget, events, handlers, the app.py dispatch block, and its tests handled together with provenance; per the owner ruling, prefer the durable option over speculative resurrection
+- [ ] #2 No unreachable keyword-event dispatch remains in app.py
+- [ ] #3 Targeted suites green; if retired, whole-tree grep for the removed names returns nothing
+<!-- AC:END -->

--- a/backlog/tasks/task-19047 - stts_profile_library-view-switch-dismissal-test-still-flakes-under-CPU-load-outside-16842s-fix.md
+++ b/backlog/tasks/task-19047 - stts_profile_library-view-switch-dismissal-test-still-flakes-under-CPU-load-outside-16842s-fix.md
@@ -1,0 +1,42 @@
+---
+id: TASK-19047
+title: >-
+  stts_profile_library view-switch dismissal test still flakes under CPU load
+  (outside 16842's family fix)
+status: To Do
+assignee: []
+created_date: '2026-08-20 08:40'
+labels:
+  - test-health
+  - flake
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-16842 fixed a five-test flake family in
+`Tests/UI/test_stts_profile_library.py` (settle on the asserted state, bound
+by wall clock — see its 2026-08-16 entry in
+`backlog/docs/lessons-testing-evidence.md`). Its reviewer then reproduced a
+sixth, pre-existing failure OUTSIDE 16842's diff:
+`test_switching_stts_view_dismisses_owned_profile_modal_and_worker` fails
+under CPU-burner load at BOTH the wave base `cef56efaf` and head.
+
+Verified still present at dev `1bf7f234e` (:2840): the test uses the file's
+`_wait_until` idiom for the modal/unmount/settings-pane/worker-finish waits,
+but still contains unsettled one-shot samples in the same shapes 16842's
+lessons entry catalogues (e.g. the `voice_profile_action` worker census and
+its `not is_finished` assert taken immediately after the modal wait, and a
+one-shot `pilot.click` before it). No backlog task covers this test (grepped
+backlog/tasks at dev). Likely another settle-on-asserted-state candidate; the
+diagnosis must come from a load reproduction, not from reading the test.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The failure is reproduced under load first (the 16842 lessons entry's CPU-burner recipe) and the exact failing assertion identified — no speculative patch
+- [ ] #2 The fix follows the established 16842 idiom: wall-clock-bounded waits polling the asserted condition itself; no new fixed pauses or attempt-count waits
+- [ ] #3 Post-fix evidence meets 16842's bar: repeated full-file runs green including runs under the same load, plus standalone runs of this test
+<!-- AC:END -->


### PR DESCRIPTION
Files the verified follow-up findings from the input-latency second-wave burn-down (tasks 16835-16852, all merged to dev). Every queue item was re-verified against dev `1bf7f234e` before filing; two items were dropped as already fixed on dev, with evidence below. IDs claimed per the collision protocol (sweep max was 19021; claimed 19041+; re-swept before commit — no foreign mints).

## Filed

- **task-19041** — Study: wire or retire the remaining 17 undispatched pane buttons. Fresh census: 18 button instances / 17 distinct ids compose in `UI/Study_Window.py` with no dispatch anywhere (16845 removed its four and explicitly deferred these; `export-md-btn` composes twice).
- **task-19042** — Wire-or-retire the orphaned mindmap subsystem: `Tools/Mind_Map` (2,803 LOC) + never-constructed `MindmapViewer` + write-only `mindmaps`/`mindmap_nodes` tables; plus the one remaining CLAUDE.md DB-list discrepancy (`VisualIdentity_DB.py` unlisted). The original `Mindmap_DB.py`/CLAUDE.md claim was already resolved by task-15481 + commit `004872669`.
- **task-19043** — Remove the orphaned `export_current_audio` pair (`app.py:11413` wrapper, zero callers; `STTSEventHandler.export_current_audio`) left by 16837's export retirement; the 16837 pin's "user-reachable on this path" docstring is stale — the playground exports via `speech_playback_mixin._export_audio`.
- **task-19044** — Packaging migration probe pins `current_schema_version == 39`, red at dev (constant is 40; `Tests/Packaging/test_installed_distribution.py:807`). The two `== 38` pins 16840 flagged red at base were fixed by `46945ebbe`, but that same commit bumped the constant past this third literal.
- **task-19045** — Pin the ChaChaNotes index set: fresh live-DB census shows 94 named indexes, only 10 referenced anywhere in Tests/ (84 unreferenced — wider than 16840's 18-of-28 chain-created subset); 16840's MUT-INDEX escape (a dropped CREATE INDEX turns nothing red) still holds by construction of its parity sweep.
- **task-19046** — Wire-or-retire `CollectionsTagWindow`: unmounted since `de367762a` (2025-08-02); its keyword events are posted only from inside the widget, so the app.py dispatch (:11953-11960) and all `collections_tag_events` handlers are unreachable; task-15471's collections repair is corpse-groundwork.
- **task-19047** — `test_switching_stts_view_dismisses_owned_profile_modal_and_worker` still flakes under CPU-burner load at both wave base and head, outside 16842's five-test fix; another settle-on-asserted-state candidate per the 16842 lessons entry.

## Dropped (stale — fixed on dev since noted)

- **VALID_TABLES missing 4 tables** (queue item 4): the missing quartet was the `visual_identity_*` tables (schema v39 at `4a2d48046`, 2026-08-14); commit `46945ebbe` (2026-08-17) added all four plus `transcript_annotations`. Live probe at dev `1bf7f234e` (isolated config, worktree import verified): `MISSING: []`, `STALE: []` against a fully-migrated `CharactersRAGDB(":memory:")` — and the TASK-864 parity guard (`TestChachanotesValidTablesMatchesLiveSchema`) now pins it.
- **Two 39==38 schema-version pins** (queue item 5, as originally shaped): the two red-at-base pins (`test_chachanotes_trajectory_metadata_migration.py:44`/`:220`) were converted to `== CharactersRAGDB._CURRENT_SCHEMA_VERSION` by `46945ebbe` and are green. The surviving instance of the same fragility class — the packaging literal, now red at 40 — is filed as task-19044 rather than dropped.

Also checked, not duplicated: task-16865 already covers SiteConfigSettings wire-or-retire + the orphaned scrapers cluster; 16845 already consumed the four pre-wave Study buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files seven backlog tasks from the input‑latency wave‑2 close‑out and marks two queue items as already fixed on dev. This tracks dead UI controls, orphaned subsystems, flaky tests, and schema/test parity so we can remove dead paths and prevent silent regressions.

- UI dead surfaces: TASK-19041 (undispatched Study buttons; remove or wire, resolve duplicate id) and TASK-19046 (unmounted `CollectionsTagWindow`; retire or remount with end‑to‑end loop).
- Orphaned features: TASK-19042 (mindmap subsystem; retire or wire with real reads and viewer mount) and TASK-19043 (orphaned `export_current_audio`; remove pair or re‑point tests to the live path).
- Test health and schema parity: TASK-19044 (remove hard‑coded schema version literal from packaging probe), TASK-19045 (add index‑census test to pin full ChaChaNotes index set and critical UNIQUEs), TASK-19047 (stts profile library dismissal flake; reproduce under load and settle on asserted state).
- Dropped as already fixed on dev: VALID_TABLES missing-4, and two schema version pins at 38; the remaining packaging literal is covered by TASK-19044.

- No runtime code or migrations change in this PR; it adds `backlog/tasks/*` files only. Review by spot‑checking task scopes and evidence; no rollout actions required.

<sup>Written for commit 5b498b458b057b3b1778a884191814cf4d5094db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

