### PR TITLE
chore(backlog): file third-wave close-out follow-ups (input-latency programme)

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5445,3 +5445,26 @@ the same file, both reproduced under CPU-burner load before patching:
    When a reactive assignment's effects arrive by message, settle on the
    cascade's own output — and if that output is indistinguishable from the
    initial state, find any other observable the same dispatch step produces.
+
+## Deleting a diagnostic-bearing call obliges the inventory hand-edit — and two reviewers missed it in one wave (tasks 19042/19043, 2026-08-20)
+
+Companion to "Adding a resource of a GUARDED KIND obliges you to run that
+kind's inventory suite" above — the DELETION direction, which proved harder to
+see. The persistent diagnostic inventory
+(`Docs/security/production-diagnostic-inventory.json`, gated by
+`Tests/Architecture/test_persistent_diagnostic_inventory.py`) keys rows on
+each file's diagnostic CONTENT, so removing a `logger.*` call changes that
+file's row and the playbook requires a hand-edit in the same PR. In the
+third-wave burn-down this was missed twice by implementers and twice by
+reviewers: task-19042 initially skipped it, and its reviewer asserted the
+inventory JSON "had zero consumers" — refuted by the controller's
+rebuild-diff, which showed the architecture gate consuming it; then
+task-19043's deletion (stts_events 30→29) shipped with BOTH implementer and
+reviewer missing the step, leaving the gate red on dev (folded into
+task-19191's per-row regeneration). Two rules with teeth: (1) any PR that
+deletes or moves diagnostic-bearing code must run
+`scripts/check_persistent_diagnostic_inventory.py` and hand-review its row
+diff before merging — a deletion feels like it needs no review precisely
+because nothing new was added; (2) a reviewer claim that a guarded artifact is
+"unconsumed" is an untested claim until checked against the gate that
+consumes it — grep for the artifact's path in `Tests/` before agreeing.

--- a/backlog/tasks/task-19190 - Remove-the-orphaned-play_current_audio-pair-app-wrapper-and-stts_events-handler.md
+++ b/backlog/tasks/task-19190 - Remove-the-orphaned-play_current_audio-pair-app-wrapper-and-stts_events-handler.md
@@ -1,0 +1,53 @@
+---
+id: TASK-19190
+title: Remove the orphaned play_current_audio pair (app wrapper + stts_events handler)
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - dead-code
+  - stts
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Third-wave burn-down residue (sibling of merged TASK-19043, which removed the
+`export_current_audio` pair the same way). At dev `7877defba`,
+`tldw_chatbook/app.py:11409` defines `async def play_current_audio` — it lazily
+initializes the S/TT/S handler and awaits
+`Event_Handlers/STTS_Events/stts_events.py:2767`'s `play_current_audio`
+handler. A whole-tree grep (production + `Tests/`) finds exactly three hits:
+the wrapper def, the wrapper's internal call (`app.py:11416`), and the handler
+def. Zero callers of the wrapper anywhere; the handler's only caller is the
+wrapper; zero test references. TASK-19043's reviewer independently confirmed
+the orphan with a grep that included dynamic-dispatch shapes
+(`getattr`/string-built names).
+
+Use merged TASK-19043 as the template, including its security-coverage-map
+discipline: before retiring anything, check whether the handler performs
+validation that needs a live-path equivalent (here the handler only does a
+path-existence check on `_current_playground_audio_path()` and notifies on
+failure — no unique validation identified, and there are no tests to retire —
+but the check must be recorded, not assumed). Two knock-ons the removal must
+chase: (1) the handler contains one `logger.error` call, so the persistent
+diagnostic inventory's `stts_events.py` row must be hand-edited in the same PR
+(the exact playbook step both 19042 and 19043 initially missed — see the
+2026-08-20 lesson in `backlog/docs/lessons-testing-evidence.md`); (2)
+`_current_playground_audio_path` (`stts_events.py:2786`) has this handler as
+its ONLY caller — decide its fate in the same PR (its underlying
+`_current_playground_artifact`/`_current_audio_file` attributes have ~25 other
+usages and stay).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The `play_current_audio` wrapper in `app.py` and the `play_current_audio` handler in `stts_events.py` no longer exist, and a whole-tree grep (including dynamic-dispatch shapes) finds no remaining reference.
+- [ ] #2 The security-coverage-map check from TASK-19043's playbook is performed and its outcome recorded in Implementation Notes: any validation the handler performed either has a live-path equivalent or is explicitly noted as not security-relevant.
+- [ ] #3 The persistent diagnostic inventory row for `stts_events.py` is hand-edited in the same PR to reflect the removed `logger.error`, and `scripts/check_persistent_diagnostic_inventory.py` does not regress further because of this change (it is already red on dev for unrelated drift — see TASK-19191).
+- [ ] #4 Any helper left caller-less by the removal (`_current_playground_audio_path`) is either removed with it or its retention justified; no new orphan is created.
+- [ ] #5 STTS-affected suites (`Tests/UI/test_stts_profile_library.py` and any suite importing the touched modules) pass.
+<!-- AC:END -->

--- a/backlog/tasks/task-19191 - Per-row-reviewed-regeneration-of-the-persistent-diagnostic-inventory-dev-red.md
+++ b/backlog/tasks/task-19191 - Per-row-reviewed-regeneration-of-the-persistent-diagnostic-inventory-dev-red.md
@@ -1,0 +1,80 @@
+---
+id: TASK-19191
+title: Per-row-reviewed regeneration of the persistent diagnostic inventory (dev red)
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - test-health
+  - diagnostics
+  - security
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/Architecture/test_persistent_diagnostic_inventory.py` is red on dev:
+`scripts/check_persistent_diagnostic_inventory.py` exits 1 at dev `7877defba`
+(reproduced 2026-08-20 in a pristine worktree, PYTHONPATH+cwd pinned,
+`tldw_chatbook.__file__` asserted inside the worktree). The checker's own
+guidance applies: review the diff row by row before running `--write` —
+regenerating without reading it is the exact failure mode the content-keyed
+digest exists to prevent (task-3750).
+
+Current rebuild-vs-committed diff (copy committed → `--write` → structured
+diff → committed file restored):
+
+Rows only in COMMITTED (1):
+- `RAG_Search/enhanced_chunking_service.py` (count=6) — file deleted, row kept.
+
+Rows only in REBUILD (22):
+- 19 `Chunking/engine/` files from the chunking-engine landing (base 13,
+  chunker 49, multilingual 9, process_text/options 1, regex_safety 1,
+  security_logger 7, strategies: code 3, code_ast 5, ebook_chapters 17,
+  fixed_size 1, json_xml 25, paragraphs 11, rolling_summarize 2, semantic 11,
+  sentences 18, structure_aware 6, tokens 28, words 15; utils/metrics 2)
+- `RAG_Search/parent_child_adapter.py` (1)
+- `UI/Library_Modules/library_media_browse_controller.py` (2) — the known
+  pre-existing 3-row library drift (post-d64608b84 regen, 1ba3d4755/b4ebe85e8
+  era)
+- `Widgets/Console/console_changed_files_section.py` (2) — NEW since the
+  wave-3 queue was written: the changed-files rail landing (12d621071 et seq.)
+
+Rows changed (10):
+- `Chat/console_chat_controller.py` 45→45 (digest only)
+- `Chunking/Chunk_Lib.py` 100→31
+- `DB/Client_Media_DB_v2.py` 354→338 (library drift)
+- `Event_Handlers/STTS_Events/stts_events.py` 30→29 (TASK-19043's merged
+  deletion — implementer and reviewer both missed the hand-edit playbook step)
+- `RAG_Search/chunking_service.py` 5→3
+- `RAG_Search/simplified/enhanced_rag_service.py` 11→10
+- `UI/Screens/change_review_screen.py` 1→13 (changed-files rail landing)
+- `UI/Screens/chat_screen.py` 153→156
+- `UI/Screens/library_screen.py` 110→109 (library drift)
+- `Widgets/enhanced_file_picker.py` 6→6 (digest only)
+
+persistent_sink_topology: +1 row in rebuild —
+`Chunking/engine/security_logger.py` (an addHandler-kind sink; sink additions
+are exactly what this inventory exists to review).
+
+Summary: owner_files 494→515, persistent_sink_files 6→7, task_492_calls
+1209→1209, task_494_calls 6974→7122.
+
+The drift has GROWN past the contributors known at wave-3 close-out (the
+changed-files rail rows and the chunking_service/enhanced_rag_service/
+chat_screen deltas are new), so re-produce the diff at the implementation
+commit before reviewing. A red gate left standing stops guarding — the next
+unreviewed diagnostic lands invisibly behind it (same failure shape as the
+task-19044 lesson).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The rebuild-vs-committed diff is re-produced at the implementation commit and every row delta is individually reviewed and dispositioned in the task's Implementation Notes (new diagnostics accepted or challenged, deleted rows confirmed against deleted/moved code, digest-only changes explained), with particular attention to the new persistent sink in `Chunking/engine/security_logger.py`.
+- [ ] #2 The committed inventory is regenerated via the checker's `--write` only after that review, and `Tests/Architecture/test_persistent_diagnostic_inventory.py` passes on the result.
+- [ ] #3 Any row the review REJECTS (a diagnostic that should not exist, e.g. one that could log sensitive content) is filed or fixed rather than silently accepted into the inventory.
+- [ ] #4 No hand edits to the regenerated JSON beyond what the review justifies; the summary counts match the accepted rows.
+<!-- AC:END -->

--- a/backlog/tasks/task-19192 - CSS-class-coverage-contract-red-on-dev-console-changed-files-section-is-unstyled.md
+++ b/backlog/tasks/task-19192 - CSS-class-coverage-contract-red-on-dev-console-changed-files-section-is-unstyled.md
@@ -1,0 +1,45 @@
+---
+id: TASK-19192
+title: 'CSS class-coverage contract red on dev: console-changed-files-section is unstyled'
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - test-health
+  - css
+  - console
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_css_class_coverage_contract.py::test_every_composed_class_is_styled_or_registered`
+is red on dev `7877defba` (re-run 2026-08-20 in a pristine worktree, isolated
+config). The failing set has CHANGED since TASK-19042's baseline: the six
+`console-*` tokens it recorded (left_rail, console_transcript,
+console_selection_menu, console_turn_file_card families) no longer fail —
+resolved since — and exactly ONE token now trips the gate:
+
+- `console-changed-files-section` (first composed in
+  `tldw_chatbook/Widgets/Console/console_changed_files_section.py`, the
+  changed-files rail section widget landed in 12d621071 / 9cc5b6420 /
+  8f7085b0c)
+
+The contract offers two legitimate exits: give the class a real rule in the
+bundle or a DEFAULT_CSS, or register it in the test's KNOWN_UNSTYLED list with
+a rationale (it may be a pure query/marker class). Pick whichever is true of
+the widget — do not blind-register a class that was meant to be styled.
+Note the same landing also left this file out of the diagnostic inventory
+(TASK-19191's diff shows it at +2 diagnostics), so the changed-files rail
+evidently shipped without running the repo's contract gates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `test_every_composed_class_is_styled_or_registered` passes on dev.
+- [ ] #2 The `console-changed-files-section` token is either genuinely styled (a `.class` or `#id` rule that actually applies to the composed widget) or registered as KNOWN_UNSTYLED with a recorded rationale for why it is a marker/query-only class; the choice is justified against the widget's intended appearance, not picked for gate convenience.
+- [ ] #3 If styling was the intended-but-missing half, the rendered Console change-review rail is verified (painted-frame or equivalent render evidence, not a style-object probe) to show the intended appearance.
+<!-- AC:END -->

--- a/backlog/tasks/task-19193 - Library-media-viewer-back-nav-test-red-on-dev-LookupError-active_app.md
+++ b/backlog/tasks/task-19193 - Library-media-viewer-back-nav-test-red-on-dev-LookupError-active_app.md
@@ -1,0 +1,47 @@
+---
+id: TASK-19193
+title: Library media-viewer back nav test red on dev (LookupError active_app)
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - test-health
+  - library
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Tests/UI/test_screen_navigation.py::test_action_library_media_viewer_back_returns_to_list_and_refocuses_it`
+is red on dev `7877defba` (re-confirmed 2026-08-20 in a pristine worktree,
+isolated config), with the same signature TASK-19046's implementer AND
+reviewer both reproduced at their pristine base:
+
+    screen.action_library_media_viewer_back()   # test_screen_navigation.py:2619
+    ...
+    textual/message_pump.py:257: in app
+        return active_app.get()
+    LookupError: <ContextVar name='active_app' at 0x...>
+
+The test is synchronous by design: it constructs `LibraryScreen` outside a
+running app, stubs `refresh`/`call_after_refresh`/`set_timer`, and pins
+task-2856's contract that Escape from the plain read-only media viewer reuses
+the exact `_exit_library_media_viewer` reset sequence and re-focuses the
+list's first row (one seam for both exits). Something on the
+`action_library_media_viewer_back` path now reaches `self.app`, which raises
+outside an app context. Diagnose which it is before fixing: a product change
+that made the exit path app-dependent (fix or stub at the new seam without
+weakening the one-seam contract) versus a test-harness gap (extend the
+harness). Per the owner's standing ruling, prefer the durable fix over
+whatever silences the test fastest.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The test passes on dev without deleting it, skipping it, or weakening the task-2856 one-seam contract it pins (same reset sequence for Escape and the back button, list first-row refocus).
+- [ ] #2 Implementation Notes identify the commit/change that introduced the `self.app` access on this path and classify the failure (product regression vs harness gap), with the fix applied at the layer that classification names.
+- [ ] #3 The surrounding `Tests/UI/test_screen_navigation.py` suite passes.
+<!-- AC:END -->

--- a/backlog/tasks/task-19194 - Owner-call-commission-a-media-tag-management-UI-or-retire-the-orphaned-keyword-DB-API.md
+++ b/backlog/tasks/task-19194 - Owner-call-commission-a-media-tag-management-UI-or-retire-the-orphaned-keyword-DB-API.md
@@ -1,0 +1,54 @@
+---
+id: TASK-19194
+title: 'Owner call: commission a media tag-management UI or retire the orphaned keyword DB API'
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - owner-decision
+  - dead-code
+  - media-db
+dependencies:
+  - TASK-19046
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Post-TASK-19046 (which retired the never-mounted CollectionsTagWindow and its
+dead keyword event loop), the media DB's keyword-management surface has no
+reachable UI. Verified at dev `7877defba`:
+
+- `DB/Client_Media_DB_v2.py::rename_keyword` (:4988) — zero production
+  callers, zero test references
+- `DB/Client_Media_DB_v2.py::merge_keywords` (:5097) — zero production
+  callers, zero test references
+- `DB/Client_Media_DB_v2.py::soft_delete_keyword` (:4865) — lost its only
+  caller with CollectionsTagWindow (same-named methods in Notes/Prompts DBs
+  are separate APIs and unaffected); DB-level tests exist in
+  `Tests/Media_DB/test_media_db_v2.py`
+- `DB/Client_Media_DB_v2.py::get_keyword_usage_stats` (:5230) — HAS a live
+  consumer (`Chat/scope_picker_listers.py:503`) and stays either way
+
+CollectionsTagWindow was the only conceivable media-keyword management UI and
+had been unreachable since 2025-08-02, so nothing user-visible was lost — the
+question is forward-looking: should users be able to rename/merge/delete media
+keywords at all? Owner decision between (a) commissioning a reachable
+tag-management surface that consumes this API, or (b) retiring the three
+orphaned methods and their DB-level tests. Per the standing ruling, prefer the
+durable outcome: a deliberate product decision either way, not an indefinite
+zombie API. If retiring: `Client_Media_DB_v2.py` is diagnostic-bearing (354
+inventory calls), so the deletion must include the diagnostic-inventory
+hand-edit, and the security-coverage-map check applies before removing the
+DB-level tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The owner has decided between commissioning a reachable media tag-management UI and retiring the orphaned DB API surface, and the decision is recorded in this task.
+- [ ] #2 If commissioning: a follow-on task (or tasks) exists specifying the surface, and this task records what it must consume (`rename_keyword`, `merge_keywords`, `soft_delete_keyword`).
+- [ ] #3 If retiring: the three orphaned methods and their now-purposeless DB-level tests are removed, `get_keyword_usage_stats` and its live consumer are untouched, the security-coverage-map check is recorded, and the diagnostic inventory row for `Client_Media_DB_v2.py` is hand-edited in the same PR.
+- [ ] #4 The caller census above is re-verified against dev at implementation time before acting on it.
+<!-- AC:END -->

--- a/backlog/tasks/task-19195 - Owner-call-Study-sidebar-tooltips-overpromise-for-sections-whose-panes-say-they-are-not-built.md
+++ b/backlog/tasks/task-19195 - Owner-call-Study-sidebar-tooltips-overpromise-for-sections-whose-panes-say-they-are-not-built.md
@@ -1,0 +1,47 @@
+---
+id: TASK-19195
+title: 'Owner call: Study sidebar tooltips overpromise for sections whose panes say they are not built'
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - owner-decision
+  - study
+  - ux-copy
+dependencies:
+  - TASK-19041
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-19041 made the unbuilt Study panes honest: `UI/Study_Window.py` now
+states "Course creation is not available yet in this build." (:477), "Study
+guides are not available yet in this build." (:527), and "The learning map is
+not available yet in this build." (:575). But the sidebar that leads users to
+those panes still overpromises. Verified at dev `7877defba`,
+`UI/Screens/study_screen.py` `_SECTION_TOOLTIPS` (:106-117) advertises:
+
+- "Generate or open study guides from your material." (:110) — Guides button
+  composed at :229-232
+- "Create course outlines and study sequences." — Course button at :238-242
+- "Open the learning map for relationships across study material." — Map
+  button at :243-247
+
+A user hovering the sidebar is promised a working feature; clicking lands on a
+pane that says the feature does not exist. Screen-IA decision for the owner:
+hide the unbuilt sections from the sidebar until they ship, or keep them
+visible with softened, honest tooltip copy (e.g. naming them as
+not-yet-available). Per the standing ruling, prefer the durable option — the
+one that will not need re-litigating each time a pane ships or slips.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The owner has chosen between hiding unbuilt Study sections and softening their sidebar copy, and the decision is recorded in this task.
+- [ ] #2 After implementation, no Study sidebar affordance promises functionality its pane then denies: tooltip copy and pane state agree for every section.
+- [ ] #3 The chosen mechanism keys off the same source of truth as the panes' built/unbuilt state, so a section shipping later does not require re-synchronizing copy by hand in two places.
+- [ ] #4 The Study page in Docs/User_Guide is updated (or its "Verified against" stamp refreshed) per the repo's UI-change rule.
+<!-- AC:END -->

--- a/backlog/tasks/task-19196 - Harden-the-stts-view-cycling-tests-five-one-shot-children-0-asserts-19047-family.md
+++ b/backlog/tasks/task-19196 - Harden-the-stts-view-cycling-tests-five-one-shot-children-0-asserts-19047-family.md
@@ -1,0 +1,47 @@
+---
+id: TASK-19196
+title: Harden the stts view-cycling test's five one-shot children[0] asserts (19047 family)
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - test-health
+  - flake
+  - stts
+dependencies:
+  - TASK-19047
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Conditional hardening candidate, filed from the third-wave close-out. At dev
+`7877defba`,
+`Tests/UI/test_stts_profile_library.py::test_voice_profiles_view_mounts_focused_library_without_hiding_other_views`
+(:1085, body :1104-1139) carries five one-shot
+`app.query_one(".stts-content").children[0]` isinstance asserts (playground →
+settings → audiobook → dictation → playground) — the exact
+raising-predicate/empty-window class TASK-19047 fixed elsewhere in the same
+file: `STTSWindow.watch_current_view` swaps the body in a `speech-view-mount`
+worker, and `.children[0]` sampled between `remove_children()` and `mount()`
+raises `IndexError` (see the 2026-08-20 "settle whose predicate can RAISE"
+entry in `backlog/docs/lessons-testing-evidence.md`, and the
+`_stts_content_first_child` helper 19047 added at :1053, used with
+`_wait_until` at e.g. :2910).
+
+Important honesty note: these five asserts NEVER fired across all of 19047's
+and its reviewer's CPU-burner load runs — this is a structural sibling of a
+proven flake class, not an observed flake. Hence the conditional shape: either
+prove it can fire (load reproduction) or convert it mechanically to the
+already-shipped helpers and re-prove the whole file under load. Do not
+half-convert.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A load-reproduction attempt (19047's CPU-burner loop methodology) against the current asserts is run FIRST and its outcome recorded — either a reproduced failure justifying the fix, or a bounded negative result; OR the five asserts are mechanically converted to `_wait_until` + `_stts_content_first_child` settles matching the file's existing pattern.
+- [ ] #2 If converted: the full file's load-loop evidence is re-run and recorded (not just the touched test), per 19047's catalogue-shapes-by-re-running lesson.
+- [ ] #3 The test's contract is unchanged: it still pins that each view switch mounts the expected pane type as the content's first child and that cycling back to playground restores `#tts-generate-btn`.
+<!-- AC:END -->


### PR DESCRIPTION
Files the accumulated follow-up findings from the third-wave burn-down close-out (tasks 19041-19047, all merged to dev) as seven backlog tasks, IDs 19190-19196, plus one lessons entry. Every item was re-verified against dev `7877defba` in a pristine worktree (isolated config; `tldw_chatbook.__file__` asserted inside the worktree for app-importing probes) before filing; the branch was then rebased onto dev `dc0fada86` (unrelated checkbox-height merge). ID range claimed via full sweep (ls-remote + branch -a + all worktree backlogs + origin/dev backlog: max 19170 → claimed 19190+), re-swept immediately before commit (external max still 19170).

## Filed

- **task-19190** — Remove the orphaned `play_current_audio` pair: `app.py:11409` wrapper → `stts_events.py:2767` handler; whole-tree grep finds only the def/def/internal-call triple, zero test refs; same removal shape as merged 19043 (cited as template incl. its security-coverage-map discipline, the inventory hand-edit for the handler's `logger.error`, and the helper `_current_playground_audio_path` left caller-less).
- **task-19191** — Per-row-reviewed diagnostic-inventory regeneration (**dev red**, high): checker exits 1 at `7877defba`; the current rebuild-vs-committed diff is enumerated in the task — 1 committed-only row (deleted `enhanced_chunking_service`), 22 rebuild-only rows (19 `Chunking/engine/` files, `parent_child_adapter`, `library_media_browse_controller`, and NEW `console_changed_files_section`), 10 changed rows (incl. `Chunk_Lib` 100→31, `Client_Media_DB_v2` 354→338, `stts_events` 30→29 from 19043, and NEW `change_review_screen` 1→13, `chat_screen` 153→156), +1 persistent sink (`Chunking/engine/security_logger.py`); summary 494→515 owner files. The drift has grown past the contributors known at close-out.
- **task-19192** — CSS class-coverage contract red on dev: re-run confirmed red, but the token list CHANGED since 19042's six-token baseline — exactly ONE token now fails, `console-changed-files-section` (changed-files rail landing `12d621071`); the six baseline tokens were resolved since. Filed with the current list.
- **task-19193** — Nav test red on dev: `test_action_library_media_viewer_back_returns_to_list_and_refocuses_it`, reproduced with the exact `LookupError: <ContextVar name='active_app'>` signature at `test_screen_navigation.py:2619`, matching 19046's implementer+reviewer pristine-base reproductions.
- **task-19194** — Owner call: media tag-management UI vs retiring the orphaned keyword DB API. Census re-verified: `rename_keyword` (:4988) and `merge_keywords` (:5097) zero production callers and zero test refs; `soft_delete_keyword` (:4865) lost its only caller with 19046's CollectionsTagWindow retirement; `get_keyword_usage_stats` (:5230) has a live consumer (`Chat/scope_picker_listers.py:503`) and stays either way. Durable-over-quick-wins ruling encoded.
- **task-19195** — Owner call: Study sidebar tooltips overpromise ("Generate or open study guides from your material.", `study_screen.py:110`, composed :229-247) for sections whose panes honestly say "not available yet in this build" post-19041 (`Study_Window.py:477/:527/:575`). Lines verified on dev. Hide vs soften; durable option preferred.
- **task-19196** — Conditional hardening: five one-shot `children[0]` asserts in `test_voice_profiles_view_mounts_focused_library_without_hiding_other_views` (:1085, body :1104-1139) — 19047's exact raising-predicate class, but never observed firing under load; AC demands load-reproduction first OR mechanical conversion to `_stts_content_first_child`/`_wait_until` with full-file load evidence.

Also: a new `lessons-testing-evidence.md` entry — deletions in diagnostic-bearing files require the inventory hand-edit; 19042 and 19043 both initially missed it, two independent reviewers missed it once (19042's reviewer asserted the JSON had zero consumers; refuted by the controller's rebuild-diff).

## Dropped (verified fixed, not filed)

- **Frontmatter extras-census red** — dev fixed it via the AREA_VISUALIZATION-consuming feature entry.
- **VALID_TABLES gap** — fixed by `46945ebbe`; already dropped at wave-2 filing.

Do not merge without the controller's go-ahead (filing agent does not merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files seven backlog tasks (19190–19196) and a lessons entry from the third‑wave close‑out to capture verified follow‑ups, surface red gates on dev, and encode required owner decisions. No runtime behavior changes; adds backlog docs only.

- Review that tasks 19191–19193 accurately pin current dev failures: persistent diagnostic inventory, CSS class coverage for console-changed-files-section, and the library media-viewer back-nav test.
- Note owner decisions required in 19194 (media tag-management UI vs retiring keyword DB API) and 19195 (hide vs soften Study sidebar tooltips); assign owners.
- 19190 proposes removing an orphaned STTS handler/wrapper pair; confirm the plan includes the required diagnostic-inventory hand-edit.
- 19196 sets a conditional hardening plan for STTS view-cycling tests; choose reproduce-under-load vs mechanical conversion.
- The lessons entry documents that diagnostic-bearing deletions must update the persistent inventory in the same PR; enforce this in reviews.

<sup>Written for commit 1d3ab36f248c64947d49e7b9abf50944ff9c042b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

