### PR TITLE
fix(packaging): unpin the migration probe from the schema tip (task-19044)

### DIFF
--- a/Tests/Packaging/test_installed_distribution.py
+++ b/Tests/Packaging/test_installed_distribution.py
@@ -74,6 +74,10 @@ MESSAGE_TRAJECTORY_MIGRATION_PATH = (
     "tldw_chatbook/DB/migrations/"
     "chachanotes_v37_to_v38_message_trajectory_metadata.sql"
 )
+TRANSCRIPT_ANNOTATIONS_MIGRATION_PATH = (
+    "tldw_chatbook/DB/migrations/"
+    "chachanotes_v39_to_v40_transcript_annotations.sql"
+)
 SAMIRA_RESOURCE_ROOT = "tldw_chatbook/assets/characters/samira"
 SAMIRA_REACTION_LABELS = (
     "admiration",
@@ -807,8 +811,12 @@ assert package_file.is_relative_to(expected_target), (package_file, expected_tar
 
 home_path = Path(os.environ["HOME"]).resolve(strict=True)
 migration_path = validate_path("installed-migration-probe.sqlite", home_path)
+# The migration target is read from the installed distribution inside this
+# child process -- never a hand-maintained literal (task-19044; the pinned
+# number went stale on two consecutive schema bumps). The only guard needed
+# is that the fixed v35 baseline below remains a genuine downgrade.
 current_schema_version = CharactersRAGDB._CURRENT_SCHEMA_VERSION
-assert current_schema_version == 40
+assert current_schema_version > 35
 CharactersRAGDB._CURRENT_SCHEMA_VERSION = 35
 try:
     legacy_db = CharactersRAGDB(migration_path, client_id="installed-probe-v35")
@@ -835,7 +843,7 @@ assert {
 } <= installed_tables
 assert "transcript_annotations" in installed_tables
 upgraded_db.close_connection()
-print("installed-wheel-v35-to-v40-ok")
+print(f"installed-wheel-v35-to-current-ok v{current_schema_version}")
 """
 
 INSTALLED_SAMIRA_PROBE = r"""
@@ -1523,7 +1531,7 @@ def test_built_artifacts_match_distribution_contract(
 
 
 @pytest.mark.parametrize("wheel_source", ["source", "sdist"])
-def test_installed_distribution_migrates_v35_database_to_v40(
+def test_installed_distribution_migrates_v35_database_to_current(
     built_distributions: BuiltDistributions,
     sdist_wheel: SdistWheel,
     tmp_path: Path,
@@ -1553,7 +1561,7 @@ def test_installed_distribution_migrates_v35_database_to_v40(
             env,
         )
 
-    assert "installed-wheel-v35-to-v40-ok" in result.stdout
+    assert "installed-wheel-v35-to-current-ok" in result.stdout
 
 
 def test_installed_wheel_loads_pinned_audio_cpp_artifact_manifest(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5335,3 +5335,42 @@ design has a cliff no threshold placement can fix; the durable resolution is
 one semantic at every size (the fix round retired the alignment tier and made
 the order-insensitive ratio the sole mechanism, with "a moved segment is not a
 change" as the documented decision), not a relocated boundary.
+
+## A probe left red on a stale trivial pin stops guarding — the real regression ships behind it (task-19044, 2026-08-20)
+
+The installed-migration probe (`Tests/Packaging/test_installed_distribution.py`,
+`INSTALLED_MIGRATION_PROBE`) proves a v35 ChaChaNotes DB migrates to the current
+schema under the *installed wheel*. It had been red since `4a2d48046` on pure
+test-health noise: a hand-bumped `assert current_schema_version == 39` pin plus
+a sentinel pair that same commit left self-inconsistent (probe printed
+`...-v35-to-v39-ok`, the outer test asserted `...-v35-to-v38-ok`, function named
+`..._to_v38`). Because the gate was already red on the pin, nobody could see
+what arrived behind it: the v39→v40 bump (`46945ebbe`) never added
+`chachanotes_v39_to_v40_transcript_annotations.sql` to
+`[tool.setuptools.package-data]` (`include-package-data = false`, explicit
+list), so **shipped wheels could not migrate an existing DB past v39 at all** —
+`_migrate_from_v39_to_v40` reads that SQL file from the installed package and
+died `FileNotFoundError → SchemaError`. The fix round proved this with a
+control: pyproject line reverted → probe red through the real chain
+(`Migration from V39 to V40 failed ... No such file or directory`); restored →
+green (`installed-wheel-v35-to-v38` run: 2 failed at the pin; fixed run:
+7 passed incl. both wheel sources and the release-checker mutation params).
+
+Two rules, both incident-backed here:
+
+1. **Every hand-bumped copy of a moving constant is a miss waiting for the
+   next bump — compare against the constant in the environment where the
+   assertion runs.** The probe already read
+   `CharactersRAGDB._CURRENT_SCHEMA_VERSION` *inside the child process against
+   the installed distribution* and asserted the migrated version equals it;
+   the literal pin added nothing but staleness. The same class hid in the
+   sentinel string pair and the test name (now version-agnostic
+   `..._to_current`). Sibling class to watch: a schema bump's packaging
+   contract spans four hand lists (pyproject package-data, both
+   `Packaging/check_manifest.py` sets, the test's `RUNTIME_MIGRATION_PATHS`)
+   — `46945ebbe` missed all four.
+2. **A known-red gate is a masked gate.** "That test is just stale on the
+   version pin" was true AND the reason a shipped production bug (installed
+   users bricked at v39→v40) went undetected for three days. Re-greening a
+   trivially-red probe is not cosmetics; until it runs green, everything it
+   guards is unguarded.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5370,7 +5370,7 @@ Two rules, both incident-backed here:
    `Packaging/check_manifest.py` sets, the test's `RUNTIME_MIGRATION_PATHS`)
    — `46945ebbe` missed all four.
 2. **A known-red gate is a masked gate.** "That test is just stale on the
-   version pin" was true AND the reason a shipped production bug (installed
-   users bricked at v39→v40) went undetected for three days. Re-greening a
-   trivially-red probe is not cosmetics; until it runs green, everything it
-   guards is unguarded.
+   version pin" was true AND the reason a production bug (any install built
+   from this tree could not migrate an existing DB past v39) sat undetected
+   from the v40 bump until this task. Re-greening a trivially-red probe is
+   not cosmetics; until it runs green, everything it guards is unguarded.

--- a/backlog/tasks/task-19044 - Packaging-migration-probe-pins-_CURRENT_SCHEMA_VERSION-39-red-at-dev-constant-is-40.md
+++ b/backlog/tasks/task-19044 - Packaging-migration-probe-pins-_CURRENT_SCHEMA_VERSION-39-red-at-dev-constant-is-40.md
@@ -3,7 +3,7 @@ id: TASK-19044
 title: >-
   Packaging migration probe pins _CURRENT_SCHEMA_VERSION == 39 — red at dev
   (constant is 40)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-20 08:40'
 labels:
@@ -37,7 +37,69 @@ migration chain reaches the current version) does not need the literal at all.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The installed-migration probe passes at current dev with no hand-maintained schema-version literal remaining in the file (owner ruling: durable over re-pinning the new number)
-- [ ] #2 The probe still proves what the literal stood in for: a v35 database migrates to whatever `_CURRENT_SCHEMA_VERSION` is, under the installed distribution
-- [ ] #3 The affected packaging test is demonstrated green at dev (run evidence, not collection)
+- [x] #1 The installed-migration probe passes at current dev with no hand-maintained schema-version literal remaining in the file (owner ruling: durable over re-pinning the new number)
+- [x] #2 The probe still proves what the literal stood in for: a v35 database migrates to whatever `_CURRENT_SCHEMA_VERSION` is, under the installed distribution
+- [x] #3 The affected packaging test is demonstrated green at dev (run evidence, not collection)
+- [x] #4 The v39→v40 migration SQL ships in the built distributions — discovered while making #1/#3 true: `chachanotes_v39_to_v40_transcript_annotations.sql` is absent from `[tool.setuptools.package-data]` (and from `Packaging/check_manifest.py` + the test's `RUNTIME_MIGRATION_PATHS` contract), so the installed migration chain cannot reach v40 regardless of how the probe asserts; the probe can only go green once the wheel/sdist actually carry the file
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Born-red evidence: run `Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_v38` unmodified at dev base and capture the `== 39` failure signature to a file.
+2. Probe fix (AC #1/#2): drop the `assert current_schema_version == 39` pin. The probe already reads `CharactersRAGDB._CURRENT_SCHEMA_VERSION` *inside the child process against the installed distribution* and asserts the upgraded DB's version equals it (line 818) — that comparison is the real proof and stays. Add `assert current_schema_version > 35` so the v35 downgrade-monkeypatch remains a genuine downgrade (35 is the fixed fixture baseline, not a moving pin).
+3. Same-class literals in the file: the sentinel pair is version-baked AND self-inconsistent since `4a2d48046` (probe prints `installed-wheel-v35-to-v39-ok`, outer test asserts `...-v38-ok`, function named `..._to_v38`). Make the sentinel version-agnostic (`installed-wheel-v35-to-current-ok`) in both places and rename the test `...migrates_v35_database_to_current`.
+4. Packaging gap (AC #4): add `chachanotes_v39_to_v40_transcript_annotations.sql` to `[tool.setuptools.package-data]` in `pyproject.toml` (the mechanism that carries the two prior migrations into both wheel and sdist; MANIFEST.in stops at v36→v37 for all of them), to both hand lists in `Packaging/check_manifest.py`, and as a `RUNTIME_MIGRATION_PATHS` row in the test so the release-checker mutation tests cover it.
+5. Green evidence: re-run the migration test (both wheel_source params) plus the release-checker tests that consume `RUNTIME_MIGRATION_PATHS`, output redirected to files, read in full.
+
+## Implementation Notes
+
+Rewrote the installed-migration probe to compare against the constant in the
+environment the assertion runs in, and fixed the real packaging regression the
+red probe had been masking.
+
+**Probe (AC #1/#2).** Deleted `assert current_schema_version == 39`. The probe
+already reads `CharactersRAGDB._CURRENT_SCHEMA_VERSION` inside the `python -c`
+child against the installed wheel and asserts the migrated DB's version equals
+it — that in-environment comparison is the proof and is unchanged. The only
+literal kept is `assert current_schema_version > 35`, guarding that the fixed
+v35 fixture baseline stays a genuine downgrade (35 is the fixture, not a
+moving pin).
+
+**Same-class literals in the file.** Commit `4a2d48046` had left the sentinel
+pair self-inconsistent — probe printed `installed-wheel-v35-to-v39-ok`, outer
+test asserted `...-v38-ok` (so the test was doubly red at dev), function named
+`..._to_v38`. All three are now version-agnostic: sentinel
+`installed-wheel-v35-to-current-ok v{current_schema_version}` (f-string
+resolved in the child), outer assert matches the version-agnostic prefix, test
+renamed `test_installed_distribution_migrates_v35_database_to_current`. Swept
+the repo for references to the old name/sentinels: none.
+
+**Shipped packaging bug (AC #4, discovered).** `46945ebbe` (v39→v40) never
+added `chachanotes_v39_to_v40_transcript_annotations.sql` to
+`[tool.setuptools.package-data]` (`include-package-data = false`), so built
+wheels/sdists did not carry it and `_migrate_from_v39_to_v40` — which reads
+that file from the installed package — failed `FileNotFoundError → SchemaError`:
+installed users could not migrate an existing DB past v39. Proven by control
+run (pyproject line reverted → probe red through the real chain; restored →
+green). Added the file to pyproject package-data, both hand lists in
+`Packaging/check_manifest.py`, and the test's `RUNTIME_MIGRATION_PATHS`
+(release-checker mutation coverage). MANIFEST.in intentionally untouched: the
+v37→v38/v38→v39 precedent ships via package-data alone, confirmed by the
+sdist-sourced param passing.
+
+**Run evidence** (all read from redirected files, venv + PYTHONPATH pinned to
+the worktree):
+- Born-red at dev base: `test_installed_distribution_migrates_v35_database_to_v38`
+  → 2 failed in 214.94s, child `AssertionError` at the `== 39` pin.
+- Fixed: 7 passed in 212.23s — migration probe `[source]` + `[sdist]`,
+  `test_built_artifacts_match_distribution_contract`,
+  `test_release_checker_accepts_fresh_artifacts`, probe-content test, and both
+  new release-checker mutation params for the v39→v40 file.
+- Control: pyproject line reverted → 2 failed in 61.12s
+  (`Migration from V39 to V40 failed ... No such file or directory`), line
+  restored (Edit-based).
+- `--collect-only`: 37 tests collected, no errors.
+
+**Files:** `Tests/Packaging/test_installed_distribution.py`, `pyproject.toml`,
+`Packaging/check_manifest.py`, `backlog/docs/lessons-testing-evidence.md`
+(new entry: a probe left red on a stale pin stops guarding), this task file.


### PR DESCRIPTION
## Summary
Closes task-19044. The installed-migration probe asserted `current_schema_version == 39` — red since the v40 bump, and the literal had been hand-bumped on every schema change (37→39 at `4a2d48046`). This PR removes every hand-maintained schema-version copy from the file: the probe now compares the migrated DB version against `_CURRENT_SCHEMA_VERSION` read inside the installed-distribution child, the sentinel is `installed-wheel-v35-to-current-ok v{N}`, and the test is `..._migrates_v35_database_to_current`. The only remaining literal is the `> 35` guard proving the fixture baseline stays a genuine downgrade.

While the probe sat red it was masking a real production bug — the v39→v40 migration SQL missing from `[tool.setuptools.package-data]`, so installs built from this tree could not migrate an existing DB past v39 (`FileNotFoundError → SchemaError`), proven by a control run through the real path. Dev healed the packaging half concurrently (`6e57cd79a` + pyproject), and this branch's rebase adopts dev's added `transcript_annotations` assert while keeping the version-agnostic probe — dev's version had re-pinned `== 40`, the exact anti-pattern this task removes.

## Evidence
- Born-red: both params failing in the child on `== 39` with the constant at 40 (base was doubly red — the outer sentinel assert also mismatched the probe's print).
- Post-rebase on current dev (`fa0268519`): **37 passed** full-file (6:30).

## Review
Independent review: **APPROVE** — production-bug chain verified end to end at base (pyproject state, `_migrate_from_v39_to_v40`'s runtime SQL read, the control-run failure signature), MANIFEST.in precedent confirmed (stops at v36→v37; package-data is the carrier), no remaining schema-version copies in the file or siblings, reviewer's own full-file run 37 passed. One doc nit (exposure-window phrasing in the lessons entry) applied pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unpins the installed-distribution migration probe from a hard-coded schema version and makes it version-agnostic. Previously the probe asserted == 39 and used version-baked sentinels, keeping the test red across bumps; it now matches the upgraded DB to `CharactersRAGDB._CURRENT_SCHEMA_VERSION` read from the installed wheel with only a > 35 guard.

- Renames the test and sentinel to "...to_current" and prints the actual target version; removes all hand-maintained schema numbers from the file.
- Adds the `transcript_annotations` presence check and the v39→v40 migration path constant to mirror the packaging state on `dev`.
- Outcome: future schema bumps need no test edits; any missing migration SQL in distributions will fail the probe instead of being masked.
- No runtime changes or rollout steps. Satisfies task-19044.

<sup>Written for commit 1dabfdaba89c4c14304c56628b6fc2cf9c2b45f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

