### PR TITLE
test: convert the STTS view-cycling one-shots to settle helpers (task-19196)

### DIFF
--- a/Tests/UI/test_stts_profile_library.py
+++ b/Tests/UI/test_stts_profile_library.py
@@ -1103,9 +1103,17 @@ async def test_voice_profiles_view_mounts_focused_library_without_hiding_other_v
 
     async with app.run_test(size=(150, 55)) as pilot:
         await pilot.pause()
-        assert isinstance(
-            app.query_one(".stts-content").children[0],
-            SpeechPlaygroundPane,
+        # Settle, don't sample: `watch_current_view` swaps the body in a
+        # worker, so `.children[0]` one-shots here sit in 19047's
+        # raising-predicate/empty-window class (task-19196). The playground
+        # settles fold in the generate button's existence so the plain
+        # asserts below read settled structure, not a mid-mount pane.
+        await _wait_until(
+            pilot,
+            lambda: (
+                isinstance(_stts_content_first_child(app), SpeechPlaygroundPane)
+                and bool(app.query("#tts-generate-btn"))
+            ),
         )
         assert app.query_one("#tts-generate-btn", Button)
 
@@ -1114,27 +1122,32 @@ async def test_voice_profiles_view_mounts_focused_library_without_hiding_other_v
         assert app.query_one(STTSProfileLibrary)
 
         await _open_stts_view(app, pilot, "settings")
-        assert isinstance(
-            app.query_one(".stts-content").children[0],
-            SpeechSettingsPane,
+        await _wait_until(
+            pilot,
+            lambda: isinstance(_stts_content_first_child(app), SpeechSettingsPane),
         )
 
         await _open_stts_view(app, pilot, "audiobook")
-        assert isinstance(
-            app.query_one(".stts-content").children[0],
-            AudioBookGenerationWidget,
+        await _wait_until(
+            pilot,
+            lambda: isinstance(
+                _stts_content_first_child(app), AudioBookGenerationWidget
+            ),
         )
 
         await _open_stts_view(app, pilot, "dictation")
-        assert isinstance(
-            app.query_one(".stts-content").children[0],
-            ImprovedDictationWindow,
+        await _wait_until(
+            pilot,
+            lambda: isinstance(_stts_content_first_child(app), ImprovedDictationWindow),
         )
 
         await _open_stts_view(app, pilot, "playground")
-        assert isinstance(
-            app.query_one(".stts-content").children[0],
-            SpeechPlaygroundPane,
+        await _wait_until(
+            pilot,
+            lambda: (
+                isinstance(_stts_content_first_child(app), SpeechPlaygroundPane)
+                and bool(app.query("#tts-generate-btn"))
+            ),
         )
         assert app.query_one("#tts-generate-btn", Button)
 

--- a/backlog/tasks/task-19196 - Harden-the-stts-view-cycling-tests-five-one-shot-children-0-asserts-19047-family.md
+++ b/backlog/tasks/task-19196 - Harden-the-stts-view-cycling-tests-five-one-shot-children-0-asserts-19047-family.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-19196
 title: Harden the stts view-cycling test's five one-shot children[0] asserts (19047 family)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-20'
 labels:
   - test-health
@@ -38,10 +39,82 @@ already-shipped helpers and re-prove the whole file under load. Do not
 half-convert.
 <!-- SECTION:DESCRIPTION:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Route A first: run the target test standalone 12-15x under 20 CPU
+   burners (19047's recipe; 20 is the count that reproduced the
+   children[0]/IndexError shape there), outputs to files, and record the
+   outcome honestly — a bounded negative result is acceptable per AC #1.
+2. If a failure fires: fix exactly what fired, born-red style. If quiet:
+   Route B — mechanically convert the five one-shot
+   `app.query_one(".stts-content").children[0]` isinstance asserts to
+   `_wait_until` + `_stts_content_first_child` settles (both helpers
+   already shipped by 19047 in this file). Wall-clock-bounded polls only;
+   helpers return None mid-swap; no fixed pauses, no attempt-count waits.
+   For the two playground steps, fold `#tts-generate-btn` existence into
+   the settled condition (non-raising `app.query`) so the conversion
+   cannot unmask the adjacent one-shot button asserts — 19047's
+   catalogue-shapes lesson: the first raise masks everything behind it.
+   Do not weaken anything: each settle ends asserting at least what the
+   one-shot asserted, and the plain button asserts stay.
+3. Evidence per AC #2: post-change target test standalone 10x under the
+   same 20-burner load; full file once under load and once unloaded, all
+   green with counts read from output files. ruff check + format on the
+   touched file. Kill all burners, verify 0 remaining via pgrep.
+<!-- SECTION:PLAN:END -->
+
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 A load-reproduction attempt (19047's CPU-burner loop methodology) against the current asserts is run FIRST and its outcome recorded — either a reproduced failure justifying the fix, or a bounded negative result; OR the five asserts are mechanically converted to `_wait_until` + `_stts_content_first_child` settles matching the file's existing pattern.
-- [ ] #2 If converted: the full file's load-loop evidence is re-run and recorded (not just the touched test), per 19047's catalogue-shapes-by-re-running lesson.
-- [ ] #3 The test's contract is unchanged: it still pins that each view switch mounts the expected pane type as the content's first child and that cycling back to playground restores `#tts-generate-btn`.
+- [x] #1 A load-reproduction attempt (19047's CPU-burner loop methodology) against the current asserts is run FIRST and its outcome recorded — either a reproduced failure justifying the fix, or a bounded negative result; OR the five asserts are mechanically converted to `_wait_until` + `_stts_content_first_child` settles matching the file's existing pattern.
+- [x] #2 If converted: the full file's load-loop evidence is re-run and recorded (not just the touched test), per 19047's catalogue-shapes-by-re-running lesson.
+- [x] #3 The test's contract is unchanged: it still pins that each view switch mounts the expected pane type as the content's first child and that cycling back to playground restores `#tts-generate-btn`.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Route A first (AC #1): bounded negative result.** 15/15 standalone runs
+of the target test passed under 20 CPU burners (busy-loop processes; 14
+logical cores, ambient load avg ~7-8; run times 7.0-11.4s) at the
+pre-change state — the five one-shots did not fire, matching 19047's
+observation across all of its runs. No reproduced failure, so the fix is
+the AC's sanctioned mechanical conversion, not born-red.
+
+**Route B conversion.** The five one-shot
+`app.query_one(".stts-content").children[0]` isinstance asserts
+(initial playground → settings → audiobook → dictation → playground)
+became `_wait_until(pilot, lambda: isinstance(_stts_content_first_child(
+app), <Pane>))` settles — the exact helpers and pattern 19047 shipped in
+this file (used at the dismissal test's settings-pane settle). All polls
+are wall-clock-bounded (`_wait_until`'s 15s monotonic deadline); no fixed
+pauses, no attempt-count waits; the helper returns None mid-swap instead
+of raising. Nothing weakened: each settle ends asserting the same
+first-child pane type the one-shot asserted (`_wait_until` raises
+AssertionError on timeout).
+
+**One deliberate strengthening, not a weakening:** the two playground
+settles also fold `bool(app.query("#tts-generate-btn"))` (non-raising
+query) into the settled condition. A bare first-child settle can return
+at the instant the pane registers as a child but before its own compose
+mounts descendants — which would leave the adjacent, in-contract
+`assert app.query_one("#tts-generate-btn", Button)` one-shots sampling a
+narrower version of the same window (19047's the-first-raise-masks-
+what's-behind-it lesson). The plain button asserts stay, satisfying
+AC #3's pinned contract (each view mounts its pane type as first child;
+cycling back restores the generate button).
+
+**Evidence (AC #2), final file state:** target standalone 10/10 green @
+20 burners (7.7-9.1s); full file 163 passed @ 20 burners (181s); full
+file 163 passed unloaded (70s). Counts read from captured output files.
+ruff check + format clean on the touched file. All burners killed and
+verified (pgrep: 0 remaining).
+
+**No lessons entry:** the raising-predicate/empty-window class is already
+recorded in `lessons-testing-evidence.md` (19047, 2026-08-20); nothing
+new surfaced here.
+
+**Files:** `Tests/UI/test_stts_profile_library.py` (only code change),
+this task file.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
Closes task-19196. The view-cycling test carried five one-shot `children[0]` asserts of the exact raising-predicate/empty-window class task-19047 fixed elsewhere in the same file. Per the task's AC, a load reproduction was attempted first (Route A: 15/15 loaded standalone passes at 20 burners — a bounded honest negative), then the sanctioned mechanical conversion (Route B): each one-shot became a wall-clock `_wait_until` settle on the same pane type via the existing non-raising `_stts_content_first_child` helper. Conversions 1 and 5 deliberately fold button existence into the predicate (a bare first-child settle can return at child-registration before descendants compose, handing the adjacent button one-shots a narrower version of the same window); the plain button asserts remain after the settles, so nothing is weakened.

## Evidence
- Post-change: 10/10 loaded standalone (20 burners), 163/163 loaded full-file, 163/163 unloaded; post-rebase on current dev: 163/163.

## Review
Independent review: **APPROVE** — all five conversions verified faithful line-by-line (same pane type, same accessor, `app.query` not `query_one` in the folded predicates, original button asserts intact), helpers confirmed pre-existing and unmodified, scope exactly two files, reviewer's own fresh loaded runs green with burners verified killed. Review incident note: a concurrent session's fetch moved `origin/dev` mid-review, making a naive ref-diff show 79 spurious files — re-pinning to the merge-base collapsed it; consistent with the repo's moving-ref lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden STTS view-cycling test by replacing five one-shot `.children[0]` isinstance asserts with wall-clock settles to remove the raising-predicate/empty-window race during background view swaps. For the two playground steps, fold generate-button existence into the predicate so adjacent button asserts read settled structure; the test contract remains unchanged. Satisfies TASK-19196 and follows the 19047 settle pattern.

- Review
  - Code changes only in `Tests/UI/test_stts_profile_library.py` and the task doc.
  - Each one-shot becomes `_wait_until(..., lambda: isinstance(_stts_content_first_child(app), <Pane>))`; playground steps also require `app.query("#tts-generate-btn")`.
  - Helpers are pre-existing and unmodified; pane types and accessors are unchanged; button asserts remain.

- Validation
  - Pre-change load attempt (Route A): 15/15 standalone passes at 20 burners (bounded negative), per AC.
  - Post-change: 10/10 standalone at 20 burners; full file 163/163 loaded; 163/163 unloaded.

<sup>Written for commit 584aff81484730e4a9657a25ac09a9af468b4361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

