### PR TITLE
feat: author and import Persona Visual packs

### DIFF
--- a/Docs/superpowers/plans/2026-08-21-task-19054-persona-visual-authoring.md
+++ b/Docs/superpowers/plans/2026-08-21-task-19054-persona-visual-authoring.md
@@ -1,0 +1,153 @@
+# TASK-19054 Persona Visual Authoring and Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users review, edit, import, stage, Save, and Cancel profile-local Persona Visual packs from Personas Workbench without changing the active runtime until one explicit, authority-checked publication.
+
+**Architecture:** Pure authoring helpers build an isolated immutable draft from an active Persona Visual graph and translate approved edits into the existing publication snapshot. A separate synchronous archive boundary validates the pinned server `.tldw-persona-vpack` layout, copies declared files into bounded profile-private staging, and returns a path-free review draft plus an opaque cleanup capability. A dedicated Textual widget renders the nine baseline states, bounded custom states, inventory, and one selected lazy preview; `PersonasScreen` owns all repository, filesystem, async, dialog, publication, cache-invalidation, and navigation fencing.
+
+**Tech Stack:** Python 3.11, Textual 8, frozen/slotted dataclasses, SQLite, `zipfile`, Pillow, existing Persona Visual validation/assets/repository/publication boundaries, pytest, Ruff.
+
+**ADR required:** no
+
+**ADR path:** `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
+
+**Reason:** ADR-074 already fixes the separate Persona Visual runtime, local-Persona ownership, review-before-publication, archive trust boundary, immutable versions, and no-provider/no-Buddy scope. This task implements that decision without adding an architectural choice.
+
+---
+
+## File map
+
+- Create `tldw_chatbook/Persona_Visual/authoring.py`: path-free immutable draft records, active-graph conversion, state add/replace/clear operations, validation inventory, authority snapshot, and publication-snapshot conversion.
+- Create `tldw_chatbook/Persona_Visual/importer.py`: pinned server V1 archive inspection, bounded private staging, archive/source identity revalidation, review result, and identity-pinned cleanup.
+- Modify `tldw_chatbook/Persona_Visual/__init__.py`: export only the small authoring/import surface intended for Workbench.
+- Create `tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py`: baseline/custom state browser, path-free inventory, selected lazy preview, explicit Preparing/Busy/Saving states, and labelled authoring actions.
+- Modify `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py`: mount the Persona Visual browser within the existing Persona editor and switch it between local/server/new-Persona availability states.
+- Modify `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`: typed Persona Visual Replace/Clear/Add/Import/Save/Cancel/select messages.
+- Modify `tldw_chatbook/UI/Screens/personas_screen.py`: active graph loading, draft lifecycle, one-operation admission, dialog/decode/import workers, publication, identity-scoped invalidation, authoritative refresh, dirty-navigation integration, and honest legacy import labels.
+- Create `Tests/Persona_Visual/test_persona_visual_authoring.py`: pure draft and publication bridge tests.
+- Create `Tests/Persona_Visual/test_persona_visual_importer.py`: golden server-compatible archive plus hostile archive/staging/cleanup tests.
+- Create `Tests/UI/test_personas_persona_visual_pack.py`: real Textual widget layout, focus, copy, and message tests.
+- Create `Tests/UI/test_personas_persona_visual_authoring.py`: screen orchestration, authority, cancellation, publication, invalidation, and server/local behavior tests.
+- Modify existing focused Persona widget/workbench tests only where the new mounted section or corrected legacy label changes an incumbent contract.
+- Modify `backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md`: status, checked acceptance criteria, and concise implementation notes after verification.
+
+## Frozen archive boundary
+
+The importer accepts only the pinned server V1 native archive:
+
+```text
+schema_version: tldw.persona_visual_pack.v1
+manifest.json
+metadata/pack.json
+metadata/assets.json
+checksums/sha256.json
+assets/...                       # every present asset declared exactly once
+README.md                        # optional, plain-text review only
+signatures/README.md             # optional reserved metadata
+```
+
+It accepts only `sprite_frames` manifest version 1. Required JSON and present asset members must be declared by the outer manifest/checksum inventory and no undeclared regular file is accepted. The importer applies the stricter programme limits already owned by Persona Visual foundation: at most 256 assets, 100 MiB uncompressed asset bytes, 2 MiB per JSON document, safe canonical POSIX member names, supported raster MIME/decode/dimensions/frame counts, and no missing-byte archive import. Compressed bytes, members, compression ratio, central-directory identity, source inode/size/timestamps/digest, and free-space needs are bounded before extraction and revalidated before review is returned.
+
+## Task 1: Add the isolated draft contract
+
+**Files:**
+- Create: `Tests/Persona_Visual/test_persona_visual_authoring.py`
+- Create: `tldw_chatbook/Persona_Visual/authoring.py`
+- Modify: `tldw_chatbook/Persona_Visual/__init__.py`
+
+- [ ] Write behavioral RED tests using real validated manifests and repository graph records. Cover all nine baseline rows, bounded safe custom states, path-free inventory, exact authority capture, Replace/Clear/Add Custom immutability, invalid custom states, required-state validation, Cancel preservation, and deterministic publication-snapshot conversion.
+- [ ] Run the focused file and confirm behavioral failures because the authoring API is absent.
+- [ ] Implement frozen/slotted draft records that snapshot every scalar and container. Reuse `validate_persona_visual_manifest`; do not accept screen widgets, database handles, absolute paths, or mutable repository records.
+- [ ] Make edits return a new draft. A cleared state removes only its direct mapping; validation reports whether required states still resolve through fallback. Save conversion refuses invalid/incomplete drafts and emits the exact existing `PersonaVisualPublicationSnapshot` contract.
+- [ ] Run the focused file GREEN and mutate draft isolation/authority checks to prove the tests discriminate them.
+- [ ] Commit the slice as `feat: add Persona Visual authoring drafts`.
+
+## Task 2: Add review-first `.tldw-persona-vpack` import
+
+**Files:**
+- Create: `Tests/Persona_Visual/test_persona_visual_importer.py`
+- Create: `tldw_chatbook/Persona_Visual/importer.py`
+
+- [ ] Create a small golden fixture builder matching the pinned server member layout and metadata fields. Write RED tests for a valid full pack and for traversal, absolute/backslash/device/Unicode-or-case collisions, links, encryption, nesting, undeclared/external/missing files, duplicate keys/members, bad checksums, MIME/decode/dimension/frame mismatch, member/count/size/ratio/free-space budgets, source replacement, cancellation, and cleanup substitution.
+- [ ] Implement synchronous import preview under a caller-supplied profile-private staging root. Open and attest the source, validate the central directory before extraction, stream declared bytes with hard limits and digests, use no-follow private staging, and validate the resulting manifest/assets through the foundation boundary.
+- [ ] Return only an immutable path-free review result plus an opaque module-issued cleanup capability. Keep private source/staging paths inside the module.
+- [ ] Revalidate source and staged identities before publication-snapshot handoff. Cleanup must reserve and verify the exact issued staging identity and delete only that tree; unverifiable cleanup fails closed.
+- [ ] Run the importer file GREEN and perform targeted mutations for archive identity, declaration, checksum, cancellation, and cleanup guards.
+- [ ] Commit the slice as `feat: import Persona Visual review drafts`.
+
+## Task 3: Add the Persona Visual Workbench widget
+
+**Files:**
+- Create: `Tests/UI/test_personas_persona_visual_pack.py`
+- Create: `tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/personas_pane_messages.py`
+- Modify: `tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py`
+
+- [ ] Write real Textual RED tests at normal and 80x24 geometry. Assert nine labelled baseline states, bounded custom rows, path-free inventory, one selected preview, keyboard-operable labelled Replace/Clear/Add Custom/Import/Save/Cancel actions, focus preservation, honest local/server/new-Persona states, and typed messages.
+- [ ] Implement one compact browser with metadata-only rows and a single selected preview node. Do not decode unselected assets or add key bindings.
+- [ ] Use distinct idle-draft, Preparing/Importing/Previewing, and non-cancellable Saving presentations. Cancel is visible for an idle draft and cancellable work, but hidden during atomic publication.
+- [ ] Mount it in the existing Persona editor scroll body. Local saved Personas can author; unsaved local Personas are prompted to Save first; server Personas show `Save Local Copy first` and no import/edit controls.
+- [ ] Run widget/profile tests GREEN, then run the required Impeccable review after the final visible change and apply only in-scope findings.
+- [ ] Commit the slice as `feat: add Persona Visual Workbench editor`.
+
+## Task 4: Wire loading, preview, edits, and import into `PersonasScreen`
+
+**Files:**
+- Create: `Tests/UI/test_personas_persona_visual_authoring.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+
+- [ ] Write RED screen tests with real frozen records and a real SQLite repository where authority matters. Cover eligible local load, inactive/no-pack empty draft, server Save Local Copy, selected-only preview, Replace/Clear/Add/import staging, first-operation cancellation, duplicate rejection, navigation decline/preserve, navigation approval/signal/drain/discard, stale session/Persona/revision/binding/draft/source/staging fences, and path-free failures.
+- [ ] Add a separate Persona Visual author snapshot and one admitted task plus caller-owned cancellation event. Every filesystem/hash/decode/import operation runs through a named shield/drain helper off the event loop; same-owner operations reject instead of queueing.
+- [ ] Reuse the existing repository/runtime/asset loader. Screen callbacks receive path-free records; only the selected asset is decoded, and every await is followed by full editor/session/Persona/binding/draft authority checks before widget mutation.
+- [ ] Keep draft changes isolated in screen state. Cancel signals/drains active work, cleans only owned imported staging, drops the draft, and reloads the authoritative graph. Dirty navigation includes draft/inflight Persona Visual work.
+- [ ] Correct legacy Character copy/filtering so `Import Expression Set` accepts only its legacy format; expose Persona Visual import only in the Persona Visual section; keep future Actor Pack import absent or separately labelled.
+- [ ] Run the focused screen/widget/workbench cases GREEN and kill admission/cancellation/session/selected-preview/import-cleanup mutations.
+- [ ] Commit the slice as `feat: author Persona Visual packs in Workbench`.
+
+## Task 5: Publish once and invalidate exact identities
+
+**Files:**
+- Modify: `Tests/UI/test_personas_persona_visual_authoring.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py`
+
+- [ ] Extend RED tests for one Save admission, draft revalidation, current Persona revision, exact expected nine-field active identity, no-pack first activation, immutable next version, publication error cleanup, cancellation during thread publication, cancellation during post-commit reconciliation, stale editor after commit, and repeated Save rejection.
+- [ ] Call existing synchronous `publish_persona_visual` off-loop with a caller authority guard that is valid both before and inside the repository transaction. Shield and drain irreversible work before releasing admission.
+- [ ] On success invalidate affected runtime/cache entries by stable old and new complete identities only, preserving unrelated Persona/pack/version entries. Isolate mounted-consumer invalidation failures and always perform the current-fenced authoritative editor reload. Failed/cancelled precommit work invalidates nothing.
+- [ ] Consume only opaque cleanup capabilities via the foundation cleanup API. Never log or display source paths, staging paths, archive members, provider text, bytes, or cleanup tokens.
+- [ ] Run publication/invalidation tests GREEN and mutate publish admission, authority, cleanup, old/new invalidation, unrelated-cache preservation, and post-commit drain checks.
+- [ ] Commit the slice as `feat: publish Persona Visual authoring drafts`.
+
+## Task 6: Focused verification and closeout
+
+**Files:**
+- Modify: `backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md`
+- Modify lessons/docs only if this task produced a genuinely reusable incident.
+
+- [ ] Establish isolated `HOME`, XDG config/data/cache, explicit config, and data roots before app imports. Record the assigned worktree path and assert imported modules resolve inside it.
+- [ ] Run all `Tests/Persona_Visual` plus the touched Persona profile widget, Persona Workbench, Persona Visual authoring, publication, and relevant architecture/privacy/diagnostic gates. Do not run the repository-wide full suite.
+- [ ] Run scoped Ruff, format, compile, and `git diff --check`. Run real SQLite publication/repository tests and normal/80x24 Pilot layouts.
+- [ ] Review the final diff against all eight ACs, ADR-074, the approved programme spec, the pinned server compatibility files, and the no-provider/no-SVI/no-Buddy/no-Actor-Pack boundaries.
+- [ ] Mark all task ACs complete, set status Done, and add concise Implementation Notes including RED/GREEN/mutation/static/Impeccable evidence and any truthful baseline deviations.
+- [ ] Commit closeout as `docs: complete Persona Visual authoring task`.
+
+## Verification commands
+
+Use the assigned worktree with the shared complete environment, while asserting import provenance:
+
+```bash
+TLDW_TEST_MODE=1 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Persona_Visual \
+  Tests/UI/test_persona_profile_widgets.py \
+  Tests/UI/test_personas_persona_visual_pack.py \
+  Tests/UI/test_personas_persona_visual_authoring.py \
+  Tests/UI/test_personas_workbench_foundation.py \
+  Tests/UI/test_personas_workbench_state.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check <touched-python-files>
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check <touched-python-files>
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q <touched-python-packages>
+git diff --check
+```
+
+The broader `Tests/UI/test_personas_workbench.py` file is added to the final touched gate because `PersonasScreen` and the Persona editor are modified. No full repository suite is authorized or claimed.

--- a/Tests/Persona_Visual/test_persona_visual_authoring.py
+++ b/Tests/Persona_Visual/test_persona_visual_authoring.py
@@ -1,0 +1,357 @@
+"""Tests for isolated Persona Visual Workbench drafts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from tldw_chatbook.Persona_Visual.assets import PersonaVisualAssetMetadata
+from tldw_chatbook.Persona_Visual.authoring import (
+    PersonaVisualAuthoringError,
+    PersonaVisualDraftAsset,
+    add_persona_visual_custom_state,
+    clear_persona_visual_draft_state,
+    create_persona_visual_draft,
+    inspect_persona_visual_draft,
+    persona_visual_draft_from_graph,
+    persona_visual_draft_publication_snapshot,
+    replace_persona_visual_draft_state,
+)
+from tldw_chatbook.Persona_Visual.contracts import RESERVED_STATES
+from tldw_chatbook.Persona_Visual.repository import (
+    PersonaVisualAssetRecord,
+    PersonaVisualBindingRecord,
+    PersonaVisualGraph,
+    PersonaVisualIdentity,
+    PersonaVisualPackRecord,
+    PersonaVisualVersionRecord,
+)
+from tldw_chatbook.Persona_Visual.validation import validate_persona_visual_manifest
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "renderer_type": "sprite_frames",
+        "manifest_version": 1,
+        "states": {
+            state: {"animation_id": "idle-loop"}
+            for state in ("idle", "listening", "thinking", "speaking", "error")
+        },
+        "animations": {
+            "idle-loop": {
+                "frames": [{"asset_id": "idle"}],
+                "frame_rate": 2,
+                "preview_asset_id": "idle",
+            }
+        },
+        "fallbacks": {},
+        "state_catalog": {},
+        "authored_triggers": [],
+    }
+
+
+def _metadata(
+    asset_key: str,
+    *,
+    marker: bytes | None = None,
+) -> PersonaVisualAssetMetadata:
+    data = marker or asset_key.encode("utf-8")
+    return PersonaVisualAssetMetadata(
+        asset_key=asset_key,
+        role="frame",
+        mime_type="image/png",
+        byte_count=len(data),
+        sha256=hashlib.sha256(data).hexdigest(),
+        width=4,
+        height=5,
+        frame_count=1,
+    )
+
+
+def _graph() -> PersonaVisualGraph:
+    manifest = validate_persona_visual_manifest(_manifest(), {"idle": (4, 5)})
+    identity = PersonaVisualIdentity(
+        persona_id="local-persona-7",
+        persona_revision=9,
+        binding_id=11,
+        binding_version=3,
+        pack_id=13,
+        pack_revision=4,
+        pack_version_id=17,
+        version_number=2,
+        manifest_sha256="a" * 64,
+    )
+    return PersonaVisualGraph(
+        identity=identity,
+        pack=PersonaVisualPackRecord(
+            id=13,
+            title="Operator states",
+            description="Local operational art",
+            status="active",
+            source_kind="manual",
+            created_at="2026-08-20 12:00:00",
+            updated_at="2026-08-20 12:00:00",
+            revision=4,
+        ),
+        version=PersonaVisualVersionRecord(
+            id=17,
+            pack_id=13,
+            version_number=2,
+            renderer_type="sprite_frames",
+            manifest_version=1,
+            manifest=manifest,
+            manifest_sha256="a" * 64,
+            created_at="2026-08-20 12:00:00",
+        ),
+        binding=PersonaVisualBindingRecord(
+            id=11,
+            persona_id="local-persona-7",
+            persona_revision=9,
+            pack_id=13,
+            active_version_id=17,
+            status="active",
+            created_at="2026-08-20 12:00:00",
+            updated_at="2026-08-20 12:00:00",
+            revision=3,
+        ),
+        assets=(
+            PersonaVisualAssetRecord(
+                id=19,
+                pack_id=13,
+                pack_version_id=17,
+                asset_key="idle",
+                role="frame",
+                mime_type="image/png",
+                byte_count=4,
+                sha256=hashlib.sha256(b"idle").hexdigest(),
+                width=4,
+                height=5,
+                frame_count=1,
+                duration_ms=None,
+                created_at="2026-08-20 12:00:00",
+            ),
+        ),
+    )
+
+
+def _active_draft():
+    return persona_visual_draft_from_graph(
+        _graph(),
+        source_storage_keys={"idle": "active/idle.png"},
+    )
+
+
+def test_active_graph_becomes_an_immutable_isolated_draft() -> None:
+    graph = _graph()
+
+    draft = persona_visual_draft_from_graph(
+        graph,
+        source_storage_keys={"idle": "active/idle.png"},
+    )
+
+    assert draft.persona_id == graph.identity.persona_id
+    assert draft.persona_revision == graph.identity.persona_revision
+    assert draft.expected_identity == graph.identity
+    assert draft.title == graph.pack.title
+    assert draft.revision == 0
+    assert draft.assets[0].metadata.asset_key == "idle"
+    assert "active/idle.png" not in repr(draft)
+    with pytest.raises(FrozenInstanceError):
+        draft.title = "mutated"  # type: ignore[misc]
+
+
+def test_inventory_always_lists_nine_baselines_then_safe_custom_states() -> None:
+    draft = add_persona_visual_custom_state(
+        _active_draft(),
+        state="deep_focus",
+        label="Deep focus",
+        kind="mood",
+    )
+
+    inventory = inspect_persona_visual_draft(draft)
+
+    assert tuple(row.state for row in inventory.rows[:9]) == RESERVED_STATES
+    assert inventory.rows[-1].state == "deep_focus"
+    assert inventory.rows[-1].label == "Deep focus"
+    assert inventory.rows[-1].custom is True
+    assert inventory.rows[-1].configured is False
+    assert inventory.activatable is True
+    assert inventory.asset_count == 1
+    assert inventory.validation_reason is None
+
+
+@pytest.mark.parametrize(
+    "state",
+    ("Idle", "../private", "secret_key", "idle", "x" * 97),
+)
+def test_custom_state_rejects_unsafe_reserved_or_private_slugs(state: str) -> None:
+    with pytest.raises(
+        PersonaVisualAuthoringError, match="^persona_visual_draft_invalid$"
+    ):
+        add_persona_visual_custom_state(
+            _active_draft(),
+            state=state,
+            label="Custom",
+            kind="mood",
+        )
+
+
+def test_replace_returns_new_draft_and_preserves_authoritative_draft() -> None:
+    original = _active_draft()
+    replacement = PersonaVisualDraftAsset("uploads/speaking.png", _metadata("speaking"))
+
+    changed = replace_persona_visual_draft_state(
+        original,
+        state="speaking",
+        asset=replacement,
+    )
+
+    original_inventory = inspect_persona_visual_draft(original)
+    changed_inventory = inspect_persona_visual_draft(changed)
+    assert original.revision == 0
+    assert changed.revision == 1
+    assert tuple(asset.metadata.asset_key for asset in original.assets) == ("idle",)
+    assert tuple(asset.metadata.asset_key for asset in changed.assets) == (
+        "idle",
+        "speaking",
+    )
+    assert (
+        next(
+            row for row in original_inventory.rows if row.state == "speaking"
+        ).asset_key
+        == "idle"
+    )
+    assert (
+        next(row for row in changed_inventory.rows if row.state == "speaking").asset_key
+        == "speaking"
+    )
+
+
+def test_replace_cannot_reuse_an_asset_key_owned_by_other_states() -> None:
+    original = _active_draft()
+
+    with pytest.raises(
+        PersonaVisualAuthoringError,
+        match="^persona_visual_draft_invalid$",
+    ):
+        replace_persona_visual_draft_state(
+            original,
+            state="speaking",
+            asset=PersonaVisualDraftAsset(
+                "uploads/different-idle.png",
+                _metadata("idle", marker=b"different"),
+            ),
+        )
+
+    assert inspect_persona_visual_draft(original).activatable is True
+
+
+def test_clear_required_state_is_reviewable_but_not_publishable() -> None:
+    original = _active_draft()
+
+    changed = clear_persona_visual_draft_state(original, state="error")
+    inventory = inspect_persona_visual_draft(changed)
+
+    assert changed.revision == 1
+    assert (
+        next(row for row in inventory.rows if row.state == "error").configured is False
+    )
+    assert inventory.activatable is False
+    assert inventory.validation_reason == "persona_visual_draft_incomplete"
+    assert inspect_persona_visual_draft(original).activatable is True
+    with pytest.raises(
+        PersonaVisualAuthoringError,
+        match="^persona_visual_draft_incomplete$",
+    ):
+        persona_visual_draft_publication_snapshot(changed)
+
+
+def test_clear_prunes_only_assets_and_animations_no_longer_referenced() -> None:
+    replaced = replace_persona_visual_draft_state(
+        _active_draft(),
+        state="speaking",
+        asset=PersonaVisualDraftAsset(
+            "uploads/speaking.png",
+            _metadata("speaking"),
+        ),
+    )
+
+    cleared = clear_persona_visual_draft_state(replaced, state="speaking")
+
+    assert tuple(asset.metadata.asset_key for asset in cleared.assets) == ("idle",)
+    assert "speaking" not in cleared.manifest_json
+
+
+def test_empty_draft_captures_first_publication_authority() -> None:
+    draft = create_persona_visual_draft(
+        persona_id="new-local-persona",
+        persona_revision=1,
+        title="New operational states",
+    )
+
+    assert draft.expected_identity is None
+    assert draft.assets == ()
+    assert inspect_persona_visual_draft(draft).activatable is False
+    assert (
+        tuple(row.state for row in inspect_persona_visual_draft(draft).rows)
+        == RESERVED_STATES
+    )
+
+
+def test_publication_snapshot_is_canonical_and_keeps_exact_authority() -> None:
+    original = _active_draft()
+    changed = replace_persona_visual_draft_state(
+        original,
+        state="speaking",
+        asset=PersonaVisualDraftAsset(
+            "uploads/speaking.png",
+            _metadata("speaking"),
+        ),
+    )
+
+    snapshot = persona_visual_draft_publication_snapshot(changed)
+
+    assert snapshot.persona_id == original.persona_id
+    assert snapshot.persona_revision == original.persona_revision
+    assert snapshot.expected_identity == original.expected_identity
+    assert snapshot.title == original.title
+    assert snapshot.manifest_json == changed.manifest_json
+    assert tuple(source.source_storage_key for source in snapshot.assets) == (
+        "active/idle.png",
+        "uploads/speaking.png",
+    )
+
+
+def test_draft_rejects_missing_or_extra_source_keys() -> None:
+    graph = _graph()
+
+    for sources in ({}, {"idle": "idle.png", "extra": "extra.png"}):
+        with pytest.raises(
+            PersonaVisualAuthoringError,
+            match="^persona_visual_draft_invalid$",
+        ):
+            persona_visual_draft_from_graph(graph, source_storage_keys=sources)
+
+
+def test_draft_revalidates_hostile_frozen_metadata_and_identity() -> None:
+    draft = _active_draft()
+    object.__setattr__(draft.assets[0].metadata, "byte_count", -1)
+
+    with pytest.raises(
+        PersonaVisualAuthoringError,
+        match="^persona_visual_draft_invalid$",
+    ):
+        inspect_persona_visual_draft(draft)
+
+    draft = _active_draft()
+    hostile_identity = replace(draft.expected_identity)
+    object.__setattr__(hostile_identity, "binding_id", ["private/path"])
+    object.__setattr__(draft, "expected_identity", hostile_identity)
+
+    with pytest.raises(
+        PersonaVisualAuthoringError,
+        match="^persona_visual_draft_invalid$",
+    ):
+        persona_visual_draft_publication_snapshot(draft)

--- a/Tests/Persona_Visual/test_persona_visual_authoring_workspace.py
+++ b/Tests/Persona_Visual/test_persona_visual_authoring_workspace.py
@@ -1,0 +1,158 @@
+"""Private staging tests for screen-owned Persona Visual authoring."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from tldw_chatbook.Persona_Visual.authoring import (
+    PersonaVisualAuthoringDraft,
+    PersonaVisualDraftAsset,
+    create_persona_visual_import_draft,
+)
+from tldw_chatbook.Persona_Visual.authoring_workspace import (
+    PersonaVisualAuthoringWorkspaceError,
+    adopt_persona_visual_draft_sources,
+    cleanup_persona_visual_authoring_workspace,
+    create_persona_visual_authoring_workspace,
+    stage_persona_visual_authoring_asset,
+)
+from tldw_chatbook.Persona_Visual.assets import PersonaVisualAssetMetadata
+
+
+def _png(color=(20, 40, 60, 255)) -> bytes:
+    output = BytesIO()
+    Image.new("RGBA", (2, 2), color).save(output, format="PNG")
+    return output.getvalue()
+
+
+def _import_draft(source_key: str, data: bytes) -> PersonaVisualAuthoringDraft:
+    digest = hashlib.sha256(data).hexdigest()
+    metadata = PersonaVisualAssetMetadata(
+        asset_key="idle-frame",
+        role="frame",
+        mime_type="image/png",
+        byte_count=len(data),
+        sha256=digest,
+        width=2,
+        height=2,
+        frame_count=1,
+        duration_ms=None,
+    )
+    manifest = (
+        '{"animations":{"idle":{"frames":[{"asset_id":"idle-frame"}]}},'
+        '"authored_triggers":[],"fallbacks":{},"manifest_version":1,'
+        '"renderer_type":"sprite_frames","state_catalog":{},'
+        '"states":{"idle":{"animation_id":"idle"}}}'
+    )
+    return create_persona_visual_import_draft(
+        persona_id="p-1",
+        persona_revision=1,
+        expected_identity=None,
+        title="Imported",
+        description="",
+        manifest_json=manifest,
+        assets=(PersonaVisualDraftAsset(source_key, metadata),),
+    )
+
+
+def test_stage_asset_returns_private_relative_source_and_path_free_repr(tmp_path: Path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace = create_persona_visual_authoring_workspace(profile_root)
+    updated, asset = stage_persona_visual_authoring_asset(
+        workspace,
+        _png(),
+        state="idle",
+    )
+
+    assert not asset.source_storage_key.startswith("/")
+    assert (profile_root / asset.source_storage_key).is_file()
+    assert asset.metadata.asset_key.startswith("idle-")
+    assert asset.metadata.role == "frame"
+    assert str(profile_root) not in repr(updated)
+    assert str(profile_root) not in repr(asset)
+
+
+def test_adopt_imported_sources_copies_bytes_and_rewrites_only_source_keys(
+    tmp_path: Path,
+):
+    data = _png()
+    imported_root = tmp_path / "imported"
+    (imported_root / "assets").mkdir(parents=True)
+    (imported_root / "assets" / "000.png").write_bytes(data)
+    draft = _import_draft("assets/000.png", data)
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace = create_persona_visual_authoring_workspace(profile_root)
+
+    updated, adopted = adopt_persona_visual_draft_sources(
+        workspace,
+        draft,
+        source_root=imported_root,
+    )
+
+    assert adopted.manifest_json == draft.manifest_json
+    assert adopted.source_kind == "imported"
+    assert adopted.assets[0].metadata == draft.assets[0].metadata
+    assert adopted.assets[0].source_storage_key != "assets/000.png"
+    assert (profile_root / adopted.assets[0].source_storage_key).read_bytes() == data
+    assert len(updated.asset_names) == 1
+
+
+def test_cleanup_refuses_same_path_replacement_with_copied_content(tmp_path: Path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace, _asset = stage_persona_visual_authoring_asset(
+        create_persona_visual_authoring_workspace(profile_root),
+        _png(),
+        state="idle",
+    )
+    issued = profile_root / workspace.relative_root
+    backup = profile_root / "issued-backup"
+    issued.rename(backup)
+    shutil.copytree(backup, issued)
+
+    assert cleanup_persona_visual_authoring_workspace(workspace) is False
+    assert issued.is_dir()
+    assert backup.is_dir()
+
+
+def test_cleanup_deletes_only_the_exact_issued_workspace(tmp_path: Path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace, asset = stage_persona_visual_authoring_asset(
+        create_persona_visual_authoring_workspace(profile_root),
+        _png(),
+        state="idle",
+    )
+    unrelated = profile_root / "keep.txt"
+    unrelated.write_text("keep")
+
+    assert cleanup_persona_visual_authoring_workspace(workspace) is True
+    assert not (profile_root / asset.source_storage_key).exists()
+    assert unrelated.read_text() == "keep"
+
+
+def test_invalid_asset_fails_path_free_without_leaving_a_file(tmp_path: Path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace = create_persona_visual_authoring_workspace(profile_root)
+
+    with pytest.raises(
+        PersonaVisualAuthoringWorkspaceError,
+        match="^persona_visual_authoring_asset_invalid$",
+    ):
+        stage_persona_visual_authoring_asset(workspace, b"not an image", state="idle")
+
+    candidate = profile_root / workspace.relative_root
+    assert sorted(path.name for path in candidate.iterdir()) == [
+        ".persona-visual-authoring",
+        "assets",
+    ]
+    assert list((candidate / "assets").iterdir()) == []

--- a/Tests/Persona_Visual/test_persona_visual_authoring_workspace.py
+++ b/Tests/Persona_Visual/test_persona_visual_authoring_workspace.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from tldw_chatbook.Persona_Visual.assets import PersonaVisualAssetMetadata
 from tldw_chatbook.Persona_Visual.authoring import (
     PersonaVisualAuthoringDraft,
     PersonaVisualDraftAsset,
@@ -22,7 +23,6 @@ from tldw_chatbook.Persona_Visual.authoring_workspace import (
     create_persona_visual_authoring_workspace,
     stage_persona_visual_authoring_asset,
 )
-from tldw_chatbook.Persona_Visual.assets import PersonaVisualAssetMetadata
 
 
 def _png(color=(20, 40, 60, 255)) -> bytes:
@@ -137,6 +137,44 @@ def test_cleanup_deletes_only_the_exact_issued_workspace(tmp_path: Path):
     assert cleanup_persona_visual_authoring_workspace(workspace) is True
     assert not (profile_root / asset.source_storage_key).exists()
     assert unrelated.read_text() == "keep"
+
+
+def test_cleanup_refuses_replaced_staged_file(tmp_path: Path):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace, asset = stage_persona_visual_authoring_asset(
+        create_persona_visual_authoring_workspace(profile_root),
+        _png(),
+        state="idle",
+    )
+    staged = profile_root / asset.source_storage_key
+    staged.unlink()
+    staged.write_bytes(b"unrelated")
+    staged.chmod(0o600)
+
+    assert cleanup_persona_visual_authoring_workspace(workspace) is False
+    assert staged.read_bytes() == b"unrelated"
+
+
+def test_stage_refuses_replaced_assets_directory_without_external_write(
+    tmp_path: Path,
+):
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    workspace = create_persona_visual_authoring_workspace(profile_root)
+    candidate = profile_root / workspace.relative_root
+    (candidate / "assets").rename(candidate / "assets-original")
+    external = tmp_path / "external"
+    external.mkdir()
+    (candidate / "assets").symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(
+        PersonaVisualAuthoringWorkspaceError,
+        match="^persona_visual_authoring_asset_invalid$",
+    ):
+        stage_persona_visual_authoring_asset(workspace, _png(), state="idle")
+
+    assert list(external.iterdir()) == []
 
 
 def test_invalid_asset_fails_path_free_without_leaving_a_file(tmp_path: Path):

--- a/Tests/Persona_Visual/test_persona_visual_importer.py
+++ b/Tests/Persona_Visual/test_persona_visual_importer.py
@@ -1,0 +1,600 @@
+"""Tests for review-first Persona Visual pack archive import."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+import threading
+import unicodedata
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+from PIL import Image
+
+import tldw_chatbook.Persona_Visual.importer as importer_module
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Visual.authoring import (
+    inspect_persona_visual_draft,
+    persona_visual_draft_publication_snapshot,
+)
+from tldw_chatbook.Persona_Visual.importer import (
+    PersonaVisualImportError,
+    cleanup_persona_visual_import_review,
+    import_persona_visual_pack,
+    persona_visual_import_source_root,
+)
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
+from tldw_chatbook.Persona_Visual.publication import publish_persona_visual
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _png_bytes(color: tuple[int, int, int] = (5, 10, 15)) -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (4, 5), color).save(output, format="PNG")
+    return output.getvalue()
+
+
+def _visual_manifest() -> dict[str, object]:
+    return {
+        "renderer_type": "sprite_frames",
+        "manifest_version": 1,
+        "states": {
+            state: {"animation_id": "idle-loop"}
+            for state in ("idle", "listening", "thinking", "speaking", "error")
+        },
+        "animations": {
+            "idle-loop": {
+                "frames": [{"asset_id": "idle"}],
+                "preview_asset_id": "idle",
+                "frame_rate": 2,
+            }
+        },
+        "fallbacks": {},
+        "state_catalog": {},
+        "authored_triggers": [],
+    }
+
+
+def _archive_payloads(
+    *,
+    asset_data: bytes | None = None,
+    asset_path: str = "assets/persona_visuals/idle.png",
+    asset_mime: str = "image/png",
+    asset_sha256: str | None = None,
+    visual_manifest: dict[str, object] | None = None,
+) -> dict[str, bytes]:
+    data = asset_data or _png_bytes()
+    digest = asset_sha256 or hashlib.sha256(data).hexdigest()
+    pack_payload = _canonical(
+        {
+            "pack": {
+                "source_pack_id": "server-pack-1",
+                "source_persona_id": "server-persona-1",
+                "title": "Imported operator states",
+                "renderer_type": "sprite_frames",
+                "manifest_version": 1,
+                "visual_manifest": visual_manifest or _visual_manifest(),
+                "provenance": "imported",
+            }
+        }
+    )
+    assets_payload = _canonical(
+        {
+            "assets": [
+                {
+                    "source_asset_id": "idle",
+                    "source_pack_id": "server-pack-1",
+                    "source_persona_id": "server-persona-1",
+                    "asset_role": "frame",
+                    "mime_type": asset_mime,
+                    "byte_size": len(data),
+                    "checksum_sha256": digest,
+                    "width": 4,
+                    "height": 5,
+                    "duration_ms": None,
+                    "asset_bytes_status": "present",
+                    "asset_path": asset_path,
+                    "asset_sha256": digest,
+                    "asset_size_bytes": len(data),
+                }
+            ]
+        }
+    )
+    checksums = {
+        "metadata/pack.json": hashlib.sha256(pack_payload).hexdigest(),
+        "metadata/assets.json": hashlib.sha256(assets_payload).hexdigest(),
+        asset_path: hashlib.sha256(data).hexdigest(),
+    }
+    outer_manifest = _canonical(
+        {
+            "schema_version": "tldw.persona_visual_pack.v1",
+            "exported_by": {"app": "tldw_server"},
+            "pack_title": "Imported operator states",
+            "renderer_type": "sprite_frames",
+            "counts": {"assets": 1, "assets_with_bytes": 1, "missing_assets": 0},
+            "encryption": {"encrypted": False, "scheme": None},
+            "sections": [
+                {"path": path, "sha256": checksum}
+                for path, checksum in sorted(checksums.items())
+            ],
+        }
+    )
+    checksums["manifest.json"] = hashlib.sha256(outer_manifest).hexdigest()
+    return {
+        "manifest.json": outer_manifest,
+        "metadata/pack.json": pack_payload,
+        "metadata/assets.json": assets_payload,
+        "checksums/sha256.json": _canonical(checksums),
+        asset_path: data,
+        "README.md": b"# Imported title\n\nUntrusted review text.\n",
+        "signatures/README.md": b"Reserved.\n",
+    }
+
+
+def _write_archive(
+    path: Path,
+    payloads: dict[str, bytes] | None = None,
+    *,
+    compression: int = zipfile.ZIP_DEFLATED,
+) -> Path:
+    with zipfile.ZipFile(path, "w", compression=compression) as archive:
+        for name, data in (payloads or _archive_payloads()).items():
+            archive.writestr(name, data)
+    return path
+
+
+def _replace_declared_payload(
+    payloads: dict[str, bytes],
+    name: str,
+    data: bytes,
+) -> None:
+    payloads[name] = data
+    checksums = json.loads(payloads["checksums/sha256.json"])
+    checksums[name] = hashlib.sha256(data).hexdigest()
+    outer = json.loads(payloads["manifest.json"])
+    for section in outer["sections"]:
+        if section["path"] == name:
+            section["sha256"] = checksums[name]
+    outer_data = _canonical(outer)
+    payloads["manifest.json"] = outer_data
+    checksums["manifest.json"] = hashlib.sha256(outer_data).hexdigest()
+    payloads["checksums/sha256.json"] = _canonical(checksums)
+
+
+def _identity() -> PersonaVisualIdentity:
+    return PersonaVisualIdentity(
+        persona_id="local-persona-1",
+        persona_revision=7,
+        binding_id=2,
+        binding_version=3,
+        pack_id=5,
+        pack_revision=7,
+        pack_version_id=11,
+        version_number=2,
+        manifest_sha256="a" * 64,
+    )
+
+
+def _import(archive: Path, staging_root: Path, **kwargs: Any):
+    staging_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return import_persona_visual_pack(
+        archive,
+        staging_root=staging_root,
+        persona_id="local-persona-1",
+        persona_revision=7,
+        expected_identity=_identity(),
+        **kwargs,
+    )
+
+
+def test_valid_server_v1_archive_becomes_inactive_path_free_review(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+
+    review = _import(archive, staging_root)
+    inventory = inspect_persona_visual_draft(review.draft)
+
+    assert review.schema_version == "tldw.persona_visual_pack.v1"
+    assert review.archive_sha256 == hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert review.pack_title == "Imported operator states"
+    assert review.asset_count == 1
+    assert review.state_count == 5
+    assert inventory.activatable is True
+    assert review.draft.expected_identity == _identity()
+    assert "private-staging" not in repr(review)
+    source_root = persona_visual_import_source_root(review, staging_root=staging_root)
+    assert source_root.is_dir()
+    assert (source_root / review.draft.assets[0].source_storage_key).is_file()
+    assert not hasattr(review, "activate")
+
+
+def test_import_cleanup_removes_only_the_exact_issued_staging_tree(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    review = _import(archive, staging_root)
+    source_root = persona_visual_import_source_root(review, staging_root=staging_root)
+    unrelated = staging_root / "unrelated"
+    unrelated.mkdir(mode=0o700)
+    (unrelated / "keep.txt").write_text("keep")
+
+    assert (
+        cleanup_persona_visual_import_review(review, staging_root=staging_root) is True
+    )
+
+    assert not source_root.exists()
+    assert (unrelated / "keep.txt").read_text() == "keep"
+
+
+def test_review_draft_publishes_once_through_the_existing_sqlite_boundary(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    staging_root.mkdir(mode=0o700)
+    review = import_persona_visual_pack(
+        archive,
+        staging_root=staging_root,
+        persona_id="first-local-persona",
+        persona_revision=1,
+        expected_identity=None,
+    )
+    source_root = persona_visual_import_source_root(
+        review,
+        staging_root=staging_root,
+    )
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir(mode=0o700)
+    db = CharactersRAGDB(tmp_path / "import-publication.db", "import-publication")
+    repository = PersonaVisualRepository(db)
+    try:
+        result = publish_persona_visual(
+            repository,
+            persona_visual_draft_publication_snapshot(review.draft),
+            source_root=source_root,
+            profile_root=profile_root,
+            authority_guard=lambda: True,
+        )
+
+        assert result.old_identity is None
+        assert (
+            repository.get_active_persona_pack("first-local-persona").identity
+            == result.new_identity
+        )
+        assert (
+            repository.get_active_persona_pack("first-local-persona").pack.source_kind
+            == "imported"
+        )
+        assert (
+            cleanup_persona_visual_import_review(
+                review,
+                staging_root=staging_root,
+            )
+            is True
+        )
+    finally:
+        db.close_connection()
+
+
+def test_cleanup_refuses_same_path_replacement_even_with_copied_marker(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    review = _import(archive, staging_root)
+    issued = persona_visual_import_source_root(review, staging_root=staging_root)
+    backup = staging_root / "issued-backup"
+    issued.rename(backup)
+    issued.mkdir(mode=0o700)
+    marker = next(path for path in backup.iterdir() if path.name.startswith("."))
+    shutil.copyfile(marker, issued / marker.name)
+    (issued / "unrelated.txt").write_text("must survive")
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cleanup_denied$",
+    ):
+        cleanup_persona_visual_import_review(review, staging_root=staging_root)
+
+    assert (issued / "unrelated.txt").read_text() == "must survive"
+    assert backup.is_dir()
+
+
+def test_cleanup_refuses_exact_same_path_copy_of_issued_candidate(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    review = _import(archive, staging_root)
+    issued = persona_visual_import_source_root(review, staging_root=staging_root)
+    backup = staging_root / "issued-backup"
+    issued.rename(backup)
+    shutil.copytree(backup, issued)
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cleanup_denied$",
+    ):
+        cleanup_persona_visual_import_review(review, staging_root=staging_root)
+
+    assert issued.is_dir()
+    assert backup.is_dir()
+
+
+def test_source_and_cleanup_refuse_a_marker_symlink(tmp_path: Path) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    review = _import(archive, staging_root)
+    issued = persona_visual_import_source_root(review, staging_root=staging_root)
+    marker = next(path for path in issued.iterdir() if path.name.startswith("."))
+    backup = issued / "marker-backup"
+    marker.rename(backup)
+    marker.symlink_to(backup.name)
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cleanup_denied$",
+    ):
+        persona_visual_import_source_root(review, staging_root=staging_root)
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cleanup_denied$",
+    ):
+        cleanup_persona_visual_import_review(review, staging_root=staging_root)
+
+    assert backup.is_file()
+
+
+@pytest.mark.parametrize(
+    "unsafe_name",
+    (
+        "../escape.png",
+        "/absolute.png",
+        "assets\\backslash.png",
+        "assets/CON.png",
+        "assets/nested.zip",
+        "other/file.png",
+    ),
+)
+def test_import_rejects_unsafe_or_unexpected_members_before_staging(
+    tmp_path: Path,
+    unsafe_name: str,
+) -> None:
+    payloads = _archive_payloads()
+    payloads[unsafe_name] = b"unsafe"
+    archive = _write_archive(tmp_path / "unsafe.tldw-persona-vpack", payloads)
+    staging_root = tmp_path / "private-staging"
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_invalid$",
+    ):
+        _import(archive, staging_root)
+
+    assert not staging_root.exists() or list(staging_root.iterdir()) == []
+
+
+def test_import_rejects_unicode_and_case_colliding_members(tmp_path: Path) -> None:
+    payloads = _archive_payloads()
+    payloads["assets/persona_visuals/IDLE.png"] = b"case"
+    payloads[
+        "assets/persona_visuals/" + unicodedata.normalize("NFD", "café") + ".png"
+    ] = b"unicode-a"
+    payloads["assets/persona_visuals/café.png"] = b"unicode-b"
+    archive = _write_archive(tmp_path / "collision.tldw-persona-vpack", payloads)
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_invalid$",
+    ):
+        _import(archive, tmp_path / "private-staging")
+
+
+def test_import_rejects_duplicate_members_and_json_keys(tmp_path: Path) -> None:
+    duplicate_archive = tmp_path / "duplicate.tldw-persona-vpack"
+    payloads = _archive_payloads()
+    with zipfile.ZipFile(duplicate_archive, "w") as archive:
+        for name, data in payloads.items():
+            archive.writestr(name, data)
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            archive.writestr("metadata/pack.json", payloads["metadata/pack.json"])
+    with pytest.raises(PersonaVisualImportError):
+        _import(duplicate_archive, tmp_path / "duplicate-staging")
+
+    payloads = _archive_payloads()
+    pack = payloads["metadata/pack.json"]
+    duplicate_pack = b'{"pack":' + pack[len(b'{"pack":') : -1] + b',"pack":{}}'
+    _replace_declared_payload(payloads, "metadata/pack.json", duplicate_pack)
+    duplicate_json = _write_archive(
+        tmp_path / "duplicate-json.tldw-persona-vpack",
+        payloads,
+    )
+    with pytest.raises(PersonaVisualImportError):
+        _import(duplicate_json, tmp_path / "json-staging")
+
+
+@pytest.mark.parametrize("encrypted", (False, True))
+def test_import_rejects_link_and_encrypted_entries(
+    tmp_path: Path,
+    encrypted: bool,
+) -> None:
+    archive_path = tmp_path / "linked.tldw-persona-vpack"
+    payloads = _archive_payloads()
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for name, data in payloads.items():
+            archive.writestr(name, data)
+        info = zipfile.ZipInfo("assets/persona_visuals/link.png")
+        info.create_system = 3
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        if encrypted:
+            info.flag_bits |= 0x1
+        archive.writestr(info, b"idle.png")
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_invalid$",
+    ):
+        _import(archive_path, tmp_path / "private-staging")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("checksum", "mime", "missing", "undeclared", "unsupported", "encrypted"),
+)
+def test_import_rejects_invalid_declarations_without_residue(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    payloads = _archive_payloads(
+        asset_sha256=("f" * 64 if mutation == "checksum" else None),
+        asset_mime=("image/jpeg" if mutation == "mime" else "image/png"),
+        visual_manifest=(
+            {**_visual_manifest(), "manifest_version": 2}
+            if mutation == "unsupported"
+            else None
+        ),
+    )
+    if mutation == "missing":
+        payloads.pop("assets/persona_visuals/idle.png")
+    elif mutation == "undeclared":
+        checksums = json.loads(payloads["checksums/sha256.json"])
+        checksums.pop("assets/persona_visuals/idle.png")
+        payloads["checksums/sha256.json"] = _canonical(checksums)
+    elif mutation == "encrypted":
+        outer = json.loads(payloads["manifest.json"])
+        outer["encryption"] = {"encrypted": True, "scheme": "secret"}
+        payloads["manifest.json"] = _canonical(outer)
+    archive = _write_archive(tmp_path / f"{mutation}.tldw-persona-vpack", payloads)
+    staging_root = tmp_path / "private-staging"
+
+    with pytest.raises(PersonaVisualImportError):
+        _import(archive, staging_root)
+
+    assert not staging_root.exists() or list(staging_root.iterdir()) == []
+
+
+def test_import_cancellation_discards_owned_staging(tmp_path: Path) -> None:
+    archive = _write_archive(tmp_path / "cancel.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+    cancelled = threading.Event()
+    cancelled.set()
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cancelled$",
+    ):
+        _import(archive, staging_root, cancel_event=cancelled)
+
+    assert not staging_root.exists() or list(staging_root.iterdir()) == []
+
+
+def test_import_cancellation_is_checked_while_streaming_checksums(
+    tmp_path: Path,
+) -> None:
+    archive = _write_archive(tmp_path / "cancel-stream.tldw-persona-vpack")
+    staging_root = tmp_path / "private-staging"
+
+    class CancelDuringChecksum:
+        calls = 0
+
+        def is_set(self) -> bool:
+            self.calls += 1
+            return self.calls >= 4
+
+    cancelled = CancelDuringChecksum()
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_cancelled$",
+    ):
+        _import(archive, staging_root, cancel_event=cancelled)
+
+    assert cancelled.calls == 4
+    assert list(staging_root.iterdir()) == []
+
+
+def test_import_rejects_source_symlink_and_insufficient_space(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_archive(tmp_path / "valid.tldw-persona-vpack")
+    linked = tmp_path / "linked.tldw-persona-vpack"
+    linked.symlink_to(archive.name)
+    with pytest.raises(PersonaVisualImportError):
+        _import(linked, tmp_path / "linked-staging")
+
+    disk_usage = shutil.disk_usage(tmp_path)
+    monkeypatch.setattr(
+        importer_module.shutil,
+        "disk_usage",
+        lambda _path: type(disk_usage)(disk_usage.total, disk_usage.used, 0),
+    )
+    staging_root = tmp_path / "space-staging"
+    with pytest.raises(PersonaVisualImportError):
+        _import(archive, staging_root)
+    assert list(staging_root.iterdir()) == []
+
+
+def test_archive_replacement_before_final_revalidation_discards_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_archive(tmp_path / "replace.tldw-persona-vpack")
+    replacement = _write_archive(
+        tmp_path / "replacement.tldw-persona-vpack",
+        _archive_payloads(asset_data=_png_bytes((90, 80, 70))),
+    )
+    staging_root = tmp_path / "private-staging"
+    original = importer_module._source_identity_current
+    replaced = False
+
+    def replace_before_check(*args: object, **kwargs: object) -> bool:
+        nonlocal replaced
+        if not replaced:
+            replaced = True
+            os.replace(replacement, archive)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        importer_module,
+        "_source_identity_current",
+        replace_before_check,
+    )
+
+    with pytest.raises(
+        PersonaVisualImportError,
+        match="^persona_visual_import_stale$",
+    ):
+        _import(archive, staging_root)
+
+    assert list(staging_root.iterdir()) == []
+
+
+def test_import_errors_and_repr_do_not_expose_private_paths(tmp_path: Path) -> None:
+    private_marker = "private-user-secret-archive"
+    archive = tmp_path / f"{private_marker}.tldw-persona-vpack"
+    archive.write_bytes(b"not a zip")
+
+    with pytest.raises(PersonaVisualImportError) as caught:
+        _import(archive, tmp_path / "private-staging")
+
+    assert private_marker not in str(caught.value)
+    assert private_marker not in repr(caught.value)

--- a/Tests/UI/test_personas_persona_visual_authoring.py
+++ b/Tests/UI/test_personas_persona_visual_authoring.py
@@ -1,0 +1,707 @@
+"""Mounted orchestration tests for Persona Visual authoring in Personas."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from PIL import Image
+
+import tldw_chatbook.UI.CCP_Modules.ccp_character_handler as character_handler_module
+import tldw_chatbook.UI.Screens.personas_screen as personas_screen_module
+from Tests.UI.test_personas_workbench import (
+    CHARACTERS,
+    PROFILE,
+    PersonasTestApp,
+    _mounted,
+)
+from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportReview
+from tldw_chatbook.Persona_Visual.publication import (
+    PersonaVisualPublicationError,
+    PersonaVisualPublicationResult,
+)
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualIdentity
+from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.Utils.paths import get_user_data_dir
+from tldw_chatbook.Widgets.Persona_Widgets.personas_pane_messages import (
+    EditPersonaProfileRequested,
+    PersonaProfileSaveRequested,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_persona_visual_pack_widget import (
+    PersonasPersonaVisualPackWidget,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def stub_characters(monkeypatch):
+    from Tests.UI.test_personas_dictionaries import patch_character_paging
+
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_all_characters",
+        lambda: [dict(character) for character in CHARACTERS],
+    )
+    monkeypatch.setattr(
+        character_handler_module,
+        "fetch_character_by_id",
+        lambda character_id: next(
+            dict(character)
+            for character in CHARACTERS
+            if str(character["id"]) == str(character_id)
+        ),
+    )
+    patch_character_paging(monkeypatch)
+
+
+class _Repository:
+    def __init__(self, _db):
+        pass
+
+    def get_active_persona_pack(self, _persona_id):
+        return None
+
+
+def _identity(version: int = 1) -> PersonaVisualIdentity:
+    return PersonaVisualIdentity(
+        persona_id="p-1",
+        persona_revision=2,
+        binding_id=11,
+        binding_version=version,
+        pack_id=12,
+        pack_revision=version,
+        pack_version_id=13,
+        version_number=version,
+        manifest_sha256="a" * 64,
+    )
+
+
+def _png() -> bytes:
+    output = BytesIO()
+    Image.new("RGBA", (4, 4), (20, 40, 60, 255)).save(output, format="PNG")
+    return output.getvalue()
+
+
+@pytest.fixture
+def local_scope(mock_app_instance):
+    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
+    local = Mock()
+    local.get_persona_profile.return_value = dict(record)
+    scope = Mock()
+    scope.local_service = local
+    scope.list_persona_profiles = AsyncMock(
+        return_value={"items": [dict(record)], "total": 1}
+    )
+    scope.get_persona_profile = AsyncMock(return_value=dict(record))
+    scope.update_persona_profile = AsyncMock(return_value=dict(record))
+    scope.create_persona_profile = AsyncMock(return_value=dict(record))
+    mock_app_instance.character_persona_scope_service = scope
+    mock_app_instance.chachanotes_db = object()
+    return scope
+
+
+async def _open_editor(pilot) -> PersonasScreen:
+    screen = await _mounted(pilot)
+    await pilot.click("#personas-mode-personas")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.click("#personas-library-row-persona-p-1")
+    await pilot.pause()
+    screen.post_message(EditPersonaProfileRequested("p-1"))
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return screen
+
+
+async def test_local_editor_loads_isolated_unbound_draft(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        state = screen._persona_visual_authoring
+        browser = screen.query_one(PersonasPersonaVisualPackWidget)
+
+        assert state is not None
+        assert state.draft.persona_id == "p-1"
+        assert state.draft.persona_revision == 2
+        assert state.dirty is False
+        assert browser.availability == "available"
+
+
+async def test_custom_edit_is_staged_and_blocks_profile_save(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+    notifications: list[str] = []
+    app.notify = lambda message, **_kwargs: notifications.append(str(message))
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        assert await screen._stage_persona_visual_custom(
+            "deep_focus", "Deep focus", "mood"
+        )
+        screen.post_message(
+            PersonaProfileSaveRequested(
+                {"id": "p-1", "version": 2, "name": "Archivist"}
+            )
+        )
+        await pilot.pause()
+
+        assert screen._persona_visual_authoring is not None
+        assert screen._persona_visual_authoring.dirty is True
+        assert local_scope.update_persona_profile.await_count == 0
+        assert any("Save or Cancel Persona Visual" in item for item in notifications)
+
+
+async def test_import_review_replaces_draft_without_publication(
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+    publish = Mock()
+    monkeypatch.setattr(personas_screen_module, "publish_persona_visual", publish)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        original = screen._persona_visual_authoring
+        imported = personas_screen_module.create_persona_visual_draft(
+            persona_id="p-1", persona_revision=2, title="Imported"
+        )
+        review = PersonaVisualImportReview(
+            schema_version="tldw.persona_visual_pack.v1",
+            archive_sha256="b" * 64,
+            pack_title="Imported",
+            asset_count=0,
+            state_count=0,
+            draft=imported,
+            cleanup_candidate="pvi1:" + "c" * 64 + ":.import-" + "d" * 32,
+            _candidate_name=".import-" + "d" * 32,
+            _candidate_identity=(1, 2),
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "import_persona_visual_pack",
+            lambda *_args, **_kwargs: review,
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "persona_visual_import_source_root",
+            lambda *_args, **_kwargs: tmp_path,
+        )
+
+        assert await screen._import_persona_visual_from_path(
+            "ignored.tldw-persona-vpack"
+        )
+        assert screen._persona_visual_authoring is original
+        assert original.draft.title == "Imported"
+        assert original.dirty is True
+        publish.assert_not_called()
+
+
+async def test_save_publishes_once_then_invalidates_exact_old_and_new(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+    invalidated: list[tuple[str, tuple[PersonaVisualIdentity, ...]]] = []
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        screen._session = SimpleNamespace(
+            invalidate_persona_visual_identities=lambda persona_id, identities: (
+                invalidated.append((persona_id, identities))
+            )
+        )
+        state = screen._persona_visual_authoring
+        assert state is not None
+        state.dirty = True
+        monkeypatch.setattr(
+            personas_screen_module,
+            "persona_visual_draft_publication_snapshot",
+            lambda _draft: object(),
+        )
+        calls: list[object] = []
+
+        def publish(*args, **_kwargs):
+            calls.append(args)
+            return PersonaVisualPublicationResult(_identity(), _identity(2), None)
+
+        monkeypatch.setattr(personas_screen_module, "publish_persona_visual", publish)
+        monkeypatch.setattr(screen, "_configure_persona_visual", AsyncMock())
+
+        assert await screen._save_persona_visual_pack()
+
+        assert len(calls) == 1
+        assert invalidated == [("p-1", (_identity(), _identity(2)))]
+        assert screen._persona_visual_authoring is None
+
+
+async def test_failed_publication_keeps_draft_and_invalidates_nothing(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+    invalidation = AsyncMock()
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        screen._session = SimpleNamespace(
+            invalidate_persona_visual_identities=invalidation
+        )
+        state = screen._persona_visual_authoring
+        assert state is not None
+        state.dirty = True
+        monkeypatch.setattr(
+            personas_screen_module,
+            "persona_visual_draft_publication_snapshot",
+            lambda _draft: object(),
+        )
+
+        def fail(*_args, **_kwargs):
+            raise PersonaVisualPublicationError("persona_visual_authority_changed")
+
+        monkeypatch.setattr(personas_screen_module, "publish_persona_visual", fail)
+
+        assert await screen._save_persona_visual_pack() is False
+        assert screen._persona_visual_authoring is state
+        invalidation.assert_not_awaited()
+
+
+async def test_persona_authority_guard_rejects_revision_and_eligibility_changes(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        state = screen._persona_visual_authoring
+        assert state is not None
+        assert screen._persona_visual_authority_guard(state.snapshot) is True
+
+        local_scope.local_service.get_persona_profile.return_value = {
+            **PROFILE,
+            "version": 3,
+            "is_active": False,
+            "deleted": False,
+        }
+        assert screen._persona_visual_authority_guard(state.snapshot) is False
+
+
+async def test_cancel_signals_active_operation_and_discards_only_draft(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        state = screen._persona_visual_authoring
+        assert state is not None
+        state.dirty = True
+        event = asyncio.Event()
+
+        async def blocked():
+            await event.wait()
+
+        task = asyncio.create_task(blocked())
+        screen._persona_visual_operation_task = task
+        screen._persona_visual_operation_event = threading.Event()
+        monkeypatch.setattr(screen, "_configure_persona_visual", AsyncMock())
+
+        cancel = asyncio.create_task(screen._cancel_persona_visual_authoring())
+        await asyncio.sleep(0)
+        assert screen._persona_visual_operation_event.is_set()
+        event.set()
+        await cancel
+
+        assert screen._persona_visual_authoring is None
+        assert screen._configure_persona_visual.await_count == 1
+
+
+async def test_stale_import_is_cleaned_and_cannot_repaint(
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        original = screen._persona_visual_authoring
+        assert original is not None
+        review = PersonaVisualImportReview(
+            schema_version="tldw.persona_visual_pack.v1",
+            archive_sha256="b" * 64,
+            pack_title="Imported",
+            asset_count=0,
+            state_count=0,
+            draft=original.draft,
+            cleanup_candidate="pvi1:" + "c" * 64 + ":.import-" + "d" * 32,
+            _candidate_name=".import-" + "d" * 32,
+            _candidate_identity=(1, 2),
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_import(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=5)
+            return review
+
+        cleaned: list[PersonaVisualImportReview] = []
+        monkeypatch.setattr(
+            personas_screen_module, "import_persona_visual_pack", blocked_import
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "cleanup_persona_visual_import_review",
+            lambda candidate, **_kwargs: cleaned.append(candidate) or True,
+        )
+        task = asyncio.create_task(
+            screen._import_persona_visual_from_path("ignored.tldw-persona-vpack")
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        screen._persona_visual_generation += 1
+        release.set()
+
+        assert await task is False
+        assert screen._persona_visual_authoring is original
+        assert cleaned == [review]
+
+
+async def test_outer_cancelled_import_drains_and_discards_review(
+    monkeypatch, mock_app_instance, stub_characters, local_scope, tmp_path
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        original = screen._persona_visual_authoring
+        assert original is not None
+        imported = personas_screen_module.create_persona_visual_draft(
+            persona_id="p-1", persona_revision=2, title="Cancelled import"
+        )
+        review = PersonaVisualImportReview(
+            schema_version="tldw.persona_visual_pack.v1",
+            archive_sha256="b" * 64,
+            pack_title="Cancelled import",
+            asset_count=0,
+            state_count=0,
+            draft=imported,
+            cleanup_candidate="pvi1:" + "c" * 64 + ":.import-" + "d" * 32,
+            _candidate_name=".import-" + "d" * 32,
+            _candidate_identity=(1, 2),
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_import(*_args, **_kwargs):
+            started.set()
+            release.wait(timeout=5)
+            return review
+
+        cleaned: list[PersonaVisualImportReview] = []
+        monkeypatch.setattr(
+            personas_screen_module, "import_persona_visual_pack", blocked_import
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "persona_visual_import_source_root",
+            lambda *_args, **_kwargs: tmp_path,
+        )
+        monkeypatch.setattr(
+            personas_screen_module,
+            "cleanup_persona_visual_import_review",
+            lambda candidate, **_kwargs: cleaned.append(candidate) or True,
+        )
+
+        operation = asyncio.create_task(
+            screen._import_persona_visual_from_path("ignored.tldw-persona-vpack")
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        operation.cancel()
+        await asyncio.sleep(0)
+        assert not operation.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+
+        assert screen._persona_visual_authoring is original
+        assert original.draft.title != "Cancelled import"
+        assert cleaned == [review]
+
+
+async def test_unexpected_import_error_category_cannot_reach_notification(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+    notifications: list[str] = []
+    app.notify = lambda message, **_kwargs: notifications.append(str(message))
+    private_marker = "/Users/alice/private/reactions.tldw-persona-vpack"
+
+    class UnexpectedImportError(Exception):
+        category = private_marker
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        monkeypatch.setattr(
+            personas_screen_module,
+            "import_persona_visual_pack",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(UnexpectedImportError()),
+        )
+
+        assert not await screen._import_persona_visual_from_path(
+            "ignored.tldw-persona-vpack"
+        )
+
+        assert notifications
+        assert all(private_marker not in item for item in notifications)
+
+
+async def test_duplicate_save_is_rejected_while_first_publication_drains(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        state = screen._persona_visual_authoring
+        assert state is not None
+        state.dirty = True
+        monkeypatch.setattr(
+            personas_screen_module,
+            "persona_visual_draft_publication_snapshot",
+            lambda _draft: object(),
+        )
+        started = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def publish(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            started.set()
+            release.wait(timeout=5)
+            return PersonaVisualPublicationResult(None, _identity(), None)
+
+        monkeypatch.setattr(personas_screen_module, "publish_persona_visual", publish)
+        monkeypatch.setattr(screen, "_configure_persona_visual", AsyncMock())
+        first = asyncio.create_task(screen._save_persona_visual_pack())
+        while not started.is_set():
+            await asyncio.sleep(0)
+
+        assert await screen._save_persona_visual_pack() is False
+        release.set()
+        assert await first is True
+        assert calls == 1
+
+
+async def test_dirty_navigation_decline_preserves_draft_and_approval_discards_it(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        state = screen._persona_visual_authoring
+        assert state is not None
+        state.dirty = True
+        assert screen._persona_visual_has_unsaved_authoring() is True
+        continued: list[str] = []
+
+        async def continuation():
+            continued.append("continued")
+
+        monkeypatch.setattr(
+            screen, "_confirm_discard_unsaved", AsyncMock(return_value=False)
+        )
+        await screen._confirm_then_run(continuation)
+        assert screen._persona_visual_authoring is state
+        assert continued == []
+
+        monkeypatch.setattr(
+            screen, "_confirm_discard_unsaved", AsyncMock(return_value=True)
+        )
+        await screen._confirm_then_run(continuation)
+        assert screen._persona_visual_authoring is None
+        assert continued == ["continued"]
+
+
+async def test_navigation_drain_defers_outer_cancellation_until_operation_settles(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        release = asyncio.Event()
+
+        async def blocked_operation():
+            await release.wait()
+
+        operation = asyncio.create_task(blocked_operation())
+        screen._persona_visual_operation_task = operation
+        screen._persona_visual_operation_event = threading.Event()
+        discard = AsyncMock()
+        monkeypatch.setattr(screen, "_discard_persona_visual_authoring_async", discard)
+
+        drain = asyncio.create_task(screen._drain_persona_visual_authoring())
+        await asyncio.sleep(0)
+        drain.cancel()
+        await asyncio.sleep(0)
+
+        assert not drain.done()
+        discard.assert_not_awaited()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await drain
+        discard.assert_awaited_once()
+
+
+async def test_replacement_stages_private_asset_and_preview_loads_selected_only(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        assert await screen._stage_persona_visual_replacement("idle", _png())
+        state = screen._persona_visual_authoring
+        assert state is not None and state.workspace is not None
+        first_workspace = state.workspace
+        assert await screen._stage_persona_visual_replacement("idle", _png())
+        assert state.workspace is not None and state.workspace != first_workspace
+        assert not (
+            first_workspace.profile_root / first_workspace.relative_root
+        ).exists()
+        assert state.dirty is True
+        loads: list[str] = []
+        original_loader = personas_screen_module.load_persona_visual_asset
+
+        def observed_loader(root, *, storage_key, metadata, selected_frame=0):
+            loads.append(metadata.asset_key)
+            return original_loader(
+                root,
+                storage_key=storage_key,
+                metadata=metadata,
+                selected_frame=selected_frame,
+            )
+
+        monkeypatch.setattr(
+            personas_screen_module, "load_persona_visual_asset", observed_loader
+        )
+
+        assert await screen._preview_persona_visual_state("idle")
+        assert len(loads) == 1
+
+
+async def test_replacement_cancellation_drains_workspace_creation_and_cleans_it(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        original_prepare = screen._prepare_persona_visual_workspace
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def blocked_prepare(state, profile_root):
+            started.set()
+            release.wait(timeout=5)
+            try:
+                return original_prepare(state, profile_root)
+            finally:
+                finished.set()
+
+        monkeypatch.setattr(
+            screen, "_prepare_persona_visual_workspace", blocked_prepare
+        )
+        replacement = asyncio.create_task(
+            screen._stage_persona_visual_replacement("idle", _png())
+        )
+        while not started.is_set():
+            await asyncio.sleep(0)
+        replacement.cancel()
+        await asyncio.sleep(0)
+
+        assert not replacement.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await replacement
+        assert finished.is_set()
+        authoring_root = get_user_data_dir() / "persona_visual" / "authoring"
+        assert not authoring_root.exists() or list(authoring_root.iterdir()) == []
+
+
+async def test_invalid_replacement_leaves_no_private_workspace(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+
+        assert not await screen._stage_persona_visual_replacement(
+            "idle", b"not an image"
+        )
+
+        authoring_root = get_user_data_dir() / "persona_visual" / "authoring"
+        assert not authoring_root.exists() or list(authoring_root.iterdir()) == []
+
+
+async def test_preview_cancellation_drains_selected_decode_before_release(
+    monkeypatch, mock_app_instance, stub_characters, local_scope
+):
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    app = PersonasTestApp(mock_app_instance)
+
+    async with app.run_test() as pilot:
+        screen = await _open_editor(pilot)
+        assert await screen._stage_persona_visual_replacement("idle", _png())
+        original_loader = personas_screen_module.load_persona_visual_asset
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_loader(*args, **kwargs):
+            started.set()
+            release.wait(timeout=5)
+            return original_loader(*args, **kwargs)
+
+        monkeypatch.setattr(
+            personas_screen_module, "load_persona_visual_asset", blocked_loader
+        )
+        preview = asyncio.create_task(screen._preview_persona_visual_state("idle"))
+        while not started.is_set():
+            await asyncio.sleep(0)
+        preview.cancel()
+        await asyncio.sleep(0)
+
+        assert not preview.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await preview

--- a/Tests/UI/test_personas_persona_visual_pack.py
+++ b/Tests/UI/test_personas_persona_visual_pack.py
@@ -1,0 +1,190 @@
+"""Mounted contract tests for Persona Visual authoring controls."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Button, OptionList, Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Persona_Visual.authoring import (
+    PersonaVisualDraftInventory,
+    PersonaVisualDraftRow,
+)
+from tldw_chatbook.Persona_Visual.contracts import RESERVED_STATES
+from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
+    PersonaProfileEditorWidget,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.personas_persona_visual_pack_widget import (
+    PersonaVisualAddCustomRequested,
+    PersonaVisualCancelRequested,
+    PersonaVisualClearRequested,
+    PersonaVisualImportRequested,
+    PersonaVisualPreviewRequested,
+    PersonaVisualReplaceRequested,
+    PersonaVisualSaveRequested,
+    PersonasPersonaVisualPackWidget,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _inventory(*, custom: bool = False, activatable: bool = True):
+    rows = tuple(
+        PersonaVisualDraftRow(
+            state=state,
+            label=state.replace("_", " ").title(),
+            custom=False,
+            configured=state == "idle",
+            animation_id="idle" if state == "idle" else None,
+            asset_key="idle-frame" if state == "idle" else None,
+        )
+        for state in RESERVED_STATES
+    )
+    if custom:
+        rows += (
+            PersonaVisualDraftRow(
+                state="operator-ready",
+                label="[bold]Operator ready[/bold]",
+                custom=True,
+                configured=True,
+                animation_id="operator-ready",
+                asset_key="operator-ready-frame",
+            ),
+        )
+    return PersonaVisualDraftInventory(
+        rows=rows,
+        asset_count=2 if custom else 1,
+        activatable=activatable,
+        validation_reason=None if activatable else "persona_visual_draft_incomplete",
+    )
+
+
+class PackApp(ConsolidatedCSSApp):
+    def compose(self) -> ComposeResult:
+        yield PersonasPersonaVisualPackWidget()
+
+
+async def test_saved_local_pack_shows_nine_baseline_rows_and_posts_typed_actions():
+    received: list[object] = []
+
+    class CaptureApp(PackApp):
+        def on_persona_visual_preview_requested(self, message):
+            received.append(message)
+
+        def on_persona_visual_replace_requested(self, message):
+            received.append(message)
+
+        def on_persona_visual_clear_requested(self, message):
+            received.append(message)
+
+        def on_persona_visual_add_custom_requested(self, message):
+            received.append(message)
+
+        def on_persona_visual_import_requested(self, message):
+            received.append(message)
+
+    async with CaptureApp().run_test(size=(100, 32)) as pilot:
+        widget = pilot.app.query_one(PersonasPersonaVisualPackWidget)
+        widget.show_inventory(_inventory(), dirty=False)
+        await pilot.pause()
+
+        options = pilot.app.query_one("#personas-persona-visual-results", OptionList)
+        assert options.option_count == 9
+        await pilot.click("#personas-persona-visual-replace")
+        await pilot.click("#personas-persona-visual-clear")
+        await pilot.click("#personas-persona-visual-add-custom")
+        await pilot.click("#personas-persona-visual-import")
+        await pilot.pause()
+
+    assert isinstance(received[0], PersonaVisualPreviewRequested)
+    assert isinstance(received[1], PersonaVisualReplaceRequested)
+    assert isinstance(received[2], PersonaVisualClearRequested)
+    assert isinstance(received[3], PersonaVisualAddCustomRequested)
+    assert isinstance(received[4], PersonaVisualImportRequested)
+    assert received[0].state == received[1].state == received[2].state == "idle"
+
+
+async def test_custom_label_is_plain_text_and_selected_preview_is_lazy():
+    async with PackApp().run_test(size=(100, 32)) as pilot:
+        widget = pilot.app.query_one(PersonasPersonaVisualPackWidget)
+        widget.show_inventory(_inventory(custom=True), dirty=False)
+        await pilot.pause()
+        options = pilot.app.query_one("#personas-persona-visual-results", OptionList)
+        assert options.option_count == 10
+        prompt = str(options.get_option_at_index(9).prompt)
+        assert "[bold]Operator ready[/bold]" in prompt
+        assert (
+            pilot.app.query_one("#personas-persona-visual-preview", Static).renderable
+            == "Loading selected preview…"
+        )
+
+
+@pytest.mark.parametrize(
+    ("availability", "copy"),
+    (("unsaved", "Save Persona first"), ("server", "Save Local Copy first")),
+)
+async def test_ineligible_persona_states_explain_recovery_and_disable_actions(
+    availability: str,
+    copy: str,
+):
+    async with PackApp().run_test() as pilot:
+        widget = pilot.app.query_one(PersonasPersonaVisualPackWidget)
+        widget.set_availability(availability)
+        await pilot.pause()
+        assert copy in str(
+            pilot.app.query_one("#personas-persona-visual-notice", Static).renderable
+        )
+        for button in widget.query(Button):
+            assert button.disabled is True
+
+
+async def test_staged_and_busy_states_keep_save_cancel_copy_honest():
+    received: list[type] = []
+
+    class CaptureApp(PackApp):
+        def on_persona_visual_save_requested(self, message):
+            received.append(type(message))
+
+        def on_persona_visual_cancel_requested(self, message):
+            received.append(type(message))
+
+    async with CaptureApp().run_test() as pilot:
+        widget = pilot.app.query_one(PersonasPersonaVisualPackWidget)
+        widget.show_inventory(_inventory(), dirty=True)
+        await pilot.pause()
+        save = pilot.app.query_one("#personas-persona-visual-save", Button)
+        cancel = pilot.app.query_one("#personas-persona-visual-cancel", Button)
+        assert save.disabled is False and cancel.disabled is False
+        await pilot.click(save)
+        await pilot.click(cancel)
+        widget.set_busy("importing")
+        assert "Importing" in str(
+            pilot.app.query_one("#personas-persona-visual-status", Static).renderable
+        )
+        assert cancel.disabled is False
+        widget.set_busy("saving")
+        assert "Saving" in str(
+            pilot.app.query_one("#personas-persona-visual-status", Static).renderable
+        )
+        assert cancel.disabled is True
+
+    assert received == [PersonaVisualSaveRequested, PersonaVisualCancelRequested]
+
+
+async def test_profile_editor_embeds_pack_section_and_compact_layout_keeps_actions():
+    class EditorApp(ConsolidatedCSSApp):
+        def compose(self) -> ComposeResult:
+            yield PersonaProfileEditorWidget()
+
+    async with EditorApp().run_test(size=(80, 24)) as pilot:
+        editor = pilot.app.query_one(PersonaProfileEditorWidget)
+        editor.load_persona({"id": "p-1", "version": 2, "name": "Archivist"})
+        await pilot.pause()
+        pack = pilot.app.query_one(PersonasPersonaVisualPackWidget)
+        assert pack is not None
+        assert pack.has_class("-narrow")
+        assert pilot.app.query_one(
+            "#personas-persona-visual-import", Button
+        ).label.plain == ("Import Pack…")
+        assert not getattr(type(pack), "BINDINGS", ())

--- a/Tests/UI/test_personas_persona_visual_pack.py
+++ b/Tests/UI/test_personas_persona_visual_pack.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 from textual.app import ComposeResult
-from textual.widgets import Button, OptionList, Static
+from textual.widgets import Button, Input, OptionList, Select, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Persona_Visual.authoring import (
@@ -16,14 +16,15 @@ from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import 
     PersonaProfileEditorWidget,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_persona_visual_pack_widget import (
+    PersonasPersonaVisualPackWidget,
     PersonaVisualAddCustomRequested,
     PersonaVisualCancelRequested,
     PersonaVisualClearRequested,
+    PersonaVisualCustomStateDialog,
     PersonaVisualImportRequested,
     PersonaVisualPreviewRequested,
     PersonaVisualReplaceRequested,
     PersonaVisualSaveRequested,
-    PersonasPersonaVisualPackWidget,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -188,3 +189,48 @@ async def test_profile_editor_embeds_pack_section_and_compact_layout_keeps_actio
             "#personas-persona-visual-import", Button
         ).label.plain == ("Import Pack…")
         assert not getattr(type(pack), "BINDINGS", ())
+
+
+async def test_profile_editor_visual_session_token_changes_on_load_and_save():
+    class EditorApp(ConsolidatedCSSApp):
+        def compose(self) -> ComposeResult:
+            yield PersonaProfileEditorWidget()
+
+    async with EditorApp().run_test() as pilot:
+        editor = pilot.app.query_one(PersonaProfileEditorWidget)
+        initial = editor.persona_visual_session_token
+        editor.load_persona({"id": "p-1", "version": 2, "name": "Archivist"})
+        loaded = editor.persona_visual_session_token
+        editor.mark_saved({"id": "p-1", "version": 3, "name": "Archivist"})
+
+        assert loaded == initial + 1
+        assert editor.persona_visual_session_token == loaded + 1
+
+
+async def test_custom_state_dialog_returns_plain_typed_values():
+    class DialogApp(ConsolidatedCSSApp):
+        result: tuple[str, str, str] | None = None
+
+        def on_mount(self) -> None:
+            self.push_screen(
+                PersonaVisualCustomStateDialog(),
+                callback=lambda value: setattr(self, "result", value),
+            )
+
+    async with DialogApp().run_test() as pilot:
+        await pilot.pause()
+        pilot.app.screen.query_one(
+            "#persona-visual-custom-key", Input
+        ).value = "deep_focus"
+        pilot.app.screen.query_one(
+            "#persona-visual-custom-label", Input
+        ).value = "[bold]Deep focus[/bold]"
+        pilot.app.screen.query_one("#persona-visual-custom-kind", Select).value = "mood"
+        await pilot.click("#persona-visual-custom-confirm")
+        await pilot.pause()
+
+        assert pilot.app.result == (
+            "deep_focus",
+            "[bold]Deep focus[/bold]",
+            "mood",
+        )

--- a/backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md
+++ b/backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-19054
 title: Author and import Persona Visual packs
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-20 17:29'
+updated_date: '2026-08-21 08:34'
 labels: []
 dependencies:
   - TASK-19053
@@ -23,18 +24,19 @@ Let users review, edit, import, stage, and explicitly publish Persona Visual pac
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Personas Workbench shows all nine baseline state slots, bounded safe custom states, path-free validation inventory, and one selected lazy preview for an eligible local Persona.
-- [ ] #2 Replace, Clear, Add Custom State, and import mutate only an isolated draft; Save revalidates Persona, binding, and draft authority, publishes exactly one immutable version, then invalidates both stable old/new full identities while preserving unrelated cache entries; failed or cancelled publication invalidates nothing; Cancel discards the draft and leaves authoritative metadata unchanged.
-- [ ] #3 `.tldw-persona-vpack` import validates full pinned sprite-frame archives into review drafts in bounded private staging and never activates before explicit Save; it rejects traversal, links, nested/encrypted archives, undeclared/external files, duplicate/colliding paths, bomb/budget violations, MIME/digest mismatches, and archive replacement races; failure or cancellation removes only identity-pinned staging and never changes active authority.
-- [ ] #4 Unsupported renderer/manifest capabilities, malformed assets, stale Persona/binding/session authority, and import cancellation fail closed without changing the active version.
-- [ ] #5 Server-backed Personas show Save Local Copy first; legacy expression-set and Actor Pack import remain separate, honestly labelled actions.
-- [ ] #6 Preview inventory/resolve/decode work is screen-owned, serialized across navigation, drained on cancellation, weak-targeted, and fenced after every await.
-- [ ] #7 No image-generation provider, recipe workflow, Shared Visual Identity merge, or Buddy window is added.
-- [ ] #8 Labelled actions are keyboard-operable, preserve focus, and add no forbidden bindings; compact and normal layouts paint usable controls; untrusted archive text renders as plain text; user-facing errors, logs, and diagnostics remain path-free. Evidence includes born-RED→GREEN tests and mutation proof for draft, Save, Cancel, authority, archive, cancellation, and invalidation guards; assigned-worktree provenance; real SQLite publication/repository tests where touched; isolated HOME/XDG/config/data roots; focused widget/screen/race/import/publication tests; Ruff, format, compile, and diff checks; diagnostic, privacy, architecture, and governance gates; and Impeccable review after the final visible change.
+- [x] #1 Personas Workbench shows all nine baseline state slots, bounded safe custom states, path-free validation inventory, and one selected lazy preview for an eligible local Persona.
+- [x] #2 Replace, Clear, Add Custom State, and import mutate only an isolated draft; Save revalidates Persona, binding, and draft authority, publishes exactly one immutable version, then invalidates both stable old/new full identities while preserving unrelated cache entries; failed or cancelled publication invalidates nothing; Cancel discards the draft and leaves authoritative metadata unchanged.
+- [x] #3 `.tldw-persona-vpack` import validates full pinned sprite-frame archives into review drafts in bounded private staging and never activates before explicit Save; it rejects traversal, links, nested/encrypted archives, undeclared/external files, duplicate/colliding paths, bomb/budget violations, MIME/digest mismatches, and archive replacement races; failure or cancellation removes only identity-pinned staging and never changes active authority.
+- [x] #4 Unsupported renderer/manifest capabilities, malformed assets, stale Persona/binding/session authority, and import cancellation fail closed without changing the active version.
+- [x] #5 Server-backed Personas show Save Local Copy first; legacy expression-set and Actor Pack import remain separate, honestly labelled actions.
+- [x] #6 Preview inventory/resolve/decode work is screen-owned, serialized across navigation, drained on cancellation, weak-targeted, and fenced after every await.
+- [x] #7 No image-generation provider, recipe workflow, Shared Visual Identity merge, or Buddy window is added.
+- [x] #8 Labelled actions are keyboard-operable, preserve focus, and add no forbidden bindings; compact and normal layouts paint usable controls; untrusted archive text renders as plain text; user-facing errors, logs, and diagnostics remain path-free. Evidence includes born-RED→GREEN tests and mutation proof for draft, Save, Cancel, authority, archive, cancellation, and invalidation guards; assigned-worktree provenance; real SQLite publication/repository tests where touched; isolated HOME/XDG/config/data roots; focused widget/screen/race/import/publication tests; Ruff, format, compile, and diff checks; diagnostic, privacy, architecture, and governance gates; and Impeccable review after the final visible change.
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Add an immutable, path-free authoring draft contract over the existing Persona Visual manifest/publication boundaries.
 2. Add a pinned-server-compatible `.tldw-persona-vpack` importer with bounded private staging and identity-pinned cleanup.
 3. Add the Persona Visual browser/editor section and typed actions to the existing Persona profile editor.
@@ -47,3 +49,15 @@ ADR required: no
 ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
 
 Reason: ADR-074 already defines the separate local Persona Visual runtime, review-first import, immutable publication, authority, and scope boundaries implemented by this task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added immutable authoring drafts, bounded `.tldw-persona-vpack` review import, and identity-pinned private workspaces over the existing ADR-074 repository/publication boundary.
+- Added the Persona Workbench pack browser with nine baseline slots, bounded custom states, selected-only preview, Replace/Clear/Import/Save/Cancel actions, compact layout, honest legacy labels, and screen-owned authority/cancellation/navigation orchestration.
+- Save publishes once after exact local Persona and draft revalidation, invalidates only the old/new full identities, reloads authoritatively, and preserves active state on failure or cancellation. No provider, Shared Visual Identity, Buddy, Actor Pack, or server-backed authoring scope was added.
+- TDD and mutation evidence covered hostile archives, draft isolation, workspace substitution, duplicate Save, Cancel/drain, stale authority, preview cancellation, import cancellation, old/new invalidation, and path-free error handling. Final touched gates were 120 authoring/import/workspace/publication/widget/screen tests, 10 legacy Workbench compatibility tests, 60 CSS/profile tests, 524 Persona Visual package tests, and 319 Workbench tests; Ruff, formatting, compilation, diff checks, isolated-profile provenance, and the one required Impeccable detector run passed.
+- Per user direction, the full repository suite was not run. The scoped diagnostic/privacy command had 107 passing tests and one generated-inventory mismatch caused partly by unrelated `retrieval.py`, `workspace.py`, and `chat_screen.py` drift; topology, classifications, and exclusions were unchanged, so unrelated generated inventory was not rewritten. Six unrelated `Client_Media_DB_v2` privacy-baseline failures reported by the preceding foundation task were also left outside this task.
+- ADR check: no new ADR; ADR-074 remains the governing decision. No reusable lesson was added because the implementation followed the existing cancellation, worktree, and testing guidance without uncovering a new cross-task trap.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md
+++ b/backlog/tasks/task-19054 - Author-and-import-Persona-Visual-packs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19054
 title: Author and import Persona Visual packs
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-20 17:29'
 labels: []
@@ -32,3 +32,18 @@ Let users review, edit, import, stage, and explicitly publish Persona Visual pac
 - [ ] #7 No image-generation provider, recipe workflow, Shared Visual Identity merge, or Buddy window is added.
 - [ ] #8 Labelled actions are keyboard-operable, preserve focus, and add no forbidden bindings; compact and normal layouts paint usable controls; untrusted archive text renders as plain text; user-facing errors, logs, and diagnostics remain path-free. Evidence includes born-RED→GREEN tests and mutation proof for draft, Save, Cancel, authority, archive, cancellation, and invalidation guards; assigned-worktree provenance; real SQLite publication/repository tests where touched; isolated HOME/XDG/config/data roots; focused widget/screen/race/import/publication tests; Ruff, format, compile, and diff checks; diagnostic, privacy, architecture, and governance gates; and Impeccable review after the final visible change.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add an immutable, path-free authoring draft contract over the existing Persona Visual manifest/publication boundaries.
+2. Add a pinned-server-compatible `.tldw-persona-vpack` importer with bounded private staging and identity-pinned cleanup.
+3. Add the Persona Visual browser/editor section and typed actions to the existing Persona profile editor.
+4. Wire screen-owned loading, selected-only preview, isolated edits/import, cancellation drain, navigation guards, and honest import labels.
+5. Publish one immutable version through the existing authority boundary, invalidate exact old/new identities, and refresh authoritatively.
+6. Run touched-component, mutation, isolated-profile, SQLite, UI, privacy, architecture, Impeccable, and static gates; then record concise implementation evidence.
+
+ADR required: no
+
+ADR path: `backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md`
+
+Reason: ADR-074 already defines the separate local Persona Visual runtime, review-first import, immutable publication, authority, and scope boundaries implemented by this task.

--- a/tldw_chatbook/Persona_Visual/__init__.py
+++ b/tldw_chatbook/Persona_Visual/__init__.py
@@ -43,6 +43,14 @@ from .contracts import (
     inspect_persona_visual_capability,
     resolve_manifest_state,
 )
+from .importer import (
+    PERSONA_VISUAL_PACK_SCHEMA,
+    PersonaVisualImportError,
+    PersonaVisualImportReview,
+    cleanup_persona_visual_import_review,
+    import_persona_visual_pack,
+    persona_visual_import_source_root,
+)
 from .validation import validate_persona_visual_manifest
 
 __all__ = [
@@ -69,19 +77,25 @@ __all__ = [
     "PersonaVisualCapability",
     "PersonaVisualCatalogEntry",
     "PersonaVisualFrame",
+    "PersonaVisualImportError",
+    "PersonaVisualImportReview",
     "PersonaVisualManifest",
     "PersonaVisualManifestError",
     "PersonaVisualRegion",
     "PersonaVisualStateSelection",
     "PersonaVisualStaticSelection",
     "PersonaVisualTrigger",
+    "PERSONA_VISUAL_PACK_SCHEMA",
     "inspect_persona_visual_capability",
     "add_persona_visual_custom_state",
     "clear_persona_visual_draft_state",
+    "cleanup_persona_visual_import_review",
     "create_persona_visual_draft",
     "inspect_persona_visual_draft",
+    "import_persona_visual_pack",
     "persona_visual_draft_from_graph",
     "persona_visual_draft_publication_snapshot",
+    "persona_visual_import_source_root",
     "replace_persona_visual_draft_state",
     "resolve_manifest_state",
     "validate_persona_visual_manifest",

--- a/tldw_chatbook/Persona_Visual/__init__.py
+++ b/tldw_chatbook/Persona_Visual/__init__.py
@@ -1,5 +1,20 @@
 """Separate local Persona Visual operational-state contracts."""
 
+from .authoring import (
+    PersonaVisualAuthoringDraft,
+    PersonaVisualAuthoringError,
+    PersonaVisualDraftAsset,
+    PersonaVisualDraftInventory,
+    PersonaVisualDraftRow,
+    add_persona_visual_custom_state,
+    clear_persona_visual_draft_state,
+    create_persona_visual_draft,
+    inspect_persona_visual_draft,
+    persona_visual_draft_from_graph,
+    persona_visual_draft_publication_snapshot,
+    replace_persona_visual_draft_state,
+)
+
 from .contracts import (
     ALLOWED_ASSET_EXTENSIONS,
     ALLOWED_ASSET_MIME_TYPES,
@@ -44,6 +59,11 @@ __all__ = [
     "MAX_TRIGGERS",
     "REQUIRED_STATES",
     "RESERVED_STATES",
+    "PersonaVisualAuthoringDraft",
+    "PersonaVisualAuthoringError",
+    "PersonaVisualDraftAsset",
+    "PersonaVisualDraftInventory",
+    "PersonaVisualDraftRow",
     "PersonaVisualAlignment",
     "PersonaVisualAnimation",
     "PersonaVisualCapability",
@@ -56,6 +76,13 @@ __all__ = [
     "PersonaVisualStaticSelection",
     "PersonaVisualTrigger",
     "inspect_persona_visual_capability",
+    "add_persona_visual_custom_state",
+    "clear_persona_visual_draft_state",
+    "create_persona_visual_draft",
+    "inspect_persona_visual_draft",
+    "persona_visual_draft_from_graph",
+    "persona_visual_draft_publication_snapshot",
+    "replace_persona_visual_draft_state",
     "resolve_manifest_state",
     "validate_persona_visual_manifest",
 ]

--- a/tldw_chatbook/Persona_Visual/authoring.py
+++ b/tldw_chatbook/Persona_Visual/authoring.py
@@ -1,0 +1,671 @@
+"""Isolated, path-free Persona Visual authoring drafts."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import PurePosixPath
+
+from .assets import (
+    PersonaVisualAssetError,
+    PersonaVisualAssetMetadata,
+    validate_persona_visual_asset_set,
+)
+from .contracts import (
+    ALLOWED_STATE_CATALOG_KINDS,
+    PersonaVisualManifest,
+    PersonaVisualManifestError,
+    RESERVED_STATES,
+)
+from .publication import (
+    PersonaVisualPublicationAssetSource,
+    PersonaVisualPublicationSnapshot,
+)
+from .repository import (
+    PersonaVisualAssetRecord,
+    PersonaVisualGraph,
+    PersonaVisualIdentity,
+)
+from .validation import validate_persona_visual_manifest
+
+
+_INVALID = "persona_visual_draft_invalid"
+_INCOMPLETE = "persona_visual_draft_incomplete"
+_MAX_TITLE = 256
+_MAX_DESCRIPTION = 4096
+_MAX_PERSONA_ID = 200
+_MAX_SOURCE_KEY = 512
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class PersonaVisualAuthoringError(ValueError):
+    """Stable path-free authoring failure."""
+
+    __slots__ = ("category",)
+
+    def __init__(self, category: str = _INVALID) -> None:
+        self.category = category if category in {_INVALID, _INCOMPLETE} else _INVALID
+        super().__init__(self.category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualDraftAsset:
+    """One immutable authoring source and its path-free metadata."""
+
+    source_storage_key: str = field(repr=False)
+    metadata: PersonaVisualAssetMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualAuthoringDraft:
+    """One isolated draft whose active identity remains unchanged until Save."""
+
+    persona_id: str
+    persona_revision: int
+    expected_identity: PersonaVisualIdentity | None
+    title: str
+    description: str
+    source_kind: str
+    source_context: tuple[tuple[str, str], ...]
+    manifest_json: str
+    assets: tuple[PersonaVisualDraftAsset, ...]
+    revision: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualDraftRow:
+    """Path-free metadata for one Workbench state row."""
+
+    state: str
+    label: str
+    custom: bool
+    configured: bool
+    animation_id: str | None
+    asset_key: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualDraftInventory:
+    """Path-free draft validation and state inventory."""
+
+    rows: tuple[PersonaVisualDraftRow, ...]
+    asset_count: int
+    activatable: bool
+    validation_reason: str | None
+
+
+def create_persona_visual_draft(
+    *,
+    persona_id: str,
+    persona_revision: int,
+    title: str,
+    description: str = "",
+) -> PersonaVisualAuthoringDraft:
+    """Create an empty first-publication draft for a saved local Persona."""
+
+    manifest = {
+        "renderer_type": "sprite_frames",
+        "manifest_version": 1,
+        "states": {},
+        "animations": {},
+        "fallbacks": {},
+        "state_catalog": {},
+        "authored_triggers": [],
+    }
+    draft = PersonaVisualAuthoringDraft(
+        persona_id=_text(persona_id, _MAX_PERSONA_ID),
+        persona_revision=_nonnegative_int(persona_revision),
+        expected_identity=None,
+        title=_text(title, _MAX_TITLE),
+        description=_text(description, _MAX_DESCRIPTION, allow_empty=True),
+        source_kind="manual",
+        source_context=(),
+        manifest_json=_canonical_json(manifest),
+        assets=(),
+    )
+    return _validated_draft(draft)
+
+
+def persona_visual_draft_from_graph(
+    graph: PersonaVisualGraph,
+    *,
+    source_storage_keys: Mapping[str, str],
+) -> PersonaVisualAuthoringDraft:
+    """Snapshot one active graph plus caller-confined materialized source keys."""
+
+    try:
+        if type(graph) is not PersonaVisualGraph or not isinstance(
+            source_storage_keys, Mapping
+        ):
+            raise ValueError
+        if type(graph.identity) is not PersonaVisualIdentity:
+            raise ValueError
+        records = tuple(graph.assets)
+        expected_keys = {record.asset_key for record in records}
+        if set(source_storage_keys) != expected_keys:
+            raise ValueError
+        assets = tuple(
+            PersonaVisualDraftAsset(
+                _source_key(source_storage_keys[record.asset_key]),
+                _metadata_from_record(record),
+            )
+            for record in records
+        )
+        draft = PersonaVisualAuthoringDraft(
+            persona_id=graph.identity.persona_id,
+            persona_revision=graph.identity.persona_revision,
+            expected_identity=replace(graph.identity),
+            title=graph.pack.title,
+            description=graph.pack.description,
+            source_kind=graph.pack.source_kind,
+            source_context=(),
+            manifest_json=_canonical_json(_manifest_document(graph.version.manifest)),
+            assets=assets,
+        )
+        return _validated_draft(draft)
+    except (
+        AttributeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        PersonaVisualManifestError,
+    ):
+        raise PersonaVisualAuthoringError() from None
+
+
+def add_persona_visual_custom_state(
+    draft: PersonaVisualAuthoringDraft,
+    *,
+    state: str,
+    label: str,
+    kind: str,
+) -> PersonaVisualAuthoringDraft:
+    """Return a new draft with one unconfigured safe custom state."""
+
+    draft = _validated_draft(draft)
+    if (
+        type(state) is not str
+        or state in RESERVED_STATES
+        or type(label) is not str
+        or type(kind) is not str
+        or kind not in ALLOWED_STATE_CATALOG_KINDS
+    ):
+        raise PersonaVisualAuthoringError()
+    document = _draft_document(draft)
+    catalog = dict(document["state_catalog"])
+    if state in catalog:
+        raise PersonaVisualAuthoringError()
+    catalog[state] = {"label": label, "kind": kind}
+    document["state_catalog"] = catalog
+    return _changed_draft(draft, document, draft.assets)
+
+
+def replace_persona_visual_draft_state(
+    draft: PersonaVisualAuthoringDraft,
+    *,
+    state: str,
+    asset: PersonaVisualDraftAsset,
+) -> PersonaVisualAuthoringDraft:
+    """Return a new draft mapping one known state to one replacement still."""
+
+    draft = _validated_draft(draft)
+    asset = _validated_asset(asset)
+    document = _draft_document(draft)
+    catalog = document["state_catalog"]
+    if type(state) is not str or (
+        state not in RESERVED_STATES and state not in catalog
+    ):
+        raise PersonaVisualAuthoringError()
+    if any(
+        existing.metadata.asset_key == asset.metadata.asset_key
+        for existing in draft.assets
+    ):
+        raise PersonaVisualAuthoringError()
+    animations = dict(document["animations"])
+    animations[state] = {
+        "frames": [{"asset_id": asset.metadata.asset_key}],
+        "preview_asset_id": asset.metadata.asset_key,
+        "frame_rate": 1,
+    }
+    states = dict(document["states"])
+    states[state] = {"animation_id": state}
+    document["animations"] = animations
+    document["states"] = states
+    by_key = {item.metadata.asset_key: item for item in draft.assets}
+    by_key[asset.metadata.asset_key] = asset
+    return _changed_draft(draft, document, tuple(by_key.values()), prune=True)
+
+
+def clear_persona_visual_draft_state(
+    draft: PersonaVisualAuthoringDraft,
+    *,
+    state: str,
+) -> PersonaVisualAuthoringDraft:
+    """Return a new draft with one direct state mapping removed."""
+
+    draft = _validated_draft(draft)
+    document = _draft_document(draft)
+    catalog = document["state_catalog"]
+    if type(state) is not str or (
+        state not in RESERVED_STATES and state not in catalog
+    ):
+        raise PersonaVisualAuthoringError()
+    states = dict(document["states"])
+    states.pop(state, None)
+    document["states"] = states
+    return _changed_draft(draft, document, draft.assets, prune=True)
+
+
+def inspect_persona_visual_draft(
+    draft: PersonaVisualAuthoringDraft,
+) -> PersonaVisualDraftInventory:
+    """Return stable validation and row metadata without loading any asset bytes."""
+
+    draft = _validated_draft(draft)
+    document = _draft_document(draft)
+    manifest = _validate_document(document, draft.assets, activate=False)
+    rows = tuple(
+        _inventory_row(state, manifest, custom=False) for state in RESERVED_STATES
+    ) + tuple(
+        _inventory_row(state, manifest, custom=True) for state in manifest.state_catalog
+    )
+    try:
+        _validate_document(document, draft.assets, activate=True)
+    except PersonaVisualManifestError:
+        activatable = False
+        reason = _INCOMPLETE
+    else:
+        activatable = True
+        reason = None
+    return PersonaVisualDraftInventory(
+        rows=rows,
+        asset_count=len(draft.assets),
+        activatable=activatable,
+        validation_reason=reason,
+    )
+
+
+def persona_visual_draft_publication_snapshot(
+    draft: PersonaVisualAuthoringDraft,
+) -> PersonaVisualPublicationSnapshot:
+    """Convert one activatable draft to the existing immutable publish request."""
+
+    draft = _validated_draft(draft)
+    try:
+        _validate_document(_draft_document(draft), draft.assets, activate=True)
+    except PersonaVisualManifestError:
+        raise PersonaVisualAuthoringError(_INCOMPLETE) from None
+    return PersonaVisualPublicationSnapshot(
+        persona_id=draft.persona_id,
+        persona_revision=draft.persona_revision,
+        title=draft.title,
+        description=draft.description,
+        source_kind=draft.source_kind,
+        source_context=draft.source_context,
+        manifest_json=draft.manifest_json,
+        assets=tuple(
+            PersonaVisualPublicationAssetSource(
+                source_storage_key=asset.source_storage_key,
+                metadata=asset.metadata,
+            )
+            for asset in draft.assets
+        ),
+        expected_identity=draft.expected_identity,
+    )
+
+
+def _changed_draft(
+    draft: PersonaVisualAuthoringDraft,
+    document: dict[str, object],
+    assets: tuple[PersonaVisualDraftAsset, ...],
+    *,
+    prune: bool = False,
+) -> PersonaVisualAuthoringDraft:
+    if prune:
+        document, assets = _pruned(document, assets)
+    try:
+        _validate_document(document, assets, activate=False)
+    except PersonaVisualManifestError:
+        raise PersonaVisualAuthoringError() from None
+    return _validated_draft(
+        replace(
+            draft,
+            manifest_json=_canonical_json(document),
+            assets=assets,
+            revision=draft.revision + 1,
+        )
+    )
+
+
+def _pruned(
+    document: dict[str, object],
+    assets: tuple[PersonaVisualDraftAsset, ...],
+) -> tuple[dict[str, object], tuple[PersonaVisualDraftAsset, ...]]:
+    states = document["states"]
+    animations = document["animations"]
+    used_animations = {
+        state["animation_id"]
+        for state in states.values()
+        if isinstance(state, dict) and type(state.get("animation_id")) is str
+    }
+    kept_animations = {
+        key: value for key, value in animations.items() if key in used_animations
+    }
+    used_assets: set[str] = set()
+    for animation in kept_animations.values():
+        if not isinstance(animation, dict):
+            continue
+        for frame in animation.get("frames", ()):
+            if isinstance(frame, dict) and type(frame.get("asset_id")) is str:
+                used_assets.add(frame["asset_id"])
+        preview = animation.get("preview_asset_id")
+        if type(preview) is str:
+            used_assets.add(preview)
+    document["animations"] = kept_animations
+    return document, tuple(
+        asset for asset in assets if asset.metadata.asset_key in used_assets
+    )
+
+
+def _inventory_row(
+    state: str,
+    manifest: PersonaVisualManifest,
+    *,
+    custom: bool,
+) -> PersonaVisualDraftRow:
+    animation_id = manifest.states.get(state)
+    asset_key = None
+    if animation_id is not None:
+        animation = manifest.animations[animation_id]
+        asset_key = animation.preview_asset_id or animation.frames[0].asset_id
+    label = (
+        manifest.state_catalog[state].label
+        if custom
+        else state.replace("_", " ").title()
+    )
+    return PersonaVisualDraftRow(
+        state=state,
+        label=label,
+        custom=custom,
+        configured=animation_id is not None,
+        animation_id=animation_id,
+        asset_key=asset_key,
+    )
+
+
+def _validated_draft(value: object) -> PersonaVisualAuthoringDraft:
+    try:
+        if type(value) is not PersonaVisualAuthoringDraft:
+            raise ValueError
+        _text(value.persona_id, _MAX_PERSONA_ID)
+        _nonnegative_int(value.persona_revision)
+        if value.expected_identity is not None:
+            identity = _validated_identity(value.expected_identity)
+            if (
+                identity.persona_id != value.persona_id
+                or identity.persona_revision != value.persona_revision
+            ):
+                raise ValueError
+        _text(value.title, _MAX_TITLE)
+        _text(value.description, _MAX_DESCRIPTION, allow_empty=True)
+        _text(value.source_kind, 64)
+        if type(value.source_context) is not tuple:
+            raise ValueError
+        for item in value.source_context:
+            if (
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not str
+            ):
+                raise ValueError
+        if type(value.manifest_json) is not str or type(value.assets) is not tuple:
+            raise ValueError
+        _nonnegative_int(value.revision)
+        assets = tuple(_validated_asset(asset) for asset in value.assets)
+        if len({asset.metadata.asset_key for asset in assets}) != len(assets):
+            raise ValueError
+        if assets:
+            normalized = validate_persona_visual_asset_set(
+                tuple(asset.metadata for asset in assets)
+            )
+            assets = tuple(
+                PersonaVisualDraftAsset(asset.source_storage_key, metadata)
+                for asset, metadata in zip(assets, normalized)
+            )
+        document = _load_canonical_document(value.manifest_json)
+        _validate_document(document, assets, activate=False)
+        return replace(
+            value,
+            expected_identity=(
+                replace(value.expected_identity)
+                if value.expected_identity is not None
+                else None
+            ),
+            assets=assets,
+        )
+    except (
+        TypeError,
+        ValueError,
+        UnicodeError,
+        PersonaVisualAssetError,
+        PersonaVisualManifestError,
+    ):
+        raise PersonaVisualAuthoringError() from None
+
+
+def _validated_asset(value: object) -> PersonaVisualDraftAsset:
+    if type(value) is not PersonaVisualDraftAsset:
+        raise PersonaVisualAuthoringError()
+    try:
+        source_key = _source_key(value.source_storage_key)
+        metadata = value.metadata
+        if type(metadata) is not PersonaVisualAssetMetadata:
+            raise ValueError
+        metadata = validate_persona_visual_asset_set((metadata,))[0]
+        return PersonaVisualDraftAsset(source_key, metadata)
+    except (TypeError, ValueError, UnicodeError, PersonaVisualAssetError):
+        raise PersonaVisualAuthoringError() from None
+
+
+def _validated_identity(value: object) -> PersonaVisualIdentity:
+    if type(value) is not PersonaVisualIdentity:
+        raise ValueError
+    _text(value.persona_id, _MAX_PERSONA_ID)
+    _nonnegative_int(value.persona_revision)
+    for field_name in (
+        "binding_id",
+        "binding_version",
+        "pack_id",
+        "pack_revision",
+        "pack_version_id",
+        "version_number",
+    ):
+        field_value = getattr(value, field_name)
+        if type(field_value) is not int or field_value <= 0:
+            raise ValueError
+    if (
+        type(value.manifest_sha256) is not str
+        or _SHA256.fullmatch(value.manifest_sha256) is None
+    ):
+        raise ValueError
+    return replace(value)
+
+
+def _validate_document(
+    document: object,
+    assets: tuple[PersonaVisualDraftAsset, ...],
+    *,
+    activate: bool,
+) -> PersonaVisualManifest:
+    dimensions = {
+        asset.metadata.asset_key: (asset.metadata.width, asset.metadata.height)
+        for asset in assets
+    }
+    return validate_persona_visual_manifest(
+        document,
+        dimensions,
+        activate=activate,
+    )
+
+
+def _draft_document(draft: PersonaVisualAuthoringDraft) -> dict[str, object]:
+    return _load_canonical_document(draft.manifest_json)
+
+
+def _load_canonical_document(value: str) -> dict[str, object]:
+    document = json.loads(value)
+    if type(document) is not dict or _canonical_json(document) != value:
+        raise ValueError
+    return document
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _manifest_document(manifest: PersonaVisualManifest) -> dict[str, object]:
+    if type(manifest) is not PersonaVisualManifest:
+        raise ValueError
+    animations: dict[str, object] = {}
+    for animation_id, animation in manifest.animations.items():
+        record: dict[str, object] = {
+            "frames": [
+                {
+                    "asset_id": frame.asset_id,
+                    **(
+                        {"duration_ms": frame.duration_ms}
+                        if frame.duration_ms is not None
+                        else {}
+                    ),
+                    **(
+                        {
+                            "region": {
+                                "x": frame.region.x,
+                                "y": frame.region.y,
+                                "width": frame.region.width,
+                                "height": frame.region.height,
+                            }
+                        }
+                        if frame.region is not None
+                        else {}
+                    ),
+                }
+                for frame in animation.frames
+            ],
+            "frame_rate": animation.frame_rate,
+            "loop": animation.loop,
+        }
+        if animation.alignment is not None:
+            record["alignment"] = {
+                "x": animation.alignment.x,
+                "y": animation.alignment.y,
+            }
+        if animation.preview_frame is not None:
+            record["preview_frame"] = animation.preview_frame
+        if animation.preview_asset_id is not None:
+            record["preview_asset_id"] = animation.preview_asset_id
+        animations[animation_id] = record
+    return {
+        "renderer_type": manifest.renderer_type,
+        "manifest_version": manifest.manifest_version,
+        "states": {
+            state: {"animation_id": animation_id}
+            for state, animation_id in manifest.states.items()
+        },
+        "animations": animations,
+        "fallbacks": {
+            state: list(fallbacks) for state, fallbacks in manifest.fallbacks.items()
+        },
+        "state_catalog": {
+            state: {
+                "label": entry.label,
+                "kind": entry.kind,
+                **(
+                    {"description": entry.description}
+                    if entry.description is not None
+                    else {}
+                ),
+                **({"tags": list(entry.tags)} if entry.tags else {}),
+            }
+            for state, entry in manifest.state_catalog.items()
+        },
+        "authored_triggers": [
+            {
+                "id": trigger.id,
+                "source": trigger.source,
+                "match": trigger.match,
+                "state": trigger.state,
+                "duration_ms": trigger.duration_ms,
+                "priority": trigger.priority,
+            }
+            for trigger in manifest.triggers
+        ],
+    }
+
+
+def _metadata_from_record(record: object) -> PersonaVisualAssetMetadata:
+    if type(record) is not PersonaVisualAssetRecord:
+        raise ValueError
+    return PersonaVisualAssetMetadata(
+        asset_key=record.asset_key,
+        role=record.role,
+        mime_type=record.mime_type,
+        byte_count=record.byte_count,
+        sha256=record.sha256,
+        width=record.width,
+        height=record.height,
+        frame_count=record.frame_count,
+        duration_ms=record.duration_ms,
+    )
+
+
+def _source_key(value: object) -> str:
+    value = _text(value, _MAX_SOURCE_KEY)
+    if "\\" in value or value.startswith("/"):
+        raise ValueError
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError
+    return path.as_posix()
+
+
+def _text(value: object, maximum: int, *, allow_empty: bool = False) -> str:
+    if (
+        type(value) is not str
+        or len(value) > maximum
+        or (not value and not allow_empty)
+    ):
+        raise ValueError
+    value.encode("utf-8")
+    return value
+
+
+def _nonnegative_int(value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError
+    return value
+
+
+__all__ = [
+    "PersonaVisualAuthoringDraft",
+    "PersonaVisualAuthoringError",
+    "PersonaVisualDraftAsset",
+    "PersonaVisualDraftInventory",
+    "PersonaVisualDraftRow",
+    "add_persona_visual_custom_state",
+    "clear_persona_visual_draft_state",
+    "create_persona_visual_draft",
+    "inspect_persona_visual_draft",
+    "persona_visual_draft_from_graph",
+    "persona_visual_draft_publication_snapshot",
+    "replace_persona_visual_draft_state",
+]

--- a/tldw_chatbook/Persona_Visual/authoring.py
+++ b/tldw_chatbook/Persona_Visual/authoring.py
@@ -128,6 +128,33 @@ def create_persona_visual_draft(
     return _validated_draft(draft)
 
 
+def create_persona_visual_import_draft(
+    *,
+    persona_id: str,
+    persona_revision: int,
+    expected_identity: PersonaVisualIdentity | None,
+    title: str,
+    description: str,
+    manifest_json: str,
+    assets: tuple[PersonaVisualDraftAsset, ...],
+) -> PersonaVisualAuthoringDraft:
+    """Create a validated review draft from already-confined imported sources."""
+
+    return _validated_draft(
+        PersonaVisualAuthoringDraft(
+            persona_id=persona_id,
+            persona_revision=persona_revision,
+            expected_identity=expected_identity,
+            title=title,
+            description=description,
+            source_kind="imported",
+            source_context=(("provenance", "untrusted-import"),),
+            manifest_json=manifest_json,
+            assets=assets,
+        )
+    )
+
+
 def persona_visual_draft_from_graph(
     graph: PersonaVisualGraph,
     *,
@@ -664,6 +691,7 @@ __all__ = [
     "add_persona_visual_custom_state",
     "clear_persona_visual_draft_state",
     "create_persona_visual_draft",
+    "create_persona_visual_import_draft",
     "inspect_persona_visual_draft",
     "persona_visual_draft_from_graph",
     "persona_visual_draft_publication_snapshot",

--- a/tldw_chatbook/Persona_Visual/authoring_workspace.py
+++ b/tldw_chatbook/Persona_Visual/authoring_workspace.py
@@ -33,7 +33,6 @@ from .contracts import (
     MAX_FRAMES_PER_ANIMATION,
 )
 
-
 _STATE = re.compile(r"[a-z][a-z0-9_.:-]{0,95}\Z")
 _MARKER_NAME = ".persona-visual-authoring"
 _FORMATS = {
@@ -72,7 +71,20 @@ class PersonaVisualAuthoringWorkspace:
     relative_root: str
     identity: tuple[int, int] = field(repr=False)
     secret: str = field(repr=False)
-    asset_names: tuple[str, ...] = ()
+    _assets: tuple[_WorkspaceAsset, ...] = field(default=(), repr=False)
+
+    @property
+    def asset_names(self) -> tuple[str, ...]:
+        """Return the bounded path-free file inventory."""
+
+        return tuple(asset.name for asset in self._assets)
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceAsset:
+    name: str
+    identity: tuple[int, int, int, int, int]
+    sha256: str
 
 
 def create_persona_visual_authoring_workspace(
@@ -223,10 +235,28 @@ def cleanup_persona_visual_authoring_workspace(
         expected = set(workspace.asset_names)
         if set(os.listdir(assets_fd)) != expected:
             return False
-        for asset_name in workspace.asset_names:
-            metadata = os.stat(asset_name, dir_fd=assets_fd, follow_symlinks=False)
-            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
-                return False
+        for asset in workspace._assets:
+            descriptor = os.open(
+                asset.name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=assets_fd
+            )
+            try:
+                opened_asset = os.fstat(descriptor)
+                named_asset = os.stat(
+                    asset.name, dir_fd=assets_fd, follow_symlinks=False
+                )
+                if (
+                    not _regular_file(opened_asset)
+                    or not _regular_file(named_asset)
+                    or _file_identity(opened_asset) != asset.identity
+                    or _file_identity(named_asset) != asset.identity
+                    or _digest_fd(descriptor, opened_asset.st_size) != asset.sha256
+                    or _file_identity(os.fstat(descriptor)) != asset.identity
+                ):
+                    return False
+            finally:
+                os.close(descriptor)
+        if set(os.listdir(assets_fd)) != expected:
+            return False
         if set(os.listdir(candidate_fd)) != {_MARKER_NAME, "assets"}:
             return False
         for asset_name in workspace.asset_names:
@@ -259,20 +289,33 @@ def _write_workspace_asset(
     *,
     suffix: str,
 ) -> tuple[PersonaVisualAuthoringWorkspace, PersonaVisualDraftAsset]:
-    candidate = workspace.profile_root / workspace.relative_root
-    current = os.lstat(candidate)
-    if (current.st_dev, current.st_ino) != workspace.identity:
-        raise PersonaVisualAuthoringWorkspaceError(
-            "persona_visual_authoring_staging_failed"
-        )
     name = f"{uuid4().hex}{suffix}"
-    target = candidate / "assets" / name
-    descriptor = os.open(
-        target,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-        0o600,
-    )
+    root_fd = base_fd = candidate_fd = assets_fd = descriptor = -1
     try:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        root_fd = os.open(workspace.profile_root, flags)
+        visual_fd = os.open("persona_visual", flags, dir_fd=root_fd)
+        os.close(root_fd)
+        root_fd = visual_fd
+        base_fd = os.open("authoring", flags, dir_fd=root_fd)
+        candidate_name = PurePosixPath(workspace.relative_root).name
+        candidate_fd = os.open(candidate_name, flags, dir_fd=base_fd)
+        named_candidate = os.stat(candidate_name, dir_fd=base_fd, follow_symlinks=False)
+        if (
+            (os.fstat(candidate_fd).st_dev, os.fstat(candidate_fd).st_ino)
+            != workspace.identity
+            or (named_candidate.st_dev, named_candidate.st_ino) != workspace.identity
+            or _read_marker(candidate_fd)
+            != _marker(workspace.secret, candidate_name, workspace.identity)
+        ):
+            raise OSError
+        assets_fd = os.open("assets", flags, dir_fd=candidate_fd)
+        descriptor = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=assets_fd,
+        )
         view = memoryview(data)
         while view:
             written = os.write(descriptor, view[:_READ_CHUNK_BYTES])
@@ -280,16 +323,31 @@ def _write_workspace_asset(
                 raise OSError
             view = view[written:]
         os.fsync(descriptor)
+        written_metadata = os.fstat(descriptor)
+        pin = _WorkspaceAsset(
+            name,
+            _file_identity(written_metadata),
+            hashlib.sha256(data).hexdigest(),
+        )
     except Exception:
-        try:
-            os.unlink(target)
-        except OSError:
-            pass
+        if assets_fd >= 0:
+            try:
+                os.unlink(name, dir_fd=assets_fd)
+            except OSError:
+                pass
         raise
     finally:
-        os.close(descriptor)
+        for file_descriptor in (
+            descriptor,
+            assets_fd,
+            candidate_fd,
+            base_fd,
+            root_fd,
+        ):
+            if file_descriptor >= 0:
+                os.close(file_descriptor)
     source_key = f"{workspace.relative_root}/assets/{name}"
-    updated = replace(workspace, asset_names=workspace.asset_names + (name,))
+    updated = replace(workspace, _assets=workspace._assets + (pin,))
     return updated, PersonaVisualDraftAsset(source_key, metadata)
 
 
@@ -353,6 +411,40 @@ def _private_directory(metadata: os.stat_result) -> bool:
         and metadata.st_uid == os.geteuid()
         and stat.S_IMODE(metadata.st_mode) & 0o077 == 0
     )
+
+
+def _regular_file(metadata: os.stat_result) -> bool:
+    return (
+        stat.S_ISREG(metadata.st_mode)
+        and metadata.st_uid == os.geteuid()
+        and stat.S_IMODE(metadata.st_mode) == 0o600
+        and metadata.st_nlink == 1
+    )
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _digest_fd(descriptor: int, expected_size: int) -> str:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    digest = hashlib.sha256()
+    remaining = expected_size
+    while remaining:
+        chunk = os.read(descriptor, min(_READ_CHUNK_BYTES, remaining))
+        if not chunk:
+            raise ValueError
+        digest.update(chunk)
+        remaining -= len(chunk)
+    if os.read(descriptor, 1):
+        raise ValueError
+    return digest.hexdigest()
 
 
 def _marker(secret: str, name: str, identity: tuple[int, int]) -> str:

--- a/tldw_chatbook/Persona_Visual/authoring_workspace.py
+++ b/tldw_chatbook/Persona_Visual/authoring_workspace.py
@@ -1,0 +1,407 @@
+"""Identity-pinned private staging for Persona Visual authoring assets."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import re
+import stat
+from dataclasses import dataclass, field, replace
+from io import BytesIO
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
+
+from PIL import Image
+
+from tldw_chatbook.Utils.private_paths import secure_private_directory
+
+from .assets import (
+    MAX_ASSET_DECODED_PIXELS,
+    PersonaVisualAssetMetadata,
+    load_persona_visual_asset,
+    validate_persona_visual_asset_set,
+)
+from .authoring import (
+    PersonaVisualAuthoringDraft,
+    PersonaVisualDraftAsset,
+    inspect_persona_visual_draft,
+)
+from .contracts import (
+    MAX_ASSET_DIMENSION,
+    MAX_FRAME_DURATION_MS,
+    MAX_FRAMES_PER_ANIMATION,
+)
+
+
+_STATE = re.compile(r"[a-z][a-z0-9_.:-]{0,95}\Z")
+_MARKER_NAME = ".persona-visual-authoring"
+_FORMATS = {
+    "GIF": ("image/gif", ".gif"),
+    "JPEG": ("image/jpeg", ".jpg"),
+    "PNG": ("image/png", ".png"),
+    "WEBP": ("image/webp", ".webp"),
+}
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+class PersonaVisualAuthoringWorkspaceError(ValueError):
+    """Stable path-free private-staging failure."""
+
+    __slots__ = ("category",)
+
+    def __init__(self, category: str) -> None:
+        self.category = (
+            category
+            if category
+            in {
+                "persona_visual_authoring_asset_invalid",
+                "persona_visual_authoring_cleanup_denied",
+                "persona_visual_authoring_staging_failed",
+            }
+            else "persona_visual_authoring_staging_failed"
+        )
+        super().__init__(self.category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualAuthoringWorkspace:
+    """One private candidate retained only by its owning editor session."""
+
+    profile_root: Path = field(repr=False, compare=False)
+    relative_root: str
+    identity: tuple[int, int] = field(repr=False)
+    secret: str = field(repr=False)
+    asset_names: tuple[str, ...] = ()
+
+
+def create_persona_visual_authoring_workspace(
+    profile_root: os.PathLike[str] | str,
+) -> PersonaVisualAuthoringWorkspace:
+    """Create one verified-private, identity-pinned authoring candidate."""
+
+    try:
+        root = _absolute_root(profile_root)
+        base = root / "persona_visual" / "authoring"
+        privacy = secure_private_directory(base, create=True, application_owned=True)
+        if not privacy.verified_private:
+            raise ValueError
+        name = f".draft-{uuid4().hex}"
+        candidate = base / name
+        candidate.mkdir(mode=0o700)
+        (candidate / "assets").mkdir(mode=0o700)
+        metadata = os.lstat(candidate)
+        if not _private_directory(metadata):
+            raise ValueError
+        identity = (metadata.st_dev, metadata.st_ino)
+        secret = os.urandom(32).hex()
+        marker = _marker(secret, name, identity)
+        _write_private(candidate / _MARKER_NAME, marker.encode("ascii"))
+        return PersonaVisualAuthoringWorkspace(
+            root,
+            f"persona_visual/authoring/{name}",
+            identity,
+            secret,
+        )
+    except Exception:
+        raise PersonaVisualAuthoringWorkspaceError(
+            "persona_visual_authoring_staging_failed"
+        ) from None
+
+
+def stage_persona_visual_authoring_asset(
+    workspace: PersonaVisualAuthoringWorkspace,
+    data: bytes,
+    *,
+    state: str,
+) -> tuple[PersonaVisualAuthoringWorkspace, PersonaVisualDraftAsset]:
+    """Validate and add one replacement raster to an existing workspace."""
+
+    try:
+        if (
+            type(workspace) is not PersonaVisualAuthoringWorkspace
+            or type(data) is not bytes
+            or not data
+            or type(state) is not str
+            or _STATE.fullmatch(state) is None
+        ):
+            raise ValueError
+        mime_type, suffix, width, height, frame_count, duration_ms = _decode(data)
+        metadata = PersonaVisualAssetMetadata(
+            asset_key=f"{state}-{uuid4().hex}",
+            role="frame",
+            mime_type=mime_type,
+            byte_count=len(data),
+            sha256=hashlib.sha256(data).hexdigest(),
+            width=width,
+            height=height,
+            frame_count=frame_count,
+            duration_ms=duration_ms,
+        )
+        metadata = validate_persona_visual_asset_set((metadata,))[0]
+        return _write_workspace_asset(workspace, data, metadata, suffix=suffix)
+    except PersonaVisualAuthoringWorkspaceError:
+        raise
+    except Exception:
+        raise PersonaVisualAuthoringWorkspaceError(
+            "persona_visual_authoring_asset_invalid"
+        ) from None
+
+
+def adopt_persona_visual_draft_sources(
+    workspace: PersonaVisualAuthoringWorkspace,
+    draft: PersonaVisualAuthoringDraft,
+    *,
+    source_root: os.PathLike[str] | str,
+) -> tuple[PersonaVisualAuthoringWorkspace, PersonaVisualAuthoringDraft]:
+    """Copy one validated draft into the workspace without changing metadata."""
+
+    if (
+        type(workspace) is not PersonaVisualAuthoringWorkspace
+        or workspace.asset_names
+        or type(draft) is not PersonaVisualAuthoringDraft
+    ):
+        raise PersonaVisualAuthoringWorkspaceError(
+            "persona_visual_authoring_staging_failed"
+        )
+    current = workspace
+    copied: list[PersonaVisualDraftAsset] = []
+    try:
+        for asset in draft.assets:
+            loaded = load_persona_visual_asset(
+                source_root,
+                storage_key=asset.source_storage_key,
+                metadata=asset.metadata,
+            )
+            suffix = _FORMATS[_format_for_mime(asset.metadata.mime_type)][1]
+            current, copied_asset = _write_workspace_asset(
+                current,
+                loaded.data,
+                asset.metadata,
+                suffix=suffix,
+            )
+            copied.append(copied_asset)
+        adopted = replace(draft, assets=tuple(copied))
+        inspect_persona_visual_draft(adopted)
+        return current, adopted
+    except Exception:
+        cleanup_persona_visual_authoring_workspace(current)
+        raise PersonaVisualAuthoringWorkspaceError(
+            "persona_visual_authoring_staging_failed"
+        ) from None
+
+
+def cleanup_persona_visual_authoring_workspace(
+    workspace: PersonaVisualAuthoringWorkspace,
+) -> bool:
+    """Delete only the exact issued workspace and its declared files."""
+
+    if type(workspace) is not PersonaVisualAuthoringWorkspace:
+        return False
+    root_fd = base_fd = candidate_fd = assets_fd = -1
+    try:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        root_fd = os.open(workspace.profile_root, flags)
+        visual_fd = os.open("persona_visual", flags, dir_fd=root_fd)
+        os.close(root_fd)
+        root_fd = visual_fd
+        base_fd = os.open("authoring", flags, dir_fd=root_fd)
+        name = PurePosixPath(workspace.relative_root).name
+        candidate_fd = os.open(name, flags, dir_fd=base_fd)
+        opened = os.fstat(candidate_fd)
+        named = os.stat(name, dir_fd=base_fd, follow_symlinks=False)
+        if (
+            not _private_directory(opened)
+            or not _private_directory(named)
+            or (opened.st_dev, opened.st_ino) != workspace.identity
+            or (named.st_dev, named.st_ino) != workspace.identity
+            or _read_marker(candidate_fd)
+            != _marker(workspace.secret, name, workspace.identity)
+        ):
+            return False
+        assets_fd = os.open("assets", flags, dir_fd=candidate_fd)
+        expected = set(workspace.asset_names)
+        if set(os.listdir(assets_fd)) != expected:
+            return False
+        for asset_name in workspace.asset_names:
+            metadata = os.stat(asset_name, dir_fd=assets_fd, follow_symlinks=False)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                return False
+        if set(os.listdir(candidate_fd)) != {_MARKER_NAME, "assets"}:
+            return False
+        for asset_name in workspace.asset_names:
+            os.unlink(asset_name, dir_fd=assets_fd)
+        os.close(assets_fd)
+        assets_fd = -1
+        os.rmdir("assets", dir_fd=candidate_fd)
+        os.unlink(_MARKER_NAME, dir_fd=candidate_fd)
+        opened = os.fstat(candidate_fd)
+        named = os.stat(name, dir_fd=base_fd, follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != workspace.identity or (
+            named.st_dev,
+            named.st_ino,
+        ) != workspace.identity:
+            return False
+        os.rmdir(name, dir_fd=base_fd)
+        return True
+    except Exception:
+        return False
+    finally:
+        for descriptor in (assets_fd, candidate_fd, base_fd, root_fd):
+            if descriptor >= 0:
+                os.close(descriptor)
+
+
+def _write_workspace_asset(
+    workspace: PersonaVisualAuthoringWorkspace,
+    data: bytes,
+    metadata: PersonaVisualAssetMetadata,
+    *,
+    suffix: str,
+) -> tuple[PersonaVisualAuthoringWorkspace, PersonaVisualDraftAsset]:
+    candidate = workspace.profile_root / workspace.relative_root
+    current = os.lstat(candidate)
+    if (current.st_dev, current.st_ino) != workspace.identity:
+        raise PersonaVisualAuthoringWorkspaceError(
+            "persona_visual_authoring_staging_failed"
+        )
+    name = f"{uuid4().hex}{suffix}"
+    target = candidate / "assets" / name
+    descriptor = os.open(
+        target,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
+    try:
+        view = memoryview(data)
+        while view:
+            written = os.write(descriptor, view[:_READ_CHUNK_BYTES])
+            if written <= 0:
+                raise OSError
+            view = view[written:]
+        os.fsync(descriptor)
+    except Exception:
+        try:
+            os.unlink(target)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(descriptor)
+    source_key = f"{workspace.relative_root}/assets/{name}"
+    updated = replace(workspace, asset_names=workspace.asset_names + (name,))
+    return updated, PersonaVisualDraftAsset(source_key, metadata)
+
+
+def _decode(data: bytes) -> tuple[str, str, int, int, int, int | None]:
+    with Image.open(BytesIO(data)) as image:
+        if image.format not in _FORMATS:
+            raise ValueError
+        mime_type, suffix = _FORMATS[image.format]
+        width, height = image.size
+        frame_count = int(getattr(image, "n_frames", 1))
+        if (
+            width < 1
+            or height < 1
+            or width > MAX_ASSET_DIMENSION
+            or height > MAX_ASSET_DIMENSION
+            or frame_count < 1
+            or frame_count > MAX_FRAMES_PER_ANIMATION
+            or width * height * frame_count > MAX_ASSET_DECODED_PIXELS
+        ):
+            raise ValueError
+        duration = 0
+        for index in range(frame_count):
+            image.seek(index)
+            frame_duration = image.info.get("duration", 0)
+            if type(frame_duration) is not int or frame_duration < 0:
+                raise ValueError
+            duration += frame_duration
+            if duration > MAX_FRAME_DURATION_MS:
+                raise ValueError
+            image.load()
+        return (
+            mime_type,
+            suffix,
+            width,
+            height,
+            frame_count,
+            duration or None,
+        )
+
+
+def _format_for_mime(mime_type: str) -> str:
+    return next(name for name, (mime, _suffix) in _FORMATS.items() if mime == mime_type)
+
+
+def _absolute_root(value: os.PathLike[str] | str) -> Path:
+    raw = os.fspath(value)
+    if type(raw) is not str or not raw or "\x00" in raw:
+        raise ValueError
+    root = Path(raw)
+    if not root.is_absolute() or str(root) != raw:
+        raise ValueError
+    metadata = os.lstat(root)
+    if not _private_directory(metadata):
+        raise ValueError
+    return root
+
+
+def _private_directory(metadata: os.stat_result) -> bool:
+    return (
+        stat.S_ISDIR(metadata.st_mode)
+        and metadata.st_uid == os.geteuid()
+        and stat.S_IMODE(metadata.st_mode) & 0o077 == 0
+    )
+
+
+def _marker(secret: str, name: str, identity: tuple[int, int]) -> str:
+    payload = f"{name}:{identity[0]}:{identity[1]}".encode("ascii")
+    return hmac.new(bytes.fromhex(secret), payload, hashlib.sha256).hexdigest()
+
+
+def _write_private(path: Path, data: bytes) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
+    try:
+        view = memoryview(data)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError
+            view = view[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _read_marker(candidate_fd: int) -> str:
+    descriptor = os.open(_MARKER_NAME, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=candidate_fd)
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+            or metadata.st_size != 64
+        ):
+            raise ValueError
+        data = os.read(descriptor, 65)
+        if len(data) != 64:
+            raise ValueError
+        return data.decode("ascii")
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "PersonaVisualAuthoringWorkspace",
+    "PersonaVisualAuthoringWorkspaceError",
+    "adopt_persona_visual_draft_sources",
+    "cleanup_persona_visual_authoring_workspace",
+    "create_persona_visual_authoring_workspace",
+    "stage_persona_visual_authoring_asset",
+]

--- a/tldw_chatbook/Persona_Visual/importer.py
+++ b/tldw_chatbook/Persona_Visual/importer.py
@@ -1,0 +1,1006 @@
+"""Review-first import for pinned Persona Visual pack archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import unicodedata
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path, PurePosixPath
+from typing import Any
+from uuid import uuid4
+
+from PIL import Image
+
+from tldw_chatbook.Utils.private_paths import secure_private_directory
+
+from .assets import (
+    PersonaVisualAssetMetadata,
+    load_persona_visual_asset,
+    validate_persona_visual_asset_set,
+)
+from .authoring import (
+    PersonaVisualAuthoringDraft,
+    PersonaVisualDraftAsset,
+    create_persona_visual_import_draft,
+)
+from .contracts import (
+    ALLOWED_ASSET_MIME_TYPES,
+    ALLOWED_ASSET_ROLES,
+    MAX_ASSET_COUNT,
+    MAX_ASSET_DIMENSION,
+    MAX_ASSET_TOTAL_BYTES,
+    MAX_FRAMES_PER_ANIMATION,
+)
+from .repository import PersonaVisualIdentity
+
+
+PERSONA_VISUAL_PACK_SCHEMA = "tldw.persona_visual_pack.v1"
+_REQUIRED_MEMBERS = frozenset(
+    {
+        "manifest.json",
+        "metadata/pack.json",
+        "metadata/assets.json",
+        "checksums/sha256.json",
+    }
+)
+_OPTIONAL_MEMBERS = frozenset({"README.md", "signatures/README.md"})
+_ALLOWED_ROOTS = frozenset({"assets", "metadata", "checksums", "signatures"})
+_NESTED_SUFFIXES = (
+    ".zip",
+    ".tar",
+    ".tgz",
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".7z",
+    ".tldw-persona-vpack",
+    ".tldw-actor-pack",
+)
+_WINDOWS_DEVICES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{index}" for index in range(1, 10)}
+    | {f"LPT{index}" for index in range(1, 10)}
+)
+_FORMAT_BY_MIME = {
+    "image/png": ("PNG", ".png"),
+    "image/jpeg": ("JPEG", ".jpg"),
+    "image/webp": ("WEBP", ".webp"),
+    "image/gif": ("GIF", ".gif"),
+}
+_MAX_ARCHIVE_BYTES = MAX_ASSET_TOTAL_BYTES + 10 * 1024 * 1024
+_MAX_JSON_BYTES = 2 * 1024 * 1024
+_MAX_MEMBER_COUNT = MAX_ASSET_COUNT + 16
+_MAX_COMPRESSION_RATIO = 200
+_READ_CHUNK = 64 * 1024
+_MARKER_NAME = ".persona-visual-import"
+_CAPABILITY = re.compile(r"\Apvi1:([0-9a-f]{64}):(\.import-[0-9a-f]{32})\Z")
+_SAFE_ASSET_NAME = re.compile(r"[0-9]{3}\.(?:png|jpg|webp|gif)\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class PersonaVisualImportError(ValueError):
+    """Stable path-free import failure with optional cleanup authority."""
+
+    __slots__ = ("category", "cleanup_candidate")
+
+    def __init__(self, category: str, *, cleanup_candidate: str | None = None) -> None:
+        if category not in {
+            "persona_visual_import_invalid",
+            "persona_visual_import_unsupported",
+            "persona_visual_import_cancelled",
+            "persona_visual_import_stale",
+            "persona_visual_import_cleanup_denied",
+            "persona_visual_import_failed",
+        }:
+            category = "persona_visual_import_failed"
+        self.category = category
+        self.cleanup_candidate = cleanup_candidate
+        super().__init__(category)
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaVisualImportReview:
+    """Path-free review metadata plus an isolated unpublished draft."""
+
+    schema_version: str
+    archive_sha256: str
+    pack_title: str
+    asset_count: int
+    state_count: int
+    draft: PersonaVisualAuthoringDraft
+    cleanup_candidate: str = field(repr=False)
+    _candidate_name: str = field(repr=False)
+    _candidate_identity: tuple[int, int] = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceSnapshot:
+    path: Path = field(repr=False)
+    identity: tuple[int, int, int, int, int]
+    sha256: str
+    data: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    root: Path = field(repr=False)
+    name: str
+    identity: tuple[int, int]
+    secret: str = field(repr=False)
+    asset_names: tuple[str, ...]
+
+    @property
+    def capability(self) -> str:
+        return f"pvi1:{self.secret}:{self.name}"
+
+
+def import_persona_visual_pack(
+    archive_path: os.PathLike[str] | str,
+    *,
+    staging_root: os.PathLike[str] | str,
+    persona_id: str,
+    persona_revision: int,
+    expected_identity: PersonaVisualIdentity | None,
+    cancel_event: object | None = None,
+) -> PersonaVisualImportReview:
+    """Validate one server-compatible archive into an unpublished review draft."""
+
+    candidate: _Candidate | None = None
+    try:
+        cancelled = _cancel_checker(cancel_event)
+        _raise_if_cancelled(cancelled)
+        source = _pin_source(archive_path)
+        root = _private_staging_root(staging_root)
+        _raise_if_cancelled(cancelled)
+        with zipfile.ZipFile(BytesIO(source.data), "r") as archive:
+            members = _validated_members(archive)
+            outer = _json_member(archive, members, "manifest.json")
+            checksums = _checksums(
+                _json_member(archive, members, "checksums/sha256.json")
+            )
+            pack = _pack(_json_member(archive, members, "metadata/pack.json"))
+            asset_records = _assets(
+                _json_member(archive, members, "metadata/assets.json")
+            )
+            _validate_declarations(
+                archive,
+                members,
+                outer,
+                checksums,
+                asset_records,
+                cancelled,
+            )
+            _preflight_space(root, members)
+            candidate = _create_candidate(root)
+            draft_assets = _extract_assets(
+                archive,
+                members,
+                asset_records,
+                candidate,
+                cancelled,
+            )
+            candidate = _candidate_with_assets(candidate, draft_assets)
+            manifest_document = pack["visual_manifest"]
+            manifest_json = _canonical_text(manifest_document)
+            _write_private(candidate.root / "manifest.json", manifest_json.encode())
+            draft = create_persona_visual_import_draft(
+                persona_id=persona_id,
+                persona_revision=persona_revision,
+                expected_identity=expected_identity,
+                title=pack["title"],
+                description="Imported Persona Visual pack",
+                manifest_json=manifest_json,
+                assets=draft_assets,
+            )
+        _raise_if_cancelled(cancelled)
+        if not _source_identity_current(
+            source.path,
+            source.identity,
+            source.sha256,
+        ):
+            raise PersonaVisualImportError("persona_visual_import_stale")
+        _candidate_current(candidate)
+        return PersonaVisualImportReview(
+            schema_version=PERSONA_VISUAL_PACK_SCHEMA,
+            archive_sha256=source.sha256,
+            pack_title=draft.title,
+            asset_count=len(draft.assets),
+            state_count=len(json.loads(draft.manifest_json)["states"]),
+            draft=draft,
+            cleanup_candidate=candidate.capability,
+            _candidate_name=candidate.name,
+            _candidate_identity=candidate.identity,
+        )
+    except PersonaVisualImportError as exc:
+        cleanup_candidate = _cleanup_failed_candidate(candidate)
+        if cleanup_candidate is not None and exc.cleanup_candidate is None:
+            exc.cleanup_candidate = cleanup_candidate
+        raise
+    except (KeyboardInterrupt, SystemExit):
+        _cleanup_failed_candidate(candidate)
+        raise
+    except Exception:
+        cleanup_candidate = _cleanup_failed_candidate(candidate)
+        raise PersonaVisualImportError(
+            "persona_visual_import_invalid",
+            cleanup_candidate=cleanup_candidate,
+        ) from None
+
+
+def persona_visual_import_source_root(
+    review: PersonaVisualImportReview,
+    *,
+    staging_root: os.PathLike[str] | str,
+) -> Path:
+    """Return the private publication source only while its exact lease is current."""
+
+    candidate = _review_candidate(review, staging_root)
+    _candidate_current(candidate)
+    return candidate.root
+
+
+def cleanup_persona_visual_import_review(
+    review: PersonaVisualImportReview,
+    *,
+    staging_root: os.PathLike[str] | str,
+) -> bool:
+    """Delete only the exact module-issued staging identity for one review."""
+
+    candidate = _review_candidate(review, staging_root)
+    if not _delete_candidate(candidate):
+        raise PersonaVisualImportError("persona_visual_import_cleanup_denied")
+    return True
+
+
+def _pin_source(value: os.PathLike[str] | str) -> _SourceSnapshot:
+    raw = os.fspath(value)
+    if type(raw) is not str or "\x00" in raw:
+        raise ValueError
+    path = Path(raw)
+    if not path.is_absolute() or str(path) != raw:
+        raise ValueError
+    before = os.lstat(path)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 1
+        or before.st_size <= 0
+        or before.st_size > _MAX_ARCHIVE_BYTES
+    ):
+        raise ValueError
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        data = _read_fd(descriptor, before.st_size)
+        after = os.fstat(descriptor)
+        named = os.lstat(path)
+    finally:
+        os.close(descriptor)
+    identity = _file_identity(before)
+    if (
+        _file_identity(opened) != identity
+        or _file_identity(after) != identity
+        or _file_identity(named) != identity
+        or not stat.S_ISREG(named.st_mode)
+        or len(data) != before.st_size
+    ):
+        raise ValueError
+    return _SourceSnapshot(
+        path=path,
+        identity=identity,
+        sha256=hashlib.sha256(data).hexdigest(),
+        data=data,
+    )
+
+
+def _source_identity_current(
+    path: Path,
+    identity: tuple[int, int, int, int, int],
+    expected_sha256: str,
+) -> bool:
+    try:
+        current = _pin_source(path)
+        return current.identity == identity and current.sha256 == expected_sha256
+    except Exception:
+        return False
+
+
+def _validated_members(
+    archive: zipfile.ZipFile,
+) -> dict[str, zipfile.ZipInfo]:
+    infos = archive.infolist()
+    if len(infos) > _MAX_MEMBER_COUNT:
+        raise ValueError
+    members: dict[str, zipfile.ZipInfo] = {}
+    collision_keys: set[str] = set()
+    total = 0
+    for info in infos:
+        raw = getattr(info, "orig_filename", info.filename)
+        if info.is_dir():
+            _member_name(raw.removesuffix("/"), directory=True)
+            continue
+        name = _member_name(raw, directory=False)
+        collision = unicodedata.normalize("NFC", name).casefold()
+        if name in members or collision in collision_keys:
+            raise ValueError
+        mode = (info.external_attr >> 16) & 0o170000
+        if mode not in {0, stat.S_IFREG} or info.flag_bits & 0x1:
+            raise ValueError
+        if name.lower().endswith(_NESTED_SUFFIXES):
+            raise ValueError
+        if info.file_size < 0 or info.compress_size < 0:
+            raise ValueError
+        if (
+            info.file_size
+            and info.file_size > max(info.compress_size, 1) * _MAX_COMPRESSION_RATIO
+        ):
+            raise ValueError
+        total += info.file_size
+        if total > MAX_ASSET_TOTAL_BYTES + 3 * _MAX_JSON_BYTES:
+            raise ValueError
+        members[name] = info
+        collision_keys.add(collision)
+    if not _REQUIRED_MEMBERS.issubset(members):
+        raise ValueError
+    return members
+
+
+def _member_name(value: object, *, directory: bool) -> str:
+    if type(value) is not str or not value or "\x00" in value or "\\" in value:
+        raise ValueError
+    value.encode("utf-8")
+    if value.startswith("/") or not value.isascii():
+        raise ValueError
+    path = PurePosixPath(value)
+    parts = tuple(value.split("/"))
+    if (
+        path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {"", ".", ".."} for part in parts)
+        or any(":" in part for part in parts)
+    ):
+        raise ValueError
+    for part in parts:
+        if (
+            len(part.encode()) > 255
+            or part.rstrip(" .").split(".", 1)[0].upper() in _WINDOWS_DEVICES
+        ):
+            raise ValueError
+    if (
+        parts[0] not in _ALLOWED_ROOTS
+        and value not in _OPTIONAL_MEMBERS
+        and value != "manifest.json"
+    ):
+        raise ValueError
+    if directory and parts[0] not in _ALLOWED_ROOTS:
+        raise ValueError
+    return value
+
+
+def _json_member(
+    archive: zipfile.ZipFile,
+    members: Mapping[str, zipfile.ZipInfo],
+    name: str,
+) -> object:
+    info = members[name]
+    if info.file_size > _MAX_JSON_BYTES:
+        raise ValueError
+    data = archive.read(info)
+    if len(data) != info.file_size:
+        raise ValueError
+    try:
+        return json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError):
+        raise ValueError from None
+
+
+def _checksums(value: object) -> dict[str, str]:
+    if type(value) is not dict or len(value) > _MAX_MEMBER_COUNT:
+        raise ValueError
+    result: dict[str, str] = {}
+    for raw_name, digest in value.items():
+        name = _member_name(raw_name, directory=False)
+        if type(digest) is not str or _SHA256.fullmatch(digest) is None:
+            raise ValueError
+        result[name] = digest
+    return result
+
+
+def _pack(value: object) -> dict[str, Any]:
+    if type(value) is not dict or type(value.get("pack")) is not dict:
+        raise ValueError
+    pack = value["pack"]
+    title = pack.get("title")
+    manifest = pack.get("visual_manifest")
+    if (
+        type(title) is not str
+        or not title
+        or len(title) > 256
+        or type(manifest) is not dict
+        or pack.get("renderer_type") != "sprite_frames"
+        or pack.get("manifest_version") != 1
+    ):
+        raise ValueError
+    title.encode("utf-8")
+    return {"title": title, "visual_manifest": manifest}
+
+
+def _assets(value: object) -> tuple[dict[str, Any], ...]:
+    if type(value) is not dict or type(value.get("assets")) is not list:
+        raise ValueError
+    records = value["assets"]
+    if not records or len(records) > MAX_ASSET_COUNT:
+        raise ValueError
+    result: list[dict[str, Any]] = []
+    keys: set[str] = set()
+    paths: set[str] = set()
+    for record in records:
+        if type(record) is not dict:
+            raise ValueError
+        key = record.get("source_asset_id")
+        role = record.get("asset_role")
+        mime = record.get("mime_type")
+        path = record.get("asset_path")
+        digest = record.get("asset_sha256") or record.get("checksum_sha256")
+        size = record.get("asset_size_bytes")
+        if size is None:
+            size = record.get("byte_size")
+        width = record.get("width")
+        height = record.get("height")
+        if (
+            record.get("asset_bytes_status") != "present"
+            or type(key) is not str
+            or key in keys
+            or type(role) is not str
+            or role not in ALLOWED_ASSET_ROLES
+            or type(mime) is not str
+            or mime not in ALLOWED_ASSET_MIME_TYPES
+            or type(path) is not str
+            or path in paths
+            or not path.startswith("assets/")
+            or type(digest) is not str
+            or _SHA256.fullmatch(digest) is None
+            or type(size) is not int
+            or size <= 0
+            or type(width) is not int
+            or width <= 0
+            or width > MAX_ASSET_DIMENSION
+            or type(height) is not int
+            or height <= 0
+            or height > MAX_ASSET_DIMENSION
+        ):
+            raise ValueError
+        _member_name(path, directory=False)
+        result.append(
+            {
+                "asset_key": key,
+                "role": role,
+                "mime_type": mime,
+                "asset_path": path,
+                "sha256": digest,
+                "byte_count": size,
+                "width": width,
+                "height": height,
+                "duration_ms": record.get("duration_ms"),
+            }
+        )
+        keys.add(key)
+        paths.add(path)
+    return tuple(result)
+
+
+def _validate_declarations(
+    archive: zipfile.ZipFile,
+    members: Mapping[str, zipfile.ZipInfo],
+    outer: object,
+    checksums: Mapping[str, str],
+    assets: tuple[dict[str, Any], ...],
+    cancelled: Any,
+) -> None:
+    if (
+        type(outer) is not dict
+        or outer.get("schema_version") != PERSONA_VISUAL_PACK_SCHEMA
+    ):
+        raise PersonaVisualImportError("persona_visual_import_unsupported")
+    encryption = outer.get("encryption")
+    if type(encryption) is not dict or encryption.get("encrypted") is not False:
+        raise ValueError
+    sections = outer.get("sections")
+    if type(sections) is not list:
+        raise ValueError
+    section_map: dict[str, str] = {}
+    for section in sections:
+        if type(section) is not dict:
+            raise ValueError
+        name = _member_name(section.get("path"), directory=False)
+        digest = section.get("sha256")
+        if (
+            type(digest) is not str
+            or _SHA256.fullmatch(digest) is None
+            or name in section_map
+        ):
+            raise ValueError
+        section_map[name] = digest
+    declared_assets = {record["asset_path"] for record in assets}
+    expected_sections = {"metadata/pack.json", "metadata/assets.json"} | declared_assets
+    if set(section_map) != expected_sections:
+        raise ValueError
+    expected_checksum_names = expected_sections | {"manifest.json"}
+    if set(checksums) != expected_checksum_names:
+        raise ValueError
+    regular_members = set(members)
+    allowed = expected_checksum_names | {"checksums/sha256.json"} | _OPTIONAL_MEMBERS
+    if regular_members - allowed:
+        raise ValueError
+    if not declared_assets.issubset(members):
+        raise ValueError
+    for name, expected in checksums.items():
+        _raise_if_cancelled(cancelled)
+        info = members.get(name)
+        if info is None or _member_digest(archive, info, cancelled) != expected:
+            raise ValueError
+    if any(section_map[name] != checksums[name] for name in section_map):
+        raise ValueError
+    for record in assets:
+        info = members[record["asset_path"]]
+        if (
+            info.file_size != record["byte_count"]
+            or checksums[record["asset_path"]] != record["sha256"]
+        ):
+            raise ValueError
+
+
+def _preflight_space(root: Path, members: Mapping[str, zipfile.ZipInfo]) -> None:
+    required = sum(info.file_size for info in members.values()) + 1024 * 1024
+    if shutil.disk_usage(root).free < required:
+        raise ValueError
+
+
+def _create_candidate(root: Path) -> _Candidate:
+    name = f".import-{uuid4().hex}"
+    candidate = root / name
+    candidate.mkdir(mode=0o700)
+    metadata = os.lstat(candidate)
+    if not _private_directory(metadata):
+        raise ValueError
+    secret = os.urandom(32).hex()
+    identity = (metadata.st_dev, metadata.st_ino)
+    marker = _marker(secret, name, identity)
+    _write_private(candidate / _MARKER_NAME, marker.encode())
+    (candidate / "assets").mkdir(mode=0o700)
+    return _Candidate(candidate, name, identity, secret, ())
+
+
+def _candidate_with_assets(
+    candidate: _Candidate,
+    assets: tuple[PersonaVisualDraftAsset, ...],
+) -> _Candidate:
+    names = tuple(PurePosixPath(asset.source_storage_key).name for asset in assets)
+    return _Candidate(
+        candidate.root,
+        candidate.name,
+        candidate.identity,
+        candidate.secret,
+        names,
+    )
+
+
+def _extract_assets(
+    archive: zipfile.ZipFile,
+    members: Mapping[str, zipfile.ZipInfo],
+    records: tuple[dict[str, Any], ...],
+    candidate: _Candidate,
+    cancelled: Any,
+) -> tuple[PersonaVisualDraftAsset, ...]:
+    draft_assets: list[PersonaVisualDraftAsset] = []
+    for index, record in enumerate(records):
+        _raise_if_cancelled(cancelled)
+        extension = _FORMAT_BY_MIME[record["mime_type"]][1]
+        target_name = f"{index:03d}{extension}"
+        target = candidate.root / "assets" / target_name
+        digest = hashlib.sha256()
+        written = 0
+        descriptor = os.open(
+            target,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        try:
+            with archive.open(members[record["asset_path"]], "r") as source:
+                while True:
+                    _raise_if_cancelled(cancelled)
+                    chunk = source.read(_READ_CHUNK)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > record["byte_count"]:
+                        raise ValueError
+                    digest.update(chunk)
+                    _write_all(descriptor, chunk)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        if written != record["byte_count"] or digest.hexdigest() != record["sha256"]:
+            raise ValueError
+        frame_count, duration_ms = _inspect_image(target, record)
+        metadata = PersonaVisualAssetMetadata(
+            asset_key=record["asset_key"],
+            role=record["role"],
+            mime_type=record["mime_type"],
+            byte_count=written,
+            sha256=digest.hexdigest(),
+            width=record["width"],
+            height=record["height"],
+            frame_count=frame_count,
+            duration_ms=duration_ms,
+        )
+        metadata = validate_persona_visual_asset_set((metadata,))[0]
+        storage_key = f"assets/{target_name}"
+        load_persona_visual_asset(
+            candidate.root,
+            storage_key=storage_key,
+            metadata=metadata,
+        )
+        draft_assets.append(PersonaVisualDraftAsset(storage_key, metadata))
+    validate_persona_visual_asset_set(tuple(asset.metadata for asset in draft_assets))
+    return tuple(draft_assets)
+
+
+def _inspect_image(path: Path, record: Mapping[str, Any]) -> tuple[int, int | None]:
+    with Image.open(path) as image:
+        if (
+            image.format != _FORMAT_BY_MIME[record["mime_type"]][0]
+            or image.width != record["width"]
+            or image.height != record["height"]
+        ):
+            raise ValueError
+        frame_count = int(getattr(image, "n_frames", 1))
+        if frame_count < 1 or frame_count > MAX_FRAMES_PER_ANIMATION:
+            raise ValueError
+        duration = 0
+        for index in range(frame_count):
+            image.seek(index)
+            image.load()
+            value = image.info.get("duration", 0)
+            if type(value) is not int or value < 0:
+                raise ValueError
+            duration += value
+        actual_duration = duration or None
+        declared_duration = record.get("duration_ms")
+        if declared_duration is not None and declared_duration != actual_duration:
+            raise ValueError
+        return frame_count, actual_duration
+
+
+def _private_staging_root(value: os.PathLike[str] | str) -> Path:
+    raw = os.fspath(value)
+    if type(raw) is not str or "\x00" in raw:
+        raise ValueError
+    root = Path(raw)
+    if not root.is_absolute() or str(root) != raw:
+        raise ValueError
+    privacy = secure_private_directory(root, create=True, application_owned=True)
+    if not privacy.verified_private:
+        raise ValueError
+    return root
+
+
+def _review_candidate(
+    review: object,
+    staging_root: os.PathLike[str] | str,
+) -> _Candidate:
+    if type(review) is not PersonaVisualImportReview:
+        raise PersonaVisualImportError("persona_visual_import_cleanup_denied")
+    root = _private_staging_root(staging_root)
+    parsed = _CAPABILITY.fullmatch(review.cleanup_candidate)
+    if (
+        parsed is None
+        or parsed.group(2) != review._candidate_name
+        or type(review._candidate_identity) is not tuple
+        or len(review._candidate_identity) != 2
+    ):
+        raise PersonaVisualImportError("persona_visual_import_cleanup_denied")
+    return _Candidate(
+        root / review._candidate_name,
+        review._candidate_name,
+        review._candidate_identity,
+        parsed.group(1),
+        tuple(
+            PurePosixPath(asset.source_storage_key).name
+            for asset in review.draft.assets
+        ),
+    )
+
+
+def _candidate_current(candidate: _Candidate) -> None:
+    root_fd = -1
+    candidate_fd = -1
+    try:
+        root_fd, candidate_fd = _open_candidate(candidate)
+        if _read_marker(candidate_fd) != _marker(
+            candidate.secret,
+            candidate.name,
+            candidate.identity,
+        ):
+            raise ValueError
+    except Exception:
+        raise PersonaVisualImportError("persona_visual_import_cleanup_denied") from None
+    finally:
+        if candidate_fd >= 0:
+            os.close(candidate_fd)
+        if root_fd >= 0:
+            os.close(root_fd)
+
+
+def _cleanup_failed_candidate(candidate: _Candidate | None) -> str | None:
+    if candidate is None:
+        return None
+    return (
+        None
+        if _delete_candidate(candidate, allow_partial=True)
+        else candidate.capability
+    )
+
+
+def _delete_candidate(candidate: _Candidate, *, allow_partial: bool = False) -> bool:
+    root_fd = -1
+    candidate_fd = -1
+    assets_fd = -1
+    try:
+        root_fd, candidate_fd = _open_candidate(candidate)
+        if _read_marker(candidate_fd) != _marker(
+            candidate.secret,
+            candidate.name,
+            candidate.identity,
+        ):
+            return False
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        assets_fd = os.open("assets", directory_flags, dir_fd=candidate_fd)
+        if not _private_directory(os.fstat(assets_fd)):
+            return False
+        actual_assets = tuple(os.listdir(assets_fd))
+        if not allow_partial and set(actual_assets) != set(candidate.asset_names):
+            return False
+        if allow_partial and len(actual_assets) > MAX_ASSET_COUNT:
+            return False
+        for name in actual_assets:
+            if _SAFE_ASSET_NAME.fullmatch(name) is None:
+                return False
+            metadata = os.stat(name, dir_fd=assets_fd, follow_symlinks=False)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                return False
+        allowed_root = {_MARKER_NAME, "manifest.json", "assets"}
+        actual_root = set(os.listdir(candidate_fd))
+        if not actual_root.issubset(allowed_root):
+            return False
+        for name in actual_assets:
+            os.unlink(name, dir_fd=assets_fd)
+        os.close(assets_fd)
+        assets_fd = -1
+        os.rmdir("assets", dir_fd=candidate_fd)
+        if "manifest.json" in actual_root:
+            manifest = os.stat(
+                "manifest.json",
+                dir_fd=candidate_fd,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISREG(manifest.st_mode) or manifest.st_nlink != 1:
+                return False
+            os.unlink("manifest.json", dir_fd=candidate_fd)
+        os.unlink(_MARKER_NAME, dir_fd=candidate_fd)
+        named = os.stat(
+            candidate.name,
+            dir_fd=root_fd,
+            follow_symlinks=False,
+        )
+        opened = os.fstat(candidate_fd)
+        if (named.st_dev, named.st_ino) != candidate.identity or (
+            opened.st_dev,
+            opened.st_ino,
+        ) != candidate.identity:
+            return False
+        os.rmdir(candidate.name, dir_fd=root_fd)
+        return True
+    except Exception:
+        return False
+    finally:
+        if assets_fd >= 0:
+            os.close(assets_fd)
+        if candidate_fd >= 0:
+            os.close(candidate_fd)
+        if root_fd >= 0:
+            os.close(root_fd)
+
+
+def _open_candidate(candidate: _Candidate) -> tuple[int, int]:
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    root_fd = os.open(candidate.root.parent, directory_flags)
+    try:
+        candidate_fd = os.open(candidate.name, directory_flags, dir_fd=root_fd)
+        opened = os.fstat(candidate_fd)
+        named = os.stat(
+            candidate.name,
+            dir_fd=root_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not _private_directory(opened)
+            or not _private_directory(named)
+            or (opened.st_dev, opened.st_ino) != candidate.identity
+            or (named.st_dev, named.st_ino) != candidate.identity
+        ):
+            raise ValueError
+        return root_fd, candidate_fd
+    except Exception:
+        os.close(root_fd)
+        raise
+
+
+def _read_marker(candidate_fd: int) -> str:
+    flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+    descriptor = os.open(_MARKER_NAME, flags, dir_fd=candidate_fd)
+    try:
+        opened = os.fstat(descriptor)
+        named = os.stat(
+            _MARKER_NAME,
+            dir_fd=candidate_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or not stat.S_ISREG(named.st_mode)
+            or opened.st_nlink != 1
+            or named.st_nlink != 1
+            or stat.S_IMODE(opened.st_mode) != 0o600
+            or (opened.st_dev, opened.st_ino, opened.st_size)
+            != (named.st_dev, named.st_ino, named.st_size)
+            or opened.st_size != 64
+        ):
+            raise ValueError
+        data = _read_fd(descriptor, 64)
+        return data.decode("ascii")
+    finally:
+        os.close(descriptor)
+
+
+def _marker(secret: str, name: str, identity: tuple[int, int]) -> str:
+    payload = f"{name}:{identity[0]}:{identity[1]}".encode()
+    return hashlib.blake2b(
+        payload,
+        digest_size=32,
+        key=bytes.fromhex(secret),
+    ).hexdigest()
+
+
+def _private_directory(metadata: os.stat_result) -> bool:
+    return (
+        stat.S_ISDIR(metadata.st_mode)
+        and metadata.st_nlink >= 1
+        and (not hasattr(os, "geteuid") or metadata.st_uid == os.geteuid())
+        and stat.S_IMODE(metadata.st_mode) == 0o700
+    )
+
+
+def _write_private(path: Path, data: bytes) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        _write_all(descriptor, data)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError
+        view = view[written:]
+
+
+def _member_digest(
+    archive: zipfile.ZipFile,
+    info: zipfile.ZipInfo,
+    cancelled: Any,
+) -> str:
+    digest = hashlib.sha256()
+    total = 0
+    with archive.open(info, "r") as source:
+        while chunk := source.read(_READ_CHUNK):
+            _raise_if_cancelled(cancelled)
+            total += len(chunk)
+            if total > info.file_size:
+                raise ValueError
+            digest.update(chunk)
+    if total != info.file_size:
+        raise ValueError
+    return digest.hexdigest()
+
+
+def _read_fd(descriptor: int, expected: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = expected + 1
+    while remaining:
+        chunk = os.read(descriptor, min(_READ_CHUNK, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    if len(data) != expected:
+        raise ValueError
+    return data
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _canonical_text(value: object) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if type(key) is not str or key in result:
+            raise ValueError
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(_value: str) -> None:
+    raise ValueError
+
+
+def _cancel_checker(value: object | None) -> Any:
+    if value is None:
+        return lambda: False
+    checker = getattr(value, "is_set", None)
+    if not callable(checker):
+        raise ValueError
+    return checker
+
+
+def _raise_if_cancelled(checker: Any) -> None:
+    if checker():
+        raise PersonaVisualImportError("persona_visual_import_cancelled")
+
+
+__all__ = [
+    "PERSONA_VISUAL_PACK_SCHEMA",
+    "PersonaVisualImportError",
+    "PersonaVisualImportReview",
+    "cleanup_persona_visual_import_review",
+    "import_persona_visual_pack",
+    "persona_visual_import_source_root",
+]

--- a/tldw_chatbook/Persona_Visual/publication.py
+++ b/tldw_chatbook/Persona_Visual/publication.py
@@ -36,6 +36,7 @@ _MANIFEST_LIMIT = 2 * 1024 * 1024
 _SOURCE_CONTEXT_KEYS = frozenset(
     {"source_id", "provenance", "license", "source_server_commit"}
 )
+_SOURCE_KINDS = frozenset({"imported", "manual"})
 _SUFFIXES = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
@@ -534,7 +535,7 @@ def _validate_snapshot(
             or type(snapshot.description) is not str
             or len(snapshot.description) > 4096
             or type(snapshot.source_kind) is not str
-            or snapshot.source_kind != "manual"
+            or snapshot.source_kind not in _SOURCE_KINDS
             or type(snapshot.manifest_json) is not str
             or len(snapshot.manifest_json.encode("utf-8")) > _MANIFEST_LIMIT
             or type(snapshot.assets) is not tuple

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -76,6 +76,38 @@ from ...Image_Generation.config import get_image_generation_config
 from ...Image_Generation.listing import list_image_models_for_catalog
 from ...Image_Generation.worker import build_request, run_generation
 from ...Media_Creation.generation_templates import GenerationTemplate, get_template
+from ...Persona_Visual.assets import load_persona_visual_asset
+from ...Persona_Visual.authoring import (
+    PersonaVisualAuthoringDraft,
+    add_persona_visual_custom_state,
+    clear_persona_visual_draft_state,
+    create_persona_visual_draft,
+    inspect_persona_visual_draft,
+    persona_visual_draft_from_graph,
+    persona_visual_draft_publication_snapshot,
+    replace_persona_visual_draft_state,
+)
+from ...Persona_Visual.authoring_workspace import (
+    PersonaVisualAuthoringWorkspace,
+    adopt_persona_visual_draft_sources,
+    cleanup_persona_visual_authoring_workspace,
+    create_persona_visual_authoring_workspace,
+    stage_persona_visual_authoring_asset,
+)
+from ...Persona_Visual.importer import (
+    PersonaVisualImportError,
+    PersonaVisualImportReview,
+    cleanup_persona_visual_import_review,
+    import_persona_visual_pack,
+    persona_visual_import_source_root,
+)
+from ...Persona_Visual.publication import (
+    PersonaVisualPublicationError,
+    PersonaVisualPublicationResult,
+    cleanup_persona_visual_publication_candidate,
+    publish_persona_visual,
+)
+from ...Persona_Visual.repository import PersonaVisualIdentity, PersonaVisualRepository
 from ...TTS import (
     AssignedTTSProfileSnapshot,
     CharacterRef,
@@ -112,6 +144,17 @@ from ...Widgets.Persona_Widgets.persona_profile_card_widget import (
 )
 from ...Widgets.Persona_Widgets.persona_profile_editor_widget import (
     PersonaProfileEditorWidget,
+)
+from ...Widgets.Persona_Widgets.personas_persona_visual_pack_widget import (
+    PersonaVisualAddCustomRequested,
+    PersonaVisualCancelRequested,
+    PersonaVisualClearRequested,
+    PersonaVisualCustomStateDialog,
+    PersonaVisualImportRequested,
+    PersonaVisualPreviewRequested,
+    PersonaVisualReplaceRequested,
+    PersonaVisualSaveRequested,
+    PersonasPersonaVisualPackWidget,
 )
 from ...Widgets.Persona_Widgets.personas_character_card_widget import (
     PersonasCharacterCardWidget,
@@ -530,6 +573,36 @@ class _VisualIdentityAuthoringState:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
+class _PersonaVisualAuthorSnapshot:
+    """Exact local Persona editor authority for one isolated visual draft."""
+
+    editor_ref: weakref.ReferenceType[PersonaProfileEditorWidget]
+    browser_ref: weakref.ReferenceType[PersonasPersonaVisualPackWidget]
+    db: object
+    local_service: object
+    persona_id: str
+    persona_revision: int
+    screen_generation: int
+    editor_session_token: int
+
+
+@dataclasses.dataclass(slots=True)
+class _PersonaVisualAuthoringState:
+    """One unpublished Persona Visual draft plus its private source lease."""
+
+    snapshot: _PersonaVisualAuthorSnapshot
+    draft: PersonaVisualAuthoringDraft
+    source_root: Path = dataclasses.field(repr=False)
+    workspace: PersonaVisualAuthoringWorkspace | None = dataclasses.field(
+        default=None, repr=False
+    )
+    import_review: PersonaVisualImportReview | None = dataclasses.field(
+        default=None, repr=False
+    )
+    dirty: bool = False
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
 class _CharacterSaveAuthority:
     """Editor identity allowed to reconcile one completed character save."""
 
@@ -590,6 +663,12 @@ async def _drain_to_thread(
     return await _drain_async(
         asyncio.to_thread(function, *args, **kwargs), task_name=task_name
     )
+
+
+async def _join_task(task: asyncio.Task[Any]) -> Any:
+    """Await an existing task through the shared shield-and-drain boundary."""
+
+    return await task
 
 
 class PersonasScreen(BaseAppScreen):
@@ -869,7 +948,13 @@ class PersonasScreen(BaseAppScreen):
         self._visual_identity_operation_task: asyncio.Task[Any] | None = None
         self._visual_identity_operation_event: threading.Event | None = None
         self._visual_identity_publication_inflight: bool = False
+        self._persona_visual_authoring: _PersonaVisualAuthoringState | None = None
+        self._persona_visual_generation = 0
+        self._persona_visual_operation_task: asyncio.Task[Any] | None = None
+        self._persona_visual_operation_event: threading.Event | None = None
+        self._persona_visual_publication_inflight = False
         self._profile_save_inflight: bool = False
+        self._profile_save_operation_inflight: bool = False
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
         # save for this session is still persisting.
@@ -5811,12 +5896,15 @@ class PersonasScreen(BaseAppScreen):
         self.call_after_refresh(self._focus_editor_name)
 
     async def _begin_create_profile(self) -> None:
+        await self._discard_persona_visual_authoring_async()
+        self._persona_visual_generation += 1
         self._edit_mode = "create"
         self.state.clear_selection()
         # A new session starts unclaimed - re-arms the save-in-place dedup
         # guard (see _handle_profile_save_requested) even if the previous
         # session ended on a successful save.
         self._profile_save_inflight = False
+        self._profile_save_operation_inflight = False
         # Change-based dirty tracking: the session starts clean (see
         # _begin_create_character).
         self.query_one(PersonaProfileEditorWidget).new_persona(
@@ -6156,18 +6244,985 @@ class PersonasScreen(BaseAppScreen):
         self._edit_mode = "edit"
         # A new session starts unclaimed (see _begin_create_profile).
         self._profile_save_inflight = False
+        self._profile_save_operation_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
-        self.query_one(PersonaProfileEditorWidget).load_persona(
+        await self._discard_persona_visual_authoring_async()
+        self._persona_visual_generation += 1
+        editor = self.query_one(PersonaProfileEditorWidget)
+        editor.load_persona(
             record,
             runtime_source=self.persona_handler.current_mode(),
         )
+        visual_snapshot = self._persona_visual_snapshot(editor)
+        if visual_snapshot is not None:
+            self.run_worker(
+                self._configure_persona_visual(visual_snapshot),
+                group="personas-persona-visual-load",
+                exit_on_error=False,
+                exclusive=True,
+            )
         self._show_center("#ccp-persona-editor-view")
         inspector = self.query_one(PersonasInspectorPane)
         inspector.set_unsaved(False)
         inspector.show_validation_editing()
         self._sync_title_and_console_actions()
         self.call_after_refresh(self._focus_editor_name)
+
+    def _persona_visual_snapshot(
+        self, editor: PersonaProfileEditorWidget | None = None
+    ) -> _PersonaVisualAuthorSnapshot | None:
+        """Capture one saved local Persona editor and its persistence authority."""
+
+        if self._edit_mode != "edit" or self.persona_handler.current_mode() != "local":
+            return None
+        try:
+            editor = editor or self.query_one(PersonaProfileEditorWidget)
+            browser = editor.query_one(PersonasPersonaVisualPackWidget)
+            data = editor.collect()
+        except (QueryError, ValueError):
+            return None
+        persona_id = data.get("id")
+        persona_revision = data.get("version")
+        db = getattr(self.app_instance, "chachanotes_db", None)
+        scope = getattr(self.app_instance, "character_persona_scope_service", None)
+        local_service = getattr(scope, "local_service", None)
+        if (
+            type(persona_id) is not str
+            or not persona_id
+            or type(persona_revision) is not int
+            or isinstance(persona_revision, bool)
+            or persona_revision < 0
+            or db is None
+            or local_service is None
+        ):
+            return None
+        return _PersonaVisualAuthorSnapshot(
+            editor_ref=weakref.ref(editor),
+            browser_ref=weakref.ref(browser),
+            db=db,
+            local_service=local_service,
+            persona_id=persona_id,
+            persona_revision=persona_revision,
+            screen_generation=self._persona_visual_generation,
+            editor_session_token=editor.persona_visual_session_token,
+        )
+
+    def _persona_visual_snapshot_is_current(
+        self, snapshot: _PersonaVisualAuthorSnapshot
+    ) -> bool:
+        """Return whether the exact local editor/browser authority still owns UI."""
+
+        editor = snapshot.editor_ref()
+        browser = snapshot.browser_ref()
+        if editor is None or browser is None or not self.is_mounted:
+            return False
+        if (
+            self._persona_visual_generation != snapshot.screen_generation
+            or self._edit_mode != "edit"
+            or self.state.active_mode != "personas"
+            or self.persona_handler.current_mode() != "local"
+            or editor.persona_visual_session_token != snapshot.editor_session_token
+        ):
+            return False
+        try:
+            current_editor = self.query_one(PersonaProfileEditorWidget)
+            current_browser = current_editor.query_one(PersonasPersonaVisualPackWidget)
+            data = current_editor.collect()
+        except (QueryError, ValueError):
+            return False
+        return (
+            current_editor is editor
+            and current_browser is browser
+            and data.get("id") == snapshot.persona_id
+            and data.get("version") == snapshot.persona_revision
+        )
+
+    @staticmethod
+    def _load_persona_visual_authoring_draft(
+        snapshot: _PersonaVisualAuthorSnapshot,
+    ) -> PersonaVisualAuthoringDraft:
+        repository = PersonaVisualRepository(snapshot.db)
+        graph = repository.get_active_persona_pack(snapshot.persona_id)
+        if graph is None:
+            return create_persona_visual_draft(
+                persona_id=snapshot.persona_id,
+                persona_revision=snapshot.persona_revision,
+                title="Persona Visual",
+            )
+        source_keys = {
+            asset.asset_key: repository._get_active_asset_storage_key(
+                graph.identity, asset
+            )
+            for asset in graph.assets
+        }
+        return persona_visual_draft_from_graph(
+            graph,
+            source_storage_keys=source_keys,
+        )
+
+    async def _configure_persona_visual(
+        self, snapshot: _PersonaVisualAuthorSnapshot
+    ) -> None:
+        """Load path-free draft metadata off-loop and mount only if still current."""
+
+        browser = snapshot.browser_ref()
+        if browser is not None:
+            browser.set_availability("loading")
+        try:
+            draft = await asyncio.to_thread(
+                self._load_persona_visual_authoring_draft, snapshot
+            )
+            inventory = inspect_persona_visual_draft(draft)
+        except Exception:
+            logger.warning(
+                "Persona Visual draft load failed (category=repository_read_failed)."
+            )
+            if self._persona_visual_snapshot_is_current(snapshot):
+                browser = snapshot.browser_ref()
+                if browser is not None:
+                    browser.set_availability("unavailable")
+            return
+        if not self._persona_visual_snapshot_is_current(snapshot):
+            return
+        state = _PersonaVisualAuthoringState(
+            snapshot=snapshot,
+            draft=draft,
+            source_root=get_user_data_dir(),
+        )
+        self._persona_visual_authoring = state
+        browser = snapshot.browser_ref()
+        if browser is not None:
+            browser.show_inventory(inventory, dirty=False)
+
+    def _persona_visual_has_unsaved_authoring(self) -> bool:
+        state = self._persona_visual_authoring
+        task = self._persona_visual_operation_task
+        return bool(
+            (state is not None and state.dirty)
+            or self._persona_visual_publication_inflight
+            or (task is not None and not task.done())
+        )
+
+    def _cleanup_persona_visual_state(
+        self, state: _PersonaVisualAuthoringState
+    ) -> None:
+        if state.workspace is not None:
+            if not cleanup_persona_visual_authoring_workspace(state.workspace):
+                logger.warning(
+                    "Persona Visual draft cleanup refused (category=cleanup_failed)."
+                )
+        if state.import_review is not None:
+            try:
+                cleanup_persona_visual_import_review(
+                    state.import_review,
+                    staging_root=get_user_data_dir() / "persona_visual" / "imports",
+                )
+            except Exception:
+                logger.warning(
+                    "Persona Visual import cleanup refused (category=cleanup_failed)."
+                )
+
+    def _discard_persona_visual_authoring(self) -> None:
+        state = self._persona_visual_authoring
+        self._persona_visual_authoring = None
+        if state is not None:
+            self._cleanup_persona_visual_state(state)
+
+    async def _discard_persona_visual_authoring_async(self) -> None:
+        state = self._persona_visual_authoring
+        self._persona_visual_authoring = None
+        if state is not None:
+            outcome = await _drain_to_thread(
+                self._cleanup_persona_visual_state,
+                state,
+                task_name="personas-persona-visual-draft-cleanup",
+            )
+            if outcome.error is not None:
+                logger.warning(
+                    "Persona Visual draft cleanup failed (category=cleanup_failed)."
+                )
+            if outcome.cancellation is not None:
+                raise outcome.cancellation
+
+    def _begin_persona_visual_operation(
+        self, snapshot: _PersonaVisualAuthorSnapshot
+    ) -> tuple[asyncio.Task[Any], threading.Event] | None:
+        current = asyncio.current_task()
+        if (
+            current is None
+            or self._profile_save_operation_inflight
+            or self._persona_visual_publication_inflight
+            or not self._persona_visual_snapshot_is_current(snapshot)
+        ):
+            if self._profile_save_operation_inflight:
+                self._notify(
+                    "Wait for Persona Save to finish before editing visuals.",
+                    "warning",
+                )
+            return None
+        active = self._persona_visual_operation_task
+        if active is not None and not active.done():
+            return None
+        event = threading.Event()
+        self._persona_visual_operation_task = current
+        self._persona_visual_operation_event = event
+        return current, event
+
+    def _finish_persona_visual_operation(
+        self, task: asyncio.Task[Any], browser: PersonasPersonaVisualPackWidget | None
+    ) -> None:
+        if self._persona_visual_operation_task is task:
+            self._persona_visual_operation_task = None
+            self._persona_visual_operation_event = None
+        if browser is not None and browser.parent is not None:
+            browser.set_busy(None)
+
+    async def _drain_persona_visual_authoring(self) -> None:
+        event = self._persona_visual_operation_event
+        task = self._persona_visual_operation_task
+        cancellation: asyncio.CancelledError | None = None
+        if event is not None:
+            event.set()
+        if task is not None and task is not asyncio.current_task() and not task.done():
+            outcome = await _drain_async(
+                _join_task(task), task_name="personas-persona-visual-operation-drain"
+            )
+            cancellation = outcome.cancellation
+        await self._discard_persona_visual_authoring_async()
+        if cancellation is not None:
+            raise cancellation
+
+    def _show_persona_visual_state(self, state: _PersonaVisualAuthoringState) -> bool:
+        if (
+            self._persona_visual_authoring is not state
+            or not self._persona_visual_snapshot_is_current(state.snapshot)
+        ):
+            return False
+        browser = state.snapshot.browser_ref()
+        if browser is None:
+            return False
+        browser.show_inventory(
+            inspect_persona_visual_draft(state.draft),
+            dirty=state.dirty,
+        )
+        return True
+
+    @staticmethod
+    def _prepare_persona_visual_workspace(
+        state: _PersonaVisualAuthoringState,
+        profile_root: Path,
+    ) -> tuple[PersonaVisualAuthoringWorkspace, PersonaVisualAuthoringDraft]:
+        workspace = create_persona_visual_authoring_workspace(profile_root)
+        if not state.draft.assets:
+            return workspace, state.draft
+        return adopt_persona_visual_draft_sources(
+            workspace,
+            state.draft,
+            source_root=state.source_root,
+        )
+
+    async def _stage_persona_visual_clear(self, state_key: str) -> bool:
+        state = self._persona_visual_authoring
+        if state is None:
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        browser = state.snapshot.browser_ref()
+        try:
+            if browser is not None:
+                browser.set_busy("preparing")
+            draft = clear_persona_visual_draft_state(state.draft, state=state_key)
+            if event.is_set() or not self._persona_visual_snapshot_is_current(
+                state.snapshot
+            ):
+                return False
+            state.draft = draft
+            state.dirty = True
+            return self._show_persona_visual_state(state)
+        except Exception:
+            self._notify("Persona Visual draft could not be changed.", "error")
+            return False
+        finally:
+            self._finish_persona_visual_operation(task, browser)
+
+    async def _stage_persona_visual_custom(
+        self, state_key: str, label: str, kind: str
+    ) -> bool:
+        state = self._persona_visual_authoring
+        if state is None:
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        browser = state.snapshot.browser_ref()
+        try:
+            if browser is not None:
+                browser.set_busy("preparing")
+            draft = add_persona_visual_custom_state(
+                state.draft,
+                state=state_key,
+                label=label,
+                kind=kind,
+            )
+            if event.is_set() or not self._persona_visual_snapshot_is_current(
+                state.snapshot
+            ):
+                return False
+            state.draft = draft
+            state.dirty = True
+            return self._show_persona_visual_state(state)
+        except Exception:
+            self._notify("Custom Persona Visual state is invalid.", "error")
+            return False
+        finally:
+            self._finish_persona_visual_operation(task, browser)
+
+    async def _stage_persona_visual_replacement(
+        self, state_key: str, data: bytes
+    ) -> bool:
+        state = self._persona_visual_authoring
+        if state is None:
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        browser = state.snapshot.browser_ref()
+        profile_root = get_user_data_dir()
+        cancellation: asyncio.CancelledError | None = None
+        pending_workspace: PersonaVisualAuthoringWorkspace | None = None
+        try:
+            if browser is not None:
+                browser.set_busy("preparing")
+            preparation = await _drain_to_thread(
+                self._prepare_persona_visual_workspace,
+                state,
+                profile_root,
+                task_name="personas-persona-visual-workspace-prepare",
+            )
+            cancellation = preparation.cancellation
+            if preparation.error is not None:
+                raise preparation.error
+            if not preparation.completed or not isinstance(preparation.value, tuple):
+                return False
+            workspace, draft = preparation.value
+            pending_workspace = workspace
+            if (
+                cancellation is not None
+                or event.is_set()
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_authoring_workspace,
+                    workspace,
+                    task_name="personas-persona-visual-workspace-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+                pending_workspace = None
+                return False
+            staging = await _drain_to_thread(
+                stage_persona_visual_authoring_asset,
+                workspace,
+                data,
+                state=state_key,
+                task_name="personas-persona-visual-asset-stage",
+            )
+            cancellation = cancellation or staging.cancellation
+            if staging.error is not None:
+                raise staging.error
+            if not staging.completed or not isinstance(staging.value, tuple):
+                return False
+            workspace, asset = staging.value
+            draft = replace_persona_visual_draft_state(
+                draft,
+                state=state_key,
+                asset=asset,
+            )
+            if (
+                cancellation is not None
+                or event.is_set()
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_authoring_workspace,
+                    workspace,
+                    task_name="personas-persona-visual-workspace-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+                pending_workspace = None
+                return False
+            old_workspace = state.workspace
+            old_review = state.import_review
+            state.workspace = workspace
+            pending_workspace = None
+            state.import_review = None
+            state.source_root = profile_root
+            state.draft = draft
+            state.dirty = True
+            if old_workspace is not None:
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_authoring_workspace,
+                    old_workspace,
+                    task_name="personas-persona-visual-old-workspace-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+            if old_review is not None:
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_import_review,
+                    old_review,
+                    staging_root=profile_root / "persona_visual" / "imports",
+                    task_name="personas-persona-visual-old-import-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+                if cleanup.error is not None:
+                    logger.warning(
+                        "Persona Visual import cleanup refused "
+                        "(category=cleanup_failed)."
+                    )
+            return self._show_persona_visual_state(state)
+        except Exception:
+            logger.warning(
+                "Persona Visual replacement failed (category=image_invalid)."
+            )
+            self._notify(
+                "Persona Visual replacement failed. Choose another image.", "error"
+            )
+            return False
+        finally:
+            if pending_workspace is not None:
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_authoring_workspace,
+                    pending_workspace,
+                    task_name="personas-persona-visual-failed-workspace-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+                if cleanup.error is not None or cleanup.value is not True:
+                    logger.warning(
+                        "Persona Visual workspace cleanup refused "
+                        "(category=cleanup_failed)."
+                    )
+            self._finish_persona_visual_operation(task, browser)
+            if cancellation is not None:
+                raise cancellation
+
+    async def _preview_persona_visual_state(self, state_key: str) -> bool:
+        state = self._persona_visual_authoring
+        if state is None:
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        browser = state.snapshot.browser_ref()
+        cancellation: asyncio.CancelledError | None = None
+        try:
+            if browser is not None:
+                browser.set_busy("previewing")
+            inventory = inspect_persona_visual_draft(state.draft)
+            row = next(
+                (item for item in inventory.rows if item.state == state_key), None
+            )
+            if row is None or row.asset_key is None:
+                if browser is not None:
+                    browser.set_preview_unavailable(state=state_key)
+                return False
+            asset = next(
+                item
+                for item in state.draft.assets
+                if item.metadata.asset_key == row.asset_key
+            )
+            loading = await _drain_to_thread(
+                load_persona_visual_asset,
+                state.source_root,
+                storage_key=asset.source_storage_key,
+                metadata=asset.metadata,
+                selected_frame=0,
+                task_name="personas-persona-visual-preview-load",
+            )
+            cancellation = loading.cancellation
+            if loading.error is not None:
+                raise loading.error
+            if not loading.completed:
+                return False
+            loaded = loading.value
+            if (
+                cancellation is not None
+                or event.is_set()
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                return False
+            from ...Chat.console_image_view import ConsoleImageRenderCache
+
+            if getattr(self, "_avatar_render_cache", None) is None:
+                self._avatar_render_cache = ConsoleImageRenderCache()
+            cache = self._avatar_render_cache
+            cache_key = (
+                f"persona-visual-{state.snapshot.persona_id}-"
+                f"{state.draft.revision}-{state_key}"
+            )
+            preparation = await _drain_to_thread(
+                cache.prepare,
+                cache_key,
+                loaded.data,
+                task_name="personas-persona-visual-preview-prepare",
+            )
+            cancellation = cancellation or preparation.cancellation
+            if preparation.error is not None:
+                raise preparation.error
+            ok = bool(preparation.value) if preparation.completed else False
+            if (
+                not ok
+                or cancellation is not None
+                or event.is_set()
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                if browser is not None:
+                    browser.set_preview_unavailable(state=state_key)
+                return False
+            renderable = self._build_avatar_pixels(cache, cache_key)
+            if browser is None or renderable is None:
+                return False
+            browser.set_preview(renderable, state=state_key)
+            return True
+        except Exception:
+            if browser is not None and self._persona_visual_snapshot_is_current(
+                state.snapshot
+            ):
+                browser.set_preview_unavailable(state=state_key)
+            return False
+        finally:
+            self._finish_persona_visual_operation(task, browser)
+            if cancellation is not None:
+                raise cancellation
+
+    async def _import_persona_visual_from_path(self, path: str) -> bool:
+        state = self._persona_visual_authoring
+        if state is None or Path(path).suffix.lower() != ".tldw-persona-vpack":
+            if state is not None:
+                self._notify("Choose a Persona Visual pack file.", "warning")
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, event = admission
+        browser = state.snapshot.browser_ref()
+        profile_root = get_user_data_dir()
+        staging_root = profile_root / "persona_visual" / "imports"
+        cancellation: asyncio.CancelledError | None = None
+
+        async def cleanup_review(review: PersonaVisualImportReview) -> None:
+            nonlocal cancellation
+            cleanup = await _drain_to_thread(
+                cleanup_persona_visual_import_review,
+                review,
+                staging_root=staging_root,
+                task_name="personas-persona-visual-import-cleanup",
+            )
+            cancellation = cancellation or cleanup.cancellation
+            if cleanup.error is not None:
+                logger.warning(
+                    "Persona Visual import cleanup refused (category=cleanup_failed)."
+                )
+
+        try:
+            if browser is not None:
+                browser.set_busy("importing")
+            outcome = await _drain_to_thread(
+                import_persona_visual_pack,
+                path,
+                staging_root=staging_root,
+                persona_id=state.snapshot.persona_id,
+                persona_revision=state.snapshot.persona_revision,
+                expected_identity=state.draft.expected_identity,
+                cancel_event=event,
+                task_name="personas-persona-visual-import",
+            )
+            cancellation = outcome.cancellation
+            if outcome.error is not None or not isinstance(
+                outcome.value, PersonaVisualImportReview
+            ):
+                category = (
+                    outcome.error.category
+                    if isinstance(outcome.error, PersonaVisualImportError)
+                    else "persona_visual_import_failed"
+                )
+                self._notify(f"Persona Visual import failed ({category}).", "error")
+                return False
+            review = outcome.value
+            if (
+                cancellation is not None
+                or event.is_set()
+                or not outcome.completed
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                await cleanup_review(review)
+                return False
+            source = await _drain_to_thread(
+                persona_visual_import_source_root,
+                review,
+                staging_root=staging_root,
+                task_name="personas-persona-visual-import-source",
+            )
+            cancellation = cancellation or source.cancellation
+            if source.error is not None or not source.completed:
+                await cleanup_review(review)
+                return False
+            source_root = source.value
+            if (
+                cancellation is not None
+                or event.is_set()
+                or not self._persona_visual_snapshot_is_current(state.snapshot)
+            ):
+                await cleanup_review(review)
+                return False
+            old_workspace = state.workspace
+            old_review = state.import_review
+            state.workspace = None
+            state.import_review = review
+            state.source_root = source_root
+            state.draft = review.draft
+            state.dirty = True
+            if old_workspace is not None:
+                cleanup = await _drain_to_thread(
+                    cleanup_persona_visual_authoring_workspace,
+                    old_workspace,
+                    task_name="personas-persona-visual-old-workspace-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+            if old_review is not None:
+                await cleanup_review(old_review)
+            return self._show_persona_visual_state(state)
+        finally:
+            self._finish_persona_visual_operation(task, browser)
+            if cancellation is not None:
+                raise cancellation
+
+    def _persona_visual_authority_guard(
+        self, snapshot: _PersonaVisualAuthorSnapshot
+    ) -> bool:
+        """Re-read exact local Persona eligibility for publication."""
+
+        try:
+            record = snapshot.local_service.get_persona_profile(snapshot.persona_id)
+        except Exception:
+            return False
+        return bool(
+            isinstance(record, Mapping)
+            and str(record.get("id") or "") == snapshot.persona_id
+            and type(record.get("version")) is int
+            and record.get("version") == snapshot.persona_revision
+            and not bool(record.get("deleted", False))
+            and bool(record.get("is_active", True))
+        )
+
+    async def _invalidate_persona_visual_publication(
+        self, result: PersonaVisualPublicationResult
+    ) -> None:
+        """Invalidate only exact old/new Persona identities in mounted consumers."""
+
+        identities = tuple(
+            identity
+            for identity in (result.old_identity, result.new_identity)
+            if isinstance(identity, PersonaVisualIdentity)
+        )
+        for screen in tuple(getattr(self.app, "screen_stack", ())):
+            session = getattr(screen, "_session", None)
+            invalidate = getattr(session, "invalidate_persona_visual_identities", None)
+            if not callable(invalidate):
+                continue
+            try:
+                response = invalidate(result.new_identity.persona_id, identities)
+                if asyncio.iscoroutine(response):
+                    await response
+            except Exception:
+                logger.warning(
+                    "Persona Visual invalidation failed "
+                    "(category=cache_invalidation_failed)."
+                )
+
+    async def _save_persona_visual_pack(self) -> bool:
+        state = self._persona_visual_authoring
+        if state is None or not state.dirty:
+            return False
+        admission = self._begin_persona_visual_operation(state.snapshot)
+        if admission is None:
+            return False
+        task, _event = admission
+        browser = state.snapshot.browser_ref()
+        profile_root = get_user_data_dir()
+        cancellation: asyncio.CancelledError | None = None
+        published = False
+        try:
+            if browser is not None:
+                browser.set_busy("saving")
+            self._persona_visual_publication_inflight = True
+            try:
+                publication = persona_visual_draft_publication_snapshot(state.draft)
+            except Exception:
+                self._notify("Persona Visual draft is incomplete.", "warning")
+                return False
+            outcome = await _drain_to_thread(
+                publish_persona_visual,
+                PersonaVisualRepository(state.snapshot.db),
+                publication,
+                source_root=state.source_root,
+                profile_root=profile_root,
+                authority_guard=lambda: self._persona_visual_authority_guard(
+                    state.snapshot
+                ),
+                task_name="personas-persona-visual-publish",
+            )
+            cancellation = outcome.cancellation
+            if isinstance(outcome.error, PersonaVisualPublicationError):
+                cleanup_candidate = outcome.error.cleanup_candidate
+                if cleanup_candidate is not None:
+                    cleanup = await _drain_to_thread(
+                        cleanup_persona_visual_publication_candidate,
+                        PersonaVisualRepository(state.snapshot.db),
+                        cleanup_candidate,
+                        profile_root=profile_root,
+                        task_name="personas-persona-visual-cleanup",
+                    )
+                    cancellation = cancellation or cleanup.cancellation
+                if self._persona_visual_snapshot_is_current(state.snapshot):
+                    self._notify(
+                        f"Persona Visual pack was not saved ({outcome.error.category}).",
+                        "error",
+                    )
+                return False
+            if outcome.error is not None:
+                logger.warning(
+                    "Persona Visual publication failed (category=publication_failed)."
+                )
+                if self._persona_visual_snapshot_is_current(state.snapshot):
+                    self._notify("Persona Visual pack was not saved.", "error")
+                return False
+            if not outcome.completed or not isinstance(
+                outcome.value, PersonaVisualPublicationResult
+            ):
+                return False
+            result = outcome.value
+            published = True
+            self._persona_visual_authoring = None
+
+            async def reconcile() -> None:
+                await self._invalidate_persona_visual_publication(result)
+                if self._persona_visual_snapshot_is_current(state.snapshot):
+                    await self._configure_persona_visual(state.snapshot)
+
+            reconciliation = await _drain_async(
+                reconcile(), task_name="personas-persona-visual-reconcile"
+            )
+            cancellation = cancellation or reconciliation.cancellation
+            if reconciliation.error is not None:
+                logger.warning(
+                    "Persona Visual publication committed but refresh failed "
+                    "(category=refresh_failed)."
+                )
+                self._notify(
+                    "Persona Visual pack saved, but the editor could not refresh.",
+                    "warning",
+                )
+            else:
+                self._notify("Persona Visual pack saved.", "information")
+            return True
+        finally:
+            self._persona_visual_publication_inflight = False
+            if published:
+                cleanup = await _drain_to_thread(
+                    self._cleanup_persona_visual_state,
+                    state,
+                    task_name="personas-persona-visual-source-cleanup",
+                )
+                cancellation = cancellation or cleanup.cancellation
+                if cleanup.error is not None:
+                    logger.warning(
+                        "Persona Visual source cleanup failed "
+                        "(category=cleanup_failed)."
+                    )
+            self._finish_persona_visual_operation(task, browser)
+            if cancellation is not None:
+                raise cancellation
+
+    async def _cancel_persona_visual_authoring(self) -> None:
+        event = self._persona_visual_operation_event
+        task = self._persona_visual_operation_task
+        cancellation: asyncio.CancelledError | None = None
+        if self._persona_visual_publication_inflight:
+            return
+        if event is not None:
+            event.set()
+        if task is not None and task is not asyncio.current_task() and not task.done():
+            outcome = await _drain_async(
+                _join_task(task), task_name="personas-persona-visual-cancel-drain"
+            )
+            cancellation = outcome.cancellation
+        state = self._persona_visual_authoring
+        snapshot = state.snapshot if state is not None else None
+        await self._discard_persona_visual_authoring_async()
+        if snapshot is not None and self._persona_visual_snapshot_is_current(snapshot):
+            await self._configure_persona_visual(snapshot)
+        if cancellation is not None:
+            raise cancellation
+
+    @on(PersonaVisualPreviewRequested)
+    def _handle_persona_visual_preview_requested(
+        self, message: PersonaVisualPreviewRequested
+    ) -> None:
+        message.stop()
+        self.run_worker(
+            self._preview_persona_visual_state(message.state),
+            group="personas-persona-visual-preview",
+            exit_on_error=False,
+        )
+
+    @on(PersonaVisualClearRequested)
+    def _handle_persona_visual_clear_requested(
+        self, message: PersonaVisualClearRequested
+    ) -> None:
+        message.stop()
+        self.run_worker(
+            self._stage_persona_visual_clear(message.state),
+            group="personas-persona-visual-authoring",
+            exit_on_error=False,
+        )
+
+    @on(PersonaVisualReplaceRequested)
+    def _handle_persona_visual_replace_requested(
+        self, message: PersonaVisualReplaceRequested
+    ) -> None:
+        message.stop()
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._persona_visual_replace_dialog(message.state),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    async def _persona_visual_replace_dialog(self, state_key: str) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            path = await self.app.push_screen_wait(
+                EnhancedFileOpen(
+                    title=f"Replace {state_key} Persona Visual",
+                    filters=Filters(
+                        (
+                            "Image Files",
+                            lambda value: (
+                                value.suffix.lower()
+                                in {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+                            ),
+                        )
+                    ),
+                    context="persona_visual_replacement",
+                )
+            )
+            if not path:
+                return
+            try:
+                data = await asyncio.to_thread(self._read_avatar_image_bytes, str(path))
+            except (OSError, ValueError) as exc:
+                logger.warning(
+                    "Persona Visual replacement read failed "
+                    "(category=image_read_failed, error_type={}).",
+                    type(exc).__name__,
+                )
+                self._notify(
+                    "Persona Visual replacement failed. Choose another image.",
+                    "error",
+                )
+                return
+            await self._stage_persona_visual_replacement(state_key, data)
+        finally:
+            self._io_dialog_active = False
+
+    @on(PersonaVisualAddCustomRequested)
+    def _handle_persona_visual_add_custom_requested(
+        self, message: PersonaVisualAddCustomRequested
+    ) -> None:
+        message.stop()
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._persona_visual_custom_dialog(),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    async def _persona_visual_custom_dialog(self) -> None:
+        try:
+            result = await self.app.push_screen_wait(PersonaVisualCustomStateDialog())
+            if result is None:
+                return
+            state_key, label, kind = result
+            await self._stage_persona_visual_custom(state_key, label, kind)
+        finally:
+            self._io_dialog_active = False
+
+    @on(PersonaVisualImportRequested)
+    def _handle_persona_visual_import_requested(
+        self, message: PersonaVisualImportRequested
+    ) -> None:
+        message.stop()
+        if self._io_dialog_active:
+            return
+        self._io_dialog_active = True
+        self.run_worker(
+            self._persona_visual_import_dialog(),
+            group="personas-io",
+            exit_on_error=False,
+        )
+
+    async def _persona_visual_import_dialog(self) -> None:
+        from ...Widgets.enhanced_file_picker import EnhancedFileOpen, Filters
+
+        try:
+            path = await self.app.push_screen_wait(
+                EnhancedFileOpen(
+                    title="Import Persona Visual Pack (.tldw-persona-vpack)",
+                    filters=Filters(
+                        (
+                            "Persona Visual Packs",
+                            lambda value: value.suffix.lower() == ".tldw-persona-vpack",
+                        )
+                    ),
+                    context="persona_visual_pack_import",
+                )
+            )
+            if path:
+                await self._import_persona_visual_from_path(str(path))
+        finally:
+            self._io_dialog_active = False
+
+    @on(PersonaVisualSaveRequested)
+    def _handle_persona_visual_save_requested(
+        self, message: PersonaVisualSaveRequested
+    ) -> None:
+        message.stop()
+        self.run_worker(
+            self._save_persona_visual_pack(),
+            group="personas-persona-visual-save",
+            exit_on_error=False,
+        )
+
+    @on(PersonaVisualCancelRequested)
+    def _handle_persona_visual_cancel_requested(
+        self, message: PersonaVisualCancelRequested
+    ) -> None:
+        message.stop()
+        self.run_worker(
+            self._cancel_persona_visual_authoring(),
+            group="personas-persona-visual-cancel",
+            exit_on_error=False,
+        )
 
     @on(EditCharacterRequested)
     def _handle_edit_requested(self, message: EditCharacterRequested) -> None:
@@ -9110,11 +10165,11 @@ class PersonasScreen(BaseAppScreen):
             if not self._local_character_actions_allowed():
                 return
             picker = EnhancedFileOpen(
-                title="Import Expression Set (.zip / .tldw-persona-vpack)",
+                title="Import Expression Set (.zip)",
                 filters=Filters(
                     (
                         "Archives",
-                        lambda p: p.suffix.lower() in (".zip", ".tldw-persona-vpack"),
+                        lambda p: p.suffix.lower() == ".zip",
                     ),
                 ),
                 context="character_expression_set_import",
@@ -9138,8 +10193,7 @@ class PersonasScreen(BaseAppScreen):
     async def _import_expression_set_from_path(
         self, character_id: int, path: str
     ) -> None:
-        """Resolve an archive at ``path`` (.zip or .tldw-persona-vpack --
-        format auto-detected by content) into an expression set and apply it.
+        """Resolve an expression-set ``.zip`` at ``path`` and apply it.
 
         Dialog-free (directly testable): the path is validated at this
         screen boundary (the pure ``expression_set_io`` module never imports
@@ -11099,14 +12153,15 @@ class PersonasScreen(BaseAppScreen):
         truth), so the screen only clears the inspector summary here.
         """
         message.stop()
-        if self._profile_save_inflight:
-            # Save-in-place keeps ``_edit_mode`` at "edit" after a successful
-            # save (it no longer flips back to "view"), so this flag is now
-            # the sole guard against a stale duplicate: it is claimed here
-            # and, on success, stays claimed until a genuinely NEW edit
-            # (_handle_editor_content_changed) or a new session
-            # (_begin_create_profile / edit-load) re-arms it. A failed save
-            # clears it immediately below so the user can retry at once.
+        if self._persona_visual_has_unsaved_authoring():
+            self._notify(
+                "Save or Cancel Persona Visual changes before saving the Persona.",
+                "warning",
+            )
+            return
+        if self._profile_save_inflight or self._profile_save_operation_inflight:
+            # Serialize the complete persistence and reconciliation interval;
+            # a later visual operation is admitted only after this releases.
             logger.debug(
                 "Persona save already in flight or already fulfilled for this "
                 "baseline; ignoring duplicate request."
@@ -11126,6 +12181,7 @@ class PersonasScreen(BaseAppScreen):
             self._notify("Save failed: personas are unavailable.", "error")
             return
         self._profile_save_inflight = True
+        self._profile_save_operation_inflight = True
         # mode/persona_id are read INSIDE the try (rather than before it) so
         # a raise from either (e.g. current_mode()) is caught below, which
         # resets the inflight flag; reading them ahead of the try would let
@@ -11185,6 +12241,7 @@ class PersonasScreen(BaseAppScreen):
             # Allow an immediate retry - only a real DB round trip (or a
             # fresh edit) may claim this flag again.
             self._profile_save_inflight = False
+            self._profile_save_operation_inflight = False
             return
         if hasattr(result, "model_dump"):
             result = result.model_dump(mode="json")
@@ -11193,7 +12250,10 @@ class PersonasScreen(BaseAppScreen):
             result = dict(data)
         saved = dict(result)
         saved.setdefault("id", persona_id)
-        await self._after_profile_save(saved)
+        try:
+            await self._after_profile_save(saved)
+        finally:
+            self._profile_save_operation_inflight = False
 
     async def _after_profile_save(self, saved: dict) -> None:
         # Refresh the cached profile list tolerantly even when the user has
@@ -11236,6 +12296,16 @@ class PersonasScreen(BaseAppScreen):
         # cache and must go back to the DB).
         editor = self.query_one(PersonaProfileEditorWidget)
         editor.mark_saved(saved)
+        await self._discard_persona_visual_authoring_async()
+        self._persona_visual_generation += 1
+        visual_snapshot = self._persona_visual_snapshot(editor)
+        if visual_snapshot is not None:
+            self.run_worker(
+                self._configure_persona_visual(visual_snapshot),
+                group="personas-persona-visual-load",
+                exit_on_error=False,
+                exclusive=True,
+            )
         self._show_center("#ccp-persona-editor-view")
         self._sync_title_and_console_actions()
         self._notify("Persona saved.", "information")
@@ -11282,6 +12352,8 @@ class PersonasScreen(BaseAppScreen):
         await self._run_guarded(_finish)
 
     def _finish_cancel_profile_edit(self) -> None:
+        self._discard_persona_visual_authoring()
+        self._persona_visual_generation += 1
         self._edit_mode = "view"
         self.state.has_unsaved_changes = False
         inspector = self.query_one(PersonasInspectorPane)
@@ -11412,6 +12484,7 @@ class PersonasScreen(BaseAppScreen):
         if not (
             self.state.has_unsaved_changes
             or self._visual_identity_has_unsaved_authoring()
+            or self._persona_visual_has_unsaved_authoring()
         ):
             await continuation()
             # Guarded continuations are exactly the transitions that change
@@ -11434,6 +12507,7 @@ class PersonasScreen(BaseAppScreen):
             # (the continuation may move the selection without a row rebuild).
             self._set_active_row_unsaved(False)
             await self._drain_visual_identity_authoring()
+            await self._drain_persona_visual_authoring()
             await continuation()
             self._sync_title_and_console_actions()
         finally:
@@ -11449,6 +12523,7 @@ class PersonasScreen(BaseAppScreen):
         if not (
             self.state.has_unsaved_changes
             or self._visual_identity_has_unsaved_authoring()
+            or self._persona_visual_has_unsaved_authoring()
         ):
             return True
         dialog = UnsavedChangesDialog(

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -16,6 +16,7 @@ from .personas_pane_messages import (
     PersonaProfileEditCancelled,
     PersonaProfileSaveRequested,
 )
+from .personas_persona_visual_pack_widget import PersonasPersonaVisualPackWidget
 
 #: The `PersonaMode` literal's values, for the editor's mode `Select` options.
 PERSONA_MODES: tuple[str, ...] = get_args(PersonaMode)
@@ -125,6 +126,7 @@ class PersonaProfileEditorWidget(Container):
             with Horizontal(classes="ds-field-row"):
                 yield Label("Enabled")
                 yield Switch(id="personas-editor-enabled", value=True)
+            yield PersonasPersonaVisualPackWidget()
         # Validation stays outside the scroll body so it is always visible
         # next to Save (anchored-footer principle, same as the character editor).
         yield Static("", id="personas-editor-validation")
@@ -164,9 +166,7 @@ class PersonaProfileEditorWidget(Container):
         self.query_one(
             "#personas-editor-personality-traits", TextArea
         ).disabled = is_server
-        self.query_one(
-            "#personas-editor-local-fields-note", Static
-        ).display = is_server
+        self.query_one("#personas-editor-local-fields-note", Static).display = is_server
 
     def load_persona(
         self,
@@ -195,9 +195,9 @@ class PersonaProfileEditorWidget(Container):
             self.query_one("#personas-editor-system-prompt", TextArea).text = str(
                 data.get("system_prompt", "")
             )
-            self.query_one(
-                "#personas-editor-personality-traits", TextArea
-            ).text = str(data.get("personality_traits", "") or "")
+            self.query_one("#personas-editor-personality-traits", TextArea).text = str(
+                data.get("personality_traits", "") or ""
+            )
             mode = data.get("mode") or _DEFAULT_MODE
             self.query_one("#personas-editor-mode", Select).value = (
                 mode if mode in PERSONA_MODES else _DEFAULT_MODE
@@ -205,6 +205,13 @@ class PersonaProfileEditorWidget(Container):
             self.query_one("#personas-editor-enabled", Switch).value = bool(
                 data.get("is_active", True)
             )
+            visual = self.query_one(PersonasPersonaVisualPackWidget)
+            if self._runtime_source == "server":
+                visual.set_availability("server")
+            elif self._persona_id is None:
+                visual.set_availability("unsaved")
+            else:
+                visual.set_availability("loading")
             self.query_one("#personas-editor-validation", Static).update("")
             # Clear any stale per-field invalid marks left by a prior session:
             # if the reopened record's values are byte-identical to what's
@@ -238,6 +245,8 @@ class PersonaProfileEditorWidget(Container):
         """
         self._persona_id = str(record.get("id", "")) or self._persona_id
         self._version = record.get("version", self._version)
+        if self._runtime_source == "local" and self._persona_id is not None:
+            self.query_one(PersonasPersonaVisualPackWidget).set_availability("loading")
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
         self.query_one("#personas-editor-validation", Static).update("")

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_profile_editor_widget.py
@@ -93,6 +93,7 @@ class PersonaProfileEditorWidget(Container):
         # interacted with it. Set True on a genuine field edit or a Save
         # click; reset on every load.
         self._user_touched: bool = False
+        self._persona_visual_session_token = 0
 
     def compose(self) -> ComposeResult:
         yield Static("Persona Editor", classes="destination-section")
@@ -179,6 +180,7 @@ class PersonaProfileEditorWidget(Container):
         CCPPersonaHandler calls this method when it queries ``#ccp-persona-editor-view``
         and finds a ``load_persona`` attribute (see ccp_persona_handler._load_editor).
         """
+        self._persona_visual_session_token += 1
         self._loading = True
         try:
             self.set_runtime_source(runtime_source or self._runtime_source)
@@ -243,6 +245,7 @@ class PersonaProfileEditorWidget(Container):
             record: The just-persisted persona record (carries the
                 incremented optimistic-lock ``version``).
         """
+        self._persona_visual_session_token += 1
         self._persona_id = str(record.get("id", "")) or self._persona_id
         self._version = record.get("version", self._version)
         if self._runtime_source == "local" and self._persona_id is not None:
@@ -250,6 +253,12 @@ class PersonaProfileEditorWidget(Container):
         self._loaded_snapshot = self._form_snapshot()
         self._dirty_posted = False
         self.query_one("#personas-editor-validation", Static).update("")
+
+    @property
+    def persona_visual_session_token(self) -> int:
+        """Return the identity of the currently loaded visual editor session."""
+
+        return self._persona_visual_session_token
 
     def collect(self) -> Dict[str, Any]:
         """Return the current form values as a dict.

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py
@@ -9,8 +9,9 @@ from textual import events, on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.message import Message
+from textual.screen import ModalScreen
 from textual.widget import Widget
-from textual.widgets import Button, OptionList, Static
+from textual.widgets import Button, Input, Label, OptionList, Select, Static
 from textual.widgets.option_list import Option
 
 from ...Persona_Visual.authoring import (
@@ -53,6 +54,76 @@ class PersonaVisualSaveRequested(Message):
 
 class PersonaVisualCancelRequested(Message):
     """Ask the screen to cancel work and discard only its isolated draft."""
+
+
+class PersonaVisualCustomStateDialog(ModalScreen[tuple[str, str, str] | None]):
+    """Collect one safe custom state key, visible label, and catalog kind."""
+
+    BUNDLED_CSS = """
+    PersonaVisualCustomStateDialog {
+        align: center middle;
+        background: $background 60%;
+    }
+
+    PersonaVisualCustomStateDialog #persona-visual-custom-dialog {
+        width: 64;
+        max-width: 92%;
+        height: auto;
+        padding: 1 2;
+        border: round $accent;
+        background: $panel;
+    }
+
+    PersonaVisualCustomStateDialog .persona-visual-custom-actions {
+        height: 3;
+        margin-top: 1;
+    }
+
+    PersonaVisualCustomStateDialog Button {
+        width: 1fr;
+        min-width: 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="persona-visual-custom-dialog"):
+            yield Label("Custom state key")
+            yield Input(placeholder="operator-ready", id="persona-visual-custom-key")
+            yield Label("Visible label")
+            yield Input(placeholder="Operator ready", id="persona-visual-custom-label")
+            yield Label("Kind")
+            yield Select(
+                (
+                    ("Mood", "mood"),
+                    ("Reaction", "reaction"),
+                    ("Live variant", "live_variant"),
+                    ("Tool variant", "tool_variant"),
+                    ("MCP runtime", "mcp_runtime"),
+                    ("Pack private", "pack_private"),
+                ),
+                value="mood",
+                allow_blank=False,
+                id="persona-visual-custom-kind",
+            )
+            with Horizontal(classes="persona-visual-custom-actions"):
+                yield Button("Add State", id="persona-visual-custom-confirm")
+                yield Button("Cancel", id="persona-visual-custom-dismiss")
+
+    @on(Button.Pressed, "#persona-visual-custom-confirm")
+    def _confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(
+            (
+                self.query_one("#persona-visual-custom-key", Input).value,
+                self.query_one("#persona-visual-custom-label", Input).value,
+                str(self.query_one("#persona-visual-custom-kind", Select).value),
+            )
+        )
+
+    @on(Button.Pressed, "#persona-visual-custom-dismiss")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
 
 
 PersonaVisualAvailability = Literal[
@@ -443,5 +514,6 @@ __all__ = [
     "PersonaVisualPreviewRequested",
     "PersonaVisualReplaceRequested",
     "PersonaVisualSaveRequested",
+    "PersonaVisualCustomStateDialog",
     "PersonasPersonaVisualPackWidget",
 ]

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py
@@ -1,0 +1,447 @@
+"""Path-free Persona Visual authoring section for the Persona editor."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from rich.text import Text
+from textual import events, on
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Button, OptionList, Static
+from textual.widgets.option_list import Option
+
+from ...Persona_Visual.authoring import (
+    PersonaVisualDraftInventory,
+    PersonaVisualDraftRow,
+)
+
+
+class _PersonaVisualStateRequested(Message):
+    """Base for a path-free action targeting one visible state."""
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        super().__init__()
+
+
+class PersonaVisualPreviewRequested(_PersonaVisualStateRequested):
+    """Ask the screen to resolve only the selected draft state."""
+
+
+class PersonaVisualReplaceRequested(_PersonaVisualStateRequested):
+    """Ask the screen to stage a replacement for the selected state."""
+
+
+class PersonaVisualClearRequested(_PersonaVisualStateRequested):
+    """Ask the screen to clear the selected state in its isolated draft."""
+
+
+class PersonaVisualAddCustomRequested(Message):
+    """Ask the screen to collect and stage one safe custom state."""
+
+
+class PersonaVisualImportRequested(Message):
+    """Ask the screen to import one Persona Visual archive for review."""
+
+
+class PersonaVisualSaveRequested(Message):
+    """Ask the screen to publish its current isolated draft exactly once."""
+
+
+class PersonaVisualCancelRequested(Message):
+    """Ask the screen to cancel work and discard only its isolated draft."""
+
+
+PersonaVisualAvailability = Literal[
+    "available", "loading", "server", "unavailable", "unsaved"
+]
+PersonaVisualBusyState = Literal["importing", "preparing", "previewing", "saving"]
+
+
+class PersonasPersonaVisualPackWidget(Vertical):
+    """Browse one path-free draft inventory and emit typed authoring actions."""
+
+    BUNDLED_CSS = """
+    PersonasPersonaVisualPackWidget {
+        width: 100%;
+        height: 27;
+        min-height: 20;
+        margin-top: 1;
+        padding: 1;
+        border: round $surface-lighten-1;
+        background: $panel;
+    }
+
+    PersonasPersonaVisualPackWidget .persona-visual-copy {
+        width: 100%;
+        height: auto;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-notice,
+    PersonasPersonaVisualPackWidget #personas-persona-visual-status {
+        color: $text-muted;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-body {
+        width: 100%;
+        height: 1fr;
+        min-height: 8;
+        margin-top: 1;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-results {
+        width: 2fr;
+        height: 100%;
+        min-width: 20;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-preview-host {
+        width: 1fr;
+        height: 100%;
+        min-width: 18;
+        margin-left: 1;
+        padding: 1;
+        background: $surface;
+        content-align: center middle;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions {
+        width: 100%;
+        height: 6;
+        layout: grid;
+        grid-size: 3 2;
+        grid-gutter: 0 1;
+        margin-top: 1;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions Button {
+        width: 1fr;
+        height: 3;
+        min-width: 0;
+        border: none;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions Button:focus {
+        outline: heavy $accent;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow {
+        height: 31;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow #personas-persona-visual-body {
+        height: 12;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow #personas-persona-visual-preview-host {
+        min-width: 14;
+        padding: 0 1;
+    }"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("id", "personas-persona-visual-pack")
+        super().__init__(**kwargs)
+        self._availability: PersonaVisualAvailability = "unsaved"
+        self._busy: PersonaVisualBusyState | None = None
+        self._inventory: PersonaVisualDraftInventory | None = None
+        self._rows: tuple[PersonaVisualDraftRow, ...] = ()
+        self._selected: PersonaVisualDraftRow | None = None
+        self._dirty = False
+        self._preview_content: Widget | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Persona Visual",
+            id="personas-persona-visual-title",
+            classes="persona-visual-copy",
+        )
+        yield Static(
+            "Save Persona first to author a visual pack.",
+            id="personas-persona-visual-notice",
+            classes="persona-visual-copy",
+            markup=False,
+        )
+        yield Static(
+            "No draft loaded",
+            id="personas-persona-visual-status",
+            classes="persona-visual-copy",
+            markup=False,
+        )
+        with Horizontal(id="personas-persona-visual-body"):
+            yield OptionList(id="personas-persona-visual-results")
+            with Container(id="personas-persona-visual-preview-host"):
+                yield Static(
+                    "Select a state to preview.",
+                    id="personas-persona-visual-preview",
+                    markup=False,
+                )
+        with Horizontal(id="personas-persona-visual-actions"):
+            yield Button(
+                "Replace…",
+                id="personas-persona-visual-replace",
+                classes="console-action-secondary",
+            )
+            yield Button(
+                "Clear",
+                id="personas-persona-visual-clear",
+                classes="console-action-subdued",
+            )
+            yield Button(
+                "Add Custom State",
+                id="personas-persona-visual-add-custom",
+                classes="console-action-secondary",
+            )
+            yield Button(
+                "Import Pack…",
+                id="personas-persona-visual-import",
+                classes="console-action-secondary",
+            )
+            yield Button(
+                "Save Pack",
+                id="personas-persona-visual-save",
+                classes="console-action-primary",
+            )
+            yield Button(
+                "Cancel Draft",
+                id="personas-persona-visual-cancel",
+                classes="console-action-subdued",
+            )
+
+    def on_mount(self) -> None:
+        self._sync_narrow()
+        self._sync_copy_and_controls()
+
+    def on_resize(self, event: events.Resize) -> None:
+        self._sync_narrow(event.size.width)
+
+    def _sync_narrow(self, width: int | None = None) -> None:
+        width = self.size.width if width is None else width
+        self.set_class(width < 96, "-narrow")
+
+    @property
+    def selected_state(self) -> str | None:
+        """Return the selected path-free state key."""
+
+        return self._selected.state if self._selected is not None else None
+
+    @property
+    def availability(self) -> PersonaVisualAvailability:
+        """Return the current local/server authoring availability."""
+
+        return self._availability
+
+    def set_availability(self, availability: PersonaVisualAvailability) -> None:
+        """Show one honest authoring eligibility state."""
+
+        if availability not in {
+            "available",
+            "loading",
+            "server",
+            "unavailable",
+            "unsaved",
+        }:
+            raise ValueError("persona_visual_availability_invalid")
+        self._availability = availability
+        if availability != "available":
+            self._inventory = None
+            self._rows = ()
+            self._selected = None
+            self._dirty = False
+            self._busy = None
+            if self.is_mounted:
+                self.query_one(
+                    "#personas-persona-visual-results", OptionList
+                ).clear_options()
+                self._replace_preview("Select a state to preview.")
+        if self.is_mounted:
+            self._sync_copy_and_controls()
+
+    def show_inventory(
+        self,
+        inventory: PersonaVisualDraftInventory,
+        *,
+        dirty: bool,
+    ) -> None:
+        """Render one path-free draft inventory without loading image bytes."""
+
+        if (
+            type(inventory) is not PersonaVisualDraftInventory
+            or type(dirty) is not bool
+        ):
+            raise ValueError("persona_visual_inventory_invalid")
+        self._availability = "available"
+        self._inventory = inventory
+        self._rows = inventory.rows
+        self._dirty = dirty
+        self._busy = None
+        options = self.query_one("#personas-persona-visual-results", OptionList)
+        options.clear_options()
+        options.add_options(
+            Option(
+                Text(f"{row.label}  {'configured' if row.configured else 'empty'}"),
+                id=f"state-{index}",
+            )
+            for index, row in enumerate(self._rows)
+        )
+        if self._rows:
+            options.highlighted = 0
+            self._select_index(0)
+        else:
+            self._selected = None
+            self._replace_preview("No states available.")
+        self._sync_copy_and_controls()
+
+    def set_busy(self, busy: PersonaVisualBusyState | None) -> None:
+        """Expose distinct cancellable preparation and atomic Save states."""
+
+        if busy not in {None, "importing", "preparing", "previewing", "saving"}:
+            raise ValueError("persona_visual_busy_state_invalid")
+        self._busy = busy
+        self._sync_copy_and_controls()
+
+    def set_preview(self, renderable: object, *, state: str) -> Widget | None:
+        """Mount a decoded selected preview and return its weak-targetable widget."""
+
+        if self.selected_state != state:
+            return None
+        return self._replace_preview(renderable)
+
+    def set_preview_unavailable(self, *, state: str) -> Widget | None:
+        """Show a fixed failure only while the failed state remains selected."""
+
+        if self.selected_state != state:
+            return None
+        return self._replace_preview("Preview unavailable.")
+
+    def _replace_preview(self, renderable: object) -> Widget:
+        host = self.query_one("#personas-persona-visual-preview-host", Container)
+        status = self.query_one("#personas-persona-visual-preview", Static)
+        if self._preview_content is not None:
+            self._preview_content.remove()
+            self._preview_content = None
+        if not isinstance(renderable, Widget):
+            status.display = True
+            status.update(renderable)
+            return status
+        status.display = False
+        self._preview_content = renderable
+        host.mount(renderable)
+        return renderable
+
+    def _select_index(self, index: int) -> None:
+        if not 0 <= index < len(self._rows):
+            return
+        row = self._rows[index]
+        changed = row != self._selected
+        self._selected = row
+        if changed:
+            self._replace_preview("Loading selected preview…")
+            self.post_message(PersonaVisualPreviewRequested(row.state))
+        self._sync_copy_and_controls()
+
+    def _sync_copy_and_controls(self) -> None:
+        if not self.is_mounted:
+            return
+        notice = {
+            "available": "Local Persona — active visuals stay unchanged until Save Pack.",
+            "loading": "Loading Persona Visual draft…",
+            "server": "Save Local Copy first to author a Persona Visual pack.",
+            "unavailable": "Persona Visual is unavailable for this Persona.",
+            "unsaved": "Save Persona first to author a visual pack.",
+        }[self._availability]
+        self.query_one("#personas-persona-visual-notice", Static).update(notice)
+        status = self._status_copy()
+        self.query_one("#personas-persona-visual-status", Static).update(status)
+        available = self._availability == "available"
+        selected = self._selected is not None
+        idle = self._busy is None
+        self.query_one("#personas-persona-visual-replace", Button).disabled = not (
+            available and selected and idle
+        )
+        self.query_one("#personas-persona-visual-clear", Button).disabled = not (
+            available and selected and idle
+        )
+        for action in ("add-custom", "import"):
+            self.query_one(
+                f"#personas-persona-visual-{action}", Button
+            ).disabled = not (available and idle)
+        activatable = self._inventory is not None and self._inventory.activatable
+        self.query_one("#personas-persona-visual-save", Button).disabled = not (
+            available and idle and self._dirty and activatable
+        )
+        cancel_allowed = available and (
+            self._dirty or self._busy in {"importing", "preparing", "previewing"}
+        )
+        self.query_one("#personas-persona-visual-cancel", Button).disabled = not (
+            cancel_allowed and self._busy != "saving"
+        )
+
+    def _status_copy(self) -> str:
+        if self._busy is not None:
+            return {
+                "importing": "Importing pack for review… Cancel Draft is available.",
+                "preparing": "Preparing draft… Cancel Draft is available.",
+                "previewing": "Loading selected preview… Cancel Draft is available.",
+                "saving": "Saving pack… publication cannot be cancelled.",
+            }[self._busy]
+        if self._availability != "available" or self._inventory is None:
+            return "No draft loaded"
+        if self._dirty:
+            return "Draft — unsaved changes"
+        readiness = "complete" if self._inventory.activatable else "incomplete"
+        suffix = "asset" if self._inventory.asset_count == 1 else "assets"
+        return f"Ready — {self._inventory.asset_count} {suffix} • {readiness}"
+
+    @on(OptionList.OptionHighlighted, "#personas-persona-visual-results")
+    def _option_highlighted(self, event: OptionList.OptionHighlighted) -> None:
+        if event.option_index is not None:
+            self._select_index(event.option_index)
+
+    def _post_selected(self, message_type: type[_PersonaVisualStateRequested]) -> None:
+        if self._selected is not None:
+            self.post_message(message_type(self._selected.state))
+
+    @on(Button.Pressed, "#personas-persona-visual-replace")
+    def _replace_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._post_selected(PersonaVisualReplaceRequested)
+
+    @on(Button.Pressed, "#personas-persona-visual-clear")
+    def _clear_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._post_selected(PersonaVisualClearRequested)
+
+    @on(Button.Pressed, "#personas-persona-visual-add-custom")
+    def _add_custom_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaVisualAddCustomRequested())
+
+    @on(Button.Pressed, "#personas-persona-visual-import")
+    def _import_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaVisualImportRequested())
+
+    @on(Button.Pressed, "#personas-persona-visual-save")
+    def _save_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaVisualSaveRequested())
+
+    @on(Button.Pressed, "#personas-persona-visual-cancel")
+    def _cancel_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(PersonaVisualCancelRequested())
+
+
+__all__ = [
+    "PersonaVisualAddCustomRequested",
+    "PersonaVisualCancelRequested",
+    "PersonaVisualClearRequested",
+    "PersonaVisualImportRequested",
+    "PersonaVisualPreviewRequested",
+    "PersonaVisualReplaceRequested",
+    "PersonaVisualSaveRequested",
+    "PersonasPersonaVisualPackWidget",
+]

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2034,6 +2034,33 @@
     }
     
 
+/* ===== WIDGET: PersonaVisualCustomStateDialog (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
+
+    PersonaVisualCustomStateDialog {
+        align: center middle;
+        background: $background 60%;
+    }
+
+    PersonaVisualCustomStateDialog #persona-visual-custom-dialog {
+        width: 64;
+        max-width: 92%;
+        height: auto;
+        padding: 1 2;
+        border: round $accent;
+        background: $panel;
+    }
+
+    PersonaVisualCustomStateDialog .persona-visual-custom-actions {
+        height: 3;
+        margin-top: 1;
+    }
+
+    PersonaVisualCustomStateDialog Button {
+        width: 1fr;
+        min-width: 0;
+    }
+
+
 /* ===== WIDGET: PersonasPersonaVisualPackWidget (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
 
     PersonasPersonaVisualPackWidget {

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2034,6 +2034,84 @@
     }
     
 
+/* ===== WIDGET: PersonasPersonaVisualPackWidget (Widgets/Persona_Widgets/personas_persona_visual_pack_widget.py) ===== */
+
+    PersonasPersonaVisualPackWidget {
+        width: 100%;
+        height: 27;
+        min-height: 20;
+        margin-top: 1;
+        padding: 1;
+        border: round $surface-lighten-1;
+        background: $panel;
+    }
+
+    PersonasPersonaVisualPackWidget .persona-visual-copy {
+        width: 100%;
+        height: auto;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-notice,
+    PersonasPersonaVisualPackWidget #personas-persona-visual-status {
+        color: $text-muted;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-body {
+        width: 100%;
+        height: 1fr;
+        min-height: 8;
+        margin-top: 1;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-results {
+        width: 2fr;
+        height: 100%;
+        min-width: 20;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-preview-host {
+        width: 1fr;
+        height: 100%;
+        min-width: 18;
+        margin-left: 1;
+        padding: 1;
+        background: $surface;
+        content-align: center middle;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions {
+        width: 100%;
+        height: 6;
+        layout: grid;
+        grid-size: 3 2;
+        grid-gutter: 0 1;
+        margin-top: 1;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions Button {
+        width: 1fr;
+        height: 3;
+        min-width: 0;
+        border: none;
+    }
+
+    PersonasPersonaVisualPackWidget #personas-persona-visual-actions Button:focus {
+        outline: heavy $accent;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow {
+        height: 31;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow #personas-persona-visual-body {
+        height: 12;
+    }
+
+    PersonasPersonaVisualPackWidget.-narrow #personas-persona-visual-preview-host {
+        min-width: 14;
+        padding: 0 1;
+    }
+
 /* ===== WIDGET: PersonasPreviewPane (Widgets/Persona_Widgets/personas_preview_pane.py) ===== */
 
     PersonasPreviewPane {


### PR DESCRIPTION
## Summary

- add immutable local Persona Visual authoring drafts and bounded review-first `.tldw-persona-vpack` import with private identity-pinned staging
- add the Persona Workbench pack browser with nine baseline states, bounded custom states, selected-only preview, Replace/Clear/Import/Save/Cancel actions, and honest legacy-import labels
- serialize and drain screen-owned work across cancellation/navigation, revalidate Persona/draft/publication authority, publish exactly once, and invalidate only exact old/new identities

## Verification

- `120 passed`: authoring, importer, workspace, publication, widget, and screen orchestration
- `10 passed, 309 deselected`: focused legacy Personas Workbench compatibility
- `60 passed`: CSS build integrity, consolidation, and Persona profile widgets
- scoped Ruff critical/import checks, Ruff format check, `py_compile`, and `git diff --check`
- isolated HOME/XDG/config/data provenance from the assigned worktree
- Impeccable detector after the final visible UI change: `[]`

## Notes

- Full repository suite was intentionally not run per user direction; only modified/touched components were tested.
- The scoped diagnostic/privacy gate had 107 passing tests and one pre-existing generated inventory mismatch involving unrelated `retrieval.py`, `workspace.py`, and `chat_screen.py` drift. Topology/classifications/exclusions were unchanged, so unrelated generated inventory was not rewritten.
- ADR-074 remains the governing architecture decision; no new ADR or provider/Buddy/Shared Visual Identity/Actor Pack scope was added.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds review-first Persona Visual pack authoring and import to Personas Workbench. Previously the Workbench had no pack editor/importer and publication only accepted source_kind "manual"; now it edits immutable drafts, imports `.tldw-persona-vpack` archives into private staging for review, and publishes exactly once as "manual" or "imported", invalidating only the exact old/new identities.

- Review
  - Core: new authoring (`authoring.py`), private staging (`authoring_workspace.py`), archive importer (`importer.py`), Workbench UI and widget wiring, and publication validator updated to allow source_kind "imported".
  - Drafts are path-free and immutable; Replace/Clear/Add Custom/Import mutate the draft only; Save revalidates authority and publishes once; Cancel discards; navigation/cancel drains any screen-owned work.
  - Importer validates the pinned archive schema, normalizes/denies traversal/symlinks, enforces type/size/frame bounds, copies declared assets to profile-private staging, and returns a path-free review draft plus a cleanup handle.
  - UI shows nine baseline states plus bounded custom states, a selected-only preview, and Replace/Clear/Import/Save/Cancel actions, with clear labels for legacy imports.
  - Tests cover authoring, importer, workspace, publication, widgets, Personas screen, and CSS. Satisfies TASK-19054 acceptance criteria.

- Rollout
  - No data or API migration required.
  - If any external validation assumes source_kind "manual" only, update it to accept "imported".

<sup>Written for commit 7958bab0b193cd51b1cc70703c52a3d1dca2af63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

