### PR TITLE
fix(ui): repair two reachable paths broken by retired-surface drift (task-19576)

### DIFF
--- a/Docs/User_Guide/console/attachments-images-voice.md
+++ b/Docs/User_Guide/console/attachments-images-voice.md
@@ -195,4 +195,9 @@ start it.
   check the OS microphone permission for your terminal and try again.
 
 —
-*Verified against dev @ ff435772c — 2026-07-31*
+*Verified against dev @ ff435772c — 2026-07-31. Verified against
+db6834c0c — 2026-08-21 (task-19576): PDF/Word/ebook attachments now
+extract real content via `parse_local_file_for_ingest` instead of a
+placeholder pointing at a retired "Media Ingestion tab" — no wording
+change needed here, since "the full content is what actually gets sent"
+was already the documented (if previously unmet) behavior.*

--- a/Tests/Chat/test_attachment_local_ingestion_extraction.py
+++ b/Tests/Chat/test_attachment_local_ingestion_extraction.py
@@ -1,0 +1,232 @@
+"""Task-19576: PDF/Word/ebook Console attachments used to return a
+placeholder pointing at a retired "Media Ingestion tab" instead of
+extracting real content -- and the plaintext-over-100KB handler pointed at
+the same retired destination (5 sites total in `file_handlers.py`, not the
+3 an earlier review summary named). All five now either extract real text
+via `parse_local_file_for_ingest` (the same extractor Library ▸ Import
+uses -- PDF/document/ebook) or, where the design intent is a deliberate
+size-based deferral rather than a missing-capability stub (plaintext over
+100KB), point at "Library" -- a real, live route -- instead of the retired
+name.
+
+Born-red: at base (before the fix), the PDF test below fails because the
+handler returns the literal placeholder string ("[PDF File: ...]\\nTo
+process this PDF file, please use the Media Ingestion tab.") instead of
+extracted text; it passes once the handler routes through the real
+extractor.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from tldw_chatbook.Local_Ingestion import local_file_ingestion
+from tldw_chatbook.Utils.file_handlers import (
+    DocumentFileHandler,
+    EbookFileHandler,
+    PDFFileHandler,
+    PlaintextDatabaseHandler,
+)
+
+# The exact retired-destination string the old placeholders used. Every
+# assertion below checks actual returned (user-visible) copy, not source
+# comments -- this module's own docstrings/comments legitimately mention
+# the retired name while explaining the fix, so a blanket source-file grep
+# would false-positive on those.
+_RETIRED_DESTINATION = "Media Ingestion tab"
+
+
+def _make_processor_result(content: str, **overrides: Any) -> Dict[str, Any]:
+    """Mirror the result shape `process_pdf`/`process_document`/
+    `process_ebook` return (see `Tests/Local_Ingestion/
+    test_local_file_ingestion.py`'s `_make_pdf_result`/`_make_ebook_result`
+    for the same shape)."""
+    result = {
+        "status": "Success",
+        "content": content,
+        "title": "Extracted title",
+        "author": "Extracted author",
+        "keywords": [],
+        "chunks": [],
+        "analysis": "",
+        "metadata": {},
+        "error": None,
+        "warnings": [],
+    }
+    result.update(overrides)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_pdf_attachment_extracts_real_text_not_placeholder(tmp_path):
+    """Born-red: builds a REAL, minimal PDF with pymupdf/fitz (already a
+    project dependency via PDF_Processing_Lib) and drives it through the
+    real, unmocked extraction chain -- proving the handler returns
+    genuinely extracted text, not a stand-in.
+    """
+    fitz = pytest.importorskip("fitz")
+
+    pdf_path = tmp_path / "report.pdf"
+    document = fitz.open()
+    page = document.new_page()
+    page.insert_text((72, 72), "Task-19576 real extracted PDF content.")
+    document.save(str(pdf_path))
+    document.close()
+
+    processed = await PDFFileHandler().process(pdf_path)
+
+    assert "Task-19576 real extracted PDF content." in processed.content
+    assert _RETIRED_DESTINATION not in processed.content
+
+
+@pytest.mark.asyncio
+async def test_document_attachment_routes_through_local_ingestion_extractor(
+    tmp_path, monkeypatch
+):
+    """Document extraction routes through `parse_local_file_for_ingest` ->
+    `process_document`, monkeypatched here (the idiom
+    `test_local_file_ingestion.py` uses) so this stays fast/deterministic
+    rather than depending on python-docx internals."""
+    docx_path = tmp_path / "report.docx"
+    # detect_file_type is purely extension-based; the bytes never need to
+    # be a real docx since process_document is mocked below.
+    docx_path.write_bytes(b"PK\x03\x04" + b"\x00" * 32)
+
+    monkeypatch.setattr(
+        local_file_ingestion,
+        "process_document",
+        lambda **kwargs: _make_processor_result("Real document body text."),
+    )
+
+    processed = await DocumentFileHandler().process(docx_path)
+
+    assert "Real document body text." in processed.content
+    assert _RETIRED_DESTINATION not in processed.content
+
+
+@pytest.mark.asyncio
+async def test_ebook_attachment_routes_through_local_ingestion_extractor(
+    tmp_path, monkeypatch
+):
+    epub_path = tmp_path / "book.epub"
+    epub_path.write_bytes(b"PK\x03\x04" + b"\x00" * 32)
+
+    monkeypatch.setattr(
+        local_file_ingestion,
+        "process_ebook",
+        lambda **kwargs: _make_processor_result("Real chapter one text."),
+    )
+
+    processed = await EbookFileHandler().process(epub_path)
+
+    assert "Real chapter one text." in processed.content
+    assert _RETIRED_DESTINATION not in processed.content
+
+
+@pytest.mark.asyncio
+async def test_pdf_extraction_failure_is_honest_not_a_retired_placeholder(
+    tmp_path, monkeypatch
+):
+    """A genuine extraction failure must not fall back to the old
+    placeholder or name any retired destination -- it should say what
+    actually happened."""
+    pdf_path = tmp_path / "corrupt.pdf"
+    pdf_path.write_bytes(b"not a real pdf")
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated extraction failure")
+
+    monkeypatch.setattr(local_file_ingestion, "process_pdf", _boom)
+
+    processed = await PDFFileHandler().process(pdf_path)
+
+    assert _RETIRED_DESTINATION not in processed.content
+    assert "simulated extraction failure" in processed.content
+
+
+@pytest.mark.asyncio
+async def test_plaintext_over_100kb_no_longer_names_the_retired_tab(tmp_path):
+    """`PlaintextDatabaseHandler` intercepts text files over 100KB and
+    defers to Library's RAG-searchable ingestion rather than inlining the
+    whole file -- a deliberate cost/context-window choice, not a
+    missing-capability stub. Only the (retired) destination name changes.
+    """
+    big_text = tmp_path / "notes.txt"
+    big_text.write_text("x" * (150 * 1024))
+
+    handler = PlaintextDatabaseHandler()
+    assert handler.can_handle(big_text) is True
+
+    processed = await handler.process(big_text)
+
+    assert _RETIRED_DESTINATION not in processed.content
+    assert "Library" in processed.content
+
+
+@pytest.mark.asyncio
+async def test_plaintext_over_10mb_no_longer_names_the_retired_tab(tmp_path):
+    """The hard 10MB cap branch of the same handler (no content at all,
+    just the too-large notice)."""
+    huge_text = tmp_path / "huge.txt"
+    huge_text.write_bytes(b"x" * (11 * 1024 * 1024))
+
+    processed = await PlaintextDatabaseHandler().process(huge_text)
+
+    assert _RETIRED_DESTINATION not in processed.content
+    assert "Library" in processed.content
+
+
+@pytest.mark.asyncio
+async def test_no_handler_output_names_the_retired_media_ingestion_tab(
+    tmp_path, monkeypatch
+):
+    """Census (task-19576 AC): drive every one of the five sites the task
+    identified and grep the actual returned (user-visible) copy -- not
+    source comments -- for the retired destination name."""
+    monkeypatch.setattr(
+        local_file_ingestion,
+        "process_document",
+        lambda **kwargs: _make_processor_result("doc body"),
+    )
+    monkeypatch.setattr(
+        local_file_ingestion,
+        "process_ebook",
+        lambda **kwargs: _make_processor_result("ebook body"),
+    )
+
+    fitz = pytest.importorskip("fitz")
+    pdf_path = tmp_path / "x.pdf"
+    document = fitz.open()
+    document.new_page()  # deliberately blank: exercises the "no
+    # extractable text" fallback copy too
+    document.save(str(pdf_path))
+    document.close()
+
+    docx_path = tmp_path / "x.docx"
+    docx_path.write_bytes(b"PK\x03\x04")
+    epub_path = tmp_path / "x.epub"
+    epub_path.write_bytes(b"PK\x03\x04")
+    big_text = tmp_path / "big.txt"
+    big_text.write_text("y" * (150 * 1024))
+    huge_text = tmp_path / "huge.txt"
+    huge_text.write_bytes(b"y" * (11 * 1024 * 1024))
+
+    outputs = {
+        "pdf": (await PDFFileHandler().process(pdf_path)).content,
+        "document": (await DocumentFileHandler().process(docx_path)).content,
+        "ebook": (await EbookFileHandler().process(epub_path)).content,
+        "plaintext_over_100kb": (
+            await PlaintextDatabaseHandler().process(big_text)
+        ).content,
+        "plaintext_over_10mb": (
+            await PlaintextDatabaseHandler().process(huge_text)
+        ).content,
+    }
+
+    for site, output in outputs.items():
+        assert _RETIRED_DESTINATION not in output, (
+            f"{site} handler output still names the retired destination: "
+            f"{output!r}"
+        )

--- a/Tests/UI/test_stts_audiobook_import_scope_services.py
+++ b/Tests/UI/test_stts_audiobook_import_scope_services.py
@@ -1,0 +1,261 @@
+"""Task-19576: STTS AudioBook "Import from Notes"/"Import from Conversation"
+used to crash with an uncaught `ImportError`.
+
+`_import_from_notes` imported `fetch_all_notes`/`fetch_note_by_id` and
+`_import_from_conversation` imported `fetch_all_conversations`/
+`fetch_messages_by_conversation_id`, all four from
+`tldw_chatbook.DB.ChaChaNotes_DB` -- none of which exist there (a regex for
+``def fetch_all_notes`` etc. returns zero matches). The imports sat OUTSIDE
+the ``try:`` blocks in both methods, so the resulting `ImportError`
+propagated on every use, on the live, routed path: `stts` route ->
+`STTSScreen` -> rail entry "AudioBook/Podcast" -> the "Import From"
+Select's Notes/Conversation options -> `#import-content-btn` ->
+`_import_content` -> `_import_from_notes`/`_import_from_conversation`.
+
+Born-red: every test below that calls `_import_from_notes()`/
+`_import_from_conversation()` directly (no `pytest.raises` wrapper) fails
+at base with that exact `ImportError` propagating out of the call --
+`cannot import name 'fetch_all_notes' from
+'tldw_chatbook.DB.ChaChaNotes_DB'`, and similarly for the other three
+names. They pass once both methods route through the live
+`notes_scope_service`/`chat_conversation_scope_service` seams instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import TextArea
+
+from tldw_chatbook.UI.STTS_Window import AudioBookGenerationWidget
+
+
+class _Host(App[None]):
+    def compose(self) -> ComposeResult:
+        yield AudioBookGenerationWidget()
+
+
+class _FakeNotesScopeService:
+    """Minimal stand-in for `notes_scope_service`, matching the async
+    `list_notes(*, scope, user_id, limit=..., offset=...)` contract."""
+
+    def __init__(self, notes: list[dict[str, Any]]) -> None:
+        self._notes = notes
+
+    async def list_notes(self, *, scope, user_id, limit: int = 100, offset: int = 0):
+        return list(self._notes)
+
+
+class _FakeConversationScopeService:
+    """Minimal stand-in for `chat_conversation_scope_service`, matching the
+    async `list_conversations`/`get_messages_with_context` contracts."""
+
+    def __init__(
+        self,
+        items: list[dict[str, Any]],
+        messages_by_id: dict[str, list[dict[str, Any]]],
+    ) -> None:
+        self._items = items
+        self._messages_by_id = messages_by_id
+
+    async def list_conversations(self, *, mode: str = "local", **kwargs: Any):
+        limit = kwargs.get("limit", 100)
+        return {
+            "items": list(self._items),
+            "pagination": {
+                "limit": limit,
+                "offset": 0,
+                "total": len(self._items),
+                "has_more": False,
+            },
+        }
+
+    async def get_messages_with_context(
+        self,
+        conversation_id: str,
+        *,
+        mode: str = "server",
+        limit: int = 200,
+        offset: int = 0,
+        include_rag_context: bool = True,
+    ):
+        messages = self._messages_by_id.get(conversation_id, [])
+        return messages[offset : offset + limit]
+
+
+@pytest.mark.asyncio
+async def test_import_from_notes_no_longer_crashes_and_loads_real_note_content():
+    """Primary born-red for the notes path (see module docstring)."""
+    app = _Host()
+    app.notes_scope_service = _FakeNotesScopeService(
+        [
+            {
+                "id": "note-1",
+                "title": "My Note",
+                "content": "Hello from a real note.",
+                "created_at": "2026-01-01",
+            }
+        ]
+    )
+    app.notes_user_id = "default_user"
+
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        # This line is where the base code raises ImportError.
+        widget._import_from_notes()
+        await pilot.pause()
+
+        # NOTE: the worker is suspended awaiting the dialog's dismissal
+        # (`wait_for_dismiss=True`), so `workers.wait_for_complete()` must
+        # not be called until AFTER `dismiss()` below -- calling it first
+        # would deadlock forever waiting on a worker that is waiting on us.
+        assert type(app.screen).__name__ == "NoteSelectionDialog"
+        app.screen.dismiss(["note-1"])
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+
+        assert "Hello from a real note." in widget.content_text
+        content_preview = app.query_one("#content-preview", TextArea)
+        assert content_preview.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_import_from_notes_notifies_instead_of_crashing_when_unavailable():
+    """Worst case: no `notes_scope_service` wired at all (a bare host, as
+    used elsewhere in this test module). At base this still raises
+    ImportError; after the fix it degrades to a notify."""
+    app = _Host()
+    notifications: list[tuple[Any, dict[str, Any]]] = []
+
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        app.notify = lambda *a, **k: notifications.append((a, k))
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        widget._import_from_notes()
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+
+        assert notifications, "expected a graceful notify, not a crash"
+        assert widget.is_mounted
+
+
+@pytest.mark.asyncio
+async def test_import_from_conversation_no_longer_crashes_and_loads_real_messages():
+    """Primary born-red for the conversation path (see module docstring)."""
+    app = _Host()
+    app.chat_conversation_scope_service = _FakeConversationScopeService(
+        items=[
+            {
+                "id": "conv-1",
+                "title": "Chat",
+                "message_count": 2,
+                "created_at": "2026-01-01",
+                "last_modified": "2026-01-02",
+            }
+        ],
+        messages_by_id={
+            "conv-1": [
+                {"role": "user", "content": "Hi there"},
+                {
+                    "role": "assistant",
+                    "content": "Hello! Real conversation content.",
+                },
+            ]
+        },
+    )
+
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        # This line is where the base code raises ImportError.
+        widget._import_from_conversation()
+        await pilot.pause()
+
+        # See the notes test above: do not wait_for_complete() before dismiss.
+        assert type(app.screen).__name__ == "ConversationSelectionDialog"
+        app.screen.dismiss(
+            {
+                "conversation_id": "conv-1",
+                "include_all": True,
+                "include_user": False,
+                "include_assistant": False,
+                "include_speakers": True,
+            }
+        )
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+
+        assert "Hi there" in widget.content_text
+        assert "Real conversation content." in widget.content_text
+
+
+@pytest.mark.asyncio
+async def test_import_from_conversation_role_filter_is_case_insensitive():
+    """Regression: the removed code compared `role != "user"` against
+    ``sender`` values the DB actually stores capitalized ("User"), so
+    "User messages only"/"Assistant messages only" could never match
+    anything. The rewritten filter normalizes case."""
+    app = _Host()
+    app.chat_conversation_scope_service = _FakeConversationScopeService(
+        items=[
+            {
+                "id": "conv-1",
+                "title": "Chat",
+                "message_count": 2,
+                "created_at": "2026-01-01",
+                "last_modified": "2026-01-02",
+            }
+        ],
+        messages_by_id={
+            "conv-1": [
+                {"role": "User", "content": "user turn"},
+                {"role": "Assistant", "content": "assistant turn"},
+            ]
+        },
+    )
+
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        widget._import_from_conversation()
+        await pilot.pause()
+
+        app.screen.dismiss(
+            {
+                "conversation_id": "conv-1",
+                "include_all": False,
+                "include_user": True,
+                "include_assistant": False,
+                "include_speakers": False,
+            }
+        )
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+
+        assert "user turn" in widget.content_text
+        assert "assistant turn" not in widget.content_text
+
+
+@pytest.mark.asyncio
+async def test_import_from_conversation_notifies_instead_of_crashing_when_unavailable():
+    app = _Host()
+    notifications: list[tuple[Any, dict[str, Any]]] = []
+
+    async with app.run_test(size=(120, 48)) as pilot:
+        await pilot.pause()
+        app.notify = lambda *a, **k: notifications.append((a, k))
+        widget = app.query_one(AudioBookGenerationWidget)
+
+        widget._import_from_conversation()
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+
+        assert notifications, "expected a graceful notify, not a crash"
+        assert widget.is_mounted

--- a/backlog/tasks/task-19576 - Two reachable user paths are broken by retired-surface drift - STTS AudioBook import crashes and Console file attach.md
+++ b/backlog/tasks/task-19576 - Two reachable user paths are broken by retired-surface drift - STTS AudioBook import crashes and Console file attach.md
@@ -3,8 +3,8 @@ id: TASK-19576
 title: >-
   Two reachable user paths broken by retired-surface drift — STTS AudioBook
   import crashes, Console PDF/Word/ebook attach points at a retired tab
-status: To Do
-assignee: []
+status: Done
+assignee: [claude]
 created_date: '2026-08-21 20:22'
 labels:
   - bug
@@ -74,20 +74,155 @@ already trusted on another surface.
 
 ## Acceptance Criteria
 
-- [ ] STTS AudioBook "Import from Notes" and "Import from Conversation"
+- [x] STTS AudioBook "Import from Notes" and "Import from Conversation"
       complete without raising, using `notes_scope_service` /
       `chat_conversation_scope_service`
-- [ ] The imports at `STTS_Window.py:592/605/648/666` no longer reference
+- [x] The imports at `STTS_Window.py:592/605/648/666` no longer reference
       symbols that do not exist
-- [ ] Attaching a PDF, Word document or ebook in Console extracts real content
+- [x] Attaching a PDF, Word document or ebook in Console extracts real content
       via `parse_local_file_for_ingest`, rather than returning a placeholder
-- [ ] All five `file_handlers.py` placeholder sites are resolved, not just the
+- [x] All five `file_handlers.py` placeholder sites are resolved, not just the
       three named in the review summary
-- [ ] No user-facing string anywhere directs the user to the "Media Ingestion
+- [x] No user-facing string anywhere directs the user to the "Media Ingestion
       tab" or any other retired destination — a test greps for retired
       destination names in user-visible copy
-- [ ] Both paths are verified by actually driving the app, not only by unit
+- [x] Both paths are verified by actually driving the app, not only by unit
       test — these are runtime reachability defects and a green import test
       would not have caught either
-- [ ] `Docs/User_Guide/` pages covering STTS AudioBook import and Console
+- [x] `Docs/User_Guide/` pages covering STTS AudioBook import and Console
       attachments are updated to match the repaired behaviour
+
+## Implementation Plan
+
+1. **Defect A (STTS AudioBook import).** Replace the two nonexistent-import
+   sites in `UI/STTS_Window.py` (`_import_from_notes`,
+   `_import_from_conversation`) with async workers that route through
+   `self.app.notes_scope_service.list_notes(scope=ScopeType.LOCAL_NOTE, ...)`
+   and `self.app.chat_conversation_scope_service.list_conversations(...)` /
+   `.get_messages_with_context(...)` -- the same seams Home/Library already
+   use (`getattr(self.app_instance, "notes_scope_service", None)` pattern).
+   Dispatch via `@work` since the services are async; use
+   `await self.app.push_screen(dialog, wait_for_dismiss=True)` for the
+   existing `NoteSelectionDialog`/`ConversationSelectionDialog` modals
+   instead of the old sync-callback form. Degrade to a notify (not a crash)
+   when the service attribute is absent.
+2. **Defect B (file_handlers.py census).** Read all five placeholder sites
+   confirmed by the task description. Add a shared
+   `_extract_local_ingest_text` helper that calls
+   `parse_local_file_for_ingest` off-thread (`asyncio.to_thread`, no DB
+   write, no LLM analysis) and wire `PDFFileHandler`/`DocumentFileHandler`/
+   `EbookFileHandler` to it, each with an honest failure-path message on
+   exception. For `PlaintextDatabaseHandler`'s two sites (a deliberate
+   size-based deferral, not a missing-capability stub), keep the existing
+   behavior and only fix the destination name to "the Library tab" (a live
+   route; Library is not itself aliased away).
+3. Add born-red tests for both defects, confirming failure at the
+   pre-fix base (origin/dev) and success after the fix.
+4. Run the STTS suites, Chat attachment tests, and a repo-wide
+   `--collect-only -q` sweep; baseline any unrelated failure against a
+   clean `origin/dev` checkout before attributing it to this change.
+5. Live-verify both paths in the real, running TUI (`verify` skill,
+   isolated scratch profile) rather than relying on unit tests alone.
+6. Update `Docs/User_Guide/console/attachments-images-voice.md`'s
+   "Verified against" stamp (its prose already described the target
+   behavior; the fix makes that prose true rather than requiring a wording
+   change).
+
+## Implementation Notes
+
+**Defect A.** `_import_from_notes`/`_import_from_conversation` in
+`UI/STTS_Window.py` are now thin sync dispatchers to new async
+`@work`-decorated methods (`_import_from_notes_worker`,
+`_import_from_conversation_worker`). Notes: `notes_scope_service.list_notes`
+already returns full note rows (title+content, not previews), so selected
+notes are combined straight from that one page -- no second per-note fetch.
+Conversations: `chat_conversation_scope_service.list_conversations(mode=
+"local", scope_type="all", ...)` lists, then
+`.get_messages_with_context(conversation_id, mode="local", ...)` pages
+messages (200/page, capped at 5000 total) -- the removed
+`fetch_messages_by_conversation_id` had no limit at all, so this is a
+deliberate bound, not a behavior regression. Both dialogs are shown via
+`await self.app.push_screen(dialog, wait_for_dismiss=True)` instead of the
+old sync-callback form; both workers degrade to a notify (never a crash)
+when their scope-service attribute is absent. Fixed a latent bug found
+while rewriting the conversation path: the removed code compared
+`role != "user"` against `sender` values the DB stores capitalized
+("User"), so the "User/Assistant messages only" radio options could never
+have matched anything even before the crash -- the new filter
+case-normalizes.
+
+**Defect B.** Census of `Utils/file_handlers.py` found exactly the five
+sites the task named. Disposition:
+- `PDFFileHandler`, `DocumentFileHandler`, `EbookFileHandler` (3 sites) --
+  wired to a new shared `_extract_local_ingest_text` helper that calls
+  `parse_local_file_for_ingest` (the same extractor Library ▸ Import uses)
+  off-thread via `asyncio.to_thread`, with `options={}` (no chunking, no
+  LLM analysis -- `perform_analysis` defaults False). An extraction
+  failure or empty-text result produces an honest message naming no
+  destination, instead of falling back to the old placeholder.
+- `PlaintextDatabaseHandler`'s two sites (>100KB, >10MB) -- kept the
+  existing deliberate size-based deferral (large text files are NOT
+  inlined into a chat turn's context; this is a genuine cost/context-
+  window concern, not a missing-capability stub) and only fixed the
+  destination name, from the retired "Media Ingestion tab" to "the Library
+  tab" (a live, un-aliased route -- `media`/`ingest` themselves alias to
+  `library` in `screen_registry.py`).
+- No new size cap was invented for PDF/document/ebook: the existing
+  `Chat/attachment_core.py` `MAX_ATTACHMENT_BYTES` (100MB) already gates
+  every attachment before any handler runs, and Library ▸ Import imposes
+  no additional file-size cap of its own at this layer either.
+
+**Born-red evidence.**
+- `Tests/UI/test_stts_audiobook_import_scope_services.py` (5 tests): each
+  calls `_import_from_notes()`/`_import_from_conversation()` directly (no
+  `pytest.raises`); at `origin/dev` baseline all 5 fail with the exact
+  `ImportError: cannot import name 'fetch_all_notes' from
+  'tldw_chatbook.DB.ChaChaNotes_DB'` signature (and the three sibling
+  names). All 5 pass after the fix, driving real fake-service note/
+  conversation selection through to `widget.content_text`.
+- `Tests/Chat/test_attachment_local_ingestion_extraction.py` (7 tests):
+  the primary one builds a REAL PDF with fitz/pymupdf and drives it
+  through the unmocked extraction chain, asserting genuinely extracted
+  text comes back and the retired-tab string does not; a census test
+  drives all five sites and greps their actual returned copy (not source
+  comments) for the retired name. All 7 fail at `origin/dev` baseline
+  (showing the literal old placeholder strings) and pass after the fix.
+- Both baselines were confirmed against a clean, separate `origin/dev`
+  worktree (not by reverting this branch), per repo convention.
+
+**Live verification.** Used the `verify` skill with an isolated scratch
+`TLDW_CONFIG_PATH` profile (real user config/DB confirmed untouched
+afterward): clicked STTS ▸ Speech ▸ AudioBook/Podcast ▸ Import Content for
+both "Notes" and "Conversation" sources on a real running app -- no crash,
+app remained fully navigable, and the in-app Logs screen showed 0 errors
+across both clicks (proving no ImportError, since the base code's crash
+was synchronous and would have surfaced there). Separately, pasted a real
+PDF's path into a real Console composer (a fresh provider-configured
+scratch profile) and confirmed via the Logs screen that the full real
+pipeline ran end to end: `Chat.attachment_core` → `Local_Ingestion.
+local_file_ingestion` → `Local_Ingestion.PDF_Processing_Lib` ("Text
+extracted successfully ... using pymupdf4llm" / "Successfully processed
+PDF") -- not the old placeholder, which performed no I/O and logged
+nothing.
+
+**Surprise / out-of-scope finding.** `Tests/Architecture/
+test_persistent_diagnostic_inventory.py::test_production_diagnostic_inventory_and_sink_topology_are_unchanged`
+fails on a clean `origin/dev` checkout with zero of this task's changes
+(confirmed in an isolated worktree) -- pre-existing drift between
+`Docs/security/production-diagnostic-inventory.json` and the current
+source, unrelated to task-19576 and spanning ~10 files this task never
+touched (`ChaChaNotes_DB.py`, `console_chat_controller.py`,
+`chat_screen.py`, `library_screen.py`, etc.). This task's own 3 new
+`logger.error(...)` call sites (in the new PDF/Document/Ebook extraction
+failure paths) were reviewed for safety -- they log only the filename and
+exception message, matching the existing safe pattern already used by
+every other handler in this file -- but regenerating the inventory
+wholesale would have bundled ~10 unrelated files' drift into this
+branch's diff, so that regeneration was reverted and left for whoever
+owns the broader drift. Not fixed here; flagging for the owner.
+
+**Files changed:** `tldw_chatbook/UI/STTS_Window.py`,
+`tldw_chatbook/Utils/file_handlers.py`,
+`Docs/User_Guide/console/attachments-images-voice.md` (stamp only),
+`Tests/UI/test_stts_audiobook_import_scope_services.py` (new),
+`Tests/Chat/test_attachment_local_ingestion_extraction.py` (new).

--- a/tldw_chatbook/UI/STTS_Window.py
+++ b/tldw_chatbook/UI/STTS_Window.py
@@ -585,149 +585,276 @@ class AudioBookGenerationWidget(Widget):
             self.app.notify(f"Failed to import file: {e}", severity="error")
 
     def _import_from_notes(self) -> None:
-        """Import content from notes"""
+        """Import content from notes.
+
+        Task-19576: this used to import `fetch_all_notes`/`fetch_note_by_id`
+        from `tldw_chatbook.DB.ChaChaNotes_DB` -- neither function exists,
+        and the imports sat outside the `try:` block, so every use of this
+        action crashed with an uncaught `ImportError`. This now routes
+        through the shared `notes_scope_service` seam (the same one
+        Library/Home use) instead of resurrecting module-level DB
+        functions. The service is async, so the actual work happens in
+        `_import_from_notes_worker`.
+        """
+        self._import_from_notes_worker()
+
+    @work(exclusive=True, group="audiobook-import-notes")
+    async def _import_from_notes_worker(self) -> None:
+        """Worker half of `_import_from_notes` (see its docstring)."""
+        from tldw_chatbook.Notes.notes_scope_service import ScopeType
         from tldw_chatbook.Widgets.Note_Widgets.note_selection_dialog import (
             NoteSelectionDialog,
         )
-        from tldw_chatbook.DB.ChaChaNotes_DB import fetch_all_notes
+
+        notes_scope_service = getattr(self.app, "notes_scope_service", None)
+        if notes_scope_service is None:
+            self.app.notify(
+                "Notes are unavailable in this session.", severity="error"
+            )
+            return
+
+        user_id = getattr(self.app, "notes_user_id", None) or "default_user"
 
         try:
-            # Fetch all notes from database
-            notes = fetch_all_notes()
-            if not notes:
-                self.app.notify("No notes found in database", severity="warning")
-                return
-
-            # Show note selection dialog
-            def handle_note_selection(selected_ids: Optional[List[int]]) -> None:
-                if selected_ids:
-                    # Fetch full content for selected notes
-                    from tldw_chatbook.DB.ChaChaNotes_DB import fetch_note_by_id
-
-                    combined_content = []
-
-                    for note_id in selected_ids:
-                        note = fetch_note_by_id(note_id)
-                        if note:
-                            # Add note title as chapter if it exists
-                            if note.get("title"):
-                                combined_content.append(f"# {note['title']}\n")
-                            combined_content.append(note.get("content", ""))
-                            combined_content.append("\n\n")  # Separator between notes
-
-                    # Load combined content
-                    self.content_text = "\n".join(combined_content)
-                    content_preview = self.query_one("#content-preview", TextArea)
-                    preview_text = (
-                        self.content_text[:1000] + "..."
-                        if len(self.content_text) > 1000
-                        else self.content_text
-                    )
-                    content_preview.load_text(preview_text)
-                    content_preview.disabled = False
-
-                    # Auto-detect chapters (see task-15478: the switch that
-                    # used to gate this is gone from the composed UI).
-                    self._detect_chapters()
-
-                    self.app.notify(
-                        f"Imported {len(selected_ids)} note(s)", severity="information"
-                    )
-
-            self.app.push_screen(NoteSelectionDialog(notes), handle_note_selection)
-
+            notes = await notes_scope_service.list_notes(
+                scope=ScopeType.LOCAL_NOTE,
+                user_id=user_id,
+            )
         except Exception as e:
             logger.error(f"Failed to import from notes: {e}")
             self.app.notify(f"Failed to import notes: {e}", severity="error")
+            return
+
+        if not notes:
+            self.app.notify("No notes found in database", severity="warning")
+            return
+
+        # `list_notes` already returns full note rows (title + content, not
+        # a preview), so the notes selected in the dialog below can be
+        # combined straight from this same page -- no second per-note fetch
+        # needed.
+        notes_by_id: Dict[str, Dict[str, Any]] = {}
+        dialog_notes: List[Dict[str, Any]] = []
+        for note in notes:
+            note_id = note.get("id")
+            if note_id is None:
+                continue
+            note_id = str(note_id)
+            notes_by_id[note_id] = note
+            dialog_notes.append(
+                {
+                    "note_id": note_id,
+                    "title": note.get("title", ""),
+                    "content": note.get("content", ""),
+                    "created_at": note.get("created_at", "Unknown"),
+                }
+            )
+
+        try:
+            selected_ids = await self.app.push_screen(
+                NoteSelectionDialog(dialog_notes), wait_for_dismiss=True
+            )
+        except Exception as e:
+            logger.error(f"Failed to import from notes: {e}")
+            self.app.notify(f"Failed to import notes: {e}", severity="error")
+            return
+
+        if not selected_ids:
+            return
+
+        combined_content = []
+        for note_id in selected_ids:
+            note = notes_by_id.get(str(note_id))
+            if note:
+                # Add note title as chapter if it exists
+                if note.get("title"):
+                    combined_content.append(f"# {note['title']}\n")
+                combined_content.append(note.get("content", ""))
+                combined_content.append("\n\n")  # Separator between notes
+
+        # Load combined content
+        self.content_text = "\n".join(combined_content)
+        content_preview = self.query_one("#content-preview", TextArea)
+        preview_text = (
+            self.content_text[:1000] + "..."
+            if len(self.content_text) > 1000
+            else self.content_text
+        )
+        content_preview.load_text(preview_text)
+        content_preview.disabled = False
+
+        # Auto-detect chapters (see task-15478: the switch that
+        # used to gate this is gone from the composed UI).
+        self._detect_chapters()
+
+        self.app.notify(
+            f"Imported {len(selected_ids)} note(s)", severity="information"
+        )
 
     def _import_from_conversation(self) -> None:
-        """Import content from conversation"""
+        """Import content from a conversation.
+
+        Task-19576: this used to import `fetch_all_conversations`/
+        `fetch_messages_by_conversation_id` from
+        `tldw_chatbook.DB.ChaChaNotes_DB` -- neither function exists, and
+        the imports sat outside the `try:` block, so every use of this
+        action crashed with an uncaught `ImportError` (same defect and
+        same fix shape as `_import_from_notes`). This now routes through
+        the shared `chat_conversation_scope_service` seam. The service is
+        async, so the actual work happens in
+        `_import_from_conversation_worker`.
+        """
+        self._import_from_conversation_worker()
+
+    # Bounded page walk for message loading (task-19576): the removed
+    # `fetch_messages_by_conversation_id` had no limit at all.
+    # `get_messages_with_context` pages in bounded chunks; this caps the
+    # total collected messages generously above what any audiobook-worthy
+    # conversation should reach, rather than reintroducing an unbounded read.
+    _CONVERSATION_IMPORT_PAGE_SIZE = 200
+    _CONVERSATION_IMPORT_MAX_MESSAGES = 5000
+
+    @work(exclusive=True, group="audiobook-import-conversation")
+    async def _import_from_conversation_worker(self) -> None:
+        """Worker half of `_import_from_conversation` (see its docstring)."""
         from tldw_chatbook.Widgets.conversation_selection_dialog import (
             ConversationSelectionDialog,
         )
-        from tldw_chatbook.DB.ChaChaNotes_DB import fetch_all_conversations
+
+        conversation_service = getattr(
+            self.app, "chat_conversation_scope_service", None
+        )
+        if conversation_service is None:
+            self.app.notify(
+                "Conversations are unavailable in this session.", severity="error"
+            )
+            return
 
         try:
-            # Fetch all conversations from database
-            conversations = fetch_all_conversations()
-            if not conversations:
-                self.app.notify(
-                    "No conversations found in database", severity="warning"
-                )
-                return
-
-            # Show conversation selection dialog
-            def handle_conversation_selection(
-                selection: Optional[Dict[str, Any]],
-            ) -> None:
-                if selection:
-                    # Fetch messages for selected conversation
-                    from tldw_chatbook.DB.ChaChaNotes_DB import (
-                        fetch_messages_by_conversation_id,
-                    )
-
-                    messages = fetch_messages_by_conversation_id(
-                        selection["conversation_id"]
-                    )
-
-                    if not messages:
-                        self.app.notify(
-                            "No messages found in conversation", severity="warning"
-                        )
-                        return
-
-                    # Build content based on options
-                    content_parts = []
-                    for msg in messages:
-                        role = msg.get("role", "unknown")
-                        content = msg.get("content", "")
-
-                        # Filter based on inclusion options
-                        if selection.get("include_all"):
-                            pass  # Include all messages
-                        elif selection.get("include_user") and role != "user":
-                            continue
-                        elif selection.get("include_assistant") and role != "assistant":
-                            continue
-
-                        # Format based on speaker option
-                        if selection.get("include_speakers"):
-                            speaker_name = "User" if role == "user" else "Assistant"
-                            content_parts.append(f"{speaker_name}: {content}")
-                        else:
-                            content_parts.append(content)
-
-                        content_parts.append("")  # Empty line between messages
-
-                    # Load combined content
-                    self.content_text = "\n".join(content_parts)
-                    content_preview = self.query_one("#content-preview", TextArea)
-                    preview_text = (
-                        self.content_text[:1000] + "..."
-                        if len(self.content_text) > 1000
-                        else self.content_text
-                    )
-                    content_preview.load_text(preview_text)
-                    content_preview.disabled = False
-
-                    # Auto-detect chapters might not be suitable for
-                    # conversations, but run it anyway (see task-15478: the
-                    # switch that used to gate this is gone from the UI).
-                    self._detect_chapters()
-
-                    self.app.notify(
-                        f"Imported conversation with {len(messages)} messages",
-                        severity="information",
-                    )
-
-            self.app.push_screen(
-                ConversationSelectionDialog(conversations),
-                handle_conversation_selection,
+            payload = await conversation_service.list_conversations(
+                mode="local",
+                # "all" spans global- and workspace-scoped conversations, so
+                # a Console chat saved inside a workspace session is still
+                # importable here.
+                scope_type="all",
+                limit=100,
+                offset=0,
             )
-
         except Exception as e:
             logger.error(f"Failed to import from conversation: {e}")
             self.app.notify(f"Failed to import conversation: {e}", severity="error")
+            return
+
+        items = payload.get("items") if isinstance(payload, dict) else None
+        conversations: List[Dict[str, Any]] = []
+        for item in items or []:
+            conversation_id = item.get("id")
+            if conversation_id is None:
+                continue
+            conversations.append(
+                {
+                    "conversation_id": str(conversation_id),
+                    "title": item.get("title", ""),
+                    "model_name": item.get("runtime_backend") or "Unknown",
+                    "message_count": item.get("message_count", 0),
+                    "created_at": item.get("created_at", "Unknown"),
+                    "updated_at": item.get("last_modified", "Unknown"),
+                }
+            )
+
+        if not conversations:
+            self.app.notify(
+                "No conversations found in database", severity="warning"
+            )
+            return
+
+        try:
+            selection = await self.app.push_screen(
+                ConversationSelectionDialog(conversations), wait_for_dismiss=True
+            )
+        except Exception as e:
+            logger.error(f"Failed to import from conversation: {e}")
+            self.app.notify(f"Failed to import conversation: {e}", severity="error")
+            return
+
+        if not selection:
+            return
+
+        conversation_id = str(selection["conversation_id"])
+
+        messages: List[Dict[str, Any]] = []
+        offset = 0
+        try:
+            while len(messages) < self._CONVERSATION_IMPORT_MAX_MESSAGES:
+                page = await conversation_service.get_messages_with_context(
+                    conversation_id,
+                    mode="local",
+                    limit=self._CONVERSATION_IMPORT_PAGE_SIZE,
+                    offset=offset,
+                    include_rag_context=False,
+                )
+                if not page:
+                    break
+                messages.extend(page)
+                if len(page) < self._CONVERSATION_IMPORT_PAGE_SIZE:
+                    break
+                offset += self._CONVERSATION_IMPORT_PAGE_SIZE
+        except Exception as e:
+            logger.error(f"Failed to import from conversation: {e}")
+            self.app.notify(f"Failed to import conversation: {e}", severity="error")
+            return
+
+        if not messages:
+            self.app.notify(
+                "No messages found in conversation", severity="warning"
+            )
+            return
+
+        # Build content based on options
+        content_parts = []
+        for msg in messages:
+            sender = str(msg.get("role") or msg.get("sender") or "")
+            is_user_message = sender.strip().lower() == "user"
+
+            # Filter based on inclusion options
+            if selection.get("include_all"):
+                pass  # Include all messages
+            elif selection.get("include_user") and not is_user_message:
+                continue
+            elif selection.get("include_assistant") and is_user_message:
+                continue
+
+            content = msg.get("content", "")
+
+            # Format based on speaker option
+            if selection.get("include_speakers"):
+                speaker_name = "User" if is_user_message else "Assistant"
+                content_parts.append(f"{speaker_name}: {content}")
+            else:
+                content_parts.append(content)
+
+            content_parts.append("")  # Empty line between messages
+
+        # Load combined content
+        self.content_text = "\n".join(content_parts)
+        content_preview = self.query_one("#content-preview", TextArea)
+        preview_text = (
+            self.content_text[:1000] + "..."
+            if len(self.content_text) > 1000
+            else self.content_text
+        )
+        content_preview.load_text(preview_text)
+        content_preview.disabled = False
+
+        # Auto-detect chapters might not be suitable for
+        # conversations, but run it anyway (see task-15478: the
+        # switch that used to gate this is gone from the UI).
+        self._detect_chapters()
+
+        self.app.notify(
+            f"Imported conversation with {len(messages)} messages",
+            severity="information",
+        )
 
     def _import_from_paste(self) -> None:
         """Import content from clipboard paste"""

--- a/tldw_chatbook/Utils/file_handlers.py
+++ b/tldw_chatbook/Utils/file_handlers.py
@@ -9,6 +9,7 @@ that users can attach to chat messages. Each handler processes files differently
 - Data files: Format and insert content
 """
 
+import asyncio
 import json
 import mimetypes
 import yaml
@@ -20,6 +21,55 @@ from loguru import logger
 
 if TYPE_CHECKING:
     pass
+
+
+async def _extract_local_ingest_text(file_path: Path, *, kind_label: str) -> str:
+    """Extract text via the shared local-ingestion parser (task-19576).
+
+    This is the same extractor (``parse_local_file_for_ingest``) Library ▸
+    Import uses -- PDF/document/ebook handlers used to return a placeholder
+    telling the user to visit a "Media Ingestion tab" that was retired (its
+    route now aliases to Library; see ``UI/Navigation/screen_registry.py``).
+
+    Runs off the event loop: PDF/document/ebook extraction is CPU-bound and
+    can easily exceed the repo's 100ms worker budget. No database write and
+    no LLM analysis happen here (``perform_analysis`` defaults to False in
+    ``parse_local_file_for_ingest``) -- this only reads and extracts text.
+    The 100MB attachment cap enforced upstream by
+    ``Chat/attachment_core.py``'s ``MAX_ATTACHMENT_BYTES`` (checked before
+    any handler is dispatched) already bounds this, matching Library ▸
+    Import's own extraction, which imposes no additional file-size cap of
+    its own at this layer.
+
+    Args:
+        file_path: Path to the file to extract text from.
+        kind_label: Human-readable file-type label used only when no text
+            could be extracted (e.g. "PDF", "document", "ebook").
+
+    Returns:
+        Formatted content wrapped with the same
+        ``--- Contents of ... ---``/``--- End of ... ---`` markers the other
+        inline handlers in this module use, or an honest "no extractable
+        text" notice (naming no destination) when extraction produced
+        nothing.
+
+    Raises:
+        Exception: Whatever ``parse_local_file_for_ingest`` raises (missing
+            optional dependency, corrupt file, etc.) -- callers catch this
+            and surface an honest, non-placeholder error message.
+    """
+    from ..Local_Ingestion.local_file_ingestion import parse_local_file_for_ingest
+
+    payload = await asyncio.to_thread(parse_local_file_for_ingest, str(file_path), {})
+    content = (payload.get("content") or "").strip()
+    if not content:
+        return (
+            f"[No extractable text found in {kind_label} file: {file_path.name}]"
+        )
+    return (
+        f"--- Contents of {file_path.name} ---\n{content}\n"
+        f"--- End of {file_path.name} ---"
+    )
 
 
 @dataclass
@@ -311,7 +361,7 @@ class DataFileHandler(FileHandler):
 
 
 class PDFFileHandler(FileHandler):
-    """Handler for PDF files using local ingestion."""
+    """Handler for PDF files, extracting real text via local ingestion."""
 
     SUPPORTED_EXTENSIONS = {".pdf"}
 
@@ -319,12 +369,18 @@ class PDFFileHandler(FileHandler):
         return file_path.suffix.lower() in self.SUPPORTED_EXTENSIONS
 
     async def process(self, file_path: Path) -> ProcessedFile:
-        """Process PDF file - just return a placeholder for now."""
-        # For now, we'll just indicate that PDF files should be processed separately
-        # The actual ingestion should happen through the dedicated ingestion UI/API
+        """Extract PDF text via the shared local-ingestion parser (task-19576).
+
+        This used to return a placeholder pointing at a retired "Media
+        Ingestion tab" -- see `_extract_local_ingest_text`'s docstring.
+        """
+        try:
+            content = await _extract_local_ingest_text(file_path, kind_label="PDF")
+        except Exception as e:
+            logger.error(f"Failed to extract PDF text from {file_path}: {e}")
+            content = f"[Could not extract text from PDF file: {file_path.name} ({e})]"
         return ProcessedFile(
-            content=f"[PDF File: {file_path.name}]\n"
-            f"To process this PDF file, please use the Media Ingestion tab.",
+            content=content,
             display_name=file_path.name,
             insert_mode="inline",
             file_type="pdf",
@@ -332,7 +388,8 @@ class PDFFileHandler(FileHandler):
 
 
 class DocumentFileHandler(FileHandler):
-    """Handler for document files (Word, RTF, ODT) using local ingestion."""
+    """Handler for document files (Word, RTF, ODT), extracting real text via
+    local ingestion."""
 
     SUPPORTED_EXTENSIONS = {".doc", ".docx", ".rtf", ".odt"}
 
@@ -340,12 +397,23 @@ class DocumentFileHandler(FileHandler):
         return file_path.suffix.lower() in self.SUPPORTED_EXTENSIONS
 
     async def process(self, file_path: Path) -> ProcessedFile:
-        """Process document file - just return a placeholder for now."""
-        # For now, we'll just indicate that document files should be processed separately
-        # The actual ingestion should happen through the dedicated ingestion UI/API
+        """Extract document text via the shared local-ingestion parser
+        (task-19576). This used to return a placeholder pointing at a
+        retired "Media Ingestion tab" -- see `_extract_local_ingest_text`'s
+        docstring.
+        """
+        try:
+            content = await _extract_local_ingest_text(
+                file_path, kind_label="document"
+            )
+        except Exception as e:
+            logger.error(f"Failed to extract document text from {file_path}: {e}")
+            content = (
+                f"[Could not extract text from document file: "
+                f"{file_path.name} ({e})]"
+            )
         return ProcessedFile(
-            content=f"[Document File: {file_path.name}]\n"
-            f"To process this document file, please use the Media Ingestion tab.",
+            content=content,
             display_name=file_path.name,
             insert_mode="inline",
             file_type="document",
@@ -353,7 +421,8 @@ class DocumentFileHandler(FileHandler):
 
 
 class EbookFileHandler(FileHandler):
-    """Handler for ebook files (EPUB, MOBI, AZW3) using local ingestion."""
+    """Handler for ebook files (EPUB, MOBI, AZW3), extracting real text via
+    local ingestion."""
 
     SUPPORTED_EXTENSIONS = {".epub", ".mobi", ".azw", ".azw3", ".fb2"}
 
@@ -361,12 +430,20 @@ class EbookFileHandler(FileHandler):
         return file_path.suffix.lower() in self.SUPPORTED_EXTENSIONS
 
     async def process(self, file_path: Path) -> ProcessedFile:
-        """Process ebook file - just return a placeholder for now."""
-        # For now, we'll just indicate that ebook files should be processed separately
-        # The actual ingestion should happen through the dedicated ingestion UI/API
+        """Extract ebook text via the shared local-ingestion parser
+        (task-19576). This used to return a placeholder pointing at a
+        retired "Media Ingestion tab" -- see `_extract_local_ingest_text`'s
+        docstring.
+        """
+        try:
+            content = await _extract_local_ingest_text(file_path, kind_label="ebook")
+        except Exception as e:
+            logger.error(f"Failed to extract ebook text from {file_path}: {e}")
+            content = (
+                f"[Could not extract text from ebook file: {file_path.name} ({e})]"
+            )
         return ProcessedFile(
-            content=f"[Ebook File: {file_path.name}]\n"
-            f"To process this ebook file, please use the Media Ingestion tab.",
+            content=content,
             display_name=file_path.name,
             insert_mode="inline",
             file_type="ebook",
@@ -388,22 +465,35 @@ class PlaintextDatabaseHandler(FileHandler):
         return file_path.stat().st_size > 100 * 1024
 
     async def process(self, file_path: Path) -> ProcessedFile:
-        """Process plaintext file for database ingestion."""
+        """Process plaintext file for database ingestion.
+
+        Task-19576: both branches used to name a "Media Ingestion tab" that
+        no longer exists (its route now aliases to Library; see
+        `UI/Navigation/screen_registry.py`). Unlike the PDF/document/ebook
+        handlers above, this is a deliberate size-based deferral, not a
+        missing-capability placeholder: reading text out of a plaintext
+        file needs no extraction step, but inlining a many-hundred-KB (or
+        multi-MB) file straight into a chat turn's context is a real
+        cost/context-window concern of its own, so this still defers to
+        Library's RAG-searchable ingestion instead of dumping raw text
+        inline -- only the (now retired) destination name is fixed.
+        """
         try:
             # Check file size
             if file_path.stat().st_size > self.MAX_FILE_SIZE:
                 return ProcessedFile(
                     content=f"[File too large: {file_path.name} ({file_path.stat().st_size / 1024 / 1024:.1f}MB)]\n"
-                    f"To process large text files, please use the Media Ingestion tab.",
+                    f"To ingest this file for search, add it via the Library tab.",
                     display_name=file_path.name,
                     insert_mode="inline",
                     file_type="text",
                 )
 
-            # For large text files, suggest using the ingestion tab
+            # For large text files, suggest using Library's RAG-searchable
+            # ingestion rather than inlining the whole file into this chat turn.
             return ProcessedFile(
                 content=f"[Large Text File: {file_path.name} ({file_path.stat().st_size / 1024:.1f}KB)]\n"
-                f"To process this file for RAG search, please use the Media Ingestion tab.",
+                f"To process this file for RAG search, add it via the Library tab.",
                 display_name=file_path.name,
                 insert_mode="inline",
                 file_type="text",


### PR DESCRIPTION
## Summary
Closes task-19576 (P1). Two paths a normal user can reach were broken by retired-surface drift.

**A — STTS AudioBook "Import from Notes / Conversation" crashed.** It imported four `DB.ChaChaNotes_DB` functions that **do not exist**, outside the `try:` blocks so the `ImportError` propagated. Both paths are now thin sync dispatchers to `@work` async workers routed through the app's notes and chat scope services — the same seams Home and Library already use — with `push_screen(wait_for_dismiss=True)` for the existing selection dialogs, degrading to a notification (never a crash) when a service is not wired.

A **latent bug** surfaced in the rewrite: the old role filter compared `role != "user"` against `sender` values stored capitalized, so "User/Assistant messages only" could never have matched anything, even before the crash. Now case-normalized. The conversation walk is also bounded (200/page, 5,000 cap) — the removed function had no limit at all.

**B — attaching a PDF/Word/ebook in Console returned a placeholder naming a retired tab**, while the app ships a real extractor that Library ▸ Import already uses. The audit reported three such stubs; the census found **five**, and all five are resolved:

| Site | Disposition |
|---|---|
| PDF handler | wired to real extraction (off-thread) |
| Document handler | wired to real extraction |
| Ebook handler | wired to real extraction |
| Plaintext > 10 MB | kept as a deliberate **size** deferral — not a missing-capability stub — destination name corrected |
| Plaintext 100 KB–10 MB | same |

No new size cap invented: the attachment layer's existing 100 MB gate already applies, matching Library ▸ Import's behaviour at this layer.

## Evidence, including live verification
Born-red for both defects, with baselines confirmed in **separate clean `origin/dev` worktrees** rather than by reverting the branch: five tests fail with the exact `ImportError: cannot import name 'fetch_all_notes'` signature, and seven fail showing the literal old placeholder string — one of them driving a real PDF through the unmocked extraction chain.

**The app was actually run.** On an isolated scratch profile: clicked AudioBook ▸ Import Content for both Notes and Conversation — no crash, zero errors in the in-app Logs screen; and pasted a real PDF path into a real Console composer, with the Logs confirming the genuine pipeline ran end to end (`attachment_core` → `local_file_ingestion` → `PDF_Processing_Lib`, "Text extracted successfully… using pymupdf4llm") rather than returning the placeholder.

Targeted regression run 585 passed with one pre-existing failure confirmed against clean `origin/dev`; 53,833 collected repo-wide, 0 errors.

## Not bundled
`Tests/Architecture/test_persistent_diagnostic_inventory.py` fails on a clean `origin/dev` too — pre-existing drift spanning ~10 unrelated files. The three new `logger.error` sites here were reviewed as safe (filename and exception message only, matching the file's existing pattern) and the `--write` regeneration was reverted rather than bundling other files' unreviewed drift into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs two user-facing regressions: STTS AudioBook imports no longer crash, and Console PDF/Word/ebook attachments extract real content instead of returning a placeholder. Aligns with task-19576.

- STTS AudioBook import: replaced nonexistent DB imports with async workers using `notes_scope_service` and `chat_conversation_scope_service`; dialogs use `push_screen(wait_for_dismiss=True)`; degrades to a notification when services are unavailable; fixes role filter by normalizing case; bounds conversation fetches (200/page, 5,000 max).
- Console attachments: `PDFFileHandler`, `DocumentFileHandler`, and `EbookFileHandler` now route through `parse_local_file_for_ingest` off-thread; plaintext >100 KB and >10 MB still defer by design but now point users to the Library tab; upstream 100 MB cap unchanged; failures surface honest messages instead of retired-tab placeholders.
- Tests and docs: adds targeted UI/Chat tests that were born-red on `dev` and pass after this change; updates the Console attachments doc verification stamp.

<sup>Written for commit 8b6a55ae9ad458bfce5e095a634aa0079b633f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

