### PR TITLE
test: settle on structure existence, not structure samples, in STTS view-switch waits (task-19047)

### DIFF
--- a/Tests/UI/test_stts_profile_library.py
+++ b/Tests/UI/test_stts_profile_library.py
@@ -929,6 +929,23 @@ async def _open_stts_view(
     await pilot.pause()
 
 
+def _profile_table_row_count(app: App[Any]) -> int | None:
+    """The profiles table's row count, or None while the view swap is mid-flight.
+
+    `STTSWindow.watch_current_view` replaces the body in a `speech-view-mount`
+    worker, so right after `current_view` is assigned the table may not exist
+    yet. Its existence is therefore part of the condition being settled on,
+    not a precondition: an unguarded `query_one` inside the predicate raised
+    `NoMatches` straight out of `_wait_until`'s first poll whenever the mount
+    worker had not run yet -- reproduced 13/13 under CPU load (task-19047).
+    """
+    try:
+        table = app.query_one("#stts-profile-table", DataTable)
+    except QueryError:
+        return None
+    return table.row_count
+
+
 async def _select_action_profile(
     app: _ActionHost,
     pilot: Any,
@@ -936,10 +953,7 @@ async def _select_action_profile(
     await _open_stts_view(app, pilot, "profiles")
     await _wait_until(
         pilot,
-        lambda: (
-            len(app.query("#stts-profile-table")) == 1
-            and app.query_one("#stts-profile-table", DataTable).row_count == 1
-        ),
+        lambda: _profile_table_row_count(app) == 1,
     )
     table = app.query_one("#stts-profile-table", DataTable)
     table.move_cursor(row=0)
@@ -1034,6 +1048,23 @@ async def _wait_availability_projected(app: App[Any], pilot: Any) -> None:
     """
     preview = app.query_one("#stts-profile-preview-btn", Button)
     await _wait_until(pilot, lambda: str(preview.label) != "Checking")
+
+
+def _stts_content_first_child(app: App[Any]) -> Widget | None:
+    """The first mounted child of the STTS body, or None mid-swap.
+
+    `STTSWindow._mount_view_unlocked` awaits `remove_children()` and then
+    `mount(...)`, so the body container is observably EMPTY between the two
+    awaits. Indexing `children[0]` inside a `_wait_until` predicate raised
+    IndexError out of the poll whenever it landed in that window --
+    reproduced 3x under 20-burner CPU load (task-19047). The container's
+    emptiness is part of the condition being settled on, not a precondition.
+    """
+    try:
+        children = app.query_one(".stts-content").children
+    except QueryError:
+        return None
+    return children[0] if children else None
 
 
 def _playground_is_mounted(app: App[Any]) -> bool:
@@ -1160,12 +1191,23 @@ async def test_audiobook_kokoro_blend_group_is_not_a_keyboard_select_option(
         # actually does and fails loudly (not silently, late) if it never
         # does.
         provider_select = app.query_one("#audiobook-provider-select", Select)
-        for _ in range(100):
-            if provider_select.value == "openai":
-                break
-            await pilot.pause()
-        else:
-            raise AssertionError("mount-time provider default never settled")
+        await _wait_until(pilot, lambda: provider_select.value == "openai")
+        # The value flip happens inside the timer callback itself, but the
+        # narrator-options rewrite rides the Select.Changed MESSAGE that the
+        # assignment posts -- still queued when the poll above returns. The
+        # openai option list is identical to the compose-time one, so the
+        # narrator select cannot witness that cascade landing; the sibling
+        # @on(Select.Changed) handler writing `provider` onto the (faked)
+        # character-voice widget runs in the same dispatch step and can.
+        # Without this settle, the queued rewrite landed AFTER the kokoro
+        # switch below and silently restored the openai options -- reproduced
+        # under 14-burner CPU load: the keyboard path then landed on
+        # 'shimmer', the LAST OPENAI option (task-19047).
+        voice_widget = app.query_one("#character-voice-widget")
+        await _wait_until(
+            pilot,
+            lambda: getattr(voice_widget, "provider", None) == "openai",
+        )
 
         widget._update_voice_options("kokoro")
         narrator = app.query_one("#narrator-voice-select", Select)
@@ -2865,10 +2907,7 @@ async def test_switching_stts_view_dismisses_owned_profile_modal_and_worker(
         await _wait_until(pilot, lambda: not isinstance(app.screen, modal_type))
         await _wait_until(
             pilot,
-            lambda: isinstance(
-                app.query_one(".stts-content").children[0],
-                SpeechSettingsPane,
-            ),
+            lambda: isinstance(_stts_content_first_child(app), SpeechSettingsPane),
         )
         await _wait_until(
             pilot,

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5409,3 +5409,39 @@ other sessions fetch into, `origin/dev` at probe time is routinely not
 `origin/dev` at branch time; (2) `git log --oneline -1` inside the probe is
 part of the probe -- a comparison whose two arms' commits were never printed
 has not established which code either arm ran.
+
+## A settle whose predicate can RAISE is still a one-shot sample — and a value flip is not its message cascade (task-19047, 2026-08-20)
+
+Follow-up to the pilot.pause() entry above: `_wait_until`-style condition polls
+only settle what their predicate can *survive observing*. Two incidents from
+the same file, both reproduced under CPU-burner load before patching:
+
+1. **Raising predicates.** `test_switching_stts_view_dismisses_owned_profile_
+   modal_and_worker` polled `app.query_one("#stts-profile-table").row_count
+   == 1` right after assigning `current_view` — but `STTSWindow.watch_current_
+   view` swaps the body in a `speech-view-mount` worker, so the table's
+   *existence* is part of the condition, and the unguarded query raised
+   `NoMatches` straight out of the FIRST poll (13/13 failing instances under
+   load). Same class one step later: `.children[0]` in a predicate raised
+   `IndexError` inside the observable empty window between `await
+   remove_children()` and `await mount(...)` (3 reproductions at 20 burners —
+   which only fired AFTER the first shape was fixed; catalogue shapes by
+   re-running the load loop after each repair, since the first raise masks
+   everything behind it). A predicate that throws mid-transition is a one-shot
+   structural sample wearing a settle's clothes: predicates must return False
+   while the structure is absent (guard the query, index only non-empty).
+2. **Value-flip settles under-wait their cascade.** The kokoro-blend audiobook
+   test settled on `provider_select.value == "openai"` — but that flips inside
+   the timer callback, while the narrator-options rewrite rides the queued
+   `Select.Changed` message. Under load the queued rewrite landed AFTER the
+   test's own `_update_voice_options("kokoro")` and silently restored the
+   openai list; the keyboard walk then honestly selected `shimmer`, the LAST
+   OPENAI option — a failure that *looks* like broken key handling and is
+   actually a wiped precondition. Trap on top: the cascade's output (openai
+   options) was byte-identical to the compose-time options, so the watched
+   widget itself could never witness the cascade landing; the settle had to
+   target a DIFFERENT observable of the same dispatch step (a sibling
+   `@on(Select.Changed)` handler's attribute write on a test-faked widget).
+   When a reactive assignment's effects arrive by message, settle on the
+   cascade's own output — and if that output is indistinguishable from the
+   initial state, find any other observable the same dispatch step produces.

--- a/backlog/tasks/task-19047 - stts_profile_library-view-switch-dismissal-test-still-flakes-under-CPU-load-outside-16842s-fix.md
+++ b/backlog/tasks/task-19047 - stts_profile_library-view-switch-dismissal-test-still-flakes-under-CPU-load-outside-16842s-fix.md
@@ -3,8 +3,9 @@ id: TASK-19047
 title: >-
   stts_profile_library view-switch dismissal test still flakes under CPU load
   (outside 16842's family fix)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-20 08:40'
 labels:
   - test-health
@@ -34,9 +35,108 @@ backlog/tasks at dev). Likely another settle-on-asserted-state candidate; the
 diagnosis must come from a load reproduction, not from reading the test.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce first, no speculative patch: run the target test (both
+   parametrizations) and the full file repeatedly under 14 parallel CPU
+   burners (the 16842 lessons recipe: one busy-loop process per logical
+   core), output captured to files; identify the exact failing assertion
+   and save its signature.
+2. Root-cause the mechanism from the reproduction against the test's
+   remaining one-shot shapes (the `pilot.click` before the modal wait; the
+   `voice_profile_action` worker census + `not is_finished` assert sampled
+   immediately after the modal wait).
+3. Fix strictly per the 16842 idiom: wall-clock-bounded `_wait_until`
+   settles polling the actual asserted condition; no fixed pauses, no
+   attempt-count waits. Preserve the pinned contract exactly: switching
+   the S/TT/S view dismisses the owned modal AND finishes its worker —
+   do not weaken the census (exactly one live worker at modal-open) or
+   the finished-after-switch assertion.
+4. If the reproduction shows a product bug (e.g. the worker genuinely
+   survives the view switch under load), capture evidence, do NOT patch
+   the product (sibling task 19043 owns Event_Handlers/TTS_Events +
+   app.py), and report for routing.
+5. Post-fix evidence at 16842's bar: repeated full-file runs green
+   including runs under the same 14-burner load, plus repeated standalone
+   runs of this test; record exact counts. ruff check + format on the
+   touched file. Kill all burners when done.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The failure is reproduced under load first (the 16842 lessons entry's CPU-burner recipe) and the exact failing assertion identified — no speculative patch
-- [ ] #2 The fix follows the established 16842 idiom: wall-clock-bounded waits polling the asserted condition itself; no new fixed pauses or attempt-count waits
-- [ ] #3 Post-fix evidence meets 16842's bar: repeated full-file runs green including runs under the same load, plus standalone runs of this test
+- [x] #1 The failure is reproduced under load first (the 16842 lessons entry's CPU-burner recipe) and the exact failing assertion identified — no speculative patch
+- [x] #2 The fix follows the established 16842 idiom: wall-clock-bounded waits polling the asserted condition itself; no new fixed pauses or attempt-count waits
+- [x] #3 Post-fix evidence meets 16842's bar: repeated full-file runs green including runs under the same load, plus standalone runs of this test
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Reproduction first (AC #1).** CPU-burner recipe (busy-loop python
+processes; 14-28 burners, plus at times extreme ambient machine load).
+The target test failed 11/11 standalone runs pre-fix (13 failing
+parametrized instances), every one with the SAME signature — not the
+catalogued worker-census/one-shot-click suspicions:
+
+    Tests/UI/test_stts_profile_library.py:937: in _select_action_profile
+    Tests/UI/test_stts_profile_library.py:939: in <lambda>
+    E  textual.css.query.NoMatches: No nodes match '#stts-profile-table'
+
+**Mechanism 1 (fixed).** `STTSWindow.watch_current_view` swaps the body in
+a `speech-view-mount` worker, so after `current_view = "profiles"` the
+table's *existence* is part of the condition being settled on — but the
+predicate sampled it as a precondition: the unguarded `query_one` raised
+NoMatches out of `_wait_until`'s first poll. Fix: `_profile_table_row_count`
+helper returning None while the swap is mid-flight; predicate
+`_profile_table_row_count(app) == 1` (shared `_select_action_profile`
+helper, so every caller is repaired).
+
+**Mechanism 2 (fixed, reproduced only after fix 1 unmasked it).** 2/15
+loaded runs then failed at the test's settings-pane settle:
+`IndexError: list index out of range` from
+`app.query_one(".stts-content").children[0]` — polled inside the
+observable empty window between `await remove_children()` and
+`await mount(...)` in `_mount_view_unlocked`. Fix:
+`_stts_content_first_child` helper (None while empty/mid-swap).
+
+**Mechanism 3 (sibling, reproduced in the AC-3 full-file load runs; same
+file, so in-boundary).** 1/3 loaded full-file runs failed
+`test_audiobook_kokoro_blend_group_is_not_a_keyboard_select_option` at
+`assert narrator.value == 'blend:duet'` — got `'shimmer'`, the LAST
+OPENAI voice. The test settled on `provider_select.value == "openai"`,
+but that flips inside the mount timer callback while the narrator-options
+rewrite rides the queued Select.Changed message; under load the queued
+rewrite landed AFTER the test's kokoro switch and silently restored the
+openai options (the keyboard walk itself worked). The openai list is
+byte-identical to the compose-time options, so the settle targets the
+sibling @on handler's `provider` attribute write on the faked
+character-voice widget — an observable of the same dispatch step. Its
+attempt-count `for _ in range(100)` wait also became `_wait_until` (the
+exhaustible-budget shape 16842 retired).
+
+**Contract preserved (AC #2).** The worker census (`len == 1`,
+`not is_finished` at modal-open) and the finished-after-switch settle are
+untouched — analysis plus 41 loaded standalone runs show the census is
+safe by construction (the worker sits inside `push_screen_wait` while the
+modal is `app.screen`). No fixed pauses, no attempt-count waits added;
+all new settles are wall-clock-bounded `_wait_until` polls of the actual
+asserted condition.
+
+**Evidence (AC #3), final file state.** Target test standalone: 15/15 @
+20 burners, 15/15 @ 28 burners, 10/10 @ 20 burners, 15/15 unloaded — zero
+failures. Sibling standalone: 10/10 @ 20 burners + 1/1 unloaded.
+Full file (163 tests): 4/4 green @ 14 burners (117-147s), 3/3 green
+unloaded (~64s), plus 3/3 unloaded at the intermediate state. ruff check
++ format clean.
+
+**Known residue (not patched — no reproduction):** the view-cycling test
+at ~:1104 carries five one-shot `children[0]` asserts of the same
+mechanism-2 class after single-pause view switches; never fired across
+all runs here. Left for a routed task if it ever flakes.
+
+**Files:** `Tests/UI/test_stts_profile_library.py` (only code change),
+this task file, `backlog/docs/lessons-testing-evidence.md` (new entry:
+raising predicates are one-shot samples; value flips are not their
+message cascade).
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
Closes task-19047. The view-switch dismissal test's load flake was reproduced FIRST (0/11 green standalone under CPU-burner load) and its real signature was none of the filed suspicions: a **raising predicate** — the settle helper's own `query_one('#stts-profile-table')` threw `NoMatches` out of `_wait_until`'s first poll, because `STTSWindow.watch_current_view` swaps the view body on a worker and the table's existence is itself part of the condition being settled. Fixing that unmasked a second mechanism: polling `children[0]` inside the awaited empty window between `remove_children()` and `mount(...)`. A third, in-boundary sibling failure surfaced during the evidence runs: a settle on `provider_select.value == "openai"` under-waits the queued `Select.Changed` cascade that wipes the options after the flip.

All fixes are wall-clock-bounded settles polling the asserted condition; helpers return `None` mid-swap instead of raising; the file's one remaining attempt-count wait became `_wait_until`. The test's pinned dismissal contract (worker census at modal-open; workers finished after switch) is byte-identical — the census one-shots were analyzed safe by construction (the worker is suspended inside `push_screen_wait` while the modal is the active screen) and never fired in 41 loaded runs.

## Evidence
- Born-red: 13 failing instances across 11 loaded runs, every one the `NoMatches` signature; the `IndexError` class reproduced at the intermediate state; the sibling's `'shimmer' == 'blend:duet'` captured live.
- Post-fix: 55 loaded standalone greens (up to 28 burners), 4/4 loaded full-file, 15/15 unloaded; post-rebase on current dev: 163/163.

## Review
Independent review: **APPROVE** — every mechanism verified against product source (the worker-driven swap, the awaited empty window, `_wait_until`'s unguarded predicate call); the crux fix-3 ordering claim was checked beyond the prose: the provider write actually dispatches BEFORE the options rewrite, but the settle is still sound on message-dispatch atomicity (both handlers are sync within one `MessagePump` dispatch — no event-loop yield between them — and only one openai-valued `Select.Changed` can exist), with the caveat recorded that making either handler async would invalidate it. Reviewer's own load runs: 5/5 loaded standalone + 163/163 loaded full-file, burners verified hot and killed.

Rebase note: a concurrent dev commit (`bc755f7fa`) had guarded the same raising-predicate site inline; this branch's helper form (which the rest of the diff builds on) supersedes it. Residue recorded for filing: five same-class one-shot asserts in the view-cycling test, never fired, left per no-speculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes STTS view-switch tests under load by settling on structure existence instead of sampling during swaps. Previously, unguarded predicates raised (`NoMatches`, `IndexError`); now waits guard queries and poll the asserted condition, and the audiobook test waits the `Select.Changed` cascade.

- In `Tests/UI/test_stts_profile_library.py`, replace unguarded `query_one`/`children[0]` polls with `_profile_table_row_count` and `_stts_content_first_child` that return `None` mid-swap; predicates settle on existence (`== 1`, `isinstance(...)`).
- Convert the attempt-count wait to `_wait_until`; for the provider flip, settle on the cascade’s observable by waiting `voice_widget.provider == "openai"` from the sibling `@on(Select.Changed)` handler.
- Preserve the dismissal contract: worker census at modal-open and finished-after-switch remain unchanged.
- Update `backlog/docs/lessons-testing-evidence.md` with the testing lesson; mark `task-19047` Done.

<sup>Written for commit 311de91a3393ea14596d0588004edc09f6c86403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

