### PR TITLE
Harden skill trust material filesystem permissions

### DIFF
--- a/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
+++ b/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
@@ -4,7 +4,7 @@
 
 **Goal:** Persist local-skill trust manifests, encrypted snapshots, and file-backed generation markers with owner-only POSIX permissions from initial temp-file creation through atomic publication.
 
-**Architecture:** Add an explicit `owner_only` opt-in to the shared atomic replace primitive, leaving its default behavior unchanged. The trust store opts into that path for JSON and bytes writes and secures both trust-owned directory levels before writing; focused tests prove pre-replace modes, legacy tightening, collision ownership, cleanup, and non-trust compatibility.
+**Architecture:** Add an explicit `owner_only` opt-in to the shared atomic replace primitive, leaving its default behavior unchanged. The trust store opts into that path for JSON and bytes writes and secures both trust-owned directory levels before writing; focused tests prove pre-replace modes, legacy tightening, collision ownership, cleanup, and non-trust compatibility. A post-review hardening amendment makes owner-only writes recover from a stale deterministic temp by trying a bounded set of random same-directory siblings while preserving every path the current call did not create.
 
 **Tech Stack:** Python 3.11+, `os.open`/`os.fchmod`, `pathlib`, pytest, existing `Skills_Interop.atomic_write` and `SkillTrustStore` APIs
 
@@ -27,6 +27,10 @@ this document before any test or production-code edit. TASK-19520 has five
 digits, so all remaining task updates must edit the source Markdown directly;
 the repository's Backlog CLI 1.44.0 can silently target a bogus task for
 five-digit IDs.
+
+Tasks 1–5 below are the completed historical implementation. Only Task 6 is
+executable for the post-review amendment; its focused verification supersedes
+the historical broad-suite commands at the user's explicit direction.
 
 ### Task 1: Characterize Owner-Only Atomic Temp Creation
 
@@ -812,3 +816,224 @@ ADR required: no
 ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
 
 Reason: the plan hardens the file-permission implementation of ADR-009's existing trust boundary without changing storage ownership, trust policy, cryptography, authentication, or platform ACL contracts.
+
+### Task 6: Recover Owner-Only Writes from Stale Temp Collisions
+
+**Post-review amendment:** Qodo review identified that a failed cleanup can leave
+the deterministic PID/thread temp occupied, causing every later write from the
+same thread to fail at `O_EXCL`. This task implements the approved design
+revision without broadening the default atomic-write path.
+
+**Files:**
+- Modify: `Tests/Skills/test_atomic_write_concurrency.py:229-360`
+- Modify: `tldw_chatbook/Skills_Interop/atomic_write.py:34-135`
+
+- [ ] **Step 1: Replace the collision-fails test with a failing recovery test**
+
+Pre-create the supplied deterministic temp with sentinel bytes, patch
+`secrets.token_hex` to return a known token, and record the path passed to the
+writer:
+
+```python
+def test_owner_only_collision_uses_fresh_sibling_and_preserves_existing_temp(
+    self, tmp_path, monkeypatch
+):
+    target = tmp_path / "trust.json"
+    temp = aw.unique_temp_path(target, hidden=True)
+    alternate = temp.with_name(f"{temp.name}.0123456789abcdef")
+    sentinel = b"do-not-overwrite-this-temp"
+    temp.write_bytes(sentinel)
+    written_paths: list[Path] = []
+
+    monkeypatch.setattr(secrets, "token_hex", lambda size: "0123456789abcdef")
+
+    def write(path: Path) -> None:
+        written_paths.append(path)
+        path.write_bytes(b"replacement")
+
+    aw.replace_atomically(temp, target, write, owner_only=True)
+
+    assert written_paths == [alternate]
+    assert temp.read_bytes() == sentinel
+    assert target.read_bytes() == b"replacement"
+    assert not alternate.exists()
+    if os.name == "posix":
+        assert _mode(target) == 0o600
+```
+
+- [ ] **Step 2: Add a failing bounded-exhaustion test**
+
+Patch `os.open` to raise a distinct `FileExistsError` on each call, record the
+writer and cleanup seams, and assert exactly eight candidates are attempted:
+
+```python
+def test_owner_only_collision_retry_is_bounded_and_preserves_unowned_paths(
+    self, tmp_path, monkeypatch
+):
+    target = tmp_path / "trust.json"
+    temp = aw.unique_temp_path(target, hidden=True)
+    collisions: list[FileExistsError] = []
+    opened: list[Path] = []
+    writer_calls: list[Path] = []
+    cleanup_calls: list[Path] = []
+
+    monkeypatch.setattr(secrets, "token_hex", lambda size: f"{len(opened):016x}")
+
+    def collide(path, flags, mode):
+        del flags, mode
+        opened.append(Path(path))
+        error = FileExistsError(errno.EEXIST, f"collision-{len(opened)}", path)
+        collisions.append(error)
+        raise error
+
+    def record_unlink(self, *, missing_ok=False):
+        del missing_ok
+        cleanup_calls.append(self)
+
+    monkeypatch.setattr(aw.os, "open", collide)
+    monkeypatch.setattr(Path, "unlink", record_unlink)
+
+    with pytest.raises(FileExistsError) as exc_info:
+        aw.replace_atomically(
+            temp, target, writer_calls.append, owner_only=True
+        )
+
+    assert exc_info.value is collisions[-1]
+    assert len(opened) == 8
+    assert len(set(opened)) == 8
+    assert opened[0] == temp
+    assert writer_calls == []
+    assert cleanup_calls == []
+    assert not target.exists()
+```
+
+- [ ] **Step 3: Add a failing alternate-ownership cleanup test**
+
+Pre-create the supplied temp, force the writer to fail after writing the fresh
+alternate, and prove only the owned alternate is removed:
+
+```python
+def test_owner_only_alternate_writer_failure_cleans_only_owned_sibling(
+    self, tmp_path, monkeypatch
+):
+    target = tmp_path / "trust.json"
+    temp = aw.unique_temp_path(target, hidden=True)
+    alternate = temp.with_name(f"{temp.name}.fedcba9876543210")
+    sentinel = b"unowned"
+    temp.write_bytes(sentinel)
+    monkeypatch.setattr(secrets, "token_hex", lambda size: "fedcba9876543210")
+
+    def fail(path: Path) -> None:
+        assert path == alternate
+        path.write_bytes(b"partial")
+        raise RuntimeError("alternate writer failed")
+
+    with pytest.raises(RuntimeError, match="alternate writer failed"):
+        aw.replace_atomically(temp, target, fail, owner_only=True)
+
+    assert temp.read_bytes() == sentinel
+    assert not alternate.exists()
+    assert not target.exists()
+```
+
+- [ ] **Step 4: Run the three new tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py::TestOwnerOnlyTempCreation::test_owner_only_collision_uses_fresh_sibling_and_preserves_existing_temp \
+  Tests/Skills/test_atomic_write_concurrency.py::TestOwnerOnlyTempCreation::test_owner_only_collision_retry_is_bounded_and_preserves_unowned_paths \
+  Tests/Skills/test_atomic_write_concurrency.py::TestOwnerOnlyTempCreation::test_owner_only_alternate_writer_failure_cleans_only_owned_sibling \
+  -q
+```
+
+Expected: all three fail because `replace_atomically` still surfaces the first
+deterministic collision rather than selecting a fresh sibling. Add `secrets`
+to the test module's standard-library imports before these tests so the RED
+failures exercise production behavior rather than test setup.
+
+- [ ] **Step 5: Implement bounded owner-only candidate selection**
+
+Import `secrets`, add `_OWNER_ONLY_TEMP_CANDIDATES = 8`, and add a private
+iterator that yields the supplied path followed by seven random siblings:
+
+```python
+def _owner_only_temp_paths(temp_path: Path):
+    yield temp_path
+    for _ in range(_OWNER_ONLY_TEMP_CANDIDATES - 1):
+        yield temp_path.with_name(f"{temp_path.name}.{secrets.token_hex(8)}")
+```
+
+In the `owner_only` branch, retry only `FileExistsError`. Store the candidate
+in `owned_temp_path` only after `os.open` succeeds. Invoke `write_fn` and
+`replace` with `owned_temp_path`, and make the exception handler unlink only
+that path. If all candidates collide, re-raise the final `FileExistsError`
+without cleanup. Do not catch other setup errors and do not alter the default
+branch.
+
+- [ ] **Step 6: Run the owner-only class and verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py::TestOwnerOnlyTempCreation -q
+```
+
+Expected: all owner-only tests pass.
+
+- [ ] **Step 7: Run only the focused TASK-19520 verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_store.py \
+  Tests/Skills/test_skill_trust_store_reset.py \
+  Tests/Skills/test_skill_trust_permissions.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+git diff --check
+```
+
+Expected: focused tests, lint, formatting, and whitespace checks pass. Do not
+run the broad Skills or repository suite; the user explicitly limited this
+review fix to tests related to the modified functionality.
+
+- [ ] **Step 8: Commit the production fix**
+
+```bash
+git add \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  Tests/Skills/test_atomic_write_concurrency.py
+git commit -m "fix(skills): recover from stale secure temps"
+```
+
+- [ ] **Step 9: Close the post-review task amendment**
+
+Update the TASK-19520 source Markdown directly: add the bounded stale-temp
+recovery to its implementation-plan and implementation-notes sections, record
+the exact focused-test/static evidence, and return frontmatter status from
+`In Progress` to `Done`. Do not use the Backlog CLI for this five-digit ID.
+
+- [ ] **Step 10: Commit documentation and address the Qodo thread**
+
+```bash
+git add \
+  Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md \
+  'backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md'
+git commit -m "docs: record TASK-19520 review amendment"
+```
+
+Push the branch, reply inline with the bounded-retry and focused-test evidence,
+and resolve the review thread only after GitHub reflects the fix.

--- a/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
+++ b/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
@@ -1,0 +1,814 @@
+# TASK-19520 Skill Trust Material Permissions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist local-skill trust manifests, encrypted snapshots, and file-backed generation markers with owner-only POSIX permissions from initial temp-file creation through atomic publication.
+
+**Architecture:** Add an explicit `owner_only` opt-in to the shared atomic replace primitive, leaving its default behavior unchanged. The trust store opts into that path for JSON and bytes writes and secures both trust-owned directory levels before writing; focused tests prove pre-replace modes, legacy tightening, collision ownership, cleanup, and non-trust compatibility.
+
+**Tech Stack:** Python 3.11+, `os.open`/`os.fchmod`, `pathlib`, pytest, existing `Skills_Interop.atomic_write` and `SkillTrustStore` APIs
+
+**Design:** [TASK-19520 skill trust permissions design](../specs/2026-08-21-task-19520-skill-trust-permissions-design.md)
+
+**Governing ADR:** [ADR-009: Local Skill Trust Boundary](../../../backlog/decisions/009-local-skill-trust-boundary.md)
+
+---
+
+## File Map
+
+- Modify `tldw_chatbook/Skills_Interop/atomic_write.py`: own exclusive `0o600` temp pre-creation and ownership-aware cleanup behind `owner_only=True`.
+- Modify `tldw_chatbook/Skills_Interop/skill_trust_store.py`: opt trust JSON/bytes writes into owner-only temp creation and normalize trust-owned directories to `0o700` on POSIX.
+- Modify `Tests/Skills/test_atomic_write_concurrency.py`: characterize the shared helper's secure ordering, EEXIST ownership, descriptor cleanup, default behavior, and the existing trust-store spy signature.
+- Create `Tests/Skills/test_skill_trust_permissions.py`: exercise manifest, snapshot, marker, pre-replace, snapshot-first, and legacy-mode behavior through production store APIs.
+- Modify `backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md`: record the implementation plan before coding, then check acceptance criteria and add implementation evidence after verification.
+
+The Backlog task's `## Implementation Plan` and ADR check were recorded with
+this document before any test or production-code edit. TASK-19520 has five
+digits, so all remaining task updates must edit the source Markdown directly;
+the repository's Backlog CLI 1.44.0 can silently target a bogus task for
+five-digit IDs.
+
+### Task 1: Characterize Owner-Only Atomic Temp Creation
+
+**Files:**
+- Modify: `Tests/Skills/test_atomic_write_concurrency.py:25-181`
+- Modify: `Tests/Skills/test_atomic_write_concurrency.py:349-375`
+
+- [ ] **Step 1: Add imports and a POSIX mode helper**
+
+Add `errno`, `os`, and `stat` imports. Add this helper beside `_stray_entries`:
+
+```python
+def _mode(path: Path) -> int:
+    """Return only the traditional POSIX permission bits for ``path``."""
+    return stat.S_IMODE(path.stat().st_mode)
+```
+
+- [ ] **Step 2: Write the failing pre-replace mode test**
+
+Add a POSIX-only test to `TestCleanupOnFailure` that delegates to the real `Path.replace` after observing the source:
+
+```python
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits required")
+def test_owner_only_temp_is_0600_before_replace(self, tmp_path, monkeypatch):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+    observed_modes: list[int] = []
+    opened_modes: list[int] = []
+    original_replace = Path.replace
+    original_open = aw.os.open
+
+    def record_open(path, flags, mode):
+        opened_modes.append(mode)
+        return original_open(path, flags, mode)
+
+    def inspect_then_replace(self, other):
+        observed_modes.append(_mode(self))
+        return original_replace(self, other)
+
+    monkeypatch.setattr(aw.os, "open", record_open)
+    monkeypatch.setattr(Path, "replace", inspect_then_replace)
+
+    aw.replace_atomically(
+        temp,
+        target,
+        lambda path: path.write_text("payload", encoding="utf-8"),
+        owner_only=True,
+    )
+
+    assert opened_modes == [0o600]
+    assert observed_modes == [0o600]
+    assert _mode(target) == 0o600
+```
+
+- [ ] **Step 3: Write the failing ownership and cleanup tests**
+
+Add four tests:
+
+```python
+def test_owner_only_collision_preserves_unowned_temp(self, tmp_path):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+    temp.write_bytes(b"unowned sentinel")
+
+    with pytest.raises(FileExistsError):
+        aw.replace_atomically(
+            temp,
+            target,
+            lambda path: path.write_text("replacement", encoding="utf-8"),
+            owner_only=True,
+        )
+
+    assert temp.read_bytes() == b"unowned sentinel"
+    assert not target.exists()
+
+
+def test_owner_only_cleans_temp_after_writer_failure(self, tmp_path):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+
+    def fail_after_precreate(path: Path) -> None:
+        assert path.exists()
+        raise RuntimeError("simulated secure writer failure")
+
+    with pytest.raises(RuntimeError, match="secure writer failure"):
+        aw.replace_atomically(temp, target, fail_after_precreate, owner_only=True)
+
+    assert not temp.exists()
+    assert not target.exists()
+
+
+def test_owner_only_cleans_temp_after_replace_failure(self, tmp_path, monkeypatch):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+
+    def fail_replace(self, other):
+        del self, other
+        raise OSError("simulated owner-only replace failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="owner-only replace failure"):
+        aw.replace_atomically(
+            temp,
+            target,
+            lambda path: path.write_text("payload", encoding="utf-8"),
+            owner_only=True,
+        )
+
+    assert not temp.exists()
+    assert not target.exists()
+
+
+def test_default_replace_does_not_precreate_temp(self, tmp_path):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+
+    def writer(path: Path) -> None:
+        assert not path.exists()
+        path.write_text("default behavior", encoding="utf-8")
+
+    aw.replace_atomically(temp, target, writer)
+
+    assert target.read_text(encoding="utf-8") == "default behavior"
+```
+
+- [ ] **Step 4: Write the failing descriptor-cleanup test**
+
+On POSIX, wrap the real `os.open`, force `os.fchmod` to fail, then prove the captured descriptor is closed and the created path is cleaned:
+
+```python
+@pytest.mark.skipif(os.name != "posix", reason="os.fchmod required")
+def test_owner_only_closes_fd_when_fchmod_fails(self, tmp_path, monkeypatch):
+    target = tmp_path / "target.json"
+    temp = aw.unique_temp_path(target)
+    opened_fds: list[int] = []
+    original_open = aw.os.open
+
+    def record_open(path, flags, mode):
+        fd = original_open(path, flags, mode)
+        opened_fds.append(fd)
+        return fd
+
+    def fail_fchmod(fd, mode):
+        del fd, mode
+        raise OSError("chmod failed")
+
+    monkeypatch.setattr(aw.os, "open", record_open)
+    monkeypatch.setattr(aw.os, "fchmod", fail_fchmod)
+
+    with pytest.raises(OSError, match="chmod failed"):
+        aw.replace_atomically(
+            temp,
+            target,
+            lambda path: path.write_text("payload", encoding="utf-8"),
+            owner_only=True,
+        )
+
+    assert len(opened_fds) == 1
+    with pytest.raises(OSError) as exc_info:
+        os.fstat(opened_fds[0])
+    assert exc_info.value.errno == errno.EBADF
+    assert not temp.exists()
+```
+
+- [ ] **Step 5: Update the existing trust-store spy for the new keyword**
+
+Change `spy_replace_atomically` in `test_trust_store_temp_name_is_dot_prefixed_hidden_convention` to accept and forward `owner_only`:
+
+```python
+def spy_replace_atomically(
+    temp_path, target_path, write_fn, *, owner_only=False
+):
+    observed_temp_names.append(temp_path.name)
+    return original_replace_atomically(
+        temp_path,
+        target_path,
+        write_fn,
+        owner_only=owner_only,
+    )
+```
+
+- [ ] **Step 6: Run the focused tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  -q
+```
+
+Expected: the new tests that pass `owner_only=True` fail with `TypeError:
+replace_atomically() got an unexpected keyword argument 'owner_only'`. The
+updated existing trust-store spy also fails when it forwards
+`owner_only=False` to the not-yet-extended helper; other pre-existing tests
+remain green.
+
+- [ ] **Step 7: Commit the RED tests**
+
+```bash
+git add Tests/Skills/test_atomic_write_concurrency.py
+git commit -m "test(skills): specify owner-only atomic temp behavior"
+```
+
+### Task 2: Implement Owner-Only Shared Atomic Creation
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/atomic_write.py:34-99`
+- Test: `Tests/Skills/test_atomic_write_concurrency.py`
+
+- [ ] **Step 1: Add the owner-only constant and flag builder**
+
+Add this constant after imports:
+
+```python
+_OWNER_ONLY_FILE_MODE = 0o600
+```
+
+Inside a private helper, build flags without assuming optional constants exist:
+
+```python
+def _owner_only_open_flags() -> int:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    for name in ("O_CLOEXEC", "O_BINARY", "O_NOFOLLOW"):
+        flags |= getattr(os, name, 0)
+    return flags
+```
+
+- [ ] **Step 2: Extend `replace_atomically` with ownership-aware creation**
+
+Change the signature and body to:
+
+```python
+def replace_atomically(
+    temp_path: Path,
+    target_path: Path,
+    write_fn: Callable[[Path], None],
+    *,
+    owner_only: bool = False,
+) -> None:
+    """Write through ``temp_path`` and atomically replace ``target_path``.
+
+    When ``owner_only`` is true, exclusively pre-create the temp file with
+    owner-only permissions before ``write_fn`` can reopen it. Cleanup never
+    unlinks an unexplained path when exclusive creation failed.
+    """
+    created_temp = False
+    try:
+        if owner_only:
+            fd = os.open(temp_path, _owner_only_open_flags(), _OWNER_ONLY_FILE_MODE)
+            created_temp = True
+            try:
+                if os.name == "posix":
+                    os.fchmod(fd, _OWNER_ONLY_FILE_MODE)
+            finally:
+                os.close(fd)
+        write_fn(temp_path)
+        temp_path.replace(target_path)
+    except BaseException:
+        if not owner_only or created_temp:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+```
+
+Retain and expand the existing Google-style `Args`/`Raises` documentation, including the `owner_only` behavior, `O_EXCL` collision ownership, and unchanged default semantics.
+
+- [ ] **Step 3: Run the focused shared-helper tests to verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run static checks for the changed helper**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  Tests/Skills/test_atomic_write_concurrency.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  Tests/Skills/test_atomic_write_concurrency.py
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 5: Commit the shared primitive**
+
+```bash
+git add tldw_chatbook/Skills_Interop/atomic_write.py Tests/Skills/test_atomic_write_concurrency.py
+git commit -m "fix(skills): create owner-only atomic temp files"
+```
+
+### Task 3: Specify Trust-Store File and Directory Modes
+
+**Files:**
+- Create: `Tests/Skills/test_skill_trust_permissions.py`
+
+- [ ] **Step 1: Add focused production-path fixtures**
+
+Create the test file with POSIX-only mode assertions and helpers:
+
+```python
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Skills_Interop import skill_trust_store as trust_store_module
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    SkillTrustStore,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX mode-bit assertions"
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _manifest(generation: int) -> dict:
+    return {
+        "version": 1,
+        "generation": generation,
+        "skills": {},
+        "audit": [],
+    }
+
+
+def _store(tmp_path: Path):
+    trust_dir = tmp_path / "trust"
+    marker_path = trust_dir / "generation_marker.json"
+    marker = FileSkillTrustGenerationMarkerStore(
+        marker_path=marker_path,
+        store_dir=trust_dir,
+    )
+    return (
+        SkillTrustStore(store_dir=trust_dir, marker_store=marker),
+        marker_path,
+    )
+```
+
+- [ ] **Step 2: Write the snapshot-first and final-mode test**
+
+```python
+def test_snapshot_first_secures_store_snapshot_manifest_and_marker(tmp_path):
+    store, marker_path = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"p" * 32)
+
+    store.save_snapshot(
+        "demo-1",
+        {"files": {"SKILL.md": "# Demo"}},
+        keys,
+        generation=1,
+    )
+
+    snapshot_path = store.snapshots_dir / "demo-1.json"
+    assert _mode(store.store_dir) == 0o700
+    assert _mode(store.snapshots_dir) == 0o700
+    assert _mode(snapshot_path) == 0o600
+
+    store.save_manifest(_manifest(1), keys, salt=b"p" * 32)
+
+    assert _mode(store.manifest_path) == 0o600
+    assert _mode(marker_path) == 0o600
+```
+
+- [ ] **Step 3: Write the pre-replace production-path test**
+
+Monkeypatch `Path.replace`, delegate to the real implementation, and assert every observed trust temp is hidden and `0o600`:
+
+```python
+def test_trust_temp_is_owner_only_before_replace(tmp_path, monkeypatch):
+    store, _ = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"q" * 32)
+    observed: list[tuple[str, int]] = []
+    observed_owner_only: list[bool] = []
+    original_replace = Path.replace
+    original_replace_atomically = trust_store_module.replace_atomically
+
+    def inspect_atomic_call(
+        temp_path, target_path, write_fn, *, owner_only=False
+    ):
+        observed_owner_only.append(owner_only)
+        return original_replace_atomically(
+            temp_path,
+            target_path,
+            write_fn,
+            owner_only=owner_only,
+        )
+
+    def inspect_then_replace(self, other):
+        observed.append((self.name, _mode(self)))
+        return original_replace(self, other)
+
+    monkeypatch.setattr(
+        trust_store_module, "replace_atomically", inspect_atomic_call
+    )
+    monkeypatch.setattr(Path, "replace", inspect_then_replace)
+    store.save_manifest(_manifest(1), keys, salt=b"q" * 32)
+
+    assert observed
+    assert observed_owner_only
+    assert all(observed_owner_only)
+    assert all(name.startswith(".") for name, _ in observed)
+    assert all(mode == 0o600 for _, mode in observed)
+```
+
+- [ ] **Step 4: Write the bytes-writer owner-only test**
+
+Call the real private bytes writer because manifest rollback reaches this seam
+directly. Spy on the module's imported `replace_atomically`, delegate to the
+real helper, and require `owner_only=True`:
+
+```python
+def test_trust_bytes_writer_requests_owner_only_creation(tmp_path, monkeypatch):
+    target = tmp_path / "trust" / "manifest-rollback.json"
+    observed_owner_only: list[bool] = []
+    original_replace_atomically = trust_store_module.replace_atomically
+
+    def inspect_atomic_call(
+        temp_path, target_path, write_fn, *, owner_only=False
+    ):
+        observed_owner_only.append(owner_only)
+        return original_replace_atomically(
+            temp_path,
+            target_path,
+            write_fn,
+            owner_only=owner_only,
+        )
+
+    monkeypatch.setattr(
+        trust_store_module, "replace_atomically", inspect_atomic_call
+    )
+    trust_store_module._atomic_write_bytes(
+        target,
+        b"previous manifest bytes",
+        base_dir=target.parent,
+    )
+
+    assert observed_owner_only == [True]
+    assert _mode(target) == 0o600
+```
+
+- [ ] **Step 5: Write the legacy-tightening test**
+
+Create valid files first, widen them and their trust-owned directories, then rewrite through public APIs:
+
+```python
+def test_next_write_tightens_legacy_files_and_directories(tmp_path):
+    store, marker_path = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"r" * 32)
+    snapshot_path = store.snapshots_dir / "demo-1.json"
+
+    store.save_snapshot("demo-1", {"files": {}}, keys, generation=1)
+    store.save_manifest(_manifest(1), keys, salt=b"r" * 32)
+
+    for directory in (store.store_dir, store.snapshots_dir):
+        directory.chmod(0o755)
+    for path in (snapshot_path, store.manifest_path, marker_path):
+        path.chmod(0o666)
+
+    store.save_snapshot("demo-1", {"files": {}}, keys, generation=2)
+    store.save_manifest(_manifest(2), keys)
+
+    assert _mode(store.store_dir) == 0o700
+    assert _mode(store.snapshots_dir) == 0o700
+    assert _mode(snapshot_path) == 0o600
+    assert _mode(store.manifest_path) == 0o600
+    assert _mode(marker_path) == 0o600
+```
+
+- [ ] **Step 6: Run the new tests to verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_skill_trust_permissions.py \
+  -q
+```
+
+Expected on POSIX: failures show permissive final/temp modes, missing
+`owner_only=True` on both JSON and bytes writers, or the missing trust root
+during snapshot-first creation. On non-POSIX: tests skip cleanly.
+
+- [ ] **Step 7: Commit the RED trust-store tests**
+
+```bash
+git add Tests/Skills/test_skill_trust_permissions.py
+git commit -m "test(skills): specify trust material permissions"
+```
+
+### Task 4: Enforce Trust-Store File and Directory Permissions
+
+**Files:**
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_store.py:1-25`
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_store.py:504-528`
+- Modify: `tldw_chatbook/Skills_Interop/skill_trust_store.py:591-630`
+- Test: `Tests/Skills/test_skill_trust_permissions.py`
+
+- [ ] **Step 1: Add the POSIX directory constant**
+
+Import `os` with the standard-library imports and define beside the trust filenames:
+
+```python
+_OWNER_ONLY_DIRECTORY_MODE = 0o700
+```
+
+- [ ] **Step 2: Secure the trust root before snapshot-first creation**
+
+At the beginning of the persistence part of `SkillTrustStore.save_snapshot`, secure both owned levels in order:
+
+```python
+_ensure_trust_directory(self.store_dir)
+snapshots_dir = _ensure_trust_directory(self.snapshots_dir)
+```
+
+This must happen before `_atomic_write_json`; do not recursively chmod ancestors above `self.store_dir`.
+
+- [ ] **Step 3: Opt both trust writers into owner-only temp creation**
+
+Change the two calls to:
+
+```python
+replace_atomically(
+    temp_path,
+    path,
+    lambda t: t.write_text(text, encoding="utf-8"),
+    owner_only=True,
+)
+```
+
+and:
+
+```python
+replace_atomically(
+    temp_path,
+    path,
+    lambda t: t.write_bytes(payload),
+    owner_only=True,
+)
+```
+
+Update the surrounding TASK-17963 comment to explain that TASK-19520 additionally pre-creates trust temps with owner-only permissions before the content callback.
+
+- [ ] **Step 4: Normalize each trust-owned leaf directory**
+
+Change `_ensure_trust_directory` to create the leaf with `0o700`, re-check the symlink invariant after creation, and normalize the leaf on POSIX:
+
+```python
+def _ensure_trust_directory(path: Path) -> Path:
+    directory = validate_path_simple(path)
+    if directory.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    directory.mkdir(
+        mode=_OWNER_ONLY_DIRECTORY_MODE,
+        parents=True,
+        exist_ok=True,
+    )
+    if directory.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    if os.name == "posix":
+        directory.chmod(_OWNER_ONLY_DIRECTORY_MODE)
+    return directory
+```
+
+Do not swallow a POSIX `chmod` failure; the write must abort before creating sensitive material.
+
+- [ ] **Step 5: Run the new trust permission tests to verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_skill_trust_permissions.py \
+  -q
+```
+
+Expected: all tests pass on POSIX or skip on non-POSIX.
+
+- [ ] **Step 6: Run the focused regression set**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_store.py \
+  Tests/Skills/test_skill_trust_store_reset.py \
+  Tests/Skills/test_skill_trust_permissions.py \
+  -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Run formatting and lint checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 8: Commit the trust-store enforcement**
+
+```bash
+git add \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_skill_trust_permissions.py
+git commit -m "fix(skills): restrict trust material permissions"
+```
+
+### Task 5: Mutation Check, Full Verification, and Backlog Close-out
+
+**Files:**
+- Modify: `backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md`
+- Verify: `tldw_chatbook/Skills_Interop/atomic_write.py`
+- Verify: `tldw_chatbook/Skills_Interop/skill_trust_store.py`
+- Verify: `Tests/Skills/test_atomic_write_concurrency.py`
+- Verify: `Tests/Skills/test_skill_trust_permissions.py`
+
+- [ ] **Step 1: Mutation-check both trust-writer file-mode guards**
+
+Temporarily disable `owner_only=True` in the JSON trust writer without
+committing it and run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_skill_trust_permissions.py::test_trust_temp_is_owner_only_before_replace \
+  -q
+```
+
+Expected: FAIL because the production writer no longer reports the explicit
+owner-only opt-in (and under a permissive umask the observed temp mode is also
+not `0o600`). Restore the line immediately with `apply_patch`.
+
+Then temporarily disable `owner_only=True` in the bytes trust writer and run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_skill_trust_permissions.py::test_trust_bytes_writer_requests_owner_only_creation \
+  -q
+```
+
+Expected: FAIL because the writer no longer requests owner-only creation.
+Restore the line immediately with `apply_patch`.
+
+- [ ] **Step 2: Mutation-check directory normalization**
+
+Temporarily disable the POSIX `directory.chmod(0o700)` call without committing it and run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Skills/test_skill_trust_permissions.py::test_next_write_tightens_legacy_files_and_directories \
+  -q
+```
+
+Expected: FAIL because widened trust directories remain `0o755`. Restore the line immediately with `apply_patch`.
+
+- [ ] **Step 3: Run the complete Skills suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Skills/ -q
+```
+
+Expected: all Skills tests pass.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q
+```
+
+Expected: the complete repository suite passes. If machine-load flakes occur,
+compare the exact failure set from the identical command against a clean
+`origin/dev` worktree per `backlog/docs/lessons-testing-evidence.md`; do not
+substitute collection success for the full gate.
+
+- [ ] **Step 5: Run reachability and static verification**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/ --collect-only -q
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  tldw_chatbook/Skills_Interop/atomic_write.py \
+  tldw_chatbook/Skills_Interop/skill_trust_store.py \
+  Tests/Skills/test_atomic_write_concurrency.py \
+  Tests/Skills/test_skill_trust_permissions.py
+git diff --check
+```
+
+Expected: collection succeeds with no errors; lint, formatting, and whitespace checks exit zero.
+
+- [ ] **Step 6: Review the final diff for scope and security ordering**
+
+Confirm:
+
+- only trust-store callers pass `owner_only=True`;
+- exclusive-create failure cannot unlink an unowned path;
+- the descriptor closes if `fchmod` fails;
+- `store_dir` is secured before snapshot-first creation;
+- legacy files and owned directories tighten only on writes;
+- no Windows ACL guarantee or same-UID isolation is claimed; and
+- no unrelated working-tree changes are staged.
+
+- [ ] **Step 7: Update TASK-19520 close-out sections**
+
+In the task file:
+
+- mark all five acceptance criteria `[x]` only after the evidence above is green;
+- add concise implementation notes naming the shared `owner_only` path, trust-store opt-in, directory ordering, legacy migration, non-POSIX boundary, mutation results, and exact test totals;
+- include:
+
+```text
+ADR required: no
+ADR path: backlog/decisions/009-local-skill-trust-boundary.md
+Reason: direct hardening of ADR-009's existing persistence boundary.
+```
+
+- [ ] **Step 8: Mark the five-digit task Done by editing its source file**
+
+Do not call `backlog task edit/view 19520`: the repository's Backlog CLI 1.44.0
+has a documented five-digit-ID bug that can create
+`backlog/tasks/task-task- - .md`. Edit the task frontmatter to `status: Done`,
+set `updated_date`, and verify the exact source file directly with `sed`/`rg`.
+Run `git status --short backlog/` and confirm no bogus task file exists.
+
+- [ ] **Step 9: Commit task close-out documentation**
+
+```bash
+git add 'backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md'
+git commit -m "docs: close TASK-19520"
+```
+
+- [ ] **Step 10: Invoke completion verification and branch-finish workflows**
+
+Use `superpowers:verification-before-completion`, then `superpowers:requesting-code-review`. After review findings are resolved and verification remains green, use `superpowers:finishing-a-development-branch` to present merge/PR/cleanup options.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
+
+Reason: the plan hardens the file-permission implementation of ADR-009's existing trust boundary without changing storage ownership, trust policy, cryptography, authentication, or platform ACL contracts.

--- a/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
+++ b/Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md
@@ -828,7 +828,7 @@ revision without broadening the default atomic-write path.
 - Modify: `Tests/Skills/test_atomic_write_concurrency.py:229-360`
 - Modify: `tldw_chatbook/Skills_Interop/atomic_write.py:34-135`
 
-- [ ] **Step 1: Replace the collision-fails test with a failing recovery test**
+- [x] **Step 1: Replace the collision-fails test with a failing recovery test**
 
 Pre-create the supplied deterministic temp with sentinel bytes, patch
 `secrets.token_hex` to return a known token, and record the path passed to the
@@ -861,7 +861,7 @@ def test_owner_only_collision_uses_fresh_sibling_and_preserves_existing_temp(
         assert _mode(target) == 0o600
 ```
 
-- [ ] **Step 2: Add a failing bounded-exhaustion test**
+- [x] **Step 2: Add a failing bounded-exhaustion test**
 
 Patch `os.open` to raise a distinct `FileExistsError` on each call, record the
 writer and cleanup seams, and assert exactly eight candidates are attempted:
@@ -907,7 +907,7 @@ def test_owner_only_collision_retry_is_bounded_and_preserves_unowned_paths(
     assert not target.exists()
 ```
 
-- [ ] **Step 3: Add a failing alternate-ownership cleanup test**
+- [x] **Step 3: Add a failing alternate-ownership cleanup test**
 
 Pre-create the supplied temp, force the writer to fail after writing the fresh
 alternate, and prove only the owned alternate is removed:
@@ -936,7 +936,7 @@ def test_owner_only_alternate_writer_failure_cleans_only_owned_sibling(
     assert not target.exists()
 ```
 
-- [ ] **Step 4: Run the three new tests and verify RED**
+- [x] **Step 4: Run the three new tests and verify RED**
 
 Run:
 
@@ -953,7 +953,7 @@ deterministic collision rather than selecting a fresh sibling. Add `secrets`
 to the test module's standard-library imports before these tests so the RED
 failures exercise production behavior rather than test setup.
 
-- [ ] **Step 5: Implement bounded owner-only candidate selection**
+- [x] **Step 5: Implement bounded owner-only candidate selection**
 
 Import `secrets`, add `_OWNER_ONLY_TEMP_CANDIDATES = 8`, and add a private
 iterator that yields the supplied path followed by seven random siblings:
@@ -972,7 +972,7 @@ that path. If all candidates collide, re-raise the final `FileExistsError`
 without cleanup. Do not catch other setup errors and do not alter the default
 branch.
 
-- [ ] **Step 6: Run the owner-only class and verify GREEN**
+- [x] **Step 6: Run the owner-only class and verify GREEN**
 
 Run:
 
@@ -983,7 +983,7 @@ Run:
 
 Expected: all owner-only tests pass.
 
-- [ ] **Step 7: Run only the focused TASK-19520 verification**
+- [x] **Step 7: Run only the focused TASK-19520 verification**
 
 Run:
 
@@ -1010,7 +1010,7 @@ Expected: focused tests, lint, formatting, and whitespace checks pass. Do not
 run the broad Skills or repository suite; the user explicitly limited this
 review fix to tests related to the modified functionality.
 
-- [ ] **Step 8: Commit the production fix**
+- [x] **Step 8: Commit the production fix**
 
 ```bash
 git add \
@@ -1019,7 +1019,7 @@ git add \
 git commit -m "fix(skills): recover from stale secure temps"
 ```
 
-- [ ] **Step 9: Close the post-review task amendment**
+- [x] **Step 9: Close the post-review task amendment**
 
 Update the TASK-19520 source Markdown directly: add the bounded stale-temp
 recovery to its implementation-plan and implementation-notes sections, record

--- a/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
+++ b/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
@@ -46,7 +46,7 @@ TASK-17963 moved these writes to writer-unique temporary paths before an atomic 
 
 ### 1. Secure creation in the shared primitive, trust-store opt-in — selected
 
-Extend the shared atomic-write boundary with an optional secure temporary-file creation step. When requested, the primitive exclusively pre-creates the writer-unique temporary path with `os.open` and mode `0o600`, normalizes its owner bits through the open descriptor on POSIX, closes it, then invokes the existing writer callback and atomic replacement. Because reopening an existing file for truncation preserves its mode, the current JSON/text/bytes callbacks and serialization remain intact. Only the trust store enables this option.
+Extend the shared atomic-write boundary with an optional owner-only temporary-file creation step. When requested, the primitive exclusively pre-creates the writer-unique temporary path with `os.open` and the fixed mode `0o600`, normalizes its owner bits through the open descriptor on POSIX, closes it, then invokes the existing writer callback and atomic replacement. Because reopening an existing file for truncation preserves its mode, the current JSON/text/bytes callbacks and serialization remain intact. Only the trust store enables this option.
 
 This centralizes the security-critical ordering beside the existing atomic replace and cleanup logic while avoiding permission changes for ordinary local-skill files.
 
@@ -66,17 +66,17 @@ Making `0o600` the default would be simple but would silently change user-visibl
 
 ### Shared atomic-write behavior
 
-`Skills_Interop/atomic_write.py` will accept an optional, keyword-only temporary-file mode on `replace_atomically`. The default remains `None` and preserves current behavior.
+`Skills_Interop/atomic_write.py` will accept an optional, keyword-only `owner_only: bool = False` switch on `replace_atomically`. The default preserves current behavior. The switch always means mode `0o600`; it is deliberately not a generic caller-supplied mode because TASK-19520 needs one security invariant, not a new permission-policy API.
 
-When a mode is provided, the helper will:
+When `owner_only` is true, the helper will:
 
 1. Exclusively create the supplied writer-unique temporary path with `os.open` using `O_WRONLY | O_CREAT | O_EXCL`, plus `O_CLOEXEC`, `O_BINARY`, and `O_NOFOLLOW` where those flags are available.
 2. Pass `0o600` at creation. A process umask can only remove permissions at this step, never add group or other access.
 3. On POSIX, call `os.fchmod` on the still-open descriptor to normalize the mode to exactly `0o600` before closing it. This preserves the no-broad-permissions invariant even under an unusual umask.
 4. Close the descriptor, invoke the existing path-based writer callback, and atomically replace the target.
-5. Use the existing `BaseException` cleanup path for exclusive-create, content-write, and replace failures.
+5. Record ownership only after `os.open` succeeds. Failures after successful creation use the existing `BaseException` cleanup path; an `EEXIST` failure before creation does not unlink the unexplained path.
 
-`O_EXCL` deliberately refuses a stale or attacker-precreated temporary path instead of truncating or following it. The existing PID-and-thread writer-unique name makes legitimate collisions exceptional; a collision fails closed and leaves the target unchanged. The task will not delete an unexplained pre-existing temporary file because ownership cannot be established safely.
+`O_EXCL` deliberately refuses a stale or attacker-precreated temporary path instead of truncating or following it. The existing PID-and-thread writer-unique name makes legitimate collisions exceptional; a collision fails closed and leaves both the target and unexplained temporary path unchanged. The implementation will track whether this invocation created the temp path so the outer cleanup handler unlinks only a path it owns. Default-mode callers retain their current cleanup behavior because their callback remains the creator.
 
 ### Trust-store integration
 
@@ -87,17 +87,20 @@ When a mode is provided, the helper will:
 - preserve JSON ordering, indentation, encoding, and trailing-newline behavior; and
 - propagate write failures.
 
-Their calls to `replace_atomically` will opt into `temp_mode=0o600`. This covers manifests, encrypted snapshots, marker writes, and manifest rollback bytes through the existing call graph.
+Their calls to `replace_atomically` will opt into `owner_only=True`. This covers manifests, encrypted snapshots, marker writes, and manifest rollback bytes through the existing call graph.
 
 ### Directory permissions
 
-`_ensure_trust_directory` will keep its existing path validation and symlink refusal, create the requested leaf directory with `mode=0o700`, and on POSIX normalize that trust-owned leaf to `0o700` before returning it to a writer. Normalizing on every write also tightens permissive trust and snapshots directories left by earlier versions. The parent hierarchy is not recursively chmodded; the security boundary is the validated trust-owned leaf directory.
+`_ensure_trust_directory` will keep its existing path validation and symlink refusal, create the requested leaf directory with `mode=0o700`, and on POSIX normalize that trust-owned leaf to `0o700` before returning it to a writer. Normalizing on every write also tightens permissive trust and snapshots directories left by earlier versions.
+
+`SkillTrustStore.save_snapshot` must explicitly secure `self.store_dir` before securing `self.snapshots_dir`. It cannot rely on `snapshots_dir.mkdir(parents=True)` because production bootstrap can save a snapshot before a manifest, and Python does not apply the leaf's requested mode to intermediate parents. Manifest and marker writes already secure their trust-store base through `_atomic_write_json`. Ancestors above `self.store_dir` remain unchanged; the two trust-owned boundaries are `store_dir` and `snapshots_dir`.
 
 On non-POSIX platforms the directory and file writes follow the same atomic code path, but `fchmod`/`chmod` enforcement and mode-bit assertions are skipped. This avoids pretending Unix mode bits implement Windows ACL policy while preserving compatibility.
 
 ## Error Handling and Recovery
 
-- Failure to create or restrict a POSIX temporary file aborts the write. The target remains unchanged and best-effort cleanup removes only this writer's temporary path.
+- Failure after this writer creates a POSIX temporary file aborts the write. The target remains unchanged and best-effort cleanup removes this writer's temporary path.
+- An exclusive-create collision before ownership is established leaves the unexplained temporary path untouched and surfaces the error.
 - Failure to restrict a POSIX trust-owned directory aborts before sensitive file creation.
 - A stale temporary-path collision raises rather than truncating an unexplained file.
 - Marker-save rollback continues to restore the previous manifest through `_atomic_write_bytes`; the restored file is therefore tightened to `0o600` as well.
@@ -112,6 +115,8 @@ Add focused tests under `Tests/Skills/` that run on real temporary filesystem pa
 - Intercept `Path.replace` and inspect the source path before delegating, proving the in-flight temporary file is already `0o600` before publication.
 - Exercise both JSON and bytes secure-write paths so manifest rollback bytes are not covered only indirectly.
 - Verify a secure-create or replace failure cleans up its temporary path and preserves the original exception.
+- Pre-create the exact writer-unique temp path, assert an `EEXIST` failure leaves that unexplained file byte-identical, and distinguish it from cleanup after successful creation.
+- Save a snapshot into a missing or permissive trust root before saving a manifest and assert both the trust root and `snapshots/` are `0o700`.
 - Keep existing concurrency and serialization-preservation tests green.
 - Gate POSIX mode assertions with `os.name == "posix"`; retain platform-neutral round-trip tests so Windows exercises the new optional path in CI without asserting advisory Unix bits.
 

--- a/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
+++ b/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
@@ -1,0 +1,123 @@
+# TASK-19520: Skill Trust Material Permissions Design
+
+**Status:** Approved for planning  
+**Date:** 2026-08-21  
+**Task:** TASK-19520  
+**Governing decision:** [ADR-009: Local Skill Trust Boundary](../../../backlog/decisions/009-local-skill-trust-boundary.md)
+
+## Context
+
+The local-skill trust store persists an authenticated manifest, encrypted approved-version snapshots, and a file-backed rollback-generation marker. These files are security-sensitive inputs to the trust boundary defined by ADR-009, but the current atomic-write path creates them with the process's default filesystem permissions. On a typical POSIX installation that can leave the material readable by other users on the same machine.
+
+TASK-17963 moved these writes to writer-unique temporary paths before an atomic `replace`, but deliberately preserved the existing permission behavior. TASK-19520 closes that remaining gap without changing the trust format, cryptography, rollback protocol, or the permissions of ordinary local-skill files.
+
+## Goals
+
+- Create trust manifest, snapshot, and file-backed generation-marker files with owner-only POSIX permissions (`0o600`).
+- Ensure a temporary trust file is never created with broader permissions and restricted only afterward.
+- Keep trust-store and snapshot directories owner-only (`0o700`) before writing sensitive files into them.
+- Tighten files and trust-owned directories created by earlier versions on their next trust-store write.
+- Preserve the atomic replacement, writer-unique naming, containment validation, serialization, cleanup, and error-propagation behavior established by TASK-17963.
+- Keep non-trust callers of the shared atomic-write module behaviorally unchanged.
+- Continue to operate on Windows and other platforms where POSIX mode bits are unavailable or advisory.
+
+## Non-goals
+
+- Managing Windows ACLs. Windows continues to inherit ACLs from the containing directory; POSIX mode enforcement is skipped there.
+- Protecting files from malicious code running as the same OS account. ADR-009 already excludes malicious active application code and active process compromise.
+- Changing trust payload formats, keys, cryptography, marker policy, or storage locations.
+- Retrofitting owner-only modes onto ordinary skill content or every caller of `Skills_Interop.atomic_write`.
+- Eagerly mutating trust files during reads or application startup. Legacy files are tightened when the store next writes them.
+- Adding durability changes such as file or directory `fsync`; atomic-write durability is unchanged.
+
+## Security Invariants
+
+1. On POSIX, every temporary file used for trust material is created with no group or other permissions before any path-based content write can occur.
+2. On POSIX, the temporary file has mode `0o600` before `Path.replace` publishes it at the final path.
+3. The trust-store directory is mode `0o700` before manifest or marker creation, and the snapshots directory is mode `0o700` before snapshot creation.
+4. Replacing a permissive legacy target publishes the restrictive temporary inode, so the rewritten target becomes `0o600` without a post-replace exposure window.
+5. Permission setup failure on a POSIX platform fails the trust write and follows the existing temporary-file cleanup path; the code does not continue with a knowingly broad mode.
+6. Callers that do not request secure creation retain the current `Path.write_text`/`Path.write_bytes` behavior and modes.
+
+## Options Considered
+
+### 1. Secure creation in the shared primitive, trust-store opt-in — selected
+
+Extend the shared atomic-write boundary with an optional secure temporary-file creation step. When requested, the primitive exclusively pre-creates the writer-unique temporary path with `os.open` and mode `0o600`, normalizes its owner bits through the open descriptor on POSIX, closes it, then invokes the existing writer callback and atomic replacement. Because reopening an existing file for truncation preserves its mode, the current JSON/text/bytes callbacks and serialization remain intact. Only the trust store enables this option.
+
+This centralizes the security-critical ordering beside the existing atomic replace and cleanup logic while avoiding permission changes for ordinary local-skill files.
+
+### 2. Private secure writers in `skill_trust_store.py`
+
+The trust store could duplicate exclusive creation and cleanup around both its JSON and bytes writers. This limits the shared API change but creates a second implementation of the same write lifecycle and makes it easier for the two trust write paths to drift.
+
+### 3. Owner-only permissions for all atomic-write callers
+
+Making `0o600` the default would be simple but would silently change user-visible skill files, imports, indexes, and future shared-helper callers. Those files are outside TASK-19520's trust-material scope and may intentionally follow the user's normal umask.
+
+### Rejected: temporarily changing the process umask
+
+`umask` is process-global. Temporarily changing it around a write is unsafe when background workers or concurrent app instances perform unrelated writes and still does not provide a narrowly owned enforcement point.
+
+## Selected Design
+
+### Shared atomic-write behavior
+
+`Skills_Interop/atomic_write.py` will accept an optional, keyword-only temporary-file mode on `replace_atomically`. The default remains `None` and preserves current behavior.
+
+When a mode is provided, the helper will:
+
+1. Exclusively create the supplied writer-unique temporary path with `os.open` using `O_WRONLY | O_CREAT | O_EXCL`, plus `O_CLOEXEC`, `O_BINARY`, and `O_NOFOLLOW` where those flags are available.
+2. Pass `0o600` at creation. A process umask can only remove permissions at this step, never add group or other access.
+3. On POSIX, call `os.fchmod` on the still-open descriptor to normalize the mode to exactly `0o600` before closing it. This preserves the no-broad-permissions invariant even under an unusual umask.
+4. Close the descriptor, invoke the existing path-based writer callback, and atomically replace the target.
+5. Use the existing `BaseException` cleanup path for exclusive-create, content-write, and replace failures.
+
+`O_EXCL` deliberately refuses a stale or attacker-precreated temporary path instead of truncating or following it. The existing PID-and-thread writer-unique name makes legitimate collisions exceptional; a collision fails closed and leaves the target unchanged. The task will not delete an unexplained pre-existing temporary file because ownership cannot be established safely.
+
+### Trust-store integration
+
+`skill_trust_store._atomic_write_json` and `_atomic_write_bytes` will continue to:
+
+- validate the target and temporary paths against the independently supplied trust base directory;
+- preserve hidden writer-unique temporary names;
+- preserve JSON ordering, indentation, encoding, and trailing-newline behavior; and
+- propagate write failures.
+
+Their calls to `replace_atomically` will opt into `temp_mode=0o600`. This covers manifests, encrypted snapshots, marker writes, and manifest rollback bytes through the existing call graph.
+
+### Directory permissions
+
+`_ensure_trust_directory` will keep its existing path validation and symlink refusal, create the requested leaf directory with `mode=0o700`, and on POSIX normalize that trust-owned leaf to `0o700` before returning it to a writer. Normalizing on every write also tightens permissive trust and snapshots directories left by earlier versions. The parent hierarchy is not recursively chmodded; the security boundary is the validated trust-owned leaf directory.
+
+On non-POSIX platforms the directory and file writes follow the same atomic code path, but `fchmod`/`chmod` enforcement and mode-bit assertions are skipped. This avoids pretending Unix mode bits implement Windows ACL policy while preserving compatibility.
+
+## Error Handling and Recovery
+
+- Failure to create or restrict a POSIX temporary file aborts the write. The target remains unchanged and best-effort cleanup removes only this writer's temporary path.
+- Failure to restrict a POSIX trust-owned directory aborts before sensitive file creation.
+- A stale temporary-path collision raises rather than truncating an unexplained file.
+- Marker-save rollback continues to restore the previous manifest through `_atomic_write_bytes`; the restored file is therefore tightened to `0o600` as well.
+- Reads remain non-mutating. A permissive legacy file can remain permissive until a trust mutation rewrites it; this is the acceptance criterion's selected migration point.
+
+## Testing Strategy
+
+Add focused tests under `Tests/Skills/` that run on real temporary filesystem paths:
+
+- On POSIX, save a manifest and snapshot through `SkillTrustStore` and a marker through `FileSkillTrustGenerationMarkerStore`; assert final file modes are exactly `0o600` and trust/snapshot directory modes are exactly `0o700`.
+- Seed legacy targets with permissive modes, rewrite them through the production APIs, and assert the resulting files and trust-owned directories are tightened.
+- Intercept `Path.replace` and inspect the source path before delegating, proving the in-flight temporary file is already `0o600` before publication.
+- Exercise both JSON and bytes secure-write paths so manifest rollback bytes are not covered only indirectly.
+- Verify a secure-create or replace failure cleans up its temporary path and preserves the original exception.
+- Keep existing concurrency and serialization-preservation tests green.
+- Gate POSIX mode assertions with `os.name == "posix"`; retain platform-neutral round-trip tests so Windows exercises the new optional path in CI without asserting advisory Unix bits.
+
+The permission tests should be mutation-checked by temporarily disabling the secure pre-creation or directory normalization and confirming the relevant assertions fail.
+
+## Documentation and Decision Record
+
+ADR required: no  
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`  
+Reason: TASK-19520 directly hardens the persistence boundary already selected by ADR-009. It does not change storage ownership, trust policy, cryptography, or a cross-module contract beyond an optional implementation detail on the existing atomic-write helper.
+
+The task implementation plan and notes will link this design and ADR-009. No user-facing configuration or workflow changes are introduced.

--- a/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
+++ b/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
@@ -33,6 +33,12 @@ TASK-17963 moved these writes to writer-unique temporary paths before an atomic 
 - Eagerly mutating trust files during reads or application startup. Legacy files are tightened when the store next writes them.
 - Adding durability changes such as file or directory `fsync`; atomic-write durability is unchanged.
 
+## Relationship to OS Access Controls
+
+This change does not supersede the operating system's access-control model; it selects stricter defaults within that model. It is useful when separate unprivileged POSIX users share a host and directory traversal or a permissive umask would otherwise make trust material readable or writable. It is mostly redundant when an existing parent directory already prevents access, but preserves the invariant if parent permissions later change.
+
+The modes do not separate application users that share one OS identity, restrict another process running under the same UID, override root or administrator authority, replace filesystem encryption for offline access, or implement Windows and storage-specific ACL policy. On ACL-backed or network filesystems, the effective ACL and mount semantics remain authoritative. TASK-19520 is therefore low-cost defence in depth around ADR-009's existing trust root, not a new authentication or tenant-isolation boundary.
+
 ## Security Invariants
 
 1. On POSIX, every temporary file used for trust material is created with no group or other permissions before any path-based content write can occur.

--- a/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
+++ b/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
@@ -4,6 +4,8 @@
 
 **Date:** 2026-08-21
 
+**Review revision:** 2026-08-21 — stale secure-temp collision recovery
+
 **Task:** TASK-19520
 
 **Governing decision:** [ADR-009: Local Skill Trust Boundary](../../../backlog/decisions/009-local-skill-trust-boundary.md)
@@ -82,7 +84,37 @@ When `owner_only` is true, the helper will:
 4. Close the descriptor, invoke the existing path-based writer callback, and atomically replace the target.
 5. Record ownership only after `os.open` succeeds. Failures after successful creation use the existing `BaseException` cleanup path; an `EEXIST` failure before creation does not unlink the unexplained path.
 
-`O_EXCL` deliberately refuses a stale or attacker-precreated temporary path instead of truncating or following it. The existing PID-and-thread writer-unique name makes legitimate collisions exceptional; a collision fails closed and leaves both the target and unexplained temporary path unchanged. The implementation will track whether this invocation created the temp path so the outer cleanup handler unlinks only a path it owns. Default-mode callers retain their current cleanup behavior because their callback remains the creator.
+`O_EXCL` deliberately refuses a stale or attacker-precreated temporary path instead of truncating or following it. The implementation tracks whether this invocation created a temp path so the outer cleanup handler unlinks only a path it owns. Default-mode callers retain their current cleanup behavior because their callback remains the creator.
+
+### Post-review stale-temp recovery
+
+Qodo review identified that the PID-and-thread name is writer-unique only
+across concurrent writers, not across sequential attempts by the same thread.
+Because cleanup is best effort, a failed unlink can leave that deterministic
+name occupied and make every later owner-only write fail at `O_EXCL`.
+
+Three remedies were evaluated:
+
+1. **Bounded alternate-name retry inside `replace_atomically` — selected.** Try
+   the caller-supplied path first. Only when owner-only `os.open` raises
+   `FileExistsError`, try same-directory siblings formed from the supplied name
+   plus a `secrets.token_hex(8)` component, for at most eight total candidates.
+2. Randomize trust-store names at each call site. This would recover current
+   trust writers but leave direct or future `owner_only=True` helper callers
+   vulnerable to the same deterministic retry failure.
+3. Delete a colliding temp judged to be stale. This cannot safely distinguish
+   a leftover from an active same-UID writer and would violate the concurrency
+   ownership rule established by TASK-17963.
+
+The selected retry remains inside the shared owner-only lifecycle. Normal
+writes still use exactly the supplied hidden PID/thread path and incur no
+random-name generation. On collision, every existing candidate is preserved;
+the writer callback and `Path.replace` receive only the candidate this attempt
+successfully created. Cleanup targets only that owned candidate. If all eight
+exclusive creates collide, the last `FileExistsError` is surfaced with the
+target and every unexplained temp unchanged. The bound prevents an unbounded
+loop under a hostile or broken filesystem while 64 random bits per fallback
+make accidental exhaustion negligible.
 
 ### Trust-store integration
 
@@ -106,9 +138,13 @@ On non-POSIX platforms the directory and file writes follow the same atomic code
 ## Error Handling and Recovery
 
 - Failure after this writer creates a POSIX temporary file aborts the write. The target remains unchanged and best-effort cleanup removes this writer's temporary path.
-- An exclusive-create collision before ownership is established leaves the unexplained temporary path untouched and surfaces the error.
+- An exclusive-create collision before ownership is established leaves that
+  unexplained path untouched and moves to the next bounded random sibling.
+- Exhausting all eight owner-only candidates surfaces the last
+  `FileExistsError`; the target and every unowned candidate remain unchanged.
 - Failure to restrict a POSIX trust-owned directory aborts before sensitive file creation.
-- A stale temporary-path collision raises rather than truncating an unexplained file.
+- A stale temporary-path collision never truncates or removes the unexplained
+  file; a fresh exclusively created sibling allows a later attempt to recover.
 - Marker-save rollback continues to restore the previous manifest through `_atomic_write_bytes`; the restored file is therefore tightened to `0o600` as well.
 - Reads remain non-mutating. A permissive legacy file can remain permissive until a trust mutation rewrites it; this is the acceptance criterion's selected migration point.
 
@@ -121,7 +157,14 @@ Add focused tests under `Tests/Skills/` that run on real temporary filesystem pa
 - Intercept `Path.replace` and inspect the source path before delegating, proving the in-flight temporary file is already `0o600` before publication.
 - Exercise both JSON and bytes secure-write paths so manifest rollback bytes are not covered only indirectly.
 - Verify a secure-create or replace failure cleans up its temporary path and preserves the original exception.
-- Pre-create the exact writer-unique temp path, assert an `EEXIST` failure leaves that unexplained file byte-identical, and distinguish it from cleanup after successful creation.
+- Pre-create the exact writer-unique temp path, assert the owner-only write
+  succeeds through an alternate sibling while the unexplained file remains
+  byte-identical, and verify the published target is still `0o600` on POSIX.
+- Force all eight candidate opens to collide and assert the last
+  `FileExistsError` propagates without a writer call, target mutation, or
+  cleanup attempt against an unowned path.
+- Force a failure after an alternate candidate is created and assert cleanup
+  targets that owned alternate only, leaving the original collision intact.
 - Save a snapshot into a missing or permissive trust root before saving a manifest and assert both the trust root and `snapshots/` are `0o700`.
 - Keep existing concurrency and serialization-preservation tests green.
 - Gate POSIX mode assertions with `os.name == "posix"`; retain platform-neutral round-trip tests so Windows exercises the new optional path in CI without asserting advisory Unix bits.

--- a/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
+++ b/Docs/superpowers/specs/2026-08-21-task-19520-skill-trust-permissions-design.md
@@ -1,8 +1,11 @@
 # TASK-19520: Skill Trust Material Permissions Design
 
-**Status:** Approved for planning  
-**Date:** 2026-08-21  
-**Task:** TASK-19520  
+**Status:** Approved for planning
+
+**Date:** 2026-08-21
+
+**Task:** TASK-19520
+
 **Governing decision:** [ADR-009: Local Skill Trust Boundary](../../../backlog/decisions/009-local-skill-trust-boundary.md)
 
 ## Context
@@ -116,8 +119,10 @@ The permission tests should be mutation-checked by temporarily disabling the sec
 
 ## Documentation and Decision Record
 
-ADR required: no  
-ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`  
+ADR required: no
+
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
+
 Reason: TASK-19520 directly hardens the persistence boundary already selected by ADR-009. It does not change storage ownership, trust policy, cryptography, or a cross-module contract beyond an optional implementation detail on the existing atomic-write helper.
 
 The task implementation plan and notes will link this design and ADR-009. No user-facing configuration or workflow changes are introduced.

--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -189,6 +189,36 @@ class TestCleanupOnFailure:
 
         assert _stray_entries(tmp_path) == []
 
+    def test_unlink_cleanup_failure_preserves_writer_exception(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "target.txt"
+        temp = aw.unique_temp_path(target)
+        writer_error = RuntimeError("sentinel writer failure")
+        cleanup_error = OSError(errno.EIO, "sentinel unlink failure")
+
+        def write_then_fail(path: Path) -> None:
+            path.write_text("partial", encoding="utf-8")
+            raise writer_error
+
+        def fail_unlink(self, *, missing_ok=False):
+            assert self == temp
+            assert missing_ok
+            raise cleanup_error
+
+        monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+        try:
+            with pytest.raises(RuntimeError) as exc_info:
+                aw.replace_atomically(temp, target, write_then_fail)
+
+            assert exc_info.value is writer_error
+            assert temp.exists()
+            assert not target.exists()
+        finally:
+            if temp.exists():
+                os.unlink(temp)
+
 
 # ---------------------------------------------------------------------------
 # Owner-only temp creation: trust material can opt into exclusive 0o600 temp
@@ -248,6 +278,10 @@ class TestOwnerOnlyTempCreation:
         assert flags & os.O_ACCMODE == os.O_WRONLY
         assert flags & os.O_CREAT
         assert flags & os.O_EXCL
+        for optional_flag_name in ("O_CLOEXEC", "O_NOFOLLOW", "O_BINARY"):
+            optional_flag = getattr(os, optional_flag_name, 0)
+            if optional_flag:
+                assert flags & optional_flag == optional_flag
         assert requested_mode == 0o600
         assert events == [("fchmod", 0o600), ("writer", 0o600)]
         assert mode_during_replace == [0o600]
@@ -379,6 +413,117 @@ class TestOwnerOnlyTempCreation:
                 except OSError as exc:
                     if exc.errno == errno.EBADF:
                         continue
+                try:
+                    real_close(fd)
+                except OSError:
+                    pass
+
+    @pytest.mark.skipif(
+        os.name != "posix" or not hasattr(os, "fchmod"),
+        reason="POSIX file descriptors and fchmod required",
+    )
+    def test_owner_only_fchmod_and_close_failure_preserves_fchmod_exception(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        real_open = os.open
+        real_close = os.close
+        setup_error = PermissionError(errno.EPERM, "sentinel fchmod failure")
+        close_error = OSError(errno.EIO, "sentinel close failure")
+        captured_fds: list[int] = []
+        writer_calls: list[Path] = []
+
+        def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+            if dir_fd is None:
+                fd = real_open(path, flags, mode)
+            else:
+                fd = real_open(path, flags, mode, dir_fd=dir_fd)
+            if Path(path) == temp:
+                captured_fds.append(fd)
+            return fd
+
+        def fail_fchmod(fd, mode):
+            assert fd in captured_fds
+            assert mode == 0o600
+            raise setup_error
+
+        def fail_close(fd):
+            assert fd in captured_fds
+            raise close_error
+
+        monkeypatch.setattr(aw.os, "open", tracking_open)
+        monkeypatch.setattr(aw.os, "fchmod", fail_fchmod)
+        monkeypatch.setattr(aw.os, "close", fail_close)
+
+        try:
+            with pytest.raises(PermissionError) as exc_info:
+                aw.replace_atomically(
+                    temp,
+                    target,
+                    writer_calls.append,
+                    owner_only=True,
+                )
+
+            assert exc_info.value is setup_error
+            assert writer_calls == []
+            assert not temp.exists()
+            assert not target.exists()
+        finally:
+            for fd in captured_fds:
+                try:
+                    real_close(fd)
+                except OSError:
+                    pass
+
+    @pytest.mark.skipif(
+        os.name != "posix" or not hasattr(os, "fchmod"),
+        reason="POSIX file descriptors and fchmod required",
+    )
+    def test_owner_only_close_failure_after_setup_propagates_close_error(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        target_sentinel = b"existing-target-must-survive"
+        target.write_bytes(target_sentinel)
+        temp = aw.unique_temp_path(target, hidden=True)
+        real_open = os.open
+        real_close = os.close
+        close_error = OSError(errno.EIO, "sentinel close failure")
+        captured_fds: list[int] = []
+        writer_calls: list[Path] = []
+
+        def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+            if dir_fd is None:
+                fd = real_open(path, flags, mode)
+            else:
+                fd = real_open(path, flags, mode, dir_fd=dir_fd)
+            if Path(path) == temp:
+                captured_fds.append(fd)
+            return fd
+
+        def fail_close(fd):
+            assert fd in captured_fds
+            raise close_error
+
+        monkeypatch.setattr(aw.os, "open", tracking_open)
+        monkeypatch.setattr(aw.os, "close", fail_close)
+
+        try:
+            with pytest.raises(OSError) as exc_info:
+                aw.replace_atomically(
+                    temp,
+                    target,
+                    writer_calls.append,
+                    owner_only=True,
+                )
+
+            assert exc_info.value is close_error
+            assert writer_calls == []
+            assert not temp.exists()
+            assert target.read_bytes() == target_sentinel
+        finally:
+            for fd in captured_fds:
                 try:
                     real_close(fd)
                 except OSError:

--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import secrets
 import stat
 import threading
 from pathlib import Path
@@ -287,23 +288,98 @@ class TestOwnerOnlyTempCreation:
         assert mode_during_replace == [0o600]
         assert _mode(target) == 0o600
 
-    def test_owner_only_existing_temp_is_preserved_and_target_is_not_created(
-        self, tmp_path
+    def test_owner_only_collision_uses_fresh_sibling_and_preserves_existing_temp(
+        self, tmp_path, monkeypatch
     ):
         target = tmp_path / "trust.json"
         temp = aw.unique_temp_path(target, hidden=True)
+        alternate = temp.with_name(f"{temp.name}.0123456789abcdef")
         sentinel = b"do-not-overwrite-this-temp"
         temp.write_bytes(sentinel)
+        written_paths: list[Path] = []
 
-        with pytest.raises(FileExistsError):
-            aw.replace_atomically(
-                temp,
-                target,
-                lambda path: path.write_bytes(b"replacement"),
-                owner_only=True,
+        monkeypatch.setattr(
+            secrets, "token_hex", lambda size: "0123456789abcdef"
+        )
+
+        def write(path: Path) -> None:
+            written_paths.append(path)
+            path.write_bytes(b"replacement")
+
+        aw.replace_atomically(temp, target, write, owner_only=True)
+
+        assert written_paths == [alternate]
+        assert temp.read_bytes() == sentinel
+        assert target.read_bytes() == b"replacement"
+        assert not alternate.exists()
+        if os.name == "posix":
+            assert _mode(target) == 0o600
+
+    def test_owner_only_collision_retry_is_bounded_and_preserves_unowned_paths(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        collisions: list[FileExistsError] = []
+        opened: list[Path] = []
+        writer_calls: list[Path] = []
+        cleanup_calls: list[Path] = []
+
+        monkeypatch.setattr(
+            secrets, "token_hex", lambda size: f"{len(opened):016x}"
+        )
+
+        def collide(path, flags, mode):
+            del flags, mode
+            opened.append(Path(path))
+            error = FileExistsError(
+                errno.EEXIST, f"collision-{len(opened)}", path
             )
+            collisions.append(error)
+            raise error
+
+        def record_unlink(self, *, missing_ok=False):
+            del missing_ok
+            cleanup_calls.append(self)
+
+        monkeypatch.setattr(aw.os, "open", collide)
+        monkeypatch.setattr(Path, "unlink", record_unlink)
+
+        with pytest.raises(FileExistsError) as exc_info:
+            aw.replace_atomically(temp, target, writer_calls.append, owner_only=True)
+
+        assert exc_info.value is collisions[-1]
+        assert len(opened) == 8
+        assert len(set(opened)) == 8
+        assert opened[0] == temp
+        assert all(candidate.parent == temp.parent for candidate in opened)
+        assert all(candidate.name.startswith(temp.name) for candidate in opened)
+        assert writer_calls == []
+        assert cleanup_calls == []
+        assert not target.exists()
+
+    def test_owner_only_alternate_writer_failure_cleans_only_owned_sibling(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        alternate = temp.with_name(f"{temp.name}.fedcba9876543210")
+        sentinel = b"unowned"
+        temp.write_bytes(sentinel)
+        monkeypatch.setattr(
+            secrets, "token_hex", lambda size: "fedcba9876543210"
+        )
+
+        def fail(path: Path) -> None:
+            assert path == alternate
+            path.write_bytes(b"partial")
+            raise RuntimeError("alternate writer failed")
+
+        with pytest.raises(RuntimeError, match="alternate writer failed"):
+            aw.replace_atomically(temp, target, fail, owner_only=True)
 
         assert temp.read_bytes() == sentinel
+        assert not alternate.exists()
         assert not target.exists()
 
     def test_owner_only_writer_failure_cleans_owned_temp(self, tmp_path):

--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -24,7 +24,10 @@ temp names (captured as the task's RED evidence) -- see TASK-17963.
 
 from __future__ import annotations
 
+import errno
 import json
+import os
+import stat
 import threading
 from pathlib import Path
 
@@ -44,6 +47,10 @@ N_ITERATIONS = 30
 _KNOWN_FIXTURE_ENTRIES = {"test_data"}
 
 
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
 def _stray_entries(tmp_path: Path, *exclude: Path) -> list[Path]:
     """Return unexpected entries directly under ``tmp_path``.
 
@@ -58,7 +65,9 @@ def _stray_entries(tmp_path: Path, *exclude: Path) -> list[Path]:
     ]
 
 
-def _run_concurrent(fn, *, n_threads: int = N_THREADS, n_iterations: int = N_ITERATIONS):
+def _run_concurrent(
+    fn, *, n_threads: int = N_THREADS, n_iterations: int = N_ITERATIONS
+):
     """Run ``fn(worker_id, i)`` from ``n_threads`` threads, ``n_iterations`` times
     each, and return every exception any call raised (empty list == clean run).
     """
@@ -179,6 +188,173 @@ class TestCleanupOnFailure:
             aw.write_bytes_atomic(target, b"payload")
 
         assert _stray_entries(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Owner-only temp creation: trust material can opt into exclusive 0o600 temp
+# creation without changing the long-standing behavior of default callers.
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerOnlyTempCreation:
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits required")
+    def test_owner_only_exclusively_opens_0o600_temp_before_real_replace(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        real_open = os.open
+        real_replace = Path.replace
+        open_calls: list[tuple[Path, int, int]] = []
+        mode_during_replace: list[int] = []
+
+        def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+            open_calls.append((Path(path), flags, mode))
+            if dir_fd is None:
+                return real_open(path, flags, mode)
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        def tracking_replace(self, other):
+            mode_during_replace.append(_mode(self))
+            return real_replace(self, other)
+
+        monkeypatch.setattr(aw.os, "open", tracking_open)
+        monkeypatch.setattr(Path, "replace", tracking_replace)
+
+        aw.replace_atomically(
+            temp,
+            target,
+            lambda path: path.write_text("secret", encoding="utf-8"),
+            owner_only=True,
+        )
+
+        temp_open_calls = [call for call in open_calls if call[0] == temp]
+        assert len(temp_open_calls) == 1
+        _, flags, requested_mode = temp_open_calls[0]
+        assert flags & os.O_CREAT
+        assert flags & os.O_EXCL
+        assert requested_mode == 0o600
+        assert mode_during_replace == [0o600]
+        assert _mode(target) == 0o600
+
+    def test_owner_only_existing_temp_is_preserved_and_target_is_not_created(
+        self, tmp_path
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        sentinel = b"do-not-overwrite-this-temp"
+        temp.write_bytes(sentinel)
+
+        with pytest.raises(FileExistsError):
+            aw.replace_atomically(
+                temp,
+                target,
+                lambda path: path.write_bytes(b"replacement"),
+                owner_only=True,
+            )
+
+        assert temp.read_bytes() == sentinel
+        assert not target.exists()
+
+    def test_owner_only_writer_failure_cleans_owned_temp(self, tmp_path):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+
+        def fail_after_precreate(path: Path) -> None:
+            assert path.exists()
+            path.write_bytes(b"partial")
+            raise RuntimeError("simulated owner-only writer failure")
+
+        with pytest.raises(RuntimeError, match="simulated owner-only writer failure"):
+            aw.replace_atomically(temp, target, fail_after_precreate, owner_only=True)
+
+        assert not temp.exists()
+        assert not target.exists()
+
+    def test_owner_only_replace_failure_is_preserved_and_cleans_temp(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        replace_error = OSError(errno.EIO, "simulated owner-only replace failure")
+
+        def fail_replace(self, other):
+            raise replace_error
+
+        monkeypatch.setattr(Path, "replace", fail_replace)
+
+        with pytest.raises(OSError) as exc_info:
+            aw.replace_atomically(
+                temp,
+                target,
+                lambda path: path.write_bytes(b"complete"),
+                owner_only=True,
+            )
+
+        assert exc_info.value is replace_error
+        assert not temp.exists()
+        assert not target.exists()
+
+    def test_default_replace_does_not_precreate_temp(self, tmp_path):
+        target = tmp_path / "ordinary.txt"
+        temp = aw.unique_temp_path(target)
+        existed_before_writer: list[bool] = []
+
+        def write(path: Path) -> None:
+            existed_before_writer.append(path.exists())
+            path.write_text("ordinary", encoding="utf-8")
+
+        aw.replace_atomically(temp, target, write)
+
+        assert existed_before_writer == [False]
+        assert target.read_text(encoding="utf-8") == "ordinary"
+        assert not temp.exists()
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file descriptors required")
+    def test_owner_only_fchmod_failure_closes_fd_and_cleans_temp(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "trust.json"
+        temp = aw.unique_temp_path(target, hidden=True)
+        real_open = os.open
+        real_fstat = os.fstat
+        real_close = os.close
+        captured_fds: list[int] = []
+
+        def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+            if dir_fd is None:
+                fd = real_open(path, flags, mode)
+            else:
+                fd = real_open(path, flags, mode, dir_fd=dir_fd)
+            if Path(path) == temp:
+                captured_fds.append(fd)
+            return fd
+
+        def fail_fchmod(fd, mode):
+            raise OSError(errno.EIO, "simulated fchmod failure")
+
+        monkeypatch.setattr(aw.os, "open", tracking_open)
+        monkeypatch.setattr(aw.os, "fchmod", fail_fchmod)
+
+        with pytest.raises(OSError, match="simulated fchmod failure"):
+            aw.replace_atomically(
+                temp,
+                target,
+                lambda path: path.write_bytes(b"must not run"),
+                owner_only=True,
+            )
+
+        assert len(captured_fds) == 1
+        fd = captured_fds[0]
+        try:
+            real_fstat(fd)
+        except OSError as exc:
+            assert exc.errno == errno.EBADF
+        else:
+            real_close(fd)
+            pytest.fail("owner-only temp file descriptor remained open")
+        assert not temp.exists()
+        assert not target.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -357,9 +533,13 @@ class TestSemanticsPreservation:
 
         original_replace_atomically = aw.replace_atomically
 
-        def spy_replace_atomically(temp_path, target_path, write_fn):
+        def spy_replace_atomically(
+            temp_path, target_path, write_fn, *, owner_only=False
+        ):
             observed_temp_names.append(temp_path.name)
-            return original_replace_atomically(temp_path, target_path, write_fn)
+            return original_replace_atomically(
+                temp_path, target_path, write_fn, owner_only=owner_only
+            )
 
         monkeypatch.setattr(
             trust_store_module, "replace_atomically", spy_replace_atomically

--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -298,9 +298,7 @@ class TestOwnerOnlyTempCreation:
         temp.write_bytes(sentinel)
         written_paths: list[Path] = []
 
-        monkeypatch.setattr(
-            secrets, "token_hex", lambda size: "0123456789abcdef"
-        )
+        monkeypatch.setattr(secrets, "token_hex", lambda size: "0123456789abcdef")
 
         def write(path: Path) -> None:
             written_paths.append(path)
@@ -325,16 +323,12 @@ class TestOwnerOnlyTempCreation:
         writer_calls: list[Path] = []
         cleanup_calls: list[Path] = []
 
-        monkeypatch.setattr(
-            secrets, "token_hex", lambda size: f"{len(opened):016x}"
-        )
+        monkeypatch.setattr(secrets, "token_hex", lambda size: f"{len(opened):016x}")
 
         def collide(path, flags, mode):
             del flags, mode
             opened.append(Path(path))
-            error = FileExistsError(
-                errno.EEXIST, f"collision-{len(opened)}", path
-            )
+            error = FileExistsError(errno.EEXIST, f"collision-{len(opened)}", path)
             collisions.append(error)
             raise error
 
@@ -366,9 +360,7 @@ class TestOwnerOnlyTempCreation:
         alternate = temp.with_name(f"{temp.name}.fedcba9876543210")
         sentinel = b"unowned"
         temp.write_bytes(sentinel)
-        monkeypatch.setattr(
-            secrets, "token_hex", lambda size: "fedcba9876543210"
-        )
+        monkeypatch.setattr(secrets, "token_hex", lambda size: "fedcba9876543210")
 
         def fail(path: Path) -> None:
             assert path == alternate

--- a/Tests/Skills/test_atomic_write_concurrency.py
+++ b/Tests/Skills/test_atomic_write_concurrency.py
@@ -197,16 +197,21 @@ class TestCleanupOnFailure:
 
 
 class TestOwnerOnlyTempCreation:
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits required")
+    @pytest.mark.skipif(
+        os.name != "posix" or not hasattr(os, "fchmod"),
+        reason="POSIX permission bits and fchmod required",
+    )
     def test_owner_only_exclusively_opens_0o600_temp_before_real_replace(
         self, tmp_path, monkeypatch
     ):
         target = tmp_path / "trust.json"
         temp = aw.unique_temp_path(target, hidden=True)
         real_open = os.open
+        real_fchmod = os.fchmod
         real_replace = Path.replace
         open_calls: list[tuple[Path, int, int]] = []
         mode_during_replace: list[int] = []
+        events: list[tuple[str, int]] = []
 
         def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
             open_calls.append((Path(path), flags, mode))
@@ -214,26 +219,37 @@ class TestOwnerOnlyTempCreation:
                 return real_open(path, flags, mode)
             return real_open(path, flags, mode, dir_fd=dir_fd)
 
+        def tracking_fchmod(fd, mode):
+            events.append(("fchmod", mode))
+            return real_fchmod(fd, mode)
+
+        def write(path: Path) -> None:
+            events.append(("writer", _mode(path)))
+            path.write_text("secret", encoding="utf-8")
+
         def tracking_replace(self, other):
             mode_during_replace.append(_mode(self))
             return real_replace(self, other)
 
         monkeypatch.setattr(aw.os, "open", tracking_open)
+        monkeypatch.setattr(aw.os, "fchmod", tracking_fchmod)
         monkeypatch.setattr(Path, "replace", tracking_replace)
 
         aw.replace_atomically(
             temp,
             target,
-            lambda path: path.write_text("secret", encoding="utf-8"),
+            write,
             owner_only=True,
         )
 
         temp_open_calls = [call for call in open_calls if call[0] == temp]
         assert len(temp_open_calls) == 1
         _, flags, requested_mode = temp_open_calls[0]
+        assert flags & os.O_ACCMODE == os.O_WRONLY
         assert flags & os.O_CREAT
         assert flags & os.O_EXCL
         assert requested_mode == 0o600
+        assert events == [("fchmod", 0o600), ("writer", 0o600)]
         assert mode_during_replace == [0o600]
         assert _mode(target) == 0o600
 
@@ -276,6 +292,8 @@ class TestOwnerOnlyTempCreation:
     ):
         target = tmp_path / "trust.json"
         temp = aw.unique_temp_path(target, hidden=True)
+        target_sentinel = b"existing-target-must-survive"
+        target.write_bytes(target_sentinel)
         replace_error = OSError(errno.EIO, "simulated owner-only replace failure")
 
         def fail_replace(self, other):
@@ -293,7 +311,7 @@ class TestOwnerOnlyTempCreation:
 
         assert exc_info.value is replace_error
         assert not temp.exists()
-        assert not target.exists()
+        assert target.read_bytes() == target_sentinel
 
     def test_default_replace_does_not_precreate_temp(self, tmp_path):
         target = tmp_path / "ordinary.txt"
@@ -310,7 +328,10 @@ class TestOwnerOnlyTempCreation:
         assert target.read_text(encoding="utf-8") == "ordinary"
         assert not temp.exists()
 
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX file descriptors required")
+    @pytest.mark.skipif(
+        os.name != "posix" or not hasattr(os, "fchmod"),
+        reason="POSIX file descriptors and fchmod required",
+    )
     def test_owner_only_fchmod_failure_closes_fd_and_cleans_temp(
         self, tmp_path, monkeypatch
     ):
@@ -336,25 +357,32 @@ class TestOwnerOnlyTempCreation:
         monkeypatch.setattr(aw.os, "open", tracking_open)
         monkeypatch.setattr(aw.os, "fchmod", fail_fchmod)
 
-        with pytest.raises(OSError, match="simulated fchmod failure"):
-            aw.replace_atomically(
-                temp,
-                target,
-                lambda path: path.write_bytes(b"must not run"),
-                owner_only=True,
-            )
-
-        assert len(captured_fds) == 1
-        fd = captured_fds[0]
         try:
-            real_fstat(fd)
-        except OSError as exc:
-            assert exc.errno == errno.EBADF
-        else:
-            real_close(fd)
-            pytest.fail("owner-only temp file descriptor remained open")
-        assert not temp.exists()
-        assert not target.exists()
+            with pytest.raises(OSError, match="simulated fchmod failure"):
+                aw.replace_atomically(
+                    temp,
+                    target,
+                    lambda path: path.write_bytes(b"must not run"),
+                    owner_only=True,
+                )
+
+            assert len(captured_fds) == 1
+            with pytest.raises(OSError) as exc_info:
+                real_fstat(captured_fds[0])
+            assert exc_info.value.errno == errno.EBADF
+            assert not temp.exists()
+            assert not target.exists()
+        finally:
+            for fd in captured_fds:
+                try:
+                    real_fstat(fd)
+                except OSError as exc:
+                    if exc.errno == errno.EBADF:
+                        continue
+                try:
+                    real_close(fd)
+                except OSError:
+                    pass
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Skills/test_skill_trust_permissions.py
+++ b/Tests/Skills/test_skill_trust_permissions.py
@@ -42,9 +42,21 @@ def _store(tmp_path: Path):
     )
 
 
-def test_snapshot_first_secures_store_snapshot_manifest_and_marker(tmp_path):
+def test_snapshot_first_secures_store_snapshot_manifest_and_marker(
+    tmp_path, monkeypatch
+):
     store, marker_path = _store(tmp_path)
     keys = derive_skill_trust_keys("passphrase", salt=b"p" * 32)
+    store.store_dir.mkdir()
+    store.store_dir.chmod(0o755)
+    observed_store_modes: list[int] = []
+    original_replace = Path.replace
+
+    def inspect_then_replace(self, other):
+        observed_store_modes.append(_mode(store.store_dir))
+        return original_replace(self, other)
+
+    monkeypatch.setattr(Path, "replace", inspect_then_replace)
 
     store.save_snapshot(
         "demo-1",
@@ -52,6 +64,9 @@ def test_snapshot_first_secures_store_snapshot_manifest_and_marker(tmp_path):
         keys,
         generation=1,
     )
+
+    assert observed_store_modes
+    assert observed_store_modes[0] == 0o700
 
     snapshot_path = store.snapshots_dir / "demo-1.json"
     assert _mode(store.store_dir) == 0o700

--- a/Tests/Skills/test_skill_trust_permissions.py
+++ b/Tests/Skills/test_skill_trust_permissions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Skills_Interop import skill_trust_store as trust_store_module
+from tldw_chatbook.Skills_Interop.skill_trust_crypto import derive_skill_trust_keys
+from tldw_chatbook.Skills_Interop.skill_trust_store import (
+    FileSkillTrustGenerationMarkerStore,
+    SkillTrustStore,
+)
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="POSIX mode-bit assertions")
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _manifest(generation: int) -> dict:
+    return {
+        "version": 1,
+        "generation": generation,
+        "skills": {},
+        "audit": [],
+    }
+
+
+def _store(tmp_path: Path):
+    trust_dir = tmp_path / "trust"
+    marker_path = trust_dir / "generation_marker.json"
+    marker = FileSkillTrustGenerationMarkerStore(
+        marker_path=marker_path,
+        store_dir=trust_dir,
+    )
+    return (
+        SkillTrustStore(store_dir=trust_dir, marker_store=marker),
+        marker_path,
+    )
+
+
+def test_snapshot_first_secures_store_snapshot_manifest_and_marker(tmp_path):
+    store, marker_path = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"p" * 32)
+
+    store.save_snapshot(
+        "demo-1",
+        {"files": {"SKILL.md": "# Demo"}},
+        keys,
+        generation=1,
+    )
+
+    snapshot_path = store.snapshots_dir / "demo-1.json"
+    assert _mode(store.store_dir) == 0o700
+    assert _mode(store.snapshots_dir) == 0o700
+    assert _mode(snapshot_path) == 0o600
+
+    store.save_manifest(_manifest(1), keys, salt=b"p" * 32)
+
+    assert _mode(store.manifest_path) == 0o600
+    assert _mode(marker_path) == 0o600
+
+
+def test_trust_temp_is_owner_only_before_replace(tmp_path, monkeypatch):
+    store, _ = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"q" * 32)
+    observed: list[tuple[str, int]] = []
+    observed_owner_only: list[bool] = []
+    original_replace = Path.replace
+    original_replace_atomically = trust_store_module.replace_atomically
+
+    def inspect_atomic_call(temp_path, target_path, write_fn, *, owner_only=False):
+        observed_owner_only.append(owner_only)
+        return original_replace_atomically(
+            temp_path,
+            target_path,
+            write_fn,
+            owner_only=owner_only,
+        )
+
+    def inspect_then_replace(self, other):
+        observed.append((self.name, _mode(self)))
+        return original_replace(self, other)
+
+    monkeypatch.setattr(trust_store_module, "replace_atomically", inspect_atomic_call)
+    monkeypatch.setattr(Path, "replace", inspect_then_replace)
+    store.save_manifest(_manifest(1), keys, salt=b"q" * 32)
+
+    assert observed
+    assert observed_owner_only
+    assert all(observed_owner_only)
+    assert all(name.startswith(".") for name, _ in observed)
+    assert all(mode == 0o600 for _, mode in observed)
+
+
+def test_trust_bytes_writer_requests_owner_only_creation(tmp_path, monkeypatch):
+    target = tmp_path / "trust" / "manifest-rollback.json"
+    observed_owner_only: list[bool] = []
+    original_replace_atomically = trust_store_module.replace_atomically
+
+    def inspect_atomic_call(temp_path, target_path, write_fn, *, owner_only=False):
+        observed_owner_only.append(owner_only)
+        return original_replace_atomically(
+            temp_path,
+            target_path,
+            write_fn,
+            owner_only=owner_only,
+        )
+
+    monkeypatch.setattr(trust_store_module, "replace_atomically", inspect_atomic_call)
+    trust_store_module._atomic_write_bytes(
+        target,
+        b"previous manifest bytes",
+        base_dir=target.parent,
+    )
+
+    assert observed_owner_only == [True]
+    assert _mode(target) == 0o600
+
+
+def test_next_write_tightens_legacy_files_and_directories(tmp_path):
+    store, marker_path = _store(tmp_path)
+    keys = derive_skill_trust_keys("passphrase", salt=b"r" * 32)
+    snapshot_path = store.snapshots_dir / "demo-1.json"
+
+    store.save_snapshot("demo-1", {"files": {}}, keys, generation=1)
+    store.save_manifest(_manifest(1), keys, salt=b"r" * 32)
+
+    for directory in (store.store_dir, store.snapshots_dir):
+        directory.chmod(0o755)
+    for path in (snapshot_path, store.manifest_path, marker_path):
+        path.chmod(0o666)
+
+    store.save_snapshot("demo-1", {"files": {}}, keys, generation=2)
+    store.save_manifest(_manifest(2), keys)
+
+    assert _mode(store.store_dir) == 0o700
+    assert _mode(store.snapshots_dir) == 0o700
+    assert _mode(snapshot_path) == 0o600
+    assert _mode(store.manifest_path) == 0o600
+    assert _mode(marker_path) == 0o600

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5711,3 +5711,18 @@ that you inferred from reading rather than from running. In a P0 data-integrity
 file, a false incident in a comment is worse than no comment — future
 maintainers will trust it, and this repo's own standard is "state the incident,
 not just the rule", which only works if the incident is real.
+## An interrupted pytest run leaves stale later-suite nodes in `lastfailed` (TASK-19520, 2026-08-21)
+
+**Incident.** A repository-wide run was interrupted when its verification
+scope was narrowed after 2h26m. Pytest reported 272 current failures/errors,
+but `.pytest_cache/v/cache/lastfailed` contained 301 keys: the 272 nodes seen
+by the interrupted run plus 29 failures from an earlier completed Skills
+gate that the broad run had not reached. Treating every cache key as current
+would have double-counted stale evidence and filed misleading tasks.
+
+**Rule.** For an interrupted run, preserve both `lastfailed` and the collected
+`nodeids`, record the last node the session actually reached, and partition
+cache keys by collection position. Keys after the cutoff are prior-session
+evidence unless independently reproduced. Keep the run's final pytest counts
+as the accounting authority; the cache is a node-name recovery aid, not a
+self-contained result report.

--- a/backlog/docs/task-19520-verification-failure-inventory.md
+++ b/backlog/docs/task-19520-verification-failure-inventory.md
@@ -1,0 +1,586 @@
+# TASK-19520 verification inventory (evidence-only)
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-19520-trust-permissions`
+
+HEAD: `ca4a03eb820a124651ce0958d67c3abc42b36970`
+
+Preserved exact-node artifacts:
+
+- `/tmp/task-19520-verification-lastfailed.json` — 301 exact node IDs.
+- `/tmp/task-19520-verification-nodeids.json` — collection order used to separate the interrupted run from stale completed-Skills failures.
+
+Partition rule:
+
+- Current partial full-suite nodes: every `lastfailed` key whose index in `nodeids` is at or before index `28213`, the node `Tests/Skills/test_project_skills_import_modal.py::test_never_during_inflight_import_is_inert`. Count: **272**.
+- Completed Skills-gate nodes: the 29 `lastfailed` keys after that cutoff, all in `Tests/Skills/test_skills_import.py` or `Tests/Skills/test_skills_library_flow.py`. Count: **29**.
+
+The interrupted run ended with: **256 failed, 27,926 passed, 217 skipped, 1 xfailed, 16 errors, 205 warnings in 8,808.04s (2:26:48)**. It is partial evidence only.
+
+## Completed Skills gate — Library shell/readiness fixture drift (29 failures)
+
+Evidence class: completed `Tests/Skills/ -q` gate.
+
+Count: **29**.
+
+Confidence: **high** for the observed shared symptom; **medium** for one common root cause across all 29.
+
+Representative captured traceback: `textual.css.query.NoMatches: No nodes match '#library-row-browse-skills' on LibraryScreen()` from `test_import_real_superpowers_skills_lands_trust_pending`. Captured background logs also repeatedly show `ValueError: Local quiz backend is unavailable` while Library composition/readiness is incomplete. The failures are confined to the import and Library-flow UI harnesses, not trust-permission assertions.
+
+Already represented: `TASK-16236` (“Repair Skills full-suite contract fixtures”, Done) covers the same general fixture-contract class, so this is a recurrence/new drift rather than an untracked class.
+
+Exact nodes:
+
+1. `Tests/Skills/test_skills_import.py::test_import_real_superpowers_skills_lands_trust_pending`
+2. `Tests/Skills/test_skills_import.py::test_import_skill_via_skill_md_file_path_derives_name_from_parent_directory`
+3. `Tests/Skills/test_skills_import.py::test_loose_file_import_success_line_names_the_service_derived_skill`
+4. `Tests/Skills/test_skills_import.py::test_import_skill_with_supporting_reference_file_threads_it_through`
+5. `Tests/Skills/test_skills_import.py::test_import_skill_with_extra_frontmatter_fields_applies_recognized_and_drops_unknown`
+6. `Tests/Skills/test_skills_import.py::test_reimporting_the_same_skill_name_is_skipped_not_duplicated`
+7. `Tests/Skills/test_skills_import.py::test_import_row_reports_missing_skill_md_and_unknown_path_gracefully`
+8. `Tests/Skills/test_skills_import.py::test_import_row_rejects_name_too_long_without_partial_state`
+9. `Tests/Skills/test_skills_import.py::test_import_row_rejects_oversized_content_without_partial_state`
+10. `Tests/Skills/test_skills_import.py::test_import_row_imports_nested_reference_subfolder`
+11. `Tests/Skills/test_skills_import.py::test_import_row_url_routes_to_remote_install_and_primes_review`
+12. `Tests/Skills/test_skills_import.py::test_import_row_url_remote_skill_error_becomes_status_line`
+13. `Tests/Skills/test_skills_import.py::test_import_row_url_generic_failure_uses_classified_name_guess`
+14. `Tests/Skills/test_skills_library_flow.py::test_saving_a_trusted_skill_warns_and_requeues_needs_review`
+15. `Tests/Skills/test_skills_library_flow.py::test_trust_panel_review_then_approve_moves_skill_to_available`
+16. `Tests/Skills/test_skills_library_flow.py::test_skill_editor_canvas_scrolls_trust_panel_into_view`
+17. `Tests/Skills/test_skills_library_flow.py::test_uninitialized_trust_shows_setup_state_and_bootstrap_enables_approve_flow`
+18. `Tests/Skills/test_skills_library_flow.py::test_already_bootstrapped_store_never_shows_setup_state`
+19. `Tests/Skills/test_skills_library_flow.py::test_uninitialized_trust_store_list_still_shows_needs_review_glyph`
+20. `Tests/Skills/test_skills_library_flow.py::test_delete_skill_returns_to_list_and_decrements_count`
+21. `Tests/Skills/test_skills_library_flow.py::test_skill_editor_opens_under_real_runtime_policy_enforcer`
+22. `Tests/Skills/test_skills_library_flow.py::test_library_shell_create_skill_row_opens_blank_editor`
+23. `Tests/Skills/test_skills_library_flow.py::test_library_shell_create_skill_save_creates_and_increments_count`
+24. `Tests/Skills/test_skills_library_flow.py::test_library_shell_create_skill_save_invalid_name_shows_classify_outcome`
+25. `Tests/Skills/test_skills_library_flow.py::test_library_shell_create_skill_save_arrives_needs_review_with_panel_primed`
+26. `Tests/Skills/test_skills_library_flow.py::test_delete_cancel_preserves_edits_typed_during_confirm`
+27. `Tests/Skills/test_skills_library_flow.py::test_derived_flag_cleared_when_snapshotting_populated_description`
+28. `Tests/Skills/test_skills_library_flow.py::test_orphaned_manifest_is_one_click_resetup`
+29. `Tests/Skills/test_skills_library_flow.py::test_list_mode_unlock_refreshes_snapshot_not_just_posture`
+
+Result: **29 failed, 441 passed, 5 warnings in 106.68s**.
+
+## Current partial-run groups (272 nodes total)
+
+All exact nodes are in `/tmp/task-19520-verification-lastfailed.json`; use the cutoff above to exclude the 29 later Skills-gate nodes. Counts below account for all 272 current nodes exactly.
+
+### 1. Sandbox-denied loopback listener setup (2 errors)
+
+Count: **2 errors**. Confidence: **high**.
+
+Representative traceback: `_DeepBacklogHTTPServer(("127.0.0.1", 0), ...)` reaches `socket.bind` and raises `PermissionError: [Errno 1] Operation not permitted`.
+
+Exact nodes:
+
+- `Tests/Chat/test_console_provider_gateway.py::test_owned_http_client_survives_agent_bridge_style_loop_swap`
+- `Tests/Chat/test_console_provider_gateway.py::test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop`
+
+Already represented: `TASK-15111` owns the test network/loopback marker contract; `TASK-16276` notes the same sandbox-only bind signature. Both are Done.
+
+### 2. RAG embedding initialization escapes offline fixtures (13 errors)
+
+Count: **13 errors**. Confidence: **high**.
+
+Representative traceback: `_no_network_io` teardown raises because background initialization calls `socket.create_connection -> huggingface.co:443` twice while `sentence-transformers/all-MiniLM-L6-v2` requests `config.json`; the Hugging Face client catches the blocked `OSError` and schedules a retry, so the guard reports the swallowed attempt at teardown.
+
+Exact nodes: the 12 current keys under `Tests/RAG/` and `Tests/RAG_Search/test_embeddings_performance.py::TestEmbeddingPerformance::test_real_model_performance` in the preserved artifact.
+
+Already represented: `TASK-16232`, `TASK-16276`, and `TASK-16198` document/fix the same offline-fixture/teardown-egress class; all are Done, so this is a broad recurrence.
+
+### 3. STT task-602 platform smoke setup/call error (1 error)
+
+Count: **1 error**. Confidence: **low** on root cause because the tool return omitted this traceback.
+
+Exact node: `Tests/STT/test_task602_platform_smoke.py::test_run_smoke_returns_only_bounded_allowlisted_observations`.
+
+Representative evidence: exact node and error status are preserved, but its traceback fell inside the truncated section. No focused rerun was performed after the stop instruction.
+
+Already represented: TASK-602 design/evidence documents this smoke, but no matching open failure task was found by text search.
+
+### 4. Console/Chat controller and harness failures (94 failures)
+
+Count: **94 failures**. Confidence: **medium** that several fixture/API drift clusters exist; **low** that all 94 share one cause.
+
+Exact-node selector: current artifact keys under `Tests/Chat/`, excluding the two `test_console_provider_gateway.py` errors above.
+
+File clusters:
+
+- 40 `test_console_generation_actions.py`
+- 19 `test_console_h3_image_edit.py`
+- 10 `test_kimi_zai_native_tools.py`
+- 8 `test_qwencloud_native_tools.py`
+- 4 `test_console_video_actions.py`
+- 3 `test_console_fleet_wake_safety.py`
+- 2 `test_console_skill_script_confirm.py`
+- 1 each in attachment riders (2 nodes total), diff feedback, headless wake, local review hook, provider failure copy, stop reliability, and Kimi/Z.ai provider contract
+
+Representative emitted summaries: generation-action routing/state assertions, H3 refusal/cancellation/persistence ordering, and hosted-native continuation/tool-history assertions. Their individual tracebacks were in the truncated portion, so a single root cause cannot be asserted from this run.
+
+Already represented: `TASK-2769`/`TASK-2780` (Done) cover earlier `test_console_generation_actions.py` fixture drift; `TASK-18605` (In Progress) covers continuation/H3/skill-confirm stale guards. The current set is much broader than those tasks.
+
+### 5. LLM transport/realtime contract failures (61 failures)
+
+Count: **61 failures**. Confidence: **medium** by file-local clustering; **low** on a single shared cause.
+
+Exact-node selector: current artifact keys under `Tests/LLM_Calls/`.
+
+File clusters:
+
+- 34 `test_openai_realtime_session.py`
+- 15 `test_hosted_chat.py`
+- 10 `test_qwencloud.py`
+- 2 `test_summarization_diagnostic_privacy.py`
+
+Representative emitted summaries: nearly the entire scripted realtime session contract, owned JSON/SSE retry and redaction behavior, QwenCloud retry/global-budget behavior, and diagnostic-manifest boundary checks. Tracebacks were truncated. The all-file breadth is consistent with fake-transport/fixture setup drift, but that is inference only.
+
+Already represented: realtime testing has `TASK-14876` (To Do, xdist serialization), `TASK-19160` (Done), `TASK-2362` (Done), and `TASK-14811.6`; none exactly accounts for this 34-node local-run cluster from the preserved evidence alone.
+
+### 6. Managed model-artifact acquisition failures (54 failures)
+
+Count: **54 failures**. Confidence: **medium** that local HTTP/acquisition fixture setup is shared across many; **low** without tracebacks.
+
+Exact-node selector: current artifact keys under `Tests/Model_Artifacts/`.
+
+File clusters:
+
+- 12 `test_stream_fetch.py`
+- 10 `test_provision_fetch.py`
+- 9 `test_source_map.py`
+- 8 `test_preflight.py`
+- 6 `test_provision_install.py`
+- 6 `test_credentials_and_boundaries.py`
+- 3 `test_provision_crash_recovery.py`
+
+Representative emitted summaries cover local/cross-origin fetch, range resume, preflight, install/finalize, credential withholding, and crash recovery. No common traceback survived truncation. The run-end FD sentinel reported growth from 25 to 981 descriptors (+956), a cross-cutting contamination signal that may affect this HTTP-heavy family; it is not proof of causation.
+
+Already represented: `TASK-1692`, `TASK-1695`, `TASK-1696`, and `TASK-1720` cover individual artifact-contract changes; no single existing task found covers this full cluster.
+
+### 7. Database/schema/owner failures (13 failures)
+
+Count: **13 failures**. Confidence: **high** for the two stale schema-head assertions; **medium/low** for the other 11.
+
+Exact-node selector: current artifact keys under `Tests/DB/`, `Tests/ChaChaNotesDB/`, and `Tests/Media_DB/`.
+
+Breakdown:
+
+- 6 `test_core_sqlite_owner_privacy.py`
+- 3 ChaChaNotesDB index/persona migration nodes
+- 2 explicit stale-v40 nodes: `test_current_schema_version_is_40` and `test_fresh_db_lands_on_v40_with_the_annotations_table`
+- 1 live-schema table census and 1 media DB migration/reopen node
+
+Representative evidence: production `_CURRENT_SCHEMA_VERSION` is 42 while two tests explicitly assert v40. `TASK-19053` shipped v41 and `TASK-16320` shipped v42; `TASK-19044` is the prior Done task for this exact moving-literal class.
+
+### 8. Packaging/install-distribution failures (7 failures)
+
+Count: **7 failures**. Confidence: **medium** by file cluster; **low** on a common cause.
+
+Exact-node selector: current artifact keys under `Tests/Packaging/`.
+
+- 5 installed-distribution nodes
+- 2 MCP unified wheel/sdist nodes
+
+Representative emitted summaries include v35-to-current migration, immutable assets/loaders, Samira seeding, and isolated MCP extras. Tracebacks were truncated.
+
+Already represented: `TASK-19044` (Done) covered prior installed migration/package-data drift; this run includes the renamed current-version nodes, so it is not the old literal itself.
+
+### 9. MCP watchlists/provider failures (5 failures)
+
+Count: **5 failures**. Confidence: **medium** that watchlists storage/service contract drift is shared.
+
+Exact-node selector: current artifact keys under `Tests/MCP/`.
+
+Representative emitted summaries: real watchlists provider structured outcomes, unexpected-failure scrubbing, off-loop database resolution, storage-lazy registration, and resolver replacement/close ordering. Tracebacks were truncated.
+
+### 10. LLM Management MLX fixture failures (4 failures)
+
+Count: **4 failures**. Confidence: **high** that all four share the `test_mlx_lm.py` fixture/config path; root cause traceback unavailable.
+
+Exact-node selector: current artifact keys under `Tests/LLM_Management/`.
+
+### 11. Startup performance policy failures (4 failures)
+
+Count: **4 failures**. Confidence: **high** that the citation reconciliation/migration policy pair is shared; root cause traceback unavailable.
+
+Exact-node selector: current artifact keys under `Tests/Performance/`.
+
+### 12. Remaining bounded families (14 failures)
+
+Count: **14 failures**. Confidence varies; exact nodes are preserved and are intentionally not collapsed into a fabricated common cause.
+
+- 2 RAG_Search functional failures (`test_fts5_match_forms_shared.py`, `test_reranker_system_prompt.py`)
+- 2 architecture ratchets (persistent diagnostic inventory, chat-screen size budget)
+- 2 chunking failures (tokenizer override, CJK token parity)
+- 2 localhost Parakeet artifact failures under `Tests/Local_Ingestion/`
+- 1 each under Agents, Evals, Internal_Prompts, Persona_Visual, RuntimePolicy, and Skills
+
+The six named one-node domains plus the four two-node families account for all 14. Tracebacks were truncated; each should be triaged from its preserved exact node rather than inferred from the count.
+
+## Backlog mapping
+
+The inventory is fully assigned as follows. Counts are node counts, including setup/teardown errors.
+
+| Coverage | Nodes | Backlog task |
+| --- | ---: | --- |
+| Skills import and Library flow | 29 | `TASK-19642.1` |
+| Project Skills import-modal session contamination | 1 | `TASK-19642.27` |
+| Provider-gateway loopback setup | 2 | `TASK-19642.2` |
+| RAG embedding egress/teardown | 13 | `TASK-19642.3` |
+| STT task-602 smoke | 1 | `TASK-19642.4` |
+| Console generation actions | 40 | `TASK-19642.5` |
+| Console H3 image editing | 19 | `TASK-19642.6` |
+| Kimi, Z.ai, and QwenCloud native-tool continuations | 19 | `TASK-19642.7` |
+| Attachment save-toast escaping | 2 | `TASK-19642.8.1` |
+| Video action routing and save behavior | 4 | `TASK-19642.8.2` |
+| Fleet and headless wake authority | 4 | `TASK-19642.8.3` |
+| Skill-confirm bridge wiring | 2 | `TASK-19642.8.4` |
+| Diff-feedback payload identity | 1 | `TASK-19642.8.5` |
+| Local-review root-swap confinement | 1 | `TASK-19642.8.6` |
+| Provider failure recovery copy | 1 | `TASK-19642.8.7` |
+| Stop content freeze | 1 | `TASK-19642.8.8` |
+| OpenAI realtime sessions | 34 | `TASK-19642.9` |
+| Hosted-chat and QwenCloud transports | 25 | `TASK-19642.10` |
+| Model-artifact transfer, source maps, and credentials | 37 | `TASK-19642.11` |
+| Model-artifact preflight, install, and recovery | 17 | `TASK-19642.12` |
+| ChaChaNotes schema, migration, and census | 6 | `TASK-19642.13` |
+| Media DB v2 migration reopen | 1 | `TASK-19642.28` |
+| SQLite owner privacy | 6 | `TASK-19642.14` |
+| Installed distribution and MCP packaging | 7 | `TASK-19642.15` |
+| MCP watchlists provider | 5 | `TASK-19642.16` |
+| MLX management fixtures | 4 | `TASK-19642.17` |
+| Startup reconciliation policy | 4 | `TASK-19642.18` |
+| FTS5 inflection search parity | 1 | `TASK-19642.19.1` |
+| Local reranker system-prompt cardinality | 1 | `TASK-19642.19.2` |
+| Persistent diagnostic inventory | 1 | `TASK-19642.20` |
+| V2 chunker tokenizer override | 1 | `TASK-19642.21.1` |
+| CJK token chunking golden parity | 1 | `TASK-19642.21.2` |
+| Parakeet v2 local artifacts | 2 | `TASK-19642.22` |
+| Tool-catalog snapshot concurrency | 1 | `TASK-19642.23` |
+| Character-probe import boundary | 1 | `TASK-19642.24` |
+| Websearch prompt parity | 1 | `TASK-19642.25` |
+| Persona visual publication bounds | 1 | `TASK-19642.26` |
+| Summarization diagnostic boundary | 2 | existing `TASK-18801` |
+| Chat screen size ratchet | 1 | existing `TASK-3070` / `TASK-3070.11` |
+| Server-client provider migration audit | 1 | existing `TASK-18610` AC 6 |
+| **Total** | **301** | `TASK-19642` parent tracker |
+
+## Cross-cutting contamination signal
+
+The run-end sentinel reported **open file descriptors grew by 956** (`start=25`, `end=981`, limit 200). This is evidence of session contamination and may explain later HTTP/socket-heavy cascades, but the interrupted run did not bisect the owning test. Do not assign downstream failures to TASK-19520 or to the FD leak without a clean identical baseline/focused reproduction.
+
+## TASK-19520 focused and mutation evidence
+
+### Mutation RED evidence (all restored immediately)
+
+1. JSON trust writer: changed only `_atomic_write_json` to pass `owner_only=False`; `test_trust_temp_is_owner_only_before_replace` failed at `assert all(observed_owner_only)`, observed `[False, False]`. **1 failed in 0.67s**.
+2. Bytes trust writer: changed only `_atomic_write_bytes` to pass `owner_only=False`; `test_trust_bytes_writer_requests_owner_only_creation` failed at `[False] == [True]`. **1 failed in 0.63s**.
+3. Directory guard: disabled POSIX directory chmod; `test_next_write_tightens_legacy_files_and_directories` failed with `493 == 448` (`0o755` vs `0o700`). **1 failed in 0.63s**.
+4. Shared fchmod ordering: omitted `os.fchmod`; `test_owner_only_exclusively_opens_0o600_temp_before_real_replace` failed because events were only `[("writer", 384)]`, not `[("fchmod", 384), ("writer", 384)]`. **1 failed in 0.54s**.
+5. Descriptor-close handling: omitted `os.close`; `test_owner_only_close_failure_after_setup_propagates_close_error` failed with `DID NOT RAISE OSError`. **1 failed in 0.55s**.
+
+`git diff --exit-code` was clean after every restoration.
+
+### Focused GREEN evidence
+
+- `python -m pytest Tests/Skills/test_atomic_write_concurrency.py::TestOwnerOnlyTempCreation -q`: **8 passed, 1 warning in 0.67s**.
+
+These tests pin exclusive `0o600` creation, fchmod-before-writer ordering, EEXIST preservation, writer/replace failure cleanup, descriptor closure, close-error precedence, and unchanged default behavior.
+
+### Static evidence
+
+- Ruff check on the four task files: **All checks passed**.
+- Ruff format `--check` on the four task files: **4 files already formatted**.
+- `git diff --check`: pass.
+- Final `git status --short`: empty.
+- Final `git diff --exit-code`: exit 0.
+
+## Security self-review
+
+- Diff scope is four files: shared atomic helper, trust store, and two Skills test files.
+- Direct-call inventory confirms only `_atomic_write_json` and `_atomic_write_bytes` in the trust store opt into `owner_only=True`; ordinary shared text/bytes atomic writers keep default behavior.
+- `O_EXCL` failure occurs before ownership is claimed, so an unexplained existing temp is preserved.
+- Created descriptors close on setup success and failure; fchmod occurs before close and before the writer callback.
+- Trust root is secured before snapshot-directory creation; snapshot directory is secured before publication.
+- POSIX directory chmod and fchmod are guarded; non-POSIX creation keeps portable open semantics without requiring chmod.
+- ACL/mount, same-UID, root/admin, and Windows ACL limits remain documentation only; no unsupported security boundary is claimed.
+- No secrets, logs, user data, or ordinary skill writes are changed.
+
+## Permanent exact-node appendix for the interrupted run
+
+The 272 current partial-run nodes are JSON-quoted below so parameterized IDs containing newlines remain unambiguous. The 29 completed Skills-gate nodes are already enumerated above.
+
+```text
+"Tests/Agents/test_tool_catalog_concurrency.py::test_invoke_by_name_takes_exactly_one_catalog_snapshot"
+"Tests/Architecture/test_persistent_diagnostic_inventory.py::test_production_diagnostic_inventory_and_sink_topology_are_unchanged"
+"Tests/Architecture/test_screen_size_ratchet.py::test_screen_does_not_grow_past_its_budget[tldw_chatbook/UI/Screens/chat_screen.py]"
+"Tests/ChaChaNotesDB/test_index_census.py::TestChachanotesIndexCensusMatchesLiveSchema::test_no_unexpected_indexes[chain_migrated_from_v4]"
+"Tests/ChaChaNotesDB/test_index_census.py::TestChachanotesIndexCensusMatchesLiveSchema::test_no_unexpected_indexes[fresh_bootstrap]"
+"Tests/ChaChaNotesDB/test_persona_visual_migration.py::test_real_v40_upgrade_installs_separate_persona_visual_schema"
+"Tests/Chat/test_console_attachment_riders.py::TestSaveImageToastEscaping::test_multi_save_toast_escapes_path"
+"Tests/Chat/test_console_attachment_riders.py::TestSaveImageToastEscaping::test_single_save_toast_escapes_path"
+"Tests/Chat/test_console_diff_feedback_delivery.py::test_no_pending_notes_leaves_payload_byte_identical"
+"Tests/Chat/test_console_fleet_wake_safety.py::test_a_wake_defers_behind_a_pending_card_and_cannot_resolve_it"
+"Tests/Chat/test_console_fleet_wake_safety.py::test_a_wake_dispatches_run_reply_under_the_same_authority_as_manual"
+"Tests/Chat/test_console_fleet_wake_safety.py::test_a_woken_turns_gated_tool_still_raises_the_approval_card"
+"Tests/Chat/test_console_generation_actions.py::test_browse_clamps_at_boundaries"
+"Tests/Chat/test_console_generation_actions.py::test_browse_next_then_previous_mutates_screen_state_only"
+"Tests/Chat/test_console_generation_actions.py::test_browse_noop_for_single_variant_message"
+"Tests/Chat/test_console_generation_actions.py::test_dispatch_console_command_blocks_generate_image_when_ephemeral"
+"Tests/Chat/test_console_generation_actions.py::test_failed_speech_clears_on_any_next_message_action"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_no_prompt_kill_switch_off_skips_llm_path"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_no_prompt_llm_call_raises_falls_back"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_no_prompt_llm_empty_response_falls_back"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_no_prompt_llm_timeout_falls_back"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_no_prompt_uses_llm_composed_context_end_to_end"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_prompt_present_never_resolves_llm_context"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_restores_draft_when_batch_raises"
+"Tests/Chat/test_console_generation_actions.py::test_generate_image_handler_threads_prepared_fields_into_batch"
+"Tests/Chat/test_console_generation_actions.py::test_h3_edit_regenerate_refuses_before_capacity_or_inflight_checks"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_blocks_generation_regenerate_when_ephemeral"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_does_not_forge_user_speech_snapshot"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_posts_store_issued_speech_snapshot"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_routes_keep_button_for_generation_message"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_routes_regenerate_for_generation_message"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_routes_speak_for_generation_message"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_routes_speak_stop_to_tts_playback_event"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_routes_variant_next_for_generation_message"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_speak_marks_message_as_speaking"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_speak_stop_does_not_clear_other_message"
+"Tests/Chat/test_console_generation_actions.py::test_handle_console_message_action_speak_stop_safe_when_nothing_speaking"
+"Tests/Chat/test_console_generation_actions.py::test_keep_evicts_stale_render_cache_entries_so_rebuild_shows_kept_variant"
+"Tests/Chat/test_console_generation_actions.py::test_keep_noop_when_browsed_index_is_zero"
+"Tests/Chat/test_console_generation_actions.py::test_keep_reorders_store_and_resets_browse"
+"Tests/Chat/test_console_generation_actions.py::test_llm_context_options_disabled_by_kill_switch"
+"Tests/Chat/test_console_generation_actions.py::test_llm_context_options_provider_not_ready"
+"Tests/Chat/test_console_generation_actions.py::test_llm_context_options_resolution_exception_degrades_gracefully"
+"Tests/Chat/test_console_generation_actions.py::test_llm_context_options_resolves_ready_provider"
+"Tests/Chat/test_console_generation_actions.py::test_real_handler_stop_order_settles_and_notifies_once"
+"Tests/Chat/test_console_generation_actions.py::test_regenerate_failure_leaves_message_untouched_and_reports_error"
+"Tests/Chat/test_console_generation_actions.py::test_regenerate_refused_at_cap"
+"Tests/Chat/test_console_generation_actions.py::test_regenerate_refused_while_inflight"
+"Tests/Chat/test_console_generation_actions.py::test_regenerate_success_appends_variant_and_browses_to_new_index"
+"Tests/Chat/test_console_generation_actions.py::test_regenerate_success_inherits_style_from_position_zero_meta"
+"Tests/Chat/test_console_generation_actions.py::test_rejected_owned_stop_retains_lifecycle_for_retry"
+"Tests/Chat/test_console_generation_actions.py::test_rejected_stop_post_does_not_claim_stopped"
+"Tests/Chat/test_console_h3_image_edit.py::test_app_owned_task_cancellation_drains_linearized_runner_before_reraise[cancel]"
+"Tests/Chat/test_console_h3_image_edit.py::test_app_owned_task_cancellation_drains_linearized_runner_before_reraise[success]"
+"Tests/Chat/test_console_h3_image_edit.py::test_failure_guidance_persistence_error_falls_back_without_masking_primary[after_append-expected_attempts1]"
+"Tests/Chat/test_console_h3_image_edit.py::test_failure_guidance_persistence_error_falls_back_without_masking_primary[before_append-expected_attempts0]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_canonical_validation_performs_the_only_full_source_decode"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_command_uses_raw_instruction_one_memory_image_and_count_one"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_oversize_source_is_rejected_before_decode_or_dispatch"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui @anime change it-pendings1]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui change it-pendings2]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui change it-pendings3]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui change it-pendings4]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui change it-pendings5]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_refusals_happen_before_generic_preparation_or_generation[:comfyui-pendings0]"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_source_header_read_runs_off_loop_while_pump_remains_responsive"
+"Tests/Chat/test_console_h3_image_edit.py::test_h3_warning_band_is_rejected_by_canonical_ceiling_before_full_decode"
+"Tests/Chat/test_console_h3_image_edit.py::test_persistence_failure_retains_source_and_emits_sanitized_copy"
+"Tests/Chat/test_console_h3_image_edit.py::test_postcommit_consume_exception_keeps_success_and_logs_only_type"
+"Tests/Chat/test_console_h3_image_edit.py::test_stop_before_adapter_success_is_expected_and_retains_source"
+"Tests/Chat/test_console_h3_image_edit.py::test_terminal_generation_never_syncs_stale_origin_screen"
+"Tests/Chat/test_console_headless_wake_invariants.py::test_a_headless_wake_takes_the_same_agent_dispatch_and_budget"
+"Tests/Chat/test_console_local_review_hook.py::test_selected_root_swap_fails_closed_before_local_invoke"
+"Tests/Chat/test_console_provider_failure_copy.py::test_agent_failure_row_carries_body_and_image_recovery_hint"
+"Tests/Chat/test_console_provider_gateway.py::test_active_http_client_concurrent_swap_never_leaves_client_bound_to_wrong_loop"
+"Tests/Chat/test_console_provider_gateway.py::test_owned_http_client_survives_agent_bridge_style_loop_swap"
+"Tests/Chat/test_console_skill_script_confirm.py::test_confirm_callback_absent_from_bridge_when_no_ui_sink_wired"
+"Tests/Chat/test_console_skill_script_confirm.py::test_confirm_callback_present_when_ui_sink_wired"
+"Tests/Chat/test_console_stop_reliability.py::test_stop_freezes_message_content_at_stop_point"
+"Tests/Chat/test_console_video_actions.py::test_handle_console_message_action_routes_video_play_with_persisted_storage_id"
+"Tests/Chat/test_console_video_actions.py::test_handle_console_message_action_routes_video_save_with_persisted_storage_id"
+"Tests/Chat/test_console_video_actions.py::test_video_play_resolves_webm_from_metadata"
+"Tests/Chat/test_console_video_actions.py::test_video_save_copy_preserves_webm_extension_and_collision_names"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_console_runs_two_native_calls_with_private_continuation[moonshot]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_console_runs_two_native_calls_with_private_continuation[zai]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_invalid_tool_history_fails_before_server_advancement[duplicate_ids-moonshot]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_invalid_tool_history_fails_before_server_advancement[duplicate_ids-zai]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_invalid_tool_history_fails_before_server_advancement[out_of_order-moonshot]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_invalid_tool_history_fails_before_server_advancement[out_of_order-zai]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_partial_call_cancellation_never_executes[moonshot]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_partial_call_cancellation_never_executes[zai]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_tool_error_continues_structurally[moonshot]"
+"Tests/Chat/test_kimi_zai_native_tools.py::test_hosted_tool_error_continues_structurally[zai]"
+"Tests/Chat/test_kimi_zai_provider_contract.py::test_streaming_adapter_carries_terminal_candidate_into_model_turn"
+"Tests/Chat/test_qwencloud_native_tools.py::test_console_agent_bridge_runs_qwencloud_two_call_continuation[chat_completions]"
+"Tests/Chat/test_qwencloud_native_tools.py::test_console_agent_bridge_runs_qwencloud_two_call_continuation[responses]"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_partial_call_cancellation_never_executes[chat_completions]"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_partial_call_cancellation_never_executes[responses]"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_responses_joined_runtime_history_pairs_out_of_order_results"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_responses_usage_enforces_agent_budget"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_tool_error_continues_structurally[chat_completions]"
+"Tests/Chat/test_qwencloud_native_tools.py::test_qwencloud_tool_error_continues_structurally[responses]"
+"Tests/Chunking/test_chunker_v2.py::TestV2Chunker::test_process_text_tokenizer_override"
+"Tests/Chunking/test_golden_parity.py::test_golden_parity[tokens-cjk]"
+"Tests/DB/test_chachanotes_default_assistant_enrichment_migration.py::test_current_schema_version_is_40"
+"Tests/DB/test_chachanotes_transcript_annotations_migration.py::test_fresh_db_lands_on_v40_with_the_annotations_table"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_core_owner_rejects_unsafe_namespace_before_raw_sqlite[media-missing_parent]"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_core_owner_rejects_unsafe_namespace_before_raw_sqlite[media-symlink_parent]"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_core_owner_rejects_unsafe_namespace_before_raw_sqlite[media-symlink_target]"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_core_owner_rejects_unsafe_namespace_before_raw_sqlite[media-writable_parent]"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_domain_connection_exception_translation_is_preserved[media-DatabaseError]"
+"Tests/DB/test_core_sqlite_owner_privacy.py::test_domain_connection_exception_translation_is_preserved_on_reconnect[media-DatabaseError]"
+"Tests/DB/test_sql_validation.py::TestChachanotesValidTablesMatchesLiveSchema::test_no_missing_tables"
+"Tests/Evals/character_probe/test_conversation_storage.py::test_character_probe_never_imports_the_word_bench_measurement_stack"
+"Tests/Internal_Prompts/test_websearch_prompt_parity.py::test_result_relevance_eval_parity"
+"Tests/LLM_Calls/test_hosted_chat.py::test_nonstreaming_2xx_malformed_body_is_not_retried[action0]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_nonstreaming_2xx_malformed_body_is_not_retried[action1]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_nonstreaming_2xx_malformed_body_is_not_retried[action2]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_honors_http_date_and_malformed_retry_after"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_http_failures_without_body_disclosure[400-ChatBadRequestError]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_http_failures_without_body_disclosure[401-ChatAuthenticationError]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_http_failures_without_body_disclosure[403-ChatAuthenticationError]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_http_failures_without_body_disclosure[429-ChatRateLimitError]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_maps_http_failures_without_body_disclosure[500-ChatProviderError]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_retries_statuses_with_one_global_budget"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_sends_exact_route_headers_payload_and_timeout[chat/completions]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_json_post_sends_exact_route_headers_payload_and_timeout[responses]"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_sse_stream_does_not_retry_after_any_body_byte"
+"Tests/LLM_Calls/test_hosted_chat.py::test_owned_sse_stream_transfers_ownership_and_closes_exactly_once"
+"Tests/LLM_Calls/test_hosted_chat.py::test_sensitive_request_forces_transport_retries_to_zero"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_append_audio_after_close_from_foreign_thread_does_not_raise_or_queue"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_append_audio_base64_roundtrip"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_append_audio_from_foreign_thread_is_delivered"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_audio_delta_decodes_to_bytes_and_first_audio_fires_once"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_bad_frame_does_not_kill_recv_loop_and_response_done_still_fires"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_barge_in_after_response_done_still_truncates"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_callback_exception_is_isolated_and_routed_to_on_error"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_cancel_response_noops_when_no_response_active"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_cancel_response_sends_cancel_then_truncate_with_played_ms"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_close_does_not_hang_when_sender_task_is_stalled"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_configured_voice_is_sent_under_audio_output"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_connect_sends_correct_input_and_output_rates_without_swapping"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_connect_sends_session_update_and_fires_ready"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_default_config_sends_the_providers_own_mode"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_error_event_routes_to_on_error_not_crash"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_input_audio_buffer_committed_fires_on_turn_committed"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_input_transcript_completed_with_usage_fires_on_transcription_usage"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_input_transcript_completed_without_usage_does_not_fire_transcription_usage"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_output_item_added_ignores_non_assistant_role_items"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_output_item_added_only_resets_first_audio_once_per_response"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_response_done_cancelled_does_not_fire_reply_done"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_response_done_completed_fires_reply_done_and_usage"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_response_done_failed_routes_to_error_and_still_fires_reply_done"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_semantic_vad_never_carries_the_server_vad_knobs"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_semantic_vad_sends_the_bare_semantic_block"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_send_seed_creates_items_in_order_without_response"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_send_text_item_with_request_response_true_sends_response_create"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_sender_loop_death_marks_session_closed_and_fires_on_error_once"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_server_close_fires_on_closed_with_reason"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_server_vad_carries_both_knobs_when_both_are_set"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_server_vad_sends_only_the_knobs_that_are_set"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_speech_started_fires_during_active_response"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_transcripts_route_to_both_callbacks"
+"Tests/LLM_Calls/test_openai_realtime_session.py::test_unset_voice_omits_the_voice_key"
+"Tests/LLM_Calls/test_qwencloud.py::test_invalid_retry_after_uses_exponential_fallback_without_disclosure[429]"
+"Tests/LLM_Calls/test_qwencloud.py::test_invalid_retry_after_uses_exponential_fallback_without_disclosure[503]"
+"Tests/LLM_Calls/test_qwencloud.py::test_malformed_success_body_is_typed_redacted_and_not_retried[invalid-content]"
+"Tests/LLM_Calls/test_qwencloud.py::test_malformed_success_body_is_typed_redacted_and_not_retried[invalid-json]"
+"Tests/LLM_Calls/test_qwencloud.py::test_retry_policy_counts_status_connection_and_timeout_attempts"
+"Tests/LLM_Calls/test_qwencloud.py::test_retry_policy_honors_retry_after_and_exponential_delay"
+"Tests/LLM_Calls/test_qwencloud.py::test_retry_policy_uses_one_global_budget_across_mixed_failures"
+"Tests/LLM_Calls/test_qwencloud.py::test_sensitive_request_forces_zero_retries"
+"Tests/LLM_Calls/test_qwencloud.py::test_stalled_nonretryable_400_is_typed_redacted_and_not_retried"
+"Tests/LLM_Calls/test_qwencloud.py::test_truncated_body_retries_once_and_closes_each_attempt"
+"Tests/LLM_Calls/test_summarization_diagnostic_privacy.py::test_manifest_boundary_changes_only_summarization_owner_diagnostics"
+"Tests/LLM_Calls/test_summarization_diagnostic_privacy.py::test_manifest_boundary_rejects_unreconciled_owned_digest"
+"Tests/LLM_Management/test_mlx_lm.py::test_chat_with_mlx_lm_api_url_override"
+"Tests/LLM_Management/test_mlx_lm.py::test_chat_with_mlx_lm_args_override_config"
+"Tests/LLM_Management/test_mlx_lm.py::test_chat_with_mlx_lm_kwargs_passthrough"
+"Tests/LLM_Management/test_mlx_lm.py::test_chat_with_mlx_lm_success_with_config"
+"Tests/Local_Ingestion/test_parakeet_v2_artifact.py::test_run_parakeet_v2_preflight_and_provision_against_localhost_fixture"
+"Tests/Local_Ingestion/test_parakeet_v2_artifact.py::test_vad_only_preflight_and_provision_never_include_a_parakeet_root"
+"Tests/MCP/test_gateway_runtime_tools.py::test_real_watchlists_database_resolution_runs_off_event_loop"
+"Tests/MCP/test_gateway_runtime_tools.py::test_real_watchlists_provider_preserves_structured_domain_outcomes"
+"Tests/MCP/test_gateway_runtime_tools.py::test_real_watchlists_provider_scrubs_unexpected_failures"
+"Tests/MCP/test_local_server_tools.py::test_watchlists_lazy_resolver_blocks_replacement_until_failed_close_succeeds"
+"Tests/MCP/test_local_server_tools.py::test_watchlists_registration_is_storage_lazy_and_server_mode_never_resolves_path"
+"Tests/Media_DB/test_media_db_v2.py::TestDatabaseCRUDAndSync::test_reading_progress_reopens_through_versioned_migration"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_credential_attached_to_same_origin_mapped_file"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_credential_withheld_from_cross_origin_mapped_file_but_both_download"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_cross_origin_redirect_strips_authorization_but_body_still_downloads"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_cross_origin_redirect_strips_client_level_default_authorization"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_gated_repo_with_resolver_provisions_and_never_leaks_token"
+"Tests/Model_Artifacts/test_credentials_and_boundaries.py::test_multi_file_source_map_urls_never_leak_into_state_manifests_or_errors"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_aggregates_and_grants"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_clamps_oversized_staged_credit_to_entry_total"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_counts_staged_credit"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_gated_repo_reports_instructions"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_insufficient_space_blocks_grant"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_stale_sidecar_credit_capped_by_actual_file_size"
+"Tests/Model_Artifacts/test_preflight.py::test_preflight_upgrade_retains_prior_active_version"
+"Tests/Model_Artifacts/test_preflight.py::test_probe_gating_head_does_not_follow_redirects"
+"Tests/Model_Artifacts/test_provision_crash_recovery.py::test_kill_between_install_and_activate_fresh_provision_activates_with_zero_requests"
+"Tests/Model_Artifacts/test_provision_crash_recovery.py::test_kill_mid_fetch_valid_sidecar_survives_and_fresh_provision_resumes"
+"Tests/Model_Artifacts/test_provision_crash_recovery.py::test_reconcile_after_crash_removes_only_orphans_leaves_everything_else"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_enospc_raises_transfer_error_retryable_and_retains_staging"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_full_download_writes_sidecar_and_reports_progress"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_mid_body_disconnect_leaves_durable_sidecar_and_reprovision_resumes"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_multi_file_descriptor_raises_catalog_error_without_touching_anything"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_over_large_checkpoint_restarts_cleanly"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_restarts_from_zero_on_changed_etag"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_resumes_partial_file_with_range_request"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_skips_file_already_complete_in_sidecar"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_fetch_zero_byte_file_creates_empty_destination_and_skips_network"
+"Tests/Model_Artifacts/test_provision_fetch.py::test_provision_cancel_mid_fetch_releases_lease_and_preserves_prior_active"
+"Tests/Model_Artifacts/test_provision_install.py::test_preverify_mismatch_persisting_past_max_refetches_raises_transfer_error"
+"Tests/Model_Artifacts/test_provision_install.py::test_preverify_mismatch_refetches_once_and_recovers_on_good_content"
+"Tests/Model_Artifacts/test_provision_install.py::test_provision_activates_already_installed_closure_with_zero_fetch_requests"
+"Tests/Model_Artifacts/test_provision_install.py::test_provision_corrupt_payload_refetches_exactly_once_then_fails"
+"Tests/Model_Artifacts/test_provision_install.py::test_provision_end_to_end_installs_and_activates_root_and_dependency"
+"Tests/Model_Artifacts/test_provision_install.py::test_retryable_finalize_failure_leaves_staged_bytes_resumable_via_range"
+"Tests/Model_Artifacts/test_source_map.py::test_gated_descriptor_url_does_not_block_public_mapped_files"
+"Tests/Model_Artifacts/test_source_map.py::test_gated_mapped_file_detected_at_preflight_even_when_descriptor_url_is_public"
+"Tests/Model_Artifacts/test_source_map.py::test_identical_source_map_at_provision_does_not_mismatch"
+"Tests/Model_Artifacts/test_source_map.py::test_multi_file_artifact_provisions_end_to_end_with_source_map"
+"Tests/Model_Artifacts/test_source_map.py::test_multi_file_artifact_with_dependency_provisions_via_source_map"
+"Tests/Model_Artifacts/test_source_map.py::test_resolution_failure_at_provision_also_precedes_any_side_effect"
+"Tests/Model_Artifacts/test_source_map.py::test_single_file_source_url_with_empty_source_map_still_works"
+"Tests/Model_Artifacts/test_source_map.py::test_single_file_source_url_without_source_map_still_works"
+"Tests/Model_Artifacts/test_source_map.py::test_source_url_changed_after_consent_raises_consent_mismatch"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_changed_last_modified_non_compliant_server_raises_restart"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_changed_last_modified_raises_restart_without_append"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_changed_validator_raises_restart"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_content_range_start_mismatch_raises_restart_without_append"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_full_fetch_writes_and_reports"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_last_modified_only_resume_succeeds"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_max_bytes_bounds_final_size"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_missing_content_range_on_resume_raises_restart_without_append"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_missing_etag_on_resume_raises_restart_without_append"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_no_range_support_raises_restart"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_resume_uses_range_and_appends"
+"Tests/Model_Artifacts/test_stream_fetch.py::test_weak_etag_never_resumes"
+"Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current[sdist]"
+"Tests/Packaging/test_installed_distribution.py::test_installed_distribution_migrates_v35_database_to_current[source]"
+"Tests/Packaging/test_installed_distribution.py::test_installed_distribution_validates_and_seeds_samira_without_package_writes[sdist]"
+"Tests/Packaging/test_installed_distribution.py::test_installed_distribution_validates_and_seeds_samira_without_package_writes[source]"
+"Tests/Packaging/test_installed_distribution.py::test_installed_wheel_loaders_entry_points_and_assets_are_immutable"
+"Tests/Packaging/test_mcp_unified_distribution.py::test_mcp_extra_installs_and_runs_from_each_isolated_artifact[sdist]"
+"Tests/Packaging/test_mcp_unified_distribution.py::test_mcp_extra_installs_and_runs_from_each_isolated_artifact[wheel]"
+"Tests/Performance/test_app_startup_performance.py::test_citation_artifact_reconciliation_is_deferred_and_policy_gated[False-0]"
+"Tests/Performance/test_app_startup_performance.py::test_citation_artifact_reconciliation_is_deferred_and_policy_gated[True-1]"
+"Tests/Performance/test_app_startup_performance.py::test_legacy_citation_migration_is_deferred_and_policy_gated[False-0]"
+"Tests/Performance/test_app_startup_performance.py::test_legacy_citation_migration_is_deferred_and_policy_gated[True-1]"
+"Tests/Persona_Visual/test_persona_visual_publication.py::test_publication_bounds_descriptors_at_contract_maximum"
+"Tests/RAG/simplified/test_search_service.py::TestKeywordSearchRealRowMapping::test_media_types_filter_is_honored"
+"Tests/RAG/simplified/test_simple_cache_basic.py::TestSimpleRAGCacheBasic::test_clear"
+"Tests/RAG/simplified/test_simple_cache_concurrent.py::TestRaceConditions::test_stats_calculation_race"
+"Tests/RAG/simplified/test_vector_store.py::TestChromaVectorStore::test_data_persists_across_reopen"
+"Tests/RAG/simplified/test_vector_store_selection.py::TestDefaultWithoutEmbeddingsDeps::test_from_settings_defaults_to_memory"
+"Tests/RAG/test_active_config_resolution.py::test_resolves_active_profiles_rag_config"
+"Tests/RAG/test_active_config_resolution.py::test_top_k_only_resolution_does_not_import_torch"
+"Tests/RAG/test_chunking_service.py::TestEveryChunkingMethodReturnsUsableText::test_method_yields_string_text[paragraphs-The first sentence is here. The second follows it. A third arrives.\\n\\nA second paragraph begins. It has two sentences.\\n\\nThird paragraph.The first sentence is here. The second follows it. A third arrives.\\n\\nA second paragraph begins. It has two sentences.\\n\\nThird paragraph.]"
+"Tests/RAG/test_config_profiles.py::test_get_profile_manager_explicit_dir_bypasses_cache"
+"Tests/RAG/test_config_profiles.py::test_legacy_blob_migration_isolates_per_entry_failures"
+"Tests/RAG/test_ingestion_indexing.py::TestMediaPostIngestHook::test_callback_exception_does_not_break_ingestion"
+"Tests/RAG/test_ingestion_indexing.py::TestMediaPostIngestHook::test_no_callback_for_duplicate_without_overwrite"
+"Tests/RAG_Search/test_embeddings_performance.py::TestEmbeddingPerformance::test_real_model_performance"
+"Tests/RAG_Search/test_fts5_match_forms_shared.py::test_plain_search_and_rag_answer_answer_the_same_inflection_miss"
+"Tests/RAG_Search/test_reranker_system_prompt.py::test_a_local_provider_receives_exactly_one_system_instruction"
+"Tests/RuntimePolicy/test_server_client_provider_migration_audit.py::test_legacy_server_client_builder_matches_are_listed_in_migration_audit"
+"Tests/STT/test_task602_platform_smoke.py::test_run_smoke_returns_only_bounded_allowlisted_observations"
+"Tests/Skills/test_project_skills_import_modal.py::test_never_during_inflight_import_is_inert"
+```

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -53,3 +53,11 @@ and defence-in-depth argues for owner-only bits regardless.
 Related: TASK-17963 (`Skills_Interop/atomic_write.py` is the natural seam —
 its `replace_atomically` already owns the pre-replace window). ADR-009
 defines the trust boundary this protects.
+
+This hardening uses existing OS controls rather than superseding them. It can
+protect trust material from other unprivileged POSIX users when directory
+traversal or a permissive umask would otherwise allow access, but it does not
+separate application users sharing one OS identity, restrict same-UID or
+root/administrator processes, replace disk encryption, or implement Windows
+and storage-specific ACL policy. Effective ACL and mount semantics remain
+authoritative; the change is defence in depth, not a new tenant boundary.

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -46,6 +46,36 @@ and defence-in-depth argues for owner-only bits regardless.
 - [ ] #5 Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
 <!-- AC:END -->
 
+## Implementation Plan
+
+1. Add RED tests for an explicit owner-only mode on the shared atomic replace
+   primitive: `0o600` before replacement, exclusive-create collision ownership,
+   descriptor and temp cleanup, and unchanged default behavior.
+2. Implement owner-only exclusive temp pre-creation in
+   `Skills_Interop/atomic_write.py` while preserving existing callers and error
+   propagation.
+3. Add RED production-path tests for manifest, snapshot, generation-marker, and
+   manifest-rollback bytes; cover snapshot-first directory creation, pre-replace
+   modes, and tightening of legacy files/directories.
+4. Opt only trust-store JSON/bytes writers into owner-only creation, normalize
+   trust-owned directories to `0o700` on POSIX, and secure the trust root before
+   snapshot-first creation.
+5. Mutation-check both file and directory guards, run the complete Skills and
+   full repository suites plus static checks, obtain independent code review,
+   then record evidence and close this five-digit task by editing its source file
+   directly.
+
+Detailed plan:
+`Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md`.
+
+ADR required: no
+
+ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
+
+Reason: direct hardening of ADR-009's existing persistence boundary; storage
+ownership, trust policy, cryptography, authentication, and ACL contracts do not
+change.
+
 
 
 ## Notes

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19520
 title: Skill trust material is written with default filesystem permissions
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-21 17:00'
@@ -86,6 +86,12 @@ change.
   writer-owned temp at `0o600`, applies POSIX `fchmod` before the writer runs,
   preserves unexplained collision files, closes descriptors on every path, and
   leaves ordinary atomic-write callers unchanged.
+- Post-review hardening now recovers when a failed cleanup leaves the
+  deterministic PID/thread temp occupied: owner-only writes preserve the stale
+  path and try at most seven random same-directory siblings, clean only the
+  candidate they created, and surface the eighth collision unchanged. Focused
+  amendment verification passed 55 related tests in 2.98s; Ruff check and
+  format checks passed; `git diff --check` passed.
 - Routed trust-store JSON and bytes publications through that path, secured the
   trust root before snapshot-first creation, normalized trust-owned directories
   to `0o700` on POSIX, and tightened legacy trust files/directories on their next

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-19520
 title: Skill trust material is written with default filesystem permissions
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-21 17:00'
@@ -64,6 +64,10 @@ and defence-in-depth argues for owner-only bits regardless.
    full repository suites plus static checks, obtain independent code review,
    then record evidence and close this five-digit task by editing its source file
    directly.
+6. Address the post-review stale deterministic-temp finding with a bounded
+   owner-only alternate-name retry, regression tests for recovery, exhaustion,
+   and cleanup ownership, and only the focused verification requested by the
+   user before returning the task to Done.
 
 Detailed plan:
 `Docs/superpowers/plans/2026-08-21-task-19520-skill-trust-permissions.md`.

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-19520
 title: Skill trust material is written with default filesystem permissions
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-21 17:00'
-updated_date: '2026-08-21 17:41'
+updated_date: '2026-08-21 23:45'
 labels:
   - skills
   - security
@@ -39,11 +39,11 @@ and defence-in-depth argues for owner-only bits regardless.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Trust-store writes (manifest, snapshots, generation marker) create files with owner-only permissions (`0o600`), and their containing directory is owner-only (`0o700`) where it is created by this code
-- [ ] #2 Permissions are applied so there is no window where the file exists world-readable before being restricted (set on the temp file BEFORE `replace`, given the atomic-write path from TASK-17963)
-- [ ] #3 Pre-existing trust files created before this change are tightened on next write (or an explicit decision is recorded that they are not)
-- [ ] #4 Behavior is verified by a test asserting the resulting mode bits, not by inspection
-- [ ] #5 Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
+- [x] #1 Trust-store writes (manifest, snapshots, generation marker) create files with owner-only permissions (`0o600`), and their containing directory is owner-only (`0o700`) where it is created by this code
+- [x] #2 Permissions are applied so there is no window where the file exists world-readable before being restricted (set on the temp file BEFORE `replace`, given the atomic-write path from TASK-17963)
+- [x] #3 Pre-existing trust files created before this change are tightened on next write (or an explicit decision is recorded that they are not)
+- [x] #4 Behavior is verified by a test asserting the resulting mode bits, not by inspection
+- [x] #5 Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -75,6 +75,42 @@ ADR path: `backlog/decisions/009-local-skill-trust-boundary.md`
 Reason: direct hardening of ADR-009's existing persistence boundary; storage
 ownership, trust policy, cryptography, authentication, and ACL contracts do not
 change.
+
+## Implementation Notes
+
+- Added an opt-in `owner_only` atomic-replace path that exclusively creates the
+  writer-owned temp at `0o600`, applies POSIX `fchmod` before the writer runs,
+  preserves unexplained collision files, closes descriptors on every path, and
+  leaves ordinary atomic-write callers unchanged.
+- Routed trust-store JSON and bytes publications through that path, secured the
+  trust root before snapshot-first creation, normalized trust-owned directories
+  to `0o700` on POSIX, and tightened legacy trust files/directories on their next
+  write. Non-POSIX platforms keep the atomic path without relying on advisory
+  Unix mode enforcement.
+- Added production-path and seam tests for manifests, encrypted snapshots,
+  generation markers, rollback bytes, pre-replace modes, descriptor/error
+  precedence, legacy tightening, and unchanged default behavior.
+- Fresh focused verification after implementation: 53 related tests passed in
+  3.46s; Ruff check passed; Ruff format reported four files already formatted;
+  `git diff --check` passed. Five targeted mutations each failed at the intended
+  permission/cleanup assertion and were restored.
+- At the user's direction, the repository-wide run was stopped and was not used
+  as TASK-19520's completion gate. Its 272 current failure/error nodes and the 29
+  failures from the completed Skills gate are preserved in
+  `backlog/docs/task-19520-verification-failure-inventory.md`; all 301 are mapped
+  through `TASK-19642` children or four defensible existing-task assignments.
+- Independent final production/security review and failure-task accounting
+  review reported no remaining findings after the task groups were made atomic
+  and allocated above the repository-wide task-ID maximum.
+- ADR check: existing ADR-009 applies; no new ADR was required. The change is
+  owner-only filesystem defence in depth, not a same-UID, administrator, ACL,
+  mount-policy, disk-encryption, Windows-ACL, or multi-tenant isolation boundary.
+- Modified implementation/test files: `Skills_Interop/atomic_write.py`,
+  `Skills_Interop/skill_trust_store.py`,
+  `Tests/Skills/test_atomic_write_concurrency.py`, and
+  `Tests/Skills/test_skill_trust_permissions.py`. Verification fallout is
+  tracked in `TASK-19642`; the interrupted-cache incident is recorded in
+  `backlog/docs/lessons-testing-evidence.md`.
 
 
 

--- a/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
+++ b/backlog/tasks/task-19520 - Skill-trust-material-is-written-with-default-filesystem-permissions.md
@@ -1,19 +1,21 @@
 ---
 id: TASK-19520
-title: >-
-  Skill trust material is written with default filesystem permissions
-status: To Do
-assignee: []
+title: Skill trust material is written with default filesystem permissions
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-21 17:00'
+updated_date: '2026-08-21 17:41'
 labels:
   - skills
   - security
-priority: medium
 dependencies: []
+priority: medium
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Found during TASK-17963's review (writer-unique temp files): nothing in
 `Skills_Interop/skill_trust_store.py`, `skill_trust_crypto.py`, or
 `skill_trust_models.py` sets restrictive permissions on the files it writes —
@@ -33,14 +35,18 @@ Note the encrypted snapshots are encrypted at rest (passphrase-derived), so
 the exposure is not equivalent to leaking plaintext skills — but the manifest
 and generation marker are metadata an attacker with read access could use,
 and defence-in-depth argues for owner-only bits regardless.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Trust-store writes (manifest, snapshots, generation marker) create files with owner-only permissions (`0o600`), and their containing directory is owner-only (`0o700`) where it is created by this code
+- [ ] #2 Permissions are applied so there is no window where the file exists world-readable before being restricted (set on the temp file BEFORE `replace`, given the atomic-write path from TASK-17963)
+- [ ] #3 Pre-existing trust files created before this change are tightened on next write (or an explicit decision is recorded that they are not)
+- [ ] #4 Behavior is verified by a test asserting the resulting mode bits, not by inspection
+- [ ] #5 Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
+<!-- AC:END -->
 
-- [ ] Trust-store writes (manifest, snapshots, generation marker) create files with owner-only permissions (`0o600`), and their containing directory is owner-only (`0o700`) where it is created by this code
-- [ ] Permissions are applied so there is no window where the file exists world-readable before being restricted (set on the temp file BEFORE `replace`, given the atomic-write path from TASK-17963)
-- [ ] Pre-existing trust files created before this change are tightened on next write (or an explicit decision is recorded that they are not)
-- [ ] Behavior is verified by a test asserting the resulting mode bits, not by inspection
-- [ ] Windows/non-POSIX behavior is considered — the change must not break on platforms where `chmod` bits are advisory
+
 
 ## Notes
 

--- a/backlog/tasks/task-19642 - Resolve-verification-failures-captured-during-TASK-19520.md
+++ b/backlog/tasks/task-19642 - Resolve-verification-failures-captured-during-TASK-19520.md
@@ -1,0 +1,35 @@
+---
+id: TASK-19642
+title: Resolve verification failures captured during TASK-19520
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:22'
+labels:
+  - testing
+  - regression
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track and close every failing or erroring pytest node observed while verifying TASK-19520. The broad run was stopped at user direction after a partial result; these failures are not attributed to TASK-19520 without focused evidence. This parent coordinates symptom-scoped triage tasks and defensible mappings to existing open work; each child must establish its actual root cause before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All 301 observed nodes are mapped to a defensibly symptom-scoped child task or an existing open task.
+- [ ] #2 Each mapped task either restores its focused tests or documents reproducible environment-only behavior with an appropriate marker or fixture contract.
+- [ ] #3 The permanent failure inventory remains self-contained and updated as child tasks are resolved.
+<!-- AC:END -->
+
+## Initial Triage
+
+- `TASK-19642.1` through `TASK-19642.28`, with atomic grandchildren under `.8`, `.19`, and `.21`, cover 297 nodes by the narrowest defensible shared symptom.
+- `TASK-18801` already covers the two summarization diagnostic-boundary failures.
+- `TASK-3070` / `TASK-3070.11` already cover the `chat_screen.py` size-ratchet failure.
+- `TASK-18610` acceptance criterion 6 already covers the server-client provider migration-audit failure.
+- The interrupted broad run is evidence of observed failures only; each child must establish a focused root cause before changing production behavior.

--- a/backlog/tasks/task-19642.1 - Repair-recurring-Skills-Library-and-import-harness-failures.md
+++ b/backlog/tasks/task-19642.1 - Repair-recurring-Skills-Library-and-import-harness-failures.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.1
+title: Repair recurring Skills Library and import harness failures
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:23'
+labels:
+  - testing
+  - skills
+  - regression
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the 29 completed Skills-gate failures in test_skills_import.py and test_skills_library_flow.py. Evidence points to Library composition/readiness fixture drift and repeated local quiz backend unavailability; confirm the actual root cause before changing production behavior. The separate project-skills import-modal session-only failure is tracked by `TASK-19642.27`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 29 completed-gate Skills nodes assigned to this task in the TASK-19520 verification inventory pass in a focused Skills run.
+- [ ] #2 Library readiness and backend fixtures fail deterministically without hidden background exceptions or missing Library rows.
+- [ ] #3 The resolution does not weaken trust-store permission assertions or bypass real runtime-policy coverage.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.10 - Restore-hosted-chat-and-QwenCloud-transport-contract-tests.md
+++ b/backlog/tasks/task-19642.10 - Restore-hosted-chat-and-QwenCloud-transport-contract-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.10
+title: Restore hosted-chat and QwenCloud transport contract tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - llm
+  - http
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the 25 failures in test_hosted_chat.py and test_qwencloud.py covering retry budgets, Retry-After, malformed bodies, redaction, SSE ownership, and sensitive-request policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 25 hosted-chat and QwenCloud nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Retry, redaction, ownership, and no-retry-after-body-byte guarantees remain pinned.
+- [ ] #3 The tests use deterministic fake transports and make no external network calls.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.11 - Repair-model-artifact-transfer-and-credential-tests.md
+++ b/backlog/tasks/task-19642.11 - Repair-model-artifact-transfer-and-credential-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.11
+title: Repair model-artifact transfer and credential tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - model-artifacts
+  - security
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the 37 model-artifact failures in stream fetch, provision fetch, source maps, and credential boundaries. Diagnose possible fixture or descriptor contamination before attributing the cluster to one cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 37 assigned transfer, fetch, source-map, and credential nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Resume, range, validator, byte-limit, redirect, and credential-withholding guarantees remain fail-closed.
+- [ ] #3 Focused tests show no authorization leakage across origins or persisted state.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.12 - Repair-model-artifact-preflight-install-and-crash-recovery-tests.md
+++ b/backlog/tasks/task-19642.12 - Repair-model-artifact-preflight-install-and-crash-recovery-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.12
+title: Repair model-artifact preflight install and crash recovery tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - model-artifacts
+  - reliability
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the 17 model-artifact failures in preflight, install and finalize, and crash recovery while preserving durable staging and activation guarantees.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 17 assigned preflight, install, and crash-recovery nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Space accounting, consent, retry, activation, and orphan reconciliation behaviors remain covered.
+- [ ] #3 Crash and cancellation paths preserve resumable state without activating corrupt content.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.13 - Update-database-schema-migration-and-census-tests.md
+++ b/backlog/tasks/task-19642.13 - Update-database-schema-migration-and-census-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.13
+title: Update database schema migration and census tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - database
+  - migrations
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the six ChaChaNotes schema, migration, index-census, and live-table-census failures. At least two assertions are stale at schema v40 while production is v42; validate all remaining failures rather than mechanically changing literals. The independent Media DB v2 reopen failure is tracked by `TASK-19642.28`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All six assigned ChaChaNotes schema and migration nodes in the TASK-19520 verification inventory pass from fresh and upgraded databases.
+- [ ] #2 Expected schema versions, tables, and indexes match the canonical v42 migration chain.
+- [ ] #3 Fresh-bootstrap and upgraded ChaChaNotes paths are covered without skipping migrations.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.14 - Restore-core-SQLite-owner-privacy-tests.md
+++ b/backlog/tasks/task-19642.14 - Restore-core-SQLite-owner-privacy-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.14
+title: Restore core SQLite owner-privacy tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - database
+  - security
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the six media-domain failures in test_core_sqlite_owner_privacy.py covering unsafe namespace rejection and exception translation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All six owner-privacy nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Missing, symlinked, or writable namespace cases are rejected before raw SQLite access.
+- [ ] #3 DatabaseError translation is preserved on initial connect and reconnect.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.15 - Restore-installed-distribution-and-MCP-packaging-tests.md
+++ b/backlog/tasks/task-19642.15 - Restore-installed-distribution-and-MCP-packaging-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.15
+title: Restore installed-distribution and MCP packaging tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - packaging
+  - mcp
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the seven packaging failures across source, sdist, wheel, immutable assets, migrations, seeding, and MCP extras in isolated installed artifacts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All seven Packaging nodes in the TASK-19520 verification inventory pass against the applicable source, sdist, and wheel artifacts.
+- [ ] #2 Installed tests do not write into package contents.
+- [ ] #3 Current-schema migration, Samira seeding, entry points, assets, and MCP extras remain verified.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.16 - Restore-MCP-watchlists-provider-contract-tests.md
+++ b/backlog/tasks/task-19642.16 - Restore-MCP-watchlists-provider-contract-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.16
+title: Restore MCP watchlists provider contract tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - mcp
+  - database
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the five watchlists provider failures covering off-loop database resolution, structured outcomes, error scrubbing, lazy registration, and resolver replacement and close ordering.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All five MCP watchlists nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Server mode remains storage-lazy and path resolution stays off the event loop.
+- [ ] #3 Unexpected failures are scrubbed while structured domain outcomes are preserved.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.17 - Restore-MLX-LLM-management-fixture-tests.md
+++ b/backlog/tasks/task-19642.17 - Restore-MLX-LLM-management-fixture-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.17
+title: Restore MLX LLM management fixture tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - llm
+  - mlx
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the four test_mlx_lm.py failures covering config resolution, argument overrides, API URL overrides, and kwargs passthrough.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All four MLX management nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Config and explicit argument precedence remain deterministic.
+- [ ] #3 The tests do not require an installed MLX runtime when exercising mocked management behavior.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.18 - Restore-deferred-startup-reconciliation-policy-tests.md
+++ b/backlog/tasks/task-19642.18 - Restore-deferred-startup-reconciliation-policy-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.18
+title: Restore deferred startup reconciliation policy tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - performance
+  - startup
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the four startup-performance failures covering deferred citation artifact reconciliation and legacy citation migration under enabled and disabled policy states.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All four startup-performance nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Citation reconciliation and migration remain deferred from startup.
+- [ ] #3 Policy gates produce the expected zero-or-one scheduling behavior without hidden eager work.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.19 - Restore-RAG-search-parity-and-reranker-prompt-tests.md
+++ b/backlog/tasks/task-19642.19 - Restore-RAG-search-parity-and-reranker-prompt-tests.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.19
+title: Restore RAG search parity and reranker prompt tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - rag
+  - search
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Coordinate separate child tasks for the FTS5 inflection-parity failure and the local reranker system-prompt-cardinality failure. This tracking parent does not assume a shared root cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The two functional RAG Search nodes are assigned separately to `TASK-19642.19.1` and `TASK-19642.19.2`.
+- [ ] #2 Both atomic children restore their focused nodes and document their root causes.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.19.1 - Restore-shared-FTS5-inflection-search-parity.md
+++ b/backlog/tasks/task-19642.19.1 - Restore-shared-FTS5-inflection-search-parity.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.19.1
+title: Restore shared FTS5 inflection search parity
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - rag
+  - search
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.19
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the RAG Search failure requiring plain search and RAG answer paths to agree on an inflection miss.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The FTS5 match-forms parity node in the TASK-19520 verification inventory passes.
+- [ ] #2 Plain search and RAG answer use the same intended MATCH-form normalization.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.19.2 - Restore-local-reranker-system-prompt-cardinality.md
+++ b/backlog/tasks/task-19642.19.2 - Restore-local-reranker-system-prompt-cardinality.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.19.2
+title: Restore local reranker system-prompt cardinality
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - rag
+  - prompts
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.19
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the reranker prompt failure requiring a local provider to receive exactly one system instruction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The reranker-system-prompt node in the TASK-19520 verification inventory passes.
+- [ ] #2 Local reranker providers receive exactly one system instruction.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
+++ b/backlog/tasks/task-19642.2 - Make-provider-gateway-loopback-tests-sandbox-safe.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.2
+title: Make provider-gateway loopback tests sandbox-safe
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:25'
+labels:
+  - testing
+  - chat
+  - network
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the two console provider-gateway setup errors where local HTTP fixtures fail at socket.bind with PermissionError in restricted environments. Preserve the event-loop ownership contract while giving the tests an explicit supported-environment or marker contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both provider-gateway nodes listed in the TASK-19520 verification inventory pass or skip for an explicit, documented capability check.
+- [ ] #2 The tests still exercise concurrent client swapping and agent-bridge loop ownership when loopback listeners are available.
+- [ ] #3 No test silently opens external network access.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.20 - Reconcile-the-persistent-diagnostic-inventory-ratchet.md
+++ b/backlog/tasks/task-19642.20 - Reconcile-the-persistent-diagnostic-inventory-ratchet.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.20
+title: Reconcile the persistent diagnostic inventory ratchet
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - architecture
+  - diagnostics
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the current persistent diagnostic inventory and sink-topology ratchet failure as a new drift incident, not the already-completed older inventory task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The persistent diagnostic inventory node in the TASK-19520 verification inventory passes.
+- [ ] #2 Every production diagnostic and sink topology change is intentionally reconciled with the canonical inventory.
+- [ ] #3 No diagnostic is removed or allowlisted solely to satisfy the ratchet.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.21 - Restore-chunking-tokenizer-override-and-CJK-parity-tests.md
+++ b/backlog/tasks/task-19642.21 - Restore-chunking-tokenizer-override-and-CJK-parity-tests.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.21
+title: Restore chunking tokenizer override and CJK parity tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - chunking
+  - rag
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Coordinate separate child tasks for the v2 tokenizer-override failure and the CJK golden-parity failure. This tracking parent does not assume a shared root cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The two Chunking nodes are assigned separately to `TASK-19642.21.1` and `TASK-19642.21.2`.
+- [ ] #2 Both atomic children restore their focused nodes and document their root causes.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.21.1 - Restore-v2-chunker-tokenizer-override-behavior.md
+++ b/backlog/tasks/task-19642.21.1 - Restore-v2-chunker-tokenizer-override-behavior.md
@@ -1,0 +1,27 @@
+---
+id: TASK-19642.21.1
+title: Restore v2 chunker tokenizer override behavior
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:38'
+labels:
+  - testing
+  - chunking
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.21
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the v2 chunker failure requiring an explicit tokenizer override to be honored.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The v2 tokenizer-override node in the TASK-19520 verification inventory passes.
+- [ ] #2 An explicit tokenizer override affects only the requested chunking operation.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.21.2 - Restore-CJK-token-chunking-golden-parity.md
+++ b/backlog/tasks/task-19642.21.2 - Restore-CJK-token-chunking-golden-parity.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.21.2
+title: Restore CJK token chunking golden parity
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:38'
+labels:
+  - testing
+  - chunking
+  - cjk
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.21
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the golden parity failure for token-based CJK chunking.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The CJK token golden-parity node in the TASK-19520 verification inventory passes.
+- [ ] #2 The supported tokenizer set produces deterministic CJK golden output.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.22 - Restore-Parakeet-v2-local-artifact-tests.md
+++ b/backlog/tasks/task-19642.22 - Restore-Parakeet-v2-local-artifact-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.22
+title: Restore Parakeet v2 local artifact tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - ingestion
+  - stt
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the two Local_Ingestion Parakeet v2 artifact failures covering localhost preflight and provision and VAD-only artifact closure.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both Parakeet v2 nodes in the TASK-19520 verification inventory pass in focused runs or skip on an explicit missing capability.
+- [ ] #2 VAD-only preflight never includes a Parakeet root.
+- [ ] #3 Local fixture setup does not depend on external network access.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.23 - Restore-tool-catalog-snapshot-concurrency-test.md
+++ b/backlog/tasks/task-19642.23 - Restore-tool-catalog-snapshot-concurrency-test.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.23
+title: Restore tool-catalog snapshot concurrency test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - agents
+  - concurrency
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the tool catalog failure asserting that invoke_by_name takes exactly one catalog snapshot.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Agents concurrency node in the TASK-19520 verification inventory passes repeatedly.
+- [ ] #2 invoke_by_name observes one coherent catalog snapshot per invocation.
+- [ ] #3 The fix adds no global serialization beyond the catalog consistency boundary.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.24 - Restore-character-probe-storage-import-boundary-test.md
+++ b/backlog/tasks/task-19642.24 - Restore-character-probe-storage-import-boundary-test.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.24
+title: Restore character-probe storage import-boundary test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - evals
+  - architecture
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the character-probe conversation-storage failure that enforces separation from the word-bench measurement stack.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Evals character-probe node in the TASK-19520 verification inventory passes.
+- [ ] #2 Conversation storage does not import the word-bench measurement stack.
+- [ ] #3 The boundary remains enforced by a deterministic import inspection.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.25 - Restore-websearch-result-relevance-prompt-parity.md
+++ b/backlog/tasks/task-19642.25 - Restore-websearch-result-relevance-prompt-parity.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.25
+title: Restore websearch result-relevance prompt parity
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - prompts
+  - websearch
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the Internal_Prompts result-relevance evaluator parity failure and reconcile the canonical prompt sources intentionally.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The websearch prompt-parity node in the TASK-19520 verification inventory passes.
+- [ ] #2 All canonical result-relevance prompt copies are semantically and byte-level consistent as required by the test.
+- [ ] #3 The chosen source of truth is documented in the test or prompt module.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.26 - Restore-persona-visual-publication-bounds-test.md
+++ b/backlog/tasks/task-19642.26 - Restore-persona-visual-publication-bounds-test.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.26
+title: Restore persona visual publication bounds test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:27'
+labels:
+  - testing
+  - personas
+  - media
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the persona visual publication failure that bounds descriptors at the contract maximum.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Persona_Visual node in the TASK-19520 verification inventory passes.
+- [ ] #2 Published descriptors never exceed the contract maximum.
+- [ ] #3 Boundary and over-boundary cases remain explicitly tested.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.27 - Isolate-project-Skills-import-modal-order-dependent-failure.md
+++ b/backlog/tasks/task-19642.27 - Isolate-project-Skills-import-modal-order-dependent-failure.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.27
+title: Isolate project Skills import-modal order-dependent failure
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:41'
+labels:
+  - testing
+  - skills
+  - isolation
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Diagnose the project-skills import-modal node that failed in the interrupted repository run but passed the completed Tests/Skills gate. Treat it as order or session contamination until a focused predecessor sequence proves otherwise; do not fold it into the separate Library-readiness fixture cluster.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A minimal focused order or state reproduction demonstrates why test_never_during_inflight_import_is_inert failed only in the long-running session.
+- [ ] #2 The node passes both in isolation and after the reproducing predecessor sequence once fixed.
+- [ ] #3 The fix restores all mutated global, async, descriptor, and fixture state without weakening the inflight-import invariant.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.28 - Restore-Media-DB-v2-migration-reopen-test.md
+++ b/backlog/tasks/task-19642.28 - Restore-Media-DB-v2-migration-reopen-test.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.28
+title: Restore Media DB v2 migration reopen test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:43'
+labels:
+  - testing
+  - database
+  - migrations
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and resolve the Client_Media_DB_v2 reading-progress reopen failure through its own version-6 migration chain. Keep this separate from ChaChaNotes schema-v42 census and migration drift.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Media_DB reading-progress reopen node in the TASK-19520 verification inventory passes from its intended legacy schema.
+- [ ] #2 Client_Media_DB_v2 upgrades to its canonical schema version 6 and preserves reading progress across reopen.
+- [ ] #3 The fix does not couple Media DB migration expectations to the ChaChaNotes schema version.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
+++ b/backlog/tasks/task-19642.3 - Keep-RAG-tests-offline-during-embedding-initialization.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.3
+title: Keep RAG tests offline during embedding initialization
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:25'
+labels:
+  - testing
+  - rag
+  - network
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Stop the 13 RAG and embedding-performance teardown errors caused by background Hugging Face requests escaping offline fixtures. The tests must not depend on internet access or swallowed retry attempts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 13 RAG embedding-egress error nodes in the TASK-19520 verification inventory pass in a network-blocked focused run.
+- [ ] #2 Embedding initialization is fully stubbed, cached locally, or explicitly integration-marked before background work starts.
+- [ ] #3 The no-network guard reports no swallowed huggingface.co connection attempts.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.4 - Diagnose-the-task-602-STT-platform-smoke-error.md
+++ b/backlog/tasks/task-19642.4 - Diagnose-the-task-602-STT-platform-smoke-error.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.4
+title: Diagnose the task-602 STT platform smoke error
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:25'
+labels:
+  - testing
+  - stt
+  - regression
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and resolve the error in the bounded task-602 platform smoke test. The interrupted run preserved the exact node but not its traceback, so this task begins with focused diagnosis rather than assuming a cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The task-602 smoke node listed in the TASK-19520 verification inventory passes in its supported platform matrix.
+- [ ] #2 The root cause and supported-platform behavior are documented from a focused traceback.
+- [ ] #3 Returned observations remain bounded and allowlisted.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.5 - Restore-Console-generation-action-contract-tests.md
+++ b/backlog/tasks/task-19642.5 - Restore-Console-generation-action-contract-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.5
+title: Restore Console generation-action contract tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:25'
+labels:
+  - testing
+  - chat
+  - regression
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the 40 failures in test_console_generation_actions.py covering browse, keep, regenerate, speech, image-generation, kill-switch, and stop lifecycle behavior. Treat multiple causes separately if focused traces do not support one fixture-drift diagnosis.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 40 generation-action nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Routing, refusal, retry, stop, and cache-state assertions remain behaviorally meaningful rather than being relaxed.
+- [ ] #3 Any fixture or API contract changes are documented and covered by a regression test.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.6 - Restore-Console-H3-image-edit-contract-tests.md
+++ b/backlog/tasks/task-19642.6 - Restore-Console-H3-image-edit-contract-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.6
+title: Restore Console H3 image-edit contract tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - chat
+  - image-generation
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the 19 H3 image-edit failures covering refusal ordering, source bounds, cancellation, persistence, and terminal-screen synchronization.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 19 test_console_h3_image_edit.py nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Source validation, cancellation, and persistence ordering remain fail-closed.
+- [ ] #3 The fix includes focused coverage for every distinct root cause found.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.7 - Restore-hosted-native-tool-continuation-tests.md
+++ b/backlog/tasks/task-19642.7 - Restore-hosted-native-tool-continuation-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.7
+title: Restore hosted native-tool continuation tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - chat
+  - llm
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the 19 Kimi, Z.ai, and QwenCloud native-tool failures across continuation history, cancellation, tool errors, budgets, and terminal candidates.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 19 native-provider nodes assigned in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Invalid or partial tool history still fails closed before execution.
+- [ ] #3 Provider-specific continuation and usage-budget contracts remain explicit.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8 - Repair-remaining-Console-action-and-lifecycle-harness-failures.md
+++ b/backlog/tasks/task-19642.8 - Repair-remaining-Console-action-and-lifecycle-harness-failures.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.8
+title: Repair remaining Console action and lifecycle harness failures
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - chat
+  - regression
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Coordinate eight atomic child tasks for the 16 remaining Console failures spanning attachments, video actions, fleet and headless wakes, skill confirmation, diff feedback, local review root swapping, provider failure copy, and stop reliability. This is a tracking parent, not an assertion that those behaviors share one root cause.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All 16 remaining Chat failure nodes are assigned to `TASK-19642.8.1` through `TASK-19642.8.8` by behavior and test file.
+- [ ] #2 Each atomic child restores its focused nodes and documents its root cause.
+- [ ] #3 Approval, path confinement, wake authority, and stop semantics are not weakened.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.1 - Restore-Console-attachment-save-toast-escaping.md
+++ b/backlog/tasks/task-19642.8.1 - Restore-Console-attachment-save-toast-escaping.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.1
+title: Restore Console attachment save-toast escaping
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - attachments
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the two attachment-rider failures covering single and multi-save toast path escaping.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both attachment-rider nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Saved paths are escaped safely without changing the underlying destination.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.2 - Restore-Console-video-action-routing-and-save-behavior.md
+++ b/backlog/tasks/task-19642.8.2 - Restore-Console-video-action-routing-and-save-behavior.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.2
+title: Restore Console video action routing and save behavior
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - video
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the four Console video-action failures covering persisted storage IDs, WebM playback resolution, save extensions, and collision naming.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All four video-action nodes in the TASK-19520 verification inventory pass in a focused run.
+- [ ] #2 Playback and save actions preserve storage identity, extension, and collision-safe naming.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.3 - Restore-Console-fleet-and-headless-wake-authority-tests.md
+++ b/backlog/tasks/task-19642.8.3 - Restore-Console-fleet-and-headless-wake-authority-tests.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.3
+title: Restore Console fleet and headless wake authority tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - agents
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the four fleet/headless wake failures covering pending-card deferral, manual-equivalent authority, approval gating, dispatch, and budget behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All four fleet/headless wake nodes in the TASK-19520 verification inventory pass in focused runs.
+- [ ] #2 Woken turns retain the same authority, approval, and budget constraints as manual turns.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.4 - Restore-Console-skill-confirm-bridge-wiring-tests.md
+++ b/backlog/tasks/task-19642.8.4 - Restore-Console-skill-confirm-bridge-wiring-tests.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.4
+title: Restore Console skill-confirm bridge wiring tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - skills
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the two skill-script confirmation failures covering absent and present UI confirmation sinks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Both skill-confirm nodes in the TASK-19520 verification inventory pass.
+- [ ] #2 The bridge exposes a confirmation callback only when a UI sink is wired.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.5 - Restore-Console-diff-feedback-payload-identity-test.md
+++ b/backlog/tasks/task-19642.8.5 - Restore-Console-diff-feedback-payload-identity-test.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.5
+title: Restore Console diff-feedback payload identity test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - diff
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the diff-feedback failure requiring byte-identical payloads when no pending notes exist.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The diff-feedback node in the TASK-19520 verification inventory passes.
+- [ ] #2 No-pending-notes delivery leaves the payload byte-identical.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.6 - Restore-Console-local-review-root-swap-confinement-test.md
+++ b/backlog/tasks/task-19642.8.6 - Restore-Console-local-review-root-swap-confinement-test.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.6
+title: Restore Console local-review root-swap confinement test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - security
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the local-review-hook failure requiring a selected-root swap to fail closed before local tool invocation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The local-review-hook node in the TASK-19520 verification inventory passes.
+- [ ] #2 A selected-root swap is rejected before any local invocation or filesystem access.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.7 - Restore-Console-provider-failure-recovery-copy-test.md
+++ b/backlog/tasks/task-19642.8.7 - Restore-Console-provider-failure-recovery-copy-test.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.7
+title: Restore Console provider failure recovery copy test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - ux
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the provider-failure-copy failure requiring agent failure rows to retain body and image recovery guidance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The provider-failure-copy node in the TASK-19520 verification inventory passes.
+- [ ] #2 Failure rows preserve the expected body and image recovery hint without leaking provider internals.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.8.8 - Restore-Console-stop-content-freeze-test.md
+++ b/backlog/tasks/task-19642.8.8 - Restore-Console-stop-content-freeze-test.md
@@ -1,0 +1,28 @@
+---
+id: TASK-19642.8.8
+title: Restore Console stop content-freeze test
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:37'
+labels:
+  - testing
+  - chat
+  - reliability
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642.8
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the stop-reliability failure requiring message content to freeze at the accepted stop point.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The stop-reliability node in the TASK-19520 verification inventory passes.
+- [ ] #2 No content arriving after the accepted stop point is committed to the message.
+<!-- AC:END -->

--- a/backlog/tasks/task-19642.9 - Restore-OpenAI-realtime-session-contract-tests.md
+++ b/backlog/tasks/task-19642.9 - Restore-OpenAI-realtime-session-contract-tests.md
@@ -1,0 +1,29 @@
+---
+id: TASK-19642.9
+title: Restore OpenAI realtime session contract tests
+status: To Do
+assignee: []
+created_date: '2026-08-21 23:26'
+labels:
+  - testing
+  - llm
+  - realtime
+dependencies: []
+references:
+  - backlog/docs/task-19520-verification-failure-inventory.md
+parent_task_id: TASK-19642
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reproduce and repair the 34 serial failures in test_openai_realtime_session.py. This is not assumed to be the existing xdist-only issue; diagnose the fake transport, session fixture, and lifecycle contracts directly.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 34 realtime-session nodes in the TASK-19520 verification inventory pass in a serial focused run.
+- [ ] #2 Connect, send, receive, cancellation, close, callback isolation, VAD, transcript, and usage contracts remain covered.
+- [ ] #3 If parallel execution differs, serial and xdist behavior are documented separately.
+<!-- AC:END -->

--- a/tldw_chatbook/Skills_Interop/atomic_write.py
+++ b/tldw_chatbook/Skills_Interop/atomic_write.py
@@ -34,11 +34,14 @@ the stray temp file it left behind, never the exception itself.
 from __future__ import annotations
 
 import os
+import secrets
 import threading
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Callable
 
 _OWNER_ONLY_FILE_MODE = 0o600
+_OWNER_ONLY_TEMP_CANDIDATES = 8
 
 
 def _owner_only_open_flags() -> int:
@@ -51,6 +54,13 @@ def _owner_only_open_flags() -> int:
         | getattr(os, "O_BINARY", 0)
         | getattr(os, "O_NOFOLLOW", 0)
     )
+
+
+def _owner_only_temp_paths(temp_path: Path) -> Iterator[Path]:
+    """Yield the supplied temp path, then bounded random sibling fallbacks."""
+    yield temp_path
+    for _ in range(_OWNER_ONLY_TEMP_CANDIDATES - 1):
+        yield temp_path.with_name(f"{temp_path.name}.{secrets.token_hex(8)}")
 
 
 def unique_temp_path(path: Path, *, hidden: bool = False) -> Path:
@@ -92,8 +102,9 @@ def replace_atomically(
     ``owner_only=True``, the temp file is instead created exclusively with mode
     ``0o600`` before content is written. On POSIX, ``fchmod`` confirms that mode
     before the descriptor is closed, the callback runs, and the atomic replace
-    occurs. An exclusive-open collision happens before this writer owns the
-    temp path, so the unexplained existing file is preserved.
+    occurs. An exclusive-open collision happens before this writer owns that
+    path, so the unexplained existing file is preserved and a bounded random
+    same-directory sibling is tried instead.
 
     Once this call creates or delegates creation of its own temp file, any
     exception from the setup, write, or replace best-effort unlinks that temp
@@ -107,39 +118,58 @@ def replace_atomically(
         target_path: Final destination, replaced in one step once the write
             has completed.
         write_fn: Callable given ``temp_path``; performs the actual write.
-        owner_only: Exclusively precreate ``temp_path`` with owner-only mode
-            before invoking ``write_fn``. The default leaves creation to
-            ``write_fn`` for compatibility with existing callers.
+        owner_only: Exclusively precreate ``temp_path`` (or, on collision, a
+            bounded random sibling) with owner-only mode before invoking
+            ``write_fn``. The default leaves creation to ``write_fn`` for
+            compatibility with existing callers.
 
     Raises:
         BaseException: Whatever secure temp setup, ``write_fn``, or
             ``Path.replace`` raised, re-raised unchanged after cleanup of a
             temp file owned by this call.
     """
-    created_temp = False
+    owned_temp_path: Path | None = None
+    active_temp_path = temp_path
     try:
         if owner_only:
-            fd = os.open(temp_path, _owner_only_open_flags(), _OWNER_ONLY_FILE_MODE)
-            created_temp = True
-            setup_succeeded = False
-            try:
-                if os.name == "posix" and hasattr(os, "fchmod"):
-                    os.fchmod(fd, _OWNER_ONLY_FILE_MODE)
-                setup_succeeded = True
-            finally:
+            last_collision: FileExistsError | None = None
+            for candidate in _owner_only_temp_paths(temp_path):
                 try:
-                    os.close(fd)
-                except BaseException:
-                    # Keep an active setup error primary; otherwise close is
-                    # the failure the caller must see.
-                    if setup_succeeded:
-                        raise
-        write_fn(temp_path)
-        temp_path.replace(target_path)
+                    fd = os.open(
+                        candidate,
+                        _owner_only_open_flags(),
+                        _OWNER_ONLY_FILE_MODE,
+                    )
+                except FileExistsError as exc:
+                    last_collision = exc
+                    continue
+
+                owned_temp_path = candidate
+                active_temp_path = candidate
+                setup_succeeded = False
+                try:
+                    if os.name == "posix" and hasattr(os, "fchmod"):
+                        os.fchmod(fd, _OWNER_ONLY_FILE_MODE)
+                    setup_succeeded = True
+                finally:
+                    try:
+                        os.close(fd)
+                    except BaseException:
+                        # Keep an active setup error primary; otherwise close is
+                        # the failure the caller must see.
+                        if setup_succeeded:
+                            raise
+                break
+            else:
+                assert last_collision is not None
+                raise last_collision
+        write_fn(active_temp_path)
+        active_temp_path.replace(target_path)
     except BaseException:
-        if not owner_only or created_temp:
+        cleanup_path = owned_temp_path if owner_only else temp_path
+        if cleanup_path is not None:
             try:
-                temp_path.unlink(missing_ok=True)
+                cleanup_path.unlink(missing_ok=True)
             except OSError:
                 pass
         raise

--- a/tldw_chatbook/Skills_Interop/atomic_write.py
+++ b/tldw_chatbook/Skills_Interop/atomic_write.py
@@ -38,6 +38,20 @@ import threading
 from pathlib import Path
 from typing import Callable
 
+_OWNER_ONLY_FILE_MODE = 0o600
+
+
+def _owner_only_open_flags() -> int:
+    """Return flags for exclusive owner-only temp-file creation."""
+    return (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
 
 def unique_temp_path(path: Path, *, hidden: bool = False) -> Path:
     """Build a writer-unique temp path alongside ``path``.
@@ -65,15 +79,26 @@ def unique_temp_path(path: Path, *, hidden: bool = False) -> Path:
 
 
 def replace_atomically(
-    temp_path: Path, target_path: Path, write_fn: Callable[[Path], None]
+    temp_path: Path,
+    target_path: Path,
+    write_fn: Callable[[Path], None],
+    *,
+    owner_only: bool = False,
 ) -> None:
     """Call ``write_fn(temp_path)`` then atomically replace ``target_path``.
 
-    On any exception from either the write or the replace, the temp file is
-    best-effort unlinked (it is this writer's own temp file -- writer-unique
-    naming means no other writer could be relying on it) and the original
-    exception is re-raised unchanged. This never swallows a genuine failure;
-    it only ever prevents a stray temp file from being left behind by one.
+    By default, behavior is unchanged: ``write_fn`` creates the temp file, and
+    any write or replace failure triggers best-effort cleanup. With
+    ``owner_only=True``, the temp file is instead created exclusively with mode
+    ``0o600`` before content is written. On POSIX, ``fchmod`` confirms that mode
+    before the descriptor is closed, the callback runs, and the atomic replace
+    occurs. An exclusive-open collision happens before this writer owns the
+    temp path, so the unexplained existing file is preserved.
+
+    Once this call creates or delegates creation of its own temp file, any
+    exception from the setup, write, or replace best-effort unlinks that temp
+    file and re-raises the original exception unchanged. Cleanup errors alone
+    are suppressed.
 
     Args:
         temp_path: Writer-unique temp file to write through, normally from
@@ -82,19 +107,33 @@ def replace_atomically(
         target_path: Final destination, replaced in one step once the write
             has completed.
         write_fn: Callable given ``temp_path``; performs the actual write.
+        owner_only: Exclusively precreate ``temp_path`` with owner-only mode
+            before invoking ``write_fn``. The default leaves creation to
+            ``write_fn`` for compatibility with existing callers.
 
     Raises:
-        BaseException: Whatever ``write_fn`` or ``Path.replace`` raised,
-            re-raised unchanged after the temp file is cleaned up.
+        BaseException: Whatever secure temp setup, ``write_fn``, or
+            ``Path.replace`` raised, re-raised unchanged after cleanup of a
+            temp file owned by this call.
     """
+    created_temp = False
     try:
+        if owner_only:
+            fd = os.open(temp_path, _owner_only_open_flags(), _OWNER_ONLY_FILE_MODE)
+            created_temp = True
+            try:
+                if os.name == "posix" and hasattr(os, "fchmod"):
+                    os.fchmod(fd, _OWNER_ONLY_FILE_MODE)
+            finally:
+                os.close(fd)
         write_fn(temp_path)
         temp_path.replace(target_path)
     except BaseException:
-        try:
-            temp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        if not owner_only or created_temp:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
         raise
 
 

--- a/tldw_chatbook/Skills_Interop/atomic_write.py
+++ b/tldw_chatbook/Skills_Interop/atomic_write.py
@@ -121,11 +121,19 @@ def replace_atomically(
         if owner_only:
             fd = os.open(temp_path, _owner_only_open_flags(), _OWNER_ONLY_FILE_MODE)
             created_temp = True
+            setup_succeeded = False
             try:
                 if os.name == "posix" and hasattr(os, "fchmod"):
                     os.fchmod(fd, _OWNER_ONLY_FILE_MODE)
+                setup_succeeded = True
             finally:
-                os.close(fd)
+                try:
+                    os.close(fd)
+                except BaseException:
+                    # Keep an active setup error primary; otherwise close is
+                    # the failure the caller must see.
+                    if setup_succeeded:
+                        raise
         write_fn(temp_path)
         temp_path.replace(target_path)
     except BaseException:

--- a/tldw_chatbook/Skills_Interop/skill_trust_store.py
+++ b/tldw_chatbook/Skills_Interop/skill_trust_store.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import math
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +30,7 @@ from .skill_trust_crypto import (
 _MANIFEST_FILENAME = "skill_trust_manifest.json"
 _SNAPSHOTS_DIRNAME = "snapshots"
 _TRUST_DIRNAME = "trust"
+_OWNER_ONLY_DIRECTORY_MODE = 0o700
 
 #: Name of the local generation-marker fallback file, used when no secure
 #: keyring backend is available (see ``build_skill_trust_marker_store_with_fallback``).
@@ -227,7 +229,11 @@ class KeyringSkillTrustGenerationMarkerStore:
 
     @property
     def _account(self) -> str:
-        return f"{_MARKER_USERNAME}:{self.account_scope}" if self.account_scope else _MARKER_USERNAME
+        return (
+            f"{_MARKER_USERNAME}:{self.account_scope}"
+            if self.account_scope
+            else _MARKER_USERNAME
+        )
 
     def load_marker(self) -> dict[str, Any] | None:
         """Load the marker from secure keyring storage."""
@@ -320,7 +326,11 @@ class KeyringSkillTrustKeyCache:
 
     @property
     def _account(self) -> str:
-        return f"{_KEY_CACHE_USERNAME}:{self.account_scope}" if self.account_scope else _KEY_CACHE_USERNAME
+        return (
+            f"{_KEY_CACHE_USERNAME}:{self.account_scope}"
+            if self.account_scope
+            else _KEY_CACHE_USERNAME
+        )
 
     def save_keys(self, keys: SkillTrustKeys, *, salt: bytes) -> None:
         """Store derived key material in a secure keyring, never the passphrase."""
@@ -344,9 +354,7 @@ class KeyringSkillTrustKeyCache:
         """Load cached derived trust keys from the secure keyring."""
 
         expected_salt_digest = _salt_digest(expected_salt)
-        payload = self.keyring_backend.get_password(
-            self.service_name, self._account
-        )
+        payload = self.keyring_backend.get_password(self.service_name, self._account)
         if not payload:
             return None
         data = json.loads(payload)
@@ -514,6 +522,7 @@ class SkillTrustStore:
         snapshot_payload = _json_safe_payload(payload)
         if not isinstance(snapshot_payload, dict):
             raise ValueError("skill trust snapshot payload must be an object")
+        _ensure_trust_directory(self.store_dir)
         snapshots_dir = _ensure_trust_directory(self.snapshots_dir)
         encrypted = encrypt_json_blob(
             snapshot_payload,
@@ -604,12 +613,19 @@ def _atomic_write_json(
     # (TASK-17963). `hidden=True` keeps this store's existing dot-prefixed
     # temp-file convention; the containment check below still re-runs
     # against the (now writer-unique) temp path exactly as it did against
-    # the old fixed one. A genuine write/replace failure still raises --
-    # only the temp-name collision class is gone.
+    # the old fixed one. `owner_only=True` precreates that temp at 0600 before
+    # serialization can write sensitive trust material (TASK-19520). A genuine
+    # write/replace failure still raises -- only the temp-name collision class
+    # is gone.
     temp_path = unique_temp_path(path, hidden=True)
     temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
     text = json.dumps(payload, indent=indent, sort_keys=True) + "\n"
-    replace_atomically(temp_path, path, lambda t: t.write_text(text, encoding="utf-8"))
+    replace_atomically(
+        temp_path,
+        path,
+        lambda t: t.write_text(text, encoding="utf-8"),
+        owner_only=True,
+    )
 
 
 def _atomic_write_bytes(
@@ -619,14 +635,27 @@ def _atomic_write_bytes(
     path = _validated_trust_file_path(path, base_dir=base_dir)
     temp_path = unique_temp_path(path, hidden=True)
     temp_path = _validated_trust_file_path(temp_path, base_dir=base_dir)
-    replace_atomically(temp_path, path, lambda t: t.write_bytes(payload))
+    replace_atomically(
+        temp_path,
+        path,
+        lambda t: t.write_bytes(payload),
+        owner_only=True,
+    )
 
 
 def _ensure_trust_directory(path: Path) -> Path:
     directory = validate_path_simple(path)
     if directory.is_symlink():
         raise ValueError("unsafe skill trust path")
-    directory.mkdir(parents=True, exist_ok=True)
+    directory.mkdir(
+        mode=_OWNER_ONLY_DIRECTORY_MODE,
+        parents=True,
+        exist_ok=True,
+    )
+    if directory.is_symlink():
+        raise ValueError("unsafe skill trust path")
+    if os.name == "posix":
+        directory.chmod(_OWNER_ONLY_DIRECTORY_MODE)
     return directory
 
 


### PR DESCRIPTION
## Summary

- add an opt-in owner-only atomic publication path with exclusive 0600 temp creation before replacement
- secure trust-store directories to 0700 on POSIX and tighten legacy trust material on its next write
- add permission, ordering, cleanup, portability, and unchanged-default regression coverage
- preserve and file the unrelated verification failures under TASK-19642

## Security boundary

This is filesystem defense in depth under ADR-009. It does not claim isolation from the same OS identity, root or administrators, storage ACLs, mount policy, disk encryption, or Windows ACL semantics.

## Test plan

- 53 focused Skills atomic-write and trust-store tests passed
- five targeted permission and cleanup mutations failed at their intended assertions and were restored
- Ruff check passed
- Ruff format check passed
- git diff --check passed

The repository-wide run was stopped at user direction. Its observed failures were not attributed to this change; all 301 captured nodes are mapped in TASK-19642 or existing open tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden trust persistence for local skills by adding an opt-in owner-only atomic write path and securing POSIX trust directories. Previously files inherited the process umask; with the opt-in, temp files are 0600 and published atomically, directories are 0700, and stale secure-temp collisions recover via bounded random sibling candidates. Side effect: other OS users can no longer read trust material on POSIX; if you relied on shared read access, run under the same OS identity or adjust that workflow. Addresses TASK-19520 (ADR-009).

- `tldw_chatbook/Skills_Interop/atomic_write.replace_atomically` adds `owner_only=True` to create exclusive 0600 temps via secure open flags; if the deterministic secure temp exists, it retries with up to 7 random sibling names; default behavior is unchanged and setup exceptions still propagate.
- The trust store opts into `owner_only` for manifests, encrypted snapshots, and the generation marker; POSIX trust directories (both levels) are ensured 0700, and legacy material is tightened on the next write.
- Focused tests cover concurrency, owner-only temp creation, stale-secure-temp recovery, ordering, cleanup, and POSIX-only permission assertions; non-POSIX skips are explicit.

<sup>Written for commit 5304b3dead39b3a02c4bc53045d800f5cf2ee551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

