### PR TITLE
fix(llm): TASK-19020 — drop top_p when Anthropic rejects the temperature+top_p pair; refresh the retired summarization fallback default

### DIFF
--- a/Docs/superpowers/plans/2026-08-20-task-19020-report.md
+++ b/Docs/superpowers/plans/2026-08-20-task-19020-report.md
@@ -1,0 +1,204 @@
+# TASK-19020 — Anthropic legacy payload sent temperature and top_p together; fallback default named a retired model
+
+**Branch:** `fix/task-19020-anthropic-sampling-combo` (from `origin/dev` `1bf7f234e`, which contains TASK-18414 + TASK-18802)
+**Status:** complete — all 4 acceptance criteria met, live-verified both ways.
+
+---
+
+## 1. What was broken
+
+TASK-18802 gated the summarization path's sampling params on the families that
+reject them *outright*. The families that still accept them individually kept
+the exact prior payload — which sends `temperature=0.1`, `top_k=0` AND
+`top_p=1.0` together, a combination every currently-served Claude model
+rejects. Separately, the function's own fallback default named the retired
+`claude-3-haiku-20240307`. Net effect after 18802: summarization still failed
+for every legacy-Anthropic config (400) and for no-model-configured setups
+(404). Discovered by 18802's *unchanged-behavior* live control leg (its lesson
+entry: a green "legacy unchanged" pin can faithfully pin behavior that is
+itself broken).
+
+## 2. Step 1 probes — boundary of the combination rule (before any code change)
+
+Standalone `curl` against `https://api.anthropic.com/v1/messages`, exact
+legacy payload shape (`stop_sequences`, `metadata.user_id`, `system`, trio
+`temperature=0.1, top_k=0, top_p=1.0`; `max_tokens` reduced to 16). No
+`tldw_chatbook` module imported.
+
+**A1 — `claude-opus-4-6` + trio** → HTTP 400:
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"`temperature` and `top_p` cannot both be specified for this model. Please use only one."},"request_id":"req_011CeEFGsbHd7VCjcjz4etar"}
+```
+
+**A2 — `claude-sonnet-4-6` + trio** → HTTP 400, identical body
+(`req_011CeEFGuRfeCzC6PiLyDtFb`).
+
+**A3 — `claude-opus-4-5` + trio** (the 4.5-era variant; the 4.0-era snapshots
+are retired) → HTTP 400, identical body (`req_011CeEFGvySC6z61NDRH5uN5`).
+
+**A4 — `claude-opus-4-6` + `temperature`+`top_k`, no `top_p`** (the post-fix
+shape) → HTTP 200 (`msg_011CeEFGzjeXQ6ftPf9KH45n`, answered "OK.").
+
+**Boundary conclusion.** Combined with 18802's discovery probes
+(`claude-haiku-4-5` req_011CeEDXPHNyF7apkaZepbTN and `claude-sonnet-4-5`
+req_011CeEDXa9V99yBoHN5vcjDG → the same 400; `temperature` alone and
+`temperature`+`top_k` → 200, req_011CeEDXQwqi7yXoozbdrXFX /
+req_011CeEDXVk4nXXCoBGdf9mFm), **every currently-served
+sampling-accepting model rejects the pair** — the probes confirm the public
+migration guidance ("passing both will error on every Claude 4+ model") for
+the whole served set. The Claude 3.x generation that accepted the pair is
+number-first-named, never parses into a family, and is entirely retired
+(`claude-3-haiku-20240307` itself → 404 `not_found_error`,
+req_011CeEDXZ8iS29MZCgyySwQa, from the 18802 run). So the predicate is true
+for the entire tier-first-named universe — capability framing kept anyway: it
+self-documents, and a future model that relaxes the rule gets a one-line
+carve-out instead of a name check.
+
+## 3. The fix
+
+* **Predicate** — `anthropic_model_rejects_temperature_top_p_combination` in
+  `tldw_chatbook/model_capabilities.py`, in the 18414/18802 style: module-level
+  pure function **outside** the config-driven, user-overridable capability
+  tables, reusing `_anthropic_model_family` (bare/dotted/dated/suffixed/
+  provider-prefixed ids all resolve). True for any parsed family with
+  `major >= 4` — tier-first naming began with the Claude 4 generation, so this
+  is exactly the probe-verified set; unparsed ids (3.x generation, unknown
+  strings) return False and keep their historical payload unchanged.
+* **Builder** — `summarize_with_anthropic` keeps `temperature` + `top_k`
+  (probe-verified compatible) and drops `top_p` when the predicate is true,
+  mirroring the chat path's temperature-over-top_p precedence
+  (`chat_with_anthropic`, LLM_API_Calls.py ~1446-1454). **Deliberate
+  deviation from the instruction to mirror the chat path's warning-log too:**
+  the diagnostic-privacy manifest
+  (`Tests/LLM_Calls/test_summarization_diagnostic_privacy.py`) freezes this
+  module's reviewed diagnostic set — `test_ledger_current_state_matches_sources`
+  fails on ANY added call ("added ... without ledger review"), the ledger's
+  523 starting sites and projection SHA are pinned, and there is no "added"
+  lifecycle outcome in its schema. 18802 made the same call ("no new logging
+  calls"). The drop is also deterministic — both values are the function's own
+  constants, not caller input — so a per-call warning would be pure noise; the
+  code comment carries the information instead.
+* **Fallback default** — `get_cli_setting("anthropic_api", "model", ...)`
+  default `claude-3-haiku-20240307` → **`claude-haiku-4-5`**. Rationale: it is
+  the retired id's served successor in the same cheap-fast-haiku lineage
+  (Anthropic's own deprecation table maps `claude-3-haiku-20240307` →
+  `claude-haiku-4-5`), preserving the original cheap-summarization intent; the
+  repo has no competing fallback convention (the shipped
+  `[api_settings.anthropic]` default `claude-sonnet-5` governs the
+  *configured* case, not this function's own last-resort default). With the
+  combo fix, the fallback payload is `temperature`+`top_k` on haiku-4-5 —
+  probe-verified 200.
+* **18802 predicates and modern-family payloads untouched** — the diff adds a
+  second, separate predicate consultation; the `anthropic_model_rejects_sampling_params`
+  gate and everything inside the modern-family branch are byte-identical.
+
+## 4. Sweep of the other retired-id sites (fixed vs filed)
+
+`grep -rn "claude-3-haiku-20240307"` over the package: **fixed only the
+summarization fallback** (per the instruction). Filed **TASK-19048** for the
+three sites that still use the id as an actual request model:
+`config.py:3841` (shipped `[character_defaults]` template default — fresh
+installs' persona calls target a 404 model), `Tools/code_audit_tool.py:141`
+(hardcoded analysis model), and `UI/Tools_Settings_Window.py:1044/2456/4116/4851/5647`
+(fallback/reset values in the DEPRECATED, nav-unreachable window). Left alone
+as metadata-only: capability/context-window maps
+(`model_capabilities.py:104`, `config.py:4133`,
+`Chat/console_session_settings.py:89`, `Utils/token_counter.py:344`); the
+providers dropdown lists (`config.py:2805/3178`) are already tracked by
+task-3600.
+
+## 5. Evidence
+
+### Red → green (read counts)
+
+| Stage | Command | Result |
+|---|---|---|
+| Red (predicate present, builder untouched) | `pytest Tests/test_probe_import_provenance.py Tests/LLM_Calls/test_summarization_model_capabilities.py -q -p no:randomly` | **6 failed, 75 passed** |
+| Green (after builder rewire + fallback swap) | same | **81 passed** |
+| Targeted gate | whole `Tests/LLM_Calls/` (incl. the diagnostic-privacy manifest) + `Tests/test_model_capabilities.py` + `Tests/Chat/test_anthropic_model_capabilities.py` + `Tests/Chat/test_openai_reasoning_sampling_params.py` + `Tests/Internal_Prompts/test_summarization_migration.py` + provenance probe | **1075 passed, 0 failed** |
+| Consumers | `Tests/test_config_model_catalog_defaults.py`, `Tests/Chat/test_openai_streaming_usage.py` | **11 passed** |
+| Import sweep | `pytest Tests/ --collect-only -q` | **51028 collected, 0 errors** |
+
+The reds were for the right reason — verbatim:
+
+```
+AssertionError: claude-haiku-4-5 rejects temperature and top_p together (400 `temperature` and `top_p` cannot both be specified) but the summarization payload still carries top_p=1.0
+```
+
+plus the fallback pin failing on `claude-3-haiku-20240307` still being the
+wire model. The new pins: combo models (haiku-4-5, sonnet-4-5, sonnet-4-6,
+opus-4-6, opus-4-5) send `temperature`+`top_k` and **no** `top_p`, with the
+rest of the payload pinned dict-equal to the 18802 shape; the modern-family
+pins now assert the **entire payload** dict-equal to the 18802 shape (AC #4);
+the unparsed 3.x id keeps its historical trio; the fallback default resolves
+to `claude-haiku-4-5`; predicate unit pins over 15 true-variants, 8
+never-match ids, and the user-capability-table immunity pin.
+
+### Mutation tests
+
+| Mutation | Result |
+|---|---|
+| A — invert the predicate consultation in the builder (reproduces the original bug) | **7 failed, 73 passed** — all 5 combo pins + the unparsed-legacy pin + the fallback pin die |
+| B — narrow the predicate to `major >= 6` | **22 failed, 58 passed** — combo payload pins, fallback pin, all 15 covers-4-plus predicate pins and the immunity pin die |
+| C — widen the predicate to match unparsed ids (`family is None -> True`) | **9 failed, 71 passed** — the unparsed-payload pin + all 8 never-match predicate pins die (two-sided) |
+
+All three restored with `Edit`; `git diff` empty against the committed fix and
+zero MUTATION markers in both files; re-green at 80 passed (+1 provenance =
+81).
+
+### Live verification (production `analyze()` seam, real key)
+
+Throwaway uncommitted pytest tests (deleted after the runs) driving
+`analyze()` → `_dispatch_to_api` → `summarize_with_anthropic`; the model id
+routed on the same `get_cli_setting` seam the function reads, and
+`requests.post` wrapped with a **passthrough spy** that records the wire
+payload and then performs the real call. `Tests/conftest.py`'s bootstrap
+scratch `TLDW_CONFIG_PATH` kept the runs off the real profile; import
+provenance pinned by `Tests/test_probe_import_provenance.py` in the same runs.
+
+| # | Checkout | Config | Wire model / sampling keys | Result |
+|---|---|---|---|---|
+| 1 | fix | `claude-haiku-4-5` | haiku-4-5 / `['temperature','top_k']` | **PASS** — `'A fox jumps over a lazy dog on a bright cold April day as clocks strike thirteen.'` |
+| 2 | fix | `claude-sonnet-4-5` | sonnet-4-5 / `['temperature','top_k']` | **PASS** — `'A fox leaps over a resting dog as clocks chime thirteen on a cold, bright April morning.'` |
+| 3 | fix | **no model configured** | **claude-haiku-4-5** (the new fallback) / `['temperature','top_k']` | **PASS** — real summary (AC #3 live) |
+| 4 | fix | `claude-sonnet-5` (modern control, run LIVE per 18802's lesson) | sonnet-5 / `[]` | **PASS** — real summary; modern payload/behavior unchanged |
+| C1 | clean `origin/dev` `1bf7f234e` (detached control worktree) | `claude-haiku-4-5` | haiku-4-5 / `['temperature','top_k','top_p']`, **HTTP 400** | **FAIL (expected)** — `'Error: Summarization failed unexpectedly.'` |
+| C2 | control worktree | no model configured | **claude-3-haiku-20240307** / trio, **HTTP 404** | **FAIL (expected)** — `'Error: Summarization failed unexpectedly.'` |
+
+C1/C2 ran the same harness on an unmodified origin/dev checkout (provenance
+probe green there; imports confirmed resolving from the control worktree),
+making this an A/B on the fix. The control worktree and both throwaway tests
+were removed afterwards; `git show` of the commit contains zero key
+fragments.
+
+## 6. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 Summarizing with claude-haiku-4-5 or claude-sonnet-4-5 completes | met | Live rows 1–2 vs C1; combo payload pins × 5 |
+| #2 Combination rule expressed via model_capabilities, not a name check | met | `anthropic_model_rejects_temperature_top_p_combination` in `model_capabilities.py`; the builder's diff contains no model-name literal; immunity pin proves it survives a user capability table |
+| #3 Fallback default is a currently-served model | met | `claude-haiku-4-5`; fallback pin + live row 3 (wire model recorded) vs C2 |
+| #4 Models unaffected by the combination rule unchanged, pinned | met | Modern-family pins now dict-equal to the 18802 payload shape; unparsed-3.x pin keeps the historical trio; mutation C kills the over-match side; live row 4 (sonnet-5, live) |
+
+## 7. Filed, not fixed
+
+* **TASK-19048** — the remaining live uses of the retired id (§4). First
+  CLI assignment was task-19022 (this checkout's local max); renumbered to
+  19048 after the all-remotes/worktrees sweep found max 19047 and a
+  ghost-check confirmed 19048/19049 free everywhere.
+
+## 8. Notes for review
+
+* No logging added or removed in `Summarization_General_Lib.py` (§3 — the
+  manifest structurally forbids it); the whole diagnostic-privacy suite is
+  green in the targeted gate.
+* The 18414 comment block above `_ANTHROPIC_MODERN_REQUEST_FAMILIES` says the
+  legacy families "return 200 for the same payloads" — true for the single
+  params those probes sent, not for the trio; the new predicate's docstring
+  carries the corrected, probe-cited picture rather than editing 18414's
+  historical comment.
+* No UI surface changed; no `Docs/User_Guide/` page cites this module's
+  payload shapes.
+* No new lessons entry: the one generalisable trap this arc surfaced (run the
+  unchanged-behavior control leg live) was already recorded by 18802.

--- a/Tests/LLM_Calls/test_summarization_model_capabilities.py
+++ b/Tests/LLM_Calls/test_summarization_model_capabilities.py
@@ -12,6 +12,18 @@ Provider facts pinned here were probe-verified against the real APIs:
   ``400 unsupported_parameter`` ("Use 'max_completion_tokens' instead") and
   ``temperature: 0.7`` returns ``400 unsupported_value`` on gpt-5, gpt-5.6,
   o3 and o4-mini; gpt-4o and gpt-4.1 accept the old shape unchanged.
+* Anthropic combination rule (TASK-19020 probes, 2026-08-20): the families
+  that still accept sampling parameters individually reject ``temperature``
+  and ``top_p`` *together* -- ``claude-haiku-4-5``
+  (req_011CeEDXPHNyF7apkaZepbTN), ``claude-sonnet-4-5``
+  (req_011CeEDXa9V99yBoHN5vcjDG), ``claude-opus-4-6``
+  (req_011CeEFGsbHd7VCjcjz4etar), ``claude-sonnet-4-6``
+  (req_011CeEFGuRfeCzC6PiLyDtFb) and ``claude-opus-4-5``
+  (req_011CeEFGvySC6z61NDRH5uN5) all return HTTP 400 for the trio, while
+  ``temperature``+``top_k`` without ``top_p`` returns 200
+  (req_011CeEDXVk4nXXCoBGdf9mFm, msg_011CeEFGzjeXQ6ftPf9KH45n). The
+  function's former fallback default ``claude-3-haiku-20240307`` is RETIRED
+  (404, req_011CeEDXZ8iS29MZCgyySwQa).
 """
 
 from __future__ import annotations
@@ -21,6 +33,7 @@ import pytest
 from tldw_chatbook.LLM_Calls import Summarization_General_Lib as sgl
 from tldw_chatbook.model_capabilities import (
     ModelCapabilities,
+    anthropic_model_rejects_temperature_top_p_combination,
     openai_model_rejects_sampling_params,
     openai_model_requires_max_completion_tokens,
 )
@@ -109,12 +122,38 @@ _ANTHROPIC_REJECTING_MODELS = [
     "claude-opus-4-7",
 ]
 
-_ANTHROPIC_LEGACY_MODELS = [
-    "claude-3-haiku-20240307",  # the function's own fallback default
-    "claude-opus-4-6",
+# Served models that still accept sampling parameters individually but reject
+# the ``temperature``+``top_p`` pair (TASK-19020 probes, module docstring).
+_ANTHROPIC_SAMPLING_COMBO_MODELS = [
+    "claude-haiku-4-5",  # the function's fallback default
     "claude-sonnet-4-5",
-    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
 ]
+
+# Number-first 3.x-generation ids never parse into a family; the payload for
+# them keeps its historical shape (the generation is retired server-side).
+_ANTHROPIC_UNPARSED_LEGACY_MODELS = [
+    "claude-3-haiku-20240307",  # the function's former (retired) fallback default
+]
+
+
+def _expected_anthropic_base_payload(model: str) -> dict:
+    """The exact non-sampling payload TASK-18802 pinned, byte-for-byte."""
+    return {
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [
+            {"role": "user", "content": "some input text \n\n\n\nSummarize this."}
+        ],
+        "stop_sequences": ["\n\nHuman:"],
+        "metadata": {"user_id": "example_user_id"},
+        "stream": False,
+        "system": (
+            "You are a helpful AI assistant who does whatever the user requests."
+        ),
+    }
 
 
 @pytest.mark.parametrize("model", _ANTHROPIC_REJECTING_MODELS)
@@ -125,18 +164,133 @@ def test_anthropic_rejecting_model_omits_sampling_params(monkeypatch, model):
         f"{model} rejects sampling params but the summarization payload "
         f"still carries {offending}"
     )
-    # The rest of the request survives the gate.
-    assert payload["model"] == model
-    assert payload["max_tokens"] == 4096
-    assert payload["messages"], payload
+    # AC #4: the whole request is byte-identical to the TASK-18802 shape.
+    assert payload == _expected_anthropic_base_payload(model)
 
 
-@pytest.mark.parametrize("model", _ANTHROPIC_LEGACY_MODELS)
-def test_anthropic_legacy_model_still_sends_sampling_params(monkeypatch, model):
+@pytest.mark.parametrize("model", _ANTHROPIC_SAMPLING_COMBO_MODELS)
+def test_anthropic_sampling_model_sends_temperature_and_top_k_without_top_p(
+    monkeypatch, model
+):
+    payload = _capture_anthropic_payload(monkeypatch, model)
+    assert "top_p" not in payload, (
+        f"{model} rejects temperature and top_p together (400 `temperature` "
+        f"and `top_p` cannot both be specified) but the summarization payload "
+        f"still carries top_p={payload.get('top_p')!r}"
+    )
+    # Temperature wins the pair, and top_k stays: probe-verified compatible
+    # alongside temperature (req_011CeEDXVk4nXXCoBGdf9mFm on claude-haiku-4-5,
+    # msg_011CeEFGzjeXQ6ftPf9KH45n on claude-opus-4-6).
+    assert payload["temperature"] == pytest.approx(0.1)
+    assert payload["top_k"] == 0
+    assert payload == {
+        **_expected_anthropic_base_payload(model),
+        "temperature": 0.1,
+        "top_k": 0,
+    }
+
+
+@pytest.mark.parametrize("model", _ANTHROPIC_UNPARSED_LEGACY_MODELS)
+def test_anthropic_unparsed_legacy_id_payload_unchanged(monkeypatch, model):
     payload = _capture_anthropic_payload(monkeypatch, model)
     assert payload["temperature"] == pytest.approx(0.1)
     assert payload["top_k"] == 0
     assert payload["top_p"] == pytest.approx(1.0)
+
+
+def test_anthropic_fallback_default_model_is_currently_served(monkeypatch):
+    """AC #3: with no model configured, the function's own fallback default
+    must resolve to a currently-served model, not the retired
+    ``claude-3-haiku-20240307`` (404, req_011CeEDXZ8iS29MZCgyySwQa)."""
+
+    def fake_get_cli_setting(sec: str, key: str, default: object = None) -> object:
+        return default  # nothing configured anywhere
+
+    monkeypatch.setattr(sgl, "get_cli_setting", fake_get_cli_setting)
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, stream=False, **kwargs):
+        captured["json"] = json
+        return _FakeAnthropicResponse()
+
+    monkeypatch.setattr(sgl.requests, "post", fake_post)
+    result = sgl.summarize_with_anthropic("test-key", "some input text", "Summarize this.")
+    assert result == "anthropic summary", result
+    payload = captured["json"]
+    assert payload["model"] == "claude-haiku-4-5"
+    # The fallback model rejects the temperature+top_p pair, so the payload it
+    # gets must already respect the combination rule.
+    assert "top_p" not in payload
+    assert payload["temperature"] == pytest.approx(0.1)
+    assert payload["top_k"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Anthropic combination-rule predicate unit pins (TASK-19020)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        # Sampling-accepting families: probe-verified 400 on the pair.
+        "claude-haiku-4-5",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-6",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-opus-4-5-20251101",  # dated snapshot
+        "Claude-Opus-4.6",  # dotted + case variant
+        "anthropic/claude-haiku-4-5",  # provider-prefixed
+        "us.anthropic.claude-sonnet-4-5",  # bedrock-prefixed
+        # Families that reject sampling outright reject the pair a fortiori.
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    ],
+)
+def test_anthropic_combination_predicate_covers_claude_4_plus(model):
+    assert anthropic_model_rejects_temperature_top_p_combination(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-3-haiku-20240307",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-opus-20240229",
+        "claude-2.1",
+        "claude-instant-1.2",
+        "",
+        None,
+        42,
+    ],
+)
+def test_anthropic_combination_predicate_never_matches_unparsed_ids(model):
+    assert anthropic_model_rejects_temperature_top_p_combination(model) is False
+
+
+def test_anthropic_combination_predicate_survives_user_capability_table():
+    """Request-validity fact: not reachable from the user-overridable
+    capability tables (same design rule as TASK-18414/18802)."""
+    ModelCapabilities(
+        config={
+            "models": {
+                "claude-haiku-4-5": {
+                    "vision": True,
+                    "rejects_temperature_top_p_combination": False,
+                }
+            },
+            "patterns": {},
+        }
+    )
+    assert (
+        anthropic_model_rejects_temperature_top_p_combination("claude-haiku-4-5")
+        is True
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
+++ b/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
@@ -3,11 +3,11 @@ id: TASK-19020
 title: >-
   Summarization Anthropic legacy payload sends temperature and top_p together,
   which every served Claude 4.x rejects; fallback default model is retired
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-20 15:15'
-updated_date: '2026-08-20 15:36'
+updated_date: '2026-08-20 15:48'
 labels:
   - llm
   - bug
@@ -23,10 +23,10 @@ Found during TASK-18802 live verification. summarize_with_anthropic's legacy-mod
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Summarizing with claude-haiku-4-5 or claude-sonnet-4-5 completes instead of returning HTTP 400
-- [ ] #2 The combination rule is expressed via model_capabilities rather than a name check in the request builder
-- [ ] #3 The summarization path's fallback default Anthropic model is a currently-served model
-- [ ] #4 Models unaffected by the combination rule are unchanged, pinned by a regression test
+- [x] #1 Summarizing with claude-haiku-4-5 or claude-sonnet-4-5 completes instead of returning HTTP 400
+- [x] #2 The combination rule is expressed via model_capabilities rather than a name check in the request builder
+- [x] #3 The summarization path's fallback default Anthropic model is a currently-served model
+- [x] #4 Models unaffected by the combination rule are unchanged, pinned by a regression test
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -34,3 +34,9 @@ Found during TASK-18802 live verification. summarize_with_anthropic's legacy-mod
 <!-- SECTION:PLAN:BEGIN -->
 1. Probe boundary: combo trio on claude-opus-4-6 / claude-sonnet-4-6 / claude-opus-4-5 (standalone curl), post-fix shape control on opus-4-6\n2. Add immutable predicate anthropic_model_rejects_temperature_top_p_combination to model_capabilities.py (18414/18802 design: parsed tier-first family, outside config tables)\n3. Red-first pins in Tests/LLM_Calls/test_summarization_model_capabilities.py: combo models send temperature+top_k without top_p; modern-family payloads unchanged; fallback default resolves to a served model; predicate unit pins\n4. Rewire summarize_with_anthropic: drop top_p when the predicate is true (temperature precedence, top_k kept); replace retired fallback default claude-3-haiku-20240307 with claude-haiku-4-5\n5. Mutation-test the predicate consultation; targeted suites incl. diagnostic-privacy manifest\n6. Live-verify via production analyze() seam: haiku-4-5 + sonnet-4-5 summaries, no-model-configured fallback, sonnet-5 modern control; dev control worktree reproduces the 400\n7. Sweep other retired-id sites, file follow-up; report + PR
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed both halves via a new immutable predicate anthropic_model_rejects_temperature_top_p_combination in model_capabilities.py (18414/18802 design: parsed tier-first family, major >= 4, outside the user-overridable capability tables). Probe-first: claude-opus-4-6 (req_011CeEFGsbHd7VCjcjz4etar), claude-sonnet-4-6 (req_011CeEFGuRfeCzC6PiLyDtFb) and claude-opus-4-5 (req_011CeEFGvySC6z61NDRH5uN5) all 400 on the temperature+top_p pair with the identical message, while temperature+top_k without top_p returns 200 (msg_011CeEFGzjeXQ6ftPf9KH45n) -- together with 18802's haiku-4-5/sonnet-4-5 probes, every served sampling-accepting model rejects the pair. summarize_with_anthropic now sends temperature+top_k and drops top_p for those families (chat-path precedence mirrored; no warning log, deliberately -- the diagnostic-privacy manifest freezes this module's reviewed diagnostic set, same call 18802 made). Fallback default claude-3-haiku-20240307 (retired, 404) replaced with claude-haiku-4-5, its served successor in the same haiku lineage. Evidence: red-first 6 failed/75 passed -> 81 passed; targeted gate 1075 passed incl. the diagnostic-privacy manifest; collect-only 51028/0 errors; three mutations (invert consultation, narrow to major>=6, widen to unparsed ids) kill 7/22/9 pins, Edit-restored with empty git diff. Live via the production analyze() seam with a passthrough wire spy: haiku-4-5, sonnet-4-5, the no-model-configured fallback (wire model claude-haiku-4-5) and sonnet-5 modern control all return real summaries on the fix; clean origin/dev control worktree reproduces HTTP 400 (haiku-4-5 trio) and HTTP 404 (retired fallback default). Files: tldw_chatbook/model_capabilities.py, tldw_chatbook/LLM_Calls/Summarization_General_Lib.py, Tests/LLM_Calls/test_summarization_model_capabilities.py, Docs/superpowers/plans/2026-08-20-task-19020-report.md. Filed TASK-19048 for the remaining retired-id sites (character_defaults template, code_audit_tool, deprecated Tools_Settings_Window).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
+++ b/backlog/tasks/task-19020 - Summarization-Anthropic-legacy-payload-sends-temperature-and-top_p-together-which-every-served-Claude-4.x-rejects-fallback-default-model-is-retired.md
@@ -3,9 +3,11 @@ id: TASK-19020
 title: >-
   Summarization Anthropic legacy payload sends temperature and top_p together,
   which every served Claude 4.x rejects; fallback default model is retired
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-20 15:15'
+updated_date: '2026-08-20 15:36'
 labels:
   - llm
   - bug
@@ -26,3 +28,9 @@ Found during TASK-18802 live verification. summarize_with_anthropic's legacy-mod
 - [ ] #3 The summarization path's fallback default Anthropic model is a currently-served model
 - [ ] #4 Models unaffected by the combination rule are unchanged, pinned by a regression test
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Probe boundary: combo trio on claude-opus-4-6 / claude-sonnet-4-6 / claude-opus-4-5 (standalone curl), post-fix shape control on opus-4-6\n2. Add immutable predicate anthropic_model_rejects_temperature_top_p_combination to model_capabilities.py (18414/18802 design: parsed tier-first family, outside config tables)\n3. Red-first pins in Tests/LLM_Calls/test_summarization_model_capabilities.py: combo models send temperature+top_k without top_p; modern-family payloads unchanged; fallback default resolves to a served model; predicate unit pins\n4. Rewire summarize_with_anthropic: drop top_p when the predicate is true (temperature precedence, top_k kept); replace retired fallback default claude-3-haiku-20240307 with claude-haiku-4-5\n5. Mutation-test the predicate consultation; targeted suites incl. diagnostic-privacy manifest\n6. Live-verify via production analyze() seam: haiku-4-5 + sonnet-4-5 summaries, no-model-configured fallback, sonnet-5 modern control; dev control worktree reproduces the 400\n7. Sweep other retired-id sites, file follow-up; report + PR
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
+++ b/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19048
+title: >-
+  Retired claude-3-haiku-20240307 survives as a live default in
+  character_defaults, code_audit_tool, and deprecated Tools_Settings_Window
+  fallbacks
+status: To Do
+assignee: []
+created_date: '2026-08-20 15:46'
+labels:
+  - llm
+  - bug
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-19020 replaced the retired claude-3-haiku-20240307 fallback in summarize_with_anthropic (the API now answers 404 not_found_error for that id, probe req_011CeEDXZ8iS29MZCgyySwQa) and swept the repo for the remaining occurrences. Three sites still use the retired id as an actual request model and were left for this follow-up: (1) config.py:3841 -- the shipped CONFIG_TOML template's [character_defaults] model default, so a fresh install's persona/character calls target a 404 model (the rp-ux QA report already observed there is no UI to change the character provider); (2) Tools/code_audit_tool.py:141 -- hardcoded model for the audit tool's live analysis call; (3) UI/Tools_Settings_Window.py:1044/2456/4116/4851/5647 -- fallback and reset values in the DEPRECATED (TASK-1346), nav-unreachable ToolsSettingsWindow (lowest priority; may be resolved by deleting the window instead). Metadata-only occurrences need no change here: capability/context-window maps (model_capabilities.py:104, config.py:4133, Chat/console_session_settings.py:89, Utils/token_counter.py:344) merely describe the id, and the providers dropdown lists (config.py:2805/3178) are already tracked by task-3600. Pick replacements consistent with TASK-19020's choice (claude-haiku-4-5 as the served successor in the haiku lineage) unless a site's intent argues otherwise.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The shipped [character_defaults] template default names a currently-served Anthropic model
+- [ ] #2 code_audit_tool's hardcoded analysis model is a currently-served model
+- [ ] #3 The deprecated Tools_Settings_Window fallbacks are updated or the surface's deletion is confirmed as covering them
+<!-- AC:END -->

--- a/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
+++ b/tldw_chatbook/LLM_Calls/Summarization_General_Lib.py
@@ -48,6 +48,7 @@ from tldw_chatbook.Internal_Prompts import get_internal_prompt
 from tldw_chatbook.Utils.persistent_diagnostics import safe_metadata_token
 from tldw_chatbook.model_capabilities import (
     anthropic_model_rejects_sampling_params,
+    anthropic_model_rejects_temperature_top_p_combination,
     openai_model_rejects_sampling_params,
     openai_model_requires_max_completion_tokens,
 )
@@ -1058,7 +1059,11 @@ def summarize_with_anthropic(
         logging.debug("Anthropic: Prompt prepared")
         user_message = {"role": "user", "content": f"{text} \n\n\n\n{anthropic_prompt}"}
 
-        model = get_cli_setting("anthropic_api", "model", "claude-3-haiku-20240307")
+        # TASK-19020: the former fallback default claude-3-haiku-20240307 is
+        # retired server-side (404 not_found_error, req_011CeEDXZ8iS29MZCgyySwQa);
+        # claude-haiku-4-5 is its currently-served successor in the same
+        # cheap-fast-haiku lineage.
+        model = get_cli_setting("anthropic_api", "model", "claude-haiku-4-5")
 
         data = {
             "model": model,
@@ -1080,7 +1085,17 @@ def summarize_with_anthropic(
         if not anthropic_model_rejects_sampling_params(model):
             data["temperature"] = temp
             data["top_k"] = 0
-            data["top_p"] = 1.0
+            # TASK-19020: every served Claude 4.x rejects temperature and top_p
+            # together ("`temperature` and `top_p` cannot both be specified for
+            # this model."). Mirror the chat path's precedence (LLM_API_Calls
+            # chat_with_anthropic): send temperature and drop top_p; top_k is
+            # probe-verified compatible alongside temperature. No warning log
+            # here, deliberately: the diagnostic-privacy manifest
+            # (test_summarization_diagnostic_privacy.py) freezes this module's
+            # reviewed diagnostic set, and the drop is deterministic -- both
+            # values are this function's own constants, not caller input.
+            if not anthropic_model_rejects_temperature_top_p_combination(model):
+                data["top_p"] = 1.0
 
         for attempt in range(max_retries):
             try:

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -250,6 +250,54 @@ def anthropic_model_rejects_fixed_thinking_budget(model: object) -> bool:
     return _anthropic_is_modern_request_family(model)
 
 
+def anthropic_model_rejects_temperature_top_p_combination(model: object) -> bool:
+    """Return whether ``model`` rejects ``temperature`` and ``top_p`` together.
+
+    Distinct from :func:`anthropic_model_rejects_sampling_params`: the families
+    that still *accept* sampling parameters individually reject the pair --
+    ``400 invalid_request_error: `temperature` and `top_p` cannot both be
+    specified for this model. Please use only one.``
+
+    Probe-verified against api.anthropic.com with the exact trio the
+    summarization path used to build (``temperature=0.1, top_k=0, top_p=1.0``):
+
+    * 2026-08-20 (TASK-18802 discovery probes): ``claude-haiku-4-5``
+      (req_011CeEDXPHNyF7apkaZepbTN) and ``claude-sonnet-4-5``
+      (req_011CeEDXa9V99yBoHN5vcjDG) -> 400; ``temperature`` alone and
+      ``temperature``+``top_k`` -> 200 (req_011CeEDXQwqi7yXoozbdrXFX,
+      req_011CeEDXVk4nXXCoBGdf9mFm).
+    * 2026-08-20 (TASK-19020 boundary probes): ``claude-opus-4-6``
+      (req_011CeEFGsbHd7VCjcjz4etar), ``claude-sonnet-4-6``
+      (req_011CeEFGuRfeCzC6PiLyDtFb) and ``claude-opus-4-5``
+      (req_011CeEFGvySC6z61NDRH5uN5) -> the identical 400;
+      ``claude-opus-4-6`` + ``temperature``+``top_k`` without ``top_p`` -> 200
+      (msg_011CeEFGzjeXQ6ftPf9KH45n).
+
+    Together with Anthropic's published migration guidance ("passing both will
+    error on every Claude 4+ model"), the rule covers every tier-first-named
+    family -- a naming scheme that began with the Claude 4 generation -- so the
+    predicate is true for any id the family parser recognises with major >= 4.
+    The Claude 3.x generation, which accepted the pair, is number-first-named
+    (``claude-3-haiku-20240307``), never parses into a family, and is entirely
+    retired (that id itself now 404s: req_011CeEDXZ8iS29MZCgyySwQa); unparsed
+    ids keep their historical payload unchanged.
+
+    Args:
+        model: An Anthropic model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when sending ``temperature`` and ``top_p`` in the same request
+        would be answered with the 400 above. A caller holding both must send
+        temperature and drop top_p (``top_k`` remains compatible alongside
+        temperature). False for unrecognisable ids.
+    """
+    family = _anthropic_model_family(model)
+    if family is None:
+        return False
+    _tier, major, _minor = family
+    return major >= 4
+
+
 #
 #######################################################################################################################
 #


### PR DESCRIPTION
## What

After TASK-18802, summarization still failed for legacy-Anthropic configs and no-model-configured setups:

1. The legacy payload sent `temperature`, `top_k` AND `top_p` together — **every currently-served sampling-accepting Claude model rejects the pair** (probe-verified: haiku-4-5 `req_011CeEDXPHNyF7apkaZepbTN`, sonnet-4-5 `req_011CeEDXa9V99yBoHN5vcjDG`, opus-4-6 `req_011CeEFGsbHd7VCjcjz4etar`, sonnet-4-6 `req_011CeEFGuRfeCzC6PiLyDtFb`, opus-4-5 `req_011CeEFGvySC6z61NDRH5uN5` — all `400 "\`temperature\` and \`top_p\` cannot both be specified"`; `temperature`+`top_k` without `top_p` returns 200).
2. The function's own fallback default named the retired `claude-3-haiku-20240307` (404, `req_011CeEDXZ8iS29MZCgyySwQa`).

## How

- New immutable predicate `anthropic_model_rejects_temperature_top_p_combination` in `model_capabilities.py` (18414/18802 design: parsed tier-first family, `major >= 4`, outside the user-overridable capability tables). `summarize_with_anthropic` keeps `temperature`+`top_k` and drops `top_p` when it is true, mirroring the chat path's precedence. Unparsed 3.x-generation ids keep their historical payload.
- Fallback default → `claude-haiku-4-5` (the retired id's served successor in the same cheap-haiku lineage; the shipped `[api_settings.anthropic]` default governs the configured case, not this last-resort default).
- No warning log added, deliberately: the diagnostic-privacy manifest freezes this module's reviewed diagnostic set (`test_ledger_current_state_matches_sources` fails on any added call); same call 18802 made. The 18802 predicates and modern-family payloads are untouched.

## Evidence

- **Red-first:** 6 failed / 75 passed → **81 passed** (combo pins + fallback pin failed for the right reason pre-fix).
- **Targeted gate:** 1075 passed, 0 failed (whole `Tests/LLM_Calls` incl. the diagnostic-privacy manifest, model-capabilities suites, migration + provenance); consumers 11 passed; collect-only 51028, 0 errors.
- **Mutations:** invert consultation → 7 pins die; narrow to `major >= 6` → 22 die; widen to unparsed ids → 9 die (two-sided). All Edit-restored, empty diff.
- **Live (production `analyze()` seam, wire-payload spy):** haiku-4-5, sonnet-4-5, the no-model-configured fallback (wire model `claude-haiku-4-5`) and sonnet-5 (modern control, live) all return real summaries on this branch; a clean `origin/dev` control worktree reproduces HTTP 400 (haiku-4-5 trio) and HTTP 404 (retired fallback default) with the same harness.

Full detail: `Docs/superpowers/plans/2026-08-20-task-19020-report.md`. Follow-up **TASK-19048** filed for the remaining live uses of the retired id (character_defaults template, code_audit_tool, deprecated Tools_Settings_Window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic summarization failures caused by sending temperature+top_p together and updates the fallback default to a served model (TASK-19020). Previously we sent temperature+top_k+top_p to Claude 4.x (HTTP 400) and defaulted to retired `claude-3-haiku-20240307` (HTTP 404); now we drop top_p when the model rejects the combination and default to `claude-haiku-4-5`. Modern-family payloads remain unchanged; unparsed 3.x ids keep their historical trio.

- Adds `anthropic_model_rejects_temperature_top_p_combination` in `model_capabilities.py` (true for Claude 4+ tier‑first families; outside user capability tables).
- Updates `summarize_with_anthropic` to send temperature+top_k and omit top_p when the predicate is true; mirrors chat path precedence; no logging changes due to diagnostic-privacy manifest.
- Changes fallback Anthropic model to `claude-haiku-4-5`; tests pin payloads and the new default; evidence shows legacy configs now succeed.
- No migration required. Users without a configured model will now use `claude-haiku-4-5`. Follow-up TASK-19048 tracks other remaining references to the retired id.

<sup>Written for commit d7b659d107ec068a96f3fcd8e9e95e0409d5c4b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

