### PR TITLE
chore: close TASK-17962/17964 follow-up batches — seam tests, provenance, pluralization, documented rulings

### DIFF
--- a/Tests/Skills/test_project_skills_import_modal.py
+++ b/Tests/Skills/test_project_skills_import_modal.py
@@ -1,11 +1,12 @@
 import asyncio
 import os
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
 from textual import on
 from textual.app import App
-from textual.widgets import Checkbox
+from textual.widgets import Checkbox, Static
 
 from tldw_chatbook.Skills_Interop.project_skills_discovery import (
     discover_project_skills,
@@ -220,6 +221,83 @@ async def test_escape_on_results_phase_dismisses_as_imported(tmp_path):
     decision, outcomes = app.result
     assert decision == "imported"
     assert outcomes is not None and len(outcomes) == 2
+
+
+# ---------------------------------------------------------------------------
+# TASK-17964 follow-ups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_offer_footer_renders_skipped_and_truncated_lines(tmp_path):
+    """``_offer_footer_lines``'s two branches -- neither exercised by any
+    existing test before now: a discovery with ``skipped`` entries renders
+    ``Skipped: <names>``, and ``truncated > 0`` renders "N more not shown".
+    """
+    base_discovery = _discovery(tmp_path, names=("alpha-skill",))
+    discovery = replace(
+        base_discovery,
+        skipped=(("weird-file", "no SKILL.md"), ("sneaky", "symlink")),
+        truncated=4,
+    )
+
+    async def _importer(entry):
+        raise AssertionError("importer should not run in this footer-only test")
+
+    modal = ProjectSkillsImportModal(
+        discovery=discovery, installed_names=frozenset(), importer=_importer
+    )
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        footer = modal.query_one("#project-skills-footer", Static)
+        text = str(footer.renderable)
+
+    assert "Skipped: weird-file, sneaky" in text
+    assert "4 more not shown" in text
+
+
+@pytest.mark.asyncio
+async def test_offer_phase_checkbox_label_escapes_markup_literally(tmp_path):
+    """A markup-hostile skill ``description`` must render as literal text
+    in the Checkbox label -- ``escape_markup()`` at the
+    ``_compose_offer_phase`` call site is the only thing defending this,
+    with no assertion pinning it before now.
+
+    The description must be YAML-quoted: unquoted brackets break the
+    frontmatter's YAML grammar and degrade to an EMPTY description
+    entirely (this file's shared ``_discovery()`` helper's unquoted
+    ``[red]desc[/red] for {name}`` hits exactly that, so it can't be
+    reused here) -- see the discovery-layer fixtures already covering this
+    in ``Tests/Skills/test_project_skills_discovery.py``
+    (``test_hostile_description_survives_as_plain_data``,
+    ``test_unparseable_frontmatter_degrades_to_empty_description``).
+    """
+    skill_dir = tmp_path / ".SKILLS" / "alpha-skill"
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        '---\ndescription: "[red]evil[/red]"\n---\nBody\n', encoding="utf-8"
+    )
+    discovery = discover_project_skills(tmp_path)
+    assert discovery is not None
+    assert discovery.entries[0].description == "[red]evil[/red]"  # sanity
+
+    async def _importer(entry):
+        raise AssertionError("importer should not run in this test")
+
+    modal = ProjectSkillsImportModal(
+        discovery=discovery, installed_names=frozenset(), importer=_importer
+    )
+    app = _HarnessApp(modal)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        checkbox = modal.query_one("#project-skill-row-0", Checkbox)
+        label = checkbox.label
+
+    assert "[red]evil[/red]" in label.plain
+    # No "red" style span was produced -- the brackets were never
+    # interpreted as a markup tag.
+    assert not any(span.style == "red" for span in label.spans)
 
 
 class _StubSkillsScopeService:

--- a/Tests/UI/test_settings_workspaces_category.py
+++ b/Tests/UI/test_settings_workspaces_category.py
@@ -191,6 +191,68 @@ async def test_create_rename_archive_unarchive_flow() -> None:
 
 
 @pytest.mark.asyncio
+async def test_activation_failure_surfaces_inline_but_creates_workspace() -> None:
+    """TASK-17962: ``set_active_workspace`` raising after a successful
+    create on the Settings surface must not crash the handler -- the
+    failure shows up inline (``#settings-workspaces-result``) while the
+    workspace itself still exists, mirroring the Console/Library seam
+    tests for the same activation-failure path (Library:
+    ``test_create_workspace_recomposes_after_activation_failure`` in
+    ``Tests/UI/test_post_release_workspaces_library_depth.py``).
+    """
+    from unittest.mock import patch
+
+    from textual.widgets import Button, Input
+
+    from tldw_chatbook.Workspaces.registry_service import (
+        WorkspaceRegistryServiceError,
+    )
+
+    app = _build_test_app(configured_default="settings")
+    registry = app.workspace_registry_service
+
+    with patch(
+        "tldw_chatbook.app.get_cli_setting",
+        side_effect=_settings_without_splash,
+    ):
+        async with app.run_test(size=(180, 50)) as pilot:
+            screen = await _wait_for_settings_screen(app, pilot)
+            await _wait_for_selector(screen, pilot, "#settings-category-workspaces")
+            category = screen.query_one("#settings-category-workspaces", Button)
+            category.scroll_visible(animate=False)
+            category.press()
+            await _wait_for_selector(screen, pilot, "#settings-workspace-create")
+
+            def _boom(workspace_id: str) -> None:
+                raise WorkspaceRegistryServiceError("boom")
+
+            registry.set_active_workspace = _boom
+
+            screen.query_one("#settings-workspace-create", Button).press()
+            await pilot.pause()
+            modal = app.screen
+            assert modal is not screen
+            await _wait_for_selector(modal, pilot, "#workspace-create-name")
+            modal.query_one("#workspace-create-name", Input).value = "Client Z"
+            # Leave "Switch to this workspace" checked (default) so Create
+            # actually attempts activation.
+            modal.query_one("#workspace-create-confirm", Button).press()
+            await pilot.pause()
+
+            created: list = []
+            for _ in range(200):
+                created = [
+                    w for w in registry.list_workspaces() if w.name == "Client Z"
+                ]
+                if created and "boom" in _visible_text(screen):
+                    break
+                await pilot.pause(0.01)
+
+            assert created, "workspace creation itself must have succeeded"
+            assert "boom" in _visible_text(screen)
+
+
+@pytest.mark.asyncio
 async def test_compact_overview_keeps_a_painted_recovery_action() -> None:
     """The full Settings app keeps one real action above the compact fold."""
     from unittest.mock import patch

--- a/Tests/Workspaces/test_console_workspace_create_handler.py
+++ b/Tests/Workspaces/test_console_workspace_create_handler.py
@@ -3,7 +3,10 @@ from types import SimpleNamespace
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateResult
-from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+)
 
 
 class _Stub:
@@ -79,6 +82,36 @@ def test_failed_folders_surface_as_warnings(tmp_path):
     )
     ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
     assert any("Folder does not exist" in n for n in stub.notifications)
+
+
+class _RaisingActivateRegistry:
+    """Wraps a real registry; ``set_active_workspace`` always raises
+    (TASK-17962: the Console activation-failure seam)."""
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def set_active_workspace(self, workspace_id):
+        raise WorkspaceRegistryServiceError("could not activate")
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_activation_failure_notifies_error_and_skips_sync(tmp_path):
+    """TASK-17962: ``set_active_workspace`` raising after a successful
+    create must not crash the handler -- it notifies an error and must not
+    run the post-activation sync sequence (core state / session activation
+    / context sync / UI worker), mirroring the Library seam test
+    (``test_create_workspace_recomposes_after_activation_failure``).
+    """
+    stub = _Stub(_RaisingActivateRegistry(_registry(tmp_path)))
+    result = WorkspaceCreateResult(
+        workspace_id="workspace-local-1", name="Workspace 1", make_active=True
+    )
+    ConsoleWorkspaceController._handle_workspace_create_result(stub, result)
+    assert stub.calls == []
+    assert any("could not be activated" in n for n in stub.notifications)
 
 
 def test_result_with_project_skills_offers_import(tmp_path, monkeypatch):

--- a/Tests/Workspaces/test_workspace_create_modal.py
+++ b/Tests/Workspaces/test_workspace_create_modal.py
@@ -55,7 +55,7 @@ class _FlakyBindRegistry:
 
 
 class _HarnessApp(App[None]):
-    def __init__(self, registry):
+    def __init__(self, registry, *, description: str | None = None):
         super().__init__()
         # NOTE: `App.__init__` already defines `self._registry` (a WeakSet of
         # mounted DOM nodes, consulted at shutdown in `_close_all`). Naming
@@ -63,15 +63,20 @@ class _HarnessApp(App[None]):
         # teardown with `TypeError: '...' object is not iterable`, so the
         # harness's own workspace registry gets a non-colliding name.
         self._workspace_registry = registry
+        # Optional per-test override of the modal's ``description`` kwarg
+        # (TASK-17962 provenance test) -- ``None`` means "don't pass it",
+        # exercising the modal's own default instead.
+        self._modal_description = description
         self.result = "unset"
 
     def on_mount(self) -> None:
         def _done(result):
             self.result = result
 
-        self.push_screen(
-            WorkspaceCreateModal(registry_service=self._workspace_registry), _done
-        )
+        kwargs: dict = {"registry_service": self._workspace_registry}
+        if self._modal_description is not None:
+            kwargs["description"] = self._modal_description
+        self.push_screen(WorkspaceCreateModal(**kwargs), _done)
 
 
 @pytest.mark.asyncio
@@ -432,7 +437,11 @@ async def test_folder_with_skills_annotated_and_carried_on_result(tmp_path):
         await pilot.click("#workspace-create-folder-add")
         await pilot.pause()
         rows = [str(s.renderable) for s in modal.query(".workspace-create-folder-locator")]
-        assert any("1 project skill" in row for row in rows)
+        # TASK-17964: exact grammar, not merely a substring -- must read
+        # "1 project skill", never the old literal "1 project skill(s)".
+        assert any(
+            row == f"{project.resolve()} — contains 1 project skill" for row in rows
+        ), rows
         await pilot.click("#workspace-create-confirm")
         await pilot.pause()
     assert len(app.result.project_skills) == 1
@@ -500,7 +509,9 @@ async def test_removed_and_rescanned_folder_clears_stale_discovery(tmp_path):
         rows = [
             str(s.renderable) for s in modal.query(".workspace-create-folder-locator")
         ]
-        assert any("1 project skill" in row for row in rows)
+        assert any(
+            row == f"{project.resolve()} — contains 1 project skill" for row in rows
+        ), rows
 
         # Remove the folder -- its discovery must be popped, not left stale.
         modal.query_one("#workspace-create-folder-remove-0", Button).press()
@@ -521,3 +532,153 @@ async def test_removed_and_rescanned_folder_clears_stale_discovery(tmp_path):
         await pilot.click("#workspace-create-confirm")
         await pilot.pause()
     assert app.result.project_skills == ()
+
+
+# ---------------------------------------------------------------------------
+# TASK-17962 follow-ups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_key_on_name_input_submits_via_real_keypress(tmp_path):
+    """The Enter-submit fast path (``Input.Submitted`` on
+    ``#workspace-create-name`` -> ``_create``) driven by a REAL keypress,
+    not a direct ``modal._create()`` call or a Button press -- the
+    task-17961 blind-spot lesson: a synthetic call can pass while the real
+    focus/keypress path is broken.
+    """
+    registry = _registry(tmp_path)
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, WorkspaceCreateModal)
+        name_input = modal.query_one("#workspace-create-name", Input)
+        # AUTO_FOCUS already targets this input on mount, but assert the
+        # precondition explicitly -- the keypress must land where the user
+        # would actually be typing.
+        assert modal.focused is name_input
+        name_input.value = "Video Tool"
+        await pilot.press("enter")
+        await pilot.pause()
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    assert result.name == "Video Tool"
+    assert len(registry.list_workspaces()) == 1
+
+
+@pytest.mark.asyncio
+async def test_real_toctou_folder_deleted_before_create_shows_inline_failure(tmp_path):
+    """A real TOCTOU race: the folder validates and is added at Add time,
+    then is deleted from disk before Create actually attempts the binding
+    -- ``failed_folders`` must come from the real ``add_folder_binding()``
+    call raising, not a synthetic result object or a stubbed registry.
+    """
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+
+        # The race: the bound folder disappears between Add and Create.
+        shutil.rmtree(project)
+
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+
+        assert app.screen is modal
+        assert app.result == "unset"  # still open -- Finding 7's retry state
+        error = modal.query_one("#workspace-create-error", Static)
+        assert str(project.resolve()) in str(error.renderable)
+        assert "does not exist" in str(error.renderable)
+
+    # The workspace itself was created -- only the folder binding failed.
+    created = registry.list_workspaces()
+    assert len(created) == 1
+    assert created[0].name == "Video Tool"
+    assert registry.list_folder_bindings(created[0].workspace_id) == ()
+
+
+@pytest.mark.asyncio
+async def test_make_active_checkbox_survives_folder_add_recompose(tmp_path):
+    """Unchecking "Switch to this workspace" via a REAL click, then adding a
+    folder (which triggers ``refresh(recompose=True)``), must not silently
+    reset the checkbox back to checked -- ``_stash_form_state`` is what
+    preserves it across the rebuild.
+    """
+    registry = _registry(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        await pilot.click("#workspace-create-make-active")
+        await pilot.pause()
+        assert (
+            modal.query_one("#workspace-create-make-active", Checkbox).value is False
+        )
+
+        modal.query_one("#workspace-create-folder-path", Input).value = str(project)
+        await pilot.click("#workspace-create-folder-add")
+        await pilot.pause()
+
+        # compose() re-ran (a new folder row now exists) -- the checkbox
+        # widget was rebuilt too, and must still read unchecked.
+        assert modal.query(".workspace-create-folder-item")
+        assert (
+            modal.query_one("#workspace-create-make-active", Checkbox).value is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_surface_description_is_carried_onto_created_record(tmp_path):
+    """TASK-17962 controller ruling: per-surface ``description`` provenance
+    is restored -- a caller-supplied ``description`` reaches
+    ``create_workspace`` verbatim, so the created record still says which
+    surface it came from (the wording Console/Settings/Library each pass
+    is pinned in their own handler tests / by inspection; this test pins
+    the modal's own plumbing all three share).
+    """
+    registry = _registry(tmp_path)
+    # Mirrors what Console's _create_console_workspace passes into the
+    # shared modal's constructor.
+    app = _HarnessApp(registry, description="Local workspace created from Console.")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    stored = registry.get_workspace(result.workspace_id)
+    assert stored is not None
+    assert stored.description == "Local workspace created from Console."
+
+
+@pytest.mark.asyncio
+async def test_default_description_used_when_surface_passes_none(tmp_path):
+    """Without an explicit ``description``, the modal falls back to its own
+    generic wording rather than an empty string."""
+    registry = _registry(tmp_path)
+    app = _HarnessApp(registry)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Video Tool"
+        await pilot.click("#workspace-create-confirm")
+        await pilot.pause()
+
+    result = app.result
+    assert isinstance(result, WorkspaceCreateResult)
+    stored = registry.get_workspace(result.workspace_id)
+    assert stored is not None
+    assert stored.description == "Created from the workspace setup dialog."

--- a/backlog/tasks/task-17962 - Workspace-create-modal-follow-up-tests-and-typed-seams.md
+++ b/backlog/tasks/task-17962 - Workspace-create-modal-follow-up-tests-and-typed-seams.md
@@ -2,7 +2,7 @@
 id: TASK-17962
 title: >-
   Workspace create modal: follow-up tests and typed seams
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-17 21:00'
 labels:
@@ -23,15 +23,134 @@ typed before that work builds on them.
 
 ## Acceptance Criteria (the what)
 
-- [ ] Activation-failure path (`set_active_workspace` raising after a successful create) has a seam test on each surface: Console handler, Settings `_done`, Library `_done` (Library's reorder is already pinned; Console/Settings are not)
-- [ ] The Enter-submit fast path (`Input.Submitted` on `#workspace-create-name` → `_create`) has a pilot test using a real keypress (not a direct method call), per the task-17961 blind-spot lesson
-- [ ] A test produces `failed_folders` through the real TOCTOU path (folder deleted between Add and Create), not a synthetic result object
-- [ ] `_remove_folder` and unchecked-checkbox-survives-recompose have pilot coverage
-- [ ] The three `_done`/handler callbacks and `WorkspaceCreateResult.project_skills` carry real type annotations (`WorkspaceCreateResult | None`; a typed tuple for `project_skills`)
-- [ ] Decide (and implement or explicitly reject) restoring per-surface `description` provenance ("Created from Console/Settings/Library") lost to the uniform modal description
+- [x] Activation-failure path (`set_active_workspace` raising after a successful create) has a seam test on each surface: Console handler, Settings `_done`, Library `_done` (Library's reorder is already pinned; Console/Settings are not)
+- [x] The Enter-submit fast path (`Input.Submitted` on `#workspace-create-name` → `_create`) has a pilot test using a real keypress (not a direct method call), per the task-17961 blind-spot lesson
+- [x] A test produces `failed_folders` through the real TOCTOU path (folder deleted between Add and Create), not a synthetic result object
+- [x] `_remove_folder` and unchecked-checkbox-survives-recompose have pilot coverage
+- [x] The three `_done`/handler callbacks and `WorkspaceCreateResult.project_skills` carry real type annotations (`WorkspaceCreateResult | None`; a typed tuple for `project_skills`)
+- [x] Decide (and implement or explicitly reject) restoring per-surface `description` provenance ("Created from Console/Settings/Library") lost to the uniform modal description
 
 ## Notes
 
 Source: final review of `feat/workspace-create-modal` (see
 `Docs/superpowers/plans/2026-08-17-workspace-create-modal.md` and the spec's
 §7). Related open defect: TASK-17961 (focused compact-widget rendering).
+
+## Implementation Plan (the how)
+
+1. Reconcile each AC against the current tree (PR #1809/#1810 final-fix
+   waves landed some of this already) before writing anything new; cite
+   file::test evidence for anything already covered.
+2. Library's activation-failure seam was already pinned
+   (`test_create_workspace_recomposes_after_activation_failure`); add the
+   matching seam for Console (unit-level, via the existing
+   `_Stub`/`ConsoleWorkspaceController._handle_workspace_create_result`
+   harness) and Settings (pilot-level, via the existing
+   `test_create_rename_archive_unarchive_flow`-style harness), since
+   neither had one.
+3. Add a real-keypress Enter-submit test, a real-TOCTOU `failed_folders`
+   test (delete the folder from disk between Add and Create), and a
+   real-click checkbox-survives-recompose test to
+   `Tests/Workspaces/test_workspace_create_modal.py`.
+4. Add `WorkspaceCreateResult | None` annotations to the three surfaces'
+   result callbacks (`TYPE_CHECKING`-gated imports to avoid real import
+   cycles), and confirm `WorkspaceCreateResult.project_skills` is already
+   a typed tuple.
+5. Implement the controller-ruled `description` provenance restore:
+   optional `description` param on `WorkspaceCreateModal.__init__`, each
+   surface passing its own wording, one test pinning it end-to-end plus
+   one pinning the modal's own default.
+6. Run the full gate (`Tests/Workspaces/`, `Tests/Skills/`, the three
+   named `Tests/UI/` files) and a repo-wide `--collect-only` sweep.
+
+## Implementation Notes
+
+**Reconciliation (ticked-by-evidence vs. newly implemented):**
+
+- Activation-failure seam: Library was ALREADY covered by
+  `test_create_workspace_recomposes_after_activation_failure` in
+  `Tests/UI/test_post_release_workspaces_library_depth.py:553`. Console and
+  Settings were NOT covered — implemented
+  `test_activation_failure_notifies_error_and_skips_sync` in
+  `Tests/Workspaces/test_console_workspace_create_handler.py` (unit-level,
+  reusing the file's existing `_Stub` harness with a
+  `_RaisingActivateRegistry` wrapper) and
+  `test_activation_failure_surfaces_inline_but_creates_workspace` in
+  `Tests/UI/test_settings_workspaces_category.py` (pilot-level, monkeypatching
+  the real registry's `set_active_workspace`).
+- Enter-submit fast path: the existing
+  `test_double_submit_creates_exactly_one_workspace_no_crash` drives
+  `modal._create()` directly, not a real keypress. Added
+  `test_enter_key_on_name_input_submits_via_real_keypress`
+  (`Tests/Workspaces/test_workspace_create_modal.py`), which asserts
+  `AUTO_FOCUS` landed on the name input and drives `pilot.press("enter")`.
+- Real TOCTOU `failed_folders`: the existing Qodo-round retry tests
+  (`test_folder_binding_failure_keeps_modal_open_and_retries`, `test_escape_
+  after_partial_create_returns_partial_result`) use a raising registry
+  stub (`_FlakyBindRegistry`), not a real filesystem race. Added
+  `test_real_toctou_folder_deleted_before_create_shows_inline_failure`: adds
+  a real folder, `shutil.rmtree`s it, presses Create, and asserts the
+  modal's real `add_folder_binding()` call raises and the inline-failure
+  state (Finding 7) is reached with that folder's path in the error text.
+- `_remove_folder` + checkbox-preservation: `_remove_folder`'s stale-error
+  behavior was already pinned (`test_remove_folder_clears_stale_error`);
+  checkbox-survives-recompose was NOT covered — added
+  `test_make_active_checkbox_survives_folder_add_recompose` (real
+  `pilot.click` on the checkbox, then a real folder-add recompose).
+- Typed seams: `WorkspaceCreateResult.project_skills` was already
+  `tuple[ProjectSkillsDiscovery, ...]` (verified, no change needed). The
+  three surface callbacks were NOT annotated — added
+  `result: WorkspaceCreateResult | None` (or a quoted string form where the
+  module lacks `from __future__ import annotations`, i.e.
+  `settings_screen.py`) to `ConsoleWorkspaceController._handle_workspace_
+  create_result`, `SettingsScreen.handle_workspace_create`'s `_done`, and
+  `LibraryScreen.create_local_workspace`'s `_done`, each behind a
+  `TYPE_CHECKING`-gated import of `WorkspaceCreateResult` to avoid a real
+  import cycle (matching each file's existing house style for such
+  type-only imports).
+- Description provenance — **controller ruling implemented**:
+  `WorkspaceCreateModal.__init__` gained an optional
+  `description: str = "Created from the workspace setup dialog."` param,
+  threaded into `_create()`'s `create_workspace(...)` call (replacing the
+  old hardcoded literal). Each surface now passes its own pre-modal
+  wording, recovered from git history
+  (`git log --all -p -S"Local workspace created from Console."`):
+  Console → `"Local workspace created from Console."`, Settings →
+  `"Local workspace created from Settings."` (no historical precedent
+  existed for Settings specifically — Settings never had a distinctive
+  description pre-modal — so this follows the controller-ruling's own
+  explicit wording), Library → `"Local workspace created from Library."`.
+  Added `test_surface_description_is_carried_onto_created_record` and
+  `test_default_description_used_when_surface_passes_none`.
+
+**Trap hit while writing the description-provenance test:** subclassing
+the test file's `_HarnessApp` and overriding `on_mount` to push a modal
+with a custom `description` silently failed — Textual's
+`MessagePump._on_message` dispatches a message handler by walking the
+**whole MRO** (`_get_dispatch_methods`), not just the most-derived
+override, so BOTH the subclass's `on_mount` (correct modal, with
+description) AND the base class's `on_mount` (default modal, no
+description) ran, each pushing its own screen; the base class's push
+landed second and became `app.screen`, so the pilot interacted with the
+UN-described modal. Fixed by giving `_HarnessApp` itself an optional
+`description` constructor param instead of subclassing — a single-class
+harness, no MRO surprise. Generalizable lesson: **a plain Python subclass
+override of a Textual message handler (`on_mount`, `on_key`, etc.) does
+NOT shadow the base class's own handler — both run** (this differs from
+ordinary Python method dispatch and is easy to assume away).
+
+**Files touched:** `tldw_chatbook/Widgets/workspace_create_modal.py`,
+`tldw_chatbook/UI/Console_Modules/workspace.py`,
+`tldw_chatbook/UI/Screens/settings_screen.py`,
+`tldw_chatbook/UI/Screens/library_screen.py`,
+`Tests/Workspaces/test_workspace_create_modal.py`,
+`Tests/Workspaces/test_console_workspace_create_handler.py`,
+`Tests/UI/test_settings_workspaces_category.py`.
+
+**Gate:** `Tests/Workspaces/` 279 passed; `Tests/Skills/` 436 passed; the
+three named `Tests/UI/` files 29 passed + 1 pre-existing, unrelated
+failure (`test_single_item_handoff_gates_on_the_selected_row_not_the_
+aggregate`, fails in complete isolation with a shifting root cause across
+runs — "Local study backend is unavailable" vs. "Local prompt backend is
+unavailable" — in a file this task never touched); repo-wide
+`--collect-only` sweep: 52305 tests collected, zero collection errors.

--- a/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
+++ b/backlog/tasks/task-17964 - Project-skills-follow-ups-offer-modal-footer-tests-checkbox-escape-assertion-off-thread-discovery.md
@@ -3,7 +3,7 @@ id: TASK-17964
 title: >-
   Project-skills follow-ups: offer-modal footer tests, checkbox-escape
   assertion, off-thread discovery in _add_folder
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-18 00:00'
 labels:
@@ -27,13 +27,13 @@ identified gaps worth closing.
 
 ## Acceptance Criteria (the what)
 
-- [ ] `ProjectSkillsImportModal`'s offer-phase footer (`_offer_footer_lines`
+- [x] `ProjectSkillsImportModal`'s offer-phase footer (`_offer_footer_lines`
       in `tldw_chatbook/Widgets/project_skills_import_modal.py`) has test
       coverage for both its branches: a discovery with `skipped` entries
       renders `Skipped: <names>`, and a discovery with `truncated > 0`
       renders `N more not shown` — neither branch is exercised by any
       existing test today
-- [ ] A test asserts Checkbox-label escaping in the offer phase: a
+- [x] A test asserts Checkbox-label escaping in the offer phase: a
       malicious/markup-hostile skill `description` (e.g. containing
       `[bold]`/`[/bold]` or other Rich markup) renders as literal text in
       the Checkbox label, not interpreted markup — the discovery-layer
@@ -41,14 +41,14 @@ identified gaps worth closing.
       markup-hostile names/descriptions can be reused; today only the
       `escape_markup()` call site in `_compose_offer_phase` defends this,
       with no assertion pinning it
-- [ ] Fix the "1 project skill(s)" pluralization in
+- [x] Fix the "1 project skill(s)" pluralization in
       `tldw_chatbook/Widgets/workspace_create_modal.py` (`compose()`'s
       folder-row label and `_add_folder`'s discovery-count usage) so a
       single discovered skill reads "1 project skill" and multiple read "N
       project skills" (live-verified as-is during TASK-18705's Step 4:
       `... — contains 1 project skill(s)`, grammatically wrong for the
       singular case)
-- [ ] Fix the stale `_folder_discoveries` entry: in
+- [x] Fix the stale `_folder_discoveries` entry: in
       `WorkspaceCreateModal._add_folder`, a folder that is removed and later
       re-added at a moment when its `.SKILLS/` folder no longer has entries
       (deleted, emptied, or now-invalid between the two adds) keeps showing
@@ -60,7 +60,7 @@ identified gaps worth closing.
       empty, or clear `_folder_discoveries[locator]` on `_remove_folder` (the
       entry is currently left in the dict, unreachable via `self._folders`
       but not deleted, when a folder is removed at all)
-- [ ] Decide (fix, or explicitly accept and document) whether
+- [x] Decide (fix, or explicitly accept and document) whether
       `discover_project_skills()` inside `_add_folder`'s synchronous button
       handler should move off the main thread — it is a bounded scan (50
       entries / 64 KiB reads, non-recursive) but still a blocking
@@ -79,4 +79,100 @@ verification in both the Name/folder Input fields and, in a new sighting, the
 "Search Library…"/"Filter skills…" inputs — not re-filed here since
 TASK-17961 already tracks the underlying rendering characteristic across
 surfaces).
-- [ ] Decide (timeout vs. accepted trade-off) the in-flight-import dismissal posture: post final-fix, Escape/Not now/Never are inert while an import runs, so a permanently-hung importer leaves no in-modal exit (final-review named risk (c), noted by the fix-wave re-review as inherent to not discarding partial imports silently)
+- [x] Decide (timeout vs. accepted trade-off) the in-flight-import dismissal posture: post final-fix, Escape/Not now/Never are inert while an import runs, so a permanently-hung importer leaves no in-modal exit (final-review named risk (c), noted by the fix-wave re-review as inherent to not discarding partial imports silently)
+
+## Implementation Plan (the how)
+
+1. Reconcile each AC against the current tree first: the stale
+   `_folder_discoveries` bug was reportedly fixed by PR #1810's final
+   fix-wave — verify with a passing test before assuming any of the rest is
+   still open.
+2. Add the two missing `_offer_footer_lines` branch tests (skipped names,
+   truncated count) to `Tests/Skills/test_project_skills_import_modal.py`.
+3. Add the checkbox-escape assertion, using a YAML-quoted hostile
+   description (unquoted brackets break the frontmatter's YAML grammar and
+   degrade to an empty description — verified against the existing
+   `test_project_skills_discovery.py` fixtures for this exact failure
+   mode) rather than this file's own `_discovery()` helper, which uses an
+   unquoted hostile string and would silently test nothing.
+4. Fix the "1 project skill(s)" pluralization in
+   `workspace_create_modal.py`'s folder-row label; strengthen the two
+   existing tests that substring-matched the old buggy string to assert
+   the exact, corrected grammar.
+5. Record the two controller-ruled accepted-tradeoff decisions
+   (off-thread discovery, hung-import dismissal posture) as comments next
+   to the code they describe, per the controller's rulings — no behavior
+   change for either.
+6. Run the full gate and a repo-wide `--collect-only` sweep.
+
+## Implementation Notes
+
+**Reconciliation (ticked-by-evidence vs. newly implemented):**
+
+- Footer tests (skipped/truncated): NOT covered before this task —
+  implemented `test_offer_footer_renders_skipped_and_truncated_lines`
+  (`Tests/Skills/test_project_skills_import_modal.py`), using
+  `dataclasses.replace()` on a real discovery to set `skipped`/`truncated`
+  without depending on the scan's own caps.
+- Checkbox-escape assertion: NOT covered before this task — implemented
+  `test_offer_phase_checkbox_label_escapes_markup_literally`. Trap hit:
+  this file's shared `_discovery()` fixture uses an **unquoted**
+  `[red]desc[/red] for {name}` description, which breaks the frontmatter's
+  YAML grammar and silently degrades to an **empty** description (per
+  `ProjectSkillEntry`'s own docstring and
+  `test_project_skills_discovery.py::test_unparseable_frontmatter_
+  degrades_to_empty_description`) — so reusing it here would have produced
+  a vacuous pass (asserting markup escaping on an empty string). Built a
+  dedicated YAML-quoted fixture (`description: "[red]evil[/red]"`,
+  matching `test_hostile_description_survives_as_plain_data`'s working
+  pattern) instead, with a sanity assertion on `entry.description` before
+  checking the rendered `Checkbox.label` (a Textual `Content` object,
+  whose `.plain`/`.spans` show the escaped brackets rendered literally
+  with no color span).
+- Pluralization: NOT fixed before this task — fixed in `compose()`'s
+  folder-row label (`workspace_create_modal.py`); there was only one live
+  code call site (the task's AC text implied two, but `_add_folder`'s
+  own reference was a comment describing the same rendering, not a second
+  formatting site — the comment was updated too for accuracy). Strengthened
+  the two existing tests that substring-matched the old "1 project
+  skill(s)" text (`test_folder_with_skills_annotated_and_carried_on_result`,
+  `test_removed_and_rescanned_folder_clears_stale_discovery`) to assert the
+  exact corrected row text.
+- Stale `_folder_discoveries` after remove: **already fixed** — PR #1810's
+  final fix-wave (Finding 9) made `_remove_folder` pop the locator and
+  `_add_folder` assign-or-pop on a rescan that finds nothing, and it's
+  pinned by the existing
+  `test_removed_and_rescanned_folder_clears_stale_discovery`
+  (`Tests/Workspaces/test_workspace_create_modal.py:480-523`) — ticked
+  with evidence, no code change needed.
+- Off-thread discovery — **controller ruling, accepted and documented, not
+  implemented**: recorded as a comment directly above the
+  `discover_project_skills()` call in `_add_folder`
+  (`workspace_create_modal.py`). Rationale: the scan is hard-bounded (500
+  scanned children / 50 recognized entries / 64 KiB reads, non-recursive);
+  the synchronous `validate_folder_binding_path()` call immediately above
+  it already stats the same filesystem, synchronously, on the same UI
+  thread, before discovery ever runs — a dead network mount hangs the
+  modal at validation regardless of what discovery does, so moving only
+  discovery off-thread cannot fix the named hang. Async validation (and
+  discovery) together is a separate, differently-scoped task if the hang
+  is ever actually observed.
+- Hung-import dismissal posture — **controller ruling, accepted and
+  documented, not implemented**: recorded in `_import_in_flight`'s
+  docstring in `project_skills_import_modal.py`. Rationale: imports here
+  are local-filesystem only, so a hung importer implies a hung filesystem
+  (the same failure class as the discovery decision above); discarding a
+  partial import silently — the only alternative while the worker is
+  mid-flight — is worse than leaving no escape hatch for a
+  previously-unseen pathological case, since it risks a half-imported
+  skill directory the user has no way to detect.
+
+**Files touched:** `tldw_chatbook/Widgets/workspace_create_modal.py`,
+`tldw_chatbook/Widgets/project_skills_import_modal.py`,
+`Tests/Skills/test_project_skills_import_modal.py`,
+`Tests/Workspaces/test_workspace_create_modal.py` (pluralization assertion
+strengthening, shared with TASK-17962's edits to the same file).
+
+**Gate:** `Tests/Skills/` 436 passed; `Tests/Workspaces/` 279 passed;
+repo-wide `--collect-only` sweep: 52305 tests collected, zero collection
+errors.

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -79,6 +79,7 @@ from ..character_display_text import sanitize_character_display_label
 
 if TYPE_CHECKING:
     from ...Chat.console_chat_controller import ConsoleChatController
+    from ...Widgets.workspace_create_modal import WorkspaceCreateResult
     from ..Screens.chat_screen import ChatScreen
 
 logger = logger.bind(module="ChatScreen")
@@ -1649,11 +1650,16 @@ class ConsoleWorkspaceController:
         from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
 
         self.push_screen(
-            WorkspaceCreateModal(registry_service=registry_service),
+            WorkspaceCreateModal(
+                registry_service=registry_service,
+                description="Local workspace created from Console.",
+            ),
             self._handle_workspace_create_result,
         )
 
-    def _handle_workspace_create_result(self, result) -> None:
+    def _handle_workspace_create_result(
+        self, result: WorkspaceCreateResult | None
+    ) -> None:
         """Console-side post-create sync; the modal already created/bound."""
         if result is None:
             return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -474,6 +474,7 @@ from .study_scope_models import (
 if TYPE_CHECKING:
     # Type-only: the shared modal owns the runtime acquisition-plan import.
     from ...Model_Artifacts.acquisition import PreflightReport
+    from ...Widgets.workspace_create_modal import WorkspaceCreateResult
 
 
 logger = logger.bind(module="LibraryScreen")
@@ -32507,7 +32508,7 @@ class LibraryScreen(BaseAppScreen):
             return
         from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
 
-        def _done(result) -> None:
+        def _done(result: WorkspaceCreateResult | None) -> None:
             if result is None:
                 return
             notify = getattr(self.app_instance, "notify", None)
@@ -32560,7 +32561,11 @@ class LibraryScreen(BaseAppScreen):
                 )
 
         self.app.push_screen(
-            WorkspaceCreateModal(registry_service=registry_service), _done
+            WorkspaceCreateModal(
+                registry_service=registry_service,
+                description="Local workspace created from Library.",
+            ),
+            _done,
         )
 
     def _preserve_library_rail_scroll(self) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import re
 import threading
 import tomllib
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from rich.cells import cell_len
@@ -345,6 +345,11 @@ from ..Navigation.pending_handoff_store import (
     HandoffValueError,
     PendingHandoffStore,
 )
+
+if TYPE_CHECKING:
+    # Type-only: the create dialog is a shared modal imported locally at its
+    # one call site (handle_workspace_create) to avoid a real import cycle.
+    from ...Widgets.workspace_create_modal import WorkspaceCreateResult
 
 
 logger = logging.getLogger(__name__)
@@ -18501,7 +18506,7 @@ class SettingsScreen(BaseAppScreen):
             return
         from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
 
-        def _done(result) -> None:
+        def _done(result: "WorkspaceCreateResult | None") -> None:
             if result is None:
                 return
             status_parts = [message for _folder, message in result.failed_folders]
@@ -18519,7 +18524,13 @@ class SettingsScreen(BaseAppScreen):
 
                 maybe_offer_project_skills_import(self.app, result.project_skills)
 
-        self.app.push_screen(WorkspaceCreateModal(registry_service=registry), _done)
+        self.app.push_screen(
+            WorkspaceCreateModal(
+                registry_service=registry,
+                description="Local workspace created from Settings.",
+            ),
+            _done,
+        )
 
     @on(Button.Pressed, "#settings-workspace-rename-apply")
     def handle_workspace_rename_apply(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/project_skills_import_modal.py
+++ b/tldw_chatbook/Widgets/project_skills_import_modal.py
@@ -250,6 +250,23 @@ class ProjectSkillsImportModal(SafeModalDismissMixin, ModalScreen[ImportDecision
         while an import the user already committed to is mid-flight. All
         three must be inert then -- dismissing (or re-running) would either
         discard a partial import silently or race the in-flight worker.
+
+        TASK-17964 (dismissal posture, decided and NOT changed): the
+        consequence of this guard is that a permanently-hung importer
+        (``self._importer`` never returning/raising) leaves no in-modal
+        exit -- Escape, backdrop-click, and "Not now"/"Never" all stay
+        inert for as long as ``_import_in_flight()`` is true, with no
+        timeout. This is an accepted trade-off, not an oversight: imports
+        here are local-filesystem only (directory copy or loose-file read,
+        see ``_project_skills_importer``), so a hung importer implies a
+        hung filesystem -- the same failure class the off-thread-discovery
+        decision above names for ``_add_folder``. Discarding a partial
+        import silently (what an escape hatch would have to do while the
+        worker is still running) is worse than leaving no exit for a
+        pathological, previously-unseen case: it risks a half-imported
+        skill directory with no way for the user to know it happened. If a
+        real hang is ever observed in practice, a bounded timeout on the
+        importer call is the fix to file -- not reopening the guard here.
         """
         return self._committed and self._outcomes is None
 

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -117,9 +117,20 @@ class WorkspaceCreateModal(
     BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
     AUTO_FOCUS = "#workspace-create-name"
 
-    def __init__(self, *, registry_service: LocalWorkspaceRegistryService) -> None:
+    def __init__(
+        self,
+        *,
+        registry_service: LocalWorkspaceRegistryService,
+        description: str = "Created from the workspace setup dialog.",
+    ) -> None:
         super().__init__()
         self._registry = registry_service
+        #: Provenance stored on the created ``WorkspaceRecord`` (TASK-17962):
+        #: each surface (Console/Settings/Library) passes its own wording so
+        #: a workspace's origin is still visible after creation -- restoring
+        #: the per-surface description the surfaces used before they shared
+        #: this one modal.
+        self._description = description
         self._folders: list[str] = []
         #: Folder locator -> its project-skills discovery, populated only
         #: for folders whose root contains a non-empty .SKILLS/ (spec §5.5
@@ -196,10 +207,12 @@ class WorkspaceCreateModal(
                 for index, folder in enumerate(self._folders):
                     discovery = self._folder_discoveries.get(folder)
                     if discovery is not None and discovery.entries:
-                        label = (
-                            f"{folder} — contains "
-                            f"{len(discovery.entries)} project skill(s)"
-                        )
+                        # TASK-17964: grammatically correct singular/plural
+                        # rather than the literal "1 project skill(s)"
+                        # live-verified during TASK-18705's Step 4.
+                        count = len(discovery.entries)
+                        noun = "project skill" if count == 1 else "project skills"
+                        label = f"{folder} — contains {count} {noun}"
                     else:
                         label = folder
                     with Horizontal(classes="workspace-create-folder-item"):
@@ -321,13 +334,30 @@ class WorkspaceCreateModal(
         resolved_locator = str(resolved)
         self._folders.append(resolved_locator)
         # Pure filesystem scan (no side effects, no trust decisions) so the
-        # row can flag "contains N project skill(s)" up front; only stored
+        # row can flag "contains N project skills" up front; only stored
         # when there's something to offer later (spec §5.5). Skipped
         # entirely when the kill-switch is off (Finding 1, final review
         # 2026-08-17): the feature's "no scanning" promise must be
         # literally true, not merely "no offer" once the flag was already
         # set. Imported locally (like app.py's startup discovery worker
         # does) rather than at module import time.
+        #
+        # TASK-17964 (off-thread discovery, decided and NOT implemented):
+        # this is a synchronous, blocking filesystem walk on the UI thread.
+        # It stays that way. The scan itself is hard-bounded (500 scanned
+        # children / 50 recognized entries / 64 KiB frontmatter reads per
+        # entry, non-recursive -- see project_skills_discovery.py), so it
+        # cannot run away on an ordinary project. The real risk named by
+        # the task -- a `.SKILLS/` that resolves onto a slow or hung
+        # network mount -- is NOT fixed by moving only this call off-
+        # thread: `validate_folder_binding_path` above (line ~330) already
+        # did a synchronous `Path.resolve()`/`is_dir()` stat on the exact
+        # same filesystem before this line ever runs, on the same UI
+        # thread, with no bound at all. A dead mount hangs the modal at
+        # validation regardless of what this discovery call does. Moving
+        # validation AND discovery off the main thread is a materially
+        # different (and separately sized) change; if the hang is ever hit
+        # in practice, that's the fix to file, not this one call site.
         from tldw_chatbook.config import get_cli_setting
 
         if get_cli_setting("skills", "project_skills_prompt_enabled", True):
@@ -485,7 +515,7 @@ class WorkspaceCreateModal(
             self._registry.create_workspace(
                 workspace_id=workspace_id,
                 name=name or generated_name,
-                description="Created from the workspace setup dialog.",
+                description=self._description,
             )
         except WorkspaceRegistryServiceError as exc:
             # Nothing was committed -- let the user fix the name/folder and

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -123,6 +123,15 @@ class WorkspaceCreateModal(
         registry_service: LocalWorkspaceRegistryService,
         description: str = "Created from the workspace setup dialog.",
     ) -> None:
+        """Build the dialog against a registry, with per-surface provenance.
+
+        Args:
+            registry_service: Local workspace registry the dialog reads the
+                next free identity from and writes the new workspace to.
+            description: Provenance stored on the created ``WorkspaceRecord``
+                (TASK-17962). Each surface passes its own wording; the
+                default covers callers that do not care.
+        """
         super().__init__()
         self._registry = registry_service
         #: Provenance stored on the created ``WorkspaceRecord`` (TASK-17962):


### PR DESCRIPTION
## Summary

Closes both follow-up batches filed during the workspace-modal (#1809) and project-skills (#1810) arcs, after reconciling their ACs against everything later PRs already landed.

**Reconciled as already-covered (with evidence):** the Library activation-failure seam test (shipped in #1809's final fix wave) and the stale-`_folder_discoveries` cleanup (shipped in #1810's fix wave, pinned by test).

**Newly implemented (TASK-17962):** Console + Settings activation-failure seam tests (real registry, surface-specific assertions); a real-keypress Enter fast-path test; a real-TOCTOU `failed_folders` test (`rmtree` between Add and Create, exercising the retry machinery); checkbox-state-survives-recompose via real click; `WorkspaceCreateResult | None` typing on all three surface callbacks; and restored per-surface `description` provenance ("Created from Console/Settings/Library") via a modal parameter — RED-proven.

**Newly implemented (TASK-17964):** offer-modal footer tests (`Skipped:` / "N more not shown"); a checkbox-escape assertion proving `[red]evil[/red]` renders literally (the old shared fixture's unquoted markup silently degraded to an empty description via YAML — new properly-quoted fixture); proper pluralization of the folder-row annotation.

**Documented rulings (not implemented, rationale in task notes + code comments):** off-thread discovery is declined because the synchronous folder validator stats the same filesystem *before* discovery — a dead mount hangs there first, so async discovery alone cannot help; the hung-import dismissal trade-off is accepted because the importer is local-filesystem-only and the inert-while-in-flight guards exist to prevent silent partial-import discard.

Also recorded: a generalizable Textual trap — overriding `on_mount` in a test-harness subclass does NOT shadow the base handler (message dispatch walks the full MRO and calls both), verified against Textual 8.2.8 internals.

## Verification

CI intentionally cancelled — verified locally: `Tests/Workspaces/` 279 passed, `Tests/Skills/` 436 passed, named UI files 29 passed (+1 pre-existing failure — `test_single_item_handoff_gates_on_the_selected_row_not_the_aggregate` — reproduced byte-for-byte on unmodified origin/dev in a throwaway worktree; untouched file, flagged for whoever owns dev reds), 52,305-test collect sweep clean. RED-first tees for the behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-surface provenance for workspace creation and fixes folder-row pluralization; documents rulings on discovery/import dismissal and adds seam tests that pin activation failures and edge cases. Previously all new workspaces used a generic description and showed “1 project skill(s)”; now Console/Settings/Library pass “Local workspace created from <Surface>.”, and folder rows render “1 project skill” or “N project skills”. (Satisfies TASK-17962 and TASK-17964.)

- Behavior and review notes
  - Activation failures: if `set_active_workspace` raises, Console notifies and skips post-activation sync; Settings surfaces the error inline; the workspace is still created. Library behavior is unchanged and already covered by tests.
  - Modal provenance: `WorkspaceCreateModal(description=...)` stores the caller’s wording; default remains “Created from the workspace setup dialog.” A Google-style docstring documents the param.
  - Input flows: pressing Enter in the name field submits; an unchecked “Switch to this workspace” survives a recompose after adding a folder.
  - TOCTOU: deleting a folder between Add and Create yields an inline failure (`failed_folders`); the workspace is created without bindings.
  - Skills import modal: footer renders “Skipped: …” and “N more not shown”; markup-hostile descriptions render literally; `_import_in_flight` docstring records the accepted no-dismissal posture; off-thread discovery in `_add_folder` is explicitly declined and documented.
  - Types: handler callbacks now accept `WorkspaceCreateResult | None`. No runtime change.
  - No migration required. Callers may optionally pass `description` and should accept a `None` result.

<sup>Written for commit a19dfb0aae8e271c76eb89f03df47f49e7f6d6ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

