### PR TITLE
docs(backlog): TASK-19602 tranche 3 notes — reader-seam bug fixed, remaining-16 mapped

### DIFF
--- a/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
+++ b/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
@@ -135,3 +135,32 @@ direction. Deterministic totals: shell 7 -> 0; prompts+file_notes
 Remaining open: prompts_canvas x17 + file_notes x1 deterministic, plus
 the shell's 3 order-flakes (media pager size0 / initial-error /
 page-error) and 2 file_notes order-flakes.
+
+## Fix progress tranche 3 (2026-08-21 late, PR #1915 merged)
+
+4 more cleared incl. ONE real product bug:
+_read_library_prompt_editor_fields preferred the persisted detail over
+the live legacy-lane TextAreas, so unsaved edits silently dropped out
+of copy/save/export. Now live-if-non-empty wins; structured/foreign
+artifacts (lanes mount empty, truth in STRUCTURE) keep the detail
+compatibility fallback -- the naive live-always form blanked those
+copies and the in-branch differential caught it pre-merge. Plus 3
+label expectations aligned to a24a2202f's relabels.
+
+Running totals: 41 of the original ~50 failures cleared across tranches
+1-3; prompts+file_notes unique failing tests 19 -> 16.
+
+Remaining-16 diagnostic map for the next tranche:
+- copy x2 unsaved-lane (11492-class): the a24a2202f editor republishes
+  block state on a system-lane change and reverts a programmatic
+  user-lane .text write (block_state non-None even for legacy); needs
+  the editor's real edit seam (_change_field / per-lane publish), not
+  textarea assignment.
+- double-notify x6: 'Library tools are now available.' (4aa59c20a
+  lifecycle graduation toast, intended) precedes the expected toast in
+  single-call assertions -- tests need the lifecycle toast filtered or
+  the graduation settled before the action.
+- NoMatches x3: #library-row-browse-prompts x2 (rail collapsed/renamed
+  at these sizes?) and #library-prompts-export (button gated or moved).
+- app_config on LibraryHarness WorkerFailed x1 + file_notes x3
+  (source-choices keyboard, database-files return, False-is-True x2).


### PR DESCRIPTION
Docs-only: records PR #1915's outcome (4 cleared, 1 real bug — the prompt-field reader dropping unsaved edits) and the diagnostic map for the remaining 16 failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents tranche 3 outcomes for TASK-19602 and the fix to the library prompt editor reader: previously copy/save/export ignored unsaved edits (persisted detail won); now live, non-empty textarea values take precedence with a fallback for structured/foreign lanes to avoid blanking.

- Clears 4 more failures (41 of ~50 total now cleared); maps the remaining 16 for the next tranche.
- Aligns three label expectations with recent relabels.
- Test updates:
  - Use the editor’s edit seam (`_change_field` with per-lane publish) instead of textarea assignment to avoid reverts on lane change.
  - Filter or wait out the lifecycle “Library tools are now available.” toast to prevent double-notify assertions.
  - Update selectors/flows for the prompts rail (collapsed/renamed at some sizes) and a gated/moved export button.
  - Triage `app_config` WorkerFailed and `file_notes` issues (keyboard source choices, database-files return, False-is-True cases).

<sup>Written for commit a647df9efdf97b86a28115041ca2f896574031d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

