### PR TITLE
fix(skills): writer-unique temp files for the skills index and trust store atomic writes (TASK-17963)

### DIFF
--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -1,0 +1,375 @@
+"""Tests/Skills/test_atomic_write_concurrency.py
+
+TASK-17963: the skills-subsystem atomic write-then-`Path.replace` helpers
+used a FIXED temp filename, so two concurrent writers to the same target
+(two app instances, or two threads/async callers in one) could race on the
+same temp path -- one writer's `replace()` consuming the other's
+still-being-written temp file, raising `FileNotFoundError`.
+
+This file exercises the shared fix (`Skills_Interop/atomic_write.py`) at
+three levels:
+  * the shared helper module itself (uniqueness, cleanup-on-failure),
+  * a concurrency race reproduction against the two converted call sites
+    (`LocalSkillsService`'s index/text/bytes writers,
+    `skill_trust_store`'s `_atomic_write_json`/`_atomic_write_bytes`),
+  * format-preservation checks (index sort_keys/trailing newline, trust
+    store's dot-prefixed temp convention) so the fix didn't change on-disk
+    shape, only temp-name uniqueness.
+
+Before `local_skills_service.py`/`skill_trust_store.py` were converted to
+call the shared helper, the race tests below reliably failed with
+`FileNotFoundError` against the old fixed `<name>.tmp` / `.{name}.tmp`
+temp names (captured as the task's RED evidence) -- see TASK-17963.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Skills_Interop import atomic_write as aw
+from tldw_chatbook.Skills_Interop import skill_trust_store as trust_store_module
+from tldw_chatbook.Skills_Interop.local_skills_service import LocalSkillsService
+
+N_THREADS = 6
+N_ITERATIONS = 30
+
+#: Tests/conftest.py's autouse XDG-isolation fixture creates `tmp_path /
+#: "test_data"` for every test in the suite (even ones that never touch
+#: RAG/config) -- it is not a stray temp file left by anything under test
+#: here, so the "no leftover temp file" assertions below must ignore it.
+_KNOWN_FIXTURE_ENTRIES = {"test_data"}
+
+
+def _stray_entries(tmp_path: Path, *exclude: Path) -> list[Path]:
+    """Return unexpected entries directly under ``tmp_path``.
+
+    Ignores the autouse XDG-isolation ``test_data`` directory and any
+    explicitly-expected paths (e.g. the write target itself).
+    """
+    excluded = set(exclude)
+    return [
+        p
+        for p in tmp_path.iterdir()
+        if p.name not in _KNOWN_FIXTURE_ENTRIES and p not in excluded
+    ]
+
+
+def _run_concurrent(fn, *, n_threads: int = N_THREADS, n_iterations: int = N_ITERATIONS):
+    """Run ``fn(worker_id, i)`` from ``n_threads`` threads, ``n_iterations`` times
+    each, and return every exception any call raised (empty list == clean run).
+    """
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def worker(worker_id: int) -> None:
+        for i in range(n_iterations):
+            try:
+                fn(worker_id, i)
+            except BaseException as exc:  # noqa: BLE001 -- captured for assertion
+                with errors_lock:
+                    errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(w,)) for w in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness: unique_temp_path derives from the target name and from the
+# writer's (pid, thread id).
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueTempPath:
+    def test_derives_from_target_name_and_writer_identity(self, monkeypatch):
+        monkeypatch.setattr(aw.os, "getpid", lambda: 4242)
+        monkeypatch.setattr(aw.threading, "get_ident", lambda: 9999)
+
+        path = Path("/some/dir/my_target.json")
+        temp = aw.unique_temp_path(path)
+
+        assert temp.parent == path.parent
+        assert temp.name == "my_target.json.4242.9999.tmp"
+
+    def test_hidden_dot_prefixes_while_keeping_the_rest(self, monkeypatch):
+        monkeypatch.setattr(aw.os, "getpid", lambda: 4242)
+        monkeypatch.setattr(aw.threading, "get_ident", lambda: 9999)
+
+        path = Path("/some/dir/skill_trust_manifest.json")
+        temp = aw.unique_temp_path(path, hidden=True)
+
+        assert temp.name == ".skill_trust_manifest.json.4242.9999.tmp"
+
+    def test_two_different_pid_tid_contexts_never_collide(self, monkeypatch):
+        path = Path("/some/dir/store.json")
+
+        monkeypatch.setattr(aw.os, "getpid", lambda: 111)
+        monkeypatch.setattr(aw.threading, "get_ident", lambda: 222)
+        first = aw.unique_temp_path(path)
+
+        monkeypatch.setattr(aw.os, "getpid", lambda: 111)
+        monkeypatch.setattr(aw.threading, "get_ident", lambda: 333)
+        second = aw.unique_temp_path(path)
+
+        monkeypatch.setattr(aw.os, "getpid", lambda: 444)
+        monkeypatch.setattr(aw.threading, "get_ident", lambda: 222)
+        third = aw.unique_temp_path(path)
+
+        assert len({first, second, third}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cleanup on failure: no stray temp file survives a write or replace failure.
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupOnFailure:
+    def test_replace_atomically_unlinks_temp_when_write_fn_raises_after_writing(
+        self, tmp_path
+    ):
+        target = tmp_path / "target.txt"
+        temp = aw.unique_temp_path(target)
+
+        def write_then_fail(path: Path) -> None:
+            path.write_text("partial content", encoding="utf-8")
+            raise RuntimeError("simulated failure after the temp file was written")
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            aw.replace_atomically(temp, target, write_then_fail)
+
+        assert not temp.exists()
+        assert not target.exists()
+        assert _stray_entries(tmp_path) == []
+
+    def test_write_text_atomic_cleans_up_on_replace_failure_and_still_raises(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "target.json"
+
+        def boom_replace(self, other):  # noqa: ANN001 -- Path.replace signature
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(Path, "replace", boom_replace)
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            aw.write_text_atomic(target, "hello")
+
+        # The genuine failure propagated (asserted above); it must not have
+        # left a stray temp file behind either.
+        assert _stray_entries(tmp_path) == []
+
+    def test_write_bytes_atomic_cleans_up_on_write_failure_and_still_raises(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "target.bin"
+
+        def boom_write_bytes(self, data):  # noqa: ANN001 -- Path.write_bytes signature
+            raise OSError("simulated disk-full failure")
+
+        monkeypatch.setattr(Path, "write_bytes", boom_write_bytes)
+
+        with pytest.raises(OSError, match="simulated disk-full failure"):
+            aw.write_bytes_atomic(target, b"payload")
+
+        assert _stray_entries(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Race reproduction: N threads hammering the SAME target path through the
+# real (converted) call sites must never raise, and the final file must be
+# one complete, valid writer's content.
+#
+# Pre-conversion, these reliably raised FileNotFoundError against the old
+# fixed `<name>.tmp` (local_skills_service.py) / `.{name}.tmp`
+# (skill_trust_store.py) temp names -- that failure was captured as this
+# task's RED evidence before the sites below were converted to
+# atomic_write.py's writer-unique naming.
+# ---------------------------------------------------------------------------
+
+
+class TestRaceLocalSkillsServiceWriteTextAtomic:
+    def test_concurrent_writers_same_target_never_raise(self, tmp_path):
+        target = tmp_path / "shared_text.txt"
+
+        def write(worker_id: int, i: int) -> None:
+            LocalSkillsService._write_text_atomic(
+                target, json.dumps({"worker": worker_id, "i": i})
+            )
+
+        errors = _run_concurrent(write)
+        assert errors == []
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert set(data.keys()) == {"worker", "i"}
+
+
+class TestRaceLocalSkillsServiceWriteBytesAtomic:
+    def test_concurrent_writers_same_target_never_raise(self, tmp_path):
+        target = tmp_path / "shared_bytes.bin"
+
+        def write(worker_id: int, i: int) -> None:
+            LocalSkillsService._write_bytes_atomic(
+                target, json.dumps({"worker": worker_id, "i": i}).encode("utf-8")
+            )
+
+        errors = _run_concurrent(write)
+        assert errors == []
+        data = json.loads(target.read_bytes())
+        assert set(data.keys()) == {"worker", "i"}
+
+
+class TestRaceLocalSkillsServiceSaveIndex:
+    def test_concurrent_save_index_never_raises(self, tmp_path):
+        service = LocalSkillsService(store_dir=tmp_path)
+
+        def write(worker_id: int, i: int) -> None:
+            service._save_index({f"skill-{worker_id}-{i}": {"name": "x"}})
+
+        errors = _run_concurrent(write)
+        assert errors == []
+        loaded = service._load_index()
+        assert len(loaded) == 1  # one writer's complete record, whichever won
+
+
+class TestRaceSkillTrustStoreAtomicWriteJson:
+    def test_concurrent_writers_same_target_never_raise(self, tmp_path):
+        target = tmp_path / "skill_trust_manifest.json"
+
+        def write(worker_id: int, i: int) -> None:
+            trust_store_module._atomic_write_json(
+                target,
+                {"worker": worker_id, "i": i},
+                indent=2,
+                base_dir=tmp_path,
+            )
+
+        errors = _run_concurrent(write)
+        assert errors == []
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert set(data.keys()) == {"worker", "i"}
+
+
+class TestRaceSkillTrustStoreAtomicWriteBytes:
+    def test_concurrent_writers_same_target_never_raise(self, tmp_path):
+        target = tmp_path / "skill_trust_snapshot.bin"
+
+        def write(worker_id: int, i: int) -> None:
+            trust_store_module._atomic_write_bytes(
+                target,
+                json.dumps({"worker": worker_id, "i": i}).encode("utf-8"),
+                base_dir=tmp_path,
+            )
+
+        errors = _run_concurrent(write)
+        assert errors == []
+        data = json.loads(target.read_bytes())
+        assert set(data.keys()) == {"worker", "i"}
+
+
+# ---------------------------------------------------------------------------
+# Semantics preservation: the fix must not change on-disk shape, only
+# temp-name uniqueness.
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticsPreservation:
+    def test_save_index_round_trips_with_sorted_keys_and_trailing_newline(
+        self, tmp_path
+    ):
+        service = LocalSkillsService(store_dir=tmp_path)
+        records = {
+            "zebra_skill": {"name": "zebra_skill"},
+            "alpha_skill": {"name": "alpha_skill"},
+        }
+
+        service._save_index(records)
+
+        raw = service.index_path.read_text(encoding="utf-8")
+        assert raw.endswith("\n")
+        parsed = json.loads(raw)
+        assert parsed["version"] == 1
+        assert list(parsed["skills"].keys()) == ["alpha_skill", "zebra_skill"]
+
+        loaded = service._load_index()
+        assert loaded == records
+
+        # No stray temp file left beside the index after a clean write.
+        assert _stray_entries(tmp_path, service.index_path) == []
+
+    def test_write_text_atomic_writes_exact_content_no_stray_temp(self, tmp_path):
+        target = tmp_path / "SKILL.md"
+        LocalSkillsService._write_text_atomic(target, "# Title\n\nBody text.\n")
+
+        assert target.read_text(encoding="utf-8") == "# Title\n\nBody text.\n"
+        assert _stray_entries(tmp_path, target) == []
+
+    def test_write_bytes_atomic_writes_exact_content_no_stray_temp(self, tmp_path):
+        target = tmp_path / "bundle.zip"
+        payload = b"\x50\x4b\x03\x04binary-ish-payload"
+        LocalSkillsService._write_bytes_atomic(target, payload)
+
+        assert target.read_bytes() == payload
+        assert _stray_entries(tmp_path, target) == []
+
+    def test_trust_store_atomic_write_json_preserves_indent_and_sort_keys(
+        self, tmp_path
+    ):
+        target = tmp_path / "skill_trust_manifest.json"
+        payload = {"zeta": 1, "alpha": 2, "nested": {"z": 1, "a": 2}}
+
+        trust_store_module._atomic_write_json(
+            target, payload, indent=2, base_dir=tmp_path
+        )
+
+        raw = target.read_text(encoding="utf-8")
+        assert raw.endswith("\n")
+        # sort_keys=True + indent=2, matching the pre-existing format exactly.
+        expected = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        assert raw == expected
+
+        # Nothing else (in particular no leftover dot-prefixed temp file)
+        # remains in the directory after a clean write.
+        assert _stray_entries(tmp_path, target) == []
+
+    def test_trust_store_atomic_write_bytes_no_stray_temp(self, tmp_path):
+        target = tmp_path / "skill_trust_manifest.json"
+        payload = b"encrypted-bytes-not-really"
+
+        trust_store_module._atomic_write_bytes(target, payload, base_dir=tmp_path)
+
+        assert target.read_bytes() == payload
+        assert _stray_entries(tmp_path, target) == []
+
+    def test_trust_store_temp_name_is_dot_prefixed_hidden_convention(
+        self, tmp_path, monkeypatch
+    ):
+        """The trust store's temp file, while in flight, keeps its
+        pre-existing dot-prefixed ("hidden") convention -- only the
+        writer-unique suffix is new."""
+        target = tmp_path / "skill_trust_manifest.json"
+        observed_temp_names: list[str] = []
+
+        original_replace_atomically = aw.replace_atomically
+
+        def spy_replace_atomically(temp_path, target_path, write_fn):
+            observed_temp_names.append(temp_path.name)
+            return original_replace_atomically(temp_path, target_path, write_fn)
+
+        monkeypatch.setattr(
+            trust_store_module, "replace_atomically", spy_replace_atomically
+        )
+
+        trust_store_module._atomic_write_json(
+            target, {"a": 1}, indent=2, base_dir=tmp_path
+        )
+
+        assert len(observed_temp_names) == 1
+        assert observed_temp_names[0].startswith(".")
+        assert observed_temp_names[0].startswith(f".{target.name}.")
+        assert observed_temp_names[0].endswith(".tmp")

--- a/backlog/tasks/task-17963 - Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
+++ b/backlog/tasks/task-17963 - Shared-fixed-name-temp-files-race-across-app-instances-in-skills-store-and-trust-store.md
@@ -3,15 +3,17 @@ id: TASK-17963
 title: >-
   Shared fixed-name temp files race across app instances in skills store and
   trust store
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-18 00:00'
+updated_date: '2026-08-21 16:31'
 labels:
   - skills
   - reliability
-priority: medium
 dependencies:
   - TASK-18705
+priority: medium
 ---
 
 ## Description (the why)
@@ -54,17 +56,110 @@ same treatment.
 
 ## Acceptance Criteria (the what)
 
-- [ ] `LocalSkillsService._save_index`'s temp file name includes a
+- [x] `LocalSkillsService._save_index`'s temp file name includes a
       writer-unique component (PID + thread id, or equivalent) so two
       concurrent callers never share a temp path
-- [ ] `LocalSkillsService._write_text_atomic`/`_write_bytes_atomic` get the
+- [x] `LocalSkillsService._write_text_atomic`/`_write_bytes_atomic` get the
       same writer-unique temp naming
-- [ ] `skill_trust_store.py`'s `_atomic_write_json`/`_atomic_write_bytes` get
+- [x] `skill_trust_store.py`'s `_atomic_write_json`/`_atomic_write_bytes` get
       the same writer-unique temp naming, preserving the existing
       `_validated_trust_file_path` containment check on the (now
       writer-unique) temp path
-- [ ] A test reproduces the race for at least one of the two modules (two
+- [x] A test reproduces the race for at least one of the two modules (two
       concurrent writers to the same target path never raise
       `FileNotFoundError` and the final file is one writer's complete,
       valid content) and passes after the fix
-- [ ] Existing `Tests/Skills/` suite remains green
+- [x] Existing `Tests/Skills/` suite remains green
+
+## Implementation Plan (the how)
+
+1. Read the reference implementation (`ProjectSkillsPromptLedger.record()` in
+   `project_skills_prompt.py`) and the two target sites' exact current
+   semantics (text vs bytes, encoding, `indent=2, sort_keys=True` +
+   trailing newline, the trust store's dot-prefix + containment check).
+   Confirm neither module imports the other (no cycle risk) and check for
+   any `chmod`/permission-bit logic on the trust material.
+2. Add one shared module `Skills_Interop/atomic_write.py` with
+   `unique_temp_path(path, *, hidden=False)`, `replace_atomically(temp,
+   target, write_fn)`, and `write_text_atomic`/`write_bytes_atomic`
+   convenience wrappers, all with cleanup-on-failure and error
+   propagation (mirroring the ledger's naming scheme, but never
+   swallowing the exception).
+3. Write `Tests/Skills/test_atomic_write_concurrency.py` (uniqueness,
+   cleanup-on-failure, semantics-preservation, and a 6-thread x
+   30-iteration race reproduction against each of the 5 (still
+   unconverted) call sites) and run it to capture RED evidence of the
+   real race (`FileNotFoundError`) against the old fixed-name code.
+4. Convert all 5 call sites to the shared helper, preserving each site's
+   exact on-disk format and its mkdir/validation steps around the write.
+5. Re-run the new test file (GREEN), then the full `Tests/Skills/` and
+   `Tests/Workspaces/` gates and a full-suite `--collect-only` sweep.
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Shared-helper choice:** a new standalone module,
+`tldw_chatbook/Skills_Interop/atomic_write.py`, rather than a shared
+implementation living inside either `local_skills_service.py` or
+`skill_trust_store.py`. The two target modules do not import each other
+(verified via their import lists), so no cycle would have forced this
+choice, but a third, dependency-free module is still cleaner: both sites
+import from it symmetrically instead of one site importing the other's
+private helper. It exports `unique_temp_path(path, *, hidden=False)`
+(`<name>.<pid>.<tid>.tmp`, or dot-prefixed when `hidden=True`),
+`replace_atomically(temp_path, target_path, write_fn)` (write, replace,
+best-effort `unlink` the temp file on any exception, always re-raise), and
+`write_text_atomic`/`write_bytes_atomic` convenience wrappers over both.
+
+**Preserved semantics (verified per site before changing it):**
+- `_save_index`: still `json.dumps(payload, indent=2, sort_keys=True) +
+  "\n"` written as UTF-8 text before the atomic replace -- same bytes on
+  disk as the old `json.dump(..., indent=2, sort_keys=True)` +
+  `handle.write("\n")` pair, verified by a round-trip test
+  (`_save_index` → `_load_index` → equal, plus sorted-key + trailing-
+  newline checks on the raw text).
+- `_write_text_atomic`/`_write_bytes_atomic`: unchanged text/bytes split,
+  same UTF-8 default encoding, still not dot-prefixed (matches this
+  module's pre-existing visible-temp-file convention, unlike the trust
+  store).
+- `skill_trust_store._atomic_write_json`/`_atomic_write_bytes`: unchanged
+  `indent`/`sort_keys=True` + trailing-newline JSON shape;
+  `_validated_trust_file_path`'s containment check still re-runs against
+  the temp path *after* the writer-unique name is built (only the name
+  changed, not when/whether it's validated); the dot-prefix ("hidden
+  trust file") convention is preserved via `hidden=True`. Checked for
+  permission bits: neither `_atomic_write_json`/`_atomic_write_bytes` nor
+  any other code in `skill_trust_store.py`/`skill_trust_crypto.py`/
+  `skill_trust_models.py` calls `chmod` or sets a file mode on the
+  manifest/snapshot/marker material -- confirmed by grep, so there is no
+  restrictive-permissions window to preserve at these two sites (the
+  `os.chmod` calls that DO exist in the skills subsystem, in
+  `local_skills_service.py`, only mark extracted script files
+  owner-executable and are unrelated to these atomic-write helpers).
+
+**Error propagation unchanged:** unlike `ProjectSkillsPromptLedger.record()`
+(advisory; swallows `OSError`), all 5 converted sites still let a genuine
+write/replace failure propagate to their caller -- `replace_atomically`
+only ever suppresses the stray-temp-file cleanup's own `OSError`, never the
+original exception, which is always re-raised. Only the fixed-temp-name
+COLLISION class is eliminated.
+
+**TDD evidence:** `Tests/Skills/test_atomic_write_concurrency.py` (17
+tests) was run against the *unconverted* sites first: the 5 race tests (6
+threads x 30 iterations hammering the same target through each of
+`LocalSkillsService._write_text_atomic`/`_write_bytes_atomic`/
+`_save_index` and `skill_trust_store._atomic_write_json`/
+`_atomic_write_bytes`) failed with 60-125 captured `FileNotFoundError(2,
+'No such file or directory')` instances out of 180 attempts each (RED,
+tee'd to `/tmp/17963-red2.txt`); after converting the 5 sites, the same
+run is 17/17 green, reproduced across 4 consecutive runs with no flakes.
+
+**Gate:** `Tests/Skills/ -q` → 453 passed (436 pre-existing + 17 new);
+`Tests/Workspaces/ -q` → 279 passed; `Tests/ --collect-only -q` → 53418
+tests collected, no collection errors.
+
+**Files:** `tldw_chatbook/Skills_Interop/atomic_write.py` (new),
+`tldw_chatbook/Skills_Interop/local_skills_service.py`,
+`tldw_chatbook/Skills_Interop/skill_trust_store.py`,
+`Tests/Skills/test_atomic_write_concurrency.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19520 - Skill trust material is written with default filesystem permissions.md
+++ b/backlog/tasks/task-19520 - Skill trust material is written with default filesystem permissions.md
@@ -1,0 +1,49 @@
+---
+id: TASK-19520
+title: >-
+  Skill trust material is written with default filesystem permissions
+status: To Do
+assignee: []
+created_date: '2026-08-21 17:00'
+labels:
+  - skills
+  - security
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Found during TASK-17963's review (writer-unique temp files): nothing in
+`Skills_Interop/skill_trust_store.py`, `skill_trust_crypto.py`, or
+`skill_trust_models.py` sets restrictive permissions on the files it writes —
+no `chmod`, no `umask`, no `0o600` (grep-verified twice, by the implementer
+and independently by the reviewer). The trust manifest, the encrypted
+approved-version snapshots, and the secure-generation marker therefore land
+with whatever the process umask gives them, typically world-readable on a
+shared machine.
+
+This is pre-existing and was explicitly out of TASK-17963's scope (that task
+converted five atomic writes to writer-unique temp names and preserved
+existing semantics deliberately). It is filed separately because trust
+material is the one thing in the skills subsystem whose confidentiality and
+integrity the ADR-009 boundary actually depends on.
+
+Note the encrypted snapshots are encrypted at rest (passphrase-derived), so
+the exposure is not equivalent to leaking plaintext skills — but the manifest
+and generation marker are metadata an attacker with read access could use,
+and defence-in-depth argues for owner-only bits regardless.
+
+## Acceptance Criteria
+
+- [ ] Trust-store writes (manifest, snapshots, generation marker) create files with owner-only permissions (`0o600`), and their containing directory is owner-only (`0o700`) where it is created by this code
+- [ ] Permissions are applied so there is no window where the file exists world-readable before being restricted (set on the temp file BEFORE `replace`, given the atomic-write path from TASK-17963)
+- [ ] Pre-existing trust files created before this change are tightened on next write (or an explicit decision is recorded that they are not)
+- [ ] Behavior is verified by a test asserting the resulting mode bits, not by inspection
+- [ ] Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
+
+## Notes
+
+Related: TASK-17963 (`Skills_Interop/atomic_write.py` is the natural seam —
+its `replace_atomically` already owns the pre-replace window). ADR-009
+defines the trust boundary this protects.

--- a/tldw_chatbook/Skills_Interop/atomic_write.py
+++ b/tldw_chatbook/Skills_Interop/atomic_write.py
@@ -74,6 +74,18 @@ def replace_atomically(
     naming means no other writer could be relying on it) and the original
     exception is re-raised unchanged. This never swallows a genuine failure;
     it only ever prevents a stray temp file from being left behind by one.
+
+    Args:
+        temp_path: Writer-unique temp file to write through, normally from
+            ``unique_temp_path``. Must be on the same filesystem as
+            ``target_path`` for the replace to be atomic.
+        target_path: Final destination, replaced in one step once the write
+            has completed.
+        write_fn: Callable given ``temp_path``; performs the actual write.
+
+    Raises:
+        BaseException: Whatever ``write_fn`` or ``Path.replace`` raised,
+            re-raised unchanged after the temp file is cleaned up.
     """
     try:
         write_fn(temp_path)
@@ -89,7 +101,19 @@ def replace_atomically(
 def write_text_atomic(
     path: Path, content: str, *, encoding: str = "utf-8", hidden: bool = False
 ) -> None:
-    """Atomically write text to ``path`` via a writer-unique temp file."""
+    """Atomically write text to ``path`` via a writer-unique temp file.
+
+    Args:
+        path: Destination file, replaced atomically once written.
+        content: Text to write.
+        encoding: Text encoding for the write.
+        hidden: Dot-prefix the temp file, for stores whose directory
+            convention hides transient artifacts.
+
+    Raises:
+        OSError: Propagated unchanged from the write or the replace; the
+            temp file is cleaned up first.
+    """
     temp_path = unique_temp_path(path, hidden=hidden)
     replace_atomically(
         temp_path, path, lambda t: t.write_text(content, encoding=encoding)
@@ -97,6 +121,17 @@ def write_text_atomic(
 
 
 def write_bytes_atomic(path: Path, data: bytes, *, hidden: bool = False) -> None:
-    """Atomically write bytes to ``path`` via a writer-unique temp file."""
+    """Atomically write bytes to ``path`` via a writer-unique temp file.
+
+    Args:
+        path: Destination file, replaced atomically once written.
+        data: Bytes to write.
+        hidden: Dot-prefix the temp file, for stores whose directory
+            convention hides transient artifacts.
+
+    Raises:
+        OSError: Propagated unchanged from the write or the replace; the
+            temp file is cleaned up first.
+    """
     temp_path = unique_temp_path(path, hidden=hidden)
     replace_atomically(temp_path, path, lambda t: t.write_bytes(data))

--- a/tldw_chatbook/Skills_Interop/atomic_write.py
+++ b/tldw_chatbook/Skills_Interop/atomic_write.py
@@ -1,0 +1,102 @@
+"""Shared writer-unique atomic write-then-replace primitive (TASK-17963).
+
+Several skills-subsystem stores do the same write-to-temp-then-`Path.replace`
+atomic write, and all of them shared the same flaw: a FIXED temp filename.
+Two writers touching the same target at close to the same moment -- two app
+instances, or two threads/async callers inside one instance -- would race on
+that one temp path: one writer's `temp.replace(target)` could consume the
+other's still-being-written temp file (or one writer's write could clobber
+the other's in-flight temp file), surfacing as a stray `FileNotFoundError`
+from `replace()` or a silently corrupted target.
+
+`ProjectSkillsPromptLedger.record()` (`project_skills_prompt.py`, shipped in
+TASK-18705) solved this first by folding the writer's pid + thread id into
+its temp name. This module lifts that scheme into one shared place so the
+other fixed-name sites (`local_skills_service.py`'s `_save_index`/
+`_write_text_atomic`/`_write_bytes_atomic`, `skill_trust_store.py`'s
+`_atomic_write_json`/`_atomic_write_bytes`) get the same fix instead of each
+re-deriving it. It lives directly under `Skills_Interop/` rather than as a
+method on either store: `local_skills_service.py` and `skill_trust_store.py`
+do not import each other (checked -- no cycle either way), but a shared
+helper used by both is preferable to two near-duplicate private
+implementations, so this module has no dependency on either of them and both
+import from it instead.
+
+Only the temp-name COLLISION class disappears here -- a genuine write or
+replace failure (disk full, permission denied, the target's directory
+vanishing, etc.) still raises. Unlike the advisory prompt ledger above (which
+swallows `OSError` because losing one record just means one extra prompt
+later), the stores that use this module expect a real write failure to
+surface to their caller; `replace_atomically` only ever best-effort cleans up
+the stray temp file it left behind, never the exception itself.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Callable
+
+
+def unique_temp_path(path: Path, *, hidden: bool = False) -> Path:
+    """Build a writer-unique temp path alongside ``path``.
+
+    Args:
+        path: The eventual write target; the temp file is a sibling of it
+            (same parent directory, derived from its name).
+        hidden: Dot-prefix the temp name. Preserves each call site's
+            existing visibility convention -- `local_skills_service.py`
+            never dot-prefixed its temp files, `skill_trust_store.py`
+            always has (its "hidden trust-material file" convention);
+            pass the matching value rather than picking one globally.
+
+    Returns:
+        `<name>.<pid>.<tid>.tmp` (or `.<name>.<pid>.<tid>.tmp` when
+        `hidden`) -- a name no other writer, another process or another
+        thread in this one, can produce for the same target at the same
+        time, so two concurrent writers to the same target never share a
+        temp path.
+    """
+    name = f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    if hidden:
+        name = f".{name}"
+    return path.with_name(name)
+
+
+def replace_atomically(
+    temp_path: Path, target_path: Path, write_fn: Callable[[Path], None]
+) -> None:
+    """Call ``write_fn(temp_path)`` then atomically replace ``target_path``.
+
+    On any exception from either the write or the replace, the temp file is
+    best-effort unlinked (it is this writer's own temp file -- writer-unique
+    naming means no other writer could be relying on it) and the original
+    exception is re-raised unchanged. This never swallows a genuine failure;
+    it only ever prevents a stray temp file from being left behind by one.
+    """
+    try:
+        write_fn(temp_path)
+        temp_path.replace(target_path)
+    except BaseException:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def write_text_atomic(
+    path: Path, content: str, *, encoding: str = "utf-8", hidden: bool = False
+) -> None:
+    """Atomically write text to ``path`` via a writer-unique temp file."""
+    temp_path = unique_temp_path(path, hidden=hidden)
+    replace_atomically(
+        temp_path, path, lambda t: t.write_text(content, encoding=encoding)
+    )
+
+
+def write_bytes_atomic(path: Path, data: bytes, *, hidden: bool = False) -> None:
+    """Atomically write bytes to ``path`` via a writer-unique temp file."""
+    temp_path = unique_temp_path(path, hidden=hidden)
+    replace_atomically(temp_path, path, lambda t: t.write_bytes(data))

--- a/tldw_chatbook/Skills_Interop/local_skills_service.py
+++ b/tldw_chatbook/Skills_Interop/local_skills_service.py
@@ -22,6 +22,7 @@ from loguru import logger
 from ..runtime_policy.types import PolicyDeniedError
 from ..Utils.input_validation import sanitize_string, validate_text_input
 from ..Utils.path_validation import get_safe_relative_path, validate_path_simple
+from .atomic_write import write_bytes_atomic, write_text_atomic
 from .skill_trust_models import SkillTrustBlockedError
 
 if TYPE_CHECKING:
@@ -300,11 +301,15 @@ class LocalSkillsService:
     def _save_index(self, records: dict[str, dict[str, Any]]) -> None:
         self.store_dir.mkdir(parents=True, exist_ok=True)
         payload = {"version": 1, "skills": records}
-        temp_path = self.index_path.with_suffix(".json.tmp")
-        with temp_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-        temp_path.replace(self.index_path)
+        # Writer-unique temp file (pid + thread id, via the shared
+        # Skills_Interop.atomic_write helper) -- a fixed `<index>.json.tmp`
+        # let two concurrent writers (two app instances, or two callers in
+        # one) race on the same temp path, so one's `replace()` could
+        # consume the other's still-being-written temp file and raise
+        # FileNotFoundError (TASK-17963). A genuine write failure still
+        # raises here -- only that temp-name collision class is gone.
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        write_text_atomic(self.index_path, text)
 
     def _skill_dir(self, skill_name: str) -> Path:
         # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
@@ -315,18 +320,16 @@ class LocalSkillsService:
     @staticmethod
     def _write_text_atomic(path: Path, content: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = path.with_name(f"{path.name}.tmp")
-        with temp_path.open("w", encoding="utf-8") as handle:
-            handle.write(content)
-        temp_path.replace(path)
+        # See _save_index above: writer-unique temp naming (TASK-17963) --
+        # a fixed `<name>.tmp` raced across concurrent writers to the same
+        # skill file. Write failures still propagate; only the collision
+        # is fixed.
+        write_text_atomic(path, content)
 
     @staticmethod
     def _write_bytes_atomic(path: Path, data: bytes) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = path.with_name(f"{path.name}.tmp")
-        with temp_path.open("wb") as handle:
-            handle.write(data)
-        temp_path.replace(path)
+        write_bytes_atomic(path, data)
 
     @staticmethod
     def _parse_front_matter(content: str) -> tuple[dict[str, Any], str]:

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from ..Utils.path_validation import get_safe_relative_path, validate_path_simple
 from ..runtime_policy.server_credentials import is_secure_keyring_backend
+from .atomic_write import replace_atomically, unique_temp_path
 from .skill_trust_crypto import (
     SkillTrustKeys,
     canonical_json,
@@ -596,11 +597,19 @@ def _atomic_write_json(
 ) -> None:
     base_dir = _ensure_trust_directory(base_dir or path.parent)
     path = _validated_trust_file_path(path, base_dir=base_dir)
-    temp_path = path.with_name(f".{path.name}.tmp")
+    # Writer-unique temp file (pid + thread id, shared Skills_Interop
+    # helper) -- a fixed `.{name}.tmp` let two concurrent writers race on
+    # the same temp path, so one's `replace()` could consume the other's
+    # still-being-written temp file and raise FileNotFoundError
+    # (TASK-17963). `hidden=True` keeps this store's existing dot-prefixed
+    # temp-file convention; the containment check below still re-runs
+    # against the (now writer-unique) temp path exactly as it did against
+    # the old fixed one. A genuine write/replace failure still raises --
+    # only the temp-name collision class is gone.
+    temp_path = unique_temp_path(path, hidden=True)
     temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
     text = json.dumps(payload, indent=indent, sort_keys=True) + "\n"
-    temp_path.write_text(text, encoding="utf-8")
-    temp_path.replace(path)
+    replace_atomically(temp_path, path, lambda t: t.write_text(text, encoding="utf-8"))
 
 
 def _atomic_write_bytes(
@@ -608,10 +617,9 @@ def _atomic_write_bytes(
 ) -> None:
     base_dir = _ensure_trust_directory(base_dir or path.parent)
     path = _validated_trust_file_path(path, base_dir=base_dir)
-    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path = unique_temp_path(path, hidden=True)
     temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
-    temp_path.write_bytes(payload)
-    temp_path.replace(path)
+    replace_atomically(temp_path, path, lambda t: t.write_bytes(payload))
 
 
 def _ensure_trust_directory(path: Path) -> Path:


### PR DESCRIPTION
## Summary

Five atomic-write helpers used a **fixed** temp filename, so two app instances writing concurrently could have one's `replace()` consume the other's temp file, surfacing `FileNotFoundError` to the caller. The repo runs concurrent instances deliberately (there is an advisory second-instance toast for it), so this was reachable.

Converted all five — `local_skills_service.py`'s `_save_index` / `_write_text_atomic` / `_write_bytes_atomic`, and `skill_trust_store.py`'s two helpers — onto a new dependency-free `Skills_Interop/atomic_write.py`: `unique_temp_path()` yields `<name>.<pid>.<tid>.tmp`, and `replace_atomically()` best-effort-unlinks a stray temp on failure while **always re-raising** the original exception (these stores' callers expect failures to surface — unlike the advisory prompt ledger, which deliberately swallows).

Semantics preserved per site, verified rather than assumed: index JSON keeps `indent=2, sort_keys=True` + trailing newline + UTF-8; the text/bytes split stays intact (`_write_bytes_atomic` genuinely carries binary zip members); the trust store keeps its hidden dot-prefix via `hidden=True`; and `_validated_trust_file_path`'s containment check is re-applied to the new temp path — the path validator has no filename allowlist, so a digits-and-dots suffix cannot trip it.

## Verification

RED-proven before conversion: the new race tests (6 threads × 30 iterations against one shared target, no lock serializing them) produced **62–124 real `FileNotFoundError`s out of 180 attempts per site**; GREEN after, re-run 4× with no flakes. Gate: `Tests/Skills/` 453 passed (436 pre-existing + 17 new), `Tests/Workspaces/` 279 passed, 53,418-test collect sweep clean, ruff/pyflakes clean.

## Follow-up filed

**TASK-19520** — review found trust material (manifest, encrypted snapshots, generation marker) is written with default OS permissions; no `chmod`/`0o600` anywhere in the trust modules. Pre-existing and out of this PR's scope, but `atomic_write.py`'s pre-replace window is the natural seam to fix it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes races in skills index and trust store atomic writes by switching from fixed temp names to writer-unique temp files. Previously a fixed `<name>.tmp` let concurrent writers collide, raising FileNotFoundError; now temp names include pid and thread id, and failures still surface while stray temps are cleaned up.

- Adds `tldw_chatbook/Skills_Interop/atomic_write.py` with `unique_temp_path`, `replace_atomically`, `write_text_atomic`, and `write_bytes_atomic`; cleans up stray temps on failure and always re-raises; updates docstrings with Google-style Args/Raises (no behavior change).
- Converts five call sites: `LocalSkillsService._save_index`, `_write_text_atomic`, `_write_bytes_atomic`, and `skill_trust_store._atomic_write_json`, `_atomic_write_bytes`.
- Preserves on-disk shape and validation: index JSON stays `indent=2, sort_keys=True` with trailing newline; trust store keeps dot-prefixed temp naming and re-validates the writer-unique temp via `_validated_trust_file_path`; text/bytes behavior unchanged.
- Adds `Tests/Skills/test_atomic_write_concurrency.py` covering uniqueness, cleanup-on-failure, semantics, and a multi-thread race reproduction that is now green; Skills and Workspaces suites remain green.
- Meets TASK-17963 acceptance criteria; follow-up TASK-19520 filed to harden trust-store permissions.
- Rollout: no config changes or migrations.

<sup>Written for commit b4e763b392d283f4c92999df7aa7790a3089f59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

