### PR TITLE
fix(tests): repair #1893's Library harness breaks — shadowed factory + hidden Back control (TASK-19602)

### DIFF
--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -160,9 +160,18 @@ from Tests.UI.test_library_content_hub import StaticLibraryCollectionsService
 from Tests.UI.app_factory import _build_test_app as _build_tldw_test_app
 
 
-def _build_test_app(*, preserve_profile_admission: bool = False):
-    """Build the legacy profile assumed by Library harness tests by default."""
-    app = _build_tldw_test_app()
+def _build_test_app(
+    configured_default: str | None = None,
+    *,
+    preserve_profile_admission: bool = False,
+):
+    """Build the legacy profile assumed by Library harness tests by default.
+
+    Forwards ``configured_default`` to the shared factory (TASK-19602: two
+    call sites pass it; this local wrapper used to shadow the shared
+    signature and reject it).
+    """
+    app = _build_tldw_test_app(configured_default)
     if not preserve_profile_admission:
         app.library_new_profile_admission = False
     return app
@@ -15808,7 +15817,7 @@ async def test_library_shell_note_back_returns_to_list():
         screen.query_one("#library-notes-row-0").press()
         await _wait_for_selector(screen, pilot, "#library-note-title")
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         await _wait_for_selector(screen, pilot, "#library-notes-row-0")
 
         assert screen._library_notes_view == "list"
@@ -16030,6 +16039,22 @@ async def _open_note_editor(screen, pilot, note_id_suffix: str = "n-1"):
     await pilot.pause()
 
 
+def _press_note_back(screen) -> None:
+    """Press whichever editor Back control is live at this terminal width.
+
+    TASK-19602: wide terminals (this suite's 170-col default) hide
+    ``#library-note-back`` while a focused task owns the canvas and show
+    ``#library-notes-task-return`` instead -- both handlers route to the
+    same ``_exit_library_note_editor_guarded`` seam, so the flush/exits
+    under test are identical either way.
+    """
+    back = screen.query_one("#library-note-back", Button)
+    if back.display:
+        back.press()
+        return
+    screen.query_one("#library-notes-task-return", Button).press()
+
+
 def _bump_note_version_externally(service, note_id: str, **field_overrides) -> None:
     """Simulate another writer changing a note: bump its stored version (and
     optionally other fields) on the fake, out from under a screen that still
@@ -16198,7 +16223,7 @@ async def test_library_shell_note_save_then_back_refreshes_list_title_age_and_or
             raise AssertionError("Save never completed.")
 
         list_calls_before = len(app.notes_scope_service.calls)
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         await _wait_for_selector(screen, pilot, "#library-notes-row-0")
 
         first_label = str(screen.query_one("#library-notes-row-0", Button).label)
@@ -16438,7 +16463,7 @@ async def test_library_shell_note_flush_on_back_saves_before_view_switches():
         ).text = "alpha budget line, flushed"
         await pilot.pause()
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(50):
             if service.save_started:
                 break
@@ -16631,7 +16656,7 @@ async def test_library_shell_flush_waits_for_inflight_autosave(monkeypatch):
         # can finish and the whole Back->flush->navigate sequence settles;
         # then assert on the OUTCOME.
         threading.Timer(0.2, release_event.set).start()
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
 
         for _ in range(300):
             if screen._library_notes_view == "list":
@@ -18202,7 +18227,7 @@ async def test_library_shell_note_back_flushes_while_previewing():
         await _wait_for_display(screen, pilot, "#library-note-preview-region")
         assert screen.query_one("#library-note-editor-region").display is False
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(50):
             if service.save_started:
                 break
@@ -19039,7 +19064,7 @@ async def test_library_shell_blank_note_untouched_is_gc_from_real_db_on_back(
         assert screen._library_note_pending_blank_gc_id == screen._selected_note_id
 
         # Leave without typing anything -- Back must GC the untouched row.
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if (
                 await app.notes_scope_service.count_notes(
@@ -19198,7 +19223,7 @@ async def test_library_shell_blank_note_edited_then_back_survives_in_real_db(
             "A real edit must clear GC eligibility."
         )
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if screen._library_notes_view == "list":
                 break
@@ -19271,7 +19296,7 @@ async def test_library_shell_blank_note_typed_then_deleted_all_is_gc_from_real_d
             "mishandled."
         )
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if (
                 await app.notes_scope_service.count_notes(
@@ -19331,7 +19356,7 @@ async def test_library_shell_pre_existing_note_emptied_out_still_saves_in_real_d
         await pilot.pause()
         assert screen._library_note_dirty is True
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if screen._library_notes_view == "list":
                 break
@@ -19409,7 +19434,7 @@ async def test_library_shell_blank_note_autosaved_then_emptied_still_gcs_on_back
         screen.query_one("#library-note-body", TextArea).text = ""
         await pilot.pause()
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if (
                 await real_service.count_notes(
@@ -19466,7 +19491,7 @@ async def test_library_shell_blank_note_titled_untitled_by_hand_survives_back(
             "longer untouched."
         )
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if screen._library_notes_view == "list":
                 break
@@ -19521,7 +19546,7 @@ async def test_library_shell_untouched_blank_note_still_gcs_after_body_round_tri
         await pilot.pause()
         assert screen._library_note_title_user_edited is False
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         for _ in range(150):
             if (
                 await real_service.count_notes(
@@ -28028,7 +28053,7 @@ async def test_library_note_compact_stage_drills_in_and_back_without_losing_orig
         await pilot.pause()
         assert screen._library_notes_active_region() == "editor"
 
-        screen.query_one("#library-note-back").press()
+        _press_note_back(screen)
         await _wait_for_selector(screen, pilot, "#library-notes-filter")
         assert screen._library_notes_active_region() == "navigator"
         await _wait_for_condition(
@@ -29408,7 +29433,7 @@ async def test_library_note_pilot_coalesces_three_edits_and_back_waits_for_chain
             screen.query_one("#library-note-save").press()
             body.text = "revision three"
             await pilot.pause()
-            screen.query_one("#library-note-back").press()
+            _press_note_back(screen)
 
             await asyncio.sleep(0.05)
             assert screen._library_notes_view == "editor"

--- a/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
+++ b/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
@@ -3,7 +3,7 @@ id: TASK-19602
 title: >-
   PR #1893 (library first-run/power-user workflows) re-broke the
   library-prompts-canvas suite
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-21'
 updated_date: '2026-08-21'
@@ -64,3 +64,27 @@ Related: TASK-18611 (whose AC#1 fix this regresses), TASK-19601/19573
 merge; `git log 2a15a72bb -- tldw_chatbook/UI/Screens/library_screen.py`
 around the workspace-registry commits is the starting point.
 <!-- SECTION:NOTES:END -->
+
+## CI confirmation (2026-08-21 ~19:30Z, post-merge shard logs)
+
+#1893's own (post-merge) shard runs confirm the local repro, with a third
+signature beyond the two predicted:
+
+1. `test_library_prompts_canvas.py` — "Prompt browse never settled"
+   (result shows status=ready/error with matching scope but the wait
+   predicate never satisfied) and "#library-prompt-row-25 never mounted
+   within 30s (1078 polls)" with visible text "Loading page 1… Page is
+   loading." — the new pagination path (page_size=20) is stalling in the
+   harness.
+2. `test_library_shell.py` — a cluster of Back/flush/autosave failures
+   ("Back never triggered the flush save", "Back never completed after
+   the in-flight autosave resolved", blank-note GC failure) — broader
+   Library fallout from the same PR, NOT limited to the prompts canvas.
+3. `_build_test_app() got an unexpected keyword argument
+   'configured_default'` — #1893 (or a sibling same-day merge) CHANGED
+   the shared test factory's signature, breaking callers across the
+   suite. Also a `NoActiveAppError` in canvas kwargs separation.
+
+Scope note: this is bigger than the prompts canvas — treat as the
+#1893 Library regression umbrella; the local repro (20 failed) plus
+these CI signatures are the evidence base.


### PR DESCRIPTION
## Summary

First two root-caused fixes from TASK-19602 (the #1893 Library regression umbrella; CI evidence recorded in PR #1906).

**Fix 1 — shadowed test factory (`e351a9c99`):** `test_library_shell.py`'s local `_build_test_app` wrapper (added for `preserve_profile_admission`) shadowed the shared factory import and rejected `configured_default=` — the `TypeError` CI signature. The wrapper now forwards it.

**Fix 2 — hidden Back control (`1bda754fa`, bisected):** in wide terminals the notes editor swaps `#library-note-back` for the new `#library-notes-task-return` (both handlers route to the same `_exit_library_note_editor_guarded` seam — the flush contract is intact in the product). But 14 pre-existing tests pressed the now-hidden button, a silent no-op — producing the "Back never triggered the flush save" cluster. New `_press_note_back` helper presses whichever control is live at the current width; all 14 call sites repointed, contracts unchanged.

Verified by direct instrumentation: session dirty-state, coordinator flush, port, and service seam all work; the failure was purely the no-op press.

## Test plan

- [x] The 9 CI-failing Back/flush/GC/conflict tests pass locally
- [x] Full `test_library_shell.py`: 720 passed / 7 failed — the 7 (rail-preferences, conversation gates, prompts count, restore-state attrs, recompose cycles) reproduce identically on **pure dev** without these fixes; they remain TASK-19602's open scope, documented in the task
- [ ] Sibling suites (`test_library_prompts_canvas.py`, `test_library_file_notes_workspace.py`) — running, will report
- [ ] CI

Task: `backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md`

🤖 Generated with [ZCode](https://github.com/ZCode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs two Library test harness regressions from #1893 that broke CI: a shadowed test factory rejected `configured_default=`, and wide-terminal runs hid the Back button so 14 tests pressed a no-op. The wrapper now forwards `configured_default`, and tests use a helper that clicks the visible Back control; product behavior is unchanged.

- In `Tests/UI/test_library_shell.py`:
  - `_build_test_app(configured_default=..., *, preserve_profile_admission=...)` now forwards `configured_default` to the shared factory, fixing the `TypeError`.
  - Adds `_press_note_back(screen)` and replaces 14 call sites. It selects `#library-note-back` or `#library-notes-task-return` based on visibility, preserving the flush-on-exit contract across terminal widths.
- Linear TASK-19602: narrows the regression surface. The Back/flush/GC CI cluster passes locally; seven unrelated failures remain tracked under the task.
- No product code changes or migrations.

<sup>Written for commit 74462c57855db19fcade2adbce61ddf7e2cbb05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

