### PR TITLE
fix(ci): stop one failing realtime test from crashing both Core jobs (xdist DumpError)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         pytest Tests --ignore=Tests/UI \
           -n auto --dist loadscope --max-worker-restart=3 \
           --timeout=300 \
-          --json-report \
+          --json-report --json-report-omit log \
           --json-report-file=core-test-results-${{ matrix.os }}-${{ matrix.python-version }}.json
 
     - name: Upload test results
@@ -211,7 +211,7 @@ jobs:
           -n auto --dist loadscope --max-worker-restart=3 \
           --shard-id=${{ matrix.shard }} --num-shards=12 \
           --timeout=180 \
-          --json-report \
+          --json-report --json-report-omit log \
           --json-report-file=ui-test-results-${{ matrix.shard }}.json
 
     - name: Upload test results
@@ -290,7 +290,7 @@ jobs:
     - name: Run all tests
       run: |
         pytest ./Tests/ \
-          --json-report \
+          --json-report --json-report-omit log \
           --json-report-file=all-test-results.json \
           --cov=tldw_chatbook \
           --cov-report=xml:coverage-all.xml \
@@ -378,7 +378,7 @@ jobs:
         pytest ./Tests/ \
           --run-slow \
           --timeout=600 \
-          --json-report \
+          --json-report --json-report-omit log \
           --json-report-file=nightly-test-results-${{ matrix.os }}-${{ matrix.python-version }}.json \
           --cov=tldw_chatbook \
           --cov-report=xml:coverage-nightly-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -335,7 +335,7 @@ def test_nightly_deep_runs_the_tiers_the_pr_gate_does_not() -> None:
 def test_every_json_report_invocation_omits_log_capture() -> None:
     """Every ``--json-report`` MUST carry ``--json-report-omit log``.
 
-    Incident (2026-08-20, TASK-19003): pytest-json-report captures RAW
+    Incident (2026-08-20, TASK-19160): pytest-json-report captures RAW
     ``logging.LogRecord`` objects per test and attaches them to the report
     (``report._json_report_extra``). The websockets library logs through a
     ``LoggerAdapter`` whose extra carries the LIVE connection object, so when
@@ -350,20 +350,27 @@ def test_every_json_report_invocation_omits_log_capture() -> None:
     consumes the log section: ``generate_test_summary.py`` reads only
     ``tests[].outcome`` and ``call.longrepr``.
     """
-    text = _workflow_text()
+    # Join shell continuation lines into logical commands first, so the
+    # activation flag and its omit argument may legally sit on different
+    # physical lines; then accept every valid spelling of the omit
+    # ("--json-report-omit log", "--json-report-omit=log", comma lists).
+    logical = _workflow_text().replace("\\\n", " ")
     activations = 0
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        # The ACTIVATION flag is the standalone token "--json-report";
-        # "--json-report-file"/"--json-report-omit" are its arguments and
-        # appear as distinct tokens.
-        tokens = line.replace("\\", " ").split()
+    for command in logical.splitlines():
+        tokens = command.split()
         if "--json-report" not in tokens:
             continue
         activations += 1
-        assert "--json-report-omit" in tokens and "log" in tokens, (
-            f"test.yml line {line_number}: '--json-report' without "
-            f"'--json-report-omit log' — raw LogRecords in reports crash "
-            f"xdist workers (see docstring): {line.strip()!r}"
+        omits: list[str] = []
+        for index, token in enumerate(tokens):
+            if token == "--json-report-omit" and index + 1 < len(tokens):
+                omits.extend(tokens[index + 1].split(","))
+            elif token.startswith("--json-report-omit="):
+                omits.extend(token.split("=", 1)[1].split(","))
+        assert "log" in omits, (
+            f"test.yml: '--json-report' without log in '--json-report-omit' "
+            f"— raw LogRecords in reports crash xdist workers (see "
+            f"docstring): {command.strip()[:120]!r}"
         )
     assert activations >= 4, (
         f"expected at least 4 json-report activations (core, UI, full, "

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -330,3 +330,42 @@ def test_nightly_deep_runs_the_tiers_the_pr_gate_does_not() -> None:
     assert "-n auto" not in nightly  # serial on purpose: order-regression canary
     assert "windows-latest" in nightly
     assert "macos-latest" in nightly
+
+
+def test_every_json_report_invocation_omits_log_capture() -> None:
+    """Every ``--json-report`` MUST carry ``--json-report-omit log``.
+
+    Incident (2026-08-20, TASK-19003): pytest-json-report captures RAW
+    ``logging.LogRecord`` objects per test and attaches them to the report
+    (``report._json_report_extra``). The websockets library logs through a
+    ``LoggerAdapter`` whose extra carries the LIVE connection object, so when
+    a realtime test failed on the runner with DEBUG-level logging left on by
+    an earlier test in the same xdist worker, execnet hit
+    ``DumpError: can't serialize <class 'websockets...ServerConnection'>``
+    while shipping the report — killing the worker and aborting BOTH Core
+    jobs with INTERNALERROR. One flaky test nuked the whole job's results.
+
+    Reproduced deterministically (failing realtime test + ``--log-level=DEBUG``
+    + xdist + json-report) and verified fixed by the omit flag. Nothing
+    consumes the log section: ``generate_test_summary.py`` reads only
+    ``tests[].outcome`` and ``call.longrepr``.
+    """
+    text = _workflow_text()
+    activations = 0
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        # The ACTIVATION flag is the standalone token "--json-report";
+        # "--json-report-file"/"--json-report-omit" are its arguments and
+        # appear as distinct tokens.
+        tokens = line.replace("\\", " ").split()
+        if "--json-report" not in tokens:
+            continue
+        activations += 1
+        assert "--json-report-omit" in tokens and "log" in tokens, (
+            f"test.yml line {line_number}: '--json-report' without "
+            f"'--json-report-omit log' — raw LogRecords in reports crash "
+            f"xdist workers (see docstring): {line.strip()!r}"
+        )
+    assert activations >= 4, (
+        f"expected at least 4 json-report activations (core, UI, full, "
+        f"nightly); found {activations} — the pin may have gone inert"
+    )

--- a/backlog/tasks/task-19160 - One failing realtime test crashes both Core CI jobs via raw LogRecords in xdist reports.md
+++ b/backlog/tasks/task-19160 - One failing realtime test crashes both Core CI jobs via raw LogRecords in xdist reports.md
@@ -1,0 +1,80 @@
+---
+id: TASK-19160
+title: >-
+  One failing realtime test crashes both Core CI jobs via raw LogRecords in
+  xdist reports
+status: Done
+assignee: []
+created_date: '2026-08-20'
+labels: [ci, testing, triage]
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+Both Core Tests jobs on dev die with an xdist INTERNALERROR —
+`execnet.gateway_base.DumpError: can't serialize <class
+'websockets.asyncio.server.ServerConnection'>` — whenever a test in
+`Tests/LLM_Calls/test_openai_realtime_session.py` fails on the runner. The
+crash aborts the whole job's reporting, so every other suite's result in
+that job is garbage. This cluster is NOT in TASK-18610's pass-2 inventory;
+it postdates it (the realtime suite is new).
+
+**The mechanism, reproduced deterministically:**
+
+1. pytest-json-report's `_capture_log` stores **raw `logging.LogRecord`
+   objects** per test phase and attaches them to the report
+   (`report._json_report_extra`).
+2. The websockets library logs through a `LoggerAdapter` whose extra
+   carries the **live connection object**, so any captured websockets
+   record embeds a `ServerConnection`/`ClientConnection`.
+3. pytest-xdist serializes `report.__dict__` over execnet, which supports
+   only basic types → `DumpError` → the worker dies mid-test → the
+   controller hits `assert not crashitem` → INTERNALERROR.
+4. Precondition: log level permitting websockets records to reach the
+   handler. Locally the default WARNING filters them; in CI an earlier
+   test in the same `loadscope` worker leaves DEBUG on.
+
+Repro: force `test_connect_sends_session_update_and_fires_ready` to fail +
+`--log-level=DEBUG` + `-n 2 --dist loadscope --json-report` = the exact CI
+DumpError. Note the existing in-file guard (`_transport_safe_error`)
+covers only the handler's own exception path — the log-capture path walks
+around it entirely.
+
+## Acceptance Criteria (the what)
+
+- [x] The crash is reproduced locally with a named mechanism, not inferred
+      from CI logs
+- [x] Every `--json-report` activation in `.github/workflows/test.yml`
+      carries `--json-report-omit log` (core, UI shards, full suite,
+      nightly — 4 sites)
+- [x] The fix is verified under the exact crash conditions: same forced
+      failure + DEBUG + xdist + json-report now reports a clean `1 failed`
+      instead of an INTERNALERROR
+- [x] Nothing consumed the omitted section:
+      `.github/scripts/generate_test_summary.py` reads only
+      `tests[].outcome` and `call.longrepr`
+- [x] Pinned in the CI contract suite
+      (`test_every_json_report_invocation_omits_log_capture`), with an
+      inertness backstop (≥4 activations must be found) —
+      mutation-verified: removing one omit flag reds the pin
+
+## Implementation Notes
+
+One workflow change (4 lines) plus one contract pin. The alternative —
+filtering websockets' loggers in the realtime test module — was rejected
+because it fixes one library's records while leaving the class open: ANY
+test whose captured logs carry a non-serializable object kills its whole
+worker. Omitting log capture closes the class; the log section had no
+consumer.
+
+The repo-side guard already present in the test file
+(`_transport_safe_error`) was necessary but insufficient: it sanitizes
+exceptions the scripted handler catches, but the leak was in json-report's
+log capture, a path that never touches the handler's error field.
+
+**Files:** `.github/workflows/test.yml`,
+`Tests/CI/test_github_actions_test_workflow.py`.
+No production source changed. Realtime suite 36 passed; CI contract 15
+passed.


### PR DESCRIPTION
> Branch name says `19003`; the task is **TASK-19160** (id leapfrogged past 19060 after the branch was cut). Cosmetic only.

## The defect

Both Core Tests jobs on dev die with an xdist INTERNALERROR whenever a test in `Tests/LLM_Calls/test_openai_realtime_session.py` fails on the runner:

```
execnet.gateway_base.DumpError: can't serialize <class 'websockets.asyncio.server.ServerConnection'>
INTERNALERROR ... assert not crashitem
```

The worker dies mid-test and the **entire job's reporting is aborted** — every other suite's result in that job becomes garbage. This cluster is not in TASK-18610's pass-2 inventory; it postdates it.

## The mechanism — reproduced deterministically, not inferred

1. **pytest-json-report captures raw `logging.LogRecord` objects** per test phase and attaches them to the report (`report._json_report_extra`).
2. **websockets logs through a `LoggerAdapter` whose `extra` carries the live connection**, so any captured websockets record embeds a `ServerConnection`/`ClientConnection`.
3. **pytest-xdist serializes `report.__dict__` over execnet**, which supports only basic types → `DumpError` → worker crash → controller `assert not crashitem` → INTERNALERROR.
4. **Precondition is log level**: default WARNING filters websockets' records, which is why the suite passes locally. In CI, an earlier test in the same `loadscope` worker leaves DEBUG on.

Repro: force `test_connect_sends_session_update_and_fires_ready` to fail + `--log-level=DEBUG` + `-n 2 --dist loadscope --json-report` → the exact CI DumpError, on this machine.

Note: the test file's existing `_transport_safe_error` guard (which already knew about this serialization hazard) covers only the scripted handler's exception path — the log-capture path walks around it entirely.

## The fix

`--json-report-omit log` on **all four** json-report activations (core, UI shards, full suite, nightly).

- **Verified under the exact crash conditions**: the same forced-failure + DEBUG + xdist + json-report combination now reports a clean `1 failed` instead of an INTERNALERROR.
- **The omitted section had no consumer**: `generate_test_summary.py` reads only `tests[].outcome` and `call.longrepr`.
- **Why not filter websockets' loggers in the test module instead**: that fixes one library while leaving the class open — *any* test whose captured logs carry a non-serializable object kills its whole worker. Omitting log capture closes the class.

## The pin

`test_every_json_report_invocation_omits_log_capture` in the CI contract suite: every `--json-report` token must be accompanied by `--json-report-omit log`, with an inertness backstop (≥4 activations must be found, or the pin itself reds). **Mutation-verified**: removing one omit flag reds the pin; restoring greens it.

## Verification

Realtime suite: **36 passed**. CI contract suite: **15 passed**. No production source changed.

Refs TASK-19160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a failing realtime test from crashing both Core CI jobs. We now omit log capture in `pytest-json-report` so `pytest-xdist` no longer tries to serialize raw `LogRecord`s from `websockets`, which previously triggered an `execnet.DumpError` and aborted the job.

- Add `--json-report-omit log` to all four JSON report invocations in `.github/workflows/test.yml` (core, UI shards, full, nightly).
- Pin with `Tests/CI/test_github_actions_test_workflow.py::test_every_json_report_invocation_omits_log_capture`; fails if any omit is missing or if activations < 4. The pin now handles `--json-report-omit log`, `--json-report-omit=log`, comma lists, and flags split across `\`-continued lines. Docstring references TASK-19160.
- Mechanism addressed: `pytest-json-report` captured raw `logging.LogRecord`s; a `websockets` `LoggerAdapter` embedded a live connection; `pytest-xdist` via `execnet` could not serialize → worker crash → INTERNALERROR.
- Impact: JSON reports no longer include logs. No consumer used them (`generate_test_summary.py` reads only outcomes and `call.longrepr`). Console logs remain. No production code changed.
- Verified by reproducing the crash with DEBUG + xdist + JSON report and confirming clean failure reporting after the change. Refs TASK-19160.

<sup>Written for commit d828836ebe912fb5cc35954531f3d84b32b136f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

