### PR TITLE
fix(models): replace retired claude-3-haiku-20240307 request defaults (TASK-19048)

### DIFF
--- a/Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md
+++ b/Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md
@@ -172,7 +172,7 @@ await record_file_operation(
 
 ## Reference Configuration (Does Not Activate Hooks)
 
-`[tools].code_audit_enabled` was the historical System A registration flag; its install caller was deleted with System A. The `[audit]` block below was only proposed/example configuration in this guide, and the retained code consumes none of its keys. Instead, it hardcodes `max_records = 10000`, `model = "claude-3-haiku-20240307"`, `temp = 0.1`, and `max_tokens = 500`; it implements neither `analysis_timeout` nor the `enable_*` toggles. None of these reference settings wire the subsystem into the Console runtime.
+`[tools].code_audit_enabled` was the historical System A registration flag; its install caller was deleted with System A. The `[audit]` block below was only proposed/example configuration in this guide, and the retained code consumes none of its keys. Instead, it hardcodes `max_records = 10000`, `model = "claude-haiku-4-5"` (TASK-19048 replaced the retired `claude-3-haiku-20240307`), `temp = 0.1`, and `max_tokens = 500`; it implements neither `analysis_timeout` nor the `enable_*` toggles. None of these reference settings wire the subsystem into the Console runtime.
 
 ```toml
 [tools]

--- a/Docs/superpowers/plans/2026-08-20-task-19048-report.md
+++ b/Docs/superpowers/plans/2026-08-20-task-19048-report.md
@@ -1,0 +1,131 @@
+# TASK-19048 — Retired claude-3-haiku-20240307 survived as a live default in character_defaults, code_audit_tool, and the deprecated Tools_Settings_Window fallbacks
+
+**Branch:** `fix/task-19048-retired-model-ids` (from `origin/dev` `f79aa9082`)
+**Status:** complete — all 3 acceptance criteria met.
+
+---
+
+## 1. What was broken
+
+TASK-19020 fixed `summarize_with_anthropic`'s retired fallback and filed this
+follow-up for the three remaining sites that use `claude-3-haiku-20240307` as
+an **actual request model**. That id is retired on the wire: the API answers
+404 `not_found_error` (probe `req_011CeEDXZ8iS29MZCgyySwQa`, recorded during
+the TASK-18802/19020 runs). No new live leg was spent here — the 404 is on
+record, and the replacements' servedness was live-verified by 19020's runs
+(`claude-haiku-4-5`: rows 1 and 3 of its live table, wire model recorded,
+HTTP 200 with a real summary; `claude-sonnet-5`: row 4, live modern control).
+
+## 2. Per-site changes
+
+| Site | Old | New | Rationale |
+|---|---|---|---|
+| `tldw_chatbook/config.py:3841` — CONFIG_TOML template `[character_defaults] model` | `claude-3-haiku-20240307` | `claude-haiku-4-5` | The retired id's served successor in the same cheap-fast haiku lineage (19020 precedent; Anthropic's own deprecation table maps 3-haiku → haiku-4-5). Preserves the site's cheap-character-default intent; a tier change (e.g. sonnet) would be a product decision, not a retired-id repair. The adjacent comment demands the model exist in `[providers.Anthropic]` — `claude-haiku-4-5` is position 4 of that template list, and the new pin asserts the membership. |
+| `tldw_chatbook/Tools/code_audit_tool.py:141` — hardcoded analysis model | `claude-3-haiku-20240307` | `claude-haiku-4-5` | Same lineage; exactly matches the site's own `# fast model for quick analysis` comment. **Kept hardcoded, no config seam added**: per `Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md`, the `[audit]` config block was only ever proposed/example configuration, the retained code consumes none of its keys, and the subsystem is not wired into the Console runtime — adding a config read would be a redesign of a semi-dormant tool, which the task brief forbids. |
+| `tldw_chatbook/UI/Tools_Settings_Window.py:1044/2456/4116/5647` — character-defaults fallback/reset literals (DEPRECATED TASK-1346, nav-unreachable) | `claude-3-haiku-20240307` | `claude-haiku-4-5` | These four sites mirror `[character_defaults]` (compose fallbacks for `#general-character-model` / `#config-character-model` and their two reset handlers) — kept in lockstep with the template fix. |
+| `tldw_chatbook/UI/Tools_Settings_Window.py:4851` — `#config-anthropic-model` reset | `claude-3-haiku-20240307` | `claude-sonnet-5` | **The one site whose intent argues against the haiku lineage**: this reset restores the `[api_settings.anthropic]` form to shipped defaults, and the shipped template default there is `claude-sonnet-5` (temperature 0.7 and `ANTHROPIC_API_KEY` in the same reset handler match that template block). Resetting to haiku would diverge from the canonical default the button claims to restore. |
+| `Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md:175` | quoted the retired hardcoded model | quotes `claude-haiku-4-5` (with a TASK-19048 note) | The doc documents what the code hardcodes; kept accurate. |
+
+### AC #3 decision: update, not deletion
+
+Evidence-checked rather than assumed. **task-1346 is Done and explicitly chose
+NOT to delete the window** — its notes: deletion was "not trivially safe"
+(`app.py` module-level import + `IngestUiStyleChanged` handler +
+`Tests/UI/test_tools_settings_window.py` exercises it directly), so it was
+scoped with a DEPRECATED/migration banner instead. A board grep
+(`grep -rli tools_settings_window backlog/tasks/`) finds no deletion task —
+only 1346 (scoping, Done), 962 (its TOML save path), and the 19020/19048 pair.
+Deletion is neither executed nor planned, so the five literals were updated —
+they were one sed away, exactly as the task anticipated.
+
+## 3. Repo-wide re-sweep (on the branch base, f79aa9082)
+
+`grep -rn "claude-3-haiku-20240307"` across the repo. **No new request-path
+site appeared since the 19020 sweep.** The task's metadata-only exclusion list
+is still accurate:
+
+* `model_capabilities.py:104`, `config.py:4133`,
+  `Chat/console_session_settings.py:89`, `Utils/token_counter.py:344` —
+  capability/context-window maps that merely describe the id. Unchanged.
+* `config.py:2805/3178` — providers dropdown lists, tracked by task-3600.
+  Unchanged.
+* `model_capabilities.py:281` and `Summarization_General_Lib.py:1062` —
+  historical comments/docstrings citing the 404 probe. Unchanged.
+* Tests (`test_summarization_model_capabilities.py`,
+  `test_pricing_catalog.py:247` historical pricing row,
+  `test_anthropic_model_capabilities.py:270`,
+  `test_anthropic_native_tools.py:816`,
+  `test_console_provider_gateway.py:2549/2564`,
+  `test_console_session_settings.py:4059/4067`) — the id is fixture/pin data
+  (several deliberately pin *legacy-id* behavior). Unchanged.
+* **One occurrence not in the task's enumerated list:** repo-root
+  `config.toml:91` — `Anthropic = [...retired 3.x ids...]` inside a checked-in
+  **sample** config (`# Located at: ~/.config/tldw_cli/config.toml` header).
+  Classified metadata-only, same dropdown-list class as `config.py:2805/3178`
+  (task-3600's subject): it is a `[providers]` model list, not a request
+  default — the file's own `[character_defaults]` has no `model` key at all —
+  and the file is dead: nothing in `tldw_chatbook/`, `pyproject.toml`, or
+  `MANIFEST.in` references it (the historical `Config_Files/config.toml`
+  probe was removed from `config.py`, per its own comment). Not fixed here
+  (outside the ACs); flagged for the coordinator — if task-3600's dropdown fix
+  doesn't reach this dead sample, deleting or refreshing it is a separate
+  one-line cleanup.
+
+## 4. Evidence (all counts READ from pytest output)
+
+| Stage | Command | Result |
+|---|---|---|
+| Red (pins added, production untouched) | `pytest Tests/test_config_model_catalog_defaults.py Tests/Tools/test_code_audit_repoint.py Tests/test_probe_import_provenance.py -q -p no:randomly` | **2 failed, 8 passed** — both failed on the retired id, verbatim: `AssertionError: assert 'claude-3-haiku-20240307' == 'claude-haiku-4-5'` |
+| Green (after the swaps) | same | **10 passed** |
+| Config-defaults family + Tools + provenance | `pytest Tests/test_config_model_catalog_defaults.py Tests/test_config_console_defaults.py Tests/test_config_private_bootstrap.py Tests/test_config_stt_provider_probe.py Tests/test_config_rag_citation_defaults.py Tests/Tools/ Tests/test_probe_import_provenance.py -q -p no:randomly` | **701 passed, 0 failed** |
+| Touched UI module's suite + provenance | `pytest Tests/UI/test_tools_settings_window.py Tests/test_probe_import_provenance.py -q -p no:randomly` | **67 passed, 0 failed** (450s) |
+| Import sweep | `pytest Tests/ --collect-only -q -p no:randomly` | **52063 tests collected in 86.15s, 0 errors** (exit 0) |
+
+The two pins:
+
+* `test_character_defaults_template_model_is_currently_served`
+  (`Tests/test_config_model_catalog_defaults.py`) — parses
+  `CONFIG_TOML_CONTENT`, asserts `[character_defaults]` provider is Anthropic,
+  model is `claude-haiku-4-5`, **and** the model is a member of the template's
+  own `[providers].Anthropic` list (the adjacent comment's contract).
+* `test_request_llm_analysis_calls_chat_api_call_and_extracts_content`
+  (`Tests/Tools/test_code_audit_repoint.py`) — the existing wire-capture test
+  now also pins `captured["model"] == "claude-haiku-4-5"`.
+
+No pin was added for the deprecated window's literals: the surface is
+nav-unreachable and its module suite (67 tests) is green; the residual-grep
+table above is the evidence the literals are gone. No template-byte/SHA pin
+exists that the template edit could break (checked: the "literal bytes"
+comment at `config.py:4612` concerns the transcription-provider placeholder
+substitution only).
+
+Live-API leg: **deliberately not run** — 404 evidence and replacement
+servedness are already on record from 19020 (see §1); spending another live
+call would duplicate cited evidence.
+
+## 5. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 `[character_defaults]` template default names a currently-served model | met | `claude-haiku-4-5`; red→green template pin incl. providers-list membership; servedness cited from 19020 live rows 1/3 |
+| #2 code_audit_tool's hardcoded analysis model is currently served | met | `claude-haiku-4-5`; red→green wire-model pin |
+| #3 Deprecated Tools_Settings_Window fallbacks updated or deletion confirmed | met | Updated (deletion confirmed NOT planned — task-1346 scoped instead of deleting; board has no deletion task); 4 character sites → haiku-4-5, the anthropic-form reset → the shipped `claude-sonnet-5` default; window suite 67 passed |
+
+## 6. Filed, not fixed
+
+Nothing filed. The only candidate (repo-root `config.toml` stale sample, §3)
+is metadata-class, adjacent to task-3600's existing scope, and reported to the
+coordinator instead of minting a near-duplicate task.
+
+## 7. Notes for review
+
+* Concurrent-agent boundary respected: `settings_screen.py`,
+  `provider_continuation.py`, `console_chat_controller.py`, and `moonshot.py`
+  untouched (verified by the diff — only the 7 files listed in the commit).
+* The window's `#general-character-model` placeholder text still says
+  "e.g., claude-3-haiku, gpt-3.5-turbo" — display-only example shorthand (not
+  the retired full id, not a request value) in a deprecated surface; left
+  outside this fix's scope.
+* No lessons entry: nothing generalisable surfaced beyond what
+  lessons-backlog-hygiene already records (the 5-digit-id CLI edit trap was
+  routed around by editing the task file directly, per the existing entry).

--- a/Tests/Tools/test_code_audit_repoint.py
+++ b/Tests/Tools/test_code_audit_repoint.py
@@ -27,6 +27,12 @@ def test_request_llm_analysis_calls_chat_api_call_and_extracts_content():
     assert captured["messages_payload"] == [
         {"role": "user", "content": "analyze this code"}
     ]
+    # TASK-19048: the analysis model must be currently served. The former
+    # hardcoded claude-3-haiku-20240307 is RETIRED on the wire (404
+    # not_found_error, probe req_011CeEDXZ8iS29MZCgyySwQa); claude-haiku-4-5
+    # is its served successor in the same cheap-fast lineage (TASK-19020
+    # precedent), preserving the site's "fast model for quick analysis" intent.
+    assert captured["model"] == "claude-haiku-4-5"
     assert captured["streaming"] is False
     assert "timeout" not in captured  # dropped — chat_api_call has no timeout param
 

--- a/Tests/test_config_model_catalog_defaults.py
+++ b/Tests/test_config_model_catalog_defaults.py
@@ -109,6 +109,23 @@ def test_bundled_provider_defaults_use_current_models():
         assert API_MODELS_BY_PROVIDER[provider] == providers[provider]
 
 
+def test_character_defaults_template_model_is_currently_served():
+    """TASK-19048: the shipped [character_defaults] default must be a served model.
+
+    The former default ``claude-3-haiku-20240307`` is RETIRED on the wire
+    (404 not_found_error, probe req_011CeEDXZ8iS29MZCgyySwQa), so a fresh
+    install's persona/character calls targeted a dead model. The replacement
+    is the retired id's served successor in the same cheap-fast haiku lineage
+    (TASK-19020 precedent). The template's own comment demands the model exist
+    in [providers.Anthropic], so that membership is pinned too.
+    """
+    parsed = tomllib.loads(CONFIG_TOML_CONTENT)
+    character_defaults = parsed["character_defaults"]
+    assert character_defaults["provider"] == "Anthropic"
+    assert character_defaults["model"] == "claude-haiku-4-5"
+    assert character_defaults["model"] in parsed["providers"]["Anthropic"]
+
+
 def test_load_settings_uses_current_models_when_legacy_api_models_are_omitted(
     tmp_path, monkeypatch
 ):

--- a/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
+++ b/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
@@ -4,7 +4,7 @@ title: >-
   Retired claude-3-haiku-20240307 survives as a live default in
   character_defaults, code_audit_tool, and deprecated Tools_Settings_Window
   fallbacks
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-20 15:46'
@@ -23,9 +23,9 @@ TASK-19020 replaced the retired claude-3-haiku-20240307 fallback in summarize_wi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The shipped [character_defaults] template default names a currently-served Anthropic model
-- [ ] #2 code_audit_tool's hardcoded analysis model is a currently-served model
-- [ ] #3 The deprecated Tools_Settings_Window fallbacks are updated or the surface's deletion is confirmed as covering them
+- [x] #1 The shipped [character_defaults] template default names a currently-served Anthropic model
+- [x] #2 code_audit_tool's hardcoded analysis model is a currently-served model
+- [x] #3 The deprecated Tools_Settings_Window fallbacks are updated or the surface's deletion is confirmed as covering them
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -38,3 +38,15 @@ TASK-19020 replaced the retired claude-3-haiku-20240307 fallback in summarize_wi
 5. Green + targeted gate with READ counts: the two touched test files + Tests/UI/test_tools_settings_window.py + Tests/test_probe_import_provenance.py. No live-API leg: the 404 is on record (req_011CeEDXZ8iS29MZCgyySwQa) and claude-haiku-4-5/claude-sonnet-5 servedness was live-verified by 19020's runs (rows 1, 3, 4).
 6. Hygiene: tick ACs, Implementation Notes, Done; report; PR against dev.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All three request-path sites replaced; branch fix/task-19048-retired-model-ids, report Docs/superpowers/plans/2026-08-20-task-19048-report.md.
+
+- config.py:3841 ([character_defaults] template default) and Tools/code_audit_tool.py:141 (hardcoded analysis model) -> claude-haiku-4-5, the retired id's served successor in the same cheap-fast haiku lineage (TASK-19020 precedent; both sites' cheap/fast intent matches, and the template's own [providers.Anthropic] list already carries the id). code_audit stays hardcoded — the [audit] config block was only ever proposed/example config and the tool is not wired into the Console runtime, so a config seam would be a redesign, not a repair.
+- UI/Tools_Settings_Window.py (DEPRECATED TASK-1346, nav-unreachable): updated, not deleted — task-1346 (Done) explicitly scoped the window with a deprecation banner INSTEAD of deleting ("not trivially safe": app.py module import + tests exercise it), and no deletion task exists on the board. The four character-defaults sites (1044/2456/4116/5647) -> claude-haiku-4-5 in lockstep with the template; the one [api_settings.anthropic] reset (4851) -> claude-sonnet-5, matching the shipped template default that reset restores (its sibling resets — ANTHROPIC_API_KEY, temperature 0.7 — mirror the same template block).
+- Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md updated where it quoted the hardcoded model.
+- Evidence (READ counts): red 2 failed 8 passed (both on the retired id) -> green 10 passed; config-defaults family + Tests/Tools/ + provenance 701 passed; Tests/UI/test_tools_settings_window.py + provenance 67 passed; collect-only sweep 52063 collected, 0 errors. No live leg spent: the 404 (req_011CeEDXZ8iS29MZCgyySwQa) and the replacements' servedness were already live-verified by 19020's runs.
+- Repo-wide re-sweep on the base: no new request-path site; exclusion list still accurate. One extra metadata occurrence flagged (repo-root config.toml:91, a dead checked-in sample's providers dropdown list — task-3600's class), reported, not filed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
+++ b/backlog/tasks/task-19048 - Retired-claude-3-haiku-20240307-survives-as-a-live-default-in-character_defaults-code_audit_tool-and-deprecated-Tools_Settings_Window-fallbacks.md
@@ -4,8 +4,9 @@ title: >-
   Retired claude-3-haiku-20240307 survives as a live default in
   character_defaults, code_audit_tool, and deprecated Tools_Settings_Window
   fallbacks
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-20 15:46'
 labels:
   - llm
@@ -26,3 +27,14 @@ TASK-19020 replaced the retired claude-3-haiku-20240307 fallback in summarize_wi
 - [ ] #2 code_audit_tool's hardcoded analysis model is a currently-served model
 - [ ] #3 The deprecated Tools_Settings_Window fallbacks are updated or the surface's deletion is confirmed as covering them
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-verify the metadata-only exclusion list with a repo-wide grep on the branch base (f79aa9082); confirm no new request-path site appeared since the 19020 sweep.
+2. Decide the Tools_Settings_Window question with evidence: check task-1346's state and the board for a deletion task. (Found: 1346 is Done and explicitly scoped the window with a deprecation banner INSTEAD of deleting — deletion was "not trivially safe"; no deletion task exists. So update the 5 literals.)
+3. Red-first pins: template parse pin in Tests/test_config_model_catalog_defaults.py ([character_defaults] model is claude-haiku-4-5 and present in the template's own [providers].Anthropic list, per the adjacent comment); code_audit wire-model pin in Tests/Tools/test_code_audit_repoint.py (captured model == claude-haiku-4-5). Run red, READ counts.
+4. Fix: config.py:3841 and code_audit_tool.py:141 -> claude-haiku-4-5 (haiku-lineage successor per 19020 precedent; both sites' cheap-fast intent matches). Tools_Settings_Window character sites (1044/2456/4116/5647) -> claude-haiku-4-5 (they mirror [character_defaults]); site 4851 -> claude-sonnet-5 (it resets the [api_settings.anthropic] form, whose shipped template default is claude-sonnet-5 — the haiku lineage would diverge from the canonical default this reset restores). Update the stale hardcoded-model mention in Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md.
+5. Green + targeted gate with READ counts: the two touched test files + Tests/UI/test_tools_settings_window.py + Tests/test_probe_import_provenance.py. No live-API leg: the 404 is on record (req_011CeEDXZ8iS29MZCgyySwQa) and claude-haiku-4-5/claude-sonnet-5 servedness was live-verified by 19020's runs (rows 1, 3, 4).
+6. Hygiene: tick ACs, Implementation Notes, Done; report; PR against dev.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Tools/code_audit_tool.py
+++ b/tldw_chatbook/Tools/code_audit_tool.py
@@ -138,7 +138,7 @@ Focus on detecting deception and incomplete implementations, not just syntax err
                 chat_api_call,
                 api_endpoint="anthropic",
                 messages_payload=[{"role": "user", "content": prompt}],
-                model="claude-3-haiku-20240307",  # fast model for quick analysis
+                model="claude-haiku-4-5",  # fast model for quick analysis
                 temp=0.1,  # low temperature for consistent analysis
                 max_tokens=500,
                 streaming=False,

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -1041,7 +1041,7 @@ class ToolsSettingsWindow(Container):
 
                     yield Label("Model:", classes="settings-label")
                     yield Input(
-                        value=character_config.get("model", "claude-3-haiku-20240307"),
+                        value=character_config.get("model", "claude-haiku-4-5"),
                         id="general-character-model",
                         classes="settings-input",
                         placeholder="e.g., claude-3-haiku, gpt-3.5-turbo",
@@ -2453,7 +2453,7 @@ class ToolsSettingsWindow(Container):
         widgets.append(Label("Default Model:", classes="form-label"))
         widgets.append(
             Input(
-                value=char_config.get("model", "claude-3-haiku-20240307"),
+                value=char_config.get("model", "claude-haiku-4-5"),
                 id="config-character-model",
                 placeholder="Enter model name",
             )
@@ -4113,7 +4113,7 @@ class ToolsSettingsWindow(Container):
             ).value = default_char_provider
             self.query_one(
                 "#general-character-model", Input
-            ).value = "claude-3-haiku-20240307"
+            ).value = "claude-haiku-4-5"
             self.query_one("#general-character-temperature", Input).value = "0.8"
 
             # Reset Encryption
@@ -4848,7 +4848,7 @@ class ToolsSettingsWindow(Container):
             self.query_one("#config-anthropic-api-key", Input).value = "<API_KEY_HERE>"
             self.query_one(
                 "#config-anthropic-model", Input
-            ).value = "claude-3-haiku-20240307"
+            ).value = "claude-sonnet-5"
             self.query_one("#config-anthropic-temperature", Input).value = "0.7"
 
             self.app_instance.notify("API configuration reset to defaults!")
@@ -5644,7 +5644,7 @@ class ToolsSettingsWindow(Container):
             self.query_one("#config-character-provider", Select).value = "Anthropic"
             self.query_one(
                 "#config-character-model", Input
-            ).value = "claude-3-haiku-20240307"
+            ).value = "claude-haiku-4-5"
             self.query_one(
                 "#config-character-system-prompt", TextArea
             ).text = "You are roleplaying as a witty pirate captain."

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3838,7 +3838,7 @@ api_key = "<API_KEY_HERE>"
 [character_defaults]
 # Default settings specifically for the 'Character' tab
 provider = "Anthropic"
-model = "claude-3-haiku-20240307" # Make sure this exists in [providers.Anthropic]
+model = "claude-haiku-4-5" # Make sure this exists in [providers.Anthropic]
 system_prompt = "You are roleplaying as a witty pirate captain."
 temperature = 0.8
 top_p = 0.9


### PR DESCRIPTION
## Summary

The Anthropic API answers 404 `not_found_error` for `claude-3-haiku-20240307` (probe `req_011CeEDXZ8iS29MZCgyySwQa`, from the TASK-18802/19020 runs). TASK-19020 fixed the summarization fallback and filed TASK-19048 for the three sites still using the retired id as an actual request model. This PR closes it.

## Per-site changes

- **`config.py` CONFIG_TOML template `[character_defaults] model`** → `claude-haiku-4-5` — the retired id's served successor in the same cheap-fast haiku lineage (19020 precedent); present in the template's own `[providers.Anthropic]` list, so the adjacent "Make sure this exists" comment stays true (now pinned).
- **`Tools/code_audit_tool.py` hardcoded analysis model** → `claude-haiku-4-5` — matches the site's "fast model for quick analysis" intent. Kept hardcoded (no config seam): the `[audit]` block was only ever proposed/example config and the tool is not wired into the Console runtime; adding a config read would be a redesign, not a repair.
- **`UI/Tools_Settings_Window.py` ×5 (DEPRECATED TASK-1346, nav-unreachable)** — updated, not deleted: task-1346 (Done) explicitly scoped the window with a deprecation banner INSTEAD of deleting ("not trivially safe": `app.py` module import + tests exercise it), and no deletion task exists on the board. The four character-defaults fallback/reset literals → `claude-haiku-4-5` in lockstep with the template; the one `[api_settings.anthropic]` reset → `claude-sonnet-5`, matching the shipped template default that reset restores.
- **`Docs/Development/Agent-Tools/Claude_Code_File_Audit_System.md`** — updated where it quoted the hardcoded model.

## Evidence (counts read from pytest output)

- Red-first pins (template parse + code_audit wire model): **2 failed, 8 passed** — both on the retired id (`assert 'claude-3-haiku-20240307' == 'claude-haiku-4-5'`) → **10 passed** after the swaps.
- Config-defaults family + `Tests/Tools/` + provenance probe: **701 passed, 0 failed**.
- `Tests/UI/test_tools_settings_window.py` + provenance: **67 passed, 0 failed**.
- Import sweep: `pytest Tests/ --collect-only -q` → **52063 collected, 0 errors**.
- No live-API leg spent: the 404 is on record and the replacements' servedness was live-verified by TASK-19020's runs (haiku-4-5 wire-recorded 200s; sonnet-5 live control).

## Re-sweep

Repo-wide grep on the branch base: no new request-path site since the 19020 sweep; the task's metadata-only exclusion list is still accurate. One extra metadata occurrence flagged in the report (repo-root `config.toml:91`, a dead checked-in sample's providers dropdown list — task-3600's class), reported rather than filed.

Full report: `Docs/superpowers/plans/2026-08-20-task-19048-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces retired Anthropic model `claude-3-haiku-20240307` to prevent 404s from default requests. Defaults now use served successors: character defaults and the code audit tool use `claude-haiku-4-5`; the Anthropic API settings reset uses `claude-sonnet-5` to match the shipped template.

- Satisfies TASK-19048: replaced the model in all three request paths (config template, `code_audit_tool`, and deprecated Tools Settings fallbacks).
- Tests pin the new defaults (template parse and audit wire-model); suite passes. Docs updated where the hardcoded model is quoted.
- No migration required: existing installs only change behavior when using shipped defaults or pressing “reset.”

<sup>Written for commit 277e7b6db1929a22279b9c412c0ad244f60d548a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

