### PR TITLE
fix(18800): thinking-effort 'off' honors the per-family Anthropic OFF capability

### DIFF
--- a/Docs/superpowers/plans/2026-08-21-task-18800-report.md
+++ b/Docs/superpowers/plans/2026-08-21-task-18800-report.md
@@ -1,7 +1,7 @@
 # TASK-18800 — Console thinking-effort `off` is not honored on Claude Opus 5 / Fable 5 / Mythos 5
 
 **Branch:** `fix/task-18800-thinking-off-capability` (from `origin/dev` `7ec0a5ee1`)
-**Status:** in progress — Step 1 (probes) complete; verdicts recorded below before any fix work.
+**Status:** complete — all 4 acceptance criteria met, live-verified both ways.
 
 ---
 
@@ -109,4 +109,164 @@ always on; `disabled` rejected; omission required).
 | Sonnet 5, Opus 5 | adaptive thinking runs + bills | accepted (Opus 5: effort ≤ high; off branch sends none) | explicit `disabled` |
 | Fable 5, Mythos 5 | adaptive thinking runs + bills | **400** | omission — OFF cannot be expressed |
 
-*(Sections 3+ — fix, evidence, live verification — follow after the fix lands.)*
+---
+
+## 3. The fix
+
+### Capability shape: two boolean predicates, not one three-way enum
+
+`tldw_chatbook/model_capabilities.py` gains two predicates alongside 18414's pair
+(and 18802/19020's), over two new hard-coded family tables outside the
+user-overridable config-driven capability tables:
+
+```python
+anthropic_model_thinks_by_default(model) -> bool        # Sonnet 5, Opus 5, Fable 5, Mythos 5
+anthropic_model_rejects_disabled_thinking(model) -> bool  # Fable 5, Mythos 5
+```
+
+The three-way behaviour is their composition:
+
+| `thinks_by_default` | `rejects_disabled` | OFF is expressed as |
+|---|---|---|
+| False | — | omission (unchanged legacy path) |
+| True | False | explicit `{"type": "disabled"}` |
+| True | True | omission — OFF cannot be expressed; thinking still runs |
+
+Two booleans rather than one enum because (a) they are independent questions
+about the request surface a future model could answer in a new combination —
+the same rationale 18414 used for keeping its two predicates separate — and
+(b) boolean family predicates are this module's established shape; an enum
+would be the odd one out. A consistency test pins that today's tables satisfy
+`rejects_disabled ⇒ thinks_by_default` so the tables cannot drift apart by
+accident, while the predicates stay independent by design.
+
+Family matching reuses 18414's `(tier, major, minor)` parser; the shared
+membership check was factored into `_anthropic_family_matches`, which
+`_anthropic_is_modern_request_family` now also uses. Both new tables are
+covered by the same `test_predicates_survive_a_user_configured_capability_table`
+guarantee.
+
+### The request builder
+
+`_anthropic_thinking_config`'s `off` branch no longer consults
+`_anthropic_is_sonnet_5` at all — it asks the two predicates. Sonnet 5 gets the
+identical wire shape it had before (via `thinks_by_default`); Opus 5 joins it;
+Fable 5 / Mythos 5 keep omission and log a lazily-formatted warning that OFF
+cannot be honored. The pre-existing "ignoring fixed thinking budget" warning
+now fires for any model on the OFF branch, not just Sonnet 5.
+
+**`_anthropic_is_sonnet_5` survives** — it has a second, legitimate call site:
+the effort branch, where Sonnet 5's thinking *shape* is a bare
+`output_config.effort` with no `thinking` key (vs `{"type": "adaptive"}` +
+effort for the other adaptive families). Its docstring now scopes it to exactly
+that.
+
+### The Fable 5 UX decision — informed via an existing seam, nothing filed
+
+Silent acceptance of a user's OFF is the original defect's shape one level up,
+so it is not silent: `console_settings_warnings`
+(`tldw_chatbook/Chat/console_session_settings.py`) — the existing ADR-066
+non-blocking warning list the Console settings modal already renders on save
+(`console_settings_modal.py` calls it at two sites) — gains one entry, gated on
+`thinking_effort == "off"` and `anthropic_model_rejects_disabled_thinking(model)`:
+
+> *"claude-fable-5 always thinks: the API rejects an explicit thinking-off
+> setting, so 'off' sends no thinking parameter and adaptive thinking still
+> runs (and is billed)."*
+
+No new UI was built; no follow-up needed filing.
+
+---
+
+## 4. Evidence
+
+### Red → green (read counts)
+
+| Stage | Command | Result |
+|---|---|---|
+| Red (predicates present, builder + warning untouched) | new pin file + `TestConsoleSettingsWarnings` | **3 failed, 64 passed** |
+| Green (after rewire) | same + 18414 file + provenance gate | **135 passed** |
+| Targeted gate | 11 test files + `Tests/UI/test_console_session_settings.py` + `Tests/LLM_Calls/` | **1589 passed, 4 failed** (all pre-existing — below) |
+| Import sweep | `pytest Tests/ --collect-only -q` | **52287 tests collected**, 0 errors |
+
+The reds were for the right reason — verbatim:
+
+```
+AssertionError: claude-opus-5 with thinking_effort='off' sent thinking=None
+assert None == {'type': 'disabled'}
+AssertionError: ('claude-fable-5', [])   # warning list empty
+```
+
+The fable-5/mythos-5 "no thinking key" payload pins **pass pre-fix** — they are
+controls against naively widening the disabled branch, not reds; the task
+report says so and the mutations below are what turn them red.
+
+The 4 gate failures are `test_summarization_diagnostic_privacy.py`'s
+manifest-boundary trio (**TASK-18801**) plus
+`test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume`
+(**TASK-16815**). All four reproduce identically on a clean detached worktree
+of `origin/dev` (`aa58ad0d8`): **4 failed, 254 passed**. The manifest test's
+actual inventory hash is byte-identical on dev and on this branch
+(`f76e90a8e522…`), so this branch's new `logger.warning` call sites did not
+even move the already-failing inventory.
+
+### Mutations (Edit-restored, `git diff` clean both times)
+
+| Mutation | Result |
+|---|---|
+| Collapse three-way to two-way (`rejects_disabled_thinking` → always False; fable-5 would be sent `{"type": "disabled"}` and 400) | **13 failed, 53 passed** — every fable/mythos payload pin, the predicate pins, and the console warning die |
+| Narrow (`("opus", 5, None)` out of the thinks-by-default table; reproduces the original silent-thinking defect) | **6 failed, 60 passed** — the opus-5 payload pins and predicate pins die |
+
+Both restores verified by re-grep (0 mutation markers) and a re-green at
+**135 passed**.
+
+### Live verification (production `chat_api_call` seam, real key)
+
+Throwaway `@pytest.mark.live` tests under `Tests/` (so the suite's conftest
+isolation applies — scratch HOME/XDG/`TLDW_CONFIG_PATH`; the network guard's
+`live` marker), driving the real dispatcher `chat_api_call("anthropic", ...)`
+non-streaming with `thinking_effort="off"`; deleted after the run. The
+import-provenance gate ran in every session.
+
+| # | Branch | Model | Result |
+|---|---|---|---|
+| 1 | fix | `claude-opus-5` | **PASS** — `msg_011CeFJ4W4kP58EcKiiHvALJ`, answer `$0.05`, `output_tokens_details.thinking_tokens: 0` — OFF actually disables |
+| 2 | fix | `claude-fable-5` | **PASS** — `msg_011CeFJ4bEJNvVsP9FwtuJ5g`, completed, **no 400** (thinking ran: 6 tokens — exactly what the new warning tells the user) |
+| 3 | fix | `claude-haiku-4-5` | **PASS** — `msg_011CeFJ4xBdKvowdzRP6kX5U`, completed with `temperature` on the wire, no `output_tokens_details` at all (legacy unchanged) |
+| C | `origin/dev` `555298a33` (clean detached worktree) | `claude-opus-5` | **defect reproduced** — `msg_011CeFJ6WMRGnYjWNWW4hpdF`, same prompt, same seam, `thinking_tokens: 33` billed under `off` |
+
+Row 1 vs row C is a true A/B: identical prompt, identical seam, the only
+difference is this branch — 0 thinking tokens vs 33.
+
+---
+
+## 5. Acceptance criteria
+
+| AC | State | Evidence |
+|---|---|---|
+| #1 `off` on Opus 5 actually disables thinking | met | `test_off_sends_explicit_disabled_thinking[claude-opus-5]` + live row 1 (`thinking_tokens: 0`) vs dev control row C (`33`) |
+| #2 `off` on Fable 5 / Mythos 5 does not 400 | met | `test_always_on_model_off_sends_no_thinking_key` (5 id forms) + live row 2; mythos-5 by documented family (probe 10: 404 on this key) |
+| #3 capability predicate alongside 18414's, not a builder name check | met | `anthropic_model_thinks_by_default` / `anthropic_model_rejects_disabled_thinking` in `model_capabilities.py`; the off branch consults only them; `_anthropic_is_sonnet_5` survives solely for the effort shape |
+| #4 omission-is-off families unchanged, pinned | met | `test_omission_is_off_family_off_sends_no_thinking_key` (8 models) + `test_legacy_sampling_model_off_still_receives_temperature` + live row 3; probes 8/9 |
+
+---
+
+## 6. Filed, not fixed
+
+Nothing new. The four targeted-gate reds were already filed (TASK-18801,
+TASK-16815); the Fable 5 UX question was answered inside this task via the
+existing warning seam. No lessons entry: the task surfaced no new generalisable
+trap beyond what the existing lessons already record.
+
+## 7. Notes for review
+
+* The one behavioural change outside the three named families: on the OFF
+  branch, a stray `thinking_budget_tokens` now logs the "ignoring fixed
+  thinking budget" warning for every model, not only Sonnet 5. The payload is
+  unchanged (the budget was already ignored everywhere on OFF).
+* One curiosity for the record: Fable 5's 400 body *recommends*
+  `thinking.type.enabled` with `budget_tokens` — which is itself a 400 on that
+  model (18414 probe B). The provider's suggested remedy is wrong; omission is
+  the only valid move, which is what the code does.
+* No schema or `Docs/User_Guide/` surface changed — the settings modal gained
+  no control, only a conditional entry in an existing warning list.

--- a/Docs/superpowers/plans/2026-08-21-task-18800-report.md
+++ b/Docs/superpowers/plans/2026-08-21-task-18800-report.md
@@ -1,0 +1,112 @@
+# TASK-18800 — Console thinking-effort `off` is not honored on Claude Opus 5 / Fable 5 / Mythos 5
+
+**Branch:** `fix/task-18800-thinking-off-capability` (from `origin/dev` `7ec0a5ee1`)
+**Status:** in progress — Step 1 (probes) complete; verdicts recorded below before any fix work.
+
+---
+
+## 1. What is broken
+
+`_anthropic_thinking_config`'s `off` branch (`tldw_chatbook/LLM_Calls/LLM_API_Calls.py`)
+emits an explicit `thinking={"type": "disabled"}` **only** for the Claude Sonnet 5 family
+(`_anthropic_is_sonnet_5`). For every other model it returns no thinking config. On
+models that think **by default** when the `thinking` parameter is omitted — Claude
+Opus 5, Fable 5, Mythos 5 — the user's `off` therefore silently leaves adaptive
+thinking running and billed.
+
+The capability is non-uniform, which is the trap: `{"type": "disabled"}` is accepted
+on Opus 5 (only alongside effort `high` or lower — the `off` branch carries no effort,
+so the cap does not bind) and is 400-rejected on Fable 5 / Mythos 5, which require
+omission. Naively widening the Sonnet 5 branch would introduce a brand-new 400 on
+Fable 5.
+
+---
+
+## 2. Step-1 probe verdicts (captured before any fix)
+
+Standalone `curl` against `https://api.anthropic.com/v1/messages` — no `tldw_chatbook`
+import, no app config touched. Real key from the repo-root key file. 2026-08-20.
+
+### The capability surface
+
+**1 — `claude-opus-5` + `thinking={"type":"disabled"}`, NO effort** → **HTTP 200**
+(`msg_011CeFGfHpYVXE7X7LnRmYCF`) — content block types `['text']`,
+`"output_tokens_details": {"thinking_tokens": 0}`. This is the payload the fixed
+`off` branch will send.
+
+**2 — `claude-opus-5` + disabled + `output_config.effort: "high"`** → **HTTP 200**
+(`msg_011CeFGfNbXtNy7y9ueFmNjp`).
+
+**3 — `claude-opus-5` + disabled + `output_config.effort: "xhigh"`** → **HTTP 400**
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"output_config.effort 'xhigh' is not supported when thinking is disabled on this model. Use effort 'high' or below, or enable thinking."},"request_id":"req_011CeFGfT1wJxmsd2rRUszbc"}
+```
+
+The effort cap on disabled thinking is real, pinned at the `high`/`xhigh` boundary —
+and irrelevant to the fix, because the builder's `off` branch never pairs `disabled`
+with an effort (verified again in the payload pins below).
+
+**4 — `claude-fable-5` + `thinking={"type":"disabled"}`** → **HTTP 400** — the trap
+the task exists for:
+
+```json
+{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.disabled\" is not supported for this model. Thinking defaults to adaptive mode when not specified; use \"thinking.type.enabled\" with \"budget_tokens\" for extended thinking."},"request_id":"req_011CeFGfU3CpiKFwRigU2jRa"}
+```
+
+(The message's suggested remedy is itself invalid on this model — 18414's probe B
+showed `thinking.type.enabled` 400s here too. The operative fact: `disabled` → 400,
+omission is the only valid OFF-adjacent move.)
+
+**5 — `claude-fable-5`, thinking omitted** → **HTTP 200**
+(`msg_011CeFGfVjQMY6gm6SzUDpHq`) — and the response carries a real thinking block even
+for "Say OK.": content block types `['thinking', 'text']`, `"thinking_tokens": 7`.
+Always-on thinking, live-observed.
+
+### The disabled-observable (what makes AC #1 checkable rather than asserted)
+
+Same prompt (bat-and-ball), same model `claude-opus-5`, one request with
+`disabled` and one with `thinking` omitted:
+
+| Request | Content block types | `usage.output_tokens_details.thinking_tokens` |
+|---|---|---|
+| **1** disabled | `['text']` | **0** |
+| **6** omitted (`msg_011CeFGfkyS1LDXT46nVU5Gb`) | `['thinking', 'text']` | **13** |
+
+Omission on Opus 5 runs — and bills — thinking; `disabled` demonstrably stops it.
+This pair is the live-verification observable for the fix, and probe 6 is also the
+dev-control observable: it is exactly what today's `off` branch sends for Opus 5.
+
+### Controls
+
+**7 — `claude-sonnet-5` + disabled** → **HTTP 200** (`msg_011CeFGfvkJLz54KaEvyYXTY`,
+`thinking_tokens: 0`) — the current Sonnet 5 branch is valid and must not change.
+
+**8 — `claude-sonnet-4-6`, thinking omitted** → **HTTP 200**
+(`msg_011CeFGfzwKC4Uqtx2G7oYJW`) — content `['text']` only, and `usage` carries **no**
+`output_tokens_details` at all: omission genuinely means no thinking on the legacy
+family (AC #4's premise, one control probe as specified).
+
+**9 — `claude-haiku-4-5`, thinking omitted** → **HTTP 200**
+(`msg_011CeFGg5DnVz6iXa22WhgRj`) — content `['text']` only.
+
+**10 — `claude-mythos-5`** → **HTTP 404**
+
+```json
+{"type":"error","error":{"type":"not_found_error","message":"model: claude-mythos-5"},"request_id":"req_011CeFGg7HZZenFq2CaQxi5A"}
+```
+
+Mythos 5 is Project Glasswing–only and this key has no access — **documented rather
+than live-observed**, same standing as in 18414. It is handled identically to Fable 5
+on the documented grounds that it shares Fable 5's request surface exactly (thinking
+always on; `disabled` rejected; omission required).
+
+### The resulting three-way capability
+
+| Family | Omitting `thinking` means | `{"type":"disabled"}` | Correct OFF move |
+|---|---|---|---|
+| Opus 4.8/4.7/4.6-, Sonnet 4.6/4.5, Haiku | no thinking | (accepted, unneeded) | omit — **unchanged** |
+| Sonnet 5, Opus 5 | adaptive thinking runs + bills | accepted (Opus 5: effort ≤ high; off branch sends none) | explicit `disabled` |
+| Fable 5, Mythos 5 | adaptive thinking runs + bills | **400** | omission — OFF cannot be expressed |
+
+*(Sections 3+ — fix, evidence, live verification — follow after the fix lands.)*

--- a/Tests/Chat/test_anthropic_thinking_off_capability.py
+++ b/Tests/Chat/test_anthropic_thinking_off_capability.py
@@ -1,0 +1,286 @@
+"""TASK-18800: Console thinking-effort `off` must actually disable thinking on
+the Anthropic families that think BY DEFAULT when `thinking` is omitted -- and
+must never send the explicit disabled config to the families that 400 on it.
+
+Every expectation below is pinned to a *live-observed* response from
+api.anthropic.com (captured 2026-08-20 with a real key, recorded verbatim in
+`Docs/superpowers/plans/2026-08-21-task-18800-report.md`):
+
+  claude-opus-5  + thinking={"type":"disabled"}, no effort -> 200
+                   (thinking_tokens 0, no thinking block)
+  claude-opus-5  , thinking omitted -> 200 WITH a thinking block and 13
+                   billed thinking tokens (the silent pre-fix defect)
+  claude-fable-5 + thinking={"type":"disabled"} -> 400
+                   '"thinking.type.disabled" is not supported for this model.'
+  claude-fable-5 , thinking omitted -> 200 (always-on: thinking block present)
+  claude-sonnet-5 + disabled -> 200          <- must stay unchanged
+  claude-sonnet-4-6 / claude-haiku-4-5, omitted -> 200 with NO thinking block
+                   (omission genuinely means off on the legacy families, AC #4)
+  claude-mythos-5 -> 404 on this key (Project Glasswing-only); handled on the
+                   documented grounds that it shares Fable 5's surface exactly.
+
+The harness mirrors `Tests/Chat/test_anthropic_model_capabilities.py`: patch
+`requests.Session.post`, drive the real dispatcher through `chat_api_call`, and
+inspect the JSON body actually put on the wire.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from tldw_chatbook.Chat.Chat_Functions import chat_api_call
+from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_disabled_thinking,
+    anthropic_model_thinks_by_default,
+)
+
+SAMPLING_KEYS = ("temperature", "top_p", "top_k")
+
+# Families where thinking runs by default AND the explicit disabled config is
+# accepted: OFF must be expressed as thinking={"type": "disabled"}.
+EXPLICIT_DISABLED_MODELS = [
+    "claude-opus-5",
+    "claude-sonnet-5",
+]
+
+# Always-on families: the disabled config is a live-observed 400, omission is
+# the only valid move (and thinking still runs -- surfaced via the Console
+# settings warning, see test_console_session_settings.py).
+ALWAYS_ON_MODELS = [
+    "claude-fable-5",
+    "claude-mythos-5",
+]
+
+# Families where omitting `thinking` already means no thinking (AC #4).
+OMISSION_IS_OFF_MODELS = [
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-3-5-sonnet-20241022",
+]
+
+
+def _anthropic_text_response():
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+def _sent_payload(mock_post, model, **extra):
+    """Drive the real dispatch path and return the JSON body actually posted."""
+    mock_response = Mock()
+    mock_response.json.return_value = _anthropic_text_response()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = Mock()
+    mock_post.return_value = mock_response
+
+    chat_api_call(
+        "anthropic",
+        messages_payload=[{"role": "user", "content": "hi"}],
+        api_key="test-key",
+        model=model,
+        streaming=False,
+        temp=0.7,
+        **extra,
+    )
+    return mock_post.call_args[1]["json"]
+
+
+# ---------------------------------------------------------------------------
+# (a) OFF on the thinks-by-default families that accept the disabled config.
+#     RED before the fix for claude-opus-5: the old branch sent no thinking
+#     key at all, which on Opus 5 silently leaves adaptive thinking running.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", EXPLICIT_DISABLED_MODELS)
+@patch("requests.Session.post")
+def test_off_sends_explicit_disabled_thinking(mock_post, model):
+    """AC #1: `off` must put thinking={"type": "disabled"} on the wire --
+    live-verified 200 with zero thinking tokens (probes 1 and 7)."""
+    sent = _sent_payload(mock_post, model, thinking_effort="off")
+    assert sent.get("thinking") == {"type": "disabled"}, (
+        f"{model} with thinking_effort='off' sent thinking={sent.get('thinking')!r}"
+    )
+    # The Opus 5 effort cap on disabled thinking binds only at xhigh/max
+    # (req_011CeFGfT1wJxmsd2rRUszbc): OFF must never carry an effort.
+    assert "output_config" not in sent
+    assert not any(key in sent for key in SAMPLING_KEYS)
+
+
+@patch("requests.Session.post")
+def test_opus_5_off_ignores_a_stray_thinking_budget(mock_post):
+    """A leftover budget must not turn OFF into a legacy enabled config."""
+    sent = _sent_payload(
+        mock_post, "claude-opus-5", thinking_effort="off", thinking_budget_tokens=4096
+    )
+    assert sent.get("thinking") == {"type": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# (b) OFF on the always-on families. The disabled config is a live-observed
+#     400 here (req_011CeFGfU3CpiKFwRigU2jRa), so the only valid payload is
+#     omission. This PASSES pre-fix (the old branch already omitted) -- it is
+#     a CONTROL against naively widening the disabled branch, not a red pin;
+#     the mutation runs below turn it red.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    ALWAYS_ON_MODELS
+    + [
+        "claude-fable-5-20260101",
+        "anthropic/claude-fable-5",
+        "claude-mythos-5[1m]",
+    ],
+)
+@patch("requests.Session.post")
+def test_always_on_model_off_sends_no_thinking_key(mock_post, model):
+    """AC #2: no thinking key, no effort, no sampling -- the exact payload
+    live-verified 200 on claude-fable-5 (probe 5)."""
+    sent = _sent_payload(mock_post, model, thinking_effort="off")
+    assert "thinking" not in sent, (
+        f"{model} with thinking_effort='off' sent thinking={sent.get('thinking')!r} "
+        "-- an explicit config is a 400 on this family"
+    )
+    assert "output_config" not in sent
+    assert not any(key in sent for key in SAMPLING_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# (c) OFF on the families where omission already means no thinking (AC #4).
+#     These pass pre-fix and must keep passing: regression pins.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", OMISSION_IS_OFF_MODELS)
+@patch("requests.Session.post")
+def test_omission_is_off_family_off_sends_no_thinking_key(mock_post, model):
+    """AC #4: Opus 4.8 and earlier, Sonnet 4.6 and earlier, and Haiku are
+    unchanged -- `off` still means simply no thinking config."""
+    sent = _sent_payload(mock_post, model, thinking_effort="off")
+    assert "thinking" not in sent, f"{model} must not gain a thinking config"
+    assert "output_config" not in sent
+
+
+@pytest.mark.parametrize(
+    "model", ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"]
+)
+@patch("requests.Session.post")
+def test_legacy_sampling_model_off_still_receives_temperature(mock_post, model):
+    """AC #4: on the families that still accept sampling parameters, `off`
+    leaves the sampling branch exactly as it was."""
+    sent = _sent_payload(mock_post, model, thinking_effort="off")
+    assert sent.get("temperature") == 0.7, f"{model} lost its temperature"
+
+
+# ---------------------------------------------------------------------------
+# The predicates themselves (AC #3): capability facts, not name checks in the
+# request builder; family matching must be robust without over-matching.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+        # dated / suffixed / prefixed variants
+        "claude-opus-5-20260101",
+        "claude-sonnet-5@20260101",
+        "claude-fable-5[1m]",
+        "anthropic/claude-opus-5",
+        "us.anthropic.claude-fable-5",
+        "Claude-Fable-5",
+    ],
+)
+def test_thinks_by_default_matches_the_whole_family(model):
+    assert anthropic_model_thinks_by_default(model) is True, model
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5-20251101",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+        "claude-3-5-sonnet-20241022",
+        "gpt-5.6",
+        "",
+        None,
+    ],
+)
+def test_thinks_by_default_does_not_over_match(model):
+    assert anthropic_model_thinks_by_default(model) is False, model
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-fable-5-20260101",
+        "claude-mythos-5[1m]",
+        "anthropic/claude-fable-5",
+        "Claude-Mythos-5",
+    ],
+)
+def test_rejects_disabled_thinking_matches_the_always_on_family(model):
+    assert anthropic_model_rejects_disabled_thinking(model) is True, model
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        # Opus 5 ACCEPTS the disabled config (probe 1) -- widening the
+        # always-on set to include it would wrongly drop the disabled config
+        # OFF depends on.
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "gpt-5.6",
+        "",
+        None,
+    ],
+)
+def test_rejects_disabled_thinking_does_not_over_match(model):
+    assert anthropic_model_rejects_disabled_thinking(model) is False, model
+
+
+def test_every_always_on_model_also_thinks_by_default():
+    """Consistency of the current table: rejecting `disabled` only makes sense
+    on a model whose omission runs thinking. A future model may break this --
+    the predicates are deliberately independent -- but today's table must not
+    break it by accident."""
+    for model in ALWAYS_ON_MODELS:
+        assert anthropic_model_thinks_by_default(model) is True, model
+
+
+def test_predicates_survive_a_user_configured_capability_table():
+    """Same guarantee as TASK-18414's predicates: the config-driven capability
+    tables are wholly replaceable from `config.toml`, and a user edit to a
+    request-validity fact could only reintroduce the 400 / the silent billing."""
+    from tldw_chatbook.model_capabilities import ModelCapabilities
+
+    caps = ModelCapabilities(config={"models": {}, "patterns": {}})
+    assert caps.get_model_capabilities("Anthropic", "claude-fable-5") is not None
+    assert anthropic_model_thinks_by_default("claude-opus-5") is True
+    assert anthropic_model_rejects_disabled_thinking("claude-fable-5") is True

--- a/Tests/Chat/test_console_session_settings.py
+++ b/Tests/Chat/test_console_session_settings.py
@@ -2283,6 +2283,34 @@ class TestConsoleSettingsWarnings:
         settings = self._settings(provider="openai", reasoning_effort="none")
         assert console_settings_warnings(settings) == []
 
+    def test_thinking_off_on_always_on_anthropic_model_warns(self):
+        # TASK-18800: Fable 5 / Mythos 5 think unconditionally -- the API
+        # 400-rejects thinking={"type": "disabled"}, so `off` can only omit
+        # the parameter and adaptive thinking still runs and bills. Silent
+        # acceptance of the user's OFF is the original defect one level up;
+        # this warning is the honest surface.
+        for model in ("claude-fable-5", "claude-mythos-5"):
+            settings = self._settings(
+                provider="anthropic", model=model, thinking_effort="off"
+            )
+            warnings = console_settings_warnings(settings)
+            assert any("always thinks" in w for w in warnings), (model, warnings)
+
+    def test_thinking_off_on_disableable_anthropic_model_does_not_warn(self):
+        # Opus 5 / Sonnet 5 accept the explicit disabled config, so OFF is
+        # genuinely honored there -- no warning.
+        for model in ("claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"):
+            settings = self._settings(
+                provider="anthropic", model=model, thinking_effort="off"
+            )
+            assert console_settings_warnings(settings) == [], model
+
+    def test_non_off_thinking_effort_on_always_on_model_does_not_warn(self):
+        settings = self._settings(
+            provider="anthropic", model="claude-fable-5", thinking_effort="high"
+        )
+        assert console_settings_warnings(settings) == []
+
 
 class TestReadinessKeySetCaching:
     """TASK-18909: the readiness key-sets are pure functions of a constant.

--- a/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
+++ b/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-18800
 title: Console thinking-effort 'off' is not honored on Claude Opus 5 or Fable 5
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-18 23:52'
-updated_date: '2026-08-21 04:35'
+updated_date: '2026-08-21 04:54'
 labels:
   - llm
   - console
@@ -23,10 +23,10 @@ Found while fixing TASK-18414 and deliberately left out of scope there: that tas
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Selecting thinking effort 'off' on Claude Opus 5 produces a request that actually disables thinking
-- [ ] #2 Selecting thinking effort 'off' on Claude Fable 5 or Mythos 5 does not produce an HTTP 400
-- [ ] #3 The by-default-thinking decision is a capability predicate alongside the two added in TASK-18414, not a new name check in the request builder
-- [ ] #4 Models where omitting the thinking parameter already means no thinking (Opus 4.8 and earlier, Sonnet 4.6 and earlier, Haiku) are unchanged, pinned by a regression test
+- [x] #1 Selecting thinking effort 'off' on Claude Opus 5 produces a request that actually disables thinking
+- [x] #2 Selecting thinking effort 'off' on Claude Fable 5 or Mythos 5 does not produce an HTTP 400
+- [x] #3 The by-default-thinking decision is a capability predicate alongside the two added in TASK-18414, not a new name check in the request builder
+- [x] #4 Models where omitting the thinking parameter already means no thinking (Opus 4.8 and earlier, Sonnet 4.6 and earlier, Haiku) are unchanged, pinned by a regression test
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -34,3 +34,9 @@ Found while fixing TASK-18414 and deliberately left out of scope there: that tas
 <!-- SECTION:PLAN:BEGIN -->
 1. Standalone curl probes pinning the capability surface (opus-5 disabled accepted; fable-5 disabled 400; disabled-observable via content block types + thinking_tokens)\n2. Commit probe verdicts (session-limit insurance)\n3. Add thinks-by-default / rejects-disabled-thinking capability predicates in model_capabilities.py (outside config tables, family-matched)\n4. Rewire _anthropic_thinking_config off branch to consult them; keep _anthropic_is_sonnet_5 for the Sonnet 5 effort shape only\n5. Red-first pins, mutation tests with Edit-based restores\n6. Live verification at the chat_api_call seam + origin/dev control\n7. Hygiene: ACs, notes, Done, report, PR
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed by making 'how must thinking OFF be expressed' a per-family capability: two predicates in model_capabilities.py alongside TASK-18414's pair (anthropic_model_thinks_by_default: Sonnet 5/Opus 5/Fable 5/Mythos 5; anthropic_model_rejects_disabled_thinking: Fable 5/Mythos 5), both hard-coded family tables outside the user-overridable capability config, probe-verified against api.anthropic.com 2026-08-20. _anthropic_thinking_config's off branch now consults them: thinks-by-default models get thinking={type: disabled} (live 200, zero thinking tokens on opus-5), always-on models keep omission (explicit disabled is a live 400 there) and the Console settings modal's existing ADR-066 warning list tells the user their OFF cannot be honored on those models. _anthropic_is_sonnet_5 survives only for Sonnet 5's bare-output_config effort shape. Evidence: red 3/green 135 (read counts), two mutations (two-way collapse kills 13 pins; opus-5 narrowed out kills 6, Edit-restored with clean diff), targeted gate 1589 passed with only the pre-filed dev reds (18801/16815, reproduced on clean origin/dev with byte-identical inventory hash), live A/B at the chat_api_call seam: fix opus-5+off thinking_tokens=0 vs origin/dev control 33; fable-5+off completes, haiku unchanged. Full report: Docs/superpowers/plans/2026-08-21-task-18800-report.md
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
+++ b/backlog/tasks/task-18800 - Console-thinking-effort-off-is-not-honored-on-Claude-Opus-5-or-Fable-5.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-18800
 title: Console thinking-effort 'off' is not honored on Claude Opus 5 or Fable 5
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-18 23:52'
+updated_date: '2026-08-21 04:35'
 labels:
   - llm
   - console
@@ -26,3 +28,9 @@ Found while fixing TASK-18414 and deliberately left out of scope there: that tas
 - [ ] #3 The by-default-thinking decision is a capability predicate alongside the two added in TASK-18414, not a new name check in the request builder
 - [ ] #4 Models where omitting the thinking parameter already means no thinking (Opus 4.8 and earlier, Sonnet 4.6 and earlier, Haiku) are unchanged, pinned by a regression test
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Standalone curl probes pinning the capability surface (opus-5 disabled accepted; fable-5 disabled 400; disabled-observable via content block types + thinking_tokens)\n2. Commit probe verdicts (session-limit insurance)\n3. Add thinks-by-default / rejects-disabled-thinking capability predicates in model_capabilities.py (outside config tables, family-matched)\n4. Rewire _anthropic_thinking_config off branch to consult them; keep _anthropic_is_sonnet_5 for the Sonnet 5 effort shape only\n5. Red-first pins, mutation tests with Edit-based restores\n6. Live verification at the chat_api_call seam + origin/dev control\n7. Hygiene: ACs, notes, Done, report, PR
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -30,6 +30,7 @@ from tldw_chatbook.Chat.provider_readiness import (
     provider_config_key,
 )
 from tldw_chatbook.config import ProviderSettingsError, provider_settings_for_key
+from tldw_chatbook.model_capabilities import anthropic_model_rejects_disabled_thinking
 from tldw_chatbook.Utils.input_validation import validate_url
 from tldw_chatbook.Utils.token_counter import count_tokens_messages
 from tldw_chatbook.UI.character_display_text import sanitize_character_display_label
@@ -598,9 +599,13 @@ def console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]:
 
     Returns:
         Zero or more user-facing warning strings: an effort value the
-        selected model family does not consume, and — for llama.cpp-family
+        selected model family does not consume; for llama.cpp-family
         providers with a thinking value set — the server requirements note
-        (``--jinja``; per-request budget needs llama.cpp b9982+).
+        (``--jinja``; per-request budget needs llama.cpp b9982+); and for
+        thinking effort ``off`` on an always-on-thinking Anthropic model
+        (Fable 5 / Mythos 5) — that thinking cannot actually be turned off
+        there (TASK-18800: the API rejects the explicit disabled config, so
+        the request omits the parameter and adaptive thinking still runs).
     """
     warnings: list[str] = []
     effort = str(settings.reasoning_effort or "").strip().lower()
@@ -614,6 +619,15 @@ def console_settings_warnings(settings: ConsoleSessionSettings) -> list[str]:
             )
     if has_thinking_value and settings.provider in _LLAMA_CPP_FAMILY_PROVIDERS:
         warnings.append(_LLAMACPP_THINKING_REQUIREMENTS_NOTE)
+    thinking_effort = str(settings.thinking_effort or "").strip().lower()
+    if thinking_effort == "off" and anthropic_model_rejects_disabled_thinking(
+        settings.model
+    ):
+        warnings.append(
+            f"{settings.model} always thinks: the API rejects an explicit "
+            "thinking-off setting, so 'off' sends no thinking parameter and "
+            "adaptive thinking still runs (and is billed)."
+        )
     return warnings
 
 

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -60,8 +60,10 @@ from tldw_chatbook.LLM_Calls.moonshot import (
 )
 from tldw_chatbook.LLM_Calls.zai import chat_with_zai as _strict_chat_with_zai
 from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_disabled_thinking,
     anthropic_model_rejects_fixed_thinking_budget,
     anthropic_model_rejects_sampling_params,
+    anthropic_model_thinks_by_default,
     openai_model_rejects_sampling_params,
     openai_model_requires_max_completion_tokens,
 )
@@ -362,11 +364,13 @@ def _anthropic_uses_adaptive_thinking(model: object) -> bool:
 def _anthropic_is_sonnet_5(model: object) -> bool:
     """Return whether model is the documented unprefixed Claude Sonnet 5 family.
 
-    This selects Sonnet 5's *thinking shape* (an explicit ``disabled`` config to
-    turn thinking off; bare ``output_config.effort`` with no ``thinking`` key
-    otherwise). It is deliberately not the answer to "does this model reject
-    sampling parameters / a fixed thinking budget" -- those are capability
-    predicates in ``model_capabilities`` (TASK-18414).
+    This selects Sonnet 5's *effort shape* (bare ``output_config.effort`` with
+    no ``thinking`` key). It is deliberately not the answer to "does this model
+    reject sampling parameters / a fixed thinking budget" -- those are
+    capability predicates in ``model_capabilities`` (TASK-18414) -- nor to
+    "how must thinking OFF be expressed", which is the
+    ``anthropic_model_thinks_by_default`` / ``anthropic_model_rejects_disabled_
+    thinking`` predicate pair (TASK-18800).
     """
     model_name = str(model or "").lower()
     return model_name == "claude-sonnet-5" or model_name.startswith("claude-sonnet-5-")
@@ -381,17 +385,28 @@ def _anthropic_thinking_config(
 ) -> tuple[dict[str, object] | None, dict[str, object] | None, int]:
     """Map Anthropic thinking settings to thinking and output configuration."""
     effort = str(thinking_effort or "").strip().lower()
-    is_sonnet_5 = _anthropic_is_sonnet_5(model)
     if effort == "off":
-        if is_sonnet_5:
-            if thinking_budget_tokens is not None:
-                logger.warning(
-                    "Anthropic: ignoring fixed thinking budget for Claude Sonnet 5 model %s",
-                    model,
-                )
-            return {"type": "disabled"}, None, max_tokens
+        if thinking_budget_tokens is not None:
+            logger.warning(
+                "Anthropic: ignoring fixed thinking budget for model %s with thinking off",
+                model,
+            )
+        # How OFF must be expressed is a per-family capability (TASK-18800):
+        # families that think by default need an explicit disabled config,
+        # EXCEPT the always-on families, which 400-reject it -- there omission
+        # is the only valid payload and thinking still runs (surfaced to the
+        # user by the Console settings warning in console_session_settings).
+        if anthropic_model_thinks_by_default(model):
+            if not anthropic_model_rejects_disabled_thinking(model):
+                return {"type": "disabled"}, None, max_tokens
+            logger.warning(
+                "Anthropic: thinking cannot be turned off on always-on model %s; "
+                "omitting the thinking parameter (adaptive thinking still runs)",
+                model,
+            )
         return None, None, max_tokens
     budget = _safe_cast(thinking_budget_tokens, int)
+    is_sonnet_5 = _anthropic_is_sonnet_5(model)
     if is_sonnet_5:
         if thinking_budget_tokens is not None:
             logger.warning(

--- a/tldw_chatbook/model_capabilities.py
+++ b/tldw_chatbook/model_capabilities.py
@@ -199,17 +199,24 @@ def _anthropic_model_family(model: object) -> Optional[Tuple[str, int, Optional[
     )
 
 
-def _anthropic_is_modern_request_family(model: object) -> bool:
-    """Return whether ``model`` is in the modern Anthropic request family."""
+def _anthropic_family_matches(
+    model: object, families: frozenset  # frozenset[Tuple[str, int, Optional[int]]]
+) -> bool:
+    """Return whether ``model`` parses into one of ``families``.
+
+    A ``(tier, major, None)`` row matches every minor version in that major
+    line; a ``(tier, major, minor)`` row matches that exact minor only.
+    """
     family = _anthropic_model_family(model)
     if family is None:
         return False
     tier, major, minor = family
-    return (tier, major, None) in _ANTHROPIC_MODERN_REQUEST_FAMILIES or (
-        tier,
-        major,
-        minor,
-    ) in _ANTHROPIC_MODERN_REQUEST_FAMILIES
+    return (tier, major, None) in families or (tier, major, minor) in families
+
+
+def _anthropic_is_modern_request_family(model: object) -> bool:
+    """Return whether ``model`` is in the modern Anthropic request family."""
+    return _anthropic_family_matches(model, _ANTHROPIC_MODERN_REQUEST_FAMILIES)
 
 
 def anthropic_model_rejects_sampling_params(model: object) -> bool:
@@ -296,6 +303,94 @@ def anthropic_model_rejects_temperature_top_p_combination(model: object) -> bool
         return False
     _tier, major, _minor = family
     return major >= 4
+
+
+# How "thinking off" must be expressed, per family (TASK-18800). Two separate
+# facts about the request surface, composed by the request builder into a
+# three-way behaviour:
+#
+#   thinks_by_default=False                          -> omission already means
+#       no thinking (Opus 4.8/4.7/4.6 and earlier, Sonnet 4.6/4.5, Haiku)
+#   thinks_by_default=True, rejects_disabled=False   -> OFF needs an explicit
+#       thinking={"type": "disabled"} (Sonnet 5, Opus 5)
+#   thinks_by_default=True, rejects_disabled=True    -> OFF cannot be expressed
+#       at all; omission is the only valid move and adaptive thinking still
+#       runs (Fable 5, Mythos 5)
+#
+# Kept as two boolean predicates rather than one three-way enum because they
+# are independent questions a future model could answer in a new combination,
+# and because boolean family predicates are this module's established shape
+# (TASK-18414 / TASK-19020).
+#
+# Probe-verified against api.anthropic.com on 2026-08-20 (TASK-18800 report):
+#
+#   * claude-opus-5 + thinking={"type": "disabled"}, no effort -> 200
+#     (msg_011CeFGfHpYVXE7X7LnRmYCF, thinking_tokens 0). The effort cap on
+#     disabled thinking binds only at xhigh/max (req_011CeFGfT1wJxmsd2rRUszbc);
+#     the builder's OFF branch never pairs disabled with an effort.
+#   * claude-opus-5, thinking omitted -> 200 WITH a thinking block and 13
+#     billed thinking tokens (msg_011CeFGfkyS1LDXT46nVU5Gb) -- omission runs
+#     thinking on this family.
+#   * claude-fable-5 + thinking={"type": "disabled"} -> 400
+#     '"thinking.type.disabled" is not supported for this model.'
+#     (req_011CeFGfU3CpiKFwRigU2jRa); omitted -> 200 with a thinking block
+#     even for "Say OK." (msg_011CeFGfVjQMY6gm6SzUDpHq, thinking_tokens 7).
+#   * claude-sonnet-5 + disabled -> 200 (msg_011CeFGfvkJLz54KaEvyYXTY).
+#   * claude-sonnet-4-6 / claude-haiku-4-5, thinking omitted -> 200 with no
+#     thinking block (msg_011CeFGfzwKC4Uqtx2G7oYJW, msg_011CeFGg5DnVz6iXa22WhgRj).
+#   * claude-mythos-5 is Project Glasswing-only (404 on this key,
+#     req_011CeFGg7HZZenFq2CaQxi5A) and is included on the documented grounds
+#     that it shares Fable 5's request surface exactly -- same standing as in
+#     the TASK-18414 capability set.
+_ANTHROPIC_DEFAULT_THINKING_FAMILIES = frozenset(
+    {
+        ("sonnet", 5, None),
+        ("opus", 5, None),
+        ("fable", 5, None),
+        ("mythos", 5, None),
+    }
+)
+
+_ANTHROPIC_ALWAYS_ON_THINKING_FAMILIES = frozenset(
+    {
+        ("fable", 5, None),
+        ("mythos", 5, None),
+    }
+)
+
+
+def anthropic_model_thinks_by_default(model: object) -> bool:
+    """Return whether omitting ``thinking`` leaves thinking RUNNING on ``model``.
+
+    Args:
+        model: An Anthropic model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when a request with no ``thinking`` key runs (and bills) adaptive
+        thinking -- the Sonnet 5, Opus 5, Fable 5 and Mythos 5 families -- so
+        that turning thinking off requires more than omission. False for
+        Opus 4.8 and earlier, Sonnet 4.6 and earlier, and Haiku, where
+        omission already means no thinking, and for unrecognisable ids.
+    """
+    return _anthropic_family_matches(model, _ANTHROPIC_DEFAULT_THINKING_FAMILIES)
+
+
+def anthropic_model_rejects_disabled_thinking(model: object) -> bool:
+    """Return whether ``thinking={"type": "disabled"}`` is a 400 on ``model``.
+
+    Args:
+        model: An Anthropic model identifier (any prefixed or suffixed form).
+
+    Returns:
+        True when an explicit disabled config would be answered with
+        ``400 invalid_request_error: "thinking.type.disabled" is not supported
+        for this model.`` -- the always-on-thinking Fable 5 and Mythos 5
+        families, where omission is the only valid move and thinking runs
+        regardless. False everywhere else, including Opus 5 (which accepts
+        ``disabled`` alongside effort ``high`` or lower -- and the builder's
+        OFF branch sends no effort at all).
+    """
+    return _anthropic_family_matches(model, _ANTHROPIC_ALWAYS_ON_THINKING_FAMILIES)
 
 
 #


### PR DESCRIPTION
## Summary

Console's thinking effort `off` did not disable thinking on Claude Opus 5 / Fable 5 / Mythos 5: those models think **by default** when the `thinking` parameter is omitted, and the builder's `off` branch emitted an explicit `{"type": "disabled"}` only for the Sonnet 5 family — everywhere else it sent no thinking config, silently leaving adaptive thinking running and billed. The capability is non-uniform: `disabled` is accepted on Opus 5 (probe: 200, effort cap binds only at xhigh/max, which the off branch never sends) and is **400-rejected on Fable 5 / Mythos 5**, so naively widening the Sonnet 5 branch would have introduced a brand-new 400.

- Two capability predicates in `model_capabilities.py` alongside TASK-18414's pair, outside the user-overridable tables: `anthropic_model_thinks_by_default` (Sonnet 5, Opus 5, Fable 5, Mythos 5) and `anthropic_model_rejects_disabled_thinking` (Fable 5, Mythos 5). Their composition is the three-way OFF behaviour; kept as two booleans because they are independent request-surface questions (18414's own rationale) and boolean family predicates are the module's shape.
- `_anthropic_thinking_config`'s off branch consults only the predicates: thinks-by-default models get `{"type": "disabled"}`; always-on models keep omission + a log warning. `_anthropic_is_sonnet_5` survives solely for Sonnet 5's bare-`output_config.effort` shape.
- Fable 5 UX: the Console settings modal's existing ADR-066 non-blocking warning list (`console_settings_warnings`) now tells the user their OFF cannot be honored on always-on models — no new UI.

## Evidence (full report: `Docs/superpowers/plans/2026-08-21-task-18800-report.md`)

- 10 standalone probes captured **before** the fix, verbatim bodies + request-ids, incl. the disabled-observable: opus-5 same prompt, disabled → `['text']` / 0 thinking tokens; omitted → `['thinking','text']` / 13.
- Red-first: **3 failed, 64 passed** (opus-5 off sent `thinking=None`; warning absent) → **135 passed**.
- Mutations: two-way collapse (fable→disabled) kills **13** pins; opus-5 narrowed out kills **6**; Edit-restored, diffs clean, re-green 135.
- Targeted gate **1589 passed, 4 failed** — all four reproduce identically on clean `origin/dev` (TASK-18801 manifest trio + TASK-16815; inventory hash byte-identical with/without this change). Collect sweep **52287, 0 errors**.
- Live A/B at the production `chat_api_call` seam: fix opus-5+off → `thinking_tokens: 0` (`msg_011CeFJ4W4kP58EcKiiHvALJ`) vs clean origin/dev control → `thinking_tokens: 33` (`msg_011CeFJ6WMRGnYjWNWW4hpdF`); fable-5+off completes with **no 400**; haiku-4-5 control unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `thinking_effort: 'off'` per Anthropic family. Previously, we only sent `{"type":"disabled"}` for Sonnet 5; on Opus 5, Fable 5, and Mythos 5 omission left adaptive thinking running (and billed), while `disabled` 400-ed on Fable/Mythos. Now: Sonnet 5 and Opus 5 get explicit `disabled`; Fable/Mythos omit `thinking` and surface a Console warning; legacy families unchanged.

- Adds capability predicates in `tldw_chatbook/model_capabilities.py` and rewires the builder to use them: `anthropic_model_thinks_by_default` and `anthropic_model_rejects_disabled_thinking`. `_anthropic_is_sonnet_5` now only controls the adaptive effort shape.
- Console: `console_settings_warnings` informs users that `off` cannot be honored on always-on models (Fable/Mythos). The existing seam/UI is reused; no new controls.
- Tests: new `Tests/Chat/test_anthropic_thinking_off_capability.py`; updates to `Tests/Chat/test_console_session_settings.py` pin the warning.
- Side effect: the "ignoring fixed thinking budget" log now fires for any model on the OFF branch, not just Sonnet 5. No API or config migrations.
- Satisfies TASK-18800 acceptance criteria.

<sup>Written for commit 512ccec07532f3740bf3f17d2a5997e7063c550a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

