### PR TITLE
docs(backlog): two CI findings — the nightly tier has never fired, and the Backlog Guard is red on dev

### DIFF
--- a/backlog/tasks/task-19600 - Nightly-deep-test-tier-has-never-fired-cron-registers-only-from-the-default-branch.md
+++ b/backlog/tasks/task-19600 - Nightly-deep-test-tier-has-never-fired-cron-registers-only-from-the-default-branch.md
@@ -1,0 +1,84 @@
+---
+id: TASK-19600
+title: >-
+  Nightly deep test tier has never fired: cron registers only from the
+  default branch
+status: To Do
+assignee: []
+created_date: '2026-08-21 18:15'
+labels:
+  - ci
+  - testing
+  - infrastructure
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Tests workflow's nightly deep tier (`cron: '30 8 * * *'`, added to `dev`
+on 2026-07-31 by task-1465) **has never executed a single time**. GitHub
+registers scheduled workflows only from the repository's DEFAULT branch;
+this repo's default is `main`, and `main`'s copy of
+`.github/workflows/test.yml` predates the change and carries no `schedule:`
+block at all. The cron therefore exists only on a branch where GitHub never
+reads it.
+
+Evidence: `gh run list --workflow Tests --event schedule` returns ZERO runs
+across the three weeks since it was added.
+
+This matters because it is the second half of a two-part design: the PR run
+is the merge gate, and the nightly deep tier was meant to be the periodic
+whole-suite verdict on `dev` (serial, `--run-slow`, thorough Hypothesis
+profile, cache-off, Windows+macOS breadth -- coverage the PR gate
+deliberately skips). Only the gate half has ever run.
+
+Compounding it, the `dev` PUSH run cannot substitute: `cancel-in-progress`
+is true for every non-`main` ref and merges land on `dev` every 20-40
+minutes against an ~80-minute run, so each merge kills the run the previous
+merge started. Measured 2026-08-21: of the last 40 Tests runs, 25 cancelled
+and 15 in flight -- ZERO completed. So `dev` currently has no automatic
+post-merge signal from either mechanism.
+
+The one path that does work today is manual `workflow_dispatch` against
+`dev`: it forms its own concurrency group (the group key includes
+`github.event_name`), so pushes cannot cancel it, and the nightly job is
+already gated on `schedule || workflow_dispatch`. That is how a `dev`
+verdict was obtained on 2026-08-21 (run 32511976568).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A scheduled Tests run appears in the Actions history without anyone triggering it manually (`--event schedule` returns a run).
+- [ ] #2 The mechanism does not depend on remembering to dispatch by hand.
+- [ ] #3 `dev` push runs either produce a usable verdict or stop consuming runners for runs that are structurally guaranteed to be cancelled.
+- [ ] #4 The workflow shape contract test pins whatever mechanism is chosen, so this cannot silently rot again.
+<!-- AC:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three options, all owner decisions -- deliberately NOT chosen here:
+
+1. **Merge `dev` -> `main`.** Fixes it as a side effect and is presumably
+   wanted eventually, but it is a release action with far wider blast
+   radius than this task.
+2. **Put a small dispatcher workflow on `main`** whose only job is
+   `workflow_dispatch`-ing Tests against `dev` on a cron. Restores the
+   nightly tier without releasing the rest of `dev`. Narrowest fix.
+3. **Accept manual dispatch** as the periodic mechanism and delete the
+   inert `schedule:` block so the workflow stops advertising a tier that
+   cannot run.
+
+Note that `Tests/CI/test_github_actions_test_workflow.py` asserts
+`"- cron:" in workflow`, which passes on `dev` while the schedule is inert
+-- a contract test that pins the TEXT but not the EFFECT. Whichever option
+is chosen, AC#4 should close that gap.
+
+Separately, if the `dev` push trigger is kept, it needs either its own
+non-cancelling concurrency group (with the caveat that ~80-minute runs
+arriving every 20-40 minutes would QUEUE unboundedly) or removal in favour
+of the PR gate, which already tests the merge commit.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19601 - Backlog-Guard-is-red-on-dev-seven-colliding-task-IDs-four-unresolvable-under-the-current-rule.md
+++ b/backlog/tasks/task-19601 - Backlog-Guard-is-red-on-dev-seven-colliding-task-IDs-four-unresolvable-under-the-current-rule.md
@@ -72,6 +72,13 @@ Owner decision required -- three options, deliberately NOT chosen here:
 3. **Renumber both sides** of each unresolvable pair to fresh ids so
    neither inherits the ambiguous one. Cleanest end state, largest churn.
 
+Self-demonstrating evidence for option 2: Qodo's review of the very PR
+that FILED this task flagged that the PR trips the guard, because adding
+any file under `backlog/tasks/**` runs a guard that hard-fails on
+pre-existing duplicates. A guard that fails the ticket reporting the guard
+is failing is a guard that only ever measures history, never the change in
+front of it.
+
 The deeper cause is unchanged and worth fixing regardless: ids are minted
 by reading the highest id on a branch, so two agents branching from the
 same base mint the same id. A mint-time reservation (or minting from a

--- a/backlog/tasks/task-19601 - Backlog-Guard-is-red-on-dev-seven-colliding-task-IDs-four-unresolvable-under-the-current-rule.md
+++ b/backlog/tasks/task-19601 - Backlog-Guard-is-red-on-dev-seven-colliding-task-IDs-four-unresolvable-under-the-current-rule.md
@@ -1,0 +1,80 @@
+---
+id: TASK-19601
+title: >-
+  Backlog Guard is red on dev: seven colliding task IDs, four unresolvable
+  under the current rule
+status: To Do
+assignee: []
+created_date: '2026-08-21 18:20'
+labels:
+  - ci
+  - backlog-hygiene
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The "No duplicate backlog task IDs" guard is FAILING on `dev` (runs
+32509983450, 32510107746 and every run since). Seven ids are each held by
+two task files, so the guard fails for every PR in the repo -- and a guard
+that is permanently red gets ignored, which is how the previous collisions
+went unnoticed.
+
+This is separate from TASK-18060, which was the eighth collision and was
+fixed in PR #1872; these seven are a different, larger batch spanning two
+active programmes (Console AGENTS.md context vs local-research engine, and
+Console Context/Inspect UX vs Library pager work).
+
+The blocker is that **four of the seven pairs are Done vs Done**, and this
+repo's standing rule is that a Done task NEVER moves (its id is already
+cited in merged commits, ADRs, and code comments). Under the current rule
+those four have no legal resolution at the file level:
+
+| id | side A | side B | resolvable? |
+|----|--------|--------|-------------|
+| 16320 | Add-startup-AGENTS.md-project-context (Done) | Trajectory-import-open-shared-traces (Done) | NO -- both Done |
+| 16322 | Add-nested-AGENTS.md-activation (Done) | Build-the-local-research-execution-engine (Done) | NO -- both Done |
+| 16323 | Enforce-run-budgets-reserve-settle-ledger (Done) | Verify-and-roll-out-Console-AGENTS.md (Done) | NO -- both Done |
+| 18912 | Reconcile-Console-Context-and-Inspect-UX (Done) | Standardize-Library-pager-display (Done) | NO -- both Done |
+| 16324 | Add-iterative-gap-driven-replanning (Done) | Atomically-pin-local-tool-workspace (To Do) | yes -- To Do side moves |
+| 18913 | Align-Library-Prompt-browsing-to-20-item-pages (Done) | Keep-Console-workspace-geometry-at-100-columns (In Progress) | yes -- In Progress side moves |
+| 18915 | Add-an-Inspector-overflow-fold-hint (To Do) | Page-Library-Skills-with-source-wide-trust-recovery (To Do) | yes -- either moves |
+
+Fixing only the three resolvable pairs does not turn the guard green, so a
+partial fix buys nothing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The Backlog Guard passes on `dev`.
+- [ ] #2 Whatever is decided for the four Done-vs-Done pairs is written down as the rule to apply next time (this is the 8th-15th collision; the pattern is not stopping on its own).
+- [ ] #3 No id cited by already-merged code, ADRs, or commit messages silently changes meaning without a provenance note (the pattern used for TASK-19300).
+<!-- AC:END -->
+
+## Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Owner decision required -- three options, deliberately NOT chosen here:
+
+1. **Relax "Done never moves" for the tie case** and renumber one side of
+   each Done-vs-Done pair (newer `created_date` moves, say), each with a
+   TASK-19300-style provenance note. Restores a green guard; costs
+   traceability churn on merged work.
+2. **Teach the guard to distinguish historical from NEW collisions** --
+   e.g. fail only when a PR ADDS a duplicate, with an explicit
+   grandfathered-ids allowlist for the four unresolvable pairs. Keeps the
+   guard's real purpose (catch collisions before merge) and stops it being
+   permanently red. This is arguably what the guard should have done all
+   along.
+3. **Renumber both sides** of each unresolvable pair to fresh ids so
+   neither inherits the ambiguous one. Cleanest end state, largest churn.
+
+The deeper cause is unchanged and worth fixing regardless: ids are minted
+by reading the highest id on a branch, so two agents branching from the
+same base mint the same id. A mint-time reservation (or minting from a
+monotonically increasing counter file that conflicts loudly on merge) would
+end the recurrence.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Docs-only. Two findings from investigating why `dev` never produces a test verdict — both blocking, neither fixable without an owner decision, so they are filed rather than guessed at.

### TASK-19600 — the nightly deep tier has never fired, not once

The `cron: '30 8 * * *'` was added to `dev` on 2026-07-31 (task-1465), but **GitHub registers scheduled workflows only from the default branch**. This repo's default is `main`, and `main`'s copy of `.github/workflows/test.yml` predates the change — no `schedule:` block at all. Evidence: `gh run list --workflow Tests --event schedule` returns **zero runs** in three weeks.

The `dev` push run can't substitute either: `cancel-in-progress` is true for every non-`main` ref, merges land every 20–40 minutes, and a run needs ~80. Measured today: of the last 40 Tests runs, **25 cancelled, 15 in flight, zero completed**. So `dev` has no automatic post-merge signal from either mechanism.

The one path that does work is manual `workflow_dispatch` against `dev` — it forms its own concurrency group, so pushes can't cancel it, and the nightly job is already gated on `schedule || workflow_dispatch`. Used today to get a real `dev` verdict (run 32511976568).

Also worth noting: `Tests/CI/test_github_actions_test_workflow.py` asserts `"- cron:" in workflow`, which passes on `dev` while the schedule is inert — a contract test pinning the *text* but not the *effect*.

### TASK-19601 — the Backlog Guard is red on `dev`

Seven ids each held by two task files (separate from the eighth, TASK-18060, fixed in #1872). The guard has been failing since at least 17:36 today, which means it is red for every PR in the repo — and a permanently-red guard is one that gets ignored.

**Four of the seven pairs are Done vs Done**, and the standing rule is that a Done task never moves (its id is cited in merged commits, ADRs, and code). Under the current rule those four have no legal resolution, and fixing only the three resolvable pairs would not turn the guard green — so a partial fix buys nothing. Both task files carry the full pair-by-pair table and the options (relax the rule for ties / teach the guard to fail only on NEW duplicates with a grandfathered allowlist / renumber both sides).

## Verification

Anchored duplicate scan after adding these two files: the two new ids (19600, 19601) are unique and clear of the highest id anywhere visible (19578 on dev, 19196 across local worktrees). This PR does not change the seven pre-existing collisions, so the guard will still fail on it — that failure is TASK-19601 itself, not something this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two CI blockers: the nightly deep test tier has never run because its `schedule` exists only on a non-default branch, and the Backlog Guard is red on `dev` due to duplicate task IDs. This matters because `dev` has no reliable test verdict and all PRs appear red.

- Docs-only; no workflow or guard logic changes. The Backlog Guard will fail on this PR; TASK-19601 records that the guard flags even the PR that reports the issue.

**Nightly tier (TASK-19600)**
- GitHub registers schedules only from the default branch; `main`’s workflow has no `schedule`, so there are zero `schedule` runs. `dev` push runs also never complete due to `cancel-in-progress` and frequent merges; only manual `workflow_dispatch` on `dev` yields a verdict.
- Decision required: merge `dev` -> `main`; add a small dispatcher on `main` that cron-triggers `Tests` on `dev`; or accept manual dispatch and remove the inert `schedule`. The current contract test pins the presence of `- cron:` but not its effect.

**Backlog Guard (TASK-19601)**
- Seven duplicate task IDs keep the guard red on `dev`; four are Done-vs-Done and unresolvable under “Done never moves,” so partial fixes won’t turn it green. Qodo flagged that this PR itself trips the guard, demonstrating the guard measures history rather than new collisions.
- Decision required: relax “Done never moves” for ties and renumber one side with provenance; make the guard fail only on new collisions with a grandfathered allowlist; or renumber both sides.

<sup>Written for commit b263387e34048602f4d545b8c67b08741b728cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

