### PR TITLE
feat: reconcile Console session with registry-active workspace on resume (TASK-18310)

### DIFF
--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -131,6 +131,12 @@ until the project's skill set changes.
 The built-in Default workspace has no "Rename" or "Archive" buttons. If you
 archive the workspace you are in, the Console switches back to Default.
 
+Activating a workspace from Settings ▸ Workspaces or Library (its "Create
+local workspace" flow, or "Set active") doesn't touch the Console screen
+directly — but the next time you visit Console, it picks up the change and
+switches its own session to match, the same as if you had switched with
+Alt+W.
+
 ### Details
 
 Open the "Details" header in the left rail to see where your chats live:
@@ -250,3 +256,9 @@ create-and-switch / create-without-switching / cancel tasks to match).*
 (task-18705: a bound folder containing `.SKILLS/` now annotates its row
 "— contains N project skill(s)" in the dialog, and a chained import prompt
 follows workspace creation).*
+*Verified against feat/task-18310-activation-seam @ c9892736f — 2026-08-20
+(task-18310: a workspace activated from Settings or Library only updates
+the registry; Console now reconciles its own session against it on the
+next resume instead of staying stale until an in-Console switch, so the
+Default-workspace paragraph above gained a one-sentence note on that; the
+rest of this page's content unchanged from the prior stamp).*

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -389,7 +389,7 @@ followed by a chained import prompt for it — see
 | Control | What it does |
 |---|---|
 | **Rename** | Renames the selected workspace (the box above it is pre-filled). |
-| **Set active** | Makes it the active workspace; replaced by "This workspace is active." when it already is. |
+| **Set active** | Makes it the active workspace; replaced by "This workspace is active." when it already is. Console doesn't switch immediately, but picks up the change and switches its own session to match the next time you visit it. |
 | **Archive** | Confirms first: "Archive \<name\>? Its conversations stay saved and remain visible in Library; the workspace disappears from the switcher and the Console browser." |
 | **Unarchive** | Returns an archived workspace to the list. It does *not* activate it. |
 | **Add folder** / **Remove** | Bind a folder for agent file tools (new bindings are read-only), or unbind it. |
@@ -694,6 +694,11 @@ page's content unchanged from the prior stamp).*
 (task-18705: a bound folder containing `.SKILLS/` now annotates its row
 "— contains N project skill(s)" in the creation dialog, followed by a
 chained import prompt after Create; the rest of this page's content
+unchanged from the prior stamp).*
+*Verified against feat/task-18310-activation-seam @ c9892736f — 2026-08-20
+(task-18310: **Set active**'s row gained a one-sentence note that Console
+doesn't switch immediately but reconciles its own session against the
+registry the next time you visit it; the rest of this page's content
 unchanged from the prior stamp).*
 *Providers & Models — Moonshot Kimi / Z.ai GLM rows updated against
 TASK-19170 — 2026-08-20 (the reasoning-effort selector and the Preserved

--- a/Tests/Workspaces/test_console_workspace_reconcile.py
+++ b/Tests/Workspaces/test_console_workspace_reconcile.py
@@ -23,7 +23,13 @@ from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryServ
 
 
 class _FakeStore:
-    """Exposes only the seams the reconcile reads: `active_session_id`/`sessions()`."""
+    """Exposes only the seams the reconcile reads.
+
+    Mirrors `ConsoleChatStore`'s contract for the active-session lookup:
+    `ensure_session()` is a pure dict hit when `active_session_id` is set
+    (never creates in that case) and raises `KeyError` on a stale id --
+    the reconcile treats that as divergent, same as the old linear scan.
+    """
 
     def __init__(self, active_session_id, sessions):
         self.active_session_id = active_session_id
@@ -31,6 +37,12 @@ class _FakeStore:
 
     def sessions(self):
         return self._sessions
+
+    def ensure_session(self):
+        for session in self._sessions:
+            if session.id == self.active_session_id:
+                return session
+        raise KeyError(self.active_session_id)
 
 
 class _Stub:

--- a/Tests/Workspaces/test_console_workspace_reconcile.py
+++ b/Tests/Workspaces/test_console_workspace_reconcile.py
@@ -14,9 +14,11 @@ session_with_registry`` repairs exactly that gap on every Console resume.
 
 from types import SimpleNamespace
 
+from tldw_chatbook.Chat.console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
+from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
 from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
 
 
@@ -137,6 +139,33 @@ def test_registry_raising_get_active_workspace_is_a_noop(tmp_path):
         sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
     )
     stub = _Stub(_RaisingRegistry(), store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+def test_global_session_aligned_with_registry_default_is_a_noop(tmp_path):
+    """Regression (found live by Tests/UI/test_console_session_settings.py):
+    a session's default/unset `workspace_id` (`CONSOLE_GLOBAL_WORKSPACE_ID`,
+    or "") and the registry's built-in Default workspace row
+    (`DEFAULT_WORKSPACE_ID`) are THE SAME state on two layers (task-15120),
+    not a divergence -- comparing them raw tore down every ordinary mounted
+    session (whose workspace_id defaults to "global") the instant the
+    registry's active workspace was the ordinary resting Default row.
+    """
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="console-reconcile-tests")
+    registry = LocalWorkspaceRegistryService(db)
+    registry.ensure_default_workspace()
+    assert registry.get_active_workspace().workspace_id == DEFAULT_WORKSPACE_ID
+
+    store = _FakeStore(
+        active_session_id="session-global",
+        sessions=[
+            ConsoleChatSession(
+                id="session-global", workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID
+            )
+        ],
+    )
+    stub = _Stub(registry, store)
     ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
     assert stub.calls == []
 

--- a/Tests/Workspaces/test_console_workspace_reconcile.py
+++ b/Tests/Workspaces/test_console_workspace_reconcile.py
@@ -1,0 +1,211 @@
+"""Tests for the TASK-18310 resume-time reconcile seam.
+
+Every IN-Console workspace-activation path (the Alt+W switcher, the shared
+create modal's Console handler, and conversation-browser row-open) calls
+``set_active_workspace`` and ``_activate_console_session_for_workspace``
+together, so the registry and the Console chat store's active session can
+never drift apart from any of those paths. Cross-screen activation --
+Settings' create-modal ``_done``, Library's ``create_local_workspace``
+``_done``, and Settings' "Set active" button (Qodo finding 5 on PR #1809) --
+only calls ``set_active_workspace`` on the registry, so a stale Console
+session can only arise from a cross-screen change. ``_reconcile_console_
+session_with_registry`` repairs exactly that gap on every Console resume.
+"""
+
+from types import SimpleNamespace
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+
+class _FakeStore:
+    """Exposes only the seams the reconcile reads: `active_session_id`/`sessions()`."""
+
+    def __init__(self, active_session_id, sessions):
+        self.active_session_id = active_session_id
+        self._sessions = sessions
+
+    def sessions(self):
+        return self._sessions
+
+
+class _Stub:
+    """House stub pattern (see test_console_workspace_create_handler.py):
+    an unbound method is invoked with this as `self`, exposing exactly the
+    seams the method under test reads. Never name a harness attr `_registry`.
+    """
+
+    def __init__(self, registry, store):
+        self.calls = []
+        self.app_instance = SimpleNamespace(workspace_registry_service=registry)
+        self._store = store
+
+    def _ensure_console_chat_store(self):
+        return self._store
+
+    def _sync_console_chat_core_state(self):
+        self.calls.append("core")
+
+    def _activate_console_session_for_workspace(self, workspace_id):
+        self.calls.append(f"activate:{workspace_id}")
+
+    def _sync_console_workspace_context(self):
+        self.calls.append("context")
+
+    def _sync_native_console_chat_ui(self):
+        return "ui-sync-sentinel"
+
+    def run_worker(self, work, **kw):
+        self.calls.append(f"worker:{work}")
+
+
+def _registry(tmp_path, *, active_id=None):
+    db = WorkspaceDB(tmp_path / "ws.sqlite", client_id="console-reconcile-tests")
+    service = LocalWorkspaceRegistryService(db)
+    service.create_workspace(workspace_id="workspace-a", name="Workspace A")
+    service.create_workspace(workspace_id="workspace-b", name="Workspace B")
+    if active_id:
+        service.set_active_workspace(active_id)
+    return service
+
+
+def test_aligned_session_is_a_cheap_noop(tmp_path):
+    """Session already belongs to the registry's active workspace -> no sync calls."""
+    registry = _registry(tmp_path, active_id="workspace-a")
+    store = _FakeStore(
+        active_session_id="session-a",
+        sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
+    )
+    stub = _Stub(registry, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+def test_cross_screen_change_runs_full_sequence_in_order(tmp_path):
+    """A registry-only activation (simulating Settings/Library) is repaired
+    by running the same four-step sequence the create handler uses, in order.
+    """
+    registry = _registry(tmp_path, active_id="workspace-a")
+    # Simulate the cross-screen change: another surface activates workspace B
+    # via the registry alone (no Console-side session sync).
+    registry.set_active_workspace("workspace-b")
+    store = _FakeStore(
+        active_session_id="session-a",
+        sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
+    )
+    stub = _Stub(registry, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == [
+        "core",
+        "activate:workspace-b",
+        "context",
+        "worker:ui-sync-sentinel",
+    ]
+
+
+def test_no_active_session_is_a_noop(tmp_path):
+    """A fresh/mount flow with no active session owns its own setup -- skip."""
+    registry = _registry(tmp_path, active_id="workspace-a")
+    store = _FakeStore(active_session_id=None, sessions=[])
+    stub = _Stub(registry, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+def test_no_registry_service_is_a_noop(tmp_path):
+    """No registry service wired yet -- return quietly, no raise."""
+    store = _FakeStore(
+        active_session_id="session-a",
+        sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
+    )
+    stub = _Stub(None, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+def test_registry_raising_get_active_workspace_is_a_noop(tmp_path):
+    """A raising registry must never break screen resume."""
+
+    class _RaisingRegistry:
+        def get_active_workspace(self):
+            raise RuntimeError("registry unavailable")
+
+    store = _FakeStore(
+        active_session_id="session-a",
+        sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
+    )
+    stub = _Stub(_RaisingRegistry(), store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+def test_no_active_workspace_is_a_noop(tmp_path):
+    """Registry present but nothing active (e.g. a global conversation) -- skip."""
+    registry = _registry(tmp_path, active_id=None)
+    store = _FakeStore(
+        active_session_id="session-a",
+        sessions=[ConsoleChatSession(id="session-a", workspace_id="workspace-a")],
+    )
+    stub = _Stub(registry, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+    assert stub.calls == []
+
+
+class _RealActivateStub(_Stub):
+    """Runs the REAL `_activate_console_session_for_workspace` body against a
+    real `ConsoleChatStore`, stubbing only the screen-sync seams (the parts
+    that touch the mounted UI, which this unit test has none of).
+    """
+
+    def __init__(self, registry, store):
+        super().__init__(registry, store)
+
+    def _activate_console_session_for_workspace(self, workspace_id):
+        ConsoleWorkspaceController._activate_console_session_for_workspace(
+            self, workspace_id
+        )
+
+    def _capture_console_draft_switch_snapshot(self):
+        pass
+
+    def _sync_console_temporary_chip(self):
+        pass
+
+    def _console_workspace_session_title(self, workspace_id):
+        return f"{workspace_id} Chat"
+
+    def _default_console_session_settings(self):
+        return None
+
+
+def test_end_to_end_library_style_cross_screen_activation_switches_session(tmp_path):
+    """AC#4: activating a workspace from a non-Console surface (a plain
+    registry call, exactly what Library's `create_local_workspace` `_done`
+    and Settings' create-modal/"Set active" do) leaves the Console session on
+    the OLD workspace until this reconcile runs -- as resume would run it --
+    at which point the store's active session belongs to the new workspace.
+    """
+    registry = _registry(tmp_path, active_id="workspace-a")
+    store = ConsoleChatStore()
+    store.create_session(
+        title="Workspace A Chat", workspace_id="workspace-a", settings=None
+    )
+    assert store.active_session_id is not None
+    original_active_session = next(
+        s for s in store.sessions() if s.id == store.active_session_id
+    )
+    assert original_active_session.workspace_id == "workspace-a"
+
+    # "Another surface" (Library/Settings) activates workspace B via the
+    # registry alone -- no Console involvement at all.
+    registry.set_active_workspace("workspace-b")
+
+    stub = _RealActivateStub(registry, store)
+    ConsoleWorkspaceController._reconcile_console_session_with_registry(stub)
+
+    active_session = next(
+        s for s in store.sessions() if s.id == store.active_session_id
+    )
+    assert active_session.workspace_id == "workspace-b"

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5489,3 +5489,39 @@ diff before merging — a deletion feels like it needs no review precisely
 because nothing new was added; (2) a reviewer claim that a guarded artifact is
 "unconsumed" is an untested claim until checked against the gate that
 consumes it — grep for the artifact's path in `Tests/` before agreeing.
+
+## A raw equality check on two IDs that alias the same state misfires the instant that state is the common case (TASK-18310, 2026-08-20)
+
+**What happened.** Implementing a Console resume-time reconcile that compares
+a session's `workspace_id` against the workspace registry's active workspace
+id, the first pass used `session.workspace_id == active.workspace_id` raw.
+That looked obviously correct and passed the task's SPECIFIED regression gate
+(`Tests/Workspaces/`, three named `Tests/UI/` files, a full-suite
+`--collect-only`) cleanly. It was still wrong: this codebase already encodes,
+elsewhere in the very same file (task-15120,
+`_set_active_workspace_for_console_session`), that a session's default/unset
+`workspace_id` (the `CONSOLE_GLOBAL_WORKSPACE_ID` sentinel, `"global"`) and
+the registry's built-in Default workspace row (`DEFAULT_WORKSPACE_ID`,
+`"workspace-default"`) are THE SAME state spelled two ways, not two
+different workspaces that happen to share a session. The raw comparison
+read every ordinary global/unset-workspace mounted session as "diverged"
+the instant the registry's active workspace was its ordinary resting Default
+row — which is the COMMON case, not an edge case — and tore the session down
+to rebuild a fresh one on every single resume. Two tests well outside the
+specified gate (`Tests/UI/test_console_session_settings.py`, picked up by an
+extra author-initiated sweep of every `on_screen_resume`-touching UI test
+file) caught it going from GREEN to RED; the specified gate never happened to
+mount a session with an unset `workspace_id` against a Default-active
+registry, only sessions with explicit non-default ids.
+
+**What to do.** Before comparing two identifiers that come from different
+layers of the same domain concept (a workspace id read off a session vs. one
+read off a registry; a scope key vs. a storage key; anything with a
+"no explicit value" sentinel), grep the surrounding module for an existing
+normalization convention — this codebase had ALREADY solved this exact
+equivalence once, and the second solver (this task) initially didn't reuse
+it. When a task's specified gate is narrower than the surface the change
+actually touches (here: "the three named workspace test files" vs. "every
+call site of `on_screen_resume`"), run the broader sweep anyway before
+declaring done; a gate scoped to the files the task author thought of is not
+the same as a gate scoped to the files the change can reach.

--- a/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
+++ b/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
@@ -30,7 +30,164 @@ fragile sequence per caller.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Activating a workspace from Settings or Library leaves Console — on next visit — in the same runtime state as an in-Console switch to that workspace (session activated or created, store context set, rail synced)
-- [ ] The mechanism is a single shared seam (or resume-time reconcile), not per-surface copies of Console's activation sequence
-- [ ] In-Console switch/create behavior is unchanged (order-pinned tests stay green)
-- [ ] Covered by a test that activates from a non-Console surface and asserts the Console-side session state after resume
+- [x] Activating a workspace from Settings or Library leaves Console — on next visit — in the same runtime state as an in-Console switch to that workspace (session activated or created, store context set, rail synced)
+- [x] The mechanism is a single shared seam (or resume-time reconcile), not per-surface copies of Console's activation sequence
+- [x] In-Console switch/create behavior is unchanged (order-pinned tests stay green)
+- [x] Covered by a test that activates from a non-Console surface and asserts the Console-side session state after resume
+
+## Implementation Plan (the how)
+
+1. Verify the controller ruling's facts: every IN-Console workspace-activation
+   path (`_open_console_workspace_switcher`'s `_switch_to`,
+   `_handle_workspace_create_result`, and the conversation-browser row-open
+   path) calls `set_active_workspace` on the registry AND
+   `_activate_console_session_for_workspace` on `ConsoleWorkspaceController`
+   together — so registry/session drift can only originate from a
+   cross-screen change (Settings' create-modal `_done`, Library's
+   `create_local_workspace` `_done`, Settings' "Set active" button).
+2. Add `ConsoleWorkspaceController._reconcile_console_session_with_registry`
+   in `tldw_chatbook/UI/Console_Modules/workspace.py`: read the registry's
+   active workspace (guarded), read the store's active session (guarded),
+   cheap-exit when aligned or when either side is `None`, otherwise re-run
+   the create-handler's own sequence (`_sync_console_chat_core_state` →
+   `_activate_console_session_for_workspace` → `_sync_console_workspace_
+   context` → `run_worker(_sync_native_console_chat_ui, ...)`) minus the
+   registry write (already done) and the toast (the originating surface
+   already announced).
+3. Wire it into `ChatScreen.on_screen_resume`
+   (`tldw_chatbook/UI/Screens/chat_screen.py`), wrapped in try/except with a
+   debug log, placed after the mount-token consumption but NOT gated by
+   `mount_already_refreshed` — the reconcile is O(1) when aligned, and the
+   mount path itself never reconciles against the registry.
+4. TDD: write `Tests/Workspaces/test_console_workspace_reconcile.py` first
+   (RED — `AttributeError`), following the house stub pattern in
+   `test_console_workspace_create_handler.py` (unbound method invoked on a
+   `_Stub`); cover the cheap-aligned-exit, the cross-screen four-step
+   sequence (order-pinned), no-active-session, no-registry/raising-registry,
+   no-active-workspace, and an end-to-end-ish test against a real
+   `ConsoleChatStore` + real registry that runs the real unbound
+   `_activate_console_session_for_workspace` body. Implement, confirm GREEN.
+5. Run the regression gate (`Tests/Workspaces/`, the three named
+   `Tests/UI/` files, a full-suite `--collect-only`) plus an extra sweep of
+   every `on_screen_resume`-touching UI test file for safety.
+6. Update `Docs/User_Guide/console/sessions-tabs-workspaces.md` and
+   `Docs/User_Guide/settings.md` with a one-sentence note on the new
+   pickup-on-resume behavior, and refresh both pages' "Verified against"
+   stamps.
+
+## Implementation Notes
+
+Implemented the resume-time reconcile per the controller ruling, not a
+push-based cross-screen seam. The invariant that makes this safe: every
+IN-Console workspace-activation path (`_open_console_workspace_switcher`'s
+`_switch_to`, `_handle_workspace_create_result`, and the
+conversation-browser row-open path) already calls `set_active_workspace`
+on the registry AND `_activate_console_session_for_workspace` on
+`ConsoleWorkspaceController` together, in the same call — so those paths
+can never leave the registry and the Console chat store's active session
+disagreeing. Only the three cross-screen callers (Settings' create-modal
+`_done`, Library's `create_local_workspace` `_done`, Settings' "Set
+active" button — the Qodo finding 5 gap on PR #1809) touch only the
+registry. A resume-time reconcile therefore fires exactly when needed
+(after a cross-screen change) and is a true no-op otherwise, which is
+both simpler and safer than adding a new push-based call from three
+separate non-Console surfaces into Console's fragile activate sequence
+(more call sites duplicating that sequence, exactly what the AC #2 "not
+per-surface copies" line rules out).
+
+Added `ConsoleWorkspaceController._reconcile_console_session_with_registry`
+(`tldw_chatbook/UI/Console_Modules/workspace.py`): reads the registry's
+active workspace and the store's active session, both guarded against
+`None`/exceptions (must never break screen resume), cheap-exits when the
+active session's `workspace_id` already matches, and otherwise re-runs the
+create handler's own four-step sequence (`_sync_console_chat_core_state`
+→ `_activate_console_session_for_workspace` → `_sync_console_workspace_
+context` → `run_worker(_sync_native_console_chat_ui, ...)`) minus the
+registry write (already done by the other surface) and the toast (that
+surface already announced the switch). Wired into `ChatScreen.
+on_screen_resume` (`tldw_chatbook/UI/Screens/chat_screen.py`), wrapped in
+try/except with a debug log, placed right after the mount-token
+consumption but deliberately NOT gated by `mount_already_refreshed` — the
+reconcile is O(1) once aligned, and the mount path itself never
+reconciles against the registry, so skipping it on the mount's own resume
+would leave a store session that predates the first mount (the store is
+app-level) permanently unreconciled.
+
+TDD: `Tests/Workspaces/test_console_workspace_reconcile.py` was written
+first and confirmed RED (`AttributeError: type object
+'ConsoleWorkspaceController' has no attribute
+'_reconcile_console_session_with_registry'`) before implementing, then
+GREEN after. Covers: the cheap aligned no-op, the cross-screen four-step
+sequence in ORDER (list-equality, matching the sibling create-handler
+test's style), no-active-session, no-registry-service,
+registry-raises-on-read, no-active-workspace, an AC#4 end-to-end-ish test
+that runs the REAL unbound `_activate_console_session_for_workspace` body
+against a real `ConsoleChatStore` + real `LocalWorkspaceRegistryService`
+(a plain registry `set_active_workspace` call simulating a non-Console
+surface, then the reconcile invoked as resume would) asserting the
+store's active session now belongs to the new workspace, and a regression
+test (below) — 8 tests total.
+
+**Bug caught by the extra sweep, not the specified gate.** The first pass
+compared `active_session.workspace_id == active.workspace_id` raw. That
+misses an established invariant already encoded elsewhere in this same
+file: a session's default `workspace_id` (unset, or the explicit
+`CONSOLE_GLOBAL_WORKSPACE_ID` sentinel `"global"`) and the registry's
+built-in Default workspace row (`DEFAULT_WORKSPACE_ID`,
+`"workspace-default"`) are THE SAME state on two layers (task-15120 owner
+ruling, see `_set_active_workspace_for_console_session`), not two
+different workspaces. The raw comparison read every ordinary
+global/unset-workspace mounted session as diverged the instant the
+registry's active workspace was its normal resting Default row, tearing
+the session down and rebuilding a fresh "Default Chat" session on every
+resume. Two tests outside the specified gate caught it going from GREEN
+to RED (`Tests/UI/test_console_session_settings.py::
+test_mounted_first_chat_ack_exception_during_resume_restores_ui` and
+`::test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume`,
+both of which call `on_screen_resume` on a mounted session with the
+default sentinel workspace_id). Fixed with a module-level
+`_normalized_console_workspace_id` helper that folds both sentinels onto
+`DEFAULT_WORKSPACE_ID` before comparing, and pinned with a new regression
+test, `test_global_session_aligned_with_registry_default_is_a_noop`
+(8th test in the file) — mutation-style: reverting the normalization
+turns it red again, confirmed manually. This is exactly the kind of trap
+`backlog/docs/lessons-testing-evidence.md` warns about (a guard that
+looks right until it meets a live fixture) — the specified gate
+(`Tests/Workspaces/`, the 3 named `Tests/UI/` files) never exercised a
+mounted session with an unset workspace_id, only ones with explicit
+non-default ids; the broader sweep is what surfaced it.
+
+**Pre-existing, unrelated flake found during triage.**
+`test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume`
+still fails intermittently after the fix, but on a DIFFERENT assertion
+each run (once a `elapsed < 0.5` timing check, once a
+`weakref` GC-liveness check) — and reproduces identically, byte-for-byte,
+against a throwaway worktree of unmodified `origin/dev` (no TASK-18310
+code present at all). Confirmed NOT a regression from this change; left
+untouched per the ACs (fixing it is out of scope here) and not filed as a
+new task since it needs its own investigation session, not a drive-by
+note.
+
+Regression gate, all green: `Tests/Workspaces/ -q` (273 passed, includes
+the order-pinned create-handler tests for AC#3 and the new regression
+test); `Tests/UI/test_console_workspace_lifecycle.py
+Tests/UI/test_console_workspace_controller.py
+Tests/UI/test_console_new_workspace.py -q` (35 passed);
+`Tests/ --collect-only -q` (52236 tests collected, no collection errors).
+Additionally swept every UI test file that exercises `on_screen_resume`
+directly (`test_console_visit_dispatch_dedupe.py`,
+`test_settings_panel_scoped_updates.py`, `test_console_workbench_
+contract.py`, `test_console_session_settings.py`,
+`test_settings_workspaces_category.py`,
+`test_settings_configuration_hub.py`, `test_console_command_composer.py`,
+`test_console_native_chat_flow.py`, `test_console_internals_
+decomposition.py`) as extra insurance beyond the specified gate, since the
+new call sits directly in that method — this second pass is what caught
+the normalization bug above; after the fix only the one pre-existing,
+dev-reproducible flake remains.
+
+Files touched: `tldw_chatbook/UI/Console_Modules/workspace.py`,
+`tldw_chatbook/UI/Screens/chat_screen.py`,
+`Tests/Workspaces/test_console_workspace_reconcile.py` (new),
+`Docs/User_Guide/console/sessions-tabs-workspaces.md`,
+`Docs/User_Guide/settings.md`.

--- a/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
+++ b/backlog/tasks/task-18310 - Centralized-workspace-activation-seam-for-cross-screen-Console-runtime-sync.md
@@ -1,15 +1,15 @@
 ---
 id: TASK-18310
-title: >-
-  Centralized workspace activation seam for cross-screen Console runtime sync
-status: To Do
+title: Centralized workspace activation seam for cross-screen Console runtime sync
+status: Done
 assignee: []
 created_date: '2026-08-18 15:30'
+updated_date: '2026-08-21 05:22'
 labels:
   - workspaces
   - console
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description (the why)
@@ -77,6 +77,7 @@ fragile sequence per caller.
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 Implemented the resume-time reconcile per the controller ruling, not a
 push-based cross-screen seam. The invariant that makes this safe: every
 IN-Console workspace-activation path (`_open_console_workspace_switcher`'s
@@ -191,3 +192,4 @@ Files touched: `tldw_chatbook/UI/Console_Modules/workspace.py`,
 `Tests/Workspaces/test_console_workspace_reconcile.py` (new),
 `Docs/User_Guide/console/sessions-tabs-workspaces.md`,
 `Docs/User_Guide/settings.md`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1948,14 +1948,15 @@ class ConsoleWorkspaceController:
             # Fresh-start/mount flows own creating the first session
             # themselves -- be conservative and let them.
             return
-        active_session = next(
-            (
-                session
-                for session in store.sessions()
-                if session.id == store.active_session_id
-            ),
-            None,
-        )
+        # O(1) active-session lookup (Qodo, PR #1880): with the None guard
+        # above satisfied, ensure_session() is a pure dict hit -- it only
+        # creates when active_session_id is None, which cannot be the case
+        # here. A stale id raising KeyError degrades to None, preserving the
+        # prior linear-scan semantics (treated as divergent -> reconcile).
+        try:
+            active_session = store.ensure_session()
+        except KeyError:
+            active_session = None
         if active_session is not None and _normalized_console_workspace_id(
             active_session.workspace_id
         ) == _normalized_console_workspace_id(active.workspace_id):

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -86,6 +86,26 @@ logger = logger.bind(module="ChatScreen")
 CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
 
 
+def _normalized_console_workspace_id(workspace_id: str | None) -> str:
+    """Fold the "no explicit workspace" sentinels onto one identity.
+
+    A Console session's default ``workspace_id`` (unset, or the explicit
+    ``CONSOLE_GLOBAL_WORKSPACE_ID`` sentinel) and the registry's built-in
+    Default workspace row (``DEFAULT_WORKSPACE_ID`` --
+    ``ensure_default_workspace`` floors every context read to it) are THE
+    SAME state on two layers (task-15120 owner ruling, see
+    ``_set_active_workspace_for_console_session``), not two different
+    workspaces that happen to share a session. Any comparison between a
+    session's ``workspace_id`` and a registry workspace id must normalize
+    through this before comparing, or an aligned "global"/Default session
+    reads as diverged purely because of which layer's spelling it carries.
+    """
+    normalized = str(workspace_id or "").strip()
+    if not normalized or normalized == CONSOLE_GLOBAL_WORKSPACE_ID:
+        return DEFAULT_WORKSPACE_ID
+    return normalized
+
+
 class ConsoleWorkspaceController:
     """Own Workspace lifecycle, resume, scope, and conversation browsing.
 
@@ -1891,6 +1911,23 @@ class ConsoleWorkspaceController:
         Deliberately conservative: any read of the registry is guarded, and
         a ``None`` registry, ``None`` active workspace, or ``None`` active
         session all return quietly -- this must never break screen resume.
+
+        Comparison is normalized, not a bare ``==``: a session's default
+        ``workspace_id`` is the "no explicit workspace" sentinel
+        (``CONSOLE_GLOBAL_WORKSPACE_ID``, `""` is treated the same), while
+        the registry represents that identical state as its built-in
+        Default workspace row (``DEFAULT_WORKSPACE_ID`` --
+        ``ensure_default_workspace`` floors every context read to it). Per
+        the task-15120 owner ruling (see
+        ``_set_active_workspace_for_console_session``), those two spellings
+        are THE SAME state on two layers, not a divergence -- comparing
+        them raw here misfired on every plain/global mounted session
+        whenever the registry's active workspace was Default (its ordinary
+        resting state), tearing down a perfectly aligned session and
+        replacing it with a fresh one on every resume. Caught by two
+        existing tests going from GREEN to RED with the naive comparison
+        (`test_mounted_first_chat_ack_exception_during_resume_restores_ui`,
+        `test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_resume`).
         """
         registry_service = getattr(
             self.app_instance, "workspace_registry_service", None
@@ -1919,10 +1956,9 @@ class ConsoleWorkspaceController:
             ),
             None,
         )
-        if (
-            active_session is not None
-            and active_session.workspace_id == active.workspace_id
-        ):
+        if active_session is not None and _normalized_console_workspace_id(
+            active_session.workspace_id
+        ) == _normalized_console_workspace_id(active.workspace_id):
             return
         self._sync_console_chat_core_state()
         self._activate_console_session_for_workspace(active.workspace_id)

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -1860,6 +1860,77 @@ class ConsoleWorkspaceController:
         # previous session was temporary.
         self._sync_console_temporary_chip()
 
+    def _reconcile_console_session_with_registry(self) -> None:
+        """Align the Console session with the registry's active workspace.
+
+        TASK-18310: every IN-Console workspace-activation path -- the Alt+W
+        switcher (``_open_console_workspace_switcher``'s ``_switch_to``), the
+        shared create modal's Console handler
+        (``_handle_workspace_create_result``), and conversation-browser
+        row-open (``_activate_console_workspace_for_browser_row`` plus the
+        session lookup around it) -- calls ``set_active_workspace`` on the
+        registry AND ``_activate_console_session_for_workspace`` on this
+        controller together, so the registry and the Console chat store's
+        active session can never drift apart from any of those paths.
+        Cross-screen activation -- Settings' create-modal ``_done``,
+        Library's ``create_local_workspace`` ``_done``, and Settings' "Set
+        active" button (Qodo finding 5 on PR #1809) -- only calls
+        ``set_active_workspace`` on the registry, so registry/session
+        misalignment can arise EXCLUSIVELY from a cross-screen change.
+
+        Called from ``ChatScreen.on_screen_resume`` on every Console resume
+        (including the mount's own -- the store is app-level and can carry
+        a session that predates the first mount). When already aligned --
+        the overwhelmingly common case, since every in-Console path keeps
+        them in lockstep -- this is an O(1) early exit. Only on an actual
+        cross-screen divergence does it re-run the same Console-side
+        activation sequence the create handler uses, minus the registry
+        write (already done by the other surface) and the toast (the
+        originating surface already announced the switch).
+
+        Deliberately conservative: any read of the registry is guarded, and
+        a ``None`` registry, ``None`` active workspace, or ``None`` active
+        session all return quietly -- this must never break screen resume.
+        """
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        if registry_service is None:
+            return
+        try:
+            active = registry_service.get_active_workspace()
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Unable to read active workspace during Console resume reconcile"
+            )
+            return
+        if active is None:
+            return
+        store = self._ensure_console_chat_store()
+        if store.active_session_id is None:
+            # Fresh-start/mount flows own creating the first session
+            # themselves -- be conservative and let them.
+            return
+        active_session = next(
+            (
+                session
+                for session in store.sessions()
+                if session.id == store.active_session_id
+            ),
+            None,
+        )
+        if (
+            active_session is not None
+            and active_session.workspace_id == active.workspace_id
+        ):
+            return
+        self._sync_console_chat_core_state()
+        self._activate_console_session_for_workspace(active.workspace_id)
+        self._sync_console_workspace_context()
+        self.run_worker(
+            self._sync_native_console_chat_ui(), exclusive=True, group="console-sync"
+        )
+
     def _console_workspace_session_title(self, workspace_id: str) -> str:
         """Return a readable title for an auto-created workspace Console tab."""
         registry_service = getattr(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -20851,6 +20851,27 @@ class ChatScreen(BaseAppScreen):
         # so every subsequent resume refreshes normally.
         mount_already_refreshed = self._console_mount_visit_refreshed
         self._console_mount_visit_refreshed = False
+        # task-18310: reconcile the Console session against the registry's
+        # active workspace on EVERY resume, including the mount's own --
+        # deliberately NOT gated by `mount_already_refreshed` like the
+        # worker refreshes below. Every in-Console activation path (Alt+W
+        # switcher, the shared create modal, conversation-browser row-open)
+        # already keeps the registry and the store's active session in
+        # lockstep, so the common case is an O(1) early exit; the mount
+        # path itself never reconciles against the registry, and the store
+        # is app-level (it can carry a session that predates this screen's
+        # first mount), so skipping it here on the mount's own resume would
+        # leave that gap uncaught. Cross-screen activation (Settings'
+        # create-modal/"Set active" button, Library's create-workspace
+        # flow) only updates the registry -- this is the seam that repairs
+        # the resulting drift. See
+        # `ConsoleWorkspaceController._reconcile_console_session_with_registry`.
+        try:
+            self._workspace._reconcile_console_session_with_registry()
+        except Exception:
+            logger.opt(exception=True).debug(
+                "Unable to reconcile Console session with registry-active workspace"
+            )
         self.consume_pending_console_first_chat_intent()
         # Re-evaluate setup-card/model readiness before touching focus. Some
         # recovery flows (e.g. certain providers' API-key recovery) navigate to


### PR DESCRIPTION
## Summary

Closes the cross-screen activation gap Qodo flagged on #1809 (filed as TASK-18310): activating a workspace from Settings or Library only updated the registry — Console's chat session stayed on the previous workspace until a manual in-Console switch.

**Design — resume-time reconcile**, not cross-screen plumbing: every in-Console path (Alt+W switcher, create modal, browser row-open) already keeps registry⟷session aligned, so misalignment arises *exclusively* from cross-screen changes. A cheap reconcile on Console `on_screen_resume` (`_reconcile_console_session_with_registry`) therefore fires exactly when needed: aligned → O(1) early exit; diverged → the existing Console activation sequence (core-state sync → session activate/create → rail resync → native UI worker), no toast (the originating surface already announced). Exception-guarded end-to-end — a raising registry can never break screen resume.

**Bug found and fixed during the author's extended sweep**: raw workspace-id equality didn't know the session-side `CONSOLE_GLOBAL_WORKSPACE_ID` sentinel and the registry's `DEFAULT_WORKSPACE_ID` are the same state (task-15120 invariant) — the reconcile would have spuriously re-activated on every resume of a global session under the Default workspace. Fixed with `_normalized_console_workspace_id` applied to both comparison sides; regression test is mutation-verified (reverting to raw `==` turns exactly that test red).

8 new tests (`Tests/Workspaces/test_console_workspace_reconcile.py`): real registry + real `ConsoleChatStore`, order-pinned divergence sequence, cheap-exit asserts zero calls, end-to-end library-style activation runs the real `_activate_console_session_for_workspace` body. User Guide (console workspaces + settings pages) notes the picked-up-on-next-visit behavior.

## Verification

CI intentionally cancelled — verified locally: RED (8 AttributeError) → GREEN; `Tests/Workspaces/` 273 passed (includes the order-pinned in-Console sequence tests — AC#3); named UI files 35 passed; a 1,143-test sweep of every `on_screen_resume`-touching UI file (1 residual failure reproduces byte-for-byte on unmodified origin/dev in a throwaway worktree — pre-existing GC-timing flake, untouched surface); 52,236-test collect sweep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles Console’s active session with the registry’s active workspace on screen resume to close the cross‑screen activation gap (TASK-18310). Previously, activating from Settings/Library only updated the registry and left Console on the old workspace until a manual switch; now Console auto-aligns on resume without user prompts.

- Adds `_reconcile_console_session_with_registry` and calls it unconditionally from `ChatScreen.on_screen_resume`; exceptions are caught to avoid breaking resume.
- Normalizes workspace ids via `_normalized_console_workspace_id` so `CONSOLE_GLOBAL_WORKSPACE_ID` and `DEFAULT_WORKSPACE_ID` are treated as the same state, preventing false re-activations for Default/global sessions.
- On divergence, reuses the existing Console activation sequence: `_sync_console_chat_core_state` → `_activate_console_session_for_workspace` → `_sync_console_workspace_context` → `run_worker(_sync_native_console_chat_ui)`; no registry write or toast.
- Active-session lookup is now O(1) via `ConsoleChatStore.ensure_session()` (replacing a linear scan), so aligned cases exit fast; in-Console switching behavior is unchanged.
- Docs note “picked up on next visit.” Tests: 8 new cases, including an end‑to‑end cross‑screen activation flow and a regression for the Default/global normalization.

<sup>Written for commit 35a9fa02df910517e3ee7d4227109175f3b03a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

