### PR TITLE
chore(tts): remove the orphaned play_current_audio pair (task-19190)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -719,8 +719,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 30,
-      "diagnostic_digest": "3f644cd30dd8e6a0fd5e",
+      "call_count": 28,
+      "diagnostic_digest": "e900ca7054c98c2d9160",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3640,6 +3640,6 @@
     "owner_files": 494,
     "persistent_sink_files": 6,
     "task_492_calls": 1209,
-    "task_494_calls": 6974
+    "task_494_calls": 6972
   }
 }

--- a/backlog/tasks/task-19190 - Remove-the-orphaned-play_current_audio-pair-app-wrapper-and-stts_events-handler.md
+++ b/backlog/tasks/task-19190 - Remove-the-orphaned-play_current_audio-pair-app-wrapper-and-stts_events-handler.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-19190
 title: Remove the orphaned play_current_audio pair (app wrapper + stts_events handler)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-20'
 labels:
   - dead-code
@@ -45,9 +46,113 @@ usages and stay).
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The `play_current_audio` wrapper in `app.py` and the `play_current_audio` handler in `stts_events.py` no longer exist, and a whole-tree grep (including dynamic-dispatch shapes) finds no remaining reference.
-- [ ] #2 The security-coverage-map check from TASK-19043's playbook is performed and its outcome recorded in Implementation Notes: any validation the handler performed either has a live-path equivalent or is explicitly noted as not security-relevant.
-- [ ] #3 The persistent diagnostic inventory row for `stts_events.py` is hand-edited in the same PR to reflect the removed `logger.error`, and `scripts/check_persistent_diagnostic_inventory.py` does not regress further because of this change (it is already red on dev for unrelated drift — see TASK-19191).
-- [ ] #4 Any helper left caller-less by the removal (`_current_playground_audio_path`) is either removed with it or its retention justified; no new orphan is created.
-- [ ] #5 STTS-affected suites (`Tests/UI/test_stts_profile_library.py` and any suite importing the touched modules) pass.
+- [x] #1 The `play_current_audio` wrapper in `app.py` and the `play_current_audio` handler in `stts_events.py` no longer exist, and a whole-tree grep (including dynamic-dispatch shapes) finds no remaining reference.
+- [x] #2 The security-coverage-map check from TASK-19043's playbook is performed and its outcome recorded in Implementation Notes: any validation the handler performed either has a live-path equivalent or is explicitly noted as not security-relevant.
+- [x] #3 The persistent diagnostic inventory row for `stts_events.py` is hand-edited in the same PR to reflect the removed `logger.error`, and `scripts/check_persistent_diagnostic_inventory.py` does not regress further because of this change (it is already red on dev for unrelated drift — see TASK-19191).
+- [x] #4 Any helper left caller-less by the removal (`_current_playground_audio_path`) is either removed with it or its retention justified; no new orphan is created.
+- [x] #5 STTS-affected suites (`Tests/UI/test_stts_profile_library.py` and any suite importing the touched modules) pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Re-verify orphanhood at the branch base (`63901c30d`) with fresh whole-tree
+   greps, including dynamic-dispatch shapes (string literals, getattr,
+   `action_` names, concat fragments of `current_audio`).
+2. Dead-graph walk both ends: census `_current_playground_audio_path`
+   consumers (expected: only the handler → remove it too); census
+   `play_audio_file` (the handler's function-local import target) for other
+   live callers so its retention is justified; check `Path`/`logger` stay
+   used in `stts_events.py`.
+3. Coverage map: record whether the handler performs validation needing a
+   live-path equivalent (expected: only a path-existence check, mirrored by
+   `speech_playback_mixin._play_audio`'s captured-artifact + `exists()`
+   checks on the real `#audio-play-btn`/`action_play_audio` path).
+4. Baseline to files BEFORE deleting: `Tests/TTS/` (failure SET), the
+   inventory gate suite `Tests/Architecture/test_persistent_diagnostic_
+   inventory.py`, and `Tests/LLM_Calls/test_summarization_diagnostic_
+   privacy.py` (its manifest-boundary hash pins the checked inventory, and is
+   already red at base); plus a per-row rebuild-vs-committed drift census of
+   `Docs/security/production-diagnostic-inventory.json`.
+5. Delete the `app.py` wrapper (~:11409) and the `stts_events.py` handler
+   (~:2767) plus the caller-less `_current_playground_audio_path` helper.
+6. Hand-edit the inventory's `stts_events.py` row: re-derive call_count +
+   diagnostic_digest from live code via the script's own `_scan_file`/
+   `diagnostic_digest` helpers; adjust `summary.task_494_calls` by the same
+   delta; verify internal invariants (len(owners)==owner_files; per-owner
+   sums match summary buckets) with a printed check. Do NOT run `--write`
+   (task-19191 owns dev's unrelated drift). Prove the residual
+   rebuild-vs-committed drift is exactly the base drift minus the
+   stts_events row.
+7. Re-run the baselined suites + `Tests/UI/test_stts_profile_library.py`,
+   repo-wide `--collect-only -q`, ruff on touched files, and a final
+   whole-tree grep for the removed names.
+
+## Implementation Notes
+
+**Removed the orphaned pair durably** (base `63901c30d`, branch
+`task/19190-burn`):
+
+- `tldw_chatbook/app.py`: deleted the 9-line `play_current_audio` wrapper
+  (was :11409). Re-verification at the base confirmed zero callers and no
+  dynamic-dispatch shape: whole-tree greps for the name, for getattr/string
+  shapes, for `action_` names, and for the `current_audio` concat fragment
+  found only the two definitions, the wrapper's internal call, and backlog
+  task records. The playground's real playback surface never touched this
+  pair (`stts_screen.action_play_audio` -> `speech_playback_mixin.
+  action_play_audio`/`_play_audio` via `#audio-play-btn`).
+- `tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py`: deleted the
+  `play_current_audio` handler (was :2767) AND
+  `_current_playground_audio_path` (was :2786). Census at base: the helper
+  had exactly two references in the tree — its definition and the call at
+  :2769 inside the deleted handler — so with the handler gone it is
+  caller-less and was removed with it (TASK-19043 had kept it precisely
+  because this handler was then a live caller). Its underlying
+  `_current_playground_artifact`/`_current_audio_file` attributes have many
+  other consumers and stay. Dead-graph walk of the handler's other end:
+  its function-locally imported `play_audio_file`
+  (`Event_Handlers/TTS_Events/tts_events.py:4014`) retains live callers
+  (tts_events itself :3546, plus the `TTS/audio_player.py` original used
+  by watchlists) — no new orphan; `Path` (27 uses) and `logger` stay live
+  in `stts_events.py`.
+
+**Security coverage map (AC #2):** the handler performed no security-
+relevant validation — only a path-existence check on the internally-tracked
+playground artifact path with a warning notify (no user-supplied path, no
+path/filename sanitization). The live playground playback path carries an
+equivalent-or-stronger check on the real surface:
+`speech_playback_mixin._play_audio` refuses with the identical "No audio
+file to play" warning when no artifact is captured, and additionally checks
+`audio_path.exists()` before playing. No tests drove the deleted handler
+(zero test references at base), so nothing was retired or re-pointed.
+
+**Inventory hand-edit (AC #3):** re-derived the
+`Docs/security/production-diagnostic-inventory.json` row for
+`stts_events.py` from live code via the script's own `_scan_file` +
+`diagnostic_digest` helpers: call_count 30 -> 28, diagnostic_digest
+`3f644cd30dd8e6a0fd5e` -> `e900ca7054c98c2d9160`, and
+`summary.task_494_calls` 6974 -> 6972 (the -2 covers this task's deleted
+`logger.error` plus TASK-19043's previously-missed decrement, which this
+row-truthing necessarily absorbs — see the 2026-08-20 deletion-direction
+lesson). Did NOT run `--write` (TASK-19191 owns dev's unrelated drift).
+Verified: committed-file internal invariants all hold
+(len(owners)=494==owner_files; sum492=1209, sum494=6972, sink_files=6 all
+match summary); rebuild-vs-committed residual drift is exactly dev's
+pre-existing drift minus the now-green stts_events row (base census: 33
+drifted rows; after: 32; line-diff of the two censuses shows the
+stts_events line as the sole change), so the check script stays red for
+dev's pre-existing reasons only, with one fewer drifted row.
+
+**Evidence** (identical commands both arms, venv python, module path
+asserted into the worktree): `Tests/TTS/` before = 4086 passed / 16
+skipped / 0 failed; after = 4086 / 16 / 0.
+`Tests/Architecture/test_persistent_diagnostic_inventory.py` 10 failed /
+55 passed both arms — failure SET diff empty (all 10 are the pre-existing
+inventory-drift + task-15103 review-ledger reds tracked by TASK-19191).
+`Tests/LLM_Calls/test_summarization_diagnostic_privacy.py` 3 failed / 254
+passed both arms — failure SET identical (the manifest-boundary hash pins
+were already red at base: the checked-inventory hash no longer matched the
+ledger pin before this change). `Tests/UI/test_stts_profile_library.py`
+163 passed. Repo-wide `--collect-only -q`: 52,113 collected, zero errors.
+`ruff check` clean on both touched Python files. Final whole-tree grep for
+the removed names: no hits outside backlog task records (this file and
+TASK-19043's notes).

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -2764,33 +2764,6 @@ class STTSEventHandler:
             except Exception:
                 pass
 
-    async def play_current_audio(self) -> None:
-        """Play the current audio file"""
-        audio_path = self._current_playground_audio_path()
-        if audio_path is None or not audio_path.exists():
-            self.app.notify("No audio file to play", severity="warning")
-            return
-
-        try:
-            # Use the existing play_audio_file function
-            from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-                play_audio_file,
-            )
-
-            play_audio_file(audio_path)
-            self.app.notify("Playing audio...", severity="information")
-        except Exception as e:
-            logger.error(f"Failed to play audio: {e}")
-            self.app.notify(f"Failed to play audio: {e}", severity="error")
-
-    def _current_playground_audio_path(self) -> Path | None:
-        """Return artifact provenance before the compatibility path field."""
-        if self._current_playground_artifact is not None:
-            return self._current_playground_artifact.path
-        if self._current_audio_file is None:
-            return None
-        return Path(self._current_audio_file)
-
     def _start_event_task(self, coroutine: Coroutine[Any, Any, None]) -> None:
         """Start and retain an event task until it finishes."""
         if self._cleanup_task is not None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -11430,15 +11430,6 @@ class TldwCli(
             return self._stts_handler
         return await self._initialize_stts_service()
 
-    async def play_current_audio(self) -> None:
-        """Play the current S/TT/S audio after lazy service initialization."""
-
-        handler = await self._ensure_stts_handler()
-        if handler is None:
-            self.notify("S/TT/S service not available", severity="error")
-            return
-        await handler.play_current_audio()
-
     async def on_shutdown_request(self) -> None:  # Use the imported ShutdownRequest
         logging.info("--- App Shutdown Requested ---")
 


### PR DESCRIPTION
## Summary
Closes task-19190. Removes the sibling orphan of merged task-19043's export pair: the `app.py::play_current_audio` wrapper (zero callers, including dynamic-dispatch shapes) and `STTSEventHandler.play_current_audio` (whose only caller was that wrapper) — plus `_current_playground_audio_path`, which 19043 had kept because this handler was then its live caller and which became caller-less with the pair gone (census-verified: exactly two tree-wide refs, both deleted here). Kept with confirmed live consumers: the `_current_playground_artifact`/`_current_audio_file` attributes, both `play_audio_file` functions, and `_ensure_stts_handler`.

Coverage map: the deleted handler only existence-checked an internally-tracked path and notified — no user-supplied input, nothing security-relevant; the live playground path (`speech_playback_mixin._play_audio`) refuses with the identical warning and additionally checks `exists()`. Zero tests drove the handler.

Inventory (the deletion-direction playbook): the stts_events row re-derived from live code (30→28, fresh digest). The −2 deliberately absorbs task-19043's previously-missed −1 — the base row was provably already wrong by one, and a row must equal live truth, so no smaller correct edit exists (disclosed in the task notes; the review independently reconstructed the base state and confirmed it). Residual rebuild-vs-committed drift is exactly dev's pre-existing drift (task-19191's scope), with the stts_events line the sole change.

## Evidence
- Tests/TTS full: 4086 passed / 16 skipped / 0 failed, both arms with empty failure-set diff; pin suite 25/25 post-rebase; collect-only 52,113 clean.
- Handoff recorded for 19191: the privacy suite's 3 reds (stale checked-inventory hash pins, red at base) mean the regeneration must also reconcile `Tests/fixtures/summarization_diagnostic_review.json`'s pins and the 10 red architecture-gate tests.

## Review
Independent review: **APPROVE** — own greps at base and HEAD (counts exact), the deleted handler and live path both read, the inventory row re-derived to a byte-exact match, invariants printed, and the residual-drift claim confirmed by an independent base-state reconstruction rather than re-reading the implementer's files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead play_current_audio pair: the `tldw_chatbook/app.py` wrapper and `STTSEventHandler.play_current_audio`, plus the now-callerless `_current_playground_audio_path`. This cleans up orphans and syncs the diagnostic inventory; playback continues via the existing speech playback mixin path with no user-visible change.

- Verified zero references (incl. dynamic dispatch) to the wrapper/handler; retained `play_audio_file` and `_current_playground_artifact`/`_current_audio_file` with live callers.
- Updated `Docs/security/production-diagnostic-inventory.json` for `stts_events.py` (call_count 30 → 28, new digest; `summary.task_494_calls` 6974 → 6972).
- No behavior change: the removed handler only checked path existence; the live mixin path issues the same warning and also checks `exists()`. No migration required.

<sup>Written for commit e3661c5e3339766a0b236302b217d1b3ac53eb64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

