### PR TITLE
fix(tests+library): TASK-19602 tranche 3 — 4 cleared, prompt-field reader seam repaired

### DIFF
--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -11031,7 +11031,7 @@ async def test_prompts_canvas_editor_copy_and_duplicate_relabeled():
         copy_button = pilot.app.query_one("#library-prompt-copy", Button)
         duplicate_button = pilot.app.query_one("#library-prompt-duplicate", Button)
         assert str(copy_button.label) == "Copy Markdown"
-        assert str(duplicate_button.label) == "Duplicate prompt"
+        assert str(duplicate_button.label) == "Duplicate"
 
 
 # ---------------------------------------------------------------------------
@@ -11959,7 +11959,7 @@ async def test_library_prompt_copy_after_compatibility_recipe_conversion_uses_pr
         detached_state = screen._current_library_prompt_editor_state()
         assert detached_state.prompt_id is None
         save = screen.query_one("#library-prompt-save", Button)
-        assert str(save.label) == "Save Prompt"
+        assert str(save.label) == "Save prompt"
         assert save.disabled is False
         assert str(screen.query_one("#library-prompt-meta", Static).renderable) == (
             "New prompt · • Unsaved changes"
@@ -12755,7 +12755,7 @@ async def test_library_shell_create_prompt_save_creates_and_increments_count(tmp
         )
         outer_update = screen.query_one("#library-prompt-save", Button)
         shared_update = screen.query_one("#prompt-editor-update-original", Button)
-        assert str(outer_update.label) == "Update original"
+        assert str(outer_update.label) == "Save changes"
         assert outer_update.disabled is False
         assert shared_update.disabled is False
         assert (
@@ -12926,7 +12926,7 @@ async def test_library_recipe_duplicate_outer_save_is_honest_and_preserves_start
         screen.query_one("#library-prompt-duplicate", Button).press()
         await pilot.pause()
         save = screen.query_one("#library-prompt-save", Button)
-        assert str(save.label) == "Save Recipe"
+        assert str(save.label) == "Save prompt"
         screen.query_one("#library-prompt-recipe-starter", Checkbox).value = True
         save.press()
         assert await _wait_for_prompt_status(screen, pilot) == "Saved."

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -22712,17 +22712,30 @@ class LibraryScreen(BaseAppScreen):
         if block_state is not None:
             system_prompt = block_state.compiled_system
             user_prompt = block_state.compiled_user
-        elif isinstance(self._library_prompt_detail, Mapping):
-            editor_state = build_prompt_editor_state(self._library_prompt_detail)
-            system_prompt = editor_state.system_prompt
-            user_prompt = editor_state.user_prompt
         else:
+            # TASK-19602: the live legacy-lane TextAreas are the working
+            # copy the user sees and edits, so non-empty live text outranks
+            # the persisted detail. Structured/foreign artifacts mount
+            # those lanes EMPTY (their truth is the STRUCTURE section) --
+            # empty live lanes fall back to the detail's compatibility
+            # text rather than blanking the copy/export.
             try:
-                system_prompt = self.query_one(
+                live_system = self.query_one(
                     "#library-prompt-system", TextArea
                 ).text
-                user_prompt = self.query_one("#library-prompt-user", TextArea).text
+                live_user = self.query_one("#library-prompt-user", TextArea).text
             except (NoMatches, QueryError):
+                live_system = live_user = None
+            if live_system or live_user:
+                system_prompt = live_system or ""
+                user_prompt = live_user or ""
+            elif isinstance(self._library_prompt_detail, Mapping):
+                editor_state = build_prompt_editor_state(
+                    self._library_prompt_detail
+                )
+                system_prompt = editor_state.system_prompt
+                user_prompt = editor_state.user_prompt
+            else:
                 return None
         return name, author, details, system_prompt, user_prompt, keywords_text
 


### PR DESCRIPTION
Tranche 3: three label expectations aligned to a24a2202f's relabels, plus one real product bug — the legacy prompt-field reader preferred persisted detail over live lane text, dropping unsaved edits from copy/save/export. Live-if-non-empty with compatibility fallback; the naive live-always form was caught by the in-branch differential (blanked structured/foreign copies) and refined before merge. Differential: 19→16 unique failing tests, 0 net regressions. Full methodology and remaining-16 map in the task notes. CI likely still congested; guard verified locally (0/0 dupes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns library prompt editor action labels and repairs the prompt-field reader to honor live TextArea content. Previously the reader preferred persisted detail over live lanes, dropping unsaved edits in copy/save/export; now non-empty live text wins, with a fallback to persisted compatibility text for structured/foreign prompts whose lanes mount empty. Addresses TASK-19602 (tranche 3).

**Review notes**
- Tests updated to match UI relabels: "Duplicate", "Save prompt", "Save changes", and recipe save now "Save prompt".
- Core change in `_read_library_prompt_editor_fields`: selects live system/user lanes when non-empty; otherwise builds from `self._library_prompt_detail`.
- No migrations or API changes. Verify copy, duplicate, and save flows on structured prompts to confirm fallback preserves content.

<sup>Written for commit 9e7afcdf79567e94ad0e993077f2cfe12c2e7994. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

