### PR TITLE
chore(backlog): file the 19191 diagnostic-privacy findings

### DIFF
--- a/backlog/tasks/task-19321 - Chunker-streaming-diagnostics-log-full-user-file-paths.md
+++ b/backlog/tasks/task-19321 - Chunker-streaming-diagnostics-log-full-user-file-paths.md
@@ -1,0 +1,63 @@
+---
+id: TASK-19321
+title: Chunker streaming diagnostics log full user file paths
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - security
+  - diagnostics
+  - chunking
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from TASK-19191's independent review; re-verified at dev `a542fd463`.
+Three diagnostic sites in `tldw_chatbook/Chunking/engine/chunker.py`'s
+file-streaming path record user file paths (ADR-029 private data) in log
+records:
+
+- `:2363` — `logger.info(f"Stream processing file: {file_path} ({file_size}
+  bytes)")` — the full user path at INFO on every streamed file, the
+  hottest of the three.
+- `:2485` — `logger.error(f"File stream decoding failed for {file_path}:
+  {e}")` — full path, plus a `UnicodeDecodeError` whose own text carries
+  byte-context from the file.
+- `:2490` — `logger.error(f"File stream processing failed: {e}")` — no
+  explicit path, but an `OSError` in `_CHUNKER_NONCRITICAL_EXCEPTIONS`
+  stringifies with the filename embedded, so the path leaks through `{e}`.
+
+Repair to the TASK-15103/15600 programme bar (ADR-029,
+`backlog/decisions/029-local-private-data-boundary.md`): keep the
+diagnostic useful while redacting the private value — basename-or-hash
+instead of full path, lengths/counts instead of content, and
+`type(e).__name__` (or an otherwise path-free rendering) where the
+exception message itself can carry the private value, as at `:2490`.
+Owner ruling applies (stability-over-quick-wins, 2026-08-11): repair the
+call sites in the established programme idiom; do not reach for a
+sink-level filter or log-formatter trick that other emit paths can bypass.
+
+Two knock-ons the fix must chase: (1) `chunker.py` is a TASK-494 owner row
+in `Docs/security/production-diagnostic-inventory.json` (call_count 49,
+digest `fae786d5d91b387794b3`) — repairing call shapes changes the digest,
+so the inventory must be regenerated with only the reviewed delta in the
+same PR and `scripts/check_persistent_diagnostic_inventory.py` must pass
+(the exact step TASK-19042/19043 initially missed; see the 2026-08-20
+lesson in `backlog/docs/lessons-testing-evidence.md`). (2) The adjacent
+raised exception messages (`InvalidInputError` at `:2487-2488` embeds the
+full path; `ChunkingError` at `:2491` embeds `str(e)`) flow to callers,
+not the log — check whether any downstream handler logs them verbatim
+before deciding they are out of scope, and record the verdict either way.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No diagnostic emitted by the chunker file-streaming path records a full user file path or user file content; the repaired records still identify the file (basename or stable hash) and size/failure class well enough to debug
+- [ ] #2 The `:2490` shape no longer interpolates raw exception text that can embed the filename; the record retains the exception type and path-free context
+- [ ] #3 The persistent diagnostic inventory's `chunker.py` owner row is regenerated with only the reviewed delta in the same PR and `scripts/check_persistent_diagnostic_inventory.py` passes
+- [ ] #4 Regression coverage pins the repaired shapes so a full path re-entering these streaming diagnostics turns a test red
+- [ ] #5 Production behavior other than log-record content is unchanged (no sink filters, no behavioral workarounds)
+<!-- AC:END -->

--- a/backlog/tasks/task-19322 - Tokens-offset-reconstruction-fallback-logs-user-document-text.md
+++ b/backlog/tasks/task-19322 - Tokens-offset-reconstruction-fallback-logs-user-document-text.md
@@ -1,0 +1,51 @@
+---
+id: TASK-19322
+title: Tokens offset-reconstruction fallback logs user document text
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - security
+  - diagnostics
+  - chunking
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from TASK-19191's independent review; re-verified at dev `a542fd463`.
+`tldw_chatbook/Chunking/engine/strategies/tokens.py:779-782` — when a token
+piece cannot be located during offset reconstruction, the fallback logs
+`piece={repr(piece[:50] + '...' if len(piece) > 50 else piece)}` — up to 50
+characters of raw user document text — at debug level.
+
+DEBUG is not a defense under the TASK-15103/15600 programme bar (ADR-029,
+`backlog/decisions/029-local-private-data-boundary.md`): users run with
+debug sinks enabled, and content redaction is level-independent. Repair in
+the house idiom — replace the content with what actually diagnoses the
+mismatch: piece length, `pos`, and, if correlation across records matters,
+a short stable hash of the piece. The diagnostic's job is "the tokenizer
+produced a piece the text search could not align, at this position" — none
+of that requires the characters themselves.
+
+Owner ruling applies (stability-over-quick-wins, 2026-08-11): redact at
+the call site in the established idiom; no formatter/sink cleverness.
+
+Knock-on: `tokens.py` is a TASK-494 owner row in
+`Docs/security/production-diagnostic-inventory.json` (call_count 28,
+digest `9d6d1bc7cce0c3cc6d4b`) — the repair changes the digest, so
+regenerate the inventory with only the reviewed delta in the same PR and
+keep `scripts/check_persistent_diagnostic_inventory.py` green (the step
+TASK-19042/19043 initially missed; 2026-08-20 lesson in
+`backlog/docs/lessons-testing-evidence.md`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The offset-reconstruction fallback diagnostic records no user document text at any log level; it still records enough to diagnose the misalignment (piece length, position, and/or a stable hash)
+- [ ] #2 The persistent diagnostic inventory's `tokens.py` owner row is regenerated with only the reviewed delta in the same PR and `scripts/check_persistent_diagnostic_inventory.py` passes
+- [ ] #3 Regression coverage pins the repaired shape so document text re-entering this diagnostic turns a test red
+- [ ] #4 Offset-reconstruction behavior itself is unchanged — only the log record content changes
+<!-- AC:END -->

--- a/backlog/tasks/task-19323 - security_logger-export_events-writes-unredacted-user-XML-via-a-checker-invisible-sink.md
+++ b/backlog/tasks/task-19323 - security_logger-export_events-writes-unredacted-user-XML-via-a-checker-invisible-sink.md
@@ -1,0 +1,84 @@
+---
+id: TASK-19323
+title: security_logger export_events writes unredacted user XML via a checker-invisible sink
+status: To Do
+assignee: []
+created_date: '2026-08-20'
+labels:
+  - security
+  - diagnostics
+  - chunking
+  - tooling
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Filed from TASK-19191's independent review; re-verified at dev `a542fd463`.
+`tldw_chatbook/Chunking/engine/security_logger.py:199-209` —
+`export_events()` writes the whole `self._events` store to disk via plain
+`open()` + `json.dump` (`:206-207`). Those events include `xml_sample` —
+up to 500 characters of raw user XML captured at `:108` by
+`log_xxe_attempt` — plus blocked-pattern details. Two problems compound:
+
+1. **Unredacted export.** The dump ships user document content verbatim to
+   an arbitrary caller-chosen file, outside every redaction guarantee the
+   TASK-15103/15600 programme established (ADR-029).
+2. **Topology blind spot.** `open` is not in
+   `scripts/check_persistent_diagnostic_inventory.py`'s `SINK_CALL_NAMES`
+   (`:49` — FileHandler variants, `addHandler`,
+   `atomic_private_write_bytes`, `open_private_text_append*`), so this
+   file-writing sink is invisible to the persistent-sink topology: the
+   inventory records `security_logger.py`'s topology as only the
+   `SecurityLogger.__init__` loguru `add` sink.
+
+`export_events` has **zero callers** today (whole-tree grep at this base
+finds only the def — no production callers, no tests), so the leak is
+latent. But latent-plus-invisible is precisely the combination the sink
+topology exists to prevent: the first future caller would ship an
+unredacted user-content export no gate can see.
+
+Fix shape — pick one repair AND close the blind spot, under the owner's
+stability-over-quick-wins ruling (2026-08-11; durable over clever):
+
+- **Repair**: either redact event details at export (drop/redact
+  `xml_sample`; keep event type, severity, timestamp, and lengths/counts),
+  or retire `export_events` outright as a zero-caller orphan using merged
+  TASK-19043's retirement discipline (record any unique validation before
+  deleting; there are no tests to retire).
+- **Blind spot**: either teach the checker to see bare `open()`-based
+  JSON/text dumps of event stores (scope it — a blanket `open` sink rule
+  may be noisy), or pin this specific file's export shape so any
+  reintroduction or change of a bare-`open()` export here trips the gate.
+
+Knock-on: `security_logger.py` is a TASK-494 owner row (call_count 7,
+digest `a872185128dda8da2366`) AND a `persistent_sink_topology` entry in
+`Docs/security/production-diagnostic-inventory.json`; regenerate with only
+the reviewed delta in the same PR and keep
+`scripts/check_persistent_diagnostic_inventory.py` green (the step
+TASK-19042/19043 initially missed; 2026-08-20 lesson in
+`backlog/docs/lessons-testing-evidence.md`).
+
+**Sub-bar observations recorded here (notes, not separate filings; give
+each a disposition — opportunistic fix or explicit defer — do not drop
+silently):**
+
+- `tldw_chatbook/Chunking/engine/strategies/json_xml.py:776` and `:843` —
+  `logger.error(f"Blocked potential XXE attack: {e}")`: a defusedxml
+  exception's `{e}` can carry an entity name from a malicious document.
+  Attack metadata rather than innocent user content, so below the repair
+  bar, but trimming to `type(e).__name__` is cheap if the file is touched.
+- `security_logger.py:209` logs the export destination path at INFO — a
+  caller-chosen filesystem path in diagnostics; below-bar alone, and moot
+  if `export_events` is retired.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No code path can write raw user XML (`xml_sample`) or other user-content event details to disk unredacted: `export_events` either redacts details at export or is removed
+- [ ] #2 The sink-topology blind spot is closed: the inventory checker (or an explicit pin) turns red if `security_logger.py` gains or changes a bare-open() export of the event store
+- [ ] #3 The persistent diagnostic inventory's `security_logger.py` owner row and persistent_sink_topology entry are regenerated with only the reviewed delta in the same PR and `scripts/check_persistent_diagnostic_inventory.py` passes
+- [ ] #4 If retirement is chosen, TASK-19043's discipline is followed (unique-validation check recorded before deletion); both sub-bar observations receive an explicit disposition in the implementation notes
+<!-- AC:END -->


### PR DESCRIPTION
Files the three diagnostic-privacy findings confirmed by TASK-19191's independent review, each re-verified line-by-line at dev `a542fd463` before filing. Backlog-only change: three new task files, no production code touched.

- **TASK-19321** — Chunker streaming diagnostics log full user file paths: `Chunking/engine/chunker.py:2363` (INFO, every streamed file), `:2485` (ERROR, path + decode-error byte context), `:2490` (ERROR, OSError text embeds the filename); repair to the 15103/15600 bar (basename-or-hash, `type(e).__name__`).
- **TASK-19322** — Tokens strategy offset-reconstruction fallback logs up to 50 chars of user document text at debug (`strategies/tokens.py:779-782`); replace content with lengths/position/hash — debug level is not a defense under ADR-029.
- **TASK-19323** — `security_logger.export_events` writes the event store, including `xml_sample` (≤500 chars of raw user XML, `:108`), via bare `open()` (`:206-207`), which is absent from the inventory checker's `SINK_CALL_NAMES` — a latent (zero-caller) unredacted export through a topology-invisible sink; task requires redact-or-retire AND closing the checker blind spot. The two sub-bar observations (`strategies/json_xml.py:776/:843` defusedxml `{e}` entity names; `security_logger.py:209` export-path INFO log) are recorded as notes on this task, not filed separately.

IDs claimed per protocol: sweep found max 19301 (across remote branches, local branches, all worktree backlogs, origin/dev tasks+drafts); claimed MAX+20 = 19321-19323; re-swept clean before the final commit. All three tasks encode the owner's stability-over-quick-wins ruling and the inventory-regeneration knock-on (`Docs/security/production-diagnostic-inventory.json` owner rows for all three files; `security_logger.py` also has a `persistent_sink_topology` entry).

Do not squash-drop the task files' AC formatting — they are hand-written to the task-191xx frontmatter shape (backlog CLI is unsafe on five-digit IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files three diagnostic-privacy findings from TASK-19191 into backlog tasks; no production code changes. These tasks define repairs to prevent user content/full paths in diagnostics and to close a sink-topology blind spot.

- Adds TASK-19321: chunker streaming diagnostics log full user file paths; repair to basename-or-hash and path-free exception types.
- Adds TASK-19322: tokens offset-reconstruction fallback logs user text at debug; replace with lengths/position/stable hash.
- Adds TASK-19323: `security_logger.export_events` writes unredacted `xml_sample` via bare `open()` and is invisible to the inventory checker; redact or retire and close the checker blind spot.

**Review notes**
- Backlog-only change: verify file/line references and acceptance criteria are correct and implementable; confirm tasks align with ADR-029 and the stability-over-quick-wins ruling.
- Spot-check ID claims (TASK-19321..19323) and frontmatter formatting match the TASK-191xx shape.

<sup>Written for commit 9d6bf2fffe40c6162dbd48627e3b3959fe76b8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

