### PR TITLE
fix(tests): library prompts canvas — press the live undo button after cancelled-import recomposes (TASK-18611 AC#1)

### DIFF
--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -6452,7 +6452,7 @@ async def test_library_prompt_import_blocks_undo_until_import_settles(tmp_path):
         retry_undo = await _wait_for_selector(
             screen, pilot, "#library-prompts-delete-undo"
         )
-        retry_undo.press()
+        screen.query_one("#library-prompts-delete-undo").press()  # TASK-18611: press the live mounted button
         await _wait_for_prompt_mutation_settlement(screen, pilot)
         assert restore_calls == [receipt.targets]
         assert screen._library_prompt_delete_receipt is None
@@ -6643,11 +6643,26 @@ async def test_cancelled_prompt_import_retains_writer_ownership_until_commit(tmp
         finally:
             import_release.set()
 
-        for _ in range(150):
+        # TASK-18611: `import_finished` fires in the save stub's `finally` --
+        # BEFORE the durable-call wrapper drains the cancelled worker to real
+        # settlement. The retry Undo below must not race that drain (the write
+        # gate refuses while the worker is live), so wait for BOTH and assert
+        # the wait itself succeeded rather than silently timing through.
+        for _ in range(250):
             if import_finished.is_set() and worker.is_finished:
                 break
             await pilot.pause(0.02)
-        assert import_finished.is_set()
+        assert import_finished.is_set(), "cancelled import never settled its save"
+        assert worker.is_finished, (
+            "cancelled import worker never drained; the retry Undo would race it"
+        )
+        import os as _os, sys as _sys
+        if _os.environ.get("TLDW_TRACE_UNDO"):
+            print(
+                f"TEST-WORKER id={id(worker)} finished={worker.is_finished} "
+                f"cancelled={worker.is_cancelled}",
+                file=_sys.stderr,
+            )
         assert worker.is_cancelled
         assert refused_restore_calls == []
         assert writer_owned_while_held
@@ -6670,7 +6685,7 @@ async def test_cancelled_prompt_import_retains_writer_ownership_until_commit(tmp
         retry_undo = await _wait_for_selector(
             screen, pilot, "#library-prompts-delete-undo"
         )
-        retry_undo.press()
+        screen.query_one("#library-prompts-delete-undo").press()  # TASK-18611: press the live mounted button
         await _wait_for_prompt_mutation_settlement(screen, pilot)
         assert restore_calls == [receipt.targets]
         assert screen._library_prompt_delete_receipt is None

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -158,6 +158,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENTIC_TERMINAL = REPO_ROOT / "tldw_chatbook/css/components/_agentic_terminal.tcss"
 BUNDLED_STYLESHEET = REPO_ROOT / "tldw_chatbook/css/tldw_cli_modular.tcss"
 PROMPT_PAGER_TEST_SIZES = ((100, 30), (170, 48))
+# TASK-18611: cancelled-import settlement wait -- the retry Undo must not race
+# the cancelled worker's drain (the write gate refuses while it is live).
+# Poll count x interval = 5s ceiling.
+IMPORT_SETTLEMENT_POLLS = 250
+IMPORT_SETTLEMENT_POLL_SECONDS = 0.02
 
 
 def _css_block(text: str, selector: str) -> str:
@@ -6449,10 +6454,10 @@ async def test_library_prompt_import_blocks_undo_until_import_settles(tmp_path):
             pilot,
             screen._library_prompt_browse_controller.mutation_refresh_scope,
         )
-        retry_undo = await _wait_for_selector(
-            screen, pilot, "#library-prompts-delete-undo"
-        )
-        screen.query_one("#library-prompts-delete-undo").press()  # TASK-18611: press the live mounted button
+        await _wait_for_selector(screen, pilot, "#library-prompts-delete-undo")
+        # TASK-18611: re-query at press time -- the awaited widget can detach
+        # across the import's recomposes, and a press on a stale node no-ops.
+        screen.query_one("#library-prompts-delete-undo", Button).press()
         await _wait_for_prompt_mutation_settlement(screen, pilot)
         assert restore_calls == [receipt.targets]
         assert screen._library_prompt_delete_receipt is None
@@ -6648,21 +6653,14 @@ async def test_cancelled_prompt_import_retains_writer_ownership_until_commit(tmp
         # settlement. The retry Undo below must not race that drain (the write
         # gate refuses while the worker is live), so wait for BOTH and assert
         # the wait itself succeeded rather than silently timing through.
-        for _ in range(250):
+        for _ in range(IMPORT_SETTLEMENT_POLLS):
             if import_finished.is_set() and worker.is_finished:
                 break
-            await pilot.pause(0.02)
+            await pilot.pause(IMPORT_SETTLEMENT_POLL_SECONDS)
         assert import_finished.is_set(), "cancelled import never settled its save"
         assert worker.is_finished, (
             "cancelled import worker never drained; the retry Undo would race it"
         )
-        import os as _os, sys as _sys
-        if _os.environ.get("TLDW_TRACE_UNDO"):
-            print(
-                f"TEST-WORKER id={id(worker)} finished={worker.is_finished} "
-                f"cancelled={worker.is_cancelled}",
-                file=_sys.stderr,
-            )
         assert worker.is_cancelled
         assert refused_restore_calls == []
         assert writer_owned_while_held
@@ -6682,10 +6680,10 @@ async def test_cancelled_prompt_import_retains_writer_ownership_until_commit(tmp
             pilot,
             screen._library_prompt_browse_controller.mutation_refresh_scope,
         )
-        retry_undo = await _wait_for_selector(
-            screen, pilot, "#library-prompts-delete-undo"
-        )
-        screen.query_one("#library-prompts-delete-undo").press()  # TASK-18611: press the live mounted button
+        await _wait_for_selector(screen, pilot, "#library-prompts-delete-undo")
+        # TASK-18611: re-query at press time -- the awaited widget can detach
+        # across the import's recomposes, and a press on a stale node no-ops.
+        screen.query_one("#library-prompts-delete-undo", Button).press()
         await _wait_for_prompt_mutation_settlement(screen, pilot)
         assert restore_calls == [receipt.targets]
         assert screen._library_prompt_delete_receipt is None

--- a/backlog/tasks/task-18611 - Library-prompts-canvas-trio-fails-locally-and-24-CI-cases-stuck-at-Loading-prompts.md
+++ b/backlog/tasks/task-18611 - Library-prompts-canvas-trio-fails-locally-and-24-CI-cases-stuck-at-Loading-prompts.md
@@ -3,7 +3,7 @@ id: TASK-18611
 title: >-
   Library prompts canvas: trio fails on clean dev and 24 CI cases stuck at
   "Loading prompts"
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-19 15:30'
 labels:
@@ -39,6 +39,27 @@ found during TASK-18610 triage:
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The trio passes on a clean dev checkout (bisect 35bb1aa98 first).
+- [x] #1 The trio passes on a clean dev checkout (bisect 35bb1aa98 first).
 - [ ] #2 The CI-only stuck-loading mode is reproduced or instrumented (e.g. capture the load worker's state on timeout) and fixed.
 <!-- AC:END -->
+
+## Implementation Notes
+
+**AC #1 (clean-dev trio) — fixed.** Bisect landed on `0dfadf463`
+(perf(library): reconcile snapshots below screen), not 35bb1aa98: its
+recomposes can detach a cached `#library-prompts-delete-undo` widget
+reference taken before the cancelled/settled import, so the retry press
+silently no-ops and the restore never runs. Fix is test-side: query the
+live mounted button at press time in both `import_blocks` and
+`cancelled_import` tests, plus a hardened settlement wait (drain the
+cancelled import's worker, not just `import_finished`). Verified: full
+`test_library_prompts_canvas.py` run green (310 passed) on a head rebased
+onto dev@25500ad87.
+
+**AC #2 (CI-only stuck-at-Loading 24) — superseded, do not duplicate.**
+Open PR #1838 (task-18912, "restore latest-dev suite health") hardens
+`_wait_for_prompt_browse_scope` (canvas-settlement condition + real
+deadline) and reworks `_open_prompts_list` in this same test file, which
+targets exactly this mode; it also covers the audio_cpp/TTS stragglers
+from TASK-18610. Re-check AC #2 against CI only after #1838 merges; close
+it there if the sharded UI runs no longer show the stuck-loading cluster.


### PR DESCRIPTION
## Summary

Fixes the clean-dev trio in `Tests/UI/test_library_prompts_canvas.py` (TASK-18611 AC #1), recovered from the pass-3 triage session that followed PRs #1826/#1828/#1833.

**Root cause** (bisected to `0dfadf463`, reconcile-snapshots-below-screen): the recomposes triggered by a cancelled/settled prompt import can detach a cached `#library-prompts-delete-undo` widget reference taken earlier, so the retry press silently no-ops and the restore never runs — the test then fails on the missing restore call. Test-side fix:

- `test_library_prompt_import_blocks_undo_until_import_settles` and `test_cancelled_prompt_import_retains_writer_ownership_until_commit` now query the live mounted button at press time.
- Hardened the cancelled-import settlement wait: also drain the cancelled import's worker (`is_finished`), not just the `import_finished` event, before pressing retry.

## Scope boundary

Deliberately excludes TASK-18611 AC #2 (the CI-only 24 stuck-at-"Loading prompts…" cases) and the audio_cpp/TTS stragglers — open PR #1838 (task-18912) already hardens `_wait_for_prompt_browse_scope`/`_open_prompts_list` in this same file for that mode. This PR's hunks (lines ~4913/5104/5122) are disjoint from #1838's (~1777/2493/3034); no conflict either way they land.

## Verification

- Both fixed tests pass on this head (rebased onto dev@`25500ad87`).
- Full `Tests/UI/test_library_prompts_canvas.py`: **310 passed, 0 failed** (290s, local macOS).
- TASK-18611 file updated: claimed In Progress, AC #1 checked with disposition notes, AC #2 deferral recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes library prompts canvas tests by pressing a live Undo button and waiting for full cancelled‑import settlement. Previously the tests pressed a cached `#library-prompts-delete-undo` that detached across recomposes; now they re-query a mounted button and assert both `import_finished` and `worker.is_finished` before pressing, satisfying TASK-18611 AC #1.

- Press-time re-query: use `screen.query_one("#library-prompts-delete-undo", Button)` in both affected tests; keep `_wait_for_selector` as the gate.
- Settlement wait asserts both conditions and uses named constants `IMPORT_SETTLEMENT_POLLS`/`IMPORT_SETTLEMENT_POLL_SECONDS`.
- Remove leftover debug traces; no product changes.
- Backlog update: TASK-18611 marks AC #1 complete; AC #2 remains out of scope here and is tracked in PR #1838.

<sup>Written for commit 363508e4823ee02d1f8a8396e38af4478f8c2a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

