### PR TITLE
docs(backlog): renumber research-durability task 18060 → 19300 (ID collision)

### DIFF
--- a/backlog/decisions/070-research-run-lease-and-durability.md
+++ b/backlog/decisions/070-research-run-lease-and-durability.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-18
-- **Task:** task-18060 (Make research runs durable, resumable jobs)
+- **Task:** task-19300 (Make research runs durable, resumable jobs; renumbered from task-18060 after an ID collision)
 - **Related:** ADR-068 (local research execution engine — this layers
   durability onto its engine); tldw_server `app/core/Jobs/` (the lease model
   adopted); `Docs/superpowers/specs/2026-08-18-durable-research-jobs-design.md`
@@ -119,4 +119,4 @@ re-searched everything it had already paid for.
   exists only in SQLite-backed mode.
 - A SIGKILLed executor's run stays declined for up to `lease_seconds`
   before takeover. Evidence read-back (skipping a completed round on
-  resume) and scheduler auto-resume remain open (task-18060 ACs #3, #5–#11).
+  resume) and scheduler auto-resume remain open (task-19300 ACs #3, #5–#11).

--- a/backlog/tasks/task-19300 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-19300 - Make-research-runs-durable-resumable-jobs.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-18060
+id: TASK-19300
 title: Make research runs durable, resumable jobs
 status: In Progress
 assignee: []
@@ -151,3 +151,17 @@ build is refused rather than silently downgraded. Four tests cover the
 upgrade, the fresh stamp, idempotent reopen, and the future-version refusal.
 ADR-070's "no migration framework" consequence entry is superseded by this.
 <!-- SECTION:NOTES:END -->
+
+## Renumbering note (2026-08-21)
+
+Renumbered from **TASK-18060** -- that ID was independently claimed by two
+sessions (the repo's 8th collision) and the other claimant
+("Inspector-rail multi-file review and review comments") is already Done,
+so per the collision playbook the Done task keeps the ID and this
+In Progress task moves. Existing `task-18060` citations in
+`tldw_chatbook/Research_Interop/*`, `Tests/Research/*`, and the
+2026-08-18 durable-research-jobs plan refer to THIS task; they are left
+in place to avoid conflicting with the active research branch and can be
+swept to 19300 when that branch lands. `task-18060` citations in
+Console/UI/AgentRuns_DB code and the review-rail docs refer to the
+inspector task.

--- a/backlog/tasks/task-19300 - Make-research-runs-durable-resumable-jobs.md
+++ b/backlog/tasks/task-19300 - Make-research-runs-durable-resumable-jobs.md
@@ -4,7 +4,7 @@ title: Make research runs durable, resumable jobs
 status: In Progress
 assignee: []
 created_date: '2026-08-18 05:10'
-updated_date: '2026-08-18 05:40'
+updated_date: '2026-08-21 02:30'
 labels:
   - research
   - scheduling

--- a/backlog/tasks/task-19301 - Sweep-research-side-task-18060-citations-to-19300.md
+++ b/backlog/tasks/task-19301 - Sweep-research-side-task-18060-citations-to-19300.md
@@ -1,0 +1,40 @@
+---
+id: TASK-19301
+title: Sweep research-side task-18060 citations to 19300
+status: To Do
+assignee: []
+created_date: '2026-08-21 02:30'
+labels:
+  - research
+  - backlog-hygiene
+dependencies:
+  - TASK-19300
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-18060 was a duplicate ID (8th collision); the research-durability task
+was renumbered to TASK-19300, but ~39 comment/docstring citations of
+`task-18060` in `tldw_chatbook/Research_Interop/*`, `Tests/Research/*`, and
+`tldw_chatbook/DB/AgentRuns_DB.py`'s research-adjacent lines still cite the
+old ID, which now resolves to the Done inspector-rail task. They were left
+in place deliberately: an agent is actively working that code on
+`feat/durable-research-jobs`, and a sweep in the renumber PR would have
+manufactured conflicts. Sweep them once that branch lands.
+
+Caution: only research-side citations move. Inspector-side `task-18060`
+citations (Console/UI, review-rail spec references in `AgentRuns_DB.py`
+v10-v12 migration comments, `Docs/User_Guide/console/agent-runs-and-tools.md`)
+are CORRECT and must not be touched. `task-15452`'s "18041-18060" is a
+source line-number range, not a task reference. See the renumbering note in
+the TASK-19300 file for the full classification.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 No `task-18060` citation remains in Research_Interop, Tests/Research, or the durable-research plan doc; all renamed to task-19300.
+- [ ] #2 Inspector-side task-18060 citations are untouched (spot-checked against the classification in TASK-19300's renumbering note).
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

`origin/dev` carries two `task-18060` files — "Inspector-rail multi-file review and review comments" (Done) and "Make research runs durable, resumable jobs" (In Progress) — the repo's 8th backlog-ID collision. This breaks the "No duplicate backlog task IDs" CI guard for every PR.

Per the established collision playbook (Done tasks never move): the inspector task keeps 18060; the research task is renumbered to **19300** (highest ID anywhere visible is 19196 across dev + all local worktrees; the gap leaves room for in-flight 192xx claims).

## Scope

- File rename + frontmatter `id:` + a provenance note mapping which existing `task-18060` code citations belong to which task.
- ADR-070 (the living decision doc for research-run leases) updated to 19300.
- **Deliberately untouched**: the ~39 `task-18060` comment citations in `Research_Interop/*` / `Tests/Research/*` (an agent is actively working that code on `feat/durable-research-jobs`; sweeping them here would manufacture conflicts — the provenance note covers traceability until that branch lands), historical plan/report docs (point-in-time records), and all inspector-side references (correct as-is).
- `task-15452`'s "18041-18060" hit is a source line-number range, not a task reference.

## Verification

Anchored duplicate scan over `backlog/tasks/` + `backlog/drafts/`: **0 duplicates** after the rename (was 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbers “Make research runs durable, resumable jobs” from task-18060 to task-19300 to resolve an ID collision and restore the no-duplicate-ID CI guard. The inspector task retains task-18060 per the collision playbook.

- Renames the research task file, updates its `id:`, and adds a provenance note mapping which `task-18060` citations belong to which task.
- Updates ADR-070 to reference task-19300.
- Adds task-19301 to track the deferred sweep of research-side `task-18060` comment/docstring citations; bumps task-19300’s `updated_date`.
- Leaves research-side citations as `task-18060` to avoid conflicts with an active branch; sweep to 19300 will happen via task-19301. Inspector-side references remain correct.
- Verified 0 duplicate task IDs after the change.

<sup>Written for commit df48496439faad30abb7e257ca6c9d9e3bae82c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

