### PR TITLE
fix(chatbooks): remove the import wizard's fake backup control (task-19550)

### DIFF
--- a/Tests/Chatbooks/test_chatbook_import_wizard_backup_honesty.py
+++ b/Tests/Chatbooks/test_chatbook_import_wizard_backup_honesty.py
@@ -1,0 +1,263 @@
+# test_chatbook_import_wizard_backup_honesty.py
+# Description: Regression coverage for task-19550 (import wizard claimed a backup it never took)
+"""
+`ChatbookImportWizard` used to offer a default-ON "Create backup" checkbox
+("Backup current database before importing"), read its value into the import
+options, and then -- with the implementation still a bare
+``# TODO: Implement actual backup functionality`` -- paint
+``"✓ Created backup"`` into the progress list before running a
+database-mutating import that has no rollback.
+
+These tests pin the honest behaviour: no backup control, no backup status
+row, no success claim for work that never ran, and an explicit statement of
+the real risk (the import cannot be undone) on the last step the user can
+still back out of.
+
+The last test is the generic guard AC#4 asks for: any function in this module
+that paints a ``"completed"`` status row must not carry a
+TODO/"For now"/"not implemented" marker, and the set of status rows that can
+be marked completed is pinned to the audited allowlist.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Checkbox, Static
+
+from tldw_chatbook.Chatbooks.chatbook_models import ChatbookManifest, ChatbookVersion
+from tldw_chatbook.UI.Wizards import ChatbookImportWizard as wizard_module
+from tldw_chatbook.UI.Wizards.BaseWizard import WizardStepConfig
+from tldw_chatbook.UI.Wizards.ChatbookImportWizard import (
+    ImportOptionsStep,
+    ImportProgressStep,
+)
+
+# Every status row this flow is allowed to mark "completed", and the work that
+# earns the claim (task-19550 audit):
+#   status-prepare       -- the importer/server request was actually built
+#   status-conversations -- ChatbookImporter.import_chatbook returned success
+#   status-notes         --   "
+#   status-characters    --   "
+#   status-media         --   "
+#   status-indexes       -- FTS5 triggers maintain the indexes inside those writes
+#   status-finalize      -- the import call returned
+# "status-backup" is deliberately absent: no backup is taken, so no row may
+# claim one.
+AUDITED_COMPLETED_STATUS_IDS = frozenset(
+    {
+        "status-prepare",
+        "status-conversations",
+        "status-notes",
+        "status-characters",
+        "status-media",
+        "status-indexes",
+        "status-finalize",
+    }
+)
+
+_UNIMPLEMENTED_MARKERS = ("TODO", "FIXME", "For now", "not implemented", "placeholder")
+
+
+class _StepHost(App):
+    """Mount a single wizard step, the idiom used by Tests/Wizards."""
+
+    def __init__(self, step):
+        super().__init__()
+        self._step = step
+
+    def compose(self) -> ComposeResult:
+        yield self._step
+
+
+def _fake_wizard(**wizard_data) -> SimpleNamespace:
+    return SimpleNamespace(
+        app_instance=MagicMock(app_config={}),
+        wizard_data=dict(wizard_data),
+        initial_execution_mode="local",
+        can_go_back=True,
+    )
+
+
+def _options_step() -> ImportOptionsStep:
+    manifest = ChatbookManifest(
+        version=ChatbookVersion.V1,
+        name="Bundle",
+        description="Bundle",
+    )
+    manifest.total_conversations = 1
+    return ImportOptionsStep(
+        wizard=_fake_wizard(**{"preview-validation": {"manifest": manifest}}),
+        config=WizardStepConfig(
+            id="import-options",
+            title="Import Options",
+            step_number=4,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_options_step_offers_no_backup_control():
+    """AC#1: the wizard must not offer to back the database up at all --
+    a disabled or greyed-out box would still read as 'backup handled'."""
+    step = _options_step()
+    async with _StepHost(step).run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+
+        checkbox_labels = [
+            str(checkbox.label).lower() for checkbox in step.query(Checkbox)
+        ]
+        checkbox_ids = [checkbox.id or "" for checkbox in step.query(Checkbox)]
+        rendered = " ".join(
+            str(static.renderable).lower() for static in step.query(Static)
+        )
+
+        assert checkbox_labels, "the options step should still offer its real options"
+        assert not any("backup" in label for label in checkbox_labels), checkbox_labels
+        assert not any("backup" in widget_id for widget_id in checkbox_ids), (
+            checkbox_ids
+        )
+        assert "backup current database" not in rendered
+
+        assert "create_backup" not in step.get_step_data()
+
+
+@pytest.mark.asyncio
+async def test_import_options_step_states_that_the_import_cannot_be_undone():
+    """AC#5: the honest risk has to be visible on the last step the user can
+    still cancel from -- the next step starts writing immediately."""
+    step = _options_step()
+    async with _StepHost(step).run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+
+        rendered = " ".join(
+            str(static.renderable).lower() for static in step.query(Static)
+        )
+
+        assert "cannot be undone" in rendered
+        assert "writes directly into your databases" in rendered
+
+
+@pytest.mark.asyncio
+async def test_import_run_never_claims_a_backup_it_did_not_take(monkeypatch):
+    """AC#2, end to end: drive the real import path with a stale
+    ``create_backup=True`` option still in the wizard data and prove no status
+    update ever mentions a backup."""
+    manifest = ChatbookManifest(
+        version=ChatbookVersion.V1,
+        name="Bundle",
+        description="Bundle",
+    )
+    manifest.total_conversations = 2
+
+    step = ImportProgressStep(
+        wizard=_fake_wizard(
+            **{
+                "file-selection": {"file_path": "/tmp/does-not-need-to-exist.zip"},
+                "preview-validation": {"manifest": manifest},
+                "conflict-resolution": {},
+                # A stale option key from an older wizard version must not be
+                # able to resurrect the claim.
+                "import-options": {"execution_mode": "local", "create_backup": True},
+            }
+        ),
+        config=WizardStepConfig(id="import-progress", title="Importing", step_number=5),
+    )
+
+    calls = {"importer": 0, "import_chatbook": 0}
+
+    class _FakeImporter:
+        def __init__(self, db_paths):
+            calls["importer"] += 1
+            self.db_paths = db_paths
+
+        def import_chatbook(self, **kwargs):
+            calls["import_chatbook"] += 1
+            status = kwargs["import_status"]
+            status.total_items = 2
+            status.processed_items = 2
+            status.successful_items = 2
+            return True, "ok"
+
+    # from-imports bind at import time: patch the CONSUMER namespace.
+    monkeypatch.setattr(wizard_module, "ChatbookImporter", _FakeImporter)
+    monkeypatch.setattr(
+        wizard_module,
+        "get_chatbook_database_paths",
+        lambda: {"ChaChaNotes": "/tmp/cn.db"},
+    )
+
+    statuses: list[tuple[str, str, str]] = []
+    completions: list[str] = []
+    errors: list[str] = []
+
+    async def _completion():
+        completions.append("completed")
+
+    async def _error(message):
+        errors.append(message)
+
+    step._update_status = lambda status_id, state, text: statuses.append(
+        (status_id, state, text)
+    )
+    step._update_progress = lambda value: None
+    step._show_completion = _completion
+    step._show_error = _error
+
+    await step._import_chatbook()
+
+    # Prove the patched seams were the ones that ran, and that the run reached
+    # the success path rather than dying early into the except branch.
+    assert errors == []
+    assert calls == {"importer": 1, "import_chatbook": 1}
+    assert completions == ["completed"]
+    assert statuses, "the import must still report its real progress"
+
+    assert not any(status_id == "status-backup" for status_id, _, _ in statuses)
+    assert not any("backup" in text.lower() for _, _, text in statuses)
+
+
+def test_no_completed_status_row_is_painted_from_an_unimplemented_code_path():
+    """AC#4: a status row may not report success from a TODO/no-op path, and
+    the rows that CAN report success are pinned to the audited allowlist."""
+    source = Path(inspect.getfile(wizard_module)).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    completed_status_ids: set[str] = set()
+    offenders: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        function_completed_ids = {
+            call.args[0].value
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "_update_status"
+            and len(call.args) >= 2
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[1], ast.Constant)
+            and call.args[1].value == "completed"
+        }
+        if not function_completed_ids:
+            continue
+
+        completed_status_ids |= function_completed_ids
+
+        segment = ast.get_source_segment(source, node) or ""
+        found = [marker for marker in _UNIMPLEMENTED_MARKERS if marker in segment]
+        if found:
+            offenders.append(f"{node.name}: {', '.join(found)}")
+
+    assert completed_status_ids, "the parser found no completed status rows at all"
+    assert offenders == [], (
+        "these functions claim a completed status row while still carrying an "
+        f"unimplemented marker: {offenders}"
+    )
+    assert completed_status_ids == set(AUDITED_COMPLETED_STATUS_IDS)

--- a/backlog/tasks/task-19550 - Chatbook import Create backup checkbox writes a success message and takes no backup.md
+++ b/backlog/tasks/task-19550 - Chatbook import Create backup checkbox writes a success message and takes no backup.md
@@ -3,9 +3,11 @@ id: TASK-19550
 title: >-
   Chatbook import "Create backup" checkbox writes a success message and takes no
   backup
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-21 20:00'
+updated_date: '2026-08-21 22:30'
 labels:
   - chatbooks
   - data-loss
@@ -50,16 +52,157 @@ real backup is wanted, it is a separate, deliberately scoped piece of work.
 
 ## Acceptance Criteria
 
-- [ ] The import wizard no longer presents any control that offers to back up
+- [x] The import wizard no longer presents any control that offers to back up
       the database unless a backup is actually performed
-- [ ] The wizard never emits "✓ Created backup" (or any equivalent success
+- [x] The wizard never emits "✓ Created backup" (or any equivalent success
       claim) for work it did not do
-- [ ] The remaining status rows in the import flow are audited: every one that
+- [x] The remaining status rows in the import flow are audited: every one that
       reports "completed" corresponds to work that actually ran
-- [ ] A test fails if a status row can report success on a code path whose
+- [x] A test fails if a status row can report success on a code path whose
       implementation is a `TODO`/no-op
-- [ ] The user-facing risk is stated honestly somewhere the user sees it
+- [x] The user-facing risk is stated honestly somewhere the user sees it
       before confirming: this import mutates the database and cannot be
       rolled back
-- [ ] `Docs/User_Guide/` is updated wherever it describes the import wizard's
+- [x] `Docs/User_Guide/` is updated wherever it describes the import wizard's
       backup behaviour
+
+## Implementation Plan
+
+1. Decide the disposition on evidence, not preference: search the repo for a
+   backup primitive the wizard could actually *call* (DB `backup_database`,
+   `private_sqlite.copy_private_sqlite`, the Settings backup workers, any
+   `.bak` convention) and cost out what a real, non-lying backup here would
+   need. Record the finding either way.
+2. Write the born-red tests first, using the repo's wizard idioms
+   (`Tests/Wizards/test_first_run_setup_wizard.py`'s single-step host app;
+   `Tests/Chatbooks/test_chatbook_import_wizard_validation.py`'s no-mount
+   style for pure logic):
+   - options step composes no backup control and `get_step_data()` carries
+     no `create_backup` key;
+   - options step states the irreversibility risk before the user confirms;
+   - driving `ImportProgressStep._import_chatbook` end-to-end never emits a
+     backup status row, even when a stale `create_backup=True` option is
+     present;
+   - a static guard (AC#4): no function in the module that emits a
+     `"completed"` status row may contain a `TODO`/"For now"/"not
+     implemented" marker, and the set of status ids that can be marked
+     completed is pinned to an audited allowlist.
+3. Show the tests red at the branch base.
+4. Apply the disposition in `ChatbookImportWizard.py`.
+5. Audit every other `_update_status(..., "completed", ...)` in the file
+   against the work that actually runs; fix what is trivially in scope,
+   report the rest for filing.
+6. Green the tests; run `Tests/Chatbooks/`, `Tests/Wizards/`, the UI tests
+   that touch this wizard, and a repo-wide `--collect-only -q`.
+7. Check `Docs/User_Guide/` for any page describing this wizard's backup
+   behaviour; update it if one exists.
+
+## Implementation Notes
+
+Removed the lying control (the lane's filed disposition), and replaced it with
+the fact it was hiding: the import writes straight into the live databases and
+cannot be undone. Gone from `ChatbookImportWizard.py`: the `Create backup`
+checkbox and its "Backup current database before importing" caption, the
+`create_backup` options key, the `○ Creating backup` progress row, and the
+`TODO`-backed block that painted `✓ Created backup`. Added an
+`#import-irreversible-warning` line at the top of the Import Options step (the
+last screen the user can still cancel from — the next step starts writing on
+`on_show`).
+
+### Why remove rather than implement
+
+The controller's bar for implementing was "only if the repo already has a
+safe, reachable primitive you can call". It does not, quite:
+
+- The primitives exist but are owner-gated. `ChaChaNotes_DB.backup_database`,
+  `Client_Media_DB_v2.backup_database` and `Prompts_DB.backup_database` all
+  route through `DB/private_sqlite.py`, whose `SQLITE_OWNER_REGISTRY` keys each
+  backup to a named owning module. Reusing `settings.bulk_backup` (owned by
+  `UI/Tools_Settings_Window`) from the wizard is registry misuse; doing it
+  properly means a **new registry row**, which
+  `Tests/DB/test_private_sqlite_inventory.py:1009` pins against
+  `backlog/docs/sqlite-private-owner-inventory.md`
+  (`set(SQLITE_OWNER_REGISTRY) == documented_owner_ids`) — a security-registry
+  change plus an inventory derivation, not a call.
+- A correct backup here is three databases, not one. `get_chatbook_database_paths()`
+  hands the importer ChaChaNotes, Prompts **and** Media; backing up a subset
+  and saying "✓ Created backup" is the same defect with a smaller blast
+  radius. The Media DB is also the one that can be multi-GB, inside a worker
+  with no cancel and no disk-space check.
+- The only correct implementation in-tree is ~120 lines. `Tools_Settings_Window`'s
+  `_backup_*_worker` shows what it actually takes: profile-scoped root,
+  `mkstemp` staging, atomic `os.replace`, cancellation checks between every
+  file, unlink of published artifacts if any later file fails, a manifest, and
+  a loud failure when a source path will not resolve. Extracting that out of a
+  retired 7.7k-line screen, or reimplementing a subset in a wizard, is exactly
+  the "hurried backup implementation" the lane warned about.
+- There is nowhere to restore it from. The DB backup/restore UI lives in
+  `ToolsSettingsWindow`, which is retired and nav-unreachable (its route
+  resolves to the MCP screen). Shipping a backup with no in-app restore would
+  need its own UX work to be worth the checkbox.
+
+That is a deliberately scoped piece of work, which is what the task says. Per
+the owner's standing stability-over-quick-wins ruling, removing the lying
+control and stating the risk is the durable answer today.
+
+### Sibling status-row audit (AC#3) — every `"completed"` row in the file
+
+Verified true, keeping their rows:
+
+- `status-prepare` → "✓ Prepared import" / "✓ Submitted server import": the
+  importer really is constructed / the server really returned a `job_id`
+  (missing id raises).
+- `status-indexes` → "✓ Server import completed": gated on a terminal
+  `completed|success` status; anything else raises.
+- `status-indexes` → "✓ Updated indexes" (local): the wizard does no index
+  work itself, but the claim is true — ChaChaNotes carries 100 `CREATE TRIGGER`
+  statements maintaining FTS5 inside the import's own writes.
+- `status-finalize` → "✓ Import completed" / "✓ Import finalized": reached only
+  on the importer's success return.
+
+**Found, not fixed here — recommend filing (same "asserts outcomes it did not
+produce" family):**
+
+1. **"✓ Imported conversations/notes/characters/media" can be false.**
+   `ChatbookImporter.import_chatbook` returns `success=True` when everything
+   was *skipped* (`chatbook_importer.py:399` — `success = (successful_items +
+   skipped_items) > 0 or total_items == 0`), and its own honest message
+   ("Skipped N/N items due to conflicts") is discarded by the wizard on the
+   success branch. The four per-type rows are gated on **manifest counts**, not
+   on results, so re-importing an already-imported chatbook under the default
+   `Skip existing items` strategy paints four "✓ Imported …" rows and
+   "✅ Import Completed Successfully!" over `Imported: 0 / Skipped: N`. Not
+   fixed here because `ImportStatus` has no per-type counters — an honest row
+   needs per-type results plumbed through the importer, and a whole-import-
+   granularity patch would just move the overstatement to the partial case
+   (3 of 5 skipped still reads "✓ Imported"). Half-measures were explicitly
+   out of scope.
+2. **Two dead controls.** `preserve_timestamps` and `import_tags` are read into
+   the options dict and consumed by nothing anywhere in the repo (grep:
+   `ChatbookImportWizard.py` is the only hit for either).
+3. **One mislabelled default-ON control.** "Merge with existing tags"
+   ("Combine imported tags with any existing tags") is passed as
+   `prefix_imported`, whose only effect is to rename every imported item
+   `[Imported] <name>` (`chatbook_importer.py:507,1180,1294,1447`). It does not
+   touch tags at all.
+
+### Evidence
+
+- Born red at base, all four for the defect itself: the options step listed
+  `'create backup'`; no irreversibility copy was rendered; the driven import
+  emitted `status-backup`; and the AST guard reported
+  `_import_chatbook: TODO, For now`.
+- Green after: 4/4. `Tests/Chatbooks/` 253 passed 1 skipped;
+  `Tests/Wizards/` + the three UI files touching this wizard 900 passed;
+  repo-wide `--collect-only -q` 53,633 collected, exit 0. `ruff check` clean
+  (the file's one pre-existing `ruff format` deviation at line ~286 was left
+  alone rather than reformatting unrelated lines).
+- AC#6 is vacuous, checked rather than assumed: no `Docs/User_Guide/` page
+  documents this wizard or its backup behaviour (the Chatbooks screen has no
+  guide page; `library/import-and-export.md` covers the Library's own
+  import/export, and `artifacts.md` is a stub). Nothing to update or restamp.
+
+### Files
+
+- `tldw_chatbook/UI/Wizards/ChatbookImportWizard.py`
+- `Tests/Chatbooks/test_chatbook_import_wizard_backup_honesty.py` (new)

--- a/backlog/tasks/task-19550 - Chatbook import Create backup checkbox writes a success message and takes no backup.md
+++ b/backlog/tasks/task-19550 - Chatbook import Create backup checkbox writes a success message and takes no backup.md
@@ -114,16 +114,24 @@ last screen the user can still cancel from — the next step starts writing on
 The controller's bar for implementing was "only if the repo already has a
 safe, reachable primitive you can call". It does not, quite:
 
-- The primitives exist but are owner-gated. `ChaChaNotes_DB.backup_database`,
+- The primitives are owner-gated. `ChaChaNotes_DB.backup_database`,
   `Client_Media_DB_v2.backup_database` and `Prompts_DB.backup_database` all
   route through `DB/private_sqlite.py`, whose `SQLITE_OWNER_REGISTRY` keys each
-  backup to a named owning module. Reusing `settings.bulk_backup` (owned by
-  `UI/Tools_Settings_Window`) from the wizard is registry misuse; doing it
-  properly means a **new registry row**, which
-  `Tests/DB/test_private_sqlite_inventory.py:1009` pins against
-  `backlog/docs/sqlite-private-owner-inventory.md`
-  (`set(SQLITE_OWNER_REGISTRY) == documented_owner_ids`) — a security-registry
-  change plus an inventory derivation, not a call.
+  backup to a named owning module, pinned by
+  `Tests/DB/test_private_sqlite_inventory.py:1009` against
+  `backlog/docs/sqlite-private-owner-inventory.md`. Reusing
+  `settings.bulk_backup` (owned by `UI/Tools_Settings_Window`) from the wizard
+  would be registry misuse.
+  **Correction (review finding — this bullet originally overstated the case):**
+  a new registry row is NOT required. `db.chachanotes.backup`, `db.media.backup`
+  and `db.prompts.backup` already exist with `centralized_backup_allowed=True`,
+  already back one-line public `backup_database(path)` methods that carry their
+  own tests, and the app already holds live instances of all three reachable
+  from the wizard. A minimal three-call backup was therefore available. The
+  REMOVE disposition does not rest on this bullet — it rests on the two below
+  (a naive three-call backup has no staging or atomicity, unlike the Settings
+  implementation) and, decisively, on the absence of any user-reachable
+  RESTORE. Recorded so a future task does not inherit the wrong premise.
 - A correct backup here is three databases, not one. `get_chatbook_database_paths()`
   hands the importer ChaChaNotes, Prompts **and** Media; backing up a subset
   and saying "✓ Created backup" is the same defect with a smaller blast

--- a/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
+++ b/tldw_chatbook/UI/Wizards/ChatbookImportWizard.py
@@ -498,6 +498,19 @@ class ImportOptionsStep(WizardStep):
 
     def compose(self) -> ComposeResult:
         """Compose import options UI."""
+        # The next step starts writing as soon as it is shown, so this is the
+        # last screen the user can still back out from -- state the real risk
+        # here (task-19550). This wizard used to offer a default-ON "Create
+        # backup" checkbox that took no backup at all; the honest replacement
+        # for a control we cannot honour is the plain fact.
+        yield Static(
+            "⚠ This import writes directly into your databases and cannot be "
+            "undone. The app takes no backup for you — copy your databases "
+            "first if you need to be able to go back.",
+            id="import-irreversible-warning",
+            classes="warning-text",
+        )
+
         with Container(classes="options-section"):
             yield Static("Execution Mode:", classes="section-title")
             yield RadioSet(
@@ -547,16 +560,6 @@ class ImportOptionsStep(WizardStep):
             yield Static(
                 "Keep original creation and modification dates",
                 classes="option-description",
-            )
-
-            yield Checkbox(
-                "Create backup",
-                value=True,
-                id="create-backup",
-                classes="checkbox-option",
-            )
-            yield Static(
-                "Backup current database before importing", classes="option-description"
             )
 
         # Tag handling
@@ -627,7 +630,6 @@ class ImportOptionsStep(WizardStep):
             "preserve_timestamps": self.query_one(
                 "#preserve-timestamps", Checkbox
             ).value,
-            "create_backup": self.query_one("#create-backup", Checkbox).value,
             "import_tags": self.query_one("#import-tags", Checkbox).value,
             "merge_tags": self.query_one("#merge-tags", Checkbox).value,
         }
@@ -661,9 +663,6 @@ class ImportProgressStep(WizardStep):
                     "⟳ Preparing import",
                     id="status-prepare",
                     classes="status-item active",
-                )
-                yield Static(
-                    "○ Creating backup", id="status-backup", classes="status-item"
                 )
                 yield Static(
                     "○ Importing conversations",
@@ -748,14 +747,9 @@ class ImportProgressStep(WizardStep):
             self._update_status("status-prepare", "active", "⟳ Preparing import...")
             self._update_progress(5)
 
-            # Create backup if requested
-            if options.get("create_backup", True):
-                self._update_status("status-backup", "active", "⟳ Creating backup...")
-                self._update_progress(10)
-                # TODO: Implement actual backup functionality
-                # For now, just mark as completed
-                self._update_status("status-backup", "completed", "✓ Created backup")
-                self._update_progress(15)
+            # No backup is taken here, and none is claimed: the import writes
+            # straight into the live databases with no rollback (task-19550).
+            # The options step states that plainly before the user confirms.
 
             if execution_mode == "server":
                 self._update_status(


### PR DESCRIPTION
## Summary
Closes task-19550 (P0). The Chatbook import wizard composed a **default-ON** checkbox labelled "Create backup", captioned "Backup current database before importing", read its value, and then displayed **"✓ Created backup"** while taking no backup — the code carried `# TODO: Implement actual backup functionality`. This ran immediately before a database-mutating import with **no rollback**.

That is worse than a dead control: it asserts a safety property it does not provide, on the one screen where a user decides whether it is safe to proceed.

**Disposition: remove, not disable** (a greyed-out box still reads as "backup already handled"). Removed the checkbox, its caption, the options key, the fake status row and the TODO block, and added an irreversibility warning on the Import Options step — verified to be the last point the user can cancel from, since the next step starts the import worker on mount. The warning reuses an existing global style class, so no CSS bundle rebuild.

Why not implement instead: a correct backup here spans **three** databases (ChaChaNotes, Prompts and a potentially multi-gigabyte Media), a naive three-call version has none of the staging or atomicity the Settings implementation has — and decisively, **there is no user-reachable restore path at all**. A backup nobody can restore is not a safety feature. (One supporting claim in the notes was overstated and has been corrected pre-merge per review: a new security-registry row would *not* have been required.)

## The theme, confirmed
The sibling audit found **three more false claims in the same wizard**, reported for filing rather than patched (a whole-import-granularity fix would just relocate the overstatement): the four "✓ Imported…" rows are gated on **manifest counts, not results**, so re-importing under the default "skip existing" paints four ✓ rows over "Imported: 0 / Skipped: N"; `preserve_timestamps` and `import_tags` are collected and consumed by nothing; and "Merge with existing tags" is default-ON but actually only renames items `[Imported] <name>`, never touching tags. The review confirmed all three at exact line numbers.

## Evidence
- Born-red 4/4 at base, each on the defect rather than a harness error (the options step listed "create backup"; no irreversibility copy rendered; the fully-driven import path emitted the fake status row, with the fake importer proven to have run).
- A generic **AST guard** ships with it: no function that emits a "completed" status row may contain a TODO/"For now"/"not implemented" marker, and the completed-row id set is pinned to the audited allowlist — turning this bug into a class-level lock.
- `Tests/Chatbooks/` 253 passed / 1 skipped; collect-only 53,633 clean.

## Review
Independent review: **APPROVE** — it traced all three load-bearing claims itself (registry pinning, no reachable restore, three databases touched), reproduced the original defect byte-identically to get genuine reds, and proved the AST guard is not hollow by planting a canary TODO near an unrelated completed-row call and confirming it fired. It also caught the one overstatement, now corrected in the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Chatbook import wizard’s fake backup control and status, and adds an explicit irreversibility warning. Previously the wizard showed a default‑ON “Create backup” and claimed “✓ Created backup” without taking any backup; now it offers no backup option, does not claim one, and warns that the import cannot be undone (task-19550).

- Code: updates `tldw_chatbook/UI/Wizards/ChatbookImportWizard.py` to remove the checkbox, caption, `create_backup` option, backup status row, and the TODO block; adds a warning on the Import Options step using an existing style (no CSS changes).
- Tests: adds `Tests/Chatbooks/test_chatbook_import_wizard_backup_honesty.py` to pin behavior (no backup control, warning rendered, end‑to‑end run ignores stale `create_backup`, and an AST guard that forbids “completed” status rows from TODO paths and pins allowed status ids).
- Behavior: the next step still begins writing on mount; the warning is shown on the last step where the user can cancel. No backup is taken or reported.
- Migration: no action required. Any persisted `create_backup` value in wizard data is ignored.
- Not in scope (file follow‑ups): per‑type “✓ Imported …” rows can overstate success when everything is skipped; `preserve_timestamps` and `import_tags` are unused; “Merge with existing tags” only prefixes names and does not merge tags.

<sup>Written for commit 37b7d01759633ee073e86b69498a253597e79e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

