### PR TITLE
Fix command palette selection refresh race

### DIFF
--- a/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
+++ b/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
@@ -189,7 +189,7 @@ git commit -m "test(ui): characterize Textual palette refresh race"
 - Create: `tldw_chatbook/UI/stable_command_palette.py`
 - Modify: `Tests/UI/test_command_palette_selection_race.py`
 
-- [ ] **Step 1: Add and run a failing API-presence test**
+- [x] **Step 1: Add and run a failing API-presence test**
 
 Add this test without importing the missing module at collection time:
 
@@ -210,7 +210,7 @@ Run:
 
 Expected: one assertion failure because the compatibility module does not exist.
 
-- [ ] **Step 2: Add the pass-through API and verify the API test GREEN**
+- [x] **Step 2: Add the pass-through API and verify the API test GREEN**
 
 Create `tldw_chatbook/UI/stable_command_palette.py` with only:
 
@@ -228,7 +228,7 @@ Run the Step 1 node again.
 
 Expected: PASS. This establishes a valid import/API boundary before behavioral RED.
 
-- [ ] **Step 3: Add failing stable-selection and early-navigation tests**
+- [x] **Step 3: Add failing stable-selection and early-navigation tests**
 
 Import `StableCommandPalette` and add mounted tests that use the same fake clock and gates:
 
@@ -379,7 +379,7 @@ async def test_escape_closes_without_running_a_command(monkeypatch):
         assert PROBE.calls == []
 ```
 
-- [ ] **Step 4: Run the behavioral tests and verify RED**
+- [x] **Step 4: Run the behavioral tests and verify RED**
 
 Run:
 
@@ -391,7 +391,7 @@ Run:
 
 Expected: the pass-through subclass fails the pending-provider stable-selection test because Textual refreshes/resets the acted-on snapshot. Early-navigation, settled, and Escape cases are non-regression controls and must pass or expose fixture errors before the override is added.
 
-- [ ] **Step 5: Implement the minimal compatibility override**
+- [x] **Step 5: Implement the minimal compatibility override**
 
 Create `tldw_chatbook/UI/stable_command_palette.py`:
 
@@ -417,13 +417,13 @@ class StableCommandPalette(CommandPalette):
 
 Do not add timers, provider coordination, callback invocation, configuration, or copied Textual code.
 
-- [ ] **Step 6: Run the Task 2 tests and verify GREEN**
+- [x] **Step 6: Run the Task 2 tests and verify GREEN**
 
 Run the Step 4 command.
 
 Expected: all selected tests pass. The stable selection test must prove callback identity/count and cancellation; the two early-navigation families must prove later results actually appear.
 
-- [ ] **Step 7: Run the stock/stable characterization together**
+- [x] **Step 7: Run the stock/stable characterization together**
 
 ```bash
 ../../.venv/bin/python -m pytest -q Tests/UI/test_command_palette_selection_race.py
@@ -431,7 +431,7 @@ Expected: all selected tests pass. The stable selection test must prove callback
 
 Expected: PASS. The stock row resets after the forced late refresh; the stable row cancels before that refresh and runs the acted-on callback once.
 
-- [ ] **Step 8: Commit the compatibility slice**
+- [x] **Step 8: Commit the compatibility slice**
 
 ```bash
 git add tldw_chatbook/UI/stable_command_palette.py \

--- a/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
+++ b/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
@@ -1,0 +1,654 @@
+# TASK-397 Command Palette Selection Race Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fast keyboard selection execute the command visible under the command-palette highlight even while Textual providers are still returning results.
+
+**Architecture:** Characterize Textual 8.2.8's clear/rebuild/highlight-reset race with a fake clock and gated providers. Add one `StableCommandPalette` compatibility subclass that cancels gathering only when a command-list action targets an actionable visible snapshot, then make `TldwCli` open that subclass through Textual's existing action contract.
+
+**Tech Stack:** Python 3.11+, Textual 8.2.8, pytest/pytest-asyncio, Ruff, MyPy, GitHub CLI
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a localized compatibility shim around an exactly pinned framework component. It preserves provider and application boundaries and introduces no durable storage, sync, security, dependency, or service-contract decision.
+
+---
+
+## File map
+
+- Create `tldw_chatbook/UI/stable_command_palette.py`: the single app-owned compatibility subclass.
+- Create `Tests/UI/test_command_palette_selection_race.py`: deterministic stock characterization, compatibility behavior, and construction tests.
+- Modify `tldw_chatbook/app.py`: import the subclass and override only command-palette construction.
+- Modify `backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md`: track the plan, upstream issue, evidence, ACs, notes, and Done status.
+- Modify `Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md`: record settled upstream evidence only if implementation disproves a design assumption.
+- Modify this plan document: check steps only after their evidence exists.
+
+No provider, dependency-pin, keybinding, CSS, or general command-palette documentation file changes are planned.
+
+### Task 1: Build the deterministic stock-Textual characterization
+
+**Files:**
+- Create: `Tests/UI/test_command_palette_selection_race.py`
+
+- [ ] **Step 1: Add a fake clock, gated providers, and callback recorder**
+
+Define a minimal harness around real Textual palette widgets and workers:
+
+```python
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.command import CommandList, CommandPalette, Hit, Provider
+from textual.widgets import Static
+from textual.widgets.option_list import Option
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float = 1.0) -> None:
+        self.now += seconds
+
+
+class PaletteProbe:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.release_batch = asyncio.Event()
+        self.release_late = asyncio.Event()
+        self.batch_waiting = asyncio.Event()
+        self.late_waiting = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    def callback(self, name: str) -> Callable[[], None]:
+        return lambda: self.calls.append(name)
+
+
+PROBE: PaletteProbe
+
+
+async def wait_event(event: asyncio.Event) -> None:
+    await asyncio.wait_for(event.wait(), timeout=1.0)
+
+
+async def wait_until(pilot, predicate, *, attempts: int = 50) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause()
+    pytest.fail("mounted palette condition was not reached")
+
+
+class ControlledProvider(Provider):
+    async def search(self, query: str) -> AsyncIterator[Hit]:
+        if query != "logs":
+            return
+        try:
+            yield Hit(0.90, "first", PROBE.callback("first"))
+            yield Hit(0.80, "second", PROBE.callback("second"))
+            PROBE.batch_waiting.set()
+            await PROBE.release_batch.wait()
+            yield Hit(0.70, "batch", PROBE.callback("batch"))
+            PROBE.late_waiting.set()
+            await PROBE.release_late.wait()
+            yield Hit(0.60, "late", PROBE.callback("late"))
+        except asyncio.CancelledError:
+            PROBE.cancelled.set()
+            raise
+
+
+class PaletteHarness(App[None]):
+    COMMANDS = {ControlledProvider}
+
+    def __init__(self, palette_type: type[CommandPalette]) -> None:
+        super().__init__()
+        self.palette_type = palette_type
+
+    def compose(self) -> ComposeResult:
+        yield Static("calling screen", id="calling-screen")
+
+    def on_mount(self) -> None:
+        self.push_screen(self.palette_type(id="--command-palette"))
+```
+
+Keep every provider gate bounded with `wait_event`; use `wait_until` for mounted
+state rather than sleeping for the expected condition. Add palette state to the
+failure message if the first RED needs more diagnostic detail.
+
+- [ ] **Step 2: Add a passing stock characterization test**
+
+Patch the exact imported clock used by Textual:
+
+```python
+@pytest.mark.asyncio
+async def test_stock_palette_refresh_resets_a_navigated_highlight(monkeypatch):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    async with PaletteHarness(CommandPalette).run_test() as pilot:
+        await pilot.press("l", "o", "g", "s")
+        await wait_event(PROBE.batch_waiting)
+        clock.advance()
+        PROBE.release_batch.set()
+        command_list = pilot.app.screen.query_one(CommandList)
+        await wait_until(pilot, lambda: command_list.option_count == 3)
+        assert PROBE.late_waiting.is_set()
+
+        await pilot.press("down")
+        assert command_list.highlighted == 1
+        clock.advance()
+        PROBE.release_late.set()
+        await wait_until(pilot, lambda: command_list.option_count == 4)
+
+        assert command_list.highlighted == 0
+        await pilot.press("enter")
+        await wait_until(pilot, lambda: not CommandPalette.is_open(pilot.app))
+        await wait_until(pilot, lambda: PROBE.calls == ["first"])
+        assert PROBE.calls == ["first"]
+```
+
+The exact hit counts may be adjusted only to match observed Textual queue ordering; the test must retain two visible commands, a still-pending provider, an explicit post-navigation refresh, and the highlight-reset assertion.
+
+- [ ] **Step 3: Run the stock characterization**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_selection_race.py \
+  -k stock_palette_refresh_resets
+```
+
+Expected: PASS on unmodified Textual 8.2.8, proving Down visibly chose `second`
+but the forced refresh reset selection and Enter ran `first`. Record that the exact
+no-command symptom did not reproduce under this deterministic ordering while the
+wrong-command selection race did. Do not generalize that one result into ruling out
+other live orderings.
+
+- [ ] **Step 4: Commit the diagnostic harness**
+
+```bash
+git add Tests/UI/test_command_palette_selection_race.py
+git commit -m "test(ui): characterize Textual palette refresh race"
+```
+
+### Task 2: Freeze an actionable visible result snapshot
+
+**Files:**
+- Create: `tldw_chatbook/UI/stable_command_palette.py`
+- Modify: `Tests/UI/test_command_palette_selection_race.py`
+
+- [ ] **Step 1: Add and run a failing API-presence test**
+
+Add this test without importing the missing module at collection time:
+
+```python
+from importlib.util import find_spec
+
+
+def test_stable_palette_api_exists() -> None:
+    assert find_spec("tldw_chatbook.UI.stable_command_palette") is not None
+```
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_selection_race.py::test_stable_palette_api_exists
+```
+
+Expected: one assertion failure because the compatibility module does not exist.
+
+- [ ] **Step 2: Add the pass-through API and verify the API test GREEN**
+
+Create `tldw_chatbook/UI/stable_command_palette.py` with only:
+
+```python
+"""Compatibility command palette with stable keyboard selection."""
+
+from textual.command import CommandPalette
+
+
+class StableCommandPalette(CommandPalette):
+    """App-owned compatibility boundary for Textual command selection."""
+```
+
+Run the Step 1 node again.
+
+Expected: PASS. This establishes a valid import/API boundary before behavioral RED.
+
+- [ ] **Step 3: Add failing stable-selection and early-navigation tests**
+
+Import `StableCommandPalette` and add mounted tests that use the same fake clock and gates:
+
+```python
+from tldw_chatbook.UI.stable_command_palette import StableCommandPalette
+
+
+@pytest.mark.asyncio
+async def test_stable_palette_runs_the_navigated_command_once(monkeypatch):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        await pilot.press("l", "o", "g", "s")
+        await wait_event(PROBE.batch_waiting)
+        clock.advance()
+        PROBE.release_batch.set()
+        command_list = app.screen.query_one(CommandList)
+        await wait_until(pilot, lambda: command_list.option_count == 3)
+        await wait_event(PROBE.late_waiting)
+
+        await pilot.press("down")
+        assert command_list.highlighted == 1
+        clock.advance()
+        PROBE.release_late.set()
+        await wait_until(
+            pilot,
+            lambda: PROBE.cancelled.is_set() or command_list.option_count == 4,
+        )
+        assert PROBE.cancelled.is_set()
+        assert command_list.option_count == 3
+        assert command_list.highlighted == 1
+
+        await pilot.press("enter")
+        await wait_until(pilot, lambda: not CommandPalette.is_open(app))
+        await wait_until(pilot, lambda: PROBE.calls == ["second"])
+        assert PROBE.calls == ["second"]
+
+        await pilot.pause()
+        assert PROBE.calls == ["second"]
+        assert not CommandPalette.is_open(app)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key", ["down", "up", "pageup", "pagedown", "ctrl+home", "ctrl+end"]
+)
+async def test_navigation_before_first_result_does_not_cancel_gathering(
+    monkeypatch, key
+):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        await pilot.press("l", "o", "g", "s")
+        await wait_event(PROBE.batch_waiting)
+        command_list = app.screen.query_one(CommandList)
+        assert command_list.option_count == 0
+
+        await pilot.press(key)
+        assert not PROBE.cancelled.is_set()
+        clock.advance()
+        PROBE.release_batch.set()
+        await wait_until(pilot, lambda: command_list.option_count == 3)
+        assert not PROBE.cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_navigation_during_stale_no_matches_does_not_cancel_new_query(
+    monkeypatch,
+):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        palette = app.screen
+        assert isinstance(palette, StableCommandPalette)
+        command_list = palette.query_one(CommandList)
+        command_list.clear_options().add_option(
+            Option("No matches found", disabled=True, id=palette._NO_MATCHES)
+        )
+        palette._list_visible = True
+
+        replacement_worker = palette._gather_commands("logs")
+        palette._action_command_list("cursor_up")
+        assert not replacement_worker.is_cancelled
+
+        await wait_event(PROBE.batch_waiting)
+        clock.advance()
+        PROBE.release_batch.set()
+        await wait_until(pilot, lambda: command_list.option_count == 3)
+        assert not PROBE.cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_settled_multi_hit_selection_runs_once(monkeypatch):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        await pilot.press("l", "o", "g", "s")
+        await wait_event(PROBE.batch_waiting)
+        clock.advance()
+        PROBE.release_batch.set()
+        await wait_event(PROBE.late_waiting)
+        clock.advance()
+        PROBE.release_late.set()
+        command_list = app.screen.query_one(CommandList)
+        await wait_until(pilot, lambda: command_list.option_count == 4)
+
+        await pilot.press("down", "enter")
+        await wait_until(pilot, lambda: not CommandPalette.is_open(app))
+        await wait_until(pilot, lambda: PROBE.calls == ["second"])
+        assert PROBE.calls == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_escape_closes_without_running_a_command(monkeypatch):
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        await pilot.press("l", "o", "g", "s")
+        await wait_event(PROBE.batch_waiting)
+        clock.advance()
+        PROBE.release_batch.set()
+        await wait_until(
+            pilot, lambda: app.screen.query_one(CommandList).option_count == 3
+        )
+
+        await pilot.press("escape")
+        await wait_until(pilot, lambda: not CommandPalette.is_open(app))
+        assert PROBE.calls == []
+```
+
+- [ ] **Step 4: Run the behavioral tests and verify RED**
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_selection_race.py \
+  -k 'stable_palette or navigation_before or stale_no_matches or settled_multi or escape_closes'
+```
+
+Expected: the pass-through subclass fails the pending-provider stable-selection test because Textual refreshes/resets the acted-on snapshot. Early-navigation, settled, and Escape cases are non-regression controls and must pass or expose fixture errors before the override is added.
+
+- [ ] **Step 5: Implement the minimal compatibility override**
+
+Create `tldw_chatbook/UI/stable_command_palette.py`:
+
+```python
+"""Compatibility command palette with stable keyboard selection."""
+
+from textual.command import CommandList, CommandPalette
+
+
+class StableCommandPalette(CommandPalette):
+    """Freeze an actionable result snapshot when keyboard selection begins."""
+
+    def _action_command_list(self, action: str) -> None:
+        command_list = self.query_one(CommandList)
+        if (
+            self._list_visible
+            and command_list.option_count
+            and command_list.get_option_at_index(0).id != self._NO_MATCHES
+        ):
+            self._cancel_gather_commands()
+        super()._action_command_list(action)
+```
+
+Do not add timers, provider coordination, callback invocation, configuration, or copied Textual code.
+
+- [ ] **Step 6: Run the Task 2 tests and verify GREEN**
+
+Run the Step 4 command.
+
+Expected: all selected tests pass. The stable selection test must prove callback identity/count and cancellation; the two early-navigation families must prove later results actually appear.
+
+- [ ] **Step 7: Run the stock/stable characterization together**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_command_palette_selection_race.py
+```
+
+Expected: PASS. The stock row resets after the forced late refresh; the stable row cancels before that refresh and runs the acted-on callback once.
+
+- [ ] **Step 8: Commit the compatibility slice**
+
+```bash
+git add tldw_chatbook/UI/stable_command_palette.py \
+  Tests/UI/test_command_palette_selection_race.py
+git commit -m "fix(ui): stabilize command palette keyboard selection"
+```
+
+### Task 3: Make TldwCli open the stable palette
+
+**Files:**
+- Modify: `tldw_chatbook/app.py:80-90`
+- Modify: `tldw_chatbook/app.py:5173-8300`
+- Modify: `Tests/UI/test_command_palette_selection_race.py`
+
+- [ ] **Step 1: Add failing construction-contract tests**
+
+Use a minimal fake app and patch the inherited open-state check:
+
+```python
+def test_tldw_cli_constructs_the_stable_palette(monkeypatch):
+    app = MagicMock()
+    app.use_command_palette = True
+    monkeypatch.setattr(StableCommandPalette, "is_open", lambda _app: False)
+
+    assert "action_command_palette" in TldwCli.__dict__
+    TldwCli.action_command_palette(app)
+
+    palette = app.push_screen.call_args.args[0]
+    assert type(palette) is StableCommandPalette
+    assert palette.id == "--command-palette"
+
+
+@pytest.mark.parametrize("enabled, already_open", [(False, False), (True, True)])
+def test_tldw_cli_does_not_open_a_duplicate_or_disabled_palette(
+    monkeypatch, enabled, already_open
+):
+    app = MagicMock()
+    app.use_command_palette = enabled
+    monkeypatch.setattr(
+        StableCommandPalette, "is_open", lambda _app: already_open
+    )
+    TldwCli.action_command_palette(app)
+    app.push_screen.assert_not_called()
+```
+
+- [ ] **Step 2: Run the construction tests and verify RED**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_selection_race.py \
+  -k tldw_cli
+```
+
+Expected: FAIL because `TldwCli` inherits Textual's stock action and does not define the stable construction contract.
+
+- [ ] **Step 3: Add the narrow TldwCli override**
+
+Import the compatibility class with the other app UI dependencies:
+
+```python
+from tldw_chatbook.UI.stable_command_palette import StableCommandPalette
+```
+
+Add one action method to `TldwCli`:
+
+```python
+def action_command_palette(self) -> None:
+    """Open the app's stable Textual command palette."""
+    if self.use_command_palette and not StableCommandPalette.is_open(self):
+        self.push_screen(StableCommandPalette(id="--command-palette"))
+```
+
+- [ ] **Step 4: Run construction and mounted behavior tests**
+
+```bash
+../../.venv/bin/python -m pytest -q Tests/UI/test_command_palette_selection_race.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run adjacent palette/provider regressions**
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_basic.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/UI/test_command_palette_shell_routes.py \
+  Tests/UI/test_command_palette_selection_race.py
+```
+
+Expected: the branch-only race file passes. If one of the three pre-existing files
+fails, create a disposable detached `origin/dev` worktree and rerun only those three
+pre-existing files there; the new race file cannot be part of a baseline command
+because it does not exist on `origin/dev`:
+
+```bash
+git worktree add --detach /private/tmp/tldw-task397-origin-dev origin/dev
+```
+
+From `/private/tmp/tldw-task397-origin-dev`, run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_command_palette_basic.py \
+  Tests/UI/test_command_palette_providers.py \
+  Tests/UI/test_command_palette_shell_routes.py
+```
+
+After recording exact parity, remove the disposable worktree from the repository root:
+
+```bash
+git worktree remove /private/tmp/tldw-task397-origin-dev
+```
+
+Do not broaden to unrelated test directories.
+
+- [ ] **Step 6: Run focused static checks**
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/UI/stable_command_palette.py \
+  Tests/UI/test_command_palette_selection_race.py \
+  tldw_chatbook/app.py
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/UI/stable_command_palette.py \
+  Tests/UI/test_command_palette_selection_race.py
+../../.venv/bin/python -m mypy --follow-imports=skip \
+  tldw_chatbook/UI/stable_command_palette.py
+../../.venv/bin/python -m compileall -q \
+  tldw_chatbook/UI/stable_command_palette.py \
+  tldw_chatbook/app.py
+git diff --check
+```
+
+Expected: new/changed code passes. If whole-file `app.py` reports inherited
+diagnostics, run the exact Ruff command against `app.py` in the disposable
+`origin/dev` worktree described in Step 5 and compare only that pre-existing file.
+Do not include the new module/test in the baseline command and do not reformat
+unrelated `app.py` lines.
+
+- [ ] **Step 7: Commit application integration**
+
+```bash
+git add tldw_chatbook/app.py Tests/UI/test_command_palette_selection_race.py
+git commit -m "fix(app): use stable command palette selection"
+```
+
+### Task 4: Report upstream and close TASK-397
+
+**Files:**
+- Modify: `backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md`
+- Modify: this plan document
+- Modify only if assumptions changed: `Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md`
+
+- [ ] **Step 1: Search upstream before filing**
+
+```bash
+gh issue list --repo Textualize/textual --state all \
+  --search 'command palette refresh highlight selection race' --limit 100
+```
+
+Expected: either identify an exact existing issue to link or establish that a new report is warranted. Record the search terms and result; do not file a duplicate.
+
+- [ ] **Step 2: File or link the upstream issue**
+
+If no exact issue exists, use `gh issue create --repo Textualize/textual` with a standalone reproduction derived from the passing stock characterization. Include Textual `8.2.8`, Python version, fake-clock/gated ordering, exact expected/actual highlight and callback identity, source behavior, and the app workaround. State whether the original no-command symptom reproduced or whether only the narrower highlight reset was confirmed.
+
+Expected: a durable GitHub issue URL. If repository permissions prevent creation,
+preserve the complete ready-to-file body in TASK-397, leave AC #2 unchecked and the
+task In Progress, commit the implemented mitigation/evidence if otherwise ready, and
+stop with an explicit filing handoff. Do not run the Done transition or claim task
+completion until a durable existing or newly filed issue URL is linked.
+
+- [ ] **Step 3: Run the final related verification matrix**
+
+Repeat Task 3 Steps 4-6 on the settled branch. Capture exact pass/fail counts, warnings, durations, and any identical `origin/dev` baseline proof.
+
+- [ ] **Step 4: Request independent cumulative review**
+
+Use `superpowers:requesting-code-review` over `origin/dev..HEAD`. Require review of the protected Textual seam, actionable/no-match guard, deterministic non-vacuity, callback exactly-once behavior, app construction, upstream report honesty, scope, and task evidence. Resolve all P0-P2 findings before closeout.
+
+- [ ] **Step 5: Complete documentation and task hygiene**
+
+Update TASK-397 with:
+
+- all ACs checked only from evidence;
+- the upstream issue URL or honest ready-to-file fallback;
+- `## Implementation Plan` linking this executable plan;
+- concise `## Implementation Notes` listing the shim, app integration, tests, tradeoff, commits, and verification;
+- ADR `no` rationale; and
+- whether a lessons entry was warranted.
+
+Check completed plan steps. Then resolve the exact task and set it Done via CLI only after every DoD item is satisfied:
+
+```bash
+backlog task 397 --plain
+backlog task edit 397 -s Done
+backlog task 397 --plain
+```
+
+- [ ] **Step 6: Commit closeout documentation**
+
+```bash
+git add \
+  'backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md' \
+  Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md \
+  Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
+git commit -m "docs(ui): complete TASK-397 palette race mitigation"
+```
+
+- [ ] **Step 7: Verify final repository state**
+
+```bash
+git status --short
+git diff --check origin/dev..HEAD
+git log --oneline --decorate -6
+backlog task 397 --plain
+```
+
+Expected: clean worktree; scoped commits; TASK-397 uniquely resolves to Done with every AC checked; no implementation or review evidence is overstated.

--- a/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
+++ b/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
@@ -32,7 +32,7 @@ No provider, dependency-pin, keybinding, CSS, or general command-palette documen
 **Files:**
 - Create: `Tests/UI/test_command_palette_selection_race.py`
 
-- [ ] **Step 1: Add a fake clock, gated providers, and callback recorder**
+- [x] **Step 1: Add a fake clock, gated providers, and callback recorder**
 
 Define a minimal harness around real Textual palette widgets and workers:
 
@@ -124,7 +124,7 @@ Keep every provider gate bounded with `wait_event`; use `wait_until` for mounted
 state rather than sleeping for the expected condition. Add palette state to the
 failure message if the first RED needs more diagnostic detail.
 
-- [ ] **Step 2: Add a passing stock characterization test**
+- [x] **Step 2: Add a passing stock characterization test**
 
 Patch the exact imported clock used by Textual:
 
@@ -160,7 +160,7 @@ async def test_stock_palette_refresh_resets_a_navigated_highlight(monkeypatch):
 
 The exact hit counts may be adjusted only to match observed Textual queue ordering; the test must retain two visible commands, a still-pending provider, an explicit post-navigation refresh, and the highlight-reset assertion.
 
-- [ ] **Step 3: Run the stock characterization**
+- [x] **Step 3: Run the stock characterization**
 
 Run:
 
@@ -176,7 +176,7 @@ no-command symptom did not reproduce under this deterministic ordering while the
 wrong-command selection race did. Do not generalize that one result into ruling out
 other live orderings.
 
-- [ ] **Step 4: Commit the diagnostic harness**
+- [x] **Step 4: Commit the diagnostic harness**
 
 ```bash
 git add Tests/UI/test_command_palette_selection_race.py

--- a/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
+++ b/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
@@ -586,7 +586,7 @@ git commit -m "fix(app): use stable command palette selection"
 - Modify: this plan document
 - Modify only if assumptions changed: `Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md`
 
-- [ ] **Step 1: Search upstream before filing**
+- [x] **Step 1: Search upstream before filing**
 
 ```bash
 gh issue list --repo Textualize/textual --state all \
@@ -595,7 +595,13 @@ gh issue list --repo Textualize/textual --state all \
 
 Expected: either identify an exact existing issue to link or establish that a new report is warranted. Record the search terms and result; do not file a duplicate.
 
-- [ ] **Step 2: File or link the upstream issue**
+Evidence: searched `command palette refresh highlight selection race`,
+`CommandPalette highlight reset`, `command palette wrong command`, and
+`command palette async provider selection` across open and closed Textual issues.
+The only nearby reports, #4705 and #3714, concern unrelated help/scroll/order and
+duplicate-ID clearing defects, so a new report was warranted.
+
+- [x] **Step 2: File or link the upstream issue**
 
 If no exact issue exists, use `gh issue create --repo Textualize/textual` with a standalone reproduction derived from the passing stock characterization. Include Textual `8.2.8`, Python version, fake-clock/gated ordering, exact expected/actual highlight and callback identity, source behavior, and the app workaround. State whether the original no-command symptom reproduced or whether only the narrower highlight reset was confirmed.
 
@@ -605,15 +611,39 @@ task In Progress, commit the implemented mitigation/evidence if otherwise ready,
 stop with an explicit filing handoff. Do not run the Done transition or claim task
 completion until a durable existing or newly filed issue URL is linked.
 
-- [ ] **Step 3: Run the final related verification matrix**
+Evidence: filed [Textual issue #6701](https://github.com/Textualize/textual/issues/6701)
+with Textual 8.2.8, Python 3.12.11, the fake-clock/gated-provider reproduction,
+expected and actual callback identities, the batch refresh mechanism, and the local
+workaround. The report explicitly says the deterministic run confirmed a
+wrong-command race but did not reproduce the original no-command symptom.
+
+- [x] **Step 3: Run the final related verification matrix**
 
 Repeat Task 3 Steps 4-6 on the settled branch. Capture exact pass/fail counts, warnings, durations, and any identical `origin/dev` baseline proof.
 
-- [ ] **Step 4: Request independent cumulative review**
+Evidence: the four exact related palette files passed with `90 passed, 1 warning in
+9.13s`; the warning was the existing Requests dependency-version warning. Focused
+Ruff, Ruff format, MyPy, compileall, and `git diff --check` all passed. No baseline
+comparison was needed because no focused check failed.
 
-Use `superpowers:requesting-code-review` over `origin/dev..HEAD`. Require review of the protected Textual seam, actionable/no-match guard, deterministic non-vacuity, callback exactly-once behavior, app construction, upstream report honesty, scope, and task evidence. Resolve all P0-P2 findings before closeout.
+- [x] **Step 4: Request independent cumulative review**
 
-- [ ] **Step 5: Complete documentation and task hygiene**
+Use `superpowers:requesting-code-review` over
+`$(git merge-base origin/dev HEAD)..HEAD`. During closeout that merge base resolved to
+`1bf7f234e`; `origin/dev` had advanced by 93 commits after the worktree was created,
+so literal `origin/dev..HEAD` included unrelated upstream changes and was not a valid
+TASK-397 review range. Require review of the protected Textual seam,
+actionable/no-match guard, deterministic non-vacuity, callback exactly-once behavior,
+app construction, upstream report honesty, scope, and task evidence. Resolve all
+P0-P2 findings before closeout.
+
+Evidence: independent cumulative review approved the protected compatibility seam,
+guards, non-vacuous behavior tests, exactly-once callback contract, app construction,
+upstream report, scope, and task evidence. The review's sole P2 corrected the stale
+literal `origin/dev..HEAD` instruction to the merge-base-scoped range above;
+re-review approved with no open P0-P2 findings.
+
+- [x] **Step 5: Complete documentation and task hygiene**
 
 Update TASK-397 with:
 
@@ -632,7 +662,12 @@ backlog task edit 397 -s Done
 backlog task 397 --plain
 ```
 
-- [ ] **Step 6: Commit closeout documentation**
+Evidence: TASK-397 now records all checked ACs, the reviewed plan, concise
+implementation/verification notes, issue #6701, the ADR-no rationale, and the
+no-lessons/no-user-guide rationale. `backlog task edit 397 -s Done` completed, and
+`backlog task 397 --plain` resolves the exact task as Done with all three ACs checked.
+
+- [x] **Step 6: Commit closeout documentation**
 
 ```bash
 git add \
@@ -642,13 +677,25 @@ git add \
 git commit -m "docs(ui): complete TASK-397 palette race mitigation"
 ```
 
-- [ ] **Step 7: Verify final repository state**
+Evidence: the task record and executable plan were committed with the prescribed
+`docs(ui): complete TASK-397 palette race mitigation` message; the unchanged design
+spec required no closeout edit because implementation did not disprove an assumption.
+
+- [x] **Step 7: Verify final repository state**
 
 ```bash
 git status --short
-git diff --check origin/dev..HEAD
+git diff --check "$(git merge-base origin/dev HEAD)..HEAD"
 git log --oneline --decorate -6
 backlog task 397 --plain
 ```
 
-Expected: clean worktree; scoped commits; TASK-397 uniquely resolves to Done with every AC checked; no implementation or review evidence is overstated.
+Expected: clean worktree; the merge-base-scoped diff contains only TASK-397 commits;
+TASK-397 uniquely resolves to Done with every AC checked; no implementation or
+review evidence is overstated. The merge-base range is required because `origin/dev`
+advanced by 93 commits after branch creation; a literal `origin/dev..HEAD` diff would
+mix those unrelated upstream changes into the closeout check.
+
+Evidence: `git status --short` was empty, merge-base-scoped `git diff --check` and
+`git show --check` passed, the log contained only the eight scoped TASK-397 commits,
+and `backlog task 397 --plain` resolved the task as Done with all three ACs checked.

--- a/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
+++ b/Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md
@@ -446,7 +446,7 @@ git commit -m "fix(ui): stabilize command palette keyboard selection"
 - Modify: `tldw_chatbook/app.py:5173-8300`
 - Modify: `Tests/UI/test_command_palette_selection_race.py`
 
-- [ ] **Step 1: Add failing construction-contract tests**
+- [x] **Step 1: Add failing construction-contract tests**
 
 Use a minimal fake app and patch the inherited open-state check:
 
@@ -477,7 +477,7 @@ def test_tldw_cli_does_not_open_a_duplicate_or_disabled_palette(
     app.push_screen.assert_not_called()
 ```
 
-- [ ] **Step 2: Run the construction tests and verify RED**
+- [x] **Step 2: Run the construction tests and verify RED**
 
 ```bash
 ../../.venv/bin/python -m pytest -q \
@@ -487,7 +487,7 @@ def test_tldw_cli_does_not_open_a_duplicate_or_disabled_palette(
 
 Expected: FAIL because `TldwCli` inherits Textual's stock action and does not define the stable construction contract.
 
-- [ ] **Step 3: Add the narrow TldwCli override**
+- [x] **Step 3: Add the narrow TldwCli override**
 
 Import the compatibility class with the other app UI dependencies:
 
@@ -504,7 +504,7 @@ def action_command_palette(self) -> None:
         self.push_screen(StableCommandPalette(id="--command-palette"))
 ```
 
-- [ ] **Step 4: Run construction and mounted behavior tests**
+- [x] **Step 4: Run construction and mounted behavior tests**
 
 ```bash
 ../../.venv/bin/python -m pytest -q Tests/UI/test_command_palette_selection_race.py
@@ -512,7 +512,7 @@ def action_command_palette(self) -> None:
 
 Expected: PASS.
 
-- [ ] **Step 5: Run adjacent palette/provider regressions**
+- [x] **Step 5: Run adjacent palette/provider regressions**
 
 ```bash
 ../../.venv/bin/python -m pytest -q \
@@ -548,7 +548,7 @@ git worktree remove /private/tmp/tldw-task397-origin-dev
 
 Do not broaden to unrelated test directories.
 
-- [ ] **Step 6: Run focused static checks**
+- [x] **Step 6: Run focused static checks**
 
 ```bash
 ../../.venv/bin/python -m ruff check \
@@ -572,7 +572,7 @@ diagnostics, run the exact Ruff command against `app.py` in the disposable
 Do not include the new module/test in the baseline command and do not reformat
 unrelated `app.py` lines.
 
-- [ ] **Step 7: Commit application integration**
+- [x] **Step 7: Commit application integration**
 
 ```bash
 git add tldw_chatbook/app.py Tests/UI/test_command_palette_selection_race.py

--- a/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
+++ b/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
@@ -12,7 +12,7 @@ the user acted on.
 TASK-397 will first reproduce or rule out the reported failure under a deterministic
 pilot harness. Regardless of whether the exact live symptom is repeatable, the app
 will add a narrow compatibility shim that stops result gathering when keyboard
-navigation or Enter/go-button selection acts on an actionable visible list. The
+navigation or Enter selection acts on an actionable visible list. The
 displayed options then remain stable for the remainder of that selection gesture.
 Navigation before any result appears, or while only Textual's stale disabled
 “No matches” placeholder is visible, continues waiting normally. The underlying
@@ -76,7 +76,7 @@ This one interception point covers:
 
 - cursor movement delegated by Down and Up;
 - page, first, and last navigation;
-- selection delegated by Enter or the palette's go button.
+- selection delegated by Enter.
 
 No provider is changed. No Textual source is copied. No timing constants, sleeps, or
 debounces are added to production behavior.
@@ -208,7 +208,7 @@ In scope:
 - `TldwCli` palette construction;
 - deterministic mounted regression tests;
 - the upstream issue; and
-- task/spec/plan/user-guide notes required by closeout.
+- task/spec/plan notes required by closeout.
 
 Out of scope:
 

--- a/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
+++ b/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
@@ -11,10 +11,12 @@ the user acted on.
 
 TASK-397 will first reproduce or rule out the reported failure under a deterministic
 pilot harness. Regardless of whether the exact live symptom is repeatable, the app
-will add a narrow compatibility shim that stops result gathering as soon as the
-user navigates or selects the visible list. The displayed options then remain stable
-for the remainder of that selection gesture. The underlying framework behavior will
-also be reported upstream with a minimal reproduction.
+will add a narrow compatibility shim that stops result gathering when keyboard
+navigation or Enter/go-button selection acts on an actionable visible list. The
+displayed options then remain stable for the remainder of that selection gesture.
+Navigation before any result appears, or while only Textual's stale disabled
+“No matches” placeholder is visible, continues waiting normally. The underlying
+framework behavior will also be reported upstream with a minimal reproduction.
 
 ## Context and Evidence
 
@@ -47,6 +49,9 @@ When command results are visible:
 6. Opening the palette, typing a query, settled-result selection, provider matching,
    command ordering before interaction, and mouse selection retain their existing
    behavior.
+7. Navigation keys pressed before an actionable result list is visible do not cancel
+   provider gathering, including when a replacement query has started while the old
+   disabled “No matches” placeholder remains visible.
 
 The mitigation intentionally prefers predictable selection over including results
 that arrive after the user begins navigating. The user can change the query or reopen
@@ -59,10 +64,13 @@ the palette to obtain a new result set.
 Add a small app-owned subclass of `textual.command.CommandPalette`, named
 `StableCommandPalette`.
 
-Override the palette's `_action_command_list(action)` compatibility seam. Before
-delegating any command-list action to Textual, cancel the palette's current gather
-worker via the existing `_cancel_gather_commands()` method. Delegation then uses the
-base implementation unchanged.
+Override the palette's `_action_command_list(action)` compatibility seam. Query the
+real `CommandList`; when `_list_visible` is true, at least one option exists, and the
+first option is not Textual's `_NO_MATCHES` placeholder, cancel the palette's current
+gather worker via the existing `_cancel_gather_commands()` method. Then delegate every
+action to the base implementation unchanged. If no actionable visible snapshot
+exists, delegate without cancellation so early navigation or a stale disabled
+placeholder cannot strand the palette without replacement results.
 
 This one interception point covers:
 
@@ -74,8 +82,9 @@ No provider is changed. No Textual source is copied. No timing constants, sleeps
 debounces are added to production behavior.
 
 The subclass is an explicit compatibility boundary around protected Textual methods.
-That dependency is acceptable because Textual is exactly pinned and the focused tests
-will fail at the upgrade boundary if the internal contract changes.
+That dependency is acceptable because Textual is exactly pinned. Any upgrade must
+explicitly review both protected seams even if behavioral tests remain green because
+upstream may have made the compatibility override redundant.
 
 ### Application integration
 
@@ -149,12 +158,20 @@ Focused tests will prove:
 - a multi-hit Down+Enter sequence while a provider is pending runs the visible
   highlighted callback exactly once;
 - the gather worker is cancelled before a late result can rebuild the list;
-- repeated deterministic iterations do not produce a lucky pass;
+- a passing stock-palette characterization proves the forced late refresh resets the
+  acted-on highlight, while the stable palette prevents that refresh;
+- navigation before the first visible result leaves gathering active and eventually
+  displays the gated results;
+- a new query followed immediately by navigation while the old disabled “No matches”
+  placeholder is visible leaves replacement gathering active;
 - settled multi-hit selection still works;
 - Escape still closes without running a callback; and
 - the existing command-provider and basic palette tests remain green.
 
-Tests must assert callback identity and count, not merely that the palette closed.
+The gate/clock tests must assert that the late provider reached its gate before
+navigation, that the stock palette performed the post-navigation refresh/reset, and
+that the stable palette's provider or gather worker observed cancellation. Tests must
+assert callback identity and count, not merely that the palette closed.
 
 ## Upstream Report
 
@@ -174,8 +191,9 @@ the narrower confirmed race honestly if that is all the harness proves.
 
 ## Error and Compatibility Handling
 
-- If protected Textual methods change, focused tests should fail rather than silently
-  bypass the mitigation.
+- A Textual upgrade requires explicit review of `_action_command_list()` and
+  `_cancel_gather_commands()`. Behavioral tests remain authoritative because an
+  upstream fix may legitimately make the compatibility override redundant.
 - Provider exceptions continue to be handled by Textual.
 - Cancellation uses Textual's existing worker-group mechanism and does not cancel
   command callbacks.

--- a/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
+++ b/Docs/superpowers/specs/2026-08-20-task-397-command-palette-selection-race-design.md
@@ -1,0 +1,212 @@
+# TASK-397 Command Palette Selection Race Design
+
+## Summary
+
+Fast keyboard selection in Textual's command palette can race the palette's
+asynchronous result refresh. When a query has several matches and providers are
+still producing results, a user can move the highlight and press Enter while
+Textual clears and rebuilds the option list. The result can be a reset selection,
+an ignored selection gesture, or a palette dismissal that does not run the command
+the user acted on.
+
+TASK-397 will first reproduce or rule out the reported failure under a deterministic
+pilot harness. Regardless of whether the exact live symptom is repeatable, the app
+will add a narrow compatibility shim that stops result gathering as soon as the
+user navigates or selects the visible list. The displayed options then remain stable
+for the remainder of that selection gesture. The underlying framework behavior will
+also be reported upstream with a minimal reproduction.
+
+## Context and Evidence
+
+- The project pins Textual `8.2.8` exactly.
+- `TldwCli` registers several independent command providers. Their results are
+  consumed concurrently by Textual's built-in `CommandPalette`.
+- Textual batches provider results. Each batch and the final refresh calls
+  `clear_options().add_options(...)` and then assigns `highlighted = 0`.
+- A user's Down or Enter can therefore act while more provider results are pending.
+- The same refresh and highlight-reset behavior is present in current upstream
+  Textual `main` as of 2026-08-20.
+- The app's providers use the ordinary Textual `Provider` contract and do not
+  independently mutate the palette or its highlight.
+
+The pilot test remains the authority for the exact failure mode. Source inspection
+establishes the race window but does not substitute for mounted behavior evidence.
+
+## User-visible Contract
+
+When command results are visible:
+
+1. Down, Up, Page Up, Page Down, Ctrl/Shift+Home, Ctrl/Shift+End, or Enter acts on
+   one stable snapshot of the displayed command list. Plain Home and End retain
+   their existing command-input editing behavior.
+2. Once the first list-navigation or list-selection gesture occurs, late provider
+   results do not replace the options beneath that gesture.
+3. Enter runs the command represented by the visible highlight exactly once.
+4. The palette closes using Textual's existing selected-command behavior.
+5. Escape remains cancellation and runs no command.
+6. Opening the palette, typing a query, settled-result selection, provider matching,
+   command ordering before interaction, and mouse selection retain their existing
+   behavior.
+
+The mitigation intentionally prefers predictable selection over including results
+that arrive after the user begins navigating. The user can change the query or reopen
+the palette to obtain a new result set.
+
+## Design
+
+### Compatibility subclass
+
+Add a small app-owned subclass of `textual.command.CommandPalette`, named
+`StableCommandPalette`.
+
+Override the palette's `_action_command_list(action)` compatibility seam. Before
+delegating any command-list action to Textual, cancel the palette's current gather
+worker via the existing `_cancel_gather_commands()` method. Delegation then uses the
+base implementation unchanged.
+
+This one interception point covers:
+
+- cursor movement delegated by Down and Up;
+- page, first, and last navigation;
+- selection delegated by Enter or the palette's go button.
+
+No provider is changed. No Textual source is copied. No timing constants, sleeps, or
+debounces are added to production behavior.
+
+The subclass is an explicit compatibility boundary around protected Textual methods.
+That dependency is acceptable because Textual is exactly pinned and the focused tests
+will fail at the upgrade boundary if the internal contract changes.
+
+### Application integration
+
+Override `TldwCli.action_command_palette()` with the same two guards used by Textual's
+`App.action_command_palette()`:
+
+- `self.use_command_palette` is true; and
+- no command palette is already open.
+
+Push `StableCommandPalette(id="--command-palette")`. Preserve Textual's canonical ID,
+open-state class, calling-screen behavior, provider discovery, messages, dismissal,
+and delayed callback execution.
+
+### Why not preserve the highlighted identity across refreshes?
+
+Restoring a matching highlight after every batch still clears and replaces the option
+objects while a selection event may be queued. It also has to define identity across
+providers with equal labels or callbacks. Freezing on interaction is smaller and
+matches the user's intent: the visible list they acted on is authoritative.
+
+### Why not change providers?
+
+The providers follow the documented async-yield contract. Coordinating or buffering
+them in application code would duplicate framework behavior and would not protect
+against future slow providers.
+
+### Why not vendor or upgrade Textual?
+
+Vendoring the palette would copy hundreds of framework-owned lines. A dependency
+upgrade is a separate, higher-risk task and current upstream `main` still contains the
+same refresh behavior. The compatibility subclass is the smallest safe boundary.
+
+## Deterministic Verification
+
+### Pilot harness
+
+Create a minimal Textual app with controlled providers, a patched
+`textual.command.monotonic`, and callback counters:
+
+- provider gates control exactly when each hit becomes available;
+- the fake monotonic clock advances before a gated hit is released, crossing
+  Textual's batch interval and materializing a partial multi-hit visible list;
+- the harness proves that partial batch is visible while at least one provider is
+  still pending;
+- after navigation, the clock advances again and another gated hit is released to
+  force the stock refresh before selection; and
+- the harness records both refreshes, their option identities, and callback counts,
+  avoiding wall-clock sleeps and scheduler luck.
+
+Use the real mounted `CommandPalette`, `CommandInput`, `CommandList`, key bindings,
+workers, option messages, dismissal, and deferred callback path.
+
+### RED evidence
+
+Run the harness against stock Textual behavior first. Record whether it reproduces the
+original no-command symptom or a narrower selection-reset/ignored-gesture form. A
+test is non-vacuous only when it proves that a late result refresh actually occurred
+after the user began the selection sequence. This stock failure is a temporary
+diagnostic and the standalone upstream reproducer; it is not committed as a failing
+repository test.
+
+Then point the application integration test at `StableCommandPalette`; before the
+production override exists, the test must fail because `TldwCli` still opens the stock
+palette or because the visible selection is not stable.
+
+### GREEN evidence
+
+Focused tests will prove:
+
+- the app opens `StableCommandPalette` with the canonical ID;
+- a multi-hit Down+Enter sequence while a provider is pending runs the visible
+  highlighted callback exactly once;
+- the gather worker is cancelled before a late result can rebuild the list;
+- repeated deterministic iterations do not produce a lucky pass;
+- settled multi-hit selection still works;
+- Escape still closes without running a callback; and
+- the existing command-provider and basic palette tests remain green.
+
+Tests must assert callback identity and count, not merely that the palette closed.
+
+## Upstream Report
+
+After the mounted stock-palette reproduction is settled, file a Textual GitHub issue
+containing:
+
+- Textual and Python versions;
+- a standalone minimal app/provider reproduction;
+- the deterministic event ordering;
+- expected and actual selected callback identities/counts;
+- the relevant batch-refresh behavior; and
+- the app-side freeze-on-interaction mitigation, clearly labeled as a workaround.
+
+Link the issue in TASK-397 Implementation Notes. Do not claim the upstream issue is
+the exact original live symptom unless the pilot reproduces that symptom; describe
+the narrower confirmed race honestly if that is all the harness proves.
+
+## Error and Compatibility Handling
+
+- If protected Textual methods change, focused tests should fail rather than silently
+  bypass the mitigation.
+- Provider exceptions continue to be handled by Textual.
+- Cancellation uses Textual's existing worker-group mechanism and does not cancel
+  command callbacks.
+- A selection already committed by Textual remains exactly-once; the subclass does
+  not invoke callbacks itself.
+
+## Scope
+
+In scope:
+
+- the compatibility subclass;
+- `TldwCli` palette construction;
+- deterministic mounted regression tests;
+- the upstream issue; and
+- task/spec/plan/user-guide notes required by closeout.
+
+Out of scope:
+
+- provider ranking or search semantics;
+- palette styling;
+- replacing Textual's command palette;
+- changing Textual's dependency pin;
+- mouse behavior beyond regression coverage; and
+- unrelated keybinding changes.
+
+## ADR Check
+
+ADR required: no.
+
+ADR path: N/A.
+
+Reason: this is a localized compatibility shim around an exactly pinned framework
+component. It preserves provider, application, and UI ownership boundaries and does
+not introduce a durable architectural decision.

--- a/Tests/UI/test_command_palette_selection_race.py
+++ b/Tests/UI/test_command_palette_selection_race.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Callable
+from importlib.util import find_spec
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.command import CommandList, CommandPalette, Hit, Provider
 from textual.pilot import Pilot
 from textual.widgets import Static
+from textual.widgets.option_list import Option
+
+from tldw_chatbook.UI.stable_command_palette import StableCommandPalette
 
 
 class FakeClock:
@@ -90,6 +94,10 @@ class PaletteHarness(App[None]):
         self.push_screen(self.palette_type(id="--command-palette"))
 
 
+def test_stable_palette_api_exists() -> None:
+    assert find_spec("tldw_chatbook.UI.stable_command_palette") is not None
+
+
 @pytest.mark.asyncio
 async def test_stock_palette_refresh_resets_a_navigated_highlight(
     monkeypatch: pytest.MonkeyPatch,
@@ -152,6 +160,252 @@ async def test_stock_palette_refresh_resets_a_navigated_highlight(
                 state=lambda: {"calls": PROBE.calls},
             )
             assert PROBE.calls == ["first"]
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()
+
+
+@pytest.mark.asyncio
+async def test_stable_palette_runs_the_navigated_command_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            await pilot.press("l", "o", "g", "s")
+            await wait_event(PROBE.batch_waiting)
+            clock.advance()
+            PROBE.release_batch.set()
+
+            command_list = app.screen.query_one(CommandList)
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 3,
+                state=lambda: {
+                    "option_count": command_list.option_count,
+                    "highlighted": command_list.highlighted,
+                    "late_waiting": PROBE.late_waiting.is_set(),
+                    "calls": PROBE.calls,
+                },
+            )
+            assert PROBE.late_waiting.is_set()
+
+            await pilot.press("down")
+            assert command_list.highlighted == 1
+            clock.advance()
+            PROBE.release_late.set()
+            await wait_until(
+                pilot,
+                lambda: PROBE.cancelled.is_set() or command_list.option_count == 4,
+                state=lambda: {
+                    "cancelled": PROBE.cancelled.is_set(),
+                    "option_count": command_list.option_count,
+                    "highlighted": command_list.highlighted,
+                    "calls": PROBE.calls,
+                },
+            )
+            assert PROBE.cancelled.is_set()
+            assert command_list.option_count == 3
+            assert command_list.highlighted == 1
+
+            await pilot.press("enter")
+            await wait_until(
+                pilot,
+                lambda: not CommandPalette.is_open(app),
+                state=lambda: {
+                    "screen": type(app.screen).__name__,
+                    "calls": PROBE.calls,
+                },
+            )
+            await wait_until(
+                pilot,
+                lambda: PROBE.calls == ["second"],
+                state=lambda: {"calls": PROBE.calls},
+            )
+            assert PROBE.calls == ["second"]
+
+            await pilot.pause()
+            assert PROBE.calls == ["second"]
+            assert not CommandPalette.is_open(app)
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key", ["down", "up", "pageup", "pagedown", "ctrl+home", "ctrl+end"]
+)
+async def test_navigation_before_first_result_does_not_cancel_gathering(
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            await pilot.press("l", "o", "g", "s")
+            await wait_event(PROBE.batch_waiting)
+            command_list = app.screen.query_one(CommandList)
+            assert command_list.option_count == 0
+
+            await pilot.press(key)
+            assert not PROBE.cancelled.is_set()
+            clock.advance()
+            PROBE.release_batch.set()
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 3,
+                state=lambda: {
+                    "key": key,
+                    "option_count": command_list.option_count,
+                    "cancelled": PROBE.cancelled.is_set(),
+                },
+            )
+            assert not PROBE.cancelled.is_set()
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()
+
+
+@pytest.mark.asyncio
+async def test_navigation_during_stale_no_matches_does_not_cancel_new_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            palette = app.screen
+            assert isinstance(palette, StableCommandPalette)
+            command_list = palette.query_one(CommandList)
+            command_list.clear_options().add_option(
+                Option("No matches found", disabled=True, id=palette._NO_MATCHES)
+            )
+            palette._list_visible = True
+
+            replacement_worker = palette._gather_commands("logs")
+            palette._action_command_list("cursor_up")
+            assert not replacement_worker.is_cancelled
+
+            await wait_event(PROBE.batch_waiting)
+            clock.advance()
+            PROBE.release_batch.set()
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 3,
+                state=lambda: {
+                    "option_count": command_list.option_count,
+                    "cancelled": PROBE.cancelled.is_set(),
+                    "worker_cancelled": replacement_worker.is_cancelled,
+                },
+            )
+            assert not PROBE.cancelled.is_set()
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()
+
+
+@pytest.mark.asyncio
+async def test_settled_multi_hit_selection_runs_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            await pilot.press("l", "o", "g", "s")
+            await wait_event(PROBE.batch_waiting)
+            clock.advance()
+            PROBE.release_batch.set()
+            await wait_event(PROBE.late_waiting)
+            clock.advance()
+            PROBE.release_late.set()
+
+            command_list = app.screen.query_one(CommandList)
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 4,
+                state=lambda: {
+                    "option_count": command_list.option_count,
+                    "calls": PROBE.calls,
+                },
+            )
+
+            await pilot.press("down", "enter")
+            await wait_until(
+                pilot,
+                lambda: not CommandPalette.is_open(app),
+                state=lambda: {
+                    "screen": type(app.screen).__name__,
+                    "calls": PROBE.calls,
+                },
+            )
+            await wait_until(
+                pilot,
+                lambda: PROBE.calls == ["second"],
+                state=lambda: {"calls": PROBE.calls},
+            )
+            await pilot.pause()
+            assert PROBE.calls == ["second"]
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()
+
+
+@pytest.mark.asyncio
+async def test_escape_closes_without_running_a_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(StableCommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            await pilot.press("l", "o", "g", "s")
+            await wait_event(PROBE.batch_waiting)
+            clock.advance()
+            PROBE.release_batch.set()
+            await wait_until(
+                pilot,
+                lambda: app.screen.query_one(CommandList).option_count == 3,
+                state=lambda: {
+                    "option_count": app.screen.query_one(CommandList).option_count,
+                    "calls": PROBE.calls,
+                },
+            )
+
+            await pilot.press("escape")
+            await wait_until(
+                pilot,
+                lambda: not CommandPalette.is_open(app),
+                state=lambda: {
+                    "screen": type(app.screen).__name__,
+                    "calls": PROBE.calls,
+                },
+            )
+            await pilot.pause()
+            assert PROBE.calls == []
         finally:
             PROBE.release_batch.set()
             PROBE.release_late.set()

--- a/Tests/UI/test_command_palette_selection_race.py
+++ b/Tests/UI/test_command_palette_selection_race.py
@@ -66,10 +66,10 @@ class ControlledProvider(Provider):
             yield Hit(0.90, "first", PROBE.callback("first"))
             yield Hit(0.80, "second", PROBE.callback("second"))
             PROBE.batch_waiting.set()
-            await PROBE.release_batch.wait()
+            await wait_event(PROBE.release_batch)
             yield Hit(0.70, "batch", PROBE.callback("batch"))
             PROBE.late_waiting.set()
-            await PROBE.release_late.wait()
+            await wait_event(PROBE.release_late)
             yield Hit(0.60, "late", PROBE.callback("late"))
         except asyncio.CancelledError:
             PROBE.cancelled.set()

--- a/Tests/UI/test_command_palette_selection_race.py
+++ b/Tests/UI/test_command_palette_selection_race.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.command import CommandList, CommandPalette, Hit, Provider
+from textual.pilot import Pilot
+from textual.widgets import Static
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float = 1.0) -> None:
+        self.now += seconds
+
+
+class PaletteProbe:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.release_batch = asyncio.Event()
+        self.release_late = asyncio.Event()
+        self.batch_waiting = asyncio.Event()
+        self.late_waiting = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    def callback(self, name: str) -> Callable[[], None]:
+        return lambda: self.calls.append(name)
+
+
+PROBE: PaletteProbe
+
+
+async def wait_event(event: asyncio.Event) -> None:
+    await asyncio.wait_for(event.wait(), timeout=1.0)
+
+
+async def wait_until(
+    pilot: Pilot[None],
+    predicate: Callable[[], bool],
+    *,
+    state: Callable[[], object],
+    attempts: int = 50,
+) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause()
+    pytest.fail(
+        f"mounted palette condition was not reached after {attempts} pauses; "
+        f"state={state()!r}"
+    )
+
+
+class ControlledProvider(Provider):
+    async def search(self, query: str) -> AsyncIterator[Hit]:
+        if query != "logs":
+            return
+        try:
+            yield Hit(0.90, "first", PROBE.callback("first"))
+            yield Hit(0.80, "second", PROBE.callback("second"))
+            PROBE.batch_waiting.set()
+            await PROBE.release_batch.wait()
+            yield Hit(0.70, "batch", PROBE.callback("batch"))
+            PROBE.late_waiting.set()
+            await PROBE.release_late.wait()
+            yield Hit(0.60, "late", PROBE.callback("late"))
+        except asyncio.CancelledError:
+            PROBE.cancelled.set()
+            raise
+
+
+class PaletteHarness(App[None]):
+    COMMANDS = {ControlledProvider}
+
+    def __init__(self, palette_type: type[CommandPalette]) -> None:
+        super().__init__()
+        self.palette_type = palette_type
+
+    def compose(self) -> ComposeResult:
+        yield Static("calling screen", id="calling-screen")
+
+    def on_mount(self) -> None:
+        self.push_screen(self.palette_type(id="--command-palette"))
+
+
+@pytest.mark.asyncio
+async def test_stock_palette_refresh_resets_a_navigated_highlight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global PROBE
+    PROBE = PaletteProbe()
+    clock = FakeClock()
+    monkeypatch.setattr("textual.command.monotonic", clock)
+
+    app = PaletteHarness(CommandPalette)
+    async with app.run_test() as pilot:
+        try:
+            await pilot.press("l", "o", "g", "s")
+            await wait_event(PROBE.batch_waiting)
+            clock.advance()
+            PROBE.release_batch.set()
+
+            command_list = app.screen.query_one(CommandList)
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 3,
+                state=lambda: {
+                    "option_count": command_list.option_count,
+                    "highlighted": command_list.highlighted,
+                    "late_waiting": PROBE.late_waiting.is_set(),
+                    "calls": PROBE.calls,
+                },
+            )
+            assert PROBE.late_waiting.is_set()
+
+            await pilot.press("down")
+            assert command_list.highlighted == 1
+            assert PROBE.calls == []
+
+            clock.advance()
+            PROBE.release_late.set()
+            await wait_until(
+                pilot,
+                lambda: command_list.option_count == 4,
+                state=lambda: {
+                    "option_count": command_list.option_count,
+                    "highlighted": command_list.highlighted,
+                    "calls": PROBE.calls,
+                },
+            )
+            assert command_list.highlighted == 0
+
+            await pilot.press("enter")
+            await wait_until(
+                pilot,
+                lambda: not CommandPalette.is_open(app),
+                state=lambda: {
+                    "screen": type(app.screen).__name__,
+                    "calls": PROBE.calls,
+                },
+            )
+            await wait_until(
+                pilot,
+                lambda: PROBE.calls == ["first"],
+                state=lambda: {"calls": PROBE.calls},
+            )
+            assert PROBE.calls == ["first"]
+        finally:
+            PROBE.release_batch.set()
+            PROBE.release_late.set()

--- a/Tests/UI/test_command_palette_selection_race.py
+++ b/Tests/UI/test_command_palette_selection_race.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator, Callable
 from importlib.util import find_spec
+from unittest.mock import MagicMock
 
 import pytest
 from textual.app import App, ComposeResult
@@ -11,6 +12,7 @@ from textual.pilot import Pilot
 from textual.widgets import Static
 from textual.widgets.option_list import Option
 
+from tldw_chatbook.app import TldwCli
 from tldw_chatbook.UI.stable_command_palette import StableCommandPalette
 
 
@@ -96,6 +98,40 @@ class PaletteHarness(App[None]):
 
 def test_stable_palette_api_exists() -> None:
     assert find_spec("tldw_chatbook.UI.stable_command_palette") is not None
+
+
+def test_tldw_cli_constructs_the_stable_palette(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = MagicMock()
+    app.use_command_palette = True
+    monkeypatch.setattr(StableCommandPalette, "is_open", lambda _app: False)
+
+    assert "action_command_palette" in TldwCli.__dict__
+    TldwCli.action_command_palette(app)
+
+    palette = app.push_screen.call_args.args[0]
+    assert type(palette) is StableCommandPalette
+    assert palette.id == "--command-palette"
+
+
+@pytest.mark.parametrize("enabled, already_open", [(False, False), (True, True)])
+def test_tldw_cli_does_not_open_a_duplicate_or_disabled_palette(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled: bool,
+    already_open: bool,
+) -> None:
+    app = MagicMock()
+    app.use_command_palette = enabled
+    monkeypatch.setattr(
+        StableCommandPalette,
+        "is_open",
+        lambda _app: already_open,
+    )
+
+    TldwCli.action_command_palette(app)
+
+    app.push_screen.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
+++ b/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
@@ -19,5 +19,5 @@ Observed during live TUI verification (2026-07-20, tmux-driven session): open th
 <!-- AC:BEGIN -->
 - [ ] #1 Reproduced (or ruled out) under a pilot-driven test: type a multi-hit query, Down+Enter while results are still refreshing
 - [ ] #2 If ours: highlighted command runs even when selection races the result refresh; if upstream: issue filed/linked and any feasible mitigation noted on this task
-- [ ] #3 A narrow app-side mitigation freezes the visible command list when the user navigates or selects it, so the acted-on command runs exactly once while provider results are still arriving
+- [ ] #3 A narrow app-side mitigation freezes an actionable visible command list on keyboard navigation or Enter/go-button selection, so the acted-on command runs exactly once while provider results are still arriving without blocking initial or replacement-query results
 <!-- AC:END -->

--- a/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
+++ b/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-397
 title: Command palette fast Down+Enter can dismiss without running the command
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-07-20 18:45'
+updated_date: '2026-08-20 15:25'
 labels: []
 dependencies: []
 ---
@@ -18,4 +19,5 @@ Observed during live TUI verification (2026-07-20, tmux-driven session): open th
 <!-- AC:BEGIN -->
 - [ ] #1 Reproduced (or ruled out) under a pilot-driven test: type a multi-hit query, Down+Enter while results are still refreshing
 - [ ] #2 If ours: highlighted command runs even when selection races the result refresh; if upstream: issue filed/linked and any feasible mitigation noted on this task
+- [ ] #3 A narrow app-side mitigation freezes the visible command list when the user navigates or selects it, so the acted-on command runs exactly once while provider results are still arriving
 <!-- AC:END -->

--- a/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
+++ b/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-397
 title: Command palette fast Down+Enter can dismiss without running the command
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-07-20 18:45'
-updated_date: '2026-08-20 15:25'
+updated_date: '2026-08-20 17:05'
 labels: []
 dependencies: []
 ---
@@ -17,13 +17,14 @@ Observed during live TUI verification (2026-07-20, tmux-driven session): open th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reproduced (or ruled out) under a pilot-driven test: type a multi-hit query, Down+Enter while results are still refreshing
-- [ ] #2 If ours: highlighted command runs even when selection races the result refresh; if upstream: issue filed/linked and any feasible mitigation noted on this task
-- [ ] #3 A narrow app-side mitigation freezes an actionable visible command list on keyboard navigation or Enter selection, so the acted-on command runs exactly once while provider results are still arriving without blocking initial or replacement-query results
+- [x] #1 Reproduced (or ruled out) under a pilot-driven test: type a multi-hit query, Down+Enter while results are still refreshing
+- [x] #2 If ours: highlighted command runs even when selection races the result refresh; if upstream: issue filed/linked and any feasible mitigation noted on this task
+- [x] #3 A narrow app-side mitigation freezes an actionable visible command list on keyboard navigation or Enter selection, so the acted-on command runs exactly once while provider results are still arriving without blocking initial or replacement-query results
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 Follow [the reviewed executable plan](../../Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md): characterize the stock Textual refresh race with a deterministic mounted harness, add the minimal actionable-snapshot compatibility subclass, wire `TldwCli` to that palette, run only related regression/static checks, file or link the upstream Textual issue, obtain cumulative review, and close the task only when every AC and DoD item has evidence.
 
 ADR required: no.
@@ -31,3 +32,55 @@ ADR required: no.
 ADR path: N/A.
 
 Reason: this localized compatibility shim preserves the existing provider and application boundaries and changes no storage, sync, security, dependency, or service contract.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a narrow compatibility boundary around Textual 8.2.8's asynchronous
+command-palette refresh behavior. A deterministic mounted Pilot test with provider
+gates and a fake batch clock proves that a late result rebuild resets a visible
+Down selection from the second command to the first and makes Enter run the first
+callback exactly once. The controlled ordering did not reproduce the original
+palette-dismisses-without-a-callback symptom, so the confirmed defect is reported
+as the narrower wrong-command race.
+
+- Added `StableCommandPalette`, which cancels gathering only when a keyboard list
+  action targets a visible, non-empty command list whose first option is not
+  Textual's disabled no-matches placeholder, then delegates to Textual unchanged.
+- Made `TldwCli.action_command_palette()` open that compatibility subclass with
+  Textual's canonical `--command-palette` ID and existing enabled/open guards.
+- Covered the stock reset, pending and settled exactly-once selection, gather
+  cancellation, pre-result navigation, stale no-matches replacement results,
+  Escape cancellation, and app construction/duplicate guards.
+- Reported the upstream framework behavior with a standalone deterministic
+  reproducer and the app-side workaround: [Textual issue #6701](https://github.com/Textualize/textual/issues/6701).
+- Final related matrix: `90 passed, 1 warning in 9.13s` across the race, basic,
+  provider, and shell-route palette tests. The warning is the environment's
+  pre-existing Requests dependency-version warning. Focused Ruff, Ruff format,
+  MyPy, compileall, and `git diff --check` all passed.
+- Core commits: `42ed24265` / `dc34d5ec3` (deterministic characterization),
+  `95ac8cd18` (stable palette), and `86fdebe88` (application integration).
+
+The deliberate tradeoff is that results arriving after the user starts navigating
+are omitted from that palette snapshot; changing the query or reopening the palette
+starts a fresh gather. No user-guide change was needed because the intended palette
+contract is unchanged. No lessons entry was warranted: the task followed the
+existing deterministic/non-vacuous testing guidance and did not uncover a new
+repository-wide trap.
+
+ADR required: no.
+
+ADR path: N/A.
+
+Reason: the exactly pinned framework compatibility shim preserves existing
+provider/application ownership and changes no durable architectural boundary.
+
+Independent cumulative review over merge base `1bf7f234e` through the implementation
+HEAD approved the protected Textual seam, guard behavior, deterministic tests,
+exactly-once callback contract, app construction, upstream-report honesty, scope,
+and this evidence record. Its sole P2 was a stale literal `origin/dev..HEAD` range in
+the closeout plan after `origin/dev` advanced by 93 commits; the plan now uses the
+merge-base-scoped range. Re-review approved the correction with no open P0-P2
+findings.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
+++ b/backlog/tasks/task-397 - Command-palette-fast-DownEnter-can-dismiss-without-running-the-command.md
@@ -19,5 +19,15 @@ Observed during live TUI verification (2026-07-20, tmux-driven session): open th
 <!-- AC:BEGIN -->
 - [ ] #1 Reproduced (or ruled out) under a pilot-driven test: type a multi-hit query, Down+Enter while results are still refreshing
 - [ ] #2 If ours: highlighted command runs even when selection races the result refresh; if upstream: issue filed/linked and any feasible mitigation noted on this task
-- [ ] #3 A narrow app-side mitigation freezes an actionable visible command list on keyboard navigation or Enter/go-button selection, so the acted-on command runs exactly once while provider results are still arriving without blocking initial or replacement-query results
+- [ ] #3 A narrow app-side mitigation freezes an actionable visible command list on keyboard navigation or Enter selection, so the acted-on command runs exactly once while provider results are still arriving without blocking initial or replacement-query results
 <!-- AC:END -->
+
+## Implementation Plan
+
+Follow [the reviewed executable plan](../../Docs/superpowers/plans/2026-08-20-task-397-command-palette-selection-race.md): characterize the stock Textual refresh race with a deterministic mounted harness, add the minimal actionable-snapshot compatibility subclass, wire `TldwCli` to that palette, run only related regression/static checks, file or link the upstream Textual issue, obtain cumulative review, and close the task only when every AC and DoD item has evidence.
+
+ADR required: no.
+
+ADR path: N/A.
+
+Reason: this localized compatibility shim preserves the existing provider and application boundaries and changes no storage, sync, security, dependency, or service contract.

--- a/tldw_chatbook/UI/stable_command_palette.py
+++ b/tldw_chatbook/UI/stable_command_palette.py
@@ -1,0 +1,17 @@
+"""Compatibility command palette with stable keyboard selection."""
+
+from textual.command import CommandList, CommandPalette
+
+
+class StableCommandPalette(CommandPalette):
+    """Freeze an actionable result snapshot when keyboard selection begins."""
+
+    def _action_command_list(self, action: str) -> None:
+        command_list = self.query_one(CommandList)
+        if (
+            self._list_visible
+            and command_list.option_count
+            and command_list.get_option_at_index(0).id != self._NO_MATCHES
+        ):
+            self._cancel_gather_commands()
+        super()._action_command_list(action)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -462,6 +462,7 @@ from .UI.Navigation.screen_registry import (
 from .UI.Navigation.shell_destinations import SHELL_DESTINATION_ORDER
 from .UI.Workbench.help import WorkbenchHelpPanel, WorkbenchHelpState
 from .UI.Screens.study_scope_models import StudyScopeContext
+from .UI.stable_command_palette import StableCommandPalette
 from .Prompt_Management.prompt_variables import PromptVariableApplication
 
 from .UI.Tools_Settings_Window import ToolsSettingsWindow  # noqa: E402
@@ -5182,6 +5183,11 @@ class TldwCli(
     """A Textual app for interacting with LLMs."""
 
     _runtime_policy_projection_snapshot: tuple[str, str | None] = ("local", None)
+
+    def action_command_palette(self) -> None:
+        """Open the app's stable Textual command palette."""
+        if self.use_command_palette and not StableCommandPalette.is_open(self):
+            self.push_screen(StableCommandPalette(id="--command-palette"))
 
     @property
     def current_runtime_backend(self) -> str:


### PR DESCRIPTION
## Summary
- characterize Textual 8.2.8 command-palette selection resets with a deterministic mounted test
- add a minimal StableCommandPalette compatibility shim that freezes an actionable keyboard snapshot
- wire TldwCli to the stable palette and document upstream Textual issue #6701

## Test plan
- 90 focused command-palette tests passed
- Ruff check and format check passed
- MyPy and compileall passed
- independent cumulative review approved with no open P0-P2 findings

## Upstream
- https://github.com/Textualize/textual/issues/6701

Closes TASK-397.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes command-palette selection by freezing the visible options once keyboard navigation begins. Previously, late `textual` provider refreshes reset the highlight, so Down+Enter could run the wrong command or close without running anything; now the selected command runs exactly once.

- Introduces `StableCommandPalette` overriding `_action_command_list` to call `_cancel_gather_commands` when the list is visible and not `_NO_MATCHES`, then delegates; no provider changes.
- Updates `TldwCli.action_command_palette()` to push `StableCommandPalette` (id `--command-palette`) with the existing enabled/open guards.
- Adds deterministic mounted tests covering stock `CommandPalette` reset vs. stable selection, early-navigation behavior, stale “No matches” handling, Escape, exactly-once callbacks, and app construction/duplicate-open guards.
- Connects to TASK-397 and links upstream `textual` issue 6701.

**Rollout**
- No migration or config changes.
- Side effect: results arriving after navigation start are omitted for that interaction; users can modify the query or reopen to refresh.

<sup>Written for commit fc62785c9313e54a6dcd0835d582ad060f986944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

