### PR TITLE
fix(notes): preserve the losing side of a sync conflict and implement disk_wins (task-19554)

### DIFF
--- a/Docs/Features/notes_bidirectional_sync.md
+++ b/Docs/Features/notes_bidirectional_sync.md
@@ -91,6 +91,45 @@ both default to `ConflictResolution.ASK` when called with no explicit
 value. The panel never relies on that default: it always resolves and
 passes one of its three exposed policies explicitly.
 
+### What each policy does to the losing copy
+
+A resolution that overwrites one side always keeps that side first
+(task-19554). What each offered policy does on a `both_changed` conflict:
+
+| Policy | Winner | What happens to the other copy |
+|---|---|---|
+| Newer wins | The side with the later timestamp (note `last_modified` vs. file mtime) | Saved as a sidecar next to the note file, then overwritten |
+| Disk wins | The file on disk | The note body is saved as a sidecar, then replaced |
+| Library wins | The note in the Library | The file's text is saved as a sidecar, then overwritten |
+| Ask (engine-only, never offered by the panel) | Neither | Nothing is written; the conflict row stays open |
+
+The sidecar is named
+`<file name>.conflict-<UTC timestamp>-<db|disk>.bak` and holds the
+discarded text **verbatim** — no header, no diff markers — so recovering
+it is a rename. Sidecars are excluded from every subsequent scan (by the
+`.conflict-` marker, not just the `.bak` suffix), so a preserved copy
+never becomes a note of its own.
+
+The same text is also written to the conflict's own row —
+`sync_conflicts.losing_side` / `losing_content` /
+`preserved_file_path` — so the discarded version survives the sidecar
+being moved or deleted. Those columns are written **only when a side is
+actually discarded**, never on mere detection, so the table does not
+become a second unbounded content shadow of `notes`.
+
+Preservation is fail-closed: if the sidecar cannot be written (an
+unwritable root, a rejected path), the overwrite does **not** happen. The
+conflict is left open, an error is recorded on the run, and both copies
+survive.
+
+Direction narrows which side a policy may write, and a policy whose
+winner cannot be written in the chosen direction applies nothing rather
+than pretending to have settled anything — e.g. "Disk wins" during a
+`db_to_disk` push has nothing to do, because the disk copy already
+stands. `SyncConflict.applied` is the engine-level fact behind this, and
+the panel's activity log distinguishes "N conflicts resolved" from "N
+conflicts left unresolved — both copies kept as they are" on it.
+
 ## Path safety
 
 Every read and write goes through `PinnedSyncRoot`
@@ -125,6 +164,20 @@ Plus two standalone tables the engine writes on every run:
 policy, status, file/conflict/error counts) and `sync_conflicts` (one row
 per detected conflict, linked to its session).
 
+`sync_conflicts` also carries the preservation columns added in schema
+v44:
+
+```sql
+losing_side TEXT,          -- 'db' | 'disk' -- which side was discarded
+losing_content TEXT,       -- that side's text, verbatim
+preserved_file_path TEXT   -- the sidecar written next to the note file
+```
+
+All three stay `NULL` for a conflict nothing was discarded for.
+`resolution` (`use_db` / `use_disk`, or `NULL` while open) and
+`resolved_at` are stamped by the engine only once a side was actually
+applied.
+
 None of `is_externally_synced`, `file_path_on_disk`, or the other sync
 columns currently drive any per-note UI indicator — the Library notes list
 shows no synced/conflict badge on individual rows (confirmed: nothing in
@@ -139,22 +192,33 @@ and `sync_conflicts` directly, beyond the `sync_folder()` call the panel
 uses:
 
 - `get_sync_history(limit=50)` — recent sessions from `sync_sessions`.
-- `get_conflicts_for_session(session_id)` — conflict rows for one session.
+- `get_conflicts_for_session(session_id)` — conflict rows for one session,
+  including `losing_side` / `losing_content` / `preserved_file_path`.
+- `get_preserved_conflict_copies(limit=50)` — every conflict whose
+  discarded side was kept, newest first, across all sessions. This is the
+  recovery entry point that does not need a session id: after an
+  unattended auto-sync pass a user knows only that a note changed under
+  them. Each row carries the discarded text itself as well as the sidecar
+  path, so recovery works whether or not the folder still has the file.
 - `resolve_conflict(conflict_id, resolution, user_id)` — records a
   resolution string on a `sync_conflicts` row. **It does not currently
   apply the resolution** — the method body has a standing
   `# TODO: Implement actual resolution logic based on resolution type`;
-  it only marks the row resolved.
+  it only marks the row resolved. It matches only rows with a `NULL`
+  resolution, i.e. conflicts the engine left open.
 - `get_notes_sync_status(root_folder=None)` — computes a per-note status
   (`synced` / `file_changed` / `db_changed` / `conflict` / `file_missing`
   / `file_error`) by re-hashing each synced note's current DB content and
   its file on disk.
 
-None of these four are called anywhere outside `sync_service.py` itself —
+None of these five are called anywhere outside `sync_service.py` itself —
 there is no history browser, conflict-review list, or per-note status
 view in the running app today. They exist as service-layer API surface;
 the Library panel's own activity log (capped at 20 entries, in-memory,
-not backed by these tables) is what a user actually sees.
+not backed by these tables) is what a user actually sees, and the sidecar
+file in the sync folder is what a user actually recovers from. A
+conflict-review surface that renders these rows is an open product
+question, not shipped.
 
 ## Configuration
 

--- a/Docs/Features/notes_bidirectional_sync.md
+++ b/Docs/Features/notes_bidirectional_sync.md
@@ -106,9 +106,22 @@ A resolution that overwrites one side always keeps that side first
 The sidecar is named
 `<file name>.conflict-<UTC timestamp>-<db|disk>.bak` and holds the
 discarded text **verbatim** — no header, no diff markers — so recovering
-it is a rename. Sidecars are excluded from every subsequent scan (by the
-`.conflict-` marker, not just the `.bak` suffix), so a preserved copy
-never becomes a note of its own.
+it is a rename. Sidecars are excluded from every subsequent scan, so a
+preserved copy never becomes a note of its own. Recognition
+(`NotesSyncEngine.is_conflict_sidecar`) requires the `.conflict-` marker
+**and** the `.bak` suffix together: the `.bak` suffix alone already keeps
+sidecars out of the default `['.md', '.txt']` scan set, and the marker
+alone would silently un-sync a user's own note named something like
+`meeting.conflict-notes.md` — a silent filter must not over-match.
+
+The name is claimed with `O_CREAT | O_EXCL` through
+`PinnedSyncRoot.create_new_text`, the never-replace counterpart to
+`write_text` (which renames over its target). Checking for a free name
+and then writing it would leave a window in which a concurrent sync run
+takes the same name, and the rename would then destroy that run's
+preserved copy. A taken name raises `FileExistsError`, the writer
+advances to the next ordinal (`…-2-disk.bak`), and an exhausted name
+space raises rather than overwriting anything.
 
 The same text is also written to the conflict's own row —
 `sync_conflicts.losing_side` / `losing_content` /

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -166,6 +166,32 @@ The status line below reports "idle", "syncing · 3/12",
 "failed · \<reason\>", and an activity log keeps the last 20 entries,
 most recent first.
 
+#### What a conflict policy does to the copy that loses
+
+A conflict is when the same note changed **both** in the Library and in
+the file on disk since the last sync. One copy has to give way, and the
+one that does is always saved first:
+
+| Policy | Which copy is kept as the note/file | What happens to the other one |
+|---|---|---|
+| **Newer wins** | Whichever was edited more recently | Saved beside the file, then replaced |
+| **Disk wins** | The file on disk | The Library's version is saved beside the file, then replaced |
+| **Library wins** | The note in the Library | The file's version is saved beside the file, then replaced |
+
+The saved copy is a plain file next to the original, named
+`your-note.md.conflict-20260821T203015Z-disk.bak` (`-disk` for the file's
+version, `-db` for the Library's). It holds the replaced text exactly, so
+recovering it is a rename — nothing is added to it. The sync never picks
+these files up again, so they will not turn into extra notes.
+
+If that copy cannot be written for any reason, **the sync does not
+overwrite anything**: both versions are left exactly as they are and the
+run reports an error instead.
+
+The activity log tells you which happened: "1 conflict resolved (Disk
+wins)" and "Replaced copy saved as …", or "1 conflict left unresolved —
+both copies kept as they are" when the run did not change either side.
+
 ## Common tasks
 
 ### Create a note from a template
@@ -233,7 +259,13 @@ click-driven. Global navigation keys live in the [guide index](../index.md).
   type and size if it keeps failing.
 - **Sync never asks about conflicts** — there is no "ask me" policy by
   design; conflicts are always resolved by the "conflicts" setting, and
-  the count is reported in the status line afterwards.
+  the count is reported in the status line afterwards. The copy that
+  loses is never simply discarded — see
+  ["What a conflict policy does to the copy that loses"](#what-a-conflict-policy-does-to-the-copy-that-loses).
+- **`.conflict-…bak` files appear in your sync folder** — those are the
+  replaced copies from a conflict, kept on purpose. Delete them once you
+  are happy with the merge; rename one back over the original to restore
+  what it holds. Sync ignores them.
 - **Notes rows have no ▸ marker** — unlike media rows, note rows show
   only the title and age; they still open on click.
 - **Notes cap at 2,000,000 characters** — longer content is rejected
@@ -305,3 +337,11 @@ the version-checked service seam.)*
 rail; database editing and Files use one focused workbench with a guarded
 `‹ Library / Notes` return; exact browse identity and independent scroll
 positions survive return and compact/wide breakpoint crossings.*
+
+*Verified against dev @ 5f720a404 — 2026-08-21 (TASK-19554): the conflict
+policies now describe what actually happens to the losing copy. "Disk wins"
+applies the disk copy (it previously applied nothing at all while reporting
+the conflict as resolved), and every policy that overwrites a side saves that
+side as a `.conflict-…bak` file next to the note first — fail-closed, so no
+overwrite happens when the copy cannot be saved. Covered end-to-end by
+`Tests/Notes/test_sync_conflict_preservation.py`.*

--- a/Tests/DB/test_chachanotes_console_project_context_migration.py
+++ b/Tests/DB/test_chachanotes_console_project_context_migration.py
@@ -440,8 +440,11 @@ def test_fresh_schema_contains_console_project_context_column(tmp_path) -> None:
     # migration (e.g. task-18300's own v42->v43 message_exchanges table)
     # legitimately bumps `_CURRENT_SCHEMA_VERSION` further without this
     # file needing to know or care. The exact current-version pin lives in
-    # exactly one place, `Tests/DB/test_chachanotes_message_exchanges.py`'s
-    # `test_schema_version_is_43` (currently 43) -- this assertion only
+    # exactly one place -- as of task-19554 that is
+    # `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py`'s
+    # `test_schema_version_is_44` (the pin moves to the newest migration's
+    # own file on every bump, rather than staying on an older one from
+    # which it can only drift) -- this assertion only
     # needs to confirm a fresh schema landed AT OR PAST this migration's
     # own version, not the overall latest.
     assert CharactersRAGDB._CURRENT_SCHEMA_VERSION >= 42

--- a/Tests/DB/test_chachanotes_message_exchanges.py
+++ b/Tests/DB/test_chachanotes_message_exchanges.py
@@ -96,17 +96,24 @@ def test_hard_delete_cascades(db):
     assert count == 0
 
 
-def test_schema_version_is_43(db):
+def test_schema_version_is_at_least_43(db):
     # Mirrors the house sibling-version test pattern (a local `_version()`
     # helper against db_schema_version -- there is no public accessor).
-    assert _version(db.get_connection()) == 43
+    #
+    # task-19554: this used to be `== 43` and was designated the repo's one
+    # exact current-version pin. That made every LATER migration edit this
+    # file, which owns only v42->v43. It now asserts at-or-past its own
+    # version, and the exact pin lives with the newest migration --
+    # `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py`'s
+    # `test_schema_version_is_44`.
+    assert _version(db.get_connection()) >= 43
 
 
 def test_migrate_from_v42_to_v43_requires_version_42(tmp_path):
     # Mirrors the version pre-check idiom in
     # test_chachanotes_default_assistant_enrichment_migration.py::
     # test_migrate_from_v31_to_v32_requires_version_31: a fresh database
-    # lands on the current (43) schema, so calling the v42->v43 step
+    # lands on the CURRENT schema (>= 43), so calling the v42->v43 step
     # directly against it must reject rather than silently re-run.
     from tldw_chatbook.DB.ChaChaNotes_DB import SchemaError
 
@@ -121,11 +128,13 @@ def test_upgrade_path_from_v42_recreates_the_table(tmp_path):
     """A database stamped back to v42 (with message_exchanges dropped, so
     the migration's CREATE TABLE genuinely has work to do rather than
     no-op against an already-existing table) must, on reopen, re-run
-    _migrate_from_v42_to_v43 and land on v43 with the table back."""
+    _migrate_from_v42_to_v43 and land on the current version with the
+    table back. (task-19554: the landing version is the CURRENT one, not
+    43 -- a stamped-back DB replays every later step too.)"""
     db_path = tmp_path / "chachanotes.db"
     db = CharactersRAGDB(db_path, client_id="upgrade-test")
     connection = db.get_connection()
-    assert _version(connection) == 43
+    assert _version(connection) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
 
     with db.transaction() as cursor:
         cursor.execute("DROP TABLE message_exchanges")
@@ -137,7 +146,7 @@ def test_upgrade_path_from_v42_recreates_the_table(tmp_path):
 
     reopened = CharactersRAGDB(db_path, client_id="upgrade-test-reopen")
     reopened_connection = reopened.get_connection()
-    assert _version(reopened_connection) == 43
+    assert _version(reopened_connection) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
     tables = {
         row[0]
         for row in reopened_connection.execute(

--- a/Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py
+++ b/Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py
@@ -1,0 +1,147 @@
+"""ChaChaNotes v43 -> v44: recoverable copy of a discarded sync side.
+
+task-19554. The Notes sync engine resolved a ``both_changed`` conflict by
+overwriting one side wholesale while ``sync_conflicts`` kept only a SHA-256 of
+it, so the discarded text was unrecoverable. This migration adds the three
+columns (``losing_side``, ``losing_content``, ``preserved_file_path``) that
+make the row a real second copy behind the on-disk sidecar.
+
+This module also carries the repo's EXACT current-schema-version pin, which
+moved here from ``test_chachanotes_message_exchanges.py`` when v44 landed:
+the pin belongs to the newest migration's own file, so a schema bump touches
+the file that caused it rather than an unrelated older one (older files assert
+``>= their own version`` instead). Updating the number here is a deliberate
+schema-review act.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
+
+SCHEMA_NAME = CharactersRAGDB._SCHEMA_NAME
+NEW_COLUMNS = ("losing_side", "losing_content", "preserved_file_path")
+
+
+def _version(connection: sqlite3.Connection) -> int:
+    return connection.execute(
+        "SELECT version FROM db_schema_version WHERE schema_name = ?",
+        (SCHEMA_NAME,),
+    ).fetchone()[0]
+
+
+def _columns(connection: sqlite3.Connection) -> dict[str, tuple]:
+    return {
+        row[1]: tuple(row)
+        for row in connection.execute("PRAGMA table_info(sync_conflicts)")
+    }
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    instance = CharactersRAGDB(tmp_path / "chachanotes.db", client_id="v44-test")
+    yield instance
+    instance.close_connection()
+
+
+def test_schema_version_is_44(db):
+    """The one exact current-version pin (see this module's docstring)."""
+    assert _version(db.get_connection()) == 44
+    assert CharactersRAGDB._CURRENT_SCHEMA_VERSION == 44
+
+
+def test_fresh_schema_has_the_preservation_columns(db):
+    columns = _columns(db.get_connection())
+    for name in NEW_COLUMNS:
+        assert name in columns, f"{name} missing from sync_conflicts"
+        assert columns[name][2].upper() == "TEXT", columns[name]
+        assert columns[name][3] == 0, "the columns must be nullable"
+        assert columns[name][4] is None, "no default -- absence must be NULL"
+
+
+def test_migrate_from_v43_to_v44_requires_version_43(db):
+    """A fresh DB is already at 44, so re-entering the step must refuse."""
+    with pytest.raises(SchemaError, match="requires schema version"):
+        db._migrate_from_v43_to_v44(db.get_connection())
+
+
+def test_upgrade_from_a_real_v43_database_adds_the_columns(tmp_path: Path):
+    """A genuine v43 database, with rows in it, migrates and keeps them."""
+    db_path = tmp_path / "chachanotes.db"
+    with chachanotes_db_at_version(db_path, 43) as historical:
+        connection = historical.get_connection()
+        assert _version(connection) == 43
+        for name in NEW_COLUMNS:
+            assert name not in _columns(connection), (
+                f"{name} must NOT exist before the migration, or this test "
+                f"proves nothing"
+            )
+        with historical.transaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO sync_sessions(
+                    session_id, sync_root_folder, sync_direction,
+                    conflict_resolution, status, client_id
+                ) VALUES ('s-1', '/tmp/root', 'bidirectional', 'newer_wins',
+                          'completed', 'v43-client')
+                """
+            )
+            cursor.execute(
+                """
+                INSERT INTO sync_conflicts(
+                    session_id, file_path, conflict_type,
+                    db_content_hash, disk_content_hash
+                ) VALUES ('s-1', 'note.md', 'both_changed', 'aaa', 'bbb')
+                """
+            )
+
+    migrated = CharactersRAGDB(db_path, client_id="v44-upgrade")
+    try:
+        connection = migrated.get_connection()
+        assert _version(connection) == 44
+        columns = _columns(connection)
+        for name in NEW_COLUMNS:
+            assert name in columns
+        row = connection.execute(
+            "SELECT db_content_hash, disk_content_hash, losing_side, "
+            "losing_content, preserved_file_path FROM sync_conflicts"
+        ).fetchone()
+        assert tuple(row) == ("aaa", "bbb", None, None, None), (
+            "the pre-existing row must survive with NULL preservation fields"
+        )
+    finally:
+        migrated.close_connection()
+
+
+def test_upgrade_is_re_enterable_after_a_half_applied_run(tmp_path: Path):
+    """The task-19553 brick shape: one ADD COLUMN applied, stamp still 43.
+
+    ``_execute_migration_statements`` skips an already-satisfied ADD COLUMN,
+    so this must land on 44 rather than dying on ``duplicate column name``
+    every launch forever.
+    """
+    db_path = tmp_path / "half_applied.db"
+    with chachanotes_db_at_version(db_path, 43):
+        pass
+
+    connection = sqlite3.connect(str(db_path))
+    try:
+        connection.execute("ALTER TABLE sync_conflicts ADD COLUMN losing_side TEXT")
+        connection.commit()
+        assert _version(connection) == 43, "a half-applied step never bumps"
+    finally:
+        connection.close()
+
+    migrated = CharactersRAGDB(db_path, client_id="v44-reentry")
+    try:
+        assert _version(migrated.get_connection()) == 44
+        columns = _columns(migrated.get_connection())
+        for name in NEW_COLUMNS:
+            assert name in columns
+    finally:
+        migrated.close_connection()

--- a/Tests/Notes/test_sync_conflict_preservation.py
+++ b/Tests/Notes/test_sync_conflict_preservation.py
@@ -607,3 +607,154 @@ class TestReportedOutcomeMatchesReality:
         assert not [c for c in progress.conflicts if c.applied]
         assert not progress.updated_files
         assert not progress.updated_notes
+
+
+# --------------------------------------------------------------------------
+# Qodo review round on PR #1922 — defects inside the shipped design
+# --------------------------------------------------------------------------
+class TestSidecarRecognitionDoesNotSwallowRealNotes:
+    """Finding 1: the sidecar filter must not un-sync legitimate notes.
+
+    ``is_conflict_sidecar`` matched the ``.conflict-`` marker ANYWHERE in a
+    filename, and ``_scan_directory`` drops what it matches. A user's own note
+    called ``meeting.conflict-notes.md`` was therefore silently excluded from
+    every sync — no error, no skip row, it simply stopped being mirrored.
+    Sidecars always end in ``.bak``, so requiring both keeps the
+    never-re-ingest guarantee without eating real notes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_note_whose_name_contains_the_marker_still_syncs(
+        self, sync_engine, notes_service, sync_dir
+    ):
+        decoy = sync_dir / "meeting.conflict-notes.md"
+        decoy.write_text("Notes about a merge conflict at work", encoding="utf-8")
+
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert len(progress.created_notes) == 1, (
+            "a legitimate note containing '.conflict-' was silently dropped "
+            f"from the scan; skipped={progress.skipped_items}"
+        )
+        titles = {note["title"] for note in notes_service.list_notes(USER)}
+        assert "meeting.conflict-notes" in titles
+
+    def test_recognition_requires_both_the_marker_and_the_bak_suffix(self):
+        recognized = NotesSyncEngine.is_conflict_sidecar
+        # Real sidecars, in every shape the writer can produce.
+        assert recognized(Path("note.md.conflict-20260821T203015Z-disk.bak"))
+        assert recognized(Path("note.md.conflict-20260821T203015Z-2-db.bak"))
+        assert recognized(Path("sub/note.txt.conflict-20260821T203015Z-db.bak"))
+        # Real notes that merely mention the marker, or merely end in .bak.
+        assert not recognized(Path("meeting.conflict-notes.md"))
+        assert not recognized(Path("the.conflict-of-1914.txt"))
+        assert not recognized(Path("archive.bak"))
+        assert not recognized(Path("notes.md"))
+
+
+class TestSidecarNameIsClaimedAtomically:
+    """Finding 2: an exists-then-write sidecar can destroy another copy.
+
+    ``_write_conflict_sidecar`` used to test ``Path.exists()`` and then call
+    ``PinnedSyncRoot.write_text``, which REPLACES whatever is at the target.
+    Two sync runs resolving the same note in the same second both saw "free"
+    and the second one's rename destroyed the first one's preserved copy —
+    losing exactly the data this task exists to preserve, in the one code path
+    whose whole job is not to.
+
+    The window is opened deterministically here through ``_before_create``,
+    the module's existing test-seam idiom (see ``_before_replace``, used the
+    same way in ``test_sync_containment.py``): a competitor claims the name
+    after the name was chosen and before this run's create.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_competitor_claiming_the_name_first_is_never_clobbered(
+        self, sync_engine, notes_service, sync_dir, monkeypatch
+    ):
+        from tldw_chatbook.Notes.sync_paths import PinnedSyncRoot
+
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        competitor = "another run's preserved copy"
+        claimed: list[Path] = []
+
+        def _claim_the_name_first(self, relative_path: Path) -> None:
+            # Fire once: a competitor that re-claimed every candidate would
+            # exhaust the name space instead of demonstrating the clobber.
+            if claimed:
+                return
+            claimed.append(relative_path)
+            (self.canonical_root / relative_path).write_text(
+                competitor, encoding="utf-8"
+            )
+
+        monkeypatch.setattr(
+            PinnedSyncRoot, "_before_create", _claim_the_name_first, raising=True
+        )
+
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert claimed, "the seam never fired -- the test proves nothing"
+        sidecars = _sidecars(sync_dir)
+        contents = {path.read_text(encoding="utf-8") for path in sidecars}
+        assert competitor in contents, (
+            "this run overwrote a preserved copy that already held the name; "
+            f"surviving sidecars: {sorted(contents)}"
+        )
+        assert "Modified on disk" in contents, (
+            "this run's own copy must land too, under the next free name"
+        )
+        assert len(sidecars) == 2, sorted(path.name for path in sidecars)
+        # ...and the resolution still went through, on the second name.
+        assert progress.conflicts[0].applied is True
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified in database"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_exhausted_name_space_fails_closed(
+        self, sync_engine, notes_service, sync_dir, monkeypatch
+    ):
+        """Raise rather than overwrite when every candidate is taken."""
+        from tldw_chatbook.Notes.sync_paths import PinnedSyncRoot
+
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        def _always_claim(self, relative_path: Path) -> None:
+            (self.canonical_root / relative_path).write_text(
+                "squatter", encoding="utf-8"
+            )
+
+        monkeypatch.setattr(
+            PinnedSyncRoot, "_before_create", _always_claim, raising=True
+        )
+
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified on disk"
+        ), "nothing may be overwritten when no copy could be saved"
+        assert _content(notes_service, note_id) == "Modified in database"
+        assert progress.conflicts[0].applied is False
+        assert progress.errors

--- a/Tests/Notes/test_sync_conflict_preservation.py
+++ b/Tests/Notes/test_sync_conflict_preservation.py
@@ -1,0 +1,609 @@
+"""Conflict-path preservation and strategy-application pins (task-19554).
+
+Why this module exists — the incident, not the rule. The 2026-08-21 holistic
+review (Lane 3, F4) found two live defects in ``NotesSyncEngine``'s conflict
+path, both reachable from the Library sync panel on an unattended 300-second
+timer:
+
+1. **Unrecoverable overwrite.** On a ``both_changed`` conflict the losing side
+   was overwritten wholesale. ``SyncConflict`` *carried* ``db_content`` and
+   ``disk_content``, but ``_record_conflict`` persisted only the two hashes and
+   ``sync_conflicts`` had no content columns at all. No ``.bak``, no history
+   row: the discarded text was gone.
+2. **``disk_wins`` was a lie.** ``ConflictResolution.DISK_WINS`` appeared in
+   ``sync_engine.py`` exactly once — its own enum definition. Selecting "Disk
+   wins" recorded the conflict, applied nothing, and reported as resolved.
+
+The two born-red pins for those are
+``test_newer_wins_db_newer_preserves_the_losing_disk_copy`` and
+``test_disk_wins_actually_applies_the_disk_copy``; every other test here guards
+a way the fix could be hollowed out (a preserved copy that is really the
+winner's text, a sidecar that gets re-ingested as a note next pass, a
+preservation failure that still lets the overwrite through, a run that reports
+"resolved" for a conflict it left alone).
+
+``_recoverable_copies`` deliberately looks in BOTH places a losing copy can
+live (sidecar on disk, ``sync_conflicts.losing_content`` in the DB) and
+tolerates the column being absent, so at base these tests go red on the
+behaviour — an empty recovery set — rather than on a missing-column
+``OperationalError``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Notes.Notes_Library import NotesInteropService
+from tldw_chatbook.Notes.sync_engine import (
+    ConflictResolution,
+    NotesSyncEngine,
+    SyncDirection,
+)
+
+USER = "test_user"
+NOTE_NAME = "conflict_test.md"
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+@pytest.fixture
+def temp_dir():
+    temp_path = Path(tempfile.mkdtemp()).resolve(strict=True)
+    yield temp_path
+    shutil.rmtree(temp_path, ignore_errors=True)
+
+
+@pytest.fixture
+def test_db(temp_dir):
+    db = CharactersRAGDB(str(temp_dir / "test_notes.db"), "test_client")
+    yield db
+    db.close_connection()
+
+
+@pytest.fixture
+def notes_service(test_db, temp_dir):
+    service = NotesInteropService(
+        base_db_directory=temp_dir,
+        api_client_id="test_api",
+        global_db_to_use=test_db,
+    )
+    yield service
+    service.close_all_user_connections()
+
+
+@pytest.fixture
+def sync_engine(notes_service, test_db):
+    return NotesSyncEngine(notes_service, test_db)
+
+
+@pytest.fixture
+def sync_dir(temp_dir):
+    path = temp_dir / "sync_root"
+    path.mkdir()
+    return path
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+def _version(notes_service: NotesInteropService, note_id: str) -> int:
+    return notes_service.get_note_by_id(USER, note_id)["version"]
+
+
+def _content(notes_service: NotesInteropService, note_id: str) -> str:
+    return notes_service.get_note_by_id(USER, note_id)["content"]
+
+
+def _make_conflicted_note(
+    notes_service: NotesInteropService,
+    sync_engine: NotesSyncEngine,
+    sync_dir: Path,
+    *,
+    db_content: str,
+    disk_content: str,
+    disk_is_newer: bool,
+    baseline: str = "Original content",
+) -> str:
+    """Build a genuine ``both_changed`` conflict with a real sync baseline.
+
+    A real baseline matters: with ``last_synced_disk_file_hash`` left NULL both
+    sides compare "changed" against ``None`` and a conflict is detected for the
+    wrong reason. Here the baseline hash/mtime are actually stored, then both
+    sides are diverged from it.
+
+    ``disk_is_newer`` sets the file's mtime an hour either side of the note's
+    ``last_modified`` (which SQLite stamps at one-second resolution), which is
+    what ``NEWER_WINS`` compares.
+    """
+    note_id = notes_service.add_note(
+        user_id=USER, title="Conflict Test", content=baseline
+    )
+    file_path = sync_dir / NOTE_NAME
+    file_path.write_text(baseline, encoding="utf-8")
+
+    assert notes_service.update_note_sync_metadata(
+        user_id=USER,
+        note_id=note_id,
+        sync_metadata={
+            "file_path_on_disk": str(file_path),
+            "relative_file_path_on_disk": NOTE_NAME,
+            "sync_root_folder": str(sync_dir),
+            "is_externally_synced": 1,
+            "file_extension": ".md",
+        },
+        expected_version=_version(notes_service, note_id),
+    )
+
+    file_info = sync_engine._get_file_info(file_path, sync_dir)
+    assert file_info is not None
+    assert notes_service.update_note_sync_metadata(
+        user_id=USER,
+        note_id=note_id,
+        sync_metadata={
+            "last_synced_disk_file_hash": file_info.content_hash,
+            "last_synced_disk_file_mtime": file_info.mtime,
+        },
+        expected_version=_version(notes_service, note_id),
+    ), "the baseline hash must actually be stored, or the conflict is bogus"
+
+    # Diverge both sides from that baseline.
+    file_path.write_text(disk_content, encoding="utf-8")
+    assert notes_service.update_note(
+        user_id=USER,
+        note_id=note_id,
+        update_data={"content": db_content},
+        expected_version=_version(notes_service, note_id),
+    )
+
+    stamp = time.time() + 3600 if disk_is_newer else time.time() - 3600
+    os.utime(file_path, (stamp, stamp))
+    return note_id
+
+
+def _recoverable_copies(db: CharactersRAGDB, sync_dir: Path, session_id: str) -> list[str]:
+    """Every text the losing side could be recovered from after a run.
+
+    Looks in both preservation surfaces and tolerates the DB one not existing,
+    so a base-version run fails on an EMPTY recovery set rather than on an
+    ``OperationalError`` about a missing column.
+    """
+    found: list[str] = []
+    for path in sorted(sync_dir.rglob("*")):
+        if path.is_file() and ".conflict-" in path.name:
+            found.append(path.read_text(encoding="utf-8"))
+    with db.transaction() as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(sync_conflicts)")
+        }
+        if "losing_content" in columns:
+            for row in conn.execute(
+                "SELECT losing_content FROM sync_conflicts "
+                "WHERE session_id = ? AND losing_content IS NOT NULL",
+                (session_id,),
+            ):
+                found.append(row[0])
+    return found
+
+
+def _sidecars(sync_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in sync_dir.rglob("*")
+        if path.is_file() and ".conflict-" in path.name
+    )
+
+
+def _conflict_rows(db: CharactersRAGDB, session_id: str) -> list[dict[str, Any]]:
+    with db.transaction() as conn:
+        columns = [
+            row[1] for row in conn.execute("PRAGMA table_info(sync_conflicts)")
+        ]
+        selected = ", ".join(columns)
+        return [
+            dict(zip(columns, row))
+            for row in conn.execute(
+                f"SELECT {selected} FROM sync_conflicts WHERE session_id = ?",
+                (session_id,),
+            )
+        ]
+
+
+async def _run(
+    sync_engine: NotesSyncEngine,
+    sync_dir: Path,
+    resolution: ConflictResolution,
+    direction: SyncDirection = SyncDirection.BIDIRECTIONAL,
+):
+    return await sync_engine.sync(
+        root_path=sync_dir,
+        user_id=USER,
+        direction=direction,
+        conflict_resolution=resolution,
+    )
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — the overwrite destroyed the losing side (BORN RED)
+# --------------------------------------------------------------------------
+class TestLosingSideIsRecoverable:
+    @pytest.mark.asyncio
+    async def test_newer_wins_db_newer_preserves_the_losing_disk_copy(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """BORN RED (defect 1). DB newer under NEWER_WINS rewrites the file.
+
+        At base the run overwrites ``conflict_test.md`` with the note body and
+        the disk text is gone: no sidecar, no history row, only a SHA-256 of it
+        in ``sync_conflicts.disk_content_hash``.
+        """
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert len(progress.conflicts) == 1
+        # The winner really was applied (this half passes at base).
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified in database"
+        )
+        # The loser must still be reachable.
+        recoverable = _recoverable_copies(test_db, sync_dir, session_id)
+        assert "Modified on disk" in recoverable, (
+            "NEWER_WINS overwrote the on-disk file and left no recoverable "
+            f"copy of it; recovery surfaces held {recoverable!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_newer_wins_disk_newer_preserves_the_losing_db_copy(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """The mirror image: disk newer replaces the note body via update_note."""
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=True,
+        )
+
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert len(progress.conflicts) == 1
+        assert _content(notes_service, note_id) == "Modified on disk"
+        recoverable = _recoverable_copies(test_db, sync_dir, session_id)
+        assert "Modified in database" in recoverable, (
+            "NEWER_WINS replaced the note content and left no recoverable "
+            f"copy of it; recovery surfaces held {recoverable!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_preserved_copy_is_the_loser_not_the_winner(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """Mutation control: preserving the WINNER would satisfy a naive pin."""
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+        session_id, _progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+        recoverable = _recoverable_copies(test_db, sync_dir, session_id)
+        assert recoverable, "nothing was preserved at all"
+        assert all(text == "Modified on disk" for text in recoverable), (
+            f"a preserved copy holds the winner's text: {recoverable!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sidecar_is_named_for_the_note_and_the_losing_side(
+        self, sync_engine, notes_service, sync_dir
+    ):
+        """The on-disk copy has to be findable by a human, next to the file."""
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+        await _run(sync_engine, sync_dir, ConflictResolution.NEWER_WINS)
+
+        sidecars = _sidecars(sync_dir)
+        assert len(sidecars) == 1, sidecars
+        sidecar = sidecars[0]
+        assert sidecar.parent == sync_dir
+        assert sidecar.name.startswith(NOTE_NAME + ".conflict-")
+        assert sidecar.name.endswith("-disk.bak")
+        assert sidecar.read_text(encoding="utf-8") == "Modified on disk", (
+            "the sidecar must be byte-exact so recovery is a rename"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sidecars_are_never_re_ingested_as_notes(
+        self, sync_engine, notes_service, sync_dir
+    ):
+        """A preserved copy must not become a note (or a sync loop) next pass."""
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+        await _run(sync_engine, sync_dir, ConflictResolution.NEWER_WINS)
+        assert _sidecars(sync_dir)
+
+        before = {note["id"] for note in notes_service.list_notes(USER)}
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+        after = {note["id"] for note in notes_service.list_notes(USER)}
+
+        assert after == before, "the conflict sidecar was ingested as a note"
+        assert not progress.created_notes
+
+    @pytest.mark.asyncio
+    async def test_preservation_failure_blocks_the_overwrite(
+        self, sync_engine, notes_service, test_db, sync_dir, monkeypatch
+    ):
+        """Fail-closed: if the losing copy cannot be saved, nothing is destroyed."""
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        def _explode(*_args, **_kwargs):
+            raise OSError("preservation is unavailable")
+
+        monkeypatch.setattr(
+            NotesSyncEngine, "_write_conflict_sidecar", _explode, raising=True
+        )
+
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.NEWER_WINS
+        )
+
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified on disk"
+        ), "the file was overwritten even though its copy could not be saved"
+        assert _content(notes_service, note_id) == "Modified in database"
+        assert len(progress.conflicts) == 1
+        assert progress.conflicts[0].applied is False
+        assert progress.errors, "a blocked resolution must be reported"
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — disk_wins applied nothing (BORN RED)
+# --------------------------------------------------------------------------
+class TestEveryOfferedStrategyApplies:
+    @pytest.mark.asyncio
+    async def test_disk_wins_actually_applies_the_disk_copy(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """BORN RED (defect 2). ``DISK_WINS`` had no branch anywhere.
+
+        At base the note keeps its database body and the run still reports the
+        conflict as resolved by the "Disk wins" policy.
+        """
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            # deliberately the side NEWER_WINS would NOT pick, so a pass here
+            # cannot come from newer-wins logic leaking in.
+            disk_is_newer=False,
+        )
+
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.DISK_WINS
+        )
+
+        assert len(progress.conflicts) == 1
+        assert _content(notes_service, note_id) == "Modified on disk", (
+            "DISK_WINS did not apply the disk copy to the note"
+        )
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified on disk"
+        )
+        recoverable = _recoverable_copies(test_db, sync_dir, session_id)
+        assert "Modified in database" in recoverable
+
+    @pytest.mark.asyncio
+    async def test_db_wins_actually_applies_the_db_copy(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """``DB_WINS`` had no bidirectional branch either — same class."""
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=True,
+        )
+
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.DB_WINS
+        )
+
+        assert len(progress.conflicts) == 1
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified in database"
+        ), "DB_WINS did not write the note body to disk"
+        assert _content(notes_service, note_id) == "Modified in database"
+        recoverable = _recoverable_copies(test_db, sync_dir, session_id)
+        assert "Modified on disk" in recoverable
+
+    @pytest.mark.asyncio
+    async def test_ask_still_applies_nothing_and_says_so(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """Control: ``ASK`` is the one policy that must NOT touch either side."""
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.ASK
+        )
+
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified on disk"
+        )
+        assert _content(notes_service, note_id) == "Modified in database"
+        assert not _sidecars(sync_dir), "nothing was discarded, so nothing to save"
+        assert len(progress.conflicts) == 1
+        assert progress.conflicts[0].applied is False
+        rows = _conflict_rows(test_db, session_id)
+        assert len(rows) == 1
+        assert rows[0]["resolution"] is None, (
+            "an unresolved conflict must stay open for later resolution"
+        )
+
+    @pytest.mark.asyncio
+    async def test_db_to_disk_newer_wins_pushes_when_the_note_is_newer(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """The one-way push path had no NEWER_WINS branch at all."""
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+
+        session_id, progress = await _run(
+            sync_engine,
+            sync_dir,
+            ConflictResolution.NEWER_WINS,
+            direction=SyncDirection.DB_TO_DISK,
+        )
+
+        assert len(progress.conflicts) == 1
+        assert (sync_dir / NOTE_NAME).read_text(encoding="utf-8") == (
+            "Modified in database"
+        )
+        assert "Modified on disk" in _recoverable_copies(
+            test_db, sync_dir, session_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_disk_to_db_conflict_preserves_the_note_body(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        """The pull path overwrote the note with no conflict record at all."""
+        note_id = _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=True,
+        )
+
+        session_id, progress = await _run(
+            sync_engine,
+            sync_dir,
+            ConflictResolution.DISK_WINS,
+            direction=SyncDirection.DISK_TO_DB,
+        )
+
+        assert _content(notes_service, note_id) == "Modified on disk"
+        assert len(progress.conflicts) == 1
+        assert "Modified in database" in _recoverable_copies(
+            test_db, sync_dir, session_id
+        )
+
+
+# --------------------------------------------------------------------------
+# The report must match what actually happened (AC #4)
+# --------------------------------------------------------------------------
+class TestReportedOutcomeMatchesReality:
+    @pytest.mark.asyncio
+    async def test_applied_flag_and_persisted_resolution_agree(
+        self, sync_engine, notes_service, test_db, sync_dir
+    ):
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+        session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.DISK_WINS
+        )
+
+        conflict = progress.conflicts[0]
+        assert conflict.applied is True
+        assert conflict.resolution == "use_disk"
+        assert conflict.preserved_path is not None
+
+        rows = _conflict_rows(test_db, session_id)
+        assert len(rows) == 1
+        assert rows[0]["resolution"] == "use_disk"
+        assert rows[0]["losing_side"] == "db"
+        assert rows[0]["losing_content"] == "Modified in database"
+        assert rows[0]["preserved_file_path"] == str(conflict.preserved_path)
+        assert rows[0]["resolved_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a_run_that_changed_nothing_reports_no_applied_conflict(
+        self, sync_engine, notes_service, sync_dir
+    ):
+        """AC #4, stated as the engine-level fact the UI line is built from."""
+        _make_conflicted_note(
+            notes_service,
+            sync_engine,
+            sync_dir,
+            db_content="Modified in database",
+            disk_content="Modified on disk",
+            disk_is_newer=False,
+        )
+        _session_id, progress = await _run(
+            sync_engine, sync_dir, ConflictResolution.ASK
+        )
+        assert progress.conflicts
+        assert not [c for c in progress.conflicts if c.applied]
+        assert not progress.updated_files
+        assert not progress.updated_notes

--- a/Tests/Notes/test_sync_containment.py
+++ b/Tests/Notes/test_sync_containment.py
@@ -216,3 +216,90 @@ def test_legacy_engine_source_has_no_pathname_sync_escape_hatches() -> None:
     assert "file_path.read_text(" not in source
     assert "file_path.parent.mkdir(" not in source
     assert "atomic_write_text(" not in source
+
+
+# --------------------------------------------------------------------------
+# create_new_text -- the never-replace counterpart to write_text (task-19554)
+# --------------------------------------------------------------------------
+def test_create_new_text_refuses_an_existing_name_without_touching_it(
+    tmp_path: Path,
+) -> None:
+    """The property the preserved-conflict-copy path depends on.
+
+    ``write_text`` renames over its target; for a saved copy of user text
+    that is destruction. ``create_new_text`` claims the name with
+    ``O_CREAT|O_EXCL`` instead, so a taken name is reported, never replaced.
+    """
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+    target = root_path / "note.md.conflict-20260821T203015Z-disk.bak"
+    target.write_text("someone else's preserved copy", encoding="utf-8")
+
+    with PinnedSyncRoot(root_path) as root:
+        with pytest.raises(FileExistsError):
+            root.create_new_text(target.relative_to(root_path), "mine")
+
+    assert target.read_text(encoding="utf-8") == "someone else's preserved copy"
+
+
+def test_create_new_text_writes_a_private_file_and_reports_it(
+    tmp_path: Path,
+) -> None:
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+
+    with PinnedSyncRoot(root_path) as root:
+        result = root.create_new_text(Path("note.md.conflict-x-db.bak"), "kept")
+
+    created = root_path / "note.md.conflict-x-db.bak"
+    assert created.read_text(encoding="utf-8") == "kept"
+    assert stat.S_IMODE(created.stat().st_mode) == 0o600
+    assert result.absolute_path == created
+    assert result.content == "kept"
+
+
+def test_create_new_text_rejects_a_symlinked_name_rather_than_following_it(
+    tmp_path: Path,
+) -> None:
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+    outside = tmp_path / "OUTSIDE-19554-SENTINEL.bak"
+    outside.write_text("OUTSIDE-19554-SENTINEL", encoding="utf-8")
+    (root_path / "note.md.conflict-x-db.bak").symlink_to(outside)
+
+    with PinnedSyncRoot(root_path) as root:
+        with pytest.raises(OSError):
+            root.create_new_text(Path("note.md.conflict-x-db.bak"), "leaked")
+
+    assert outside.read_text(encoding="utf-8") == "OUTSIDE-19554-SENTINEL"
+
+
+def test_create_new_text_refuses_a_missing_parent(tmp_path: Path) -> None:
+    """A sidecar goes beside an existing note; it never creates directories."""
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+
+    with PinnedSyncRoot(root_path) as root:
+        with pytest.raises(SyncPathError, match="missing_parent"):
+            root.create_new_text(Path("nope/note.md.conflict-x-db.bak"), "x")
+
+    assert not (root_path / "nope").exists()
+
+
+def test_create_new_text_leaves_nothing_behind_when_it_fails_after_creating(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller told the write failed must not find a half-written file."""
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+
+    def explode(_file_fd: int, _content: bytes) -> None:
+        raise OSError("short write")
+
+    with PinnedSyncRoot(root_path) as root:
+        monkeypatch.setattr(root, "_write_all", explode)
+        with pytest.raises(OSError, match="short write"):
+            root.create_new_text(Path("note.md.conflict-x-db.bak"), "partial")
+
+    assert list(root_path.iterdir()) == []

--- a/Tests/Notes/test_sync_engine.py
+++ b/Tests/Notes/test_sync_engine.py
@@ -237,25 +237,43 @@ class TestSyncEngine:
         # Create the file with initial content
         file_path.write_text("Original content")
 
-        # Update sync metadata to establish baseline
+        # Update sync metadata to establish baseline.
+        #
+        # task-19554: this block used to pass `expected_version=1` for a note
+        # the PREVIOUS call had already bumped to 2. `update_note_sync_metadata`
+        # reports a version miss by returning False and logging -- it does not
+        # raise -- so the baseline hash was silently never stored, both sides
+        # compared "changed" against NULL, and this test detected a "conflict"
+        # for a note that had simply never been synced. Assert every setup
+        # call's return, and read the version rather than hard-coding it.
         file_info = sync_engine._get_file_info(file_path, sync_dir)
-        notes_service.update_note_sync_metadata(
+        assert notes_service.update_note_sync_metadata(
             user_id="test_user",
             note_id=note_id,
             sync_metadata={
                 "last_synced_disk_file_hash": file_info.content_hash,
                 "last_synced_disk_file_mtime": file_info.mtime,
             },
-            expected_version=1,
+            expected_version=notes_service.get_note_by_id("test_user", note_id)[
+                "version"
+            ],
         )
+        assert (
+            notes_service.get_note_by_id("test_user", note_id)[
+                "last_synced_disk_file_hash"
+            ]
+            == file_info.content_hash
+        ), "without a stored baseline this test detects a conflict for any note"
 
         # Now modify both the file and the database note
         file_path.write_text("Modified on disk")
-        notes_service.update_note(
+        assert notes_service.update_note(
             user_id="test_user",
             note_id=note_id,
             update_data={"content": "Modified in database"},
-            expected_version=2,
+            expected_version=notes_service.get_note_by_id("test_user", note_id)[
+                "version"
+            ],
         )
 
         # Run bidirectional sync

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -21870,8 +21870,17 @@ async def test_library_shell_notes_sync_conflicts_get_honest_resolved_copy(
 ):
     """A2/B1: the activity line for recorded conflicts must state the
     resolved policy (truthful: this panel never offers a review surface)
-    and pluralize correctly."""
+    and pluralize correctly.
+
+    task-19554 tightened the fake: the conflict here is a real
+    ``SyncConflict`` that the engine marked ``applied``. It used to be the
+    bare string ``"c-1"``, which could not distinguish a conflict the run
+    resolved from one it merely wrote down -- and at that time every conflict
+    under "Disk wins"/"Library wins" was the latter while this line still
+    claimed "resolved".
+    """
     from tldw_chatbook.Notes import sync_service as sync_service_module
+    from tldw_chatbook.Notes.sync_engine import SyncConflict
 
     class _ConflictResults:
         def __init__(self):
@@ -21879,7 +21888,19 @@ async def test_library_shell_notes_sync_conflicts_get_honest_resolved_copy(
             self.updated_notes = []
             self.created_files = []
             self.updated_files = []
-            self.conflicts = ["c-1"]
+            self.conflicts = [
+                SyncConflict(
+                    note_id="note-1",
+                    file_path=Path("note.md"),
+                    conflict_type="both_changed",
+                    applied=True,
+                    resolution="use_db",
+                    preserved_path=Path("note.md.conflict-20260821T000000Z-disk.bak"),
+                )
+            ]
+            self.preserved_files = [
+                Path("note.md.conflict-20260821T000000Z-disk.bak")
+            ]
             self.errors = []
 
     class _ConflictSyncService:
@@ -21935,6 +21956,100 @@ async def test_library_shell_notes_sync_conflicts_get_honest_resolved_copy(
             "recorded for review" in line
             for line in screen._library_notes_sync_activity
         )
+        # ...and it names where the replaced copy went (task-19554).
+        assert any(
+            "Replaced copy saved as note.md.conflict-" in line
+            for line in screen._library_notes_sync_activity
+        ), screen._library_notes_sync_activity
+        assert not any(
+            "left unresolved" in line
+            for line in screen._library_notes_sync_activity
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_shell_notes_sync_unapplied_conflict_is_not_called_resolved(
+    monkeypatch, tmp_path
+):
+    """task-19554 AC #4: a run that applied nothing must not claim it did.
+
+    The panel used to print "N conflicts resolved (<policy>)" for every
+    RECORDED conflict, so selecting "Disk wins" -- which had no branch in the
+    engine at all -- read as a successful resolution while the note kept its
+    old body. This is the pin for the opposite line.
+    """
+    from tldw_chatbook.Notes import sync_service as sync_service_module
+    from tldw_chatbook.Notes.sync_engine import SyncConflict
+
+    class _UnresolvedResults:
+        def __init__(self):
+            self.created_notes = []
+            self.updated_notes = []
+            self.created_files = []
+            self.updated_files = []
+            self.conflicts = [
+                SyncConflict(
+                    note_id="note-1",
+                    file_path=Path("note.md"),
+                    conflict_type="both_changed",
+                )
+            ]
+            self.preserved_files = []
+            self.errors = []
+
+    class _UnresolvedSyncService:
+        def __init__(self, notes_service, db):
+            pass
+
+        async def sync_folder(
+            self,
+            *,
+            root_folder,
+            user_id,
+            direction,
+            conflict_resolution,
+            progress_callback=None,
+            extensions=None,
+        ):
+            return ("session-unresolved", _UnresolvedResults())
+
+    monkeypatch.setattr(
+        sync_service_module, "NotesSyncService", _UnresolvedSyncService
+    )
+
+    app = _build_test_app()
+    _prepare_library_notes_sync_app(app)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_library_notes_sync_panel(screen, pilot)
+
+        folder_input = screen.query_one("#library-notes-sync-folder", Input)
+        folder_input.value = str(tmp_path)
+        folder_input.focus()
+        await pilot.pause()
+
+        screen.query_one("#library-notes-sync-run").press()
+        for _ in range(150):
+            if (
+                not screen._library_notes_sync_running
+                and screen._library_notes_sync_status != "idle"
+            ):
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError("Sync run never completed.")
+
+        assert not any(
+            "resolved (" in line
+            for line in screen._library_notes_sync_activity
+        ), screen._library_notes_sync_activity
+        assert any(
+            "1 conflict left unresolved" in line
+            for line in screen._library_notes_sync_activity
+        ), screen._library_notes_sync_activity
 
 
 async def _run_library_search_and_wait_for_open_result(

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5795,3 +5795,37 @@ Threat model, recorded because it is what makes the above worth the effort: no
 `.git` exclusion exists in `Tools/workspace_file_roots.py` or
 `Tools/file_operation_tools.py`, so an agent can write `.git/config` in the very
 root these features operate on (TASK-19700).
+
+
+
+## A setup step whose failure is only a log line builds the wrong fixture (TASK-19554, 2026-08-21)
+
+**What happened.** `Tests/Notes/test_sync_engine.py::test_conflict_detection`
+has passed since it was written, and it asserts the right things: a
+`both_changed` conflict is detected with the right `db_content` and
+`disk_content`. Reading it while writing the born-red pins for task-19554, I
+found it never builds the scenario it claims to. It calls
+`NotesInteropService.update_note_sync_metadata` twice with
+`expected_version=1`. The FIRST call bumps the row to version 2, so the second
+one matches no rows — and that method does not raise on a version miss, it
+logs `"No rows updated ... version mismatch or deleted"` and returns `False`.
+The return value was not asserted, so `last_synced_disk_file_hash` was silently
+never stored.
+
+With that column NULL, the engine's `db_changed = hash != last_synced` and
+`disk_changed = hash != last_synced` are BOTH trivially true against `None`.
+The test detects a "conflict" for every synced note in existence, including
+ones where neither side moved. It could not tell a real conflict from a note
+that had never been synced at all — which is precisely the distinction the
+conflict path turns on.
+
+**What to do.** When a fixture is built through an API that reports failure by
+RETURN VALUE (`bool`) or by log line rather than by raising, assert the return
+of every setup call — `assert service.update_x(...)`, not `service.update_x(...)`.
+Optimistic-locking helpers in this repo are the recurring shape: they take an
+`expected_version`, they return `False` on a miss, and every successful call
+invalidates the version you were about to reuse. Re-read the version between
+calls instead of reusing a literal. The tell that something is wrong is a
+fixture that passes against a *stronger* claim than it set up: here, deleting
+the entire baseline step would not have changed the test's result, which is the
+definition of a setup step that is not doing anything.

--- a/backlog/tasks/task-19554 - Notes sync destroys the losing side with no recoverable copy and disk_wins is a silent no-op.md
+++ b/backlog/tasks/task-19554 - Notes sync destroys the losing side with no recoverable copy and disk_wins is a silent no-op.md
@@ -3,8 +3,9 @@ id: TASK-19554
 title: >-
   Notes sync destroys the losing side with no recoverable copy, and disk_wins is
   a silent no-op
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-21 20:04'
 labels:
   - notes
@@ -45,21 +46,231 @@ what the selected strategy says.
 
 ## Acceptance Criteria
 
-- [ ] No conflict resolution strategy destroys content without a recoverable
+- [x] No conflict resolution strategy destroys content without a recoverable
       copy of the losing side (persisted content, a sidecar file, or a history
       row — chosen for durability, not cleverness)
-- [ ] `_record_conflict` persists enough to reconstruct the discarded version,
+- [x] `_record_conflict` persists enough to reconstruct the discarded version,
       not just its hash
-- [ ] `DISK_WINS` either applies the disk copy as its name states, or is
+- [x] `DISK_WINS` either applies the disk copy as its name states, or is
       removed from the enum and from every UI surface that offers it — it must
       not remain selectable while doing nothing
-- [ ] A sync run that applied no changes never reports as though it resolved
+- [x] A sync run that applied no changes never reports as though it resolved
       the conflict
-- [ ] Tests cover each offered strategy end-to-end: the winning side is
+- [x] Tests cover each offered strategy end-to-end: the winning side is
       applied, the losing side is recoverable, and the reported outcome matches
       what actually happened
-- [ ] The decision on whether to re-offer `ASK` in the Library UI is made
+- [x] The decision on whether to re-offer `ASK` in the Library UI is made
       explicitly and recorded, given that excluding it currently leaves only
       destructive options
-- [ ] `Docs/User_Guide/` states plainly what each strategy does to the losing
+- [x] `Docs/User_Guide/` states plainly what each strategy does to the losing
       copy
+
+## Implementation Plan
+
+1. **Born-red first.** `Tests/Notes/test_sync_conflict_preservation.py` — one
+   pin per defect (NEWER_WINS loses the disk copy; `disk_wins` applies
+   nothing), plus mutation controls (preserving the *winner* must not pass),
+   run at base and recorded.
+2. **Preservation, two surfaces, fail-closed.**
+   - Primary, user-visible: a byte-exact sidecar written through the existing
+     `PinnedSyncRoot` boundary next to the note file,
+     `<name>.conflict-<UTC>-<side>.bak`. Recovery is a rename.
+   - Second copy: `sync_conflicts` gains `losing_side` / `losing_content` /
+     `preserved_file_path` (schema v43→v44, new-style atomic step per
+     task-19553). Written only when a side is actually discarded, so the
+     content shadow is bounded by real destruction events rather than by
+     conflict *detection*.
+   - If the sidecar cannot be written, the overwrite does **not** happen: the
+     conflict is left unresolved and an error is recorded.
+3. **Sidecars must not feed back.** Filter the sidecar marker out of
+   `_scan_directory` so a preserved copy can never be re-ingested as a note
+   (belt and braces on top of the non-scanned `.bak` suffix).
+4. **Implement every offered strategy** on `both_changed`, in all three
+   directions: `DB_WINS`, `DISK_WINS`, `NEWER_WINS`. Add conflict detection to
+   `_sync_disk_to_db`, which had none and overwrote note bodies silently.
+5. **Honest reporting.** `SyncConflict` gains `resolution` / `applied` /
+   `preserved_path`; the row's `resolution`+`resolved_at` are stamped with what
+   actually happened; the Library sync panel counts applied vs unresolved and
+   names the sidecar.
+6. Docs: `Docs/User_Guide/library/notes.md` +
+   `Docs/Features/notes_bidirectional_sync.md` state per strategy what happens
+   to the losing copy and where it goes.
+7. Record the `ASK` re-offer question as an owner call, do not change it.
+
+## Implementation Notes
+
+Both defects fixed at the engine, plus a third of the same family the audit
+did not name (see "Also found"). Two born-red pins, run and recorded at base
+before any code changed:
+
+* `test_newer_wins_db_newer_preserves_the_losing_disk_copy` →
+  `assert 'Modified on disk' in []` — the overwritten file's text existed
+  nowhere afterwards.
+* `test_disk_wins_actually_applies_the_disk_copy` →
+  `assert 'Modified in database' == 'Modified on disk'` — the note kept its
+  database body.
+
+13 of 13 red at base, 13 of 13 green after.
+
+### Preservation design (and what was rejected)
+
+**Shipped: sidecar first, DB row second, fail-closed.**
+
+Before any resolution overwrites a side, that side's text is written verbatim
+to `<file name>.conflict-<UTC>-<db|disk>.bak` next to the note file, through
+the existing `PinnedSyncRoot` boundary (so a swapped root or a symlinked path
+fails closed here exactly as it does for a note write). Then — and only then —
+the winner is applied and the conflict row is stamped with `losing_side`,
+`losing_content`, `preserved_file_path`, `resolution`, `resolved_at`.
+
+*Why the sidecar is primary.* It is the only surface a user can already reach
+with no new UI: it appears in the folder they are already syncing, sorts
+directly beside the file it came from, says in its name which side and when,
+and recovering it is a `mv`. It is deliberately byte-exact — no header, no diff
+markers — because anything prepended turns recovery from a rename into an edit.
+
+*Why the DB row as well* (AC #2 asks `_record_conflict` to persist enough to
+reconstruct, not just a hash). The sidecar lives in a folder the user cleans
+up, moves, or points a different tool at; the row survives that. The row is
+also the only copy reachable programmatically. Cost is bounded by writing it
+**only when a side is actually discarded**, never on mere detection: an `ask`
+run, or a strategy that declines to apply, stores no content at all. That
+matters because `sync_log` is already an unpruned full-content shadow of
+`notes` and a second unconditional one would be a real regression.
+
+*What surfaces it.* Three things, and no more — a conflict-review UI is an
+owner question, not shipped:
+1. The Library sync panel's activity log names the sidecar file
+   ("Replaced copy saved as note.md.conflict-…-disk.bak").
+2. `NotesSyncService.get_conflicts_for_session()` now returns the three
+   columns, and a new `get_preserved_conflict_copies(limit)` lists every
+   preserved copy across all sessions newest-first — the entry point that does
+   NOT need a session id, because after an unattended 300-second auto-sync a
+   user knows only that a note changed under them.
+3. `Docs/User_Guide/library/notes.md` tells the user the files exist, what they
+   are named, how to restore one, and that sync ignores them.
+
+*Rejected — DB columns only.* This is the "preserved copy nothing can reach"
+the brief warns about: nothing in the app renders `sync_conflicts`, so the
+recovery story would have been "write a SQL query". It also stores content
+where the user cannot see that anything was saved.
+
+*Rejected — sidecar only.* Fails AC #2 literally, and ties the only copy to a
+directory the user is actively managing (and, in the `disk_to_db` direction,
+one they may treat as a scratch import folder).
+
+*Rejected — a `.bak` of the whole file, or a notes-history table.* A history
+table is the right long-term answer for note versioning generally, but it is a
+much larger change than this conflict path and would be a schema and UI
+programme of its own; scoping it here would have delayed a live P0.
+
+*Fail-closed is the load-bearing part.* If the sidecar cannot be written the
+overwrite does not happen: the conflict is left open, an error is recorded, and
+both copies survive. Note that a read-only or otherwise unwritable root does
+NOT stop `disk_wins`/`newer_wins` from destroying the note in the database —
+that path only needs the DB — so without this rule preservation would fail
+exactly where destruction still succeeded.
+
+*Feedback loop closed.* Sidecars are dropped from every scan by the
+`.conflict-` marker (not merely by the `.bak` suffix being outside the default
+`['.md', '.txt']` set), so a preserved copy can never be ingested as a note,
+which would otherwise turn each conflict into a duplicate note and then into
+another file. Pinned by
+`test_sidecars_are_never_re_ingested_as_notes`.
+
+### `DISK_WINS`: implemented, not removed
+
+Implemented. Removing it would have broken persisted user preferences
+(`sync_conflict_resolution = "disk_wins"`), the `sync_sessions` CHECK
+constraint that already lists it, and the engine's public enum — while
+deleting a policy that is genuinely wanted (the file on disk is the
+editor-of-record for anyone using an external editor). It now applies the disk
+copy to the note, preserving the note body first.
+
+`_resolve_both_changed` is one implementation shared by all three directions;
+the direction only restricts which side may be written. A policy whose winner
+cannot be written in the chosen direction (e.g. "Disk wins" during a
+Library → Disk push) applies nothing and leaves the conflict OPEN — it does not
+claim to have settled anything.
+
+### Also found and fixed (same defect family)
+
+* **`DB_WINS` was equally a no-op in bidirectional** — the `both_changed`
+  branch there tested only `NEWER_WINS`. The audit named `DISK_WINS` because
+  it has no branch anywhere; `DB_WINS` had one in `db_to_disk` only.
+* **`NEWER_WINS` was a no-op in `db_to_disk`** even when the note was the newer
+  side.
+* **`disk_to_db` had no conflict detection at all.** "The file changed since
+  the baseline" was treated as sufficient reason to overwrite the note, without
+  ever asking whether the note had changed too — silent loss with not even a
+  conflict row. It now detects, preserves, and resolves like the other two
+  directions.
+* **The panel called every recorded conflict "resolved"** (AC #4). It now
+  counts `SyncConflict.applied`, names the preserved copy, and says
+  "N conflicts left unresolved — both copies kept as they are" otherwise.
+  The existing UI test's fake was tightened from the bare string `"c-1"` to a
+  real `SyncConflict`, because a string cannot distinguish the two.
+
+`deleted_on_disk` conflicts were left behaving exactly as before (auto-unlink
+in `disk_to_db`, file recreation under `DB_WINS` in bidirectional, nothing
+otherwise) — nothing is destroyed on that path, so it is not a data-loss
+question. Only the bookkeeping changed, so the run cannot over-claim. Whether
+bidirectional should also unlink under `disk_wins` is an open product question
+(below).
+
+### Schema
+
+`_CURRENT_SCHEMA_VERSION` 43 → 44, `_migrate_from_v43_to_v44` +
+`migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql`
+(three `ADD COLUMN`s, DDL-only, rowcount-guarded version bump in the runner).
+New-style per task-19553: entry-version guard, statements run through
+`_execute_migration_statements` inside the step's transaction, so a half-applied
+run is re-enterable (its already-applied `ADD COLUMN` skip) and a failure rolls
+back. No new indexes, so the index census literal is unchanged.
+
+The repo's one EXACT current-schema-version pin moved from
+`Tests/DB/test_chachanotes_message_exchanges.py::test_schema_version_is_43`
+(which owns v42→v43 only) to the newest migration's own file. Older migration
+files now assert `>= their own version`, so a future bump touches the file that
+caused it instead of an unrelated older one.
+
+### Owner questions
+
+1. **Should the Library panel re-offer `ASK`?** Not changed here — recording it
+   as asked, per the task. The argument for: with `ASK` excluded, every policy
+   the panel offers is one that overwrites something, on a 300-second unattended
+   timer. The argument against, and why it is not a one-line revert: `ASK` is
+   only meaningful if something *asks*, and nothing in the Library prompts on a
+   conflict. Re-offering it today would produce a policy that records conflicts
+   and never resolves them, with no surface to resolve them from — the same
+   "selectable but does nothing" shape this task just removed from `DISK_WINS`.
+   Making `ASK` real means building a conflict-review surface over
+   `get_preserved_conflict_copies()` / `get_conflicts_for_session()`. That is a
+   product decision and a separate task. What ships now is the mitigation that
+   does not need it: the destructive policies are no longer destructive without
+   a recoverable copy.
+2. **Should bidirectional `disk_wins` unlink a note whose file was deleted?**
+   `disk_to_db` already does this for every non-`ASK` policy; bidirectional does
+   nothing. Aligning them is a behaviour change ("the file is gone" could mean
+   the user deleted it, or that a sync partner has not created it yet), so it is
+   left alone and reported honestly as unresolved rather than changed
+   unilaterally.
+
+### Files
+
+* `tldw_chatbook/Notes/sync_engine.py` — preservation, strategy dispatch,
+  sidecar write/filter, outcome bookkeeping.
+* `tldw_chatbook/Notes/sync_service.py` — preservation columns in the session
+  reader, new `get_preserved_conflict_copies`.
+* `tldw_chatbook/DB/ChaChaNotes_DB.py` +
+  `tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql`
+* `tldw_chatbook/UI/Screens/library_screen.py` — honest conflict reporting.
+* `Tests/Notes/test_sync_conflict_preservation.py` (new, 13 tests),
+  `Tests/DB/test_chachanotes_sync_conflict_preservation_migration.py` (new,
+  5 tests), `Tests/UI/test_library_shell.py` (+1 test, 1 fake tightened),
+  `Tests/Notes/test_sync_engine.py` (hollow fixture repaired — see the lesson),
+  `Tests/DB/test_chachanotes_message_exchanges.py`,
+  `Tests/DB/test_chachanotes_console_project_context_migration.py`.
+* `Docs/Features/notes_bidirectional_sync.md`,
+  `Docs/User_Guide/library/notes.md`,
+  `backlog/docs/lessons-testing-evidence.md`.

--- a/backlog/tasks/task-19554 - Notes sync destroys the losing side with no recoverable copy and disk_wins is a silent no-op.md
+++ b/backlog/tasks/task-19554 - Notes sync destroys the losing side with no recoverable copy and disk_wins is a silent no-op.md
@@ -171,12 +171,13 @@ NOT stop `disk_wins`/`newer_wins` from destroying the note in the database —
 that path only needs the DB — so without this rule preservation would fail
 exactly where destruction still succeeded.
 
-*Feedback loop closed.* Sidecars are dropped from every scan by the
-`.conflict-` marker (not merely by the `.bak` suffix being outside the default
-`['.md', '.txt']` set), so a preserved copy can never be ingested as a note,
-which would otherwise turn each conflict into a duplicate note and then into
-another file. Pinned by
-`test_sidecars_are_never_re_ingested_as_notes`.
+*Feedback loop closed.* Sidecars are dropped from every scan, so a preserved
+copy can never be ingested as a note, which would otherwise turn each conflict
+into a duplicate note and then into another file. Recognition needs the
+`.conflict-` marker AND the `.bak` suffix together — see the Qodo round below
+for why the marker alone was wrong. Pinned by
+`test_sidecars_are_never_re_ingested_as_notes` and
+`test_a_note_whose_name_contains_the_marker_still_syncs`.
 
 ### `DISK_WINS`: implemented, not removed
 
@@ -274,3 +275,70 @@ caused it instead of an unrelated older one.
 * `Docs/Features/notes_bidirectional_sync.md`,
   `Docs/User_Guide/library/notes.md`,
   `backlog/docs/lessons-testing-evidence.md`.
+
+### Qodo review round (PR #1922)
+
+The design (sidecar-first + DB row + fail-closed) was endorsed over both
+alternatives. Three defects *within* it, all fixed. Findings 2 and 3 are the
+same code region and one change resolves both.
+
+**1. `is_conflict_sidecar` over-matched and silently un-synced real notes.**
+It tested for `.conflict-` anywhere in the filename, and `_scan_directory`
+drops what it matches — so a user's own `meeting.conflict-notes.md` was
+excluded from every sync with no error and no skip row. A silent filter that
+over-matches is a worse failure than the one it prevents. Recognition now
+requires the marker **and** the `.bak` suffix, which keeps the never-re-ingest
+guarantee (every sidecar this engine writes ends `.bak`) without eating real
+notes. Born red on behaviour, not on a missing symbol:
+`AssertionError: a legitimate note containing '.conflict-' was silently
+dropped from the scan; skipped=[] / assert 0 == 1`. Both halves are pinned —
+a suffix-only predicate goes red on `archive.bak`, a marker-only one on
+`meeting.conflict-notes.md`.
+
+**2 + 3. The sidecar name was checked and then written (TOCTOU), and the check
+was a raw `.exists()` outside the module's path boundary.** `Path.exists()`
+followed by `PinnedSyncRoot.write_text` — which renames over its target — left
+a window in which a concurrent run could take the same name; the second writer
+then destroyed the first writer's preserved copy. That is precisely the data
+loss this task exists to prevent, in the one path whose whole job is to
+prevent it. And the `.exists()` probe was an ad-hoc filesystem call on a
+constructed path, bypassing the boundary every other operation in this module
+goes through.
+
+Both are gone in one change: a new `PinnedSyncRoot.create_new_text` claims the
+name with `O_CREAT | O_EXCL | O_NOFOLLOW` in a single syscall — check and
+claim are the same operation, so two runs cannot both decide a name is free.
+A taken name surfaces as `FileExistsError` and the writer advances to the next
+ordinal; an exhausted name space raises rather than falling back to a
+replacing write, which keeps the fail-closed rule intact (a raise means "could
+not preserve", so the destructive path does not run). `_write_conflict_sidecar`
+now performs **no** filesystem call of its own — everything routes through
+`PinnedSyncRoot`, which is this module's path boundary by design
+(`sync_paths.py` exists because the descriptor-anchored boundary is stronger
+than the lexical checks in `Utils/path_validation.py`, which is why the sync
+engine has never imported the latter).
+
+The window is opened deterministically in the test through `_before_create`,
+following the module's existing `_before_replace` seam idiom. **Mutation
+evidence** (the fix is one flag, so the flag is what gets mutated): dropping
+`O_EXCL` for `O_TRUNC` in `create_new_text` turns both atomicity tests red —
+`assert "another run's preserved copy" in {'Modified on disk'}` (the competitor's
+copy destroyed) and `assert 'Modified in database' == 'Modified on disk'` (the
+squatter silently overwritten *and* the destructive path allowed to proceed).
+Restored, both green. A real two-thread race was not used: it would be
+non-deterministic and could pass on a machine that happened not to interleave,
+whereas the seam pins the exact window with no flake surface.
+
+`create_new_text` also carries its own boundary tests next to `write_text`'s in
+`test_sync_containment.py`: it refuses an existing name without touching it,
+refuses to follow a symlinked name, refuses a missing parent (a sidecar goes
+beside an existing note; it never creates directories), writes 0o600, and
+unlinks its own file if anything fails after the create so a caller told the
+write failed never finds a half-written one.
+
+Files touched this round: `tldw_chatbook/Notes/sync_paths.py`
+(`create_new_text`, `_before_create`), `tldw_chatbook/Notes/sync_engine.py`
+(`is_conflict_sidecar`, `_write_conflict_sidecar`),
+`Tests/Notes/test_sync_conflict_preservation.py` (+4),
+`Tests/Notes/test_sync_containment.py` (+5),
+`Docs/Features/notes_bidirectional_sync.md`.

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -447,7 +447,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 43  # Local message_exchanges captures (task-18300, Console Conversation Inspector).
+    _CURRENT_SCHEMA_VERSION = 44  # Recoverable copy of a discarded Notes-sync side (task-19554).
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -5813,6 +5813,76 @@ UPDATE db_schema_version
                 f"Migration from V42 to V43 failed for '{self._SCHEMA_NAME}': {exc}"
             ) from exc
 
+    def _migrate_from_v43_to_v44(self, conn: sqlite3.Connection) -> None:
+        """Give ``sync_conflicts`` room for the side a resolution discards.
+
+        task-19554: the Notes sync engine overwrote the losing side of a
+        ``both_changed`` conflict wholesale while persisting only its SHA-256,
+        so the discarded text was unrecoverable. The three columns added here
+        (``losing_side``, ``losing_content``, ``preserved_file_path``) are the
+        durable second copy behind the on-disk sidecar; see the migration
+        file's header for why they are written only on actual destruction.
+
+        Args:
+            conn: The active connection, inside ``_initialize_schema``'s
+                transaction.
+
+        Raises:
+            SchemaError: If the database is not at v43, the file cannot be
+                read/split, or the version bump does not land.
+        """
+        self._require_migration_entry_version(conn, 43, "V43→V44")
+        logger.info(
+            f"Migrating schema from V43 to V44 for '{self._SCHEMA_NAME}' in DB: {self.db_path_str}..."
+        )
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v43_to_v44_sync_conflict_preservation.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                # ``_execute_migration_statements`` rather than a bare
+                # per-statement loop: it carries task-19553's
+                # already-applied ``ADD COLUMN`` skip, so a database left
+                # half-migrated by an interrupted run re-enters cleanly
+                # instead of aborting on ``duplicate column name``.
+                self._execute_migration_statements(
+                    cursor,
+                    migration_path.read_text(encoding="utf-8"),
+                    "V43→V44",
+                )
+                version_cursor = cursor.execute(
+                    """
+                    UPDATE db_schema_version
+                       SET version = 44
+                     WHERE schema_name = ?
+                       AND version = 43
+                    """,
+                    (self._SCHEMA_NAME,),
+                )
+                if version_cursor.rowcount != 1:
+                    raise SchemaError(
+                        f"[{self._SCHEMA_NAME} V43→V44] Migration version update was not applied"
+                    )
+
+            final_version = self._get_db_version(conn)
+            if final_version != 44:
+                raise SchemaError(
+                    f"[{self._SCHEMA_NAME} V43→V44] Migration version check failed. "
+                    f"Expected 44, got: {final_version}"
+                )
+            logger.info(
+                f"[{self._SCHEMA_NAME} V43→V44] Migration completed successfully for DB: {self.db_path_str}."
+            )
+        except (OSError, sqlite3.Error, CharactersRAGDBError, SchemaError) as exc:
+            logger.opt(exception=True).error(
+                f"[{self._SCHEMA_NAME} V43→V44] Migration failed: {exc}"
+            )
+            raise SchemaError(
+                f"Migration from V43 to V44 failed for '{self._SCHEMA_NAME}': {exc}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -5994,6 +6064,7 @@ UPDATE db_schema_version
                     40: self._migrate_from_v40_to_v41,
                     41: self._migrate_from_v41_to_v42,
                     42: self._migrate_from_v42_to_v43,
+                    43: self._migrate_from_v43_to_v44,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v43_to_v44_sync_conflict_preservation.sql
@@ -1,0 +1,30 @@
+-- ChaChaNotes v43 -> v44: recoverable copy of a discarded sync side
+-- (task-19554).
+--
+-- Before this, `sync_conflicts` held only `db_content_hash` and
+-- `disk_content_hash`. When the Notes sync engine resolved a `both_changed`
+-- conflict it overwrote the losing side wholesale and the discarded text was
+-- unrecoverable -- a SHA-256 is not a backup.
+--
+-- These three columns are written ONLY when a side is actually discarded, not
+-- on every conflict DETECTION: a conflict that is merely recorded (the `ask`
+-- policy, or a strategy that declines to apply) destroys nothing and needs no
+-- copy. That keeps this from becoming a second unbounded full-content shadow
+-- of `notes` the way `sync_log` already is.
+--
+--   losing_side         'db' | 'disk' -- which side was thrown away
+--   losing_content      that side's text, verbatim, for reconstruction
+--   preserved_file_path the sidecar written next to the note file, which is
+--                       the copy a user actually recovers from (a rename);
+--                       this row is the second copy for when that file is
+--                       gone.
+--
+-- DDL only. The schema-version bump is a separate rowcount-guarded UPDATE in
+-- the runner (`CharactersRAGDB._migrate_from_v43_to_v44`), matching the
+-- v42->v43 precedent.
+
+ALTER TABLE sync_conflicts ADD COLUMN losing_side TEXT;
+
+ALTER TABLE sync_conflicts ADD COLUMN losing_content TEXT;
+
+ALTER TABLE sync_conflicts ADD COLUMN preserved_file_path TEXT;

--- a/tldw_chatbook/Notes/sync_engine.py
+++ b/tldw_chatbook/Notes/sync_engine.py
@@ -32,12 +32,15 @@ from .sync_paths import PinnedSyncRoot, SafeSyncFile, SyncPathError
 #
 # A resolution that overwrites one side writes that side's text, verbatim,
 # to a sidecar next to the note file BEFORE the overwrite happens, so
-# recovery is a rename. The marker is what makes a sidecar recognizable:
-# ``_scan_directory`` drops anything carrying it so a preserved copy can
-# never be re-ingested as a note (which would turn every conflict into a
-# duplicate note, and every subsequent pass into another one). The ``.bak``
-# suffix is belt to that braces -- it is outside the default
-# ``['.md', '.txt']`` scan set as well.
+# recovery is a rename. A sidecar is recognized by the marker AND the
+# ``.bak`` suffix together (``is_conflict_sidecar``), and ``_scan_directory``
+# drops what it recognizes, so a preserved copy can never be re-ingested as a
+# note -- which would turn every conflict into a duplicate note, and every
+# subsequent pass into another one. Requiring both halves is what keeps that
+# filter from eating a real note whose own name contains ``.conflict-``; the
+# ``.bak`` suffix additionally sits outside the default ``['.md', '.txt']``
+# scan set, so the marker only has to hold for a caller passing custom
+# extensions.
 CONFLICT_SIDECAR_MARKER = ".conflict-"
 CONFLICT_SIDECAR_SUFFIX = ".bak"
 _CONFLICT_SIDECAR_ATTEMPTS = 64
@@ -309,9 +312,11 @@ class NotesSyncEngine:
                 selected_root.__exit__(None, None, None)
         # Preserved conflict copies are never sync candidates. Their ``.bak``
         # suffix already keeps them out of the default extension set, but the
-        # marker check is what holds if a caller passes custom extensions:
-        # ingesting one would create a duplicate note per conflict, and its
-        # own file on the next pass.
+        # check is what holds if a caller passes custom extensions: ingesting
+        # one would create a duplicate note per conflict, and its own file on
+        # the next pass. ``is_conflict_sidecar`` requires the marker AND the
+        # suffix precisely because this filter is SILENT -- an over-match here
+        # removes a real note from sync with nothing to show for it.
         files_map = {
             relative_path: self._from_safe_file(safe_file)
             for relative_path, safe_file in safe_files.items()
@@ -573,9 +578,26 @@ class NotesSyncEngine:
 
     @staticmethod
     def is_conflict_sidecar(relative_path: Path) -> bool:
-        """Return whether a scanned entry is one of our preserved copies."""
+        """Return whether a scanned entry is one of our preserved copies.
 
-        return CONFLICT_SIDECAR_MARKER in relative_path.name
+        Both halves are required. Matching the marker alone silently un-synced
+        a user's own note if its name happened to contain ``.conflict-`` --
+        ``meeting.conflict-notes.md`` was dropped from every scan with no
+        error and no skip row, which is a worse failure than the one the
+        filter exists to prevent. Every sidecar this engine writes ends in
+        ``.bak``, so requiring the suffix as well keeps the never-re-ingest
+        guarantee intact while leaving real notes alone.
+
+        Args:
+            relative_path: A scanned entry's path relative to the sync root.
+
+        Returns:
+            Whether the entry is a preserved conflict copy.
+        """
+        name = relative_path.name
+        return name.endswith(CONFLICT_SIDECAR_SUFFIX) and (
+            CONFLICT_SIDECAR_MARKER in name
+        )
 
     def _write_conflict_sidecar(
         self,
@@ -612,16 +634,30 @@ class NotesSyncEngine:
         """
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         for attempt in range(_CONFLICT_SIDECAR_ATTEMPTS):
-            # Second-resolution stamps can repeat within one run, and an
-            # earlier preserved copy must never be clobbered by a later one.
+            # Second-resolution stamps repeat within one run and across
+            # concurrent runs, so the name has to be CLAIMED, not merely
+            # checked: ``create_new_text`` does it with O_CREAT|O_EXCL, one
+            # syscall, and reports a taken name as FileExistsError. The
+            # previous shape here -- ``if not path.exists(): write_text(...)``
+            # -- had a window between the two in which another run could
+            # create the file, and ``write_text`` renames over its target, so
+            # the winner of that race destroyed the loser's preserved copy:
+            # the one kind of data loss this whole code path exists to
+            # prevent. It also put a raw filesystem probe on a constructed
+            # path outside the module's path boundary; there is now no
+            # filesystem call here at all, only ``PinnedSyncRoot``.
             ordinal = "" if attempt == 0 else f"-{attempt + 1}"
             candidate = relative_path.with_name(
                 f"{relative_path.name}{CONFLICT_SIDECAR_MARKER}"
                 f"{stamp}{ordinal}-{side}{CONFLICT_SIDECAR_SUFFIX}"
             )
-            if (pinned_root.canonical_root / candidate).exists():
+            try:
+                return pinned_root.create_new_text(candidate, content).absolute_path
+            except FileExistsError:
                 continue
-            return pinned_root.write_text(candidate, content).absolute_path
+        # Never fall back to a replacing write: the caller treats a raise as
+        # "could not preserve" and leaves both sides alone, which is the
+        # recoverable outcome. Overwriting someone else's copy is not.
         raise SyncPathError("conflict_sidecar_name_exhausted", relative_path)
 
     def _resolve_with_preservation(

--- a/tldw_chatbook/Notes/sync_engine.py
+++ b/tldw_chatbook/Notes/sync_engine.py
@@ -28,6 +28,30 @@ from .sync_paths import PinnedSyncRoot, SafeSyncFile, SyncPathError
 # Classes and Functions:
 
 
+# --- Conflict preservation (task-19554) ----------------------------------
+#
+# A resolution that overwrites one side writes that side's text, verbatim,
+# to a sidecar next to the note file BEFORE the overwrite happens, so
+# recovery is a rename. The marker is what makes a sidecar recognizable:
+# ``_scan_directory`` drops anything carrying it so a preserved copy can
+# never be re-ingested as a note (which would turn every conflict into a
+# duplicate note, and every subsequent pass into another one). The ``.bak``
+# suffix is belt to that braces -- it is outside the default
+# ``['.md', '.txt']`` scan set as well.
+CONFLICT_SIDECAR_MARKER = ".conflict-"
+CONFLICT_SIDECAR_SUFFIX = ".bak"
+_CONFLICT_SIDECAR_ATTEMPTS = 64
+
+#: The two sides a conflict has: used both for the winner a strategy
+#: picks and for the side a resolution throws away.
+SIDE_DB = "db"
+SIDE_DISK = "disk"
+
+#: Values ``sync_conflicts.resolution`` accepts (its CHECK constraint).
+RESOLUTION_USE_DB = "use_db"
+RESOLUTION_USE_DISK = "use_disk"
+
+
 class SyncDirection(Enum):
     """Enumeration for sync directions."""
 
@@ -68,7 +92,24 @@ class SyncFileInfo:
 
 @dataclass
 class SyncConflict:
-    """Represents a sync conflict."""
+    """Represents a sync conflict.
+
+    The last four fields record what the run actually DID about it, which is
+    not the same thing as the policy that was selected (task-19554: every
+    strategy but ``NEWER_WINS`` used to apply nothing on a ``both_changed``
+    conflict while the UI reported it as resolved).
+
+    Attributes:
+        applied: Whether this run changed a side because of this conflict.
+            ``False`` means the conflict is still open -- never report it as
+            resolved.
+        resolution: The value stamped into ``sync_conflicts.resolution``:
+            ``"use_db"``, ``"use_disk"``, or ``None`` when nothing was applied.
+        preserved_path: Absolute path of the sidecar holding the discarded
+            side, when one was discarded.
+        row_id: ``sync_conflicts.id`` of the recorded row, so the outcome can
+            be stamped back onto it.
+    """
 
     note_id: Optional[str]
     file_path: Path
@@ -79,6 +120,10 @@ class SyncConflict:
     disk_hash: Optional[str] = None
     db_modified: Optional[datetime] = None
     disk_modified: Optional[float] = None
+    applied: bool = False
+    resolution: Optional[str] = None
+    preserved_path: Optional[Path] = None
+    row_id: Optional[int] = None
 
 
 @dataclass
@@ -94,6 +139,22 @@ class SyncProgress:
     created_files: List[Path] = field(default_factory=list)
     updated_files: List[Path] = field(default_factory=list)
     skipped_items: List[Tuple[str, str]] = field(default_factory=list)  # (item, reason)
+    # Sidecars holding a discarded side. Deliberately NOT in
+    # ``created_files``: they are not synced notes and must never be counted
+    # as changes the run made to the user's content.
+    preserved_files: List[Path] = field(default_factory=list)
+
+    @property
+    def applied_conflicts(self) -> List[SyncConflict]:
+        """Conflicts this run actually resolved by changing a side."""
+
+        return [conflict for conflict in self.conflicts if conflict.applied]
+
+    @property
+    def unresolved_conflicts(self) -> List[SyncConflict]:
+        """Conflicts this run recorded but left for the user to settle."""
+
+        return [conflict for conflict in self.conflicts if not conflict.applied]
 
 
 class NotesSyncEngine:
@@ -246,9 +307,15 @@ class NotesSyncEngine:
         finally:
             if owns_root:
                 selected_root.__exit__(None, None, None)
+        # Preserved conflict copies are never sync candidates. Their ``.bak``
+        # suffix already keeps them out of the default extension set, but the
+        # marker check is what holds if a caller passes custom extensions:
+        # ingesting one would create a duplicate note per conflict, and its
+        # own file on the next pass.
         files_map = {
             relative_path: self._from_safe_file(safe_file)
             for relative_path, safe_file in safe_files.items()
+            if not self.is_conflict_sidecar(relative_path)
         }
         files_failed = len(issues)
         if progress is not None:
@@ -413,14 +480,30 @@ class NotesSyncEngine:
                 values,
             )
 
-    def _record_conflict(self, session_id: str, conflict: SyncConflict):
-        """Record a sync conflict in the database."""
+    def _record_conflict(self, session_id: str, conflict: SyncConflict) -> Optional[int]:
+        """Record a sync conflict in the database.
+
+        Only the detection facts are written here -- the discarded side's text
+        is written later, by ``_resolve_with_preservation``, and only if a side
+        is actually discarded. Recording content on mere DETECTION would make
+        this table a second unbounded full-content shadow of ``notes``
+        (``sync_log`` already is one) and would store a "backup" of text
+        nothing was going to destroy.
+
+        Args:
+            session_id: The sync session recording the conflict.
+            conflict: The conflict; its ``row_id`` is set from the new row.
+
+        Returns:
+            The new ``sync_conflicts.id``, or ``None`` if SQLite did not
+            report one.
+        """
         with self.db.transaction() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 INSERT INTO sync_conflicts
                 (session_id, note_id, file_path, conflict_type,
-                 db_content_hash, disk_content_hash, 
+                 db_content_hash, disk_content_hash,
                  db_modified_time, disk_modified_time)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -435,6 +518,339 @@ class NotesSyncEngine:
                     conflict.disk_modified,
                 ),
             )
+            conflict.row_id = cursor.lastrowid
+        return conflict.row_id
+
+    def _update_conflict_record(
+        self,
+        conflict: SyncConflict,
+        *,
+        losing_side: Optional[str] = None,
+        losing_content: Optional[str] = None,
+        preserved_path: Optional[Path] = None,
+        resolution: Optional[str] = None,
+    ) -> None:
+        """Stamp a recorded conflict with what was preserved and/or applied.
+
+        ``resolution`` is left NULL until a side is genuinely applied, which is
+        what keeps ``NotesSyncService.resolve_conflict`` (``WHERE resolution IS
+        NULL``) able to find the conflicts that are still open.
+
+        Args:
+            conflict: The conflict whose row to update (no-op without a
+                ``row_id``).
+            losing_side: ``"db"``/``"disk"``, the side being discarded.
+            losing_content: That side's text, verbatim.
+            preserved_path: Absolute path of the sidecar holding it.
+            resolution: ``"use_db"``/``"use_disk"`` once applied.
+        """
+        if conflict.row_id is None:
+            return
+        with self.db.transaction() as conn:
+            conn.execute(
+                """
+                UPDATE sync_conflicts
+                   SET losing_side = ?,
+                       losing_content = ?,
+                       preserved_file_path = ?,
+                       resolution = ?,
+                       resolved_at = ?
+                 WHERE id = ?
+            """,
+                (
+                    losing_side,
+                    losing_content,
+                    str(preserved_path) if preserved_path is not None else None,
+                    resolution,
+                    (
+                        datetime.now(timezone.utc).isoformat()
+                        if resolution is not None
+                        else None
+                    ),
+                    conflict.row_id,
+                ),
+            )
+
+    @staticmethod
+    def is_conflict_sidecar(relative_path: Path) -> bool:
+        """Return whether a scanned entry is one of our preserved copies."""
+
+        return CONFLICT_SIDECAR_MARKER in relative_path.name
+
+    def _write_conflict_sidecar(
+        self,
+        pinned_root: PinnedSyncRoot,
+        relative_path: Path,
+        side: str,
+        content: str,
+    ) -> Path:
+        """Write the discarded side next to the note file, byte-exact.
+
+        Verbatim content and nothing else -- no header, no diff markers -- so
+        recovering the lost text is a rename, not an edit. Which side it holds
+        and when it was taken are carried by the NAME
+        (``note.md.conflict-20260821T203015Z-disk.bak``), which also sorts
+        directly beside the file it came from.
+
+        The write goes through the same ``PinnedSyncRoot`` boundary as every
+        other sync write, so a swapped root or a symlinked path fails closed
+        here exactly as it does for a note file.
+
+        Args:
+            pinned_root: The entered sync root.
+            relative_path: The note file's path relative to that root.
+            side: ``"db"`` or ``"disk"``.
+            content: The text being discarded.
+
+        Returns:
+            Absolute path of the sidecar just written.
+
+        Raises:
+            SyncPathError: If a free name cannot be found, or the write is
+                refused by the boundary.
+            OSError: Propagated from the write.
+        """
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for attempt in range(_CONFLICT_SIDECAR_ATTEMPTS):
+            # Second-resolution stamps can repeat within one run, and an
+            # earlier preserved copy must never be clobbered by a later one.
+            ordinal = "" if attempt == 0 else f"-{attempt + 1}"
+            candidate = relative_path.with_name(
+                f"{relative_path.name}{CONFLICT_SIDECAR_MARKER}"
+                f"{stamp}{ordinal}-{side}{CONFLICT_SIDECAR_SUFFIX}"
+            )
+            if (pinned_root.canonical_root / candidate).exists():
+                continue
+            return pinned_root.write_text(candidate, content).absolute_path
+        raise SyncPathError("conflict_sidecar_name_exhausted", relative_path)
+
+    def _resolve_with_preservation(
+        self,
+        *,
+        conflict: SyncConflict,
+        progress: SyncProgress,
+        pinned_root: PinnedSyncRoot,
+        relative_path: Path,
+        losing_side: str,
+        losing_content: str,
+        resolution: str,
+        apply_winner: Callable[[], None],
+    ) -> bool:
+        """Save the losing side, then apply the winner. Fail closed.
+
+        The ordering is the whole point: if the discarded text cannot be
+        written somewhere recoverable, the overwrite does **not** happen. A
+        run that cannot preserve reports an error and leaves both sides alone,
+        which is always recoverable; the alternative -- destroying anyway --
+        never is.
+
+        Args:
+            conflict: The recorded conflict, updated in place with the outcome.
+            progress: The run's progress, for the sidecar and any error.
+            pinned_root: The entered sync root.
+            relative_path: The note file's path relative to that root.
+            losing_side: ``"db"``/``"disk"``, the side about to be discarded.
+            losing_content: That side's text.
+            resolution: ``"use_db"``/``"use_disk"`` to stamp once applied.
+            apply_winner: Performs the destructive write. May raise; the
+                caller's handler records it and the conflict stays unresolved
+                with its copy already saved.
+
+        Returns:
+            Whether the winner was applied.
+        """
+        try:
+            preserved = self._write_conflict_sidecar(
+                pinned_root, relative_path, losing_side, losing_content
+            )
+        except Exception as exc:
+            logger.error(
+                "Refusing to resolve conflict: the losing side could not be "
+                "preserved (side={}, error_type={})",
+                losing_side,
+                type(exc).__name__,
+            )
+            log_counter(
+                "sync_engine_conflict_preservation_failed",
+                labels={"losing_side": losing_side},
+            )
+            progress.errors.append((str(relative_path), exc))
+            return False
+
+        conflict.preserved_path = preserved
+        progress.preserved_files.append(preserved)
+        # Persist the copy BEFORE the overwrite too, so an apply that dies
+        # part-way still leaves the discarded text reconstructible from the
+        # row (with a NULL resolution saying the run never finished).
+        self._update_conflict_record(
+            conflict,
+            losing_side=losing_side,
+            losing_content=losing_content,
+            preserved_path=preserved,
+        )
+
+        apply_winner()
+
+        conflict.applied = True
+        conflict.resolution = resolution
+        self._update_conflict_record(
+            conflict,
+            losing_side=losing_side,
+            losing_content=losing_content,
+            preserved_path=preserved,
+            resolution=resolution,
+        )
+        log_counter(
+            "sync_engine_conflict_resolved",
+            labels={"resolution": resolution, "losing_side": losing_side},
+        )
+        return True
+
+    def _resolve_both_changed(
+        self,
+        *,
+        conflict: SyncConflict,
+        conflict_resolution: ConflictResolution,
+        progress: SyncProgress,
+        pinned_root: PinnedSyncRoot,
+        relative_path: Path,
+        root_path: Path,
+        user_id: str,
+        db_note: Dict[str, Any],
+        disk_file: SyncFileInfo,
+        may_write_disk: bool,
+        may_write_db: bool,
+        include_title: bool = False,
+    ) -> None:
+        """Apply the selected strategy to a ``both_changed`` conflict.
+
+        One implementation for all three directions; the direction only
+        restricts which side may be written (``may_write_*``). A strategy whose
+        winner cannot be written in this direction applies nothing and leaves
+        the conflict OPEN rather than pretending to have settled it -- e.g.
+        "Disk wins" during a Library → Disk push has nothing to do, because the
+        disk copy already stands.
+
+        Args:
+            conflict: The recorded conflict, updated in place.
+            conflict_resolution: The selected strategy.
+            progress: The run's progress.
+            pinned_root: The entered sync root.
+            relative_path: The note file's path relative to that root.
+            root_path: The canonical sync root.
+            user_id: User whose notes are being synced.
+            db_note: The note row (content, version, id, last_modified).
+            disk_file: The scanned file.
+            may_write_disk: Whether this direction may overwrite the file.
+            may_write_db: Whether this direction may overwrite the note.
+            include_title: Whether applying the disk side also renames the note
+                from the file stem (the disk → DB direction does; the
+                bidirectional path never did).
+        """
+        winner = self._both_changed_winner(
+            conflict_resolution, db_note, disk_file
+        )
+
+        if winner == SIDE_DB and may_write_disk:
+
+            def apply_db_content() -> None:
+                new_file_info = self._write_file_info(
+                    pinned_root, relative_path, db_note["content"]
+                )
+                self._update_note_sync_metadata(
+                    db_note["id"],
+                    new_file_info,
+                    root_path,
+                    user_id,
+                    db_note["version"],
+                )
+                progress.updated_files.append(new_file_info.absolute_path)
+
+            self._resolve_with_preservation(
+                conflict=conflict,
+                progress=progress,
+                pinned_root=pinned_root,
+                relative_path=relative_path,
+                losing_side=SIDE_DISK,
+                losing_content=disk_file.content,
+                resolution=RESOLUTION_USE_DB,
+                apply_winner=apply_db_content,
+            )
+            return
+
+        if winner == SIDE_DISK and may_write_db:
+
+            def apply_disk_content() -> None:
+                update_data: Dict[str, Any] = {"content": disk_file.content}
+                if include_title:
+                    update_data["title"] = disk_file.absolute_path.stem
+                success = self.notes_service.update_note(
+                    user_id=user_id,
+                    note_id=db_note["id"],
+                    update_data=update_data,
+                    expected_version=db_note["version"],
+                )
+                if not success:
+                    raise ConflictError(
+                        f"Version mismatch applying disk content to note "
+                        f"{db_note['id']}"
+                    )
+                updated_note = self.notes_service.get_note_by_id(
+                    user_id, db_note["id"]
+                )
+                if updated_note:
+                    self._update_note_sync_metadata(
+                        db_note["id"],
+                        disk_file,
+                        root_path,
+                        user_id,
+                        updated_note["version"],
+                    )
+                progress.updated_notes.append(db_note["id"])
+
+            self._resolve_with_preservation(
+                conflict=conflict,
+                progress=progress,
+                pinned_root=pinned_root,
+                relative_path=relative_path,
+                losing_side=SIDE_DB,
+                losing_content=db_note["content"],
+                resolution=RESOLUTION_USE_DISK,
+                apply_winner=apply_disk_content,
+            )
+            return
+
+        logger.info(
+            "Conflict left unresolved (strategy={}, winner={}, "
+            "may_write_disk={}, may_write_db={})",
+            conflict_resolution.value,
+            winner,
+            may_write_disk,
+            may_write_db,
+        )
+
+    def _both_changed_winner(
+        self,
+        conflict_resolution: ConflictResolution,
+        db_note: Dict[str, Any],
+        disk_file: SyncFileInfo,
+    ) -> Optional[str]:
+        """Return which side a strategy picks, or ``None`` for "don't touch".
+
+        ``ASK`` is the only strategy with no winner: it records the conflict
+        for a human and changes nothing. (Nothing in the shipped UI offers it
+        -- see the Library sync panel -- which is exactly why every other
+        strategy has to actually apply.)
+        """
+        if conflict_resolution == ConflictResolution.DB_WINS:
+            return SIDE_DB
+        if conflict_resolution == ConflictResolution.DISK_WINS:
+            return SIDE_DISK
+        if conflict_resolution == ConflictResolution.NEWER_WINS:
+            db_modified = self._coerce_aware_datetime(db_note["last_modified"])
+            disk_modified = datetime.fromtimestamp(disk_file.mtime, tz=timezone.utc)
+            return SIDE_DB if db_modified > disk_modified else SIDE_DISK
+        return None
 
     def _update_note_sync_metadata(
         self,
@@ -595,6 +1011,7 @@ class NotesSyncEngine:
                     conflict_resolution,
                     user_id,
                     progress,
+                    pinned_root,
                 )
             elif direction == SyncDirection.DB_TO_DISK:
                 await self._sync_db_to_disk(
@@ -631,6 +1048,11 @@ class NotesSyncEngine:
                 "created_files": len(progress.created_files),
                 "updated_files": len(progress.updated_files),
                 "conflicts": len(progress.conflicts),
+                # Split out so a session's record can never imply the run
+                # settled a conflict it only wrote down (task-19554).
+                "conflicts_applied": len(progress.applied_conflicts),
+                "conflicts_unresolved": len(progress.unresolved_conflicts),
+                "preserved_files": len(progress.preserved_files),
                 "errors": len(progress.errors),
                 "skipped": len(progress.skipped_items),
             }
@@ -697,8 +1119,17 @@ class NotesSyncEngine:
         conflict_resolution: ConflictResolution,
         user_id: str,
         progress: SyncProgress,
+        pinned_root: PinnedSyncRoot,
     ):
-        """Sync from disk to database."""
+        """Sync from disk to database.
+
+        task-19554: this direction used to treat "the file changed" as
+        sufficient reason to overwrite the note, without ever asking whether
+        the NOTE had changed too. A note edited in the app and a file edited
+        outside it is the same ``both_changed`` conflict the other two
+        directions detect, and the note body went silently. It is now detected,
+        preserved, and resolved by the selected strategy like everywhere else.
+        """
         for rel_path, file_info in disk_files.items():
             if self.is_cancelled(session_id):
                 break
@@ -723,33 +1154,67 @@ class NotesSyncEngine:
                 elif file_info.content_hash != db_note.get(
                     "last_synced_disk_file_hash"
                 ):
-                    # File changed on disk -> Update note in DB
-                    success = self.notes_service.update_note(
-                        user_id=user_id,
-                        note_id=db_note["id"],
-                        update_data={
-                            "content": file_info.content,
-                            "title": file_info.absolute_path.stem,
-                        },
-                        expected_version=db_note["version"],
-                    )
+                    last_synced_hash = db_note.get("last_synced_disk_file_hash")
+                    db_changed = db_note["content_hash"] != last_synced_hash
 
-                    if success:
-                        # Get updated version
-                        updated_note = self.notes_service.get_note_by_id(
-                            user_id, db_note["id"]
+                    if db_changed:
+                        # Both sides moved since the baseline -- a conflict,
+                        # not a one-way pull.
+                        conflict = SyncConflict(
+                            note_id=db_note["id"],
+                            file_path=rel_path,
+                            conflict_type="both_changed",
+                            db_content=db_note["content"],
+                            disk_content=file_info.content,
+                            db_hash=db_note["content_hash"],
+                            disk_hash=file_info.content_hash,
                         )
-                        if updated_note:
-                            self._update_note_sync_metadata(
-                                db_note["id"],
-                                file_info,
-                                root_path,
-                                user_id,
-                                updated_note["version"],
-                            )
-                            progress.updated_notes.append(db_note["id"])
-                            logger.info(f"Updated note from file: {rel_path}")
+                        progress.conflicts.append(conflict)
+                        self._record_conflict(session_id, conflict)
+                        self._resolve_both_changed(
+                            conflict=conflict,
+                            conflict_resolution=conflict_resolution,
+                            progress=progress,
+                            pinned_root=pinned_root,
+                            relative_path=rel_path,
+                            root_path=root_path,
+                            user_id=user_id,
+                            db_note=db_note,
+                            disk_file=file_info,
+                            may_write_disk=False,
+                            may_write_db=True,
+                            include_title=True,
+                        )
+                    else:
+                        # Only the file changed -> Update note in DB
+                        success = self.notes_service.update_note(
+                            user_id=user_id,
+                            note_id=db_note["id"],
+                            update_data={
+                                "content": file_info.content,
+                                "title": file_info.absolute_path.stem,
+                            },
+                            expected_version=db_note["version"],
+                        )
 
+                        if success:
+                            # Get updated version
+                            updated_note = self.notes_service.get_note_by_id(
+                                user_id, db_note["id"]
+                            )
+                            if updated_note:
+                                self._update_note_sync_metadata(
+                                    db_note["id"],
+                                    file_info,
+                                    root_path,
+                                    user_id,
+                                    updated_note["version"],
+                                )
+                                progress.updated_notes.append(db_note["id"])
+                                logger.info(f"Updated note from file: {rel_path}")
+
+            except SyncPathError as exc:
+                self._record_path_skip(progress, rel_path, exc)
             except Exception as e:
                 logger.error(f"Error syncing {rel_path}: {e}")
                 progress.errors.append((str(rel_path), e))
@@ -774,15 +1239,24 @@ class NotesSyncEngine:
                 progress.conflicts.append(conflict)
                 self._record_conflict(session_id, conflict)
 
-                # Auto-unlink if not asking
+                # Auto-unlink if not asking. Nothing is destroyed here -- the
+                # note keeps its content and simply stops being mirrored --
+                # so there is no losing side to preserve, but the outcome is
+                # still stamped so the run cannot over-claim.
                 if conflict_resolution != ConflictResolution.ASK:
                     try:
                         self._unlink_note_from_sync(db_note["id"], db_note["version"])
+                        conflict.applied = True
+                        conflict.resolution = RESOLUTION_USE_DISK
+                        self._update_conflict_record(
+                            conflict, resolution=RESOLUTION_USE_DISK
+                        )
                         logger.info(
                             f"Unlinked note {db_note['id']} - file deleted on disk"
                         )
                     except Exception as e:
                         logger.error(f"Error unlinking note {db_note['id']}: {e}")
+                        progress.errors.append((str(rel_path), e))
 
     async def _sync_db_to_disk(
         self,
@@ -847,23 +1321,24 @@ class NotesSyncEngine:
                             progress.conflicts.append(conflict)
                             self._record_conflict(session_id, conflict)
 
-                            # Resolve based on strategy
-                            if conflict_resolution == ConflictResolution.DB_WINS:
-                                new_file_info = self._write_file_info(
-                                    pinned_root,
-                                    rel_path,
-                                    db_note["content"],
-                                )
-                                self._update_note_sync_metadata(
-                                    db_note["id"],
-                                    new_file_info,
-                                    root_path,
-                                    user_id,
-                                    db_note["version"],
-                                )
-                                progress.updated_files.append(
-                                    new_file_info.absolute_path
-                                )
+                            # Resolve based on strategy. Only DB_WINS had a
+                            # branch here before task-19554, so NEWER_WINS
+                            # silently declined to push even when the note WAS
+                            # the newer side -- and the DB_WINS push destroyed
+                            # the file's text with no copy kept.
+                            self._resolve_both_changed(
+                                conflict=conflict,
+                                conflict_resolution=conflict_resolution,
+                                progress=progress,
+                                pinned_root=pinned_root,
+                                relative_path=rel_path,
+                                root_path=root_path,
+                                user_id=user_id,
+                                db_note=db_note,
+                                disk_file=disk_file,
+                                may_write_disk=True,
+                                may_write_db=False,
+                            )
                         else:
                             # Only DB changed
                             new_file_info = self._write_file_info(
@@ -948,7 +1423,12 @@ class NotesSyncEngine:
                     progress.conflicts.append(conflict)
                     self._record_conflict(session_id, conflict)
 
-                    # Auto-resolve based on strategy
+                    # Auto-resolve based on strategy. Only DB_WINS acts; the
+                    # other strategies genuinely have no defined answer for a
+                    # vanished file (there is no disk mtime to compare, and
+                    # "the disk wins" would mean guessing that the user meant
+                    # to delete the note). They leave it OPEN -- see
+                    # ``applied`` -- rather than reporting it as settled.
                     if conflict_resolution == ConflictResolution.DB_WINS:
                         # Recreate file
                         new_file_info = self._write_file_info(
@@ -964,6 +1444,11 @@ class NotesSyncEngine:
                             db_note["version"],
                         )
                         progress.created_files.append(new_file_info.absolute_path)
+                        conflict.applied = True
+                        conflict.resolution = RESOLUTION_USE_DB
+                        self._update_conflict_record(
+                            conflict, resolution=RESOLUTION_USE_DB
+                        )
 
                 elif disk_file and db_note:
                     # Exists in both - check for changes
@@ -1030,61 +1515,23 @@ class NotesSyncEngine:
                         progress.conflicts.append(conflict)
                         self._record_conflict(session_id, conflict)
 
-                        # Auto-resolve if not asking
-                        if conflict_resolution == ConflictResolution.NEWER_WINS:
-                            # Compare timestamps. ``last_modified`` normally
-                            # comes back as the raw TEXT column, but
-                            # sqlite3.PARSE_DECLTYPES (set on every
-                            # CharactersRAGDB connection) auto-converts a
-                            # TIMESTAMP-declared column to a real
-                            # ``datetime`` for some call paths -- accept
-                            # both instead of assuming a string.
-                            db_modified = self._coerce_aware_datetime(
-                                db_note["last_modified"]
-                            )
-                            disk_modified = datetime.fromtimestamp(
-                                disk_file.mtime, tz=timezone.utc
-                            )
-
-                            if db_modified > disk_modified:
-                                # DB is newer
-                                new_file_info = self._write_file_info(
-                                    pinned_root,
-                                    rel_path,
-                                    db_note["content"],
-                                )
-                                self._update_note_sync_metadata(
-                                    db_note["id"],
-                                    new_file_info,
-                                    root_path,
-                                    user_id,
-                                    db_note["version"],
-                                )
-                                progress.updated_files.append(
-                                    new_file_info.absolute_path
-                                )
-                            else:
-                                # Disk is newer
-                                success = self.notes_service.update_note(
-                                    user_id=user_id,
-                                    note_id=db_note["id"],
-                                    update_data={"content": disk_file.content},
-                                    expected_version=db_note["version"],
-                                )
-                                if success:
-                                    updated_note = self.notes_service.get_note_by_id(
-                                        user_id,
-                                        db_note["id"],
-                                    )
-                                    if updated_note:
-                                        self._update_note_sync_metadata(
-                                            db_note["id"],
-                                            disk_file,
-                                            root_path,
-                                            user_id,
-                                            updated_note["version"],
-                                        )
-                                    progress.updated_notes.append(db_note["id"])
+                        # Auto-resolve if not asking. Before task-19554 only
+                        # NEWER_WINS was implemented here, and it overwrote the
+                        # losing side with no copy kept; DB_WINS and DISK_WINS
+                        # recorded the conflict and applied nothing at all.
+                        self._resolve_both_changed(
+                            conflict=conflict,
+                            conflict_resolution=conflict_resolution,
+                            progress=progress,
+                            pinned_root=pinned_root,
+                            relative_path=rel_path,
+                            root_path=root_path,
+                            user_id=user_id,
+                            db_note=db_note,
+                            disk_file=disk_file,
+                            may_write_disk=True,
+                            may_write_db=True,
+                        )
 
             except SyncPathError as exc:
                 self._record_path_skip(progress, rel_path, exc)

--- a/tldw_chatbook/Notes/sync_paths.py
+++ b/tldw_chatbook/Notes/sync_paths.py
@@ -361,6 +361,9 @@ class PinnedSyncRoot:
     def _before_replace(self, _relative_path: Path) -> None:
         """Test seam immediately before identity rechecks and replacement."""
 
+    def _before_create(self, _relative_path: Path) -> None:
+        """Test seam immediately before the exclusive create in ``create_new_text``."""
+
     def _existing_target(
         self,
         parent_fd: int,
@@ -389,6 +392,93 @@ class PinnedSyncRoot:
             if written <= 0:
                 raise OSError("short write")
             remaining = remaining[written:]
+
+    def create_new_text(
+        self,
+        relative_path: Path | str,
+        content: str,
+    ) -> SafeSyncFile:
+        """Create a NEW file beneath the pinned root; never replace one.
+
+        The counterpart to ``write_text`` for content that must not collide
+        with content already at the target. ``write_text`` writes a temporary
+        file and renames it over the destination, which is atomic but
+        **replacing** -- correct for a synced note (the file IS the note), and
+        wrong for a preserved conflict copy, where the thing already at that
+        name is another run's saved copy of user text.
+
+        The name is claimed with ``O_CREAT | O_EXCL`` (plus the usual
+        ``O_NOFOLLOW``), so the claim and the check are one syscall: two
+        concurrent runs cannot both decide a name is free. The loser gets
+        ``FileExistsError`` and is expected to pick another name rather than
+        overwrite. Anything that goes wrong after the create unlinks the file
+        this call made, so a caller never sees a half-written file it was told
+        had failed.
+
+        Args:
+            relative_path: Destination relative to the pinned root.
+            content: Text to write, encoded UTF-8.
+
+        Returns:
+            The created file, described the same way ``write_text`` describes
+            a replaced one.
+
+        Raises:
+            FileExistsError: If the name is already taken. This is the signal
+                to try another name -- it is NOT a boundary violation.
+            SyncPathError: If the path, its parent, or the resulting file
+                fails the pinned-root checks.
+            OSError: Propagated from the create or the write.
+        """
+        selected = self._validate_relative(relative_path)
+        self._require_supported()
+        self._verify_root_path_identity()
+        parent_fd = self._open_parent(selected, create=False)
+        created = False
+        try:
+            self._before_create(selected)
+            file_fd = os.open(
+                selected.name,
+                _FILE_WRITE_FLAGS,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            created = True
+            try:
+                self._write_all(file_fd, content.encode("utf-8"))
+                os.fchmod(file_fd, 0o600)
+                os.fsync(file_fd)
+                opened = os.fstat(file_fd)
+            finally:
+                os.close(file_fd)
+
+            self._verify_root_path_identity()
+            self._verify_parent_identity(selected, parent_fd)
+            current = os.stat(selected.name, dir_fd=parent_fd, follow_symlinks=False)
+            if not _same_identity(opened, current):
+                raise SyncPathError("target_identity_changed", selected)
+            if not stat.S_ISREG(current.st_mode) or current.st_nlink != 1:
+                raise SyncPathError("multiple_links", selected)
+            if not self._same_device(current):
+                raise SyncPathError("cross_device", selected)
+            return SafeSyncFile(
+                absolute_path=self.canonical_root / selected,
+                relative_path=selected,
+                content=content,
+                mtime=current.st_mtime,
+                extension=selected.suffix.lower(),
+            )
+        except Exception:
+            # Only ever our own file: ``created`` is False when the create
+            # itself failed, so a name someone else holds is never unlinked.
+            if created:
+                try:
+                    os.unlink(selected.name, dir_fd=parent_fd)
+                except OSError:
+                    pass
+            raise
+        finally:
+            os.close(parent_fd)
 
     def write_text(
         self,

--- a/tldw_chatbook/Notes/sync_service.py
+++ b/tldw_chatbook/Notes/sync_service.py
@@ -104,7 +104,22 @@ class NotesSyncService:
         return history
 
     def get_conflicts_for_session(self, session_id: str) -> List[Dict[str, Any]]:
-        """Get conflicts for a specific sync session."""
+        """Get conflicts for a specific sync session.
+
+        This is the read surface for the preservation columns added in
+        task-19554. When a resolution discarded a side, ``losing_side`` says
+        which, ``losing_content`` is that side's text verbatim (enough to
+        reconstruct it without the file), and ``preserved_file_path`` points at
+        the sidecar written next to the note -- which is the copy a user
+        actually recovers from, by renaming it. When nothing was discarded all
+        three are ``None``.
+
+        Args:
+            session_id: The sync session to read.
+
+        Returns:
+            One dict per conflict row, newest first.
+        """
         conflicts = []
 
         with self.db.transaction() as conn:
@@ -113,7 +128,8 @@ class NotesSyncService:
                 SELECT id, note_id, file_path, conflict_type,
                        db_content_hash, disk_content_hash,
                        db_modified_time, disk_modified_time,
-                       resolution, resolved_at, created_at
+                       resolution, resolved_at, created_at,
+                       losing_side, losing_content, preserved_file_path
                 FROM sync_conflicts
                 WHERE session_id = ?
                 ORDER BY created_at DESC
@@ -134,10 +150,58 @@ class NotesSyncService:
                     "resolution": row[8],
                     "resolved_at": row[9],
                     "created_at": row[10],
+                    "losing_side": row[11],
+                    "losing_content": row[12],
+                    "preserved_file_path": row[13],
                 }
                 conflicts.append(conflict_data)
 
         return conflicts
+
+    def get_preserved_conflict_copies(
+        self, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Get every conflict whose discarded side was kept, newest first.
+
+        The recovery entry point that is not scoped to one session: after an
+        unattended auto-sync pass the user does not know the session id, only
+        that a note changed under them. Each row carries the discarded text
+        itself plus the sidecar path, so recovery works whether or not the
+        folder still has the file.
+
+        Args:
+            limit: Maximum rows to return.
+
+        Returns:
+            One dict per preserved conflict, newest first.
+        """
+        with self.db.transaction() as conn:
+            cursor = conn.execute(
+                """
+                SELECT id, session_id, note_id, file_path, conflict_type,
+                       losing_side, losing_content, preserved_file_path,
+                       resolution, resolved_at, created_at
+                FROM sync_conflicts
+                WHERE losing_content IS NOT NULL
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+            """,
+                (limit,),
+            )
+            keys = (
+                "id",
+                "session_id",
+                "note_id",
+                "file_path",
+                "conflict_type",
+                "losing_side",
+                "losing_content",
+                "preserved_file_path",
+                "resolution",
+                "resolved_at",
+                "created_at",
+            )
+            return [dict(zip(keys, row)) for row in cursor]
 
     def resolve_conflict(self, conflict_id: int, resolution: str, user_id: str) -> bool:
         """

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -26585,11 +26585,38 @@ class LibraryScreen(BaseAppScreen):
                 # Honest-copy fix: this used to promise a "review" surface
                 # that doesn't exist in this panel. State the resolved
                 # policy instead -- what actually happened to the conflict.
-                self._library_notes_sync_activity = append_activity(
-                    self._library_notes_sync_activity,
-                    f"{count_noun(conflicts, 'conflict')} resolved "
-                    f"({sync_conflict_label(resolution.value)})",
-                )
+                #
+                # task-19554 second pass: it also used to call EVERY recorded
+                # conflict "resolved", including the ones the engine applied
+                # nothing for (which, before that task, was every conflict
+                # under "Disk wins" and "Library wins"). Count what the run
+                # actually applied, name what it kept, and say plainly when
+                # some are still open.
+                applied = [
+                    conflict
+                    for conflict in results.conflicts
+                    if getattr(conflict, "applied", False)
+                ]
+                if applied:
+                    self._library_notes_sync_activity = append_activity(
+                        self._library_notes_sync_activity,
+                        f"{count_noun(len(applied), 'conflict')} resolved "
+                        f"({sync_conflict_label(resolution.value)})",
+                    )
+                preserved = list(getattr(results, "preserved_files", ()))
+                if preserved:
+                    self._library_notes_sync_activity = append_activity(
+                        self._library_notes_sync_activity,
+                        "Replaced copy saved as "
+                        + ", ".join(Path(path).name for path in preserved[:3])
+                        + ("…" if len(preserved) > 3 else ""),
+                    )
+                if len(applied) < conflicts:
+                    self._library_notes_sync_activity = append_activity(
+                        self._library_notes_sync_activity,
+                        f"{count_noun(conflicts - len(applied), 'conflict')} "
+                        "left unresolved — both copies kept as they are",
+                    )
             if results.errors:
                 self._library_notes_sync_activity = append_activity(
                     self._library_notes_sync_activity,


### PR DESCRIPTION
## Summary
Closes task-19554 (P0, data loss). Notes sync overwrote the losing side of a `both_changed` conflict **wholesale, with no recoverable copy** — the `SyncConflict` dataclass carried both texts but only hashes were persisted, and the `sync_conflicts` table had no content columns. No `.bak`, no note history. Aggravating: the Library UI deliberately offers only destructive strategies, and auto-sync runs unattended every 300 s.

Second defect: `"disk_wins"` was offered in the UI but `DISK_WINS` appeared in the engine exactly once — its enum definition. Selecting it recorded a conflict and applied nothing, which the user reads as "synced".

## Preservation design: sidecar first, DB row second, fail-closed
Before any resolution overwrites a side, that side's text is written verbatim to `<note>.conflict-<UTC>-<db|disk>.bak` beside the note file, through the existing pinned-root boundary. Only then is the winner applied.

**The sidecar is primary** because it is the only surface a user can already reach with no new UI: it lands in the folder they are already syncing, sorts beside the file it came from, names which side and when, and recovery is a `mv`. It is deliberately **byte-exact** — no header, no diff markers — because anything prepended turns recovery from a rename into an edit.

**The DB row as well** (`losing_side` / `losing_content` / `preserved_file_path`, schema v43→v44) because the criterion asks for reconstruction, not a hash: it survives the folder being tidied up and is the only programmatically reachable copy. Written **only when a side is actually discarded**, never on mere detection — `sync_log` is already an unpruned full-content shadow of `notes`, and a second unconditional one would be a real regression.

**Fail-closed is load-bearing**: an unwritable root does not stop `disk_wins` from destroying the note (that path only needs the DB), so without the rule, preservation would fail in exactly the case where destruction still succeeded.

**What surfaces it**, since a preserved copy nothing can reach is barely better than none: the Library activity log names the sidecar; `get_conflicts_for_session()` returns the new columns; and a new `get_preserved_conflict_copies(limit)` lists every preserved copy across all sessions — the entry point that needs no session id, because after an unattended sync the user knows only that a note changed under them.

Rejected: DB-only (nothing renders `sync_conflicts`, so recovery would be "write a SQL query"); sidecar-only (fails the reconstruction criterion and ties the only copy to a directory the user actively manages); a notes-history table (the right long-term answer, but a schema-plus-UI programme that would delay a live P0).

`DISK_WINS` is **implemented, not removed** — removing it would break persisted preferences, a CHECK constraint that already lists it, and the public enum. One shared resolver now serves all three directions, and a policy whose winner cannot be written leaves the conflict **open** rather than claiming to have settled it.

## Three more unfiled defects found and fixed
`DB_WINS` was equally a no-op in bidirectional; `NEWER_WINS` was a no-op in `db_to_disk` even when the note was newer; and `disk_to_db` overwrote note bodies **with no conflict row at all**. The panel also reported every *recorded* conflict as "resolved" — it now counts what was actually applied.

## Evidence
13/13 born-red at base, including `assert 0 == 1` on the conflict count for `disk_to_db` — proving that direction had no conflict detection whatsoever. `Tests/Notes/` **2431 passed / 0 failed** post-rebase; every other suite's failure set is identical to `origin/dev`.

Three traps closed along the way: the existing `test_conflict_detection` was **hollow** (a stale expected version meant the baseline hash was never stored, so it "detected" a conflict for any never-synced note); the repo's one exact schema-version pin lived in an unrelated older file, so every future bump would edit a file that does not own it; and a sidecar written into the sync root **would have been re-ingested as a note** on the next pass, compounding one duplicate per conflict.

Owner questions recorded, not acted on: whether to re-offer `ASK` (meaningless while nothing in the Library prompts — re-offering today would recreate the selectable-but-inert shape this task removes), and whether bidirectional `disk_wins` should unlink a note whose file was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the losing side on Notes sync conflicts and makes `DISK_WINS` actually apply. Previously we overwrote the loser with no recoverable copy and “Disk wins” did nothing; now we save the loser as a sidecar and apply the chosen policy safely.

- Conflict preservation and safety: write `<note>.conflict-<UTC>-<db|disk>.bak` before any overwrite; claim names atomically via `PinnedSyncRoot.create_new_text` (O_CREAT|O_EXCL|O_NOFOLLOW); recognize sidecars only when both the `.conflict-` marker and `.bak` suffix are present to avoid dropping legitimate notes; exclude sidecars from scans; fail closed if preservation cannot be written.
- Policies and detection: implement `DISK_WINS`; fix `DB_WINS` and `NEWER_WINS`; add conflict detection for `disk_to_db`; leave the conflict open if the winner cannot be applied.
- Data/UI/Docs: add `losing_side`, `losing_content`, and `preserved_file_path` to `sync_conflicts` (written only when a side is discarded); `get_conflicts_for_session` exposes them; the activity line counts applied vs unresolved and names the policy; docs describe policies and sidecar location.
- Migration: bump schema to v44; run the DB migration (task-19554).

<sup>Written for commit 4d525bbb84b2cbb09347f44e0d000ba63b85fba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

