### PR TITLE
docs(adr): renumber server-offload ADR 076→077 + fix task-18300 frontmatter (TASK-19610)

### DIFF
--- a/backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md
+++ b/backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md
@@ -1,7 +1,8 @@
-# ADR-076: Server-offloaded scheduled agent tasks — execution seam and result pass-back
+# ADR-077: Server-offloaded scheduled agent tasks — execution seam and result pass-back
 
 Status: Proposed
 Date: 2026-08-19
+Renumbered: 072 → 076 → 077 (072–075 claimed by concurrent branches at the PR #1832 merge; 076 proven claimed earlier by `076-library-lifecycle-progressive-disclosure` — see TASK-19610 for the trace)
 Related Task: [TASK-18940](../tasks/task-18940%20-%20Server-offloaded-scheduled-agent-tasks-execution-seam.md)
 Amends: ADR-018 (its "execution remains `execution_unavailable` until server-side automation execution is integrated" clause)
 Related client work: ADR-018 (local/server hybrid storage + sync), TASK-18937 (missed-fire accounting), TASK-18938 (Run-now), TASK-18939 (execution timeouts)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -69,7 +69,8 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-072](072-checkpoint-harness-process-ownership.md) | Accepted | Bound the suite-health checkpoint harness to retained cooperative process signals with PID-version-safe Darwin cleanup. |
 | [ADR-074](074-portable-actor-packs-and-local-persona-visual-runtime.md) | Proposed | Keep Shared Visual Identity and Persona Visual as separate local runtimes inside one self-contained portable Actor Pack envelope. |
 | [ADR-075](075-durable-character-emote-metadata.md) | Proposed | Match the pinned server emote grammar while persisting bounded final-expression metadata and immutable visual references. |
-| [ADR-076](076-server-offloaded-scheduled-agent-tasks.md) | Proposed | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
+| [ADR-076](076-library-lifecycle-progressive-disclosure.md) | Accepted | Library uses destination-local, profile-persisted lifecycle composition rather than a global Beginner/Expert mode or a second onboarding wizard. |
+| [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Proposed | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -530,7 +530,11 @@ branch (PR #1832) drafted its server-offload ADR as 072 on 2026-08-19 and discov
 the collision only as a merge conflict in `backlog/decisions/README.md` — by merge
 time on 2026-08-21, dev had claimed 072 (checkpoint harness), 073, 074, AND 075 from
 other branches, forcing a rename to ADR-076 (file, `# ADR-NNN` header, README row,
-and the owning task's plan references) mid-merge.
+and the owning task's plan references) mid-merge. The thesis then recurred on
+itself: 076 was ALREADY claimed (library-lifecycle landed `1c567f3ae` at 14:24 the
+same day, four hours before the 18:44 renumber), caught only the next day, and the
+ADR renumbered again to 077 (TASK-19610) — the merge-time check must cover the
+number being renamed TO, not just the one being renamed FROM.
 
 **What to do.** ADR numbers have exactly the same collision dynamics as task IDs
 (see "assign against origin/dev" above), but no CI guard. Treat the drafted number

--- a/backlog/tasks/task-18300 - Console-Conversation-Inspector-exchange-capture-and-unified-cost-context-review.md
+++ b/backlog/tasks/task-18300 - Console-Conversation-Inspector-exchange-capture-and-unified-cost-context-review.md
@@ -1,5 +1,5 @@
 ---
-id: task-18300
+id: TASK-18300
 title: Console Conversation Inspector — exchange capture + unified cost/context review
 status: In Progress
 assignee: ['@claude']

--- a/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
+++ b/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
@@ -50,10 +50,10 @@ This is architecture-first work: an ADR defining the client↔server execution c
 
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: yes.
-ADR path: backlog/decisions/076-server-offloaded-scheduled-agent-tasks.md (renumbered from 072 at merge time — dev's 072/073/074/075 were claimed by concurrent branches; DRAFTED 2026-08-19 — review before implementation; amends ADR-018's "execution remains execution_unavailable until server-side automation execution is integrated" clause).
+ADR path: backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md (renumber chain: drafted 072 → 076 at the PR #1832 merge (072–075 claimed concurrently) → 077 per TASK-19610 (076 was proven claimed earlier by the library-lifecycle ADR); DRAFTED 2026-08-19 — review before implementation; amends ADR-018's "execution remains execution_unavailable until server-side automation execution is integrated" clause).
 Reason: cross-system service contract (client↔server execution ownership, result delivery, approval policy for server-side tool use) — squarely in ADR-required territory, and the owner has stated the long-term direction this task exists to realize.
 
-1. Draft ADR-076: execution contract, result-delivery channels, approval policy, reconciliation semantics
+1. Draft ADR-077: execution contract, result-delivery channels, approval policy, reconciliation semantics
 2. Server client + service layer: definition submission, execution status polling/push, result retrieval
 3. Client UI: health/lifecycle honesty for server owners; result row/notification/Console handoff per ADR
 4. Audit trail wiring (AutomationAuditEvent end-to-end)

--- a/backlog/tasks/task-19610 - Renumber-duplicate-ADR-076-server-offload-ADR-moves-to-077.md
+++ b/backlog/tasks/task-19610 - Renumber-duplicate-ADR-076-server-offload-ADR-moves-to-077.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-19610
 title: 'Renumber duplicate ADR-076: server-offload ADR moves to 077 (later claimant)'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@robert'
 created_date: '2026-08-21 11:30'
 updated_date: '2026-08-21 11:30'
 labels:
@@ -33,11 +34,11 @@ Scope of the renumber (grep both forms — per the ADR-collision lesson in this 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Exactly one ADR numbered 076 remains on dev (library-lifecycle); `backlog/decisions/` contains no duplicate numbers (verified with a sorted listing assertion or equivalent check)
-- [ ] #2 The server-offload ADR exists as `077-server-offloaded-scheduled-agent-tasks.md` with a matching `# ADR-077:` header, and its README row links the new filename
-- [ ] #3 Every reference to the server-offload ADR resolves to 077 (TASK-18940 plan section records the renumber chain 072→076→077); no library-ADR reference was modified (before/after grep diff scoped to `076-server-offloaded`/`ADR-077`-after contexts)
-- [ ] #4 The library-lifecycle ADR gains a README index row (it is currently unindexed)
-- [ ] #5 The renumber commit message states the provenance (add-commit ids and timestamps) so the board records why the later claimant moved
+- [x] #1 Exactly one ADR numbered 076 remains on dev (library-lifecycle); `backlog/decisions/` contains no duplicate numbers (verified with a sorted listing assertion or equivalent check)
+- [x] #2 The server-offload ADR exists as `077-server-offloaded-scheduled-agent-tasks.md` with a matching `# ADR-077:` header, and its README row links the new filename
+- [x] #3 Every reference to the server-offload ADR resolves to 077 (TASK-18940 plan section records the renumber chain 072→076→077); no library-ADR reference was modified (before/after grep diff scoped to `076-server-offloaded`/`ADR-077`-after contexts)
+- [x] #4 The library-lifecycle ADR gains a README index row (it is currently unindexed)
+- [x] #5 The renumber commit message states the provenance (add-commit ids and timestamps) so the board records why the later claimant moved
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,3 +54,14 @@ Reason: hygiene renumber of an existing Proposed ADR; the ADR's content and stat
 4. Scoped greps to confirm no stragglers and no library-side edits
 5. Commit with the provenance in the message
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Executed 2026-08-21 on `fix/adr-076-renumber` (isolated worktree; the shared hermes-parity-audit worktree held a parallel session's uncommitted work and was left untouched).
+
+- `git mv` 076→077 server-offload ADR; header updated; a `Renumbered:` line in the frontmatter records the full 072→076→077 chain with causes.
+- README: server-offload row now links 077; the library-lifecycle ADR gained its previously-missing row (summary taken verbatim from its Decision section, status Accepted from its header).
+- TASK-18940's plan references carry the chain note; its step 1 says ADR-077.
+- Scoped sweeps per the lesson (slug + both header forms): every remaining `ADR-076` is library-side (tasks 19022–19026, untouched by design), the lessons file's incident history, or this task's own instruction text. The lesson additionally gained the sequel sentence — the renumber target itself collided, proving the check must cover the number being renamed TO.
+- Also in this PR (separate commit): `task-18300`'s frontmatter id was lowercase (`task-18300`), redding the duplicate-ID guard for every PR since it landed; fixed to `TASK-18300` (guard verified green locally).
+- Verification: `test_backlog_task_frontmatter_ids_are_unique` passes; `backlog/decisions/` has no duplicate numbers (sorted listing: one each 070–077).


### PR DESCRIPTION
## Summary

Executes **TASK-19610** (the duplicate-ADR-076 renumber filed via PR #1870), plus the CI-blocking frontmatter fix found during that PR's merge.

**Renumber (later claimant moves, per the recorded trace):** library-lifecycle 076 landed `1c567f3ae` (08-20 14:24); the server-offload ADR's 072→076 renumber landed `222379065` (18:44), missing the earlier claim — so server-offload becomes **ADR-077** (verified free) and library keeps 076. Scope: file + header + frontmatter `Renumbered:` chain (072→076→077), README row, TASK-18940 plan references. The library ADR also gains its previously-missing README row (summary verbatim from its Decision section) — its absence is how the collision stayed invisible. The lessons entry gains the sequel sentence: the renumber target itself collided, so the merge-time check must cover the number being renamed TO.

**task-18300 fix (separate commit):** its frontmatter id was lowercase (`task-18300`), redding `test_backlog_task_frontmatter_ids_are_unique` for every PR since it landed. One line to `TASK-18300`.

## Verification

- `Tests/UI/test_product_maturity_phase1_harness.py` (both guard tests): **passed** locally
- `backlog/decisions/` duplicate-number groups: **0** (one each 070–077)
- Scoped sweeps per the lesson (slug + `ADR-NNN` + `ADR NNN`): every remaining `ADR-076` reference is library-side (tasks 19022–19026, untouched by design), the lessons file's incident history, or TASK-19610's own instruction text
- Docs/backlog-only diff; no production code

Closes TASK-19610.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbers the server-offload ADR from 076 to 077 to resolve a collision with the already-landed library-lifecycle ADR-076, and fixes TASK-18300’s lowercase frontmatter id to restore the CI uniqueness guard. Old: server-offload held ADR-076; new: library retains ADR-076 and server-offload is ADR-077; references and index entries updated.

- Renumbering (TASK-19610): move/rename the server-offload ADR file to 077, update the `# ADR-077:` header, and add a `Renumbered: 072 → 076 → 077` frontmatter note. Update README to point server-offload to 077 and add the missing library ADR-076 row. Update TASK-18940 plan to reference ADR-077. Extend the lessons doc to note checking the target number during renumbering.
- CI fix: change TASK-18300 frontmatter `id` from `task-18300` to `TASK-18300` to satisfy `test_backlog_task_frontmatter_ids_are_unique`.
- Scope: docs/backlog only. Verified zero duplicate ADR numbers and green ID-guard tests.

<sup>Written for commit 3db10bee120a1d2c4cb10fc9be6bedb7bb274820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

