### PR TITLE
fix(security): enforce the sensitive-path denylist in the agent fs_* tools (task-19551)

### DIFF
--- a/Docs/Design/MCP.md
+++ b/Docs/Design/MCP.md
@@ -380,6 +380,10 @@ fixed `GatewayLimits` defaults: 600 requests per minute and 16 in-flight
 requests. Those limits are not Chatbook config keys. When local tools are
 enabled, workspace confinement comes from `[console] workspace_root` and each
 call still uses the shared permission store and kill switch described above.
+Confinement is not the only path check: credential, permission-store and
+app-database paths (`Utils/sensitive_paths.py`) are refused regardless of the
+configured root, enforced for these tools inside
+`Tools/local_tool_impls.py`'s `resolve_workspace_path`.
 
 ## Installation and Setup
 

--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -156,6 +156,13 @@ feature is enabled for that session. Bindings marked read-only expose only
 read-capable tools. Folder names and instruction contents are not synchronized;
 the local control fields stay with the local conversation record.
 
+Whichever root is in effect, some paths inside it are still refused: your SSH,
+GPG and cloud-provider credential directories, Chatbook's own `config.toml`,
+its permission store, and its databases. A tool asking for one of those is
+answered with "protected path", even when the root you chose contains it — so
+a session rooted at your home directory cannot read `~/.ssh/id_rsa` or rewrite
+the file that records which tools you approved.
+
 ### Details
 
 Open the "Details" header in the left rail to see where your chats live:

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -363,8 +363,19 @@ def _denylisted_candidates() -> list[tuple[str, Path]]:
     DOTTED. That matters only for the second family: its
     ``validate_path_multi`` refuses a dotted base directory outright
     (``allow_hidden`` defaults False there), so for those candidates its
-    refusal comes from confinement, not the denylist -- an honest
-    distinction the assertions below keep rather than paper over.
+    refusal comes from confinement, not the denylist -- a distinction the
+    assertions below keep rather than paper over.
+
+    Read that distinction accurately (review round): it is not purely a
+    design difference. Because the second family rejects dotted components
+    at confinement, it ALSO refuses dotted credential files the denylist
+    does not enumerate at all (``~/.netrc``, ``~/.git-credentials``,
+    ``~/.npmrc``, ...), which the ``fs_*`` family -- passing
+    ``allow_hidden=True`` -- returns in full. For dotted paths the ``fs_*``
+    family is therefore strictly the weaker of the two, and part of what
+    looks like an honest difference of mechanism is residue. Tracked as
+    TASK-19633; the candidates below are all genuinely denylisted, so this
+    test is unaffected either way.
     """
     from tldw_chatbook import config as app_config
 
@@ -439,22 +450,46 @@ def test_both_file_tool_families_refuse_the_same_denylisted_paths(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+#: Helpers in ``git_tool_impls`` that resolve their path argument through
+#: ``resolve_workspace_path`` themselves, so a git tool calling one of them
+#: IS on the choke point -- just one hop away. Enumerated (rather than
+#: chasing the call graph) so that adding a FOURTH indirect resolver is a
+#: deliberate edit here, with the same "does it call the choke point?"
+#: question asked of it directly below.
+_INDIRECT_CHOKE_POINT_RESOLVERS = frozenset(
+    {"prepare_repository", "_prepare_for_path", "_repo_relative_path"}
+)
+
+
 def test_every_workspace_rooted_function_uses_the_choke_point():
     """AST tripwire, TASK-19551 AC5.
 
-    Any module-level function in the ``fs_*`` core modules that accepts a
-    ``workspace_root`` is a filesystem entry point for the agent, and must
-    resolve its target through ``resolve_workspace_path`` -- the ONE place
-    the denylist is enforced for this family. A new tool that resolves its
-    own path (``Path(workspace_root) / arg``) would reintroduce exactly the
-    hole this task closed, so it fails here instead.
+    Any module-level function in the agent file/git tool core modules that
+    accepts a ``workspace_root`` is a filesystem entry point for the agent,
+    and must resolve its target through ``resolve_workspace_path`` -- the
+    ONE place the denylist is enforced for this family. A new tool that
+    resolves its own path (``Path(workspace_root) / arg``) would reintroduce
+    exactly the hole this task closed, so it fails here instead.
+
+    ``git_tool_impls`` is covered too (fix round): its four repo-scoped
+    tools reach the choke point INDIRECTLY, through the three helpers in
+    ``_INDIRECT_CHOKE_POINT_RESOLVERS`` -- each of which is itself required
+    below to call ``resolve_workspace_path`` directly, so the indirection is
+    verified rather than assumed. Covering only two of the family's three
+    modules is what let this test tick AC5 while a new git tool would have
+    got zero tripwire coverage.
+
+    NOTE what this tripwire does NOT claim: reaching the choke point proves
+    a tool's PATH ARGUMENT is denylist-checked, not that its OUTPUT is
+    filtered. ``git_diff`` called without a path never presents one, and
+    leaks committed file CONTENT for denylisted paths -- see TASK-19632.
     """
     import ast
 
-    from tldw_chatbook.Tools import local_tool_impls, patch_tool_impls
+    from tldw_chatbook.Tools import git_tool_impls, local_tool_impls, patch_tool_impls
 
     offenders: list[str] = []
-    for module in (local_tool_impls, patch_tool_impls):
+    for module in (local_tool_impls, patch_tool_impls, git_tool_impls):
         tree = ast.parse(Path(module.__file__).read_text())
         for node in tree.body:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -470,12 +505,19 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
                 for sub in ast.walk(node)
                 if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
             }
-            if "resolve_workspace_path" not in calls:
+            accepted = {"resolve_workspace_path"}
+            if node.name not in _INDIRECT_CHOKE_POINT_RESOLVERS:
+                # A resolver itself must reach the choke point DIRECTLY;
+                # only its callers may go through it.
+                accepted |= _INDIRECT_CHOKE_POINT_RESOLVERS
+            if not (calls & accepted):
                 offenders.append(f"{module.__name__}.{node.name}")
 
     assert not offenders, (
-        "these workspace-rooted functions never call resolve_workspace_path, "
-        f"so they bypass the sensitive-path denylist: {offenders}"
+        "these workspace-rooted functions never reach resolve_workspace_path "
+        "(directly or via one of "
+        f"{sorted(_INDIRECT_CHOKE_POINT_RESOLVERS)}), so they bypass the "
+        f"sensitive-path denylist: {offenders}"
     )
 
 

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -485,11 +485,46 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
     leaks committed file CONTENT for denylisted paths -- see TASK-19632.
     """
     import ast
+    import importlib
 
-    from tldw_chatbook.Tools import git_tool_impls, local_tool_impls, patch_tool_impls
+    import tldw_chatbook.Tools as tools_pkg
+
+    # DERIVED, not hand-listed. A hardcoded module tuple is the same shape as
+    # the bug this task fixed (an enforcer list that can only name what existed
+    # when it was written) -- a fourth module joining the family would silently
+    # get zero coverage. Discover the family instead: any Tools/ module with a
+    # module-level function taking ``workspace_root`` is in it by definition.
+    tools_dir = Path(tools_pkg.__file__).parent
+    modules = []
+    for source in sorted(tools_dir.glob("*.py")):
+        if source.name == "__init__.py":
+            continue
+        text = source.read_text()
+        if "workspace_root" not in text:
+            continue
+        candidate = ast.parse(text)
+        takes_root = any(
+            "workspace_root"
+            in {
+                a.arg
+                for a in node.args.args + node.args.kwonlyargs + node.args.posonlyargs
+            }
+            for node in candidate.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        )
+        if takes_root:
+            modules.append(importlib.import_module(f"tldw_chatbook.Tools.{source.stem}"))
+
+    # The three known members must be present; discovery may only ADD.
+    discovered = {m.__name__.rsplit(".", 1)[-1] for m in modules}
+    assert {"local_tool_impls", "patch_tool_impls", "git_tool_impls"} <= discovered, (
+        "the workspace-rooted tool family lost a known member -- discovery found "
+        f"{sorted(discovered)}; if a module was renamed or retired, say so here"
+    )
 
     offenders: list[str] = []
-    for module in (local_tool_impls, patch_tool_impls, git_tool_impls):
+    verified_resolvers: set[str] = set()
+    for module in modules:
         tree = ast.parse(Path(module.__file__).read_text())
         for node in tree.body:
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -512,12 +547,29 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
                 accepted |= _INDIRECT_CHOKE_POINT_RESOLVERS
             if not (calls & accepted):
                 offenders.append(f"{module.__name__}.{node.name}")
+            if node.name in _INDIRECT_CHOKE_POINT_RESOLVERS:
+                verified_resolvers.add(node.name)
 
     assert not offenders, (
         "these workspace-rooted functions never reach resolve_workspace_path "
         "(directly or via one of "
         f"{sorted(_INDIRECT_CHOKE_POINT_RESOLVERS)}), so they bypass the "
         f"sensitive-path denylist: {offenders}"
+    )
+
+    # Every accepted resolver must itself have been VISITED and verified above.
+    # Without this, the accept-set is a hole rather than a delegation: the loop
+    # only inspects functions that take a parameter literally named
+    # ``workspace_root``, so a resolver spelling it differently is added to the
+    # accept-set, never checked itself, and silently launders its callers past
+    # the choke point (demonstrated in review with a `root`-named resolver).
+    unverified = set(_INDIRECT_CHOKE_POINT_RESOLVERS) - verified_resolvers
+    assert not unverified, (
+        "these names are trusted in _INDIRECT_CHOKE_POINT_RESOLVERS but were "
+        "never themselves inspected by the scan above -- they are an unchecked "
+        "hole, not a verified delegation. A resolver must live in one of the "
+        "scanned modules and take a `workspace_root` parameter so that its own "
+        f"call to the choke point is proven: {sorted(unverified)}"
     )
 
 

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -1,0 +1,521 @@
+"""Sensitive-path denylist coverage for the workspace-local ``fs_*`` family.
+
+TASK-19551. The seven ``fs_*`` agent tools confine every path to the
+configured ``[console] workspace_root`` but never consulted
+``Utils.sensitive_paths.is_sensitive_path`` -- so with the shipped default
+root (the app's cwd at startup; launch from ``$HOME`` and ``$HOME`` IS the
+root) ``fs_read`` returned ``~/.ssh/id_rsa`` and ``fs_write``/``fs_patch``
+could rewrite ``mcp_permissions.json``, turning every ``ask`` into
+``allow`` -- a one-step bypass of the permission gate, reachable by prompt
+injection from fetched web content.
+
+These tests are the mirror image of ``Tests/Tools/test_file_tool_sandbox.py``
+(which pins the same property for the OTHER file-tool family,
+``Tools/file_operation_tools.py``); the last test here pins that the two
+families cannot drift apart again, since that drift IS this bug.
+
+``Tests/conftest.py``'s autouse ``isolate_test_environment`` fixture
+redirects HOME/XDG/``TLDW_CONFIG_PATH`` to per-test tmp directories, so
+every "credential" file below is a synthesized marker under an isolated
+home -- no real credential file is ever created or read.
+
+Each scenario deliberately puts the denied path under the workspace root
+with NO dotted component in the RELATIVE portion where that is possible, so
+``validate_path``'s own hidden-component check cannot mask whether the
+denylist ran at all -- except the two tests that specifically exercise a
+dotfile component, which is the shape ``allow_hidden=True`` (ADR-032)
+deliberately lets past confinement and which therefore depends entirely on
+the denylist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools.local_tool_impls import (
+    LocalToolError,
+    edit_file,
+    glob_files,
+    grep_files,
+    list_directory,
+    read_file,
+    resolve_workspace_path,
+    write_file,
+)
+from tldw_chatbook.Tools.patch_tool_impls import patch_files
+
+SSH_KEY_MARKER = "SYNTHETIC-NOT-A-REAL-PRIVATE-KEY-19551"
+AWS_MARKER = "aws_secret_access_key = SYNTHETIC-19551"
+
+
+def _refused(call, label: str) -> str:
+    """Run ``call``; return its refusal message or fail showing what leaked.
+
+    Born-red evidence lives in the failure message: at base (before the
+    fix) each of these calls SUCCEEDS, and the assertion failure prints the
+    exact credential content / write receipt the tool handed back.
+    """
+    try:
+        result = call()
+    except LocalToolError as exc:
+        return str(exc)
+    pytest.fail(f"{label} was NOT refused -- the tool returned: {result!r}")
+
+
+def _home() -> Path:
+    return Path(os.environ["HOME"]).resolve()
+
+
+def _plant_ssh_key() -> Path:
+    key = _home() / ".ssh" / "id_rsa"
+    key.parent.mkdir(parents=True, exist_ok=True)
+    key.write_text(f"-----BEGIN OPENSSH PRIVATE KEY-----\n{SSH_KEY_MARKER}\n")
+    return key
+
+
+def _plant_permission_store() -> Path:
+    from tldw_chatbook import config as app_config
+
+    user_data_dir = app_config.get_user_data_dir()
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    store = user_data_dir / "mcp_permissions.json"
+    store.write_text('{"version": 1}\n')
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Shape 1: reading a denylisted credential path through fs_read.
+# ---------------------------------------------------------------------------
+
+
+def test_fs_read_refuses_denylisted_credential_path():
+    """``fs_read`` must not hand ``~/.ssh/id_rsa`` to the model.
+
+    The workspace root is ``$HOME`` -- exactly what the shipped
+    ``workspace_root`` default (app cwd at startup) produces when the app is
+    launched from the user's home directory.
+    """
+    key = _plant_ssh_key()
+    message = _refused(
+        lambda: read_file(".ssh/id_rsa", workspace_root=_home()), "fs_read(~/.ssh/id_rsa)"
+    )
+    assert "protected path" in message
+    assert SSH_KEY_MARKER not in message
+    assert key.read_text().count(SSH_KEY_MARKER) == 1  # untouched
+
+
+def test_fs_read_refuses_this_apps_own_config_toml():
+    """The file holding the user's provider API keys.
+
+    Resolved through ``config._get_effective_config_path()`` (which honors
+    ``TLDW_CONFIG_PATH``), never a ``~/.config/tldw_cli/config.toml``
+    literal, and reached with NO dotted relative component -- the workspace
+    root IS the config directory, so confinement alone cannot explain the
+    refusal.
+    """
+    from tldw_chatbook import config as app_config
+
+    config_path = app_config._get_effective_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("api_key = 'super-secret-19551'\n")
+
+    message = _refused(
+        lambda: read_file(config_path.name, workspace_root=config_path.parent),
+        "fs_read(config.toml)",
+    )
+    assert "protected path" in message
+    assert "super-secret-19551" not in message
+
+
+def test_fs_read_refuses_this_apps_own_sqlite_db():
+    """Reading ``chachanotes.db`` exfiltrates every conversation and note."""
+    from tldw_chatbook import config as app_config
+
+    db_path = app_config.get_chachanotes_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text("not-a-real-sqlite-file-19551")
+
+    message = _refused(
+        lambda: read_file(db_path.name, workspace_root=db_path.parent),
+        "fs_read(chachanotes.db)",
+    )
+    assert "protected path" in message
+    assert "19551" not in message.replace("TASK-19551", "")
+
+
+# ---------------------------------------------------------------------------
+# Shape 2: writing the permission store -- the one-step gate bypass.
+# ---------------------------------------------------------------------------
+
+
+def test_fs_write_refuses_rewriting_the_permission_store():
+    """``fs_write`` must not disarm the gate that authorized it."""
+    store = _plant_permission_store()
+
+    message = _refused(
+        lambda: write_file(
+            "mcp_permissions.json",
+            '{"pwned": true}',
+            workspace_root=store.parent,
+        ),
+        "fs_write(mcp_permissions.json)",
+    )
+    assert "protected path" in message
+    assert store.read_text() == '{"version": 1}\n'  # untouched
+
+
+def test_fs_edit_refuses_rewriting_the_permission_store():
+    """Same gate, other write tool: ``fs_edit``'s exact-string replacement."""
+    store = _plant_permission_store()
+
+    message = _refused(
+        lambda: edit_file(
+            "mcp_permissions.json",
+            '"version": 1',
+            '"default_verdict": "allow"',
+            workspace_root=store.parent,
+        ),
+        "fs_edit(mcp_permissions.json)",
+    )
+    assert "protected path" in message
+    assert store.read_text() == '{"version": 1}\n'  # untouched
+
+
+def test_fs_patch_refuses_rewriting_the_permission_store():
+    """Same gate, third write tool: ``fs_patch``'s unified diff.
+
+    ``patch_tool_impls.patch_files`` resolves every diff target through the
+    SAME ``resolve_workspace_path`` choke point, so it inherits the check
+    rather than re-implementing it.
+    """
+    store = _plant_permission_store()
+    diff = (
+        "--- mcp_permissions.json\n"
+        "+++ mcp_permissions.json\n"
+        "@@ -1 +1 @@\n"
+        '-{"version": 1}\n'
+        '+{"pwned": true}\n'
+    )
+
+    message = _refused(
+        lambda: patch_files(diff, workspace_root=store.parent),
+        "fs_patch(mcp_permissions.json)",
+    )
+    assert "protected path" in message
+    assert store.read_text() == '{"version": 1}\n'  # untouched
+
+
+def test_fs_patch_dry_run_also_refuses_the_permission_store():
+    """``dry_run`` still reads the target, so it must refuse identically."""
+    store = _plant_permission_store()
+    diff = (
+        "--- mcp_permissions.json\n"
+        "+++ mcp_permissions.json\n"
+        "@@ -1 +1 @@\n"
+        '-{"version": 1}\n'
+        '+{"pwned": true}\n'
+    )
+
+    message = _refused(
+        lambda: patch_files(diff, workspace_root=store.parent, dry_run=True),
+        "fs_patch(dry_run, mcp_permissions.json)",
+    )
+    assert "protected path" in message
+
+
+# ---------------------------------------------------------------------------
+# Shape 3: a dotfile-component path -- the shape allow_hidden=True permits.
+# ---------------------------------------------------------------------------
+
+
+def test_fs_read_refuses_dotfile_component_credential_path():
+    """``~/.aws/credentials``, reached through a DOTTED relative component.
+
+    ``resolve_workspace_path`` passes ``allow_hidden=True`` to
+    ``validate_path`` (ADR-032: real workspaces need ``.git``/``.github``/
+    dotfile configs), so confinement alone lets ``.aws/credentials``
+    through. Only the denylist stops it -- which is precisely why this
+    shape is pinned separately.
+    """
+    creds = _home() / ".aws" / "credentials"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(f"[default]\n{AWS_MARKER}\n")
+
+    message = _refused(
+        lambda: read_file(".aws/credentials", workspace_root=_home()),
+        "fs_read(~/.aws/credentials)",
+    )
+    assert "protected path" in message
+    assert AWS_MARKER not in message
+
+
+def test_fs_write_refuses_dotfile_component_credential_path():
+    """The same dotted shape on the write side (``~/.ssh/authorized_keys``)."""
+    ssh_dir = _home() / ".ssh"
+    ssh_dir.mkdir(parents=True, exist_ok=True)
+
+    message = _refused(
+        lambda: write_file(
+            ".ssh/authorized_keys",
+            "ssh-rsa ATTACKER-KEY-19551\n",
+            workspace_root=_home(),
+        ),
+        "fs_write(~/.ssh/authorized_keys)",
+    )
+    assert "protected path" in message
+    assert not (ssh_dir / "authorized_keys").exists()
+
+
+def test_benign_workspace_dotfiles_stay_readable():
+    """The allow_hidden=True decision, pinned.
+
+    ADR-032 keeps hidden components reachable under the workspace root on
+    purpose -- a coding agent that cannot read ``.github/workflows/ci.yml``
+    or ``.gitignore`` is useless. The denylist is what makes that safe: it
+    matches by RESOLVED ANCESTRY against real credential/state locations,
+    not by "the name starts with a dot". If this test ever has to change,
+    the allow_hidden decision is being reversed and ADR-032 needs amending.
+    """
+    ws = _home() / "projects" / "repo"
+    (ws / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (ws / ".github" / "workflows" / "ci.yml").write_text("name: ci\n")
+    (ws / ".gitignore").write_text("*.pyc\n")
+
+    assert "name: ci" in read_file(".github/workflows/ci.yml", workspace_root=ws)
+    assert "*.pyc" in read_file(".gitignore", workspace_root=ws)
+    assert ".github/" in list_directory(".", workspace_root=ws)
+
+
+# ---------------------------------------------------------------------------
+# The enumerating tools: fs_list / fs_glob / fs_grep.
+#
+# resolve_workspace_path only ever sees the ROOT for these three, so the
+# choke point alone cannot cover the entries they walk -- each result must
+# be filtered too, exactly as GlobFiles/GrepFiles/ListDirectoryTool do in
+# the sibling family. fs_grep is the sharpest of the three: it READS every
+# file it walks and prints matching lines.
+# ---------------------------------------------------------------------------
+
+
+def test_fs_list_hides_sensitive_directories_from_a_home_rooted_workspace():
+    """The shipped-default shape: workspace root == ``$HOME``."""
+    _plant_ssh_key()
+    (_home() / ".aws").mkdir(parents=True, exist_ok=True)
+    (_home() / "notes.txt").write_text("fine\n")
+
+    listing = list_directory(".", workspace_root=_home())
+
+    assert "notes.txt" in listing  # ordinary entry still listed
+    assert ".ssh" not in listing
+    assert ".aws" not in listing
+
+
+def test_fs_list_hides_the_permission_store_from_the_user_data_dir():
+    """A denylisted FILE inside a listable directory, by name alone.
+
+    Subdirectories of ``get_user_data_dir()`` stay listable (the
+    direct-child-file rule is about loose FILES) -- ``sub_dir`` below is
+    the control proving the listing itself still works.
+    """
+    store = _plant_permission_store()
+    (store.parent / "sub_dir").mkdir(exist_ok=True)
+
+    listing = list_directory(".", workspace_root=store.parent)
+
+    assert "sub_dir/" in listing
+    assert "mcp_permissions.json" not in listing
+
+
+def test_fs_grep_never_reads_denylisted_file_contents():
+    _plant_ssh_key()
+    (_home() / "notes.txt").write_text(f"decoy {SSH_KEY_MARKER}\n")
+
+    out = grep_files(SSH_KEY_MARKER, workspace_root=_home())
+
+    assert "notes.txt" in out  # ordinary file still searched
+    assert ".ssh/id_rsa" not in out
+    assert out.count(SSH_KEY_MARKER) == 1  # only the decoy line
+
+
+def test_fs_glob_omits_denylisted_matches():
+    _plant_ssh_key()
+    (_home() / "keep.txt").write_text("x\n")
+
+    out = glob_files("**/*", workspace_root=_home())
+
+    assert "keep.txt" in out
+    assert "id_rsa" not in out
+
+
+# ---------------------------------------------------------------------------
+# Drift pin: the two file-tool families must agree on the denylist.
+# ---------------------------------------------------------------------------
+
+
+def _denylisted_candidates() -> list[tuple[str, Path]]:
+    """Denylisted paths, each planted as a synthetic marker file.
+
+    The third element says whether the file's own parent directory is
+    DOTTED. That matters only for the second family: its
+    ``validate_path_multi`` refuses a dotted base directory outright
+    (``allow_hidden`` defaults False there), so for those candidates its
+    refusal comes from confinement, not the denylist -- an honest
+    distinction the assertions below keep rather than paper over.
+    """
+    from tldw_chatbook import config as app_config
+
+    home = _home()
+    candidates: list[tuple[str, Path, bool]] = [
+        ("ssh private key", home / ".ssh" / "id_rsa", True),
+        ("aws credentials", home / ".aws" / "credentials", True),
+        ("gnupg secring", home / ".gnupg" / "secring.gpg", True),
+        ("app config.toml", app_config._get_effective_config_path(), False),
+        (
+            "mcp permission store",
+            app_config.get_user_data_dir() / "mcp_permissions.json",
+            False,
+        ),
+        ("chachanotes db", app_config.get_chachanotes_db_path(), False),
+    ]
+    for _label, path, _dotted in candidates:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("synthetic-19551\n")
+    return candidates
+
+
+def test_both_file_tool_families_refuse_the_same_denylisted_paths(monkeypatch):
+    """Neither family may drift from the other on the denylist.
+
+    ``fs_*`` (``Tools/local_tool_impls.py``, workspace-root confined) and
+    ``read_file``/``write_file`` (``Tools/file_operation_tools.py``,
+    sandbox-root confined) are two independent file-tool families reaching
+    the same filesystem for the same agent runtime. The second one enforced
+    ``is_sensitive_path``; the first never called it -- that drift IS
+    TASK-19551. This pins them together: for every candidate, BOTH refuse
+    and neither returns the file's contents.
+
+    Family A's refusal must specifically be the DENYLIST's ("protected
+    path"): it passes ``allow_hidden=True``, and each root here is the
+    file's own directory, so nothing else could refuse it.
+    """
+    from tldw_chatbook.Tools import file_operation_tools as fot
+    from tldw_chatbook.Tools import workspace_file_roots as wfr
+    from tldw_chatbook.Utils.sensitive_paths import is_sensitive_path
+
+    def _raise():
+        raise RuntimeError("no workspace registry in this test")
+
+    monkeypatch.setattr(wfr, "_registry_factory", _raise)
+
+    for label, path, dotted_parent in _denylisted_candidates():
+        # The shared oracle both families are supposed to consult.
+        assert is_sensitive_path(path), label
+
+        # Family A: fs_read, workspace root set to the file's own directory
+        # (so confinement alone cannot be what refuses it).
+        fs_message = _refused(
+            lambda p=path: read_file(p.name, workspace_root=p.parent),
+            f"fs_read({label})",
+        )
+        assert "protected path" in fs_message, label
+        assert "synthetic-19551" not in fs_message, label
+
+        # Family B: read_file, sandbox root set to the same directory.
+        monkeypatch.setattr(fot, "_tool_sandbox_root", lambda p=path: p.parent.resolve())
+        legacy = asyncio.run(fot.ReadFileTool().execute(file_path=path.name))
+        assert "error" in legacy, label
+        assert "synthetic-19551" not in str(legacy), label
+        if not dotted_parent:
+            assert "protected path" in legacy["error"], label
+
+
+# ---------------------------------------------------------------------------
+# Choke-point tripwire: a new fs_* tool cannot reach the filesystem without
+# passing through resolve_workspace_path.
+# ---------------------------------------------------------------------------
+
+
+def test_every_workspace_rooted_function_uses_the_choke_point():
+    """AST tripwire, TASK-19551 AC5.
+
+    Any module-level function in the ``fs_*`` core modules that accepts a
+    ``workspace_root`` is a filesystem entry point for the agent, and must
+    resolve its target through ``resolve_workspace_path`` -- the ONE place
+    the denylist is enforced for this family. A new tool that resolves its
+    own path (``Path(workspace_root) / arg``) would reintroduce exactly the
+    hole this task closed, so it fails here instead.
+    """
+    import ast
+
+    from tldw_chatbook.Tools import local_tool_impls, patch_tool_impls
+
+    offenders: list[str] = []
+    for module in (local_tool_impls, patch_tool_impls):
+        tree = ast.parse(Path(module.__file__).read_text())
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            args = node.args
+            names = {a.arg for a in args.args + args.kwonlyargs + args.posonlyargs}
+            if "workspace_root" not in names:
+                continue
+            if node.name == "resolve_workspace_path":
+                continue  # the choke point itself IS the enforcement
+            calls = {
+                sub.func.id
+                for sub in ast.walk(node)
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+            }
+            if "resolve_workspace_path" not in calls:
+                offenders.append(f"{module.__name__}.{node.name}")
+
+    assert not offenders, (
+        "these workspace-rooted functions never call resolve_workspace_path, "
+        f"so they bypass the sensitive-path denylist: {offenders}"
+    )
+
+
+def test_fs_family_never_creates_directories_on_the_agents_behalf():
+    """Companion to the tripwire above: no ``mkdir`` in the ``fs_*`` core.
+
+    ``WriteFileTool`` in the sibling family creates parent directories on
+    request, which is why it must consult
+    ``Utils.sensitive_paths.refuses_new_directory_chain`` before calling
+    ``mkdir(parents=True)`` (TASK-849: otherwise an agent can plant a
+    directory where this app later expects its own state FILE -- a denial
+    of service). The ``fs_*`` family deliberately requires the parent
+    directory to already exist, so it has no such call site;
+    ``resolve_workspace_path`` still applies the guard for write intents.
+    If a ``mkdir`` ever appears here, that decision is being reversed and
+    the guard's placement has to be re-examined.
+    """
+    import ast
+
+    from tldw_chatbook.Tools import local_tool_impls, patch_tool_impls
+
+    for module in (local_tool_impls, patch_tool_impls):
+        tree = ast.parse(Path(module.__file__).read_text())
+        attr_calls = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "mkdir" not in attr_calls, (
+            f"{module.__name__} now creates directories -- it must consult "
+            "Utils.sensitive_paths.refuses_new_directory_chain first"
+        )
+        assert "makedirs" not in attr_calls, f"{module.__name__} now creates directories"
+
+
+def test_resolve_workspace_path_still_confines_and_still_allows_hidden(tmp_path):
+    """The pre-existing contract is unchanged by the denylist addition."""
+    ws = tmp_path / "ws"
+    (ws / ".github").mkdir(parents=True)
+    assert resolve_workspace_path("a/b", ws) == (ws / "a/b").resolve()
+    assert resolve_workspace_path(".github", ws) == (ws / ".github").resolve()
+    with pytest.raises(LocalToolError, match="outside the workspace root"):
+        resolve_workspace_path("../x", ws)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5593,3 +5593,39 @@ check the exit code) — never `tail -1`. The habit of tailing to keep output
 small is exactly what makes a per-item check unreadable. Note the exit code
 alone was also insufficient here: the script printed `::error::` and still
 exited 0 under the shell pipeline used.
+
+## A contract whose enforcer list lives only in a docstring cannot notice a second implementation (TASK-19551, 2026-08-21)
+
+`Utils/sensitive_paths.py` is the denylist that keeps agent file tools out of
+`~/.ssh`, `~/.aws`, this app's `config.toml`, `mcp_permissions.json` and its
+databases. Its module docstring named its enforcers precisely — the five tools
+in `Tools/file_operation_tools.py` — and every one of them really did call
+`is_sensitive_path`. Tests covered them thoroughly (`Tests/Tools/
+test_file_tool_sandbox.py`). All of that was true and none of it helped: the
+`fs_*` family (`Tools/local_tool_impls.py`, ADR-032) was added LATER as a
+second, independent file-tool family, confined paths to `[console]
+workspace_root`, and never joined the contract. `grep is_sensitive_path` over
+`Tools/`+`Agents/` returned nine hits, all in the file that was already
+correct, and zero in the three modules that were not. With the shipped default
+root (the app's cwd at startup), launching from `$HOME` made `fs_read` return
+`~/.ssh/id_rsa` and let `fs_write`/`fs_patch` rewrite `mcp_permissions.json` —
+a one-step disarm of the permission gate that authorized the call.
+
+The tell was structural, not behavioural: the docstring listed enforcers by
+NAME, so it could only ever describe the implementations that existed when it
+was written. Nothing in the test suite asked "do all families agree?", so the
+second family's silence was indistinguishable from its absence.
+
+**What to do.** When a security primitive is enforced by callers rather than
+by the primitive itself, the coverage that matters is a CROSS-IMPLEMENTATION
+agreement test: take a list of inputs the primitive is supposed to refuse and
+drive every family through it in one test, so a new family is either wired in
+or visibly red. Pair it with a structural tripwire (an AST check that every
+path-taking entry point resolves through the one choke point) — a source-text
+`grep`-style check is not enough, and in this task's first draft a literal
+`"mkdir" not in source` assertion failed on the word `mkdir` appearing in a
+DOCSTRING. Also worth knowing when writing the agreement test: two families
+can refuse the same path for different REASONS (here the older family rejects
+a dotted base directory at confinement, before the denylist runs), so assert
+the denylist-sourced message only where the denylist is genuinely what fires,
+rather than papering the difference over with a bare "is refused".

--- a/backlog/tasks/task-19551 - Agent fs_ tools never consult the sensitive-path denylist.md
+++ b/backlog/tasks/task-19551 - Agent fs_ tools never consult the sensitive-path denylist.md
@@ -63,20 +63,128 @@ primitive. The denylist is correct; these tools just do not call it.
 
 ## Acceptance Criteria
 
-- [ ] `is_sensitive_path` is consulted inside `resolve_workspace_path`, so that
+- [x] `is_sensitive_path` is consulted inside `resolve_workspace_path`, so that
       all seven `fs_*` tools inherit the check from the one choke point rather
       than each re-implementing it
-- [ ] Reading, writing, or patching any denylisted path through an `fs_*` tool
+- [x] Reading, writing, or patching any denylisted path through an `fs_*` tool
       is refused or routed to an explicit approval, matching the behaviour the
       `file_operation_tools` enforcers already have
-- [ ] Specifically pinned by test: `~/.ssh/id_rsa`, `~/.aws/credentials`, the
+- [x] Specifically pinned by test: `~/.ssh/id_rsa`, `~/.aws/credentials`, the
       app's own `config.toml`, `mcp_permissions.json`, and `chachanotes.db` are
       not silently readable or writable via `fs_read`/`fs_write`/`fs_patch`
-- [ ] A regression test pins that `fs_write`/`fs_patch` cannot rewrite the
+- [x] A regression test pins that `fs_write`/`fs_patch` cannot rewrite the
       permission store — the gate cannot be disarmed by a gated tool
-- [ ] `Utils/sensitive_paths.py`'s enforcer list is updated so the contract
+- [x] `Utils/sensitive_paths.py`'s enforcer list is updated so the contract
       names its real enforcement points, and a test fails if a new tool reaches
       the filesystem without passing through the choke point
-- [ ] The shipped `workspace_root` default is reviewed: launching from `$HOME`
+- [x] The shipped `workspace_root` default is reviewed: launching from `$HOME`
       must not silently confine the agent to a root containing the user's
       credentials
+
+## Implementation Plan
+
+1. Read both file-tool families end to end and mirror the sibling
+   (`file_operation_tools.py`) exactly — error shape, context reuse, the
+   `refuses_new_directory_chain` write guard.
+2. Write the born-red tests FIRST and run them at a pristine `origin/dev`
+   worktree, so the accepted credential read / permission-store rewrite is
+   recorded verbatim before any fix exists.
+3. Enforce the denylist inside `resolve_workspace_path` (the single choke
+   point), threading a read/write/list intent rather than weakening the check.
+4. Cover what the choke point structurally cannot: the three enumerating tools
+   walk their own candidates, so each filters entries against the same denylist
+   with one shared `SensitivePathContext`.
+5. Update the `Utils/sensitive_paths.py` contract to name the second family,
+   add the drift pin and the AST tripwire, re-run the affected suites, and
+   baseline every failure against `origin/dev` before attributing it.
+
+## Implementation Notes
+
+**Approach.** The denylist is now enforced inside
+`Tools/local_tool_impls.py::resolve_workspace_path` — the one choke point every
+`fs_*` core function, `patch_tool_impls.patch_files` and `git_tool_impls`
+already funnelled through — so all seven tools inherit it from a single change
+instead of seven copies that can drift (that drift is exactly how this bug
+happened: the contract's enforcer list was a docstring, and the `fs_*` family
+shipped later without ever joining it).
+
+The function grew an `intent: "read" | "write" | "list"` keyword and an optional
+pre-resolved `SensitivePathContext`:
+
+* `intent` selects the refusal verb, so refusals read the same as the sibling
+  family's (`Refused: '<path>' is a protected path and cannot be read/written/
+  listed`), and for `"write"` it additionally applies
+  `refuses_new_directory_chain` to the target's parent chain — the same guard
+  `WriteFileTool` consults before `mkdir(parents=True)`. No tool in this family
+  creates directories today (a write target's parent must already exist), so it
+  short-circuits on the first existing ancestor; it is wired now so a future
+  `create_directories`-style option cannot silently reintroduce TASK-849. A
+  test pins that no `mkdir`/`makedirs` call exists in these modules.
+* `context` lets a caller resolve the ~11 config accessors behind the denylist
+  once per CALL rather than once per path (`patch_files`' multi-file loop and
+  the three enumerating tools do this). Deliberately not a module-level cache —
+  see `resolve_sensitive_context`'s own docstring for why.
+
+**What the choke point structurally cannot cover.** `list_directory`,
+`glob_files` and `grep_files` resolve only the workspace ROOT through it, then
+walk their own candidates, so each now filters entries against the same
+denylist with the shared context. `grep_files` is the sharpest — it READS every
+file it walks and prints matching lines, so its check runs *before* the read;
+at base, a home-rooted workspace and a pattern as bland as `KEY` dumped
+`~/.ssh/id_rsa` into the transcript.
+
+**`allow_hidden=True` is KEPT, deliberately.** ADR-032 adopted it for this
+family precisely because real workspaces need `.git`/`.github`/dotfile configs,
+and a coding agent that cannot read `.github/workflows/ci.yml` is useless.
+Dotted names are how `~/.ssh` and `~/.aws` are spelled, but "starts with a dot"
+is a name heuristic, not a security boundary — `is_sensitive_path` answers that
+question properly, by RESOLVED ancestry, so `~/.sshfoo` is not mistaken for
+`~/.ssh` and a symlink cannot smuggle a path past it. Reversing the flag would
+contradict a signed ADR, break the family's core use case, and still not cover
+non-dotted credentials. Both halves are pinned:
+`test_fs_read_refuses_dotfile_component_credential_path` (a dotted path IS
+refused, and only the denylist can be what refuses it) and
+`test_benign_workspace_dotfiles_stay_readable` (`.github/`, `.gitignore` stay
+readable — if that test ever has to change, ADR-032 needs amending).
+
+**Born-red evidence** (final tests, run against a pristine `origin/dev`
+worktree): 14 failed / 4 passed, each failure printing the exact accept —
+`fs_read(~/.ssh/id_rsa)` returning the key body, `fs_read(config.toml)`
+returning `api_key = '…'`, `fs_write/fs_edit/fs_patch(mcp_permissions.json)`
+returning `wrote 15 characters` / `made 1 replacement` / `patched
+mcp_permissions.json`, `fs_grep` emitting the key contents, `fs_glob`/`fs_list`
+emitting `.ssh/id_rsa`. After the fix: 18 passed. The 4 that pass on both sides
+are the controls (the allow_hidden pin, the AST tripwire, the no-mkdir pin, and
+the unchanged confinement contract).
+
+**Drift pin.** `test_both_file_tool_families_refuse_the_same_denylisted_paths`
+runs six denylisted paths through BOTH families and requires the shared oracle
+(`is_sensitive_path`) plus both tools to refuse, with no content leaked. It
+keeps an honest distinction: for a candidate whose parent directory is dotted
+(`~/.ssh/id_rsa`), the second family refuses at *confinement* — its
+`validate_path_multi` rejects a dotted base directory outright — so only the
+non-dotted candidates assert its refusal is denylist-sourced.
+
+**`workspace_root` default (AC6), reviewed — kept, documented.** The default
+(app cwd at startup) is an explicit, signed ADR-032 trade-off, and changing it
+would break every existing coding-agent workflow; it needs an ADR amendment,
+not a side effect of a security fix. What made it dangerous was that the root
+was the ONLY check — that is now false: credential/gate-state/app-state paths
+are refused regardless of the root. The shipped `config.py` comment no longer
+states the default without stating its consequence (it names the `$HOME`
+launch, points at `Utils/sensitive_paths.py`, and says plainly that the
+denylist is a guardrail, not a substitute for pointing the root at one project
+directory).
+
+**Cost.** The denylist resolution is the same one the sibling family already
+pays per call: measured on this branch vs base, `fs_read` ~0.1ms → ~7ms per
+call, a 300-entry `fs_list` ~1ms → ~50ms, `fs_grep` over 300 files ~18ms →
+~67ms. Parity with the existing enforcing family was preferred over caching the
+security primitive.
+
+**Modified/added files.** `tldw_chatbook/Tools/local_tool_impls.py` (choke
+point + three enumerating filters), `tldw_chatbook/Tools/patch_tool_impls.py`
+(shared context, write intent), `tldw_chatbook/Agents/local_tool_provider.py`
+(`path_targets` intents), `tldw_chatbook/Utils/sensitive_paths.py` (contract now
+names BOTH enforcing families), `tldw_chatbook/config.py` (shipped
+`workspace_root` comment), new `Tests/Tools/test_local_tool_sensitive_paths.py`.

--- a/backlog/tasks/task-19551 - Agent fs_ tools never consult the sensitive-path denylist.md
+++ b/backlog/tasks/task-19551 - Agent fs_ tools never consult the sensitive-path denylist.md
@@ -2,7 +2,7 @@
 id: TASK-19551
 title: >-
   Agent fs_* tools never consult the sensitive-path denylist
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:01'
 labels:
@@ -133,15 +133,27 @@ file it walks and prints matching lines, so its check runs *before* the read;
 at base, a home-rooted workspace and a pattern as bland as `KEY` dumped
 `~/.ssh/id_rsa` into the transcript.
 
-**`allow_hidden=True` is KEPT, deliberately.** ADR-032 adopted it for this
-family precisely because real workspaces need `.git`/`.github`/dotfile configs,
-and a coding agent that cannot read `.github/workflows/ci.yml` is useless.
-Dotted names are how `~/.ssh` and `~/.aws` are spelled, but "starts with a dot"
-is a name heuristic, not a security boundary — `is_sensitive_path` answers that
-question properly, by RESOLVED ancestry, so `~/.sshfoo` is not mistaken for
-`~/.ssh` and a symlink cannot smuggle a path past it. Reversing the flag would
-contradict a signed ADR, break the family's core use case, and still not cover
-non-dotted credentials. Both halves are pinned:
+**`allow_hidden=True` is KEPT, deliberately — with one correction to the
+argument.** ADR-032 adopted it for this family precisely because real
+workspaces need `.git`/`.github`/dotfile configs, and a coding agent that
+cannot read `.github/workflows/ci.yml` is useless. Dotted names are how
+`~/.ssh` and `~/.aws` are spelled, but "starts with a dot" is a name heuristic,
+not a security boundary — `is_sensitive_path` answers that question by RESOLVED
+ancestry, so `~/.sshfoo` is not mistaken for `~/.ssh` and a symlink cannot
+smuggle a path past it. Reversing the flag would contradict a signed ADR, break
+the family's core use case, and still not cover non-dotted credentials.
+
+The correction (review round, re-measured while filing): resolved-ancestry
+matching is only as strong as what the denylist ENUMERATES, and `~/.netrc`,
+`~/.git-credentials`, `~/.npmrc`, `~/.pypirc`, `~/.cargo/credentials.toml` and
+`~/.config/gh/hosts.yml` are in none of its entries — `fs_read` returns all six
+bodies, while the sibling family refuses them at confinement because its
+`allow_hidden` defaults False. So for DOTTED credential paths this family is
+strictly the weaker of the two, and the drift pin's comment calling that
+asymmetry "an honest distinction" is only partly right: it is partly residue.
+Filed as **TASK-19633** (denylist CONTENT gap, shared with the primitive); the
+decision to keep `allow_hidden=True` stands, since flipping it would fix none
+of the non-dotted cases. Both halves of the decision are pinned:
 `test_fs_read_refuses_dotfile_component_credential_path` (a dotted path IS
 refused, and only the denylist can be what refuses it) and
 `test_benign_workspace_dotfiles_stay_readable` (`.github/`, `.gitignore` stay
@@ -164,6 +176,42 @@ keeps an honest distinction: for a candidate whose parent directory is dotted
 (`~/.ssh/id_rsa`), the second family refuses at *confinement* — its
 `validate_path_multi` rejects a dotted base directory outright — so only the
 non-dotted candidates assert its refusal is denylist-sourced.
+
+**A confirmed live leak found during this work, in the neighbouring `git_*`
+family — filed as TASK-19632.** The choke point governs a path the model
+NAMES. `path` is optional on `git_status`/`git_log`/`git_diff`, and when it is
+omitted `Agents/local_tool_provider.py:444-445` returns the repo root and
+stops, so nothing reaches the denylist; git then enumerates the repository and
+the tool returns its output verbatim. Measured on a `$HOME`-rooted workspace
+containing a synthetic `~/.ssh/id_rsa`: `git_diff` returns the file's CONTENT,
+and — this is worse than my first report — it needs **no write primitive and no
+dirty worktree**, because `commit_range="HEAD~1..HEAD"` reads it out of
+history. `git_diff(stat=True)` and a dirty-tree `git_status` return the NAME;
+`git_log` leaks nothing (commit metadata only), so my original "three git
+tools" framing was wrong and is corrected in the filing. Not fixed here: it is
+a different tool family, and the fix (pathspec exclusion vs. parsing diff
+output) is a design decision that must not ship as a hurried diff filter.
+
+**The contract text was rewritten in the review round**, because the first
+version said the choke point covered "every `fs_*` and `git_*` core function
+... so the check lives in ONE place for all of them". A reader could have used
+that to conclude `git_*` was safe — which is precisely the failure this task
+exists to fix (an enforcer list that describes only the implementations
+existing when it was written). `Utils/sensitive_paths.py`,
+`Tools/local_tool_impls.py`'s module docstring and `resolve_workspace_path`'s
+now state the path-argument/output distinction explicitly and name TASK-19632
+and TASK-19633 as open exceptions.
+
+**AC5's tripwire covered 2 of the family's 3 modules** in the first round
+(`local_tool_impls`, `patch_tool_impls`), so a new `git_*` tool would have had
+zero coverage. Fixed: `git_tool_impls` is in the module tuple, with the three
+documented indirect resolvers (`prepare_repository`, `_prepare_for_path`,
+`_repo_relative_path`) accepted — each of which is itself required to call the
+choke point DIRECTLY, so the indirection is verified rather than assumed.
+Mutation-tested four ways: without the accept-set the four repo-scoped git
+tools are reported (reproducing the gap exactly); as shipped all three modules
+are clean; a synthetic `git_show` that resolves its own path IS reported; and
+an indirect resolver that stops calling the choke point IS reported.
 
 **`workspace_root` default (AC6), reviewed — kept, documented.** The default
 (app cwd at startup) is an explicit, signed ADR-032 trade-off, and changing it

--- a/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
+++ b/backlog/tasks/task-19632 - git_diff leaks denylisted file content when path is omitted.md
@@ -1,0 +1,104 @@
+---
+id: TASK-19632
+title: >-
+  git_diff leaks denylisted file content when path is omitted
+status: To Do
+assignee: []
+created_date: '2026-08-21 12:05'
+labels:
+  - security
+  - agents
+  - tools
+priority: high
+dependencies: []
+---
+
+## Description
+
+Found and reproduced during TASK-19551 (which closed the same class of hole for
+the `fs_*` tools), then re-verified by that task's reviewer. TASK-19551 made
+`Tools/local_tool_impls.py::resolve_workspace_path` enforce the sensitive-path
+denylist (`Utils/sensitive_paths.py`) for every path a model NAMES, and made the
+three enumerating `fs_*` tools (`fs_list`/`fs_glob`/`fs_grep`) filter the
+entries they present but the model never named.
+
+The `git_*` tools share that choke point for their path argument, but have no
+equivalent output filter — and on three of them `path` is OPTIONAL. When it is
+omitted, no candidate path reaches the denylist at all: the seam is explicit at
+`Agents/local_tool_provider.py:444-445`, where `path_targets` returns the
+repository root and stops:
+
+```
+if raw_path is None:
+    return (ToolPathTarget(path=repo_root, kind="repository"),)
+```
+
+git then enumerates the whole repository on the tool's behalf and the tool
+returns its output verbatim. Under the shipped `workspace_root` default (the
+app's cwd at startup), an app launched from `$HOME` inside a git repository puts
+`~/.ssh/id_rsa` in that enumeration.
+
+Measured on this branch with an isolated `$HOME` that is a git repo containing a
+synthetic `.ssh/id_rsa` (probe re-run twice; second run added the clean-tree
+case):
+
+| call | leaks |
+| --- | --- |
+| `git_diff(commit_range="HEAD~1..HEAD")`, no `path` | **file CONTENT**, on a CLEAN worktree |
+| `git_diff()`, no `path`, dirty worktree | **file CONTENT** |
+| `git_diff(stat=True)`, no `path` | file NAME only |
+| `git_status()`, no `path`, dirty worktree | file NAME only |
+| `git_log()`, no `path` | nothing — commit metadata only |
+| any of the above WITH `path=".ssh/id_rsa"` | nothing; refused "protected path" (TASK-19551) |
+
+Two properties make this worse than the `fs_grep` gap TASK-19551 closed:
+
+1. **No write primitive is required.** The `commit_range` form reads the
+   credential out of history, so a read-only agent on a clean checkout is
+   enough. An earlier draft of this finding claimed a dirty worktree was
+   needed; that is wrong.
+2. It is reachable by **prompt injection** from fetched web content, exactly
+   like the hole TASK-19551 closed — the model only has to call a read-only,
+   `reads`-tagged git tool with no arguments.
+
+Scope note: `git_log` is clean and `git_status` discloses names only. The fix
+should not be described or built as "the three git tools leak".
+
+## Acceptance Criteria
+
+- [ ] `git_diff` never returns the content of a path `is_sensitive_path` refuses,
+      whether that path is reached via the worktree, the index, or a
+      `commit_range`, and whether or not the caller supplied `path`
+- [ ] `git_status` never names such a path
+- [ ] The behaviour is enforced by construction (e.g. denylisted paths inside the
+      repository are excluded from git's own output via pathspec, or the output
+      is filtered before it is returned) rather than by asking the model to pass
+      `path`
+- [ ] A born-red test reproduces the clean-worktree `commit_range` content leak
+      and the `stat=True`/`git_status` name leaks, and each is refused after
+      the fix
+- [ ] A test pins that `git_log` output is unchanged, and that ordinary
+      (non-denylisted) diffs, stats and statuses are unchanged — the fix must not
+      silently truncate legitimate multi-file diffs
+- [ ] `Utils/sensitive_paths.py`'s module docstring and
+      `Tools/local_tool_impls.py`'s drop the TASK-19632 exception once it no
+      longer applies (both currently state it explicitly)
+
+## Notes
+
+The two obvious implementations both need care, which is why this is its own
+task rather than a rider on TASK-19551:
+
+* **Pathspec exclusion** (`git diff -- . ':(exclude)<relpath>'`) keeps git the
+  authority and never parses diff text, but the exclusions must be computed
+  per call from the resolved denylist, restricted to paths inside the
+  repository root, and rendered repo-relative; `run_git`'s argv allowlist
+  (`_validate_argv`) has to accept them.
+* **Output filtering** means parsing unified diff / porcelain v2 text, and a
+  half-parsed diff is worse than none.
+
+`Tests/Tools/test_local_tool_sensitive_paths.py::
+test_every_workspace_rooted_function_uses_the_choke_point` already covers
+`git_tool_impls` structurally and carries a NOTE that reaching the choke point
+proves the path ARGUMENT is checked, not that output is filtered — that note
+points here.

--- a/backlog/tasks/task-19633 - Denylist does not enumerate common dotfile credentials.md
+++ b/backlog/tasks/task-19633 - Denylist does not enumerate common dotfile credentials.md
@@ -1,0 +1,92 @@
+---
+id: TASK-19633
+title: >-
+  Denylist does not enumerate common dotfile credentials
+status: To Do
+assignee: []
+created_date: '2026-08-21 12:05'
+labels:
+  - security
+  - agents
+  - tools
+priority: medium
+dependencies: []
+---
+
+## Description
+
+Demonstrated by TASK-19551's reviewer and independently re-measured while
+filing this. TASK-19551 made the `fs_*` family consult
+`Utils/sensitive_paths.py` and kept `allow_hidden=True` (ADR-032) on the
+argument that "starts with a dot" is a name heuristic while `is_sensitive_path`
+answers the question properly, by resolved ancestry. The decision is right; the
+argument is overstated in one specific way, and this task records the gap it
+hides.
+
+Resolved-ancestry matching is only as strong as what the denylist ENUMERATES.
+`_SENSITIVE_DIRS` lists `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`,
+`~/.docker`, `~/.kube`, `~/.local/share/keyrings` — and nothing else. Common
+credential files outside those trees are simply not refused.
+
+Measured on a `$HOME`-rooted workspace with synthetic marker files (isolated
+HOME; "family A" = the workspace-confined `fs_*` tools, "family B" = the
+sandbox-confined `Tools/file_operation_tools.py` tools):
+
+| path | `is_sensitive_path` | `fs_read` (A) | `read_file` (B) |
+| --- | --- | --- | --- |
+| `~/.netrc` | False | **returns body** | refused (confinement) |
+| `~/.git-credentials` | False | **returns body** | refused (confinement) |
+| `~/.npmrc` | False | **returns body** | refused (confinement) |
+| `~/.pypirc` | False | **returns body** | refused (confinement) |
+| `~/.cargo/credentials.toml` | False | **returns body** | refused (confinement) |
+| `~/.config/gh/hosts.yml` | False | **returns body** | refused (confinement) |
+
+Two consequences:
+
+1. **A denylist-CONTENT gap**, shared with the primitive itself: family B is
+   only protected here by accident — its `validate_path_multi` defaults
+   `allow_hidden=False`, so a dotted component is rejected at confinement
+   before the denylist is ever consulted. Widening a sandbox root to a
+   non-dotted directory that contains one of these (or binding such a folder)
+   would expose family B too.
+2. **For dotted credential paths, family A is strictly weaker than family B.**
+   That asymmetry deserves a decision, not silence. TASK-19551's own drift-pin
+   comment describes it as "an honest distinction" between the two families'
+   refusal reasons; that is true as far as it goes, but part of what it is
+   describing is residue, not design.
+
+Scope note: this is not an argument to reverse `allow_hidden=True`. Doing so
+would contradict ADR-032, break the coding-agent use case (`.github/`,
+`.gitignore`, `.pre-commit-config.yaml`), and still not refuse a non-dotted
+credential file. The fix belongs in the denylist's CONTENT and in whatever
+supplementary rule the team wants for high-signal credential filenames.
+
+## Acceptance Criteria
+
+- [ ] The paths measured above are refused by BOTH file-tool families, in a
+      configuration where confinement alone does not explain the refusal (root
+      set so no dotted component appears in the relative portion)
+- [ ] The additions are expressed the way the rest of the module already
+      prefers — a rule or accessor where one exists, a literal only where the
+      location genuinely is fixed — and the module docstring says which
+      choice was made and why
+- [ ] A born-red test per added path shape, showing the accept before and the
+      refusal after
+- [ ] The asymmetry is resolved deliberately and recorded: either both families
+      apply the same hidden-component policy, or the module docstring states
+      which family is stricter and why that is acceptable
+- [ ] `Utils/sensitive_paths.py`'s docstring paragraph naming this task
+      (added by TASK-19551) is updated or removed to match the new state
+- [ ] TASK-19551's drift-pin comment in
+      `Tests/Tools/test_local_tool_sensitive_paths.py` is re-read: the phrase
+      "an honest distinction" must still be true after this change
+
+## Notes
+
+Worth deciding at the same time: whether the denylist should grow a
+NAME-based rule for a small set of unambiguous credential filenames
+(`.netrc`, `.git-credentials`, `credentials.toml`, ...) in addition to
+location-based rules. The module deliberately prefers rules over
+enumerations because enumerations trail reality — that reasoning applies to
+this gap too, and an enumeration of six filenames will itself be stale within
+a year.

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -387,11 +387,19 @@ class LocalToolProvider:
         )
 
         root = Path(self._root).resolve()
-        if name in {"fs_read", "fs_write", "fs_edit"}:
-            path = resolve_workspace_path(args["path"], root)
+        # `intent` only selects the refusal wording (and, for writes, the
+        # new-directory-chain guard) inside the choke point; a protected
+        # path raises LocalToolError here exactly as it does at execution
+        # time, so this preflight can never report a target the tool would
+        # then refuse to touch.
+        if name == "fs_read":
+            path = resolve_workspace_path(args["path"], root, intent="read")
+            return (ToolPathTarget(path=path, kind="exact"),)
+        if name in {"fs_write", "fs_edit"}:
+            path = resolve_workspace_path(args["path"], root, intent="write")
             return (ToolPathTarget(path=path, kind="exact"),)
         if name == "fs_list":
-            path = resolve_workspace_path(args["path"], root)
+            path = resolve_workspace_path(args["path"], root, intent="list")
             return (ToolPathTarget(path=path, kind="directory"),)
         if name in {"fs_glob", "fs_grep"}:
             return (ToolPathTarget(path=root, kind="directory"),)
@@ -411,7 +419,7 @@ class LocalToolProvider:
             seen: set[Path] = set()
             for plan in plans:
                 assert plan.new_path is not None
-                path = resolve_workspace_path(plan.new_path, root)
+                path = resolve_workspace_path(plan.new_path, root, intent="write")
                 if path in seen:
                     continue
                 seen.add(path)

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -5,6 +5,32 @@ agent runtime's worker thread via Agents/local_tool_provider.py. Every
 failure raises LocalToolError; the provider converts those (and any other
 exception) into ToolResult error strings — nothing raises across the
 provider boundary.
+
+Path safety has TWO layers, and both are mandatory (TASK-19551):
+
+1. **Confinement** to the configured ``[console] workspace_root``
+   (ADR-032), enforced by ``validate_path`` inside
+   ``resolve_workspace_path`` — the single choke point every path-taking
+   function here (and in ``patch_tool_impls``/``git_tool_impls``) funnels
+   through.
+2. **The sensitive-path denylist** (``Utils/sensitive_paths.py``), also
+   enforced inside that same choke point. Confinement alone is not enough:
+   the shipped ``workspace_root`` default is the app's cwd at startup, so
+   launching from ``$HOME`` makes ``$HOME`` the confinement root — and
+   ``~/.ssh/id_rsa``, ``~/.aws/credentials``, this app's own ``config.toml``
+   and ``mcp_permissions.json`` are all inside it. Reading them exfiltrates
+   credentials into a transcript sent to a provider; WRITING
+   ``mcp_permissions.json`` turns every ``ask`` into ``allow``, a one-step
+   bypass of the permission gate that authorized the call.
+
+The three ENUMERATING tools (``list_directory``/``glob_files``/
+``grep_files``) resolve only the workspace root through the choke point, so
+the choke point cannot cover the entries they walk: each filters its own
+candidates against the same denylist, resolving the sensitive-path context
+ONCE per invocation (see ``Utils.sensitive_paths.resolve_sensitive_context``)
+rather than once per candidate. ``grep_files`` is the sharpest of the three
+— it READS every file it walks and prints matching lines — so its check
+must run before the read, not after.
 """
 
 from __future__ import annotations
@@ -12,8 +38,15 @@ from __future__ import annotations
 import os
 import heapq
 from pathlib import Path
+from typing import Literal
 
 from tldw_chatbook.Utils.path_validation import validate_path
+from tldw_chatbook.Utils.sensitive_paths import (
+    SensitivePathContext,
+    is_sensitive_path,
+    refuses_new_directory_chain,
+    resolve_sensitive_context,
+)
 
 MAX_LIST_ENTRIES = 200
 #: Upper bound on how many directory entries ``list_directory`` will even
@@ -31,30 +64,97 @@ class LocalToolError(ValueError):
     """Model-actionable failure from a local tool (path, not-found, …)."""
 
 
-def resolve_workspace_path(path: str, workspace_root: Path) -> Path:
-    """Resolve ``path`` against ``workspace_root``, confined to it.
+#: Intent of the access a caller is about to perform, threaded into the
+#: choke point below. It selects the refusal verb AND, for ``"write"``,
+#: the extra ``refuses_new_directory_chain`` guard — never a weaker check.
+PathIntent = Literal["read", "write", "list"]
 
-    Hidden components (``.github/``) are allowed under the root; anything
-    resolving outside it is refused.
+_INTENT_VERBS: dict[str, str] = {"read": "read", "write": "written", "list": "listed"}
+
+
+def resolve_workspace_path(
+    path: str,
+    workspace_root: Path,
+    *,
+    intent: PathIntent = "read",
+    context: SensitivePathContext | None = None,
+) -> Path:
+    """Resolve ``path`` against ``workspace_root``, confined and denylisted.
+
+    The single choke point for this tool family: every ``fs_*`` and
+    ``git_*`` core function resolves its target here, so both path checks
+    are enforced in ONE place rather than re-implemented per tool (which is
+    exactly how the denylist came to be missing from all seven of them —
+    TASK-19551).
+
+    Two checks, in order:
+
+    1. **Confinement** (``validate_path``). Hidden components (``.github/``,
+       ``.gitignore``) are allowed under the root, per ADR-032: a coding
+       agent that cannot read a repository's dotfile configuration is
+       useless, and the ADR adopted ``allow_hidden`` for exactly this
+       family. That parameter is deliberately KEPT — dotted names are how
+       ``~/.ssh``/``~/.aws`` are spelled, but "starts with a dot" is a name
+       heuristic, not a security boundary, and check 2 is the one designed
+       to answer that question (by resolved ancestry, so a symlink or a
+       ``~/.sshfoo`` lookalike cannot game it).
+    2. **The sensitive-path denylist** (``is_sensitive_path``), matching
+       what ``Tools/file_operation_tools.py``'s ``ReadFileTool``/
+       ``WriteFileTool``/``ListDirectoryTool`` already do for the other
+       file-tool family, message shape included, so agent-facing refusals
+       stay consistent across the two.
+
+    For ``intent="write"`` the denylist check is additionally applied to
+    every not-yet-existing ancestor of the target
+    (``refuses_new_directory_chain``), the same guard ``WriteFileTool``
+    consults before ``mkdir(parents=True)``. No tool in this family creates
+    directories today (a write target's parent must already exist), so this
+    normally short-circuits on the first existing ancestor; it is here so
+    that a future ``create_directories``-style option cannot reintroduce
+    TASK-849's shadow-directory denial of service by forgetting it.
 
     Args:
         path: The user/model-supplied path, absolute or relative to
             ``workspace_root``.
         workspace_root: The confinement root the resolved path must stay
             within.
+        intent: What the caller is about to do with the path — selects the
+            refusal verb and enables the new-directory-chain guard for
+            writes. Never weakens a check.
+        context: Optional pre-resolved ``SensitivePathContext``. Callers
+            that check many paths in one tool invocation (the enumerating
+            tools, ``patch_files``' multi-file loop) resolve one with
+            ``Utils.sensitive_paths.resolve_sensitive_context()`` and pass
+            it through, so the ~11 config accessors behind the denylist are
+            resolved once per CALL rather than once per path. ``None``
+            resolves it fresh — that still enforces the denylist.
 
     Returns:
         The validated absolute ``Path`` inside ``workspace_root``.
 
     Raises:
-        LocalToolError: If the path resolves outside ``workspace_root``.
+        LocalToolError: If the path resolves outside ``workspace_root``, or
+            is a protected credential/gate-state/app-state path.
     """
     try:
-        return validate_path(path, workspace_root, allow_hidden=True)
+        resolved = validate_path(path, workspace_root, allow_hidden=True)
     except ValueError as exc:
         raise LocalToolError(
             f"Path '{path}' is outside the workspace root ({workspace_root})"
         ) from exc
+
+    verb = _INTENT_VERBS.get(intent, "accessed")
+    if is_sensitive_path(resolved, context=context):
+        raise LocalToolError(
+            f"Refused: '{path}' is a protected path and cannot be {verb}"
+        )
+    if intent == "write" and refuses_new_directory_chain(
+        resolved.parent, context=context
+    ):
+        raise LocalToolError(
+            f"Refused: creating '{resolved.parent}' would collide with a protected path"
+        )
+    return resolved
 
 
 def list_directory(
@@ -68,6 +168,13 @@ def list_directory(
     the scanned entries are sorted (dirs-first contract preserved for the
     scanned set), and hitting the scan cap appends a "directory too large"
     notice instead of silently presenting a partial listing as complete.
+
+    Individual denylisted ENTRIES are omitted from the listing (TASK-19551),
+    mirroring ``ListDirectoryTool``'s per-entry check in
+    ``Tools/file_operation_tools.py``: refusing the target directory alone
+    would still disclose this app's own ``mcp_permissions.json`` or
+    ``chachanotes.db`` by name and existence whenever an ordinary,
+    listable ancestor happens to contain them.
 
     Args:
         path: Directory to list, absolute or relative to
@@ -84,7 +191,10 @@ def list_directory(
         LocalToolError: If ``path`` is not an existing directory, or
             resolves outside ``workspace_root``.
     """
-    root = resolve_workspace_path(path, workspace_root)
+    sensitive_ctx = resolve_sensitive_context()
+    root = resolve_workspace_path(
+        path, workspace_root, intent="list", context=sensitive_ctx
+    )
     if not root.is_dir():
         raise LocalToolError(f"not a directory: {path}")
     scanned: list[Path] = []
@@ -93,6 +203,10 @@ def list_directory(
         if index >= MAX_SCAN_ENTRIES:
             scan_capped = True
             break
+        # Skipped entries still count against the scan cap: the cap bounds
+        # the WORK done, and a denied entry was still scanned.
+        if is_sensitive_path(entry, context=sensitive_ctx):
+            continue
         scanned.append(entry)
     entries = sorted(scanned, key=lambda p: (p.is_file(), p.name.lower()))
     lines = [
@@ -123,7 +237,7 @@ def read_file(
     LocalToolError with model-actionable messages. UTF-16 files trip the
     binary sniff; other non-UTF-8 text reads with U+FFFD replacement.
     """
-    root = resolve_workspace_path(path, workspace_root)
+    root = resolve_workspace_path(path, workspace_root, intent="read")
     if not root.is_file():
         raise LocalToolError(f"file not found: {path}")
     with open(root, "rb") as fh:
@@ -150,7 +264,7 @@ def write_file(path: str, content: str, *, workspace_root: Path) -> str:
     The parent directory must already exist (deliberate divergence from
     claude-code's Write, to catch model path typos early — spec §2).
     """
-    root = resolve_workspace_path(path, workspace_root)
+    root = resolve_workspace_path(path, workspace_root, intent="write")
     if not root.parent.is_dir():
         raise LocalToolError(f"parent directory does not exist for: {path}")
     try:
@@ -187,7 +301,7 @@ def edit_file(
         raise LocalToolError("old_string must not be empty")
     if old_string == new_string:
         raise LocalToolError("old_string and new_string are identical")
-    root = resolve_workspace_path(path, workspace_root)
+    root = resolve_workspace_path(path, workspace_root, intent="write")
     if not root.is_file():
         raise LocalToolError(f"file not found: {path}")
     try:
@@ -225,7 +339,9 @@ def glob_files(
     Paths in the result are workspace-relative. Hidden files/dirs under the
     root ARE matched (workspace policy, ADR-032). Matches that escape the
     root via ``..`` pattern segments are excluded (lexical check only —
-    symlinks are not resolved, per ADR-032 review).
+    symlinks are not resolved, per ADR-032 review). Denylisted matches are
+    excluded too (TASK-19551): under a home-rooted workspace ``**/*`` would
+    otherwise report ``.ssh/id_rsa`` back to the model by name.
 
     Memory is bounded at ``max_results``: a min-heap keeps only the newest N
     while the total is counted in one pass (no full-list materialization or
@@ -236,7 +352,10 @@ def glob_files(
     """
     if max_results < 1:
         raise LocalToolError("max_results must be >= 1")
-    root = resolve_workspace_path(".", workspace_root)
+    sensitive_ctx = resolve_sensitive_context()
+    root = resolve_workspace_path(
+        ".", workspace_root, intent="list", context=sensitive_ctx
+    )
     heap: list[tuple[float, Path]] = []  # min-heap of (mtime, normpath)
     total = 0
     for p in root.glob(pattern):
@@ -246,6 +365,8 @@ def glob_files(
             norm = Path(os.path.normpath(p))
             if not norm.is_relative_to(root):
                 continue
+            if is_sensitive_path(norm, context=sensitive_ctx):
+                continue  # never disclose a protected path, even by name
             mtime = p.stat().st_mtime
         except OSError:
             continue  # racy/unreadable entry — skip it, not the whole search
@@ -276,6 +397,11 @@ def grep_files(
     filesystem order (no global sort — that would materialize the whole
     tree); within a file, lines are in order.
 
+    Denylisted files are skipped BEFORE they are read (TASK-19551): this is
+    the sharpest of the three enumerating tools, since ``content`` mode
+    prints matching LINES — a home-rooted workspace and a pattern as bland
+    as ``KEY`` would otherwise emit ``~/.ssh/id_rsa`` into the transcript.
+
     Raises:
         LocalToolError: If ``max_results`` is below 1.
     """
@@ -289,7 +415,10 @@ def grep_files(
         raise LocalToolError(f"unknown mode: {mode}")
     if max_results < 1:
         raise LocalToolError("max_results must be >= 1")
-    root = resolve_workspace_path(".", workspace_root)
+    sensitive_ctx = resolve_sensitive_context()
+    root = resolve_workspace_path(
+        ".", workspace_root, intent="list", context=sensitive_ctx
+    )
     # Memory-bounded: only the first max_results output lines are kept; the
     # rest are counted, not stored. Per-entry fs errors (races, permissions)
     # skip the entry rather than failing the whole search.
@@ -301,6 +430,8 @@ def grep_files(
                 continue
             if not p.resolve().is_relative_to(root):
                 continue  # symlink escaping the root — never read outside content
+            if is_sensitive_path(p, context=sensitive_ctx):
+                continue  # protected path — skipped BEFORE it is read
         except OSError:
             continue  # racy/unreadable entry — skip it, not the whole search
         try:

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -23,14 +23,21 @@ Path safety has TWO layers, and both are mandatory (TASK-19551):
    ``mcp_permissions.json`` turns every ``ask`` into ``allow``, a one-step
    bypass of the permission gate that authorized the call.
 
-The three ENUMERATING tools (``list_directory``/``glob_files``/
-``grep_files``) resolve only the workspace root through the choke point, so
-the choke point cannot cover the entries they walk: each filters its own
-candidates against the same denylist, resolving the sensitive-path context
-ONCE per invocation (see ``Utils.sensitive_paths.resolve_sensitive_context``)
-rather than once per candidate. ``grep_files`` is the sharpest of the three
-— it READS every file it walks and prints matching lines — so its check
-must run before the read, not after.
+The choke point covers a path the model NAMES. It cannot cover entries a
+tool presents that the model never named, so the three ENUMERATING tools
+(``list_directory``/``glob_files``/``grep_files``) — which resolve only the
+workspace ROOT through it — each filter their own candidates against the
+same denylist, resolving the sensitive-path context ONCE per invocation
+(see ``Utils.sensitive_paths.resolve_sensitive_context``) rather than once
+per candidate. ``grep_files`` is the sharpest of the three — it READS every
+file it walks and prints matching lines — so its check runs before the
+read, not after.
+
+``Tools/git_tool_impls.py`` shares this choke point for its path arguments
+but has NO such output filter, and ``path`` is optional on ``git_status``/
+``git_log``/``git_diff``: with it omitted, ``git_diff`` returns the CONTENT
+of a denylisted file (TASK-19632, open). Do not extend that family assuming
+the choke point alone makes its output safe.
 """
 
 from __future__ import annotations
@@ -82,10 +89,13 @@ def resolve_workspace_path(
     """Resolve ``path`` against ``workspace_root``, confined and denylisted.
 
     The single choke point for this tool family: every ``fs_*`` and
-    ``git_*`` core function resolves its target here, so both path checks
-    are enforced in ONE place rather than re-implemented per tool (which is
-    exactly how the denylist came to be missing from all seven of them —
-    TASK-19551).
+    ``git_*`` core function resolves a model-supplied path here (the git
+    ones one hop away, via ``prepare_repository``/``_prepare_for_path``/
+    ``_repo_relative_path``), so both path checks are enforced in ONE place
+    rather than re-implemented per tool — which is exactly how the denylist
+    came to be missing from all seven ``fs_*`` tools (TASK-19551). It
+    governs the path a caller PASSES; it does not filter what a tool
+    returns (see the module docstring for where that distinction bites).
 
     Two checks, in order:
 

--- a/tldw_chatbook/Tools/patch_tool_impls.py
+++ b/tldw_chatbook/Tools/patch_tool_impls.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Literal
 
 from tldw_chatbook.Tools.local_tool_impls import LocalToolError, resolve_workspace_path
+from tldw_chatbook.Utils.sensitive_paths import resolve_sensitive_context
 
 PATCH_MAX_BYTES = 256 * 1024
 PATCH_MAX_FILES = 20
@@ -380,12 +381,20 @@ def _line_has_trailing_newline(line: str) -> bool:
 def patch_files(diff_text: str, *, workspace_root: Path, dry_run: bool = False) -> str:
     """Parse and apply a unified diff to workspace files.
 
-    Every target is confined via resolve_workspace_path. Modify targets must
-    exist; create targets must not. dry_run validates and reports without
-    writing. Returns a per-file summary ("patched X", "would patch X").
-    Files are applied sequentially; if a later file fails, earlier files stay
-    patched — the error names the failed file so the model can recover
-    (atomic multi-file apply is a documented non-goal for this phase).
+    Every target is confined AND denylist-checked via
+    ``resolve_workspace_path`` — this tool owns no path resolution of its
+    own, so it inherits the sensitive-path guard from that one choke point
+    (TASK-19551; without it, a diff against ``mcp_permissions.json`` was a
+    one-step permission-gate bypass). ``dry_run`` is checked identically:
+    it still reads the target, and reporting "would patch
+    mcp_permissions.json" is itself a disclosure.
+
+    Modify targets must exist; create targets must not. dry_run validates
+    and reports without writing. Returns a per-file summary ("patched X",
+    "would patch X"). Files are applied sequentially; if a later file
+    fails, earlier files stay patched — the error names the failed file so
+    the model can recover (atomic multi-file apply is a documented non-goal
+    for this phase).
     """
 
     try:
@@ -393,12 +402,20 @@ def patch_files(diff_text: str, *, workspace_root: Path, dry_run: bool = False) 
     except FilesystemPatchError as exc:
         raise LocalToolError(f"fs_patch failed [{exc.reason_code}]") from exc
 
+    # One sensitive-path resolution for the whole multi-file apply, threaded
+    # into every target's check (see Utils.sensitive_paths.
+    # resolve_sensitive_context) instead of re-resolving ~11 config
+    # accessors per file in the diff.
+    sensitive_ctx = resolve_sensitive_context()
+
     summaries: list[str] = []
     for patch_file in parsed:
         rel_path = patch_file.new_path
         assert rel_path is not None  # guaranteed by parse_unified_diff
         try:
-            root = resolve_workspace_path(rel_path, workspace_root)
+            root = resolve_workspace_path(
+                rel_path, workspace_root, intent="write", context=sensitive_ctx
+            )
             if patch_file.action == "modify":
                 if not root.is_file():
                     raise LocalToolError(f"file not found: {rel_path}")

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -1,11 +1,36 @@
 # tldw_chatbook/Utils/sensitive_paths.py
 """Paths refused by the agent-facing file tools, regardless of configured root.
 
-Enforced directly inside ``Tools/file_operation_tools.py``'s ``ReadFileTool``,
-``WriteFileTool``, ``ListDirectoryTool``, ``GlobFiles`` and ``GrepFiles`` --
-each calls :func:`is_sensitive_path` (directly, or through that module's
-``is_within`` helper) on every candidate path immediately after path
-validation and before touching the filesystem. It is *not* wired into
+TWO independent agent file-tool families enforce this, and both must:
+
+1. ``Tools/file_operation_tools.py``'s ``ReadFileTool``, ``WriteFileTool``,
+   ``ListDirectoryTool``, ``GlobFiles`` and ``GrepFiles`` (sandbox-root
+   confined) -- each calls :func:`is_sensitive_path` (directly, or through
+   that module's ``is_within`` helper) on every candidate path immediately
+   after path validation and before touching the filesystem.
+2. The workspace-local ``fs_*`` family -- ``Tools/local_tool_impls.py``'s
+   ``resolve_workspace_path``, the single choke point every ``fs_*`` and
+   ``git_*`` core function (including ``Tools/patch_tool_impls.py``'s
+   ``patch_files`` and ``Tools/git_tool_impls.py``) resolves its target
+   through, so the check lives in ONE place for all of them. The three
+   ENUMERATING tools there (``list_directory``/``glob_files``/
+   ``grep_files``) additionally filter their own walked candidates, since
+   the choke point only ever sees their root.
+
+   That family was added AFTER this contract was written and, until
+   TASK-19551, called none of this: it confined paths to ``[console]
+   workspace_root`` and stopped there. With the shipped default root (the
+   app's cwd at startup) an app launched from ``$HOME`` made ``$HOME`` the
+   confinement root, so ``fs_read`` returned ``~/.ssh/id_rsa`` and
+   ``fs_write``/``fs_patch`` could rewrite ``mcp_permissions.json`` -- the
+   one-step gate bypass described below -- reachable by prompt injection
+   from fetched web content. **A new agent-facing file tool joins one of
+   these two families; it does not get a third path-resolution seam.**
+   ``Tests/Tools/test_local_tool_sensitive_paths.py`` pins both the choke
+   point and the two families' agreement, so they cannot drift apart
+   again.
+
+This is *not* wired into
 ``Utils/path_validation.validate_path``/``validate_path_multi`` themselves:
 those helpers are the app's general-purpose validators, used by ~40
 first-party call sites (config screens, DB path resolution, exports, ...) to
@@ -508,11 +533,17 @@ def is_sensitive_path(
     recent data as the database itself.
 
     This function only decides the question; it enforces nothing by
-    itself. Callers -- ``ReadFileTool.execute``, ``WriteFileTool.execute``,
-    ``ListDirectoryTool.execute``, ``GlobFiles.execute`` and
-    ``GrepFiles.execute`` in ``Tools/file_operation_tools.py`` -- must call
-    it (directly, or via that module's ``is_within``) explicitly on their
-    target before touching the filesystem.
+    itself. Callers must call it explicitly on their target before touching
+    the filesystem:
+
+    * ``ReadFileTool.execute``, ``WriteFileTool.execute``,
+      ``ListDirectoryTool.execute``, ``GlobFiles.execute`` and
+      ``GrepFiles.execute`` in ``Tools/file_operation_tools.py`` (directly,
+      or via that module's ``is_within``).
+    * ``Tools/local_tool_impls.py``'s ``resolve_workspace_path`` -- the
+      choke point the whole workspace-local ``fs_*``/``git_*`` family
+      resolves through -- plus the per-candidate filters in
+      ``list_directory``/``glob_files``/``grep_files`` there (TASK-19551).
 
     Args:
         candidate: The path a tool intends to touch.

--- a/tldw_chatbook/Utils/sensitive_paths.py
+++ b/tldw_chatbook/Utils/sensitive_paths.py
@@ -8,27 +8,60 @@ TWO independent agent file-tool families enforce this, and both must:
    confined) -- each calls :func:`is_sensitive_path` (directly, or through
    that module's ``is_within`` helper) on every candidate path immediately
    after path validation and before touching the filesystem.
-2. The workspace-local ``fs_*`` family -- ``Tools/local_tool_impls.py``'s
-   ``resolve_workspace_path``, the single choke point every ``fs_*`` and
-   ``git_*`` core function (including ``Tools/patch_tool_impls.py``'s
-   ``patch_files`` and ``Tools/git_tool_impls.py``) resolves its target
-   through, so the check lives in ONE place for all of them. The three
-   ENUMERATING tools there (``list_directory``/``glob_files``/
-   ``grep_files``) additionally filter their own walked candidates, since
-   the choke point only ever sees their root.
+2. The workspace-local ``fs_*``/``git_*`` family --
+   ``Tools/local_tool_impls.py``'s ``resolve_workspace_path``, the single
+   choke point through which every one of them resolves a path ARGUMENT
+   (``Tools/patch_tool_impls.py``'s ``patch_files`` directly; the four
+   repo-scoped tools in ``Tools/git_tool_impls.py`` one hop away, via
+   ``prepare_repository``/``_prepare_for_path``/``_repo_relative_path``).
 
-   That family was added AFTER this contract was written and, until
+   Read what that sentence does and does not say. It covers a path the
+   model NAMES. It does not make a tool's OUTPUT safe:
+
+   * The three enumerating ``fs_*`` tools (``list_directory``/
+     ``glob_files``/``grep_files``) present entries the model never named,
+     so each additionally filters its own walked candidates against
+     :func:`is_sensitive_path` -- the choke point only ever sees their
+     root.
+   * **The ``git_*`` tools do NOT have that filtering, and one of them
+     leaks (TASK-19632, open).** ``path`` is OPTIONAL on ``git_status``/
+     ``git_log``/``git_diff``, and when it is omitted nothing reaches this
+     module at all (``Agents/local_tool_provider.py``'s ``path_targets``
+     returns the repo root and stops). Measured on a ``$HOME``-rooted
+     workspace containing ``~/.ssh/id_rsa``: ``git_diff`` returns the
+     file's CONTENT (a clean worktree is enough -- ``commit_range=
+     "HEAD~1..HEAD"`` reads it out of history, no write primitive needed);
+     ``git_diff(stat=True)`` and ``git_status`` on a dirty tree return the
+     NAME; ``git_log`` returns commit metadata only and leaks nothing. Do
+     not read item 2 as "the git tools are covered" -- their path
+     ARGUMENT is, their output is not.
+
+   This family was added AFTER this contract was written and, until
    TASK-19551, called none of this: it confined paths to ``[console]
    workspace_root`` and stopped there. With the shipped default root (the
    app's cwd at startup) an app launched from ``$HOME`` made ``$HOME`` the
    confinement root, so ``fs_read`` returned ``~/.ssh/id_rsa`` and
    ``fs_write``/``fs_patch`` could rewrite ``mcp_permissions.json`` -- the
    one-step gate bypass described below -- reachable by prompt injection
-   from fetched web content. **A new agent-facing file tool joins one of
-   these two families; it does not get a third path-resolution seam.**
-   ``Tests/Tools/test_local_tool_sensitive_paths.py`` pins both the choke
-   point and the two families' agreement, so they cannot drift apart
-   again.
+   from fetched web content. The failure was not a wrong check; it was an
+   enforcer list that could only ever name the implementations existing
+   when it was written, and a second family that never joined it. Hence
+   the exception above is stated rather than smoothed over: **a new
+   agent-facing file tool joins one of these two families; it does not get
+   a third path-resolution seam** --
+   ``Tests/Tools/test_local_tool_sensitive_paths.py`` pins that
+   structurally (an AST tripwire over all three ``fs_*``/``git_*`` core
+   modules) and pins the two families' agreement on the denylist, so they
+   cannot drift apart again.
+
+Also worth knowing before relying on this module: the denylist is an
+ENUMERATION (``_SENSITIVE_DIRS`` plus the accessor-resolved paths below),
+so its coverage is exactly what it lists. Credential files it does not
+enumerate -- ``~/.netrc``, ``~/.git-credentials``, ``~/.npmrc``,
+``~/.pypirc``, ``~/.cargo/credentials.toml``, ``~/.config/gh/hosts.yml`` --
+are NOT refused by it, and family 2 passes ``allow_hidden=True`` while
+family 1 does not, so for dotted paths family 2 is strictly the weaker of
+the two (TASK-19633, open).
 
 This is *not* wired into
 ``Utils/path_validation.validate_path``/``validate_path_multi`` themselves:
@@ -541,9 +574,12 @@ def is_sensitive_path(
       ``GrepFiles.execute`` in ``Tools/file_operation_tools.py`` (directly,
       or via that module's ``is_within``).
     * ``Tools/local_tool_impls.py``'s ``resolve_workspace_path`` -- the
-      choke point the whole workspace-local ``fs_*``/``git_*`` family
-      resolves through -- plus the per-candidate filters in
+      choke point the workspace-local ``fs_*``/``git_*`` family resolves
+      its path ARGUMENTS through -- plus the per-candidate filters in
       ``list_directory``/``glob_files``/``grep_files`` there (TASK-19551).
+      The ``git_*`` tools have no output filter and ``git_diff`` leaks
+      content for a denylisted path when ``path`` is omitted; see this
+      module's docstring and TASK-19632.
 
     Args:
         candidate: The path a tool intends to touch.

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -2949,7 +2949,16 @@ compaction_target_ratio = 0.55
 compaction_summary_max_tokens = 1024
 compaction_failure_behavior = "stop_and_ask"  # stop_and_ask, omit_older_context
 compaction_carry_forward_mode = "memory_with_recent_turns"  # memory_with_recent_turns, memory_with_latest_exchange
-# workspace_root = ""           # confinement root for fs_* tools; empty = app cwd at startup
+# Confinement root for the fs_*/git_* agent tools (ADR-032). Empty = the app's
+# cwd at startup, so the boundary MOVES with where you launch the app: start it
+# from your home directory and every personal file under it is inside the
+# agent's reach. Credential, gate-state and app-state paths (~/.ssh, ~/.aws,
+# this file, mcp_permissions.json, the app's databases) are refused regardless
+# of this setting -- see Utils/sensitive_paths.py, enforced for these tools in
+# Tools/local_tool_impls.py's resolve_workspace_path (TASK-19551) -- but that
+# denylist is a guardrail, not a substitute for pointing this at the one
+# project directory you actually want an agent working in.
+# workspace_root = ""
 
 # Agent run budget (Settings > Console Behavior > Agent run budget).
 # Applies to ONE run = one user message; sub-agents inherit turns/steps/tokens


### PR DESCRIPTION
## Summary
Closes task-19551 (P0, security). The seven `fs_*` agent file tools confined every path to a workspace root but **never consulted the sensitive-path denylist**. With the shipped default (the app's cwd at startup), launching from `$HOME` makes `$HOME` the root — so `fs_read` returned `~/.ssh/id_rsa` and the API-key config, and `fs_write`/`fs_edit`/`fs_patch` could rewrite `mcp_permissions.json` to turn every `ask` into `allow`: **a one-step bypass of the permission gate that authorized the tool**, reachable by prompt injection from fetched web content rather than only by a malicious user.

The denylist existed and already listed every one of those paths. It was simply never asked.

## The fix
Enforced at the single choke point `resolve_workspace_path`, so one change covers all seven tools plus `patch_files` and the repo-scoped git tools. An `intent` parameter ("read"/"write"/"list") threads the read/write distinction through rather than weakening the check (writes additionally run `refuses_new_directory_chain`), and a `context` parameter lets multi-path callers resolve config accessors once.

**The choke point structurally cannot cover the enumerating tools** — it only ever sees their *root* — so `list_directory`/`glob_files`/`grep_files` filter their own walked candidates, with grep filtering **before** the read: at base, `fs_grep "KEY"` under a home root printed the key's contents, not just a filename.

`allow_hidden=True` is kept deliberately (ADR-032: real workspaces need `.git` and dotfile configs), on the argument that `is_sensitive_path` answers by *resolved ancestry* rather than a name heuristic — pinned in both directions.

## Evidence
Born-red 14 failed / 4 passed at base → 18 passed, with the base failures **printing what the tools actually returned**: the private key body, `api_key = 'super-secret-19551'`, `'wrote 15 characters'` for the write to the permission store. Reviewer reproduced all of it independently at the merge-base and confirmed refusal at head for every vector including dry-run and a symlink from inside the workspace.

Cost measured and caching **rejected** for a security primitive (`fs_read` 0.1→6 ms; these are agent tool calls behind an LLM round-trip). The reviewer re-measured and agreed.

## Review: FIX-FIRST, then APPROVE
The enforcement was correct on the first pass; what blocked it was the **record**. The new contract text claimed the choke point covers "every `fs_*` and `git_*` core function" — false, because three `git_*` tools enumerate through an optional path and filter nothing. Shipping that would have recreated the exact stale-enforcer-list failure this task exists to fix. Corrected: the contract now states that it governs *the path a caller passes, not what a tool returns*, names the git exception with a measured table, and explains why the exception is stated rather than smoothed over.

Two follow-ups filed with independent re-measurement, with the reviewer's corrections preserved rather than softened:
- **TASK-19632** (high) — `git_diff` with no path leaks denylisted file **content**, on a *clean* worktree via `commit_range`, so no write primitive is needed. Corrected in both directions: `git_status` leaks names only, and `git_log` leaks nothing.
- **TASK-19633** — the denylist is an *enumeration*, and `~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`, `~/.cargo/credentials.toml`, `~/.config/gh/hosts.yml` aren't in it. Explicitly scoped as **not** an argument to reverse `allow_hidden`.

## The anti-drift tripwire, and its own two holes
An AST tripwire fails if any workspace-rooted function reaches the filesystem without the choke point — the drift between the two tool families *is* this bug. Review found the tripwire covered two of the family's three modules, then found two deeper holes, both closed here after reproducing each:
1. **The accept-set could be widened into a hole**: the scan only inspects functions whose parameter is literally named `workspace_root`, so a resolver spelling it differently was trusted and never itself verified. Every accepted name must now have been visited and verified.
2. **The module tuple was itself a hand-list** — the same shape as the original bug, one level up. It is now *derived* by scanning `Tools/` for functions taking `workspace_root`, with an assertion that the three known members survive discovery so a rename is loud.

Tests/Tools/ 634 passed; the family suite 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the sensitive‑path denylist for all workspace‑local `fs_*` tools and their enumerators, closing the hole where confinement to `workspace_root` alone allowed reads like `~/.ssh/id_rsa` and writes to `mcp_permissions.json`. Old behavior: confined paths, no denylist; enumerators could list/grep protected entries. New behavior: paths are both confined and denylisted at a single choke point; enumerators filter results (with `fs_grep` filtering before read).

- `resolve_workspace_path` now consults `Utils/sensitive_paths.is_sensitive_path` for every path, adds `intent=("read"|"write"|"list")` to align refusal wording and apply `refuses_new_directory_chain` on writes, and accepts an optional pre‑resolved context.
- `fs_list`, `fs_glob`, and `fs_grep` filter walked candidates against the same context; `fs_grep` skips protected files before reading.
- `patch_files` routes targets through the same choke point; `Agents/local_tool_provider.path_targets` passes the appropriate `intent`.
- Keeps `allow_hidden=True` (ADR‑032) and documents why; adds cross‑family agreement tests, an AST tripwire to ensure all workspace‑rooted functions use the choke point, and a “no mkdir” pin. Docs and config comments updated accordingly.

**Reviewer focus**
- Verify denylist enforcement and error shape in `Tools/local_tool_impls.py::resolve_workspace_path` and its new `intent/context` usage.
- Check per‑entry filtering in `list_directory`/`glob_files`/`grep_files` (pre‑read check in grep).
- Confirm `patch_tool_impls.patch_files` and `local_tool_provider.path_targets` pass `intent` and share the context.
- Tests: new `Tests/Tools/test_local_tool_sensitive_paths.py` covers read/write/patch/enum paths, cross‑family parity, AST tripwire, and no‑mkdir; ensure they exercise your platform.
- Performance: modest added latency per call; no caching by design for this security primitive.

**Follow‑ups**
- TASK‑19632: `git_diff` can leak protected content when `path` is omitted; this PR documents the exception but does not change `git_*`.
- TASK‑19633: denylist enumeration gaps for common dotfile credentials (`~/.netrc`, `~/.git-credentials`, etc.) tracked separately; decision to keep `allow_hidden=True` stands pending denylist updates.

<sup>Written for commit f815a8585b2d2e869b68e0a9a7e73fe63c82d2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

