### PR TITLE
chore(security): per-row-reviewed regeneration of the diagnostic inventory (task-19191)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -992,8 +992,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 139,
-      "diagnostic_digest": "3f36dc36f8d1f0ed0bfa",
+      "call_count": 140,
+      "diagnostic_digest": "9f344fad707f28908851",
       "owner": "TASK-492",
       "path": "tldw_chatbook/LLM_Calls/LLM_API_Calls.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -3811,7 +3811,7 @@
   "summary": {
     "owner_files": 517,
     "persistent_sink_files": 7,
-    "task_492_calls": 1209,
+    "task_492_calls": 1210,
     "task_494_calls": 7128
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -244,7 +244,7 @@
     },
     {
       "call_count": 45,
-      "diagnostic_digest": "be3bb71ba933d593fda2",
+      "diagnostic_digest": "eff5df07bf7976b9805a",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -418,8 +418,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 100,
-      "diagnostic_digest": "4032494883893d8593ec",
+      "call_count": 31,
+      "diagnostic_digest": "843a41dfe7352f687179",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/Chunk_Lib.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -436,6 +436,139 @@
       "diagnostic_digest": "f98a98c58c9a6a2ae297",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Chunking/chunking_templates.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 13,
+      "diagnostic_digest": "bb708e95cfa43445ac0c",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/base.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 49,
+      "diagnostic_digest": "fae786d5d91b387794b3",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/chunker.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 9,
+      "diagnostic_digest": "acb85f8566b494cf1f78",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/multilingual.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "b86d997fc5f92d76384c",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/process_text/options.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "2fa578486628970cce4e",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/regex_safety.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 7,
+      "diagnostic_digest": "a872185128dda8da2366",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/security_logger.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 3,
+      "diagnostic_digest": "ba3ade9b3020f0672700",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/code.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 5,
+      "diagnostic_digest": "26ca8c86ded0133bf43b",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/code_ast.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 17,
+      "diagnostic_digest": "2372dd2d74d5a6af2c86",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/ebook_chapters.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "6f1ad27efa2e2c918b62",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/fixed_size.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 25,
+      "diagnostic_digest": "7395a9bdd485bb09babf",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/json_xml.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 11,
+      "diagnostic_digest": "eb340e29797183422734",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/paragraphs.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "fdc080dc579ef1a68184",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/rolling_summarize.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 11,
+      "diagnostic_digest": "bbc3d4eb55d2a51cbd4b",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/semantic.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 18,
+      "diagnostic_digest": "44e8ab6363dc713ba363",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/sentences.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 6,
+      "diagnostic_digest": "50978423f59732cb0762",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/structure_aware.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 28,
+      "diagnostic_digest": "9d6d1bc7cce0c3cc6d4b",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/tokens.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 15,
+      "diagnostic_digest": "15590c60369dc2419382",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/strategies/words.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
+      "diagnostic_digest": "ec2f6dd80d0af71ca50b",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Chunking/engine/utils/metrics.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -467,8 +600,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 354,
-      "diagnostic_digest": "348e4eb5acc184e41a4e",
+      "call_count": 338,
+      "diagnostic_digest": "73ec76b8c78459022689",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Client_Media_DB_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1286,8 +1419,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 5,
-      "diagnostic_digest": "f69926a6d905e46a5b67",
+      "call_count": 3,
+      "diagnostic_digest": "86416c97b52a00eba47f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/chunking_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1297,13 +1430,6 @@
       "diagnostic_digest": "48de569e66d28ea95375",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/config_profiles.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 6,
-      "diagnostic_digest": "137e6bedad997559a63c",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/RAG_Search/enhanced_chunking_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -1332,6 +1458,13 @@
       "diagnostic_digest": "a7257cdee4615878f370",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/parallel_processor.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "4213328ff47c2aa328cc",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/RAG_Search/parent_child_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -1426,8 +1559,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 11,
-      "diagnostic_digest": "1147d51137ac236d6d45",
+      "call_count": 10,
+      "diagnostic_digest": "5dd269c015b2a7bef02a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/RAG_Search/simplified/enhanced_rag_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1517,6 +1650,20 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "3d659da222ba81b9c89d",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/db/migrations/v1_to_v2.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "4020b39201fe7caf2714",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/db/migrations/v2_to_v3.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 3,
       "diagnostic_digest": "2c0a87947d6065c00575",
       "owner": "TASK-494",
@@ -1538,15 +1685,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 4,
-      "diagnostic_digest": "cf29ada6dae092debc36",
+      "call_count": 6,
+      "diagnostic_digest": "3a01bd3222d1bf8254f1",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 6,
-      "diagnostic_digest": "67cc7787adc013da495a",
+      "call_count": 8,
+      "diagnostic_digest": "7e5174010d9423ebe609",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2196,6 +2343,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 2,
+      "diagnostic_digest": "a5d9efad9e09d4fd1244",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 1,
       "diagnostic_digest": "738ee5f3783f1528d3c2",
       "owner": "TASK-494",
@@ -2315,15 +2469,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "ce8b76c5a9ec33bfbb28",
+      "call_count": 13,
+      "diagnostic_digest": "003a1b7bcf88e43ebf39",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/change_review_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 153,
-      "diagnostic_digest": "270e1e72e945cf646c20",
+      "call_count": 156,
+      "diagnostic_digest": "704f83552d529b048e3c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2364,8 +2518,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 110,
-      "diagnostic_digest": "ea4adcac3a98c2b57c47",
+      "call_count": 109,
+      "diagnostic_digest": "2b4e866f30fc5df8b13c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2434,8 +2588,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 10,
-      "diagnostic_digest": "ec77a2d70a78b6d9a9ac",
+      "call_count": 11,
+      "diagnostic_digest": "804f7ee3c0d8aeb67b0e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3036,6 +3190,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 2,
+      "diagnostic_digest": "30cb4d1c2a5479d20251",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Widgets/Console/console_changed_files_section.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 1,
       "diagnostic_digest": "073af2d6a9e12fbf65a4",
       "owner": "TASK-494",
@@ -3226,7 +3387,7 @@
     },
     {
       "call_count": 6,
-      "diagnostic_digest": "c5300d89688c20397bed",
+      "diagnostic_digest": "25de982311a49f4d7633",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/enhanced_file_picker.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3479,6 +3640,17 @@
   ],
   "persistent_sink_topology": [
     {
+      "path": "tldw_chatbook/Chunking/engine/security_logger.py",
+      "sinks": [
+        {
+          "digest": "7e3c515ca8d99167",
+          "kind": "loguru_sink",
+          "method": "add",
+          "scope": "SecurityLogger.__init__"
+        }
+      ]
+    },
+    {
       "path": "tldw_chatbook/Local_Ingestion/ingest_parse_worker.py",
       "sinks": [
         {
@@ -3637,9 +3809,9 @@
   "schema_version": 2,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 494,
-    "persistent_sink_files": 6,
+    "owner_files": 517,
+    "persistent_sink_files": 7,
     "task_492_calls": 1209,
-    "task_494_calls": 6972
+    "task_494_calls": 7128
   }
 }

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "32c915a3985b4e34136982bf1962de289945e505e16d9fb55beb732d2cd77447",
-        "origin_dev_generated_normalized_inventory_sha256": "32c915a3985b4e34136982bf1962de289945e505e16d9fb55beb732d2cd77447",
+        "checked_normalized_inventory_sha256": "bcd5b70ec5e17256b3efd23289758a7feeb7d1e345b0dd557751ebce7e91334c",
+        "origin_dev_generated_normalized_inventory_sha256": "bcd5b70ec5e17256b3efd23289758a7feeb7d1e345b0dd557751ebce7e91334c",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "bcd5b70ec5e17256b3efd23289758a7feeb7d1e345b0dd557751ebce7e91334c",
-        "origin_dev_generated_normalized_inventory_sha256": "bcd5b70ec5e17256b3efd23289758a7feeb7d1e345b0dd557751ebce7e91334c",
+        "checked_normalized_inventory_sha256": "c463bf02f9396087cccd76f7a8cbc6842ef17d7f0839a084c63d576b7dbf1f7d",
+        "origin_dev_generated_normalized_inventory_sha256": "c463bf02f9396087cccd76f7a8cbc6842ef17d7f0839a084c63d576b7dbf1f7d",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/backlog/tasks/task-19191 - Per-row-reviewed-regeneration-of-the-persistent-diagnostic-inventory-dev-red.md
+++ b/backlog/tasks/task-19191 - Per-row-reviewed-regeneration-of-the-persistent-diagnostic-inventory-dev-red.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-19191
 title: Per-row-reviewed regeneration of the persistent diagnostic inventory (dev red)
-status: To Do
-assignee: []
+status: Done
+assignee: ['@claude']
 created_date: '2026-08-20'
 labels:
   - test-health
@@ -73,8 +73,165 @@ task-19044 lesson).
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 The rebuild-vs-committed diff is re-produced at the implementation commit and every row delta is individually reviewed and dispositioned in the task's Implementation Notes (new diagnostics accepted or challenged, deleted rows confirmed against deleted/moved code, digest-only changes explained), with particular attention to the new persistent sink in `Chunking/engine/security_logger.py`.
-- [ ] #2 The committed inventory is regenerated via the checker's `--write` only after that review, and `Tests/Architecture/test_persistent_diagnostic_inventory.py` passes on the result.
-- [ ] #3 Any row the review REJECTS (a diagnostic that should not exist, e.g. one that could log sensitive content) is filed or fixed rather than silently accepted into the inventory.
-- [ ] #4 No hand edits to the regenerated JSON beyond what the review justifies; the summary counts match the accepted rows.
+- [x] #1 The rebuild-vs-committed diff is re-produced at the implementation commit and every row delta is individually reviewed and dispositioned in the task's Implementation Notes (new diagnostics accepted or challenged, deleted rows confirmed against deleted/moved code, digest-only changes explained), with particular attention to the new persistent sink in `Chunking/engine/security_logger.py`.
+- [x] #2 The committed inventory is regenerated via the checker's `--write` only after that review, and `Tests/Architecture/test_persistent_diagnostic_inventory.py` passes on the result.
+- [x] #3 Any row the review REJECTS (a diagnostic that should not exist, e.g. one that could log sensitive content) is filed or fixed rather than silently accepted into the inventory. (No whole row was rejected; three call-level findings — F1–F3 in the Implementation Notes — are recorded there and handed to the controller for filing rather than silently absorbed.)
+- [x] #4 No hand edits to the regenerated JSON beyond what the review justifies; the summary counts match the accepted rows. (The JSON is the untouched `--write` output; all four summary invariants re-verified by probe.)
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Worktree off origin/dev (`555298a33`, includes 19190's stts_events row fix); baseline both gates
+   (arch 10 red / summ 3 red) and the checker (exit 1) with PYTHONPATH+cwd pinned.
+2. Re-produce the rebuild-vs-committed diff at the implementation commit via an in-memory
+   `build_inventory()` vs the committed JSON (committed file untouched): structured
+   rows-only-in-committed / rows-only-in-rebuild / changed / sink deltas.
+3. Review every row: for NEW rows print and read every diagnostic call's source segment; for
+   CHANGED rows walk git history to the revision whose scan matches the committed digest and diff
+   added/removed call segments; for the REMOVED row verify the file's current state on disk.
+   Classify against the script's TASK-492/494 rules and the 15103/15600 privacy bar; record any
+   unsafe diagnostics as findings without blocking the truthful regeneration.
+4. Read `Chunking/engine/security_logger.py` end-to-end and judge the new addHandler-kind sink.
+5. Run `--write`; verify checker exit 0 and the four summary invariants with a printed probe.
+6. Reconcile `Tests/fixtures/summarization_diagnostic_review.json`: recompute the
+   `_normalized_inventory_projection` sha256 with the test module's own helpers (checked ==
+   generated required) and stamp both boundary fields, per the d64608b84/5899c31a1 precedent.
+7. Gates: arch 65/65, summarization all pass, repo-wide `--collect-only -q` clean; commit.
+
+## Implementation Notes
+
+Regenerated `Docs/security/production-diagnostic-inventory.json` via the checker's `--write`
+after a per-row review of every delta, and reconciled the summarization boundary fixture.
+Base: origin/dev `555298a33`. Summary moved 494→517 owner files, 6→7 sink files,
+task_492_calls 1209 (unchanged), task_494_calls 6972→7128. The drift had grown past the
+filing-time diff: three Scheduling count changes and two new Scheduling migration rows joined,
+and the stts_events row from the filing diff was already resolved by task-19190's hand-fix.
+
+The review is organized BY FILE (not by absolute counts), so a mechanical re-regen on a rebase
+does not invalidate it: each disposition below is about that file's diagnostic content, and a
+future merge that touches other files changes only rows outside this review.
+
+### Removed row (1) — accepted
+
+- `RAG_Search/enhanced_chunking_service.py` (was 6 calls): correction to the filing-time diff,
+  which said "file deleted". The file still EXISTS — `a762a9731` (Phase B retirement) rewrote it
+  as a diagnostic-free delegating shim over the vendored engine + `parent_child_adapter`;
+  scanning it yields 0 logger calls, so the row rightly leaves the inventory. Verified by
+  reading the file, not just the git log.
+
+### New rows (24) — all TASK-494, all accepted
+
+Classification: every new path is outside the TASK-492 prefixes (`Chat/`, `LLM_Calls/`,
+`MCP/`, `Tools/`) and not `Agents/mcp_tool_provider.py`, so TASK-494 with the standard reason
+is correct for all 24.
+
+- 19 `Chunking/engine/**` rows (vendored tldw_server engine, `72a295a7e`): every diagnostic
+  call segment was printed and read. The corpus is overwhelmingly counts, method/strategy
+  names, config keys/defaults, overlap/max_size adjustments, and optional-dependency
+  availability at debug/info/warning — squarely metadata. Borderlines accepted deliberately:
+  `chunker.py`'s "Suspicious control characters found: {control_char_samples}" logs at most 10
+  repr'd control characters (category Cc) from user input — control chars carry no prose, so
+  this cannot reconstruct user text; `strategies/ebook_chapters.py` logs the user-CONFIGURED
+  custom chapter regex at debug (config, not content). Three call-level findings recorded
+  below (F1, F2) rather than silently absorbed; none rises to rejecting a row.
+- `RAG_Search/parent_child_adapter.py` (1 debug, %d counts only) — new seam from `a762a9731`.
+- `Scheduling/db/migrations/v1_to_v2.py`, `v2_to_v3.py` (1 constant debug each) — schema
+  migration landings (task-18937/18939 era).
+- `UI/Library_Modules/library_media_browse_controller.py` (2 warnings: operation +
+  exception_type only, the 15600 house style) — the known library drift.
+- `Widgets/Console/console_changed_files_section.py` (2 constant-message
+  `opt(exception=True).warning`) — changed-files rail landing.
+
+### Changed rows (12) — every one diffed at CALL level, all accepted
+
+Method: for each row, walked `git log` back to the revision whose scan reproduces the
+committed digest, then diffed the (method, segment) multisets old→new — stronger evidence
+than the required 2–3 spot-checks.
+
+- `Chat/console_chat_controller.py` (digest-only, 45→45): four debug messages reworded
+  (approval/skill "clear" → "remount" during teardown/revocation); constant strings.
+- `Chunking/Chunk_Lib.py` (100→31): compat-shim rewrite (`70542dbef`). The 76 removed calls
+  include two former user-content leaks now GONE ("Extracted JSON metadata: {…}", "Extracted
+  header text: {…}" at debug) — a privacy improvement; the 7 added are counts/option messages.
+- `DB/Client_Media_DB_v2.py` (354→338): the library privacy rework. Removed calls logged DB
+  paths (`self.db_path_str`), user search queries and result titles at info; added calls are
+  error_type/count/mode-only structured events — a clear privacy improvement.
+- `RAG_Search/chunking_service.py` (5→3) and `RAG_Search/simplified/enhanced_rag_service.py`
+  (11→10): engine-migration residue; counts-only messages removed/reworded.
+- `Scheduling/scheduler/loop.py` (4→6), `Scheduling/services/scheduling_service.py` (6→8),
+  `UI/Screens/scheduling/schedules_workbench.py` (10→11): task-18939 handler timeout + manual
+  reminder run; new calls log task ids/types, timeout seconds, callback `__qualname__` —
+  metadata only ( `logger.exception` in the scheduler loop matches the pre-existing pattern
+  there).
+- `UI/Screens/change_review_screen.py` (1→13): annotate-loop rail; 12 constant-message
+  `opt(exception=True).warning` calls.
+- `UI/Screens/chat_screen.py` (153→156): changed-files rail; adds log conversation_id (an
+  internal DB id, consistent with pinned precedent) and one constant-message warning.
+- `UI/Screens/library_screen.py` (110→109): removed one warning that logged conversation_id.
+- `Widgets/enhanced_file_picker.py` (digest-only, 6→6): the same
+  "Failed to persist file-picker recent/last-dir state" error call reflowed (whitespace inside
+  the source segment changes the content digest); method and fields unchanged, still
+  `type(e).__name__` only — matches its TASK-14651 metadata-only registry pin.
+
+### New persistent sink — accepted with a caveat
+
+`Chunking/engine/security_logger.py`, `loguru_sink` kind, scope `SecurityLogger.__init__`:
+`logger.add(log_file, filter="security" in extra, format=time|level|event_type|message,
+rotation 100 MB, retention 30 days)`. Judgment: acceptable. (a) It is DORMANT in production —
+the sink registers only when a `log_file` is passed, the global `get_security_logger()` path
+passes none, and `configure_security_logging` has zero production callers. (b) When
+configured, the format persists only the message; messages are constant summaries plus
+sizes/category labels. The user-content payloads (`xml_sample` ≤500 chars of user XML from
+`json_xml.py`, blocked regex pattern ≤200 chars) live in the `details` dict, which is stored
+in the in-memory `_events` list and never reaches the sink format (extra carries only
+`security` + `event_type`). The latent export path is finding F3.
+
+### Findings for filing (recorded, regenerated truthfully — not fixed here)
+
+- F1 `Chunking/engine/chunker.py`: logs the FULL user file path at info ("Stream processing
+  file: {file_path} ({file_size} bytes)") and error ("File stream decoding failed for
+  {file_path}: {e}") in the file-streaming path — against the 15103/15600 "no full paths of
+  user files" bar if app code ever drives `chunk_file`/streaming.
+- F2 `Chunking/engine/strategies/tokens.py`: offset-reconstruction fallback logs up to 50
+  chars of the document text at debug ("Token piece not found … piece={repr(piece[:50]…)}") —
+  user text in a diagnostic.
+- F3 `Chunking/engine/security_logger.py`: latent `export_events()` writes the in-memory event
+  list — including `xml_sample` user content — to an arbitrary path with a plain `open()`
+  (invisible to the sink topology, which does not track bare `open`). No production caller
+  today; worth redacting `details` at capture or gating the export.
+
+### Fixture reconciliation (handoff from 19190)
+
+`Tests/fixtures/summarization_diagnostic_review.json` pins
+`manifest_boundary.checked_normalized_inventory_sha256` /
+`origin_dev_generated_normalized_inventory_sha256`: sha256 over
+`_normalized_inventory_projection` (the WHOLE inventory with only the two summarization
+owners' call_count/digest and `summary.task_492_calls` masked), so ANY reviewed inventory
+change outside those two owners legitimately moves it. Following the d64608b84/5899c31a1
+precedent: recomputed the projection hash with the test module's own helpers on the
+regenerated inventory (checked == generated == `bcd5b70ec5e17256…` asserted before stamping)
+and stamped BOTH fields. The two owner rows themselves were untouched by this regeneration
+(1209 TASK-492 calls unchanged), which is exactly the boundary the fixture protects. The three
+red tests were all downstream of the stale hash (the two mutant tests failed early on the
+projection assert with a non-matching message); no test was modified.
+
+### Gates (exact, read from output files)
+
+- `Tests/Architecture/test_persistent_diagnostic_inventory.py`: 65 passed (was 10 failed/55).
+- `Tests/LLM_Calls/test_summarization_diagnostic_privacy.py`: 257 passed (was 3 failed/254).
+- Repo-wide `pytest --collect-only -q`: 52228 tests collected, exit 0.
+- Checker: exit 0 — "517 owners, 1209 TASK-492 calls, 7128 TASK-494 calls, 7 sink files";
+  probe-verified len(owners)==owner_files, per-owner sums == summary, len(topology)==sink files.
+
+### Controller caveat (concurrency)
+
+Dev merges touching diagnostics re-drift this inventory constantly. At merge time, re-run the
+checker; if red, a mechanical re-regen (`--write` + re-stamp of the two fixture boundary
+fields via `_normalized_inventory_projection`/`_canonical_sha256`) is justified for rows
+already dispositioned above — the review is per-file, so only rows for files NOT covered here
+need fresh eyes.
+
+Files changed: `Docs/security/production-diagnostic-inventory.json` (regenerated),
+`Tests/fixtures/summarization_diagnostic_review.json` (two boundary hashes), this task file.
+No lessons entry added: the 19042/19043 deletion-direction lesson in
+`lessons-testing-evidence.md` already records this incident and names task-19191.


### PR DESCRIPTION
## Summary
Closes task-19191 (high), the largest standing dev red: the persistent-diagnostic-inventory pin had been red for days as merges accumulated drift without the hand-edit playbook. This is a per-row-REVIEWED regeneration, not a blind `--write`:

- **24 new rows** accepted (all TASK-494; every diagnostic call segment of the 19 `Chunking/engine/` files + parent_child_adapter + 2 Scheduling migrations + the library browse controller + the changed-files rail was printed and read; borderlines reasoned: control-char samples are ≤10 repr'd Cc chars, the ebook chapter regex is user config).
- **12 changed rows** diffed at call level against the git revision reproducing each committed digest — two are privacy *improvements* already on dev (Chunk_Lib's content leaks removed; Client_Media's DB paths/user queries/titles removed).
- **1 removed row with a filing correction**: `enhanced_chunking_service.py` was not deleted — `a762a9731` rewrote it as a diagnostic-free shim.
- **New persistent sink** (`security_logger.py` loguru sink) judged acceptable: dormant (no production caller configures a log file) and its format persists only constant summaries.
- **Fixture reconciliation**: the summarization-privacy fixture's two inventory-hash pins restamped per the documented precedent using the test module's own helpers (checked == generated asserted); no test file modified.
- **Three privacy findings recorded for filing, deliberately not absorbed**: F1 full user file path at info/error in the chunker's streaming path (+ the `:2490` OSError variant the review added); F2 up to 50 chars of document text at debug in a tokenizer fallback; F3 latent `export_events()` writing unredacted details via plain `open()`, invisible to the sink topology (+ two sub-bar observations).

At merge time dev re-drifted by exactly one row (#1877's thinking-off warnings — model name only, config not content); handled by the task's documented mechanical re-regen + restamp flow.

## Gates
Checker exit 0; architecture inventory 65/65 (was 10 failed); summarization privacy 257/257 (was 3 failed); post-rebase combined run **322 passed**; collect-only clean.

## Review
Independent review: **APPROVE** — byte-identical rebuild reproduced; 7 rows sampled adversarially including both named borderlines (no missed finding at the F1-F3 bar); F1-F3 verified real with exact lines and provably unfixed here; the enhanced_chunking_service correction, sink dormancy, and the Chunk_Lib call-level-diff method all independently confirmed; the fixture hash recomputed independently to an exact match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates the persistent diagnostic inventory after per‑row review to clear dev red and align with current code for task-19191. The old inventory was stale and failing checks; the new inventory adds the vendored chunking engine rows, adjusts changed owners, removes a shimmed service row, and records a dormant security logging sink.

- 24 new rows (19 under `Chunking/engine/**`, `RAG_Search/parent_child_adapter.py`, two `Scheduling` migrations, `UI/Library_Modules/library_media_browse_controller.py`, `Widgets/Console/console_changed_files_section.py`), 12 changed, 1 removed (`RAG_Search/enhanced_chunking_service.py` now a diagnostic‑free shim).
- Adds a persistent sink in `Chunking/engine/security_logger.py` (dormant unless a log file is configured; format persists constant summaries only).
- Call‑level privacy: removes prior content leaks in `Chunking/Chunk_Lib.py` and `DB/Client_Media_DB_v2.py`. Records three findings for follow‑up (full user file path in `engine/chunker.py`; ≤50 chars of text at debug in `engine/strategies/tokens.py`; latent unredacted `export_events()` in `engine/security_logger.py`).
- Re‑stamps `Tests/fixtures/summarization_diagnostic_review.json` using the test module’s normalized projection helpers; no test code changed.
- Summary counters: owners 494→517, sink files 6→7, TASK‑492 calls 1209 (unchanged), TASK‑494 calls 6972→7128. Gates now pass (Architecture 65/65, Summarization 257/257).

**Merge/rollout**
- No runtime behavior change; the new sink is dormant by default.
- If dev drifts before merge, rerun the checker with `--write` and restamp the two summarization fixture boundary hashes using the test helpers.

<sup>Written for commit d186bcc3817f170b6a58aa25e781c5041fbe0d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

