### PR TITLE
fix(security): stop logging the Google Search API key (task-19552)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3170,7 +3170,7 @@
     },
     {
       "call_count": 104,
-      "diagnostic_digest": "63f3ddaba4b6557c0714",
+      "diagnostic_digest": "37972e1ac99fc6d3d304",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Web_Scraping/WebSearch_APIs.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/Web_Scraping/test_websearch_credential_logging.py
+++ b/Tests/Web_Scraping/test_websearch_credential_logging.py
@@ -1,0 +1,246 @@
+"""TASK-19552: the Google Custom Search API key must never reach a log
+record, at any level, regardless of whether the request succeeds or fails.
+
+Two independent leak vectors existed in `search_web_google`
+(`tldw_chatbook/Web_Scraping/WebSearch_APIs.py`), both on the DEFAULT
+search engine path (`search_engine` defaults to "google"):
+
+  1. `logger.info(f"Prepared parameters for Google Search: {params}")`
+     formatted the whole `params` dict, including `params["key"]` -- the
+     API key -- at INFO, on every successful call.
+  2. `logger.error(f"Error during API request: {str(re)}")` formatted a
+     `requests` exception's `str()`. Because this engine (unlike every
+     other one in the file) sends `key` as a URL query parameter rather
+     than a header, `requests`'s own `HTTPError`/`ConnectionError` text
+     embeds the full request URL -- including the key -- via
+     `response.url`. This fires on exactly the failure modes a user hits
+     debugging a bad/expired key (401/403/429/connection failure).
+
+Both are fixed at the point of formatting: vector 1 via an explicit
+ALLOWLIST of safe param keys (`SAFE_GOOGLE_SEARCH_PARAM_KEYS`), vector 2 via
+`Utils.log_sanitizer.sanitize_string`, which carries a dedicated
+`AIza[A-Za-z0-9_-]{35}` pattern for Google API keys. Each test below proves
+the leak is real for the exact runtime value in play (not a hardcoded
+string) as a methodology check, then asserts the actual emitted log
+records never carry it, while the non-credential diagnostic value survives.
+"""
+
+import logging
+from urllib.parse import urlencode
+
+import pytest
+import requests as real_requests
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.Logging_Config import _forward_loguru_to_standard
+from tldw_chatbook.Web_Scraping import WebSearch_APIs
+
+# Shaped to match log_sanitizer's Google-API-key pattern (AIza + 35 chars)
+# so the redaction path under test actually engages -- an arbitrarily
+# shaped secret would NOT be caught by that specific pattern, which is a
+# real, disclosed limitation of vector 2's fix (see the task's Implementation
+# Notes). Real Google API keys are uniformly AIza-prefixed, so this is the
+# shape that matters for this engine.
+_SENTINEL_SUFFIX = "TASK19552SENTINELKEYNOTREAL00011234"
+assert len(_SENTINEL_SUFFIX) == 35, len(_SENTINEL_SUFFIX)
+SENTINEL_KEY = "AIza" + _SENTINEL_SUFFIX
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = {"Content-Type": "application/json"}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise real_requests.exceptions.HTTPError(f"status {self.status_code}")
+
+
+class _FakeRequests:
+    """Stands in for the module's `requests` import; records the call."""
+
+    exceptions = real_requests.exceptions
+
+    def __init__(self, payload, status_code=200):
+        self.calls = []
+        self._payload = payload
+        self._status = status_code
+
+    def get(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return _FakeResponse(self._payload, self._status)
+
+
+class _HTTPErrorRequests:
+    """Raises the SAME exception `requests` itself would raise for a failed
+    GET -- built from a real `requests.models.Response` so the message
+    format (including the URL) is authentic, not hand-rolled."""
+
+    exceptions = real_requests.exceptions
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, params=None, **kwargs):
+        full_url = f"{url}?{urlencode(params or {})}"
+        self.calls.append({"url": full_url, "params": params})
+        resp = real_requests.models.Response()
+        resp.status_code = 403
+        resp.reason = "Forbidden"
+        resp.url = full_url
+        resp.raise_for_status()  # raises the real requests.exceptions.HTTPError
+
+
+def _set_key(monkeypatch, key, value):
+    monkeypatch.setitem(WebSearch_APIs.loaded_config_data["search_engines"], key, value)
+
+
+@pytest.fixture
+def loguru_caplog(caplog):
+    """Bridge loguru records into caplog (the repo's standard pattern --
+    see Tests/Chat/test_chat_api_call_endpoint_redaction.py)."""
+    sink_id = loguru_logger.add(_forward_loguru_to_standard, level="DEBUG")
+    caplog.set_level(logging.DEBUG)
+    try:
+        yield caplog
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+_GOOGLE_PAYLOAD = {"items": [{"title": "G Title", "link": "https://g.example/", "snippet": "g snippet"}]}
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: the allowlist helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_safe_search_params_for_log_drops_key_keeps_allowlisted_and_unknown():
+    """The allowlist drops the credential AND any key it doesn't recognize
+    -- an unknown/future param key is safe by default, not exposed by
+    default (the property Utils/sensitive_llm_logging.py documents)."""
+    params = {
+        "q": "hello",
+        "key": SENTINEL_KEY,
+        "cx": "cx123",
+        "num": 5,
+        "some_future_field_nobody_allowlisted_yet": "x",
+    }
+    safe = WebSearch_APIs._safe_search_params_for_log(
+        params, WebSearch_APIs.SAFE_GOOGLE_SEARCH_PARAM_KEYS
+    )
+    assert safe == {"q": "hello", "cx": "cx123", "num": 5}
+    assert "key" not in safe
+    assert "some_future_field_nobody_allowlisted_yet" not in safe
+
+
+# ---------------------------------------------------------------------------
+# Vector 1: the params-dict INFO log on the success path
+# ---------------------------------------------------------------------------
+
+
+def test_google_success_path_never_logs_the_key(monkeypatch, loguru_caplog):
+    _set_key(monkeypatch, "google_search_api_key", SENTINEL_KEY)
+    _set_key(monkeypatch, "google_search_engine_id", "cx123")
+    fake = _FakeRequests(_GOOGLE_PAYLOAD)
+    monkeypatch.setattr(WebSearch_APIs, "requests", fake)
+
+    WebSearch_APIs.search_web_google("cherry cake")
+
+    # Baseline / methodology check: the dict that was ACTUALLY sent on the
+    # wire really does carry the key, and formatting that same dict (as the
+    # old code did) would leak it -- proves this test can detect the leak.
+    assert fake.calls, "search_web_google made no request"
+    sent_params = fake.calls[0]["params"]
+    assert sent_params["key"] == SENTINEL_KEY
+    assert SENTINEL_KEY in str(sent_params)
+
+    # Actual: no emitted log record contains the key.
+    messages = [r.getMessage() for r in loguru_caplog.records]
+    assert not any(SENTINEL_KEY in m for m in messages), messages
+
+    # The diagnostic must still be useful -- not merely deleted.
+    prepared = [m for m in messages if "Prepared parameters for Google Search" in m]
+    assert prepared, "expected the params-preparation log line"
+    assert "cherry cake" in prepared[0]
+    assert "cx123" in prepared[0]
+
+
+# ---------------------------------------------------------------------------
+# Vector 2: the exception-text ERROR log on a failed request
+# ---------------------------------------------------------------------------
+
+
+def test_google_http_error_never_logs_the_key_via_exception_text(monkeypatch, loguru_caplog):
+    _set_key(monkeypatch, "google_search_api_key", SENTINEL_KEY)
+    _set_key(monkeypatch, "google_search_engine_id", "cx123")
+    fake = _HTTPErrorRequests()
+    monkeypatch.setattr(WebSearch_APIs, "requests", fake)
+
+    with pytest.raises(real_requests.exceptions.HTTPError) as excinfo:
+        WebSearch_APIs.search_web_google("cherry cake")
+
+    # Baseline / methodology check: requests' OWN exception text really
+    # does embed the key for this call shape (GET + key as a query param)
+    # -- proves this test can detect the leak, and explains why Google
+    # (unlike header-auth engines such as Bing) needs this second fix.
+    assert SENTINEL_KEY in str(excinfo.value)
+
+    # Actual: no emitted log record contains the key.
+    messages = [r.getMessage() for r in loguru_caplog.records]
+    assert not any(SENTINEL_KEY in m for m in messages), messages
+
+    # The diagnostic must still be useful -- the error line survives,
+    # just without the credential.
+    error_lines = [m for m in messages if "Error during API request" in m]
+    assert error_lines, "expected the RequestException error log line"
+    assert "403" in error_lines[0] or "Forbidden" in error_lines[0]
+
+
+def test_google_value_error_never_logs_the_key_via_exception_text(monkeypatch, loguru_caplog):
+    """Defense in depth for the `except ValueError` branch.
+
+    `response.json()` raises `requests.exceptions.JSONDecodeError` on
+    malformed content -- which is ALSO a `ValueError` subclass, so a
+    real-world bad-JSON response is caught by this function's FIRST except
+    clause (`except ValueError as ve`), not the `RequestException`/generic
+    `Exception` clauses covered above. A naturally occurring JSON-decode
+    message never embeds the request URL, so this test injects the
+    sentinel into a ValueError message directly (a synthetic, not a
+    naturally-occurring, message) to prove this branch is *also* sanitized
+    -- not merely the two branches a JSONDecodeError happens not to reach.
+    """
+    _set_key(monkeypatch, "google_search_api_key", SENTINEL_KEY)
+    _set_key(monkeypatch, "google_search_engine_id", "cx123")
+
+    class _BadJSONResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            raise ValueError(f"synthetic decode failure embedding key={SENTINEL_KEY}")
+
+    class _BadJSONRequests:
+        exceptions = real_requests.exceptions
+
+        def get(self, url, params=None, **kwargs):
+            return _BadJSONResponse()
+
+    monkeypatch.setattr(WebSearch_APIs, "requests", _BadJSONRequests())
+
+    with pytest.raises(ValueError) as excinfo:
+        WebSearch_APIs.search_web_google("cherry cake")
+
+    assert SENTINEL_KEY in str(excinfo.value)
+
+    messages = [r.getMessage() for r in loguru_caplog.records]
+    assert not any(SENTINEL_KEY in m for m in messages), messages
+    error_lines = [m for m in messages if "Configuration error" in m]
+    assert error_lines, "expected the ValueError error log line"

--- a/backlog/tasks/task-19552 - Google Search API key is logged at INFO on the default search engine.md
+++ b/backlog/tasks/task-19552 - Google Search API key is logged at INFO on the default search engine.md
@@ -2,7 +2,7 @@
 id: TASK-19552
 title: >-
   Google Search API key is logged at INFO on the default search engine
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:02'
 labels:
@@ -50,16 +50,235 @@ Two things make this worse than a single leaky line:
 
 ## Acceptance Criteria
 
-- [ ] No search-provider credential reaches any log record, at any level, on
+- [x] No search-provider credential reaches any log record, at any level, on
       any engine — the Google path in particular never formats a dict that
       contains `key`
-- [ ] The fix redacts at the point of formatting rather than relying on the
+- [x] The fix redacts at the point of formatting rather than relying on the
       caller's log level, so raising the log level for troubleshooting cannot
       re-expose it
-- [ ] A regression test asserts that a configured Google CSE key does not
+- [x] A regression test asserts that a configured Google CSE key does not
       appear in emitted log records for a search call, and that the test would
       fail if the redaction were removed (mutation-checked, not merely green)
-- [ ] The other search-provider paths in `WebSearch_APIs.py` are swept for the
+- [x] The other search-provider paths in `WebSearch_APIs.py` are swept for the
       same shape and any further instances are fixed in the same change
-- [ ] Owner is advised whether the affected key needs rotating, given the key
+- [x] Owner is advised whether the affected key needs rotating, given the key
       may already be in existing local log files
+
+## Implementation Plan
+
+1. Read `Utils/log_sanitizer.py` (denylist-based) and `Utils/sensitive_llm_logging.py`
+   (allowlist-based, with its documented rationale: a denylist has already
+   failed twice on the analogous LLM-request logging path in this repo).
+   Prefer the allowlist shape for the Google `params` dict per the
+   controller's brief.
+2. Sweep every `logger.*` call in `WebSearch_APIs.py` for a credential-bearing
+   interpolation: params dicts, headers dicts, auth values, or exception
+   text that could embed a URL built with `params=`. Cross-reference each
+   engine's request shape (header-based auth vs. URL-query auth) to know
+   which sites are even capable of leaking a credential.
+3. Empirically verify (small script against the real `requests` exception
+   classes) whether an HTTPError/ConnectionError's `str()` embeds the full
+   request URL for a GET request that carries the key as a query param —
+   this determines whether the Google function's exception-log site
+   (`logger.error(f"Error during API request: {str(re)}")`) is a second,
+   independent leak vector beyond the already-identified params-dict log.
+4. Fix the Google `search_web_google` function:
+   a. Add a module-level allowlist of safe-to-log Google CSE param keys
+      (everything currently set except `key`) and a small helper that
+      projects `params` through it before formatting into the INFO log.
+   b. If step 3 confirms the exception-text vector, redact exception text
+      at the formatting point (reusing `Utils/log_sanitizer.sanitize_string`,
+      which already has a Google `AIza...` key pattern) rather than
+      widening the allowlist helper to unstructured text.
+5. Write born-red regression tests: capture loguru records (the
+   `Tests/Chat/test_chat_api_call_endpoint_redaction.py` bridge idiom) while
+   invoking the Google parameter-preparation path and the exception path
+   with a sentinel API key; assert the sentinel is absent from every log
+   record while the non-credential params are still present.
+6. Run the targeted web-search test suites plus a repo-wide
+   `--collect-only -q` sweep to confirm no collection regressions.
+7. Update task file: AC checkboxes, Implementation Notes, status Done.
+
+## Implementation Notes
+
+Approach: fixed two independent credential-log vectors in
+`search_web_google` (`tldw_chatbook/Web_Scraping/WebSearch_APIs.py`), swept
+every other `logger.*` call in the file and every sibling
+`search_web_*`/`test_search_*` function for the same shape, and added
+born-red regression coverage.
+
+**Vector 1 (the filed defect):** `logger.info(f"Prepared parameters for
+Google Search: {params}")` at line 3428 formatted the whole `params` dict,
+including `params["key"]`. Fixed with an explicit ALLOWLIST —
+`SAFE_GOOGLE_SEARCH_PARAM_KEYS` (`q, c2coff, cr, cx, num, dateRestrict,
+exactTerms, excludeTerms, filter, gl, hl, lr, safe, sort` — i.e. every key
+`search_web_google` sets except `key`) plus a `_safe_search_params_for_log`
+helper that projects `params` through it before formatting. Any future
+param this function starts setting is dropped from the log by default
+unless someone explicitly adds it to the allowlist — matching the "unknown
+key is safe by default, not exposed by default" property
+`Utils/sensitive_llm_logging.py` documents and that the controller's brief
+asked to follow, in preference to a denylist (`Utils/log_sanitizer.py`
+documents two prior denylist failures on the analogous LLM-request path).
+
+**Vector 2 (found during the sweep, not in the original filing):**
+`logger.error(f"Error during API request: {str(re)}")` (now line 3490).
+Empirically verified against the real `requests` library (a `requests.
+models.Response` with `.url` set to a URL carrying a sentinel `AIza...`
+key, `.raise_for_status()` called) that both `HTTPError` and
+`ConnectionError` embed the full request URL — including `key=<value>` —
+in their `str()` when the key was passed as a GET query param
+(`requests.get(search_url, params=params, ...)`, as Google's call does).
+This fires on exactly the failure modes a user hits while debugging a
+bad/expired key: 401/403/429/connection failure. This is why the Bing
+branch is clean by comparison — Bing sends its key as a header, so
+`response.url`/the connection-pool message never contains it. Fixed by
+wrapping the `RequestException` handler text through `Utils/log_sanitizer.
+sanitize_string`, which already carries a dedicated
+`AIza[A-Za-z0-9_-]{35}` pattern for Google API keys (plus generic
+Bearer/URL-userinfo/other vendor-key patterns) — pattern-based redaction is
+the right tool here specifically because exception text is unstructured (no
+"keys" to allowlist), unlike the params dict in vector 1. Disclosed
+limitation: this only catches known credential *shapes*; Google's real CSE
+keys are uniformly `AIza`-prefixed, so this is adequate coverage for this
+engine, but the fix would not catch an arbitrarily-shaped secret in free
+text.
+
+**Vector 3 (also found during the sweep):** the `except ValueError as ve:`
+branch (line 3481), which sits *before* `RequestException` in the chain.
+`requests.exceptions.JSONDecodeError` (raised by `response.json()` on
+malformed content) is itself a `ValueError` subclass, so a bad-JSON
+response is caught here, not by the `RequestException`/`Exception`
+handlers vector 2 fixed — meaning those two fixes alone would have left one
+branch that can still receive a `ValueError` unprotected. This function's
+own two hardcoded config-error `ValueError`s never carry the key, and a
+real JSON-decode message doesn't naturally embed the URL either, but the
+branch is sanitized defensively anyway (via the same `sanitize_string`
+call) so the "at any level, on any engine" AC holds unconditionally rather
+than "in the cases I happened to think of." The catch-all
+`except Exception as e:` (line 3494) got the same treatment for the same
+reason.
+
+**Sweep results — every `logger.*` call in the file, by engine:**
+- Bing (2638-2760): clean, unchanged — key travels via header
+  (`Ocp-Apim-Subscription-Key`), never formatted; `params` logged at DEBUG
+  contains no key. Confirmed as the reference shape.
+- Brave (2923-3096): clean — key in header (`X-Subscription-Token`); no
+  logger call touches `params`/`headers`.
+- Kagi (3616-3640): clean re: credentials — key in header
+  (`Authorization: Bot ...`); `logger.debug(response.json())` logs
+  *response* content, not the request/key. Flagged (not fixed — different
+  task) as a content-logging concern for TASK-19555.
+- SearX (3730-3838): no API key at all for this engine; `logger.info(f"Search
+  URL: {search_url}")` embeds the user's query text in a URL, which is a
+  content concern for TASK-19555, not a credential.
+- Serper (3919-3952), Exa (3991-4022), Yandex (4159-4196): clean — key in
+  header, POST body (not URL query params), and **no logger call in any of
+  the three functions**.
+- Tavily (4057-4093): key is embedded directly in the JSON POST `payload`
+  dict (`payload["api_key"] = tavily_api_key`) rather than a header — the
+  same structural smell as Google, but **no logger call in the function
+  formats `payload`** today, so nothing currently leaks. Flagged as a
+  latent risk for a future maintainer (a debug log of `payload` here would
+  leak immediately) but not fixed — no live defect, and reshaping Tavily's
+  auth transport is outside this task's scope (logging, not transport).
+- Google (3317-3499): the three vectors fixed above.
+- Every other `logger.*` call in the file (result counts, `raw_results`
+  response-content dumps, generic error-message text with no request
+  object embedded, sub-query/relevance-pipeline logging) was checked and
+  contains no provider credential — several ARE response/query content and
+  are reported (not fixed) as TASK-19555 scope per the controller's brief.
+
+**Tests added:** `Tests/Web_Scraping/test_websearch_credential_logging.py`
+(4 tests), using the repo's standard loguru→caplog bridge
+(`Logging_Config._forward_loguru_to_standard`, per
+`Tests/Chat/test_chat_api_call_endpoint_redaction.py`):
+- `test_safe_search_params_for_log_drops_key_keeps_allowlisted_and_unknown`
+  — unit-level: the allowlist helper drops `key` AND an unlisted/future key.
+- `test_google_success_path_never_logs_the_key` — vector 1: baseline proves
+  the actual sent `params` dict (containing the real sentinel) would leak
+  if formatted directly; asserts the emitted INFO log doesn't carry it
+  while `cherry cake` and `cx123` still appear.
+- `test_google_http_error_never_logs_the_key_via_exception_text` — vector 2:
+  baseline proves `requests`'s own `HTTPError.__str__()` embeds the
+  sentinel via the URL; asserts the emitted ERROR log doesn't, while
+  "403"/"Forbidden" still appear.
+- `test_google_value_error_never_logs_the_key_via_exception_text` — vector 3
+  (the `except ValueError` branch), same shape.
+
+Each is mutation-checked, not merely green: I reverted each of the three
+`sanitize_string(...)`/allowlist call sites in turn (via Edit, back to the
+original `{params}`/`{str(re)}`/`{str(ve)}` formatting) and reran the
+corresponding test — all three failed red with the sentinel key visibly
+present in the captured log record (e.g. `...&key=AIzaTASK19552SENTINEL...`
+for vector 2) — then restored the fix and reran the full file green again.
+Full 4/4 file run: `4 passed, 1 warning in 0.57s`.
+
+**Owner advisory:** no real API key was used anywhere in this branch's
+tests or logs — only synthetic sentinels shaped like `AIza<35 chars>`.
+Whether to rotate any Google CSE key that may already be sitting in an
+existing user's local log file from before this fix is an owner decision;
+this task cannot inspect anyone's local logs to answer that, so it is
+surfaced here rather than assumed either way.
+
+**Verification run (venv `../../.venv/bin/python`, `PYTHONPATH`+cwd pinned
+to this worktree, confirmed via a `tldw_chatbook.__file__` path assert):**
+- New file: `Tests/Web_Scraping/test_websearch_credential_logging.py` —
+  4 passed.
+- `Tests/Web_Scraping/` (full dir, incl. `test_search_backends.py`'s
+  existing google/bing/brave/kagi/serper/exa/tavily/yandex/searx request-
+  shape pins) — 222 passed, 3 skipped (`TLDW_LIVE_SEARCH_TESTS` live tests,
+  unrelated).
+- `Tests/Tools/test_web_search_tool.py` (the `web_search` local-tool entry
+  point) — 2 passed.
+- `Tests/Internal_Prompts/test_websearch_prompt_parity.py` — 5 passed,
+  1 pre-existing failure (`test_result_relevance_eval_parity`, a Jinja2
+  whitespace assertion unrelated to logging/credentials). Confirmed
+  pre-existing and unrelated to this change by running the identical test
+  against a throwaway `origin/dev` worktree at the same base commit
+  (`2a15a72bb`) — it fails there too, byte-for-byte the same assertion.
+  Not touched; out of this task's scope.
+- `Tests/Utils/test_log_sanitizer.py` (the reused `sanitize_string` utility,
+  unmodified by this change) — 57 passed.
+- Repo-wide `pytest --collect-only -q` — 53633 tests collected, zero
+  collection errors.
+- Mutation check (see above): all 3 fixed log sites individually reverted
+  and reran red, then restored and reran green.
+
+Also noted, not fixed (pre-existing, out of scope): `Tests/Web_Scraping/
+test_security.py::TestAPIKeySecurity::test_api_keys_not_logged` and
+`test_api_key_masking` are vacuous — they patch `logging.info` in isolation
+and never call any real search function, so they could not have caught
+this defect and don't exercise the fix either. Left as-is; not this task's
+scope to rewrite a pre-existing test.
+
+**Diagnostic-inventory restamp (`Docs/security/production-diagnostic-
+inventory.json`):** the 3 log-site edits change the AST source text of 3
+diagnostic calls (content, not count — still 104 calls for this file), so
+the `WebSearch_APIs.py` row's `diagnostic_digest` needed restamping per
+`scripts/check_persistent_diagnostic_inventory.py`. Recomputed the digest
+for just this file (`63f3ddaba4b6557c0714` → `37972e1ac99fc6d3d304`,
+`call_count` unchanged at 104) and hand-edited only that one row, rather
+than running `--write` (which regenerates the whole file).
+
+**Owner-relevant finding, NOT caused by this task:** running the checker's
+full `--write` regeneration surfaced that the checked-in inventory is
+*already stale on `origin/dev`* for two unrelated files —
+`tldw_chatbook/DB/Client_Media_DB_v2.py` (338→339 calls) and
+`tldw_chatbook/UI/Screens/library_screen.py` (109→111 calls) — meaning
+`Tests/Architecture/test_persistent_diagnostic_inventory.py::
+test_production_diagnostic_inventory_and_sink_topology_are_unchanged`
+already fails on a pristine `origin/dev` checkout at this branch's base
+commit (`2a15a72bb`), confirmed by running the identical check in a
+throwaway `origin/dev` worktree before touching any source. This task
+deliberately did not touch those two files or restamp their rows — I
+haven't reviewed what diagnostic calls changed there, and bundling an
+unreviewed restamp into this PR would blur the credential-logging fix with
+unrelated content. Surfacing this for the controller/owner: someone needs
+to review those two files' diagnostic changes and restamp their rows
+separately; until then this one Architecture test stays red for a reason
+unrelated to TASK-19552.
+
+**Files changed:**
+- `tldw_chatbook/Web_Scraping/WebSearch_APIs.py`
+- `Tests/Web_Scraping/test_websearch_credential_logging.py` (new)

--- a/backlog/tasks/task-19552 - Google Search API key is logged at INFO on the default search engine.md
+++ b/backlog/tasks/task-19552 - Google Search API key is logged at INFO on the default search engine.md
@@ -231,8 +231,10 @@ to this worktree, confirmed via a `tldw_chatbook.__file__` path assert):**
   unrelated).
 - `Tests/Tools/test_web_search_tool.py` (the `web_search` local-tool entry
   point) — 2 passed.
-- `Tests/Internal_Prompts/test_websearch_prompt_parity.py` — 5 passed,
-  1 pre-existing failure (`test_result_relevance_eval_parity`, a Jinja2
+- `Tests/Internal_Prompts/test_websearch_prompt_parity.py` — 3 passed,
+  1 pre-existing failure (the file has 4 tests, not 6; the earlier "5 passed"
+  in this note was a bookkeeping error caught in review) —
+  (`test_result_relevance_eval_parity`, a Jinja2
   whitespace assertion unrelated to logging/credentials). Confirmed
   pre-existing and unrelated to this change by running the identical test
   against a throwaway `origin/dev` worktree at the same base commit

--- a/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
+++ b/tldw_chatbook/Web_Scraping/WebSearch_APIs.py
@@ -83,6 +83,7 @@ from tldw_chatbook.config import load_settings
 from tldw_chatbook.Internal_Prompts import render_internal_prompt
 from tldw_chatbook.Metrics.metrics_logger import log_counter, log_histogram
 from tldw_chatbook.Utils.egress import is_public_http_url
+from tldw_chatbook.Utils.log_sanitizer import sanitize_string
 from tldw_chatbook.Web_Scraping import deep_search_citations
 from tldw_chatbook.Web_Scraping.Article_Extractor_Lib import scrape_article
 
@@ -3314,6 +3315,31 @@ def test_parse_duckduckgo_results():
 ######################### Google Search #########################
 #
 # https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list
+
+# task-19552: allowlist of the Google Custom Search `params` keys that are
+# safe to write to a log record at any level. This is an ALLOWLIST, not a
+# denylist -- Utils/sensitive_llm_logging.py documents why a denylist has
+# already failed twice on the analogous LLM-request logging path in this
+# repo (new content-bearing keys kept slipping through unrecognized).
+# `key` -- the Google CSE API credential written into `params` below -- is
+# deliberately absent: any key not listed here, now or added in the future,
+# is dropped from the logged view instead of exposed by default.
+SAFE_GOOGLE_SEARCH_PARAM_KEYS: frozenset = frozenset({
+    "q", "c2coff", "cr", "cx", "num", "dateRestrict", "exactTerms",
+    "excludeTerms", "filter", "gl", "hl", "lr", "safe", "sort",
+})
+
+
+def _safe_search_params_for_log(params: Dict[str, Any], safe_keys: frozenset) -> Dict[str, Any]:
+    """Return an allowlisted, credential-free view of a request params dict.
+
+    Only keys present in ``safe_keys`` are copied through; everything else
+    (including a credential like Google's ``key``) is silently dropped so
+    the diagnostic stays useful without ever formatting a secret.
+    """
+    return {k: v for k, v in params.items() if k in safe_keys}
+
+
 def search_web_google(
     search_query: str,
     google_search_api_key: Optional[str] = None,
@@ -3425,7 +3451,13 @@ def search_web_google(
         if sort_results_by:
             params["sort"] = sort_results_by
 
-        logger.info(f"Prepared parameters for Google Search: {params}")
+        # task-19552: never format the raw `params` dict -- it carries the
+        # API key set above (`params["key"]`). Log only the allowlisted,
+        # credential-free view.
+        logger.info(
+            f"Prepared parameters for Google Search: "
+            f"{_safe_search_params_for_log(params, SAFE_GOOGLE_SEARCH_PARAM_KEYS)}"
+        )
 
         # Make the API call
         # task-3060: bound worst-case latency -- an unresponsive Google CSE
@@ -3441,15 +3473,25 @@ def search_web_google(
         return google_search_results
 
     except ValueError as ve:
-        logger.error(f"Configuration error: {str(ve)}")
+        # task-19552: this function's own config-error ValueErrors never
+        # embed the key, but `requests.exceptions.JSONDecodeError` (raised
+        # by `response.json()` above) is ALSO a ValueError and is caught
+        # here rather than below -- sanitize defensively so nothing that
+        # lands in this branch, now or later, can carry the credential.
+        logger.error(f"Configuration error: {sanitize_string(str(ve))}")
         raise
 
     except RequestException as re:
-        logger.error(f"Error during API request: {str(re)}")
+        # task-19552: `key` travels as a URL query param for this engine
+        # (unlike every other engine here, which sends it as a header), so
+        # `requests`'s own HTTPError/ConnectionError text embeds the full
+        # request URL -- including the key -- via `response.url`. Redact at
+        # the formatting point rather than trust the exception's shape.
+        logger.error(f"Error during API request: {sanitize_string(str(re))}")
         raise
 
     except Exception as e:
-        logger.error(f"Unexpected error occurred: {str(e)}")
+        logger.error(f"Unexpected error occurred: {sanitize_string(str(e))}")
         raise
 
 


### PR DESCRIPTION
## Summary
Closes task-19552 (P0). The Google Custom Search API key was being written to the application log **at INFO on the default search engine** (`search_params.get("engine", "google")`), reachable from the live `web_search` tool and deep search. The in-app log buffer is unfiltered and its "Copy all" ships to the clipboard, so this is a real exposure path, not a theoretical one.

The audit filed one leak; the fix found **three**:
1. The filed one — `logger.info(f"...{params}")` where `params["key"]` is the credential. Replaced with an explicit **allowlist** of the 14 non-credential parameters the function sets, so a future parameter is dropped by default rather than exposed by default (the repo chose allowlists here before, after two recorded denylist failures).
2. **The exception text.** Google is the only engine that sends its key as a **URL query parameter** rather than a header, so `requests`' `HTTPError`/`ConnectionError` embed `key=<value>` in `str(e)` — and that was logged at ERROR. This is the same class as task-19321's `OSError`-stringifies-the-filename finding.
3. The `except ValueError` branch preceding it, which catches `JSONDecodeError` and had the same exposure.

Sweep of every other engine: Bing, Brave, Kagi, Serper, Exa, Yandex and SearX are clean (header or POST-body auth). **Tavily** carries the same shape (`api_key` in the payload dict) but nothing logs that payload — recorded as latent, and the review independently confirmed its exception text can't carry the key either.

## Evidence
- Born-red per vector: each of the three sites individually reverted and re-run, each confirmed red with the sentinel visible in the captured record (`...&key=AIzaTASK19552SENTINEL...`), then restored.
- The tests also assert the **useful** parameters still appear, so "delete the log line" would not pass.
- New file 4/4; `Tests/Web_Scraping/` 222 passed / 3 skipped; collect-only 53,633 clean.

## Review
Independent review: **APPROVE** — it reproduced vector 2 itself by constructing the real exception objects (a `Response` with `raise_for_status()`, and a refused loopback connection) rather than trusting the claim, and read `requests`' own `__str__` to confirm. It enumerated all 15 parameter assignments and verified the allowlist covers exactly the 14 non-credential ones. It also caught a bookkeeping error in the notes (a test count reported as 5 passed where the file has 4 tests) — corrected pre-merge.

Honest limit, disclosed in the notes and confirmed in review: the exception-path redaction keys on the `AIza…{35}` shape, so an arbitrarily-shaped secret in free text would not be caught by that pattern.

**Owner note:** whether the real key needs rotating because of pre-fix local log exposure is a decision only you can make — no real key was used anywhere in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking the Google Custom Search API key to logs. Previously the Google path logged the full `params` dict (including `key`) and `requests` exception text that embedded the URL with `key`; now it logs an allowlisted view of params and sanitizes exception messages.

- Old vs new: INFO no longer formats raw `params`; it logs only allowlisted fields via `_safe_search_params_for_log` and `SAFE_GOOGLE_SEARCH_PARAM_KEYS`. ERROR paths (`ValueError`, `RequestException`, catch‑all) now wrap messages with `Utils.log_sanitizer.sanitize_string` (covers `AIza...` keys). Logs stay useful but may omit unknown/future params unless added to the allowlist.

- Code touched: `tldw_chatbook/Web_Scraping/WebSearch_APIs.py` (Google only). Other engines swept: Bing, Brave, Kagi, Serper, Exa, Yandex, SearX are clean; Tavily carries a latent risk (key in JSON payload) but nothing currently logs that payload.

- Tests: new `Tests/Web_Scraping/test_websearch_credential_logging.py` ensures no key appears in emitted logs on success and failure paths and that diagnostics remain.

- Inventory: restamped `Docs/security/production-diagnostic-inventory.json` for `WebSearch_APIs.py` (digest only; call count unchanged). Two unrelated rows in the repo are already stale and not modified here.

- Linear: satisfies TASK-19552 acceptance criteria (no credential in logs at any level; redaction at formatting point; regression coverage; sweep completed; owner advised on potential rotation).

Bold Rollout
- No config or code migrations.

- Action: consider rotating any Google CSE keys that may exist in pre-fix local logs.

- If the architecture inventory test fails due to unrelated stale rows, restamp those in a separate PR.

<sup>Written for commit b0632c14f8e8523b9676f9d933d13f067f1d9ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

