### PR TITLE
docs(backlog): file TASK-19425 — Core CI jobs exceed their 120-minute ceiling

### DIFF
--- a/backlog/tasks/task-19425 - Core CI jobs now exceed their 120-minute ceiling and get canceled mid-suite.md
+++ b/backlog/tasks/task-19425 - Core CI jobs now exceed their 120-minute ceiling and get canceled mid-suite.md
@@ -1,0 +1,48 @@
+---
+id: TASK-19425
+title: >-
+  Core CI jobs now exceed their 120-minute ceiling and get canceled mid-suite
+status: To Do
+assignee: []
+created_date: '2026-08-21'
+labels: [ci, testing, triage]
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+With TASK-19160's fix in (PR #1858), the Core jobs no longer die on the
+xdist INTERNALERROR — the workers survive the full run. What that exposed:
+**both Core jobs now hit `timeout-minutes: 120`** (`test.yml` line 50) and
+are canceled while still making progress, so the job reports no test
+summary at all.
+
+The growth trend predates 19160 and is visible in merged PRs' Core
+durations (ubuntu): **#1840 79 min → #1835 87 min → #1823 121 min
+(canceled) → #1858 120 min (canceled, both platforms)**. Dev gained ~17
+PRs on 2026-08-19/20 (realtime voice, research runs, focus mode, latency
+guardrails, …), and the all-but-UI suite was ~20.6k tests at the last
+completed count.
+
+Confounder to rule out at measurement time: the #1858 runs executed on
+runners after a ~7-hour queue backlog (03:40–06:00 UTC), which may inflate
+wall-time; #1835's runs at similar hours took 61–87 min, so backlog alone
+does not explain the full jump.
+
+## Acceptance Criteria (the what)
+
+- [ ] The slowest test files/modules in a Core run are measured (pytest
+      `--durations` or the json-report artifact), not guessed — naming
+      whether the growth is a few pathological tests, a hang, or broad
+      accretion
+- [ ] A deliberate remedy ships: split/shard the Core job, raise the
+      ceiling with the reason recorded, or fix the named slow tests —
+      chosen from the measurement, with the owner consulted if the ceiling
+      moves
+- [ ] Both Core jobs complete (pass or fail) within their ceiling on a PR
+      run, reporting a real test summary
+- [ ] Any per-test timeout interaction is checked: `--timeout=300` with
+      `timeout_method = "thread"` kills the whole worker process on a
+      single hung test, which under `--max-worker-restart=3` can silently
+      re-run large scopes and multiply wall-time


### PR DESCRIPTION
## One task file, no code

With TASK-19160 merged (#1858), the Core jobs no longer die on the xdist INTERNALERROR — both ran the full 120 minutes with **zero worker crashes** in either log. What that exposed: they now hit `timeout-minutes: 120` and get **canceled mid-suite with no test summary at all**.

The growth predates the fix — ubuntu Core across merged PRs: **#1840 79 min → #1835 87 min → #1823 121 min (canceled) → #1858 120 min (canceled, both platforms)** — while ~17 PRs landed on dev over 2026-08-19/20.

Filed measurement-first: name the slow tests/hang before choosing between sharding the job, raising the ceiling (owner call), or fixing named tests. One interaction flagged for the measurement: `--timeout=300` with `timeout_method = "thread"` kills the whole worker on a single hung test, and `--max-worker-restart=3` then silently re-runs large scopes — a plausible wall-time multiplier.

The runner-backlog confounder (the #1858 run sat ~7 h in queue and executed at 03:40 UTC) is recorded in the task to be ruled out at measurement time.

Refs TASK-19425, TASK-19160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents that Core CI jobs now hit the 120-minute `timeout-minutes` ceiling and are canceled mid-suite, hiding test summaries. Previously they failed earlier on a `pytest-xdist` INTERNALERROR; after TASK-19160 the workers survive and expose the timeout.

- Adds a single backlog task doc; no code changes.
- Calls out `test.yml`’s 120-minute ceiling and the recent runtime trend that now exceeds it.
- Aligns with TASK-19425: measure slowest tests via `pytest --durations` or JSON report, then either shard Core, raise the ceiling with owner sign-off, or fix named slow tests; ensure both Core jobs finish within the ceiling with a real summary.
- Flags `pytest-timeout` (timeout=300, thread) + `pytest-xdist` + `--max-worker-restart=3` interaction that can multiply wall time.
- Notes runner backlog as a confounder to verify, not assume.

<sup>Written for commit 7f52f05cd3b07e7270e09eeb9326eab49a518fe5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

