### PR TITLE
refactor(console): extract character controller

### DIFF
--- a/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
+++ b/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
@@ -36,7 +36,7 @@
 - Already controller-owned: `_refresh_active_character_avatar_if_scope_changed`
 - Already deleted: `_fetch_expression_image_bytes`
 - Focused baseline: 2 failed, 21 passed, 2 warnings. Both failures are the inherited `ChatScreen.__new__` avatar fixture reaching `console_view_hooks()` without `_skill`; all character production and architecture nodes in that command passed.
-- Clean test-commit RED at `ba58442d8`: 6 failed, 1 passed, 1 warning. The four no-mount policy tests fail because the new constructor/API is absent, the dependency contract fails on the old constructor shape, and ownership fails on the six methods still on `ChatScreen`; only the synthetic oracle passes.
+- Clean test-commit RED at `ba58442d8` in the original history (rebased as `e05a3971b`): 6 failed, 1 passed, 1 warning. The four no-mount policy tests fail because the new constructor/API is absent, the dependency contract fails on the old constructor shape, and ownership fails on the six methods still on `ChatScreen`; only the synthetic oracle passes.
 - Preserved dirty continuity checkpoint after the pre-existing partial controller additions: 1 failed, 6 passed, 1 warning. The sole failure is the ownership assertion listing those same six `ChatScreen` methods; controller-policy, dependency, and oracle nodes collect and pass.
 
 ## File map
@@ -56,9 +56,12 @@
 
 - [x] Record the exact worktree branch/base, source line/direct-method counts, task status, and current seven-method/latest-dev character inventory.
 - [x] Reproduce and classify the focused baseline. Record the inherited avatar-fixture failure caused by bypassing `ChatScreen.__init__` after TASK-3070.6 added `_skill` to runtime hooks; prove no character production path is involved.
-- [ ] Commit only this reviewed plan/task metadata before production implementation.
+- [x] Commit only this reviewed plan/task metadata before production implementation.
 
-The initial plan/task commit is `d6cd2640a`. Before resuming implementation, run:
+The initial plan/task commit was `d6cd2640a` in the original history and is
+`55747c257` after the final rebase. The reviewed plan hardening commit was
+`b651540f5` originally and is `b8b185fd9` after the final rebase. Before resuming
+implementation, run:
 
 ```bash
 git status --short
@@ -70,11 +73,11 @@ inspect existing dirty bytes; never overwrite them merely to obtain a clean tree
 
 ### Task 1: Lock controller ownership and behavior with RED tests
 
-- [ ] Add plain, no-mount controller tests for picker option projection/error containment, active rail conversation/character identity, card fetch containment, and new/swap character choice behavior.
-- [ ] Extend the Wave 6 inventory so all seven current M methods exist only on `ConsoleCharacterController`, the already-deleted expression helper stays absent, four compatibility descriptors remain controller-backed, and the controller has only named non-DOM dependencies.
-- [ ] Add a non-vacuity mutation/oracle proving a synthetic screen-owned moved method or DOM access fails the architecture contract.
-- [ ] On the clean production base, run only the new controller/architecture nodes and confirm the expected policy/API, dependency-shape, and ownership RED set, with no unrelated collection/fixture failure.
-- [ ] On the preserved dirty continuity state after partial controller additions, confirm only the six-method ownership assertion remains RED.
+- [x] Add plain, no-mount controller tests for picker option projection/error containment, active rail conversation/character identity, card fetch containment, and new/swap character choice behavior.
+- [x] Extend the Wave 6 inventory so all seven current M methods exist only on `ConsoleCharacterController`, the already-deleted expression helper stays absent, four compatibility descriptors remain controller-backed, and the controller has only named non-DOM dependencies.
+- [x] Add a non-vacuity mutation/oracle proving a synthetic screen-owned moved method or DOM access fails the architecture contract.
+- [x] On the clean production base, run only the new controller/architecture nodes and confirm the expected policy/API, dependency-shape, and ownership RED set, with no unrelated collection/fixture failure.
+- [x] On the preserved dirty continuity state after partial controller additions, confirm only the six-method ownership assertion remains RED.
 
 **Files:**
 
@@ -109,12 +112,12 @@ git commit -m "test(console): harden character extraction contract"
 
 ### Task 2: Move character policy into the controller
 
-- [ ] Move `_console_character_picker_options`, `_current_console_rail_conversation_id`, `_current_console_rail_character_id`, `_current_console_rail_character_name`, `_fetch_character_card_for_avatar`, and `_apply_console_character_choice_async` into `ConsoleCharacterController`.
-- [ ] Add the minimum explicit dependencies for DB access, active/current session identity, store/config access, default settings/swap, notifications, and final UI synchronization; keep all callbacks late-bound.
-- [ ] Repoint `character.py`'s existing avatar request name lookup to its own character-identity method and retain existing avatar request/stale-result behavior.
-- [ ] Route screen picker presentation and worker callback to `_character`; route screen/retrieval/agent and other production conversation/character consumers directly to `_character`; retain no moved-method screen shim.
-- [ ] Update the stale `session.py` ownership documentation and remove imports that lost their final screen caller.
-- [ ] Run isolated controller, architecture, wiring, picker, prompt-seed/handoff, avatar, composer-menu, and rail-focused nodes to GREEN.
+- [x] Move `_console_character_picker_options`, `_current_console_rail_conversation_id`, `_current_console_rail_character_id`, `_current_console_rail_character_name`, `_fetch_character_card_for_avatar`, and `_apply_console_character_choice_async` into `ConsoleCharacterController`.
+- [x] Add the minimum explicit dependencies for DB access, active/current session identity, store/config access, default settings/swap, notifications, and final UI synchronization; keep all callbacks late-bound.
+- [x] Repoint `character.py`'s existing avatar request name lookup to its own character-identity method and retain existing avatar request/stale-result behavior.
+- [x] Route screen picker presentation and worker callback to `_character`; route screen/retrieval/agent and other production conversation/character consumers directly to `_character`; retain no moved-method screen shim.
+- [x] Update the stale `session.py` ownership documentation and remove imports that lost their final screen caller.
+- [x] Run isolated controller, architecture, wiring, picker, prompt-seed/handoff, avatar, composer-menu, and rail-focused nodes to GREEN.
 
 **Files:**
 
@@ -157,10 +160,10 @@ git commit -m "refactor(console): extract character controller"
 
 ### Task 3: Repair affected fixtures without weakening product wiring
 
-- [ ] Replace the stale avatar bare-screen setup with the smallest real/controller-level fixture that does not attach runtime hooks through an incompletely initialized `ChatScreen`.
-- [ ] Update tests that monkeypatch or call moved screen methods to patch/call `_character` instead; preserve assertions, cardinality, copy, and durable-state oracles.
-- [ ] Keep presentation tests mounted where pixels/layout matter and controller tests unmounted where only policy/data matters.
-- [ ] Rerun the exact formerly failing avatar nodes and the focused affected matrix.
+- [x] Replace the stale avatar bare-screen setup with the smallest real/controller-level fixture that does not attach runtime hooks through an incompletely initialized `ChatScreen`.
+- [x] Update tests that monkeypatch or call moved screen methods to patch/call `_character` instead; preserve assertions, cardinality, copy, and durable-state oracles.
+- [x] Keep presentation tests mounted where pixels/layout matter and controller tests unmounted where only policy/data matters.
+- [x] Rerun the exact formerly failing avatar nodes and the focused affected matrix.
 
 **Files:**
 
@@ -203,11 +206,11 @@ git commit -m "test(console): cover character controller behavior"
 
 ### Task 4: Prove behavior and mutation sensitivity
 
-- [ ] Mutate picker validation/error containment and confirm the no-mount picker test fails, then restore.
-- [ ] Mutate new/swap placement or prompt seed/config propagation and confirm the focused handoff test fails, then restore.
-- [ ] Break one late-bound wiring edge and confirm the wiring test fails, then restore.
-- [ ] Reintroduce one moved method on a synthetic `ChatScreen` AST fixture and confirm the ownership oracle fails, then restore.
-- [ ] Re-run the affected functionality matrix and record exact passes, skips, warnings, and any inherited exceptions.
+- [x] Mutate picker validation/error containment and confirm the no-mount picker test fails, then restore.
+- [x] Mutate new/swap placement or prompt seed/config propagation and confirm the focused handoff test fails, then restore.
+- [x] Break one late-bound wiring edge and confirm the wiring test fails, then restore.
+- [x] Reintroduce one moved method on a synthetic `ChatScreen` AST fixture and confirm the ownership oracle fails, then restore.
+- [x] Re-run the affected functionality matrix and record exact passes, skips, warnings, and any inherited exceptions.
 
 Use `apply_patch` for each mutation and its inverse. Before each mutation, record
 `git diff --binary -- <mutated-paths> | shasum -a 256`; after the inverse patch, require
@@ -224,11 +227,11 @@ node to GREEN, and confirm `git diff --check` plus a focused residue scan are cl
 
 ### Task 5: Static checks, review, and closeout
 
-- [ ] Run Ruff lint/format checks on changed Python files only, `py_compile` for changed production modules under a validated temporary cache root, `git diff --check`, and the focused screen-size/Wave 6 architecture nodes.
-- [ ] Run the persistent-diagnostic checker; update its inventory only for a proven content-identical owner move and verify sink topology is unchanged.
-- [ ] Review the cumulative diff for Ponytail/YAGNI scope: one existing controller, no new abstraction/dependency/config/schema/copy/layout/DOM ID, no compatibility method shim, and no unrelated formatter churn.
-- [ ] Update plan checkboxes and TASK-3070.7 ACs/Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, and the affected-only test constraint.
-- [ ] Commit the candidate, rebase on latest `origin/dev`, rerun touched-functionality gates, push, open one atomic PR against `dev`, address validated Qodo/CI comments, and merge when required checks are green.
+- [x] Run Ruff lint/format checks on changed Python files only, `py_compile` for changed production modules under a validated temporary cache root, `git diff --check`, and the focused screen-size/Wave 6 architecture nodes.
+- [x] Run the persistent-diagnostic checker; update its inventory only for a proven content-identical owner move and verify sink topology is unchanged.
+- [x] Review the cumulative diff for Ponytail/YAGNI scope: one existing controller, no new abstraction/dependency/config/schema/copy/layout/DOM ID, no compatibility method shim, and no unrelated formatter churn.
+- [x] Update plan checkboxes and TASK-3070.7 ACs/Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, and the affected-only test constraint.
+- [x] Commit the candidate, rebase on latest `origin/dev` (`690435d0a54260164eb98b67b6389d39d43a4881`), and rerun the touched-functionality gates on the rebased candidate. Push/PR/Qodo/CI/merge delivery follows task closeout and is not claimed by this checkbox.
 
 Run Ruff on every changed Python path; the initial expected set is:
 
@@ -308,3 +311,56 @@ architecture command above on the rebased SHA. If the diagnostic checker is red,
 the same owner-transfer/count/topology review and conditional single writer sequence
 before proceeding. Only these fresh post-rebase results may support task Done, push, or
 merge.
+
+## Closeout evidence
+
+- Final post-rebase base: `690435d0a54260164eb98b67b6389d39d43a4881`.
+  The immutable original planning base remains recorded above; rebasing changed commit
+  identities without changing that starting-point history.
+- Ownership: all seven character methods are on `ConsoleCharacterController` only:
+  `_console_character_picker_options`, `_apply_console_character_choice_async`,
+  `_current_console_rail_conversation_id`, `_current_console_rail_character_id`,
+  `_current_console_rail_character_name`, `_fetch_character_card_for_avatar`, and
+  `_refresh_active_character_avatar_if_scope_changed`. `ChatScreen` retains only
+  `_open_console_character_picker`, `_apply_console_character_choice`, and
+  `_render_character_avatar_into_section` for modal, worker, and pixel presentation.
+- Dependency boundary: the existing controller remains DOM-free and receives explicit,
+  late-bound callables for app config, chat store, active/current session identity,
+  character DB access, store readiness, provider readiness/default settings, session
+  swap, temporary-chip/native-chat synchronization, notification, actor scope, manual
+  reaction key, visual identity, image-view setup/default mode, mount state, and avatar
+  rendering. No compatibility shim or new abstraction was added.
+- RED/GREEN: the clean test contract failed 6 and passed 1 with 1 warning; the preserved
+  partial-controller checkpoint failed only the six-method ownership node while 6 nodes
+  passed with 1 warning. The final fresh character matrix passed 87 tests, the exact
+  ownership-caller selection passed 27 tests, the inherited avatar fixture nodes passed
+  2 tests, the restored mutation selection passed 4 tests with 2 warnings, and the final
+  architecture selection passed 6 tests. The final reviewer also ran 372 directly
+  affected caller tests successfully. No full repository suite was run, honoring the
+  user's affected-only constraint.
+- Mutation evidence: the invalid empty-name picker-card mutation failed with unexpected
+  ID 8 and restored to 1 pass; the `new`-to-`swap` placement mutation failed because no
+  new session existed and restored to 1 pass; eager DB-edge binding failed because the
+  old `None` replaced the expected sentinel and restored to 1 pass; the synthetic moved
+  screen method failed as still owned by `ChatScreen` and restored to 1 pass. An initial
+  empty-system-prompt probe stayed GREEN because roleplay seeding correctly supplied a
+  prompt; it was restored immediately and replaced by the discriminating placement
+  probe. Each before/after path-scoped diff checksum was exactly
+  `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+- Static/scope verification: Ruff lint and format passed for all 16 changed Python
+  files. Changed production modules compiled under a fresh validated isolated pycache
+  root; entries were inspected, the exact root was removed, and absence was proven.
+  `git diff --check`, the exact moved-name ownership scan, and the cumulative
+  Ponytail/YAGNI scope review were clean. Modified paths comprise the existing
+  character/session/wiring/screen/agent boundary, focused character/controller consumer
+  tests, the Wave 6 inventory test, this plan, and the task record.
+- Diagnostic exception: current `origin/dev` already has 8 unrelated stale owner
+  deltas. This branch transfers 3 unchanged diagnostic calls from `chat_screen.py` to
+  `character.py`, changing owner counts from `145 + 1` to `142 + 4`; the combined exact
+  146-call `(method, digest)` multiset and sink topology are unchanged. The manifest was
+  intentionally not rewritten because doing so would bless unrelated upstream drift.
+  The non-write checker therefore remains inherited-red, while the metadata-only node
+  passes.
+- ADR required: no. This is a behavior-preserving implementation of the existing Wave 6
+  decomposition design. No new lesson was added because no genuinely new generalizable
+  incident arose beyond the repository's existing testing/backlog lessons.

--- a/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
+++ b/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
@@ -36,7 +36,8 @@
 - Already controller-owned: `_refresh_active_character_avatar_if_scope_changed`
 - Already deleted: `_fetch_expression_image_bytes`
 - Focused baseline: 2 failed, 21 passed, 2 warnings. Both failures are the inherited `ChatScreen.__new__` avatar fixture reaching `console_view_hooks()` without `_skill`; all character production and architecture nodes in that command passed.
-- Current RED slice: 1 failed, 6 passed, 1 warning. The failure is the exact ownership assertion listing the six methods still on `ChatScreen`; controller-policy and oracle tests collect and pass.
+- Clean test-commit RED at `ba58442d8`: 6 failed, 1 passed, 1 warning. The four no-mount policy tests fail because the new constructor/API is absent, the dependency contract fails on the old constructor shape, and ownership fails on the six methods still on `ChatScreen`; only the synthetic oracle passes.
+- Preserved dirty continuity checkpoint after the pre-existing partial controller additions: 1 failed, 6 passed, 1 warning. The sole failure is the ownership assertion listing those same six `ChatScreen` methods; controller-policy, dependency, and oracle nodes collect and pass.
 
 ## File map
 
@@ -72,7 +73,8 @@ inspect existing dirty bytes; never overwrite them merely to obtain a clean tree
 - [ ] Add plain, no-mount controller tests for picker option projection/error containment, active rail conversation/character identity, card fetch containment, and new/swap character choice behavior.
 - [ ] Extend the Wave 6 inventory so all seven current M methods exist only on `ConsoleCharacterController`, the already-deleted expression helper stays absent, four compatibility descriptors remain controller-backed, and the controller has only named non-DOM dependencies.
 - [ ] Add a non-vacuity mutation/oracle proving a synthetic screen-owned moved method or DOM access fails the architecture contract.
-- [ ] Run only the new controller/architecture nodes and confirm RED comes from missing controller ownership, not an unrelated fixture failure.
+- [ ] On the clean production base, run only the new controller/architecture nodes and confirm the expected policy/API, dependency-shape, and ownership RED set, with no unrelated collection/fixture failure.
+- [ ] On the preserved dirty continuity state after partial controller additions, confirm only the six-method ownership assertion remains RED.
 
 **Files:**
 
@@ -89,16 +91,20 @@ Run:
   Tests/Architecture/test_console_wave6_inventory.py::test_character_controller_has_only_named_non_dom_dependencies
 ```
 
-Expected before screen extraction: the ownership node fails and names exactly the six
-remaining screen methods; the no-mount policy and structural-oracle nodes pass. A
-collection/fixture error is not acceptable RED evidence.
+Expected on the clean production base: the four policy nodes fail on the absent
+controller API, the dependency node fails on the old constructor shape, ownership names
+the six remaining screen methods, and the synthetic oracle passes. On the preserved
+dirty continuity state after the partial controller additions, only that ownership node
+fails; the six other nodes pass. A collection/fixture error is not acceptable RED
+evidence in either state.
 
 Commit the reviewed RED contract before completing production movement:
 
 ```bash
-git add Tests/UI/test_console_character_controller.py \
+git add Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md \
+  Tests/UI/test_console_character_controller.py \
   Tests/Architecture/test_console_wave6_inventory.py
-git commit -m "test(console): lock character controller extraction"
+git commit -m "test(console): harden character extraction contract"
 ```
 
 ### Task 2: Move character policy into the controller

--- a/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
+++ b/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
@@ -1,6 +1,6 @@
 # TASK-3070.7 Console Character Controller Implementation Plan
 
-> **For implementers:** Follow strict RED/GREEN TDD and the repository's affected-functionality-only test constraint. Do not run the full repository suite.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make the existing DOM-free `ConsoleCharacterController` own character picker projection, session handoff policy, active character/conversation identity, card retrieval, and avatar refresh state while leaving the picker modal and rail pixels screen-owned.
 
@@ -27,6 +27,17 @@
 - Repair the inherited bare-screen avatar fixture by constructing/using the real character ownership seam; do not add a production fallback for missing `_skill` or partially initialized `ChatScreen` instances.
 - Run only tests related to changed files or character behavior, per the user's standing instruction. After each mutation, restore candidate bytes exactly.
 
+## Recorded starting point
+
+- Branch: `codex/task-3070-7-console-character`
+- Immutable implementation base: `f4c45fc14a47d79ae86c0c58bd97af0a759a6f87` (`origin/dev` when planning began)
+- `ChatScreen`: 20,202 physical lines and 655 direct methods
+- Remaining screen-owned character inventory: six methods / 167 physical definition lines
+- Already controller-owned: `_refresh_active_character_avatar_if_scope_changed`
+- Already deleted: `_fetch_expression_image_bytes`
+- Focused baseline: 2 failed, 21 passed, 2 warnings. Both failures are the inherited `ChatScreen.__new__` avatar fixture reaching `console_view_hooks()` without `_skill`; all character production and architecture nodes in that command passed.
+- Current RED slice: 1 failed, 6 passed, 1 warning. The failure is the exact ownership assertion listing the six methods still on `ChatScreen`; controller-policy and oracle tests collect and pass.
+
 ## File map
 
 - Modify `tldw_chatbook/UI/Console_Modules/character.py`: own picker projection, active rail identity, card retrieval, character choice/session handoff, and existing avatar refresh orchestration.
@@ -46,12 +57,49 @@
 - [x] Reproduce and classify the focused baseline. Record the inherited avatar-fixture failure caused by bypassing `ChatScreen.__init__` after TASK-3070.6 added `_skill` to runtime hooks; prove no character production path is involved.
 - [ ] Commit only this reviewed plan/task metadata before production implementation.
 
+The initial plan/task commit is `d6cd2640a`. Before resuming implementation, run:
+
+```bash
+git status --short
+git diff --check
+```
+
+Expected: only reviewed paths from the file map and no whitespace errors. Preserve and
+inspect existing dirty bytes; never overwrite them merely to obtain a clean tree.
+
 ### Task 1: Lock controller ownership and behavior with RED tests
 
 - [ ] Add plain, no-mount controller tests for picker option projection/error containment, active rail conversation/character identity, card fetch containment, and new/swap character choice behavior.
 - [ ] Extend the Wave 6 inventory so all seven current M methods exist only on `ConsoleCharacterController`, the already-deleted expression helper stays absent, four compatibility descriptors remain controller-backed, and the controller has only named non-DOM dependencies.
 - [ ] Add a non-vacuity mutation/oracle proving a synthetic screen-owned moved method or DOM access fails the architecture contract.
 - [ ] Run only the new controller/architecture nodes and confirm RED comes from missing controller ownership, not an unrelated fixture failure.
+
+**Files:**
+
+- Create: `Tests/UI/test_console_character_controller.py`
+- Modify: `Tests/Architecture/test_console_wave6_inventory.py`
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_character_controller.py \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_family_has_completed_controller_ownership \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_move_ownership_oracle_is_non_vacuous \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_controller_has_only_named_non_dom_dependencies
+```
+
+Expected before screen extraction: the ownership node fails and names exactly the six
+remaining screen methods; the no-mount policy and structural-oracle nodes pass. A
+collection/fixture error is not acceptable RED evidence.
+
+Commit the reviewed RED contract before completing production movement:
+
+```bash
+git add Tests/UI/test_console_character_controller.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+git commit -m "test(console): lock character controller extraction"
+```
 
 ### Task 2: Move character policy into the controller
 
@@ -62,12 +110,90 @@
 - [ ] Update the stale `session.py` ownership documentation and remove imports that lost their final screen caller.
 - [ ] Run isolated controller, architecture, wiring, picker, prompt-seed/handoff, avatar, composer-menu, and rail-focused nodes to GREEN.
 
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/character.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `Tests/UI/test_console_controller_wiring.py`
+
+Keep the constructor keyword-only. Add exactly these policy edges beside the existing
+avatar edges: `active_native_session_accessor`, `current_conversation_id_accessor`,
+`character_db_accessor`, `ensure_chat_store`, `provider_readiness_config_accessor`,
+`default_session_settings`, `swap_session_character`, `sync_temporary_chip`,
+`sync_native_chat_ui`, and `notify`. Use the controller's own
+`_current_console_rail_character_name()` in the avatar request; delete the redundant
+`character_name_accessor` edge.
+
+Run:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_character_controller.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_family_has_completed_controller_ownership \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_move_ownership_oracle_is_non_vacuous \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_controller_has_only_named_non_dom_dependencies \
+  Tests/Architecture/test_console_wave6_inventory.py::test_wave6_compatibility_inventory_is_complete_and_phase_safe
+```
+
+Expected: all selected nodes pass. Then commit the controller move:
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/character.py \
+  tldw_chatbook/UI/Console_Modules/wiring.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  tldw_chatbook/UI/Console_Modules/session.py \
+  Tests/UI/test_console_controller_wiring.py
+git commit -m "refactor(console): extract character controller"
+```
+
 ### Task 3: Repair affected fixtures without weakening product wiring
 
 - [ ] Replace the stale avatar bare-screen setup with the smallest real/controller-level fixture that does not attach runtime hooks through an incompletely initialized `ChatScreen`.
 - [ ] Update tests that monkeypatch or call moved screen methods to patch/call `_character` instead; preserve assertions, cardinality, copy, and durable-state oracles.
 - [ ] Keep presentation tests mounted where pixels/layout matter and controller tests unmounted where only policy/data matters.
 - [ ] Rerun the exact formerly failing avatar nodes and the focused affected matrix.
+
+**Files:**
+
+- Modify: `Tests/UI/test_console_character_avatar.py`
+- Modify: `Tests/UI/test_character_session_prompt_seed.py`
+- Modify: `Tests/UI/test_console_composer_menu.py`
+- Modify only additional tests returned by an exact moved-name caller scan.
+
+First prove the inherited fixture repair:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_character_avatar.py::test_current_console_rail_character_id_reads_active_session \
+  Tests/UI/test_console_character_avatar.py::test_current_console_rail_character_id_none_for_generic_session
+```
+
+Expected: 2 passed. Then run the focused behavior matrix:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/UI/test_console_character_controller.py \
+  Tests/UI/test_character_session_prompt_seed.py \
+  Tests/UI/test_console_character_avatar.py \
+  Tests/UI/test_console_composer_menu.py::test_character_picker_new_chat_clears_a_stale_temporary_chip \
+  Tests/UI/test_console_controller_wiring.py
+```
+
+Expected: all selected nodes pass. If the avatar file reaches the repository's
+20-minute checkpoint, stop, record completed nodes, and resume in named node groups;
+do not silently narrow the claimed matrix.
+
+Commit only ownership-driven fixture changes:
+
+```bash
+git add Tests/UI/test_console_character_avatar.py \
+  Tests/UI/test_character_session_prompt_seed.py \
+  Tests/UI/test_console_composer_menu.py
+git commit -m "test(console): cover character controller behavior"
+```
 
 ### Task 4: Prove behavior and mutation sensitivity
 
@@ -77,6 +203,19 @@
 - [ ] Reintroduce one moved method on a synthetic `ChatScreen` AST fixture and confirm the ownership oracle fails, then restore.
 - [ ] Re-run the affected functionality matrix and record exact passes, skips, warnings, and any inherited exceptions.
 
+Use `apply_patch` for each mutation and its inverse. Before each mutation, record
+`git diff --binary -- <mutated-paths> | shasum -a 256`; after the inverse patch, require
+the same checksum so restoration proves exact candidate bytes rather than mere syntax.
+Required discriminators:
+
+1. Accept one invalid picker card or leak one DB exception; the picker projection node fails.
+2. Change `new`/`current` placement or drop prompt-derived settings; the handoff node fails.
+3. Eagerly bind one wiring edge; the `_character` late-binding node fails.
+4. Add one moved method to the synthetic screen map; the ownership oracle fails.
+
+After every failure, restore immediately, compare the exact diff checksum, rerun the
+node to GREEN, and confirm `git diff --check` plus a focused residue scan are clean.
+
 ### Task 5: Static checks, review, and closeout
 
 - [ ] Run Ruff lint/format checks on changed Python files only, `py_compile` for changed production modules under a validated temporary cache root, `git diff --check`, and the focused screen-size/Wave 6 architecture nodes.
@@ -84,3 +223,82 @@
 - [ ] Review the cumulative diff for Ponytail/YAGNI scope: one existing controller, no new abstraction/dependency/config/schema/copy/layout/DOM ID, no compatibility method shim, and no unrelated formatter churn.
 - [ ] Update plan checkboxes and TASK-3070.7 ACs/Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, and the affected-only test constraint.
 - [ ] Commit the candidate, rebase on latest `origin/dev`, rerun touched-functionality gates, push, open one atomic PR against `dev`, address validated Qodo/CI comments, and merge when required checks are green.
+
+Run Ruff on every changed Python path; the initial expected set is:
+
+```bash
+../../.venv/bin/python -m ruff check \
+  tldw_chatbook/UI/Console_Modules/character.py \
+  tldw_chatbook/UI/Console_Modules/wiring.py \
+  tldw_chatbook/UI/Console_Modules/session.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/UI/test_console_character_controller.py \
+  Tests/UI/test_console_character_avatar.py \
+  Tests/UI/test_character_session_prompt_seed.py \
+  Tests/UI/test_console_composer_menu.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+
+../../.venv/bin/python -m ruff format --check \
+  tldw_chatbook/UI/Console_Modules/character.py \
+  tldw_chatbook/UI/Console_Modules/wiring.py \
+  tldw_chatbook/UI/Console_Modules/session.py \
+  tldw_chatbook/UI/Screens/chat_screen.py \
+  Tests/UI/test_console_character_controller.py \
+  Tests/UI/test_console_character_avatar.py \
+  Tests/UI/test_character_session_prompt_seed.py \
+  Tests/UI/test_console_composer_menu.py \
+  Tests/UI/test_console_controller_wiring.py \
+  Tests/Architecture/test_console_wave6_inventory.py
+```
+
+Append any additional changed Python test before running both commands. Expected: both
+exit 0. Compile changed production modules with `PYTHONPYCACHEPREFIX` under one fresh,
+owner-validated `/private/tmp/task-3070-7-pycache.*` directory; reject links/non-regular
+entries, remove exactly that validated root, and prove it absent.
+
+Run the diagnostic gate before writing:
+
+```bash
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+```
+
+If red, prove it is only a content-identical diagnostic transfer from `chat_screen.py`
+to `character.py`, with aggregate counts and sink topology unchanged. Only then run:
+
+```bash
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py --write
+git diff -- Docs/security/production-diagnostic-inventory.json
+../../.venv/bin/python scripts/check_persistent_diagnostic_inventory.py
+../../.venv/bin/python -m pytest -q \
+  Tests/Architecture/test_persistent_diagnostic_inventory.py::test_production_diagnostic_inventory_and_sink_topology_are_unchanged \
+  Tests/Architecture/test_persistent_diagnostic_inventory.py::test_reviewed_diagnostic_changes_are_metadata_only
+```
+
+Expected: non-write checker and both nodes pass; JSON changes only redistribute
+identical moved calls and do not alter sink topology.
+
+Final focused architecture gate:
+
+```bash
+../../.venv/bin/python -m pytest -q \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_family_has_completed_controller_ownership \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_move_ownership_oracle_is_non_vacuous \
+  Tests/Architecture/test_console_wave6_inventory.py::test_character_controller_has_only_named_non_dom_dependencies \
+  Tests/Architecture/test_console_wave6_inventory.py::test_wave6_projection_clears_both_ratchet_overages \
+  Tests/Architecture/test_console_wave6_inventory.py::test_wave6_compatibility_inventory_is_complete_and_phase_safe \
+  Tests/Architecture/test_console_wave6_inventory.py::test_wave6_structural_oracles_are_non_vacuous
+git diff --check
+```
+
+Expected: all selected nodes pass and `git diff --check` is silent. Do not run the full
+repository suite. Record the user-authorized affected-only deviation in task notes,
+check every AC, and set TASK-3070.7 Done only after all focused/static/diagnostic gates.
+
+After rebasing onto the then-current `origin/dev`, do not reuse any pre-rebase generated
+or architecture evidence. Rerun the affected behavior matrix, both Ruff commands, the
+non-write diagnostic checker, the two diagnostic nodes, and the exact final focused
+architecture command above on the rebased SHA. If the diagnostic checker is red, repeat
+the same owner-transfer/count/topology review and conditional single writer sequence
+before proceeding. Only these fresh post-rebase results may support task Done, push, or
+merge.

--- a/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
+++ b/Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
@@ -1,0 +1,86 @@
+# TASK-3070.7 Console Character Controller Implementation Plan
+
+> **For implementers:** Follow strict RED/GREEN TDD and the repository's affected-functionality-only test constraint. Do not run the full repository suite.
+
+**Goal:** Make the existing DOM-free `ConsoleCharacterController` own character picker projection, session handoff policy, active character/conversation identity, card retrieval, and avatar refresh state while leaving the picker modal and rail pixels screen-owned.
+
+**Architecture:** Move the six remaining approved non-DOM `ChatScreen` methods into the existing character controller and keep the already-moved avatar refresher there. Wire explicit late-bound callables for session/store/config/notification/UI-sync edges; retain no screen handle and no DOM access in the controller. Keep `_open_console_character_picker`, the worker-launching picker callback, and avatar rendering on `ChatScreen`, but route them directly to `_character`.
+
+**Tech Stack:** Python 3.11+, Textual 8, pytest/pytest-asyncio, Ruff, stdlib AST checks.
+
+---
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This is a behavior-preserving implementation of the character ownership boundary already approved in `Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md`; it changes no storage, runtime/service contract, dependency, security boundary, or user-visible application structure.
+
+## Constraints and evidence rules
+
+- Treat latest merged `origin/dev` as authoritative: `_refresh_active_character_avatar_if_scope_changed` already lives in `character.py`, and `_fetch_expression_image_bytes` is already retired. Move only the six remaining screen methods and preserve the seven-method controller inventory.
+- `ConsoleCharacterController` must not hold `ChatScreen`, query the DOM, push a modal, or launch a Textual worker. Every non-owned edge is an explicit late-bound callable.
+- `ChatScreen` retains `_open_console_character_picker`, `_apply_console_character_choice`, and `_render_character_avatar_into_section` as bounded presentation/framework seams.
+- Preserve prompt templates, raw character identity, sanitized notification copy, new-vs-current placement, durable session behavior, avatar request fencing, picker ordering, and rail rendering.
+- Preserve the four existing `_ControllerState` compatibility descriptors and defaults; do not add aliases for moved methods.
+- Preserve `test_console_controller_wiring.py`'s original six-controller `_EXPECTED_SLOTS`, order, and shared-accessor characterization. Add only focused `_character` construction and late-binding checks.
+- Repair the inherited bare-screen avatar fixture by constructing/using the real character ownership seam; do not add a production fallback for missing `_skill` or partially initialized `ChatScreen` instances.
+- Run only tests related to changed files or character behavior, per the user's standing instruction. After each mutation, restore candidate bytes exactly.
+
+## File map
+
+- Modify `tldw_chatbook/UI/Console_Modules/character.py`: own picker projection, active rail identity, card retrieval, character choice/session handoff, and existing avatar refresh orchestration.
+- Modify `tldw_chatbook/UI/Console_Modules/wiring.py`: construct `_character` with named late-bound dependencies and route retrieval/agent conversation access through `_character`.
+- Modify `tldw_chatbook/UI/Screens/chat_screen.py`: route picker presentation, picker callback, avatar rendering inputs, and all remaining production callers directly to `_character`; remove the six moved method bodies and obsolete imports.
+- Modify `tldw_chatbook/UI/Console_Modules/session.py`: update the historical ownership documentation that still says the picker policy remains screen-owned.
+- Create `Tests/UI/test_console_character_controller.py`: isolated no-mount controller behavior and mutation-sensitive tests.
+- Modify `Tests/Architecture/test_console_wave6_inventory.py`: exact moved/deleted/state/default/no-DOM dependency contracts and non-vacuity.
+- Modify `Tests/UI/test_console_controller_wiring.py`: focused `_character` construction/late-bound edge checks only.
+- Modify focused character behavior tests (`test_character_session_prompt_seed.py`, `test_console_character_avatar.py`, `test_console_composer_menu.py`, and directly affected controller-consumer tests) only where ownership changed.
+- Modify `Docs/security/production-diagnostic-inventory.json` only if fresh generation proves an owner-file move with identical diagnostic content and unchanged sink topology.
+- Modify the TASK-3070.7 task and this plan for truthful closeout evidence.
+
+### Task 0: Freeze the latest-dev baseline and plan
+
+- [x] Record the exact worktree branch/base, source line/direct-method counts, task status, and current seven-method/latest-dev character inventory.
+- [x] Reproduce and classify the focused baseline. Record the inherited avatar-fixture failure caused by bypassing `ChatScreen.__init__` after TASK-3070.6 added `_skill` to runtime hooks; prove no character production path is involved.
+- [ ] Commit only this reviewed plan/task metadata before production implementation.
+
+### Task 1: Lock controller ownership and behavior with RED tests
+
+- [ ] Add plain, no-mount controller tests for picker option projection/error containment, active rail conversation/character identity, card fetch containment, and new/swap character choice behavior.
+- [ ] Extend the Wave 6 inventory so all seven current M methods exist only on `ConsoleCharacterController`, the already-deleted expression helper stays absent, four compatibility descriptors remain controller-backed, and the controller has only named non-DOM dependencies.
+- [ ] Add a non-vacuity mutation/oracle proving a synthetic screen-owned moved method or DOM access fails the architecture contract.
+- [ ] Run only the new controller/architecture nodes and confirm RED comes from missing controller ownership, not an unrelated fixture failure.
+
+### Task 2: Move character policy into the controller
+
+- [ ] Move `_console_character_picker_options`, `_current_console_rail_conversation_id`, `_current_console_rail_character_id`, `_current_console_rail_character_name`, `_fetch_character_card_for_avatar`, and `_apply_console_character_choice_async` into `ConsoleCharacterController`.
+- [ ] Add the minimum explicit dependencies for DB access, active/current session identity, store/config access, default settings/swap, notifications, and final UI synchronization; keep all callbacks late-bound.
+- [ ] Repoint `character.py`'s existing avatar request name lookup to its own character-identity method and retain existing avatar request/stale-result behavior.
+- [ ] Route screen picker presentation and worker callback to `_character`; route screen/retrieval/agent and other production conversation/character consumers directly to `_character`; retain no moved-method screen shim.
+- [ ] Update the stale `session.py` ownership documentation and remove imports that lost their final screen caller.
+- [ ] Run isolated controller, architecture, wiring, picker, prompt-seed/handoff, avatar, composer-menu, and rail-focused nodes to GREEN.
+
+### Task 3: Repair affected fixtures without weakening product wiring
+
+- [ ] Replace the stale avatar bare-screen setup with the smallest real/controller-level fixture that does not attach runtime hooks through an incompletely initialized `ChatScreen`.
+- [ ] Update tests that monkeypatch or call moved screen methods to patch/call `_character` instead; preserve assertions, cardinality, copy, and durable-state oracles.
+- [ ] Keep presentation tests mounted where pixels/layout matter and controller tests unmounted where only policy/data matters.
+- [ ] Rerun the exact formerly failing avatar nodes and the focused affected matrix.
+
+### Task 4: Prove behavior and mutation sensitivity
+
+- [ ] Mutate picker validation/error containment and confirm the no-mount picker test fails, then restore.
+- [ ] Mutate new/swap placement or prompt seed/config propagation and confirm the focused handoff test fails, then restore.
+- [ ] Break one late-bound wiring edge and confirm the wiring test fails, then restore.
+- [ ] Reintroduce one moved method on a synthetic `ChatScreen` AST fixture and confirm the ownership oracle fails, then restore.
+- [ ] Re-run the affected functionality matrix and record exact passes, skips, warnings, and any inherited exceptions.
+
+### Task 5: Static checks, review, and closeout
+
+- [ ] Run Ruff lint/format checks on changed Python files only, `py_compile` for changed production modules under a validated temporary cache root, `git diff --check`, and the focused screen-size/Wave 6 architecture nodes.
+- [ ] Run the persistent-diagnostic checker; update its inventory only for a proven content-identical owner move and verify sink topology is unchanged.
+- [ ] Review the cumulative diff for Ponytail/YAGNI scope: one existing controller, no new abstraction/dependency/config/schema/copy/layout/DOM ID, no compatibility method shim, and no unrelated formatter churn.
+- [ ] Update plan checkboxes and TASK-3070.7 ACs/Implementation Notes with exact RED/GREEN/mutation/static evidence, ADR decision, modified files, and the affected-only test constraint.
+- [ ] Commit the candidate, rebase on latest `origin/dev`, rerun touched-functionality gates, push, open one atomic PR against `dev`, address validated Qodo/CI comments, and merge when required checks are green.

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -1568,6 +1568,57 @@ def test_wave6_compatibility_inventory_is_complete_and_phase_safe() -> None:
 
 
 @pytest.mark.unit
+def test_character_family_has_completed_controller_ownership() -> None:
+    """Require the current seven-M/deleted-one character inventory."""
+    group = WAVE6_GROUPS["character"]
+    target_path = _REPO_ROOT / group.target_path
+    screen_methods = _methods(_SCREEN_PATH, "ChatScreen")
+    character_state = {
+        "_active_character_avatar",
+        "_active_character_avatar_name",
+        "_last_console_avatar_scope",
+        "_console_expression_spec_cache",
+    }
+
+    assert target_path.exists(), "ConsoleCharacterController module is missing"
+    assert COMPATIBILITY_TARGETS[group.owner_name] == character_state
+    assert set(BASELINE_DEFAULTS) & character_state == character_state
+    target_methods = _methods(target_path, group.target_class)
+    assert not (group.moved & screen_methods.keys()), (
+        "character methods still owned by ChatScreen: "
+        f"{sorted(group.moved & screen_methods.keys())}"
+    )
+    assert group.moved <= target_methods.keys(), (
+        "character methods missing from ConsoleCharacterController: "
+        f"{sorted(group.moved - target_methods.keys())}"
+    )
+    assert not (group.deleted & screen_methods.keys())
+    assert not (group.deleted & target_methods.keys())
+    _assert_no_dom_access(target_methods[name] for name in group.moved)
+    assert "_screen" not in _self_assignments(target_methods["__init__"])
+
+    presentation = {
+        "_open_console_character_picker",
+        "_apply_console_character_choice",
+        "_render_character_avatar_into_section",
+    }
+    assert presentation <= screen_methods.keys()
+
+
+@pytest.mark.unit
+def test_character_move_ownership_oracle_is_non_vacuous() -> None:
+    """Prove one synthetic screen-owned character method is rejected."""
+    group = WAVE6_GROUPS["character"]
+    moved_method = "_console_character_picker_options"
+    assert moved_method in group.moved
+    synthetic_screen = {moved_method: object()}
+    with pytest.raises(AssertionError, match="still owned by ChatScreen"):
+        assert not (group.moved & synthetic_screen.keys()), (
+            "character methods still owned by ChatScreen"
+        )
+
+
+@pytest.mark.unit
 def test_character_controller_has_only_named_non_dom_dependencies() -> None:
     """Lock Task10 orchestration behind the approved controller boundary."""
 
@@ -1576,12 +1627,22 @@ def test_character_controller_has_only_named_non_dom_dependencies() -> None:
     methods = _methods_from_class(controller)
     init = methods["__init__"]
     assert isinstance(init, ast.FunctionDef)
+    assert not init.args.posonlyargs
     assert [argument.arg for argument in init.args.args] == ["self"]
     assert {argument.arg for argument in init.args.kwonlyargs} == {
         "app_config_accessor",
         "chat_store_accessor",
+        "active_native_session_accessor",
+        "current_conversation_id_accessor",
+        "character_db_accessor",
+        "ensure_chat_store",
+        "provider_readiness_config_accessor",
+        "default_session_settings",
+        "swap_session_character",
+        "sync_temporary_chip",
+        "sync_native_chat_ui",
+        "notify",
         "actor_scope_accessor",
-        "character_name_accessor",
         "manual_reaction_key",
         "resolve_visual_identity",
         "ensure_console_image_view",
@@ -1589,6 +1650,9 @@ def test_character_controller_has_only_named_non_dom_dependencies() -> None:
         "is_mounted",
         "render_character_avatar",
     }
+    assert init.args.kw_defaults == [None] * len(init.args.kwonlyargs)
+    assert init.args.vararg is None
+    assert init.args.kwarg is None
     assert "_screen" not in _self_assignments(controller)
     _assert_no_dom_access(methods.values())
 

--- a/Tests/Architecture/test_console_wave6_inventory.py
+++ b/Tests/Architecture/test_console_wave6_inventory.py
@@ -1567,6 +1567,41 @@ def test_wave6_compatibility_inventory_is_complete_and_phase_safe() -> None:
             _assert_descriptor_contract(ChatScreen, owner_name, state_name)
 
 
+def _assert_character_ownership_contract(
+    screen_methods: dict[str, ast.AST],
+    target_methods: dict[str, ast.AST],
+) -> None:
+    """Require character policy and presentation to have one approved owner."""
+    group = WAVE6_GROUPS["character"]
+    assert not (group.moved & screen_methods.keys()), (
+        "character methods still owned by ChatScreen: "
+        f"{sorted(group.moved & screen_methods.keys())}"
+    )
+    assert group.moved <= target_methods.keys(), (
+        "character methods missing from ConsoleCharacterController: "
+        f"{sorted(group.moved - target_methods.keys())}"
+    )
+    assert not (group.deleted & screen_methods.keys())
+    assert not (group.deleted & target_methods.keys())
+    dom_offenders = {
+        name for name in group.moved if _calls_dom_query(target_methods[name])
+    }
+    assert not dom_offenders, (
+        f"character controller methods query DOM: {sorted(dom_offenders)}"
+    )
+
+    presentation = {
+        "_open_console_character_picker",
+        "_apply_console_character_choice",
+        "_render_character_avatar_into_section",
+    }
+    assert presentation <= screen_methods.keys()
+    assert not (presentation & target_methods.keys()), (
+        "character presentation duplicated on controller: "
+        f"{sorted(presentation & target_methods.keys())}"
+    )
+
+
 @pytest.mark.unit
 def test_character_family_has_completed_controller_ownership() -> None:
     """Require the current seven-M/deleted-one character inventory."""
@@ -1584,37 +1619,40 @@ def test_character_family_has_completed_controller_ownership() -> None:
     assert COMPATIBILITY_TARGETS[group.owner_name] == character_state
     assert set(BASELINE_DEFAULTS) & character_state == character_state
     target_methods = _methods(target_path, group.target_class)
-    assert not (group.moved & screen_methods.keys()), (
-        "character methods still owned by ChatScreen: "
-        f"{sorted(group.moved & screen_methods.keys())}"
-    )
-    assert group.moved <= target_methods.keys(), (
-        "character methods missing from ConsoleCharacterController: "
-        f"{sorted(group.moved - target_methods.keys())}"
-    )
-    assert not (group.deleted & screen_methods.keys())
-    assert not (group.deleted & target_methods.keys())
-    _assert_no_dom_access(target_methods[name] for name in group.moved)
+    _assert_character_ownership_contract(screen_methods, target_methods)
     assert "_screen" not in _self_assignments(target_methods["__init__"])
-
-    presentation = {
-        "_open_console_character_picker",
-        "_apply_console_character_choice",
-        "_render_character_avatar_into_section",
-    }
-    assert presentation <= screen_methods.keys()
 
 
 @pytest.mark.unit
 def test_character_move_ownership_oracle_is_non_vacuous() -> None:
-    """Prove one synthetic screen-owned character method is rejected."""
+    """Prove the shared oracle rejects screen ownership and DOM queries."""
     group = WAVE6_GROUPS["character"]
     moved_method = "_console_character_picker_options"
     assert moved_method in group.moved
-    synthetic_screen = {moved_method: object()}
+    screen_methods = _methods(_SCREEN_PATH, "ChatScreen")
+    extracted_screen = {
+        name: method
+        for name, method in screen_methods.items()
+        if name not in group.moved
+    }
+    target_methods = {
+        name: ast.parse(f"def {name}(self): pass").body[0] for name in group.moved
+    }
+    synthetic_screen = {
+        **extracted_screen,
+        moved_method: target_methods[moved_method],
+    }
     with pytest.raises(AssertionError, match="still owned by ChatScreen"):
-        assert not (group.moved & synthetic_screen.keys()), (
-            "character methods still owned by ChatScreen"
+        _assert_character_ownership_contract(synthetic_screen, target_methods)
+
+    synthetic_target = dict(target_methods)
+    synthetic_target[moved_method] = ast.parse(
+        "def _console_character_picker_options(self): self.query('.row')"
+    ).body[0]
+    with pytest.raises(AssertionError, match="query DOM"):
+        _assert_character_ownership_contract(
+            extracted_screen,
+            synthetic_target,
         )
 
 
@@ -1654,7 +1692,7 @@ def test_character_controller_has_only_named_non_dom_dependencies() -> None:
     assert init.args.vararg is None
     assert init.args.kwarg is None
     assert "_screen" not in _self_assignments(controller)
-    _assert_no_dom_access(methods.values())
+    assert not any(_calls_dom_query(method) for method in methods.values())
 
 
 @pytest.mark.unit

--- a/Tests/UI/test_character_session_prompt_seed.py
+++ b/Tests/UI/test_character_session_prompt_seed.py
@@ -344,14 +344,14 @@ async def test_character_picker_swap_uses_override_and_only_greets_empty_chat(
     )
 
     await screen._character._apply_console_character_choice_async(
-        ConsoleCharacterChoice(character_id=7, name="Alraune", placement="current")
+        ConsoleCharacterChoice(character_id=7, name="Alraune", placement="swap")
     )
     first_messages = store.messages_for_session(session.id)
     assert [message.content for message in first_messages] == ["Hello, Per Chat."]
     assert first_messages[0].metadata.template_source == "Hello, {{user}}."
 
     await screen._character._apply_console_character_choice_async(
-        ConsoleCharacterChoice(character_id=8, name="Brynn", placement="current")
+        ConsoleCharacterChoice(character_id=8, name="Brynn", placement="swap")
     )
 
     assert session.character_name == "Brynn"

--- a/Tests/UI/test_character_session_prompt_seed.py
+++ b/Tests/UI/test_character_session_prompt_seed.py
@@ -25,7 +25,7 @@ from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
-from tldw_chatbook.UI.Screens.chat_screen import _character_session_prompt_seed
+from tldw_chatbook.UI.Console_Modules.session import _character_session_prompt_seed
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
     ConsoleCharacterChoice,
@@ -276,9 +276,11 @@ async def test_character_picker_new_chat_seeds_template_provenance(monkeypatch):
     """The picker-new path must not fall back to ordinary eager greeting text."""
     card = _roleplay_card()
     screen = _character_screen(monkeypatch, card)
-    monkeypatch.setattr(screen, "_fetch_character_card_for_avatar", lambda _id: card)
+    monkeypatch.setattr(
+        screen._character, "_fetch_character_card_for_avatar", lambda _id: card
+    )
 
-    await screen._apply_console_character_choice_async(
+    await screen._character._apply_console_character_choice_async(
         ConsoleCharacterChoice(character_id=7, name="Alraune", placement="new")
     )
 
@@ -296,11 +298,13 @@ async def test_character_picker_keeps_raw_identity_but_sanitizes_notification(mo
     raw_name = "Nyx\n\tAdmin\x00[/bold]"
     card = _roleplay_card(name=raw_name)
     screen = _character_screen(monkeypatch, card)
-    monkeypatch.setattr(screen, "_fetch_character_card_for_avatar", lambda _id: card)
+    monkeypatch.setattr(
+        screen._character, "_fetch_character_card_for_avatar", lambda _id: card
+    )
     notify = MagicMock()
     monkeypatch.setattr(screen.app_instance, "notify", notify)
 
-    await screen._apply_console_character_choice_async(
+    await screen._character._apply_console_character_choice_async(
         ConsoleCharacterChoice(character_id=7, name=raw_name, placement="new")
     )
 
@@ -325,7 +329,9 @@ async def test_character_picker_swap_uses_override_and_only_greets_empty_chat(
     cards = {7: first_card, 8: second_card}
     screen = _character_screen(monkeypatch, first_card)
     monkeypatch.setattr(
-        screen, "_fetch_character_card_for_avatar", lambda card_id: cards[card_id]
+        screen._character,
+        "_fetch_character_card_for_avatar",
+        lambda card_id: cards[card_id],
     )
     store = screen._ensure_console_chat_store()
     session = store.ensure_session(
@@ -337,14 +343,14 @@ async def test_character_picker_swap_uses_override_and_only_greets_empty_chat(
         global_default="Captain Rowan",
     )
 
-    await screen._apply_console_character_choice_async(
+    await screen._character._apply_console_character_choice_async(
         ConsoleCharacterChoice(character_id=7, name="Alraune", placement="current")
     )
     first_messages = store.messages_for_session(session.id)
     assert [message.content for message in first_messages] == ["Hello, Per Chat."]
     assert first_messages[0].metadata.template_source == "Hello, {{user}}."
 
-    await screen._apply_console_character_choice_async(
+    await screen._character._apply_console_character_choice_async(
         ConsoleCharacterChoice(character_id=8, name="Brynn", placement="current")
     )
 

--- a/Tests/UI/test_character_session_prompt_seed.py
+++ b/Tests/UI/test_character_session_prompt_seed.py
@@ -84,9 +84,7 @@ def test_character_alias_macros_resolve_to_character_name():
 
 def test_empty_card_falls_back_to_defaults():
     """An empty card yields the name hint, default prompt, and no greeting."""
-    seed = _character_session_prompt_seed(
-        {}, name_hint="Hinted"
-    )
+    seed = _character_session_prompt_seed({}, name_hint="Hinted")
 
     assert seed.name == "Hinted"
     assert seed.system_template == "Stay in character."
@@ -294,7 +292,9 @@ async def test_character_picker_new_chat_seeds_template_provenance(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_character_picker_keeps_raw_identity_but_sanitizes_notification(monkeypatch):
+async def test_character_picker_keeps_raw_identity_but_sanitizes_notification(
+    monkeypatch,
+):
     raw_name = "Nyx\n\tAdmin\x00[/bold]"
     card = _roleplay_card(name=raw_name)
     screen = _character_screen(monkeypatch, card)

--- a/Tests/UI/test_console_agent_controller.py
+++ b/Tests/UI/test_console_agent_controller.py
@@ -134,7 +134,7 @@ async def test_persisted_run_state_reaches_the_mounted_agent_rail_statics(tmp_pa
         bridge = _bridge_over(db_path)
         console._console_agent_bridge = bridge
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
         # Precondition: nothing live -- the text below can only come from the
@@ -214,7 +214,7 @@ async def test_agent_section_sync_skips_repainting_an_unchanged_payload(tmp_path
 
         console._console_agent_bridge = _bridge_over(db_path)
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
         console._sync_console_agent_section()
@@ -262,7 +262,7 @@ async def test_drilldown_row_click_retargets_the_full_log_to_that_run(
 
         console._console_agent_bridge = _bridge_over(db_path)
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
         # Overview: the affordance targets the conversation's latest primary.
@@ -429,7 +429,7 @@ async def test_drilldown_header_names_the_resumed_from_run(tmp_path):
         await _wait_for_selector(console, pilot, "#console-rail-section-header-agent")
 
         console._console_agent_bridge = _bridge_over(db_path)
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
         console._agent._drill_into_console_agent_subagent(resumed_sub)

--- a/Tests/UI/test_console_agent_rail.py
+++ b/Tests/UI/test_console_agent_rail.py
@@ -621,7 +621,7 @@ async def test_drilldown_falls_back_to_overview_after_conversation_switch():
 
         fake_bridge = _FakeBridge()
         console._console_agent_bridge = fake_bridge
-        console._current_console_rail_conversation_id = lambda: (
+        console._character._current_console_rail_conversation_id = lambda: (
             fake_bridge.active_conversation_id
         )
 
@@ -673,7 +673,7 @@ async def test_drilldown_render_path_rejects_record_from_other_conversation():
                 return AgentLiveSnapshot()
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-active"
+        console._character._current_console_rail_conversation_id = lambda: "conv-active"
         # Bypass the click-handler's own conversation tracking to isolate
         # the render path's independent conversation_id verification.
         console._console_agent_drilldown_run_id = "run-x"
@@ -725,7 +725,7 @@ async def test_drilldown_step_text_grows_with_a_configured_cap_above_eighty(
                 }
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._console_agent_drilldown_run_id = "run-x"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
@@ -784,7 +784,7 @@ async def test_full_log_probe_never_touches_the_bridge_while_collapsed():
 
         console._console_agent_bridge = _FakeBridge()
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
         console._current_console_rail_state = lambda: SimpleNamespace(agent_open=False)
 
@@ -831,7 +831,7 @@ async def test_full_log_probe_is_cached_per_run_id_while_open():
         fake_bridge = _FakeBridge()
         console._console_agent_bridge = fake_bridge
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
         console._current_console_rail_state = lambda: SimpleNamespace(agent_open=True)
 
@@ -885,7 +885,7 @@ async def test_view_full_log_loads_off_thread_then_opens_the_modal():
 
         console._console_agent_bridge = _FakeBridge()
         console._console_agent_drilldown_run_id = None
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
         stack_len_before = len(host.screen_stack)
@@ -1018,7 +1018,7 @@ async def test_clicking_a_specific_subagent_row_drills_into_that_run_directly():
                 )
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
 
         rows = console._agent._console_agent_fleet_rows()
         assert [row.row_id for row in rows] == [
@@ -1084,11 +1084,11 @@ async def test_console_agent_fleet_token_total_sums_live_handles():
                 return list(handles) if conversation_id == "conv-A" else []
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
 
         assert console._agent._console_agent_fleet_token_total() == 350
         # An unrelated conversation id never sees this fleet's spend.
-        console._current_console_rail_conversation_id = lambda: "conv-other"
+        console._character._current_console_rail_conversation_id = lambda: "conv-other"
         assert console._agent._console_agent_fleet_token_total() == 0
 
 
@@ -1125,7 +1125,7 @@ async def test_cancel_console_agent_fleet_row_delegates_to_the_bridge():
                 return True
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
 
         assert console._agent._cancel_console_agent_fleet_row("h1") is True
         assert calls == [("conv-A", "h1")]
@@ -1157,7 +1157,7 @@ async def test_cancel_console_agent_fleet_row_returns_false_with_no_row_id():
                 raise AssertionError("must not be called with an empty row id")
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         assert console._agent._cancel_console_agent_fleet_row("") is False
 
 
@@ -1208,7 +1208,7 @@ async def test_drilldown_shows_a_live_childs_steps_before_they_reach_the_db():
                 )
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._console_agent_drilldown_run_id = "run-child"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
@@ -1261,7 +1261,7 @@ async def test_drilldown_still_prefers_the_persisted_steps_once_they_exist():
                 )
 
         console._console_agent_bridge = _FakeBridge()
-        console._current_console_rail_conversation_id = lambda: "conv-A"
+        console._character._current_console_rail_conversation_id = lambda: "conv-A"
         console._console_agent_drilldown_run_id = "run-child"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 

--- a/Tests/UI/test_console_agent_rail.py
+++ b/Tests/UI/test_console_agent_rail.py
@@ -442,7 +442,9 @@ async def test_agent_section_lines_render_brackets_literally_not_escaped():
 
         console._console_agent_bridge = _FakeBridge()
         console._console_agent_drilldown_run_id = None
-        status_line, steps_text, subagents_text = console._agent._console_agent_section_lines()
+        status_line, steps_text, subagents_text = (
+            console._agent._console_agent_section_lines()
+        )
 
         assert "fetch [docs] ok" in steps_text
         assert "\\[" not in steps_text
@@ -489,7 +491,9 @@ async def test_agent_section_falls_back_to_historical_snapshot_when_live_is_idle
 
         console._console_agent_bridge = _FakeBridge()
         console._console_agent_drilldown_run_id = None
-        status_line, steps_text, subagents_text = console._agent._console_agent_section_lines()
+        status_line, steps_text, subagents_text = (
+            console._agent._console_agent_section_lines()
+        )
 
         assert status_line == "Agent: done"
         assert "Paris" in steps_text
@@ -729,15 +733,13 @@ async def test_drilldown_step_text_grows_with_a_configured_cap_above_eighty(
         console._console_agent_drilldown_run_id = "run-x"
         console._agent._console_agent_drilldown_conversation_id = "conv-A"
 
-        monkeypatch.setattr(
-            "tldw_chatbook.config.get_cli_setting", lambda *a, **k: 40
-        )
+        monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", lambda *a, **k: 40)
         _status, steps_at_40, _subagents = console._agent._console_agent_section_lines()
 
-        monkeypatch.setattr(
-            "tldw_chatbook.config.get_cli_setting", lambda *a, **k: 300
+        monkeypatch.setattr("tldw_chatbook.config.get_cli_setting", lambda *a, **k: 300)
+        _status, steps_at_300, _subagents = (
+            console._agent._console_agent_section_lines()
         )
-        _status, steps_at_300, _subagents = console._agent._console_agent_section_lines()
 
         # A bare `[:80]` slice (the pre-fix behavior) would make BOTH of
         # these identical (both capped at 80) regardless of the configured
@@ -1066,16 +1068,28 @@ async def test_console_agent_fleet_token_total_sums_live_handles():
 
         handles = (
             FleetHandle(
-                handle_id="h1", run_id="run-1", agent="a", task="t1",
-                status="done", total_tokens=100,
+                handle_id="h1",
+                run_id="run-1",
+                agent="a",
+                task="t1",
+                status="done",
+                total_tokens=100,
             ),
             FleetHandle(
-                handle_id="h2", run_id="run-2", agent="a", task="t2",
-                status="running", total_tokens=0,
+                handle_id="h2",
+                run_id="run-2",
+                agent="a",
+                task="t2",
+                status="running",
+                total_tokens=0,
             ),
             FleetHandle(
-                handle_id="h3", run_id="run-3", agent="a", task="t3",
-                status="done", total_tokens=250,
+                handle_id="h3",
+                run_id="run-3",
+                agent="a",
+                task="t3",
+                status="done",
+                total_tokens=250,
             ),
         )
 
@@ -1202,9 +1216,7 @@ async def test_drilldown_shows_a_live_childs_steps_before_they_reach_the_db():
                 return AgentLiveSnapshot(
                     status="running",
                     step=2,
-                    steps=(
-                        AgentLiveStep("tool_result", "read notes.md", "subagent"),
-                    ),
+                    steps=(AgentLiveStep("tool_result", "read notes.md", "subagent"),),
                 )
 
         console._console_agent_bridge = _FakeBridge()

--- a/Tests/UI/test_console_changed_files_wiring.py
+++ b/Tests/UI/test_console_changed_files_wiring.py
@@ -63,9 +63,7 @@ def _disable_turn_file_cards(monkeypatch) -> None:
         console_transcript_module,
         "get_cli_setting",
         lambda section, key, default=None: (
-            False
-            if (section, key) == ("console", "turn_file_cards")
-            else default
+            False if (section, key) == ("console", "turn_file_cards") else default
         ),
     )
 
@@ -124,7 +122,9 @@ def workspace_fixture(tmp_path) -> _Workspace:
     return _Workspace(root, service, tracker, db)
 
 
-async def _mount_console_session(pilot, console, store, ws: _Workspace, *, conv_id=CONV_ID):
+async def _mount_console_session(
+    pilot, console, store, ws: _Workspace, *, conv_id=CONV_ID
+):
     """Wait for the composer, create + activate a persisted-looking session,
     wire a REAL provider bridge, return the session.
     """
@@ -154,7 +154,10 @@ async def test_section_renders_aggregated_entries_after_worker_lands(workspace_f
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -188,7 +191,10 @@ async def test_guard_skips_idle_ticks_and_recomputes_once_on_new_marker(
     ws = workspace_fixture
     run1 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run1,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run1,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -235,7 +241,10 @@ async def test_guard_skips_idle_ticks_and_recomputes_once_on_new_marker(
 
         run2 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
         _record_turn(
-            ws.db, ws.tracker, ws.root, run2,
+            ws.db,
+            ws.tracker,
+            ws.root,
+            run2,
             lambda: (ws.root / "a.py").write_text("line1\nCHANGED AGAIN\n"),
         )
         store.append_message(
@@ -265,7 +274,10 @@ async def test_notes_changed_message_resets_guard_without_clearing_summary(
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -334,7 +346,10 @@ async def test_conversation_switch_clears_memo_and_summary_synchronously(
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -386,7 +401,10 @@ async def test_stale_worker_land_after_conversation_switch_does_not_clobber_summ
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -444,7 +462,10 @@ async def test_file_selected_opens_review_screen_with_matching_initials(
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
     provider = AgentRunsChangeReviewProvider(
@@ -484,7 +505,10 @@ async def test_config_off_renders_nothing_and_never_dispatches_worker(
     ws = workspace_fixture
     run_id = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run_id,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run_id,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -501,7 +525,9 @@ async def test_config_off_renders_nothing_and_never_dispatches_worker(
     # Surgical: only the section's own gate, never the whole module's
     # `get_cli_setting` (dozens of unrelated lookups run in the same tick).
     monkeypatch.setattr(
-        ChatScreen, "_console_changed_files_section_enabled", staticmethod(lambda: False)
+        ChatScreen,
+        "_console_changed_files_section_enabled",
+        staticmethod(lambda: False),
     )
 
     app = _build_test_app()
@@ -543,7 +569,10 @@ async def test_row_cache_skips_git_for_already_seen_rows_on_note_mutation_refres
     ws = workspace_fixture
     run1 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run1,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run1,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -583,9 +612,7 @@ async def test_row_cache_skips_git_for_already_seen_rows_on_note_mutation_refres
             # append-before-call signal fired too early once and produced
             # a real, reproduced flake (the row-cache assertions below ran
             # against a still-in-flight recompute).
-            result = original_conversation_changed_files(
-                self, row_cache=row_cache
-            )
+            result = original_conversation_changed_files(self, row_cache=row_cache)
             recompute_calls.append(1)
             return result
 
@@ -621,7 +648,10 @@ async def test_row_cache_skips_git_for_already_seen_rows_on_note_mutation_refres
         # A NEW turn's refresh must compute ONLY the new row.
         run2 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
         _record_turn(
-            ws.db, ws.tracker, ws.root, run2,
+            ws.db,
+            ws.tracker,
+            ws.root,
+            run2,
             lambda: (ws.root / "a.py").write_text("line1\nCHANGED AGAIN\n"),
         )
         store.append_message(
@@ -659,7 +689,10 @@ async def test_worker_failure_leaves_stale_state_and_sync_loop_recovers(
     ws = workspace_fixture
     run1 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
     _record_turn(
-        ws.db, ws.tracker, ws.root, run1,
+        ws.db,
+        ws.tracker,
+        ws.root,
+        run1,
         lambda: (ws.root / "a.py").write_text("line1\nCHANGED\n"),
     )
 
@@ -692,7 +725,10 @@ async def test_worker_failure_leaves_stale_state_and_sync_loop_recovers(
 
         run2 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
         _record_turn(
-            ws.db, ws.tracker, ws.root, run2,
+            ws.db,
+            ws.tracker,
+            ws.root,
+            run2,
             lambda: (ws.root / "a.py").write_text("line1\nCHANGED AGAIN\n"),
         )
         store.append_message(
@@ -734,7 +770,10 @@ async def test_worker_failure_leaves_stale_state_and_sync_loop_recovers(
         monkeypatch.undo()
         run3 = ws.db.create_run(conversation_id=CONV_ID, agent_kind="primary")
         _record_turn(
-            ws.db, ws.tracker, ws.root, run3,
+            ws.db,
+            ws.tracker,
+            ws.root,
+            run3,
             lambda: (ws.root / "a.py").write_text("line1\nTHIRD CHANGE\n"),
         )
         store.append_message(

--- a/Tests/UI/test_console_changed_files_wiring.py
+++ b/Tests/UI/test_console_changed_files_wiring.py
@@ -416,7 +416,7 @@ async def test_stale_worker_land_after_conversation_switch_does_not_clobber_summ
         session2 = store.create_session(session_id="conv-wiring-stale-2")
         session2.persisted_conversation_id = "conv-wiring-stale-2"
         assert (
-            console._current_console_rail_conversation_id()
+            console._character._current_console_rail_conversation_id()
             == "conv-wiring-stale-2"
         )
 

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -102,28 +102,42 @@ def _resolution(
 
 
 def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
-    """Build a native-console screen shell for direct accessor calls.
-
-    See ``Tests/UI/test_console_native_chat_flow.py::_bare_console_screen``
-    for the rationale (bypasses ``ChatScreen.__init__``).
-    """
+    """Build a screen shell around the real character-controller seam."""
     screen = ChatScreen.__new__(ChatScreen)
     screen._retrieval = object.__new__(ConsoleRetrievalController)
     screen._retrieval._capture_console_staged_rag = AsyncMock()
-    screen._retrieval._current_conversation_id = (
-        lambda: screen._current_console_rail_conversation_id()
+    screen._retrieval._current_conversation_id = lambda: (
+        screen._character._current_console_rail_conversation_id()
     )
-    screen._character = ConsoleCharacterController.__new__(ConsoleCharacterController)
-    screen._character._active_character_avatar = None
-    screen._character._active_character_avatar_name = None
-    screen._character._last_console_avatar_scope = None
-    screen._character._console_expression_spec_cache = {}
-    screen._console_chat_store = store
-    screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
-    screen._session._chat_store_accessor = lambda: screen._console_chat_store
-    screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
-    screen._console_visible_draft_session_id = None
-    screen._console_composer_or_none = lambda: None
+
+    def active_session():
+        active_id = store.active_session_id
+        return next(
+            (session for session in store.sessions() if session.id == active_id),
+            None,
+        )
+
+    screen._character = ConsoleCharacterController(
+        app_config_accessor=lambda: {},
+        chat_store_accessor=lambda: store,
+        active_native_session_accessor=active_session,
+        current_conversation_id_accessor=lambda: None,
+        character_db_accessor=lambda: None,
+        ensure_chat_store=lambda: store,
+        provider_readiness_config_accessor=lambda: {},
+        default_session_settings=lambda: SimpleNamespace(),
+        swap_session_character=lambda *_args, **_kwargs: False,
+        sync_temporary_chip=lambda: None,
+        sync_native_chat_ui=AsyncMock(),
+        notify=lambda *_args, **_kwargs: None,
+        actor_scope_accessor=lambda: None,
+        manual_reaction_key=lambda _scope: None,
+        resolve_visual_identity=lambda *_args: None,
+        ensure_console_image_view=lambda: (None, None),
+        console_image_default_mode=lambda: None,
+        is_mounted=lambda: False,
+        render_character_avatar=AsyncMock(),
+    )
     return screen
 
 
@@ -148,16 +162,16 @@ def test_current_console_rail_character_id_reads_active_session():
     )
     screen = _bare_console_screen(_store_with_session(session))
 
-    assert screen._current_console_rail_character_id() == 7
-    assert screen._current_console_rail_character_name() == "Ada"
+    assert screen._character._current_console_rail_character_id() == 7
+    assert screen._character._current_console_rail_character_name() == "Ada"
 
 
 def test_current_console_rail_character_id_none_for_generic_session():
     session = ConsoleChatSession(id="session-a")
     screen = _bare_console_screen(_store_with_session(session))
 
-    assert screen._current_console_rail_character_id() is None
-    assert screen._current_console_rail_character_name() is None
+    assert screen._character._current_console_rail_character_id() is None
+    assert screen._character._current_console_rail_character_name() is None
 
 
 def test_p3c_leaves_dictionary_scope_ids_unchanged():
@@ -430,8 +444,8 @@ async def test_refresh_populates_avatar_cache_and_mounts(console_screen_with_db)
 
     # unchanged scope -> no re-fetch (spy the DB fetch)
     calls = []
-    orig = screen._fetch_character_card_for_avatar  # the off-thread fetch wrapper
-    screen._fetch_character_card_for_avatar = lambda cid: (
+    orig = screen._character._fetch_character_card_for_avatar
+    screen._character._fetch_character_card_for_avatar = lambda cid: (
         calls.append(cid),
         orig(cid),
     )[1]
@@ -562,8 +576,8 @@ async def test_refresh_skips_db_fetch_when_config_off(
     _set_active_console_character(screen, char_id, "Ada")
 
     calls = []
-    orig = screen._fetch_character_card_for_avatar
-    screen._fetch_character_card_for_avatar = lambda cid: (
+    orig = screen._character._fetch_character_card_for_avatar
+    screen._character._fetch_character_card_for_avatar = lambda cid: (
         calls.append(cid),
         orig(cid),
     )[1]

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -191,7 +191,9 @@ def test_p3c_leaves_dictionary_scope_ids_unchanged():
     )
     screen = _bare_console_screen(_store_with_session(session))
 
-    conversation_id, character_id = screen._retrieval._active_console_dictionary_scope_ids()
+    conversation_id, character_id = (
+        screen._retrieval._active_console_dictionary_scope_ids()
+    )
     assert conversation_id == "conv-1"
     assert character_id is None
 
@@ -878,7 +880,9 @@ async def test_personas_publication_targets_mounted_console_cache_before_return(
 ):
     _app, console, _db = console_screen_with_db
     invalidate = AsyncMock()
-    monkeypatch.setattr(console._session, "invalidate_visual_identity_actor", invalidate)
+    monkeypatch.setattr(
+        console._session, "invalidate_visual_identity_actor", invalidate
+    )
     owner = SimpleNamespace(app=SimpleNamespace(screen_stack=(console,)))
     result = VisualIdentityPublicationResult(
         actor_kind="character",

--- a/Tests/UI/test_console_character_controller.py
+++ b/Tests/UI/test_console_character_controller.py
@@ -49,6 +49,8 @@ def _controller(**overrides: Any) -> ConsoleCharacterController:
 
 
 def test_character_picker_projection_is_bounded_and_fail_closed() -> None:
+    long_description = "b" * 201
+
     class CharacterDb:
         def list_character_cards(self, *, limit: int) -> list[dict[str, object]]:
             assert limit == 500
@@ -56,7 +58,7 @@ def test_character_picker_projection_is_bounded_and_fail_closed() -> None:
                 {"id": "7", "name": "  Alraune  ", "description": "forest"},
                 {"id": None, "name": "Missing identity"},
                 {"id": 8, "name": ""},
-                {"id": 9, "name": "Brynn", "description": None},
+                {"id": 9, "name": "Brynn", "description": long_description},
             ]
 
         def get_character_card_by_id(self, character_id: int) -> dict[str, object]:
@@ -70,7 +72,7 @@ def test_character_picker_projection_is_bounded_and_fail_closed() -> None:
         ConsoleCharacterOption(
             character_id=9,
             name="Brynn",
-            description="",
+            description="b" * 200,
         ),
     )
     assert controller._fetch_character_card_for_avatar(7) == {
@@ -216,7 +218,7 @@ async def test_current_character_choice_uses_named_swap_edge() -> None:
         ConsoleCharacterChoice(
             character_id=8,
             name="Brynn",
-            placement="current",
+            placement="swap",
         )
     )
 

--- a/Tests/UI/test_console_character_controller.py
+++ b/Tests/UI/test_console_character_controller.py
@@ -1,0 +1,229 @@
+"""No-mount behavior contract for the Console character controller."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
+from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
+    ConsoleCharacterChoice,
+    ConsoleCharacterOption,
+)
+
+
+async def _noop_async(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+def _controller(**overrides: Any) -> ConsoleCharacterController:
+    """Build the real controller with plain late-bound test edges."""
+
+    dependencies: dict[str, Any] = {
+        "app_config_accessor": lambda: {},
+        "chat_store_accessor": lambda: None,
+        "active_native_session_accessor": lambda: None,
+        "current_conversation_id_accessor": lambda: None,
+        "character_db_accessor": lambda: None,
+        "ensure_chat_store": ConsoleChatStore,
+        "provider_readiness_config_accessor": lambda: {},
+        "default_session_settings": lambda: ConsoleSessionSettings(),
+        "swap_session_character": lambda *_args, **_kwargs: False,
+        "sync_temporary_chip": lambda: None,
+        "sync_native_chat_ui": _noop_async,
+        "notify": lambda *_args, **_kwargs: None,
+        "actor_scope_accessor": lambda: None,
+        "manual_reaction_key": lambda _scope: None,
+        "resolve_visual_identity": lambda *_args: None,
+        "ensure_console_image_view": lambda: (None, None),
+        "console_image_default_mode": lambda: "pixels",
+        "is_mounted": lambda: False,
+        "render_character_avatar": _noop_async,
+    }
+    dependencies.update(overrides)
+    return ConsoleCharacterController(**dependencies)
+
+
+def test_character_picker_projection_is_bounded_and_fail_closed() -> None:
+    class CharacterDb:
+        def list_character_cards(self, *, limit: int) -> list[dict[str, object]]:
+            assert limit == 500
+            return [
+                {"id": "7", "name": "  Alraune  ", "description": "forest"},
+                {"id": None, "name": "Missing identity"},
+                {"id": 8, "name": ""},
+                {"id": 9, "name": "Brynn", "description": None},
+            ]
+
+        def get_character_card_by_id(self, character_id: int) -> dict[str, object]:
+            assert character_id == 7
+            return {"id": character_id, "name": "Alraune"}
+
+    controller = _controller(character_db_accessor=CharacterDb)
+
+    assert controller._console_character_picker_options() == (
+        ConsoleCharacterOption(character_id=7, name="Alraune", description="forest"),
+        ConsoleCharacterOption(
+            character_id=9,
+            name="Brynn",
+            description="",
+        ),
+    )
+    assert controller._fetch_character_card_for_avatar(7) == {
+        "id": 7,
+        "name": "Alraune",
+    }
+
+    class FailingDb:
+        def list_character_cards(self, *, limit: int) -> list[dict[str, object]]:
+            raise RuntimeError(limit)
+
+        def get_character_card_by_id(self, character_id: int) -> dict[str, object]:
+            raise RuntimeError(character_id)
+
+    controller._character_db_accessor = FailingDb
+    assert controller._console_character_picker_options() == ()
+    assert controller._fetch_character_card_for_avatar(7) is None
+
+
+def test_character_identity_reads_active_session_and_conversation_fallback() -> None:
+    active = SimpleNamespace(
+        persisted_conversation_id="conversation-A",
+        character_name="Alraune",
+        local_character_id=lambda: 7,
+    )
+    current = active
+    controller = _controller(
+        active_native_session_accessor=lambda: current,
+        current_conversation_id_accessor=lambda: "fallback-conversation",
+    )
+
+    assert controller._current_console_rail_conversation_id() == "conversation-A"
+    assert controller._current_console_rail_character_id() == 7
+    assert controller._current_console_rail_character_name() == "Alraune"
+
+    current = None
+    assert controller._current_console_rail_conversation_id() == (
+        "fallback-conversation"
+    )
+    assert controller._current_console_rail_character_id() is None
+    assert controller._current_console_rail_character_name() is None
+
+
+@pytest.mark.asyncio
+async def test_new_character_choice_preserves_prompt_seed_and_sync_order() -> None:
+    store = ConsoleChatStore()
+    notifications: list[tuple[str, str | None]] = []
+    syncs: list[str] = []
+    card = {
+        "id": 7,
+        "name": "Alraune",
+        "system_prompt": "Protect {{user}} as {{character}}.",
+        "first_message": "Hello, {{user}}.",
+    }
+
+    async def sync_ui() -> None:
+        syncs.append("ui")
+
+    controller = _controller(
+        chat_store_accessor=lambda: store,
+        character_db_accessor=lambda: SimpleNamespace(
+            get_character_card_by_id=lambda character_id: (
+                card if character_id == 7 else None
+            )
+        ),
+        ensure_chat_store=lambda: store,
+        provider_readiness_config_accessor=lambda: {
+            "chat_defaults": {"user_display_name": "Captain Rowan"}
+        },
+        default_session_settings=lambda: ConsoleSessionSettings(
+            provider="openai",
+            model="gpt-4.1",
+        ),
+        sync_temporary_chip=lambda: syncs.append("temporary"),
+        sync_native_chat_ui=sync_ui,
+        notify=lambda message, severity=None: notifications.append((message, severity)),
+    )
+
+    await controller._apply_console_character_choice_async(
+        ConsoleCharacterChoice(
+            character_id=7,
+            name="Alraune",
+            placement="new",
+        )
+    )
+
+    session = store.switch_session(store.active_session_id)
+    assert session.character_id == 7
+    assert session.character_name == "Alraune"
+    assert session.settings.system_prompt == "Protect Captain Rowan as Alraune."
+    messages = store.messages_for_session(session.id)
+    assert [message.content for message in messages] == ["Hello, Captain Rowan."]
+    assert syncs == ["temporary", "ui"]
+    assert notifications == [("Started a new chat with Alraune.", None)]
+
+
+@pytest.mark.asyncio
+async def test_current_character_choice_uses_named_swap_edge() -> None:
+    store = ConsoleChatStore()
+    session = store.ensure_session(
+        settings=ConsoleSessionSettings(provider="openai", model="gpt-4.1")
+    )
+    store.set_session_user_display_name_override(
+        session.id,
+        "Per Chat",
+        global_default="Global User",
+    )
+    card = {
+        "id": 8,
+        "name": "Brynn",
+        "system_prompt": "Guard {{user}} beside {{character}}.",
+        "first_message": "Hello, {{user}}.",
+    }
+    swaps: list[tuple[object, int, str, str]] = []
+    syncs: list[str] = []
+    notifications: list[tuple[str, str | None]] = []
+
+    def swap(
+        actual_store: ConsoleChatStore,
+        character_id: int,
+        seed: Any,
+        *,
+        global_default: str,
+    ) -> bool:
+        swaps.append((actual_store, character_id, seed.system_prompt, global_default))
+        return True
+
+    controller = _controller(
+        chat_store_accessor=lambda: store,
+        character_db_accessor=lambda: SimpleNamespace(
+            get_character_card_by_id=lambda _character_id: card
+        ),
+        ensure_chat_store=lambda: store,
+        provider_readiness_config_accessor=lambda: {
+            "chat_defaults": {"user_display_name": "Global User"}
+        },
+        swap_session_character=swap,
+        sync_native_chat_ui=lambda: _record_async(syncs, "ui"),
+        notify=lambda message, severity=None: notifications.append((message, severity)),
+    )
+
+    await controller._apply_console_character_choice_async(
+        ConsoleCharacterChoice(
+            character_id=8,
+            name="Brynn",
+            placement="current",
+        )
+    )
+
+    assert swaps == [(store, 8, "Guard Per Chat beside Brynn.", "Global User")]
+    assert syncs == ["ui"]
+    assert notifications == [("This chat now uses Brynn.", None)]
+
+
+async def _record_async(records: list[str], value: str) -> None:
+    records.append(value)

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -765,11 +765,11 @@ async def test_character_picker_new_chat_clears_a_stale_temporary_chip():
 
         # Bypass the real character-card DB lookup (irrelevant to this
         # regression) while exercising the real create/switch/notify body.
-        console._fetch_character_card_for_avatar = lambda character_id: {
+        console._character._fetch_character_card_for_avatar = lambda character_id: {
             "name": "Nova",
             "first_message": "",
         }
-        await console._apply_console_character_choice_async(
+        await console._character._apply_console_character_choice_async(
             ConsoleCharacterChoice(character_id=1, name="Nova", placement="new")
         )
         await pilot.pause()

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -230,9 +230,7 @@ def test_workspace_resolves_the_session_sibling_at_call_time():
     """
     screen = _unmounted_console()
     sentinel = object()
-    screen._session = SimpleNamespace(
-        _current_console_conversation_id=lambda: sentinel
-    )
+    screen._session = SimpleNamespace(_current_console_conversation_id=lambda: sentinel)
 
     assert screen._workspace._current_conversation_id_accessor() is sentinel
 
@@ -300,6 +298,4 @@ def test_prompts_resolves_the_session_sibling_at_call_time():
         _ensure_active_console_session_settings=lambda: sentinel
     )
 
-    assert (
-        screen._prompts._ensure_active_console_session_settings_fn() is sentinel
-    )
+    assert screen._prompts._ensure_active_console_session_settings_fn() is sentinel

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -36,6 +36,7 @@ from types import SimpleNamespace
 import pytest
 
 from Tests.UI.test_destination_shells import _build_test_app
+from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
 from tldw_chatbook.UI.Console_Modules.dictation import ConsoleDictationController
 from tldw_chatbook.UI.Console_Modules.hands_free import ConsoleHandsFreeController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
@@ -90,8 +91,30 @@ def test_retrieval_controller_is_constructed_with_late_bound_screen_edges():
 
     assert isinstance(screen._retrieval, ConsoleRetrievalController)
     sentinel = object()
-    screen._current_console_rail_conversation_id = lambda: sentinel
+    screen._character._current_console_rail_conversation_id = lambda: sentinel
     assert screen._retrieval._current_conversation_id() is sentinel
+
+
+def test_character_controller_is_constructed_with_late_bound_screen_edges():
+    """Wave 6 wires `_character` without changing the six-slot contract."""
+    screen = _unmounted_console()
+
+    assert isinstance(screen._character, ConsoleCharacterController)
+    native_session = object()
+    conversation_id = object()
+    default_settings = object()
+    character_db = object()
+    screen._session = SimpleNamespace(
+        _active_native_console_session=lambda: native_session,
+        _current_console_conversation_id=lambda: conversation_id,
+        _default_console_session_settings=lambda: default_settings,
+    )
+    screen.app_instance.chachanotes_db = character_db
+
+    assert screen._character._active_native_session_accessor() is native_session
+    assert screen._character._current_conversation_id_accessor() is conversation_id
+    assert screen._character._default_session_settings() is default_settings
+    assert screen._character._character_db_accessor() is character_db
 
 
 def test_skill_controller_is_constructed_with_late_bound_screen_edges():

--- a/Tests/UI/test_console_fleet_panel.py
+++ b/Tests/UI/test_console_fleet_panel.py
@@ -119,7 +119,7 @@ async def _setup_console(pilot, host, bridge, *, conversation_id: str = "conv-A"
     await _wait_for_selector(console, pilot, "#console-rail-section-header-agent")
     console._console_agent_bridge = bridge
     console._console_agent_drilldown_run_id = None
-    console._current_console_rail_conversation_id = lambda: conversation_id
+    console._character._current_console_rail_conversation_id = lambda: conversation_id
     console._agent._console_agent_drilldown_conversation_id = conversation_id
     console._set_console_rail_preference(
         section_updates={"agent": True}, notify_on_failure=False

--- a/Tests/UI/test_console_fleet_panel.py
+++ b/Tests/UI/test_console_fleet_panel.py
@@ -205,9 +205,7 @@ async def test_state_1_summary_line_shows_glyph_cluster_and_working_done_counts(
         # (Task 3's own mutation-testing lesson: a structural assertion
         # alone can pass vacuously against a broken `.update()` call).
         assert (
-            _static_text(
-                console, f"#console-inspector-section-{_SECTION_ID}-summary"
-            )
+            _static_text(console, f"#console-inspector-section-{_SECTION_ID}-summary")
             == "●●✓ 2 working, 1 done"
         )
         summary_static = console.query_one(
@@ -219,31 +217,56 @@ async def test_state_1_summary_line_shows_glyph_cluster_and_working_done_counts(
 
 @pytest.mark.asyncio
 async def test_state_1_summary_counts_every_terminal_status_as_done_not_just_literal_done():
-    """"Working" is `status == "running"`; every other status this
+    """ "Working" is `status == "running"`; every other status this
     codebase's fleet vocabulary uses (`done`/`error`/`stuck`/`cancelled` --
     see `SubAgentSummary.status`'s own docstring, and `TERMINAL_RUN_
     STATUSES`) is terminal, i.e. counted as "done" in the summary's second
     bucket -- not just a literal `status == "done"` check."""
     handles = (
         FleetHandle(
-            handle_id="h1", run_id="run-1", agent="a", task="t1", status="running",
+            handle_id="h1",
+            run_id="run-1",
+            agent="a",
+            task="t1",
+            status="running",
             started_at=1000.0,
         ),
         FleetHandle(
-            handle_id="h2", run_id="run-2", agent="a", task="t2", status="done",
-            started_at=1000.0, finished_at=1001.0,
+            handle_id="h2",
+            run_id="run-2",
+            agent="a",
+            task="t2",
+            status="done",
+            started_at=1000.0,
+            finished_at=1001.0,
         ),
         FleetHandle(
-            handle_id="h3", run_id="run-3", agent="a", task="t3", status="error",
-            error="boom", started_at=1000.0, finished_at=1001.0,
+            handle_id="h3",
+            run_id="run-3",
+            agent="a",
+            task="t3",
+            status="error",
+            error="boom",
+            started_at=1000.0,
+            finished_at=1001.0,
         ),
         FleetHandle(
-            handle_id="h4", run_id="run-4", agent="a", task="t4", status="cancelled",
-            started_at=1000.0, finished_at=1001.0,
+            handle_id="h4",
+            run_id="run-4",
+            agent="a",
+            task="t4",
+            status="cancelled",
+            started_at=1000.0,
+            finished_at=1001.0,
         ),
         FleetHandle(
-            handle_id="h5", run_id="run-5", agent="a", task="t5", status="stuck",
-            started_at=1000.0, finished_at=1001.0,
+            handle_id="h5",
+            run_id="run-5",
+            agent="a",
+            task="t5",
+            status="stuck",
+            started_at=1000.0,
+            finished_at=1001.0,
         ),
     )
     bridge = _FleetBridge(handles)
@@ -394,16 +417,28 @@ async def test_clicking_the_last_row_drills_into_that_child_directly_not_via_a_c
     happened to be "next" from wherever the cursor was) to reach it."""
     handles = (
         FleetHandle(
-            handle_id="h1", run_id="run-1", agent="researcher", task="t1",
-            status="running", started_at=1000.0,
+            handle_id="h1",
+            run_id="run-1",
+            agent="researcher",
+            task="t1",
+            status="running",
+            started_at=1000.0,
         ),
         FleetHandle(
-            handle_id="h2", run_id="run-2", agent="writer", task="t2",
-            status="running", started_at=1000.0,
+            handle_id="h2",
+            run_id="run-2",
+            agent="writer",
+            task="t2",
+            status="running",
+            started_at=1000.0,
         ),
         FleetHandle(
-            handle_id="h3", run_id="run-3", agent="reviewer", task="t3",
-            status="running", started_at=1000.0,
+            handle_id="h3",
+            run_id="run-3",
+            agent="reviewer",
+            task="t3",
+            status="running",
+            started_at=1000.0,
         ),
     )
     bridge = _FleetBridge(handles)
@@ -434,12 +469,20 @@ async def test_clicking_the_first_row_drills_into_that_child_directly():
     only the position a cycling cursor would land on next."""
     handles = (
         FleetHandle(
-            handle_id="h1", run_id="run-1", agent="researcher", task="t1",
-            status="running", started_at=1000.0,
+            handle_id="h1",
+            run_id="run-1",
+            agent="researcher",
+            task="t1",
+            status="running",
+            started_at=1000.0,
         ),
         FleetHandle(
-            handle_id="h2", run_id="run-2", agent="writer", task="t2",
-            status="running", started_at=1000.0,
+            handle_id="h2",
+            run_id="run-2",
+            agent="writer",
+            task="t2",
+            status="running",
+            started_at=1000.0,
         ),
     )
     bridge = _FleetBridge(handles)

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -58,6 +58,7 @@ from tldw_chatbook.Chat.console_provider_gateway import (
 from tldw_chatbook.Chat.console_project_instructions import (
     ProjectInstructionControlState,
 )
+from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
@@ -74,6 +75,7 @@ from tldw_chatbook.UI.Screens.chat_screen import (
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
 import tldw_chatbook.UI.Console_Modules.message as message_module
 import tldw_chatbook.UI.Console_Modules.session as session_module
+from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
@@ -10050,6 +10052,7 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
             suitable for unit-level serialize/restore round-trip testing.
     """
     screen = ChatScreen.__new__(ChatScreen)
+    screen._console_runtime_ref = ConsoleRuntime(None)
     screen._console_chat_store = store
     # A bare, uninitialized `ConsoleSessionController` -- `__init__` was
     # never run, so every OTHER dependency is unset by default. Only the
@@ -10064,6 +10067,10 @@ def _bare_console_screen(store: ConsoleChatStore) -> ChatScreen:
     screen._session = ConsoleSessionController.__new__(ConsoleSessionController)
     screen._session._chat_store_accessor = lambda: screen._console_chat_store
     screen._session._current_chat_store_accessor = lambda: screen._console_chat_store
+    screen._character = ConsoleCharacterController.__new__(ConsoleCharacterController)
+    screen._character._active_native_session_accessor = lambda: (
+        screen._session._active_native_console_session()
+    )
     screen._console_visible_draft_session_id = None
     screen._console_composer_or_none = lambda: None
     screen._task_resume_state = TaskResumeState()
@@ -10387,7 +10394,7 @@ def test_live_server_session_never_exposes_local_character_projection():
     )
     screen = _bare_console_screen(store)
 
-    assert screen._current_console_rail_character_id() is None
+    assert screen._character._current_console_rail_character_id() is None
 
     payload = _console_snapshot_with_sessions(screen)
     assert payload is not None

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -1868,7 +1868,9 @@ def _console_conversation_browser_rows(console):
     always the dataclass default (``""``). Rebuilding the full context state
     is the seam that actually feeds the rendered row label.
     """
-    browser = console._workspace._build_console_workspace_context_state().conversation_browser
+    browser = (
+        console._workspace._build_console_workspace_context_state().conversation_browser
+    )
     rows = []
     for section in browser.sections:
         rows.extend(section.rows)
@@ -7465,9 +7467,9 @@ async def test_console_conversation_browser_search_ignores_stale_results():
         # found. Rows: [stale-alpha]" while the state already held only
         # fresh-beta. Now a real regression fails here and names itself, and a
         # render that is merely late fails below saying so.
-        assert [row.conversation_id for row in console._console_conversation_browser_rows] == [
-            "fresh-beta"
-        ], "the stale search result overwrote the fresh one"
+        assert [
+            row.conversation_id for row in console._console_conversation_browser_rows
+        ] == ["fresh-beta"], "the stale search result overwrote the fresh one"
 
         await _wait_for_browser_conversation_row(console, pilot, "fresh-beta")
         row_texts = _console_workspace_conversation_texts(console)
@@ -8978,7 +8980,9 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         console._resolve_resumed_character_name = local_lookup
 
         assert (
-            await console._workspace._resume_console_workspace_conversation("server-scoped")
+            await console._workspace._resume_console_workspace_conversation(
+                "server-scoped"
+            )
             is True
         )
         scoped = store.switch_session(store.active_session_id)
@@ -8992,7 +8996,9 @@ async def test_console_resume_restores_server_character_identity_without_local_l
         assert scoped.settings.character_label == ""
 
         assert (
-            await console._workspace._resume_console_workspace_conversation("server-unscoped")
+            await console._workspace._resume_console_workspace_conversation(
+                "server-unscoped"
+            )
             is True
         )
         unscoped = store.switch_session(store.active_session_id)
@@ -9078,7 +9084,9 @@ async def test_console_resume_rejects_character_identity_without_valid_source(
         console._resolve_resumed_character_name = local_lookup
 
         assert (
-            await console._workspace._resume_console_workspace_conversation("invalid-source")
+            await console._workspace._resume_console_workspace_conversation(
+                "invalid-source"
+            )
             is True
         )
 
@@ -9123,7 +9131,9 @@ async def test_console_resume_rehydrates_local_character_name_from_local_project
         console._resolve_resumed_character_name = name_lookup
 
         assert (
-            await console._workspace._resume_console_workspace_conversation("local-character")
+            await console._workspace._resume_console_workspace_conversation(
+                "local-character"
+            )
             is True
         )
 
@@ -12332,9 +12342,9 @@ async def test_console_save_as_savers_confirm_at_success_severity():
     success_toasts = [m for m, severity in notifications if severity == "success"]
     assert "Saved message as Note." in success_toasts
     assert "Saved message as Media. It appears under Library ▸ Media." in success_toasts
-    assert any(
-        m.startswith("Saved message as Prompt '") for m in success_toasts
-    ), success_toasts
+    assert any(m.startswith("Saved message as Prompt '") for m in success_toasts), (
+        success_toasts
+    )
     assert (
         "Saved message as a Chatbook artifact. It appears under Artifacts."
         in success_toasts
@@ -12374,9 +12384,7 @@ async def test_console_retry_accepted_fires_success_toast():
         await _wait_for_selector(
             console, pilot, f"#console-message-action-retry-{failed.id}"
         )
-        success_before = [
-            m for m, severity in notifications if severity == "success"
-        ]
+        success_before = [m for m, severity in notifications if severity == "success"]
         await pilot.click(f"#console-message-action-retry-{failed.id}")
         await _wait_for_text(console, pilot, "recovered")
 
@@ -12452,7 +12460,9 @@ async def test_console_routine_send_fires_no_success_toast():
     app = _build_test_app()
     app.chat_api_provider_value = "llama_cpp"
     app.chat_api_model_value = "test-model"
-    app.console_provider_gateway_factory = lambda: CapturingGateway(chunks=("hel", "lo"))
+    app.console_provider_gateway_factory = lambda: CapturingGateway(
+        chunks=("hel", "lo")
+    )
     notifications = _capture_notify_severities(app)
     host = ConsoleHarness(app)
 

--- a/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
+++ b/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3070.7
 title: Extract Console character controller
-status: To Do
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:09'
-updated_date: '2026-08-13 17:15'
+updated_date: '2026-08-21 08:28'
 labels:
   - console
   - characters
@@ -13,6 +13,8 @@ dependencies:
   - TASK-3070.6
 references:
   - Docs/superpowers/specs/2026-08-13-console-decomposition-wave6-design.md
+  - >-
+    Docs/superpowers/plans/2026-08-21-task-3070-7-console-character-controller.md
 parent_task_id: TASK-3070
 priority: high
 ---
@@ -29,3 +31,13 @@ Move character picker projection, handoff policy, identity, and avatar retrieval
 - [ ] #2 Prompt seed, session handoff, avatar refresh, and rail rendering behavior is unchanged
 - [ ] #3 Isolated controller tests run without mounting Textual
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Freeze latest-dev baseline, inventory, counts, and inherited fixture exception; commit plan/task metadata.
+2. Add RED no-mount controller and exact Wave 6 ownership/non-DOM tests.
+3. Move the six remaining character policy/identity methods into ConsoleCharacterController with named late-bound dependencies; route all production callers directly to _character while modal/worker/pixels stay screen-owned.
+4. Repair only affected fixtures and prove picker, prompt seed/session handoff, avatar refresh, and rail behavior with focused GREEN and mutation evidence.
+5. Run touched-file Ruff/format, py_compile, architecture, diagnostic-inventory, diff, and Ponytail scope review; close task, rebase, PR, address Qodo/CI, and merge.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
+++ b/backlog/tasks/task-3070.7 - Extract-Console-character-controller.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-3070.7
 title: Extract Console character controller
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-13 17:09'
-updated_date: '2026-08-21 08:28'
+updated_date: '2026-08-21 10:32'
 labels:
   - console
   - characters
@@ -27,9 +27,9 @@ Move character picker projection, handoff policy, identity, and avatar retrieval
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Character move inventory is controller-owned and screen/region presentation seams are bounded
-- [ ] #2 Prompt seed, session handoff, avatar refresh, and rail rendering behavior is unchanged
-- [ ] #3 Isolated controller tests run without mounting Textual
+- [x] #1 Character move inventory is controller-owned and screen/region presentation seams are bounded
+- [x] #2 Prompt seed, session handoff, avatar refresh, and rail rendering behavior is unchanged
+- [x] #3 Isolated controller tests run without mounting Textual
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -41,3 +41,17 @@ Move character picker projection, handoff policy, identity, and avatar retrieval
 4. Repair only affected fixtures and prove picker, prompt seed/session handoff, avatar refresh, and rail behavior with focused GREEN and mutation evidence.
 5. Run touched-file Ruff/format, py_compile, architecture, diagnostic-inventory, diff, and Ponytail scope review; close task, rebase, PR, address Qodo/CI, and merge.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended the existing DOM-free `ConsoleCharacterController` instead of adding another abstraction. The controller now owns the full seven-method character inventory: picker projection, choice/session handoff, active rail conversation/character ID and name, character-card retrieval, and the existing scope-sensitive avatar refresh. `ChatScreen` retains only the bounded Textual presentation seams for opening the picker, launching the choice worker, and rendering avatar pixels. Wiring supplies explicit late-bound accessors/callbacks for config, stores, session identity, character DB access, provider readiness/default settings, swap/synchronization, notifications, actor scope, image-view setup, mount state, and avatar rendering; the controller holds no screen reference and performs no DOM query.
+
+Repaired ownership-driven fixtures and caller tests to use the real `_character` seam, including the inherited bare-screen avatar fixture, without adding a production fallback. Production changes are confined to the existing character/session/wiring/screen/agent controller boundary; tests cover the controller, wiring, prompt seed/handoff, avatar, composer menu, rail, fleet, native-chat, changed-files, and Wave 6 inventory contracts. No new ADR was required because this is the direct implementation of the already approved Wave 6 decomposition design.
+
+Evidence was affected-only per the user's explicit constraint; no full suite was run. The clean RED contract produced 6 failed / 1 passed / 1 warning, and the partial-controller continuity checkpoint produced 1 failed / 6 passed / 1 warning before implementation. Fresh post-rebase verification on base `690435d0a54260164eb98b67b6389d39d43a4881` passed the 87-test character matrix, the exact 27 ownership-caller tests, both formerly failing avatar nodes, all 4 mutation-sensitive nodes, and all 6 focused architecture nodes; the final reviewer additionally ran 372 directly affected caller tests successfully. Ruff lint and format checks passed for all 16 changed Python files. Changed production modules compiled under an isolated validated temporary pycache root, which was inspected, removed exactly, and proven absent. `git diff --check` and exact ownership/scope scans were clean.
+
+All four mutation probes went RED for the intended reason and GREEN after immediate inverse restoration: an invalid empty-name picker card exposed ID 8; `new` changed to `swap` prevented session creation; eager DB binding returned the old `None` instead of the replacement sentinel; and a synthetic screen method was reported as still owned by `ChatScreen`. A preliminary empty-system-prompt probe stayed GREEN because roleplay seeding correctly supplied the prompt, so it was discarded and replaced by the discriminating placement mutation. Every path-scoped before/after diff checksum matched exactly: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`; the combined restored probe nodes passed 4 tests with 2 warnings.
+
+The persistent-diagnostic manifest was intentionally not rewritten. Latest `origin/dev` already contains 8 unrelated stale owner deltas; this branch only transfers 3 content-identical calls from `chat_screen.py` to `character.py` (`145 + 1` becomes `142 + 4`). The combined 146-call `(method, digest)` multiset and sink topology are unchanged. Accordingly, the non-write checker remains inherited-red while the metadata-only diagnostic node passes; rewriting the manifest would incorrectly bless unrelated upstream drift. No lesson was added because this task did not surface a new generalizable incident beyond the existing testing and backlog lessons.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -394,7 +394,9 @@ def _fleet_row_from_handle(handle: "FleetHandle", *, now: float) -> InspectorSec
     )
 
 
-def _fleet_row_from_summary(summary: "SubAgentSummary", index: int) -> InspectorSectionRow:
+def _fleet_row_from_summary(
+    summary: "SubAgentSummary", index: int
+) -> InspectorSectionRow:
     """Build one fleet row from a HISTORICAL/resumed ``SubAgentSummary``.
 
     No elapsed segment: unlike a live ``FleetHandle``,
@@ -803,9 +805,7 @@ class ConsoleAgentController:
                         else None
                     )
                     if live_run is not None:
-                        steps = "\n".join(
-                            f"{s.kind}: {s.text}" for s in live_run.steps
-                        )
+                        steps = "\n".join(f"{s.kind}: {s.text}" for s in live_run.steps)
                 # PR3b Task 4: a resumed sub-agent (send_to_agent to a
                 # finished child starts a NEW run seeded with its retained
                 # transcript) carries its lineage in the header. The run
@@ -1233,7 +1233,9 @@ class ConsoleAgentController:
         subagent_runs = getattr(bridge, "subagent_runs", None)
         if subagent_runs is None:
             return ()
-        return tuple(_fleet_row_from_record(record) for record in subagent_runs(conversation_id))
+        return tuple(
+            _fleet_row_from_record(record) for record in subagent_runs(conversation_id)
+        )
 
     def _console_agent_fleet_token_total(self) -> int:
         """Sum the active conversation's LIVE fleet's measured token spend.

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -476,11 +476,10 @@ class ConsoleAgentController:
            `_ensure_console_agent_bridge` only ever `getattr`s off it.
         3. Every **app-level dependency** is a named keyword-only callable,
            wired at the call site as a late-binding lambda -- never a bound
-           method, which would freeze the screen's CURRENT method and stop
-           observing a later `monkeypatch.setattr` on the instance. Two of
-           these are patched by name in the pre-existing suite
-           (`_current_console_rail_conversation_id` and
-           `_current_console_rail_state`, both in
+           method, which would freeze the current target and stop observing
+           a later `monkeypatch.setattr`. The pre-existing suite patches
+           `_current_console_rail_conversation_id` on `screen._character`
+           and `_current_console_rail_state` on the screen (both in
            `Tests/UI/test_console_agent_rail.py`), so this is load-bearing,
            not ceremony.
 
@@ -592,7 +591,7 @@ class ConsoleAgentController:
 
     @property
     def _current_console_rail_conversation_id(self) -> Any:
-        """`ChatScreen._current_console_rail_conversation_id`, by name."""
+        """The character controller's rail-conversation accessor, by name."""
         return self._current_rail_conversation_id
 
     @property

--- a/tldw_chatbook/UI/Console_Modules/character.py
+++ b/tldw_chatbook/UI/Console_Modules/character.py
@@ -1,22 +1,36 @@
-"""Controller-owned Console character avatar refresh orchestration.
+"""Controller-owned Console character policy and avatar orchestration.
 
-The controller owns request snapshots, resolution/cache policy, invalidation,
-and stale-result arbitration.  It intentionally has no screen or DOM handle;
-the final Textual mutation is supplied as one named, fenced callback.
+The controller owns picker projection, session handoff, active identity, card
+retrieval, request snapshots, resolution/cache policy, invalidation, and
+stale-result arbitration.  It intentionally has no screen or DOM handle; the
+framework worker/modal edges and final Textual mutation remain named callbacks.
 """
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import replace
 from typing import Any
 
 from loguru import logger
+from rich.markup import escape as escape_markup
 
+from ...Chat.console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
 from ...Chat.console_expression_state import resolve_console_expression_state
 from ...Chat.console_image_view import (
     resolve_react_character_expressions,
     resolve_show_character_avatar,
+)
+from ...Widgets.Console.console_character_picker_modal import (
+    ConsoleCharacterChoice,
+    ConsoleCharacterOption,
+)
+from ..character_display_text import sanitize_character_display_label
+from .session import (
+    _canonical_card_character_id,
+    _character_session_prompt_seed,
+    _console_global_user_display_name,
 )
 
 _EXPRESSION_SPEC_CACHE_MAX = 16
@@ -35,15 +49,24 @@ AvatarRequest = tuple[
 
 
 class ConsoleCharacterController:
-    """Own non-DOM character-avatar state and refresh decisions."""
+    """Own non-DOM character policy, identity, and avatar decisions."""
 
     def __init__(
         self,
         *,
         app_config_accessor: Callable[[], Mapping[str, Any]],
         chat_store_accessor: Callable[[], Any | None],
+        active_native_session_accessor: Callable[[], Any | None],
+        current_conversation_id_accessor: Callable[[], str | None],
+        character_db_accessor: Callable[[], Any | None],
+        ensure_chat_store: Callable[[], Any],
+        provider_readiness_config_accessor: Callable[[], Mapping[str, Any]],
+        default_session_settings: Callable[[], Any],
+        swap_session_character: Callable[..., bool],
+        sync_temporary_chip: Callable[[], None],
+        sync_native_chat_ui: Callable[[], Awaitable[None]],
+        notify: Callable[..., None],
         actor_scope_accessor: Callable[[], ActorScope | None],
-        character_name_accessor: Callable[[], str | None],
         manual_reaction_key: Callable[[ActorScope], str | None],
         resolve_visual_identity: Callable[[ActorScope, str, str | None], Any | None],
         ensure_console_image_view: Callable[[], tuple[Any, Any]],
@@ -53,8 +76,17 @@ class ConsoleCharacterController:
     ) -> None:
         self._app_config_accessor = app_config_accessor
         self._chat_store_accessor = chat_store_accessor
+        self._active_native_session_accessor = active_native_session_accessor
+        self._current_conversation_id_accessor = current_conversation_id_accessor
+        self._character_db_accessor = character_db_accessor
+        self._ensure_chat_store = ensure_chat_store
+        self._provider_readiness_config_accessor = provider_readiness_config_accessor
+        self._default_session_settings = default_session_settings
+        self._swap_session_character = swap_session_character
+        self._sync_temporary_chip = sync_temporary_chip
+        self._sync_native_chat_ui = sync_native_chat_ui
+        self._notify = notify
         self._actor_scope_accessor = actor_scope_accessor
-        self._character_name_accessor = character_name_accessor
         self._manual_reaction_key = manual_reaction_key
         self._resolve_visual_identity = resolve_visual_identity
         self._ensure_console_image_view = ensure_console_image_view
@@ -69,6 +101,157 @@ class ConsoleCharacterController:
 
     def _live_config(self) -> Mapping[str, Any]:
         return self._app_config_accessor() or {}
+
+    def _console_character_picker_options(
+        self,
+    ) -> tuple[ConsoleCharacterOption, ...]:
+        """Read selectable character cards (worker thread; never raises)."""
+        db = self._character_db_accessor()
+        if db is None:
+            return ()
+        try:
+            cards = db.list_character_cards(limit=500)
+        except Exception:
+            logger.opt(exception=True).warning("Character picker: list failed.")
+            return ()
+        options: list[ConsoleCharacterOption] = []
+        for card in cards or ():
+            card_id = _canonical_card_character_id(card.get("id"))
+            name = str(card.get("name") or "").strip()
+            if card_id is None or not name:
+                continue
+            options.append(
+                ConsoleCharacterOption(
+                    character_id=card_id,
+                    name=name,
+                    description=str(card.get("description") or "")[:200],
+                )
+            )
+        return tuple(options)
+
+    def _current_console_rail_conversation_id(self) -> str | None:
+        """Return the conversation scope used only for rail persistence."""
+        native_session = self._active_native_session_accessor()
+        if native_session is not None:
+            conversation_id = getattr(
+                native_session,
+                "persisted_conversation_id",
+                None,
+            )
+            return str(conversation_id) if conversation_id else None
+        return self._current_conversation_id_accessor()
+
+    def _current_console_rail_character_id(self) -> int | None:
+        """Return the active native session's local character id, if any."""
+        native_session = self._active_native_session_accessor()
+        if native_session is None:
+            return None
+        return native_session.local_character_id()
+
+    def _current_console_rail_character_name(self) -> str | None:
+        """Return the active native session's character name, if any."""
+        native_session = self._active_native_session_accessor()
+        if native_session is None:
+            return None
+        name = getattr(native_session, "character_name", None)
+        return str(name) if name else None
+
+    def _fetch_character_card_for_avatar(self, character_id: int) -> dict | None:
+        """Fetch one character card off-thread, failing soft on DB errors."""
+        db = self._character_db_accessor()
+        if db is None:
+            return None
+        try:
+            return db.get_character_card_by_id(int(character_id))
+        except Exception:
+            logger.opt(exception=True).debug("avatar: character fetch failed")
+            return None
+
+    async def _apply_console_character_choice_async(
+        self,
+        choice: ConsoleCharacterChoice,
+    ) -> None:
+        """Apply a picked character to this session or a fresh one."""
+        card = await asyncio.to_thread(
+            self._fetch_character_card_for_avatar,
+            choice.character_id,
+        )
+        if card is None:
+            display_name = (
+                sanitize_character_display_label(
+                    choice.name,
+                    max_characters=180,
+                )
+                or "that character"
+            )
+            self._notify(
+                f"Could not load {escape_markup(display_name)}.",
+                severity="error",
+            )
+            return
+
+        store = self._ensure_chat_store()
+        global_name = _console_global_user_display_name(
+            self._provider_readiness_config_accessor()
+        )
+        if choice.placement == "new" or store.active_session_id is None:
+            effective_name = global_name
+        else:
+            effective_name = store.presentation_context(
+                store.active_session_id,
+                global_name,
+            ).user_name
+        seed = _character_session_prompt_seed(
+            card,
+            choice.name,
+            user_name=effective_name,
+        )
+        display_name = (
+            sanitize_character_display_label(seed.name, max_characters=180)
+            or "that character"
+        )
+        notification_name = escape_markup(display_name)
+        if choice.placement == "new":
+            settings = replace(
+                self._default_session_settings(),
+                system_prompt=seed.system_prompt,
+            )
+            session = store.create_session(
+                title=f"Chat with {seed.name}",
+                workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+                settings=settings,
+                runtime_backend="local",
+                assistant_kind="character",
+                assistant_id=str(choice.character_id),
+                assistant_authority_id=None,
+                character_id=choice.character_id,
+                character_name=seed.name,
+            )
+            try:
+                store.seed_character_roleplay(
+                    session.id,
+                    system_template=seed.system_template,
+                    greeting_template=seed.greeting_template,
+                    global_default=global_name,
+                )
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Character picker: roleplay template seed failed; continuing."
+                )
+            store.switch_session(session.id)
+            self._sync_temporary_chip()
+            self._notify(f"Started a new chat with {notification_name}.")
+        else:
+            if not self._swap_session_character(
+                store,
+                choice.character_id,
+                seed,
+                global_default=global_name,
+            ):
+                return
+            self._notify(f"This chat now uses {notification_name}.")
+        await self._sync_native_chat_ui()
+        await self._refresh_active_character_avatar_if_scope_changed()
 
     def _current_request(self) -> AvatarRequest:
         config = self._live_config()
@@ -86,7 +269,7 @@ class ConsoleCharacterController:
             session_id,
             react,
             resolve_show_character_avatar(config),
-            self._character_name_accessor(),
+            self._current_console_rail_character_name(),
         )
 
     def _request_is_current(self, request: AvatarRequest) -> bool:

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -167,7 +167,6 @@ from ...Chat.console_project_instructions import (
     decode_project_context_json,
     encode_project_context_json,
 )
-from ...Chat.console_prefill import pinned_prefill_from_conversation_metadata
 from ...Chat.console_session_settings import (
     ConsoleSessionSettings,
     build_console_settings_readiness,
@@ -2661,9 +2660,7 @@ class ConsoleSessionController:
         native_rows.sort(key=lambda row: 0 if row.selected else 1)
         return replace(
             state,
-            conversation_rows=tuple(
-                self._merge_workspace_rows(native_rows, rows)
-            ),
+            conversation_rows=tuple(self._merge_workspace_rows(native_rows, rows)),
         )
 
     # -- Screen-state (de)serialization for one session ----------------------
@@ -2945,9 +2942,7 @@ class ConsoleSessionController:
                         byte_count=metadata.byte_count,
                         outcome=metadata.outcome,
                         warning_code=(
-                            metadata.warning_codes[0]
-                            if metadata.warning_codes
-                            else ""
+                            metadata.warning_codes[0] if metadata.warning_codes else ""
                         ),
                     ),
                 )

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -58,13 +58,12 @@ this cluster's own remaining screen-side callers) use:
 `_default_console_session_settings` needs; `ChatScreen` imports both back --
 `_is_empty_select_value` has its own independent `@on(Select.Changed)`
 consumer, `_has_selected_text` a dozen more, none of them session-shaped),
-and the character-handoff quartet `_canonical_card_character_id`/
+and the character-handoff quintet `_canonical_card_character_id`/
 `_canonical_character_id_text`/`_character_session_identity_from_handoff`/
 `_character_session_prompt_seed`/`_SERVER_CHARACTER_AUTHORITY_PATTERN`
-(`_start_character_console_session`'s own dependencies; `ChatScreen` imports
-back the two of those its own character-PICKER cluster --
-`_console_character_picker_options`/`_apply_console_character_choice_async`,
-which stay screen-side, see below -- still needs).
+(`_start_character_console_session`'s own dependencies; the character
+controller imports the card-id and prompt-seed helpers for its picker and
+session-choice policy).
 
 `_console_active_session_is_ephemeral` is the one exception to "moved for
 real": its IMPLEMENTATION lives here, but `ChatScreen` keeps a one-line

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -908,9 +908,10 @@ def build_console_controllers(
         native_tool_calls_enabled_accessor=(
             lambda: screen._console_native_tool_calls_enabled
         ),
-        # Both of these are replaced by name on the screen instance in
-        # `Tests/UI/test_console_agent_rail.py` (5 and 3 sites), so a bound
-        # method captured here would silently stop observing those patches.
+        # These targets are replaced by name in
+        # `Tests/UI/test_console_agent_rail.py`: the conversation accessor
+        # on `screen._character` and the rail-state accessor on `screen`.
+        # Bound methods captured here would stop observing those patches.
         current_rail_conversation_id=(
             lambda: screen._character._current_console_rail_conversation_id()
         ),

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -173,7 +173,7 @@ def build_console_controllers(
             lambda: screen._session._active_native_console_session()
         ),
         current_conversation_id=(
-            lambda: screen._current_console_rail_conversation_id()
+            lambda: screen._character._current_console_rail_conversation_id()
         ),
         clear_evidence_sent_notice=(
             lambda: screen._clear_console_evidence_sent_notice()
@@ -364,10 +364,38 @@ def build_console_controllers(
                 getattr(screen, "_console_chat_controller", None), "store", None
             )
         ),
+        active_native_session_accessor=(
+            lambda: screen._session._active_native_console_session()
+        ),
+        current_conversation_id_accessor=(
+            lambda: screen._session._current_console_conversation_id()
+        ),
+        character_db_accessor=(
+            lambda: getattr(screen.app_instance, "chachanotes_db", None)
+        ),
+        ensure_chat_store=lambda: screen._ensure_console_chat_store(),
+        provider_readiness_config_accessor=(
+            lambda: screen._provider_readiness_app_config()
+        ),
+        default_session_settings=(
+            lambda: screen._session._default_console_session_settings()
+        ),
+        swap_session_character=(
+            lambda store, character_id, seed, *, global_default: (
+                screen._session._swap_console_session_character(
+                    store,
+                    character_id,
+                    seed,
+                    global_default=global_default,
+                )
+            )
+        ),
+        sync_temporary_chip=lambda: screen._sync_console_temporary_chip(),
+        sync_native_chat_ui=lambda: screen._sync_native_console_chat_ui(),
+        notify=(lambda message, **kwargs: screen.app.notify(message, **kwargs)),
         actor_scope_accessor=(
             lambda: screen._session._current_visual_identity_actor_scope()
         ),
-        character_name_accessor=lambda: screen._current_console_rail_character_name(),
         manual_reaction_key=lambda scope: screen._session._manual_reaction_key(scope),
         resolve_visual_identity=(
             lambda scope, state, manual: screen._session._resolve_visual_identity(
@@ -884,7 +912,7 @@ def build_console_controllers(
         # `Tests/UI/test_console_agent_rail.py` (5 and 3 sites), so a bound
         # method captured here would silently stop observing those patches.
         current_rail_conversation_id=(
-            lambda: screen._current_console_rail_conversation_id()
+            lambda: screen._character._current_console_rail_conversation_id()
         ),
         current_rail_state_accessor=lambda: screen._current_console_rail_state(),
         # `getattr` with a default, matching the pre-move body: the fleet

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -106,9 +106,6 @@ from ..Console_Modules.retrieval import (
 from ..Console_Modules.transcript import _ConsoleTranscriptReadingState
 from ..Console_Modules.wiring import build_console_controllers
 from ..Console_Modules.session import (
-    _canonical_card_character_id,
-    _console_global_user_display_name,
-    _character_session_prompt_seed,
     _has_selected_text,
     _is_empty_select_value,
 )
@@ -498,7 +495,6 @@ from ...Widgets.Console.console_retrieval_scope_row import (
 )
 from ...Widgets.Console.console_character_picker_modal import (
     ConsoleCharacterChoice,
-    ConsoleCharacterOption,
     ConsoleCharacterPickerModal,
 )
 from ...Widgets.Console.console_composer_menu_modal import (
@@ -9047,7 +9043,7 @@ class ChatScreen(BaseAppScreen):
             # rail name covers resumed conversations.
             character=(
                 getattr(settings, "character_label", None)
-                or self._current_console_rail_character_name()
+                or self._character._current_console_rail_character_name()
             ),
             assistant_kind=getattr(active_session, "assistant_kind", None),
             assistant_name=getattr(active_session, "assistant_name", None),
@@ -9831,7 +9827,9 @@ class ChatScreen(BaseAppScreen):
 
     async def _open_console_character_picker(self) -> None:
         """Load characters off-thread and open the picker modal (task-1672)."""
-        options = await asyncio.to_thread(self._console_character_picker_options)
+        options = await asyncio.to_thread(
+            self._character._console_character_picker_options
+        )
         if not options:
             self.app.notify(
                 "No characters saved yet — import a card in Roleplay first.",
@@ -9841,37 +9839,12 @@ class ChatScreen(BaseAppScreen):
         self.app.push_screen(
             ConsoleCharacterPickerModal(
                 options=options,
-                current_character_id=self._current_console_rail_character_id(),
+                current_character_id=(
+                    self._character._current_console_rail_character_id()
+                ),
             ),
             callback=self._apply_console_character_choice,
         )
-
-    def _console_character_picker_options(
-        self,
-    ) -> tuple[ConsoleCharacterOption, ...]:
-        """Read selectable character cards (worker thread; never raises)."""
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        if db is None:
-            return ()
-        try:
-            cards = db.list_character_cards(limit=500)
-        except Exception:
-            logger.opt(exception=True).warning("Character picker: list failed.")
-            return ()
-        options: list[ConsoleCharacterOption] = []
-        for card in cards or ():
-            card_id = _canonical_card_character_id(card.get("id"))
-            name = str(card.get("name") or "").strip()
-            if card_id is None or not name:
-                continue
-            options.append(
-                ConsoleCharacterOption(
-                    character_id=card_id,
-                    name=name,
-                    description=str(card.get("description") or "")[:200],
-                )
-            )
-        return tuple(options)
 
     def _apply_console_character_choice(
         self, choice: "ConsoleCharacterChoice | None"
@@ -9880,108 +9853,10 @@ class ChatScreen(BaseAppScreen):
         if choice is None:
             return
         self.run_worker(
-            self._apply_console_character_choice_async(choice),
+            self._character._apply_console_character_choice_async(choice),
             exclusive=True,
             group="console-character-pick",
         )
-
-    async def _apply_console_character_choice_async(
-        self, choice: "ConsoleCharacterChoice"
-    ) -> None:
-        """Apply the picked character to this session or a fresh one."""
-        card = await asyncio.to_thread(
-            self._fetch_character_card_for_avatar, choice.character_id
-        )
-        if card is None:
-            display_name = (
-                sanitize_character_display_label(
-                    choice.name,
-                    max_characters=180,
-                )
-                or "that character"
-            )
-            self.app.notify(
-                f"Could not load {escape_markup(display_name)}.",
-                severity="error",
-            )
-            return
-        # cubic PR #1153 P1: the store lives on the SCREEN behind a lazy
-        # accessor -- `app_instance.console_chat_store` is always None, so
-        # the whole feature silently did nothing.
-        store = self._ensure_console_chat_store()
-        global_name = _console_global_user_display_name(
-            self._provider_readiness_app_config()
-        )
-        if choice.placement == "new" or store.active_session_id is None:
-            effective_name = global_name
-        else:
-            effective_name = store.presentation_context(
-                store.active_session_id,
-                global_name,
-            ).user_name
-        seed = _character_session_prompt_seed(
-            card,
-            choice.name,
-            user_name=effective_name,
-        )
-        display_name = (
-            sanitize_character_display_label(
-                seed.name,
-                max_characters=180,
-            )
-            or "that character"
-        )
-        notification_name = escape_markup(display_name)
-        if choice.placement == "new":
-            # cubic PR #1153 P1: the card's system prompt was computed and
-            # discarded, leaving the new chat on the default prompt. Mirror
-            # the Start-Chat path, which seeds it into the session settings.
-            settings = replace(
-                self._session._default_console_session_settings(),
-                system_prompt=seed.system_prompt,
-            )
-            session = store.create_session(
-                title=f"Chat with {seed.name}",
-                workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
-                settings=settings,
-                runtime_backend="local",
-                assistant_kind="character",
-                assistant_id=str(choice.character_id),
-                assistant_authority_id=None,
-                character_id=choice.character_id,
-                character_name=seed.name,
-            )
-            try:
-                store.seed_character_roleplay(
-                    session.id,
-                    system_template=seed.system_template,
-                    greeting_template=seed.greeting_template,
-                    global_default=global_name,
-                )
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "Character picker: roleplay template seed failed; continuing."
-                )
-            store.switch_session(session.id)
-            # task-7 review: a new (never-ephemeral) session may be
-            # replacing a temporary one as the active tab; the awaited
-            # `_sync_native_console_chat_ui()` below never touches the
-            # temporary chip (see `_sync_console_temporary_chip`).
-            self._sync_console_temporary_chip()
-            self.app.notify(f"Started a new chat with {notification_name}.")
-        else:
-            if not self._session._swap_console_session_character(
-                store,
-                choice.character_id,
-                seed,
-                global_default=global_name,
-            ):
-                return
-            self.app.notify(f"This chat now uses {notification_name}.")
-        # cubic PR #1153 P2: this refresher is async -- calling it without
-        # awaiting produced a never-run coroutine (and a RuntimeWarning).
-        await self._sync_native_console_chat_ui()
-        await self._character._refresh_active_character_avatar_if_scope_changed()
 
     @on(ConsoleScopeChip.OpenRequested)
     async def _console_scope_chip_activated(
@@ -10007,54 +9882,6 @@ class ChatScreen(BaseAppScreen):
         until this seam existed.
         """
         return self._session._current_console_conversation_id()
-
-    def _current_console_rail_conversation_id(self) -> Optional[str]:
-        """Return the conversation scope used only for Console rail persistence."""
-        native_session = self._session._active_native_console_session()
-        if native_session is not None:
-            conversation_id = getattr(
-                native_session,
-                "persisted_conversation_id",
-                None,
-            )
-            return str(conversation_id) if conversation_id else None
-        return self._session._current_console_conversation_id()
-
-    def _current_console_rail_character_id(self) -> Optional[int]:
-        """Active native Console session's character id (int), or None.
-
-        Resolved ONLY off the live session (#754 sets it at Start-Chat, on
-        DB-resume, and on screen-state restore); never from legacy
-        ``app.current_chat_*`` reactives. None for a generic session.
-        """
-        native_session = self._session._active_native_console_session()
-        if native_session is None:
-            return None
-        return native_session.local_character_id()
-
-    def _current_console_rail_character_name(self) -> Optional[str]:
-        """Active native Console session's character name, or None."""
-        native_session = self._session._active_native_console_session()
-        if native_session is None:
-            return None
-        name = getattr(native_session, "character_name", None)
-        return str(name) if name else None
-
-    def _fetch_character_card_for_avatar(self, character_id: int) -> dict | None:
-        """Synchronous character-card fetch for the avatar refresh (off-thread).
-
-        Canonical DB accessor used throughout `chat_screen.py` (e.g. the
-        resume path `_resolve_resumed_character_name`); there is no
-        `self.chachanotes_db`.
-        """
-        db = getattr(self.app_instance, "chachanotes_db", None)
-        if db is None:
-            return None
-        try:
-            return db.get_character_card_by_id(int(character_id))
-        except Exception:
-            logger.opt(exception=True).debug("avatar: character fetch failed")
-            return None
 
     async def _render_character_avatar_into_section(
         self,
@@ -10896,7 +10723,7 @@ class ChatScreen(BaseAppScreen):
                     break
         preference_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
-            conversation_id=self._current_console_rail_conversation_id(),
+            conversation_id=(self._character._current_console_rail_conversation_id()),
             session_id=self._session._current_console_session_id(),
         )
         self._migrate_console_rail_fallback_preferences(
@@ -11139,7 +10966,7 @@ class ChatScreen(BaseAppScreen):
         workspace_context = self._workspace._current_console_workspace_context()
         preference_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
-            conversation_id=self._current_console_rail_conversation_id(),
+            conversation_id=(self._character._current_console_rail_conversation_id()),
             session_id=self._session._current_console_session_id(),
         )
         self._migrate_console_rail_fallback_preferences(
@@ -11620,7 +11447,7 @@ class ChatScreen(BaseAppScreen):
         (worst case is still O(messages), when no message in the session
         carries a marker at all).
         """
-        conversation_id = self._current_console_rail_conversation_id()
+        conversation_id = self._character._current_console_rail_conversation_id()
         store = self._console_chat_store
         session_id = store.active_session_id if store is not None else None
         newest_run_id: str | None = None
@@ -11686,7 +11513,7 @@ class ChatScreen(BaseAppScreen):
             entries: The recompute's cross-turn summary.
             pruned_rows: How many rows retention pruned out of it.
         """
-        if self._current_console_rail_conversation_id() != conversation_id:
+        if self._character._current_console_rail_conversation_id() != conversation_id:
             logger.debug(
                 "Console changed-files: dropping a stale worker result for "
                 f"conversation {conversation_id!r} -- no longer current"
@@ -11696,9 +11523,7 @@ class ChatScreen(BaseAppScreen):
         self._console_changed_files_pruned_rows = pruned_rows
         self._sync_console_changed_files_section()
 
-    def _land_console_changed_files_empty(
-        self, conversation_id: "str | None"
-    ) -> None:
+    def _land_console_changed_files_empty(self, conversation_id: "str | None") -> None:
         """The no-provider variant of `_land_console_changed_files`.
 
         Same stale-conversation guard (Fix 4c) -- see that method's
@@ -11707,7 +11532,7 @@ class ChatScreen(BaseAppScreen):
         Args:
             conversation_id: The conversation live at DISPATCH time.
         """
-        if self._current_console_rail_conversation_id() != conversation_id:
+        if self._character._current_console_rail_conversation_id() != conversation_id:
             logger.debug(
                 "Console changed-files: dropping a stale empty-land for "
                 f"conversation {conversation_id!r} -- no longer current"
@@ -11840,6 +11665,7 @@ class ChatScreen(BaseAppScreen):
             self._console_changed_files_row_cache = {}
             self._sync_console_changed_files_section()
         self._dispatch_console_changed_files_worker(scope[0])
+
     async def _console_dictionary_attach_worker(self) -> None:
         """Pick and attach a chat dictionary to the active Console conversation.
 
@@ -11850,7 +11676,7 @@ class ChatScreen(BaseAppScreen):
         ``run_worker(exit_on_error=True)``.
         """
         try:
-            conversation_id = self._current_console_rail_conversation_id()
+            conversation_id = self._character._current_console_rail_conversation_id()
             if not conversation_id:
                 self.app_instance.notify(
                     "Start or load a conversation first.", severity="warning"
@@ -11902,7 +11728,7 @@ class ChatScreen(BaseAppScreen):
         ``run_worker(exit_on_error=True)``.
         """
         try:
-            conversation_id = self._current_console_rail_conversation_id()
+            conversation_id = self._character._current_console_rail_conversation_id()
             if not conversation_id:
                 self.app_instance.notify(
                     "Start or load a conversation first.", severity="warning"
@@ -11969,7 +11795,7 @@ class ChatScreen(BaseAppScreen):
         Analogous to :meth:`_console_worldbook_attach_worker`.
         """
         try:
-            conversation_id = self._current_console_rail_conversation_id()
+            conversation_id = self._character._current_console_rail_conversation_id()
             if not conversation_id:
                 self.app_instance.notify(
                     "Start or load a conversation first.", severity="warning"
@@ -12037,7 +11863,7 @@ class ChatScreen(BaseAppScreen):
         ``console_attached_dictionaries``/``handle_console_dictionary_detach``.
         """
         try:
-            conversation_id = self._current_console_rail_conversation_id()
+            conversation_id = self._character._current_console_rail_conversation_id()
             if not conversation_id:
                 self.app_instance.notify(
                     "Start or load a conversation first.", severity="warning"

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1170,7 +1170,9 @@ CONSOLE_WORKBENCH_SHORTCUTS_SETUP_BLOCKED = tuple(
 )
 
 
-def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectorySnapshot":
+def _build_trajectory_snapshot(
+    store: Any, conversation_id: str
+) -> "TrajectorySnapshot":
     """Assemble the ``derive_trajectory`` inputs for one persisted conversation.
 
     task-5 (console trajectory view). Best-effort at every seam: any source
@@ -1223,9 +1225,7 @@ def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectoryS
         try:
             # The projection itself filters purpose == "conversation_compaction".
             compaction_records = list(
-                context_repository.list_auxiliary_attempts(
-                    conversation_id, limit=500
-                )
+                context_repository.list_auxiliary_attempts(conversation_id, limit=500)
             )
         except Exception:  # noqa: BLE001
             compaction_records = []
@@ -1237,6 +1237,7 @@ def _build_trajectory_snapshot(store: Any, conversation_id: str) -> "TrajectoryS
         compaction_records,
         active_leaf_message_id=active_leaf,
     )
+
 
 #: TASK-362: the full Console keyboard vocabulary for the F1 help panel, grouped
 #: by surface. The flat CONSOLE_WORKBENCH_SHORTCUTS above stays the compact
@@ -1591,9 +1592,7 @@ def _console_screen_is_torn_down(screen: Any) -> bool:
       they are absent from ``dir(ChatScreen)``, and a spec'd mock -- like
       a never-mounted screen -- correctly reads as LIVE.
     """
-    return bool(
-        getattr(screen, "_closing", False) or getattr(screen, "_closed", False)
-    )
+    return bool(getattr(screen, "_closing", False) or getattr(screen, "_closed", False))
 
 
 def _console_inspector_turn_preview(content: Any) -> str:
@@ -3862,9 +3861,7 @@ class ChatScreen(BaseAppScreen):
         # is a git subprocess PER snapshot row (spec §2's cost model), so it
         # runs on a `thread=True` worker rather than an in-tick awaited
         # `asyncio.to_thread`.
-        self._console_changed_files_summary: (
-            "tuple[ConversationFileEntry, ...] | None"
-        ) = None
+        self._console_changed_files_summary: "tuple[ConversationFileEntry, ...] | None" = None
         self._console_changed_files_pruned_rows: int = 0
         # Per-row git-diff memo (fix round, spec §2's stated per-row memo),
         # keyed by the owning `change_snapshots` row's own DB id -- handed
@@ -3891,9 +3888,7 @@ class ChatScreen(BaseAppScreen):
         # note-mutation path (the card's save/delete, the Review screen's
         # dismissal callback) so the rail's `✎ N` badges never go stale --
         # the guard tuple alone only moves on a NEW run.
-        self._last_console_changed_files_scope: (
-            "tuple[str | None, str | None] | None"
-        ) = None
+        self._last_console_changed_files_scope: "tuple[str | None, str | None] | None" = None
         # Tracks ONLY the conversation-id half, across resets that use the
         # sentinel above -- distinguishes a genuine conversation switch
         # (clears the summary) from a note-mutation-forced re-check on the
@@ -5152,9 +5147,7 @@ class ChatScreen(BaseAppScreen):
             cancel_all_button = self.query_one(
                 f"#{CONSOLE_AGENT_CANCEL_ALL_ID}", Button
             )
-            cancel_all_button.styles.display = (
-                "block" if cancel_all_visible else "none"
-            )
+            cancel_all_button.styles.display = "block" if cancel_all_visible else "none"
             agent_body = self.query_one("#console-rail-section-body-agent")
             agent_body.styles.display = "block" if section_open else "none"
             agent_header = self.query_one(
@@ -11523,9 +11516,7 @@ class ChatScreen(BaseAppScreen):
         self._console_changed_files_pruned_rows = pruned_rows
         self._sync_console_changed_files_section()
 
-    def _land_console_changed_files_empty(
-        self, conversation_id: "str | None"
-    ) -> None:
+    def _land_console_changed_files_empty(self, conversation_id: "str | None") -> None:
         """The no-provider variant of `_land_console_changed_files`.
 
         Same stale-conversation guard (Fix 4c) -- see that method's
@@ -11667,6 +11658,7 @@ class ChatScreen(BaseAppScreen):
             self._console_changed_files_row_cache = {}
             self._sync_console_changed_files_section()
         self._dispatch_console_changed_files_worker(scope[0])
+
     async def _console_dictionary_attach_worker(self) -> None:
         """Pick and attach a chat dictionary to the active Console conversation.
 
@@ -13288,9 +13280,7 @@ class ChatScreen(BaseAppScreen):
                     agent_full_log_available=(
                         self._agent._console_agent_full_log_available()
                     ),
-                    agent_steering_state=(
-                        self._agent._console_agent_steering_state()
-                    ),
+                    agent_steering_state=(self._agent._console_agent_steering_state()),
                     agent_cancel_all_visible=(
                         self._agent._console_agent_cancel_all_visible()
                     ),
@@ -15410,10 +15400,12 @@ class ChatScreen(BaseAppScreen):
             # depending on how far the tick had got.
             if not _console_screen_is_torn_down(self):
                 raise
+            # fmt: off
             logger.debug(
                 "Console sync tick raced this screen's teardown; nothing to "
                 "render.",
             )
+            # fmt: on
         finally:
             self._record_ui_worker_finished("console-sync")
             self._console_sync_in_progress = False
@@ -16506,8 +16498,7 @@ class ChatScreen(BaseAppScreen):
         conversation_id = self._current_console_conversation_id()
         if not conversation_id:
             await self._append_native_console_system_message(
-                "Deep research needs an active conversation to deliver its "
-                "report into."
+                "Deep research needs an active conversation to deliver its report into."
             )
             return
         app = self.app
@@ -16545,7 +16536,10 @@ class ChatScreen(BaseAppScreen):
         async def _run_research() -> None:
             launch_kwargs: dict = {
                 "query": question,
-                "chat_handoff": {"conversation_id": conversation_id, "origin": "console"},
+                "chat_handoff": {
+                    "conversation_id": conversation_id,
+                    "origin": "console",
+                },
                 "source_policy": source_policy,
             }
             if provider_overrides:
@@ -18737,7 +18731,9 @@ class ChatScreen(BaseAppScreen):
         try:
             controller = self._ensure_console_chat_controller()
             store = controller.store
-            database = getattr(store.persistence, "db", None) if store.persistence else None
+            database = (
+                getattr(store.persistence, "db", None) if store.persistence else None
+            )
             if database is None:
                 self.notify(
                     "Notes are unavailable (no notes database).",
@@ -18867,8 +18863,8 @@ class ChatScreen(BaseAppScreen):
                     existing = self._console_annotation_previews.get(
                         anchor_message_id, ()
                     )
-                    self._console_annotation_previews[anchor_message_id] = (
-                        existing + (comment,)
+                    self._console_annotation_previews[anchor_message_id] = existing + (
+                        comment,
                     )
         except Exception:
             logger.warning(
@@ -19090,9 +19086,7 @@ class ChatScreen(BaseAppScreen):
                 if not validate_text_input(
                     new_comment, max_length=SELECTION_QUOTE_CAP, allow_html=True
                 ):
-                    self.notify(
-                        "That note is too long to save.", severity="warning"
-                    )
+                    self.notify("That note is too long to save.", severity="warning")
                     return False
                 if not _conversation_still_current():
                     self.notify(
@@ -19267,7 +19261,9 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         event.prevent_default()
 
-    def _dismiss_console_selection_menus_outside_transcript(self, target: object) -> None:
+    def _dismiss_console_selection_menus_outside_transcript(
+        self, target: object
+    ) -> None:
         """Fold selection menus when a click lands outside every transcript.
 
         Console selection phase 1 (click-outside dismissal, screen half).

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -11523,7 +11523,9 @@ class ChatScreen(BaseAppScreen):
         self._console_changed_files_pruned_rows = pruned_rows
         self._sync_console_changed_files_section()
 
-    def _land_console_changed_files_empty(self, conversation_id: "str | None") -> None:
+    def _land_console_changed_files_empty(
+        self, conversation_id: "str | None"
+    ) -> None:
         """The no-provider variant of `_land_console_changed_files`.
 
         Same stale-conversation guard (Fix 4c) -- see that method's
@@ -11665,7 +11667,6 @@ class ChatScreen(BaseAppScreen):
             self._console_changed_files_row_cache = {}
             self._sync_console_changed_files_section()
         self._dispatch_console_changed_files_worker(scope[0])
-
     async def _console_dictionary_attach_worker(self) -> None:
         """Pick and attach a chat dictionary to the active Console conversation.
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1686,9 +1686,7 @@ def _build_console_inspector_exchanges_loader(
                 (capture, capture.run_tag in abandoned_tags)
                 for capture in message.exchanges
             ]
-        persisted_id = (
-            message.persisted_message_id if message is not None else None
-        )
+        persisted_id = message.persisted_message_id if message is not None else None
         if not persisted_id:
             return []
 
@@ -9641,7 +9639,9 @@ class ChatScreen(BaseAppScreen):
         supplies them, via ``project_instruction_ui.
         project_instruction_context_kwargs``.
         """
-        rows, totals, turns, exchanges_loader = self._build_console_inspector_cost_data()
+        rows, totals, turns, exchanges_loader = (
+            self._build_console_inspector_cost_data()
+        )
         self.app.push_screen(
             ConsoleConversationInspector(
                 rows=rows,


### PR DESCRIPTION
## Summary
- Move character picker projection, session handoff policy, active identity, card retrieval, and avatar refresh ownership into ConsoleCharacterController.
- Keep Textual modal, worker launch, and rail rendering presentation seams on ChatScreen with explicit late-bound controller dependencies.
- Repair ownership-driven fixtures, add no-mount controller and architecture contracts, and close TASK-3070.7.

## Verification
- 87 focused character behavior tests passed.
- 27 exact ownership-driven caller tests and the two former avatar fixture failures passed.
- Four mutation discriminators failed as intended, restored exactly, and passed after restoration.
- Focused Wave 6 architecture gates passed.
- Ruff check and Ruff format passed for all 16 changed Python files.
- Changed production modules compiled under an isolated validated cache root; cleanup was proven.
- git diff --check and focused scope, privacy, and artifact scans passed.

## Notes
- Per user instruction, no full test suite was run; verification was limited to modified functionality.
- The persistent diagnostic checker is already red on current dev because of eight unrelated stale owner deltas. This branch only transfers three content-identical calls from chat_screen.py to character.py; the combined 146-call method and digest multiset and sink topology are unchanged, so the manifest was intentionally not rewritten.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts Console character policy from `ChatScreen` into `ConsoleCharacterController` to make the flow testable and DOM-free. Old: `ChatScreen` owned picker projection, session handoff, active identity, card retrieval, and avatar refresh. New: `ConsoleCharacterController` owns them and adds request snapshot/cache/invalidation; `ChatScreen` only opens the picker modal and renders avatars/rail. Behavior is unchanged and completes TASK-3070.7.

- Review focus
  - `tldw_chatbook/UI/Console_Modules/character.py`: new controller owns picker projection, choice/session handoff, active identity, card/card-derived avatar refresh, and request snapshot/cache/invalidation via late-bound, DOM-free callbacks.
  - `tldw_chatbook/UI/Screens/chat_screen.py`: removes character logic; keeps picker modal open and avatar/rail rendering only.
  - `tldw_chatbook/UI/Console_Modules/wiring.py`: wires `_character` with app config, chat store, active native session, current conversation id, character DB, notifications, UI sync, and store ensure; retrieval/agent read the conversation id via `screen._character._current_console_rail_conversation_id`.
  - `tldw_chatbook/UI/Console_Modules/session.py`: exports `_character_session_prompt_seed` and card-id helpers used by the controller.
  - Tests: adds `Tests/UI/test_console_character_controller.py` (no-mount contract) and tightens Wave 6 ownership gates; updates call sites to route through `_character`.

- Migration
  - Update internal callers to use `screen._character.*` for character APIs (e.g., `_current_console_rail_conversation_id`, `_apply_console_character_choice_async`, `_fetch_character_card_for_avatar`).
  - Import `_character_session_prompt_seed` from `tldw_chatbook/UI/Console_Modules/session`.
  - Retrieval/agent helpers must read the current conversation id via `screen._character._current_console_rail_conversation_id`.
  - No user-visible changes, config changes, or data migrations.

<sup>Written for commit 7a0cf0bb75d635fe45d1141450aa4cb445444536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

