### PR TITLE
docs(adr): ADR-077 accepted — server-offloaded scheduled agent tasks (task-18940 AC#1)

### DIFF
--- a/backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md
+++ b/backlog/decisions/077-server-offloaded-scheduled-agent-tasks.md
@@ -1,7 +1,8 @@
 # ADR-077: Server-offloaded scheduled agent tasks — execution seam and result pass-back
 
-Status: Proposed
+Status: Accepted
 Date: 2026-08-19
+Accepted: 2026-08-21 — owner ruling on the two judgment decisions: single-owner execution (decision 1, including the documented behavior change for server-scoped reminders) and phase-1 side-effect-free scope (decision 4)
 Renumbered: 072 → 076 → 077 (072–075 claimed by concurrent branches at the PR #1832 merge; 076 proven claimed earlier by `076-library-lifecycle-progressive-disclosure` — see TASK-19610 for the trace)
 Related Task: [TASK-18940](../tasks/task-18940%20-%20Server-offloaded-scheduled-agent-tasks-execution-seam.md)
 Amends: ADR-018 (its "execution remains `execution_unavailable` until server-side automation execution is integrated" clause)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -70,7 +70,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-074](074-portable-actor-packs-and-local-persona-visual-runtime.md) | Proposed | Keep Shared Visual Identity and Persona Visual as separate local runtimes inside one self-contained portable Actor Pack envelope. |
 | [ADR-075](075-durable-character-emote-metadata.md) | Proposed | Match the pinned server emote grammar while persisting bounded final-expression metadata and immutable visual references. |
 | [ADR-076](076-library-lifecycle-progressive-disclosure.md) | Accepted | Library uses destination-local, profile-persisted lifecycle composition rather than a global Beginner/Expert mode or a second onboarding wizard. |
-| [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Proposed | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
+| [ADR-077](077-server-offloaded-scheduled-agent-tasks.md) | Accepted | tldw_server is the execution authority for server-scoped scheduled agent work (single-owner execution, notifications pass-back, phase-1 side-effect-free runs), amending ADR-018's execution-unavailable clause. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
+++ b/backlog/tasks/task-18940 - Server-offloaded-scheduled-agent-tasks-execution-seam.md
@@ -36,7 +36,7 @@ This is architecture-first work: an ADR defining the client↔server execution c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An ADR (amending/superseding the relevant ADR-018 clause) defines the server-execution contract: definition upload, execution ownership, result-delivery channel(s), approval policy for server-side tool use, failure/timeout semantics, and reconnect reconciliation — drafted and accepted before implementation begins
+- [x] #1 An ADR (amending/superseding the relevant ADR-018 clause) defines the server-execution contract: definition upload, execution ownership, result-delivery channel(s), approval policy for server-side tool use, failure/timeout semantics, and reconnect reconciliation — drafted and accepted before implementation begins — DONE: ADR-077 drafted 2026-08-19 (grounded in the tldw_server dev survey recorded in this task), ACCEPTED 2026-08-21 by owner ruling on both judgment decisions (single-owner execution incl. the server-scoped-reminder behavior change; phase-1 side-effect-free scope)
 - [ ] #2 A server-scoped `agent_task` definition can be created/previewed locally, submitted for server execution, and its `health`/lifecycle transitions honestly (no more permanent `execution_unavailable` for server owners)
 - [ ] #3 Completed server executions deliver results back to the client through at least one concrete channel (workbench result row, notification, or Console handoff — per the ADR), with the delivery visible in the UI and durable
 - [ ] #4 Execution-audit history is durable end-to-end (client-visible audit trail of server executions, reusing `AutomationAuditEvent`)


### PR DESCRIPTION
Records the owner's 2026-08-21 acceptance of ADR-077 (both judgment decisions: single-owner execution, phase-1 side-effect-free scope), flips the README index row, and ticks TASK-18940 AC#1 — opening the implementation gate. First implementation lands in tldw_server per the ADR's sequencing (definition scheduler feed, agent_task consumer, timeout run-status, run-now endpoint). Docs-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts ADR-077, making `tldw_server` the execution authority for server‑scoped scheduled agent work and locking a side‑effect‑free phase‑1 scope. Old behavior: server‑scoped reminders could fire locally or remain execution_unavailable; new behavior: single‑owner server execution, reminders no longer fire locally, and notifications/results are delivered via the server feed—satisfying TASK‑18940 AC#1 and opening implementation.

- Review scope: ADR-077 status changed to Accepted with dated owner ruling; ADR index updated; TASK‑18940 AC#1 checked with acceptance details.
- Behavior and rollout: plan for server‑scoped reminders to stop local firing; phase‑1 runs are side‑effect‑free (server tool use deferred to a follow‑up approval ADR); initial implementation will land in `tldw_server` (definition scheduler feed, agent_task consumer, timeout run‑status, run‑now endpoint).

<sup>Written for commit 8dc7d423c0b850ce935b2868c4baf6f26d90dea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

