### PR TITLE
fix(console): preserve the Anthropic cache-write bucket through gateway usage normalization (TASK-18607)

### DIFF
--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1295,19 +1295,17 @@ def test_qwencloud_terminal_usage_reaches_agent_native_budget_without_fallback(
 # 11,065) are still what `_usage_total_tokens` reports and still what the
 # provider billed in RAW tokens; they were just never what the run cost.
 #
-# Note what the gateway's normalization does to the third bucket: it folds
-# `cache_creation_input_tokens` into `prompt_tokens` and reports only
-# `cached_tokens` separately, so a cache WRITE arrives indistinguishable
-# from uncached input and is weighted at 1.0x instead of its real 1.25x
-# rate. For a budget that is UNDER-counting (the permissive direction): a
-# write-heavy run consumes less budget than it truly costs and can overshoot
-# the user's spend ceiling by ~25% of its write portion. Accepted here as a
-# known gap in the gateway's normalization, filed as TASK-18607; this test
-# asserts the accounting the normalization currently makes possible, which
-# is why the 111-token case simply adds 111.
+# The third bucket (TASK-18607): the gateway's normalization still folds
+# `cache_creation_input_tokens` into `prompt_tokens` -- readers of the flat
+# sum are unchanged -- but now ALSO preserves it as
+# `prompt_tokens_details.cache_creation_tokens`, so the budget prices a
+# cache WRITE at its real published rate (3.75 vs 3.0 per mtok on
+# claude-sonnet-4-6 -- 1.25x) instead of 1.0x, matching the
+# Anthropic-native path. The 111-token case therefore adds
+# ceil(111 * 1.25) worth of budget, not 111.
 @pytest.mark.parametrize(
     ("cache_creation_input_tokens", "expected_total"),
-    [(0, 4_964), (111, 5_075)],
+    [(0, 4_964), (111, 5_103)],
     ids=("cache-read", "cache-read-and-creation"),
 )
 def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
@@ -1379,14 +1377,18 @@ def test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets(
     assert outcome.final_text == "answer"
     assert outcome.total_tokens == expected_total
     assert estimator_calls == []
+    expected_details: dict = {"cached_tokens": 6_656}
+    if cache_creation_input_tokens:
+        expected_details["cache_creation_tokens"] = cache_creation_input_tokens
     assert captured_usage == [
         {
             "prompt_tokens": 3_571 + 6_656 + cache_creation_input_tokens,
-            "prompt_tokens_details": {"cached_tokens": 6_656},
+            "prompt_tokens_details": expected_details,
             "completion_tokens": 727,
             # Still the RAW total the provider billed in tokens -- this
-            # asserts the gateway's normalization, which TASK-18603 did not
-            # change. Only what the BUDGET counts it as changed.
+            # asserts the gateway's normalization: TASK-18607 adds the
+            # write bucket to the DETAILS only; the flat sums are
+            # unchanged. Only what the BUDGET counts it as changed.
             "total_tokens": 3_571 + 6_656 + cache_creation_input_tokens + 727,
         }
     ]
@@ -1503,6 +1505,36 @@ def test_openai_usage_handoff_preserves_chat_completion_cache_details():
         "completion_tokens": 20,
         "total_tokens": 120,
     }
+
+
+def test_normalized_usage_round_trips_cache_write_bucket():
+    # TASK-18607 AC#3/#4: normalization must preserve Anthropic's write
+    # bucket so the native and normalized shapes account identically, while
+    # the flat `prompt_tokens` sum -- what the cost ticker and persistence
+    # read -- keeps the full billed total.
+    from tldw_chatbook.Chat.provider_usage import ProviderUsage
+
+    native = {
+        "input_tokens": 3_571,
+        "cache_read_input_tokens": 6_656,
+        "cache_creation_input_tokens": 111,
+        "output_tokens": 727,
+    }
+    normalized = _openai_usage_from_provider_call(
+        native, provider="anthropic", model="claude-sonnet-4-6"
+    )
+    assert normalized["prompt_tokens"] == 3_571 + 6_656 + 111
+    assert normalized["prompt_tokens_details"] == {
+        "cached_tokens": 6_656,
+        "cache_creation_tokens": 111,
+    }
+    direct = ProviderUsage.from_provider_payload(
+        native, provider="anthropic", model="claude-sonnet-4-6"
+    )
+    round_tripped = ProviderUsage.from_provider_payload(
+        normalized, provider="anthropic", model="claude-sonnet-4-6"
+    )
+    assert round_tripped == direct
 
 
 @pytest.mark.parametrize(

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1508,10 +1508,13 @@ def test_openai_usage_handoff_preserves_chat_completion_cache_details():
 
 
 def test_normalized_usage_round_trips_cache_write_bucket():
-    # TASK-18607 AC#3/#4: normalization must preserve Anthropic's write
-    # bucket so the native and normalized shapes account identically, while
-    # the flat `prompt_tokens` sum -- what the cost ticker and persistence
-    # read -- keeps the full billed total.
+    """Native and gateway-normalized usage parse to identical buckets.
+
+    TASK-18607 AC#3/#4: normalization must preserve Anthropic's write
+    bucket so the native and normalized shapes account identically, while
+    the flat ``prompt_tokens`` sum -- what the cost ticker and persistence
+    read -- keeps the full billed total.
+    """
     from tldw_chatbook.Chat.provider_usage import ProviderUsage
 
     native = {

--- a/Tests/Chat/test_provider_usage.py
+++ b/Tests/Chat/test_provider_usage.py
@@ -271,3 +271,26 @@ def test_an_infinite_token_count_degrades_instead_of_raising():
 
     assert restored is not None
     assert restored.output == 0
+
+
+def test_openai_chat_payload_reads_cache_creation_tokens_as_write():
+    # TASK-18607: the Console gateway's normalization preserves Anthropic's
+    # write bucket as `prompt_tokens_details.cache_creation_tokens`;
+    # `prompt_tokens` still INCLUDES it (readers of the flat sum are
+    # unchanged), so it must be subtracted like the read bucket.
+    payload = {
+        "prompt_tokens": 2000,
+        "completion_tokens": 150,
+        "total_tokens": 2150,
+        "prompt_tokens_details": {
+            "cached_tokens": 1536,
+            "cache_creation_tokens": 111,
+        },
+    }
+    usage = ProviderUsage.from_provider_payload(
+        payload, provider="anthropic", model="claude-sonnet-4-6"
+    )
+    assert usage.uncached_input == 353
+    assert usage.cache_read == 1536
+    assert usage.cache_write == 111
+    assert usage.output == 150

--- a/Tests/Chat/test_provider_usage.py
+++ b/Tests/Chat/test_provider_usage.py
@@ -274,10 +274,13 @@ def test_an_infinite_token_count_degrades_instead_of_raising():
 
 
 def test_openai_chat_payload_reads_cache_creation_tokens_as_write():
-    # TASK-18607: the Console gateway's normalization preserves Anthropic's
-    # write bucket as `prompt_tokens_details.cache_creation_tokens`;
-    # `prompt_tokens` still INCLUDES it (readers of the flat sum are
-    # unchanged), so it must be subtracted like the read bucket.
+    """The chat-completions branch splits our cache-write extension key.
+
+    TASK-18607: the Console gateway's normalization preserves Anthropic's
+    write bucket as ``prompt_tokens_details.cache_creation_tokens``;
+    ``prompt_tokens`` still INCLUDES it (readers of the flat sum are
+    unchanged), so it must be subtracted like the read bucket.
+    """
     payload = {
         "prompt_tokens": 2000,
         "completion_tokens": 150,

--- a/backlog/tasks/task-18607 - Gateway-normalization-folds-Anthropic-cache-writes-into-prompt_tokens-so-the-run-budget-underprices-them.md
+++ b/backlog/tasks/task-18607 - Gateway-normalization-folds-Anthropic-cache-writes-into-prompt_tokens-so-the-run-budget-underprices-them.md
@@ -3,8 +3,9 @@ id: TASK-18607
 title: >-
   Gateway normalization folds Anthropic cache writes into prompt_tokens, so
   the run budget underprices them
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Robert'
 created_date: '2026-08-19 03:30'
 labels:
   - agents
@@ -40,10 +41,10 @@ defensive-only.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The gateway's split-usage normalization preserves the cache-write bucket (or an equivalent marker) so `_budget_weighted_tokens` can price writes at their published rate on the Console send path.
-- [ ] #2 A streamed Anthropic turn with `cache_creation_input_tokens > 0` consumes budget at the 1.25x write rate, matching the native-shape accounting.
-- [ ] #3 Consumers of the normalized OpenAI-shaped usage that cannot see a write bucket (cost ticker, persistence) keep their current totals -- the raw `prompt_tokens` sum may not change under whatever representation is chosen.
-- [ ] #4 The two shapes (native Anthropic envelope vs gateway-normalized) produce identical weighted totals for identical provider numbers.
+- [x] #1 The gateway's split-usage normalization preserves the cache-write bucket (or an equivalent marker) so `_budget_weighted_tokens` can price writes at their published rate on the Console send path.
+- [x] #2 A streamed Anthropic turn with `cache_creation_input_tokens > 0` consumes budget at the 1.25x write rate, matching the native-shape accounting.
+- [x] #3 Consumers of the normalized OpenAI-shaped usage that cannot see a write bucket (cost ticker, persistence) keep their current totals -- the raw `prompt_tokens` sum may not change under whatever representation is chosen.
+- [x] #4 The two shapes (native Anthropic envelope vs gateway-normalized) produce identical weighted totals for identical provider numbers.
 <!-- AC:END -->
 
 ## Notes
@@ -57,3 +58,48 @@ riding a budget PR. The PR documents the gap at
 `agent_service._budget_weighted_tokens` and in
 `test_anthropic_split_usage_reaches_agent_budget_with_cache_buckets`.
 <!-- SECTION:NOTES:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: unit test — chat-completions-shaped usage with a
+   `prompt_tokens_details.cache_creation_tokens` key parses into
+   `ProviderUsage.cache_write` (uncached excludes it); parity test — a native
+   Anthropic split payload run through `_openai_usage_from_provider_call`
+   then re-parsed yields identical buckets to parsing the native payload
+   directly, with top-level `prompt_tokens` unchanged (AC#3/#4); flip the
+   pinning test so the gateway shape budgets writes at 1.25x (AC#2).
+2. GREEN: emit `cache_creation_tokens` in the bridge's normalized
+   `prompt_tokens_details`; read it in `from_provider_payload`'s
+   chat-completions branch; add the key to the strict-count validator.
+3. Update the two known-gap comment blocks (agent_service docstring, bridge
+   test comment) that document the fold.
+4. Run touched suites; PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Two-hunk fix, TDD (all three tests watched failing first):
+
+- `console_agent_bridge._openai_usage_from_provider_call` now also emits the
+  write bucket as `prompt_tokens_details.cache_creation_tokens` (an
+  extension key of ours, mirroring the `cached_tokens` emit pattern);
+  top-level `prompt_tokens`/`total_tokens` are byte-identical to before, so
+  flat-sum readers (cost ticker, persistence) are untouched (AC#3).
+- `ProviderUsage.from_provider_payload`'s chat-completions branch reads the
+  key into `cache_write` and subtracts it from `uncached_input`, so
+  `_budget_weighted_tokens` prices writes at their published rate (1.25x on
+  Anthropic) with NO change to the budget code itself (AC#1/#2).
+- `cache_creation_tokens` added to `_BUDGET_USAGE_DETAIL_COUNT_KEYS` so the
+  strict validator vets the key we now emit on round-trips.
+- Tests: unit (details key -> cache_write bucket), round-trip parity
+  (native vs normalized -> identical ProviderUsage, AC#4), and the
+  end-to-end pinning test's 111-write case flipped 5,075 -> 5,103
+  (ceil of 111 x 1.25 on claude-sonnet-4-6 catalog rates). Stale known-gap
+  comment blocks in agent_service and the bridge test updated.
+- 565 tests green across provider_usage / console_agent_bridge /
+  console_agent_run_budget / console_provider_gateway / agent_service.
+
+No second fold site exists: the gateway's stream signals store RAW provider
+payloads and every consumer normalizes via `ProviderUsage`, which handles
+both envelope shapes.

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -571,14 +571,15 @@ def _budget_weighted_tokens(resp, *, provider: str, model: str) -> int | None:
     or unknown model keeps exactly the previous accounting rather than
     silently getting a free ride.
 
-    Known gap (TASK-18607): the Console gateway's streaming normalization
-    folds Anthropic `cache_creation_input_tokens` into `prompt_tokens`
-    without preserving the write bucket, so through that path a cache WRITE
-    is weighted at 1.0x instead of its real 1.25x rate -- an UNDER-count,
-    i.e. the permissive direction for a budget: a write-heavy run can
-    overshoot the user's spend ceiling by ~25% of its write portion. The
-    Anthropic-native path below weights writes correctly; the two agree
-    again once the normalization preserves the bucket.
+    Closed gap (TASK-18607): the Console gateway's streaming normalization
+    used to fold Anthropic `cache_creation_input_tokens` into
+    `prompt_tokens` without preserving the write bucket, so through that
+    path a cache WRITE was weighted at 1.0x instead of its real 1.25x
+    rate. Now the normalization now also emits the bucket as
+    `prompt_tokens_details.cache_creation_tokens` (still inside
+    `prompt_tokens` for flat-sum readers) and `ProviderUsage` re-splits it,
+    so both envelope shapes produce identical weighted totals for identical
+    provider numbers.
 
     Args:
         resp: The provider response.

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1472,6 +1472,10 @@ _BUDGET_USAGE_DETAILS_KEYS = (
 )
 _BUDGET_USAGE_DETAIL_COUNT_KEYS = (
     "cached_tokens",
+    # TASK-18607: our own normalized-output extension carrying Anthropic's
+    # cache-write bucket; validated here so a persisted normalized usage
+    # block re-entering this path gets the same strictness as the rest.
+    "cache_creation_tokens",
     "reasoning_tokens",
     "audio_tokens",
     "text_tokens",
@@ -1542,6 +1546,11 @@ def _openai_usage_from_provider_call(
     )
     if "cached_tokens" in normalized_prompt_details or normalized.cache_read:
         normalized_prompt_details["cached_tokens"] = normalized.cache_read
+    # TASK-18607: preserve the cache WRITE bucket (folded into prompt_tokens
+    # like everything else) so `ProviderUsage` can re-split it and the run
+    # budget prices writes at their real rate on the normalized path.
+    if "cache_creation_tokens" in normalized_prompt_details or normalized.cache_write:
+        normalized_prompt_details["cache_creation_tokens"] = normalized.cache_write
     if normalized_prompt_details:
         usage["prompt_tokens_details"] = normalized_prompt_details
     completion_details = payload.get(

--- a/tldw_chatbook/Chat/provider_usage.py
+++ b/tldw_chatbook/Chat/provider_usage.py
@@ -254,6 +254,10 @@ class ProviderUsage:
                 **common,
             )
         # OpenAI chat-completions shape: prompt_tokens INCLUDES cached tokens.
+        # `cache_creation_tokens` is our own extension (TASK-18607): the
+        # Console gateway's normalization preserves Anthropic's write bucket
+        # under this key -- also folded into prompt_tokens -- so the budget
+        # can price writes at their real rate through the normalized path.
         if "prompt_tokens" in payload:
             total_input = _as_count(payload.get("prompt_tokens"))
             details = payload.get("prompt_tokens_details")
@@ -262,9 +266,15 @@ class ProviderUsage:
                 if isinstance(details, Mapping)
                 else 0
             )
+            cache_write = (
+                _as_count(details.get("cache_creation_tokens"))
+                if isinstance(details, Mapping)
+                else 0
+            )
             return cls(
-                uncached_input=max(total_input - cached, 0),
+                uncached_input=max(total_input - cached - cache_write, 0),
                 cache_read=cached,
+                cache_write=cache_write,
                 output=_as_count(payload.get("completion_tokens")),
                 **common,
             )


### PR DESCRIPTION
## Summary

Closes TASK-18607, the last open follow-up from the PR #1824 review. The Console gateway's streaming normalization folded Anthropic `cache_creation_input_tokens` into `prompt_tokens`, keeping only the read bucket (`cached_tokens`) — so on the production send path a cache **write** was budget-weighted at 1.0× instead of its published 1.25× rate. That's the *permissive* direction for a budget: a write-heavy run could overshoot the user's spend ceiling by ~25% of its write portion, and the same run was accounted differently depending on which envelope shape reached the service.

## Changes (two hunks + validator row)

- `console_agent_bridge._openai_usage_from_provider_call` also emits the write bucket as `prompt_tokens_details.cache_creation_tokens` (our extension key, mirroring the existing `cached_tokens` emit). Top-level `prompt_tokens`/`total_tokens` are byte-identical to before — flat-sum readers (cost ticker, persistence) untouched (AC#3).
- `ProviderUsage.from_provider_payload`'s chat-completions branch reads the key into `cache_write` and subtracts it from `uncached_input` — `_budget_weighted_tokens` then prices writes at the catalog rate with **zero change to the budget code** (AC#1/#2).
- `cache_creation_tokens` added to `_BUDGET_USAGE_DETAIL_COUNT_KEYS` so the strict validator vets the key we now emit if a normalized block round-trips.

No second fold site exists: the gateway's stream signals store raw provider payloads and every consumer normalizes via `ProviderUsage`, which handles both shapes.

## Verification (TDD — each test watched failing first)

- Unit: chat-completions shape with the details key parses into `cache_write` (was `uncached_input` 464 → now 353/1536/111 buckets).
- Round-trip parity (AC#4): native Anthropic payload → normalize → re-parse yields a `ProviderUsage` identical to parsing the native payload directly.
- The end-to-end pinning test's 111-write case flipped from the documented-gap total 5,075 to 5,103 (= ceil of 111 × 1.25 on claude-sonnet-4-6 catalog rates: 3.75/3.0 per mtok).
- **565 passed** across `test_provider_usage`, `test_console_agent_bridge`, `test_console_agent_run_budget`, `test_console_provider_gateway`, `test_agent_service`. Stale known-gap comment blocks updated in `agent_service` and the bridge test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Anthropic cache-write tokens through Console gateway normalization so budgets price writes correctly. Previously the gateway folded `cache_creation_input_tokens` into `prompt_tokens` and priced writes at 1.0x; now it exposes `prompt_tokens_details.cache_creation_tokens` and `ProviderUsage` re-splits it so writes price at 1.25x with flat sums unchanged.

- The bridge emits `cache_creation_tokens` alongside `cached_tokens`; top-level `prompt_tokens`/`total_tokens` stay identical for flat-sum consumers.
- `ProviderUsage.from_provider_payload` reads `cache_creation_tokens`, sets `cache_write`, and subtracts it from `uncached_input`; budget code unchanged, and native vs normalized envelopes now produce identical weighted totals.
- The strict detail-key validator includes `cache_creation_tokens` so normalized blocks round-trip and validate consistently.
- Tests cover parsing, round-trip parity, and the 111-token write pin (budget total 5,103 vs 5,075); comments updated to mark the gap closed; added Google-style docstrings on the two TASK-18607 tests. Satisfies TASK-18607 acceptance criteria.

<sup>Written for commit ced65eb2a4c6c9592e9a54e44df318f0d297ff62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

