### PR TITLE
fix(tests): clear TASK-19602's deterministic library_shell residue — 7 tests

### DIFF
--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -1312,7 +1312,7 @@ async def test_prompts_canvas_supported_artifact_uses_shared_editor_and_read_onl
         user_preview = pilot.app.query_one("#library-prompt-user", TextArea)
         assert system_preview.read_only is True
         assert user_preview.read_only is True
-        assert system_preview.text == "# Role\n\nBe exact."
+        assert system_preview.text == "Be exact."
         assert user_preview.text == "Ship it."
         assert (
             pilot.app.query_one("#library-prompt-recipe-starter", Checkbox).value
@@ -1358,7 +1358,10 @@ async def test_prompts_canvas_shared_editor_patches_preview_without_recomposing_
             id(pilot.app.query_one("#library-prompt-system", TextArea))
             == preview_identity
         )
-        assert preview.text == "# Role\n\nBe concise."
+        # TASK-19602: a24a2202f's simplification mounts/patches the raw
+        # single-block content (its own test pins "Be exact." verbatim) --
+        # the compiled header no longer appears in these previews.
+        assert preview.text == "Be concise."
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -78,7 +78,10 @@ from tldw_chatbook.Library.library_rag_state import (
     LibraryRagPanelState,
 )
 from tldw_chatbook.Library.library_notes_state import LibraryNotesFocusIdentity
-from tldw_chatbook.Library.library_media_state import MediaBrowseScope
+from tldw_chatbook.Library.library_media_state import (
+    MediaBrowseResult,
+    MediaBrowseScope,
+)
 from tldw_chatbook.Library.library_prompts_state import (
     PromptSelectionBasket,
     PromptSelectionEntry,
@@ -5580,8 +5583,17 @@ async def test_library_shell_rail_preferences_prefers_app_config_over_cli_config
         assert screen._library_rail_preferences().details_open is True
 
     # Recorded, not raised -- see the sibling search-history test for why.
-    assert ("library", "rail_state") not in cli_reads, (
-        f"rail preferences fell back to the CLI config despite app_config: {cli_reads}"
+    # TASK-19602: the blanket "no rail_state CLI reads" form predates
+    # `_load_library_lifecycle_value` (11b2fa700), whose own by-design
+    # app_config-first/CLI-fallback reads library.rail_state for the
+    # lifecycle key. The contract under test is narrower: the SECTIONS
+    # reader must not fall back while app_config carries sections -- proven
+    # by a fresh resolution adding no reads.
+    reads_before_resolved = len(cli_reads)
+    assert screen._library_rail_preferences().details_open is True
+    assert len(cli_reads) == reads_before_resolved, (
+        "rail sections fell back to the CLI config despite app_config: "
+        f"{cli_reads[reads_before_resolved:]}"
     )
 
 
@@ -10825,6 +10837,11 @@ async def test_library_conversation_canvas_sync_preserves_intrinsic_action_gates
             and not screen.query(".library-conversation-row"),
             message="Fresh empty Conversation page never applied.",
         )
+        # TASK-19602: a FRESH filtered-empty now renders the distilled
+        # CTA branch ("Clear filter") with no action row (3aef9bcd1) --
+        # the gates contract needs the STALE empty path, where the status
+        # copy keeps the action row composed with disabled controls.
+        screen._library_conversation_freshness = "stale"
         empty_sync_finished = asyncio.Event()
         screen._sync_library_conversation_canvas(then=empty_sync_finished.set)
         await _wait_for_condition(
@@ -10836,7 +10853,11 @@ async def test_library_conversation_canvas_sync_preserves_intrinsic_action_gates
         select = screen.query_one("#library-conversations-select-toggle", Button)
         assert select.label.plain == f"{LIBRARY_DISABLED_ACTION_MARKER} Select"
         assert select.disabled is True
-        assert str(select.tooltip) == LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP
+        # TASK-19602: on the STALE empty path the stale reason outranks the
+        # empty-count reason for the disabled tooltip (the list may be
+        # wrong, not merely empty) -- the empty tooltip itself is covered
+        # by the fresh-empty matrix above.
+        assert str(select.tooltip) == "List may be out of date"
         select.press()
         await pilot.pause()
         assert screen._library_conversations_select_mode is False
@@ -14472,12 +14493,19 @@ async def test_library_shell_prompts_rail_row_shows_exact_count():
         assert "Prompts (2)" in rail_label
 
         button.press()
-        error = await _wait_for_selector(screen, pilot, "#library-prompts-error")
+        # TASK-19602: with the pager always composed (3aef9bcd1 pagination)
+        # the service-failure copy renders in the pager status line -- the
+        # legacy pager-None "#library-prompts-error" node no longer mounts.
+        error = await _wait_for_selector(
+            screen, pilot, "#library-prompts-page-status"
+        )
 
         assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_PROMPTS
         assert screen.query_one("#library-prompts-canvas")
         header = screen.query_one("#library-prompts-header", Static)
-        assert str(header.renderable) == "Prompts (…)"
+        # TASK-19602: the count comes from the pager's own total, unknown
+        # on a service failure -- the header now renders the bare title.
+        assert str(header.renderable) == "Prompts"
         assert "unavailable" in str(error.renderable)
         assert screen.query_one("#library-prompts-retry", Button)
     assert app.prompt_scope_service.count_calls
@@ -23785,7 +23813,17 @@ def test_library_shell_restore_state_sets_per_pane_filter_attrs_on_fresh_unmount
     """
     app = _build_test_app()
     original = LibraryScreen(app)
-    original._library_media_type_filter = "audio"
+    # TASK-19602: c9ac43eff moved media-filter persistence out of the bare
+    # attr and into the browse controller's applied scope -- seed an applied
+    # result whose scope carries the filter; save_state serializes that
+    # scope and restore republishes it onto the attr.
+    original._library_media_browse_controller.applied_result = MediaBrowseResult(
+        scope=MediaBrowseScope(media_type="audio"),
+        items=(),
+        total=0,
+        limit=20,
+        offset=0,
+    )
     original._library_notes_sort = "oldest"
     original._library_notes_filter = "retro"
     original._library_notes_filter_records = ["must never be persisted"]
@@ -23834,7 +23872,11 @@ def test_library_shell_restore_state_defaults_per_pane_filters_on_garbage_values
         }
     )
 
-    assert screen._library_media_type_filter == "All"
+    # TASK-19602: c9ac43eff's scope-era default is None (no filter), not
+    # the legacy sentinel "All" -- garbage under the retired
+    # library_media_type_filter key is ignored, and the scope parser's
+    # own defaults apply.
+    assert screen._library_media_type_filter is None
     assert screen._library_notes_sort == "newest"
     assert screen._library_notes_filter == ""
     assert screen._library_conversation_query == ""
@@ -30874,7 +30916,12 @@ async def test_library_note_recompose_and_fifty_route_cycles_return_to_baseline(
         LibraryNotesCanvas, "on_unmount", counted_canvas_unmount, raising=False
     )
     app = _build_test_app()
-    _seed_conversations(app, _two_conversations(), notes=_two_notes())
+    # TASK-19602: a pristine-empty Media canvas now renders the distilled
+    # empty CTA (3aef9bcd1) instead of #library-media-list -- seed media
+    # so the fifty-route cycle visits the real list canvas.
+    _seed_conversations(
+        app, _two_conversations(), notes=_two_notes(), media=_two_media_items()
+    )
     host = LibraryHarness(app)
 
     async with host.run_test(size=(60, 20)) as pilot:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24367,11 +24367,25 @@ class LibraryScreen(BaseAppScreen):
         self._library_prompt_delete_pending_editor_prompt_id = None
 
     def _library_prompt_write_worker_is_active(self) -> bool:
-        """Return whether an admitted Prompt writer has not settled yet."""
+        """Return whether an admitted Prompt writer has not settled yet.
+
+        TASK-19602: the screen-owned worker manager is only reachable on a
+        mounted screen (``self.workers`` resolves through the active-app
+        context); headless callers (``_library_prompts_canvas_kwargs`` on
+        an unmounted instance) still get the app-owned half of the scan.
+        """
+        managers = [self.app_instance.workers]
+        try:
+            managers.append(self.workers)
+        except Exception:
+            # An unmounted screen's worker walk surfaces NoActiveAppError
+            # or its raw LookupError depending on entry point; neither
+            # exists off the app tree.
+            pass
         return any(
             worker.group in _LIBRARY_PROMPT_WRITE_WORKER_GROUPS
             and not worker.is_finished
-            for manager in (self.workers, self.app_instance.workers)
+            for manager in managers
             for worker in manager
         )
 


### PR DESCRIPTION
## Summary

Second tranche of TASK-19602: all seven deterministic `test_library_shell.py` failures on pure dev, each root-caused and fixed at its seam — no assertion-deleting, every contract preserved or strengthened:

| Test | Root cause | Fix |
|---|---|---|
| rail_preferences_prefers_app_config | `11b2fa700`'s `_load_library_lifecycle_value` reads `library.rail_state` from CLI by design, tripping the blanket "no rail_state CLI reads" assert | Assert narrowed to the actual contract: fresh sections resolution adds no CLI reads |
| conversation_canvas_sync_gates ×2 | `3aef9bcd1`'s fresh-empty renders the CTA branch with no action row | Test moved to the STALE empty path (action row composes; disabled Select + stale tooltip) |
| prompts_rail_row_exact_count | Pager always composed → error copy lives in `#library-prompts-page-status`; header shows bare title on failed count | Repointed to the new nodes |
| restore per-pane attrs ×2 | `c9ac43eff` moved media-filter persistence into `MediaBrowseResult`'s scope | Round-trip seeds the scope; garbage-values aligns to the scope-era default `None` |
| fifty_route_cycles | Pristine-empty Media renders the empty CTA, not `#library-media-list` | Seeds media via the existing `media=` kwarg |

## Test plan

- [x] All 7 target tests pass individually
- [x] Full `test_library_shell.py`: **724 passed / 3 failed** — the 3 (media pager geometry size0, media initial-error, media page-error) are **pre-existing flakes**: they fail identically on pristine dev in isolation (verified with edits stashed) yet passed the pre-edit full run; untouched by this diff, left for 19602's flake pass
- [ ] CI

Task: `backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md`

🤖 Generated with [ZCode](https://github.com/ZCode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears seven deterministic failures in `Tests/UI/test_library_shell.py`, updates prompts-canvas expectations, and fixes a headless crash in the prompts writer scan. Aligns tests with current library-shell and prompts-canvas contracts to unblock TASK-19602.

- Product fix: `_library_prompt_write_worker_is_active` no longer crashes when the screen is unmounted; previously it required `self.workers`. It now scans app-owned workers and returns the active state; mounted behavior is unchanged.
- Shell tests updated to current contracts:
  - Rail preferences: assert now checks that a fresh SECTIONS resolution adds no new CLI reads (instead of banning any lifecycle-key CLI reads).
  - Conversation canvas gates: target the stale-empty path; action row remains composed/disabled with tooltip "List may be out of date".
  - Prompts rail count: error lives in `#library-prompts-page-status`; header shows "Prompts" when the pager total is unknown.
  - Media pane restore: persist filter via `MediaBrowseResult`/`MediaBrowseScope`; default is None on garbage.
  - Fifty route cycles: seed media so the cycle exercises the list, not the empty CTA.
- Known flakes unchanged: media pager geometry size0, media initial-error, media page-error. No migrations.

<sup>Written for commit 220a9619ebae411e356dfe461c96e4d74f7360b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

