### PR TITLE
refactor(console): extract retrieval controller

### DIFF
--- a/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
+++ b/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
@@ -98,5 +98,5 @@
 - [x] Run `git diff --check`, inspect the cumulative diff for the one-controller/YAGNI boundary, and verify no CSS, DOM IDs, storage schema, dependency, or user-visible copy changed.
 - [x] Run the persistent-diagnostic checker and its two focused architecture tests. Regenerate the manifest only for proven moved-owner metadata with unchanged sink topology.
 - [x] Obtain an independent correctness/spec review if the active collaboration policy permits it; otherwise perform and record a separate self-review pass without changing scope.
-- [ ] Update the task ACs and concise Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, inherited baseline classification, and the explicit no-full-suite user constraint.
+- [x] Update the task ACs and concise Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, inherited baseline classification, and the explicit no-full-suite user constraint.
 - [ ] Commit the implementation, rebase onto latest `origin/dev`, rerun the same focused gates on the rebased head, then push and open one atomic PR against `dev`.

--- a/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
+++ b/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
@@ -41,62 +41,62 @@
 
 ### Task 1: Lock retrieval ownership and no-mount behavior with RED tests
 
-- [ ] Add `Tests/UI/test_console_retrieval_controller.py` with a small constructor fixture using plain call recorders and no Textual mount.
-- [ ] Assert controller defaults for `_console_retrieval_scope_cache`, `_console_effective_scope_cache`, `_active_dictionaries_summary`, `_last_console_dictionary_scope_ids`, `_active_world_books_summary`, and `_last_console_world_book_scope_ids`.
-- [ ] Characterize the four high-risk policy families before moving code:
+- [x] Add `Tests/UI/test_console_retrieval_controller.py` with a small constructor fixture using plain call recorders and no Textual mount.
+- [x] Assert controller defaults for `_console_retrieval_scope_cache`, `_console_effective_scope_cache`, `_active_dictionaries_summary`, `_last_console_dictionary_scope_ids`, `_active_world_books_summary`, and `_last_console_world_book_scope_ids`.
+- [x] Characterize the four high-risk policy families before moving code:
   - effective-scope cache build/read and persisted-vs-unpersisted save;
   - dictionary/world-book summary refresh guards and cached row/action projection;
   - Library RAG scoped/empty/results/blocked outcomes and stage ordering;
   - auto-retrieve gates, placeholder identity, timeout/failure containment, cancellation, and same-send capture.
-- [ ] Extend the architecture test so the retrieval family must be complete: all 32 M names only on `ConsoleRetrievalController`; the two D names remain on `ChatScreen` with their exact decorators/groups and at-most-five-line definition spans; all six descriptors target `_retrieval`; moved methods contain no DOM calls or sibling-controller reach-through.
-- [ ] Add a structural assertion that ordinary production callers use `_retrieval` directly and that no moved default is assigned in `ChatScreen.__init__`.
-- [ ] Run the new controller and architecture nodes. Confirm RED is caused by the absent controller/current screen ownership, not the known line-ceiling failure alone.
+- [x] Extend the architecture test so the retrieval family must be complete: all 32 M names only on `ConsoleRetrievalController`; the two D names remain on `ChatScreen` with their exact decorators/groups and at-most-five-line definition spans; all six descriptors target `_retrieval`; moved methods contain no DOM calls or sibling-controller reach-through.
+- [x] Add a structural assertion that ordinary production callers use `_retrieval` directly and that no moved default is assigned in `ChatScreen.__init__`.
+- [x] Run the new controller and architecture nodes. Confirm RED is caused by the absent controller/current screen ownership, not the known line-ceiling failure alone.
 
 ### Task 2: Create the controller and move scope/cache ownership
 
-- [ ] Create `ConsoleRetrievalController` with `app_instance` plus explicit keyword-only late-bound callables for active session/conversation, pending-launch state transitions, source/query setters, screen sync/refresh, scope-row/control-bar sync, visible-run dispatch, launch payload inspection, and evidence consume/release.
-- [ ] Initialize all six compatibility defaults in the controller constructor.
-- [ ] Move the scope/cache methods verbatim in behavior: staged capture, pure display-state build, recipe count, effective resolution/warm, DB read/write, lister construction, and scope save.
-- [ ] Add six `_ControllerState("_retrieval", ...)` assignments to `ChatScreen` and remove the corresponding `__init__` assignments.
-- [ ] Repoint Workspace and Session late-bound scope dependencies in `wiring.py` to `screen._retrieval` at call time.
-- [ ] Run the focused controller/scope/architecture tests. Expect defaults, descriptors, cache, and save cases green while later inspector/RAG ownership remains RED.
+- [x] Create `ConsoleRetrievalController` with `app_instance` plus explicit keyword-only late-bound callables for active session/conversation, pending-launch state transitions, source/query setters, screen sync/refresh, scope-row/control-bar sync, visible-run dispatch, launch payload inspection, and evidence consume/release.
+- [x] Initialize all six compatibility defaults in the controller constructor.
+- [x] Move the scope/cache methods verbatim in behavior: staged capture, pure display-state build, recipe count, effective resolution/warm, DB read/write, lister construction, and scope save.
+- [x] Add six `_ControllerState("_retrieval", ...)` assignments to `ChatScreen` and remove the corresponding `__init__` assignments.
+- [x] Repoint Workspace and Session late-bound scope dependencies in `wiring.py` to `screen._retrieval` at call time.
+- [x] Run the focused controller/scope/architecture tests. Expect defaults, descriptors, cache, and save cases green while later inspector/RAG ownership remains RED.
 
 ### Task 3: Move inspector and Library RAG policy
 
-- [ ] Move cached dictionary/world-book scope IDs, refresh guards, summaries, rows, and action projections. Keep attach/detach pickers and workers on `ChatScreen`; route their refresh calls to `_retrieval`.
-- [ ] Move source-status and source-scope-label builders. Keep screen-owned inspector composition and widget label updates, but source their plain values from `_retrieval`.
-- [ ] Move stage, settings-choice, scope resolution, outcome application, service-initialization detection, notification, placeholder clearing, and auto-retrieve orchestration.
-- [ ] Preserve the pending-launch screen state through explicit getter/setter callbacks and keep all DOM refresh/recompose operations behind named screen callbacks.
-- [ ] Move the body of `_capture_console_staged_rag` and rewire both provider registration sites directly to `_retrieval`.
-- [ ] Run the no-mount controller tests plus existing auto-RAG, dictionary, world-book, RAG-settings, and Library-scope tests to GREEN.
+- [x] Move cached dictionary/world-book scope IDs, refresh guards, summaries, rows, and action projections. Keep attach/detach pickers and workers on `ChatScreen`; route their refresh calls to `_retrieval`.
+- [x] Move source-status and source-scope-label builders. Keep screen-owned inspector composition and widget label updates, but source their plain values from `_retrieval`.
+- [x] Move stage, settings-choice, scope resolution, outcome application, service-initialization detection, notification, placeholder clearing, and auto-retrieve orchestration.
+- [x] Preserve the pending-launch screen state through explicit getter/setter callbacks and keep all DOM refresh/recompose operations behind named screen callbacks.
+- [x] Move the body of `_capture_console_staged_rag` and rewire both provider registration sites directly to `_retrieval`.
+- [x] Run the no-mount controller tests plus existing auto-RAG, dictionary, world-book, RAG-settings, and Library-scope tests to GREEN.
 
 ### Task 4: Finish worker delegates, wiring, and call-site migration
 
-- [ ] Add `_retrieval = ConsoleRetrievalController(...)` to `build_console_controllers`; update its documented build order/count and wiring tests.
-- [ ] Keep `_persist_console_rag_auto_retrieve_on_send` on `ChatScreen` with `@work(thread=True)` and a one-statement controller delegation.
-- [ ] Keep `_execute_console_library_rag_search` on `ChatScreen` with `@work(exclusive=True, group="console-library-rag-search")` and an awaited controller delegation.
-- [ ] Repoint all ordinary production callers to `_retrieval`, including compose/inspector/sync, explicit RAG run, scope flush/resume, staged handoff, attach/detach refresh, and the Session/Workspace seams.
-- [ ] Mechanically retarget direct private-method tests to the controller owner. Do not alter assertions or mounted user flows.
-- [ ] Register `ConsoleRetrievalController` in the moved-seam AST guard and prove the guard reports a synthetic stale `screen.<moved method>()` call.
-- [ ] Remove imports from `chat_screen.py` only when `rg` and Ruff prove they are no longer screen-owned; import them in `retrieval.py` from their defining modules.
-- [ ] Run the controller, architecture, wiring, moved-seam, and exact mounted retrieval files to GREEN.
+- [x] Add `_retrieval = ConsoleRetrievalController(...)` to `build_console_controllers`; update its documented build order/count and wiring tests.
+- [x] Keep `_persist_console_rag_auto_retrieve_on_send` on `ChatScreen` with `@work(thread=True)` and a one-statement controller delegation.
+- [x] Keep `_execute_console_library_rag_search` on `ChatScreen` with `@work(exclusive=True, group="console-library-rag-search")` and an awaited controller delegation.
+- [x] Repoint all ordinary production callers to `_retrieval`, including compose/inspector/sync, explicit RAG run, scope flush/resume, staged handoff, attach/detach refresh, and the Session/Workspace seams.
+- [x] Mechanically retarget direct private-method tests to the controller owner. Do not alter assertions or mounted user flows.
+- [x] Register `ConsoleRetrievalController` in the moved-seam AST guard and prove the guard reports a synthetic stale `screen.<moved method>()` call.
+- [x] Remove imports from `chat_screen.py` only when `rg` and Ruff prove they are no longer screen-owned; import them in `retrieval.py` from their defining modules.
+- [x] Run the controller, architecture, wiring, moved-seam, and exact mounted retrieval files to GREEN.
 
 ### Task 5: Mutation and focused regression evidence
 
-- [ ] Remove one `_retrieval` descriptor setter/retarget it to screen shadow state; confirm the descriptor test fails, then restore.
-- [ ] Put one moved method back on `ChatScreen` or add a DOM call inside the controller; confirm the ownership/DOM AST test fails, then restore.
-- [ ] Bypass the effective-scope empty short-circuit; confirm the scoped retrieval test fails, then restore.
-- [ ] Remove placeholder identity guarding or failure cleanup; confirm the auto-RAG test fails, then restore.
-- [ ] Remove the dictionary/world-book unchanged-scope guard; confirm the zero-repeat summary test fails, then restore.
-- [ ] Remove each worker delegation in turn; confirm the exact delegate/behavior test fails for the intended reason, then restore.
-- [ ] Run only touched-functionality groups: retrieval controller/architecture/wiring, scope/modal/Library RAG, auto-send/capture/staging, dictionary/world-book inspector, and any mechanically retargeted seam tests.
+- [x] Remove one `_retrieval` descriptor setter/retarget it to screen shadow state; confirm the descriptor test fails, then restore.
+- [x] Put one moved method back on `ChatScreen` or add a DOM call inside the controller; confirm the ownership/DOM AST test fails, then restore.
+- [x] Bypass the effective-scope empty short-circuit; confirm the scoped retrieval test fails, then restore.
+- [x] Remove placeholder identity guarding or failure cleanup; confirm the auto-RAG test fails, then restore.
+- [x] Remove the dictionary/world-book unchanged-scope guard; confirm the zero-repeat summary test fails, then restore.
+- [x] Remove each worker delegation in turn; confirm the exact delegate/behavior test fails for the intended reason, then restore.
+- [x] Run only touched-functionality groups: retrieval controller/architecture/wiring, scope/modal/Library RAG, auto-send/capture/staging, dictionary/world-book inspector, and any mechanically retargeted seam tests.
 
 ### Task 6: Static checks, diagnostics, review, and closeout
 
-- [ ] Run Ruff format/check on every changed Python file only. Do not bulk-format unrelated files.
-- [ ] Run `py_compile` for `retrieval.py`, `wiring.py`, and `chat_screen.py` under one validated temporary pycache root; remove only that exact root and prove it absent.
-- [ ] Run `git diff --check`, inspect the cumulative diff for the one-controller/YAGNI boundary, and verify no CSS, DOM IDs, storage schema, dependency, or user-visible copy changed.
-- [ ] Run the persistent-diagnostic checker and its two focused architecture tests. Regenerate the manifest only for proven moved-owner metadata with unchanged sink topology.
-- [ ] Obtain an independent correctness/spec review if the active collaboration policy permits it; otherwise perform and record a separate self-review pass without changing scope.
+- [x] Run Ruff format/check on every changed Python file only. Do not bulk-format unrelated files.
+- [x] Run `py_compile` for `retrieval.py`, `wiring.py`, and `chat_screen.py` under one validated temporary pycache root; remove only that exact root and prove it absent.
+- [x] Run `git diff --check`, inspect the cumulative diff for the one-controller/YAGNI boundary, and verify no CSS, DOM IDs, storage schema, dependency, or user-visible copy changed.
+- [x] Run the persistent-diagnostic checker and its two focused architecture tests. Regenerate the manifest only for proven moved-owner metadata with unchanged sink topology.
+- [x] Obtain an independent correctness/spec review if the active collaboration policy permits it; otherwise perform and record a separate self-review pass without changing scope.
 - [ ] Update the task ACs and concise Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, inherited baseline classification, and the explicit no-full-suite user constraint.
 - [ ] Commit the implementation, rebase onto latest `origin/dev`, rerun the same focused gates on the rebased head, then push and open one atomic PR against `dev`.

--- a/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
+++ b/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
@@ -1,0 +1,102 @@
+# TASK-3070.5 Console Retrieval Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ConsoleRetrievalController` the sole non-DOM owner of Console retrieval scope, Library RAG, auto-retrieve, and cached dictionary/world-book inspector policy without changing behavior.
+
+**Architecture:** Move the 32 reviewed non-framework methods and six state defaults from `ChatScreen` into one DOM-free controller. Keep the two Textual `@work` names on `ChatScreen` as bounded delegates, keep picker/modal and widget synchronization on the screen, and pass every remaining screen or sibling dependency through an explicit late-bound callable in `wiring.py`.
+
+**Tech Stack:** Python 3.11+, Textual 8, pytest/pytest-asyncio, Ruff, stdlib AST checks.
+
+---
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This implements the ownership boundary already approved in `Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md` and `DESIGN.md` section 7; it changes no storage, security, provider, dependency, or service contract.
+
+## Constraints and evidence rules
+
+- Preserve the exact method inventory in `Tests/Architecture/test_console_wave6_inventory.py`: 32 moved methods, two bounded delegates, and six assignable compatibility fields.
+- The controller must never call `query_one`, `query`, `push_screen`, or another controller through the screen. DOM, modal presentation, and decorated worker registration stay screen-owned.
+- Preserve worker decorators and groups exactly: `@work(thread=True)` for preference persistence and `@work(exclusive=True, group="console-library-rag-search")` for explicit retrieval.
+- Preserve scope persistence and cache keys, in-memory SQLite behavior, effective conversation/workspace intersection, auto-retrieve timeout/cancellation/placeholder identity, and cached inspector zero-DB-on-build behavior.
+- Existing mounted tests may be retargeted mechanically from `screen.<moved method>` to `screen._retrieval.<moved method>`; their assertions and user-visible expectations do not change.
+- Do not run the full repository suite. The user explicitly limited verification to touched files and functionality.
+- The focused pre-change baseline is 132 passed and one inherited architecture failure: current `chat_screen.py` is 21,357 lines versus the committed 20,943 incremental ceiling. The reviewed retrieval extraction removes at least 982 net lines and must make that gate green without raising the ceiling.
+- After every mutation probe, restore the exact candidate bytes before continuing.
+
+## File map
+
+- Create `tldw_chatbook/UI/Console_Modules/retrieval.py`: controller state, scope persistence/effective-state policy, inspector projections, Library RAG outcome policy, and auto-retrieve orchestration.
+- Modify `tldw_chatbook/UI/Console_Modules/wiring.py`: construct `_retrieval`, expose named late-bound dependencies, and repoint Workspace/Session retrieval callables directly to the controller.
+- Modify `tldw_chatbook/UI/Screens/chat_screen.py`: add six `_ControllerState` descriptors, remove moved defaults/methods/imports, retain two bounded worker delegates, and route production callers to `_retrieval`.
+- Create `Tests/UI/test_console_retrieval_controller.py`: isolated no-mount controller tests.
+- Modify `Tests/Architecture/test_console_wave6_inventory.py`: require complete retrieval ownership, exact delegate spans/decorators/groups, descriptor targets, DOM prohibition, and non-vacuity.
+- Modify `Tests/UI/test_console_controller_wiring.py` and `Tests/UI/test_console_moved_seam_guard.py`: register `_retrieval`, prove late binding, and reject stale screen method calls.
+- Mechanically retarget only directly affected tests, expected primarily in `Tests/UI/test_console_auto_rag_on_send.py`, `Tests/UI/test_console_dictionaries_screen.py`, `Tests/UI/test_console_worldbook_inspector.py`, `Tests/UI/test_console_rag_settings_modal.py`, `Tests/UI/test_console_scope_row.py`, `Tests/UI/test_console_live_work_handoffs.py`, `Tests/UI/test_console_staged_evidence_strip.py`, `Tests/Library/test_library_rag_scope.py`, and the small citation/cost/resume/character seam tests found by the moved-seam guard.
+- Modify `backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md`: link this plan now; complete ACs and notes only after all focused gates and review pass.
+- Modify `Docs/security/production-diagnostic-inventory.json` only if the canonical non-write checker proves an expected owner/digest move; regenerate once and review the exact generated diff.
+
+### Task 1: Lock retrieval ownership and no-mount behavior with RED tests
+
+- [ ] Add `Tests/UI/test_console_retrieval_controller.py` with a small constructor fixture using plain call recorders and no Textual mount.
+- [ ] Assert controller defaults for `_console_retrieval_scope_cache`, `_console_effective_scope_cache`, `_active_dictionaries_summary`, `_last_console_dictionary_scope_ids`, `_active_world_books_summary`, and `_last_console_world_book_scope_ids`.
+- [ ] Characterize the four high-risk policy families before moving code:
+  - effective-scope cache build/read and persisted-vs-unpersisted save;
+  - dictionary/world-book summary refresh guards and cached row/action projection;
+  - Library RAG scoped/empty/results/blocked outcomes and stage ordering;
+  - auto-retrieve gates, placeholder identity, timeout/failure containment, cancellation, and same-send capture.
+- [ ] Extend the architecture test so the retrieval family must be complete: all 32 M names only on `ConsoleRetrievalController`; the two D names remain on `ChatScreen` with their exact decorators/groups and at-most-five-line definition spans; all six descriptors target `_retrieval`; moved methods contain no DOM calls or sibling-controller reach-through.
+- [ ] Add a structural assertion that ordinary production callers use `_retrieval` directly and that no moved default is assigned in `ChatScreen.__init__`.
+- [ ] Run the new controller and architecture nodes. Confirm RED is caused by the absent controller/current screen ownership, not the known line-ceiling failure alone.
+
+### Task 2: Create the controller and move scope/cache ownership
+
+- [ ] Create `ConsoleRetrievalController` with `app_instance` plus explicit keyword-only late-bound callables for active session/conversation, pending-launch state transitions, source/query setters, screen sync/refresh, scope-row/control-bar sync, visible-run dispatch, launch payload inspection, and evidence consume/release.
+- [ ] Initialize all six compatibility defaults in the controller constructor.
+- [ ] Move the scope/cache methods verbatim in behavior: staged capture, pure display-state build, recipe count, effective resolution/warm, DB read/write, lister construction, and scope save.
+- [ ] Add six `_ControllerState("_retrieval", ...)` assignments to `ChatScreen` and remove the corresponding `__init__` assignments.
+- [ ] Repoint Workspace and Session late-bound scope dependencies in `wiring.py` to `screen._retrieval` at call time.
+- [ ] Run the focused controller/scope/architecture tests. Expect defaults, descriptors, cache, and save cases green while later inspector/RAG ownership remains RED.
+
+### Task 3: Move inspector and Library RAG policy
+
+- [ ] Move cached dictionary/world-book scope IDs, refresh guards, summaries, rows, and action projections. Keep attach/detach pickers and workers on `ChatScreen`; route their refresh calls to `_retrieval`.
+- [ ] Move source-status and source-scope-label builders. Keep screen-owned inspector composition and widget label updates, but source their plain values from `_retrieval`.
+- [ ] Move stage, settings-choice, scope resolution, outcome application, service-initialization detection, notification, placeholder clearing, and auto-retrieve orchestration.
+- [ ] Preserve the pending-launch screen state through explicit getter/setter callbacks and keep all DOM refresh/recompose operations behind named screen callbacks.
+- [ ] Move the body of `_capture_console_staged_rag` and rewire both provider registration sites directly to `_retrieval`.
+- [ ] Run the no-mount controller tests plus existing auto-RAG, dictionary, world-book, RAG-settings, and Library-scope tests to GREEN.
+
+### Task 4: Finish worker delegates, wiring, and call-site migration
+
+- [ ] Add `_retrieval = ConsoleRetrievalController(...)` to `build_console_controllers`; update its documented build order/count and wiring tests.
+- [ ] Keep `_persist_console_rag_auto_retrieve_on_send` on `ChatScreen` with `@work(thread=True)` and a one-statement controller delegation.
+- [ ] Keep `_execute_console_library_rag_search` on `ChatScreen` with `@work(exclusive=True, group="console-library-rag-search")` and an awaited controller delegation.
+- [ ] Repoint all ordinary production callers to `_retrieval`, including compose/inspector/sync, explicit RAG run, scope flush/resume, staged handoff, attach/detach refresh, and the Session/Workspace seams.
+- [ ] Mechanically retarget direct private-method tests to the controller owner. Do not alter assertions or mounted user flows.
+- [ ] Register `ConsoleRetrievalController` in the moved-seam AST guard and prove the guard reports a synthetic stale `screen.<moved method>()` call.
+- [ ] Remove imports from `chat_screen.py` only when `rg` and Ruff prove they are no longer screen-owned; import them in `retrieval.py` from their defining modules.
+- [ ] Run the controller, architecture, wiring, moved-seam, and exact mounted retrieval files to GREEN.
+
+### Task 5: Mutation and focused regression evidence
+
+- [ ] Remove one `_retrieval` descriptor setter/retarget it to screen shadow state; confirm the descriptor test fails, then restore.
+- [ ] Put one moved method back on `ChatScreen` or add a DOM call inside the controller; confirm the ownership/DOM AST test fails, then restore.
+- [ ] Bypass the effective-scope empty short-circuit; confirm the scoped retrieval test fails, then restore.
+- [ ] Remove placeholder identity guarding or failure cleanup; confirm the auto-RAG test fails, then restore.
+- [ ] Remove the dictionary/world-book unchanged-scope guard; confirm the zero-repeat summary test fails, then restore.
+- [ ] Remove each worker delegation in turn; confirm the exact delegate/behavior test fails for the intended reason, then restore.
+- [ ] Run only touched-functionality groups: retrieval controller/architecture/wiring, scope/modal/Library RAG, auto-send/capture/staging, dictionary/world-book inspector, and any mechanically retargeted seam tests.
+
+### Task 6: Static checks, diagnostics, review, and closeout
+
+- [ ] Run Ruff format/check on every changed Python file only. Do not bulk-format unrelated files.
+- [ ] Run `py_compile` for `retrieval.py`, `wiring.py`, and `chat_screen.py` under one validated temporary pycache root; remove only that exact root and prove it absent.
+- [ ] Run `git diff --check`, inspect the cumulative diff for the one-controller/YAGNI boundary, and verify no CSS, DOM IDs, storage schema, dependency, or user-visible copy changed.
+- [ ] Run the persistent-diagnostic checker and its two focused architecture tests. Regenerate the manifest only for proven moved-owner metadata with unchanged sink topology.
+- [ ] Obtain an independent correctness/spec review if the active collaboration policy permits it; otherwise perform and record a separate self-review pass without changing scope.
+- [ ] Update the task ACs and concise Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, inherited baseline classification, and the explicit no-full-suite user constraint.
+- [ ] Commit the implementation, rebase onto latest `origin/dev`, rerun the same focused gates on the rebased head, then push and open one atomic PR against `dev`.

--- a/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
+++ b/Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md
@@ -99,4 +99,4 @@
 - [x] Run the persistent-diagnostic checker and its two focused architecture tests. Regenerate the manifest only for proven moved-owner metadata with unchanged sink topology.
 - [x] Obtain an independent correctness/spec review if the active collaboration policy permits it; otherwise perform and record a separate self-review pass without changing scope.
 - [x] Update the task ACs and concise Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, inherited baseline classification, and the explicit no-full-suite user constraint.
-- [ ] Commit the implementation, rebase onto latest `origin/dev`, rerun the same focused gates on the rebased head, then push and open one atomic PR against `dev`.
+- [x] Commit the implementation, rebase onto latest `origin/dev`, rerun the same focused gates on the rebased head, then push and open one atomic PR against `dev`.

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -1176,6 +1176,77 @@ def test_browser_family_has_completed_workspace_ownership() -> None:
 
 
 @pytest.mark.unit
+def test_retrieval_family_has_completed_controller_ownership() -> None:
+    """Require every reviewed retrieval method to have its final owner."""
+    group = WAVE6_GROUPS["retrieval"]
+    target_path = _REPO_ROOT / group.target_path
+    screen_methods = _methods(_SCREEN_PATH, "ChatScreen")
+
+    assert target_path.exists(), "ConsoleRetrievalController module is missing"
+    target_methods = _methods(target_path, group.target_class)
+    assert not (group.moved & screen_methods.keys()), (
+        "retrieval methods still owned by ChatScreen: "
+        f"{sorted(group.moved & screen_methods.keys())}"
+    )
+    assert group.moved <= target_methods.keys(), (
+        "retrieval methods missing from ConsoleRetrievalController: "
+        f"{sorted(group.moved - target_methods.keys())}"
+    )
+    assert group.delegates <= screen_methods.keys()
+    assert group.delegates <= target_methods.keys()
+    owned_methods = [target_methods[name] for name in group.moved | group.delegates]
+    assert not any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"query", "query_one", "push_screen"}
+        for method in owned_methods
+        for node in ast.walk(method)
+    )
+    assert "_screen" not in _self_assignments(target_methods["__init__"])
+
+
+@pytest.mark.unit
+def test_retrieval_compatibility_descriptors_all_target_retrieval() -> None:
+    """Require all six assignable retrieval names to proxy to one owner."""
+    _, screen_class = _class_node(_SCREEN_PATH, "ChatScreen")
+    names = COMPATIBILITY_TARGETS["_retrieval"]
+
+    assert _controller_state_assignments(screen_class, names) == {
+        name: "_retrieval" for name in names
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("method_name", "awaited"),
+    [
+        ("_persist_console_rag_auto_retrieve_on_send", False),
+        ("_execute_console_library_rag_search", True),
+    ],
+)
+def test_retrieval_worker_delegates_call_exact_controller_methods(
+    method_name: str, awaited: bool
+) -> None:
+    """Both decorated screen names contain one exact controller call."""
+    method = _methods(_SCREEN_PATH, "ChatScreen")[method_name]
+    assert len(method.body) == 1
+    statement = method.body[0]
+    assert isinstance(statement, ast.Expr)
+    value = statement.value
+    if awaited:
+        assert isinstance(value, ast.Await)
+        value = value.value
+    assert isinstance(value, ast.Call)
+    assert isinstance(value.func, ast.Attribute)
+    assert value.func.attr == method_name
+    owner = value.func.value
+    assert isinstance(owner, ast.Attribute)
+    assert isinstance(owner.value, ast.Name)
+    assert owner.value.id == "self"
+    assert owner.attr == "_retrieval"
+
+
+@pytest.mark.unit
 def test_browser_search_handler_is_exact_bounded_textual_delegate() -> None:
     """Keep the framework handler bound and within its five-line residue."""
     group = WAVE6_GROUPS["browser"]

--- a/Tests/Library/test_library_rag_scope.py
+++ b/Tests/Library/test_library_rag_scope.py
@@ -741,7 +741,10 @@ async def test_console_scope_resolution_scopes_request_for_scoped_conversation(
         query="q", source_types=("notes", "media", "conversations")
     )
 
-    scoped_request, outcome = await screen._resolve_console_library_rag_scope(request)
+    (
+        scoped_request,
+        outcome,
+    ) = await screen._retrieval._resolve_console_library_rag_scope(request)
 
     assert outcome is None
     assert scoped_request.scope is not None
@@ -774,7 +777,10 @@ async def test_console_scope_resolution_short_circuits_on_empty_scope(tmp_path):
     app._screen_stacks[app._current_mode] = [screen]
     request = LibraryRagSearchRequest(query="q", source_types=("notes",))
 
-    scoped_request, outcome = await screen._resolve_console_library_rag_scope(request)
+    (
+        scoped_request,
+        outcome,
+    ) = await screen._retrieval._resolve_console_library_rag_scope(request)
 
     assert outcome is not None
     assert outcome.status == "empty"
@@ -795,7 +801,10 @@ async def test_console_scope_resolution_unscoped_when_no_active_session():
     app._screen_stacks[app._current_mode] = [screen]
     request = LibraryRagSearchRequest(query="q", source_types=("notes",))
 
-    scoped_request, outcome = await screen._resolve_console_library_rag_scope(request)
+    (
+        scoped_request,
+        outcome,
+    ) = await screen._retrieval._resolve_console_library_rag_scope(request)
 
     assert outcome is None
     assert scoped_request is request

--- a/Tests/UI/test_console_auto_rag_on_send.py
+++ b/Tests/UI/test_console_auto_rag_on_send.py
@@ -1,6 +1,6 @@
 """Console opt-in RAG auto-retrieve on send (TASK-406 / TASK-3170 task 8).
 
-The send path grows ONE new hook, ``ChatScreen._maybe_auto_retrieve_for_send``,
+The send path grows ONE new hook, ``ConsoleRetrievalController._maybe_auto_retrieve_for_send``,
 called from the consume-on-send seam (``_capture_console_staged_rag``) so an
 auto-retrieved bundle is staged and consumed by the SAME send and renders in
 the staged-evidence strip exactly like a manual chip run.
@@ -13,12 +13,10 @@ tests are deliberately split so a dropped clause reds exactly one of them.
 from __future__ import annotations
 
 import asyncio
-from types import MethodType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import Static
-
 from Tests.fixtures.required_doubles import exploding_double
 from Tests.UI.test_console_dictionary_send_integration import (
     _CapturingGateway,
@@ -42,25 +40,10 @@ from tldw_chatbook.Library.library_rag_service import (
 )
 from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
-from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Console_Modules import retrieval as retrieval_module
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 
 STRIP_ID = "#console-staged-evidence-strip"
-
-#: Real ChatScreen methods bound onto the lightweight stand-in below. Every
-#: one is production code -- the stand-in supplies only state and the two
-#: surface-refresh seams a mounted screen would provide.
-_REAL_METHODS = (
-    "_maybe_auto_retrieve_for_send",
-    "_has_staged_console_evidence",
-    "_rag_service_still_initializing",
-    "_notify_console_auto_rag_scope_empty",
-    "_notify_auto_rag_degraded",
-    "_notify_console_auto_rag",
-    "_clear_console_auto_rag_placeholder",
-    "_stage_console_library_rag_launch",
-    "_apply_console_library_rag_search_outcome",
-    "_resolve_console_library_rag_scope",
-)
 
 
 @pytest.fixture(autouse=True)
@@ -150,7 +133,7 @@ def _staged_launch() -> ConsoleLiveWorkLaunch:
 
 
 def _auto_rag_screen(*, service=None, staged=None, has_pending: bool = False):
-    """A ChatScreen stand-in carrying the REAL auto-retrieve methods."""
+    """A screen-state stand-in wired to the real retrieval controller."""
     notices: list[tuple[str, str]] = []
 
     def _notify(message, severity="information", **_kwargs):
@@ -172,18 +155,57 @@ def _auto_rag_screen(*, service=None, staged=None, has_pending: bool = False):
         _console_library_rag_source_types=("media",),
         _sync_console_pending_launch_surfaces=lambda: True,
     )
-    for name in _REAL_METHODS:
-        setattr(screen, name, MethodType(getattr(ChatScreen, name), screen))
+    screen._has_staged_console_evidence = lambda: bool(
+        screen._pending_console_launch_context is not None
+        or app.pending_handoffs.has_pending(None)
+    )
+    screen._retrieval = ConsoleRetrievalController(
+        app_instance=app,
+        active_native_session=lambda: None,
+        current_conversation_id=lambda: None,
+        clear_evidence_sent_notice=lambda: setattr(
+            screen, "_console_evidence_sent_notice", None
+        ),
+        consume_pending_launch=lambda: screen._pending_console_launch_context,
+        release_consumed_launch=lambda *_args: None,
+        is_mounted=lambda: screen.is_mounted,
+        sync_retrieval_scope_row=lambda: None,
+        sync_control_bar=lambda: None,
+        request_control_bar_sync=lambda: None,
+        dictionary_scope_service=lambda: None,
+        set_library_rag_source_scope=lambda value: setattr(
+            screen, "_console_library_rag_source_types", tuple(value)
+        ),
+        set_library_rag_query=lambda _value: None,
+        run_library_rag_action=lambda: None,
+        library_rag_source_scope=(
+            lambda: tuple(screen._console_library_rag_source_types)
+        ),
+        library_rag_top_k=lambda: (
+            chat_screen_module._console_library_rag_profile_top_k()
+        ),
+        pending_launch=lambda: screen._pending_console_launch_context,
+        set_pending_launch=lambda launch: setattr(
+            screen, "_pending_console_launch_context", launch
+        ),
+        set_pending_auto_open=lambda value: setattr(
+            screen, "_pending_console_launch_auto_open_inspector", value
+        ),
+        set_evidence_sent_notice=lambda value: setattr(
+            screen, "_console_evidence_sent_notice", value
+        ),
+        sync_pending_launch_surfaces=screen._sync_console_pending_launch_surfaces,
+        refresh_screen=lambda: None,
+        has_staged_evidence=screen._has_staged_console_evidence,
+    )
     return screen
 
 
 def _patch_scope(monkeypatch, state: str = "unscoped", cause=None) -> None:
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "resolve_effective_scope_for_chat",
-        AsyncMock(
-            return_value=EffectiveScope(state=state, allowlist={}, cause=cause)
-        ),
+        AsyncMock(return_value=EffectiveScope(state=state, allowlist={}, cause=cause)),
     )
 
 
@@ -199,7 +221,7 @@ async def test_toggle_off_means_no_retrieval_call(monkeypatch):
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert service.calls == []
     assert screen._pending_console_launch_context is None
@@ -222,14 +244,12 @@ async def test_toggle_default_is_off_at_the_read_site(monkeypatch):
         seen[(section, key)] = default
         return default
 
-    monkeypatch.setattr(
-        chat_screen_module, "get_cli_setting", _recording_get_cli_setting
-    )
+    monkeypatch.setattr(retrieval_module, "get_cli_setting", _recording_get_cli_setting)
     _patch_scope(monkeypatch)
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert seen[("chat_defaults", "rag_auto_retrieve_on_send")] is False
     assert service.calls == []
@@ -249,7 +269,7 @@ async def test_slash_command_send_never_retrieves(monkeypatch, draft):
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send(draft)
+    await screen._retrieval._maybe_auto_retrieve_for_send(draft)
 
     assert service.calls == []
     assert screen._pending_console_launch_context is None
@@ -263,7 +283,7 @@ async def test_plain_text_send_does_retrieve(monkeypatch):
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert len(service.calls) == 1
     assert service.calls[0]["query"] == "what changed in the notes"
@@ -284,7 +304,7 @@ async def test_already_staged_evidence_skips_auto_retrieve(monkeypatch):
     staged = _staged_launch()
     screen = _auto_rag_screen(service=service, staged=staged)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert service.calls == []
     assert screen._pending_console_launch_context is staged
@@ -303,7 +323,7 @@ async def test_unclaimed_handoff_also_counts_as_already_staged(monkeypatch):
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service, has_pending=True)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert service.calls == []
     assert screen._pending_console_launch_context is None
@@ -322,7 +342,7 @@ async def test_empty_scope_short_circuits_with_shared_copy(monkeypatch):
     service = _RecordingRagService(_rows(2))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert service.calls == []
     assert screen._pending_console_launch_context is None
@@ -346,10 +366,10 @@ async def test_query_is_length_capped_before_it_reaches_retrieval(monkeypatch):
     service = _RecordingRagService(_rows(1))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("a" * 9_000)
+    await screen._retrieval._maybe_auto_retrieve_for_send("a" * 9_000)
 
     assert len(service.calls) == 1
-    assert len(service.calls[0]["query"]) == chat_screen_module.AUTO_RAG_QUERY_MAX_CHARS
+    assert len(service.calls[0]["query"]) == retrieval_module.AUTO_RAG_QUERY_MAX_CHARS
 
 
 @pytest.mark.asyncio
@@ -363,7 +383,7 @@ async def test_retrieval_requests_the_active_profile_top_k(monkeypatch):
     service = _RecordingRagService(_rows(1))
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert service.calls[0]["top_k"] == 7
 
@@ -413,7 +433,7 @@ async def test_in_flight_placeholder_is_staged_while_retrieval_runs(monkeypatch)
 
     screen.app_instance.library_rag_search_service = _StagingObservingRagService()
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert len(observed) == 1
     in_flight, was_staged = observed[0]
@@ -421,7 +441,7 @@ async def test_in_flight_placeholder_is_staged_while_retrieval_runs(monkeypatch)
     assert was_staged is True
     assert in_flight.status == "searching"
     assert in_flight.payload["query"] == "what changed in the notes"
-    assert in_flight.recovery == chat_screen_module.CONSOLE_AUTO_RAG_SEARCHING_COPY
+    assert in_flight.recovery == retrieval_module.CONSOLE_AUTO_RAG_SEARCHING_COPY
     # ...and the results replaced it rather than piling up a second card.
     settled = screen._pending_console_launch_context
     assert settled is not in_flight
@@ -442,7 +462,7 @@ async def test_zero_results_never_leaves_a_blocking_launch_staged(monkeypatch):
     service = _RecordingRagService(())
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert len(service.calls) == 1
     assert screen._pending_console_launch_context is None
@@ -453,11 +473,11 @@ async def test_timeout_sends_without_evidence_and_notifies(monkeypatch):
     """A slow backend never holds the send: quiet notice, nothing staged."""
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
-    monkeypatch.setattr(chat_screen_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(retrieval_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
     service = _RecordingRagService(_rows(2), delay=5.0)
     screen = _auto_rag_screen(service=service)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert screen._pending_console_launch_context is None
     assert len(screen.notices) == 1
@@ -465,7 +485,7 @@ async def test_timeout_sends_without_evidence_and_notifies(monkeypatch):
     assert severity == "warning"
     # No cached runtime on the app -> the timeout is first-run model load,
     # and the copy must say so rather than blaming retrieval.
-    assert message == chat_screen_module.CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
+    assert message == retrieval_module.CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
 
 
 @pytest.mark.asyncio
@@ -475,17 +495,17 @@ async def test_timeout_with_a_live_runtime_reports_failure_not_initializing(
     """With a warm runtime the same timeout is an honest retrieval failure."""
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
-    monkeypatch.setattr(chat_screen_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(retrieval_module, "AUTO_RAG_TIMEOUT_SECONDS", 0.01)
     service = _RecordingRagService(_rows(2), delay=5.0)
     screen = _auto_rag_screen(service=service)
     screen.app_instance._rag_service = SimpleNamespace(search=lambda *a, **k: None)
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert screen.notices == [
-        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+        (retrieval_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
     ]
-    assert RETRIEVAL_FAILED_WHY in chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE
+    assert RETRIEVAL_FAILED_WHY in retrieval_module.CONSOLE_AUTO_RAG_FAILED_NOTICE
 
 
 @pytest.mark.asyncio
@@ -494,7 +514,7 @@ async def test_retrieval_exception_sends_without_evidence(monkeypatch):
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "run_library_rag_search",
         exploding_double(
             RuntimeError("backend exploded"),
@@ -503,11 +523,11 @@ async def test_retrieval_exception_sends_without_evidence(monkeypatch):
     )
     screen = _auto_rag_screen(service=_RecordingRagService(_rows(2)))
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert screen._pending_console_launch_context is None
     assert screen.notices == [
-        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+        (retrieval_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
     ]
 
 
@@ -517,17 +537,17 @@ async def test_failed_outcome_is_reported_not_silently_swallowed(monkeypatch):
     _enable_auto_retrieve()
     _patch_scope(monkeypatch)
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "run_library_rag_search",
         AsyncMock(return_value=LibraryRagSearchOutcome(status="failed")),
     )
     screen = _auto_rag_screen(service=_RecordingRagService(()))
 
-    await screen._maybe_auto_retrieve_for_send("what changed in the notes")
+    await screen._retrieval._maybe_auto_retrieve_for_send("what changed in the notes")
 
     assert screen._pending_console_launch_context is None
     assert screen.notices == [
-        (chat_screen_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
+        (retrieval_module.CONSOLE_AUTO_RAG_FAILED_NOTICE, "warning")
     ]
 
 
@@ -549,7 +569,7 @@ async def test_happy_path_stages_then_send_consumes(monkeypatch):
         return_value=LocalRagContextResult(context=context, citation_builder=None)
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
@@ -608,9 +628,7 @@ async def test_send_proceeds_when_auto_retrieve_fails(monkeypatch):
         RuntimeError("backend exploded"),
         reason="the send must be shown surviving a retrieval failure",
     )
-    monkeypatch.setattr(
-        chat_screen_module, "run_library_rag_search", exploding_search
-    )
+    monkeypatch.setattr(retrieval_module, "run_library_rag_search", exploding_search)
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
@@ -638,11 +656,11 @@ def test_send_kind_classification_is_shared_not_duplicated():
     from tldw_chatbook.Chat.console_command_grammar import COMMAND_PREFIX
     from tldw_chatbook.Chat.console_skill_resolver import MENTION_SIGIL
 
-    assert chat_screen_module._is_plain_text_send("a plain question") is True
-    assert chat_screen_module._is_plain_text_send(f"{COMMAND_PREFIX}prompt x") is False
-    assert chat_screen_module._is_plain_text_send(f"{MENTION_SIGIL}skill x") is False
-    assert chat_screen_module._is_plain_text_send("   ") is False
-    assert chat_screen_module._is_plain_text_send(None) is False
+    assert retrieval_module.is_plain_text_send("a plain question") is True
+    assert retrieval_module.is_plain_text_send(f"{COMMAND_PREFIX}prompt x") is False
+    assert retrieval_module.is_plain_text_send(f"{MENTION_SIGIL}skill x") is False
+    assert retrieval_module.is_plain_text_send("   ") is False
+    assert retrieval_module.is_plain_text_send(None) is False
 
 
 @pytest.mark.asyncio
@@ -672,22 +690,19 @@ async def test_capture_seam_calls_the_hook_before_consuming(monkeypatch):
         order.append("consume")
         return None
 
-    screen = SimpleNamespace(
-        app_instance=SimpleNamespace(),
-        _clear_console_evidence_sent_notice=lambda: order.append("clear-notice"),
-        _maybe_auto_retrieve_for_send=_hook,
-        _consume_pending_console_launch=_consume,
-        _release_consumed_console_launch=lambda *a: None,
-    )
+    screen = _auto_rag_screen()
+    screen._retrieval._clear_evidence_sent_notice = lambda: order.append("clear-notice")
+    screen._retrieval._maybe_auto_retrieve_for_send = _hook
+    screen._retrieval._consume_pending_launch = _consume
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "capture_console_staged_evidence_for_chat",
         AsyncMock(
             return_value=LocalRagContextResult(context=None, citation_builder=None)
         ),
     )
 
-    await ChatScreen._capture_console_staged_rag(screen, "question", turn_context)
+    await screen._retrieval._capture_console_staged_rag("question", turn_context)
 
     assert order == ["clear-notice", "auto-retrieve", "consume"]
     # ...and the hook retrieves for THIS turn's captured configuration, not
@@ -708,27 +723,22 @@ async def test_capture_seam_contains_an_exploding_auto_retrieve(monkeypatch):
     released: list[tuple] = []
     context = "[S1] MEDIA — Source 1\nBody 1"
 
-    async def _explode(_draft):
+    async def _explode(_draft, turn_context=None):
         raise RuntimeError("auto-retrieve exploded")
 
-    screen = SimpleNamespace(
-        app_instance=SimpleNamespace(),
-        _clear_console_evidence_sent_notice=lambda: None,
-        _maybe_auto_retrieve_for_send=_explode,
-        _consume_pending_console_launch=lambda: launch,
-        _release_consumed_console_launch=lambda *args: released.append(args),
-    )
+    screen = _auto_rag_screen()
+    screen._retrieval._maybe_auto_retrieve_for_send = _explode
+    screen._retrieval._consume_pending_launch = lambda: launch
+    screen._retrieval._release_consumed_launch = lambda *args: released.append(args)
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "capture_console_staged_evidence_for_chat",
         AsyncMock(
-            return_value=LocalRagContextResult(
-                context=context, citation_builder=None
-            )
+            return_value=LocalRagContextResult(context=context, citation_builder=None)
         ),
     )
 
-    result = await ChatScreen._capture_console_staged_rag(screen, "question")
+    result = await screen._retrieval._capture_console_staged_rag("question")
 
     assert result.context == context
     assert len(released) == 1

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -43,6 +43,7 @@ from tldw_chatbook.Character_Chat.visual_identity import (
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 from tldw_chatbook.UI.Console_Modules.session import (
     CharacterSessionPromptSeed,
     ConsoleSessionController,
@@ -107,6 +108,11 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     for the rationale (bypasses ``ChatScreen.__init__``).
     """
     screen = ChatScreen.__new__(ChatScreen)
+    screen._retrieval = object.__new__(ConsoleRetrievalController)
+    screen._retrieval._capture_console_staged_rag = AsyncMock()
+    screen._retrieval._current_conversation_id = (
+        lambda: screen._current_console_rail_conversation_id()
+    )
     screen._character = ConsoleCharacterController.__new__(ConsoleCharacterController)
     screen._character._active_character_avatar = None
     screen._character._active_character_avatar_name = None
@@ -171,7 +177,7 @@ def test_p3c_leaves_dictionary_scope_ids_unchanged():
     )
     screen = _bare_console_screen(_store_with_session(session))
 
-    conversation_id, character_id = screen._active_console_dictionary_scope_ids()
+    conversation_id, character_id = screen._retrieval._active_console_dictionary_scope_ids()
     assert conversation_id == "conv-1"
     assert character_id is None
 

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -40,6 +40,7 @@ from tldw_chatbook.UI.Console_Modules.dictation import ConsoleDictationControlle
 from tldw_chatbook.UI.Console_Modules.hands_free import ConsoleHandsFreeController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
@@ -80,6 +81,16 @@ def test_all_six_controllers_are_constructed_with_the_right_classes():
         assert isinstance(controller, cls), (
             f"{attr} is {type(controller).__name__}, expected {cls.__name__}"
         )
+
+
+def test_retrieval_controller_is_constructed_with_late_bound_screen_edges():
+    """Wave 6 wires one retrieval owner without freezing screen state."""
+    screen = _unmounted_console()
+
+    assert isinstance(screen._retrieval, ConsoleRetrievalController)
+    sentinel = object()
+    screen._current_console_rail_conversation_id = lambda: sentinel
+    assert screen._retrieval._current_conversation_id() is sentinel
 
 
 def test_controllers_are_built_in_the_documented_order():

--- a/Tests/UI/test_console_cost_chip_estimate_cache.py
+++ b/Tests/UI/test_console_cost_chip_estimate_cache.py
@@ -186,7 +186,7 @@ async def test_staged_evidence_row_is_not_retokenized_every_tick(monkeypatch):
         # Spy BEFORE staging: staging itself drives a sync pass, so the
         # pseudo-row's one legitimate estimate may be spent there.
         spy = _spy_on_estimator(monkeypatch)
-        console._stage_console_library_rag_launch(
+        console._retrieval._stage_console_library_rag_launch(
             ConsoleLiveWorkLaunch.from_values(
                 source="Library Search/RAG",
                 title="Library Search/RAG retrieval",

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -531,7 +531,7 @@ async def test_build_console_cost_state_counts_staged_evidence_before_send():
             payload={"query": "question", "evidence_bundle": bundle.to_payload()},
             status="staged",
         )
-        console._stage_console_library_rag_launch(launch)
+        console._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         state = console._build_console_cost_state()

--- a/Tests/UI/test_console_dictionaries_screen.py
+++ b/Tests/UI/test_console_dictionaries_screen.py
@@ -126,7 +126,7 @@ async def test_refresh_caches_summary_and_build_projects_dictionary_rows():
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-1"
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
         assert screen._active_dictionaries_summary == summary
         assert service.calls == [("conv-1", None, "local")]
@@ -160,7 +160,7 @@ async def test_build_console_inspector_state_never_re_queries_the_summarize_serv
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-1"
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
         assert len(service.calls) == 1
 
         # A bare, recompose-equivalent build must read only the cache -- no
@@ -186,10 +186,10 @@ async def test_refresh_with_no_service_and_no_chat_caches_empty():
         # Fresh default native session has no persisted conversation yet.
         assert _active_native_session(screen).persisted_conversation_id is None
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
         assert screen._active_dictionaries_summary == {"dictionaries": []}
-        rows = screen._console_dictionary_inspector_rows()
+        rows = screen._retrieval._console_dictionary_inspector_rows()
         assert rows == (ConsoleDisplayRow("No active chat", ""),)
 
 
@@ -204,7 +204,7 @@ async def test_refresh_with_service_but_no_active_chat_caches_empty_without_call
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         assert _active_native_session(screen).persisted_conversation_id is None
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
         assert service.calls == []
         assert screen._active_dictionaries_summary == {"dictionaries": []}
@@ -221,9 +221,9 @@ async def test_empty_dictionaries_summary_renders_empty_row():
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-1"
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
-        rows = screen._console_dictionary_inspector_rows()
+        rows = screen._retrieval._console_dictionary_inspector_rows()
         assert rows == (ConsoleDisplayRow("No dictionaries in play", ""),)
 
 
@@ -264,7 +264,7 @@ async def test_shadowed_and_disabled_suffixes_render_on_the_row_value():
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-1"
 
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
         # Native Console sessions do not yet track a numeric character id
         # (Roleplay P1e Attachments is net-new work) -- character_id is
@@ -273,7 +273,7 @@ async def test_shadowed_and_disabled_suffixes_render_on_the_row_value():
         # unconditionally; this proves row *rendering* of shadowed/disabled
         # character entries is unaffected by that).
         assert service.calls == [("conv-1", None, "local")]
-        rows = screen._console_dictionary_inspector_rows()
+        rows = screen._retrieval._console_dictionary_inspector_rows()
         assert rows == (
             ConsoleDisplayRow("Slang", "from conversation"),
             ConsoleDisplayRow("Slang", "from character (shadowed)"),
@@ -295,9 +295,9 @@ async def test_actions_reflect_conversation_and_attach_state():
         # disabled (with the recovery copy) and detach has no
         # conversation-source dict to detach either.
         assert _active_native_session(screen).persisted_conversation_id is None
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
-        actions = screen._console_dictionary_inspector_actions()
+        actions = screen._retrieval._console_dictionary_inspector_actions()
         attach = next(
             a for a in actions if a.widget_id == "console-inspector-dictionaries-attach"
         )
@@ -323,9 +323,9 @@ async def test_actions_reflect_conversation_and_attach_state():
             ],
             "source": "local",
         }
-        await screen.refresh_active_dictionaries_summary()
+        await screen._retrieval.refresh_active_dictionaries_summary()
 
-        actions2 = screen._console_dictionary_inspector_actions()
+        actions2 = screen._retrieval._console_dictionary_inspector_actions()
         attach2 = next(
             a
             for a in actions2

--- a/Tests/UI/test_console_internals_decomposition.py
+++ b/Tests/UI/test_console_internals_decomposition.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 from rich.console import Console
 from rich.text import Text
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -30,7 +30,6 @@ from Tests.Agents.test_mcp_tool_provider import (
     _tool_dict,
 )
 from tldw_chatbook.Chat.chat_models import ChatSessionData
-from tldw_chatbook.Chat.console_ephemeral import blocked_reason
 from tldw_chatbook.Widgets.Console.console_composer_menu_modal import (
     ACTION_SAVE_CHATBOOK,
 )
@@ -3552,12 +3551,12 @@ def test_console_rag_source_status_unchanged_with_a_pending_launch():
         status="ready",
     )
 
-    assert screen._console_rag_source_status(launch) == (
+    assert screen._retrieval._console_rag_source_status(launch) == (
         "staged from Library Search/RAG"
     )
     # A stale sent-notice sitting alongside a NEW pending launch changes
     # nothing -- pending-launch derivation takes over unconditionally.
-    assert screen._console_rag_source_status(launch, sent_source_count=5) == (
+    assert screen._retrieval._console_rag_source_status(launch, sent_source_count=5) == (
         "staged from Library Search/RAG"
     )
 
@@ -3567,10 +3566,10 @@ def test_console_rag_source_status_remembers_the_last_send_when_nothing_is_stage
     app = _build_test_app()
     screen = ChatScreen(app)
 
-    assert screen._console_rag_source_status(None, sent_source_count=5) == (
+    assert screen._retrieval._console_rag_source_status(None, sent_source_count=5) == (
         "sent with the last message · 5 sources"
     )
-    assert screen._console_rag_source_status(None, sent_source_count=1) == (
+    assert screen._retrieval._console_rag_source_status(None, sent_source_count=1) == (
         "sent with the last message · 1 source"
     )
 
@@ -3580,9 +3579,9 @@ def test_console_rag_source_status_genuinely_empty_reads_not_staged():
     app = _build_test_app()
     screen = ChatScreen(app)
 
-    assert screen._console_rag_source_status(None) == "not staged"
-    assert screen._console_rag_source_status(None, sent_source_count=0) == "not staged"
-    assert screen._console_rag_source_status(None, sent_source_count=None) == (
+    assert screen._retrieval._console_rag_source_status(None) == "not staged"
+    assert screen._retrieval._console_rag_source_status(None, sent_source_count=0) == "not staged"
+    assert screen._retrieval._console_rag_source_status(None, sent_source_count=None) == (
         "not staged"
     )
 
@@ -4066,8 +4065,8 @@ async def test_console_rag_action_falls_back_to_default_top_k_when_profile_unava
 ):
     """TASK-3170 task 9: the chip run's OTHER branch -- profile unresolvable.
 
-    ``_console_library_rag_profile_top_k`` degrades to
-    ``CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K`` when the active RAG profile can't
+    ``_console_library_rag_profile_top_k`` degrades to the shared Library
+    fallback when the active RAG profile can't
     be read (broken/absent profile), so a manual chip run must never raise
     inside a send just because profile resolution failed. Patches
     ``resolve_active_rag_top_k`` itself (what the helper actually reads,
@@ -4075,6 +4074,7 @@ async def test_console_rag_action_falls_back_to_default_top_k_when_profile_unava
     TASK-15020/B3) rather than the helper, so this exercises the real
     try/except fallback path end to end -- not a mock standing in for it.
     """
+    from tldw_chatbook.Library.library_rag_state import LIBRARY_RAG_FALLBACK_TOP_K
     from tldw_chatbook.RAG_Search.simplified import active_config
 
     def _raise_profile_unavailable():
@@ -4124,7 +4124,7 @@ async def test_console_rag_action_falls_back_to_default_top_k_when_profile_unava
                 "query": query,
                 "scope": ("notes", "media", "conversations"),
                 "mode": "rag",
-                "top_k": chat_screen_module.CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K,
+                "top_k": LIBRARY_RAG_FALLBACK_TOP_K,
                 "include_citations": True,
             }
         ]
@@ -4540,7 +4540,7 @@ async def test_console_rag_modal_source_toggle_narrows_the_retrieval_request(
         # request carried, so what ran is visible after the fact too.
         assert "source_scope: notes, conversations" in _visible_text(console)
         assert (
-            ChatScreen._console_library_rag_scope_label(console)
+            console._retrieval._console_library_rag_scope_label()
             == "Sources: Notes, Conversations (Media, Prompts off)"
         )
 

--- a/Tests/UI/test_console_live_work_handoffs.py
+++ b/Tests/UI/test_console_live_work_handoffs.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock
 
 import pytest
 from textual.css.query import NoMatches
-from textual.app import App
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -55,7 +54,6 @@ _RECOVERY_POLL_LIMIT = 600
 #: Shorter than the recovery budget on purpose: by this point the press has
 #: landed, so a long wait here would only slow a genuine failure down.
 _EFFECT_POLL_LIMIT = 100
-
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -1953,6 +1951,7 @@ def _bare_console_screen_for_restore(app_instance=None) -> ChatScreen:
 
     screen = ChatScreen.__new__(ChatScreen)
     screen.app_instance = app_instance
+    screen._retrieval = SimpleNamespace(_capture_console_staged_rag=Mock())
     screen._console_chat_store = ConsoleChatStore()
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._console_visible_draft_session_id = None
@@ -2567,7 +2566,7 @@ async def test_stage_console_library_rag_launch_swaps_card_without_screen_recomp
         composer_before = screen.query_one("#console-native-composer")
         recompose_calls = _spy_screen_recompose(screen)
 
-        screen._stage_console_library_rag_launch(_library_rag_launch())
+        screen._retrieval._stage_console_library_rag_launch(_library_rag_launch())
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#console-pending-launch-card")
 
@@ -2602,11 +2601,15 @@ async def test_stage_console_library_rag_launch_restage_replaces_single_card():
         await _wait_for_selector(screen, pilot, "#console-live-work-source-readiness")
         recompose_calls = _spy_screen_recompose(screen)
 
-        screen._stage_console_library_rag_launch(_library_rag_launch("searching"))
+        screen._retrieval._stage_console_library_rag_launch(
+            _library_rag_launch("searching")
+        )
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#console-pending-launch-card")
 
-        screen._stage_console_library_rag_launch(_library_rag_launch("staged"))
+        screen._retrieval._stage_console_library_rag_launch(
+            _library_rag_launch("staged")
+        )
         await pilot.pause()
         await pilot.pause()
 
@@ -2645,7 +2648,9 @@ async def test_console_live_work_card_swap_keeps_tray_on_top_and_cards_at_bottom
         assert list(rail_body.children).index(tray) == 0
 
         # Readiness -> pending-launch swap mounts after the run inspector.
-        screen._stage_console_library_rag_launch(_library_rag_launch("searching"))
+        screen._retrieval._stage_console_library_rag_launch(
+            _library_rag_launch("searching")
+        )
         await pilot.pause()
         await _wait_for_selector(screen, pilot, "#console-pending-launch-card")
         card = screen.query_one("#console-pending-launch-card")
@@ -2689,7 +2694,9 @@ async def test_stage_console_library_rag_launch_still_auto_opens_inspector():
         # Mirrors `_apply_console_library_rag_search_outcome`'s blocked
         # branch: flag set BEFORE staging (TASK-259 ordering).
         screen._pending_console_launch_auto_open_inspector = True
-        screen._stage_console_library_rag_launch(_library_rag_launch("blocked"))
+        screen._retrieval._stage_console_library_rag_launch(
+            _library_rag_launch("blocked")
+        )
         await pilot.pause()
 
         assert screen.query_one("#console-right-rail").styles.display != "none"
@@ -2886,8 +2893,7 @@ class _ExistingChaChaDBDouble:
         requested_notes = set(json.loads(params[0]))
         requested_conversations = set(json.loads(params[1]))
         rows = [
-            ("notes", note_id)
-            for note_id in sorted(requested_notes & self.note_ids)
+            ("notes", note_id) for note_id in sorted(requested_notes & self.note_ids)
         ]
         rows += [
             ("chat_history", conversation_id)
@@ -3029,4 +3035,3 @@ async def test_console_send_blocked_reason_sendable_for_media_handoff_with_new_b
         assert isinstance(launch.payload.get("evidence_bundle"), dict)
         assert chat_screen_module._source_mentions_rag(launch.source) is False
         assert screen._console_send_blocked_reason() == ""
-

--- a/Tests/UI/test_console_local_citation_capture.py
+++ b/Tests/UI/test_console_local_citation_capture.py
@@ -29,7 +29,8 @@ from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
 )
 from tldw_chatbook.Library.library_rag_service import LibraryRagSearchRequest
 from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
-from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules import retrieval as retrieval_module
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 
 
 def _repair_contract(context: str) -> CitationRepairContract:
@@ -202,7 +203,7 @@ async def test_console_controller_wires_current_staged_rag_capture(monkeypatch):
         )
     )
     monkeypatch.setattr(
-        chat_screen_module,
+        retrieval_module,
         "capture_console_staged_evidence_for_chat",
         capture,
     )
@@ -250,8 +251,8 @@ async def test_console_library_rag_stages_all_retrieved_evidence():
         for index in (1, 2)
     )
     staged = []
-    screen = SimpleNamespace(
-        is_mounted=True,
+    owner = SimpleNamespace(
+        _is_mounted=lambda: True,
         _stage_console_library_rag_launch=staged.append,
     )
     request = LibraryRagSearchRequest(
@@ -262,8 +263,8 @@ async def test_console_library_rag_stages_all_retrieved_evidence():
     )
     outcome = SimpleNamespace(results=rows)
 
-    await chat_screen_module.ChatScreen._apply_console_library_rag_search_outcome(
-        screen,
+    await ConsoleRetrievalController._apply_console_library_rag_search_outcome(
+        owner,
         request,
         outcome,
     )

--- a/Tests/UI/test_console_moved_seam_guard.py
+++ b/Tests/UI/test_console_moved_seam_guard.py
@@ -32,6 +32,7 @@ import pytest
 from tldw_chatbook.UI.Console_Modules.left_rail import ConsoleLeftRail
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.prompts import ConsolePromptsController
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Console_Modules.transcript import ConsoleTranscriptRegion
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
@@ -45,6 +46,7 @@ CONSOLE_CONTROLLERS = (
     ConsoleWorkspaceController,
     ConsoleTranscriptRegion,
     ConsolePromptsController,
+    ConsoleRetrievalController,
     ConsoleLeftRail,
 )
 
@@ -61,6 +63,7 @@ CONTROLLER_VARIABLE_NAMES = frozenset(
         "workspace_controller",
         "transcript_controller",
         "prompts_controller",
+        "retrieval_controller",
         "left_rail",
         "rail",
         "region",

--- a/Tests/UI/test_console_rag_settings_modal.py
+++ b/Tests/UI/test_console_rag_settings_modal.py
@@ -9,7 +9,6 @@ screen.
 from unittest.mock import Mock
 
 import pytest
-from textual.app import App
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -20,6 +19,7 @@ from tldw_chatbook.Library.library_rag_state import (
     LIBRARY_RAG_SCOPE_TOGGLE_SOURCE_TYPES,
     LIBRARY_RAG_SOURCE_TYPES,
 )
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
 from tldw_chatbook.Widgets.Console.console_rag_settings_modal import (
     CONSOLE_RAG_AUTO_RETRIEVE_TOGGLE_ID,
     CONSOLE_RAG_DEFAULT_SOURCE_TYPES,
@@ -29,6 +29,18 @@ from tldw_chatbook.Widgets.Console.console_rag_settings_modal import (
     console_rag_source_toggle_label,
     normalize_console_rag_source_types,
 )
+
+
+def _retrieval_for(screen) -> ConsoleRetrievalController:
+    """Bind the controller's pure settings edges to a lightweight screen."""
+    owner = object.__new__(ConsoleRetrievalController)
+    owner._library_rag_source_scope = lambda: normalize_console_rag_source_types(
+        getattr(screen, "_console_library_rag_source_types", None)
+    )
+    owner._set_library_rag_source_scope = screen._set_console_library_rag_source_scope
+    owner._set_library_rag_query = screen._set_console_library_rag_query
+    owner._run_library_rag_action = screen._run_console_library_rag_from_visible_action
+    return owner
 
 
 @pytest.mark.integration
@@ -559,10 +571,8 @@ async def test_cancel_discards_toggle_changes():
 def test_cancel_leaves_the_screens_stored_scope_untouched():
     """(c) screen half: the ``None`` callback writes neither the query nor
     the source scope."""
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-
     screen = Mock()
-    ChatScreen._apply_console_rag_settings_choice(screen, None)
+    _retrieval_for(screen)._apply_console_rag_settings_choice(None)
 
     screen._set_console_library_rag_query.assert_not_called()
     screen._set_console_library_rag_source_scope.assert_not_called()
@@ -624,7 +634,7 @@ async def test_modal_summary_line_and_readiness_card_share_one_builder():
         summary = modal.query_one("#console-rag-settings-scope", Static)
 
         assert _static_plain_text(summary) == (
-            ChatScreen._console_library_rag_scope_label(screen)
+            _retrieval_for(screen)._console_library_rag_scope_label()
         )
         assert _static_plain_text(summary) == (
             "Sources: Notes, Conversations (Media, Prompts off)"
@@ -634,7 +644,7 @@ async def test_modal_summary_line_and_readiness_card_share_one_builder():
         await pilot.pause()
         screen._console_library_rag_source_types = ("notes", "media", "conversations")
         assert _static_plain_text(summary) == (
-            ChatScreen._console_library_rag_scope_label(screen)
+            _retrieval_for(screen)._console_library_rag_scope_label()
         )
 
 
@@ -650,19 +660,19 @@ def test_readiness_card_label_uses_the_library_summary_grammar():
 
     screen._console_library_rag_source_types = ("notes", "conversations")
     assert (
-        ChatScreen._console_library_rag_scope_label(screen)
+        _retrieval_for(screen)._console_library_rag_scope_label()
         == "Sources: Notes, Conversations (Media, Prompts off)"
     )
 
     screen._console_library_rag_source_types = ("notes", "media", "conversations")
     assert (
-        ChatScreen._console_library_rag_scope_label(screen)
+        _retrieval_for(screen)._console_library_rag_scope_label()
         == "Sources: Notes, Media, Conversations (Prompts off)"
     )
 
     screen._console_library_rag_source_types = LIBRARY_RAG_SCOPE_TOGGLE_SOURCE_TYPES
     assert (
-        ChatScreen._console_library_rag_scope_label(screen)
+        _retrieval_for(screen)._console_library_rag_scope_label()
         == "Sources: all local sources"
     )
 
@@ -709,11 +719,8 @@ def test_stored_source_scope_is_what_retrieval_receives():
 def test_modal_choice_stores_the_source_scope_before_running():
     """The modal's Run stores the chosen sources through the one writer,
     then delegates the run -- so the retrieval that follows uses them."""
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-
     screen = Mock()
-    ChatScreen._apply_console_rag_settings_choice(
-        screen,
+    _retrieval_for(screen)._apply_console_rag_settings_choice(
         ConsoleRagSettingsResult(
             query="what changed",
             run=True,
@@ -736,15 +743,13 @@ def test_apply_choice_never_writes_config_the_toggle_persists_separately():
     dismiss handler. Guards against the fix regressing back to an
     unconditional write on every Run."""
     from tldw_chatbook.config import get_cli_setting
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
     )
 
     screen = Mock()
-    ChatScreen._apply_console_rag_settings_choice(
-        screen,
+    _retrieval_for(screen)._apply_console_rag_settings_choice(
         ConsoleRagSettingsResult(
             query="what changed", run=False, auto_retrieve_on_send=True
         ),
@@ -793,21 +798,19 @@ def test_persist_worker_body_writes_through_to_config():
     in ``Tests/UI/test_parakeet_v2_install_ui.py``. This is a genuine round
     trip through the real production code, not a duplicate helper."""
     from tldw_chatbook.config import get_cli_setting
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
     )
 
     screen = Mock()
-    ChatScreen._persist_console_rag_auto_retrieve_on_send.__wrapped__(screen, True)
+    ConsoleRetrievalController._persist_console_rag_auto_retrieve_on_send(screen, True)
 
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is True
     )
 
     # Not a one-way ratchet: flipping back off persists too.
-    ChatScreen._persist_console_rag_auto_retrieve_on_send.__wrapped__(screen, False)
+    ConsoleRetrievalController._persist_console_rag_auto_retrieve_on_send(screen, False)
 
     assert (
         get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False) is False
@@ -854,6 +857,7 @@ def test_source_scope_survives_a_screen_state_round_trip():
 
     def _bare_screen(store: ConsoleChatStore) -> ChatScreen:
         screen = ChatScreen.__new__(ChatScreen)
+        screen._retrieval = Mock()
         screen._console_chat_store = store
         screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
         screen._console_visible_draft_session_id = None
@@ -894,7 +898,7 @@ def test_source_scope_survives_a_screen_state_round_trip():
 
     assert restored._console_library_rag_source_types == ("notes", "prompts")
     assert (
-        ChatScreen._console_library_rag_scope_label(restored)
+        _retrieval_for(restored)._console_library_rag_scope_label()
         == "Sources: Notes, Prompts (Media, Conversations off)"
     )
 
@@ -952,30 +956,28 @@ def test_screen_callback_stores_sanitized_query_and_delegates_run():
     """The screen-side callback owns sanitization and the run delegation."""
     from textual.css.query import QueryError
 
-    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
-
     screen = Mock()
     screen._console_library_rag_query = ""
     screen.query_one = Mock(side_effect=QueryError("not mounted"))
 
     # The bare state contract: sanitize, store through the one query
     # writer (`_set_console_library_rag_query`), delegate when run=True.
-    ChatScreen._apply_console_rag_settings_choice(
-        screen, ConsoleRagSettingsResult(query="  spaced   query  ", run=True)
+    _retrieval_for(screen)._apply_console_rag_settings_choice(
+        ConsoleRagSettingsResult(query="  spaced   query  ", run=True)
     )
     screen._set_console_library_rag_query.assert_called_once_with("spaced query")
     screen._run_console_library_rag_from_visible_action.assert_called_once()
 
     screen._set_console_library_rag_query.reset_mock()
     screen._run_console_library_rag_from_visible_action.reset_mock()
-    ChatScreen._apply_console_rag_settings_choice(
-        screen, ConsoleRagSettingsResult(query="no run", run=False)
+    _retrieval_for(screen)._apply_console_rag_settings_choice(
+        ConsoleRagSettingsResult(query="no run", run=False)
     )
     screen._set_console_library_rag_query.assert_called_once_with("no run")
     screen._run_console_library_rag_from_visible_action.assert_not_called()
 
     screen._set_console_library_rag_query.reset_mock()
-    ChatScreen._apply_console_rag_settings_choice(screen, None)
+    _retrieval_for(screen)._apply_console_rag_settings_choice(None)
     screen._set_console_library_rag_query.assert_not_called()
 
 
@@ -1005,8 +1007,8 @@ def test_visible_run_action_falls_back_to_the_composer_draft():
         "what changed in auth"
     )
     screen.app_instance.notify.assert_not_called()
-    screen._stage_console_library_rag_launch.assert_called_once()
-    launch = screen._stage_console_library_rag_launch.call_args.args[0]
+    screen._retrieval._stage_console_library_rag_launch.assert_called_once()
+    launch = screen._retrieval._stage_console_library_rag_launch.call_args.args[0]
     assert launch.payload["query"] == "what changed in auth"
     request = screen._execute_console_library_rag_search.call_args.args[0]
     assert request.query == "what changed in auth"
@@ -1023,7 +1025,7 @@ def test_visible_run_action_falls_back_to_the_composer_draft():
 
     empty.app_instance.notify.assert_not_called()
     empty._open_console_rag_settings.assert_called_once()
-    empty._stage_console_library_rag_launch.assert_not_called()
+    empty._retrieval._stage_console_library_rag_launch.assert_not_called()
 
 
 @pytest.mark.unit
@@ -1118,7 +1120,7 @@ def test_prefill_guards_reject_paths_urls_and_oversized_drafts_at_both_sites(
     ChatScreen._run_console_library_rag_from_visible_action(run_screen)
 
     run_screen._set_console_library_rag_query.assert_not_called()
-    run_screen._stage_console_library_rag_launch.assert_not_called()
+    run_screen._retrieval._stage_console_library_rag_launch.assert_not_called()
     run_screen.app_instance.notify.assert_not_called()
     run_screen._open_console_rag_settings.assert_called_once()
 

--- a/Tests/UI/test_console_retrieval_controller.py
+++ b/Tests/UI/test_console_retrieval_controller.py
@@ -1,0 +1,131 @@
+"""No-mount contracts for Console retrieval ownership."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+from tldw_chatbook.UI.Console_Modules.retrieval import ConsoleRetrievalController
+
+
+def _controller() -> tuple[ConsoleRetrievalController, SimpleNamespace]:
+    """Build the real controller with observable no-mount boundary doubles."""
+    state = SimpleNamespace(
+        pending=None,
+        pending_auto_open=False,
+        sent_notice=3,
+        sync_result=True,
+        sync_calls=0,
+        refresh_calls=0,
+    )
+
+    def sync_pending_launch_surfaces() -> bool:
+        state.sync_calls += 1
+        return state.sync_result
+
+    controller = ConsoleRetrievalController(
+        app_instance=SimpleNamespace(),
+        active_native_session=lambda: None,
+        current_conversation_id=lambda: None,
+        clear_evidence_sent_notice=lambda: None,
+        consume_pending_launch=lambda: None,
+        release_consumed_launch=lambda _launch, _result: None,
+        is_mounted=lambda: False,
+        sync_retrieval_scope_row=lambda: None,
+        sync_control_bar=lambda: None,
+        request_control_bar_sync=lambda: None,
+        dictionary_scope_service=lambda: None,
+        set_library_rag_source_scope=lambda _scope: None,
+        set_library_rag_query=lambda _query: None,
+        run_library_rag_action=lambda: None,
+        library_rag_source_scope=lambda: ("notes", "media", "conversations"),
+        library_rag_top_k=lambda: 5,
+        pending_launch=lambda: state.pending,
+        set_pending_launch=lambda value: setattr(state, "pending", value),
+        set_pending_auto_open=lambda value: setattr(state, "pending_auto_open", value),
+        set_evidence_sent_notice=lambda value: setattr(state, "sent_notice", value),
+        sync_pending_launch_surfaces=sync_pending_launch_surfaces,
+        refresh_screen=lambda: setattr(state, "refresh_calls", state.refresh_calls + 1),
+        has_staged_evidence=lambda: False,
+    )
+    return controller, state
+
+
+@pytest.mark.unit
+def test_retrieval_controller_initializes_owned_cache_state() -> None:
+    """The six extracted state fields start with the historical defaults."""
+    controller, _state = _controller()
+
+    assert controller._console_retrieval_scope_cache == {}
+    assert controller._console_effective_scope_cache == {}
+    assert controller._active_dictionaries_summary is None
+    assert controller._last_console_dictionary_scope_ids is None
+    assert controller._active_world_books_summary is None
+    assert controller._last_console_world_book_scope_ids is None
+
+
+@pytest.mark.unit
+def test_retrieval_status_vocabulary_is_controller_owned() -> None:
+    """Status projection stays usable without a mounted ChatScreen."""
+    controller, _state = _controller()
+    searching = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Library retrieval",
+        status="searching",
+    )
+
+    assert controller._console_rag_source_status(None) == "not staged"
+    assert (
+        controller._console_rag_source_status(None, sent_source_count=2)
+        == "sent with the last message · 2 sources"
+    )
+    assert (
+        controller._console_rag_source_status(searching)
+        == "retrieving from Library Search/RAG"
+    )
+
+
+@pytest.mark.unit
+def test_staging_updates_state_before_sync_and_recomposes_only_as_fallback() -> None:
+    """The controller stages once and keeps full recompose as a fallback."""
+    controller, state = _controller()
+    launch = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Library retrieval",
+        status="staged",
+    )
+
+    controller._stage_console_library_rag_launch(launch)
+
+    assert state.pending is launch
+    assert state.sent_notice is None
+    assert state.sync_calls == 1
+    assert state.refresh_calls == 0
+
+    state.sync_result = False
+    controller._stage_console_library_rag_launch(launch)
+
+    assert state.sync_calls == 2
+    assert state.refresh_calls == 1
+
+
+@pytest.mark.unit
+def test_placeholder_cleanup_never_drops_newer_staging() -> None:
+    """Identity ownership keeps an older retrieval from clearing newer work."""
+    controller, state = _controller()
+    placeholder = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="First retrieval",
+        status="searching",
+    )
+    newer = ConsoleLiveWorkLaunch.from_values(
+        source="Library Search/RAG",
+        title="Newer retrieval",
+        status="staged",
+    )
+    state.pending = newer
+
+    controller._clear_console_auto_rag_placeholder(placeholder)
+
+    assert state.pending is newer
+    assert state.sync_calls == 0

--- a/Tests/UI/test_console_scope_row.py
+++ b/Tests/UI/test_console_scope_row.py
@@ -425,7 +425,7 @@ async def test_save_unpersisted_stores_in_holder_and_refreshes_row():
         assert session.persisted_conversation_id is None
         scope = RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
 
-        await console._apply_console_retrieval_scope_save(session, scope)
+        await console._retrieval._apply_console_retrieval_scope_save(session, scope)
         await pilot.pause()
 
         assert session.rag_scope_holder.scope == scope
@@ -469,7 +469,7 @@ async def test_scope_saved_unpersisted_then_first_send_flush_refreshes_row():
             )
 
             # 1. Narrow the scope FIRST, while still unpersisted.
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             assert session.rag_scope_holder.scope == scope
             assert session.persisted_conversation_id is None
 
@@ -490,7 +490,7 @@ async def test_scope_saved_unpersisted_then_first_send_flush_refreshes_row():
             # The scope persisted correctly...
             assert read_conversation_scope(db, conversation_id) == scope
             # ...and the row must already reflect it (no modal-open/resume).
-            state = console._build_console_retrieval_scope_state()
+            state = console._retrieval._build_console_retrieval_scope_state()
             assert state.is_scoped
             assert state.item_count == 2
             row = console.query_one(f"#{ROW_ID}")
@@ -523,7 +523,7 @@ async def test_save_persisted_writes_through_refreshes_row_and_run_recipe():
                 updated_at="2026-01-01T00:00:00Z",
             )
 
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             await pilot.pause()
 
             assert read_conversation_scope(db, conversation_id) == scope
@@ -562,7 +562,7 @@ async def test_save_persisted_corrupt_metadata_surfaces_honest_notify():
                 items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
             )
 
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             await pilot.pause()
 
             assert notifications, "expected an honest notify on write refusal"
@@ -612,7 +612,7 @@ async def test_save_persisted_conflict_error_surfaces_specific_notify():
                 items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
             )
 
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             await pilot.pause()
 
             assert notifications, "expected an honest notify on write conflict"
@@ -647,7 +647,7 @@ async def test_save_persisted_conversation_not_found_surfaces_specific_notify():
                 items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
             )
 
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             await pilot.pause()
 
             assert notifications, "expected an honest notify when the conversation is gone"
@@ -700,7 +700,7 @@ async def test_clear_button_persisted_session():
             scope = RagScope(
                 items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z"
             )
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             await pilot.pause()
             row = console.query_one(f"#{ROW_ID}")
             assert list(row.query(f"#{CLEAR_BTN_ID}"))
@@ -958,7 +958,7 @@ async def test_scope_chip_refreshes_on_modal_save():
         assert session.persisted_conversation_id is None
         scope = RagScope(items=(ScopeItem("media", "m1"),), updated_at="2026-01-01T00:00:00Z")
 
-        await console._apply_console_retrieval_scope_save(session, scope)
+        await console._retrieval._apply_console_retrieval_scope_save(session, scope)
         await pilot.pause()
 
         chip = console.query_one(f"#{SCOPE_CHIP_ID}", ConsoleScopeChip)
@@ -989,7 +989,7 @@ async def test_scope_chip_refreshes_on_persist_transition_flush():
                 updated_at="2026-01-01T00:00:00Z",
             )
 
-            await console._apply_console_retrieval_scope_save(session, scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, scope)
             assert console.query_one(f"#{SCOPE_CHIP_ID}").display is True
 
             store.append_message(
@@ -1057,7 +1057,7 @@ async def test_scope_chip_empty_state_action_required_styling_and_cause_tooltip(
         console = host.screen_stack[-1]
         await _open_console_inspector(console, pilot)
 
-        console._build_console_retrieval_scope_state = lambda: ConsoleRetrievalScopeState.empty(
+        console._retrieval._build_console_retrieval_scope_state = lambda: ConsoleRetrievalScopeState.empty(
             cause="deleted-items"
         )
         console._sync_console_retrieval_scope_row()
@@ -1274,7 +1274,7 @@ async def test_chip_tooltip_shows_intersection_breakdown_when_both_levels_set():
                 updated_at="2026-01-01T00:00:00Z",
             )
 
-            await console._apply_console_retrieval_scope_save(session, conv_scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, conv_scope)
             await pilot.pause()
 
             chip = console.query_one(f"#{SCOPE_CHIP_ID}", ConsoleScopeChip)
@@ -1307,7 +1307,7 @@ async def test_chip_tooltip_shows_workspace_only_breakdown():
         )
         session = console._session._active_native_console_session()
 
-        await console._resolve_console_effective_scope_state(session)
+        await console._retrieval._resolve_console_effective_scope_state(session)
         console._sync_console_retrieval_scope_row()
         await pilot.pause()
 
@@ -1347,7 +1347,7 @@ async def test_no_workspace_overlap_renders_empty_state_on_row_and_chip():
                 items=(ScopeItem("media", "m-conv"),), updated_at="2026-01-01T00:00:00Z"
             )
 
-            await console._apply_console_retrieval_scope_save(session, conv_scope)
+            await console._retrieval._apply_console_retrieval_scope_save(session, conv_scope)
             await pilot.pause()
 
             row = console.query_one(f"#{ROW_ID}")
@@ -1410,7 +1410,7 @@ async def test_switch_between_resumed_sessions_refreshes_stale_workspace_scope()
                 updated_at="2026-01-01T00:00:00Z",
             ),
         )
-        await console._resolve_console_effective_scope_state(first_session)
+        await console._retrieval._resolve_console_effective_scope_state(first_session)
         stale = console._console_effective_scope_cache[first_session.id]
         assert stale.item_count == 1
 

--- a/Tests/UI/test_console_staged_evidence_strip.py
+++ b/Tests/UI/test_console_staged_evidence_strip.py
@@ -36,7 +36,7 @@ from tldw_chatbook.Event_Handlers.Chat_Events.chat_rag_events import (
     LocalRagContextResult,
 )
 from tldw_chatbook.UI.Console_Modules import workspace as workspace_module
-from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.UI.Console_Modules import retrieval as retrieval_module
 from tldw_chatbook.Widgets.Console.console_staged_context import (
     ConsoleStagedContextTray,
 )
@@ -392,7 +392,7 @@ async def test_console_run_staging_fans_out_to_strip_and_truthful_chip() -> None
         await _wait_for_selector(screen, pilot, STRIP_ID)
         assert screen.query_one(STRIP_ID, ConsoleStagedEvidenceStrip).display is False
 
-        screen._stage_console_library_rag_launch(_launch(4))
+        screen._retrieval._stage_console_library_rag_launch(_launch(4))
         await pilot.pause()
 
         strip = screen.query_one(STRIP_ID, ConsoleStagedEvidenceStrip)
@@ -414,7 +414,7 @@ async def test_console_unstage_clears_context_strip_chip_and_tray() -> None:
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, STRIP_ID)
-        screen._stage_console_library_rag_launch(_launch(3))
+        screen._retrieval._stage_console_library_rag_launch(_launch(3))
         await pilot.pause()
 
         screen.query_one(UNSTAGE_ID, Button).press()
@@ -446,7 +446,7 @@ async def test_console_unstage_click_heals_a_stale_strip_when_context_already_no
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, STRIP_ID)
-        screen._stage_console_library_rag_launch(_launch(3))
+        screen._retrieval._stage_console_library_rag_launch(_launch(3))
         await pilot.pause()
         strip = screen.query_one(STRIP_ID, ConsoleStagedEvidenceStrip)
         assert strip.display is True
@@ -503,13 +503,13 @@ async def test_console_send_consumes_staging_and_shows_the_sent_transient(
         )
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         result = await _submit(screen, "question")
@@ -547,13 +547,13 @@ async def test_console_sent_notice_counts_only_what_reached_the_model(
         )
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
         sources_chip = screen.query_one("#console-sources-label", Static)
         assert "Sources: 4" in str(sources_chip.renderable)
@@ -589,13 +589,13 @@ async def test_console_sent_notice_prefers_the_exact_prompted_entry_count(
         )
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         await _submit(screen, "question")
@@ -621,13 +621,13 @@ async def test_console_surface_refresh_failure_never_costs_the_send_its_evidence
         return_value=LocalRagContextResult(context=context, citation_builder=None)
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         def _explode() -> bool:
@@ -692,7 +692,7 @@ async def test_console_rail_badge_and_chip_report_the_same_staged_count() -> Non
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, STRIP_ID)
-        screen._stage_console_library_rag_launch(_launch(4))
+        screen._retrieval._stage_console_library_rag_launch(_launch(4))
         await pilot.pause()
 
         workspace_context = screen._workspace._current_console_workspace_context()
@@ -767,7 +767,7 @@ async def test_context_estimate_counts_staged_evidence_before_send() -> None:
             payload={"query": "question", "evidence_bundle": bundle.to_payload()},
             status="staged",
         )
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         staged = screen._active_console_settings_context_estimate()
@@ -785,13 +785,13 @@ async def test_console_capture_without_prompt_context_keeps_staging(
     launch = _launch(2)
     capture = AsyncMock(return_value=LocalRagContextResult(None, None))
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         await _submit(screen, "question")
@@ -809,7 +809,7 @@ async def test_console_blocked_send_keeps_staged_evidence(monkeypatch) -> None:
         return_value=LocalRagContextResult(context="ctx", citation_builder=None)
     )
     monkeypatch.setattr(
-        chat_screen_module, "capture_console_staged_evidence_for_chat", capture
+        retrieval_module, "capture_console_staged_evidence_for_chat", capture
     )
 
     class _BlockedGateway:
@@ -823,7 +823,7 @@ async def test_console_blocked_send_keeps_staged_evidence(monkeypatch) -> None:
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         controller = screen._ensure_console_chat_controller()
@@ -869,7 +869,7 @@ async def test_console_send_blocked_reason_sendable_for_library_staged_one_ref()
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         assert screen._console_send_blocked_reason() == ""
@@ -899,7 +899,7 @@ async def test_console_send_blocked_reason_blocks_for_library_staged_zero_availa
     async with ConsoleHarness(app).run_test(size=(180, 48)) as pilot:
         screen = pilot.app.screen_stack[-1]
         await _wait_for_selector(screen, pilot, "#console-native-composer")
-        screen._stage_console_library_rag_launch(launch)
+        screen._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
         reason = screen._console_send_blocked_reason()

--- a/Tests/UI/test_console_worldbook_inspector.py
+++ b/Tests/UI/test_console_worldbook_inspector.py
@@ -65,9 +65,9 @@ async def test_refresh_caches_summary_and_build_projects_world_book_rows(wb_db):
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-wb"
 
-        await screen.refresh_active_world_books_summary()
+        await screen._retrieval.refresh_active_world_books_summary()
 
-        rows = screen._console_world_book_inspector_rows()
+        rows = screen._retrieval._console_world_book_inspector_rows()
         row_texts = [row.text for row in rows]
         assert any("Alpha" in text for text in row_texts)
         assert any("Beta" in text for text in row_texts)
@@ -80,7 +80,9 @@ async def test_refresh_caches_summary_and_build_projects_world_book_rows(wb_db):
 
 
 @pytest.mark.asyncio
-async def test_build_console_inspector_state_never_re_queries_the_db(wb_db, monkeypatch):
+async def test_build_console_inspector_state_never_re_queries_the_db(
+    wb_db, monkeypatch
+):
     wb_db.add_conversation({"id": "conv-wb", "title": "C"})
     manager = WorldBookManager(wb_db)
     book_a = manager.create_world_book("Alpha")
@@ -109,7 +111,7 @@ async def test_build_console_inspector_state_never_re_queries_the_db(wb_db, monk
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-wb"
 
-        await screen.refresh_active_world_books_summary()
+        await screen._retrieval.refresh_active_world_books_summary()
         assert len(calls) == 1
 
         # A bare, recompose-equivalent build must read only the cache -- no
@@ -132,9 +134,9 @@ async def test_no_active_chat_renders_no_active_chat_row(wb_db):
         # Fresh default native session has no persisted conversation yet.
         assert _active_native_session(screen).persisted_conversation_id is None
 
-        await screen.refresh_active_world_books_summary()
+        await screen._retrieval.refresh_active_world_books_summary()
 
-        rows = screen._console_world_book_inspector_rows()
+        rows = screen._retrieval._console_world_book_inspector_rows()
         assert rows == (ConsoleDisplayRow("No active chat", ""),)
 
 
@@ -150,9 +152,9 @@ async def test_conversation_with_no_books_renders_no_world_books_in_play_row(wb_
         await _wait_for_selector(screen, pilot, "#console-native-composer")
         _active_native_session(screen).persisted_conversation_id = "conv-empty"
 
-        await screen.refresh_active_world_books_summary()
+        await screen._retrieval.refresh_active_world_books_summary()
 
-        rows = screen._console_world_book_inspector_rows()
+        rows = screen._retrieval._console_world_book_inspector_rows()
         assert rows == (ConsoleDisplayRow("No world books in play", ""),)
 
 
@@ -174,7 +176,7 @@ async def test_sync_native_console_chat_ui_refreshes_world_books_on_scope_change
 
         await screen._sync_native_console_chat_ui()
 
-        rows = screen._console_world_book_inspector_rows()
+        rows = screen._retrieval._console_world_book_inspector_rows()
         assert any("Alpha" in row.text for row in rows)
 
 
@@ -212,8 +214,10 @@ async def test_console_worldbook_attach_then_detach_round_trips_through_real_db(
             raising=False,
         )
 
-        await screen.refresh_active_world_books_summary()
-        assert manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
+        await screen._retrieval.refresh_active_world_books_summary()
+        assert (
+            manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
+        )
 
         # --- Attach ---
         await screen._console_worldbook_attach_worker()
@@ -221,7 +225,7 @@ async def test_console_worldbook_attach_then_detach_round_trips_through_real_db(
 
         attached = manager.get_world_books_for_conversation(conv_id, enabled_only=False)
         assert [b["id"] for b in attached] == [book_id]
-        rows = screen._console_world_book_inspector_rows()
+        rows = screen._retrieval._console_world_book_inspector_rows()
         assert any("Standalone Lore" in row.text for row in rows)
         assert screen._console_worldbook_dialog_active is False
 
@@ -229,8 +233,10 @@ async def test_console_worldbook_attach_then_detach_round_trips_through_real_db(
         await screen._console_worldbook_detach_worker()
         await pilot.pause()
 
-        assert manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
-        rows_after = screen._console_world_book_inspector_rows()
+        assert (
+            manager.get_world_books_for_conversation(conv_id, enabled_only=False) == []
+        )
+        rows_after = screen._retrieval._console_world_book_inspector_rows()
         assert rows_after == (ConsoleDisplayRow("No world books in play", ""),)
         assert screen._console_worldbook_dialog_active is False
 
@@ -297,7 +303,7 @@ async def test_console_world_book_inspector_actions_gate_on_conversation_and_att
         await _wait_for_selector(screen, pilot, "#console-native-composer")
 
         # No conversation yet: Attach disabled, Detach disabled (no summary).
-        actions = screen._console_world_book_inspector_actions()
+        actions = screen._retrieval._console_world_book_inspector_actions()
         attach = next(
             a for a in actions if a.widget_id == "console-inspector-worldbooks-attach"
         )
@@ -310,8 +316,8 @@ async def test_console_world_book_inspector_actions_gate_on_conversation_and_att
         # Conversation active, but nothing attached yet: Attach enabled,
         # Detach still disabled.
         _active_native_session(screen).persisted_conversation_id = conv_id
-        await screen.refresh_active_world_books_summary()
-        actions = screen._console_world_book_inspector_actions()
+        await screen._retrieval.refresh_active_world_books_summary()
+        actions = screen._retrieval._console_world_book_inspector_actions()
         attach = next(
             a for a in actions if a.widget_id == "console-inspector-worldbooks-attach"
         )
@@ -323,8 +329,8 @@ async def test_console_world_book_inspector_actions_gate_on_conversation_and_att
 
         # After attaching: Detach becomes enabled too.
         manager.associate_world_book_with_conversation(conv_id, book_id)
-        await screen.refresh_active_world_books_summary()
-        actions = screen._console_world_book_inspector_actions()
+        await screen._retrieval.refresh_active_world_books_summary()
+        actions = screen._retrieval._console_world_book_inspector_actions()
         detach = next(
             a for a in actions if a.widget_id == "console-inspector-worldbooks-detach"
         )

--- a/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
+++ b/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:09'
-updated_date: '2026-08-20 20:28'
+updated_date: '2026-08-20 22:16'
 labels:
   - console
   - rag
@@ -25,9 +25,9 @@ Move retrieval scope, library-RAG, auto-retrieve, and cached inspector policy ou
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Retrieval move inventory is controller-owned and decorated screen entry points are bounded delegates
-- [ ] #2 Scope persistence, worker groups, auto-retrieve, degraded-state, and inspector behavior are unchanged
-- [ ] #3 Isolated controller tests run without mounting Textual
+- [x] #1 Retrieval move inventory is controller-owned and decorated screen entry points are bounded delegates
+- [x] #2 Scope persistence, worker groups, auto-retrieve, degraded-state, and inspector behavior are unchanged
+- [x] #3 Isolated controller tests run without mounting Textual
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,3 +39,15 @@ ADR required: no
 ADR path: N/A
 Reason: this is the behavior-preserving implementation of the retrieval ownership boundary already approved in the Wave 6 design; it introduces no new storage, security, dependency, or service contract.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a DOM-free ConsoleRetrievalController as the sole owner of the reviewed 32 retrieval methods and six compatibility fields. ChatScreen retains only the two Textual worker names as exact bounded delegates; picker/modal/DOM work stays screen-owned, while Session and Workspace receive late-bound retrieval callables. The extraction reduced chat_screen.py from the 21,357-line task baseline to 20,572 lines after rebasing onto origin/dev, below the fixed 20,943 ceiling.
+
+Verification: post-rebase touched-functionality matrix 482 passed; changed-files conflict-adjacent matrix 17 passed; projection/compatibility ratchets 2 passed; exact unawaited-coroutine warning node passed under RuntimeWarning-as-error. RED/GREEN mutations killed descriptor retargeting, controller DOM access, empty-scope bypass, placeholder identity removal, repeated dictionary refresh, and both worker-delegate removals; every mutation was restored byte-exact before the candidate gates. Ruff lint, production py_compile under an isolated removed pycache root, and cumulative diff-check passed. Whole-file Ruff format reports the same nine inherited files as exact origin/dev.
+
+Inherited exceptions: the broad Wave-6 inventory now clears the line/method/retrieval assertions and then fails on untouched hands_free.py::_sync_hands_free_switch querying the DOM. The repository diagnostic checker remains red from unrelated dev-wide owner drift plus the vendored Chunking security sink; TASK-3070.5 itself moves exactly 11 diagnostic calls from chat_screen.py to retrieval.py and changes no sink topology. The metadata-only diagnostic architecture node passes. No full suite was run, per the user's explicit touched-functionality constraint.
+
+ADR required: no. This implements the ownership boundary already approved by the Wave-6 design and changes no storage, schema, dependency, security boundary, CSS, DOM ID, or user-visible copy.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
+++ b/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3070.5
 title: Extract Console retrieval controller
-status: To Do
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:09'
-updated_date: '2026-08-13 17:15'
+updated_date: '2026-08-20 20:28'
 labels:
   - console
   - rag
@@ -29,3 +29,13 @@ Move retrieval scope, library-RAG, auto-retrieve, and cached inspector policy ou
 - [ ] #2 Scope persistence, worker groups, auto-retrieve, degraded-state, and inspector behavior are unchanged
 - [ ] #3 Isolated controller tests run without mounting Textual
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Follow [the implementation plan](../../Docs/superpowers/plans/2026-08-20-task-3070-5-console-retrieval-controller.md).
+
+ADR required: no
+ADR path: N/A
+Reason: this is the behavior-preserving implementation of the retrieval ownership boundary already approved in the Wave 6 design; it introduces no new storage, security, dependency, or service contract.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
+++ b/backlog/tasks/task-3070.5 - Extract-Console-retrieval-controller.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3070.5
 title: Extract Console retrieval controller
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:09'
-updated_date: '2026-08-20 22:16'
+updated_date: '2026-08-20 22:18'
 labels:
   - console
   - rag
@@ -50,4 +50,6 @@ Verification: post-rebase touched-functionality matrix 482 passed; changed-files
 Inherited exceptions: the broad Wave-6 inventory now clears the line/method/retrieval assertions and then fails on untouched hands_free.py::_sync_hands_free_switch querying the DOM. The repository diagnostic checker remains red from unrelated dev-wide owner drift plus the vendored Chunking security sink; TASK-3070.5 itself moves exactly 11 diagnostic calls from chat_screen.py to retrieval.py and changes no sink topology. The metadata-only diagnostic architecture node passes. No full suite was run, per the user's explicit touched-functionality constraint.
 
 ADR required: no. This implements the ownership boundary already approved by the Wave-6 design and changes no storage, schema, dependency, security boundary, CSS, DOM ID, or user-visible copy.
+
+Delivery: implementation commit c0201544c was rebased onto origin/dev 6f3f12d9f, the same scoped gates were rerun, branch codex/task-3070-5-console-retrieval was pushed, and PR #1869 was opened against dev.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/retrieval.py
+++ b/tldw_chatbook/UI/Console_Modules/retrieval.py
@@ -1,0 +1,823 @@
+"""Controller-owned Console retrieval and cached inspector policy."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import replace
+import re
+from typing import Any
+
+from loguru import logger
+
+from ...Chat.console_chat_store import ConsoleChatSession
+from ...Chat.console_command_grammar import COMMAND_PREFIX
+from ...Chat.console_display_state import (
+    ConsoleDisplayRow,
+    ConsoleInspectorAction,
+    ConsoleRetrievalScopeState,
+)
+from ...Chat.console_live_work import ConsoleLiveWorkLaunch
+from ...Chat.console_turn_context import ConsoleTurnExecutionContext
+from ...Chat.console_skill_resolver import MENTION_SIGIL
+from ...Chat.rag_scope import (
+    RagScope,
+    SCOPE_EMPTY_NOTICE_TEMPLATE,
+    read_conversation_scope,
+    write_conversation_scope,
+)
+from ...Chat.scope_picker_listers import (
+    build_keyword_tag_lister,
+    build_media_source_lister,
+    build_notes_source_lister,
+)
+from ...config import coerce_bool_setting, get_cli_setting, save_setting_to_cli_config
+from ...Event_Handlers.Chat_Events.chat_rag_events import (
+    capture_console_staged_evidence_for_chat,
+    resolve_effective_scope_for_chat,
+    resolve_scope_for_session,
+)
+from ...Library.library_rag_service import (
+    LibraryRagSearchOutcome,
+    LibraryRagSearchRequest,
+    RETRIEVAL_FAILED_WHY,
+    run_library_rag_search,
+    scope_empty_recovery_state,
+)
+from ...Library.library_rag_state import library_rag_source_scope_summary
+from ...Utils.input_validation import sanitize_string, validate_text_input
+from ...Widgets.Console.console_rag_settings_modal import (
+    CONSOLE_RAG_SOURCE_SUMMARY_PREFIX,
+    ConsoleRagSettingsResult,
+)
+from ..Views.RAGSearch.search_handoff import (
+    build_library_rag_console_live_work_payload,
+    build_library_rag_evidence_bundle,
+)
+
+logger = logger.bind(module="ConsoleRetrievalController")
+
+CONSOLE_LIBRARY_RAG_RECOVERY_COPY = "Review citations before sending."
+AUTO_RAG_QUERY_MAX_CHARS = 2_000
+AUTO_RAG_TIMEOUT_SECONDS = 5.0
+CONSOLE_AUTO_RAG_INITIALIZING_NOTICE = (
+    "Auto-retrieve skipped: the RAG service is still initializing. "
+    "Message sent without Library evidence."
+)
+CONSOLE_AUTO_RAG_FAILED_NOTICE = (
+    f"Auto-retrieve skipped: {RETRIEVAL_FAILED_WHY}. "
+    "Message sent without Library evidence."
+)
+CONSOLE_AUTO_RAG_SEARCHING_COPY = "Auto-retrieving Library evidence for this message."
+
+
+def source_mentions_rag(source: Any) -> bool:
+    """Return whether a source label contains a standalone RAG token."""
+    return "rag" in re.split(r"[^a-z0-9]+", str(source or "").lower())
+
+
+def sanitize_console_library_rag_query(value: Any) -> str:
+    """Return a centralized-validation-safe Console Library query."""
+    sanitized = sanitize_string(str(value or ""), max_length=2_000)
+    query = " ".join(sanitized.strip().split())
+    if not query:
+        return ""
+    if not validate_text_input(query, max_length=2_000, allow_html=False):
+        return ""
+    return query
+
+
+def is_plain_text_send(draft_text: Any) -> bool:
+    """Return whether a draft is plain prose worth retrieving for."""
+    draft = str(draft_text or "").lstrip()
+    return bool(draft) and not draft.startswith((COMMAND_PREFIX, MENTION_SIGIL))
+
+
+def launch_has_rag_source_payload(launch: ConsoleLiveWorkLaunch) -> bool:
+    """Return whether a launch carries at least one source-bearing field."""
+    return any(
+        str(launch.payload.get(key) or "").strip()
+        for key in (
+            "source_id",
+            "source_count",
+            "citation_count",
+            "chunk_id",
+            "query",
+            "result_id",
+        )
+    )
+
+
+def _run_dictionary_summary_off_thread(
+    service: Any,
+    conversation_id: Any,
+    character_id: Any,
+) -> Any:
+    """Run the async dictionary summary on a private worker-thread loop."""
+    return asyncio.run(
+        service.summarize_active_dictionaries(
+            conversation_id, character_id, mode="local"
+        )
+    )
+
+
+class ConsoleRetrievalController:
+    """Own non-DOM retrieval state and behavior for the Console."""
+
+    def __init__(
+        self,
+        *,
+        app_instance: Any,
+        active_native_session: Callable[[], ConsoleChatSession | None],
+        current_conversation_id: Callable[[], str | None],
+        clear_evidence_sent_notice: Callable[[], None],
+        consume_pending_launch: Callable[[], ConsoleLiveWorkLaunch | None],
+        release_consumed_launch: Callable[[ConsoleLiveWorkLaunch, Any], None],
+        is_mounted: Callable[[], bool],
+        sync_retrieval_scope_row: Callable[[], None],
+        sync_control_bar: Callable[[], None],
+        request_control_bar_sync: Callable[[], None],
+        dictionary_scope_service: Callable[[], Any],
+        set_library_rag_source_scope: Callable[[Any], None],
+        set_library_rag_query: Callable[[str], None],
+        run_library_rag_action: Callable[[], None],
+        library_rag_source_scope: Callable[[], tuple[str, ...]],
+        library_rag_top_k: Callable[[], int],
+        pending_launch: Callable[[], ConsoleLiveWorkLaunch | None],
+        set_pending_launch: Callable[[ConsoleLiveWorkLaunch | None], None],
+        set_pending_auto_open: Callable[[bool], None],
+        set_evidence_sent_notice: Callable[[int | None], None],
+        sync_pending_launch_surfaces: Callable[[], bool],
+        refresh_screen: Callable[[], None],
+        has_staged_evidence: Callable[[], bool],
+    ) -> None:
+        """Bind explicit late-bound screen edges and initialize owned state."""
+        self.app_instance = app_instance
+        self._active_native_session = active_native_session
+        self._current_conversation_id = current_conversation_id
+        self._clear_evidence_sent_notice = clear_evidence_sent_notice
+        self._consume_pending_launch = consume_pending_launch
+        self._release_consumed_launch = release_consumed_launch
+        self._is_mounted = is_mounted
+        self._sync_retrieval_scope_row = sync_retrieval_scope_row
+        self._sync_control_bar = sync_control_bar
+        self._request_control_bar_sync = request_control_bar_sync
+        self._dictionary_scope_service = dictionary_scope_service
+        self._set_library_rag_source_scope = set_library_rag_source_scope
+        self._set_library_rag_query = set_library_rag_query
+        self._run_library_rag_action = run_library_rag_action
+        self._library_rag_source_scope = library_rag_source_scope
+        self._library_rag_top_k = library_rag_top_k
+        self._pending_launch = pending_launch
+        self._set_pending_launch = set_pending_launch
+        self._set_pending_auto_open = set_pending_auto_open
+        self._set_evidence_sent_notice = set_evidence_sent_notice
+        self._sync_pending_launch_surfaces = sync_pending_launch_surfaces
+        self._refresh_screen = refresh_screen
+        self._has_staged_evidence = has_staged_evidence
+
+        self._console_retrieval_scope_cache: dict[str, RagScope | None] = {}
+        self._console_effective_scope_cache: dict[str, ConsoleRetrievalScopeState] = {}
+        self._active_dictionaries_summary: dict | None = None
+        self._last_console_dictionary_scope_ids: (
+            tuple[str | None, int | None] | None
+        ) = None
+        self._active_world_books_summary: dict | None = None
+        self._last_console_world_book_scope_ids: tuple[str | None] | None = None
+
+    async def _capture_console_staged_rag(
+        self,
+        draft: str,
+        turn_context: ConsoleTurnExecutionContext | None = None,
+    ) -> Any:
+        """Capture staged evidence once, after optional auto-retrieval."""
+        self._clear_evidence_sent_notice()
+        try:
+            await self._maybe_auto_retrieve_for_send(draft, turn_context=turn_context)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Console auto-retrieve raised; the send proceeds "
+                "(exception_category={})",
+                type(exc).__name__,
+            )
+        launch = self._consume_pending_launch()
+        result = await capture_console_staged_evidence_for_chat(
+            self.app_instance,
+            launch,
+            user_message=draft,
+        )
+        context = getattr(result, "context", None)
+        if launch is not None and isinstance(context, str) and context.strip():
+            self._release_consumed_launch(launch, result)
+        return result
+
+    def _build_console_retrieval_scope_state(self) -> ConsoleRetrievalScopeState:
+        """Return the cached effective scope for the active session."""
+        session = self._active_native_session()
+        if session is None:
+            return ConsoleRetrievalScopeState.unscoped()
+        cache_key = session.persisted_conversation_id or session.id
+        cached = self._console_effective_scope_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        if session.persisted_conversation_id is None:
+            return ConsoleRetrievalScopeState.from_scope(session.rag_scope_holder.scope)
+        return ConsoleRetrievalScopeState.unscoped()
+
+    def _console_retrieval_scope_run_recipe_count(self) -> int | None:
+        """Return the effective scoped-item count, or ``None`` when unscoped."""
+        state = self._build_console_retrieval_scope_state()
+        return state.item_count if state.is_scoped else None
+
+    async def _resolve_console_effective_scope_state(
+        self, session: ConsoleChatSession
+    ) -> ConsoleRetrievalScopeState:
+        """Resolve and cache the conversation/workspace effective scope."""
+        resolution = await resolve_scope_for_session(self.app_instance, session)
+        if session.persisted_conversation_id is not None:
+            self._console_retrieval_scope_cache[session.persisted_conversation_id] = (
+                resolution.conv_scope
+            )
+        state = ConsoleRetrievalScopeState.from_effective(
+            resolution.effective,
+            conv_item_count=(
+                len(resolution.conv_scope.items)
+                if resolution.conv_scope is not None
+                else None
+            ),
+            ws_item_count=(
+                len(resolution.ws_scope.items)
+                if resolution.ws_scope is not None
+                else None
+            ),
+        )
+        cache_key = session.persisted_conversation_id or session.id
+        self._console_effective_scope_cache[cache_key] = state
+        return state
+
+    async def _refresh_console_effective_scope_and_sync(
+        self, session: ConsoleChatSession
+    ) -> None:
+        """Resolve effective scope, then refresh mounted screen projections."""
+        await self._resolve_console_effective_scope_state(session)
+        if self._is_mounted():
+            self._sync_retrieval_scope_row()
+            self._sync_control_bar()
+
+    async def _warm_console_effective_scope_cache_if_stale(self) -> None:
+        """Warm a restored persisted session's effective-scope cache once."""
+        session = self._active_native_session()
+        if session is None or session.persisted_conversation_id is None:
+            return
+        cache_key = session.persisted_conversation_id
+        if cache_key in self._console_effective_scope_cache:
+            return
+        try:
+            await self._refresh_console_effective_scope_and_sync(session)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to warm retrieval scope cache for conversation {}",
+                cache_key,
+            )
+
+    @staticmethod
+    async def _read_console_retrieval_scope(
+        db: Any, conversation_id: str
+    ) -> RagScope | None:
+        """Read a stored scope off-loop except for thread-local memory DBs."""
+        if getattr(db, "is_memory_db", False):
+            return read_conversation_scope(db, conversation_id)
+        return await asyncio.to_thread(read_conversation_scope, db, conversation_id)
+
+    @staticmethod
+    async def _write_console_retrieval_scope(
+        db: Any, conversation_id: str, scope: RagScope | None
+    ) -> None:
+        """Write a stored scope off-loop except for thread-local memory DBs."""
+        if getattr(db, "is_memory_db", False):
+            write_conversation_scope(db, conversation_id, scope)
+            return
+        await asyncio.to_thread(write_conversation_scope, db, conversation_id, scope)
+
+    def _console_scope_picker_listers(self) -> tuple[Any, Any, Any]:
+        """Build the real media, notes, and keyword listers."""
+        user_id = getattr(self.app_instance, "notes_user_id", None) or "default_user"
+        return (
+            build_media_source_lister(self.app_instance),
+            build_notes_source_lister(self.app_instance, user_id=user_id),
+            build_keyword_tag_lister(self.app_instance),
+        )
+
+    async def _apply_console_retrieval_scope_save(
+        self,
+        session: ConsoleChatSession,
+        scope: RagScope | None,
+    ) -> None:
+        """Persist or session-hold a picker result, then refresh effective scope."""
+        if session.persisted_conversation_id is not None:
+            conversation_id = session.persisted_conversation_id
+            db = getattr(self.app_instance, "chachanotes_db", None)
+            if db is None:
+                self.app_instance.notify(
+                    "Couldn't save scope: no database is available.", severity="error"
+                )
+                return
+            from ...DB.ChaChaNotes_DB import ConflictError
+
+            try:
+                await self._write_console_retrieval_scope(db, conversation_id, scope)
+            except ConflictError:
+                logger.opt(exception=True).warning(
+                    "Retrieval scope write conflict for conversation {}",
+                    conversation_id,
+                )
+                self.app_instance.notify(
+                    "Couldn't save scope: the conversation was modified "
+                    "concurrently — try again.",
+                    severity="error",
+                )
+                return
+            except ValueError:
+                logger.opt(exception=True).warning(
+                    "Retrieval scope write target missing for conversation {}",
+                    conversation_id,
+                )
+                self.app_instance.notify(
+                    "Couldn't save scope: this conversation no longer exists.",
+                    severity="error",
+                )
+                return
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Failed to write retrieval scope for conversation {}",
+                    conversation_id,
+                )
+                self.app_instance.notify(
+                    "Couldn't save scope: conversation metadata is corrupted.",
+                    severity="error",
+                )
+                return
+            after = await self._read_console_retrieval_scope(db, conversation_id)
+            if scope is not None and after is None:
+                self.app_instance.notify(
+                    "Couldn't save scope: conversation metadata is corrupted.",
+                    severity="error",
+                )
+                return
+            self._console_retrieval_scope_cache[conversation_id] = after
+        else:
+            session.rag_scope_holder.set(scope)
+        await self._refresh_console_effective_scope_and_sync(session)
+
+    def _apply_console_rag_settings_choice(
+        self, result: ConsoleRagSettingsResult | None
+    ) -> None:
+        """Store modal query/source values and optionally run retrieval."""
+        if result is None:
+            return
+        self._set_library_rag_source_scope(result.source_types)
+        self._set_library_rag_query(sanitize_console_library_rag_query(result.query))
+        if result.run:
+            self._run_library_rag_action()
+
+    def _persist_console_rag_auto_retrieve_on_send(self, value: bool) -> None:
+        """Persist the auto-retrieve preference off the UI thread."""
+        try:
+            save_setting_to_cli_config(
+                "chat_defaults", "rag_auto_retrieve_on_send", bool(value)
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to persist Console auto-retrieve-on-send setting: {}", exc
+            )
+
+    def _console_rag_source_status(
+        self,
+        pending_launch: ConsoleLiveWorkLaunch | None,
+        sent_source_count: int | None = None,
+    ) -> str:
+        """Return the Inspector's staged/sent Library source status."""
+        if pending_launch is None:
+            if sent_source_count:
+                count = int(sent_source_count)
+                noun = "source" if count == 1 else "sources"
+                return f"sent with the last message · {count} {noun}"
+            return "not staged"
+        if source_mentions_rag(pending_launch.source):
+            launch_status = str(pending_launch.status or "").strip().lower()
+            if launch_status in {"blocked", "failed", "unavailable"}:
+                return "unavailable"
+            if launch_status == "empty":
+                return "no results"
+            if launch_status == "searching":
+                return "retrieving from Library Search/RAG"
+            if launch_has_rag_source_payload(pending_launch):
+                return "staged from Library Search/RAG"
+            return "missing source"
+        return "not requested"
+
+    def _active_console_dictionary_scope_ids(
+        self,
+    ) -> tuple[str | None, int | None]:
+        """Return the active native conversation and character scope IDs."""
+        return self._current_conversation_id(), None
+
+    async def refresh_active_dictionaries_summary(self) -> None:
+        """Refresh the DB-backed dictionary summary cache off the UI loop."""
+        conversation_id, character_id = self._active_console_dictionary_scope_ids()
+        service = self._dictionary_scope_service()
+        if service is None or (conversation_id is None and character_id is None):
+            self._active_dictionaries_summary = {"dictionaries": []}
+        else:
+            try:
+                summary = await asyncio.to_thread(
+                    _run_dictionary_summary_off_thread,
+                    service,
+                    conversation_id,
+                    character_id,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Could not summarize active chat dictionaries for the Console "
+                    "inspector."
+                )
+                summary = {"dictionaries": []}
+            self._active_dictionaries_summary = (
+                summary if isinstance(summary, dict) else {"dictionaries": []}
+            )
+        self._request_control_bar_sync()
+
+    async def _refresh_active_dictionaries_summary_if_scope_changed(self) -> None:
+        """Refresh dictionary summary only when its native scope changes."""
+        scope_ids = self._active_console_dictionary_scope_ids()
+        if scope_ids == self._last_console_dictionary_scope_ids:
+            return
+        self._last_console_dictionary_scope_ids = scope_ids
+        await self.refresh_active_dictionaries_summary()
+
+    def _console_dictionary_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
+        """Project cached dictionary data into inspector rows without I/O."""
+        conversation_id, character_id = self._active_console_dictionary_scope_ids()
+        if conversation_id is None and character_id is None:
+            return (ConsoleDisplayRow("No active chat", ""),)
+        dictionaries = (self._active_dictionaries_summary or {}).get(
+            "dictionaries"
+        ) or []
+        if not dictionaries:
+            return (ConsoleDisplayRow("No dictionaries in play", ""),)
+        rows = []
+        for entry in dictionaries:
+            if not isinstance(entry, dict):
+                continue
+            value = (
+                "from conversation"
+                if entry.get("source") == "conversation"
+                else "from character"
+            )
+            if entry.get("shadowed"):
+                value += " (shadowed)"
+            if not entry.get("enabled", True):
+                value += " (disabled)"
+            rows.append(ConsoleDisplayRow(str(entry.get("name") or "Unnamed"), value))
+        return tuple(rows)
+
+    def _active_console_world_book_scope_ids(self) -> tuple[str | None]:
+        """Return the active native conversation's world-book scope."""
+        return (self._current_conversation_id(),)
+
+    async def refresh_active_world_books_summary(self) -> None:
+        """Refresh the DB-backed world-book summary cache off the UI loop."""
+        conversation_id = self._current_conversation_id()
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        if not conversation_id or db is None:
+            self._active_world_books_summary = {"world_books": []}
+            self._request_control_bar_sync()
+            return
+        try:
+            from ...Character_Chat.world_info_resolver import (
+                summarize_active_world_books,
+            )
+
+            summary = await asyncio.to_thread(
+                summarize_active_world_books, db, conversation_id, None
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Could not summarize active world books for the Console inspector."
+            )
+            summary = {"world_books": []}
+        self._active_world_books_summary = (
+            summary if isinstance(summary, dict) else {"world_books": []}
+        )
+        self._request_control_bar_sync()
+
+    async def _refresh_active_world_books_summary_if_scope_changed(self) -> None:
+        """Refresh world-book summary only when its native scope changes."""
+        scope_ids = self._active_console_world_book_scope_ids()
+        if scope_ids == self._last_console_world_book_scope_ids:
+            return
+        self._last_console_world_book_scope_ids = scope_ids
+        await self.refresh_active_world_books_summary()
+
+    def _console_world_book_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
+        """Project cached world-book data into inspector rows without I/O."""
+        if self._current_conversation_id() is None:
+            return (ConsoleDisplayRow("No active chat", ""),)
+        books = (self._active_world_books_summary or {}).get("world_books") or []
+        if not books:
+            return (ConsoleDisplayRow("No world books in play", ""),)
+        rows = []
+        for entry in books:
+            if not isinstance(entry, dict):
+                continue
+            count = entry.get("entry_count")
+            value = f"{count} entries" if isinstance(count, int) else "0 entries"
+            if not entry.get("enabled", True):
+                value += " (disabled)"
+            rows.append(ConsoleDisplayRow(str(entry.get("name") or "Unnamed"), value))
+        return tuple(rows)
+
+    def _console_dictionary_inspector_actions(
+        self,
+    ) -> tuple[ConsoleInspectorAction, ...]:
+        """Build dictionary attach/detach actions from cached state."""
+        conversation_id, _ = self._active_console_dictionary_scope_ids()
+        dictionaries = (self._active_dictionaries_summary or {}).get(
+            "dictionaries"
+        ) or []
+        has_attached = any(
+            isinstance(entry, dict) and entry.get("source") == "conversation"
+            for entry in dictionaries
+        )
+        return (
+            ConsoleInspectorAction(
+                "console-inspector-dictionaries-attach",
+                "Attach dictionary…",
+                enabled=bool(conversation_id),
+                disabled_reason="Start or load a conversation first",
+            ),
+            ConsoleInspectorAction(
+                "console-inspector-dictionaries-detach",
+                "Detach dictionary…",
+                enabled=has_attached,
+            ),
+        )
+
+    def _console_world_book_inspector_actions(
+        self,
+    ) -> tuple[ConsoleInspectorAction, ...]:
+        """Build world-book attach/detach actions from cached state."""
+        conversation_id = self._current_conversation_id()
+        has_attached = bool((self._active_world_books_summary or {}).get("world_books"))
+        return (
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-attach",
+                "Attach world book…",
+                enabled=bool(conversation_id),
+                disabled_reason="Start or load a conversation first",
+            ),
+            ConsoleInspectorAction(
+                "console-inspector-worldbooks-detach",
+                "Detach world book…",
+                enabled=has_attached,
+            ),
+        )
+
+    def _console_library_rag_scope_label(self) -> str:
+        """Return the readiness card's normalized Library source summary."""
+        return library_rag_source_scope_summary(
+            self._library_rag_source_scope(), prefix=CONSOLE_RAG_SOURCE_SUMMARY_PREFIX
+        )
+
+    def _stage_console_library_rag_launch(
+        self,
+        launch: ConsoleLiveWorkLaunch,
+        *,
+        allow_recompose: bool = True,
+    ) -> None:
+        """Stage a launch and refresh mounted pending-launch projections."""
+        self._set_pending_launch(launch)
+        self._set_evidence_sent_notice(None)
+        if not self._sync_pending_launch_surfaces() and allow_recompose:
+            self._refresh_screen()
+
+    async def _resolve_console_library_rag_scope(
+        self, request: LibraryRagSearchRequest
+    ) -> tuple[LibraryRagSearchRequest, LibraryRagSearchOutcome | None]:
+        """Apply the active effective item scope to a Library request."""
+        effective_scope = await resolve_effective_scope_for_chat(self.app_instance)
+        if effective_scope.state == "empty":
+            return request, LibraryRagSearchOutcome(
+                status="empty",
+                recovery_state=scope_empty_recovery_state(effective_scope.cause),
+            )
+        if effective_scope.state == "scoped":
+            return replace(request, scope=effective_scope), None
+        return request, None
+
+    async def _execute_console_library_rag_search(
+        self, request: LibraryRagSearchRequest
+    ) -> None:
+        """Resolve scope, execute Library retrieval, and apply the outcome."""
+        scoped_request, short_circuit = await self._resolve_console_library_rag_scope(
+            request
+        )
+        outcome = short_circuit or await run_library_rag_search(
+            self.app_instance, scoped_request
+        )
+        await self._apply_console_library_rag_search_outcome(scoped_request, outcome)
+
+    async def _apply_console_library_rag_search_outcome(
+        self,
+        request: LibraryRagSearchRequest,
+        outcome: Any,
+    ) -> None:
+        """Convert a Library result or recovery into staged live work."""
+        if not self._is_mounted():
+            return
+        if outcome.results:
+            result = outcome.results[0]
+            launch_payload = build_library_rag_console_live_work_payload(
+                result, query=request.query
+            )
+            launch_payload["evidence_bundle"] = build_library_rag_evidence_bundle(
+                outcome.results, query=request.query
+            ).to_payload()
+            launch_payload["requested_top_k"] = request.top_k
+            launch_payload["search_mode"] = request.mode
+            self._stage_console_library_rag_launch(
+                ConsoleLiveWorkLaunch.from_values(
+                    source="Library Search/RAG",
+                    title=result.title,
+                    payload=launch_payload,
+                    status="staged",
+                    recovery=CONSOLE_LIBRARY_RAG_RECOVERY_COPY,
+                    action_label="Review evidence in Console",
+                )
+            )
+            return
+
+        recovery_state = outcome.recovery_state
+        recovery_copy = (
+            recovery_state.visible_copy
+            if recovery_state is not None
+            else "Library Search/RAG did not return usable evidence."
+        )
+        self._set_pending_auto_open(True)
+        self._stage_console_library_rag_launch(
+            ConsoleLiveWorkLaunch.from_values(
+                source="Library Search/RAG",
+                title="Library Search/RAG retrieval",
+                payload={
+                    "query": request.query,
+                    "source_scope": ", ".join(request.source_types),
+                },
+                status=outcome.status or "blocked",
+                recovery=recovery_copy,
+                action_label="Resolve Library search setup",
+            )
+        )
+
+    def _rag_service_still_initializing(self) -> bool:
+        """Return whether the shared RAG runtime has not initialized yet."""
+        try:
+            from ...RAG_Search.semantic_availability import current_app_rag_service
+
+            return current_app_rag_service(self.app_instance) is None
+        except Exception:
+            return False
+
+    def _notify_console_auto_rag_scope_empty(self, outcome: Any) -> None:
+        """Surface the shared effective-scope-empty recovery copy."""
+        recovery = getattr(outcome, "recovery_state", None)
+        message = str(getattr(recovery, "why", "") or "").strip()
+        if not message:
+            message = SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause="unknown")
+        self._notify_console_auto_rag(message)
+
+    def _notify_auto_rag_degraded(self, *, initializing: bool) -> None:
+        """Tell the user a send proceeded without requested evidence."""
+        self._notify_console_auto_rag(
+            CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
+            if initializing
+            else CONSOLE_AUTO_RAG_FAILED_NOTICE
+        )
+
+    def _notify_console_auto_rag(self, message: str) -> None:
+        """Emit a best-effort warning without risking the active send."""
+        try:
+            self.app_instance.notify(message, severity="warning")
+        except Exception:
+            logger.debug(
+                "Console auto-retrieve notification unavailable; "
+                "reason=auto_rag_notification_failure"
+            )
+
+    def _clear_console_auto_rag_placeholder(
+        self, placeholder: ConsoleLiveWorkLaunch
+    ) -> None:
+        """Clear only the in-flight placeholder owned by this retrieval."""
+        if self._pending_launch() is not placeholder:
+            return
+        self._set_pending_launch(None)
+        self._set_pending_auto_open(False)
+        try:
+            self._sync_pending_launch_surfaces()
+        except Exception as exc:
+            logger.warning(
+                "Console surfaces did not refresh after clearing an "
+                "auto-retrieve placeholder (exception_category={})",
+                type(exc).__name__,
+            )
+
+    async def _maybe_auto_retrieve_for_send(
+        self,
+        draft_text: str,
+        turn_context: ConsoleTurnExecutionContext | None = None,
+    ) -> None:
+        """Optionally retrieve evidence before a plain-text send."""
+        auto_retrieve_enabled = (
+            coerce_bool_setting(
+                turn_context.rag_defaults.get("auto_retrieve_on_send", False), False
+            )
+            if turn_context is not None
+            else coerce_bool_setting(
+                get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False),
+                False,
+            )
+        )
+        if not auto_retrieve_enabled:
+            return
+        if not is_plain_text_send(draft_text) or self._has_staged_evidence():
+            return
+        query = sanitize_console_library_rag_query(
+            str(draft_text or "")[:AUTO_RAG_QUERY_MAX_CHARS]
+        )
+        if not query:
+            return
+        source_types = (
+            turn_context.rag_defaults.get("source_types", ())
+            if turn_context is not None
+            else self._library_rag_source_scope()
+        )
+        top_k = (
+            int(turn_context.rag_defaults.get("top_k", 0) or 0)
+            if turn_context is not None
+            else self._library_rag_top_k()
+        )
+        request = LibraryRagSearchRequest(
+            query=query,
+            source_types=source_types,
+            mode="rag",
+            top_k=top_k,
+            include_citations=True,
+        )
+        scoped_request, scope_empty = await self._resolve_console_library_rag_scope(
+            request
+        )
+        if scope_empty is not None:
+            self._notify_console_auto_rag_scope_empty(scope_empty)
+            return
+        placeholder = ConsoleLiveWorkLaunch.from_values(
+            source="Library Search/RAG",
+            title="Library Search/RAG retrieval",
+            payload={
+                "query": scoped_request.query,
+                "source_scope": ", ".join(scoped_request.source_types),
+            },
+            status="searching",
+            recovery=CONSOLE_AUTO_RAG_SEARCHING_COPY,
+            action_label="Review evidence in Console",
+        )
+        self._stage_console_library_rag_launch(placeholder)
+        try:
+            async with asyncio.timeout(AUTO_RAG_TIMEOUT_SECONDS):
+                outcome = await run_library_rag_search(
+                    self.app_instance, scoped_request
+                )
+        except asyncio.CancelledError:
+            self._clear_console_auto_rag_placeholder(placeholder)
+            raise
+        except TimeoutError:
+            self._clear_console_auto_rag_placeholder(placeholder)
+            self._notify_auto_rag_degraded(
+                initializing=self._rag_service_still_initializing()
+            )
+            return
+        except Exception as exc:
+            logger.warning(
+                "Console auto-retrieve failed; the send proceeds without "
+                "evidence (exception_category={})",
+                type(exc).__name__,
+            )
+            self._clear_console_auto_rag_placeholder(placeholder)
+            self._notify_auto_rag_degraded(initializing=False)
+            return
+        if not getattr(outcome, "results", ()):
+            self._clear_console_auto_rag_placeholder(placeholder)
+            if str(getattr(outcome, "status", "") or "") in {"failed", "blocked"}:
+                self._notify_auto_rag_degraded(initializing=False)
+            return
+        await self._apply_console_library_rag_search_outcome(scoped_request, outcome)

--- a/tldw_chatbook/UI/Console_Modules/retrieval.py
+++ b/tldw_chatbook/UI/Console_Modules/retrieval.py
@@ -77,12 +77,21 @@ def source_mentions_rag(source: Any) -> bool:
 
 
 def sanitize_console_library_rag_query(value: Any) -> str:
-    """Return a centralized-validation-safe Console Library query."""
-    sanitized = sanitize_string(str(value or ""), max_length=2_000)
+    """Return a centralized-validation-safe Console Library query.
+
+    Args:
+        value: Raw query value to normalize and validate.
+
+    Returns:
+        The normalized query, or an empty string when validation fails.
+    """
+    sanitized = sanitize_string(str(value or ""), max_length=AUTO_RAG_QUERY_MAX_CHARS)
     query = " ".join(sanitized.strip().split())
     if not query:
         return ""
-    if not validate_text_input(query, max_length=2_000, allow_html=False):
+    if not validate_text_input(
+        query, max_length=AUTO_RAG_QUERY_MAX_CHARS, allow_html=False
+    ):
         return ""
     return query
 

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -64,6 +64,7 @@ from .prompt_queue import (
 )
 from .prompts import ConsolePromptsController
 from .reaction_preview import get_console_reaction_preview_coordinator
+from .retrieval import ConsoleRetrievalController
 from .session import ConsoleSessionController
 from .video import ConsoleVideoController
 from .workspace import ConsoleWorkspaceController
@@ -80,10 +81,10 @@ def build_console_controllers(
     rag_source_types_accessor: Callable[[], tuple[str, ...]],
     rag_top_k_accessor: Callable[[], int],
 ) -> None:
-    """Construct the Console screen's ten controllers and attach them.
+    """Construct the Console screen's eleven controllers and attach them.
 
-    Assigns, in this order, `screen._image`, `screen._workspace`,
-    `screen._character`,
+    Assigns, in this order, `screen._image`, `screen._retrieval`,
+    `screen._workspace`, `screen._character`,
     `screen._session`, `screen._dictation`, `screen._hands_free`,
     `screen._message`, `screen._prompts`, `screen._agent`, and
     `screen._prompt_queue`. The order is documentation, not a constraint:
@@ -94,7 +95,7 @@ def build_console_controllers(
     `ChatScreen.__init__` calls this at exactly the point the first
     construction used to occupy. That position matters: the ~250 attribute
     assignments around it in `__init__` include names these lambdas read, and
-    none of the nine constructors reads anything off `screen` eagerly (each
+    none of the eleven constructors reads anything off `screen` eagerly (each
     stores `screen` and its callables and nothing else), so the call needs to
     sit where it can see everything the pre-move constructions could.
 
@@ -165,6 +166,60 @@ def build_console_controllers(
         clear_console_composer_draft=lambda: screen._clear_console_composer_draft(),
     )
 
+    screen._retrieval = ConsoleRetrievalController(
+        app_instance=screen.app_instance,
+        active_native_session=(
+            lambda: screen._session._active_native_console_session()
+        ),
+        current_conversation_id=(
+            lambda: screen._current_console_rail_conversation_id()
+        ),
+        clear_evidence_sent_notice=(
+            lambda: screen._clear_console_evidence_sent_notice()
+        ),
+        consume_pending_launch=lambda: screen._consume_pending_console_launch(),
+        release_consumed_launch=(
+            lambda launch, result: screen._release_consumed_console_launch(
+                launch, result
+            )
+        ),
+        is_mounted=lambda: screen.is_mounted,
+        sync_retrieval_scope_row=(lambda: screen._sync_console_retrieval_scope_row()),
+        sync_control_bar=lambda: screen._sync_console_control_bar(),
+        request_control_bar_sync=(lambda: screen._request_console_control_bar_sync()),
+        dictionary_scope_service=lambda: screen._dictionary_scope_service(),
+        set_library_rag_source_scope=(
+            lambda source_types: screen._set_console_library_rag_source_scope(
+                source_types
+            )
+        ),
+        set_library_rag_query=(
+            lambda query: screen._set_console_library_rag_query(query)
+        ),
+        run_library_rag_action=(
+            lambda: screen._run_console_library_rag_from_visible_action()
+        ),
+        library_rag_source_scope=rag_source_types_accessor,
+        library_rag_top_k=rag_top_k_accessor,
+        pending_launch=lambda: screen._pending_console_launch_context,
+        set_pending_launch=(
+            lambda launch: setattr(screen, "_pending_console_launch_context", launch)
+        ),
+        set_pending_auto_open=(
+            lambda value: setattr(
+                screen, "_pending_console_launch_auto_open_inspector", value
+            )
+        ),
+        set_evidence_sent_notice=(
+            lambda value: setattr(screen, "_console_evidence_sent_notice", value)
+        ),
+        sync_pending_launch_surfaces=(
+            lambda: screen._sync_console_pending_launch_surfaces()
+        ),
+        refresh_screen=lambda: screen.refresh(recompose=True),
+        has_staged_evidence=lambda: screen._has_staged_console_evidence(),
+    )
+
     #: Workspace policy, lifecycle, resume, scope, and conversation-browser
     #: behavior have one owner. The controller keeps canonical rich browser
     #: state and projects legacy Workspace rows through compatibility aliases.
@@ -195,12 +250,16 @@ def build_console_controllers(
         default_session_settings_accessor=(
             lambda: screen._session._default_console_session_settings()
         ),
-        scope_picker_listers_accessor=(lambda: screen._console_scope_picker_listers()),
+        scope_picker_listers_accessor=(
+            lambda: screen._retrieval._console_scope_picker_listers()
+        ),
         active_native_session_accessor=(
             lambda: screen._session._active_native_console_session()
         ),
         refresh_effective_scope_and_sync=(
-            lambda session: screen._refresh_console_effective_scope_and_sync(session)
+            lambda session: screen._retrieval._refresh_console_effective_scope_and_sync(
+                session
+            )
         ),
         # Message <-> workspace seam (the reverse direction of the
         # session/message seams the message controller's own
@@ -233,7 +292,9 @@ def build_console_controllers(
             )
         ),
         resolve_effective_scope_state=(
-            lambda session: screen._resolve_console_effective_scope_state(session)
+            lambda session: screen._retrieval._resolve_console_effective_scope_state(
+                session
+            )
         ),
         sync_retrieval_scope_row=(lambda: screen._sync_console_retrieval_scope_row()),
         note_follow_intent=lambda: screen._note_console_follow_intent(),
@@ -360,7 +421,9 @@ def build_console_controllers(
             )
         ),
         refresh_effective_scope_and_sync=(
-            lambda session: screen._refresh_console_effective_scope_and_sync(session)
+            lambda session: screen._retrieval._refresh_console_effective_scope_and_sync(
+                session
+            )
         ),
         # Session<->workspace seam (design spec: "a named callable
         # between them; design it deliberately, never a back-door

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, replace
 import asyncio
 from functools import partial
-import inspect
 import logging
 import os
 from pathlib import Path
@@ -99,6 +98,10 @@ from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.provider_continuation_recovery import (
     ProviderContinuationTranscriptRegion as ConsoleTranscriptRegion,
 )
+from ..Console_Modules.retrieval import (
+    sanitize_console_library_rag_query as _sanitize_console_library_rag_query,
+    source_mentions_rag as _source_mentions_rag,
+)
 from ..Console_Modules.transcript import _ConsoleTranscriptReadingState
 from ..Console_Modules.wiring import build_console_controllers
 from ..Console_Modules.session import (
@@ -151,24 +154,8 @@ from ...Event_Handlers.Chat_Events.chat_events_console_dictionaries import (
 # resolution the native-Console chat entry point uses (task-5) -- session
 # identity via `persisted_conversation_id`, `SessionScopeHolder` for
 # unpersisted sessions, `EffectiveScope` state.
-from ...Event_Handlers.Chat_Events.chat_rag_events import (
-    capture_console_staged_evidence_for_chat,
-    resolve_effective_scope_for_chat,
-    resolve_scope_for_session,
-)
-from ...Chat.rag_scope import (
-    RagScope,
-    SCOPE_EMPTY_NOTICE_TEMPLATE,
-    read_conversation_scope,
-    write_conversation_scope,
-)
-from ...Chat.scope_picker_listers import (
-    build_keyword_tag_lister,
-    build_media_source_lister,
-    build_notes_source_lister,
-)
+from ...Chat.rag_scope import RagScope
 from ...Chat.console_command_grammar import (
-    COMMAND_PREFIX,
     GENERATE_IMAGE_COMMAND_HANDLER_ID,
     GENERATE_IMAGE_COMMAND_NAME,
     GENERATE_VIDEO_COMMAND_HANDLER_ID,
@@ -207,7 +194,6 @@ from ...Chat.console_prefill import (
 from ...Chat.console_generate_image import insert_style_token_into_draft
 from ...Chat.console_side_chat import ConsoleSideChatService, render_prompt
 from ...Chat.console_skill_resolver import (
-    MENTION_SIGIL,
     SKILL_UNTRUSTED_REFUSE,
     SkillCommandCandidate,
     cap_skill_args,
@@ -309,7 +295,6 @@ from ...Chat.console_display_state import (
     CONSOLE_INSPECTOR_SAVE_CHATBOOK_ID,
     ConsoleControlState,
     ConsoleDisplayRow,
-    ConsoleInspectorAction,
     ConsoleInspectorState,
     ConsoleRetrievalScopeState,
     ConsoleStagedContextState,
@@ -392,17 +377,10 @@ from ...config import (
     save_setting_to_cli_config,
     save_settings_to_cli_config,
 )
-from ...Library.library_rag_service import (
-    LibraryRagSearchOutcome,
-    LibraryRagSearchRequest,
-    RETRIEVAL_FAILED_WHY,
-    run_library_rag_search,
-    scope_empty_recovery_state,
-)
+from ...Library.library_rag_service import LibraryRagSearchRequest
 from ...Library.library_rag_state import (
     LIBRARY_RAG_FALLBACK_TOP_K,
     library_rag_profile_top_k,
-    library_rag_source_scope_summary,
 )
 from ...Constants import (
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
@@ -413,7 +391,6 @@ from ...Utils.console_background_effects import (
     ConsoleBackgroundEffectSettings,
     normalize_console_background_effects,
 )
-from ...Utils.input_validation import sanitize_string, validate_text_input
 from ...Utils.persistent_diagnostics import persist_event, safe_metadata_token
 from ...Utils.token_counter import estimate_tokens
 from ...UI.Workbench import (
@@ -500,9 +477,7 @@ from ...Widgets.Console.console_generation_card import generation_card_signature
 from ...Widgets.Console.console_video_card import video_card_signature
 from ...Widgets.Console.console_rag_settings_modal import (
     CONSOLE_RAG_DEFAULT_SOURCE_TYPES,
-    CONSOLE_RAG_SOURCE_SUMMARY_PREFIX,
     ConsoleRagSettingsModal,
-    ConsoleRagSettingsResult,
     normalize_console_rag_source_types,
 )
 from ...Widgets.Console.console_status_chips import (
@@ -570,10 +545,6 @@ from ...Workspaces.display_state import (
 )
 from ...Widgets.compact_model_bar import CompactModelBar
 from ...Widgets.Persona_Widgets.dictionary_picker import DictionaryPicker
-from ..Views.RAGSearch.search_handoff import (
-    build_library_rag_console_live_work_payload,
-    build_library_rag_evidence_bundle,
-)
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -588,8 +559,8 @@ Changed = Input.Changed
 #: retrieval item scope (`EffectiveScope`, conversation ∩ workspace) that
 #: `_resolve_console_library_rag_scope` resolves separately.
 CONSOLE_LIBRARY_RAG_SOURCE_SCOPE = CONSOLE_RAG_DEFAULT_SOURCE_TYPES
-CONSOLE_LIBRARY_RAG_RECOVERY_COPY = "Review citations before sending."
 CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH = 2_000
+CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K = LIBRARY_RAG_FALLBACK_TOP_K
 # TASK-346: below this terminal height the composer row was clipped out of
 # existence at 97x30 (no input box, no warning). The visible header banner
 # (title + purpose + Ready, ~5 rows) is pure chrome; dropping it below the
@@ -1510,37 +1481,6 @@ def _is_personas_preview_handoff(payload: ChatHandoffPayload) -> bool:
     )
 
 
-def _source_mentions_rag(source: Any) -> bool:
-    """Return whether a source label explicitly includes a RAG token.
-
-    Args:
-        source: Source label or source-like seam value.
-
-    Returns:
-        True when the normalized source tokens include `rag`.
-    """
-    tokens = re.split(r"[^a-z0-9]+", str(source or "").lower())
-    return "rag" in tokens
-
-
-def _sanitize_console_library_rag_query(value: Any) -> str:
-    """Return a centralized-validation-safe Console Library RAG query."""
-    sanitized = sanitize_string(
-        str(value or ""),
-        max_length=CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH,
-    )
-    query = " ".join(sanitized.strip().split())
-    if not query:
-        return ""
-    if not validate_text_input(
-        query,
-        max_length=CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH,
-        allow_html=False,
-    ):
-        return ""
-    return query
-
-
 def _console_library_rag_source_scope(screen: Any) -> tuple[str, ...]:
     """Return a Console screen's stored Library RAG source kinds (RAG-44).
 
@@ -1561,73 +1501,11 @@ def _console_library_rag_source_scope(screen: Any) -> tuple[str, ...]:
     )
 
 
-#: TASK-406: hard cap on how much of a composer draft is turned into an
-#: auto-retrieve query. Aliased to the explicitly-typed-query ceiling rather
-#: than re-declared as a second `2000`, so the implicit and explicit paths
-#: can never drift to different limits.
-AUTO_RAG_QUERY_MAX_CHARS = CONSOLE_LIBRARY_RAG_QUERY_MAX_LENGTH
-#: TASK-406: how long an accepted send will wait for auto-retrieval before
-#: giving up and going out WITHOUT evidence. Deliberately short: this await
-#: sits inside the send worker, between "Send pressed" and the first provider
-#: byte, so every second here is dead time the user is staring at.
-AUTO_RAG_TIMEOUT_SECONDS = 5.0
-#: TASK-406: result count used when the active RAG profile's own `default_
-#: top_k` cannot be resolved. Matches the Console chip's historical literal.
-#: TASK-15020/B3 made the Library window read the same profile through the
-#: same seam, so this is now an alias of that seam's fallback rather than a
-#: second literal 5 -- two surfaces degrading to different depths would be a
-#: silent disagreement about how deep "a search" goes.
-CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K = LIBRARY_RAG_FALLBACK_TOP_K
-#: TASK-406: the two auto-retrieve degradation notices. Both are toasts on an
-#: otherwise-successful send, so they say what the user LOSES (evidence), not
-#: what to click -- the send is already gone by the time either fires.
-CONSOLE_AUTO_RAG_INITIALIZING_NOTICE = (
-    "Auto-retrieve skipped: the RAG service is still initializing. "
-    "Message sent without Library evidence."
-)
-CONSOLE_AUTO_RAG_FAILED_NOTICE = (
-    f"Auto-retrieve skipped: {RETRIEVAL_FAILED_WHY}. "
-    "Message sent without Library evidence."
-)
-#: TASK-406: recovery copy on the in-flight ("Retrieving...") auto-retrieve
-#: card, distinct from the manual run's so a user can tell which one is
-#: spending time on their behalf.
-CONSOLE_AUTO_RAG_SEARCHING_COPY = "Auto-retrieving Library evidence for this message."
-
 #: RAG-43: above this length a composer draft reads as a paste/attachment,
 #: not a retrieval question -- well under ``CONSOLE_LIBRARY_RAG_QUERY_MAX_
 #: LENGTH`` (2000, a safety ceiling for an explicitly-typed query, not a
 #: "does this look like a question" heuristic for an implicit prefill).
 CONSOLE_LIBRARY_RAG_DRAFT_PREFILL_MAX_LENGTH = 200
-
-
-def _is_plain_text_send(draft_text: Any) -> bool:
-    """Return whether ``draft_text`` is an ordinary user question (TASK-406).
-
-    The Console has exactly two sigils that make a draft something other
-    than prose, and both are owned elsewhere: ``COMMAND_PREFIX`` (``/``, the
-    slash-command grammar) and ``MENTION_SIGIL`` (``$``, the skill
-    resolver). They are imported rather than re-spelled here so registering
-    a new command or changing a sigil cannot leave this gate behind.
-
-    Two send kinds reach the controller carrying one of those sigils
-    verbatim: a resolved ``$name`` skill invocation
-    (``_run_resolved_console_skill``) and the deliberate second-Enter
-    literal send of an unrecognized ``/word``. Neither is a retrieval
-    question, so neither auto-retrieves. Tool approvals and regenerations
-    never reach this classification at all -- they do not go through
-    ``submit_draft``/``_capture_rag_context``, which is the only caller.
-
-    Args:
-        draft_text: The validated draft about to be submitted.
-
-    Returns:
-        True when the draft is plain prose worth retrieving evidence for.
-    """
-    draft = str(draft_text or "").lstrip()
-    if not draft:
-        return False
-    return not draft.startswith((COMMAND_PREFIX, MENTION_SIGIL))
 
 
 def _console_library_rag_profile_top_k() -> int:
@@ -1650,7 +1528,7 @@ def _console_library_rag_profile_top_k() -> int:
 
     Returns:
         The profile's ``search.default_top_k`` when it resolves to a
-        positive integer, else ``CONSOLE_LIBRARY_RAG_FALLBACK_TOP_K`` -- a
+        positive integer, else the shared Library RAG fallback -- a
         broken/absent profile must degrade to retrieving, not to raising
         inside a send.
     """
@@ -1732,28 +1610,6 @@ def _console_screen_is_torn_down(screen: Any) -> bool:
     """
     return bool(
         getattr(screen, "_closing", False) or getattr(screen, "_closed", False)
-    )
-
-
-def _run_dictionary_summary_off_thread(
-    service: Any,
-    conversation_id: Any,
-    character_id: Any,
-) -> Any:
-    """Drive the async scope-service ``summarize_active_dictionaries`` call
-    to completion on a *private* event loop.
-
-    Called via ``asyncio.to_thread`` from
-    ``ChatScreen.refresh_active_dictionaries_summary`` -- this function body
-    runs in a worker thread, so ``asyncio.run`` here spins up a fresh loop on
-    that thread rather than reentering the UI's event loop. That keeps the
-    underlying (synchronous) DB read the local chat-dictionary service
-    performs entirely off the UI thread.
-    """
-    return asyncio.run(
-        service.summarize_active_dictionaries(
-            conversation_id, character_id, mode="local"
-        )
     )
 
 
@@ -1840,6 +1696,24 @@ class ChatScreen(BaseAppScreen):
     )
     _console_conversation_browser_error = _ControllerState(
         "_workspace", "_console_conversation_browser_error"
+    )
+    _console_retrieval_scope_cache = _ControllerState(
+        "_retrieval", "_console_retrieval_scope_cache"
+    )
+    _console_effective_scope_cache = _ControllerState(
+        "_retrieval", "_console_effective_scope_cache"
+    )
+    _active_dictionaries_summary = _ControllerState(
+        "_retrieval", "_active_dictionaries_summary"
+    )
+    _last_console_dictionary_scope_ids = _ControllerState(
+        "_retrieval", "_last_console_dictionary_scope_ids"
+    )
+    _active_world_books_summary = _ControllerState(
+        "_retrieval", "_active_world_books_summary"
+    )
+    _last_console_world_book_scope_ids = _ControllerState(
+        "_retrieval", "_last_console_world_book_scope_ids"
     )
     _active_character_avatar = _ControllerState(
         "_character", "_active_character_avatar"
@@ -3608,21 +3482,6 @@ class ChatScreen(BaseAppScreen):
         ) = None
         self._console_identity_refresh_generation = 0
         self._console_appearance_refresh_generation = 0
-        # task-9: cache of persisted-conversation RAG retrieval scopes,
-        # keyed by conversation id -- populated off-loop at resume time and
-        # by the scope picker's modal-open/after-save reads (never during
-        # compose/recompose), so the Inspector's retrieval-scope row and
-        # run-recipe line render from pure session state.
-        self._console_retrieval_scope_cache: Dict[str, Optional[RagScope]] = {}
-        # task-13: cache of resolved EFFECTIVE (conversation ∩ workspace)
-        # retrieval-scope display state, keyed the same way as the cache
-        # above (persisted conversation id, or the session id while
-        # unpersisted) -- populated off-loop at the same three trigger
-        # points (scope-picker save on either target, resume, and the
-        # first-persist flush hook), never during compose/recompose, so
-        # the Inspector row and header chip can render the intersection
-        # with zero DB work.
-        self._console_effective_scope_cache: Dict[str, ConsoleRetrievalScopeState] = {}
         # TASK-340: keyboard-send draft stashes — keypress->handler handoff,
         # then the queued submit's accept/refuse consumption slot.
         # `_console_pending_send_stash` stays a single slot: it is consumed
@@ -3839,38 +3698,6 @@ class ChatScreen(BaseAppScreen):
         self._console_fleet_coachmark_seen_cached: bool | None = None
         self._console_detected_local_server: DiscoveredLocalServer | None = None
         self._console_local_discovery_started = False
-        # P1g: cached "what's in play" chat-dictionary summary for the
-        # active native Console session's conversation/character scope,
-        # recomputed only by `refresh_active_dictionaries_summary()`.
-        # Fix-wave (Critical, Task 4 review): the old recompute trigger
-        # watched root-owned conversation and character mirrors that native
-        # Console never wrote, so the summary was permanently stuck at
-        # "No active chat" in the real app. `_sync_native_console_chat_ui()`
-        # recomputes whenever the active native session's
-        # (conversation_id, character_id) scope changes -- see
-        # `_active_console_dictionary_scope_ids()` and
-        # `_refresh_active_dictionaries_summary_if_scope_changed()`.
-        # `_build_console_inspector_state` and the inspector compose path
-        # read ONLY this cache -- never a DB query on recompose.
-        self._active_dictionaries_summary: dict | None = None
-        # Last (conversation_id, character_id) scope a refresh was run
-        # for. `_sync_native_console_chat_ui()` also runs on a 0.2s
-        # transcript-poll timer while a run is streaming
-        # (`_start_console_transcript_sync_timer`), so this guard is what
-        # keeps the recompute from hitting the DB (via the scope service)
-        # several times a second instead of only on a real scope change.
-        self._last_console_dictionary_scope_ids: (
-            tuple[str | None, int | None] | None
-        ) = None
-        # P2g-2: cached "what's in play" world-book summary for the active
-        # native Console session's conversation scope, recomputed only by
-        # `refresh_active_world_books_summary()`. Mirrors the dictionary
-        # cache above -- `_build_console_inspector_state` reads only this
-        # cache, never a DB query on recompose.
-        self._active_world_books_summary: dict | None = None
-        # Sentinel distinct from any real `(conversation_id,)` tuple so the
-        # first scope check always refreshes.
-        self._last_console_world_book_scope_ids: tuple | None = None
         # TASK-18060 Task 5 (review-rail spec §2): cached cross-turn
         # "Changed files" summary for the active native Console session's
         # conversation. Mirrors the dictionary/world-book caches above --
@@ -4195,7 +4022,9 @@ class ChatScreen(BaseAppScreen):
         self._pending_console_launch_auto_open_inspector = True
         store.acknowledge(claim)
         try:
-            self._stage_console_library_rag_launch(launch, allow_recompose=False)
+            self._retrieval._stage_console_library_rag_launch(
+                launch, allow_recompose=False
+            )
         except Exception as exc:
             # Includes the never-composed screen shell, where the staging
             # seam's surface sync has no DOM to query.
@@ -5657,7 +5486,7 @@ class ChatScreen(BaseAppScreen):
                 skills_service=getattr(self.app_instance, "skills_scope_service", None),
                 chat_dictionary_applier=self._console_chat_dictionary_applier,
                 world_info_applier=self._console_world_info_applier,
-                rag_capture_provider=self._capture_console_staged_rag,
+                rag_capture_provider=self._retrieval._capture_console_staged_rag,
                 default_session_settings=self._session._default_console_session_settings,
                 library_provider_factory=self._console_library_provider_factory,
                 global_user_display_name=self._global_chat_display_name,
@@ -5712,7 +5541,7 @@ class ChatScreen(BaseAppScreen):
             # constructor-supplied callables
             "_chat_dictionary_applier": self._console_chat_dictionary_applier,
             "_world_info_applier": self._console_world_info_applier,
-            "_rag_capture_provider": self._capture_console_staged_rag,
+            "_rag_capture_provider": self._retrieval._capture_console_staged_rag,
             "_default_session_settings": getattr(
                 session, "_default_console_session_settings", None
             ),
@@ -5760,64 +5589,6 @@ class ChatScreen(BaseAppScreen):
             # 4+ minute mid-delivery freeze, PR3a-2 Task 7 finding 1).
             "delivery_ui_hook": self._on_console_wake_delivery_started,
         }
-
-    async def _capture_console_staged_rag(
-        self,
-        draft: str,
-        turn_context: ConsoleTurnExecutionContext | None = None,
-    ):
-        """Resolve the current staged Library-RAG bundle for one Console send.
-
-        This is the ONLY consume-on-send seam. The controller calls it once
-        per accepted send, AFTER every block gate (provider readiness, skill
-        substitution refusal), so a blocked send never reaches this method
-        and keeps its staging -- which is why the release below needs no
-        block check of its own.
-
-        Capture-boundary ruling: the launch is released only when the
-        capture returned a non-empty ``context`` string -- exactly the
-        predicate ``ConsoleChatController._capture_rag_context`` uses to
-        decide whether the evidence is prepended to the provider messages.
-        ``capture_console_staged_evidence_for_chat`` has several honest
-        no-op returns (invalid bundle, no canonical-local references, prompt
-        authority incomplete, empty formatted context) that all yield
-        ``context=None``; releasing on those would silently discard evidence
-        that never reached the model.
-        """
-
-        # Whatever the previous send consumed is no longer "this message".
-        self._clear_console_evidence_sent_notice()
-        # TASK-406: opt-in auto-retrieve runs HERE, immediately before the
-        # consume, so anything it stages is picked up by this same send. It
-        # is a no-op unless the toggle is on and nothing is already staged.
-        # Contained: this method sits on the provider's capture path, where
-        # `ConsoleChatController._capture_rag_context` turns ANY exception
-        # into `context=None` -- so an auto-retrieve failure escaping here
-        # would also discard whatever the consume below was about to hand
-        # the model. An optional convenience must never be able to do that.
-        try:
-            await self._maybe_auto_retrieve_for_send(draft, turn_context=turn_context)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.warning(
-                "Console auto-retrieve raised; the send proceeds "
-                "(exception_category={})",
-                type(exc).__name__,
-            )
-        launch = self._consume_pending_console_launch()
-        result = await capture_console_staged_evidence_for_chat(
-            self.app_instance,
-            launch,
-            user_message=draft,
-        )
-        context = getattr(result, "context", None)
-        if launch is not None and isinstance(context, str) and context.strip():
-            self._release_consumed_console_launch(launch, result)
-        # The captured result is returned unconditionally: nothing in the
-        # release above may change what this send transmits (see the
-        # containment note there).
-        return result
 
     def _release_consumed_console_launch(
         self,
@@ -9430,50 +9201,6 @@ class ChatScreen(BaseAppScreen):
             return ConsoleStagedContextState.empty()
         return ConsoleStagedContextState.from_live_work(pending_launch)
 
-    def _build_console_retrieval_scope_state(self) -> ConsoleRetrievalScopeState:
-        """Pure display state for the Inspector's "Retrieval scope" row.
-
-        Reads only in-memory session state -- the EFFECTIVE
-        (conversation ∩ workspace, task-13) scope cache
-        (``self._console_effective_scope_cache``), populated off-loop by
-        ``_resolve_console_effective_scope_state`` at the scope-picker
-        save/resume/first-persist-flush trigger points -- never the DB
-        directly. Safe to call on every compose/recompose (task-9's
-        zero-DB-on-recompose contract).
-
-        Falls back to the conversation-only ``SessionScopeHolder`` (still
-        zero-DB, purely in-memory) for an UNPERSISTED session whose
-        effective state has not been resolved yet, so a scope narrowed via
-        the picker still reflects immediately even before the off-loop
-        workspace-intersection resolve lands.
-
-        Returns:
-            "Everything" (unscoped) when there is no active session, an
-            unpersisted session with no held scope and no resolved
-            effective state yet, or a persisted session whose conversation
-            id has not yet been resolved into the cache.
-        """
-        session = self._session._active_native_console_session()
-        if session is None:
-            return ConsoleRetrievalScopeState.unscoped()
-        cache_key = session.persisted_conversation_id or session.id
-        cached = self._console_effective_scope_cache.get(cache_key)
-        if cached is not None:
-            return cached
-        if session.persisted_conversation_id is None:
-            return ConsoleRetrievalScopeState.from_scope(session.rag_scope_holder.scope)
-        return ConsoleRetrievalScopeState.unscoped()
-
-    def _console_retrieval_scope_run_recipe_count(self) -> Optional[int]:
-        """Item count for the Inspector run-recipe's "/ scope N items" suffix.
-
-        ``None`` when unscoped (the run-recipe line stays unchanged); the
-        same pure, zero-DB session-state read
-        ``_build_console_retrieval_scope_state`` uses.
-        """
-        state = self._build_console_retrieval_scope_state()
-        return state.item_count if state.is_scoped else None
-
     def _sync_console_retrieval_scope_row(self) -> None:
         """Refresh the mounted retrieval-scope row AND status-strip chips.
 
@@ -9493,7 +9220,7 @@ class ChatScreen(BaseAppScreen):
         ``sync_temporary_chip`` for why it is kept off the general
         control-bar sync tick, same as the scope chip.
         """
-        state = self._build_console_retrieval_scope_state()
+        state = self._retrieval._build_console_retrieval_scope_state()
         try:
             row = self.query_one(
                 f"#{CONSOLE_RETRIEVAL_SCOPE_ROW_ID}", ConsoleRetrievalScopeRow
@@ -9508,159 +9235,6 @@ class ChatScreen(BaseAppScreen):
             return
         status_chips.sync_scope_chip(state)
         status_chips.sync_temporary_chip(self._console_active_session_is_ephemeral())
-
-    async def _resolve_console_effective_scope_state(
-        self, session: "ConsoleChatSession"
-    ) -> ConsoleRetrievalScopeState:
-        """Resolve+cache the EFFECTIVE (conversation ∩ workspace) scope
-        display state for ``session``, off-loop (task-13).
-
-        Delegates to ``chat_rag_events.resolve_scope_for_session`` -- the
-        SAME resolution core ``resolve_effective_scope_for_chat`` uses to
-        enforce retrieval -- so the Inspector row/header chip and actual
-        enforcement never diverge. The returned ``ScopeResolution`` also
-        carries the raw conversation/workspace scopes, used here only for
-        the chip's intersection-breakdown tooltip counts.
-
-        Refreshes ``self._console_retrieval_scope_cache`` (the
-        conversation-only cache the picker's ``initial`` seed reads) from
-        the SAME resolved conversation scope -- one DB read serves both
-        caches -- and caches the built ``ConsoleRetrievalScopeState`` in
-        ``self._console_effective_scope_cache``, keyed by the persisted
-        conversation id or the session id while unpersisted, so
-        ``_build_console_retrieval_scope_state`` can read it back with
-        zero DB work on compose/recompose.
-
-        Call sites: the scope-picker save handlers (either the
-        conversation or the workspace target), resume
-        (``_resume_console_workspace_conversation``), and the first-persist
-        flush hook (``_on_console_scope_flushed``) -- never
-        compose/recompose.
-
-        Args:
-            session: The Console session to resolve scope for.
-
-        Returns:
-            The resolved, cached ``ConsoleRetrievalScopeState``.
-        """
-        resolution = await resolve_scope_for_session(self.app_instance, session)
-        if session.persisted_conversation_id is not None:
-            self._console_retrieval_scope_cache[session.persisted_conversation_id] = (
-                resolution.conv_scope
-            )
-        conv_item_count = (
-            len(resolution.conv_scope.items)
-            if resolution.conv_scope is not None
-            else None
-        )
-        ws_item_count = (
-            len(resolution.ws_scope.items) if resolution.ws_scope is not None else None
-        )
-        state = ConsoleRetrievalScopeState.from_effective(
-            resolution.effective,
-            conv_item_count=conv_item_count,
-            ws_item_count=ws_item_count,
-        )
-        cache_key = session.persisted_conversation_id or session.id
-        self._console_effective_scope_cache[cache_key] = state
-        return state
-
-    async def _refresh_console_effective_scope_and_sync(
-        self, session: "ConsoleChatSession"
-    ) -> None:
-        """Resolve the effective scope for ``session`` and refresh the row/chip.
-
-        Thin convenience wrapper around ``_resolve_console_effective_scope_
-        state`` for the (common) case where the caller wants the resolved
-        state pushed straight into the mounted Inspector row and header
-        chip afterward. A no-op refresh when the screen is not mounted
-        (mirrors every other post-save sync call site in this file).
-
-        Args:
-            session: The Console session to resolve scope for.
-        """
-        await self._resolve_console_effective_scope_state(session)
-        if self.is_mounted:
-            self._sync_console_retrieval_scope_row()
-            self._sync_console_control_bar()
-
-    async def _warm_console_effective_scope_cache_if_stale(self) -> None:
-        """Warm the effective-scope cache for an already-active persisted session.
-
-        Covers a gap the picker-save/resume/first-persist-flush warmers
-        (``_resolve_console_effective_scope_state``'s three call sites)
-        never reach: ``restore_state`` (screen restore on app start, or
-        switching back to the Console screen) can reactivate a native
-        session whose ``persisted_conversation_id`` is already set BEFORE
-        this screen ever mounts, so ``_console_effective_scope_cache`` has
-        no entry for it yet. Left alone, ``_build_console_retrieval_scope_
-        state`` falls through to its cache-miss branch for a persisted
-        session and renders "Everything" for a conversation that is
-        actually scoped, until the user happens to resume/switch/save.
-
-        Called at the start of every ``_sync_native_console_chat_ui`` tick
-        (the initial-mount sync path included), but the cache-key presence
-        check below makes it a no-op once the session has been warmed --
-        the same one-time guard every other warmer relies on -- so this
-        adds no repeated DB work.
-        """
-        session = self._session._active_native_console_session()
-        if session is None or session.persisted_conversation_id is None:
-            return
-        cache_key = session.persisted_conversation_id
-        if cache_key in self._console_effective_scope_cache:
-            return
-        try:
-            await self._refresh_console_effective_scope_and_sync(session)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Failed to warm retrieval scope cache for conversation {}",
-                cache_key,
-            )
-
-    @staticmethod
-    async def _read_console_retrieval_scope(
-        db: Any, conversation_id: str
-    ) -> Optional[RagScope]:
-        """Read a conversation's stored scope, off-loop for file-backed DBs.
-
-        In-memory SQLite connections are thread-local -- the same trap
-        ``library_local_rag_search_service._search_conversations`` already
-        documents and guards: offloading to a worker thread via
-        ``asyncio.to_thread`` would open a FRESH, blank in-memory
-        connection with no migrated schema, since only the thread that
-        created the DB has one. Real app usage is always file-backed
-        (``asyncio.to_thread`` applies normally); the guard only matters
-        for the in-memory DBs the test suite uses per repo convention.
-        """
-        if getattr(db, "is_memory_db", False):
-            return read_conversation_scope(db, conversation_id)
-        return await asyncio.to_thread(read_conversation_scope, db, conversation_id)
-
-    @staticmethod
-    async def _write_console_retrieval_scope(
-        db: Any, conversation_id: str, scope: Optional[RagScope]
-    ) -> None:
-        """Write (or clear) a conversation's stored scope; see the read twin's
-        in-memory-DB guard docstring for why this isn't unconditionally
-        ``asyncio.to_thread``."""
-        if getattr(db, "is_memory_db", False):
-            write_conversation_scope(db, conversation_id, scope)
-        else:
-            await asyncio.to_thread(
-                write_conversation_scope, db, conversation_id, scope
-            )
-
-    def _console_scope_picker_listers(
-        self,
-    ) -> tuple[Any, Any, Any]:
-        """Build the real (media, notes, tag) listers for the scope picker."""
-        user_id = getattr(self.app_instance, "notes_user_id", None) or "default_user"
-        return (
-            build_media_source_lister(self.app_instance),
-            build_notes_source_lister(self.app_instance, user_id=user_id),
-            build_keyword_tag_lister(self.app_instance),
-        )
 
     async def _open_console_retrieval_scope_picker(self) -> None:
         """Open the RAG retrieval-scope picker for the active Console session.
@@ -9686,7 +9260,7 @@ class ChatScreen(BaseAppScreen):
         if conversation_id is not None:
             db = getattr(self.app_instance, "chachanotes_db", None)
             initial = (
-                await self._read_console_retrieval_scope(db, conversation_id)
+                await self._retrieval._read_console_retrieval_scope(db, conversation_id)
                 if db is not None
                 else None
             )
@@ -9721,11 +9295,13 @@ class ChatScreen(BaseAppScreen):
             max_characters=500,
         )
         target_label = title or "this conversation"
-        media_lister, notes_lister, tag_lister = self._console_scope_picker_listers()
+        media_lister, notes_lister, tag_lister = (
+            self._retrieval._console_scope_picker_listers()
+        )
 
         def _on_save(scope: Optional[RagScope]) -> None:
             self.run_worker(
-                self._apply_console_retrieval_scope_save(session, scope),
+                self._retrieval._apply_console_retrieval_scope_save(session, scope),
                 exclusive=True,
                 group="console-retrieval-scope-save",
             )
@@ -9747,99 +9323,7 @@ class ChatScreen(BaseAppScreen):
         session = self._session._active_native_console_session()
         if session is None:
             return
-        await self._apply_console_retrieval_scope_save(session, None)
-
-    async def _apply_console_retrieval_scope_save(
-        self,
-        session: ConsoleChatSession,
-        scope: Optional[RagScope],
-    ) -> None:
-        """Persist (or session-hold) a scope chosen in the picker modal.
-
-        A persisted conversation writes through ``write_conversation_scope``
-        off-loop; ``write_conversation_scope`` fails SOFT on corrupt
-        existing metadata (silently skips the write rather than raising or
-        erasing sibling metadata keys) -- this is detected here by
-        re-reading afterward: a non-``None`` target scope that reads back
-        as ``None`` means the write was refused, and an honest notify is
-        surfaced rather than a false "saved". A not-yet-persisted session
-        holds the scope in ``session.rag_scope_holder`` instead --
-        ``ConsoleChatStore.persist_session_if_needed`` flushes it through
-        exactly once, at first persistence. Either branch ends by
-        refreshing the Inspector row and the run-recipe line.
-
-        ``write_conversation_scope`` can also raise (task-9 review finding
-        4): a ``ConflictError`` (optimistic-lock version race -- a
-        concurrent write, e.g. a dictionary attach/detach, landed on the
-        same conversation row between read and write; real per PR #734's
-        docs) and a ``ValueError`` (the conversation no longer exists) are
-        both genuine, distinct failure modes -- neither is "corrupted
-        metadata", so each gets its own honest notify instead of the
-        generic corrupt-metadata wording.
-
-        Args:
-            session: The Console session the scope applies to.
-            scope: The new scope, or ``None`` to clear it.
-        """
-        if session.persisted_conversation_id is not None:
-            conversation_id = session.persisted_conversation_id
-            db = getattr(self.app_instance, "chachanotes_db", None)
-            if db is None:
-                self.app_instance.notify(
-                    "Couldn't save scope: no database is available.",
-                    severity="error",
-                )
-                return
-            from ...DB.ChaChaNotes_DB import ConflictError
-
-            try:
-                await self._write_console_retrieval_scope(db, conversation_id, scope)
-            except ConflictError:
-                logger.opt(exception=True).warning(
-                    "Retrieval scope write conflict for conversation {}",
-                    conversation_id,
-                )
-                self.app_instance.notify(
-                    "Couldn't save scope: the conversation was modified "
-                    "concurrently — try again.",
-                    severity="error",
-                )
-                return
-            except ValueError:
-                logger.opt(exception=True).warning(
-                    "Retrieval scope write target missing for conversation {}",
-                    conversation_id,
-                )
-                self.app_instance.notify(
-                    "Couldn't save scope: this conversation no longer exists.",
-                    severity="error",
-                )
-                return
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Failed to write retrieval scope for conversation {}",
-                    conversation_id,
-                )
-                self.app_instance.notify(
-                    "Couldn't save scope: conversation metadata is corrupted.",
-                    severity="error",
-                )
-                return
-            after = await self._read_console_retrieval_scope(db, conversation_id)
-            if scope is not None and after is None:
-                self.app_instance.notify(
-                    "Couldn't save scope: conversation metadata is corrupted.",
-                    severity="error",
-                )
-                return
-            self._console_retrieval_scope_cache[conversation_id] = after
-        else:
-            session.rag_scope_holder.set(scope)
-        # task-13: resolve the EFFECTIVE (conversation ∩ workspace) state
-        # for the row/chip, not just the conversation-only scope just
-        # saved -- a workspace scope may already be narrowing this
-        # conversation's retrieval too.
-        await self._refresh_console_effective_scope_and_sync(session)
+        await self._retrieval._apply_console_retrieval_scope_save(session, None)
 
     @on(Button.Pressed, ".console-retrieval-scope-open-btn")
     async def _console_retrieval_scope_open_pressed(
@@ -9999,7 +9483,7 @@ class ChatScreen(BaseAppScreen):
                 ),
                 on_auto_retrieve_changed=self._persist_console_rag_auto_retrieve_on_send,
             ),
-            callback=self._apply_console_rag_settings_choice,
+            callback=self._retrieval._apply_console_rag_settings_choice,
         )
 
     def _set_console_library_rag_query(self, query: str) -> None:
@@ -10045,54 +9529,11 @@ class ChatScreen(BaseAppScreen):
             scope_label = self.query_one("#console-library-rag-scope", Static)
         except QueryError:
             return
-        scope_label.update(self._console_library_rag_scope_label())
-
-    def _apply_console_rag_settings_choice(
-        self, result: ConsoleRagSettingsResult | None
-    ) -> None:
-        """Store the modal's query and sources, then optionally run now.
-
-        The "Auto-retrieve on send" toggle (TASK-3170 / RAG-port P0 task 7)
-        is NOT handled here -- it is a standing preference, not part of
-        this draft, so it already persisted the instant it flipped inside
-        the modal (see ``_open_console_rag_settings``'s
-        ``on_auto_retrieve_changed=self._persist_console_rag_auto_retrieve_
-        on_send`` and that method below). Gating it on this dismiss
-        callback the way the query/source-type edits are gated would have
-        silently lost the toggle on Escape/Cancel/a backdrop click, and
-        given a blank-query user no way to save it without running a
-        throwaway retrieval.
-        """
-        if result is None:
-            return
-        self._set_console_library_rag_source_scope(result.source_types)
-        self._set_console_library_rag_query(
-            _sanitize_console_library_rag_query(result.query)
-        )
-        if result.run:
-            self._run_console_library_rag_from_visible_action()
+        scope_label.update(self._retrieval._console_library_rag_scope_label())
 
     @work(thread=True)
     def _persist_console_rag_auto_retrieve_on_send(self, value: bool) -> None:
-        """Persist the "Auto-retrieve on send" toggle without blocking the UI thread.
-
-        TASK-3170 (RAG-port P0 task 7, re-critique fix): fired the instant
-        the RAG settings modal's switch flips (via its
-        ``on_auto_retrieve_changed`` callback), independent of how -- or
-        whether -- the modal is later dismissed. Mirrors the sibling
-        Console preference writers (``_save_console_rail_preferences``,
-        ``_save_console_onboarding_flag``, ``_save_console_fleet_coachmark_
-        flag``): a small best-effort ``save_setting_to_cli_config`` write
-        on a thread worker, not the UI thread.
-        """
-        try:
-            save_setting_to_cli_config(
-                "chat_defaults", "rag_auto_retrieve_on_send", bool(value)
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed to persist Console auto-retrieve-on-send setting: {}", exc
-            )
+        self._retrieval._persist_console_rag_auto_retrieve_on_send(value)
 
     async def _open_console_character_picker(self) -> None:
         """Load characters off-thread and open the picker modal (task-1672)."""
@@ -10657,7 +10098,7 @@ class ChatScreen(BaseAppScreen):
         session = self._session._active_native_console_session()
         if session is not None and session.persisted_conversation_id == conversation_id:
             self.run_worker(
-                self._refresh_console_effective_scope_and_sync(session),
+                self._retrieval._refresh_console_effective_scope_and_sync(session),
                 exclusive=True,
                 group="console-effective-scope-refresh",
             )
@@ -11623,20 +11064,6 @@ class ChatScreen(BaseAppScreen):
         target_id = str(pending_launch.payload.get("target_id") or "").strip()
         return source in {"artifacts", "chatbooks"} and ":chatbook:" in target_id
 
-    @staticmethod
-    def _launch_has_rag_source_payload(pending_launch: ConsoleLiveWorkLaunch) -> bool:
-        source_keys = (
-            "source_id",
-            "source_count",
-            "citation_count",
-            "chunk_id",
-            "query",
-            "result_id",
-        )
-        return any(
-            str(pending_launch.payload.get(key) or "").strip() for key in source_keys
-        )
-
     def _console_pending_approval_count(self) -> int:
         explicit_count = getattr(
             self.app_instance, "console_pending_approval_count", None
@@ -11671,47 +11098,6 @@ class ChatScreen(BaseAppScreen):
         return coerce_non_negative_int(
             getattr(self.app_instance, "console_mcp_not_connected_count", 0)
         )
-
-    def _console_rag_source_status(
-        self,
-        pending_launch: Optional[ConsoleLiveWorkLaunch],
-        sent_source_count: Optional[int] = None,
-    ) -> str:
-        """Return the Inspector's "Sources" row text (D1b).
-
-        Args:
-            pending_launch: Currently staged live-work launch, if any.
-            sent_source_count: The one-send "evidence sent" memory
-                (``ChatScreen._console_evidence_sent_notice``) -- the SAME
-                count the staged-evidence strip reads for its "Evidence
-                sent with this message" line. Only consulted when nothing
-                is staged: live staging always wins, exactly like the
-                strip (``build_console_staged_evidence_strip_state``).
-
-        Returns:
-            The existing staged/blocked/not-requested vocabulary when a
-            launch is pending; the last-send memory sentence when nothing
-            is staged but a send just consumed evidence; else the
-            genuinely-empty ``"not staged"``.
-        """
-        if pending_launch is None:
-            if sent_source_count:
-                count = int(sent_source_count)
-                noun = "source" if count == 1 else "sources"
-                return f"sent with the last message · {count} {noun}"
-            return "not staged"
-        if _source_mentions_rag(pending_launch.source):
-            launch_status = str(pending_launch.status or "").strip().lower()
-            if launch_status in {"blocked", "failed", "unavailable"}:
-                return "unavailable"
-            if launch_status == "empty":
-                return "no results"
-            if launch_status == "searching":
-                return "retrieving from Library Search/RAG"
-            if self._launch_has_rag_source_payload(pending_launch):
-                return "staged from Library Search/RAG"
-            return "missing source"
-        return "not requested"
 
     def _console_artifact_status(
         self,
@@ -11784,7 +11170,7 @@ class ChatScreen(BaseAppScreen):
             model_label=model,
             provider_ready=provider_ready,
             provider_recovery=provider_recovery,
-            rag_status=self._console_rag_source_status(
+            rag_status=self._retrieval._console_rag_source_status(
                 pending_launch,
                 sent_source_count=self._console_evidence_sent_notice,
             ),
@@ -11801,7 +11187,7 @@ class ChatScreen(BaseAppScreen):
             mcp_tool_count=self._console_mcp_tool_count(),
             mcp_not_connected_count=self._console_mcp_not_connected_count(),
             can_save_chatbook=can_save_chatbook,
-            scope_item_count=self._console_retrieval_scope_run_recipe_count(),
+            scope_item_count=self._retrieval._console_retrieval_scope_run_recipe_count(),
             change_review_available=(
                 getattr(self._console_agent_bridge, "change_tracking_enabled", False)
                 if self._console_agent_bridge is not None
@@ -11851,10 +11237,10 @@ class ChatScreen(BaseAppScreen):
         # current by `refresh_active_dictionaries_summary()`).
         inspector_state = replace(
             inspector_state,
-            dictionary_rows=self._console_dictionary_inspector_rows(),
-            dictionary_actions=self._console_dictionary_inspector_actions(),
-            world_book_rows=self._console_world_book_inspector_rows(),
-            world_book_actions=self._console_world_book_inspector_actions(),
+            dictionary_rows=self._retrieval._console_dictionary_inspector_rows(),
+            dictionary_actions=self._retrieval._console_dictionary_inspector_actions(),
+            world_book_rows=self._retrieval._console_world_book_inspector_rows(),
+            world_book_actions=self._retrieval._console_world_book_inspector_actions(),
         )
         return inspector_state
 
@@ -11910,177 +11296,6 @@ class ChatScreen(BaseAppScreen):
         return apply_world_info_to_message(
             db, conversation_id, None, message_text, history or []
         )
-
-    def _active_console_dictionary_scope_ids(self) -> tuple[str | None, int | None]:
-        """Return (conversation_id, character_id) for the active native
-        Console session's chat-dictionary scope.
-
-        `conversation_id` comes from `_current_console_rail_conversation_id()`
-        -- the existing accessor that already resolves the active native
-        session's `persisted_conversation_id` (falling back to the native
-        Console conversation accessor when no active session exists).
-        `character_id` is always `None`: native
-        Console sessions do not yet track a numeric character id --
-        `ConsoleSessionSettings.character_label` is only a free-text display
-        string, never a DB id. Character-scoped dictionary attachment for the
-        native Console is net-new work (tracked separately as Roleplay P1e
-        Attachments); once it lands, this is the one place to source a real
-        character id from.
-        """
-        return self._current_console_rail_conversation_id(), None
-
-    async def refresh_active_dictionaries_summary(self) -> None:
-        """Recompute and cache the "what's in play" chat-dictionary summary
-        for the active native Console session's conversation/character, then
-        refresh the Console inspector.
-
-        This is the ONLY place that performs the (DB-backed) dictionary
-        summarize call -- `_build_console_inspector_state` (and therefore
-        every Console recompose/refresh) reads only the cache set here. The
-        scope-service call is marshalled onto a worker thread via
-        `asyncio.to_thread` so this never performs a synchronous DB read on
-        the UI event loop.
-        """
-        conversation_id, character_id = self._active_console_dictionary_scope_ids()
-        service = self._dictionary_scope_service()
-        if service is None or (conversation_id is None and character_id is None):
-            self._active_dictionaries_summary = {"dictionaries": []}
-        else:
-            try:
-                summary = await asyncio.to_thread(
-                    _run_dictionary_summary_off_thread,
-                    service,
-                    conversation_id,
-                    character_id,
-                )
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Could not summarize active chat dictionaries for the Console inspector."
-                )
-                summary = {"dictionaries": []}
-            self._active_dictionaries_summary = (
-                summary if isinstance(summary, dict) else {"dictionaries": []}
-            )
-        self._request_console_control_bar_sync()
-
-    async def _refresh_active_dictionaries_summary_if_scope_changed(self) -> None:
-        """Recompute the "what's in play" summary only when the active
-        native Console session's dictionary scope actually changed.
-
-        Called from `_sync_native_console_chat_ui()`, the central Console
-        UI-sync entrypoint -- which also runs on a 0.2s transcript-poll timer
-        while a run is streaming (`_start_console_transcript_sync_timer`).
-        Without this guard, every one of those polls would re-run the
-        DB-backed summarize call. The guard is driven by the actual
-        native-session change signal.
-        """
-        scope_ids = self._active_console_dictionary_scope_ids()
-        if scope_ids == self._last_console_dictionary_scope_ids:
-            return
-        self._last_console_dictionary_scope_ids = scope_ids
-        await self.refresh_active_dictionaries_summary()
-
-    def _console_dictionary_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
-        """Project the cached dictionary summary into inspector rows.
-
-        Reads ONLY `self._active_dictionaries_summary` (and the active native
-        Console session's conversation/character ids, to distinguish "no
-        active chat" from "no dictionaries attached yet") -- never touches
-        the DB.
-        """
-        conversation_id, character_id = self._active_console_dictionary_scope_ids()
-        if conversation_id is None and character_id is None:
-            return (ConsoleDisplayRow("No active chat", ""),)
-
-        summary = self._active_dictionaries_summary or {}
-        dictionaries = summary.get("dictionaries") or []
-        if not dictionaries:
-            return (ConsoleDisplayRow("No dictionaries in play", ""),)
-
-        rows = []
-        for entry in dictionaries:
-            if not isinstance(entry, dict):
-                continue
-            name = str(entry.get("name") or "Unnamed")
-            value = (
-                "from conversation"
-                if entry.get("source") == "conversation"
-                else "from character"
-            )
-            if entry.get("shadowed"):
-                value += " (shadowed)"
-            if not entry.get("enabled", True):
-                value += " (disabled)"
-            rows.append(ConsoleDisplayRow(name, value))
-        return tuple(rows)
-
-    def _active_console_world_book_scope_ids(self) -> tuple[str | None]:
-        """(conversation_id,) for the active native Console world-book scope.
-
-        Conversation-only: native Console has no character (see
-        `_active_console_dictionary_scope_ids`).
-        """
-        return (self._current_console_rail_conversation_id(),)
-
-    async def refresh_active_world_books_summary(self) -> None:
-        """The ONLY place that performs the DB-backed world-book summarize.
-
-        `_build_console_inspector_state` reads only the cache set here. The
-        sync summarize is marshalled onto a worker thread via `asyncio.to_thread`
-        so it never blocks the UI loop.
-        """
-        conversation_id = self._current_console_rail_conversation_id()
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        if not conversation_id or db is None:
-            self._active_world_books_summary = {"world_books": []}
-            self._request_console_control_bar_sync()
-            return
-        try:
-            from ...Character_Chat.world_info_resolver import (
-                summarize_active_world_books,
-            )
-
-            summary = await asyncio.to_thread(
-                summarize_active_world_books, db, conversation_id, None
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Could not summarize active world books for the Console inspector."
-            )
-            summary = {"world_books": []}
-        self._active_world_books_summary = (
-            summary if isinstance(summary, dict) else {"world_books": []}
-        )
-        self._request_console_control_bar_sync()
-
-    async def _refresh_active_world_books_summary_if_scope_changed(self) -> None:
-        """Recompute the world-book summary only when the scope changed."""
-        scope_ids = self._active_console_world_book_scope_ids()
-        if scope_ids == self._last_console_world_book_scope_ids:
-            return
-        self._last_console_world_book_scope_ids = scope_ids
-        await self.refresh_active_world_books_summary()
-
-    def _console_world_book_inspector_rows(self) -> tuple[ConsoleDisplayRow, ...]:
-        """Project the cached world-book summary into inspector rows (no DB)."""
-        conversation_id = self._current_console_rail_conversation_id()
-        if conversation_id is None:
-            return (ConsoleDisplayRow("No active chat", ""),)
-        summary = self._active_world_books_summary or {}
-        books = summary.get("world_books") or []
-        if not books:
-            return (ConsoleDisplayRow("No world books in play", ""),)
-        rows = []
-        for entry in books:
-            if not isinstance(entry, dict):
-                continue
-            name = str(entry.get("name") or "Unnamed")
-            count = entry.get("entry_count")
-            value = f"{count} entries" if isinstance(count, int) else "0 entries"
-            if not entry.get("enabled", True):
-                value += " (disabled)"
-            rows.append(ConsoleDisplayRow(name, value))
-        return tuple(rows)
 
     # -- Changed-files rail section (TASK-18060 Task 5, review-rail spec §2) -
 
@@ -12332,36 +11547,6 @@ class ChatScreen(BaseAppScreen):
             self._console_changed_files_row_cache = {}
             self._sync_console_changed_files_section()
         self._dispatch_console_changed_files_worker(scope[0])
-
-    def _console_dictionary_inspector_actions(
-        self,
-    ) -> tuple[ConsoleInspectorAction, ...]:
-        """Attach/Detach actions for the Console dictionary inspector block.
-
-        Reads ONLY the cache + the active native Console session's
-        conversation id -- never the DB.
-        """
-        conversation_id, _character_id = self._active_console_dictionary_scope_ids()
-        summary = self._active_dictionaries_summary or {}
-        dictionaries = summary.get("dictionaries") or []
-        has_conversation_dictionary = any(
-            isinstance(entry, dict) and entry.get("source") == "conversation"
-            for entry in dictionaries
-        )
-        return (
-            ConsoleInspectorAction(
-                "console-inspector-dictionaries-attach",
-                "Attach dictionary…",
-                enabled=bool(conversation_id),
-                disabled_reason="Start or load a conversation first",
-            ),
-            ConsoleInspectorAction(
-                "console-inspector-dictionaries-detach",
-                "Detach dictionary…",
-                enabled=has_conversation_dictionary,
-            ),
-        )
-
     async def _console_dictionary_attach_worker(self) -> None:
         """Pick and attach a chat dictionary to the active Console conversation.
 
@@ -12411,30 +11596,9 @@ class ChatScreen(BaseAppScreen):
             # -> notify + refresh): on success the summary gains the dict; on a
             # ConflictError the DB changed under us and the cache must re-read
             # the current truth rather than stay stale until the next switch.
-            await self.refresh_active_dictionaries_summary()
+            await self._retrieval.refresh_active_dictionaries_summary()
         finally:
             self._console_dictionary_dialog_active = False
-
-    def _console_world_book_inspector_actions(
-        self,
-    ) -> tuple[ConsoleInspectorAction, ...]:
-        """Attach/Detach actions for the Console world-book block (cache + conv id only)."""
-        conversation_id = self._current_console_rail_conversation_id()
-        summary = self._active_world_books_summary or {}
-        has_attached = bool(summary.get("world_books"))
-        return (
-            ConsoleInspectorAction(
-                "console-inspector-worldbooks-attach",
-                "Attach world book…",
-                enabled=bool(conversation_id),
-                disabled_reason="Start or load a conversation first",
-            ),
-            ConsoleInspectorAction(
-                "console-inspector-worldbooks-detach",
-                "Detach world book…",
-                enabled=has_attached,
-            ),
-        )
 
     async def _console_worldbook_attach_worker(self) -> None:
         """Pick and attach a world book to the active Console conversation.
@@ -12502,7 +11666,7 @@ class ChatScreen(BaseAppScreen):
                 logger.opt(exception=True).warning("Could not attach the world book.")
                 self.app_instance.notify(f"Attach failed: {exc}", severity="error")
                 return
-            await self.refresh_active_world_books_summary()
+            await self._retrieval.refresh_active_world_books_summary()
         finally:
             self._console_worldbook_dialog_active = False
 
@@ -12569,7 +11733,7 @@ class ChatScreen(BaseAppScreen):
                 logger.opt(exception=True).warning("Could not detach the world book.")
                 self.app_instance.notify(f"Detach failed: {exc}", severity="error")
                 return
-            await self.refresh_active_world_books_summary()
+            await self._retrieval.refresh_active_world_books_summary()
         finally:
             self._console_worldbook_dialog_active = False
 
@@ -12620,7 +11784,7 @@ class ChatScreen(BaseAppScreen):
             )
             # Always resync after an attempted detach (spec AC5: ConflictError
             # -> notify + refresh); see _console_dictionary_attach_worker.
-            await self.refresh_active_dictionaries_summary()
+            await self._retrieval.refresh_active_dictionaries_summary()
         finally:
             self._console_dictionary_dialog_active = False
 
@@ -12814,21 +11978,6 @@ class ChatScreen(BaseAppScreen):
             *children,
             id=card_state.container_id,
             classes=card_state.container_classes,
-        )
-
-    def _console_library_rag_scope_label(self) -> str:
-        """Return the readiness card's Library RAG source line (RAG-44).
-
-        Library's scope-summary grammar (`library_rag_source_scope_summary`
-        -- selected sources in canonical order, the deselected ones named
-        as off) under the Console's own noun: "Sources", never "Scope",
-        which this screen already spends on the retrieval ITEM scope
-        ("Scope: 2 items"). The settings modal's own summary line is the
-        same builder on the same state -- two seams, one builder.
-        """
-        return library_rag_source_scope_summary(
-            _console_library_rag_source_scope(self),
-            prefix=CONSOLE_RAG_SOURCE_SUMMARY_PREFIX,
         )
 
     @staticmethod
@@ -13500,7 +12649,7 @@ class ChatScreen(BaseAppScreen):
                 classes=readiness.title_classes,
             ),
             Static(
-                self._console_library_rag_scope_label(),
+                self._retrieval._console_library_rag_scope_label(),
                 id="console-library-rag-scope",
                 classes="destination-section",
             ),
@@ -13608,7 +12757,7 @@ class ChatScreen(BaseAppScreen):
             top_k=_console_library_rag_profile_top_k(),
             include_citations=True,
         )
-        self._stage_console_library_rag_launch(
+        self._retrieval._stage_console_library_rag_launch(
             ConsoleLiveWorkLaunch.from_values(
                 source="Library Search/RAG",
                 title="Library Search/RAG retrieval",
@@ -13622,37 +12771,6 @@ class ChatScreen(BaseAppScreen):
             )
         )
         self._execute_console_library_rag_search(request)
-
-    def _stage_console_library_rag_launch(
-        self,
-        launch: ConsoleLiveWorkLaunch,
-        *,
-        allow_recompose: bool = True,
-    ) -> None:
-        """Stage live-work launch context and refresh Console surfaces in place.
-
-        TASK-259: previously this recomposed the ENTIRE ChatScreen to show
-        one pending launch card. Now every mounted reader of
-        ``_pending_console_launch_context`` is refreshed with a targeted
-        update instead; the full recompose survives only as a fallback for
-        the never-composed case (Console shell not mounted yet).
-
-        Args:
-            launch: Live-work launch metadata to stage for Console.
-            allow_recompose: Whether the never-composed case may fall back
-                to a full recompose. Only ``_supersede_resident_console_
-                launch_from_store`` passes ``False``: its unmounted case is
-                ``compose_content`` itself calling
-                ``_consume_pending_console_launch`` on its first line, so
-                the compose in progress already renders this exact launch
-                and scheduling a second one mid-compose would tear the
-                just-built DOM back down for no change.
-        """
-        self._pending_console_launch_context = launch
-        # New staging supersedes the previous send's "evidence sent" line.
-        self._console_evidence_sent_notice = None
-        if not self._sync_console_pending_launch_surfaces() and allow_recompose:
-            self.refresh(recompose=True)
 
     def _sync_console_pending_launch_surfaces(self) -> bool:
         """Refresh every mounted reader of the pending launch context in place.
@@ -13823,107 +12941,11 @@ class ChatScreen(BaseAppScreen):
         tray.styles.max_height = 6 if state.is_empty else 10
         tray.sync_state(state)
 
-    async def _resolve_console_library_rag_scope(
-        self, request: LibraryRagSearchRequest
-    ) -> tuple[LibraryRagSearchRequest, Optional[LibraryRagSearchOutcome]]:
-        """Resolve the active conversation's RAG retrieval scope for `request`.
-
-        Plain `async def` (not `@work`-decorated) so it is directly
-        awaitable in tests without the Textual worker machinery -- only
-        `_execute_console_library_rag_search` itself needs to run as a
-        worker.
-
-        Args:
-            request: The unscoped Library RAG search request as built by the
-                run-action call site.
-
-        Returns:
-            A `(request, outcome)` tuple. When the resolved scope is EMPTY
-            (a configured scope with nothing left to search), `outcome`
-            carries the short-circuit recovery state and `request` is
-            returned unchanged -- the caller must not proceed to
-            `run_library_rag_search`. Otherwise `outcome` is `None` and
-            `request` carries `scope=effective_scope` when scoped, or is
-            returned unchanged when unscoped (byte-identical to before this
-            resolution step existed).
-        """
-        effective_scope = await resolve_effective_scope_for_chat(self.app_instance)
-        if effective_scope.state == "empty":
-            return request, LibraryRagSearchOutcome(
-                status="empty",
-                recovery_state=scope_empty_recovery_state(effective_scope.cause),
-            )
-        if effective_scope.state == "scoped":
-            return replace(request, scope=effective_scope), None
-        return request, None
-
     @work(exclusive=True, group="console-library-rag-search")
     async def _execute_console_library_rag_search(
         self, request: LibraryRagSearchRequest
     ) -> None:
-        (
-            scoped_request,
-            short_circuit_outcome,
-        ) = await self._resolve_console_library_rag_scope(request)
-        outcome = short_circuit_outcome or await run_library_rag_search(
-            self.app_instance, scoped_request
-        )
-        await self._apply_console_library_rag_search_outcome(scoped_request, outcome)
-
-    async def _apply_console_library_rag_search_outcome(
-        self,
-        request: LibraryRagSearchRequest,
-        outcome: Any,
-    ) -> None:
-        if not self.is_mounted:
-            return
-        if outcome.results:
-            result = outcome.results[0]
-            launch_payload = build_library_rag_console_live_work_payload(
-                result,
-                query=request.query,
-            )
-            launch_payload["evidence_bundle"] = build_library_rag_evidence_bundle(
-                outcome.results,
-                query=request.query,
-            ).to_payload()
-            launch_payload["requested_top_k"] = request.top_k
-            launch_payload["search_mode"] = request.mode
-            self._stage_console_library_rag_launch(
-                ConsoleLiveWorkLaunch.from_values(
-                    source="Library Search/RAG",
-                    title=result.title,
-                    payload=launch_payload,
-                    status="staged",
-                    recovery=CONSOLE_LIBRARY_RAG_RECOVERY_COPY,
-                    action_label="Review evidence in Console",
-                )
-            )
-            return
-
-        recovery_state = outcome.recovery_state
-        recovery_copy = (
-            recovery_state.visible_copy
-            if recovery_state is not None
-            else "Library Search/RAG did not return usable evidence."
-        )
-        # TASK-259: set the auto-open flag BEFORE staging. Staging now syncs
-        # the rail state synchronously (no deferred screen recompose), so a
-        # flag set after the stage call would miss the rail-visibility pass.
-        self._pending_console_launch_auto_open_inspector = True
-        self._stage_console_library_rag_launch(
-            ConsoleLiveWorkLaunch.from_values(
-                source="Library Search/RAG",
-                title="Library Search/RAG retrieval",
-                payload={
-                    "query": request.query,
-                    "source_scope": ", ".join(request.source_types),
-                },
-                status=outcome.status or "blocked",
-                recovery=recovery_copy,
-                action_label="Resolve Library search setup",
-            )
-        )
+        await self._retrieval._execute_console_library_rag_search(request)
 
     def _has_staged_console_evidence(self) -> bool:
         """Whether this send already has evidence the user staged themselves.
@@ -13949,228 +12971,6 @@ class ChatScreen(BaseAppScreen):
             # failure here (worst case a claim supersedes the result).
             return False
 
-    def _rag_service_still_initializing(self) -> bool:
-        """Whether a timed-out retrieval was most likely first-run warm-up.
-
-        The distinction is real, not cosmetic: the shared RAG runtime's
-        FIRST construction loads an embedding model and can take seconds
-        (``library_local_rag_search_service._resolve_rag_runtime``), which
-        is precisely what blows :data:`AUTO_RAG_TIMEOUT_SECONDS`. A cached
-        runtime on the app means that cost was already paid, so the same
-        timeout is an honest retrieval failure instead.
-
-        Returns:
-            True when no usable, current runtime is cached on the app.
-        """
-        try:
-            from ...RAG_Search.semantic_availability import current_app_rag_service
-
-            return current_app_rag_service(self.app_instance) is None
-        except Exception:
-            return False
-
-    def _notify_console_auto_rag_scope_empty(self, outcome: Any) -> None:
-        """Surface the SHARED empty-scope copy for a skipped auto-retrieve.
-
-        Reuses ``scope_empty_recovery_state``'s ``why`` -- i.e.
-        ``SCOPE_EMPTY_NOTICE_TEMPLATE`` -- rather than writing a third
-        version of this sentence, so the Console's implicit path says
-        exactly what its explicit path and the chat entry point already say.
-
-        Args:
-            outcome: The short-circuit outcome from
-                ``_resolve_console_library_rag_scope``.
-        """
-        recovery = getattr(outcome, "recovery_state", None)
-        message = str(getattr(recovery, "why", "") or "").strip()
-        if not message:
-            message = SCOPE_EMPTY_NOTICE_TEMPLATE.format(cause="unknown")
-        self._notify_console_auto_rag(message)
-
-    def _notify_auto_rag_degraded(self, *, initializing: bool) -> None:
-        """Tell the user this send went out without the evidence it wanted.
-
-        Args:
-            initializing: True when the RAG runtime had not finished
-                building (see ``_rag_service_still_initializing``) -- a
-                "try again in a moment" situation, which reads very
-                differently from a retrieval that genuinely failed.
-        """
-        self._notify_console_auto_rag(
-            CONSOLE_AUTO_RAG_INITIALIZING_NOTICE
-            if initializing
-            else CONSOLE_AUTO_RAG_FAILED_NOTICE
-        )
-
-    def _notify_console_auto_rag(self, message: str) -> None:
-        """Toast one auto-retrieve notice, never at the cost of the send.
-
-        This runs from inside the send worker's capture seam, where an
-        escaping exception costs the message its evidence (see
-        ``_release_consumed_console_launch``) -- so a failing notify is
-        logged and swallowed, exactly as the sibling RAG notice sites do.
-        """
-        try:
-            self.app_instance.notify(message, severity="warning")
-        except Exception:
-            logger.debug(
-                "Console auto-retrieve notification unavailable; "
-                "reason=auto_rag_notification_failure"
-            )
-
-    def _clear_console_auto_rag_placeholder(
-        self, placeholder: ConsoleLiveWorkLaunch
-    ) -> None:
-        """Drop the in-flight "Retrieving..." card when nothing came back.
-
-        Identity-guarded like ``_release_consumed_console_launch``: if
-        anything staged over the placeholder while retrieval was awaited,
-        that newer context is left alone rather than silently dropped.
-
-        Leaving the placeholder behind would be worse than cosmetic --
-        ``_console_send_blocked_reason`` BLOCKS every send while a
-        RAG-sourced launch with zero available evidence is staged, so a
-        single failed auto-retrieve would lock the composer until the user
-        found the un-stage button.
-
-        Args:
-            placeholder: The launch this retrieval staged before awaiting.
-        """
-        if self._pending_console_launch_context is not placeholder:
-            return
-        self._pending_console_launch_context = None
-        self._pending_console_launch_auto_open_inspector = False
-        try:
-            self._sync_console_pending_launch_surfaces()
-        except Exception as exc:
-            logger.warning(
-                "Console surfaces did not refresh after clearing an "
-                "auto-retrieve placeholder (exception_category={})",
-                type(exc).__name__,
-            )
-
-    async def _maybe_auto_retrieve_for_send(
-        self,
-        draft_text: str,
-        turn_context: ConsoleTurnExecutionContext | None = None,
-    ) -> None:
-        """Auto-retrieve library evidence for a plain text send (TASK-406).
-
-        Fires only when ALL hold: the config toggle is on; the send is plain
-        user text (not a slash command, tool approval, or regeneration); and
-        nothing is already staged (manual staging always wins -- no double
-        spend). Retrieval failure or timeout NEVER blocks the send.
-
-        Called from ``_capture_console_staged_rag``, the one consume-on-send
-        seam, so anything staged here is picked up by the SAME send and
-        renders in the staged-evidence strip exactly like a manual chip run.
-        That seam runs inside the per-session exclusive send worker, past
-        every block gate, which is why this needs no worker of its own: a
-        double-send cannot double-retrieve, and a refused send never
-        retrieves at all.
-
-        Args:
-            draft_text: The validated draft this send is about to transmit.
-        """
-        auto_retrieve_enabled = (
-            coerce_bool_setting(
-                turn_context.rag_defaults.get("auto_retrieve_on_send", False),
-                False,
-            )
-            if turn_context is not None
-            else coerce_bool_setting(
-                get_cli_setting("chat_defaults", "rag_auto_retrieve_on_send", False),
-                False,
-            )
-        )
-        if not auto_retrieve_enabled:
-            return
-        if not _is_plain_text_send(draft_text):
-            return
-        if self._has_staged_console_evidence():
-            return
-        query = _sanitize_console_library_rag_query(
-            str(draft_text or "")[:AUTO_RAG_QUERY_MAX_CHARS]
-        )
-        if not query:
-            # Nothing survived centralized validation -- there is no query to
-            # run, and no user action to recommend. Stay silent.
-            return
-        source_types = (
-            turn_context.rag_defaults.get("source_types", ())
-            if turn_context is not None
-            else _console_library_rag_source_scope(self)
-        )
-        top_k = (
-            int(turn_context.rag_defaults.get("top_k", 0) or 0)
-            if turn_context is not None
-            else _console_library_rag_profile_top_k()
-        )
-        request = LibraryRagSearchRequest(
-            query=query,
-            source_types=source_types,
-            mode="rag",
-            top_k=top_k,
-            include_citations=True,
-        )
-        (
-            scoped_request,
-            scope_empty_outcome,
-        ) = await self._resolve_console_library_rag_scope(request)
-        if scope_empty_outcome is not None:
-            self._notify_console_auto_rag_scope_empty(scope_empty_outcome)
-            return
-        placeholder = ConsoleLiveWorkLaunch.from_values(
-            source="Library Search/RAG",
-            title="Library Search/RAG retrieval",
-            payload={
-                "query": scoped_request.query,
-                "source_scope": ", ".join(scoped_request.source_types),
-            },
-            status="searching",
-            recovery=CONSOLE_AUTO_RAG_SEARCHING_COPY,
-            action_label="Review evidence in Console",
-        )
-        self._stage_console_library_rag_launch(placeholder)
-        try:
-            async with asyncio.timeout(AUTO_RAG_TIMEOUT_SECONDS):
-                outcome = await run_library_rag_search(
-                    self.app_instance, scoped_request
-                )
-        except asyncio.CancelledError:
-            # An interrupted send must not leave its placeholder behind.
-            self._clear_console_auto_rag_placeholder(placeholder)
-            raise
-        except TimeoutError:
-            self._clear_console_auto_rag_placeholder(placeholder)
-            self._notify_auto_rag_degraded(
-                initializing=self._rag_service_still_initializing()
-            )
-            return
-        except Exception as exc:
-            logger.warning(
-                "Console auto-retrieve failed; the send proceeds without "
-                "evidence (exception_category={})",
-                type(exc).__name__,
-            )
-            self._clear_console_auto_rag_placeholder(placeholder)
-            self._notify_auto_rag_degraded(initializing=False)
-            return
-        if not getattr(outcome, "results", ()):
-            # Deliberately NOT `_apply_console_library_rag_search_outcome`'s
-            # zero-result branch: that stages a recovery card, and a staged
-            # RAG launch with no available evidence blocks the NEXT send
-            # (`_console_send_blocked_reason`). One empty implicit retrieval
-            # must never lock the composer.
-            self._clear_console_auto_rag_placeholder(placeholder)
-            if str(getattr(outcome, "status", "") or "") in ("failed", "blocked"):
-                # An empty result set is an ordinary "nothing matched" and
-                # stays silent; a failed/blocked retrieval is a capability
-                # the user turned on not working, and must say so.
-                self._notify_auto_rag_degraded(initializing=False)
-            return
-        await self._apply_console_library_rag_search_outcome(scoped_request, outcome)
-
     def compose_content(self) -> ComposeResult:
         """Compose the chat content."""
         pending_launch = self._consume_pending_console_launch()
@@ -14183,7 +12983,7 @@ class ChatScreen(BaseAppScreen):
         # task-10: built once, shared verbatim by the header's "Scope" chip
         # and the Inspector's retrieval-scope row below -- one zero-DB
         # state, two renderers.
-        retrieval_scope_state = self._build_console_retrieval_scope_state()
+        retrieval_scope_state = self._retrieval._build_console_retrieval_scope_state()
         available_columns = self._console_rail_available_columns()
         rail_state = self._build_console_rail_state(
             staged_context_state=staged_context_state,
@@ -15597,7 +14397,7 @@ class ChatScreen(BaseAppScreen):
         # Library-RAG failure path does: staging syncs the rail state
         # synchronously, so a flag set afterwards misses that pass.
         self._pending_console_launch_auto_open_inspector = True
-        self._stage_console_library_rag_launch(
+        self._retrieval._stage_console_library_rag_launch(
             ConsoleLiveWorkLaunch.from_values(
                 source=payload.source,
                 title=payload.title,
@@ -16425,7 +15225,7 @@ class ChatScreen(BaseAppScreen):
             # reads it -- see `_warm_console_effective_scope_cache_if_stale`
             # docstring for why the picker/resume/flush warmers alone leave
             # a restore_state-reactivated session uncovered.
-            await self._warm_console_effective_scope_cache_if_stale()
+            await self._retrieval._warm_console_effective_scope_cache_if_stale()
             # Fix-wave (Critical, Task 4 review): this is the trigger for the
             # "what's in play" chat-dictionary summary now -- it replaces the
             # removed app-level `watch_current_chat_conversation_id`/
@@ -16437,8 +15237,10 @@ class ChatScreen(BaseAppScreen):
             # `_sync_console_control_bar()` below so that call's inspector
             # build already sees the freshly recomputed cache instead of one
             # stale frame behind.
-            await self._refresh_active_dictionaries_summary_if_scope_changed()
-            await self._refresh_active_world_books_summary_if_scope_changed()
+            await (
+                self._retrieval._refresh_active_dictionaries_summary_if_scope_changed()
+            )
+            await self._retrieval._refresh_active_world_books_summary_if_scope_changed()
             # P3c Task 4: mirrors the dictionary/world-book scope-guarded
             # refresh pattern immediately above -- safe to call unconditionally
             # on every sync tick because the refresh is itself scope-guarded


### PR DESCRIPTION
## Summary

- extract the reviewed Console retrieval scope, Library RAG, auto-retrieve, and cached inspector policy into a DOM-free `ConsoleRetrievalController`
- keep modal/DOM work and the two Textual worker entry points on `ChatScreen` as bounded delegates
- route Session/Workspace retrieval seams through late-bound controller callables and reduce `chat_screen.py` to 20,572 lines (ceiling: 20,943)

## Verification

- post-rebase touched-functionality matrix: 482 passed
- conflict-adjacent changed-files matrix: 17 passed
- Wave-6 projection/compatibility ratchets: 2 passed
- isolated RuntimeWarning-as-error reproduction: 1 passed
- Ruff lint: passed for every touched Python file
- `py_compile`: passed for retrieval.py, wiring.py, and chat_screen.py under an isolated removed pycache root
- `git diff --check origin/dev...HEAD`: passed
- mutation checks killed descriptor retargeting, controller DOM access, empty-scope bypass, placeholder-identity removal, repeat-summary refresh, and both worker-delegate removals

## Known inherited gates

- the broad Wave-6 inventory clears this tasks line/method/retrieval assertions, then fails on untouched `hands_free.py::_sync_hands_free_switch` DOM access
- the repository diagnostic inventory is already red from unrelated dev-wide owner drift and the vendored Chunking security sink; this task moves exactly 11 diagnostic calls from chat_screen.py to retrieval.py and changes no sink topology
- whole-file Ruff format reports the same nine files as exact `origin/dev`

No full repository suite was run, per the explicit touched-functionality-only constraint.

ADR required: no; this implements the ownership boundary already approved by the Wave-6 design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts Console retrieval into a DOM-free `ConsoleRetrievalController` to preserve behavior and enable mountless tests. Previously `ChatScreen` owned retrieval and touched the DOM; now the controller owns it via late-bound callables, and `ChatScreen` delegates the two Textual worker entry points.

- Review notes
  - New controller `tldw_chatbook/UI/Console_Modules/retrieval.py`: owns retrieval scope, Library RAG, auto-retrieve, cached inspector policy, and query sanitization/mention parsing; contains no DOM access. Architecture test enforces ownership: `Tests/Architecture/test_console_wave6_inventory.py::test_retrieval_family_has_completed_controller_ownership`.
  - Wiring: `tldw_chatbook/UI/Console_Modules/wiring.py::build_console_controllers` now constructs `screen._retrieval` first and binds late edges (current conversation ID, session accessors, staged-evidence capture, sent-notice clear, strip sync, RAG source types and `top_k`). The Console now has eleven controllers.
  - Delegations: `ChatScreen` calls `screen._retrieval.*` for scope saves, Library RAG staging, inspector summaries/rows, source-status text, and auto-retrieve on send; modal/picker/DOM sync stays on `ChatScreen`. Helpers `_sanitize_console_library_rag_query` and `_source_mentions_rag` import from the controller.
  - Tests: new no-mount controller contracts `Tests/UI/test_console_retrieval_controller.py`; UI/Library tests updated to reference `screen._retrieval`; architecture inventory extended to the retrieval family.
  - Docs/backlog: plan and evidence added; TASK-3070.5 AC 1–3 are met; retrieval query validation clarified.

- Migration
  - Update call sites to `screen._retrieval.*` and keep retrieval logic DOM-free. Ensure `build_console_controllers` runs so late-bound edges are wired. No user-visible behavior or data migrations.

<sup>Written for commit 22107a569868dae4e5e189e6411017f746f0a4f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

