### PR TITLE
docs(backlog): TASK-19602 tranche 5 notes — 5→3

### DIFF
--- a/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
+++ b/backlog/tasks/task-19602 - PR-1893-library-workflows-re-broke-the-library-prompts-canvas-suite.md
@@ -190,3 +190,28 @@ Remaining 5, with root-cause evidence:
 - source-choices keyboard (sizes 1/2): keyboard switch path.
 - cancelled_prompt_import: order-dependent with the trio fix's
   drain semantics (18611 notes).
+
+## Fix progress tranche 5 (2026-08-22, PR #1921 merged)
+
+2 more cleared (5 -> 3): both were the wide focused-task contract
+(1bda754fa) reaching the file-notes suite -- the db-files switch test's
+post-reload Database press never entered its handler (spy: zero handler
+entries) because wide terminals hide the source strip behind
+#library-notes-task-return; the test now presses the live control. The
+source-choices keyboard test aligns its wide-size rail assert and
+returns via task-return; the compact size keeps the strip flow.
+
+Remaining 3, with evidence:
+- cancelled_prompt_import retry Undo: post-settlement probe shows
+  receipt set, mutation_in_flight False, mutation_status '' -- yet the
+  receipt row (and Undo) is NOT composed; the canvas recompose after
+  the import's browse projection drops the row despite
+  delete_receipt in kwargs. Next: instrument
+  _library_prompts_canvas_kwargs timing vs the recompose that follows
+  import settlement; likely a state-object refresh ordering gap
+  (possibly a real product bug).
+- copy-lane x2: the a24a2202f editor republishes block state on a
+  system-lane change and reverts a programmatic user-lane .text write
+  (block_state non-None even for legacy prompts). Needs the editor's
+  real edit seam (_change_field / per-lane publish), not textarea
+  assignment.


### PR DESCRIPTION
Docs-only: records PR #1921's outcome and the remaining-3 evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates TASK-19602 backlog notes to record tranche 5 progress: reduces remaining cases from 5 to 3 and captures evidence and next steps. This clarifies which test failures were resolved by the recent library workflows fix and what remains blocked.

- Documents two cleared cases: the db-files switch test now presses the live control in wide terminals where the source strip is hidden; the source-choices keyboard test aligns the wide-rail assertion and returns via task-return while the compact size keeps the strip flow.
- Records evidence and planned probes for the three remaining cases: cancelled_prompt_import Undo not composed after import settlement (instrument timing of canvas kwargs vs recompose), and two copy-lane paths blocked by the editor’s block-state republish requiring edits via the editor’s change seam instead of textarea assignment.

<sup>Written for commit eae505b28fb0d39c4c2d9d8ba4bdfa5474c0de7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

