### PR TITLE
fix(db): make every ChaChaNotes migration step atomic and re-enterable (task-19553)

### DIFF
--- a/Tests/ChaChaNotesDB/legacy_conversation_schema.py
+++ b/Tests/ChaChaNotesDB/legacy_conversation_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -194,6 +195,16 @@ def migrated_legacy_conversations_db(
     connection.row_factory = sqlite3.Row
     db = CharactersRAGDB.__new__(CharactersRAGDB)
     db.db_path_str = str(db_path)
+    # task-19553: migration steps now run their DDL through
+    # ``self.transaction()`` (one ``cursor.execute`` per statement) instead of
+    # ``conn.executescript``, so this __new__-built stand-in has to expose the
+    # thread-local connection the transaction manager reaches for. Pointing it
+    # at the SAME raw connection keeps the fixture's "one migration, no
+    # unrelated schema init" property while giving the step a real,
+    # rollback-capable transaction.
+    db._local = threading.local()
+    db._local.conn = connection
+    db._local.transaction_depth = 0
     try:
         migration(db, connection)
         yield connection

--- a/Tests/ChaChaNotesDB/test_migration_atomicity.py
+++ b/Tests/ChaChaNotesDB/test_migration_atomicity.py
@@ -364,12 +364,24 @@ class TestFailingStepRollsBack:
     def test_interrupted_base_schema_apply_recovers(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The v4 base apply is atomic too.
+        """The v4 base apply leaves nothing behind when it fails.
 
-        ``_FULL_SCHEMA_SQL_V4`` ships 42 ``CREATE TRIGGER`` statements with no
-        ``IF NOT EXISTS``, so a base apply interrupted after some of them had
-        been autocommitted used to make the brand-new file unopenable
-        ("trigger ... already exists") rather than merely incomplete.
+        Scope this claim carefully -- it is NOT the brick the migration steps
+        had. ``_FULL_SCHEMA_SQL_V4`` is already re-enterable on its own terms:
+        42 ``CREATE TRIGGER`` statements but 42 matching
+        ``DROP TRIGGER IF EXISTS`` (zero creates without a preceding drop),
+        every ``CREATE TABLE``/``VIRTUAL TABLE``/``INDEX`` carrying
+        ``IF NOT EXISTS``, and both top-level inserts ``INSERT OR IGNORE``.
+        Sweeping all 120 interruption points of the script on the pre-fix
+        code, the retry reached the current version 120 times out of 120.
+
+        What changed is the leftover state: pre-fix, the worst interruption
+        point left 111 ``sqlite_master`` rows committed in a file the caller
+        was told had failed to initialize, and 119 of the 120 points left
+        something. This test pins the post-fix number -- zero, at every point
+        -- which is why its assertion is about leftovers and not about the
+        retry. (The retry is checked at the end too, but it passed before the
+        fix as well and is not the property under test.)
         """
         path = tmp_path / "interrupted_base.sqlite"
         statements = _split_sql_statements(CharactersRAGDB._FULL_SCHEMA_SQL_V4)
@@ -477,6 +489,31 @@ class TestEntryVersionGuards:
         )
 
 
+def _remaining_sql_after_first_statement(chunk: str) -> str:
+    """Return the SQL left over after ``chunk``'s FIRST complete statement.
+
+    The splitter completes a chunk only at a LINE boundary, so two statements
+    written on one source line share a chunk — and ``cursor.execute`` rejects
+    that. Finding the boundary needs character granularity, which this gets by
+    testing ``sqlite3.complete_statement`` at each ``;``: SQLite reports False
+    for a ``;`` inside a string, a comment, or a ``BEGIN``/``END`` trigger
+    body, so the first True is the real end of statement one.
+
+    Args:
+        chunk: One chunk as produced by ``_split_sql_statements``.
+
+    Returns:
+        The trailing SQL after the first statement with leading whitespace and
+        comments removed, or ``""`` when the chunk holds exactly one.
+    """
+    for index, char in enumerate(chunk):
+        if char != ";":
+            continue
+        if sqlite3.complete_statement(chunk[: index + 1]):
+            return _strip_leading_sql_noise(chunk[index + 1 :])
+    return ""
+
+
 def _code_only(source: str) -> str:
     """Drop whole-line ``#`` comments so prose about the defect is not a hit."""
     return "\n".join(
@@ -517,9 +554,15 @@ class TestExecutescriptIsGone:
     def test_base_schema_apply_does_not_use_executescript(self) -> None:
         source = _code_only(inspect.getsource(CharactersRAGDB._apply_schema_v4))
         assert ".executescript(" not in source, (
-            "_apply_schema_v4 calls executescript; an interrupted base-schema "
-            "apply then leaves a half-built, unopenable new database "
-            "(task-19553)."
+            "_apply_schema_v4 calls executescript, so an interrupted "
+            "base-schema apply commits its DDL into a file the caller was "
+            "told had failed to initialize — measured at up to 111 "
+            "sqlite_master rows, on 119 of the script's 120 interruption "
+            "points (task-19553). Unlike the migration steps this is a "
+            "leftover-state defect, NOT a brick: the v4 script is internally "
+            "re-enterable and retried successfully 120/120 times even before "
+            "the fix. It also reintroduces the one commit that would make "
+            "'no step commits' conditional again."
         )
 
 
@@ -537,6 +580,37 @@ class TestStatementSplitting:
         statements = _split_sql_statements(script)
         assert len(statements) == 2, statements
         assert statements[0].count("INSERT INTO y") == 2
+
+    def test_multi_statement_chunk_detector_actually_fires(self) -> None:
+        """Mutation control for the exactly-one-statement pin above.
+
+        Two statements on ONE line share a chunk (the splitter can only break
+        at a line boundary) and `cursor.execute` rejects that — so the pin is
+        only worth anything if this detector goes red on it.
+        """
+        one_line = "CREATE INDEX a ON t(x); CREATE INDEX b ON t(y);\n"
+        chunks = _split_sql_statements(one_line)
+        assert len(chunks) == 1, "the splitter cannot break inside a line"
+        assert _remaining_sql_after_first_statement(chunks[0]).startswith(
+            "CREATE INDEX b"
+        )
+        with sqlite3.connect(":memory:") as connection:
+            connection.execute("CREATE TABLE t(x, y)")
+            with pytest.raises(sqlite3.ProgrammingError):
+                connection.execute(chunks[0])
+
+        # ...and stays quiet on the shapes that are legitimately one statement.
+        for single in (
+            "CREATE INDEX a ON t(x);\n",
+            "INSERT INTO t VALUES ('a;b');\n",
+            "CREATE TRIGGER tr AFTER INSERT ON t BEGIN\n"
+            "  INSERT INTO t VALUES (1, 2);\n"
+            "  INSERT INTO t VALUES (3, 4);\n"
+            "END;\n",
+            "-- lead\nCREATE INDEX a ON t(x); -- trail\n",
+        ):
+            chunk = _split_sql_statements(single)[0]
+            assert _remaining_sql_after_first_statement(chunk) == "", single
 
     def test_incomplete_trailing_sql_is_rejected(self) -> None:
         with pytest.raises(SchemaError, match="incomplete SQL statement"):
@@ -557,17 +631,36 @@ class TestStatementSplitting:
         assert head.startswith(expected_head)
 
     def test_every_shipped_migration_script_splits_cleanly(self) -> None:
-        """Each embedded script must be splittable into runnable statements."""
+        """Each embedded script must split into SINGLE runnable statements.
+
+        Splittability alone is not enough. ``sqlite3.complete_statement`` is
+        checked per accumulated LINE, so two statements written on one source
+        line land in the same chunk — and ``cursor.execute`` refuses a chunk
+        holding more than one statement, which would turn a formatting choice
+        in a future migration into a failed upgrade. The
+        ``sqlite3_stmt``-level count below is what actually closes that trap;
+        it holds for all statements shipped today, base script included.
+        """
         scripts = [
             name
             for name in dir(CharactersRAGDB)
             if re.fullmatch(r"_MIGRATE_V\d+_TO_V\d+_SQL", name)
-        ]
-        assert scripts, "no embedded migration scripts found"
+        ] + ["_FULL_SCHEMA_SQL_V4"]
+        assert len(scripts) > 20, scripts
+        checked = 0
         for name in scripts:
             statements = _split_sql_statements(getattr(CharactersRAGDB, name))
             assert statements, name
-            for statement in statements:
-                assert _strip_leading_sql_noise(statement), (
-                    f"{name} produced a statement with no SQL in it"
+            for index, statement in enumerate(statements):
+                head = _strip_leading_sql_noise(statement)
+                assert head, f"{name}[{index}] produced a chunk with no SQL in it"
+                remainder = _remaining_sql_after_first_statement(statement)
+                assert not remainder, (
+                    f"{name}[{index}] holds MORE THAN ONE statement, so "
+                    f"cursor.execute would reject it: trailing SQL is "
+                    f"{remainder[:120]!r}. Put each statement on its own "
+                    f"line(s) — the splitter completes a chunk only at a line "
+                    f"boundary."
                 )
+                checked += 1
+        assert checked > 300, f"expected the full corpus, counted {checked}"

--- a/Tests/ChaChaNotesDB/test_migration_atomicity.py
+++ b/Tests/ChaChaNotesDB/test_migration_atomicity.py
@@ -1,0 +1,573 @@
+"""Atomicity and re-enterability of the ChaChaNotes migration chain (task-19553).
+
+Why this exists — the incident, not the rule. The 2026-08-21 holistic review's
+Lane 3 ran a live experiment, and this module reproduces it: on a genuine v11
+database with ONE of the v11→v12 ``ADD COLUMN`` statements already applied (the
+shape an interrupted migration leaves), ``conn.executescript`` COMMITTED the
+three ``ALTER``s that ran before the duplicate, then failed — while the schema
+version stamp stayed at 11. Every subsequent launch re-entered the step,
+re-raised ``duplicate column name`` (on a *different* column the second time),
+and ``CharactersRAGDB.__init__`` failed permanently. Conversations, notes and
+characters became unreachable with no in-app recovery path.
+
+``executescript`` is the mechanism: it commits whatever transaction is open and
+then autocommits each statement individually, so a step driven that way can
+neither roll back nor be re-entered. The migration steps now run their scripts
+one statement at a time through ``_execute_migration_statements`` inside the
+caller's transaction.
+
+What each test pins:
+
+* ``test_interrupted_add_column_step_recovers`` — the audit's exact scenario,
+  now reaching the current version, with a schema identical to a clean replay.
+* ``test_interrupted_trigger_step_recovers`` — the same for V7→V8, whose bare
+  ``CREATE TRIGGER`` statements are the other half-applied shape.
+* ``test_failure_mid_step_leaves_no_partial_ddl`` — a statement that fails
+  part-way through a step rewinds the run to its entry version with nothing
+  applied, and the same file migrates on the next attempt.
+* ``test_long_chain_from_v4_*`` — the reachable population is v4–v25
+  databases replaying the longest chain, so the long chain is tested with real
+  rows in it.
+* ``test_no_migration_step_uses_executescript`` — a source-level pin so the
+  defect cannot be reintroduced by a new step copying an old one.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    SchemaError,
+    _split_sql_statements,
+    _strip_leading_sql_noise,
+)
+from Tests.ChaChaNotesDB.historical_bootstrap import (
+    MINIMUM_BOOTSTRAP_VERSION,
+    SCHEMA_NAME,
+    chachanotes_db_at_version,
+)
+
+CURRENT = CharactersRAGDB._CURRENT_SCHEMA_VERSION
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+def _version(path: Path) -> int | None:
+    """Read the stamped schema version straight off disk."""
+    connection = sqlite3.connect(str(path))
+    try:
+        row = connection.execute(
+            "SELECT version FROM db_schema_version WHERE schema_name = ?",
+            (SCHEMA_NAME,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        connection.close()
+
+
+def _columns(path: Path, table: str) -> list[str]:
+    """Column names of ``table`` in declaration order, read off disk."""
+    connection = sqlite3.connect(str(path))
+    try:
+        return [
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM pragma_table_info(?)", (table,)
+            ).fetchall()
+        ]
+    finally:
+        connection.close()
+
+
+def _pre_apply_statements(path: Path, script: str, count: int) -> list[str]:
+    """Apply and COMMIT the first ``count`` statements of a migration script.
+
+    This is exactly the residue ``executescript`` leaves when it is killed
+    part-way through: the statements that already ran are committed, and the
+    version stamp — updated by the script's LAST statement — is not.
+
+    Args:
+        path: The database file.
+        script: A migration script constant.
+        count: How many leading statements to apply.
+
+    Returns:
+        The statements that were applied (for the failure message).
+    """
+    applied = _split_sql_statements(script)[:count]
+    connection = sqlite3.connect(str(path))
+    try:
+        for statement in applied:
+            connection.execute(statement)
+        connection.commit()
+    finally:
+        connection.close()
+    return applied
+
+
+def _schema_fingerprint(connection: sqlite3.Connection) -> dict[str, object]:
+    """Full schema shape: object SQL text plus ORDERED column definitions."""
+    master = sorted(
+        (row[0], row[1], row[3])
+        for row in connection.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_master"
+        ).fetchall()
+    )
+    columns: dict[str, list[tuple]] = {}
+    for (table,) in connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table'"
+    ).fetchall():
+        columns[table] = [
+            tuple(row)
+            for row in connection.execute(f'PRAGMA table_info("{table}")').fetchall()
+        ]
+    return {"master": master, "columns": columns}
+
+
+def _fingerprint_of_clean_replay(tmp_path: Path, from_version: int) -> dict:
+    """Fingerprint of an UNINTERRUPTED bootstrap-at-N-then-replay database."""
+    path = tmp_path / f"clean_replay_v{from_version}.sqlite"
+    with chachanotes_db_at_version(path, from_version):
+        pass
+    db = CharactersRAGDB(str(path), client_id="clean-replay")
+    try:
+        return _schema_fingerprint(db.get_connection())
+    finally:
+        db.close_connection()
+
+
+def _open_current(path: Path, client_id: str) -> CharactersRAGDB:
+    return CharactersRAGDB(str(path), client_id=client_id)
+
+
+# --------------------------------------------------------------------------
+# the audit's brick, and its two shapes
+# --------------------------------------------------------------------------
+class TestInterruptedStepIsRecoverable:
+    """A half-applied step must not strand the database."""
+
+    def test_interrupted_add_column_step_recovers(self, tmp_path: Path) -> None:
+        """The audit's experiment: v11 + 3 of v11→v12's 4 ``ALTER``s applied.
+
+        Before task-19553 this raised ``duplicate column name`` on every
+        launch forever. It must now migrate to the current version, and the
+        resulting schema must be indistinguishable from a clean replay.
+        """
+        path = tmp_path / "interrupted_v11_to_v12.sqlite"
+        with chachanotes_db_at_version(path, 11):
+            pass
+        assert _version(path) == 11
+
+        applied = _pre_apply_statements(
+            path, CharactersRAGDB._MIGRATE_V11_TO_V12_SQL, 3
+        )
+        assert len(applied) == 3, applied
+        partial_columns = _columns(path, "messages")
+        assert "variant_of" in partial_columns
+        assert "total_variants" not in partial_columns, (
+            "fixture must leave the step genuinely HALF applied"
+        )
+        assert _version(path) == 11, "an interrupted step never bumps the stamp"
+
+        db = _open_current(path, "interrupted-add-column")
+        try:
+            assert _version(path) == CURRENT
+            recovered = _schema_fingerprint(db.get_connection())
+        finally:
+            db.close_connection()
+
+        assert recovered == _fingerprint_of_clean_replay(tmp_path, 11), (
+            "a database recovered from a half-applied step must end up with "
+            "byte-identical schema SQL and identical column order to one that "
+            "was never interrupted"
+        )
+
+        # And it keeps opening: the brick failed on the SECOND launch too.
+        db = _open_current(path, "interrupted-add-column-again")
+        try:
+            assert _version(path) == CURRENT
+        finally:
+            db.close_connection()
+
+    def test_interrupted_trigger_step_recovers(self, tmp_path: Path) -> None:
+        """V7→V8 creates triggers with no ``IF NOT EXISTS`` and no ``DROP``.
+
+        A half-applied V7→V8 therefore strands on ``trigger ... already
+        exists`` rather than ``duplicate column name`` — the same brick with a
+        different error string.
+        """
+        path = tmp_path / "interrupted_v7_to_v8.sqlite"
+        with chachanotes_db_at_version(path, 7):
+            pass
+        assert _version(path) == 7
+
+        _pre_apply_statements(path, CharactersRAGDB._MIGRATE_V7_TO_V8_SQL, 3)
+        connection = sqlite3.connect(str(path))
+        try:
+            triggers = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+                ).fetchall()
+            }
+        finally:
+            connection.close()
+        assert "chat_dictionaries_ai" in triggers, (
+            "fixture must leave a bare CREATE TRIGGER already applied"
+        )
+        assert _version(path) == 7
+
+        db = _open_current(path, "interrupted-trigger")
+        try:
+            assert _version(path) == CURRENT
+            recovered = _schema_fingerprint(db.get_connection())
+        finally:
+            db.close_connection()
+
+        assert recovered == _fingerprint_of_clean_replay(tmp_path, 7)
+
+    def test_long_chain_from_v4_with_interrupted_step_recovers(
+        self, tmp_path: Path
+    ) -> None:
+        """AC #5: the reachable population is old databases with real rows.
+
+        A v4-era database (the oldest the chain can build) carrying user data,
+        interrupted inside V11→V12, must reach the current version with its
+        rows intact.
+        """
+        path = tmp_path / "long_chain_v4.sqlite"
+        conversation_id = str(uuid.uuid4())
+        note_id = str(uuid.uuid4())
+        with chachanotes_db_at_version(path, MINIMUM_BOOTSTRAP_VERSION) as db:
+            connection = db.get_connection()
+            connection.execute(
+                """
+                INSERT INTO conversations(
+                    id, root_id, title, created_at, last_modified,
+                    deleted, client_id, version
+                ) VALUES (?, ?, ?, ?, ?, 0, ?, 1)
+                """,
+                (
+                    conversation_id,
+                    conversation_id,
+                    "Survives the upgrade",
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:00:00Z",
+                    "long-chain",
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO notes(
+                    id, title, content, created_at, last_modified,
+                    deleted, client_id, version
+                ) VALUES (?, ?, ?, ?, ?, 0, ?, 1)
+                """,
+                (
+                    note_id,
+                    "Old note",
+                    "old body",
+                    "2026-01-01T00:00:00Z",
+                    "2026-01-01T00:00:00Z",
+                    "long-chain",
+                ),
+            )
+            connection.commit()
+        assert _version(path) == MINIMUM_BOOTSTRAP_VERSION
+
+        # Walk the chain to v11 the way a real upgrade would, stop there, then
+        # leave V11->V12 half applied.
+        with chachanotes_db_at_version(path, 11):
+            pass
+        assert _version(path) == 11
+        _pre_apply_statements(path, CharactersRAGDB._MIGRATE_V11_TO_V12_SQL, 2)
+
+        db = _open_current(path, "long-chain-recovered")
+        try:
+            connection = db.get_connection()
+            assert _version(path) == CURRENT
+            assert (
+                connection.execute(
+                    "SELECT title FROM conversations WHERE id = ?", (conversation_id,)
+                ).fetchone()["title"]
+                == "Survives the upgrade"
+            )
+            assert (
+                connection.execute(
+                    "SELECT content FROM notes WHERE id = ?", (note_id,)
+                ).fetchone()["content"]
+                == "old body"
+            )
+        finally:
+            db.close_connection()
+
+
+class TestFailingStepRollsBack:
+    """A step that cannot finish must leave nothing behind."""
+
+    def test_failure_mid_step_leaves_no_partial_ddl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Poison statement 7 of V12→V13's 32 and require a full rewind.
+
+        Before task-19553 the six ``ALTER``s ahead of the poison committed
+        individually and stayed on disk. The run must now rewind to its ENTRY
+        version — 11, because V11→V12 is part of the same transaction — with
+        none of the columns from either step present.
+        """
+        path = tmp_path / "poisoned_v12_to_v13.sqlite"
+        with chachanotes_db_at_version(path, 11):
+            pass
+
+        statements = _split_sql_statements(CharactersRAGDB._MIGRATE_V12_TO_V13_SQL)
+        assert len(statements) > 8, len(statements)
+        poisoned = "".join(
+            statements[:6]
+            + ["\nINSERT INTO no_such_table_19553(x) VALUES (1);\n"]
+            + statements[6:]
+        )
+        monkeypatch.setattr(
+            CharactersRAGDB, "_MIGRATE_V12_TO_V13_SQL", poisoned, raising=True
+        )
+
+        with pytest.raises(SchemaError, match="no_such_table_19553"):
+            _open_current(path, "poisoned")
+
+        assert _version(path) == 11, (
+            "a failing step must leave the stamp at the run's entry version"
+        )
+        message_columns = _columns(path, "messages")
+        assert "variant_of" not in message_columns, (
+            "V11->V12's DDL must have rolled back with the failing run"
+        )
+        conversation_columns = _columns(path, "conversations")
+        assert "assistant_kind" not in conversation_columns, (
+            "the six ALTERs ahead of the poison must NOT survive"
+        )
+
+        # Re-enterable: with the poison removed the same file migrates.
+        monkeypatch.undo()
+        db = _open_current(path, "poison-removed")
+        try:
+            assert _version(path) == CURRENT
+        finally:
+            db.close_connection()
+
+    def test_interrupted_base_schema_apply_recovers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The v4 base apply is atomic too.
+
+        ``_FULL_SCHEMA_SQL_V4`` ships 42 ``CREATE TRIGGER`` statements with no
+        ``IF NOT EXISTS``, so a base apply interrupted after some of them had
+        been autocommitted used to make the brand-new file unopenable
+        ("trigger ... already exists") rather than merely incomplete.
+        """
+        path = tmp_path / "interrupted_base.sqlite"
+        statements = _split_sql_statements(CharactersRAGDB._FULL_SCHEMA_SQL_V4)
+        assert len(statements) > 60, len(statements)
+        poisoned = "".join(
+            statements[:50]
+            + ["\nINSERT INTO no_such_table_19553(x) VALUES (1);\n"]
+            + statements[50:]
+        )
+        monkeypatch.setattr(
+            CharactersRAGDB, "_FULL_SCHEMA_SQL_V4", poisoned, raising=True
+        )
+
+        with pytest.raises(SchemaError, match="no_such_table_19553"):
+            _open_current(path, "poisoned-base")
+
+        connection = sqlite3.connect(str(path))
+        try:
+            leftovers = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            }
+        finally:
+            connection.close()
+        assert not leftovers, (
+            f"an interrupted base-schema apply left objects behind: "
+            f"{sorted(leftovers)}"
+        )
+
+        monkeypatch.undo()
+        db = _open_current(path, "base-retry")
+        try:
+            assert _version(path) == CURRENT
+        finally:
+            db.close_connection()
+
+    def test_foreign_keys_remain_enforced_on_a_fresh_database(
+        self, tmp_path: Path
+    ) -> None:
+        """The one statement deliberately left outside the transaction.
+
+        ``_FULL_SCHEMA_SQL_V4`` opens with ``PRAGMA foreign_keys = ON``, which
+        SQLite silently IGNORES inside a transaction. The guarantee is carried
+        by ``_get_thread_connection`` instead, which issues the same pragma on
+        every connection — this test is the pin for that hand-off.
+        """
+        path = tmp_path / "fk_enforced.sqlite"
+        db = _open_current(path, "fk-pin")
+        try:
+            connection = db.get_connection()
+            assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+            with pytest.raises(sqlite3.IntegrityError):
+                connection.execute(
+                    """
+                    INSERT INTO messages(
+                        id, conversation_id, sender, content, timestamp,
+                        client_id, version
+                    ) VALUES (?, ?, 'user', 'x', '2026-01-01T00:00:00Z', 'fk', 1)
+                    """,
+                    (str(uuid.uuid4()), "no-such-conversation"),
+                )
+        finally:
+            db.close_connection()
+
+
+class TestEntryVersionGuards:
+    """Every ported step refuses to run against the wrong version."""
+
+    @pytest.mark.parametrize(
+        ("step", "entry_version"),
+        [
+            ("_migrate_from_v4_to_v5", 4),
+            ("_migrate_from_v7_to_v8", 7),
+            ("_migrate_from_v11_to_v12", 11),
+            ("_migrate_from_v12_to_v13", 12),
+            ("_migrate_from_v17_to_v18", 17),
+            ("_migrate_from_v28_to_v29", 28),
+        ],
+    )
+    def test_step_rejects_a_database_at_the_wrong_version(
+        self, tmp_path: Path, step: str, entry_version: int
+    ) -> None:
+        path = tmp_path / f"guard_{step}.sqlite"
+        with chachanotes_db_at_version(path, entry_version + 1) as db:
+            with pytest.raises(SchemaError, match="requires schema version"):
+                getattr(db, step)(db.get_connection())
+
+    def test_every_migration_step_has_an_entry_version_guard(self) -> None:
+        """No step may run without first checking the version it expects."""
+        unguarded = []
+        for name, method in _migration_steps():
+            source = inspect.getsource(method)
+            if (
+                "_require_migration_entry_version" not in source
+                and "_get_db_version(conn) != " not in source
+                and "requires schema version" not in source
+            ):
+                unguarded.append(name)
+        assert not unguarded, (
+            "these ChaChaNotes migration steps have no entry-version guard, so "
+            "they can be re-entered against an already-advanced database: "
+            f"{unguarded}"
+        )
+
+
+def _code_only(source: str) -> str:
+    """Drop whole-line ``#`` comments so prose about the defect is not a hit."""
+    return "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _migration_steps() -> list[tuple[str, object]]:
+    """Every ``_migrate_from_vN_to_vM`` method on ``CharactersRAGDB``."""
+    steps = [
+        (name, getattr(CharactersRAGDB, name))
+        for name in dir(CharactersRAGDB)
+        if re.fullmatch(r"_migrate_from_v\d+_to_v\d+", name)
+    ]
+    assert len(steps) >= 38, f"expected the full chain, found {len(steps)}"
+    return steps
+
+
+class TestExecutescriptIsGone:
+    """Source-level pin: the mechanism itself must not come back."""
+
+    def test_no_migration_step_uses_executescript(self) -> None:
+        offenders = [
+            name
+            for name, method in _migration_steps()
+            if ".executescript(" in _code_only(inspect.getsource(method))
+        ]
+        assert not offenders, (
+            "these ChaChaNotes migration steps call executescript, which "
+            "COMMITS the caller's transaction and then autocommits each "
+            "statement — a failure part-way through leaves committed DDL with "
+            "a stale version stamp and permanently bricks the database "
+            f"(task-19553): {offenders}. Use "
+            "`self._execute_migration_statements(cursor, script, label)` "
+            "inside `with self.transaction() as cursor:` instead."
+        )
+
+    def test_base_schema_apply_does_not_use_executescript(self) -> None:
+        source = _code_only(inspect.getsource(CharactersRAGDB._apply_schema_v4))
+        assert ".executescript(" not in source, (
+            "_apply_schema_v4 calls executescript; an interrupted base-schema "
+            "apply then leaves a half-built, unopenable new database "
+            "(task-19553)."
+        )
+
+
+class TestStatementSplitting:
+    """The runner's two text primitives, pinned directly."""
+
+    def test_trigger_bodies_are_not_split_on_inner_semicolons(self) -> None:
+        script = (
+            "CREATE TRIGGER t AFTER INSERT ON x BEGIN\n"
+            "  INSERT INTO y VALUES (1);\n"
+            "  INSERT INTO y VALUES (2);\n"
+            "END;\n"
+            "CREATE INDEX i ON x(a);\n"
+        )
+        statements = _split_sql_statements(script)
+        assert len(statements) == 2, statements
+        assert statements[0].count("INSERT INTO y") == 2
+
+    def test_incomplete_trailing_sql_is_rejected(self) -> None:
+        with pytest.raises(SchemaError, match="incomplete SQL statement"):
+            _split_sql_statements("CREATE TABLE t(a INT)\n")
+
+    @pytest.mark.parametrize(
+        ("raw", "expected_head"),
+        [
+            ("\n-- lead\nALTER TABLE t ADD COLUMN c TEXT;\n", "ALTER"),
+            ("/* block */\nCREATE INDEX i ON t(a);\n", "CREATE"),
+            ("  \n-- only a comment\n", ""),
+        ],
+    )
+    def test_leading_comments_are_stripped_for_matching_only(
+        self, raw: str, expected_head: str
+    ) -> None:
+        head = _strip_leading_sql_noise(raw)
+        assert head.startswith(expected_head)
+
+    def test_every_shipped_migration_script_splits_cleanly(self) -> None:
+        """Each embedded script must be splittable into runnable statements."""
+        scripts = [
+            name
+            for name in dir(CharactersRAGDB)
+            if re.fullmatch(r"_MIGRATE_V\d+_TO_V\d+_SQL", name)
+        ]
+        assert scripts, "no embedded migration scripts found"
+        for name in scripts:
+            statements = _split_sql_statements(getattr(CharactersRAGDB, name))
+            assert statements, name
+            for statement in statements:
+                assert _strip_leading_sql_noise(statement), (
+                    f"{name} produced a statement with no SQL in it"
+                )

--- a/Tests/DB/test_chachanotes_citation_provenance_migration.py
+++ b/Tests/DB/test_chachanotes_citation_provenance_migration.py
@@ -855,11 +855,27 @@ def test_migration_failure_rolls_back_schema_context_and_version(
         assert not (PROVENANCE_TABLES & _table_names(connection))
 
 
-def test_citation_failure_after_dev_migrations_leaves_clean_v26(
+def test_citation_failure_after_dev_migrations_leaves_clean_v24(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The sequential v24→v27 path must keep the final migration atomic."""
+    """A failed sequential v24→v27 run rewinds the WHOLE run, then replays.
+
+    Rewritten in task-19553. This test previously asserted the database was
+    left at v26 with v24→v25's and v25→v26's artifacts still present: that was
+    an artifact of ``conn.executescript``, which COMMITTED each intermediate
+    step before the failing one ran. Those steps now execute one statement at
+    a time inside ``_initialize_schema``'s transaction, so the run is
+    all-or-nothing and rewinds to its ENTRY version (24) with none of the
+    intermediate DDL applied.
+
+    That is the stronger guarantee, not a weaker one -- a half-upgraded
+    database is unusable by current code either way, and the old
+    partial-commit behaviour is precisely what could strand a database with
+    committed DDL and a stale version stamp. The final assertion proves the
+    point that matters to a user: the rewound database still opens and
+    migrates on the next attempt.
+    """
 
     path = tmp_path / "sequential-rollback.sqlite"
     _minimal_v24(path)
@@ -875,16 +891,26 @@ def test_citation_failure_after_dev_migrations_leaves_clean_v26(
         _fresh_db(path)
 
     with sqlite3.connect(path) as connection:
-        assert _version(connection) == 26
-        assert "message_generation_metadata" in _table_names(connection)
+        assert _version(connection) == 24
+        assert "message_generation_metadata" not in _table_names(connection)
         conversation_columns = {
             row[1]
             for row in connection.execute("PRAGMA table_info(conversations)").fetchall()
         }
-        assert {"context_summary", "summary_boundary_message_id"} <= (
-            conversation_columns
+        assert not (
+            {"context_summary", "summary_boundary_message_id"} & conversation_columns
         )
         assert not (PROVENANCE_TABLES & _table_names(connection))
+
+    # Re-enterable: with the forced failure removed, the same file migrates.
+    monkeypatch.undo()
+    db = _fresh_db(path)
+    try:
+        assert (
+            _version(db.get_connection()) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        )
+    finally:
+        db.close_connection()
 
 
 def test_migration_sql_is_ddl_only_and_provenance_is_not_indexed_or_synced(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5678,3 +5678,36 @@ the defect. When a test asserts the shape of a bug, rewrite it to assert the
 property that actually matters — here, that the rewound database still opens
 and migrates on the next attempt — and say in the docstring why the
 expectation moved.
+
+## A green test validates the assertion, not the story you told about it (TASK-19553, 2026-08-21)
+
+**What happened.** Porting the ChaChaNotes v4 base-schema apply off
+`executescript`, I wrote a permanent code comment explaining WHY it mattered:
+the script's 42 `CREATE TRIGGER` statements have no `IF NOT EXISTS`, so an
+interrupted apply "died on 'trigger already exists'" on the next launch. I
+shipped a test alongside it that passed. The comment was **false**. The script
+also ships 42 matching `DROP TRIGGER IF EXISTS` — zero creates without a
+preceding drop — plus `IF NOT EXISTS` on every table/index and
+`INSERT OR IGNORE` on both inserts. Sweeping all 120 interruption points of
+the script on the pre-fix code, the retry succeeded **120 out of 120 times**.
+The failure mode I described could not occur.
+
+The review caught it; the mechanism that let it through is worth naming. My
+test asserted *leftovers are zero after a failed apply* — which the pre-fix
+code genuinely fails — so it went red at the leftovers check and returned
+green after the fix, **without ever reaching the retry the comment was about**.
+The test proved a real (and worthwhile) property: 111 committed
+`sqlite_master` rows before versus 0 after. It never touched the claim.
+
+**What to do.** When you write down a failure mode as the justification for a
+change, run *that* failure mode, not a neighbouring one — and prefer a sweep
+over a single anecdote (all 120 interruption points here, which is what turned
+a plausible story into a measured 120/120). If the property your test actually
+asserts is narrower than the story in the comment, either widen the test or
+narrow the prose to what you measured. Two smells that should trigger this
+check: a comment whose claim your test would still pass without, and any
+sentence about a mechanism (`no IF NOT EXISTS`, `no guard`, `always commits`)
+that you inferred from reading rather than from running. In a P0 data-integrity
+file, a false incident in a comment is worse than no comment — future
+maintainers will trust it, and this repo's own standard is "state the incident,
+not just the rule", which only works if the incident is real.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5629,3 +5629,52 @@ can refuse the same path for different REASONS (here the older family rejects
 a dotted base directory at confinement, before the denylist runs), so assert
 the denylist-sourced message only where the denylist is genuinely what fires,
 rather than papering the difference over with a bare "is refused".
+
+## `executescript` COMMITS — and a "rolled back cleanly" check can lie (TASK-19553, 2026-08-21)
+
+**What happened.** The ChaChaNotes migration chain had 25 steps calling
+`conn.executescript(...)`. `sqlite3.Connection.executescript` commits whatever
+transaction is open and then autocommits each statement individually, so those
+steps were neither atomic nor re-enterable — but nothing in `Tests/` was red,
+because the whole test suite only ever runs migrations that SUCCEED. The
+defect only exists on the failure path, and no test drove one.
+
+Reproducing it took a fixture that manufactured the interrupted state
+directly: bootstrap a genuine v11 DB, apply-and-commit the first 3 of
+`_MIGRATE_V11_TO_V12_SQL`'s 4 `ALTER`s with a raw connection, then open the DB
+the way the app does. The probe printed what it read: version stamp still 11,
+three columns committed on disk, `SchemaError` on open — and on the SECOND
+open a DIFFERENT column name in the error, which is the tell that the database
+is permanently unreachable rather than transiently failing.
+
+**Two things that generalise.**
+
+1. *For a failure-path defect, the fixture IS the test.* "Run the suite and
+   see" cannot find a bug that only exists when a migration dies half-way; you
+   have to build the half-dead state by hand. `_pre_apply_statements` in
+   `Tests/ChaChaNotesDB/test_migration_atomicity.py` is the reusable shape:
+   split the real script with the production splitter, apply the first N,
+   commit, reopen.
+
+2. *A mechanical rewrite of shipped DDL needs an oracle, and the oracle needs
+   its own mutation test.* Porting 25 steps from `executescript` to
+   per-statement `cursor.execute` could silently change the schema. The oracle
+   was a snapshot of ALL 39 bootstrap versions plus the v4→current chain replay
+   plus a fresh build — capturing verbatim `sqlite_master.sql` text and
+   `PRAGMA table_info` INCLUDING `cid` (column order) — taken BEFORE the edit
+   and diffed after: 11,177 objects, 22,815 column entries, 0 divergences.
+   That number means nothing on its own, so the oracle was mutation-tested
+   twice: deleting one `CREATE INDEX` from a step produced 40 divergences, and
+   swapping two `ADD COLUMN` statements (order only) produced 64. An oracle
+   that has not been shown to go red is not evidence that anything is
+   unchanged.
+
+**One decision worth recording.** Making every step atomic means the chain is
+now ONE transaction, so a failure at step N rewinds to the RUN's entry version,
+not to step N-1. An existing test
+(`test_citation_failure_after_dev_migrations_leaves_clean_v26`) had pinned the
+old partial-commit behaviour as if it were a guarantee. It was an artifact of
+the defect. When a test asserts the shape of a bug, rewrite it to assert the
+property that actually matters — here, that the rewound database still opens
+and migrates on the next attempt — and say in the docstring why the
+expectation moved.

--- a/backlog/tasks/task-19553 - Old-style ChaChaNotes migration steps are non-atomic and can permanently brick a database.md
+++ b/backlog/tasks/task-19553 - Old-style ChaChaNotes migration steps are non-atomic and can permanently brick a database.md
@@ -3,7 +3,7 @@ id: TASK-19553
 title: >-
   Old-style ChaChaNotes migration steps are non-atomic and can permanently brick
   a database
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21 20:03'
 labels:
@@ -54,19 +54,113 @@ the safe pattern.
 
 ## Acceptance Criteria
 
-- [ ] Every migration step in `ChaChaNotes_DB.py` applies atomically: an
+- [x] Every migration step in `ChaChaNotes_DB.py` applies atomically: an
       interrupted or failing step leaves the database at its entry version with
       no partially-applied DDL
-- [ ] Every step is idempotent or entry-version guarded, so re-running a step
+- [x] Every step is idempotent or entry-version guarded, so re-running a step
       after an interruption is safe rather than fatal
-- [ ] The remaining `executescript` steps are ported to the
+- [x] The remaining `executescript` steps are ported to the
       `transaction()` + per-statement pattern at `ChaChaNotes_DB.py:5203`
       (durable, already proven in-repo) rather than a new mechanism
-- [ ] A test reproduces the lane's experiment: a genuine older-version database
+- [x] A test reproduces the lane's experiment: a genuine older-version database
       with one column of a multi-`ALTER` step pre-applied migrates to current
       **or** rolls back cleanly to its entry version — it never lands
       half-applied with a stale version stamp
-- [ ] The test covers the long-chain case (a v4-era database replayed to
+- [x] The test covers the long-chain case (a v4-era database replayed to
       current), since that is the reachable population
-- [ ] If any already-bricked shape is recoverable, a recovery path exists that
+- [x] If any already-bricked shape is recoverable, a recovery path exists that
       does not require the user to hand-edit SQLite
+
+## Implementation Plan
+
+1. Reproduce the lane's brick as a runnable probe (genuine v11 DB, one
+   statement of V11→V12 pre-applied) and record the exact failure signature.
+2. Build a byte-identity oracle BEFORE editing: snapshot every bootstrap
+   version 4..42 plus the chain replay plus a fresh build, capturing verbatim
+   `sqlite_master.sql` and `PRAGMA table_info` including column order.
+3. Add a shared statement runner (split on `sqlite3.complete_statement`, one
+   `cursor.execute` per statement) mirroring `_migrate_from_v37_to_v38`.
+4. Port every `executescript` migration step to it, wrapped in
+   `self.transaction()`; add the entry-version guard where missing.
+5. Add the two idempotence rules that make an already-half-applied step
+   re-enterable, both no-ops on a healthy chain.
+6. Re-run the oracle and require ZERO divergence; mutation-test the oracle so
+   the zero means something.
+7. Land the born-red regression suite; baseline every test gate against
+   `origin/dev` before attributing any red.
+
+## Implementation Notes
+
+Ported all 25 `conn.executescript(...)` migration steps — plus
+`_apply_schema_v4`, the v4 base apply — to the
+`with self.transaction() as cursor:` + one-`cursor.execute`-per-statement
+pattern already proven by `_migrate_from_v37_to_v38`. `executescript` commits
+the caller's transaction and then autocommits each statement, which is exactly
+why a half-applied step used to strand a database with committed DDL under a
+stale version stamp. No step was renumbered or merged and
+`_CURRENT_SCHEMA_VERSION` is untouched.
+
+**New shared machinery** (`tldw_chatbook/DB/ChaChaNotes_DB.py`):
+
+* `_split_sql_statements` / `_strip_leading_sql_noise` (module level) — the
+  splitter the new-style steps already used for their `.sql` files, now shared;
+  leading comments are stripped only for MATCHING, never for execution, so
+  `sqlite_master.sql` text is untouched.
+* `_execute_migration_statements(cursor, script, label)` — the runner.
+* `_require_migration_entry_version(conn, expected, label)` — the guard the
+  new-style steps carry, now on every step.
+* Two idempotence rules, both provably no-ops on a healthy chain (the column /
+  trigger can only pre-exist on an already-damaged database):
+  `_skip_already_applied_add_column` (SQLite has no `ADD COLUMN IF NOT EXISTS`;
+  this is the same guard v19→v20 and v29→v30 already hand-rolled, generalised)
+  and `_drop_superseded_trigger` (V7→V8 and V8→V9 create ~19 triggers with
+  neither `IF NOT EXISTS` nor a preceding `DROP`; statements that DO say
+  `IF NOT EXISTS` are deliberately left alone so SQLite's keep-the-existing-one
+  semantics are not overridden).
+
+**One statement deliberately left outside a transaction.**
+`_FULL_SCHEMA_SQL_V4` opens with `PRAGMA foreign_keys = ON`, which SQLite
+silently IGNORES inside a transaction. It is not forced: the guarantee is
+carried by `_get_thread_connection`, which issues the same pragma on every
+connection before the schema apply runs. Verified live (fresh DB reports
+`PRAGMA foreign_keys = 1` and a dangling-FK insert raises `IntegrityError`) and
+pinned by `test_foreign_keys_remain_enforced_on_a_fresh_database`.
+
+**Deliberate behaviour change.** With no step committing, the whole chain is
+one transaction, so a failure at step N rewinds to the RUN's entry version, not
+to step N-1. `Tests/DB/test_chachanotes_citation_provenance_migration.py`'s
+`test_citation_failure_after_dev_migrations_leaves_clean_v26` had pinned the
+old partial-commit behaviour; it is rewritten (and renamed `..._v24`) to assert
+whole-run atomicity plus the property that actually matters — the rewound
+database still opens and migrates on the next attempt.
+
+**Evidence.**
+
+* Byte identity: a snapshot of all 39 bootstrap versions (v4..v42) + the
+  v4→current chain replay + a fresh in-memory build, capturing verbatim
+  `sqlite_master.sql` and `PRAGMA table_info` including `cid`, taken before the
+  edit and diffed after — 11,177 objects, 22,815 column entries, **0
+  divergences**. The oracle was mutation-tested so that zero means something:
+  deleting one `CREATE INDEX` from a step → 40 divergences; swapping two
+  `ADD COLUMN` statements (order only) → 64.
+* Born-red: 12 of the 21 new tests fail on `origin/dev` (with local copies of
+  the two new text helpers so they fail on BEHAVIOUR, not `ImportError`); all
+  21 pass here.
+* `Tests/ChaChaNotesDB/`: 298 passed / 3 failed — the same 3 failures
+  `origin/dev` has (277/3 there; +21 new). `Tests/DB/`: 1045 passed / 9 failed
+  — identical to `origin/dev`'s 1045/9. Focused consumer sweep (12 files
+  incl. packaging + notes sync + chatbooks): 488 passed / 5 failed on BOTH.
+  Repo-wide `pytest --collect-only -q`: 53,650 collected, exit 0.
+
+**Scoped out, deliberately.** 15 of the `DB/migrations/*.sql` files are
+decorative twins of the embedded constants (never opened by any code path);
+this port kept the embedded constant as the single source of truth for each
+ported step rather than switching to the on-disk file, because switching would
+have risked exactly the semantic divergence the byte-identity oracle exists to
+prevent. The decorative-file cleanup remains its own task.
+
+**Modified/added files:** `tldw_chatbook/DB/ChaChaNotes_DB.py`,
+`Tests/ChaChaNotesDB/test_migration_atomicity.py` (new),
+`Tests/ChaChaNotesDB/legacy_conversation_schema.py`,
+`Tests/DB/test_chachanotes_citation_provenance_migration.py`,
+`backlog/docs/lessons-testing-evidence.md`.

--- a/backlog/tasks/task-19553 - Old-style ChaChaNotes migration steps are non-atomic and can permanently brick a database.md
+++ b/backlog/tasks/task-19553 - Old-style ChaChaNotes migration steps are non-atomic and can permanently brick a database.md
@@ -3,7 +3,7 @@ id: TASK-19553
 title: >-
   Old-style ChaChaNotes migration steps are non-atomic and can permanently brick
   a database
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-21 20:03'
 labels:
@@ -118,6 +118,37 @@ stale version stamp. No step was renumbered or merged and
   `IF NOT EXISTS` are deliberately left alone so SQLite's keep-the-existing-one
   semantics are not overridden).
 
+**What porting `_apply_schema_v4` did and did NOT buy** (corrected in the fix
+round — the first version of this note claimed a brick that does not exist).
+The v4 base script is already re-enterable on its own terms: 42
+`CREATE TRIGGER` but 42 matching `DROP TRIGGER IF EXISTS` (zero creates
+without a preceding drop), every `CREATE TABLE`/`VIRTUAL TABLE`/`INDEX`
+carrying `IF NOT EXISTS`, both top-level inserts `INSERT OR IGNORE`. Sweeping
+all 120 interruption points of the script at the merge base, the retry reached
+version 42 in **120 of 120** cases. The real, measured benefit is leftover
+state: at the worst point the pre-fix path committed **111 `sqlite_master`
+rows** into a file the caller was told had failed to initialize (119 of 120
+points left something), versus **0 at every point** after. It also removes the
+last `executescript` from the schema path, making "no step commits"
+unconditional. The genuine bare-trigger hazard is in the MIGRATION steps, and
+it is exactly two of them: V7→V8 (8) and V8→V9 (13), 21 unprotected
+`CREATE TRIGGER`s in total — reproduced red on the pre-fix code by
+`test_interrupted_trigger_step_recovers`.
+
+**Trade-off worth knowing: one long write transaction.** Because no step
+commits any more, an upgrade is a single transaction spanning the whole chain
+instead of dev's ~38 per-step commits. On a very large v4-era database that
+means more WAL growth before the single commit, and the write lock is held for
+the whole upgrade rather than released between steps. That is the right price
+for atomicity — partial progress through a migration chain has no value, since
+a database stranded at an intermediate version is unusable by current code
+either way — but it is a real change in resource profile, not a free win, and
+the WAL only checkpoints back down after the commit. Contention is not a
+practical concern here (this runs inside `CharactersRAGDB.__init__`, before
+the app has any other user of the connection), and `_initialize_schema`'s
+`BEGIN` is DEFERRED exactly as before, so the read-then-write upgrade window
+is unchanged from dev.
+
 **One statement deliberately left outside a transaction.**
 `_FULL_SCHEMA_SQL_V4` opens with `PRAGMA foreign_keys = ON`, which SQLite
 silently IGNORES inside a transaction. It is not forced: the guarantee is
@@ -151,6 +182,35 @@ database still opens and migrates on the next attempt.
   — identical to `origin/dev`'s 1045/9. Focused consumer sweep (12 files
   incl. packaging + notes sync + chatbooks): 488 passed / 5 failed on BOTH.
   Repo-wide `pytest --collect-only -q`: 53,650 collected, exit 0.
+
+**Fix round (post-review).** The reviewer endorsed the code change and
+adjudicated the whole-run-atomicity behaviour change in its favour, but caught
+a **false incident recorded as fact** in a permanent code comment: the claim
+that the v4 base apply's bare `CREATE TRIGGER`s made a retry die on "trigger
+already exists". I re-measured and confirmed the reviewer: it never happens
+(120/120 retries recovered pre-fix). Corrected at all three sites
+(`ChaChaNotes_DB.py:_apply_schema_v4`, and the test's docstring and assertion
+message) to state the measured leftover-state benefit instead. Why it survived
+is the instructive part: the test asserts *leftovers are zero*, which the
+pre-fix code genuinely fails, so it reds before ever reaching the retry — the
+claimed failure mode was never actually observed, and a green test validated
+the assertion, not the story told about it.
+
+Also in the fix round: `test_every_shipped_migration_script_splits_cleanly`
+now asserts each chunk holds **exactly one** statement (359 statements across
+all embedded scripts plus the base script), with its own mutation control
+proving the detector reds on two statements sharing a line; and the eleven
+file-backed steps' inline splitter copies were de-duplicated onto
+`_split_sql_statements` via `_migration_file_statements`, preserving both
+monkeypatch seams (`_execute_citation_migration_statement`,
+`_execute_character_authority_migration_statement`) and V36→V37's
+already-has-the-column skip. Verified a no-op, not assumed: the byte-identity
+oracle re-run after the de-duplication is still 0 divergences against the
+golden taken before any edit, and `Tests/ChaChaNotesDB/` + `Tests/DB/` is
+1344 passed / 12 failed — the same 12 pre-existing failures the merge base has.
+The only intentional behaviour delta is that a malformed migration file is now
+rejected before any statement executes rather than after; both paths roll back
+inside the step's transaction.
 
 **Scoped out, deliberately.** 15 of the `DB/migrations/*.sql` files are
 decorative twins of the embedded constants (never opened by any code path);

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -184,6 +184,111 @@ class ConflictError(CharactersRAGDBError):
 # never stored in character_expression_images.
 _EXPRESSION_IMAGE_STATE_IDS = frozenset({"thinking", "speaking", "error"})
 
+# --- Migration script runner primitives (task-19553) ------------------------
+#
+# ``sqlite3.Connection.executescript`` COMMITS whatever transaction is open and
+# then autocommits each statement in the script individually. A migration step
+# driven that way is neither atomic nor re-enterable: task-19553 reproduced the
+# failure on a genuine v11 database with one of the v11->v12 ``ADD COLUMN``s
+# already present (the shape an interrupted script leaves behind) -- three
+# ``ALTER``s stayed COMMITTED while the schema version stamp stayed at 11, so
+# every subsequent launch re-entered the step, re-raised ``duplicate column
+# name``, and ``CharactersRAGDB.__init__`` failed permanently with no in-app
+# recovery. The migration steps now run their scripts one statement at a time
+# through ``CharactersRAGDB._execute_migration_statements``, inside the
+# caller's transaction, mirroring ``_migrate_from_v37_to_v38``.
+
+#: A SQLite identifier as the migration scripts actually spell them: a bare
+#: word, or one wrapped in double quotes / backticks / square brackets.
+_SQL_IDENTIFIER_PATTERN = r"(?:[A-Za-z_][A-Za-z0-9_]*|\"[^\"]+\"|`[^`]+`|\[[^\]]+\])"
+
+#: Head of an ``ALTER TABLE <table> ADD [COLUMN] <column> ...`` statement.
+_MIGRATION_ADD_COLUMN_RE = re.compile(
+    rf"\AALTER\s+TABLE\s+(?P<table>{_SQL_IDENTIFIER_PATTERN})"
+    rf"\s+ADD\s+(?:COLUMN\s+)?(?P<column>{_SQL_IDENTIFIER_PATTERN})",
+    re.IGNORECASE,
+)
+
+#: Head of a ``CREATE [TEMP] TRIGGER [IF NOT EXISTS] <name> ...`` statement.
+_MIGRATION_CREATE_TRIGGER_RE = re.compile(
+    rf"\ACREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\s+"
+    rf"(?P<if_not_exists>IF\s+NOT\s+EXISTS\s+)?"
+    rf"(?P<name>{_SQL_IDENTIFIER_PATTERN})",
+    re.IGNORECASE,
+)
+
+#: Only plain identifiers are ever interpolated into generated SQL.
+_PLAIN_SQL_IDENTIFIER_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _unquote_sql_identifier(token: str) -> str:
+    """Return ``token`` with one layer of SQLite identifier quoting removed."""
+    if len(token) >= 2 and token[0] in {'"', "`", "["}:
+        return token[1:-1]
+    return token
+
+
+def _strip_leading_sql_noise(statement: str) -> str:
+    """Return ``statement`` without its leading whitespace and comments.
+
+    The migration scripts attach a header comment to the statement that
+    follows it, so the raw chunk cannot be pattern-matched directly. Only the
+    HEAD is trimmed; the statement handed to SQLite is always the original
+    text, so ``sqlite_master.sql`` is unaffected.
+
+    Args:
+        statement: One complete statement, possibly comment-prefixed.
+
+    Returns:
+        The statement text starting at its first SQL token, or ``""`` when the
+        chunk carries no SQL at all.
+    """
+    text = statement
+    while True:
+        text = text.lstrip()
+        if text.startswith("--"):
+            newline = text.find("\n")
+            if newline == -1:
+                return ""
+            text = text[newline + 1 :]
+            continue
+        if text.startswith("/*"):
+            end = text.find("*/")
+            if end == -1:
+                return ""
+            text = text[end + 2 :]
+            continue
+        return text
+
+
+def _split_sql_statements(script: str) -> List[str]:
+    """Split a migration script into complete statements.
+
+    Uses ``sqlite3.complete_statement`` over accumulated lines -- the same
+    splitter the new-style migration steps already use for their on-disk
+    ``.sql`` files -- so trigger bodies containing ``;`` stay intact.
+
+    Args:
+        script: The full migration script text.
+
+    Returns:
+        The statements in source order, each keeping its original text
+        (leading comments included).
+
+    Raises:
+        SchemaError: If the script ends with an incomplete statement.
+    """
+    statements: List[str] = []
+    pending = ""
+    for line in script.splitlines(keepends=True):
+        pending += line
+        if sqlite3.complete_statement(pending):
+            statements.append(pending)
+            pending = ""
+    if pending.strip():
+        raise SchemaError("Migration script contains an incomplete SQL statement")
+    return statements
+
 
 def _table_check_references_console_project_context(create_sql: str) -> bool:
     """Return whether a CHECK expression references the local-only column."""
@@ -3413,6 +3518,148 @@ UPDATE db_schema_version
                 f"Could not determine schema version for '{self._SCHEMA_NAME}': {e}"
             ) from e
 
+    def _require_migration_entry_version(
+        self,
+        conn: sqlite3.Connection,
+        expected: int,
+        label: str,
+    ) -> None:
+        """Refuse to run a migration step against the wrong schema version.
+
+        Mirrors the guard the new-style steps carry (e.g.
+        ``_migrate_from_v37_to_v38``). Without it a step could be re-entered
+        against an already-advanced database and re-apply its DDL.
+
+        Args:
+            conn: The active connection.
+            expected: The schema version the step is written against.
+            label: Human-readable step label, e.g. ``"V4→V5"``.
+
+        Raises:
+            SchemaError: If the database is not at ``expected``.
+        """
+        actual = self._get_db_version(conn)
+        if actual != expected:
+            raise SchemaError(
+                f"[{self._SCHEMA_NAME} {label}] Migration requires schema "
+                f"version {expected}, found {actual}"
+            )
+
+    def _skip_already_applied_add_column(
+        self,
+        cursor: sqlite3.Cursor,
+        head: str,
+        label: str,
+    ) -> bool:
+        """Return whether an ``ADD COLUMN`` statement is already satisfied.
+
+        SQLite has no ``ADD COLUMN IF NOT EXISTS``, so a database left with a
+        column from a half-applied historical run (the task-19553 brick shape)
+        would abort the whole upgrade with ``duplicate column name``. Skipping
+        exactly that statement lands such a database where a clean one lands.
+        On a healthy chain the column never pre-exists, so this is a no-op and
+        the statement stream is unchanged.
+
+        Args:
+            cursor: Cursor inside the step's transaction.
+            head: The statement with leading comments stripped.
+            label: Human-readable step label, for logging.
+
+        Returns:
+            True when the column already exists and the ``ALTER`` must be
+            skipped.
+        """
+        match = _MIGRATION_ADD_COLUMN_RE.match(head)
+        if match is None:
+            return False
+        table = _unquote_sql_identifier(match.group("table"))
+        column = _unquote_sql_identifier(match.group("column"))
+        existing = {
+            row[0]
+            for row in cursor.execute(
+                "SELECT name FROM pragma_table_info(?)", (table,)
+            ).fetchall()
+        }
+        if column not in existing:
+            return False
+        logger.info(
+            f"[{self._SCHEMA_NAME} {label}] {table}.{column} already present; "
+            "skipping the ADD COLUMN (idempotent replay)."
+        )
+        return True
+
+    def _drop_superseded_trigger(
+        self,
+        cursor: sqlite3.Cursor,
+        head: str,
+        label: str,
+    ) -> None:
+        """Drop a same-named trigger before a bare ``CREATE TRIGGER``.
+
+        Several historical steps (V7→V8, V8→V9) create triggers without
+        ``IF NOT EXISTS`` and without a preceding ``DROP``; replaying such a
+        step over a half-applied database would raise ``trigger ... already
+        exists``. Dropping first makes the step re-enterable and leaves the
+        exact same ``sqlite_master`` row the step intended. Statements that
+        already say ``IF NOT EXISTS`` are left alone -- SQLite's own
+        keep-the-existing-one semantics are not overridden.
+
+        Args:
+            cursor: Cursor inside the step's transaction.
+            head: The statement with leading comments stripped.
+            label: Human-readable step label, for logging.
+        """
+        match = _MIGRATION_CREATE_TRIGGER_RE.match(head)
+        if match is None or match.group("if_not_exists"):
+            return
+        name = _unquote_sql_identifier(match.group("name"))
+        if not _PLAIN_SQL_IDENTIFIER_RE.match(name):
+            # Never interpolate anything but a plain identifier; an exotic
+            # name simply keeps the historical (non-idempotent) behaviour.
+            return
+        exists = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ? LIMIT 1",
+            (name,),
+        ).fetchone()
+        if exists is None:
+            return
+        logger.info(
+            f"[{self._SCHEMA_NAME} {label}] trigger {name} already present; "
+            "dropping it so the step's definition is re-applied."
+        )
+        cursor.execute(f'DROP TRIGGER IF EXISTS "{name}"')
+
+    def _execute_migration_statements(
+        self,
+        cursor: sqlite3.Cursor,
+        script: str,
+        label: str,
+    ) -> None:
+        """Run a migration script statement-by-statement, atomically.
+
+        The rollback-safe replacement for ``conn.executescript`` (task-19553):
+        every statement runs through ``cursor``, so it participates in the
+        caller's transaction and a failure part-way through rolls the whole
+        step back to its entry state instead of leaving committed DDL behind.
+
+        Args:
+            cursor: Cursor inside the step's transaction.
+            script: The migration script text.
+            label: Human-readable step label, e.g. ``"V12→V13"``.
+
+        Raises:
+            SchemaError: If the script ends with an incomplete statement.
+            sqlite3.Error: Propagated from a failing statement.
+        """
+        for statement in _split_sql_statements(script):
+            head = _strip_leading_sql_noise(statement)
+            if not head:
+                continue
+            if self._skip_already_applied_add_column(cursor, head, label):
+                continue
+            self._drop_superseded_trigger(cursor, head, label)
+            cursor.execute(statement)
+
     def _apply_schema_v4(self, conn: sqlite3.Connection):
         """
         Applies the full SQL schema for version 4.
@@ -3433,8 +3680,27 @@ UPDATE db_schema_version
             f"Applying schema Version 4 for '{self._SCHEMA_NAME}' to DB: {self.db_path_str}..."
         )
         try:
-            # Using conn.executescript directly as it manages its own transaction
-            conn.executescript(self._FULL_SCHEMA_SQL_V4)
+            # task-19553: this used to run through ``conn.executescript``,
+            # which COMMITS the caller's transaction and autocommits each
+            # statement. An interrupted base-schema apply therefore left a
+            # half-built database that the next launch could not finish -- the
+            # 42 bare ``CREATE TRIGGER`` statements here have no
+            # ``IF NOT EXISTS``, so a retry died on "trigger already exists".
+            # Running through the shared statement runner keeps the whole
+            # apply inside ``_initialize_schema``'s transaction and makes a
+            # retry safe.
+            #
+            # The ONE statement that cannot participate: the script's leading
+            # ``PRAGMA foreign_keys = ON``. SQLite silently IGNORES that pragma
+            # inside a transaction, so it is deliberately left to
+            # ``_get_thread_connection``, which already issues it on every
+            # connection before this runs (see the PRAGMA block there). The
+            # statement stays in the script -- harmless, and the script remains
+            # the readable definition of the v4 schema.
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._FULL_SCHEMA_SQL_V4, "V4 base"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V4] Full schema script executed.")
 
             final_version = self._get_db_version(conn)
@@ -3724,12 +3990,17 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 5 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 4, "V4→V5")
         logger.info(
             f"Migrating schema from V4 to V5 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V4_TO_V5_SQL)
+            # Execute the migration script (task-19553: one statement per
+            # ``cursor.execute`` inside the transaction, never executescript).
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V4_TO_V5_SQL, "V4→V5"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V4→V5] Migration script executed.")
 
             # Verify the migration was successful
@@ -3772,12 +4043,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 6 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 5, "V5→V6")
         logger.info(
             f"Migrating schema from V5 to V6 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V5_TO_V6_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V5_TO_V6_SQL, "V5→V6"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V5→V6] Migration script executed.")
 
             # Verify the migration was successful
@@ -3820,12 +4094,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 7 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 6, "V6→V7")
         logger.info(
             f"Migrating schema from V6 to V7 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V6_TO_V7_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V6_TO_V7_SQL, "V6→V7"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V6→V7] Migration script executed.")
 
             # Verify the migration was successful
@@ -3868,12 +4145,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 9 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 8, "V8→V9")
         logger.info(
             f"Migrating schema from V8 to V9 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V8_TO_V9_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V8_TO_V9_SQL, "V8→V9"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V8→V9] Migration script executed.")
 
             # Verify the migration was successful
@@ -3916,12 +4196,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 10 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 9, "V9→V10")
         logger.info(
             f"Migrating schema from V9 to V10 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V9_TO_V10_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V9_TO_V10_SQL, "V9→V10"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V9→V10] Migration script executed.")
 
             # Verify the migration was successful
@@ -3964,12 +4247,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 11 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 10, "V10→V11")
         logger.info(
             f"Migrating schema from V10 to V11 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V10_TO_V11_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V10_TO_V11_SQL, "V10→V11"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V10→V11] Migration script executed.")
 
             # Verify the migration was successful
@@ -4012,12 +4298,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 12 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 11, "V11→V12")
         logger.info(
             f"Migrating schema from V11 to V12 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V11_TO_V12_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V11_TO_V12_SQL, "V11→V12"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V11→V12] Migration script executed.")
 
             # Verify the migration was successful
@@ -4052,11 +4341,15 @@ UPDATE db_schema_version
         This migration adds conversation metadata fields needed for local/server
         conversation parity and backfills legacy rows with safe defaults.
         """
+        self._require_migration_entry_version(conn, 12, "V12→V13")
         logger.info(
             f"Migrating schema from V12 to V13 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V12_TO_V13_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V12_TO_V13_SQL, "V12→V13"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V12→V13] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4089,11 +4382,15 @@ UPDATE db_schema_version
 
         This migration adds runtime/discovery metadata fields and backfills legacy rows with safe defaults.
         """
+        self._require_migration_entry_version(conn, 13, "V13→V14")
         logger.info(
             f"Migrating schema from V13 to V14 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V13_TO_V14_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V13_TO_V14_SQL, "V13→V14"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V13→V14] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4126,11 +4423,15 @@ UPDATE db_schema_version
 
         This migration adds local quiz parity tables for quizzes, questions, and attempts.
         """
+        self._require_migration_entry_version(conn, 14, "V14→V15")
         logger.info(
             f"Migrating schema from V14 to V15 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V14_TO_V15_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V14_TO_V15_SQL, "V14→V15"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V14→V15] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4164,47 +4465,53 @@ UPDATE db_schema_version
         This migration repairs flashcard FTS5 triggers and rebuilds the local
         flashcard FTS index so multi-token flashcard updates remain searchable.
         """
+        self._require_migration_entry_version(conn, 15, "V15→V16")
         logger.info(
             f"Migrating schema from V15 to V16 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            existing_flashcard_tables = {
-                row[0]
-                for row in conn.execute(
-                    """
-                    SELECT name
-                    FROM sqlite_master
-                    WHERE type IN ('table', 'virtual table')
-                      AND name IN ('flashcards', 'flashcards_fts')
-                    """
-                ).fetchall()
-            }
-            if "flashcards" not in existing_flashcard_tables:
-                logger.info(
-                    f"[{self._SCHEMA_NAME} V15→V16] No flashcards table present; skipping FTS repair."
-                )
-                conn.execute(
-                    """
-                    UPDATE db_schema_version
-                       SET version = 16
-                     WHERE schema_name = ?
-                       AND version = 15
-                    """,
-                    (self._SCHEMA_NAME,),
-                )
-            else:
-                if "flashcards_fts" not in existing_flashcard_tables:
-                    conn.execute(
+            # task-19553: the probe AND the script share one transaction, so a
+            # failure anywhere leaves the database at v15 with no partial DDL.
+            with self.transaction() as cursor:
+                existing_flashcard_tables = {
+                    row[0]
+                    for row in cursor.execute(
                         """
-                        CREATE VIRTUAL TABLE IF NOT EXISTS flashcards_fts USING fts5(
-                            front, back, tags, content=flashcards, content_rowid=rowid
-                        )
+                        SELECT name
+                        FROM sqlite_master
+                        WHERE type IN ('table', 'virtual table')
+                          AND name IN ('flashcards', 'flashcards_fts')
                         """
+                    ).fetchall()
+                }
+                if "flashcards" not in existing_flashcard_tables:
+                    logger.info(
+                        f"[{self._SCHEMA_NAME} V15→V16] No flashcards table present; skipping FTS repair."
                     )
-                conn.executescript(self._MIGRATE_V15_TO_V16_SQL)
-                logger.debug(
-                    f"[{self._SCHEMA_NAME} V15→V16] Migration script executed."
-                )
+                    cursor.execute(
+                        """
+                        UPDATE db_schema_version
+                           SET version = 16
+                         WHERE schema_name = ?
+                           AND version = 15
+                        """,
+                        (self._SCHEMA_NAME,),
+                    )
+                else:
+                    if "flashcards_fts" not in existing_flashcard_tables:
+                        cursor.execute(
+                            """
+                            CREATE VIRTUAL TABLE IF NOT EXISTS flashcards_fts USING fts5(
+                                front, back, tags, content=flashcards, content_rowid=rowid
+                            )
+                            """
+                        )
+                    self._execute_migration_statements(
+                        cursor, self._MIGRATE_V15_TO_V16_SQL, "V15→V16"
+                    )
+                    logger.debug(
+                        f"[{self._SCHEMA_NAME} V15→V16] Migration script executed."
+                    )
 
             final_version = self._get_db_version(conn)
             if final_version != 16:
@@ -4237,11 +4544,15 @@ UPDATE db_schema_version
         This migration adds durable local-only conversation marks without adding
         sync triggers or changing normalized conversation metadata.
         """
+        self._require_migration_entry_version(conn, 16, "V16→V17")
         logger.info(
             f"Migrating schema from V16 to V17 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V16_TO_V17_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V16_TO_V17_SQL, "V16→V17"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V16→V17] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4277,11 +4588,15 @@ UPDATE db_schema_version
         feature, and redefines the ``conversations_sync_*`` triggers so edits
         to the new column are reflected in ``sync_log``.
         """
+        self._require_migration_entry_version(conn, 17, "V17→V18")
         logger.info(
             f"Migrating schema from V17 to V18 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V17_TO_V18_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V17_TO_V18_SQL, "V17→V18"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V17→V18] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4317,20 +4632,26 @@ UPDATE db_schema_version
         (e.g., active_dictionaries), and redefines the ``conversations_sync_*``
         triggers so edits to the new column are reflected in ``sync_log``.
         """
+        self._require_migration_entry_version(conn, 19, "V19→V20")
         logger.info(
             f"Migrating schema from V19 to V20 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Idempotent column add: SQLite has no ``ADD COLUMN IF NOT EXISTS``, so
-            # skip the ALTER when a replayed/partial migration already left the
-            # column in place (mirrors the v18->v19 ``CREATE TABLE IF NOT EXISTS``).
-            existing_columns = {
-                row[1]
-                for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
-            }
-            if "metadata" not in existing_columns:
-                conn.execute("ALTER TABLE conversations ADD COLUMN metadata TEXT")
-            conn.executescript(self._MIGRATE_V19_TO_V20_SQL)
+            with self.transaction() as cursor:
+                # Idempotent column add: SQLite has no ``ADD COLUMN IF NOT EXISTS``, so
+                # skip the ALTER when a replayed/partial migration already left the
+                # column in place (mirrors the v18->v19 ``CREATE TABLE IF NOT EXISTS``).
+                existing_columns = {
+                    row[1]
+                    for row in cursor.execute(
+                        "PRAGMA table_info(conversations)"
+                    ).fetchall()
+                }
+                if "metadata" not in existing_columns:
+                    cursor.execute("ALTER TABLE conversations ADD COLUMN metadata TEXT")
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V19_TO_V20_SQL, "V19→V20"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V19→V20] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4366,24 +4687,28 @@ UPDATE db_schema_version
         the ``world_book_entries_sync_*`` triggers so edits to the new
         column are reflected in ``sync_log``.
         """
+        self._require_migration_entry_version(conn, 20, "V20→V21")
         logger.info(
             f"Migrating schema from V20 to V21 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Idempotent column add: SQLite has no ``ADD COLUMN IF NOT EXISTS``, so
-            # skip the ALTER when a replayed/partial migration already left the
-            # column in place (mirrors the v19->v20 ``metadata`` column guard).
-            existing_columns = {
-                row[1]
-                for row in conn.execute(
-                    "PRAGMA table_info(world_book_entries)"
-                ).fetchall()
-            }
-            if "priority" not in existing_columns:
-                conn.execute(
-                    "ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0"
+            with self.transaction() as cursor:
+                # Idempotent column add: SQLite has no ``ADD COLUMN IF NOT EXISTS``, so
+                # skip the ALTER when a replayed/partial migration already left the
+                # column in place (mirrors the v19->v20 ``metadata`` column guard).
+                existing_columns = {
+                    row[1]
+                    for row in cursor.execute(
+                        "PRAGMA table_info(world_book_entries)"
+                    ).fetchall()
+                }
+                if "priority" not in existing_columns:
+                    cursor.execute(
+                        "ALTER TABLE world_book_entries ADD COLUMN priority INTEGER DEFAULT 0"
+                    )
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V20_TO_V21_SQL, "V20→V21"
                 )
-            conn.executescript(self._MIGRATE_V20_TO_V21_SQL)
             logger.debug(f"[{self._SCHEMA_NAME} V20→V21] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4413,14 +4738,18 @@ UPDATE db_schema_version
     def _migrate_from_v21_to_v22(self, conn: sqlite3.Connection):
         """Migrate schema V21→V22: add ``regex`` to ``world_book_entries`` and
         redefine the sync triggers so edits to it reach ``sync_log``."""
+        self._require_migration_entry_version(conn, 21, "V21→V22")
         logger.info(f"Migrating schema from V21 to V22 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
         try:
-            existing_columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(world_book_entries)").fetchall()
-            }
-            if "regex" not in existing_columns:
-                conn.execute("ALTER TABLE world_book_entries ADD COLUMN regex BOOLEAN DEFAULT 0")
-            conn.executescript(self._MIGRATE_V21_TO_V22_SQL)
+            with self.transaction() as cursor:
+                existing_columns = {
+                    row[1] for row in cursor.execute("PRAGMA table_info(world_book_entries)").fetchall()
+                }
+                if "regex" not in existing_columns:
+                    cursor.execute("ALTER TABLE world_book_entries ADD COLUMN regex BOOLEAN DEFAULT 0")
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V21_TO_V22_SQL, "V21→V22"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V21→V22] Migration script executed.")
             final_version = self._get_db_version(conn)
             if final_version != 22:
@@ -4438,9 +4767,13 @@ UPDATE db_schema_version
     def _migrate_from_v22_to_v23(self, conn: sqlite3.Connection):
         """Migrate schema V22→V23: add the local ``character_expression_images``
         BLOB table (per-state reaction avatars; idle reuses character_cards.image)."""
+        self._require_migration_entry_version(conn, 22, "V22→V23")
         logger.info(f"Migrating schema from V22 to V23 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
         try:
-            conn.executescript(self._MIGRATE_V22_TO_V23_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V22_TO_V23_SQL, "V22→V23"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V22→V23] Migration script executed.")
             final_version = self._get_db_version(conn)
             if final_version != 23:
@@ -4459,14 +4792,18 @@ UPDATE db_schema_version
         """Migrate schema V23→V24: add the local-only ``active_leaf_message_id``
         pointer column to ``conversations``. No triggers change — the column is
         never synced (see ``set_conversation_active_leaf``)."""
+        self._require_migration_entry_version(conn, 23, "V23→V24")
         logger.info(f"Migrating schema from V23 to V24 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
         try:
-            existing_columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
-            }
-            if "active_leaf_message_id" not in existing_columns:
-                conn.execute("ALTER TABLE conversations ADD COLUMN active_leaf_message_id TEXT")
-            conn.executescript(self._MIGRATE_V23_TO_V24_SQL)
+            with self.transaction() as cursor:
+                existing_columns = {
+                    row[1] for row in cursor.execute("PRAGMA table_info(conversations)").fetchall()
+                }
+                if "active_leaf_message_id" not in existing_columns:
+                    cursor.execute("ALTER TABLE conversations ADD COLUMN active_leaf_message_id TEXT")
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V23_TO_V24_SQL, "V23→V24"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V23→V24] Migration script executed.")
             final_version = self._get_db_version(conn)
             if final_version != 24:
@@ -4485,9 +4822,13 @@ UPDATE db_schema_version
         """Migrate schema V24→V25: add the ``message_generation_metadata`` sidecar
         table for storing image generation metadata (prompts, backend, model, etc.).
         No sync triggers are added; this table is local-only (v19/v24 precedent)."""
+        self._require_migration_entry_version(conn, 24, "V24→V25")
         logger.info(f"Migrating schema from V24 to V25 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
         try:
-            conn.executescript(self._MIGRATE_V24_TO_V25_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V24_TO_V25_SQL, "V24→V25"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V24→V25] Migration script executed.")
             final_version = self._get_db_version(conn)
             if final_version != 25:
@@ -4507,16 +4848,20 @@ UPDATE db_schema_version
         ``summary_boundary_message_id`` columns to ``conversations`` (Console
         `/rewind` "summarize up to here"). No triggers change -- the columns
         are never synced (see ``set_conversation_context_summary``)."""
+        self._require_migration_entry_version(conn, 25, "V25→V26")
         logger.info(f"Migrating schema from V25 to V26 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}...")
         try:
-            existing_columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(conversations)").fetchall()
-            }
-            if "context_summary" not in existing_columns:
-                conn.execute("ALTER TABLE conversations ADD COLUMN context_summary TEXT")
-            if "summary_boundary_message_id" not in existing_columns:
-                conn.execute("ALTER TABLE conversations ADD COLUMN summary_boundary_message_id TEXT")
-            conn.executescript(self._MIGRATE_V25_TO_V26_SQL)
+            with self.transaction() as cursor:
+                existing_columns = {
+                    row[1] for row in cursor.execute("PRAGMA table_info(conversations)").fetchall()
+                }
+                if "context_summary" not in existing_columns:
+                    cursor.execute("ALTER TABLE conversations ADD COLUMN context_summary TEXT")
+                if "summary_boundary_message_id" not in existing_columns:
+                    cursor.execute("ALTER TABLE conversations ADD COLUMN summary_boundary_message_id TEXT")
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V25_TO_V26_SQL, "V25→V26"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V25→V26] Migration script executed.")
             final_version = self._get_db_version(conn)
             if final_version != 26:
@@ -4713,11 +5058,15 @@ UPDATE db_schema_version
         no backfill needed since these tables have no prior rows. No sync
         triggers are added; this is a deliberate, local-only divergence (see
         the migration file's header comment)."""
+        self._require_migration_entry_version(conn, 28, "V28→V29")
         logger.info(
             f"Migrating schema from V28 to V29 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V28_TO_V29_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V28_TO_V29_SQL, "V28→V29"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V28→V29] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -4765,33 +5114,39 @@ UPDATE db_schema_version
             # would abort the whole upgrade with "duplicate column name".
             # Skipping just the DDL (never the version bump) lands such a
             # database at v30 exactly like a clean one.
-            existing_columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()
-            }
-            if "usage_json" in existing_columns:
-                logger.info(
-                    f"[{self._SCHEMA_NAME} V29→V30] messages.usage_json already present; "
-                    "skipping the ALTER and applying the version bump only."
-                )
-            else:
-                conn.executescript(self._MIGRATE_V29_TO_V30_SQL)
-                logger.debug(
-                    f"[{self._SCHEMA_NAME} V29→V30] Migration script executed."
-                )
+            with self.transaction() as cursor:
+                existing_columns = {
+                    row[1]
+                    for row in cursor.execute(
+                        "PRAGMA table_info(messages)"
+                    ).fetchall()
+                }
+                if "usage_json" in existing_columns:
+                    logger.info(
+                        f"[{self._SCHEMA_NAME} V29→V30] messages.usage_json already present; "
+                        "skipping the ALTER and applying the version bump only."
+                    )
+                else:
+                    self._execute_migration_statements(
+                        cursor, self._MIGRATE_V29_TO_V30_SQL, "V29→V30"
+                    )
+                    logger.debug(
+                        f"[{self._SCHEMA_NAME} V29→V30] Migration script executed."
+                    )
 
-            version_cursor = conn.execute(
-                """
-                UPDATE db_schema_version
-                   SET version = 30
-                 WHERE schema_name = ?
-                   AND version = 29
-                """,
-                (self._SCHEMA_NAME,),
-            )
-            if version_cursor.rowcount != 1:
-                raise SchemaError(
-                    f"[{self._SCHEMA_NAME} V29→V30] Migration version update was not applied"
+                cursor.execute(
+                    """
+                    UPDATE db_schema_version
+                       SET version = 30
+                     WHERE schema_name = ?
+                       AND version = 29
+                    """,
+                    (self._SCHEMA_NAME,),
                 )
+                if cursor.rowcount != 1:
+                    raise SchemaError(
+                        f"[{self._SCHEMA_NAME} V29→V30] Migration version update was not applied"
+                    )
 
             final_version = self._get_db_version(conn)
             if final_version != 30:
@@ -4838,33 +5193,39 @@ UPDATE db_schema_version
             # -- would abort the whole upgrade with "duplicate column name".
             # Skipping just the DDL (never the version bump) lands such a
             # database at v31 exactly like a clean one.
-            existing_columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()
-            }
-            if "metadata_json" in existing_columns:
-                logger.info(
-                    f"[{self._SCHEMA_NAME} V30→V31] messages.metadata_json already present; "
-                    "skipping the ALTER and applying the version bump only."
-                )
-            else:
-                conn.executescript(self._MIGRATE_V30_TO_V31_SQL)
-                logger.debug(
-                    f"[{self._SCHEMA_NAME} V30→V31] Migration script executed."
-                )
+            with self.transaction() as cursor:
+                existing_columns = {
+                    row[1]
+                    for row in cursor.execute(
+                        "PRAGMA table_info(messages)"
+                    ).fetchall()
+                }
+                if "metadata_json" in existing_columns:
+                    logger.info(
+                        f"[{self._SCHEMA_NAME} V30→V31] messages.metadata_json already present; "
+                        "skipping the ALTER and applying the version bump only."
+                    )
+                else:
+                    self._execute_migration_statements(
+                        cursor, self._MIGRATE_V30_TO_V31_SQL, "V30→V31"
+                    )
+                    logger.debug(
+                        f"[{self._SCHEMA_NAME} V30→V31] Migration script executed."
+                    )
 
-            version_cursor = conn.execute(
-                """
-                UPDATE db_schema_version
-                   SET version = 31
-                 WHERE schema_name = ?
-                   AND version = 30
-                """,
-                (self._SCHEMA_NAME,),
-            )
-            if version_cursor.rowcount != 1:
-                raise SchemaError(
-                    f"[{self._SCHEMA_NAME} V30→V31] Migration version update was not applied"
+                cursor.execute(
+                    """
+                    UPDATE db_schema_version
+                       SET version = 31
+                     WHERE schema_name = ?
+                       AND version = 30
+                    """,
+                    (self._SCHEMA_NAME,),
                 )
+                if cursor.rowcount != 1:
+                    raise SchemaError(
+                        f"[{self._SCHEMA_NAME} V30→V31] Migration version update was not applied"
+                    )
 
             final_version = self._get_db_version(conn)
             if final_version != 31:
@@ -5533,11 +5894,15 @@ UPDATE db_schema_version
         triggers are added here; sync wiring is tracked separately
         (TASK-220).
         """
+        self._require_migration_entry_version(conn, 18, "V18→V19")
         logger.info(
             f"Migrating schema from V18 to V19 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            conn.executescript(self._MIGRATE_V18_TO_V19_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V18_TO_V19_SQL, "V18→V19"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V18→V19] Migration script executed.")
 
             final_version = self._get_db_version(conn)
@@ -5579,12 +5944,15 @@ UPDATE db_schema_version
             SchemaError: If the migration fails or the version is not correctly
                          updated to 8 in db_schema_version.
         """
+        self._require_migration_entry_version(conn, 7, "V7→V8")
         logger.info(
             f"Migrating schema from V7 to V8 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
         )
         try:
-            # Execute the migration script
-            conn.executescript(self._MIGRATE_V7_TO_V8_SQL)
+            with self.transaction() as cursor:
+                self._execute_migration_statements(
+                    cursor, self._MIGRATE_V7_TO_V8_SQL, "V7→V8"
+                )
             logger.debug(f"[{self._SCHEMA_NAME} V7→V8] Migration script executed.")
 
             # Verify the migration was successful
@@ -5710,12 +6078,16 @@ UPDATE db_schema_version
                             f"Migration path undefined for '{self._SCHEMA_NAME}' from version {current_initial_version} to {target_version}. "
                             f"Manual migration or a new database may be required."
                         )
+                    # Defensive backstop. This existed because
                     # ``Connection.executescript`` commits any active
-                    # transaction before running a script. Several historical
-                    # migrations use it, while the transaction context's
-                    # logical nesting depth remains active. Restore the real
-                    # SQLite transaction before every step so the next
-                    # cursor-driven migration remains rollback-safe.
+                    # transaction before running a script, and the historical
+                    # migration steps used it -- leaving the context manager's
+                    # logical nesting depth active over no real SQLite
+                    # transaction. task-19553 removed the last
+                    # ``executescript`` from the migration path, so on the
+                    # supported paths this branch no longer fires; it stays so
+                    # that any future step which does commit cannot silently
+                    # make the following steps non-rollback-safe.
                     if not conn.in_transaction:
                         conn.execute("BEGIN")
                     migration(conn)

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -3596,10 +3596,14 @@ UPDATE db_schema_version
     ) -> None:
         """Drop a same-named trigger before a bare ``CREATE TRIGGER``.
 
-        Several historical steps (V7→V8, V8→V9) create triggers without
-        ``IF NOT EXISTS`` and without a preceding ``DROP``; replaying such a
-        step over a half-applied database would raise ``trigger ... already
-        exists``. Dropping first makes the step re-enterable and leaves the
+        Exactly two historical steps create triggers with neither
+        ``IF NOT EXISTS`` nor a preceding ``DROP`` -- V7→V8 (8 of them) and
+        V8→V9 (13), 21 in total, and no other step; replaying one of those
+        over a half-applied database raises ``trigger ... already exists``
+        (reproduced in ``test_interrupted_trigger_step_recovers``, which is
+        red on the pre-fix code). Note this is NOT true of the v4 base script,
+        whose 42 creates all have a matching ``DROP TRIGGER IF EXISTS``.
+        Dropping first makes the step re-enterable and leaves the
         exact same ``sqlite_master`` row the step intended. Statements that
         already say ``IF NOT EXISTS`` are left alone -- SQLite's own
         keep-the-existing-one semantics are not overridden.
@@ -3628,6 +3632,30 @@ UPDATE db_schema_version
             "dropping it so the step's definition is re-applied."
         )
         cursor.execute(f'DROP TRIGGER IF EXISTS "{name}"')
+
+    @staticmethod
+    def _migration_file_statements(migration_path: Path) -> List[str]:
+        """Read an on-disk migration file and split it into statements.
+
+        The file-backed steps each carried their own copy of this
+        accumulate-lines-until-``complete_statement`` loop (task-19553
+        de-duplicated eleven of them onto ``_split_sql_statements``). Note the
+        tail check now happens BEFORE anything executes rather than after the
+        loop; both roll back inside the step's transaction, so the only
+        difference is that a malformed file is rejected before it touches the
+        database.
+
+        Args:
+            migration_path: Path to a ``DB/migrations/*.sql`` file.
+
+        Returns:
+            The file's statements in source order.
+
+        Raises:
+            OSError: If the file cannot be read.
+            SchemaError: If the file ends with an incomplete statement.
+        """
+        return _split_sql_statements(migration_path.read_text(encoding="utf-8"))
 
     def _execute_migration_statements(
         self,
@@ -3682,13 +3710,29 @@ UPDATE db_schema_version
         try:
             # task-19553: this used to run through ``conn.executescript``,
             # which COMMITS the caller's transaction and autocommits each
-            # statement. An interrupted base-schema apply therefore left a
-            # half-built database that the next launch could not finish -- the
-            # 42 bare ``CREATE TRIGGER`` statements here have no
-            # ``IF NOT EXISTS``, so a retry died on "trigger already exists".
-            # Running through the shared statement runner keeps the whole
-            # apply inside ``_initialize_schema``'s transaction and makes a
-            # retry safe.
+            # statement, so an interrupted base-schema apply left its
+            # already-executed DDL on disk.
+            #
+            # Be precise about what that did and did not cost, because the
+            # answer is NOT the same as for the migration steps. This script
+            # is already fully re-enterable on its own terms -- measured, not
+            # assumed: 42 ``CREATE TRIGGER`` statements but 42 matching
+            # ``DROP TRIGGER IF EXISTS`` (zero creates without a preceding
+            # drop), all 12 ``CREATE TABLE`` / 6 ``CREATE VIRTUAL TABLE`` /
+            # 15 ``CREATE INDEX`` carrying ``IF NOT EXISTS``, and both
+            # top-level inserts written ``INSERT OR IGNORE``. Sweeping all
+            # 120 interruption points of this script on the pre-fix code, the
+            # retry reached version 42 in 120 of 120 cases. A half-applied v4
+            # base was never a brick.
+            #
+            # What the port buys is the leftover state, not the recovery: at
+            # the worst interruption point the pre-fix path left 111
+            # ``sqlite_master`` rows committed in a file the caller believes
+            # failed to initialize (119 of the 120 points left something),
+            # versus 0 rows at every point once the apply runs inside
+            # ``_initialize_schema``'s transaction. That also removes the last
+            # ``executescript`` from the schema path, so "no step commits" is
+            # an unconditional property rather than one with an exception.
             #
             # The ONE statement that cannot participate: the script's leading
             # ``PRAGMA foreign_keys = ON``. SQLite silently IGNORES that pragma
@@ -4912,18 +4956,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        self._execute_citation_migration_statement(cursor, pending)
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Citation provenance migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    self._execute_citation_migration_statement(cursor, statement)
                 cursor.execute(
                     """
                     INSERT INTO rag_identity_context(
@@ -5018,20 +5052,10 @@ UPDATE db_schema_version
         try:
             with self.transaction() as cursor:
                 local_authority_id = self.get_local_authority_id()
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        self._execute_character_authority_migration_statement(
-                            cursor,
-                            pending,
-                        )
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Character authority migration contains incomplete SQL"
+                for statement in self._migration_file_statements(migration_path):
+                    self._execute_character_authority_migration_statement(
+                        cursor,
+                        statement,
                     )
                 self._backfill_conversation_character_authority(
                     cursor,
@@ -5331,18 +5355,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        cursor.execute(pending)
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Console context-memory migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5369,18 +5383,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        cursor.execute(pending)
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Visual-compaction policy migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5415,19 +5419,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        cursor.execute(pending)
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Conversation dictionary attachment migration contains "
-                        "incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5456,18 +5449,8 @@ UPDATE db_schema_version
             )
 
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if sqlite3.complete_statement(pending):
-                        cursor.execute(pending)
-                        pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Note-folder migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5516,15 +5499,7 @@ UPDATE db_schema_version
                         "Provider continuation column is incompatible with schema V37"
                     )
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if not sqlite3.complete_statement(pending):
-                        continue
-                    statement = pending
-                    pending = ""
+                for statement in self._migration_file_statements(migration_path):
                     if (
                         continuation_column is not None
                         and statement.lstrip().startswith("-- Migration:")
@@ -5532,10 +5507,6 @@ UPDATE db_schema_version
                     ):
                         continue
                     cursor.execute(statement)
-                if pending.strip():
-                    raise SchemaError(
-                        "Provider continuation migration contains incomplete SQL"
-                    )
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5562,20 +5533,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if not sqlite3.complete_statement(pending):
-                        continue
-                    statement = pending
-                    pending = ""
+                for statement in self._migration_file_statements(migration_path):
                     cursor.execute(statement)
-                if pending.strip():
-                    raise SchemaError(
-                        "Trajectory metadata migration contains incomplete SQL"
-                    )
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5602,19 +5561,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if not sqlite3.complete_statement(pending):
-                        continue
-                    cursor.execute(pending)
-                    pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Visual Identity migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5641,19 +5589,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if not sqlite3.complete_statement(pending):
-                        continue
-                    cursor.execute(pending)
-                    pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Transcript annotations migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),
@@ -5680,19 +5617,8 @@ UPDATE db_schema_version
         )
         try:
             with self.transaction() as cursor:
-                pending = ""
-                for line in migration_path.read_text(encoding="utf-8").splitlines(
-                    keepends=True
-                ):
-                    pending += line
-                    if not sqlite3.complete_statement(pending):
-                        continue
-                    cursor.execute(pending)
-                    pending = ""
-                if pending.strip():
-                    raise SchemaError(
-                        "Persona Visual migration contains incomplete SQL"
-                    )
+                for statement in self._migration_file_statements(migration_path):
+                    cursor.execute(statement)
                 row = cursor.execute(
                     "SELECT version FROM db_schema_version WHERE schema_name = ?",
                     (self._SCHEMA_NAME,),

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -3653,7 +3653,10 @@ UPDATE db_schema_version
 
         Raises:
             OSError: If the file cannot be read.
-            SchemaError: If the file ends with an incomplete statement.
+            SchemaError: If the file ends with an incomplete statement -- which
+                includes a trailing comment after the final statement. That is
+                pre-existing behaviour, preserved byte-for-byte from the eleven
+                inline copies this replaced; no shipped ``.sql`` file trips it.
         """
         return _split_sql_statements(migration_path.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
Closes task-19553 (P0, data integrity). `sqlite3.Connection.executescript` **commits** whatever transaction is open and then autocommits each statement individually. Every old-style ChaChaNotes migration step used it, so a partial apply — disk full, OOM, a kill, a contended lock — left DDL committed while the version stamp stayed put. Every subsequent launch re-entered the same step, re-raised, and `CharactersRAGDB.__init__` failed: **conversations, notes and characters became permanently unreachable, with no in-app recovery.**

This was demonstrated by running it, not by reasoning: a genuine v11 database with one column of v11→v12 pre-applied raises `duplicate column name`, keeps the stamp at 11 with the DDL committed, and on the *second* launch fails on a *different* column.

## What changed
**All 25 `executescript` steps ported** to `with self.transaction()` + per-statement `cursor.execute` via a shared runner (the audit counted 22; a census found 25). **Plus `_apply_schema_v4`**, the base apply — so the whole v0→v43 path is now a single transaction. No step renumbered or merged, and `_CURRENT_SCHEMA_VERSION` is untouched.

Two idempotence rules let already-damaged databases recover: skip an `ADD COLUMN` whose column exists, and drop a same-named trigger before a **bare** `CREATE TRIGGER` (`IF NOT EXISTS` statements deliberately untouched). Both are provable no-ops on a healthy chain. One statement stays outside a transaction — `PRAGMA foreign_keys = ON`, which SQLite silently ignores inside one; the connection factory issues it per-connection anyway, verified live and pinned.

## Evidence
A byte-identity oracle over 41 snapshots (39 chain builds, a fresh build, and an incremental one-version-per-run build), capturing verbatim `sqlite_master.sql` and `PRAGMA table_info` **including column order**: **11,177 objects / 22,815 column entries / 0 divergences**. The oracle was itself mutation-tested — deleting one index and swapping two `ADD COLUMN`s produces 160 divergences — so the zero means something.

The reviewer swept **55 interruption prefixes** across three steps: at head 55/55 recover byte-identically; at base 45/55 brick permanently, with one step recovering at base too as a working negative control. It also added a **data-survival** check: a seeded v12 database, half-applied, opens at head and reads back the conversation, message, note and a full-text match — rows that at base sit on disk unreachable.

Post-rebase onto dev (now schema v43, whose new step already uses `transaction()`): **1354 passed / 10 failed**, an *identical* failure set to current dev measured in a pristine worktree — zero regressions, +22 tests.

## Review: FIX-FIRST, then APPROVE
The reviewer approved the code and blocked on the **record**: a code comment claimed the v4 base apply's 42 bare `CREATE TRIGGER`s meant a retry "died on trigger already exists". Measured, that is false — there are 42 matching `DROP TRIGGER IF EXISTS`, every table and index is guarded, and a sweep of all 120 interruption points recovered 120/120. The base apply was always re-enterable.

Why it survived is the lesson, now recorded: **the test reds at the leftovers check and never reaches the retry, so the claimed failure mode was never exercised.** A green test validates the assertion, not the story told about it. All three sites now state the measured benefit instead — an interrupted base apply leaves up to 111 `sqlite_master` rows before and 0 after, with the metric named.

The implementer re-measured rather than complying, reconciled a 111-vs-99 discrepancy (different metrics, same point) instead of guessing, and ran an unprompted **guilt-by-association sweep** of its other inferred claim — correcting "~19" unprotected triggers to a measured 21 confined to two steps. The reviewer independently confirmed every now-load-bearing number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
