### PR TITLE
task-19021: probe-first close-out — no remaining summarize_with_* provider reproduced a rejection

### DIFF
--- a/Docs/superpowers/plans/2026-08-20-task-19021-report.md
+++ b/Docs/superpowers/plans/2026-08-20-task-19021-report.md
@@ -1,0 +1,149 @@
+# TASK-19021 — Remaining `summarize_with_*` providers: probe-first sweep
+
+**Branch:** `fix/task-19021-summarize-provider-gates` (from `origin/dev` `25500ad87`, which contains TASK-18414 + 18802 + 19020)
+**Status:** complete — all 3 acceptance criteria met, with **zero code changes**. That is the
+outcome, not a shortfall: the task's own spec ("if a provider rejects nothing, record that
+and close") and AC #3 make "probed, accepted, left unchanged" a first-class result, and
+every site that could not be probed is recorded honestly rather than fixed on inference.
+
+---
+
+## 1. Scope
+
+TASK-18802 fixed the Anthropic and OpenAI halves of
+`tldw_chatbook/LLM_Calls/Summarization_General_Lib.py` and code-read (not probe-verified)
+the same unconditional-sampling-params shape in six more builders:
+`summarize_with_cohere` (temperature), `summarize_with_groq` (temperature),
+`summarize_with_openrouter` (temperature ×2 call paths), `summarize_with_huggingface`
+(max_tokens + temperature), `summarize_with_deepseek` (temperature),
+`summarize_with_mistral` (temperature AND top_p together, plus max_tokens). This task's
+mandate: probe first, fix ONLY what reproduces, record honestly what cannot be probed.
+
+## 2. Probe inventory (Step 1) — the honest matrix
+
+Credential sweep: `ls /Users/macbook-dev/Documents/GitHub/tldw_chatbook/*api-key*.txt`
+plus an environment-variable sweep (`env | grep -iE "groq|huggingface|hf_|deepseek|mistral|openrouter|cohere"`
+→ empty). All probes standalone `curl`, no `tldw_chatbook` import.
+
+| Provider | Key? | Probed model(s) | Verdict |
+|---|---|---|---|
+| cohere | **yes** (working) | `command-a-plus-05-2026` (current flagship, per the API's own model list), `command-a-03-2025` (the function's default), `command-a-reasoning-08-2025` (reasoning family — the archetypal rejector) | **HTTP 200 on all three** with the exact payload shape → **no defect; function left unchanged** |
+| openrouter | key file present, **dead** | — | **unprobeable** — 401 `{"error":{"message":"User not found.","code":401}}` on BOTH `GET /api/v1/key` and `POST /chat/completions` (verbatim body below); confirms the prior session's caveat. The suspected routed-model inheritance of 18802's 400s remains a suspicion, not a finding |
+| groq | no | — | unprobeable — no credential available, unprobed, left unchanged |
+| huggingface | no | — | unprobeable for params — **but its endpoint host is gone entirely** (§4) |
+| deepseek | no | — | unprobeable — no credential available, unprobed, left unchanged |
+| mistral | no | — | unprobeable — no credential available, unprobed, left unchanged |
+
+### Cohere probes — verbatim
+
+Exact `summarize_with_cohere` shape against `https://api.cohere.com/v2/chat`
+(headers `accept`/`content-type: application/json` + bearer; body
+`{"model": …, "messages": [system, user], "temperature": 0.3, "stream": false}`):
+
+* **C1 — `command-a-plus-05-2026`** → HTTP 200, id `7b261fcc-3219-4c4f-bec5-e1fe2a1cd466`.
+  Response content is `[{type: thinking}, {type: text}]`.
+* **C2 — `command-a-03-2025`** → HTTP 200, id `758bb2de-cb5f-4412-b8e8-84537d39ac8d`,
+  `finish_reason: "COMPLETE"`, plain text part.
+* **C3 — `command-a-reasoning-08-2025`** → HTTP 200, id
+  `838a8ebe-580d-41b7-9c3c-50c30d390acf`, thinking + text parts.
+
+Wrinkle checked and cleared: the two thinking models interleave a `{"type": "thinking"}`
+part before the text part. The builder's parser
+(`"".join(part.get("text") or "" for part in content_parts if isinstance(part, dict))`)
+skips thinking parts by construction — verified standalone against the captured C1/C3
+bodies (extracted summaries were real sentences) and live through the seam (§5).
+
+### OpenRouter probes — verbatim
+
+```json
+{"error":{"message":"User not found.","code":401}}
+```
+
+— identical on `GET https://openrouter.ai/api/v1/key` (the key-metadata endpoint, which
+would 200 for any live key regardless of credit) and on a minimal
+`POST /api/v1/chat/completions`. This is a dead/deleted key, not a model-level rejection;
+**openrouter is unprobeable** and the task-suspected inheritance of the upstream
+OpenAI/Anthropic 400s by routed `openai/gpt-5` / `anthropic/claude-sonnet-5` could not be
+tested. Per the brief, no probe result is fabricated or inferred for it.
+
+## 3. Fixes (Step 2) — none owed
+
+No probed provider rejected anything, and no unprobed provider may be fixed on a
+code-read. Zero edits to `Summarization_General_Lib.py`, zero new predicates in
+`model_capabilities.py`. Consequently the openrouter design question
+(vendor-prefix-stripping onto the existing openai/anthropic predicates vs. a new
+openrouter table) is **deliberately left open** — it is recorded as design guidance
+inside the follow-up filing (§6) to be decided from real probe evidence, exactly as this
+task decided cohere from evidence rather than fixing it on suspicion.
+
+## 4. Bonus credential-free finding: `summarize_with_huggingface`'s endpoint no longer exists
+
+`api-inference.huggingface.co` is **NXDOMAIN** (`dig +short` returns nothing; curl:
+`Could not resolve host`), while the control hosts `router.huggingface.co` and
+`huggingface.co` resolve normally — so this is host retirement, not local DNS. Every call
+through `summarize_with_huggingface` therefore fails at connect, before any parameter is
+evaluated. Its real fix is an endpoint migration (HF's serverless Inference API moved to
+`router.huggingface.co`), not a param gate; folded into the follow-up filing rather than
+fixed here (out of this task's ACs, and unprobeable end-to-end without an HF credential).
+
+## 5. Evidence (Step 3)
+
+No fixes → no red-first pins, no mutations, no dev controls owed (the branch is
+byte-identical to origin/dev in `tldw_chatbook/`). What WAS owed and run:
+
+### 18802/19020 pins stay green untouched
+
+```
+pytest Tests/test_probe_import_provenance.py Tests/LLM_Calls/test_summarization_model_capabilities.py -q -p no:randomly
+→ 81 passed, 1 warning
+```
+
+— the exact count 19020 closed at, on unmodified pins.
+
+### Live seam runs (production `analyze()` → `_dispatch_to_api` → `summarize_with_*`)
+
+Throwaway uncommitted pytest tests (deleted after the run; `git status` clean of them),
+`@pytest.mark.allow_network`, model ids routed on the same `get_cli_setting` seam the
+builders read, keys passed as the `api_key` parameter (never written to config).
+`Tests/conftest.py`'s bootstrap kept the runs off the real profile; import provenance
+pinned in the same run (`PROBE imported tldw_chatbook from: …/.worktrees/summ-providers/…`).
+
+| # | Provider / model | Purpose | Result |
+|---|---|---|---|
+| 1 | anthropic / `claude-sonnet-5` | 18802/19020 no-regression | **PASS** — `'**Summary**\n- A **quick brown fox** jumps over a **lazy dog** on a bright, cold April day while the clocks strike thirteen.'` |
+| 2 | openai / `gpt-5` | 18802 no-regression | **PASS** — real structured summary (`'**Summary:**\n- A nimble **fox** leaps over a sluggish **dog** …'`) |
+| 3 | cohere / `command-a-plus-05-2026` | AC #3: the UNTOUCHED builder against the current flagship, with a passthrough wire spy | **PASS** — wire payload sampling keys `['temperature']`, model `command-a-plus-05-2026`, HTTP 200, `'A quick brown fox leaps over a lazy dog on a bright April day as the clocks strike thirteen.'` |
+
+Row 3 doubles as the "left unchanged is CORRECT" proof: the production payload carries
+exactly the unconditional `temperature` the task suspected, and the modern flagship
+accepts it — including through the thinking-part response shape.
+
+## 6. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 Each provider's modern-model behavior probed and recorded before any code change | met | §2 matrix: probed where a working credential exists (cohere, 3 models, verbatim ids); "no credential available, unprobed, left unchanged" recorded for openrouter (dead key, verbatim 401)/groq/huggingface/deepseek/mistral — the honest satisfaction the brief prescribes for keyless providers |
+| #2 Reproduced rejections consult a model_capabilities predicate | met (vacuously) | no rejection reproduced anywhere probeable; no predicate owed, none added |
+| #3 Providers whose models accept the params left unchanged | met | zero code changes (branch `tldw_chatbook/` byte-identical to origin/dev); live row 3 proves the untouched cohere builder + flagship pair works on the production seam |
+
+## 7. Filed, not fixed
+
+* **TASK-19051** — ONE follow-up (per the brief: one task, not five) listing the five
+  unprobeable providers with per-site line numbers on `25500ad87`, the openrouter
+  prefix-stripping-vs-new-table design guidance, the dead-openrouter-key evidence, and
+  the `api-inference.huggingface.co` NXDOMAIN finding (its fix is endpoint migration).
+  ID hygiene: the CLI assigned 19049; the all-refs sweep (638 refs) found max 19048 but
+  the filesystem sweep of all 154 worktrees found an unpushed `task-19050` in
+  `.worktrees/task-18060-review-rail`, so the filing was renumbered to **19051** after a
+  ghost-check confirmed 19051 absent from every ref and every worktree.
+
+## 8. Notes for review
+
+* This PR contains **no production code change** — it is a probe-evidence close-out:
+  task file (ACs ticked, Implementation Notes), this report, and the TASK-19051 filing.
+* Owner action worth flagging: the repo-root `openrouter-api-key.txt` is dead
+  (401 "User not found" at the account level). Replacing it is the unblocking
+  precondition for the openrouter leg of TASK-19051.
+* No lessons entry added: the generalisable rules this task exercised (probe before
+  fixing; a matrix with honest "unprobed" cells; dead-key vs model-rejection
+  distinction) are already recorded by 18802/19020 and the live-verification lessons.

--- a/backlog/tasks/task-19021 - Remaining-summarize_with_-providers-send-unconditional-sampling-params-with-no-capability-gate.md
+++ b/backlog/tasks/task-19021 - Remaining-summarize_with_-providers-send-unconditional-sampling-params-with-no-capability-gate.md
@@ -3,9 +3,10 @@ id: TASK-19021
 title: >-
   Remaining summarize_with_* providers send unconditional sampling params with
   no capability gate
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-20 15:16'
+updated_date: '2026-08-20 16:08'
 labels:
   - llm
 dependencies: []
@@ -20,7 +21,19 @@ TASK-18802 fixed the Anthropic and OpenAI halves of the summarization path and s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each provider's modern-model behavior toward its unconditional params is probed and recorded before any code change
-- [ ] #2 Any provider that reproduces a rejection consults a model_capabilities predicate instead of sending the param unconditionally
-- [ ] #3 Providers whose models accept the params are left unchanged
+- [x] #1 Each provider's modern-model behavior toward its unconditional params is probed and recorded before any code change
+- [x] #2 Any provider that reproduces a rejection consults a model_capabilities predicate instead of sending the param unconditionally
+- [x] #3 Providers whose models accept the params are left unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Build honest key matrix (ls repo-root key files): cohere YES, openrouter YES-but-verify (known 401), groq/huggingface/deepseek/mistral NO KEY\n2. Probe cohere with the exact summarize_with_cohere payload shape (system+user messages, temperature, stream:false) against the current flagship (ask the API for the model list first); capture verbatim bodies\n3. Verify the openrouter key; if working, probe routed openai/gpt-5 and anthropic/claude-sonnet-5 with summarize_with_openrouter's exact shape (temperature only)\n4. Record groq/huggingface/deepseek/mistral as unprobed (no credential), leave their functions unchanged\n5. For each reproduced rejection only: immutable predicate in model_capabilities.py (18414/18802 design), red-first payload pins, legacy control pins, mutation tests, live analyze() seam call + clean origin/dev control\n6. No-regression: 18802/19020 pins stay green untouched; one live modern-Anthropic + one live modern-OpenAI summarization on the branch\n7. Report, task close-out, PR against dev
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Probe-first close-out with ZERO code changes -- the honest outcome the task allows. Key matrix (repo-root key files + env sweep): cohere YES; openrouter key file present but DEAD (401 'User not found' on both GET /api/v1/key and POST /chat/completions -- matches the prior session's caveat); groq/huggingface/deepseek/mistral NO credential anywhere. Cohere probes (standalone curl, exact summarize_with_cohere v2 /chat payload shape: system+user messages, temperature 0.3, stream false): current flagship command-a-plus-05-2026 HTTP 200, function default command-a-03-2025 HTTP 200, command-a-reasoning-08-2025 HTTP 200 -- no rejection anywhere, including the reasoning family; the thinking-part responses still parse (the builder joins only 'text' parts). AC #1 satisfied by the recorded matrix (probed where a credential exists, 'no credential, unprobed, left unchanged' recorded for the rest); AC #2 vacuously satisfied (no provider reproduced a rejection, so no predicate was owed); AC #3 satisfied by leaving all six functions byte-untouched, with live seam evidence for cohere: production analyze() -> _dispatch_to_api -> summarize_with_cohere against command-a-plus-05-2026 with a passthrough wire spy -- wire sampling keys ['temperature'], HTTP 200, real summary. No-regression: the 18802/19020 pin suite (Tests/test_probe_import_provenance.py + Tests/LLM_Calls/test_summarization_model_capabilities.py) green at 81 passed untouched, plus live modern-Anthropic (claude-sonnet-5) and modern-OpenAI (gpt-5) summaries through the production analyze() seam on this branch. Bonus credential-free finding: api-inference.huggingface.co is NXDOMAIN (control hosts resolve), so summarize_with_huggingface fails at connect regardless of params. Filed TASK-19051 (single follow-up) for the five unprobeable providers, carrying the openrouter prefix-stripping design guidance and the HF endpoint migration. Full evidence: Docs/superpowers/plans/2026-08-20-task-19021-report.md
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19051 - Reproduce-unconditional-sampling-param-behavior-for-the-five-unprobeable-summarize_with_-providers-openrouter-groq-huggingface-deepseek-mistral.md
+++ b/backlog/tasks/task-19051 - Reproduce-unconditional-sampling-param-behavior-for-the-five-unprobeable-summarize_with_-providers-openrouter-groq-huggingface-deepseek-mistral.md
@@ -1,0 +1,27 @@
+---
+id: TASK-19051
+title: >-
+  Reproduce unconditional-sampling-param behavior for the five unprobeable
+  summarize_with_ providers (openrouter, groq, huggingface, deepseek, mistral)
+status: To Do
+assignee: []
+created_date: '2026-08-20 16:07'
+labels:
+  - llm
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-19021 probed what it could: cohere (working key) accepts its unconditional temperature on the current flagship command-a-plus-05-2026, the function default command-a-03-2025, and command-a-reasoning-08-2025 -- all HTTP 200 with the exact summarize_with_cohere payload shape -- so that function was left unchanged. The remaining five sites could not be probed for lack of working credentials: the repo-root openrouter key returns 401 'User not found' on both /api/v1/key and chat completions (dead key, matching the prior session's caveat), and there are no groq/huggingface/deepseek/mistral keys in the repo root or environment. Suspect sites (line numbers on origin/dev 25500ad87): summarize_with_groq :1570 temperature; summarize_with_openrouter :1794/:1883 temperature (routed vendor-prefixed ids may inherit the upstream OpenAI/Anthropic 400s TASK-18802/19020 fixed -- probe a routed openai/gpt-5 and anthropic/claude-sonnet-5 first; if the rejection is just the upstream rule, prefer stripping the vendor prefix and consulting the EXISTING openai/anthropic predicates in model_capabilities.py over minting an openrouter-specific table); summarize_with_huggingface :1980-1985 max_tokens+temperature; summarize_with_deepseek :2174 temperature; summarize_with_mistral :2357-2359 temperature AND top_p together plus max_tokens (the both-at-once shape that 400s on Anthropic Claude 4.x per TASK-19020). Additionally, credential-free probing established that summarize_with_huggingface's endpoint host api-inference.huggingface.co no longer exists in DNS (NXDOMAIN while router.huggingface.co and huggingface.co resolve), so that function fails at connect for every caller regardless of params -- its real fix is an endpoint migration, not only a param gate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each provider's modern-model behavior toward its function's exact unconditional-param payload shape is probed and recorded before any code change, once a working credential exists
+- [ ] #2 Any reproduced rejection consults a model_capabilities predicate per the TASK-18414/18802 design; for openrouter, prefix-stripping onto the existing openai/anthropic predicates is preferred over a new table if the rejection is the upstream rule
+- [ ] #3 summarize_with_huggingface's dead api-inference.huggingface.co endpoint is migrated to a served host or its failure mode made honest
+- [ ] #4 Providers whose models accept the params are left unchanged
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

TASK-19021 mandated: probe the six remaining `summarize_with_*` providers' unconditional sampling params first, fix ONLY what reproduces, and record honestly what cannot be probed. The honest outcome is **zero production code changes** — this PR is the probe-evidence close-out (task file, report, one follow-up filing).

### Probe matrix

| Provider | Key? | Probed | Verdict |
|---|---|---|---|
| cohere | yes (working) | `command-a-plus-05-2026` (flagship), `command-a-03-2025` (function default), `command-a-reasoning-08-2025` | **HTTP 200 on all three** with the exact payload shape → no defect, left unchanged |
| openrouter | key file dead | — | 401 `{"error":{"message":"User not found.","code":401}}` on BOTH `/api/v1/key` and chat completions → unprobeable |
| groq / huggingface / deepseek / mistral | none | — | unprobeable — recorded, left unchanged |

Bonus credential-free finding: `api-inference.huggingface.co` is **NXDOMAIN** (control hosts resolve), so `summarize_with_huggingface` fails at connect regardless of params — its real fix is endpoint migration, captured in the filing.

### Evidence

- 18802/19020 pin suite untouched and green: `Tests/test_probe_import_provenance.py` + `Tests/LLM_Calls/test_summarization_model_capabilities.py` → **81 passed**
- Live production `analyze()` seam runs (throwaway uncommitted tests, deleted after): anthropic/`claude-sonnet-5` PASS, openai/`gpt-5` PASS (no regression to 18802/19020), cohere/`command-a-plus-05-2026` PASS with a passthrough wire spy proving the untouched builder sends `['temperature']` and the flagship accepts it (thinking-part responses parse correctly)

### Filed

- **TASK-19051** — single follow-up for the five unprobeable providers, carrying the openrouter prefix-stripping-vs-new-table design guidance and the HF dead-endpoint finding. ID leapfrogged past an unpushed `task-19050` found in another worktree; ghost-checked across all 638 refs + 154 worktrees.

Owner action: `openrouter-api-key.txt` is dead at the account level — replacing it unblocks TASK-19051's openrouter leg.

Full report: `Docs/superpowers/plans/2026-08-20-task-19021-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-19021 by recording probe-first results for remaining `summarize_with_*` providers; no rejections reproduced, so no production code changes. Adds a probe report and files TASK-19051 to handle unprobeable providers and the Hugging Face endpoint migration.

- Behavior unchanged. This PR adds documentation only: `Docs/superpowers/plans/2026-08-20-task-19021-report.md`, marks TASK-19021 Done, and adds TASK-19051.

**Review notes**
- Cohere accepted the existing payload (unconditional `temperature`) across `command-a-plus-05-2026`, `command-a-03-2025`, and `command-a-reasoning-08-2025` (HTTP 200 for all); left `summarize_with_cohere` unchanged.
- OpenRouter key is dead (401 “User not found” on both `/api/v1/key` and chat completions); `summarize_with_openrouter` unprobeable.
- No credentials for `groq`, `deepseek`, or `mistral`; those `summarize_with_*` functions left unchanged.
- `api-inference.huggingface.co` is NXDOMAIN; `summarize_with_huggingface` fails at connect regardless of params. Real fix is endpoint migration; captured in TASK-19051.
- Test pins from 18802/19020 remain green (81 passed). Live seam checks for `anthropic/claude-sonnet-5`, `openai/gpt-5`, and Cohere flagship pass.

**Follow-ups and actions**
- Replace the dead OpenRouter API key in `openrouter-api-key.txt` to unblock TASK-19051’s probes.
- Execute TASK-19051: probe `openrouter`, `groq`, `huggingface` (post-endpoint migration), `deepseek`, and `mistral`; prefer prefix-stripping to existing OpenAI/Anthropic predicates for routed OpenRouter models if rejections mirror upstream rules.

<sup>Written for commit b604e55a6935ec43fe973998dcb48793a66503db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

