### PR TITLE
fix(logs): close the in-app log share path (task-19555)

### DIFF
--- a/Docs/Development/RAG/RAG-OCR.md
+++ b/Docs/Development/RAG/RAG-OCR.md
@@ -821,6 +821,19 @@ import logging
 logging.getLogger("tldw_chatbook.Local_Ingestion").setLevel(logging.DEBUG)
 ```
 
+Read the output in the **Logs** screen (`F8`); the rotating log file is
+metadata-only by design (ADR-029) and does not carry this detail.
+
+> **What `DEBUG` exposes.** It widens the in-app log well past the default:
+> ingestion source paths, extracted document text, OCR output and SQL
+> parameter previews all become visible. Recognised API-key formats and your
+> account name are stripped before anything is buffered — a denylist, so not
+> a guarantee for every secret — and **Copy all (redacted)** exports
+> only timings, loggers and error types — but **Copy visible logs** copies the
+> log text as shown, so read it before attaching it to an issue. Turn `DEBUG`
+> back off when you are done. See
+> [Sharing logs safely](../../User_Guide/logs.md#sharing-logs-safely).
+
 ### Validation Tools
 
 ```python

--- a/Docs/Features/ChatDictionaries-Documented.md
+++ b/Docs/Features/ChatDictionaries-Documented.md
@@ -460,7 +460,18 @@ Enable debug logging in `config.toml`:
 log_level = "DEBUG"
 ```
 
-Check logs at: `~/.share/tldw_cli/logs/`
+Read the output in the **Logs** screen (`F8`). The rotating file under
+`~/.share/tldw_cli/logs/` is metadata-only by design (ADR-029) and does not
+carry dictionary matches or replacement text.
+
+> **What `DEBUG` exposes.** It widens the in-app log well past the default:
+> matched keywords, replacement content, file paths and SQL parameter
+> previews all become visible. Recognised API-key formats and your account
+> name are stripped before anything is buffered — a denylist, so not a
+> guarantee for every secret — and **Copy all (redacted)** exports only
+> timings, loggers and error types — but **Copy visible logs** copies the log
+> text as shown, so read it before sharing. Turn `DEBUG` back off when you are
+> done. See [Sharing logs safely](../User_Guide/logs.md#sharing-logs-safely).
 
 ## Comparison with World Books
 

--- a/Docs/Features/World-Lore-Books-Documented.md
+++ b/Docs/Features/World-Lore-Books-Documented.md
@@ -507,7 +507,18 @@ Enable debug logging to see world book processing:
 log_level = "DEBUG"
 ```
 
-Check logs at: `~/.share/tldw_cli/logs/`
+Read the output in the **Logs** screen (`F8`). The rotating file under
+`~/.share/tldw_cli/logs/` is metadata-only by design (ADR-029) and does not
+carry the lines below.
+
+> **What `DEBUG` exposes.** It widens the in-app log well past the default:
+> matched keywords, world-book entry content, file paths and SQL parameter
+> previews all become visible. Recognised API-key formats and your account
+> name are stripped before anything is buffered — a denylist, so not a
+> guarantee for every secret — and **Copy all (redacted)** exports only
+> timings, loggers and error types — but **Copy visible logs** copies the log
+> text as shown, so read it before sharing. Turn `DEBUG` back off when you are
+> done. See [Sharing logs safely](../User_Guide/logs.md#sharing-logs-safely).
 
 Look for:
 - "World info keyword found"

--- a/Docs/User_Guide/logs.md
+++ b/Docs/User_Guide/logs.md
@@ -40,8 +40,12 @@ credential in a format it does not recognise, with no `key=`-style label
 beside it, will pass through. Treat the list above as "the common shapes are
 handled", not "nothing can leak".
 
-Lines longer than 2,000 characters are truncated before anything is stored,
-so a dumped response body is never retained whole.
+Lines longer than 2,000 characters are shortened before anything is stored,
+so a dumped response body is never retained whole. The cut lands on a word
+boundary and the redactor sees everything that survives it, so a key sitting
+across the limit is dropped rather than half-shown. A single unbroken run of
+more than 2,000 characters — one enormous token with no spaces in it — is
+withheld entirely for the same reason.
 
 What is **not** removed from the visible log, and therefore not from
 **Copy visible logs**: file names, note titles, keywords, search terms,

--- a/Docs/User_Guide/logs.md
+++ b/Docs/User_Guide/logs.md
@@ -13,3 +13,41 @@ Logs shows application logs and diagnostics (on-screen subtitle:
 - Press **F8**, click **F8 Logs** in the nav bar, or press **Ctrl+P** →
   "Tab Navigation: Switch to Logs".
   There is no hotkey digit for Logs.
+
+## Sharing logs safely
+
+Two copy actions sit at the bottom of the screen, and they hand you
+deliberately different things (TASK-19555):
+
+- **Copy visible logs** (`y`) copies the lines the current filter matches —
+  the real log text, so it is what you want when someone is helping you
+  debug. You can read it before you send it, which is the point.
+- **Copy all (redacted)** copies the whole session as timestamps, logger
+  names, levels and exception types, with the message bodies removed. It
+  exports thousands of lines you have never read, so it deliberately carries
+  no log text.
+
+What is removed, on screen and on the clipboard alike:
+
+- credentials in **recognised** formats — `Bearer` prefixes, URL userinfo,
+  `api_key=`/`x-auth-token:`-style labelled values, and the standalone key
+  shapes the redactor knows (OpenAI, Anthropic, OpenRouter, Google, GitHub,
+  Hugging Face, AWS, Slack, JWTs);
+- your operating-system account name — home paths are shown as `~/…`.
+
+This is a denylist, so it is **not** a promise that every secret is caught: a
+credential in a format it does not recognise, with no `key=`-style label
+beside it, will pass through. Treat the list above as "the common shapes are
+handled", not "nothing can leak".
+
+Lines longer than 2,000 characters are truncated before anything is stored,
+so a dumped response body is never retained whole.
+
+What is **not** removed from the visible log, and therefore not from
+**Copy visible logs**: file names, note titles, keywords, search terms,
+prompts, tool arguments, and provider response text. Read what you copied
+before you post it in a bug report.
+
+The rotating log file on disk (see the paths in the feature docs) is
+narrower still: under [ADR-029](../../backlog/decisions/029-local-private-data-boundary.md)
+it is metadata-only, so it holds operational events rather than log text.

--- a/Tests/UI/test_logs_ux_fixes.py
+++ b/Tests/UI/test_logs_ux_fixes.py
@@ -163,7 +163,14 @@ async def test_empty_state_shows_guidance() -> None:
         assert empty.display is True
         text = str(empty.render())
         assert "No log entries yet" in text
-        assert "share them when asking for help" in text
+        # TASK-19555: the guidance must describe the artifact it is inviting
+        # the user to share. It used to say "copy the logs and share them"
+        # with no mention that the payload carried their file names, note
+        # titles and search terms -- and, before the sink-side redaction, any
+        # API key that had been logged.
+        assert "Copy visible logs" in text
+        assert "file names" in text
+        assert "read before you share" in text
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -430,3 +430,122 @@ class TestLogSanitizer:
         assert "***REDACTED***" in clean_args[2]
         assert clean_kwargs["token"] == "***REDACTED***"
         assert clean_kwargs["safe"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# TASK-19555: the sink-side redactor applied to every record entering the
+# in-app log collector, plus the hyphen-normalization repair it depends on.
+# ---------------------------------------------------------------------------
+
+
+class TestSinkRedaction:
+    """`redact_log_line` and its two halves."""
+
+    @pytest.mark.parametrize(
+        "header",
+        ["x-auth-token", "X-Session-Key", "x-client-secret", "api-secret"],
+    )
+    def test_hyphenated_header_names_are_recognised_as_secret_bearing(
+        self, header: str
+    ) -> None:
+        """The normalization used to be computed and then thrown away.
+
+        `is_sensitive_config_key` received the RAW key, and its
+        `_key`/`_token`/`_secret` rules are underscore-suffix matches, so
+        every hyphenated header whose sensitivity comes from a suffix was
+        classified harmless and its value written out verbatim. These are the
+        exact names provider request logging produces.
+        """
+        line = f"sending {header}: DONOTUSEEXAMPLEONLYzz9911"
+        assert "DONOTUSEEXAMPLEONLYzz9911" not in sanitize_string(line)
+
+    def test_max_tokens_is_not_a_false_positive_after_normalization(self) -> None:
+        """`max-tokens` normalizes to `max_tokens`, which is still not `_token`."""
+        assert sanitize_string("max-tokens=4096") == "max-tokens=4096"
+
+    def test_home_directory_collapses_to_tilde(self) -> None:
+        """The account name is a real-name identifier; the path shape is not."""
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        assert (
+            redact_user_paths("saved /Users/janedoe/Notes/Q3.pdf")
+            == "saved ~/Notes/Q3.pdf"
+        )
+        assert redact_user_paths("/home/janedoe/.cache/x") == "~/.cache/x"
+        assert (
+            redact_user_paths(r"read C:\Users\janedoe\AppData\x") == r"read ~\AppData\x"
+        )
+
+    def test_url_paths_are_not_mistaken_for_home_directories(self) -> None:
+        """Case-sensitive on purpose: `/users/` in a REST URL is not a home."""
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        url = "GET https://api.example.com/users/alice/profile"
+        assert redact_user_paths(url) == url
+
+    def test_redact_log_line_applies_both_halves(self) -> None:
+        from tldw_chatbook.Utils.log_sanitizer import redact_log_line
+
+        line = (
+            "upload /Users/janedoe/x.pdf with api_key=sk-DONOTUSEEXAMPLE1234567890"
+        )
+        redacted = redact_log_line(line)
+        assert "janedoe" not in redacted
+        assert "sk-DONOTUSEEXAMPLE1234567890" not in redacted
+        assert "upload ~/x.pdf" in redacted
+
+    def test_redact_log_line_leaves_ordinary_diagnostics_alone(self) -> None:
+        """Redaction must not be so eager that the Logs screen stops helping."""
+        from tldw_chatbook.Utils.log_sanitizer import redact_log_line
+
+        line = "RAG search returned 12 chunks in 340ms (mode=hybrid)"
+        assert redact_log_line(line) == line
+
+    @pytest.mark.parametrize(
+        "credential",
+        [
+            "ghp_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa",
+            "gho_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa",
+            "github_pat_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaa",
+            "hf_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa",
+            "sk-or-v1-DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa",
+            "AKIADONOTUSEEXAMPLE1",
+            # Assembled rather than written literally: a literal in this shape
+            # trips GitHub push protection (Slack detector) even though the value
+            # is synthetic. The redactor under test sees the identical string.
+            "xox" + "b-1234567890-DONOTUSEEXAMPLEONLY",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.DONOTUSEEXAMPLE1",
+        ],
+    )
+    def test_unlabelled_provider_token_shapes_are_redacted(
+        self, credential: str
+    ) -> None:
+        """TASK-19555 review: the empty state claimed API keys were "always"
+        removed while `ghp_`, `hf_`, `sk-or-v1-`, `AKIA…` and JWTs all walked
+        straight through, because the standalone set only knew four shapes.
+        The copy is now "recognised formats" AND the set is wider."""
+        assert credential not in sanitize_string(f"request failed: {credential}")
+
+    def test_windows_home_paths_redact_in_either_case_and_over_unc(self) -> None:
+        """`Users` was a literal, so only the `C:\\Users\\` spelling redacted."""
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        assert redact_user_paths(r"c:\users\janedoe\Notes") == r"~\Notes"
+        assert redact_user_paths(r"C:\Users\janedoe\Notes") == r"~\Notes"
+        assert redact_user_paths(r"\\FILESRV\Users\janedoe\Notes") == r"~\Notes"
+
+    def test_oversized_lines_are_truncated_before_redaction(self) -> None:
+        """Cost is linear in length and the buffer bounds line COUNT only."""
+        from tldw_chatbook.Utils.log_sanitizer import (
+            MAX_REDACTED_LINE_CHARS,
+            redact_log_line,
+        )
+
+        redacted = redact_log_line("payload " + "y" * 60_000)
+        assert len(redacted) < MAX_REDACTED_LINE_CHARS + 200
+        assert "truncated, 60008 chars" in redacted
+
+    def test_ordinary_length_lines_are_not_marked_truncated(self) -> None:
+        from tldw_chatbook.Utils.log_sanitizer import redact_log_line
+
+        assert "truncated" not in redact_log_line("a short diagnostic line")

--- a/Tests/Utils/test_log_sanitizer.py
+++ b/Tests/Utils/test_log_sanitizer.py
@@ -16,6 +16,26 @@ from tldw_chatbook.Utils.log_sanitizer import (
 from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
 
 
+def _synthetic(*parts: str) -> str:
+    """Assemble a synthetic credential at import time from fragments.
+
+    The fragments exist so that no committed line of this file contains a
+    contiguous string in a real token shape (TASK-19555 Qodo round, rule
+    497144). Secret scanners -- including GitHub push protection, which
+    rejects the whole branch rather than the file -- match on the literal, so
+    splitting the detector-bearing prefix is what makes the fixture shippable.
+    The assembled value is byte-identical to the one the redactor must handle,
+    so nothing about the test weakens.
+
+    Args:
+        *parts: Fragments to join, split at the detector prefix.
+
+    Returns:
+        The joined synthetic credential.
+    """
+    return "".join(parts)
+
+
 def _iter_leaf_key_names(mapping):
     """Yield leaf mapping keys from the shipped configuration structure."""
     for key, value in mapping.items():
@@ -236,9 +256,10 @@ def test_url_userinfo_removes_both_username_and_password() -> None:
 @pytest.mark.parametrize(
     "raw",
     [
-        "sk-proj-DO_NOT_USE_EXAMPLE_123456",
-        "sk-ant-api03-DO_NOT_USE_EXAMPLE_123456",
-        "sk-DONOTUSEEXAMPLEONLY1234567890",
+        # Assembled, not literal -- see `_synthetic` (TASK-19555 Qodo round).
+        _synthetic("sk", "-proj-DO_NOT_USE_EXAMPLE_123456"),
+        _synthetic("sk", "-ant-api03-DO_NOT_USE_EXAMPLE_123456"),
+        _synthetic("sk", "-DONOTUSEEXAMPLEONLY1234567890"),
         "AIza" + "DO_NOT_USE_EXAMPLE_ONLY_" + "0" * 11,
     ],
     ids=("openai-project", "anthropic", "openai-legacy", "google"),
@@ -270,7 +291,8 @@ def test_uppercase_standalone_credential_shapes_are_not_recognized(raw: str) -> 
 
 def test_labeled_standalone_shaped_value_has_one_idempotent_marker() -> None:
     """Assignment redaction consumes a key-shaped quoted secret only once."""
-    raw = 'api_key="sk-proj-DO_NOT_USE_EXAMPLE_123456"'
+    secret = _synthetic("sk", "-proj-DO_NOT_USE_EXAMPLE_123456")
+    raw = f'api_key="{secret}"'
     sanitized = sanitize_string(raw)
 
     assert sanitized == 'api_key="***REDACTED***"'
@@ -410,7 +432,7 @@ class TestLogSanitizer:
         msg = create_safe_log_message(
             "User {} logged in with key {}",
             "john",
-            "sk-DONOTUSEEXAMPLEONLY1234567890",
+            _synthetic("sk", "-DONOTUSEEXAMPLEONLY1234567890"),
         )
         assert msg == "User john logged in with key ***REDACTED***"
 
@@ -486,12 +508,11 @@ class TestSinkRedaction:
     def test_redact_log_line_applies_both_halves(self) -> None:
         from tldw_chatbook.Utils.log_sanitizer import redact_log_line
 
-        line = (
-            "upload /Users/janedoe/x.pdf with api_key=sk-DONOTUSEEXAMPLE1234567890"
-        )
+        secret = _synthetic("sk", "-DONOTUSEEXAMPLE1234567890")
+        line = f"upload /Users/janedoe/x.pdf with api_key={secret}"
         redacted = redact_log_line(line)
         assert "janedoe" not in redacted
-        assert "sk-DONOTUSEEXAMPLE1234567890" not in redacted
+        assert secret not in redacted
         assert "upload ~/x.pdf" in redacted
 
     def test_redact_log_line_leaves_ordinary_diagnostics_alone(self) -> None:
@@ -504,17 +525,20 @@ class TestSinkRedaction:
     @pytest.mark.parametrize(
         "credential",
         [
-            "ghp_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa",
-            "gho_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa",
-            "github_pat_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaa",
-            "hf_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa",
-            "sk-or-v1-DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa",
-            "AKIADONOTUSEEXAMPLE1",
-            # Assembled rather than written literally: a literal in this shape
-            # trips GitHub push protection (Slack detector) even though the value
-            # is synthetic. The redactor under test sees the identical string.
-            "xox" + "b-1234567890-DONOTUSEEXAMPLEONLY",
-            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.DONOTUSEEXAMPLE1",
+            # Every one is assembled by `_synthetic` rather than written as a
+            # literal: see that helper for why (Qodo rule 497144 / GitHub push
+            # protection). The values reaching the redactor are unchanged.
+            _synthetic("ghp", "_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa"),
+            _synthetic("gho", "_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaaaa"),
+            _synthetic("github", "_pat_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaaaaaa"),
+            _synthetic("hf", "_DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa"),
+            _synthetic("sk", "-or-v1-DONOTUSEEXAMPLEONLYaaaaaaaaaaaaaaaa"),
+            _synthetic("AKI", "ADONOTUSEEXAMPLE1"),
+            _synthetic("xox", "b-1234567890-DONOTUSEEXAMPLEONLY"),
+            _synthetic(
+                "eyJ", "hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+                ".DONOTUSEEXAMPLE1",
+            ),
         ],
     )
     def test_unlabelled_provider_token_shapes_are_redacted(
@@ -549,3 +573,103 @@ class TestSinkRedaction:
         from tldw_chatbook.Utils.log_sanitizer import redact_log_line
 
         assert "truncated" not in redact_log_line("a short diagnostic line")
+
+
+# ---------------------------------------------------------------------------
+# TASK-19555 Qodo round: two security defects in the first cut of the above.
+# ---------------------------------------------------------------------------
+
+
+class TestRedactionOrderAndPathBoundaries:
+    """Truncation must not manufacture a partial secret, and the literal
+    home substitution must not rewrite half of somebody else's username."""
+
+    def test_credential_astride_the_truncation_boundary_leaves_no_fragment(
+        self,
+    ) -> None:
+        """Truncating BEFORE redaction cut tokens out of pattern range.
+
+        `_STANDALONE_CREDENTIALS` all carry minimum lengths (`sk-` needs 20+
+        trailing characters). A secret straddling the cap was therefore sliced
+        into a fragment too short to match, and the fragment stayed in the
+        Logs view and in "Copy visible logs" -- the exact surface this task
+        exists to protect.
+        """
+        from tldw_chatbook.Utils.log_sanitizer import (
+            MAX_REDACTED_LINE_CHARS,
+            redact_log_line,
+        )
+
+        secret = _synthetic("sk", "-", "B" * 40)
+        # Land the cap inside the token: 13 of its characters fall before it.
+        head = "x" * (MAX_REDACTED_LINE_CHARS - 20)
+        line = f"{head} token {secret} tail " + "y " * 5000
+
+        redacted = redact_log_line(line)
+
+        assert secret not in redacted
+        # ...and no leading slice of it either.
+        assert _synthetic("sk", "-B") not in redacted
+
+    def test_truncation_keeps_whole_tokens_and_still_reports_the_real_length(
+        self,
+    ) -> None:
+        from tldw_chatbook.Utils.log_sanitizer import (
+            MAX_REDACTED_LINE_CHARS,
+            redact_log_line,
+        )
+
+        line = "chunk " * 5000
+        redacted = redact_log_line(line)
+
+        assert "truncated, 30000 chars" in redacted
+        assert len(redacted) < MAX_REDACTED_LINE_CHARS + 100
+        # No half-word at the seam: every retained token is intact.
+        body = redacted.split("…")[0]
+        assert set(body.split()) <= {"chunk"}
+
+    def test_one_unbroken_token_larger_than_the_cap_is_withheld_entirely(
+        self,
+    ) -> None:
+        """No safe cut exists inside a single token, so none is attempted."""
+        from tldw_chatbook.Utils.log_sanitizer import redact_log_line
+
+        blob = "Q" * 9000
+        redacted = redact_log_line(blob)
+
+        assert "Q" * 50 not in redacted
+        assert "9000" in redacted
+
+    def test_a_home_prefixing_another_account_is_not_partially_replaced(
+        self, monkeypatch
+    ) -> None:
+        """`str.replace` rewrote `/Users/jan` inside `/Users/janedoe`.
+
+        That left `edoe` -- still identifying -- and destroyed the `/Users/`
+        prefix `_HOME_ROOTS_POSIX` needed in order to fire, so the fallback
+        could not clean up after it either.
+        """
+        monkeypatch.setenv("HOME", "/Users/jan")
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        assert redact_user_paths("/Users/janedoe/Notes/x.pdf") == "~/Notes/x.pdf"
+        assert "edoe" not in redact_user_paths("/Users/janedoe/Notes/x.pdf")
+
+    def test_the_windows_home_literal_respects_segment_boundaries_too(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("USERPROFILE", r"C:\Users\jan")
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        assert redact_user_paths(r"C:\Users\janedoe\Notes") == r"~\Notes"
+
+    def test_an_exotic_home_outside_users_and_home_still_collapses(
+        self, monkeypatch
+    ) -> None:
+        """The literal pass is what covers `/root` and `$HOME` overrides."""
+        monkeypatch.setenv("HOME", "/srv/appdata")
+        from tldw_chatbook.Utils.log_sanitizer import redact_user_paths
+
+        assert redact_user_paths("/srv/appdata/db.sqlite") == "~/db.sqlite"
+        # A sibling that merely shares the prefix must survive intact.
+        assert redact_user_paths("/srv/appdata-backup/db") == "/srv/appdata-backup/db"

--- a/Tests/test_logs_share_path_privacy.py
+++ b/Tests/test_logs_share_path_privacy.py
@@ -1,0 +1,259 @@
+"""TASK-19555: the in-app log collector and the "Copy all" share path.
+
+ADR-029 says persistent application logs are metadata-only with respect to
+user and model content. Before this task that guarantee was enforced by
+``PersistentDiagnosticFilter``, attached at exactly two places -- both the
+rotating FILE handler (``Logging_Config._configure_private_file_logging``).
+
+``TldwCli._setup_buffered_logging`` installs a second, unrelated collector on
+the SAME root logger: ``PersistentLogHandler``, level ``NOTSET``, no filter,
+feeding an unbounded ``_log_buffer`` that ``LogsWindow._on_copy_all`` joins
+straight onto the system clipboard -- under an empty state that tells the user
+to reproduce the problem and share their logs.
+
+The pre-existing privacy suite proved the gap by omission: it attaches a
+filtered file handler *and* an unfiltered collector, then asserts only that
+the sentinel stays out of the FILE. These tests assert against the real app
+collector, which is what the app actually installs.
+
+The bar this file pins (see the task's Implementation Notes for the argument):
+
+* credentials and the operating-system user identity NEVER reach the buffer,
+  the record store, or the live view -- they have no debugging value, so
+  redacting them costs nothing;
+* the "Copy all" share artifact is metadata-only in the ADR-029 sense, since
+  it bulk-exports thousands of lines the user has never read;
+* the live view and the deliberate, filtered "Copy visible" action stay rich,
+  because that is the whole reason the Logs screen exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tldw_chatbook.UI.Logs_Window import MAX_LOG_RECORDS
+from tldw_chatbook.Utils.persistent_diagnostics import log_persistent_metadata
+
+pytestmark = pytest.mark.unit
+
+
+API_KEY_SENTINEL = "sk-19555PRIVATEsentinelKEYnotreal01"
+CONTENT_SENTINEL = "19555-PRIVATE-NOTE-TITLE-divorce-papers"
+
+
+class _AppStub:
+    """Bare object for binding ``TldwCli._setup_buffered_logging``."""
+
+
+class _Collector:
+    """Install the real app collector on the root logger, then tear it down."""
+
+    def __enter__(self) -> _AppStub:
+        from tldw_chatbook.Logging_Config import _forward_loguru_to_standard
+        from tldw_chatbook.app import TldwCli
+
+        self._sinks_before = set(loguru_logger._core.handlers)
+        loguru_logger.add(
+            _forward_loguru_to_standard,
+            level="TRACE",
+            diagnose=False,
+            backtrace=True,
+        )
+        self._root = logging.getLogger()
+        self._old_level = self._root.level
+        self._root.setLevel(logging.DEBUG)
+        self.stub = _AppStub()
+        TldwCli._setup_buffered_logging(self.stub)
+        return self.stub
+
+    def __exit__(self, *exc_info) -> None:
+        for sink_id in set(loguru_logger._core.handlers) - self._sinks_before:
+            try:
+                loguru_logger.remove(sink_id)
+            except ValueError:
+                pass
+        handler = getattr(self.stub, "_persistent_log_handler", None)
+        if handler is not None:
+            self._root.removeHandler(handler)
+        self._root.setLevel(self._old_level)
+
+
+def _buffer_text(stub: _AppStub) -> str:
+    """The exact payload ``LogsWindow._on_copy_all`` puts on the clipboard."""
+    return "\n".join(stub._log_buffer)
+
+
+def _records_text(stub: _AppStub) -> str:
+    """Everything the in-app Logs view renders and can copy."""
+    return "\n".join(message for _level, _name, message in stub._log_records)
+
+
+# ---------------------------------------------------------------------------
+# Credentials and user identity: refused everywhere on the in-app path.
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_never_reaches_the_in_app_collector() -> None:
+    """A key logged at INFO stays out of the buffer, the records, and the view."""
+    with _Collector() as stub:
+        loguru_logger.info("calling provider with api_key={}", API_KEY_SENTINEL)
+        loguru_logger.error("Authorization: Bearer {}", API_KEY_SENTINEL)
+
+        assert API_KEY_SENTINEL not in _buffer_text(stub)
+        assert API_KEY_SENTINEL not in _records_text(stub)
+        # The redaction is a substitution, not a drop: the records survive.
+        assert "***REDACTED***" in _records_text(stub)
+
+
+def test_home_directory_username_never_reaches_the_in_app_collector() -> None:
+    """Paths keep their shape; the OS account name is not an identity leak."""
+    with _Collector() as stub:
+        loguru_logger.info("attachment saved to /Users/privateperson/Notes/x.pdf")
+        loguru_logger.info("cache dir /home/privateperson/.cache/tldw")
+
+        rendered = _records_text(stub)
+        assert "privateperson" not in rendered
+        assert "privateperson" not in _buffer_text(stub)
+        # Still debuggable: the path below the home root is untouched.
+        assert "~/Notes/x.pdf" in rendered
+        assert "~/.cache/tldw" in rendered
+
+
+# ---------------------------------------------------------------------------
+# The share path: "Copy all" bulk-exports what the user has never read.
+# ---------------------------------------------------------------------------
+
+
+def test_copy_all_share_artifact_carries_no_user_content() -> None:
+    """User content reaches the live view but never the clipboard payload."""
+    with _Collector() as stub:
+        loguru_logger.info("Created note: {}", CONTENT_SENTINEL)
+
+        # The viewer stays rich -- that is the point of the Logs screen.
+        assert CONTENT_SENTINEL in _records_text(stub)
+        # The clipboard payload does not.
+        assert CONTENT_SENTINEL not in _buffer_text(stub)
+
+
+def test_copy_all_share_artifact_keeps_triage_metadata() -> None:
+    """Redaction is not deletion: level, logger, and exception type survive."""
+    with _Collector() as stub:
+        try:
+            raise TimeoutError(CONTENT_SENTINEL)
+        except TimeoutError:
+            logging.getLogger("tldw_chatbook.RAG_Search.demo").exception(
+                "search failed for %s", CONTENT_SENTINEL
+            )
+
+        share = _buffer_text(stub)
+        assert CONTENT_SENTINEL not in share
+        assert "tldw_chatbook.RAG_Search.demo" in share
+        assert "ERROR" in share
+        assert "exception_type=TimeoutError" in share
+
+
+def test_schema_validated_metadata_records_survive_the_share_artifact() -> None:
+    """ADR-029 metadata events are admitted verbatim, exactly as to the file."""
+    with _Collector() as stub:
+        log_persistent_metadata(
+            logging.getLogger("tldw_chatbook.diagnostics.app"),
+            logging.INFO,
+            "operation_complete",
+            operation="rag_search",
+            status="success",
+            duration_ms=12,
+        )
+
+        share = _buffer_text(stub)
+        assert "event=operation_complete" in share
+        assert "operation=rag_search" in share
+        assert "status=success" in share
+        assert "duration_ms=12" in share
+
+
+# ---------------------------------------------------------------------------
+# The buffer itself.
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_buffer_is_bounded() -> None:
+    """An unbounded session buffer is a memory *and* a disclosure surface."""
+    with _Collector() as stub:
+        assert isinstance(stub._log_buffer, deque)
+        assert stub._log_buffer.maxlen == MAX_LOG_RECORDS
+        # Both in-app stores retain the same window, so "Copy all" cannot
+        # export more history than the screen admits to keeping.
+        assert stub._log_records.maxlen == MAX_LOG_RECORDS
+
+
+def test_oversized_lines_are_truncated_before_they_are_stored() -> None:
+    """The buffer bounds line COUNT; without this it did not bound line SIZE."""
+    with _Collector() as stub:
+        loguru_logger.info("body " + "x" * 50_000)
+
+        stored = _records_text(stub)
+        assert "truncated, " in stored
+        assert len(max(stub._log_records, key=lambda r: len(r[2]))[2]) < 3_000
+
+
+# ---------------------------------------------------------------------------
+# The LIVE FEED. `emit` fills two stores and then hands the line to whichever
+# on-screen surface is mounted. Pinning the stores does not pin the feed:
+# a review mutation that passed the UNREDACTED line to `append_record` left
+# the whole suite green, while putting live credentials into
+# `LogsWindow._records` -- which is exactly what `_on_copy_visible` copies to
+# the clipboard. The stores and the feed are separate seams; both need a pin.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLogsWindow:
+    """Stands in for the mounted `LogsWindow` the handler feeds live."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def append_record(self, level: str, name: str, message: str) -> None:
+        self.calls.append((level, name, message))
+
+
+class _FakeRichLog:
+    """Stands in for the legacy `_current_log_widget` fallback."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write(self, message: str) -> None:
+        self.lines.append(message)
+
+
+def test_live_logs_window_feed_receives_the_redacted_line() -> None:
+    """What reaches the mounted widget is what `_on_copy_visible` copies."""
+    with _Collector() as stub:
+        window = _FakeLogsWindow()
+        stub._current_logs_window = window
+        loguru_logger.error(
+            "provider call failed api_key={} at /Users/privateperson/x.pdf",
+            API_KEY_SENTINEL,
+        )
+
+        assert window.calls, "the handler never fed the mounted window"
+        fed = "\n".join(message for _level, _name, message in window.calls)
+        assert API_KEY_SENTINEL not in fed
+        assert "privateperson" not in fed
+        assert "***REDACTED***" in fed
+
+
+def test_legacy_rich_log_feed_receives_the_redacted_line() -> None:
+    """The fallback branch of the same `emit` is a clipboard path too."""
+    with _Collector() as stub:
+        widget = _FakeRichLog()
+        stub._current_logs_window = None
+        stub._current_log_widget = widget
+        loguru_logger.error("legacy path api_key={}", API_KEY_SENTINEL)
+
+        assert widget.lines, "the handler never fed the legacy widget"
+        assert API_KEY_SENTINEL not in "\n".join(widget.lines)

--- a/Tests/test_logs_share_path_privacy.py
+++ b/Tests/test_logs_share_path_privacy.py
@@ -41,7 +41,26 @@ from tldw_chatbook.Utils.persistent_diagnostics import log_persistent_metadata
 pytestmark = pytest.mark.unit
 
 
-API_KEY_SENTINEL = "sk-19555PRIVATEsentinelKEYnotreal01"
+def _synthetic(*parts: str) -> str:
+    """Assemble a synthetic credential at import time from fragments.
+
+    No committed line here may contain a contiguous string in a real token
+    shape (TASK-19555 Qodo round, rule 497144): secret scanners match the
+    literal, and GitHub push protection rejects the whole branch rather than
+    the file. Splitting the detector-bearing prefix is what makes the fixture
+    shippable; the assembled value is byte-identical to what the redactor is
+    asked to handle.
+
+    Args:
+        *parts: Fragments to join, split at the detector prefix.
+
+    Returns:
+        The joined synthetic credential.
+    """
+    return "".join(parts)
+
+
+API_KEY_SENTINEL = _synthetic("sk", "-19555PRIVATEsentinelKEYnotreal01")
 CONTENT_SENTINEL = "19555-PRIVATE-NOTE-TITLE-divorce-papers"
 
 
@@ -193,11 +212,74 @@ def test_session_log_buffer_is_bounded() -> None:
 def test_oversized_lines_are_truncated_before_they_are_stored() -> None:
     """The buffer bounds line COUNT; without this it did not bound line SIZE."""
     with _Collector() as stub:
-        loguru_logger.info("body " + "x" * 50_000)
+        loguru_logger.info("body " + "chunk " * 20_000)
 
         stored = _records_text(stub)
         assert "truncated, " in stored
         assert len(max(stub._log_records, key=lambda r: len(r[2]))[2]) < 3_000
+
+
+def test_a_credential_astride_the_truncation_boundary_reaches_no_surface() -> None:
+    """The unit-level guarantee, re-proved through the real handler.
+
+    Truncating before redaction sliced a straddling key into a fragment too
+    short for any `_STANDALONE_CREDENTIALS` pattern, and the fragment then
+    reached the live view and "Copy visible logs".
+
+    A SWEEP, not an anecdote, and one whose alignment is MEASURED rather than
+    assumed: the handler's formatter prepends a timestamp and a logger name,
+    so a hand-computed padding length does not reliably land the key across
+    the cap. Two earlier drafts of this test guessed and passed against the
+    broken implementation. The prefix width is read off a probe record, then
+    every straddle position is walked.
+    """
+    from tldw_chatbook.Utils.log_sanitizer import MAX_REDACTED_LINE_CHARS
+
+    with _Collector() as stub:
+        window = _FakeLogsWindow()
+        stub._current_logs_window = window
+
+        loguru_logger.info("PROBE")
+        prefix_width = len(stub._log_records[-1][2]) - len("PROBE")
+        assert 0 < prefix_width < MAX_REDACTED_LINE_CHARS
+
+        # Anti-vacuity control. Without it the sweep below could assert
+        # nothing at all -- an earlier draft used a `%s` template, which
+        # loguru renders literally, so it logged no key and passed happily
+        # against the broken implementation.
+        loguru_logger.info("control {}", API_KEY_SENTINEL)
+        assert "***REDACTED***" in stub._log_records[-1][2]
+
+        # Walk the key's start position across the cap, so at least one
+        # emission is cut through the middle of it.
+        for start in range(
+            MAX_REDACTED_LINE_CHARS - len(API_KEY_SENTINEL),
+            MAX_REDACTED_LINE_CHARS + 1,
+        ):
+            padding = start - prefix_width - 1
+            assert padding > 0
+            # Braces, not %s: loguru formats with str.format, so a %s template
+            # emits the template and silently drops the payload. An earlier
+            # draft did that and the test passed while logging nothing.
+            loguru_logger.info(
+                "{} {} tail {}", "x" * padding, API_KEY_SENTINEL, "y " * 2_000
+            )
+
+        # ...and the sweep really did produce oversized lines to cut.
+        assert any(
+            "truncated," in message for _l, _n, message in stub._log_records
+        )
+
+        surfaces = "\n".join(
+            (
+                _records_text(stub),
+                _buffer_text(stub),
+                "\n".join(message for _l, _n, message in window.calls),
+            )
+        )
+        assert API_KEY_SENTINEL not in surfaces
+        # No leading slice of it either -- the fragment is the whole point.
+        assert API_KEY_SENTINEL[:12] not in surfaces
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/test_remaining_diagnostic_sentinel_matrix.py
+++ b/Tests/test_remaining_diagnostic_sentinel_matrix.py
@@ -159,3 +159,71 @@ def test_third_party_payload_is_file_filtered_but_remains_available_to_ui(
 
     assert any(PRIVATE_SENTINEL in message for message in collecting.messages)
     assert PRIVATE_SENTINEL not in _all_generations(path)
+
+
+# ---------------------------------------------------------------------------
+# TASK-19555: this suite used to prove the metadata-only guarantee by
+# attaching a filtered FILE handler beside an unfiltered ``_CollectingHandler``
+# and asserting only against the file. The app installs exactly such an
+# unfiltered collector -- ``TldwCli._setup_buffered_logging``'s
+# ``PersistentLogHandler``, root logger, level NOTSET -- and
+# ``LogsWindow._on_copy_all`` joins its buffer onto the system clipboard. The
+# collector above is a stand-in that nothing shares with production, so the
+# omission below is the one that mattered: the REAL collector was never
+# asserted against at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("operation", "module_name"), DOMAIN_OWNERS)
+def test_remaining_domain_records_stay_out_of_the_clipboard_artifact(
+    operation: str,
+    module_name: str,
+) -> None:
+    """The app's own collector, not a stand-in: no sentinel on the share path."""
+    from tldw_chatbook.app import TldwCli
+
+    class _AppStub:
+        pass
+
+    stub = _AppStub()
+    root = logging.getLogger()
+    old_level = root.level
+    root.setLevel(logging.DEBUG)
+    TldwCli._setup_buffered_logging(stub)
+    sink_id = loguru_logger.add(_forward_loguru_to_standard, level="DEBUG")
+    domain_logger = logging.getLogger(module_name)
+    try:
+        domain_logger.debug("query=%s", PRIVATE_SENTINEL)
+        domain_logger.info("content=%s", PRIVATE_SENTINEL)
+        try:
+            raise RuntimeError(PRIVATE_SENTINEL)
+        except RuntimeError:
+            domain_logger.exception("operation failed: %s", PRIVATE_SENTINEL)
+        _emit_owned_loguru_payload(
+            module_name,
+            f"response body and config value: {PRIVATE_SENTINEL}",
+        )
+        log_persistent_metadata(
+            domain_logger,
+            logging.INFO,
+            "operation_complete",
+            operation=operation,
+            status="success",
+            duration_ms=12,
+        )
+    finally:
+        loguru_logger.remove(sink_id)
+        root.removeHandler(stub._persistent_log_handler)
+        root.setLevel(old_level)
+
+    shareable = "\n".join(stub._log_buffer)
+    assert PRIVATE_SENTINEL not in shareable
+    assert "sk-not-a-real-key" not in shareable
+    # Not a drop: the schema-validated event and triage metadata survive.
+    assert "event=operation_complete" in shareable
+    assert f"operation={operation}" in shareable
+    assert "exception_type=RuntimeError" in shareable
+    # The live view keeps the payload -- redacting it would empty the Logs
+    # screen of the content it exists to show (see TASK-19555's argument).
+    rendered = "\n".join(message for _l, _n, message in stub._log_records)
+    assert PRIVATE_SENTINEL in rendered

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5829,3 +5829,53 @@ calls instead of reusing a literal. The tell that something is wrong is a
 fixture that passes against a *stronger* claim than it set up: here, deleting
 the entire baseline step would not have changed the test's result, which is the
 definition of a setup step that is not doing anything.
+
+
+
+## A guarantee is only proved for the sink you asserted against — and a test's stand-in is not the shipped one (TASK-19555, 2026-08-21)
+
+**What happened.** ADR-029 says persistent application logs are metadata-only
+with respect to user content. `Tests/test_remaining_diagnostic_sentinel_matrix.py`
+looked like thorough proof: for seven domain owners it injected a private
+sentinel, attached a **filtered** `PrivateRotatingFileHandler` and an
+**unfiltered** `_CollectingHandler`, and asserted the sentinel stayed out of
+the file. Green for months.
+
+The app installs an unfiltered collector too — `TldwCli._setup_buffered_
+logging`'s `PersistentLogHandler`, root logger, level `NOTSET`, no filter,
+feeding an unbounded `deque` that the Logs screen's "Copy all" joined onto the
+system clipboard, under an empty state telling the user to reproduce the
+problem and share their logs. The suite never asserted against it. Its
+`_CollectingHandler` was a test-local stand-in, present to prove the *other*
+half of the design (that payloads stay available to the UI), and its existence
+made the file assertion read as coverage of "the collector" in general. It was
+not. Writing a first assertion against the real handler produced the sentinel,
+an `sk-` key and a full traceback carrying a note title, all on the clipboard
+path, immediately.
+
+**What to do.** When a test proves a security property at a sink, count the
+sinks. `grep` for every `addHandler`/`add` on the same logger and name in the
+test which ones are covered — the filter that enforces the guarantee was
+attached at exactly two call sites here, both the same handler, and that was
+findable in one search. And when a test constructs a second handler as scenery,
+ask whether the *production* object of that kind is asserted anywhere; a
+stand-in beside the thing under test is the most convincing way to look covered
+while covering nothing. The tell is an assertion list where the dangerous
+surface appears only as a positive (`assert sentinel in collector.messages`)
+and never as a negative.
+
+**And then it happened again, to the person writing this entry, in the same
+task.** The fix redacted at `PersistentLogHandler.emit`, which fills two
+stores (`_log_buffer`, `_log_records`) and *then* hands the line to whichever
+on-screen surface is mounted. I pinned both stores, wrote the paragraph above
+about counting sinks, and shipped. Review mutated
+`logs_window.append_record(…, msg)` to `…, formatted` — feeding the
+UNREDACTED line to the mounted widget and therefore into `LogsWindow._records`,
+which is exactly what "Copy visible logs" puts on the clipboard — and the
+suite returned **111 passed, 0 failed**. A *store* is not a *feed*. When one
+function writes the same value to several places, the count that matters is
+the number of **assignments and calls that carry it outward**, not the number
+of collections it lands in; walk the function line by line and pin each one.
+Cheapest reliable check: mutate each outward hand-off in turn and require a
+red for every one — three lines of test closed this, but only after a mutation
+found it.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -5879,3 +5879,37 @@ of collections it lands in; walk the function line by line and pin each one.
 Cheapest reliable check: mutate each outward hand-off in turn and require a
 red for every one — three lines of test closed this, but only after a mutation
 found it.
+
+## A security test that never emitted its payload, twice (TASK-19555, 2026-08-22)
+
+**What happened.** Fixing a truncation bug that could leave a partial API key
+in the Logs view, I wrote the obvious regression test: log a line with the key
+positioned across the 2,000-character cap, assert no fragment survives. It
+passed against the **broken** implementation — twice, for two different
+reasons.
+
+1. The padding length was hand-computed from the cap alone. The handler's
+   formatter prepends `asctime - name - LEVEL - `, roughly 68 characters of
+   unpredictable width, so the key landed comfortably past the cut and was
+   discarded whole. Nothing was ever astride anything.
+2. The rewrite used `logger.info("%s %s", padding, secret)`. **Loguru formats
+   with `str.format`, not `%`.** With no `{}` in the template, loguru logged
+   the template verbatim and silently dropped every argument. The test emitted
+   the literal string `%s %s` and asserted, truthfully, that it contained no
+   credential.
+
+Both were found by mutating the fix and expecting red, not by reading the
+test. The shipped version measures the prefix width off a probe record,
+sweeps every straddle position rather than guessing one, and carries an
+anti-vacuity control that asserts the sentinel is a shape the redactor
+actually recognises.
+
+**What to do.** For a "secret X must not appear in Y" test, the assertion is
+satisfied by an empty Y, so it proves nothing until you separately prove X was
+there. Add a control in the same test — log the payload plainly and assert it
+*was* redacted — and where the position of X matters, sweep the range and
+derive the offsets from a measured value instead of arithmetic on a constant.
+Then mutate the fix: a negative-space assertion that stays green under the
+mutation is not a test. And in this codebase specifically: **`loguru` uses
+brace formatting**; a `%s` template is a silent no-op that drops your payload,
+while stdlib `logging` calls on the same page take `%s` correctly.

--- a/backlog/tasks/task-19555 - The metadata-only diagnostic guarantee stops at the file sink and the Copy all share path is unfiltered.md
+++ b/backlog/tasks/task-19555 - The metadata-only diagnostic guarantee stops at the file sink and the Copy all share path is unfiltered.md
@@ -242,22 +242,83 @@ wrong** and the review round corrected it: it is only true while the Logs
 screen is OPEN. With no screen mounted there is no downstream work at all,
 and redaction is ~93% of what the handler costs.
 
-Worse, cost is linear in line length, so an uncapped kv-dense line scaled
-badly: 3.4 KB → 755 µs, 100 KB → **22 ms**, paid on whichever thread emitted
-the record, the UI thread included.
+Cost is linear in line length, and a second measurement in the Qodo round
+corrected a further claim: it is **not** driven by key/value density, as the
+first note implied. A 100 KB line costs 14–21 ms whatever its shape —
+kv-dense 20.9 ms, JSON 18.5 ms, prose 16.3 ms, base64 with no `=` at all
+14.5 ms — paid on whichever thread emitted the record, the UI thread
+included. So the cap is not a defence against a pathological input; it is a
+defence against large inputs, which is a much more ordinary thing to hit.
 
 No fast path was added — a fast path on a redactor is a bypass hole. A
 **length cap** was, which is the opposite: it keeps strictly *less* data than
-the uncapped line, so it cannot be a bypass. Lines are truncated to
-`MAX_REDACTED_LINE_CHARS` (2,000) before redaction, with the original length
-disclosed in the marker. Measured effect: typical unchanged (33.0 vs 33.6 µs),
-3.4 KB 755 → 501 µs, 100 KB **22.2 ms → 0.50 ms**, a 45× bound on the worst
-case. 2,000 characters is far past terminal readability and still keeps a
+the uncapped line, so it cannot be a bypass.
+
+**Order and alignment (Qodo finding 2).** The first cut truncated at a fixed
+offset and redacted the remainder, which *manufactured* secrets: every
+`_STANDALONE_CREDENTIALS` pattern carries a minimum length, so a key
+straddling the cap was sliced into a fragment too short to match and the
+fragment stayed in the Logs view and in "Copy visible logs". The fix cuts on
+a **token boundary** — the last whitespace inside the cap — and redacts
+everything that survives the cut. A credential never contains whitespace, so
+it is either wholly inside the cut and redacted, or wholly outside it and
+discarded; no fragment is reachable. A single unbroken token longer than the
+cap has no safe cut at all, so its body is withheld rather than sliced (a
+2,000-character prefix of an opaque token is most of a secret). Formatter
+output always carries whitespace in its timestamp prefix, so that branch is
+reached only by raw input.
+
+Redacting the *whole* line and truncating afterwards — the literal reading of
+the review instruction — is equally sound but gives the bound back. Measured
+side by side (token-cut vs `max_length=0`):
+
+| shape | 2 KB | 16 KB | 100 KB |
+| --- | --- | --- | --- |
+| kv-dense | 0.445 / 0.446 ms | 0.445 / 3.434 ms | **0.448 / 20.898 ms** |
+| JSON | 0.384 / 0.384 ms | 0.378 / 3.004 ms | **0.389 / 18.518 ms** |
+| prose | 0.332 / 0.334 ms | 0.342 / 2.644 ms | **0.335 / 16.252 ms** |
+
+Typical 140-character lines are unaffected either way (0.032 ms). The
+token-aligned cut holds cost flat at ~0.4 ms for any input size — a 47×
+bound at 100 KB — while giving up nothing in soundness, so it is what
+shipped. 2,000 characters is far past terminal readability and still keeps a
 20-parameter `sql_logging.preview_params` line (80 chars each) whole.
 
 This also closes the second residual the first draft recorded honestly and
 could not then fix: the buffer bounded line *count* but not line *size*, so a
 dumped provider response body was retained whole. It no longer is.
+
+### Home-path substitution (Qodo finding 1)
+
+`redact_user_paths` replaced the literal `$HOME` with `str.replace`, which is
+wrong whenever one home path prefixes another string:
+
+* with `$HOME=/Users/jan`, `/Users/janedoe/Notes/x.pdf` became
+  `~edoe/Notes/x.pdf` — half of a **different** account's name left in place,
+  still identifying, and with the `/Users/` prefix destroyed so
+  `_HOME_ROOTS_POSIX` could no longer clean up after it;
+* with `$HOME=/srv/appdata`, the unrelated `/srv/appdata-backup/db` became
+  `~-backup/db`, which is a plain correctness bug as well as a privacy one.
+
+The literal candidates (`$HOME`, `$USERPROFILE`, `Path.home()`) are now one
+`lru_cache`d alternation anchored on path-segment characters at both ends, so
+a home matches only a complete final segment; longest candidate first, so a
+disagreement between `$HOME` and `Path.home()` resolves to the more specific
+one. Both the POSIX and Windows halves were checked, and the Windows literal
+had the same defect.
+
+### Token-shaped literals in fixtures (Qodo finding 3)
+
+Every synthetic credential in the changed files is assembled at import time
+from fragments (`_synthetic`), so no committed line contains a contiguous
+string in a real token shape. This is not cosmetic: GitHub push protection
+rejects the **branch**, not the file, and it had already blocked this one
+once. The sweep was run over all 13 changed files with 16 detectors — the
+redactor's own patterns plus Stripe, npm, PyPI, SendGrid and PEM private
+keys — and reports **0 hits**. Five pre-existing literals in
+`Tests/Utils/test_log_sanitizer.py` were converted too, rather than only the
+ones Qodo flagged, since scanners gain detectors over time and a file that
+trips protection blocks everything behind it.
 
 ### Verification
 
@@ -290,6 +351,25 @@ reds — the reviewer's `append_record` mutation now fails with both the key
 and the account name present in the captured feed, and the equivalent
 mutation on the legacy `_current_log_widget.write` branch reds too. The
 lessons entry has been updated with this second incident.
+
+**Qodo round.** Six further tests, all born red against the shipped code and
+each showing the defect rather than an abstraction of it: the fragment
+`sk-19555PRIVATEsentine` surviving the cap; a half-word `'ch'` at the seam;
+an unbroken token emitted as a 2,000-character prefix; `~edoe/Notes/x.pdf`;
+`~edoe\Notes`; and `/srv/appdata-backup/db` mangled to `~-backup/db`.
+Mutation-checked after the fix: a fixed-offset cut (4 red), an unanchored
+home alternation (3 red), and the earlier live-feed mutation re-run to
+confirm it still reds (2 red).
+
+**Two vacuous drafts of the astride test were caught by that discipline, not
+by review.** The first hand-computed a padding length that ignored the
+formatter's timestamp prefix, so the key never landed across the cap. The
+second used a `%s` template with `loguru`, which formats with `str.format` —
+so the template was logged verbatim and the key was never emitted at all.
+Both passed against the broken implementation. The shipped version measures
+the prefix width off a probe record, sweeps every straddle position, and
+carries an explicit anti-vacuity control asserting the sentinel is a shape
+the redactor actually recognises.
 
 ### Modified or added files
 

--- a/backlog/tasks/task-19555 - The metadata-only diagnostic guarantee stops at the file sink and the Copy all share path is unfiltered.md
+++ b/backlog/tasks/task-19555 - The metadata-only diagnostic guarantee stops at the file sink and the Copy all share path is unfiltered.md
@@ -3,7 +3,7 @@ id: TASK-19555
 title: >-
   The metadata-only diagnostic guarantee stops at the file sink; the in-app log
   buffer and "Copy all" share path are unfiltered
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21 20:05'
 labels:
@@ -66,20 +66,271 @@ unused. Its own normalization defect is filed separately (TASK-19558).
 
 ## Acceptance Criteria
 
-- [ ] The metadata-only guarantee holds on the in-app path, not just the file
-      sink — attaching the existing filter at `PersistentLogHandler.emit` is
-      the preferred repair, since it is one choke point covering ~800 call
-      sites (durable and pragmatic; per-call-site edits are neither)
-- [ ] "Copy all" cannot place unredacted user content or credentials on the
+**AC #1 was rewritten before implementing** (see Implementation Notes, "The
+one AC that changed"). The filed wording asked for the existing
+`PersistentDiagnosticFilter` to be attached at `PersistentLogHandler.emit`.
+That filter is an all-or-nothing *admission* filter, not a redactor: attaching
+it there drops every descriptive record on the floor and leaves the Logs
+screen showing only `event=… status=…` lines. That is not a privacy fix with a
+usability cost, it is the deletion of the screen. The original text is kept
+below, struck, so the deviation is visible rather than quietly absorbed.
+
+- ~~[ ] The metadata-only guarantee holds on the in-app path, not just the
+  file sink — attaching the existing filter at `PersistentLogHandler.emit` is
+  the preferred repair~~
+- [x] `PersistentLogHandler.emit` is the single choke point where the in-app
+      path is made safe, covering every consumer of the buffer at once (~800
+      call sites, no per-call-site edits), splitting the two surfaces by what
+      each can honestly carry:
+      - the **live view** keeps descriptive text but never credentials and
+        never the operating-system account name;
+      - the **"Copy all" artifact** is metadata-only in exactly the ADR-029
+        sense, decided by an instance of the same `PersistentDiagnosticFilter`
+        class the rotating file handler uses — not the same object, but the
+        class is stateless (no `__init__`, `filter` fully overridden), so the
+        two sinks cannot drift on what counts as metadata-only.
+- [x] "Copy all" cannot place unredacted user content or credentials on the
       system clipboard
-- [ ] `_log_buffer` is bounded — an unbounded session buffer is both a
+- [x] `_log_buffer` is bounded — an unbounded session buffer is both a
       memory and a disclosure surface
-- [ ] The privacy suite asserts against the **collector**, not only the file
+- [x] The privacy suite asserts against the **collector**, not only the file
       handler, so the omission that hid this cannot recur
-- [ ] The assertion is mutation-checked: removing the filter makes the test
+- [x] The assertion is mutation-checked: removing the filter makes the test
       red
-- [ ] The empty-state copy that invites users to share logs is only shown once
+- [x] The empty-state copy that invites users to share logs is only shown once
       the shared artifact is actually safe to share
-- [ ] The `log_level=DEBUG` troubleshooting advice in the three shipped docs is
+- [x] The `log_level=DEBUG` troubleshooting advice in the three shipped docs is
       revisited in light of what DEBUG admits, and either made safe or made
       honest about what it exposes
+
+## Implementation Plan
+
+1. Reproduce the leak against the real collector (born-red), not a stand-in.
+2. Decide the bar per surface; rewrite AC #1 with the argument before coding.
+3. Add the sink-side redactor to `Utils/log_sanitizer.py`, repairing the
+   normalization defect it depends on.
+4. Redact at `PersistentLogHandler.emit`; bound `_log_buffer`.
+5. Make the Logs screen's labels, notifications and empty state describe what
+   each action actually produces.
+6. Mutation-check every new assertion; revisit the three `DEBUG` docs.
+
+## Implementation Notes
+
+### What was wrong
+
+ADR-029's metadata-only guarantee was enforced by `PersistentDiagnosticFilter`
+at exactly two places, both the rotating FILE handler. `TldwCli._setup_
+buffered_logging` installs a second collector on the *same* root logger —
+`PersistentLogHandler`, level `NOTSET`, no filter — feeding an **unbounded**
+`deque`, which `LogsWindow._on_copy_all` joined onto the system clipboard,
+under an empty state that told the user to reproduce the problem and share
+their logs. The existing privacy suite attached a filtered file handler beside
+an unfiltered collector and asserted only against the file, so the collector
+the app actually ships was never asserted against at all.
+
+### The one AC that changed, and why
+
+The filed repair — attach `PersistentDiagnosticFilter` at the collector —
+fails on contact. That filter admits only schema-validated
+`log_persistent_metadata` records and drops everything else, so the Logs
+screen would render `event=app_started component=app` and almost nothing
+besides. Its filter bar, level chips, regex search and next-error jump would
+all operate on an empty set, and "reproduce the problem, then share the logs"
+would hand a helper nothing. The metadata-only artifact already exists on
+disk; the in-app screen's entire value is that it is the rich one.
+
+So the bar is set per surface, by a single rule: **remove what is never
+wanted; disclose what is sometimes wanted.**
+
+- *Never wanted*: API keys, bearer tokens, `Authorization`-class headers,
+  passwords, and the operating-system account name. No maintainer has ever
+  needed to read a key, and `/Users/janedoe/…` is a real-name identifier on
+  most desktops. These are removed from **everything** the in-app path holds
+  — buffer, record store, live view — so a screenshot is covered too.
+- *Sometimes wanted*: note titles, search queries, prompts, tool arguments,
+  file names. These are the content a user is deliberately disclosing when
+  they ask for help, and no sink-side rule can tell them apart from the
+  wording around them. They stay in the live view and in **Copy visible
+  logs**, which copies a set the user chose with a filter and can read.
+- *Never consented to*: the whole session, unread. **"Copy all"** exports
+  thousands of lines nobody looked at, so it now carries the metadata-only
+  form and is labelled "Copy all (redacted)".
+
+Alternatives rejected: (a) the filed all-or-nothing filter at emit, above;
+(b) redacting only in the copy handlers — leaves the buffer and the on-screen
+view holding live credentials for the whole session, and protects nothing
+against a screenshot or a future surface wired to the same buffer; (c) a
+separate unredacted field for the viewer — unnecessary, because `_log_buffer`
+and `_log_records` were *already* two stores fed by the one emit and merely
+duplicated each other; this change gives each of them one job instead of
+adding a third.
+
+### What a user can still leak
+
+Everything in the *sometimes wanted* class, via **Copy visible logs** or a
+screenshot: file names and paths below `~`, note titles, keywords, search
+queries, prompts, tool argument values, provider response text, and the
+message-body prefix. That is a real residual and it is not closable at a
+sink — it is per-call-site work (TASK-492's class), deliberately out of scope
+here. It is now *disclosed* rather than silent: the empty state, both copy
+notifications and `Docs/User_Guide/logs.md` say so in as many words.
+
+The narrower residual is credential coverage. Redaction is a **denylist**, so
+a secret survives when it is in a shape `_STANDALONE_CREDENTIALS` does not
+know *and* carries no label `_is_sensitive_log_key` recognises. The review
+round widened the shape set (GitHub `ghp_`/`github_pat_`, Hugging Face `hf_`,
+OpenRouter `sk-or-v1-`, AWS `AKIA…`, Slack `xox…`, bare JWTs — the first four
+of which the original set genuinely missed) and every user-facing claim now
+says **"recognised API-key formats"** rather than "always removed", which was
+false as written.
+
+One label gap is deliberately left open: bare `key=` is **not** treated as
+sensitive, though bare `token`/`secret`/`password` are. A census of every
+`key=`/`key:` label inside a logger call in this package found **5 sites, all
+of them non-secrets** — a dict key name, a cache key, a provider settings key
+name, and two config key *names* (`config_encryption.py:221`,
+`config.py:4886`). Adding `key` would redact 5 known debugging values, catch
+0 known secrets, and blind a security-adjacent diagnostic that reports which
+config key failed to decrypt. The shape patterns are the right investment for
+that risk, and they are label-independent.
+
+### The buffer bound
+
+Bounded to `Logs_Window.MAX_LOG_RECORDS` (10,000), the same window
+`_log_records`, the `RichLog` widget and the screen's own status line
+("buffer keeps last 10,000") already use. Beyond memory, the unbounded buffer
+was a straight honesty defect: "Copy all" could export an entire multi-hour
+session while the screen told the user it kept the last 10,000 lines. The two
+stores are now pinned equal by test.
+
+### Also repaired here
+
+`log_sanitizer._is_sensitive_log_key` computed a hyphen normalization and
+then passed the **raw** key to `is_sensitive_config_key`, whose
+`_key`/`_token`/`_secret`/`_password` rules are underscore-suffix matches. So
+`x-auth-token`, `x-session-key` and `x-client-secret` — the exact names
+provider request logging produces — were classified harmless and their values
+written out verbatim. Fixed here rather than deferred, because the sink-side
+redactor depends on that predicate. Normalizing cannot create a false
+positive: `max-tokens` → `max_tokens`, which still does not end in `_token`.
+
+**TASK-19558 must NOT be closed against this.** It carries five items (FTS5
+dead-store quoting, defusedxml OPML, this predicate, `redact_paths=True`,
+local-tool risk tags); closing it wholesale would silently drop four security
+items. This branch satisfies **part of item 3 only** — the hyphenated-suffix
+header shapes — and even there bare `key` remains open by the deliberate
+decision recorded above.
+
+The same review round also repaired the Windows half of `redact_user_paths`:
+`Users` was a literal in a pattern whose comment claimed case-insensitivity,
+so `c:\users\<name>\…` and every UNC `\\SERVER\Users\<name>\…` path kept the
+account name. Windows paths are case-insensitive end to end, so the Windows
+branch is now its own `re.IGNORECASE` pattern with a UNC alternative, while
+the POSIX branch stays case-sensitive (a case-insensitive `/users/` would
+rewrite REST URLs).
+
+`app._display_buffered_logs` (dead code, zero callers) was pointed at
+`_log_records` so that reviving it shows real diagnostics rather than a
+screen of redaction markers.
+
+### Measured cost, and the length cap
+
+`redact_log_line` costs 22–33 µs on a typical ~140-character line against
+~1.4 µs for the `Formatter` call it follows. The first draft of this note
+called that "small beside the downstream render work" — **that framing was
+wrong** and the review round corrected it: it is only true while the Logs
+screen is OPEN. With no screen mounted there is no downstream work at all,
+and redaction is ~93% of what the handler costs.
+
+Worse, cost is linear in line length, so an uncapped kv-dense line scaled
+badly: 3.4 KB → 755 µs, 100 KB → **22 ms**, paid on whichever thread emitted
+the record, the UI thread included.
+
+No fast path was added — a fast path on a redactor is a bypass hole. A
+**length cap** was, which is the opposite: it keeps strictly *less* data than
+the uncapped line, so it cannot be a bypass. Lines are truncated to
+`MAX_REDACTED_LINE_CHARS` (2,000) before redaction, with the original length
+disclosed in the marker. Measured effect: typical unchanged (33.0 vs 33.6 µs),
+3.4 KB 755 → 501 µs, 100 KB **22.2 ms → 0.50 ms**, a 45× bound on the worst
+case. 2,000 characters is far past terminal readability and still keeps a
+20-parameter `sql_logging.preview_params` line (80 chars each) whole.
+
+This also closes the second residual the first draft recorded honestly and
+could not then fix: the buffer bounded line *count* but not line *size*, so a
+dumped provider response body was retained whole. It no longer is.
+
+### Verification
+
+Born red at base: 5 of 6 new tests in `Tests/test_logs_share_path_privacy.py`
+failed with the sentinel present, including a full traceback carrying the
+user's content into the clipboard buffer, and `_log_buffer.maxlen` reading
+`None`. Mutation-checked three ways after the fix: removing the share
+admission (11 red), removing the emit redaction (2 red), reverting the
+hyphen normalization (4 red). A sandboxed-`HOME` runtime probe through the
+real handler confirmed a realistic leak set — an attachment path, a note
+title, a search query, an `x-auth-token`, an `sk-` key and an exception
+carrying a note title — lands in the view but not on the clipboard, with the
+key and the account name in neither.
+
+**The review round found a fourth mutation that SURVIVED**, and it is the
+important one. `emit` fills two stores and then hands the line to whichever
+on-screen surface is mounted; the first draft pinned the two STORES and left
+the live FEED unpinned. Passing the unredacted `formatted` to
+`logs_window.append_record` — which puts live credentials into
+`LogsWindow._records`, precisely what `_on_copy_visible` copies to the
+clipboard — produced **111 passed, 0 failed**. Only
+`Tests/UI/test_logs_ux_fixes.py` referenced `append_record` at all, and it
+passed under the mutation.
+
+That is this task's own lesson ("count the sinks") failing one seam further
+in: I counted the *stores* and stopped. Both feeds are now pinned
+(`test_live_logs_window_feed_receives_the_redacted_line`,
+`test_legacy_rich_log_feed_receives_the_redacted_line`) and each mutation
+reds — the reviewer's `append_record` mutation now fails with both the key
+and the account name present in the captured feed, and the equivalent
+mutation on the legacy `_current_log_widget.write` branch reds too. The
+lessons entry has been updated with this second incident.
+
+### Modified or added files
+
+- `tldw_chatbook/app.py` — bounded buffer, sink-side redaction, share-artifact
+  construction, `_display_buffered_logs` store fix
+- `tldw_chatbook/Utils/log_sanitizer.py` — `redact_log_line` (with the length
+  cap), `redact_user_paths` (POSIX + case-insensitive Windows/UNC),
+  `_is_sensitive_log_key` normalization repair, six added standalone
+  credential shapes
+- `tldw_chatbook/UI/Logs_Window.py` — button label, empty state, both copy
+  notifications
+- `Tests/test_logs_share_path_privacy.py` (new)
+- `Tests/test_remaining_diagnostic_sentinel_matrix.py` — asserts against the
+  real collector, closing the omission
+- `Tests/Utils/test_log_sanitizer.py`, `Tests/UI/test_logs_ux_fixes.py`
+- `Docs/User_Guide/logs.md`, `Docs/Features/ChatDictionaries-Documented.md`,
+  `Docs/Features/World-Lore-Books-Documented.md`,
+  `Docs/Development/RAG/RAG-OCR.md`
+
+### Inventory note for the merge controller
+
+`Docs/security/production-diagnostic-inventory.json` is **not** restamped
+here. It is already stale on `origin/dev` — 9 owner rows drifted before this
+branch existed — and restamping would absorb that unreviewed drift into a
+privacy commit, which is the exact failure mode the checker's own docstring
+warns about.
+
+**Two suites are red at base for that reason, and both stay red here:**
+
+1. `Tests/LLM_Calls/test_summarization_diagnostic_privacy.py` — 3 failed /
+   254 passed, identical count at base and on this branch. Whole-inventory
+   digest mismatch; this branch does not change it further.
+2. `Tests/Architecture/test_persistent_diagnostic_inventory.py::
+   test_production_diagnostic_inventory_and_sink_topology_are_unchanged` —
+   1 failed / 64 passed. Verified red at base by running it in a detached
+   worktree at `origin/dev` (`fdc6ad663`), same 1/64. **Unlike (1), this
+   branch contributes the 10th drifted row**, so the row count in its diff
+   will be one higher than a clean `origin/dev` run.
+
+This branch's own delta, recomputed against its base `5f720a404`, is exactly
+one row: `tldw_chatbook/app.py`, `call_count` unchanged at 325,
+`diagnostic_digest` `bb5156c2be2e60286533` → `14fba1fb194bef30c90b`, from
+rewording one `logger.debug` in `_display_buffered_logs`. No owners added or
+removed; sink topology byte-identical.

--- a/tldw_chatbook/UI/Logs_Window.py
+++ b/tldw_chatbook/UI/Logs_Window.py
@@ -193,10 +193,21 @@ class LogsWindow(Container):
                 )
             yield Input(placeholder="Filter logs (regex ok)…", id="logs-filter-text")
             yield Button("Pause", id="logs-pause")
+        # TASK-19555: this text used to say, flatly, "copy the logs and share
+        # them when asking for help" -- an invitation to put an unfiltered
+        # session transcript on the clipboard. Credentials and the account
+        # name are now stripped at the sink, but file names, note titles and
+        # search terms are still in there, so the invitation says what it is
+        # inviting and points at the action the user can actually read first.
         yield Static(
             "No log entries yet.\n"
-            "Something not working? Reproduce the problem, then copy the logs "
-            "and share them when asking for help.",
+            "Something not working? Reproduce the problem, filter to the "
+            "lines that matter, then use Copy visible logs — you share "
+            "exactly what you can see.\n"
+            "Recognised API-key formats and your account name are removed; "
+            "file names, titles and search terms are not, so read before you "
+            "share. Copy all (redacted) shares timings, loggers and error "
+            "types only.",
             id="logs-empty-state",
         )
         yield RichLog(
@@ -216,7 +227,9 @@ class LogsWindow(Container):
                 variant="primary",
             )
             yield Button(
-                "Copy all",
+                # The label must not promise more than the artifact carries
+                # (TASK-19555): "Copy all" now yields the metadata-only form.
+                "Copy all (redacted)",
                 id="copy-logs-button",
                 classes="logs-action-button",
             )
@@ -504,16 +517,29 @@ class LogsWindow(Container):
             )
             return
         self.app.copy_to_clipboard("\n".join(record.message for record in records))
+        # TASK-19555: this is the deliberate, filtered action, so the payload
+        # stays descriptive -- but the notification names the residual
+        # exposure rather than leaving the user to discover it in a bug report.
         self.app.notify(
-            f"Copied {len(records)} visible log lines to clipboard!",
+            f"Copied {len(records)} visible log lines. Recognised key formats "
+            "and your account name were removed; file names and search terms "
+            "were not.",
             title="Clipboard",
             severity="information",
-            timeout=4,
+            timeout=6,
         )
 
     @on(Button.Pressed, "#copy-logs-button")
     def _on_copy_all(self) -> None:
-        """Copy the full session log (unbounded buffer) to the clipboard."""
+        """Copy the redacted session log to the clipboard.
+
+        The app's ``PersistentLogHandler`` fills ``_log_buffer`` with the
+        metadata-only form of each record (TASK-19555): this action exports
+        thousands of lines the user has never read, so it carries timestamps,
+        loggers, levels and exception types, and no message bodies. Sharing
+        actual log text is the job of "Copy visible logs", where the user can
+        see what they are sharing first.
+        """
         buffer = getattr(self.app_instance, "_log_buffer", None)
         if not buffer:
             self.app.notify(
@@ -525,10 +551,11 @@ class LogsWindow(Container):
             return
         self.app.copy_to_clipboard("\n".join(buffer))
         self.app.notify(
-            f"Copied {len(buffer)} log entries to clipboard!",
+            f"Copied {len(buffer)} redacted log entries — timings, loggers "
+            "and error types only. Use Copy visible logs to share log text.",
             title="Clipboard",
             severity="information",
-            timeout=4,
+            timeout=6,
         )
 
     # ------------------------------------------------------------------

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -5,7 +5,9 @@ This module provides functions to scrub API keys, passwords, and other
 sensitive information from log messages.
 """
 
+import os
 import re
+from pathlib import Path
 from typing import Any, Dict, List
 
 from tldw_chatbook.Utils.sensitive_config_keys import is_sensitive_config_key
@@ -28,8 +30,28 @@ _LOG_ONLY_SENSITIVE_FIELDS = frozenset(
 
 
 def _is_sensitive_log_key(key: object) -> bool:
+    """Return whether a ``key=value`` label in a log line names a secret.
+
+    The hyphen normalization is applied to BOTH checks (TASK-19555; the defect
+    itself is filed as TASK-19558). It used to be computed and then passed
+    only to the ``_LOG_ONLY_SENSITIVE_FIELDS`` membership test, while
+    ``is_sensitive_config_key`` received the raw key -- and that predicate's
+    ``_key``/``_token``/``_secret``/``_password`` rules are suffix matches on
+    underscore forms. So every hyphenated HTTP header name whose sensitivity
+    comes from a suffix rather than the ``api-key`` containment rule --
+    ``x-auth-token``, ``x-session-key``, ``x-client-secret`` -- was classified
+    as harmless and its value was written out verbatim. Those are exactly the
+    names provider request logging produces.
+
+    Normalizing cannot create a false positive here: ``max-tokens`` normalizes
+    to ``max_tokens``, which still does not end in ``_token``.
+    """
     normalized = str(key).strip().lower().replace("-", "_")
-    return is_sensitive_config_key(key) or normalized in _LOG_ONLY_SENSITIVE_FIELDS
+    return (
+        is_sensitive_config_key(key)
+        or is_sensitive_config_key(normalized)
+        or normalized in _LOG_ONLY_SENSITIVE_FIELDS
+    )
 
 
 _ASSIGNMENT_PREFIX = re.compile(
@@ -52,8 +74,28 @@ _BEARER = re.compile(
 _STANDALONE_CREDENTIALS = (
     re.compile(r"(?<![A-Za-z0-9_-])sk-proj-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
     re.compile(r"(?<![A-Za-z0-9_-])sk-ant-api03-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
+    # TASK-19555 review: OpenRouter keys carry hyphens inside the body, so the
+    # generic `sk-[A-Za-z0-9]{20,}` rule below never matched one.
+    re.compile(r"(?<![A-Za-z0-9_-])sk-or-v1-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])"),
     re.compile(r"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])"),
     re.compile(r"(?<![A-Za-z0-9_-])AIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])"),
+    # GitHub personal access / OAuth / server / refresh tokens, and the
+    # fine-grained `github_pat_` form.
+    re.compile(r"(?<![A-Za-z0-9_-])gh[pousr]_[A-Za-z0-9]{30,}(?![A-Za-z0-9_-])"),
+    re.compile(r"(?<![A-Za-z0-9_-])github_pat_[A-Za-z0-9_]{30,}(?![A-Za-z0-9_-])"),
+    # Hugging Face user access tokens.
+    re.compile(r"(?<![A-Za-z0-9_-])hf_[A-Za-z0-9]{30,}(?![A-Za-z0-9_-])"),
+    # AWS access key ids (the id alone identifies an account and is paired
+    # with a secret often logged on the same line).
+    re.compile(r"(?<![A-Za-z0-9_-])(?:AKIA|ASIA|AGPA|AIDA|AROA)[0-9A-Z]{16}(?![A-Za-z0-9_-])"),
+    # Slack bot/user/app tokens.
+    re.compile(r"(?<![A-Za-z0-9_-])xox[baprs]-[A-Za-z0-9-]{10,}(?![A-Za-z0-9_-])"),
+    # JSON Web Tokens: three base64url segments, header first. Bearer-prefixed
+    # ones are already covered; these are the bare ones in bodies and errors.
+    re.compile(
+        r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+        r"\.[A-Za-z0-9_-]{8,}(?![A-Za-z0-9_-])"
+    ),
 )
 
 
@@ -162,6 +204,123 @@ def sanitize_string(text: str) -> str:
     for pattern in _STANDALONE_CREDENTIALS:
         result = pattern.sub(REDACTION_MARKER, result)
     return result
+
+
+#: POSIX home roots whose next path segment is an operating-system account
+#: name. Deliberately case-SENSITIVE: a case-insensitive ``/users/`` would also
+#: rewrite REST URLs such as ``https://api.example.com/users/alice``, which is
+#: not a home directory and whose shape a maintainer may need.
+_HOME_ROOTS_POSIX = re.compile(
+    r"(?:(?<=^)|(?<=[^A-Za-z0-9_.-]))(?:/Users/|/home/)[^/\\\s:'\"<>|]+"
+)
+
+#: Windows home roots -- a drive form (``C:\Users\name``) and a UNC form
+#: (``\\SERVER\Users\name``). Matched case-INSENSITIVELY in full: Windows paths
+#: are case-insensitive end to end, so ``c:\users\name`` and ``C:\Users\name``
+#: are the same path and both must redact. An earlier revision applied
+#: ``re.IGNORECASE`` to the drive letter only in intent but matched ``Users``
+#: as a literal, so the lowercase spelling -- and every UNC path -- kept the
+#: account name (caught in TASK-19555 review). There is no URL-collision risk
+#: here because these forms are backslash-delimited.
+_HOME_ROOTS_WINDOWS = re.compile(
+    r"(?:(?<=^)|(?<=[^A-Za-z0-9_.-]))"
+    r"(?:[A-Za-z]:\\Users\\|\\\\[^\\/\s:'\"<>|]+\\Users\\)"
+    r"[^/\\\s:'\"<>|]+",
+    re.IGNORECASE,
+)
+
+#: Cap applied to one line before redaction (TASK-19555 review). Two reasons,
+#: and neither is a bypass -- truncation keeps strictly LESS data than the
+#: uncapped line:
+#:
+#: * cost. Redaction is linear in line length, so an uncapped kv-dense line
+#:   costs proportionally: ~21 us at a normal ~140 chars, ~553 us at 3.4 KB,
+#:   ~7.9 ms at 100 KB -- paid on whichever thread emitted the record, the UI
+#:   thread included.
+#: * disclosure. The buffer bounds the number of lines but not their size, so
+#:   a single dumped provider response body used to be retained whole.
+#:
+#: 2000 chars is far past the point a log line is readable in a terminal, so
+#: nothing legible is lost, and it bounds the worst case at roughly 0.3 ms.
+MAX_REDACTED_LINE_CHARS = 2000
+
+
+def redact_user_paths(text: str) -> str:
+    """Replace home-directory prefixes with ``~`` so no account name survives.
+
+    ``/Users/alice/Notes/Q3.pdf`` becomes ``~/Notes/Q3.pdf``: the operating
+    system account name -- a real-name identifier on most desktops, and the
+    single most repeated identity token in this application's path logging --
+    is gone, while everything a maintainer reads the path for is intact.
+
+    The running user's own home is substituted first and literally, so the
+    rule still holds for accounts that live outside ``/Users`` or ``/home``
+    (``/root``, or any ``$HOME`` override).
+
+    Args:
+        text: One log line, or any free text that may embed filesystem paths.
+
+    Returns:
+        ``text`` with home-directory roots collapsed to ``~``.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    result = text
+    # os.environ first: Path.home() falls back to the password database, which
+    # would rewrite paths the user's own $HOME no longer points at.
+    for candidate in (os.environ.get("HOME"), os.environ.get("USERPROFILE")):
+        if candidate and len(candidate) > 1:
+            result = result.replace(candidate, "~")
+    try:
+        home = str(Path.home())
+    except (OSError, RuntimeError):  # pragma: no cover - no resolvable home
+        home = ""
+    if len(home) > 1:
+        result = result.replace(home, "~")
+    result = _HOME_ROOTS_POSIX.sub("~", result)
+    return _HOME_ROOTS_WINDOWS.sub("~", result)
+
+
+def redact_log_line(text: str, max_length: int = MAX_REDACTED_LINE_CHARS) -> str:
+    """Redact credentials and user identity from one formatted log line.
+
+    This is the sink-side redaction applied to every record entering the
+    in-app log collector (TASK-19555). It is deliberately narrower than
+    ADR-029's metadata-only admission filter, which is an all-or-nothing DROP
+    and would empty the Logs screen of the very content it exists to show.
+    The bar here is *what is never wanted*: secrets and the operating-system
+    account name have no debugging value, so removing them costs a maintainer
+    nothing.
+
+    Two honest limits, both disclosed to users in the Logs screen copy:
+
+    * It removes credentials in RECOGNISED formats -- labelled ``key=``-style
+      assignments, ``Bearer`` prefixes, URL userinfo, and the standalone
+      shapes in ``_STANDALONE_CREDENTIALS``. A bare opaque token in a format
+      none of those match survives. This is a denylist and denylists are never
+      complete; the claim is "recognised formats", not "all credentials".
+    * It does NOT remove free-form user content -- a note title, a search
+      query, a prompt, a tool argument -- because nothing at a sink can tell
+      which substring of a message was interpolated from user data. That
+      exposure is handled by bounding what the bulk share action exports.
+
+    Args:
+        text: One fully formatted log line.
+        max_length: Characters kept before truncation. See
+            ``MAX_REDACTED_LINE_CHARS`` for why truncation happens first.
+
+    Returns:
+        The line, truncated if oversized, with recognised credentials and
+        home-directory account names redacted.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    if max_length > 0 and len(text) > max_length:
+        # Truncate BEFORE redacting: redaction is linear in length, and the
+        # tail is being discarded either way.
+        text = f"{text[:max_length]}… [truncated, {len(text)} chars]"
+    return redact_user_paths(sanitize_string(text))
 
 
 def sanitize_dict(data: Dict[str, Any], deep: bool = True) -> Dict[str, Any]:

--- a/tldw_chatbook/Utils/log_sanitizer.py
+++ b/tldw_chatbook/Utils/log_sanitizer.py
@@ -7,6 +7,7 @@ sensitive information from log messages.
 
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -244,6 +245,54 @@ _HOME_ROOTS_WINDOWS = re.compile(
 #: nothing legible is lost, and it bounds the worst case at roughly 0.3 ms.
 MAX_REDACTED_LINE_CHARS = 2000
 
+#: Characters that may continue a path segment. Used as both lookbehind and
+#: lookahead when substituting a literal home directory, so the match has to
+#: cover a WHOLE segment.
+_PATH_SEGMENT_CHARS = r"A-Za-z0-9_.\-~"
+
+#: Whitespace treated as a token boundary when truncating (see
+#: ``redact_log_line``). Credentials never contain whitespace, so cutting on
+#: one cannot split a credential in half.
+_TOKEN_BOUNDARY_CHARS = " \t\n\r\v\f"
+
+
+@lru_cache(maxsize=8)
+def _home_literal_pattern(candidates: tuple[str, ...]) -> "re.Pattern | None":
+    """Compile a segment-anchored alternation over literal home directories.
+
+    TASK-19555 Qodo round. This used to be a bare ``str.replace(home, "~")``,
+    which is wrong in both directions when one home path is a prefix of
+    another:
+
+    * with ``$HOME=/Users/jan``, the line ``/Users/janedoe/Notes/x.pdf``
+      became ``~edoe/Notes/x.pdf`` -- half of a DIFFERENT account's name left
+      in place, still identifying, and with the ``/Users/`` prefix destroyed
+      so ``_HOME_ROOTS_POSIX`` could no longer clean up after it;
+    * with ``$HOME=/srv/appdata``, the unrelated ``/srv/appdata-backup/db``
+      became ``~-backup/db``.
+
+    Anchoring on ``_PATH_SEGMENT_CHARS`` at both ends makes a home match only
+    a complete final segment. Longest candidate first, so when ``$HOME`` and
+    ``Path.home()`` disagree by a prefix the more specific one wins.
+
+    Args:
+        candidates: Home-directory strings; empty entries are ignored.
+
+    Returns:
+        A compiled pattern, or None when no usable candidate was supplied.
+    """
+    usable = sorted(
+        {candidate for candidate in candidates if candidate and len(candidate) > 1},
+        key=len,
+        reverse=True,
+    )
+    if not usable:
+        return None
+    alternation = "|".join(re.escape(candidate) for candidate in usable)
+    return re.compile(
+        rf"(?<![{_PATH_SEGMENT_CHARS}])(?:{alternation})(?![{_PATH_SEGMENT_CHARS}])"
+    )
+
 
 def redact_user_paths(text: str) -> str:
     """Replace home-directory prefixes with ``~`` so no account name survives.
@@ -255,7 +304,8 @@ def redact_user_paths(text: str) -> str:
 
     The running user's own home is substituted first and literally, so the
     rule still holds for accounts that live outside ``/Users`` or ``/home``
-    (``/root``, or any ``$HOME`` override).
+    (``/root``, or any ``$HOME`` override). That substitution is anchored on
+    path-segment boundaries -- see ``_home_literal_pattern``.
 
     Args:
         text: One log line, or any free text that may embed filesystem paths.
@@ -266,18 +316,20 @@ def redact_user_paths(text: str) -> str:
     if not isinstance(text, str) or not text:
         return text
 
-    result = text
     # os.environ first: Path.home() falls back to the password database, which
     # would rewrite paths the user's own $HOME no longer points at.
-    for candidate in (os.environ.get("HOME"), os.environ.get("USERPROFILE")):
-        if candidate and len(candidate) > 1:
-            result = result.replace(candidate, "~")
     try:
-        home = str(Path.home())
+        resolved_home = str(Path.home())
     except (OSError, RuntimeError):  # pragma: no cover - no resolvable home
-        home = ""
-    if len(home) > 1:
-        result = result.replace(home, "~")
+        resolved_home = ""
+    pattern = _home_literal_pattern(
+        (
+            os.environ.get("HOME") or "",
+            os.environ.get("USERPROFILE") or "",
+            resolved_home,
+        )
+    )
+    result = pattern.sub("~", text) if pattern is not None else text
     result = _HOME_ROOTS_POSIX.sub("~", result)
     return _HOME_ROOTS_WINDOWS.sub("~", result)
 
@@ -305,22 +357,56 @@ def redact_log_line(text: str, max_length: int = MAX_REDACTED_LINE_CHARS) -> str
       which substring of a message was interpolated from user data. That
       exposure is handled by bounding what the bulk share action exports.
 
+    Oversized lines are cut on a TOKEN boundary, and redaction then runs over
+    everything that survives the cut (TASK-19555 Qodo round). The first
+    revision truncated at a fixed offset and redacted afterwards, which
+    manufactured secrets: every pattern in ``_STANDALONE_CREDENTIALS`` carries
+    a minimum length, so a key straddling the cap was sliced into a fragment
+    too short to match and the fragment stayed in the Logs view and in "Copy
+    visible logs".
+
+    Cutting on whitespace fixes that without giving up the cost bound, because
+    a credential never contains whitespace: it is either wholly inside the cut
+    and redacted, or wholly outside it and discarded. Redaction over the full
+    line would also be correct, but it is linear in length -- 14-20 ms for a
+    100 KB line, on whichever thread emitted the record -- and that bound is
+    the reason the cap exists.
+
     Args:
         text: One fully formatted log line.
-        max_length: Characters kept before truncation. See
-            ``MAX_REDACTED_LINE_CHARS`` for why truncation happens first.
+        max_length: Characters kept before the token-aligned cut, or 0 to
+            redact the whole line however long it is. See
+            ``MAX_REDACTED_LINE_CHARS``.
 
     Returns:
-        The line, truncated if oversized, with recognised credentials and
-        home-directory account names redacted.
+        The line, cut on a token boundary if oversized, with recognised
+        credentials and home-directory account names redacted.
     """
     if not isinstance(text, str):
         text = str(text)
-    if max_length > 0 and len(text) > max_length:
-        # Truncate BEFORE redacting: redaction is linear in length, and the
-        # tail is being discarded either way.
-        text = f"{text[:max_length]}… [truncated, {len(text)} chars]"
-    return redact_user_paths(sanitize_string(text))
+    original_length = len(text)
+    suffix = ""
+    if max_length > 0 and original_length > max_length:
+        head = text[:max_length]
+        boundary = max(
+            (head.rfind(character) for character in _TOKEN_BOUNDARY_CHARS),
+            default=-1,
+        )
+        if boundary <= 0:
+            # One unbroken token longer than the cap. There is no cut that
+            # cannot split it, and a 2,000-character prefix of an opaque token
+            # is most of a secret, so the body is withheld rather than sliced.
+            # Formatter output always has whitespace in its timestamp prefix,
+            # so this is reached only by raw, unformatted input.
+            return (
+                f"{REDACTION_MARKER} [oversized unbroken log line withheld, "
+                f"{original_length} chars]"
+            )
+        text = head[:boundary]
+        suffix = f"… [truncated, {original_length} chars]"
+    # The suffix is generated text, so it is appended after redaction rather
+    # than being fed through it.
+    return redact_user_paths(sanitize_string(text)) + suffix
 
 
 def sanitize_dict(data: Dict[str, Any], deep: bool = True) -> Dict[str, Any]:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -7829,18 +7829,79 @@ class TldwCli(
     # unreferenced here but out of this task's scope.
 
     def _setup_buffered_logging(self):
-        """Set up a persistent buffered logging handler for screen navigation mode."""
+        """Set up a persistent buffered logging handler for screen navigation mode.
+
+        TASK-19555 (privacy). This is the ONE choke point every in-app
+        diagnostic passes through, and the two stores it fills have different
+        jobs and therefore different privacy bars:
+
+        * ``_log_records`` is the LIVE VIEW. It stays descriptive -- redacting
+          it would empty the Logs screen of the content the screen exists to
+          show -- but every line is first stripped of credentials and of the
+          operating-system account name, which are never worth reading and are
+          the two things a screenshot or a shoulder-surfer must not capture.
+        * ``_log_buffer`` is the SHARE ARTIFACT: the exact payload
+          ``LogsWindow._on_copy_all`` joins onto the system clipboard. It holds
+          the metadata-only form, because "Copy all" bulk-exports thousands of
+          lines the user has never read -- consent that cannot be informed.
+          Anything a user deliberately shares, they share by filtering the view
+          and pressing "Copy visible".
+
+        Both stores are bounded to the same window, so the share action cannot
+        export more history than the screen admits to keeping.
+        """
         from collections import deque
         import logging
 
-        # Create a buffer to store ALL log messages (no max length)
+        from tldw_chatbook.UI.Logs_Window import MAX_LOG_RECORDS
+        from tldw_chatbook.Utils.log_sanitizer import (
+            REDACTION_MARKER,
+            redact_log_line,
+        )
+        from tldw_chatbook.Utils.persistent_diagnostics import (
+            PersistentDiagnosticFilter,
+            safe_metadata_token,
+        )
+
+        # The clipboard payload for "Copy all". Bounded (TASK-19555): an
+        # unbounded session buffer is a memory leak and a disclosure surface,
+        # and it let "Copy all" export far more history than the Logs screen
+        # itself retains or discloses in its status line.
         if not hasattr(self, "_log_buffer"):
-            self._log_buffer = deque()  # No maxlen - keep all logs
+            self._log_buffer = deque(maxlen=MAX_LOG_RECORDS)
 
         # Structured records (level, name, formatted message) for the Logs
         # screen's filtering; bounded like the RichLog widget itself.
         if not hasattr(self, "_log_records"):
-            self._log_records = deque(maxlen=10000)
+            self._log_records = deque(maxlen=MAX_LOG_RECORDS)
+
+        # The SAME admission rule the rotating file handler uses, so the
+        # clipboard and the disk sink cannot drift apart on what counts as
+        # metadata-only. Reused as an object, not re-implemented.
+        share_admission = PersistentDiagnosticFilter()
+
+        def _share_line(record, formatted, formatter):
+            """Return the metadata-only form of one record for the clipboard.
+
+            Schema-validated ADR-029 metadata events pass through verbatim --
+            they are already the safe artifact. Everything else keeps its
+            timestamp, logger, level and exception type, and loses its message
+            body: the body is where interpolated paths, titles, queries,
+            prompts, tool arguments and provider payloads live, and no
+            sink-side rule can tell those apart from the wording around them.
+            """
+            if share_admission.filter(record):
+                return formatted
+            detail = ""
+            exc_type = record.exc_info[0] if record.exc_info else None
+            if exc_type is not None:
+                name = safe_metadata_token(getattr(exc_type, "__name__", ""))
+                detail = f" (exception_type={name})"
+            stamp = formatter.formatTime(record, formatter.datefmt)
+            return (
+                f"{stamp} - {record.name} - {record.levelname} - "
+                f"{REDACTION_MARKER}{detail}"
+            )
 
         # Create a custom handler that stores logs in the buffer
         class PersistentLogHandler(logging.Handler):
@@ -7851,8 +7912,10 @@ class TldwCli(
 
             def emit(self, record):
                 try:
-                    msg = self.format(record)
-                    self.buffer.append(msg)
+                    formatted = self.format(record)
+                    formatter = self.formatter or logging.Formatter()
+                    self.buffer.append(_share_line(record, formatted, formatter))
+                    msg = redact_log_line(formatted)
                     self.app._log_records.append((record.levelname, record.name, msg))
 
                     # Preferred live path: the Logs screen's LogsWindow applies
@@ -7904,8 +7967,15 @@ class TldwCli(
         self._current_log_widget = None
 
     def _display_buffered_logs(self, log_widget):
-        """Display all buffered logs in the RichLog widget."""
-        if not hasattr(self, "_log_buffer"):
+        """Display all buffered logs in the RichLog widget.
+
+        Reads ``_log_records`` (the live-view store), NOT ``_log_buffer``
+        (the metadata-only clipboard artifact) -- TASK-19555. This legacy
+        path currently has no callers; it is pointed at the right store so
+        that reviving it shows a maintainer real diagnostics rather than a
+        screen of redaction markers.
+        """
+        if not hasattr(self, "_log_records"):
             return
 
         # Store reference to current log widget
@@ -7915,13 +7985,13 @@ class TldwCli(
         log_widget.clear()
 
         # Write all buffered messages to the widget
-        for msg in self._log_buffer:
+        for _level, _name, msg in self._log_records:
             log_widget.write(msg)
 
         # Scroll to the latest entry
         log_widget.scroll_end()
 
-        logger.debug(f"Displayed {len(self._log_buffer)} buffered log entries")
+        logger.debug(f"Displayed {len(self._log_records)} buffered log entries")
 
     def _setup_logging(self):
         """Set up logging for the application.


### PR DESCRIPTION
## Summary
Closes task-19555 (P1, privacy). ADR-029's "persistent logs are metadata-only" guarantee is enforced by `PersistentDiagnosticFilter`, attached in exactly two places — **both the rotating file handler**. The file sink is airtight. But `PersistentLogHandler` was installed unconditionally at level NOTSET with **no filter**, feeding an **unbounded** buffer; the Logs window did no sanitization; and "Copy all" joined the entire session to the system clipboard — under empty-state text telling the user to reproduce the problem and share their logs.

The privacy suite proved this **by omission**: it attaches both a filtered file handler and an unfiltered collector, and asserts only against the file.

## Design — deviates from the filed suggestion, and the AC was rewritten with the original struck through
`PersistentDiagnosticFilter` is an all-or-nothing **admission** filter, not a redactor: 12 `persist_event` call sites against ~6,081 loguru call sites, so attaching it at `emit` would drop >99.8% of records. The chips, regex filter, counters and next-error jump would all operate on the output of 12 call sites. That is not a privacy fix with a usability cost — it is deleting the screen.

Instead, the two stores already fed by the one `emit` each get **one job**:
- **live view / "Copy visible logs"** — descriptive, but never credentials and never the OS account name (`/Users/janedoe/x.pdf` → `~/x.pdf`);
- **"Copy all (redacted)"** — metadata-only, decided by the *same filter class* the file handler uses, so clipboard and disk cannot drift.

Buffer bounded to 10,000 records; lines capped at 2,000 characters **before** redaction — strictly less data, not a bypass, and 45× faster on a 100 KB line.

## Two real bugs found alongside
- `log_sanitizer._is_sensitive_log_key` computed a hyphen normalization and then passed the **raw** key to an underscore-suffix checker, so `x-auth-token`, `x-session-key` and `x-client-secret` — exactly what provider request logging emits — were classified harmless.
- The home-path pattern was case-sensitive throughout, so `c:\users\<name>` and `\\SERVER\Users\<name>` kept the account name. Now split into POSIX (case-sensitive, so REST URLs are untouched) and Windows (fully case-insensitive, plus a UNC form).

## Review: FIX-FIRST, then addressed
The reviewer adjudicated the design deviation **in the implementation's favour** and strengthened it with the call-site census above. Its substantive catch: the two **stores** were pinned but the live **feed** was not — its mutation survived 111 passed / 0 failed. No production code was wrong there; the tests were missing. Both feeds are now pinned and that exact mutation reds.

It also caught an absolute claim — "API keys … are always removed" — shipping in five places while several common token formats survived into the live view. In a task whose thesis is *disclose what you cannot remove*, that was the one sentence that could not ship. It now reads "recognised API-key formats", and the denylist was widened by six shapes rather than only softening the words. On bare `key=`, a census (all five such labels in the package are non-secrets, and redacting them would blind a diagnostic reporting *which* config key failed to decrypt) settled it as a wording fix.

## Note on the branch shape
Collapsed to a single commit: GitHub push protection rejected an earlier commit over a **synthetic** test fixture in the real Slack token format. The scanner was right to fire, so the fixture is now assembled at runtime — the redactor under test receives the identical string — rather than clicking through the unblock URL. A repo that trains people to bypass push protection is worse off than one with an awkward fixture.

882 passed / 0 failed on the targeted sweep; 53,857 collected repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes TASK-19555 by sealing the in‑app log share path and bounding the session buffer to uphold ADR‑029. Previously the in‑app collector buffered unfiltered logs and “Copy all” exported raw text; now the live feed is redacted and “Copy all (redacted)” exports metadata only.

- Apply sink-side redaction in `PersistentLogHandler.emit`: strip recognised credentials (Bearer, URL userinfo, labelled values, and standalone shapes for OpenAI/Anthropic/OpenRouter, Google, GitHub, Hugging Face, AWS, Slack, JWT) and home-directory usernames; fix hyphen-normalised key checks.
- Build the share artifact with `PersistentDiagnosticFilter` (metadata-only); keep the live view descriptive but never with credentials or OS account names; relabel UI (“Copy all (redacted)”) and notifications.
- Bound `_log_buffer` and `_log_records` to 10,000; truncate oversized lines at a token boundary, redact the remainder, withhold a single unbroken token larger than the cap, and append a length notice.
- Anchor home‑path redaction: segment‑bounded literal home replacements; POSIX case‑sensitive roots; Windows case‑insensitive drive and UNC forms.
- Pin tests to the real collector and both live feeds; add astride‑boundary and path‑anchoring regressions; assemble synthetic credentials at runtime; update docs to reflect DEBUG scope and “Sharing logs safely”.

<sup>Written for commit 012ed6ab81ff74339d1b60ed557a12d2d69f354e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

