### PR TITLE
test: seed the applied page in the media-viewer back nav test (task-19193)

### DIFF
--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2592,6 +2592,11 @@ def test_action_library_media_viewer_back_returns_to_list_and_refocuses_it():
     reset sequence as the "‹ Back to list" button
     (``_exit_library_media_viewer``) and then re-focuses the list's first
     row, one seam for both exits."""
+    from tldw_chatbook.Library.library_media_state import (
+        LIBRARY_MEDIA_BROWSE_PAGE_SIZE,
+        MediaBrowseResult,
+        MediaBrowseScope,
+    )
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
     from tldw_chatbook.UI.Screens.library_screen import (
         LIBRARY_LIST_ENTRY_FOCUS_ARMED_SECONDS,
@@ -2605,16 +2610,53 @@ def test_action_library_media_viewer_back_returns_to_list_and_refocuses_it():
     screen._library_media_editing = False
     screen._library_media_confirming_delete = False
     screen._library_media_editing_analysis = False
+    # The Escape-from-viewer flow this test pins starts from a BROWSED
+    # list: the user loaded a Media page, opened an item, and Escape
+    # returns to that same applied page. Seed the browse controller with
+    # that applied page (task-19193). Without it the controller reports
+    # the DEEP-LINK entry state (no page ever applied), and since
+    # f86c636af ("fix(library): close media lifecycle authority gaps")
+    # ``_exit_library_media_viewer`` closes that gap by requesting a real
+    # page+facet load (``_load_library_media_list_if_needed`` ->
+    # ``run_worker``) -- app-context work this synchronous harness cannot
+    # host (``self.app`` raised NoActiveAppError). The deep-link exit flow
+    # is covered live in ``Tests/UI/test_library_shell.py::
+    # test_library_media_deep_link_back_loads_exact_page_and_facets``.
+    applied_scope = MediaBrowseScope()
+    screen._library_media_browse_controller.applied_result = MediaBrowseResult(
+        scope=applied_scope,
+        items=(
+            {
+                "id": "local:media:1",
+                "backing_media_id": 1,
+                "title": "Clip",
+                "media_type": "video",
+                "updated_at": "2026-08-20T00:00:00Z",
+            },
+        ),
+        total=1,
+        limit=LIBRARY_MEDIA_BROWSE_PAGE_SIZE,
+        offset=0,
+    )
 
     refresh_calls = []
     focus_calls = []
     timer_calls = []
+    worker_requests = []
     screen.refresh = lambda recompose=False: refresh_calls.append(recompose)
     screen.call_after_refresh = lambda callback: focus_calls.append(callback)
     # ``_arm_library_list_entry_focus`` also arms a settle-window timer
     # (task-2856) -- stub it out, a real ``set_timer`` needs a running
     # event loop this synchronous test has none of.
     screen.set_timer = lambda delay, callback: timer_calls.append((delay, callback))
+
+    def _capture_worker(work, **kwargs):
+        # Close a captured coroutine so it never warns as never-awaited.
+        if hasattr(work, "close"):
+            work.close()
+        worker_requests.append(kwargs)
+
+    screen.run_worker = _capture_worker
 
     screen.action_library_media_viewer_back()
 
@@ -2624,6 +2666,11 @@ def test_action_library_media_viewer_back_returns_to_list_and_refocuses_it():
         (LIBRARY_LIST_ENTRY_FOCUS_ARMED_SECONDS, screen._disarm_library_list_entry_focus)
     ]
     assert focus_calls == [screen._focus_library_list_entry]
+    # With a page already applied, the exit must NOT re-request it:
+    # ``_load_library_media_list_if_needed`` is for deep-link entries that
+    # never applied a page (f86c636af). A worker request here would mean
+    # the exit path started reloading the list the user is returning to.
+    assert worker_requests == []
 
 
 @pytest.mark.parametrize(

--- a/backlog/tasks/task-19193 - Library-media-viewer-back-nav-test-red-on-dev-LookupError-active_app.md
+++ b/backlog/tasks/task-19193 - Library-media-viewer-back-nav-test-red-on-dev-LookupError-active_app.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19193
 title: Library media-viewer back nav test red on dev (LookupError active_app)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-20'
 labels:
@@ -41,7 +41,85 @@ whatever silences the test fastest.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The test passes on dev without deleting it, skipping it, or weakening the task-2856 one-seam contract it pins (same reset sequence for Escape and the back button, list first-row refocus).
-- [ ] #2 Implementation Notes identify the commit/change that introduced the `self.app` access on this path and classify the failure (product regression vs harness gap), with the fix applied at the layer that classification names.
-- [ ] #3 The surrounding `Tests/UI/test_screen_navigation.py` suite passes.
+- [x] #1 The test passes on dev without deleting it, skipping it, or weakening the task-2856 one-seam contract it pins (same reset sequence for Escape and the back button, list first-row refocus).
+- [x] #2 Implementation Notes identify the commit/change that introduced the `self.app` access on this path and classify the failure (product regression vs harness gap), with the fix applied at the layer that classification names.
+- [x] #3 The surrounding `Tests/UI/test_screen_navigation.py` suite passes.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce at base (origin/dev 63901c30d) and capture the full traceback;
+   read which frame reaches `self.app` (`active_app.get()`).
+2. `git log -S _load_library_media_list_if_needed` to find the change that
+   made `_exit_library_media_viewer` app-dependent; read that commit's own
+   test coverage for the new behavior.
+3. Classify: product regression vs harness gap. Production always runs the
+   exit inside an app context (button handler / key action); `run_worker`
+   is the sanctioned mechanism, so out-of-context is test-only reachable.
+4. Fix at the layer the classification names. If harness: make the sync
+   test's fixture represent the browsed-list flow it pins (seed the browse
+   controller's applied page) instead of the deep-link state that now
+   legitimately schedules a worker load, and pin the applied-page exit's
+   no-reload contract with a run_worker capture asserting zero requests.
+5. Green after; full `Tests/UI/test_screen_navigation.py` run (expect
+   129 passed); repo-wide `--collect-only -q`; grep for sibling tests
+   sharing the mechanism and report.
+
+## Implementation Notes
+
+**Classification: harness gap, not a product regression.** Fixed at the
+test layer only; no product code changed.
+
+**Root cause, frame by frame** (base = dev `63901c30d`, reproduced in a
+pristine worktree with the pytest-isolated config):
+`action_library_media_viewer_back()` → `_exit_library_media_viewer()` →
+`_load_library_media_list_if_needed()` → (controller has
+`applied_result is None`) → `LibraryMediaBrowseController.request()` →
+`self._run_worker(...)` which is `screen.run_worker` → Textual
+`dom.py:527` reads `self.app._thread_id` → `active_app.get()` raises
+`LookupError` / `NoActiveAppError` because the synchronous test constructs
+an un-mounted `LibraryScreen` with no running app.
+
+**Introducing change:** `f86c636af` ("fix(library): close media lifecycle
+authority gaps", 2026-08-16) added `self._load_library_media_list_if_
+needed()` to `_exit_library_media_viewer` so a DEEP-LINK viewer entry
+(no Media page ever applied) loads the exact page + facets on exit. That
+is deliberate, sanctioned product behavior (`run_worker` is the repo's
+background-work mechanism and always has an app context in production —
+the exit only ever runs from a button handler or key action). The commit
+covers that flow itself with the live-pilot test
+`Tests/UI/test_library_shell.py::test_library_media_deep_link_back_loads_
+exact_page_and_facets`. The one-seam contract the red test pins (Escape
+and the "‹ Back to list" button share `_exit_library_media_viewer`'s
+reset sequence + first-row refocus) is intact — only the synchronous
+harness predated the exit path's new applied-page dependency.
+
+**Fix (harness):** the scenario this test pins — Escape from a viewer the
+user opened FROM the browsed list — implies an applied page, so the test
+now seeds `screen._library_media_browse_controller.applied_result` with a
+real one-item `MediaBrowseResult` (validated by the product's own
+`__post_init__`, no fakes). `_load_library_media_list_if_needed()` then
+early-returns, and every original assert stands unchanged (reset
+sequence, single recompose refresh, settle-window timer, first-row
+refocus). Added a `run_worker` capture stub asserting
+`worker_requests == []`: with a page applied the exit must NOT re-request
+it (pins f86c636af's early-return, and turns any future app-dependent
+work on this path into a clear assertion instead of a LookupError).
+
+**Evidence:**
+- Born-red: full `LookupError: <ContextVar name='active_app'>` traceback
+  captured at base before any change.
+- Mutation check (Edit-based, restored): with the applied-page seed
+  disabled and only the worker stub in place, the test fails loudly —
+  `refresh_calls == [True, True, True]` (the load's two canvas-sync
+  fallback refreshes) — proving the new pin is not vacuous.
+- `Tests/UI/test_screen_navigation.py`: 1 failed / 128 passed at base →
+  **129 passed** after (299s → 177s wall).
+- Repo-wide `pytest --collect-only -q`: 52113 tests collected, exit 0.
+- Same-mechanism sweep: the only other test invoking
+  `action_library_media_viewer_back` (`Tests/UI/test_library_canvas_
+  sync_defects.py:160`) runs inside a live pilot (`host.run_test`) and is
+  unaffected; the sub-state parametrized sibling never reaches the seam.
+
+**Files changed:** `Tests/UI/test_screen_navigation.py` (one test), this
+task file.


### PR DESCRIPTION
## Summary
Closes task-19193, a dev red since 2026-08-16: `test_action_library_media_viewer_back_returns_to_list_and_refocuses_it` failed with `LookupError: ContextVar active_app`. Root cause: `f86c636af` added `_load_library_media_list_if_needed()` to the shared viewer-exit seam (so a deep-link viewer entry loads the exact page + facets on Back); the sync harness's un-mounted screen, with `applied_result is None`, followed that call into `run_worker` → `active_app.get()` → LookupError.

Classification: **harness gap, not a product bug** — review-verified: `_exit_library_media_viewer` has exactly two callers (the Back button handler and the Escape action), both reachable only via a running app's dispatch; the deep-link flow has its own live-pilot coverage added by the same commit, exercising exactly the worker path the sync harness cannot host.

Fix (test file only): seed the controller's `applied_result` with a real validated `MediaBrowseResult` — the pinned scenario (Escape from a viewer opened from the browsed list) strictly implies an applied page (review traced `retained_items`' three writers: all require or set `applied_result`). All original asserts unchanged, plus a new `worker_requests == []` capture pinning `f86c636af`'s early-return, so future app-dependent work on this path fails as a clear assertion instead of a LookupError.

## Evidence
- Born-red: the full LookupError traceback captured at base.
- Mutation (reviewer-reproduced): with the seed disabled, the test fails loudly on `refresh_calls == [True, True, True]` — non-vacuous.
- File suite: 128 passed / 1 failed at base → **129 passed**; post-rebase on current dev: 129 passed.

## Review
Independent review: **APPROVE**, classification confirmed as the lead item (no production path reaches the seam outside app context; the deep-link live test at test_library_shell.py:5007 is real and load-bearing). One cosmetic nit recorded (the seed omits `retained_items`/`freshness`, which nothing on the exit path reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the media viewer back-navigation test by seeding an applied Media page in the sync harness to prevent a `LookupError` on `active_app`. Previously the test built a deep-link state (no applied page) that triggered a worker-backed list load; now it mirrors the browsed-list scenario and asserts no worker requests.

- Classification: harness gap, not a product bug. The exit path only runs inside an app context in production; deep-link exit is already covered by a live test.
- Keeps all original behavior checks: view resets to list, first row refocused, single recompose refresh, and settle-window timer armed.
- Adds a `run_worker` capture asserting zero calls when a page is applied, so future app-dependent work fails clearly instead of raising a context error.
- Addresses task-19193 acceptance criteria: test passes without weakening the one-seam contract; identifies the app-context dependency; surrounding suite remains green.

<sup>Written for commit d89890e4957f7d2d9b4c5dfab46363c37bbe4113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

